### PR TITLE
Add tests for BasementRequest.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,9 @@ dependencies {
 
 	testImplementation 'org.hamcrest:hamcrest:2.2'
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.0'
+	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.0'
 	testImplementation 'junit:junit:4.13.2'
-	testImplementation 'org.mockito:mockito-core:3.+'
+	testImplementation 'org.mockito:mockito-inline:3.+'
 
 	implementation 'com.formdev:flatlaf:1.6'
 	implementation 'com.formdev:flatlaf-intellij-themes:1.6'

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,5 @@ org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAME
   --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
-javaSourceCompatibility=9
-javaTargetCompatibility=9
+javaSourceCompatibility=11
+javaTargetCompatibility=11

--- a/src/net/sourceforge/kolmafia/request/BasementRequest.java
+++ b/src/net/sourceforge/kolmafia/request/BasementRequest.java
@@ -737,7 +737,7 @@ public class BasementRequest extends AdventureRequest {
         if (autoSwitch) {
           BasementRequest.changeBasementOutfit("muscle");
           if (KoLCharacter.getAdjustedMuscle() < statRequirement) {
-            KoLmafiaCLI.DEFAULT_SHELL.executeCommand("maximize", "mus " + statRequirement + " min");
+            KoLmafiaCLI.DEFAULT_SHELL.executeCommand("maximize", "mus");
           }
         }
 
@@ -761,7 +761,7 @@ public class BasementRequest extends AdventureRequest {
         if (autoSwitch) {
           BasementRequest.changeBasementOutfit("mysticality");
           if (KoLCharacter.getAdjustedMysticality() < statRequirement) {
-            KoLmafiaCLI.DEFAULT_SHELL.executeCommand("maximize", "mys " + statRequirement + " min");
+            KoLmafiaCLI.DEFAULT_SHELL.executeCommand("maximize", "mys");
           }
         }
 
@@ -785,7 +785,7 @@ public class BasementRequest extends AdventureRequest {
         if (autoSwitch) {
           BasementRequest.changeBasementOutfit("moxie");
           if (KoLCharacter.getAdjustedMoxie() < statRequirement) {
-            KoLmafiaCLI.DEFAULT_SHELL.executeCommand("maximize", "mox " + statRequirement + " min");
+            KoLmafiaCLI.DEFAULT_SHELL.executeCommand("maximize", "mox");
           }
         }
 
@@ -867,7 +867,7 @@ public class BasementRequest extends AdventureRequest {
         if (autoSwitch) {
           BasementRequest.changeBasementOutfit("mpdrain");
           if (KoLCharacter.getMaximumMP() < drainRequirement) {
-            KoLmafiaCLI.DEFAULT_SHELL.executeCommand("maximize", "MP " + drainRequirement + " min");
+            KoLmafiaCLI.DEFAULT_SHELL.executeCommand("maximize", "MP");
           }
         }
 

--- a/test/net/sourceforge/kolmafia/request/BasementRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/BasementRequestTest.java
@@ -1,0 +1,75 @@
+package net.sourceforge.kolmafia.request;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+
+import java.util.stream.Stream;
+import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class BasementRequestTest extends RequestTestBase {
+
+  private static Stream<Arguments> monsterFights() {
+    return Stream.of(
+        Arguments.of("Commence to Pokin'", "Beast with X Eyes"),
+        Arguments.of("Don't Fear the Ear", "Beast with X Ears"),
+        Arguments.of("Stone Golem'", "X Stone Golem"),
+        Arguments.of("Hydra'", "X-headed Hydra"),
+        Arguments.of("Toast that Ghost'", "Ghost of Fernswarthy's Grandfather"),
+        Arguments.of("Bottles of Beer on a Golem", "X Bottles of Beer on a Golem"),
+        Arguments.of("Collapse That Waveform!", "X-dimensional horror"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("monsterFights")
+  void matchesMonsterFightFromResponse(String encounter, String monster) {
+    var req = new BasementRequest("Fernswarthy's Basement, Level 499");
+
+    // Monster fights don't actually have stat requirements, so BasementRequest won't bail before
+    // trying to enter the fight if we use run().
+    req.responseText = "Fernswarthy's Basement, Level 499: " + encounter;
+    req.processResults();
+
+    assertEquals(monster, BasementRequest.basementMonster);
+  }
+
+  private static Stream<Arguments> statTests() {
+    return Stream.of(
+        Arguments.of("Don't Wake the Baby", "Buffed Moxie Test"),
+        Arguments.of("Grab a cue", "Buffed Moxie Test"),
+        Arguments.of("Smooth Moves", "Buffed Moxie Test"),
+        Arguments.of("Lift 'em", "Buffed Muscle Test"),
+        Arguments.of("Push it Real Good", "Buffed Muscle Test"),
+        Arguments.of("Ring that Bell", "Buffed Muscle Test"),
+        Arguments.of("Gathering:  The Magic", "Buffed Mysticality Test"),
+        Arguments.of("Mop the Floor", "Buffed Mysticality Test"),
+        Arguments.of("Do away with the 'doo", "Buffed Mysticality Test"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("statTests")
+  void matchesImpassableStatTestFromResponse(String encounter, String summary) {
+    try (var mockPreferences = mockStatic(Preferences.class)) {
+      mockPreferences.when(() -> Preferences.getFloat("basementSafetyMargin")).thenReturn(1.08f);
+      // Default expectation returns null, which generates NPEs all over the place.
+      mockPreferences.when(() -> Preferences.getString(any())).thenReturn("");
+      var req = spy(new BasementRequest("Fernswarthy's Basement, Level 499"));
+      expectSuccess(req, "Fernswarthy's Basement, Level 499: " + encounter);
+      // Clear the error state, since we can't pass any of these tests.
+      KoLmafia.forceContinue();
+
+      req.run();
+
+      assertEquals(499, BasementRequest.getBasementLevel());
+      assertEquals(6470, BasementRequest.getBasementTestValue());
+      assertEquals(
+          summary + ": 0 current, 6,470 needed", BasementRequest.getBasementLevelSummary());
+    }
+  }
+}


### PR DESCRIPTION
Another proof-of-concept of parameterized JUnit5 tests with injecting response data.

This also incrementally bumps the required version of Java to 11 (the next LTS release) because I wanted to use var. This should be a non-issue for users who had to upgrade earlier, since Java 9 is unsupported, and we strongly recommended that users switch to Java 17. (But also, if this is a dealbreaker, I can spell out a few redundant types...)