### PR TITLE
feat: try multiple faxbots if the first fails in the CLI

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/command/FaxbotCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/FaxbotCommand.java
@@ -20,10 +20,10 @@ public class FaxbotCommand
 	{
 		this.usage = " [command] - send the command to faxbot";
 	}
-	
+
 	@Override
 	public void run( final String cmd, final String command )
-	{	
+	{
 		FaxBotDatabase.configure();
 
 		boolean tried = false;
@@ -62,12 +62,14 @@ public class FaxbotCommand
 
 			Monster monster = bot.getMonsterByCommand( (String)commands.get( 0 ) );
 			tried = true;
-			if (FaxRequestFrame.requestFax( botName, monster, false )) {
+			if ( FaxRequestFrame.requestFax( botName, monster, false ) )
+			{
 				return;
 			}
 		}
-		if (!tried) {
-			KoLmafia.updateDisplay(KoLConstants.MafiaState.ABORT, "No faxbots accept that command.");
+		if ( !tried )
+		{
+			KoLmafia.updateDisplay( KoLConstants.MafiaState.ABORT, "No faxbots accept that command." );
 		}
 	}
 }

--- a/src/net/sourceforge/kolmafia/textui/command/FaxbotCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/FaxbotCommand.java
@@ -51,8 +51,8 @@ public class FaxbotCommand
 				RequestLogger.printList( commands );
 				RequestLogger.printLine();
 
-				KoLmafia.updateDisplay( MafiaState.ERROR, "[" + command + "] has too many matches in bot " + botName );
-				return;
+				RequestLogger.printLine( "[" + command + "] has too many matches in bot " + botName );
+				continue;
 			}
 
 			if ( !FaxRequestFrame.isBotOnline( botName ) )

--- a/src/net/sourceforge/kolmafia/textui/command/FaxbotCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/FaxbotCommand.java
@@ -26,6 +26,8 @@ public class FaxbotCommand
 	{	
 		FaxBotDatabase.configure();
 
+		boolean tried = false;
+
 		for ( FaxBot bot : FaxBotDatabase.faxbots )
 		{
 			if ( bot == null )
@@ -59,9 +61,13 @@ public class FaxbotCommand
 			}
 
 			Monster monster = bot.getMonsterByCommand( (String)commands.get( 0 ) );
-			FaxRequestFrame.requestFax( botName, monster, false );
-			return;
+			tried = true;
+			if (FaxRequestFrame.requestFax( botName, monster, false )) {
+				return;
+			}
 		}
-		KoLmafia.updateDisplay( KoLConstants.MafiaState.ABORT, "No faxbots accept that command." );
+		if (!tried) {
+			KoLmafia.updateDisplay(KoLConstants.MafiaState.ABORT, "No faxbots accept that command.");
+		}
 	}
 }


### PR DESCRIPTION
Reference: https://kolmafia.us/threads/trying-to-use-ash-to-faxbot-a-factory-overseer-fails.26271/

The bug occurs when, for example:

1. easyfax is tried first
2. easyfax offers the monster you want
3. easyfax has become trapped in a clan over rollover, so can't actually return the monster you want

The thread talks about several other options, but I think this change is still good.