### PR TITLE
revert_lib_removal_temporarily

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ mainClassName = 'net.sourceforge.kolmafia.KoLmafia'
 sourceSets {
 	main {
 		java {
-			srcDirs = ['src']
+			srcDirs = ['src', 'lib']
 			destinationDirectory.set(file('build/main'))
 		}
 		resources {


### PR DESCRIPTION
IntelliJ is falling all over itself failing because srcDirs doesn't include 'lib'.  While I am all in favor of pulling it out, it's breaking things.  We may need a more tailored srcDirs, or some excludes, or to move the 3rd party stuff into src.  But that's a follow-on fix.