### PR TITLE
Track last explosion date for zap wand

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -875,6 +875,7 @@ user	lastWartDinseyDefeated	-1
 user	lastWuTangDefeated	-1
 user	lastYearbookCameraAscension	-1
 user	lastZapperWand	0
+user	lastZapperWandExplosionDay	-3
 user	latteModifier	
 user	latteUnlocks	cinnamon,pumpkin,vanilla
 user	lawOfAveragesAvailable	true

--- a/src/net/sourceforge/kolmafia/request/ZapRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ZapRequest.java
@@ -153,6 +153,8 @@ public class ZapRequest extends GenericRequest {
       ResultProcessor.processResult(KoLCharacter.getZapper().getNegation());
       // set to -1 because will be incremented below
       Preferences.setInteger("_zapCount", -1);
+      // a new wand can be made in 3 days
+      Preferences.setInteger("lastZapperWandExplosionDay", KoLCharacter.getCurrentDays());
     }
 
     Matcher itemMatcher = ZapRequest.ZAP_PATTERN.matcher(urlString);

--- a/src/net/sourceforge/kolmafia/session/ValhallaManager.java
+++ b/src/net/sourceforge/kolmafia/session/ValhallaManager.java
@@ -370,6 +370,7 @@ public class ValhallaManager {
     Preferences.setString("edPiece", "");
     Preferences.setInteger("eldritchTentaclesFought", 0);
     Preferences.setString("lastCopyableMonster", "");
+    Preferences.resetToDefault("lastZapperWandExplosionDay");
     Preferences.setInteger("guzzlrDeliveryProgress", 0);
     Preferences.setBoolean("itemBoughtPerAscension637", false);
     Preferences.setBoolean("itemBoughtPerAscension8266", false);


### PR DESCRIPTION
Since you can get a new zap wand three days after your last one exploded (reset by ascension), we should track this. There is another pref which we should deprecate if such a thing existed.

Thanks @phulin for the idea of setting the default to "-3" to make everyone's scripting easier!