### PR TITLE
Language Server - Command class

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -68,6 +68,7 @@ import net.sourceforge.kolmafia.textui.parsetree.Assignment;
 import net.sourceforge.kolmafia.textui.parsetree.BasicScope;
 import net.sourceforge.kolmafia.textui.parsetree.BasicScript;
 import net.sourceforge.kolmafia.textui.parsetree.Catch;
+import net.sourceforge.kolmafia.textui.parsetree.Command;
 import net.sourceforge.kolmafia.textui.parsetree.CompositeReference;
 import net.sourceforge.kolmafia.textui.parsetree.Concatenate;
 import net.sourceforge.kolmafia.textui.parsetree.Conditional;
@@ -89,7 +90,6 @@ import net.sourceforge.kolmafia.textui.parsetree.LoopContinue;
 import net.sourceforge.kolmafia.textui.parsetree.MapLiteral;
 import net.sourceforge.kolmafia.textui.parsetree.Operation;
 import net.sourceforge.kolmafia.textui.parsetree.Operator;
-import net.sourceforge.kolmafia.textui.parsetree.ParseTreeNode;
 import net.sourceforge.kolmafia.textui.parsetree.PluralValue;
 import net.sourceforge.kolmafia.textui.parsetree.RecordType;
 import net.sourceforge.kolmafia.textui.parsetree.RepeatUntilLoop;
@@ -437,7 +437,7 @@ public class Parser
 		// If there is no data type, it's a command of some sort
 		if ( t == null )
 		{
-			ParseTreeNode c = this.parseCommand( expectedType, result, false, false, false );
+			Command c = this.parseCommand( expectedType, result, false, false, false );
 			if ( c != null )
 			{
 				result.addCommand( c, this );
@@ -517,7 +517,7 @@ public class Parser
 			if ( t == null )
 			{
 				// See if it's a regular command
-				ParseTreeNode c = this.parseCommand( expectedType, result, false, allowBreak, allowContinue );
+				Command c = this.parseCommand( expectedType, result, false, allowBreak, allowContinue );
 				if ( c != null )
 				{
 					result.addCommand( c, this );
@@ -846,7 +846,7 @@ public class Parser
 		Scope scope = this.parseBlockOrSingleCommand( functionType, paramList, parentScope, false, false, false );
 
 		result.setScope( scope );
-		if ( !result.assertBarrier() && !functionType.equals( DataTypes.TYPE_VOID ) )
+		if ( !scope.assertBarrier() && !functionType.equals( DataTypes.TYPE_VOID ) )
 		{
 			throw this.parseException( "Missing return value" );
 		}
@@ -1086,7 +1086,7 @@ public class Parser
 				// It is OK to redefine a typedef with an equivalent type
 				return true;
 			}
-				
+
 			throw this.parseException( "Type name '" + typeName + "' is already defined" );
 		}
 		else
@@ -1099,9 +1099,9 @@ public class Parser
 		return true;
 	}
 
-	private ParseTreeNode parseCommand( final Type functionType, final BasicScope scope, final boolean noElse, boolean allowBreak, boolean allowContinue )
+	private Command parseCommand( final Type functionType, final BasicScope scope, final boolean noElse, boolean allowBreak, boolean allowContinue )
 	{
-		ParseTreeNode result;
+		Command result;
 
 		if ( this.currentToken().equalsIgnoreCase( "break" ) )
 		{
@@ -1587,7 +1587,7 @@ public class Parser
 	{
 		Scope result = new Scope( parentScope );
 
-		ParseTreeNode command = this.parseCommand( functionType, parentScope, noElse, allowBreak, allowContinue );
+		Command command = this.parseCommand( functionType, parentScope, noElse, allowBreak, allowContinue );
 		if ( command != null )
 		{
 			result.addCommand( command, this );
@@ -2053,7 +2053,7 @@ public class Parser
 			if ( t == null )
 			{
 				// See if it's a regular command
-				ParseTreeNode c = this.parseCommand( functionType, scope, false, true, allowContinue );
+				Command c = this.parseCommand( functionType, scope, false, true, allowContinue );
 				if ( c != null )
 				{
 					scope.addCommand( c, this );
@@ -2153,7 +2153,7 @@ public class Parser
 
 		this.readToken(); // catch
 
-		ParseTreeNode body = this.parseBlock( null, null, parentScope, true, false, false );
+		Command body = this.parseBlock( null, null, parentScope, true, false, false );
 		if ( body == null )
 		{
 			Value value = this.parseExpression( parentScope );
@@ -2587,7 +2587,7 @@ public class Parser
 
 		// Parse incrementers in context of scope
 
-		List<ParseTreeNode> incrementers = new ArrayList<ParseTreeNode>();
+		List<Command> incrementers = new ArrayList<>();
 
 		while ( !this.atEndOfFile() && !this.currentToken().equals( ")" ) )
 		{
@@ -2679,7 +2679,7 @@ public class Parser
 		else
 		{
 			// Scope is a single command
-			ParseTreeNode command = this.parseCommand( functionType, result, false, true, true );
+			Command command = this.parseCommand( functionType, result, false, true, true );
 			if ( command == null )
 			{
 				if ( this.currentToken().equals( ";" ) )
@@ -3615,7 +3615,7 @@ public class Parser
 					conc.addString( lhs );
 					conc.addString( rhs );
 				}
-				
+
 				resultString.setLength( 0 );
 				continue;
 			}

--- a/src/net/sourceforge/kolmafia/textui/parsetree/BasicScope.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/BasicScope.java
@@ -53,14 +53,14 @@ import net.sourceforge.kolmafia.textui.parsetree.Function.MatchType;
 import net.sourceforge.kolmafia.utilities.PauseObject;
 
 public abstract class BasicScope
-	extends ParseTreeNode
+	extends Command
 {
 	private final PauseObject pauser = new PauseObject();
 	private static long nextPause = System.currentTimeMillis();
-	
+
 	protected static final int BARRIER_NONE = 0;	// no return, etc. yet
 	protected static final int BARRIER_SEEN = 1;	// just seen
-	protected static final int BARRIER_PAST = 2;	// already warned about dead code	
+	protected static final int BARRIER_PAST = 2;	// already warned about dead code
 
 	protected TypeList types;
 	protected VariableList variables;
@@ -284,7 +284,7 @@ public abstract class BasicScope
 	}
 
 	private Function findFunction( final Function[] functions, boolean library, String name,
-                                   final List<Value> params, MatchType match, boolean vararg )
+	                               final List<Value> params, MatchType match, boolean vararg )
 	{
 		// Search the function list for a match
 		for ( Function function : functions )
@@ -334,7 +334,7 @@ public abstract class BasicScope
 
 		return null;
 	}
-	
+
 	public Function findVarargClash( final UserDefinedFunction f )
 	{
 		// We will consider functions from this scope and from the RuntimeLibrary.
@@ -402,12 +402,12 @@ public abstract class BasicScope
 	public Function findFunction( final String name, boolean hasParameters )
 	{
 		Function function = findFunction( name, this.functions, hasParameters );
-		
+
 		if ( function != null )
 		{
 			return function;
 		}
-		
+
 		function = findFunction( name, RuntimeLibrary.functions, hasParameters );
 
 		return function;
@@ -416,7 +416,7 @@ public abstract class BasicScope
 	public Function findFunction( final String name, final FunctionList functionList, final boolean hasParameters )
 	{
 		Function[] functions = functionList.findFunctions( name );
-		
+
 		if ( functions.length == 0 )
 		{
 			return null;
@@ -442,14 +442,14 @@ public abstract class BasicScope
 				}
 				paramCount = 1;
 			}
-			
+
 			while ( refIterator.hasNext() )
 			{
 				refIterator.next();
 				isSingleString = false;
 				++paramCount;
 			}
-			
+
 			if ( paramCount == 0 )
 			{
 				if ( !hasParameters )
@@ -463,12 +463,12 @@ public abstract class BasicScope
 				{
 					return functions[ i ];
 				}
-				
+
 				if ( minParamCount == 1 )
 				{
 					isAmbiguous = true;
 				}
-				
+
 				bestMatch = functions[ i ];
 				minParamCount = 1;
 			}
@@ -483,10 +483,10 @@ public abstract class BasicScope
 				else if ( minParamCount == paramCount )
 				{
 					isAmbiguous = true;
-				}				
+				}
 			}
 		}
-		
+
 		if ( isAmbiguous )
 		{
 			return null;
@@ -528,10 +528,10 @@ public abstract class BasicScope
 		AshRuntime.indentLine( stream, indent + 1 );
 		stream.println( "<COMMANDS>" );
 
-		Iterator<ParseTreeNode> it = this.getCommands();
+		Iterator<Command> it = this.getCommands();
 		while ( it.hasNext() )
 		{
-			ParseTreeNode currentCommand = it.next();
+			Command currentCommand = it.next();
 			currentCommand.print( stream, indent + 2 );
 		}
 	}
@@ -559,10 +559,10 @@ public abstract class BasicScope
 			Value result = DataTypes.VOID_VALUE;
 			interpreter.traceIndent();
 
-			Iterator<ParseTreeNode> it = this.getCommands();
+			Iterator<Command> it = this.getCommands();
 			while ( it.hasNext() )
 			{
-				ParseTreeNode current = it.next();
+				Command current = it.next();
 				result = current.execute( interpreter );
 
 				// Abort processing now if command failed
@@ -596,7 +596,7 @@ public abstract class BasicScope
 		}
 	}
 
-	public abstract void addCommand( final ParseTreeNode c, final Parser p );
+	public abstract void addCommand( final Command c, final Parser p );
 
-	public abstract Iterator<ParseTreeNode> getCommands();
+	public abstract Iterator<Command> getCommands();
 }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/BasicScript.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/BasicScript.java
@@ -43,7 +43,7 @@ import net.sourceforge.kolmafia.textui.AshRuntime;
 import net.sourceforge.kolmafia.utilities.ByteArrayStream;
 
 public class BasicScript
-	extends ParseTreeNode
+	extends Command
 {
 	private final ByteArrayStream data;
 

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Catch.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Catch.java
@@ -43,11 +43,11 @@ import net.sourceforge.kolmafia.textui.ScriptRuntime;
 import net.sourceforge.kolmafia.textui.ScriptException;
 
 public class Catch
-        extends Value
+	extends Value
 {
-	private final ParseTreeNode node;
+	private final Command node;
 
-	public Catch( final ParseTreeNode node  )
+	public Catch( final Command node  )
 	{
 		super( DataTypes.STRING_TYPE );
 		this.node = node;
@@ -109,13 +109,13 @@ public class Catch
 
 		return new Value( errorMessage );
 	}
-	
+
 	@Override
 	public boolean assertBarrier()
 	{
 		return this.node.assertBarrier();
 	}
-	
+
 	@Override
 	public boolean assertBreakable()
 	{

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Command.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Command.java
@@ -33,90 +33,41 @@
 
 package net.sourceforge.kolmafia.textui.parsetree;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
-import net.sourceforge.kolmafia.textui.Parser;
-
-public class Scope
-	extends BasicScope
+public abstract class Command
+	extends ParseTreeNode
 {
-	private final ArrayList<Command> commands;
-	private int barrier = BasicScope.BARRIER_NONE;
-	private boolean breakable = false;
-
-	public Scope( VariableList variables, final BasicScope parentScope )
-	{
-		super( variables, parentScope );
-		this.commands = new ArrayList<>();
-	}
-
-	public Scope( final BasicScope parentScope )
-	{
-		super( parentScope );
-		this.commands = new ArrayList<>();
-	}
-
-	public Scope( FunctionList functions, VariableList variables, TypeList types )
-	{
-		super( functions, variables, types, null );
-		this.commands = new ArrayList<>();
-	}
-
-	@Override
-	public void addCommand( final Command c, final Parser p )
-	{
-		if ( c == null )
-		{
-			// We shouldn't be called with no command, but don't do
-			// the wrong thing with one.
-			return;
-		}
-
-		this.commands.add( c );
-
-		if ( this.barrier == BasicScope.BARRIER_NONE &&
-			c.assertBarrier() )
-		{
-			this.barrier = BasicScope.BARRIER_SEEN;
-		}
-		else if ( this.barrier == BasicScope.BARRIER_SEEN &&
-			!(c instanceof FunctionReturn) )
-		{	// A return statement after a barrier is temporarily allowed,
-			// since they were previously required in some cases that didn't
-			// really need them.
-			this.barrier = BasicScope.BARRIER_PAST;
-			p.warning( "Unreachable code" );
-		}
-
-		if ( !this.breakable )
-		{
-			this.breakable = c.assertBreakable();
-		}
-	}
-
-	public List<Command> getCommandList()
-	{
-		return this.commands;
-	}
-
-	@Override
-	public Iterator<Command> getCommands()
-	{
-		return this.commands.iterator();
-	}
-
-	@Override
+	// A barrier is any code construct that is fundamentally incapable of
+	// completing normally; any subsequent code in the same scope is
+	// therefore dead code (exception: case labels can make code live again).
+	// The basic barriers are the RETURN, EXIT, BREAK, and CONTINUE statements
+	// (THROW would also be a barrier if we had something like that).
+	// Any compound statement that unavoidably hits a barrier is itself a
+	// barrier: IF/ELSEIF/ELSE with barriers in all branches; SWITCH with no
+	// breaks and a barrier at the end; TRY with a barrier in either the code
+	// block or the FINALLY clause; and infinite loops with no break.
+	// Note that most looping constructs cannot be barriers, due to the
+	// possibility of the loop executing zero times and just falling thru.
+	// Note that function calls cannot be a barrier, not even abort(), due
+	// to the existence of the "disable" CLI command.  The code currently
+	// assumes that no expression can be a barrier.
+	// Note that BREAK and CONTINUE are disallowed outside of loops, so the
+	// presence of a barrier in a non-void function's body is exactly
+	// equivalent to the requirement that it not return without a return value.
 	public boolean assertBarrier()
 	{
-		return this.barrier >= BasicScope.BARRIER_SEEN;
+		return false;
 	}
 
-	@Override
+	// A breakable code construct is a BREAK statement, or any compound
+	// statement that can possibly execute a BREAK that isn't caught internally.
+	// Looping statements are therefore not considered breakable, since they
+	// would handle the break themselves.
 	public boolean assertBreakable()
 	{
-		return this.breakable;
+		return false;
 	}
-}
 
+	// There is no need for a corresponding check for CONTINUE statements.
+	// Since they can only branch back to already-executed code, they have
+	// no effect on code reachability.
+}

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Command.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Command.java
@@ -1,36 +1,3 @@
-/*
- * Copyright (c) 2005-2021, KoLmafia development team
- * http://kolmafia.sourceforge.net/
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *  [1] Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.
- *  [2] Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in
- *      the documentation and/or other materials provided with the
- *      distribution.
- *  [3] Neither the name "KoLmafia" nor the names of its contributors may
- *      be used to endorse or promote products derived from this software
- *      without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION ) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE ) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package net.sourceforge.kolmafia.textui.parsetree;
 
 public abstract class Command

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Conditional.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Conditional.java
@@ -40,7 +40,7 @@ import net.sourceforge.kolmafia.textui.AshRuntime;
 import net.sourceforge.kolmafia.textui.ScriptRuntime;
 
 public abstract class Conditional
-	extends ParseTreeNode
+	extends Command
 {
 	public Scope scope;
 	private final Value condition;

--- a/src/net/sourceforge/kolmafia/textui/parsetree/FunctionReturn.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/FunctionReturn.java
@@ -42,7 +42,7 @@ import net.sourceforge.kolmafia.textui.AshRuntime;
 import net.sourceforge.kolmafia.textui.ScriptRuntime;
 
 public class FunctionReturn
-	extends ParseTreeNode
+	extends Command
 {
 	private final Value returnValue;
 	private final Type expectedType;
@@ -116,7 +116,7 @@ public class FunctionReturn
 		{
 			interpreter.setState( ScriptRuntime.State.RETURN );
 		}
-		
+
 		if ( this.expectedType == null )
 		{
 			return result;
@@ -156,7 +156,7 @@ public class FunctionReturn
 			this.returnValue.print( stream, indent + 1 );
 		}
 	}
-	
+
 	@Override
 	public boolean assertBarrier()
 	{

--- a/src/net/sourceforge/kolmafia/textui/parsetree/JavaForLoop.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/JavaForLoop.java
@@ -48,12 +48,12 @@ public class JavaForLoop
 {
 	private final List<Assignment> initializers;
 	private final Value condition;
-	private final List<ParseTreeNode> incrementers;
+	private final List<Command> incrementers;
 
 	public JavaForLoop( final Scope scope,
 			    final List<Assignment> initializers,
 			    final Value condition,
-			    final List<ParseTreeNode> incrementers )
+			    final List<Command> incrementers )
 	{
 		super( scope );
 		this.initializers = initializers;
@@ -154,7 +154,7 @@ public class JavaForLoop
 			}
 
 			// Execute incrementers
-			for ( ParseTreeNode incrementer : this.incrementers )
+			for ( Command incrementer : this.incrementers )
 			{
 				Value iresult = incrementer.execute( interpreter );
 
@@ -198,7 +198,7 @@ public class JavaForLoop
 			initializer.print( stream, indent + 1 );
 		}
 		this.getCondition().print( stream, indent + 1 );
-		for ( ParseTreeNode incrementer : this.incrementers )
+		for ( Command incrementer : this.incrementers )
 		{
 			AshRuntime.indentLine( stream, indent + 1 );
 			stream.println( "<ITERATE>" );

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Loop.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Loop.java
@@ -40,7 +40,7 @@ import net.sourceforge.kolmafia.textui.AshRuntime;
 import net.sourceforge.kolmafia.textui.ScriptRuntime;
 
 public abstract class Loop
-	extends ParseTreeNode
+	extends Command
 {
 	private final Scope scope;
 

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Operator.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Operator.java
@@ -43,7 +43,7 @@ import net.sourceforge.kolmafia.textui.Parser;
 import net.sourceforge.kolmafia.textui.ScriptRuntime;
 
 public class Operator
-	extends ParseTreeNode
+	extends Command
 {
 	String operator;
 

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ParseTreeNode.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ParseTreeNode.java
@@ -41,39 +41,4 @@ public abstract class ParseTreeNode
 {
 	public abstract Value execute( final AshRuntime interpreter );
 	public abstract void print( final PrintStream stream, final int indent );
-	
-	// A barrier is any code construct that is fundamentally incapable of
-	// completing normally; any subsequent code in the same scope is
-	// therefore dead code (exception: case labels can make code live again).
-	// The basic barriers are the RETURN, EXIT, BREAK, and CONTINUE statements
-	// (THROW would also be a barrier if we had something like that).
-	// Any compound statement that unavoidably hits a barrier is itself a
-	// barrier: IF/ELSEIF/ELSE with barriers in all branches; SWITCH with no
-	// breaks and a barrier at the end; TRY with a barrier in either the code
-	// block or the FINALLY clause; and infinite loops with no break.
-	// Note that most looping constructs cannot be barriers, due to the
-	// possibility of the loop executing zero times and just falling thru.
-	// Note that function calls cannot be a barrier, not even abort(), due
-	// to the existence of the "disable" CLI command.  The code currently
-	// assumes that no expression can be a barrier.
-	// Note that BREAK and CONTINUE are disallowed outside of loops, so the
-	// presence of a barrier in a non-void function's body is exactly
-	// equivalent to the requirement that it not return without a return value.
-	public boolean assertBarrier()
-	{
-		return false;
-	}
-	
-	// A breakable code construct is a BREAK statement, or any compound
-	// statement that can possibly execute a BREAK that isn't caught internally.
-	// Looping statements are therefore not considered breakable, since they
-	// would handle the break themselves.
-	public boolean assertBreakable()
-	{
-		return false;
-	}
-	
-	// There is no need for a corresponding check for CONTINUE statements.
-	// Since they can only branch back to already-executed code, they have
-	// no effect on code reachability.
 }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ScriptState.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ScriptState.java
@@ -40,7 +40,7 @@ import net.sourceforge.kolmafia.textui.AshRuntime;
 import net.sourceforge.kolmafia.textui.ScriptRuntime;
 
 public abstract class ScriptState
-	extends ParseTreeNode
+	extends Command
 {
 	private final ScriptRuntime.State state;
 
@@ -74,7 +74,7 @@ public abstract class ScriptState
 		AshRuntime.indentLine( stream, indent );
 		stream.println( "<COMMAND " + this.state + ">" );
 	}
-	
+
 	@Override
 	public boolean assertBarrier()
 	{

--- a/src/net/sourceforge/kolmafia/textui/parsetree/SortBy.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/SortBy.java
@@ -47,7 +47,7 @@ import net.sourceforge.kolmafia.textui.Parser;
 import net.sourceforge.kolmafia.textui.ScriptRuntime;
 
 public class SortBy
-	extends ParseTreeNode
+	extends Command
 {
 	private final VariableReference aggregate;
 	private final Variable indexvar, valuevar;
@@ -94,7 +94,7 @@ public class SortBy
 
 		Value[] keys = map.keys();
 		Pair[] values = new Pair[ keys.length ];
-		
+
 		for ( int i = 0; i < keys.length; ++i )
 		{
 			Value index = keys[i];
@@ -118,7 +118,7 @@ public class SortBy
 			}
 			values[i] = new Pair( sortkey, value );
 		}
-		
+
 		try
 		{
 			Arrays.sort( values );
@@ -128,7 +128,7 @@ public class SortBy
 			interpreter.setLineAndFile( this.fileName, this.lineNumber );
 			throw interpreter.runtimeException( "Illegal argument exception during sort" );
 		}
-		
+
 		for ( int i = 0; i < keys.length; ++i )
 		{
 			Value index = keys[ i ];
@@ -153,18 +153,18 @@ public class SortBy
 		this.aggregate.print( stream, indent + 1 );
 		this.expr.print( stream, indent + 1 );
 	}
-	
+
 	private static class Pair
 		implements Comparable<Pair>
 	{
 		public Value key, value;
-		
+
 		public Pair( Value key, Value value )
 		{
 			this.key = key;
 			this.value = value;
 		}
-		
+
 		public int compareTo( Pair o )
 		{
 			return this.key.compareTo( o.key );

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Switch.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Switch.java
@@ -45,7 +45,7 @@ import net.sourceforge.kolmafia.textui.AshRuntime;
 import net.sourceforge.kolmafia.textui.ScriptRuntime;
 
 public class Switch
-	extends ParseTreeNode
+	extends Command
 {
 	private final Value condition;
 	private final Value [] tests;
@@ -187,7 +187,7 @@ public class Switch
 		this.getCondition().print( stream, indent + 1 );
 		this.getScope().print( stream, indent + 1, tests, offsets, defaultIndex );
 	}
-	
+
 	@Override
 	public boolean assertBarrier()
 	{

--- a/src/net/sourceforge/kolmafia/textui/parsetree/SwitchScope.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/SwitchScope.java
@@ -44,7 +44,7 @@ import net.sourceforge.kolmafia.textui.Parser;
 public class SwitchScope
 	extends BasicScope
 {
-	private final ArrayList<ParseTreeNode> commands = new ArrayList<ParseTreeNode>();
+	private final ArrayList<Command> commands = new ArrayList<>();
 	private int offset = -1;
 	private int barrier = BasicScope.BARRIER_SEEN;
 	private boolean breakable = false;
@@ -55,7 +55,7 @@ public class SwitchScope
 	}
 
 	@Override
-	public void addCommand( final ParseTreeNode c, final Parser p )
+	public void addCommand( final Command c, final Parser p )
 	{
 		this.commands.add( c );
 		if ( this.barrier == BasicScope.BARRIER_NONE &&
@@ -68,20 +68,20 @@ public class SwitchScope
 			this.barrier = BasicScope.BARRIER_PAST;
 			p.warning( "Unreachable code" );
 		}
-		
+
 		if ( !this.breakable )
 		{
 			this.breakable = c.assertBreakable();
 		}
 	}
-	
+
 	public void resetBarrier()
 	{
 		this.barrier = BasicScope.BARRIER_NONE;
 	}
 
 	@Override
-	public Iterator<ParseTreeNode> getCommands()
+	public Iterator<Command> getCommands()
 	{
 		return this.commands.listIterator( this.offset );
 	}
@@ -101,7 +101,7 @@ public class SwitchScope
 	{
 		return this.barrier >= BasicScope.BARRIER_SEEN;
 	}
-	
+
 	@Override
 	public boolean assertBreakable()
 	{
@@ -145,13 +145,13 @@ public class SwitchScope
 				testIndex++;
 			}
 
-                        if ( defaultIndex == index )
-                        {
-                                AshRuntime.indentLine( stream, indent + 1 );
-                                stream.println( "<DEFAULT>" );
-                        }
+			if ( defaultIndex == index )
+			{
+				AshRuntime.indentLine( stream, indent + 1 );
+				stream.println( "<DEFAULT>" );
+			}
 
-			ParseTreeNode command = commands.get( index );
+			Command command = commands.get( index );
 			command.print( stream, indent + 2 );
 		}
 	}

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Try.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Try.java
@@ -44,7 +44,7 @@ import net.sourceforge.kolmafia.textui.AshRuntime;
 import net.sourceforge.kolmafia.textui.ScriptRuntime;
 
 public class Try
-	extends ParseTreeNode
+	extends Command
 {
 	private final Scope body, finalClause;
 
@@ -111,17 +111,17 @@ public class Try
 				}
 			}
 		}
-	
+
 		interpreter.traceUnindent();
 		return result;
 	}
-	
+
 	@Override
 	public boolean assertBarrier()
 	{
 		return this.body.assertBarrier() || this.finalClause.assertBarrier();
 	}
-	
+
 	@Override
 	public boolean assertBreakable()
 	{
@@ -141,7 +141,7 @@ public class Try
 		stream.println( "<TRY>" );
 
 		this.body.print( stream, indent + 1 );
-		
+
 		if ( this.finalClause != null )
 		{
 			AshRuntime.indentLine( stream, indent );

--- a/src/net/sourceforge/kolmafia/textui/parsetree/UserDefinedFunction.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/UserDefinedFunction.java
@@ -74,7 +74,7 @@ public class UserDefinedFunction
 		{
 			return;
 		}
-		
+
 		ArrayList<Value> values = new ArrayList<Value>();
 
 		for ( BasicScope next : this.scope.getScopes() )
@@ -159,12 +159,6 @@ public class UserDefinedFunction
 		}
 
 		return false;
-	}
-
-	@Override
-	public boolean assertBarrier()
-	{
-		return this.scope.assertBarrier();
 	}
 
 	@Override

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Value.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Value.java
@@ -54,7 +54,7 @@ import net.sourceforge.kolmafia.textui.Parser;
 import org.json.JSONException;
 
 public class Value
-	extends ParseTreeNode
+	extends Command
 	implements Comparable<Value>
 {
 	public Type type;
@@ -247,7 +247,7 @@ public class Value
 	{
 		return this;
 	}
-	
+
 	public Value asProxy()
 	{
 		if ( this.getType() == DataTypes.CLASS_TYPE )
@@ -316,7 +316,7 @@ public class Value
 		}
 		return this;
 	}
-	
+
 	/* null-safe version of the above */
 	public static Value asProxy( Value value )
 	{


### PR DESCRIPTION
Adds the Command class as an abstract subtype of ParseTreeNode.

Its existence was already assumed (shown with the presence of variable names and methods like "parseCommand", to spell it out loud), but never officially added.

This class creates a distinction between it and Symbol, and shields previous uses of "ParseTreeNode" from having a Symbol slipped in its place.