### PR TITLE
Publish reports for all OSes.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,4 +45,5 @@ jobs:
         if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: "Test Report (${{ matrix.os }})"
           report_paths: "**/build/test-results/test/TEST-*.xml"


### PR DESCRIPTION
Currently, it just picks one arbitrarily as a result of race
conditions. This is not great.