### PR TITLE
Fix taskbar detection for setAdventuresLeft.

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -2342,8 +2342,9 @@ public abstract class KoLCharacter {
     if (adventuresLeft != KoLCharacter.adventuresLeft) {
       if (Taskbar.isTaskbarSupported()) {
         Taskbar taskbar = Taskbar.getTaskbar();
-        if (taskbar.isSupported(Taskbar.Feature.ICON_BADGE_TEXT)
-            || Preferences.getBoolean("useDockIconBadge")) {
+        if ((taskbar.isSupported(Taskbar.Feature.ICON_BADGE_TEXT)
+                || taskbar.isSupported(Taskbar.Feature.ICON_BADGE_NUMBER))
+            && Preferences.getBoolean("useDockIconBadge")) {
           taskbar.setIconBadge(String.valueOf(adventuresLeft));
         }
       }

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -39,8 +39,10 @@ public class KoLCharacterTest {
     Preferences.setBoolean("useDockIconBadge", true);
 
     assertEquals(0, KoLCharacter.getAdventuresLeft());
-    // On Windows, this will trigger a debug log and bail early.
     KoLCharacter.setAdventuresLeft(10);
+
+    // Unfortunately there's no easy way to check taskbar badge state, so we're instead relying on
+    // this not bailing or raising an exception before it updates its internal state.
 
     assertEquals(10, KoLCharacter.getAdventuresLeft());
 


### PR DESCRIPTION
Right now, useDockIconBadge is overriding our careful taskbar feature detection. This is generating debug logs for users who have this preference set to true (e.g. if they previously used these settings on a Mac once upon a time).