### PR TITLE
Language Server - parseLiteral warnings

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -3086,19 +3086,27 @@ public class Parser {
         }
 
         if (names.size() > 1) {
-          ScriptException ex =
-              this.parseException2(
-                  "Multiple matches for \"" + s1 + "\"; using \"" + s2 + "\".",
-                  "Clarify by using one of:");
-          RequestLogger.printLine(ex.getMessage());
+          String message =
+              "Multiple matches for \""
+                  + s1
+                  + "\"; using \""
+                  + s2
+                  + "\". "
+                  + this.getLineAndFile()
+                  + " Clarify by using one of:";
+          RequestLogger.printLine(message);
           for (String name : names) {
             RequestLogger.printLine(name);
           }
         } else {
-          ScriptException ex =
-              this.parseException(
-                  "Changing \"" + s1 + "\" to \"" + s2 + "\" would get rid of this message.");
-          RequestLogger.printLine(ex.getMessage());
+          String message =
+              "Changing \""
+                  + s1
+                  + "\" to \""
+                  + s2
+                  + "\" would get rid of this message. "
+                  + this.getLineAndFile();
+          RequestLogger.printLine(message);
         }
       }
     }
@@ -4040,10 +4048,6 @@ public class Parser {
 
   private ScriptException parseException(final String message) {
     return new ScriptException(message + " " + this.getLineAndFile());
-  }
-
-  private ScriptException parseException2(final String message1, final String message2) {
-    return new ScriptException(message1 + " " + this.getLineAndFile() + " " + message2);
   }
 
   private ScriptException undefinedFunctionException(final String name, final List<Value> params) {

--- a/test/root/expected/test_ambiguous_literal.ash.out
+++ b/test/root/expected/test_ambiguous_literal.ash.out
@@ -1,0 +1,4 @@
+Changing "dire warren" to "The Dire Warren" would get rid of this message. (test_ambiguous_literal.ash, line 1)
+Multiple matches for "staff of ed"; using "[7961]Staff of Ed". (test_ambiguous_literal.ash, line 2) Clarify by using one of:
+$item[[2325]Staff of Ed]
+$item[[7961]Staff of Ed]

--- a/test/root/scripts/test_ambiguous_literal.ash
+++ b/test/root/scripts/test_ambiguous_literal.ash
@@ -1,0 +1,2 @@
+$location[dire warren];
+$item[staff of ed];


### PR DESCRIPTION
Have parseLiteral create his warning messages by itself, rather than making a ScriptException.

This is just a transitional state. They will eventually go back to not building the warning message by themselves. It just won't use a ScriptException.