### PR TITLE
Make $outfit and $tattoo a type in ASH

### DIFF
--- a/src/data/tattoos.txt
+++ b/src/data/tattoos.txt
@@ -1,0 +1,306 @@
+1
+# image	requirement type	requirement
+aerotat.gif	outfit	Aeroutfit
+animelftat.gif	outfit	Animelf Apparel
+aol1.gif	other
+aol2.gif	other
+aol3.gif	other
+aol4.gif	other
+aol5.gif	other
+arbortat.gif	outfit	Arrrbor Day Apparrrrrel
+arborween.gif	outfit	Vestments of the Treeslayer
+armortat.gif	outfit	Antique Arms And Armor
+asc01.gif	ascension	1
+asc02.gif	ascension	2
+asc03.gif	ascension	3
+asc04.gif	ascension	4
+asc05.gif	ascension	5
+asc06.gif	ascension	6
+asc07.gif	ascension	7
+asc08.gif	ascension	8
+asc09.gif	ascension	9
+asc10.gif	ascension	10
+asc11.gif	ascension	11
+asc12.gif	ascension	12
+baketat.gif	outfit	Bakelite Brigandine
+barreltat.gif	outfit	Cooper's Couture
+batmantat.gif	item	battoo kit
+bauxtat.gif	outfit	Bauxite Baubles
+bbatttat.gif	item	Bastille Battalion tattoo kit
+bearclawta.gif	outfit	Warbear Dress Armor
+bknight.gif	outfit	Knight's Armor
+blacktat.gif	outfit	Black Armaments
+blacktie.gif	outfit	Fancy Tux
+bonertat.gif	custom
+bosstat.gif	outfit	Raiments of the Final Boss
+bowtat.gif	outfit	Bow Tux
+brimtat.gif	outfit	Blasphemous Bedizenment
+brogretat.gif	outfit	Brogre Brouture
+bugbear.gif	outfit	Bugbear Costume
+bunny.gif	custom
+c18tattoo.gif	item	Crimbo tattoo kit
+c20carols.gif	item	Crimbo Carol tattoo kit
+c20cheer.gif	item	Crimbo Cheer tattoo kit
+c20commerce.gif	item	Crimbo Commerce tattoo kit
+canadiatat.gif	outfit	OK Lumberjack Outfit
+chalktat.gif	outfit	Chalk Chostume
+class1.gif	class	Seal Clubber
+class11.gif	class	Avatar of Boris
+class11hc.gif	hc_class	Avatar of Boris
+class12.gif	class	Zombie Master
+class12hc.gif	hc_class	Zombie Master
+class14.gif	class	Avatar of Jarlsberg
+class14hc.gif	hc_class	Avatar of Jarlsberg
+class15.gif	class	Avatar of Sneaky Pete
+class15hc.gif	hc_class	Avatar of Sneaky Pete
+class17.gif	class	Actually Ed the Undying
+class17hc.gif	hc_class	Actually Ed the Undying
+class18.gif	class	Cow Puncher
+class18hc.gif	hc_class	Cow Puncher
+class19.gif	class	Beanslinger
+class19hc.gif	hc_class	Beanslinger
+class1hc.gif	hc_class	Seal Clubber
+class1hc0.gif	other
+class2.gif	class	Turtle Tamer
+class20.gif	class	Snake Oiler
+class20hc.gif	hc_class	Snake Oiler
+class23.gif	class	Gelatinous Noob
+class23hc.gif	hc_class	Gelatinous Noob
+class24.gif	class	Vampyre
+class24hc.gif	hc_class	Vampyre
+class25.gif	class	Plumber
+class25hc.gif	hc_class	Plumber
+class2hc.gif	hc_class	Turtle Tamer
+class2hc0.gif	other
+class3.gif	class	Pastamancer
+class3hc.gif	hc_class	Pastamancer
+class3hc0.gif	other
+class4.gif	class	Sauceror
+class4hc.gif	hc_class	Sauceror
+class4hc0.gif	other
+class5.gif	class	Disco Bandit
+class5hc.gif	hc_class	Disco Bandit
+class5hc0.gif	other
+class6.gif	class	Accordion Thief
+class6hc.gif	hc_class	Accordion Thief
+class6hc0.gif	other
+claytat.gif	outfit	Hot Daub Ensemble
+cliptat.gif	outfit	Paperclippery
+clocktat.gif	outfit	Clockwork Apparatus
+clown.gif	outfit	Terrifying Clown Suit
+cola1tat.gif	outfit	Cloaca-Cola Uniform
+cola2tat.gif	outfit	Dyspepsi-Cola Uniform
+coldgear.gif	outfit	eXtreme-Cold Weather gear
+colhobotat.gif	outfit	Hyperborean Hobo Habiliments
+crayontat.gif	outfit	Wax Wardrobe
+crimbeard.gif	outfit	Uncle Hobo's Rags
+cutter.gif	custom
+daisytat.gif	custom
+datatat.gif	itemchance	currupted data
+debbietat.gif	item	"DEBBIE" tattoo kit
+demontat.gif	item	red-hot medallion
+detbadge.gif	item	detective tattoo
+dinseytat.gif	item	Dinsey tattoo kit
+dnatat.gif	outfit	Mutant Couture
+doubicetat.gif	outfit	Cold Comforts
+ducttat.gif	outfit	Tapered Threads
+dv_tat1.gif	item	Mark of the Bugbear
+dv_tat2.gif	item	Mark of the Werewolf
+dv_tat3.gif	item	Mark of the Zombie
+dv_tat4.gif	item	Mark of the Ghost
+dv_tat5.gif	item	Mark of the Vampire
+dv_tat6.gif	item	Mark of the Skeleton
+dvinntat.gif	item	Official Seal of Dreadsylvania
+dvotat1.gif	outfit	Dreadful Pajamas
+dvotat2.gif	outfit	Dreadful Bugbear Suit
+dvotat3.gif	outfit	Dreadful Werewolf Suit
+dvotat4.gif	outfit	Dreadful Zombie Suit
+dvotat5.gif	outfit	Dreadful Ghost Suit
+dvotat6.gif	outfit	Dreadful Skeleton Suit
+dvotat7.gif	outfit	Dreadful Vampire Suit
+dvotat8.gif	outfit	Cool Irons
+dwarvish.gif	outfit	Dwarvish War uniform
+eggtat.gif	outfit	Grass Guise
+elbereth.gif	outfit	Yendorian Finery
+elditchtat.gif	outfit	Eldritch Equipage
+eliteguard.gif	outfit	Knob Goblin Elite Guard Uniform
+elvtat.gif	outfit	El Vibrato Relics
+emperortat.gif	outfit	The Emperor's New Clothes
+eternaltat.gif	item	eternal knot tattoo
+fdkoltat.gif	other
+fibertat.gif	outfit	Fiberglass Finery
+fishingtat.gif	outfit	Shallow Sea Fishing Outfit
+foilheart.gif	item	Alice's Army Foil tattoo
+fpmtat.gif	outfit	Pyrotechnic Paper Paraphernalia
+fratboy.gif	outfit	Frat Boy Ensemble
+frtat.gif	item	FantasyRealm tattoo kit
+frtat1.gif	outfit	FantasyRealm Warrior's Outfit
+frtat2.gif	outfit	FantasyRealm Wizard's Outfit
+frtat3.gif	outfit	FantasyRealm Thief's Outfit
+gabtat.gif	outfit	Garbardine Guise
+genietat.gif	outfit	Genie Garments
+gingercitytat.gif	other
+gingertat.gif	outfit	Gingerbread Best
+gnaugatat.gif	outfit	Gnauga Hides
+gtat.gif	other
+guzzlrtat.gif	outfit	Guzzlr Uniform
+guzzlrtat2.gif	item	Guzzlr tattoo kit
+halotat.gif	outfit	Crimborg Assault Armor
+haremgirl.gif	outfit	Knob Goblin Harem Girl Disguise
+hasc01.gif	hc_ascension	1
+hasc02.gif	hc_ascension	2
+hasc03.gif	hc_ascension	3
+hasc04.gif	hc_ascension	4
+hasc05.gif	hc_ascension	5
+hasc06.gif	hc_ascension	6
+hasc07.gif	hc_ascension	7
+hasc08.gif	hc_ascension	8
+hasc09.gif	hc_ascension	9
+hasc10.gif	hc_ascension	10
+hasc11.gif	hc_ascension	11
+hasc12.gif	hc_ascension	12
+hippy.gif	outfit	Filthy Hippy Disguise
+hobotat1.gif	other
+hobotat10.gif	other
+hobotat11.gif	other
+hobotat12.gif	other
+hobotat13.gif	other
+hobotat14.gif	other
+hobotat15.gif	other
+hobotat16.gif	other
+hobotat17.gif	other
+hobotat18.gif	other
+hobotat19.gif	other
+hobotat2.gif	other
+hobotat3.gif	other
+hobotat4.gif	other
+hobotat5.gif	other
+hobotat6.gif	other
+hobotat7.gif	other
+hobotat8.gif	other
+hobotat9.gif	other
+hodgmantat.gif	outfit	Hodgman's Regal Frippery
+honeytat.gif	outfit	Bits o' Honey
+hotghosttat.gif	outfit	Ghast Iron Gear
+hothobotat.gif	outfit	Pyretic Panhandler Paraphernalia
+hourtat.gif	outfit	Time Trappings
+jfishtat.gif	outfit	Encephalic Ensemble
+kgbtat.gif	item	golden tattoo gun
+lathetat.gif	outfit	Lathed Livery
+lltat.gif	item	Loathing Legion tattoo needle
+loathetat.gif	outfit	Clothing of Loathing
+lollitat.gif	outfit	Sucker Samurai Suit
+losertat.gif	outfit	Furry Suit
+ltttat.gif	item	LT&T tattoo kit
+lunartat.gif	outfit	Luniform
+marbletat.gif	outfit	Marble Materials
+margaraxe.gif	item	BGE temporary tattoo
+martinitat.gif	itemchance	delicious salad
+meattat.gif	outfit	Bounty-Hunting Rig
+merctat.gif	item	Merc Core challenge coin
+merkgtat.gif	outfit	Mer-kin Gladiatorial Gear
+merkintat.gif	outfit	Crappy Mer-kin Disguise
+merkstat.gif	outfit	Mer-kin Scholar's Vestments
+meteortat.gif	outfit	Meteor Masquerade
+mimetat.gif	outfit	Miming Paraphernalia
+miner.gif	outfit	Mining Gear
+minifigtat.gif	outfit	BRICKOfig Outfit
+mushtat.gif	outfit	Mushroom Masquerade
+necbrotat.gif	outfit	Dark Bro's Vestments
+newyou.gif	other
+ninja.gif	outfit	Hot and Cold Running Ninja Suit
+nobeertat.gif	path	Teetotaler
+nofood.gif	path	Boozetefarian
+nosealtat.gif	outfit	Frigid Northlands Garb
+nutctat.gif	outfit	Antique Nutcracker Outfit
+oiltat.gif	outfit	Oil Rig
+orbisontat.gif	outfit	Roy Orbison Disguise
+oxy.gif	path	Oxygenarian
+palette2.gif	itemchance	martini
+palmtat.gif	outfit	Palmist Paraphernalia
+para_tat.gif	outfit	Paraffinalia
+partytat.gif	item	Party Tattoo™ gift certificate
+pigirontat.gif	outfit	Pork Elf Prizes
+pirate.gif	outfit	Swashbuckling Getup
+planetat.gif	item	airplane tattoo
+platytat.gif	custom
+plexitat.gif	outfit	Transparent Trappings
+polytat.gif	outfit	Synthetic Suit
+porctat.gif	outfit	Ceramic Suit
+potterytat.gif	outfit	Smoked Pottery
+prealmtat.gif	outfit	PirateRealm Assortment
+pressietat.gif	outfit	Crimbo Duds
+protontat.gif	other
+psychictat.gif	outfit	Psychic Enpsemble
+rad_tat.gif	outfit	Pinata Provisions
+radiotat.gif	outfit	Radio Free Regalia
+radminetat.gif	outfit	High-Radiation Mining Gear
+reapertat.gif	outfit	Grimy Reaper's Vestments
+recyctat.gif	outfit	Glad Bag Glad Rags
+reintat.gif	outfit	Cheerful Reindeer Suit
+revclass1.gif	outfit	Legendary Regalia of the Seal Crusher
+revclass2.gif	outfit	Legendary Regalia of the Chelonian Overlord
+revclass3.gif	outfit	Legendary Regalia of the Pasta Master
+revclass4.gif	outfit	Legendary Regalia of the Saucemaestro
+revclass5.gif	outfit	Legendary Regalia of the Groovelord
+revclass6.gif	outfit	Legendary Regalia of the Master Squeezeboxer
+rock_tat.gif	outfit	Floaty Fatigues
+sailortat.gif	outfit	Seafaring Suit
+sbeasttat.gif	outfit	Space Beast Furs
+sbreaktat.gif	item	Spring Break Beach tattoo coupon
+sgtat.gif	item	Spacegate Initiative tattoo unit
+shubtat.gif	outfit	Violent Vestments
+skelepiratetat.gif	outfit	Cursed Skeleton Pirate Costume
+skeletat.gif	outfit	Thousandth Birthday Suit
+slehobotat.gif	outfit	Tawdry Tramp Togs
+slimetat.gif	outfit	Slimesuit
+slimetat.gif	outfit	The Jokester's Costume
+smoochtat.gif	outfit	SMOOCH Army Uniform
+snowmantat.gif	outfit	Snowman Suit
+sourcetat.gif	item	green pill
+spantat.gif	outfit	Spant Armor
+spelunktat.gif	outfit	Spelunker's Gear
+spohobotat.gif	outfit	Dire Drifter Duds
+spqktat.gif	outfit	Gladiatorial Glad Rags
+ssodfi5if.gif	other
+sspd4plunk.gif	other
+sspdfipp3.gif	other
+sspdpook2.gif	other
+sspdtat1.gif	other
+stainedtat.gif	outfit	Stained Glass Suit
+staintat.gif	outfit	Unblemished Uniform
+startat.gif	outfit	Star Garb
+stehobotat.gif	outfit	Vile Vagrant Vestments
+swordtat.gif	outfit	8-Bit Finery
+tc_tat.gif	outfit	Terra Cotta Tackle
+tedrogertat.gif	item	Red Roger tattoo kit
+tehclub.gif	custom
+tehclub_f.gif	custom
+tikidemon.gif	custom
+topitat.gif	outfit	Topiaria
+toweltat.gif	outfit	Terrycloth Tackle
+toxictat.gif	outfit	Toxic Togs
+tropictat.gif	outfit	Tropical Crimbo Duds
+twitchtat.gif	item	Twitching Television Tattoo
+velourtat.gif	outfit	Velour Vestments
+vol_tat.gif	outfit	Primitive Radio Duds
+vwgovttat.gif	outfit	Government-Issued Garb
+vwmuttat.gif	outfit	Mutant Parts Apparel
+vwslimetat.gif	outfit	Slime Enslamble
+vwsnaketat.gif	outfit	Snakeskin Suit
+walmarttat.gif	item	Wal-Mart tattoo kit
+warfrattat.gif	outfit	Frat Warrior Fatigues
+warhiptat.gif	outfit	War Hippy Fatigues
+wdbraintat.gif	outfit	Dinsey's Exoskeleton
+whittletat.gif	outfit	Whittled Wearables
+wickertat.gif	outfit	Wicker Wear
+wintat.gif	custom
+workouttat.gif	outfit	Workoutfit
+wreathtat.gif	outfit	Arboreal Raiment
+wroughttat.gif	outfit	Wrought Wrappings
+wumpustat.gif	outfit	Wumpus-Hair Wardrobe
+xiblaxtat.gif	outfit	Xiblaxian Stealth Suit
+yegtat.gif	item	fancy chess set
+yogtat.gif	outfit	Hateful Habiliment
+zaptat.gif	outfit	Crimbot Crimboutfit
+zompirtat.gif	outfit	Cursed Zombie Pirate Costume

--- a/src/net/sourceforge/kolmafia/KoLConstants.java
+++ b/src/net/sourceforge/kolmafia/KoLConstants.java
@@ -211,6 +211,7 @@ public interface KoLConstants extends UtilityConstants {
   int QUESTSLOG_VERSION = 1;
   int SPLEENHIT_VERSION = 3;
   int STATUSEFFECTS_VERSION = 4;
+  int TATTOOS_VERSION = 1;
   int ZAPGROUPS_VERSION = 1;
   int ZONELIST_VERSION = 1;
 

--- a/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
@@ -43,7 +43,7 @@ public class EquipmentDatabase {
 
   private static final HashMap<Integer, Integer> outfitPieces = new HashMap<Integer, Integer>();
   public static final SpecialOutfitArray normalOutfits = new SpecialOutfitArray();
-  private static final Map<Integer, String> outfitById = new TreeMap<Integer, String>();
+  private static final Map<Integer, String> outfitById = new TreeMap<>();
   public static final SpecialOutfitArray weirdOutfits = new SpecialOutfitArray();
 
   private static final IntegerArray pulverize = new IntegerArray();
@@ -926,6 +926,16 @@ public class EquipmentDatabase {
 
   public static final SpecialOutfit getOutfit(final int id) {
     return EquipmentDatabase.normalOutfits.get(id);
+  }
+
+  public static final SpecialOutfit getOutfit(final String name) {
+    for (SpecialOutfit outfit : EquipmentDatabase.normalOutfits) {
+      if (outfit != null && outfit.getName().equalsIgnoreCase(name)) {
+        return outfit;
+      }
+    }
+
+    return null;
   }
 
   public static final SpecialOutfit getAvailableOutfit(final int id) {

--- a/src/net/sourceforge/kolmafia/persistence/TattooDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/TattooDatabase.java
@@ -1,0 +1,103 @@
+package net.sourceforge.kolmafia.persistence;
+
+import java.io.BufferedReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import net.sourceforge.kolmafia.AdventureResult;
+import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.RequestLogger;
+import net.sourceforge.kolmafia.SpecialOutfit;
+import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.utilities.FileUtilities;
+
+public class TattooDatabase {
+  public static final ArrayList<String> tattoos = new ArrayList<>();
+  private static final HashMap<String, String> nameToRequirement = new HashMap<>();
+  private static final HashMap<String, String> nameToRequirementType = new HashMap<>();
+
+  static {
+    reset();
+  }
+
+  public static void reset() {
+    BufferedReader reader =
+        FileUtilities.getVersionedReader("tattoos.txt", KoLConstants.TATTOOS_VERSION);
+
+    String[] data;
+
+    while ((data = FileUtilities.readData(reader)) != null) {
+      if (data.length < 2) {
+        continue;
+      }
+
+      String image = data[0];
+      String name = getName(image);
+      String requirementType = data[1];
+
+      if (!requirementType.equals("custom") && !requirementType.equals("other")) {
+        if (data.length < 3) {
+          RequestLogger.printLine("Tattoo \"" + name + "\" needs a requirement type");
+          continue;
+        } else {
+          nameToRequirement.put(name, data[2]);
+        }
+      }
+      tattoos.add(name);
+      nameToRequirementType.put(name, requirementType);
+    }
+
+    try {
+      reader.close();
+    } catch (Exception e) {
+      // This should not happen.  Therefore, print
+      // a stack trace for debug purposes.
+
+      StaticEntity.printStackTrace(e);
+    }
+  }
+
+  public static boolean hasItemRequirement(final String name) {
+    return nameToRequirementType.get(name).equals("item");
+  }
+
+  public static boolean hasOutfitRequirement(final String name) {
+    return nameToRequirementType.get(name).equals("outfit");
+  }
+
+  public static boolean hasClassRequirement(final String name) {
+    return nameToRequirementType.get(name).endsWith("class");
+  }
+
+  public static String getImage(final String name) {
+    return name + ".gif";
+  }
+
+  public static String getName(final String image) {
+    return image.substring(0, image.length() - 4);
+  }
+
+  public static AdventureResult getItemRequirement(final String name) {
+    if (!hasItemRequirement(name)) {
+      return null;
+    }
+
+    return ItemPool.get(nameToRequirement.get(name), 1);
+  }
+
+  public static SpecialOutfit getOutfitRequirement(final String name) {
+    if (!hasOutfitRequirement(name)) {
+      return null;
+    }
+
+    return EquipmentDatabase.getOutfit(nameToRequirement.get(name));
+  }
+
+  public static String getClassRequirement(final String name) {
+    if (!hasClassRequirement(name)) {
+      return null;
+    }
+
+    return nameToRequirement.get(name);
+  }
+}

--- a/src/net/sourceforge/kolmafia/textui/DataTypes.java
+++ b/src/net/sourceforge/kolmafia/textui/DataTypes.java
@@ -12,16 +12,19 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants.Stat;
 import net.sourceforge.kolmafia.MonsterData;
 import net.sourceforge.kolmafia.PastaThrallData;
+import net.sourceforge.kolmafia.SpecialOutfit;
 import net.sourceforge.kolmafia.VYKEACompanionData;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.BountyDatabase;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
+import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
 import net.sourceforge.kolmafia.persistence.FamiliarDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase.Element;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase.Phylum;
 import net.sourceforge.kolmafia.persistence.SkillDatabase;
+import net.sourceforge.kolmafia.persistence.TattooDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.UseSkillRequest;
@@ -59,6 +62,8 @@ public class DataTypes {
   public static final int TYPE_BOUNTY = 113;
   public static final int TYPE_SERVANT = 114;
   public static final int TYPE_VYKEA = 115;
+  public static final int TYPE_OUTFIT = 116;
+  public static final int TYPE_TATTOO = 117;
 
   public static final int TYPE_STRICT_STRING = 1000;
   public static final int TYPE_AGGREGATE = 1001;
@@ -119,6 +124,8 @@ public class DataTypes {
   public static final Type THRALL_TYPE = new Type("thrall", DataTypes.TYPE_THRALL);
   public static final Type SERVANT_TYPE = new Type("servant", DataTypes.TYPE_SERVANT);
   public static final Type VYKEA_TYPE = new Type("vykea", DataTypes.TYPE_VYKEA);
+  public static final Type OUTFIT_TYPE = new Type("outfit", DataTypes.TYPE_OUTFIT);
+  public static final Type TATTOO_TYPE = new Type("tattoo", DataTypes.TYPE_TATTOO);
 
   public static final Type STRICT_STRING_TYPE =
       new Type("strict_string", DataTypes.TYPE_STRICT_STRING);
@@ -207,6 +214,8 @@ public class DataTypes {
   public static final Value SERVANT_INIT = new Value(DataTypes.SERVANT_TYPE, 0, "none", null);
   public static final Value VYKEA_INIT =
       new Value(DataTypes.VYKEA_TYPE, 0, "none", VYKEACompanionData.NO_COMPANION);
+  public static final Value OUTFIT_INIT = new Value(DataTypes.OUTFIT_TYPE, 0, "none", null);
+  public static final Value TATTOO_INIT = new Value(DataTypes.TATTOO_TYPE, 0, "none", null);
 
   public static final TypeList enumeratedTypes = new TypeList();
   public static final TypeList simpleTypes = new TypeList();
@@ -237,6 +246,8 @@ public class DataTypes {
     enumeratedTypes.add(DataTypes.THRALL_TYPE);
     enumeratedTypes.add(DataTypes.SERVANT_TYPE);
     enumeratedTypes.add(DataTypes.VYKEA_TYPE);
+    enumeratedTypes.add(DataTypes.OUTFIT_TYPE);
+    enumeratedTypes.add(DataTypes.TATTOO_TYPE);
 
     for (Type type : enumeratedTypes) {
       simpleTypes.add(type);
@@ -663,6 +674,31 @@ public class DataTypes {
     return new Value(DataTypes.VYKEA_TYPE, companion.getType(), name, companion);
   }
 
+  public static final Value parseOutfitValue(String name, final boolean returnDefault) {
+    if (name == null || name.equals("")) {
+      return returnDefault ? DataTypes.OUTFIT_INIT : null;
+    }
+
+    if (name.equalsIgnoreCase("none")) {
+      return DataTypes.OUTFIT_INIT;
+    }
+
+    SpecialOutfit outfit = EquipmentDatabase.getOutfit(name);
+
+    if (outfit == null) {
+      return returnDefault ? DataTypes.OUTFIT_INIT : null;
+    }
+
+    return new Value(DataTypes.OUTFIT_TYPE, outfit.getOutfitId(), outfit.getName(), outfit);
+  }
+
+  public static final Value parseTattooValue(final String name, final boolean returnDefault) {
+    if (name == null || name.equals("")) {
+      return returnDefault ? DataTypes.TATTOO_INIT : null;
+    }
+    return new Value(DataTypes.TATTOO_TYPE, name, name);
+  }
+
   public static final Value parseBountyValue(String name, final boolean returnDefault) {
     if (name == null || name.equals("")) {
       return returnDefault ? DataTypes.BOUNTY_INIT : null;
@@ -915,6 +951,19 @@ public class DataTypes {
     return new Value(DataTypes.VYKEA_TYPE, companion.getType(), companion.toString(), companion);
   }
 
+  public static final Value makeOutfitValue(
+      final SpecialOutfit outfit, final boolean returnDefault) {
+    if (outfit == null || outfit.getOutfitId() == 0) {
+      return returnDefault ? DataTypes.OUTFIT_INIT : null;
+    }
+    return new Value(DataTypes.OUTFIT_TYPE, outfit.getOutfitId(), outfit.getName(), outfit);
+  }
+
+  public static final Value makeOutfitValue(final int outfitId, final boolean returnDefault) {
+    SpecialOutfit outfit = EquipmentDatabase.getOutfit(outfitId);
+    return makeOutfitValue(outfit, returnDefault);
+  }
+
   public static final Value makeMonsterValue(final MonsterData monster) {
     if (monster == null) {
       return DataTypes.MONSTER_INIT;
@@ -986,6 +1035,13 @@ public class DataTypes {
 
       case TYPE_VYKEA:
         return (String) InputFieldUtilities.input(message, VYKEACompanionData.VYKEA);
+
+      case TYPE_OUTFIT:
+        return (String)
+            InputFieldUtilities.input(message, EquipmentDatabase.outfitEntrySet().toArray());
+
+      case TYPE_TATTOO:
+        return (String) InputFieldUtilities.input(message, TattooDatabase.tattoos.toArray());
 
       case TYPE_CLASS:
         return (String) InputFieldUtilities.input(message, DataTypes.CLASSES);

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
@@ -16,10 +16,12 @@ import net.sourceforge.kolmafia.VYKEACompanionData;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.BountyDatabase;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
+import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
 import net.sourceforge.kolmafia.persistence.FamiliarDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import net.sourceforge.kolmafia.persistence.SkillDatabase;
+import net.sourceforge.kolmafia.persistence.TattooDatabase;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.textui.AshRuntime;
 import net.sourceforge.kolmafia.textui.DataTypes;
@@ -109,6 +111,12 @@ public class Type extends Symbol {
     }
     if (this.equals(DataTypes.STAT_TYPE)) {
       return ProxyRecordValue.StatProxy._type;
+    }
+    if (this.equals(DataTypes.OUTFIT_TYPE)) {
+      return ProxyRecordValue.OutfitProxy._type;
+    }
+    if (this.equals(DataTypes.TATTOO_TYPE)) {
+      return ProxyRecordValue.TattooProxy._type;
     }
     return this;
   }
@@ -207,6 +215,10 @@ public class Type extends Symbol {
         return DataTypes.parseServantValue(name, returnDefault);
       case DataTypes.TYPE_VYKEA:
         return DataTypes.parseVykeaValue(name, returnDefault);
+      case DataTypes.TYPE_OUTFIT:
+        return DataTypes.parseOutfitValue(name, returnDefault);
+      case DataTypes.TYPE_TATTOO:
+        return DataTypes.parseTattooValue(name, returnDefault);
     }
     return null;
   }
@@ -240,6 +252,8 @@ public class Type extends Symbol {
         return DataTypes.parseLocationValue(id, returnDefault);
       case DataTypes.TYPE_SLOT:
         return DataTypes.makeSlotValue(id, returnDefault);
+      case DataTypes.TYPE_OUTFIT:
+        return DataTypes.makeOutfitValue(id, returnDefault);
 
         // The following don't have an integer -> object mapping
       case DataTypes.TYPE_CLASS:
@@ -256,6 +270,8 @@ public class Type extends Symbol {
         return DataTypes.BOUNTY_INIT;
       case DataTypes.TYPE_VYKEA:
         return DataTypes.VYKEA_INIT;
+      case DataTypes.TYPE_TATTOO:
+        return DataTypes.TATTOO_INIT;
     }
     return null;
   }
@@ -362,6 +378,8 @@ public class Type extends Symbol {
           return DataTypes.makeThrallValue(integer, returnDefault);
         case DataTypes.TYPE_SERVANT:
           return DataTypes.makeServantValue(integer, returnDefault);
+        case DataTypes.TYPE_OUTFIT:
+          return DataTypes.makeOutfitValue(integer, returnDefault);
       }
       return null;
     }
@@ -440,6 +458,12 @@ public class Type extends Symbol {
         break;
       case DataTypes.TYPE_VYKEA:
         this.addValues(list, VYKEACompanionData.VYKEA);
+        break;
+      case DataTypes.TYPE_OUTFIT:
+        this.addValues(list, EquipmentDatabase.outfitEntrySet());
+        break;
+      case DataTypes.TYPE_TATTOO:
+        this.addValues(list, TattooDatabase.tattoos);
         break;
       default:
         return null;

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Value.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Value.java
@@ -222,6 +222,12 @@ public class Value extends Command implements Comparable<Value> {
     if (this.getType().equals(DataTypes.SLOT_TYPE)) {
       return new ProxyRecordValue.SlotProxy(this);
     }
+    if (this.getType().equals(DataTypes.OUTFIT_TYPE)) {
+      return new ProxyRecordValue.OutfitProxy(this);
+    }
+    if (this.getType().equals(DataTypes.TATTOO_TYPE)) {
+      return new ProxyRecordValue.TattooProxy(this);
+    }
     return this;
   }
 
@@ -262,7 +268,8 @@ public class Value extends Command implements Comparable<Value> {
         || this.getType().equals(DataTypes.FAMILIAR_TYPE)
         || this.getType().equals(DataTypes.SLOT_TYPE)
         || this.getType().equals(DataTypes.THRALL_TYPE)
-        || this.getType().equals(DataTypes.SERVANT_TYPE)) {
+        || this.getType().equals(DataTypes.SERVANT_TYPE)
+        || this.getType().equals(DataTypes.OUTFIT_TYPE)) {
       return this.contentLong < o.contentLong ? -1 : this.contentLong == o.contentLong ? 0 : 1;
     }
 


### PR DESCRIPTION
This is an breaking change for ASH. 

```
get_outfits() is now $outfits[]
all_normal_outfits() is now $outfits[]
outfit_treats(string) is now $outfit[].treats
outfit_tattoo(string) is now $outfit[].tattoo
```

Still in draft and we might not want to do it, but it addresses a long standing deficiency (in my opinion) in the constants available to our scripting runtimes.

This still allows custom outfits to be referenced with a string.

In the future we can add functions to check if you have a specific tattoo unlocked and if you current have it on your profile