### PR TITLE
Security lint

### DIFF
--- a/src/net/sourceforge/kolmafia/combat/Macrofier.java
+++ b/src/net/sourceforge/kolmafia/combat/Macrofier.java
@@ -629,7 +629,7 @@ public class Macrofier
 
 	public static void macroCombo( StringBuffer macro, int[] combo )
 	{
-		int cost = 0;
+		long cost = 0;
 		for ( int i = 0; i < combo.length; ++i )
 		{
 			cost += SkillDatabase.getMPConsumptionById( combo[ i ] );

--- a/src/net/sourceforge/kolmafia/session/BuffBotManager.java
+++ b/src/net/sourceforge/kolmafia/session/BuffBotManager.java
@@ -810,7 +810,7 @@ public abstract class BuffBotManager
 
 		public void updateFreeState()
 		{
-			int totalCost = 0;
+			long totalCost = 0;
 
 			for ( int i = 0; i < this.casts.length; ++i )
 			{

--- a/src/net/sourceforge/kolmafia/webui/DiscoCombatHelper.java
+++ b/src/net/sourceforge/kolmafia/webui/DiscoCombatHelper.java
@@ -802,7 +802,7 @@ public class DiscoCombatHelper
 		buffer.append( "<input type=hidden name=\"action\" value=\"macro\">" );
 		buffer.append( "<input type=hidden name=\"macrotext\" value=\"" );
 
-		int cost = 0;
+		long cost = 0;
 		for ( int i = 0; i < combo.length; ++i )
 		{
 			int skillId = combo[ i ];


### PR DESCRIPTION
Addressed instances of Implicit narrowing conversion in compound assignment flagged by security checking.  Trivial since the issue was just a local int that should have been changed when MP, HP, etc. went to longs.  Remaining instances seem to require changing global structures or method signatures.  Keeping this small to validate that I know how to "commit changes with git".