### PR TITLE
Upgrade swingx to 1.6.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
 	runtimeOnly 'net.java.dev.jna:jna-platform:5.9.0'
 	runtimeOnly 'org.antlr:antlr-runtime:3.5.2'
 
-	libImplementation 'org.swinglabs:swingx:1.6'
+	libImplementation 'org.swinglabs:swingx:1.6.1'
 
 	implementation files('build/lib') {
 		builtBy 'compileLibJava'
@@ -80,7 +80,7 @@ dependencies {
 	implementation 'org.fusesource.jansi:jansi:2.3.4'
 	implementation 'org.json:json:20210307'
 	implementation 'org.mozilla:rhino:1.7.13'
-	implementation 'org.swinglabs:swingx:1.6'
+	implementation 'org.swinglabs:swingx:1.6.1'
 	implementation 'org.tmatesoft.svnkit:svnkit:1.10.3'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
 	runtimeOnly 'net.java.dev.jna:jna-platform:5.9.0'
 	runtimeOnly 'org.antlr:antlr-runtime:3.5.2'
 
-	libImplementation 'org.swinglabs:swingx:1.0'
+	libImplementation 'org.swinglabs:swingx:1.6'
 
 	implementation files('build/lib') {
 		builtBy 'compileLibJava'
@@ -80,10 +80,8 @@ dependencies {
 	implementation 'org.fusesource.jansi:jansi:2.3.4'
 	implementation 'org.json:json:20210307'
 	implementation 'org.mozilla:rhino:1.7.13'
-	implementation 'org.swinglabs:swingx:1.0'
+	implementation 'org.swinglabs:swingx:1.6'
 	implementation 'org.tmatesoft.svnkit:svnkit:1.10.3'
-
-	toCopy 'org.swinglabs:swingx:1.0'
 }
 
 application {
@@ -184,11 +182,6 @@ shadowJar {
 	duplicatesStrategy = 'exclude'
 	destinationDirectory = file('dist/')
 	archiveClassifier.set("${versioning.info.dirty ? 'M' : ''}")
-}
-
-task download(type: Copy) {
-	from configurations.toCopy
-	into 'src/jar'
 }
 
 task getRevision() {

--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,6 @@ repositories {
 	mavenCentral()
 }
 
-configurations {
-	toCopy
-	implementation.canBeResolved = true
-}
-
 dependencies {
 	// Use JUnit Jupiter for running JUnit5 tests.
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.8.0'

--- a/lib/net/java/dev/spellcast/utilities/LockableListModel.java
+++ b/lib/net/java/dev/spellcast/utilities/LockableListModel.java
@@ -119,7 +119,7 @@ public class LockableListModel<E>
 			}
 			else
 			{
-				this.updateFilter( false );
+				this.updateFilter();
 			}
 		}
 	}
@@ -260,7 +260,7 @@ public class LockableListModel<E>
 		{
 			if ( this.currentFilter != LockableListModel.NO_FILTER || !this.mirrorList.isEmpty() )
 			{
-				this.updateFilter( false );
+				this.updateFilter();
 			}
 
 			this.actualElements.add( index, element );
@@ -333,7 +333,7 @@ public class LockableListModel<E>
 		synchronized ( this.actualElements )
 		{
 			boolean result = this.actualElements.addAll( index, c );
-			this.updateFilter( false );
+			this.updateFilter();
 			return result;
 		}
 	}
@@ -597,7 +597,7 @@ public class LockableListModel<E>
 
 			if ( this.currentFilter != LockableListModel.NO_FILTER || !this.mirrorList.isEmpty() )
 			{
-				this.updateFilter( false );
+				this.updateFilter();
 			}
 
 			E originalValue = this.actualElements.get( index );
@@ -707,7 +707,7 @@ public class LockableListModel<E>
 
 			if ( this.currentFilter != LockableListModel.NO_FILTER || !this.mirrorList.isEmpty() )
 			{
-				this.updateFilter( false );
+				this.updateFilter();
 			}
 
 			E originalValue = this.actualElements.set( index, element );
@@ -794,11 +794,11 @@ public class LockableListModel<E>
 		return this.actualElements.toArray( a );
 	}
 
-	public void updateFilter( final boolean refresh )
+	public void updateFilter()
 	{
 		synchronized ( this.actualElements )
 		{
-			this.updateSingleFilter( refresh );
+			this.updateSingleFilter();
 
 			Iterator<WeakReference<LockableListModel<E>>> it = this.mirrorList.iterator();
 			while ( it.hasNext() )
@@ -809,12 +809,12 @@ public class LockableListModel<E>
 					return;
 				}
 
-				mirror.updateSingleFilter( refresh );
+				mirror.updateSingleFilter();
 			}
 		}
 	}
 
-	private void updateSingleFilter( final boolean refresh )
+	private void updateSingleFilter()
 	{
 		int visibleIndex = 0;
 		int low = -1;
@@ -885,10 +885,7 @@ public class LockableListModel<E>
 			}
 		}
 
-		if ( refresh )
-		{
-			this.fireContentsChanged( this, 0, this.visibleElements.size() - 1 );
-		}
+		this.fireContentsChanged( this, 0, this.visibleElements.size() - 1 );
 	}
 
 	private int computeVisibleIndex( final int actualIndex )

--- a/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
@@ -1329,12 +1329,14 @@ public class ConcoctionDatabase {
     ConcoctionDatabase.usableList.sort();
 
     // Now tell the GUI about the changes
-    ConcoctionDatabase.creatableList.updateFilter(changeDetected);
-    ConcoctionDatabase.usableList.updateFilter(changeDetected);
-    ConcoctionDatabase.queuedFood.updateFilter(changeDetected);
-    ConcoctionDatabase.queuedBooze.updateFilter(changeDetected);
-    ConcoctionDatabase.queuedSpleen.updateFilter(changeDetected);
-    ConcoctionDatabase.queuedPotions.updateFilter(changeDetected);
+    if (changeDetected) {
+      ConcoctionDatabase.creatableList.updateFilter();
+      ConcoctionDatabase.usableList.updateFilter();
+      ConcoctionDatabase.queuedFood.updateFilter();
+      ConcoctionDatabase.queuedBooze.updateFilter();
+      ConcoctionDatabase.queuedSpleen.updateFilter();
+      ConcoctionDatabase.queuedPotions.updateFilter();
+    }
   }
 
   /** Reset concoction stat gains when you've logged in a new character. */

--- a/src/net/sourceforge/kolmafia/swingui/panel/AdventureSelectPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/AdventureSelectPanel.java
@@ -234,7 +234,7 @@ public class AdventureSelectPanel extends JPanel {
     public void setSelectedItem(final Object element) {
       super.setSelectedItem(element);
       this.selectedZone = element;
-      AdventureSelectPanel.this.matchingAdventures.updateFilter(false);
+      AdventureSelectPanel.this.matchingAdventures.updateFilter();
     }
 
     public boolean isVisible(final Object element) {

--- a/src/net/sourceforge/kolmafia/swingui/panel/CreateItemPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/CreateItemPanel.java
@@ -58,7 +58,7 @@ public class CreateItemPanel extends InventoryPanel {
       this.setFixedFilter(food, booze, equip, other, true);
     }
 
-    ConcoctionDatabase.getCreatables().updateFilter(false);
+    ConcoctionDatabase.getCreatables().updateFilter();
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/swingui/panel/CreateSpecialPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/CreateSpecialPanel.java
@@ -73,10 +73,6 @@ public class CreateSpecialPanel extends InventoryPanel {
     box.add(Box.createGlue());
     box.add(new JLabel("List below is not implemented yet:"));
     this.northPanel.add(box, BorderLayout.CENTER);
-
-    // this.setFixedFilter( food, booze, equip, other, true );
-
-    // ConcoctionDatabase.getCreatables().updateFilter( false );
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/swingui/panel/SynthesizePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/SynthesizePanel.java
@@ -508,11 +508,8 @@ public class SynthesizePanel extends JPanel implements ActionListener, Listener 
       }
 
       public void filterItems(final Candy selected) {
-        this.model.updateFilter(false);
+        this.model.updateFilter();
         int size = this.model.getSize();
-
-        // Update displayed rows
-        this.model.fireContentsChanged(this.model, 0, size - 1);
 
         if (size == 0) {
           this.table.clearSelection();

--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemDequeuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemDequeuePanel.java
@@ -78,7 +78,7 @@ public class UseItemDequeuePanel extends ItemListManagePanel {
 
   @Override
   public void filterItems() {
-    this.queue.updateFilter(true);
+    this.queue.updateFilter();
   }
 
   public JTabbedPane getQueueTabs() {

--- a/src/net/sourceforge/kolmafia/swingui/widget/AutoFilterComboBox.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/AutoFilterComboBox.java
@@ -86,14 +86,14 @@ public class AutoFilterComboBox extends DisabledItemsComboBox implements ListEle
     this.matchString = this.currentName.toLowerCase();
 
     this.strict = true;
-    this.model.updateFilter(false);
+    this.model.updateFilter();
 
     if (this.model.getSize() > 0) {
       return;
     }
 
     this.strict = false;
-    this.model.updateFilter(false);
+    this.model.updateFilter();
   }
 
   public synchronized void findMatch(final int keyCode) {
@@ -189,7 +189,7 @@ public class AutoFilterComboBox extends DisabledItemsComboBox implements ListEle
 
       if (!AutoFilterComboBox.this.isPopupVisible()) {
         AutoFilterComboBox.this.active = false;
-        AutoFilterComboBox.this.model.updateFilter(false);
+        AutoFilterComboBox.this.model.updateFilter();
       }
     }
 

--- a/src/net/sourceforge/kolmafia/swingui/widget/AutoFilterTextField.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/AutoFilterTextField.java
@@ -268,11 +268,11 @@ public class AutoFilterTextField extends AutoHighlightTextField
     }
 
     AutoFilterTextField.this.strict = true;
-    AutoFilterTextField.this.model.updateFilter(true);
+    AutoFilterTextField.this.model.updateFilter();
 
     if (AutoFilterTextField.this.model.getSize() == 0) {
       AutoFilterTextField.this.strict = false;
-      AutoFilterTextField.this.model.updateFilter(true);
+      AutoFilterTextField.this.model.updateFilter();
     }
 
     if (AutoFilterTextField.this.list != null) {

--- a/src/net/sourceforge/kolmafia/swingui/widget/AutoFilterTextField.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/AutoFilterTextField.java
@@ -223,73 +223,66 @@ public class AutoFilterTextField extends AutoHighlightTextField
   }
 
   public void update() {
-    try {
-      AutoFilterTextField.this.qtyChecked = false;
-      AutoFilterTextField.this.asChecked = false;
-      AutoFilterTextField.this.notChecked = false;
-      AutoFilterTextField.this.text = AutoFilterTextField.this.getText().toLowerCase();
+    AutoFilterTextField.this.qtyChecked = false;
+    AutoFilterTextField.this.asChecked = false;
+    AutoFilterTextField.this.notChecked = false;
+    AutoFilterTextField.this.text = AutoFilterTextField.this.getText().toLowerCase();
 
-      if (AutoFilterTextField.this.text != null
-          && AutoFilterTextField.this.text.length() > 1
-          && AutoFilterTextField.this.text.charAt(0) == "-".charAt(0)) {
-        AutoFilterTextField.this.notChecked = true;
-        AutoFilterTextField.this.text = AutoFilterTextField.this.text.substring(1).trim();
-      }
+    if (AutoFilterTextField.this.text != null
+        && AutoFilterTextField.this.text.length() > 1
+        && AutoFilterTextField.this.text.charAt(0) == "-".charAt(0)) {
+      AutoFilterTextField.this.notChecked = true;
+      AutoFilterTextField.this.text = AutoFilterTextField.this.text.substring(1).trim();
+    }
 
-      Matcher mqty = AutoFilterTextField.QTYSEARCH_PATTERN.matcher(AutoFilterTextField.this.text);
-      if (mqty.find()) {
-        AutoFilterTextField.this.qtyChecked = true;
-        AutoFilterTextField.this.quantity = StringUtilities.parseInt(mqty.group(2));
+    Matcher mqty = AutoFilterTextField.QTYSEARCH_PATTERN.matcher(AutoFilterTextField.this.text);
+    if (mqty.find()) {
+      AutoFilterTextField.this.qtyChecked = true;
+      AutoFilterTextField.this.quantity = StringUtilities.parseInt(mqty.group(2));
 
-        String op = mqty.group(1);
+      String op = mqty.group(1);
 
-        AutoFilterTextField.this.qtyEQ = op.indexOf("=") != -1;
-        AutoFilterTextField.this.qtyLT = op.indexOf("<") != -1;
-        AutoFilterTextField.this.qtyGT = op.indexOf(">") != -1;
-        AutoFilterTextField.this.text = mqty.replaceFirst("");
-      }
+      AutoFilterTextField.this.qtyEQ = op.indexOf("=") != -1;
+      AutoFilterTextField.this.qtyLT = op.indexOf("<") != -1;
+      AutoFilterTextField.this.qtyGT = op.indexOf(">") != -1;
+      AutoFilterTextField.this.text = mqty.replaceFirst("");
+    }
 
-      Matcher mas = AutoFilterTextField.ASSEARCH_PATTERN.matcher(AutoFilterTextField.this.text);
-      if (mas.find()) {
-        AutoFilterTextField.this.asChecked = true;
-        AutoFilterTextField.this.price = StringUtilities.parseInt(mas.group(2));
+    Matcher mas = AutoFilterTextField.ASSEARCH_PATTERN.matcher(AutoFilterTextField.this.text);
+    if (mas.find()) {
+      AutoFilterTextField.this.asChecked = true;
+      AutoFilterTextField.this.price = StringUtilities.parseInt(mas.group(2));
 
-        String op = mas.group(1);
+      String op = mas.group(1);
 
-        AutoFilterTextField.this.asEQ = op.indexOf("=") != -1;
-        AutoFilterTextField.this.asLT = op.indexOf("<") != -1;
-        AutoFilterTextField.this.asGT = op.indexOf(">") != -1;
-        AutoFilterTextField.this.text = mas.replaceFirst("");
-      }
+      AutoFilterTextField.this.asEQ = op.indexOf("=") != -1;
+      AutoFilterTextField.this.asLT = op.indexOf("<") != -1;
+      AutoFilterTextField.this.asGT = op.indexOf(">") != -1;
+      AutoFilterTextField.this.text = mas.replaceFirst("");
+    }
 
-      Matcher mnot = AutoFilterTextField.NOTSEARCH_PATTERN.matcher(AutoFilterTextField.this.text);
-      if (mnot.find()) {
-        AutoFilterTextField.this.notChecked = true;
-        AutoFilterTextField.this.text = mnot.group(1);
-      }
+    Matcher mnot = AutoFilterTextField.NOTSEARCH_PATTERN.matcher(AutoFilterTextField.this.text);
+    if (mnot.find()) {
+      AutoFilterTextField.this.notChecked = true;
+      AutoFilterTextField.this.text = mnot.group(1);
+    }
 
-      AutoFilterTextField.this.strict = true;
-      AutoFilterTextField.this.model.updateFilter(false);
+    AutoFilterTextField.this.strict = true;
+    AutoFilterTextField.this.model.updateFilter(true);
 
-      if (AutoFilterTextField.this.model.getSize() == 0) {
-        AutoFilterTextField.this.strict = false;
-        AutoFilterTextField.this.model.updateFilter(false);
-      }
+    if (AutoFilterTextField.this.model.getSize() == 0) {
+      AutoFilterTextField.this.strict = false;
+      AutoFilterTextField.this.model.updateFilter(true);
+    }
 
-      if (AutoFilterTextField.this.list != null) {
-        JList list = AutoFilterTextField.this.list;
-        if (AutoFilterTextField.this.model.getSize() == 1) {
-          list.setSelectedIndex(0);
-        } else if (list.getSelectedIndices().length == 1) {
-          list.ensureIndexIsVisible(list.getSelectedIndex());
-        } else {
-          list.clearSelection();
-        }
-      }
-    } finally {
-      if (AutoFilterTextField.this.model.size() > 0) {
-        AutoFilterTextField.this.model.fireContentsChanged(
-            AutoFilterTextField.this.model, 0, AutoFilterTextField.this.model.size() - 1);
+    if (AutoFilterTextField.this.list != null) {
+      JList list = AutoFilterTextField.this.list;
+      if (AutoFilterTextField.this.model.getSize() == 1) {
+        list.setSelectedIndex(0);
+      } else if (list.getSelectedIndices().length == 1) {
+        list.ensureIndexIsVisible(list.getSelectedIndex());
+      } else {
+        list.clearSelection();
       }
     }
   }

--- a/src/net/sourceforge/kolmafia/swingui/widget/AutoFilterTextField.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/AutoFilterTextField.java
@@ -136,11 +136,11 @@ public class AutoFilterTextField extends AutoHighlightTextField
     String elementName = AutoFilterTextField.getResultName(element);
 
     if (this.notChecked) {
-      return elementName.indexOf(this.text) == -1;
+      return !elementName.contains(this.text);
     }
 
     return this.strict
-        ? elementName.indexOf(this.text) != -1
+        ? elementName.contains(this.text)
         : StringUtilities.fuzzyMatches(elementName, this.text);
   }
 
@@ -242,9 +242,9 @@ public class AutoFilterTextField extends AutoHighlightTextField
 
       String op = mqty.group(1);
 
-      AutoFilterTextField.this.qtyEQ = op.indexOf("=") != -1;
-      AutoFilterTextField.this.qtyLT = op.indexOf("<") != -1;
-      AutoFilterTextField.this.qtyGT = op.indexOf(">") != -1;
+      AutoFilterTextField.this.qtyEQ = op.contains("=");
+      AutoFilterTextField.this.qtyLT = op.contains("<");
+      AutoFilterTextField.this.qtyGT = op.contains(">");
       AutoFilterTextField.this.text = mqty.replaceFirst("");
     }
 
@@ -255,9 +255,9 @@ public class AutoFilterTextField extends AutoHighlightTextField
 
       String op = mas.group(1);
 
-      AutoFilterTextField.this.asEQ = op.indexOf("=") != -1;
-      AutoFilterTextField.this.asLT = op.indexOf("<") != -1;
-      AutoFilterTextField.this.asGT = op.indexOf(">") != -1;
+      AutoFilterTextField.this.asEQ = op.contains("=");
+      AutoFilterTextField.this.asLT = op.contains("<");
+      AutoFilterTextField.this.asGT = op.contains(">");
       AutoFilterTextField.this.text = mas.replaceFirst("");
     }
 

--- a/src/net/sourceforge/kolmafia/swingui/widget/ShowDescriptionTable.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/ShowDescriptionTable.java
@@ -282,6 +282,9 @@ public class ShowDescriptionTable extends JXTable {
 
     // install a handler to provide saner clipboard behavior
     this.setTransferHandler(new ClipboardHandler());
+
+    this.setAutoCreateRowSorter(false);
+    this.setRowSorter(null);
   }
 
   protected void fireSearch(String searchField) {

--- a/src/net/sourceforge/kolmafia/swingui/widget/ShowDescriptionTable.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/ShowDescriptionTable.java
@@ -282,9 +282,6 @@ public class ShowDescriptionTable extends JXTable {
 
     // install a handler to provide saner clipboard behavior
     this.setTransferHandler(new ClipboardHandler());
-
-    this.setAutoCreateRowSorter(false);
-    this.setRowSorter(null);
   }
 
   protected void fireSearch(String searchField) {

--- a/src/net/sourceforge/kolmafia/utilities/InputFieldUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/InputFieldUtilities.java
@@ -240,7 +240,7 @@ public class InputFieldUtilities {
               }
             },
         BorderLayout.NORTH);
-    inputs.updateFilter(false);
+    inputs.updateFilter();
     panel.add(new GenericScrollPane(selector), BorderLayout.CENTER);
 
     int option =


### PR DESCRIPTION
~This disables the auto-sorting tables that SwingX enables, since it's
incompatible with LockableListModel, I guess.~

~(This seems to work for me, at least with what was previously a
consistent reproducing example no longer reproduces with this change.)~

This removes the optional "force update" parameter of
LockableListModel.updateFilter, as it is error-prone and can cause listeners
to desynchronize from the actual list. This is especially evident due to
changes in SwingX 1.0 -> 1.6 implementation details.