### PR TITLE
Rearranged StaticEntity check for null revision for developers runnin…

### DIFF
--- a/src/net/sourceforge/kolmafia/StaticEntity.java
+++ b/src/net/sourceforge/kolmafia/StaticEntity.java
@@ -120,6 +120,8 @@ public abstract class StaticEntity
 				{
 					Manifest manifest = new Manifest( resource.openStream() );
 					String buildRevision = manifest.getMainAttributes().getValue( "Build-Revision" );
+
+					StaticEntity.cachedRevisionNumber = 0;
 					if ( StringUtilities.isNumeric( buildRevision ) )
 					{
 						try
@@ -129,6 +131,7 @@ public abstract class StaticEntity
 						catch ( NumberFormatException e )
 						{
 							StaticEntity.cachedRevisionNumber = 0;
+
 						}
 					}
 				}


### PR DESCRIPTION
fixed the revision 0 causing an NPE in the IDE.

initialized the cachedRevisionNumber prior to setting it.

Tested with IJ