### PR TITLE
Revert "Downgrade gradle wrapper to 7.0."

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This reverts commit c77effb1e47a8731e8029b52e84dc0a7efe71af0.

Now that we're recommending that people use Java 17, they're having
issues building with it.

We need at least Gradle 7.1.1 to build with Java 17.