### PR TITLE
Keep state from leaking across tests.

### DIFF
--- a/test/net/sourceforge/kolmafia/CustomScriptTest.java
+++ b/test/net/sourceforge/kolmafia/CustomScriptTest.java
@@ -64,7 +64,6 @@ public class CustomScriptTest {
     ContactManager.registerPlayerId("heeheehee", "354981");
     StaticEntity.overrideRevision(10000);
     TurnCounter.clearCounters();
-    KoLmafia.forceContinue();
   }
 
   @AfterEach

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -6,7 +6,6 @@ import net.sourceforge.kolmafia.KoLConstants.ZodiacType;
 import net.sourceforge.kolmafia.KoLConstants.ZodiacZone;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class KoLCharacterTest {
@@ -71,11 +70,5 @@ public class KoLCharacterTest {
   @AfterEach
   void resetUsername() {
     KoLCharacter.reset("");
-    Preferences.saveSettingsToFile = true;
-  }
-
-  @BeforeEach
-  void skipWritingPreferences() {
-    Preferences.saveSettingsToFile = false;
   }
 }

--- a/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
+++ b/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
@@ -1,0 +1,26 @@
+package net.sourceforge.kolmafia.extensions;
+
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class ClearSharedState implements AfterAllCallback {
+
+  // Prevents leakage of shared state across test classes.
+
+  @Override
+  public void afterAll(ExtensionContext context) {
+    // Among other things, this sets KoLCharacter.username.
+    KoLCharacter.reset("");
+    // But, if username is already "", then it doesn't do the bulk of resetting state.
+    KoLCharacter.reset(true);
+    KoLCharacter.setUserId(0);
+    // If you explicitly want saveSettingsToFile to be true, then set it yourself.
+    Preferences.saveSettingsToFile = false;
+
+    KoLmafia.lastMessage = "";
+    KoLmafia.forceContinue();
+  }
+}

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 public class MaximizerTest {
   @BeforeEach
   public void init() {
-    KoLCharacter.reset(false);
+    KoLCharacter.reset(true);
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/persistence/DebugDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/DebugDatabaseTest.java
@@ -5,18 +5,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import net.sourceforge.kolmafia.RequestLogger;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class DebugDatabaseTest {
 
-  @BeforeEach
-  public void setUp() throws Exception {}
-
-  @AfterEach
-  public void tearDown() throws Exception {}
   /* TODO: implement or delete these tests
   @Test
   public void checkItems()

--- a/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
@@ -7,7 +7,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.preferences.Preferences;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -15,16 +14,8 @@ public class AscensionHistoryRequestTest extends RequestTestBase {
 
   @BeforeAll
   protected static void init() {
-    Preferences.saveSettingsToFile = false;
     KoLCharacter.reset("the Tristero");
     KoLCharacter.setUserId(177122);
-  }
-
-  @AfterAll
-  protected static void tidyUp() {
-    KoLCharacter.reset("");
-    KoLCharacter.setUserId(0);
-    Preferences.saveSettingsToFile = true;
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/request/BasementRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/BasementRequestTest.java
@@ -6,8 +6,6 @@ import static org.mockito.Mockito.spy;
 import java.util.stream.Stream;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLmafia;
-import net.sourceforge.kolmafia.preferences.Preferences;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -17,15 +15,8 @@ class BasementRequestTest extends RequestTestBase {
 
   @BeforeAll
   protected static void injectPreferences() {
-    Preferences.saveSettingsToFile = false;
     // Set a username so we can edit preferences and have per-user defaults.
     KoLCharacter.reset("fakeUserName");
-  }
-
-  @AfterAll
-  protected static void cleanupSession() {
-    KoLCharacter.reset("");
-    Preferences.saveSettingsToFile = true;
   }
 
   private static Stream<Arguments> monsterFights() {

--- a/test/net/sourceforge/kolmafia/request/PixelRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/PixelRequestTest.java
@@ -2,21 +2,14 @@ package net.sourceforge.kolmafia.request;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.ConcoctionPool;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class PixelRequestTest {
-  @AfterEach
-  public void after() {
-    KoLCharacter.reset(false);
-  }
-
   @Test
   public void whitePixelPurchaseConsumesOtherPixels() {
     // 1 of each of red / green / blue pixel

--- a/test/net/sourceforge/kolmafia/request/ScrapheapRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/ScrapheapRequestTest.java
@@ -9,7 +9,6 @@ import java.nio.file.Paths;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.ChoiceManager;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -17,14 +16,7 @@ public class ScrapheapRequestTest extends RequestTestBase {
 
   @BeforeEach
   protected void initEach() {
-    Preferences.saveSettingsToFile = false;
     KoLCharacter.reset("fakeUserName");
-  }
-
-  @AfterEach
-  protected void tidyUp() {
-    KoLCharacter.reset("");
-    Preferences.saveSettingsToFile = true;
   }
 
   private int parseActivations(String path) throws IOException {

--- a/test/net/sourceforge/kolmafia/request/ZapRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/ZapRequestTest.java
@@ -4,19 +4,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import net.java.dev.spellcast.utilities.LockableListModel;
 import net.sourceforge.kolmafia.AdventureResult;
-import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class ZapRequestTest {
-
-  @AfterEach
-  public void after() {
-    KoLCharacter.reset(false);
-  }
 
   // Copied from a Maximizer Test.  Good candidate for a library that supports tests.
   private void loadInventory(String jsonInventory) {

--- a/test/net/sourceforge/kolmafia/textui/command/SnapperCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/SnapperCommandTest.java
@@ -5,11 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.GenericRequest;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -17,20 +15,10 @@ public class SnapperCommandTest extends AbstractCommandTest {
   @BeforeEach
   public void initEach() {
     KoLCharacter.reset("testUser");
-    KoLCharacter.reset(false);
     Preferences.resetToDefault("redSnapperPhylum");
-
-    // Reset the state
-    KoLmafia.forceContinue();
 
     // Stop requests from actually running
     GenericRequest.sessionId = null;
-  }
-
-  @AfterAll
-  public static void tearDown() {
-    // Reset the state
-    KoLmafia.forceContinue();
   }
 
   public SnapperCommandTest() {

--- a/test/net/sourceforge/kolmafia/textui/command/SpoonCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/SpoonCommandTest.java
@@ -7,11 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
-import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.GenericRequest;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -19,20 +17,11 @@ public class SpoonCommandTest extends AbstractCommandTest {
   @BeforeEach
   public void initEach() {
     KoLCharacter.reset("testUser");
-    KoLCharacter.reset(false);
+    KoLCharacter.reset(true);
     Preferences.resetToDefault("moonTuned");
-
-    // Reset the state
-    KoLmafia.forceContinue();
 
     // Stop requests from actually running
     GenericRequest.sessionId = null;
-  }
-
-  @AfterAll
-  public static void tearDown() {
-    // Reset the state
-    KoLmafia.forceContinue();
   }
 
   public SpoonCommandTest() {

--- a/test/net/sourceforge/kolmafia/textui/javascript/AshInteropTest.java
+++ b/test/net/sourceforge/kolmafia/textui/javascript/AshInteropTest.java
@@ -5,16 +5,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.session.ContactManager;
 import net.sourceforge.kolmafia.textui.parsetree.Value;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class AshInteropTest {
-
-  @BeforeEach
-  void clearMessage() {
-    KoLmafia.forceContinue();
-    KoLmafia.lastMessage = "";
-  }
 
   @Test
   void getPlayerIdReturnsInt() {

--- a/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,1 +1,2 @@
 net.sourceforge.kolmafia.extensions.ForbidNetworkAccess
+net.sourceforge.kolmafia.extensions.ClearSharedState


### PR DESCRIPTION
Strongly requesting that test authors clear state themselves is error prone and evidently doesn't work. So, let's do it for them.

This obviously doesn't clear everything, but it's a start.

Among other things, this should fix state leakage from SnapperCommandTest and SpoonCommandTest.