### PR TITLE
fix _chronolithActivations incorrect values

### DIFF
--- a/src/net/sourceforge/kolmafia/request/ScrapheapRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ScrapheapRequest.java
@@ -61,9 +61,9 @@ public class ScrapheapRequest extends PlaceRequest {
     if (m.find()) {
       int cost = StringUtilities.parseInt(m.group(1));
 
-      if (cost > 158) {
+      if (cost > 148) {
         cost /= 10;
-      } else if (cost > 37) {
+      } else if (cost > 47) {
         cost /= 2;
       }
 


### PR DESCRIPTION
Chronolith activations tracking displays incorrect values.
This fixes it

This is how it is supposed to work
> Energy cost for the Chronolith increases by 1 after each use for each of the first 37 uses (10, 11, 12, 13, etc). After 37 uses, the energy cost is doubled (45, 46, 47, 96, 98, 100), and after 74 uses, the energy cost is multiplied by 10 (144, 146, 148, 750, 760, 770).

however mafia uses incorrect breakpoints for cost of 37 and 158 instead of 47 and 148