### PR TITLE
Require all files in test/root use newlines.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 gradlew text eol=lf
+test/root/** text eol=lf


### PR DESCRIPTION
Our test setup specifies that the newline separator be \n so we can
actually use golden files for testing output of scripts. This doesn't
work so well when git mangles the golden files by adding newlines to
them.