### PR TITLE
Language Server - Remove VariableReference(String, BasicScope)

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -2515,7 +2515,7 @@ public class Parser
 
 			this.readToken(); // name
 
-			VariableReference lhs = new VariableReference( name.content, scope );
+			VariableReference lhs = new VariableReference( variable );
 			Value rhs = null;
 
 			if ( this.currentToken().equals( "=" ) )

--- a/src/net/sourceforge/kolmafia/textui/parsetree/VariableReference.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/VariableReference.java
@@ -9,21 +9,11 @@ import net.sourceforge.kolmafia.textui.AshRuntime;
 public class VariableReference
 	extends Value
 {
-	public Variable target;
+	public final Variable target;
 
 	public VariableReference( final Variable target )
 	{
 		this.target = target;
-	}
-
-	public VariableReference( final String varName, final BasicScope scope )
-	{
-		this.target = scope.findVariable( varName, true );
-	}
-
-	public boolean valid()
-	{
-		return this.target != null;
 	}
 
 	@Override
@@ -32,6 +22,7 @@ public class VariableReference
 		return this.target.getBaseType();
 	}
 
+	@Override
 	public Type getRawType()
 	{
 		return this.target.getType();


### PR DESCRIPTION
We never make a new VariableReference without also having access to the Variable we want it to hold.