### PR TITLE
Add spotless w/ google java style.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
   id 'com.bmuschko.clover' version '3.0.1'
   id 'net.nemerosa.versioning' version '2.8.2'
   id 'com.github.johnrengelman.shadow' version '6.0.0'
+  id 'com.diffplug.spotless' version '5.15.1'
 }
 mainClassName = 'net.sourceforge.kolmafia.KoLmafia'
 
@@ -88,6 +89,20 @@ dependencies {
 application {
   // Define the main class for the application.
   mainClass = 'net.sourceforge.kolmafia.KoLmafia'
+}
+
+spotless {
+  format 'misc', {
+    target '*.gradle', '*.md', '.gitignore'
+
+    trimTrailingWhitespace()
+    indentWithSpaces(2)
+    endWithNewline()
+  }
+  java {
+    target 'src/**/*.java', 'test/**/*.java'
+    googleJavaFormat()
+  }
 }
 
 task cleanDist(type: Delete) {

--- a/default.properties
+++ b/default.properties
@@ -12,7 +12,7 @@ build=build
 dist=dist
 docs=${dist}/docs
 
-java.release=1.8
+java.release=9
 
 # This should point to INPUT_LOCATION in ReleaseNotes.java instead of being listed like this...
 logfile=${dist}/history.txt

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,6 @@
 org.gradle.parallel=true
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/src/net/sourceforge/kolmafia/KoLConstants.java
+++ b/src/net/sourceforge/kolmafia/KoLConstants.java
@@ -26,9 +26,6 @@ import net.sourceforge.kolmafia.swingui.menu.ScriptMRUList;
 
 import net.sourceforge.kolmafia.utilities.LockableListFactory;
 
-// The following are objects that go into various global data lists.
-// Perhaps we should have a DataModel.java?
-
 import net.sourceforge.kolmafia.request.UseSkillRequest;
 import net.sourceforge.kolmafia.session.EncounterManager.RegisteredEncounter;
 


### PR DESCRIPTION
This is a proof-of-concept, and does not actually apply any formatting
changes yet. I'd prefer to make that formatting change in a standalone
commit.

This also removes some comments in the middle of imports in
KoLConstants.java because `./gradlew spotlessCheck` was yelling at me,
because Google Java Format (gojf) doesn't like that.

To reformat the code, you'll run `./gradlew spotlessApply`.

This adds some flags so gojf continues to work for newer Java versions
(16+). But for that, requires that the Java compiler be new enough to
support exports, aka at least Java 9, which coincidentally is the
highest version supported by OpenClover.

We really should switch away from OpenClover to something like JaCoCo.