### PR TITLE
Fix gradle deprecation warnings.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 	id 'java'
 
 	id 'com.diffplug.spotless' version '5.15.1'
-	id 'com.github.johnrengelman.shadow' version '6.0.0'
+	id 'com.github.johnrengelman.shadow' version '7.1.0'
 	id 'net.nemerosa.versioning' version '2.8.2'
 	id 'org.ajoberstar.grgit' version '4.1.0'
 	id 'org.panteleyev.jpackageplugin' version '1.3.1'
@@ -145,14 +145,14 @@ test {
 	workingDir 'test/root'
 
 	reports {
-		html.enabled = true
-		junitXml.enabled = true
+		html.required = true
+		junitXml.required = true
 	}
 }
 
 jacocoTestReport {
 	reports {
-		xml.enabled = true
+		xml.required = true
 	}
 }
 


### PR DESCRIPTION
shadow@7.1.0 was released in the past week and resolves JavaExec.main
deprecation warnings.

Further, Report.enabled is being replaced with Report.required.