### PR TITLE
Log test output to stdout.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,8 @@ test {
 	systemProperty 'useCWDasROOT', true
 	workingDir 'test/root'
 
+	testLogging.showStandardStreams = true
+
 	reports {
 		html.required = true
 		junitXml.required = true


### PR DESCRIPTION
If devs want to use print debugging for tests, now they can actually
see the results of that.