### PR TITLE
Add unit tests for SnapperCommand

### DIFF
--- a/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTest.java
@@ -1,0 +1,35 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import net.sourceforge.kolmafia.KoLConstants.MafiaState;
+import net.sourceforge.kolmafia.KoLmafiaCLI;
+import net.sourceforge.kolmafia.RequestLogger;
+import net.sourceforge.kolmafia.StaticEntity;
+
+public abstract class AbstractCommandTest {
+  protected String command = "abort";
+
+  public String execute(final String params) {
+    var outputStream = new ByteArrayOutputStream();
+    RequestLogger.openCustom(new PrintStream(outputStream));
+    var cli = new KoLmafiaCLI(System.in);
+    cli.executeCommand(this.command, params);
+    RequestLogger.closeCustom();
+    return outputStream.toString();
+  }
+
+  public static void assertState(final MafiaState state) {
+    assertEquals(state, StaticEntity.getContinuationState());
+  }
+
+  public static void assertContinueState() {
+    assertState(MafiaState.CONTINUE);
+  }
+
+  public static void assertErrorState() {
+    assertState(MafiaState.ERROR);
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/command/SnapperCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/SnapperCommandTest.java
@@ -1,0 +1,83 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.sourceforge.kolmafia.FamiliarData;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.objectpool.FamiliarPool;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.GenericRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SnapperCommandTest extends AbstractCommandTest {
+  @BeforeEach
+  public void initEach() {
+    KoLCharacter.reset("testUser");
+    Preferences.resetToDefault("redSnapperPhylum");
+
+    // Reset the state
+    KoLmafia.forceContinue();
+
+    // Stop requests from actually running
+    GenericRequest.sessionId = null;
+  }
+
+  public SnapperCommandTest() {
+    this.command = "snapper";
+  }
+
+  static String getPhylum() {
+    return Preferences.getString("redSnapperPhylum");
+  }
+
+  static void setSnapper() {
+    var familiar = FamiliarData.registerFamiliar(FamiliarPool.RED_SNAPPER, 1);
+    KoLCharacter.setFamiliar(familiar);
+  }
+
+  @Test
+  void mustHaveSnapper() {
+    KoLCharacter.setFamiliar(FamiliarData.NO_FAMILIAR);
+    String output = execute("bug");
+
+    assertTrue(output.contains("You need to take your Red-Nosed Snapper with you"));
+    assertContinueState();
+    assertEquals("", getPhylum());
+  }
+
+  @Test
+  void mustSpecifyPhylum() {
+    setSnapper();
+    execute("");
+    assertErrorState();
+    assertEquals("", getPhylum());
+  }
+
+  @Test
+  void mustSpecifyValidPhylum() {
+    setSnapper();
+    execute("dog");
+    assertErrorState();
+    assertEquals("", getPhylum());
+  }
+
+  @Test
+  void alreadyTrackingPhylum() {
+    Preferences.setString("redSnapperPhylum", "beast");
+    setSnapper();
+    String output = execute("beast");
+    assertContinueState();
+    assertTrue(output.contains("already hot on the tail"));
+  }
+
+  @Test
+  void changesPhylum() {
+    setSnapper();
+    String output = execute("beast");
+    assertContinueState();
+    assertTrue(output.contains("guiding you towards beasts"));
+  }
+}


### PR DESCRIPTION
This is an example of how we might test CLI commands.

@heeheehee-kolmafia doesn't actually apply in this case, but how would you recommend mocking GenericRequest here for commands that actually do check the result of calls?