### PR TITLE
Check for null in UseItemEnqueuePanel.

### DIFF
--- a/src/data/inebriety.txt
+++ b/src/data/inebriety.txt
@@ -4,6 +4,7 @@
 
 # Drink	Inebriety	Level Req	quality	Adv	Musc	Myst	Moxie
 
+1950 Vampire Vintner wine	1	1	awesome	5	0	0	0	Unspaded, WINE
 5-hour acrimony	5	1	awesome	0	0	0	0	+10 PvP fights
 a little sump'm sump'm	4	4	good	10-14	0	25-27	8-10
 acceptable vodka	3	1	decent	4-5	0	20-30	10-20
@@ -661,7 +662,6 @@ unquiet spirits	1	1	good	2-3	0	0	5-10	50 Hollow Inside (+6 Maximum Hooch)
 Uovo Marcio Shiraz	1	10	EPIC	6-10	60	60	60
 used beer	2	1	crappy	0	0	0	0	+1 PvP fight
 vampagne	1	1	EPIC	23	25-30	25-30	25-30	Vampyre
-Vampire Vintner wine	1	1	awesome	5	0	0	0	Unspaded, WINE
 very fancy whiskey	2	1	EPIC	13-15	5-20	5-20	5-20
 vesper	6	6	awesome	22-26	0	0	16-20	tiny plastic sword
 vintage smart drink	10	1	awesome	40	0	0	0	1 Smart Drunk (+120 HP, +20 Familiar Weight)

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -8890,7 +8890,7 @@ Item	Turtle Bowl	Effect: "Tiki Thoughtfulness", Effect Duration: 40
 Item	twice-haunted screwdriver	Effect: "Haunted Liver", Effect Duration: 40
 Item	unfinished fruitcake	Effect: "Holiday Disappointment", Effect Duration: 10
 Item	unquiet spirits	Effect: "Hollow Inside", Effect Duration: 50
-Item	Vampire Vintner wine	Effect Duration: 10
+Item	1950 Vampire Vintner wine	Effect Duration: 10
 Item	vintage smart drink	Effect: "Smart Drunk", Effect Duration: 1
 Item	vodka barracuda	Effect: "Mer-kinkiness", Effect Duration: 40
 Item	vodka stinger	Effect: "Mer-kindliness", Effect Duration: 40

--- a/src/data/statuseffects.txt
+++ b/src/data/statuseffects.txt
@@ -2657,10 +2657,10 @@
 2656	Confidence of the Votive	candlecvotive.gif	f52d3796283d5783af6be18126cade6b	neutral	none	use 1 votive of confidence
 2657	Fireproof Foam Suit	foam4.gif	5eab5cbe23379f4c4b969f717401fd06	good	nohookah
 2658	Cyclonic Filth	foam3.gif	c60d5383f361a7fe48cca6d74caae999	good	nohookah
-2659	Wine-Fortified	redwine.gif	e7ec714f1fdc254831f8fec3c74ba803	neutral	none	drink 1 Vampire Vintner wine
-2660	Wine-Hot	redwine.gif	f562dd161fe50cc22b3ab10f04e1f26a	neutral	none	drink 1 Vampire Vintner wine
-2661	Wine-Frisky	redwine.gif	98cf0260d82830c8b4d3723f790b6d9a	neutral	none	drink 1 Vampire Vintner wine
-2662	Wine-Cold	redwine.gif	2c8403618f61dcb65a076c48979812e1	neutral	none	drink 1 Vampire Vintner wine
-2663	Wine-Dark	redwine.gif	91221f225a1cfcc58156624ba3342349	neutral	none	drink 1 Vampire Vintner wine
-2664	Wine-Befouled	redwine.gif	4a8aaadf65ca893d80287e7a4225ff96	neutral	none	drink 1 Vampire Vintner wine
-2665	Wine-Friendly	redwine.gif	14e58c7caa942927ebdb75d93f1de316	neutral	none	drink 1 Vampire Vintner wine
+2659	Wine-Fortified	redwine.gif	e7ec714f1fdc254831f8fec3c74ba803	neutral	none	drink 1 1950 Vampire Vintner wine
+2660	Wine-Hot	redwine.gif	f562dd161fe50cc22b3ab10f04e1f26a	neutral	none	drink 1 1950 Vampire Vintner wine
+2661	Wine-Frisky	redwine.gif	98cf0260d82830c8b4d3723f790b6d9a	neutral	none	drink 1 1950 Vampire Vintner wine
+2662	Wine-Cold	redwine.gif	2c8403618f61dcb65a076c48979812e1	neutral	none	drink 1 1950 Vampire Vintner wine
+2663	Wine-Dark	redwine.gif	91221f225a1cfcc58156624ba3342349	neutral	none	drink 1 1950 Vampire Vintner wine
+2664	Wine-Befouled	redwine.gif	4a8aaadf65ca893d80287e7a4225ff96	neutral	none	drink 1 1950 Vampire Vintner wine
+2665	Wine-Friendly	redwine.gif	14e58c7caa942927ebdb75d93f1de316	neutral	none	drink 1 1950 Vampire Vintner wine

--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
@@ -758,7 +758,8 @@ public class UseItemEnqueuePanel extends ItemListManagePanel {
         return false;
       }
 
-      if (item.getItemId() == ItemPool.BOTTLE_OF_CHATEAU_DE_VINEGAR
+      if (item != null
+          && item.getItemId() == ItemPool.BOTTLE_OF_CHATEAU_DE_VINEGAR
           && ConsumablesDatabase.getAdventureRange(item.getName()) == 0) {
         return false;
       }

--- a/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
@@ -10,9 +10,13 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.utilities.FileUtilities;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /* Checks for consistency across datafiles.
 
@@ -49,28 +53,40 @@ public class DataFileConsistencyTest {
     return items;
   }
 
-  @Test
-  public void testEquipmentPresence() {
-    Set<String> equipment;
+  public static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(
+            "equipment.txt",
+            2,
+            (Function<Integer, Boolean>)
+                (itemId) ->
+                    ItemDatabase.isEquipment(itemId) && !ItemDatabase.isFamiliarEquipment(itemId)),
+        Arguments.of("inebriety.txt", 2, (Function<Integer, Boolean>) ItemDatabase::isBooze),
+        Arguments.of("fullness.txt", 2, (Function<Integer, Boolean>) ItemDatabase::isFood));
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testItemPresence(String dataFile, int version, Function<Integer, Boolean> predicate) {
+    Set<String> filteredItems;
     try {
-      equipment = datafileItems("equipment.txt", 2);
+      filteredItems = datafileItems(dataFile, version);
     } catch (IOException exception) {
-      fail("failed initialization of equipment.txt");
+      fail("failed initialization of " + dataFile);
       return;
     }
     List<Integer> items = allItems();
 
     for (int id : items) {
-      // Familiar equipment is not present in equipment.txt...
-      if (ItemDatabase.isEquipment(id) && !ItemDatabase.isFamiliarEquipment(id)) {
+      if (predicate.apply(id)) {
         // At least one of "seal-clubbing club", "[1]seal-clubbing club" should be present.
         String name = ItemDatabase.getItemDataName(id);
         String bracketedName = "[" + id + "]" + name;
         assertThat(
-            bracketedName + " is not present in equipment.txt",
+            bracketedName + " is not present in " + dataFile,
             true,
             // Explicitly apply the matcher to keep the error message manageable.
-            equalTo(anyOf(hasItem(name), hasItem(bracketedName)).matches(equipment)));
+            equalTo(anyOf(hasItem(name), hasItem(bracketedName)).matches(filteredItems)));
       }
     }
   }


### PR DESCRIPTION
We apparently need to do this every time we want to access a method of
item. Worth refactoring on a later date so this is less dangerous.

This change also resolves a mismatch between the item name (1950
Vampire Vintner wine) and its presence in inebriety.txt,
modiiers.txt, and statuseffects.txt.

For reasons, we only expanded DataFileConsistencyTest to cover
inebriety.txt (since it best fit the model used by the existing check
of equipment.txt).