### PR TITLE
Run checks against latest mac/windows.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,8 +10,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
 
-    # This needs to be called Run Tests to satisfy our github setup.
-    name: Run Tests
+    name: Run Checks
 
     steps:
       - name: Checkout repository
@@ -42,3 +41,10 @@ jobs:
       #  with:
       #    github_token: ${{ secrets.GITHUB_TOKEN }}
       #    report_paths: "**/build/test-results/test/TEST-*.xml"
+  test:
+    needs: check
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder action
+        run: echo 1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,10 +41,14 @@ jobs:
       #  with:
       #    github_token: ${{ secrets.GITHUB_TOKEN }}
       #    report_paths: "**/build/test-results/test/TEST-*.xml"
+
+  # Our branch protection requires a check called "Run Tests".
+  # This is incompatible with the strategy matrix we use above, since that
+  # mutates the job name for each subjob. Thus, create a single dependent task
+  # that blocks on all of the components of `check` passing before it runs.
   test:
     needs: check
     name: Run Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Placeholder action
-        run: echo 1
+      - run: echo 'All checks succeeded.'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,7 +5,10 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     # This needs to be called Run Tests to satisfy our github setup.
     name: Run Tests


### PR DESCRIPTION
This also opts to use ubuntu-latest so we don't have to manually
configure it in the future.

Note that there are technically newer OSes than windows-latest and
macos-latest at this time, but I anticipate that these labels will be
automatically migrated over time (unlike a fixed label that will
require periodic maintenance).