### PR TITLE
Back out previous change to Preferences.

### DIFF
--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -170,9 +170,7 @@ public class Preferences {
     synchronized (Preferences.userValues) {
       if (username == null || username.equals("")) {
         if (Preferences.userPropertiesFile != null) {
-          if (Preferences.getBoolean("saveSettingsOnSet")) {
-            Preferences.saveToFile(Preferences.userPropertiesFile, Preferences.userValues);
-          }
+          Preferences.saveToFile(Preferences.userPropertiesFile, Preferences.userValues);
           Preferences.userPropertiesFile = null;
           Preferences.userValues.clear();
         }


### PR DESCRIPTION
This was intended for use in tests, but has since been supplanted by a
more test-accessible field.