### PR TITLE
Reject risky character names.

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import net.java.dev.spellcast.utilities.LockableListModel;
 import net.java.dev.spellcast.utilities.SortedListModel;
 import net.sourceforge.kolmafia.AscensionPath.Path;
@@ -429,6 +430,11 @@ public abstract class KoLCharacter {
 
   public static final void reset(final String newUserName) {
     if (newUserName.equals(KoLCharacter.username)) {
+      return;
+    }
+
+    // Forbid characters that could be used for directory traversal.
+    if (Stream.of("/", "\\", ".").anyMatch(newUserName::contains)) {
       return;
     }
 

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -1,0 +1,26 @@
+package net.sourceforge.kolmafia;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class KoLCharacterTest {
+  @Test
+  public void rejectsUsernameWithPeriod() {
+    KoLCharacter.reset("test.name");
+    // Unset value.
+    assertEquals("", KoLCharacter.getUserName());
+  }
+
+  @Test
+  public void rejectsUsernameWithForwardSlash() {
+    KoLCharacter.reset("test/name");
+    assertEquals("", KoLCharacter.getUserName());
+  }
+
+  @Test
+  public void rejectsUsernameWithBackslash() {
+    KoLCharacter.reset("test\\name");
+    assertEquals("", KoLCharacter.getUserName());
+  }
+}

--- a/test/root/ccs/default.ccs
+++ b/test/root/ccs/default.ccs
@@ -1,0 +1,3 @@
+[ default ]
+special action
+attack with weapon


### PR DESCRIPTION
We don't expect to ever receive character names containing '.', '/',
or '\', but if we do, we shouldn't accept them, as this introduces a
risk of directory traversal which can allow attackers to break out of
$KOLMAFIA_ROOT.

(This attempts to address some/most of the identified security risks.)