### PR TITLE
Delete svnrepo.json if it's bad.

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/ScriptManager.java
+++ b/src/net/sourceforge/kolmafia/persistence/ScriptManager.java
@@ -119,6 +119,8 @@ public class ScriptManager {
     try {
       return new JSONArray(string);
     } catch (JSONException e) {
+      // This file is evidently bad. Delete it so it doesn't keep causing problems.
+      repoFile.delete();
       StaticEntity.printStackTrace(e);
     }
 


### PR DESCRIPTION
If the file throws a JSONException when we try to parse it, it's most
likely not valid JSON. So, let's delete it.

Anything else that we should do here? At the very least, this should get users out of a bad state.

Maybe we should also make sure that the Content-Type isn't text/html?

We already reject file downloads that aren't 200s.