### PR TITLE
Js test

### DIFF
--- a/test/net/sourceforge/kolmafia/textui/javascript/AshInteropTest.java
+++ b/test/net/sourceforge/kolmafia/textui/javascript/AshInteropTest.java
@@ -17,15 +17,18 @@ public class AshInteropTest {
 
   @Test
   void getPlayerIdReturnsInt() {
+    // The lastMessage checks are left over from some debugging.  They remain in this first test but
+    // there is no obvious benefit to including them in other tests.  If the assertion fails it is a
+    // suggestion that an exception was thrown but not otherwise handled.  Note that the assertion
+    // failure message will include the value of lastMessage.
     ContactManager.registerPlayerId("heeheehee", "354981");
     var js = new JavascriptRuntime("getPlayerId(\"heeheehee\")");
-    // before clearing lastMessage before the test, it wasn't empty
     String x = KoLmafia.getLastMessage();
-    assertEquals(x, "", "Last message not empty getting runtime.");
+    assertEquals(x, "", "Last message not empty after getting runtime.");
     assertNotNull(js, "JavascriptRuntime returned as null.");
     Value ret = js.execute(null, null, true);
     x = KoLmafia.getLastMessage();
-    assertEquals(x, "", "Last message not empty executing.");
+    assertEquals(x, "", "Last message not empty after executing.");
     assertNotNull(ret, "Javascript execute returns null instead of a result to be tested.");
     String retS = ret.toString();
     assertEquals("354981", retS);


### PR DESCRIPTION
All tests pass in IntelliJ.  Current code passes in Gradle.  If there was no operator error then enabling one of the disabled tests fails in Gradle.  Seems to be related to the number of enabled tests and not which ones.  Don't think there is a spill over between tests and wonder if it is the Gradle threading?