### PR TITLE
Fix java source & target compatibility settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -243,8 +243,8 @@ task gitUpdate() {
 }
 
 java {
-	sourceCompatibility = JavaVersion.toVersion(gradle.properties['java.release'])
-	targetCompatibility = JavaVersion.toVersion(gradle.properties['java.release'])
+	sourceCompatibility = JavaVersion.toVersion(property(javaSourceCompatibility))
+	targetCompatibility = JavaVersion.toVersion(property(javaTargetCompatibility))
 }
 
 tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -243,8 +243,8 @@ task gitUpdate() {
 }
 
 java {
-	sourceCompatibility = JavaVersion.toVersion(property(javaSourceCompatibility))
-	targetCompatibility = JavaVersion.toVersion(property(javaTargetCompatibility))
+	sourceCompatibility = JavaVersion.toVersion(javaSourceCompatibility)
+	targetCompatibility = JavaVersion.toVersion(javaTargetCompatibility)
 }
 
 tasks.withType(JavaCompile) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,5 @@ org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAME
   --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
-java.release = 9
+javaSourceCompatibility=9
+javaTargetCompatibility=9


### PR DESCRIPTION
The syntax to get the project property wasn't correct.

Also split into two properties and use recommended camelCase so they can be overridden with environment variables.