### PR TITLE
Disable DebugDatabaseTest.checkZapGroups().

### DIFF
--- a/test/net/sourceforge/kolmafia/persistence/DebugDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/DebugDatabaseTest.java
@@ -363,6 +363,7 @@ public class DebugDatabaseTest {
   }
 
   @Test
+  @Disabled("Relies on external resources (wiki)")
   public void checkZapGroups() {
     String expectedOutput = "Checking zap groups...\n";
     ByteArrayOutputStream ostream = new ByteArrayOutputStream();


### PR DESCRIPTION
This test relies on the wiki, which seems to be down for me right
now.

In general, tests that rely on external data (especially ones that
rely on the network) should be avoided to ensure future
reproducibility.

I don't know if the test is hanging just for me or for everyone else.
Maybe they've IP-banned me for running too many tests :(