### PR TITLE
Migrate from OpenClover to JaCoCo for coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
         run: mkdir -p ./build
 
       - name: Run Tests
-        run: ./gradlew --no-daemon cloverGenerateReport
+        run: ./gradlew --no-daemon jacocoTestReport
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
@@ -43,4 +43,4 @@ jobs:
         uses: codecov/codecov-action@v2
         if: always()
         with:
-          file: ./build/reports/clover-root/clover.xml
+          file: ./build/reports/jacoco/test/jacocoTestReport.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,12 +37,3 @@ jobs:
       #  with:
       #    github_token: ${{ secrets.GITHUB_TOKEN }}
       #    report_paths: "**/build/test-results/test/TEST-*.xml"
-
-      # Requires 'pull_request_target' instead of `pull_request' which doesn't checkout PR code
-      # Disabled, creates a comment that is too large to post
-      #- name: Coverage Report as Comment (Clover)
-      #  uses: lucassabreu/comment-coverage-clover@main
-      #  if: github.event_name == 'pull_request_target'
-      #  with:
-      #    github-token: ${{ secrets.GITHUB_TOKEN }}
-      #    file: ./build/clover-root/clover.xml

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,11 @@
 
 plugins {
   id 'application'
-  id 'java'
-  id 'net.nemerosa.versioning' version '2.8.2'
-  id 'com.github.johnrengelman.shadow' version '6.0.0'
   id 'jacoco'
+  id 'java'
+
+  id 'com.github.johnrengelman.shadow' version '6.0.0'
+  id 'net.nemerosa.versioning' version '2.8.2'
 }
 mainClassName = 'net.sourceforge.kolmafia.KoLmafia'
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,9 @@
 plugins {
   id 'application'
   id 'java'
-  id 'com.bmuschko.clover' version '3.0.1'
   id 'net.nemerosa.versioning' version '2.8.2'
   id 'com.github.johnrengelman.shadow' version '6.0.0'
+  id 'jacoco'
 }
 mainClassName = 'net.sourceforge.kolmafia.KoLmafia'
 
@@ -58,8 +58,6 @@ dependencies {
   testImplementation 'org.hamcrest:hamcrest:2.2'
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
   testImplementation 'junit:junit:4.13.2'
-
-  clover 'org.openclover:clover:4.4.1'
 
   implementation 'com.formdev:flatlaf:1.5'
   implementation 'com.formdev:flatlaf-intellij-themes:1.5'
@@ -124,8 +122,6 @@ task pruneDist(type: Delete) {
 
 test {
   useJUnitPlatform()
-  // Exclude Clover-instrumented inner classes...
-  exclude '**/*$__CLR*.class'
 
   systemProperty 'line.separator', '\n'
   jvmArgs '-DuseCWDasROOT=true'
@@ -134,6 +130,12 @@ test {
   reports {
     html.enabled = true
     junitXml.enabled = true
+  }
+}
+
+jacocoTestReport {
+  reports {
+    xml.enabled = true
   }
 }
 
@@ -210,25 +212,6 @@ tasks.withType(JavaCompile) {
   options.encoding = 'UTF-8'
 }
 
-clover {
-  excludes = [
-    // These files have huge methods. Ideally we'd use a method filter, but that's broken in the
-    // latest versions of Gradle; tracked in
-    // https://github.com/bmuschko/gradle-clover-plugin/issues/153
-    '**/UseItemRequest.java', '**/ChoiceManager.java',
-    // I don't know how to do this without manually excluding all the libs...
-    'apple/**', 'ca/**', 'com/**', 'darrylbu/**', 'net/java/**', 'tab/**',
-  ]
-
-  report {
-    html = true
-    xml = true
-
-    // Support capturing test results from JUnix XML report
-    testResultsDir = project.tasks.getByName('test').reports.junitXml.destination
-    testResultsInclude = 'TEST-*.xml'
-  }
-}
 
 clean.dependsOn cleanDist
 pruneDist.dependsOn gitRevList
@@ -239,6 +222,8 @@ jar.dependsOn svnRevList
 shadowJar.dependsOn pruneDist
 shadowJar.dependsOn gitRevList
 shadowJar.dependsOn svnRevList
+
+jacocoTestReport.dependsOn test
 
 def lastRevision() {
   def revisionFile = file('build/revision.txt')

--- a/jenkinsfile
+++ b/jenkinsfile
@@ -31,11 +31,11 @@ pipeline {
       steps {
         script {
           withEnv(["JAVA_HOME=/usr/lib/jvm/adoptopenjdk-16-hotspot-amd64"]) {
-            sh './gradlew --no-daemon --stacktrace cloverGenerateReport'
+            sh './gradlew --no-daemon --stacktrace jacocoTestReport'
             step([
-              $class: 'CloverPublisher',
-              cloverReportDir: 'build/reports/clover-root',
-              cloverReportFileName: 'clover.xml',
+              $class: 'JacocoPublisher',
+              reportDir: 'build/reports/jacoco/test',
+              reportFileName: 'jacocoTestReport.xml',
               healthyTarget: [methodCoverage: 70, conditionalCoverage: 70, statementCoverage: 70],
               unhealthyTarget: [methodCoverage: 50, conditionalCoverage: 50, statementCoverage: 50],
               failingTarget: [methodCoverage: 0, conditionalCoverage: 0, statementCoverage: 0]
@@ -46,7 +46,7 @@ pipeline {
               keepAll: true,
               reportDir: 'build/reports/tests/test',
               reportFiles: 'index.html',
-              reportName: 'Clover Test Report'
+              reportName: 'JaCoCo Test Report'
             ])
           }
         }


### PR DESCRIPTION
They have support for Java > 9...

I think I got all the references to Clover (outside of the ant build), but it's hard to be sure.

Also this may have broken the jenkinsfile, so please read this PR with extreme skepticism.