### PR TITLE
Preferences

### DIFF
--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -531,6 +531,10 @@ public class Preferences {
   }
 
   private static void loadUserPreferences(final String username) {
+    // Apparently the CodeQL security scan requires this as a fix...
+    if ((username != null) && (username.contains(".."))) {
+      return;
+    }
     File file =
         new File(KoLConstants.SETTINGS_LOCATION, Preferences.baseUserName(username) + "_prefs.txt");
     Preferences.userPropertiesFile = file;

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -1,6 +1,6 @@
 package net.sourceforge.kolmafia;
 
-import static net.sourceforge.kolmafia.extensions.ClearSharedState.deleteEm;
+import static net.sourceforge.kolmafia.extensions.ClearSharedState.deleteUserPrefsAndMoodsFiles;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.sourceforge.kolmafia.KoLConstants.ZodiacType;
@@ -71,7 +71,7 @@ public class KoLCharacterTest {
 
   @AfterEach
   void resetUsername() {
-    deleteEm(KoLCharacter.baseUserName());
+    deleteUserPrefsAndMoodsFiles(KoLCharacter.baseUserName());
     KoLCharacter.reset("");
   }
 }

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 public class KoLCharacterTest {
   @AfterAll
   protected static void cleanUp() {
-    //exists to trigger hooked routine
+    // exists to trigger hooked routine
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import net.sourceforge.kolmafia.KoLConstants.ZodiacType;
 import net.sourceforge.kolmafia.KoLConstants.ZodiacZone;
 import net.sourceforge.kolmafia.preferences.Preferences;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia;
 
+import static net.sourceforge.kolmafia.extensions.ClearSharedState.deleteEm;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.sourceforge.kolmafia.KoLConstants.ZodiacType;
@@ -10,10 +11,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class KoLCharacterTest {
-  @AfterAll
-  protected static void cleanUp() {
-    // exists to trigger hooked routine
-  }
 
   @Test
   public void rejectsUsernameWithTwoPeriods() {
@@ -75,6 +72,7 @@ public class KoLCharacterTest {
 
   @AfterEach
   void resetUsername() {
+    deleteEm(KoLCharacter.baseUserName());
     KoLCharacter.reset("");
   }
 }

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -5,10 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import net.sourceforge.kolmafia.KoLConstants.ZodiacType;
 import net.sourceforge.kolmafia.KoLConstants.ZodiacZone;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class KoLCharacterTest {
+  @AfterAll
+  protected static void cleanUp() {
+    //exists to trigger hooked routine
+  }
+
   @Test
   public void rejectsUsernameWithTwoPeriods() {
     KoLCharacter.reset("test..name");

--- a/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
+++ b/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
@@ -16,7 +16,7 @@ public class ClearSharedState implements AfterAllCallback {
   @Override
   public void afterAll(ExtensionContext context) {
     // Clean up user files
-    deleteEm(KoLCharacter.baseUserName());
+    deleteUserPrefsAndMoodsFiles(KoLCharacter.baseUserName());
     // and GLOBALS
     deleteGlobals();
     // Among other things, this sets KoLCharacter.username.
@@ -35,7 +35,7 @@ public class ClearSharedState implements AfterAllCallback {
     KoLmafia.forceContinue();
   }
 
-  public static void deleteEm(String user) {
+  public static void deleteUserPrefsAndMoodsFiles(String user) {
     String begin = "settings/" + user;
     File file = new File(begin + "_prefs.txt");
     if (file.exists()) {
@@ -48,7 +48,7 @@ public class ClearSharedState implements AfterAllCallback {
   }
 
   public static void deleteGlobals() {
-    deleteEm("GLOBAL");
+    deleteUserPrefsAndMoodsFiles("GLOBAL");
     File file = new File("settings/GLOBAL_aliases.txt");
     if (file.exists()) {
       file.deleteOnExit();

--- a/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
+++ b/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.extensions;
 
+import java.io.File;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -12,6 +13,8 @@ public class ClearSharedState implements AfterAllCallback {
 
   @Override
   public void afterAll(ExtensionContext context) {
+    // Clean up files
+    deleteEm(KoLCharacter.getUserName());
     // Among other things, this sets KoLCharacter.username.
     KoLCharacter.reset("");
     // But, if username is already "", then it doesn't do the bulk of resetting state.
@@ -22,5 +25,17 @@ public class ClearSharedState implements AfterAllCallback {
 
     KoLmafia.lastMessage = "";
     KoLmafia.forceContinue();
+  }
+
+  void deleteEm(String user) {
+    String begin = "settings/" + user;
+    File file = new File(begin + "_prefs.txt");
+    if (file.exists()) {
+      file.deleteOnExit();
+    }
+    file = new File(begin + "_moods.txt");
+    if (file.exists()) {
+      file.deleteOnExit();
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
+++ b/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.extensions;
 
+import java.io.File;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.KoLmafiaCLI;
@@ -14,6 +15,10 @@ public class ClearSharedState implements AfterAllCallback {
 
   @Override
   public void afterAll(ExtensionContext context) {
+    // Clean up user files
+    deleteEm(KoLCharacter.baseUserName());
+    // and GLOBALS
+    deleteGlobals();
     // Among other things, this sets KoLCharacter.username.
     KoLCharacter.reset("");
     // But, if username is already "", then it doesn't do the bulk of resetting state.
@@ -28,5 +33,25 @@ public class ClearSharedState implements AfterAllCallback {
 
     KoLmafia.lastMessage = "";
     KoLmafia.forceContinue();
+  }
+
+  public static void deleteEm(String user) {
+    String begin = "settings/" + user;
+    File file = new File(begin + "_prefs.txt");
+    if (file.exists()) {
+      file.deleteOnExit();
+    }
+    file = new File(begin + "_moods.txt");
+    if (file.exists()) {
+      file.deleteOnExit();
+    }
+  }
+
+  public static void deleteGlobals() {
+    deleteEm("GLOBAL");
+    File file = new File("settings/GLOBAL_aliases.txt");
+    if (file.exists()) {
+      file.deleteOnExit();
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
+++ b/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
@@ -15,6 +15,8 @@ public class ClearSharedState implements AfterAllCallback {
   public void afterAll(ExtensionContext context) {
     // Clean up user files
     deleteEm(KoLCharacter.baseUserName());
+    // and GLOBALS
+    deleteGlobals();
     // Among other things, this sets KoLCharacter.username.
     KoLCharacter.reset("");
     // But, if username is already "", then it doesn't do the bulk of resetting state.
@@ -22,7 +24,6 @@ public class ClearSharedState implements AfterAllCallback {
     KoLCharacter.setUserId(0);
     // If you explicitly want saveSettingsToFile to be true, then set it yourself.
     Preferences.saveSettingsToFile = false;
-
     KoLmafia.lastMessage = "";
     KoLmafia.forceContinue();
   }
@@ -34,6 +35,14 @@ public class ClearSharedState implements AfterAllCallback {
       file.deleteOnExit();
     }
     file = new File(begin + "_moods.txt");
+    if (file.exists()) {
+      file.deleteOnExit();
+    }
+  }
+
+  public static void deleteGlobals() {
+    deleteEm("GLOBAL");
+    File file = new File("settings/GLOBAL_aliases.txt");
     if (file.exists()) {
       file.deleteOnExit();
     }

--- a/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
+++ b/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
@@ -13,8 +13,8 @@ public class ClearSharedState implements AfterAllCallback {
 
   @Override
   public void afterAll(ExtensionContext context) {
-    // Clean up files
-    deleteEm(KoLCharacter.getUserName());
+    // Clean up user files
+    deleteEm(KoLCharacter.baseUserName());
     // Among other things, this sets KoLCharacter.username.
     KoLCharacter.reset("");
     // But, if username is already "", then it doesn't do the bulk of resetting state.
@@ -27,7 +27,7 @@ public class ClearSharedState implements AfterAllCallback {
     KoLmafia.forceContinue();
   }
 
-  void deleteEm(String user) {
+  public static void deleteEm(String user) {
     String begin = "settings/" + user;
     File file = new File(begin + "_prefs.txt");
     if (file.exists()) {

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -342,7 +342,9 @@ class PreferencesTest {
         Integer.parseInt(globalDefaultsMap.get(globalProp)),
         "Map value not equal to set value");
     assertEquals(
-        userPropFloat, Float.parseFloat(userDefaultsMap.get(propName)), "Map value not equal to set value");
+        userPropFloat,
+        Float.parseFloat(userDefaultsMap.get(propName)),
+        "Map value not equal to set value");
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -2,6 +2,7 @@ package net.sourceforge.kolmafia.preferences;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.File;
 import java.util.TreeMap;
 import net.sourceforge.kolmafia.KoLCharacter;
 import org.junit.jupiter.api.*;
@@ -14,6 +15,18 @@ class PreferencesTest {
     KoLCharacter.reset("fakePrefUser");
     KoLCharacter.reset(true);
     Preferences.saveSettingsToFile = false;
+  }
+
+  @AfterAll
+  protected static void cleanUpSettings() {
+    File file = new File("settings/GLOBAL_aliases.txt");
+    if (file.exists()) {
+      file.deleteOnExit();
+    }
+    file = new File("settings/GLOBAL_prefs.txt");
+    if (file.exists()) {
+      file.deleteOnExit();
+    }
   }
 
   @Test
@@ -328,8 +341,8 @@ class PreferencesTest {
         globalIntValue,
         Integer.parseInt(globalDefaultsMap.get(globalProp)),
         "Map value not equal to set value");
-    assertNotEquals(
-        userPropFloat, userDefaultsMap.get(propName), "Map value not equal to set value");
+    assertEquals(
+        userPropFloat, Float.parseFloat(userDefaultsMap.get(propName)), "Map value not equal to set value");
   }
 
   @Test
@@ -390,21 +403,21 @@ class PreferencesTest {
 
   @Test
   void ResetGlobalDailies() {
-    String gloablDailypref = "_testDaily";
+    String globalDailyPref = "_testDaily";
     Integer testValue = 2112;
-    Integer preTest = Preferences.getInteger("GLOBAL", gloablDailypref);
-    assertNotEquals(testValue, preTest, "new pref " + gloablDailypref + " is not empty.");
+    Integer preTest = Preferences.getInteger("GLOBAL", globalDailyPref);
+    assertNotEquals(testValue, preTest, "new pref " + globalDailyPref + " is not empty.");
 
-    Preferences.setInteger("GLOBAL", gloablDailypref, testValue);
-    Integer postSetPref = Preferences.getInteger(gloablDailypref);
-    assertEquals(testValue, postSetPref, "new pref " + gloablDailypref + " should be set");
+    Preferences.setInteger("GLOBAL", globalDailyPref, testValue);
+    Integer postSetPref = Preferences.getInteger(globalDailyPref);
+    assertEquals(testValue, postSetPref, "new pref " + globalDailyPref + " should be set");
 
     Preferences.resetGlobalDailies();
-    Integer afterReset = Preferences.getInteger("GLOBAL", gloablDailypref);
+    Integer afterReset = Preferences.getInteger("GLOBAL", globalDailyPref);
     assertNotEquals(
         testValue,
         afterReset,
-        "new pref " + gloablDailypref + " should be reset by resetGlobalDailies");
+        "new pref " + globalDailyPref + " should be reset by resetGlobalDailies");
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -20,7 +20,6 @@ class PreferencesTest {
   void ResetClearsPrefs() {
     String propName = "aTestProp";
     Preferences.setBoolean(propName, true);
-
     assertTrue(Preferences.getBoolean(propName), "Property Set but does not exist.");
     Preferences.reset("fakePrefUser"); // reload from disk
     assertFalse(Preferences.getBoolean(propName), "Property not restored from disk by reset.");
@@ -414,6 +413,78 @@ class PreferencesTest {
     String prefName = "autoLogin";
     boolean result = Preferences.containsDefault(prefName);
     assertTrue(result, "default not in defaultsSet for pref " + prefName);
+  }
+
+  @Test
+  void resetAscensionProperties() {
+    String name = "charitableDonations";
+    int val = 1337;
+    Preferences.setInteger(name, val);
+    //Confirm it was set
+    assertEquals(val, Preferences.getInteger(name));
+    //reset
+    Preferences.resetPerAscension();
+    //confirm changed
+    assertNotEquals(val, Preferences.getInteger(name));
+  }
+
+  @Test
+  void makeAndTestUnspecifiedProperty() {
+    String name = "makeMine";
+    String value = "the P Funk";
+    //Doesn't exist as either user or GLOBAL
+    assertFalse(Preferences.propertyExists(name, true));
+    assertFalse(Preferences.propertyExists(name, false));
+    assertFalse(Preferences.isGlobalProperty(name));
+    //Create it as unspecified
+    Preferences.setString(name, value);
+    //Exists as user
+    assertFalse(Preferences.propertyExists(name, true));
+    assertTrue(Preferences.propertyExists(name, false));
+    assertFalse(Preferences.isGlobalProperty(name));
+    assertFalse(Preferences.isPerUserGlobalProperty(name));
+    //Remove it and confirm it is gone
+    Preferences.removeProperty(name, false);
+    assertFalse(Preferences.propertyExists(name, true));
+    assertFalse(Preferences.propertyExists(name, false));
+    assertFalse(Preferences.isGlobalProperty(name));
+  }
+  @Test
+  void makeAndTestUserProperty() {
+    String name = "makeMine";
+    String value = "the P Funk";
+    //Doesn't exist as either user or GLOBAL
+    assertFalse(Preferences.propertyExists(name, true));
+    assertFalse(Preferences.propertyExists(name, false));
+    assertFalse(Preferences.isGlobalProperty(name));
+    //Create it as user
+    String userName = KoLCharacter.getUserName();
+    Preferences.setString(userName, name, value);
+    //Exists as user
+    assertFalse(Preferences.propertyExists(name, true));
+    assertTrue(Preferences.propertyExists(name, false));
+    assertFalse(Preferences.isGlobalProperty(name));
+    //Remove it and confirm it is gone
+    Preferences.removeProperty(name, false);
+    assertFalse(Preferences.propertyExists(name, true));
+    assertFalse(Preferences.propertyExists(name, false));
+    assertFalse(Preferences.isGlobalProperty(name));
+  }
+  @Test
+  public void exerciseIsPerUserGlobalProperty() {
+    //not a property
+    assertFalse(Preferences.isPerUserGlobalProperty("xyzzy"));
+    assertFalse(Preferences.isPerUserGlobalProperty("xy..z.zy"));
+    //property
+    assertTrue(Preferences.isPerUserGlobalProperty("getBreakfast.fakePrefUser"));
+  }
+  @Test
+  public void actuallySaveFileToIncreaseCoverage() {
+    Preferences.saveSettingsToFile = true;
+    Preferences.setString("tabby", "*\\t*");
+    Preferences.setString("removeMe","please");
+    Preferences.removeProperty("removeMe", false);
+    assertFalse(Preferences.propertyExists("removeMe", false));
   }
 }
 

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -18,7 +18,7 @@ class PreferencesTest {
   }
 
   @AfterAll
-  protected static void cleanUpSettings() {
+  protected static void cleanUpGlobalSettings() {
     File file = new File("settings/GLOBAL_aliases.txt");
     if (file.exists()) {
       file.deleteOnExit();

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -17,10 +17,10 @@ class PreferencesTest {
   }
 
   @Test
-  //This test fails when another test sets Preferences.saveSettingsToFile = true;
-  //The comment about restoring from disk is concerning since there is nothing
-  //to restore from (AFAIK) when the setting is false;  But if the other test
-  //restores the value to false, this test passes.
+  // This test fails when another test sets Preferences.saveSettingsToFile = true;
+  // The comment about restoring from disk is concerning since there is nothing
+  // to restore from (AFAIK) when the setting is false;  But if the other test
+  // restores the value to false, this test passes.
   void ResetClearsPrefs() {
     String propName = "aTestProp";
     Preferences.setBoolean(propName, true);
@@ -424,11 +424,11 @@ class PreferencesTest {
     String name = "charitableDonations";
     int val = 1337;
     Preferences.setInteger(name, val);
-    //Confirm it was set
+    // Confirm it was set
     assertEquals(val, Preferences.getInteger(name));
-    //reset
+    // reset
     Preferences.resetPerAscension();
-    //confirm changed
+    // confirm changed
     assertNotEquals(val, Preferences.getInteger(name));
   }
 
@@ -436,57 +436,68 @@ class PreferencesTest {
   void makeAndTestUnspecifiedProperty() {
     String name = "makeMine";
     String value = "the P Funk";
-    //Doesn't exist as either user or GLOBAL
+    // Doesn't exist as either user or GLOBAL
     assertFalse(Preferences.propertyExists(name, true));
     assertFalse(Preferences.propertyExists(name, false));
     assertFalse(Preferences.isGlobalProperty(name));
-    //Create it as unspecified
+    // Create it as unspecified
     Preferences.setString(name, value);
-    //Exists as user
+    // Exists as user
     assertFalse(Preferences.propertyExists(name, true));
     assertTrue(Preferences.propertyExists(name, false));
     assertFalse(Preferences.isGlobalProperty(name));
     assertFalse(Preferences.isPerUserGlobalProperty(name));
-    //Remove it and confirm it is gone
+    // Remove it and confirm it is gone
     Preferences.removeProperty(name, false);
     assertFalse(Preferences.propertyExists(name, true));
     assertFalse(Preferences.propertyExists(name, false));
     assertFalse(Preferences.isGlobalProperty(name));
   }
+
   @Test
   void makeAndTestUserProperty() {
     String name = "makeMine";
     String value = "the P Funk";
-    //Doesn't exist as either user or GLOBAL
+    // Doesn't exist as either user or GLOBAL
     assertFalse(Preferences.propertyExists(name, true));
     assertFalse(Preferences.propertyExists(name, false));
     assertFalse(Preferences.isGlobalProperty(name));
-    //Create it as user
+    // Create it as user
     String userName = KoLCharacter.getUserName();
     Preferences.setString(userName, name, value);
-    //Exists as user
+    // Exists as user
     assertFalse(Preferences.propertyExists(name, true));
     assertTrue(Preferences.propertyExists(name, false));
     assertFalse(Preferences.isGlobalProperty(name));
-    //Remove it and confirm it is gone
+    // Remove it and confirm it is gone
     Preferences.removeProperty(name, false);
     assertFalse(Preferences.propertyExists(name, true));
     assertFalse(Preferences.propertyExists(name, false));
     assertFalse(Preferences.isGlobalProperty(name));
   }
+
   @Test
   public void exerciseIsPerUserGlobalProperty() {
-    //not a property
+    // not a property
     assertFalse(Preferences.isPerUserGlobalProperty("xyzzy"));
     assertFalse(Preferences.isPerUserGlobalProperty("xy..z.zy"));
-    //property
+    // property
     assertTrue(Preferences.isPerUserGlobalProperty("getBreakfast.fakePrefUser"));
   }
+
   @Test
   public void actuallySaveFileToIncreaseCoverage() {
     Preferences.saveSettingsToFile = true;
     Preferences.setString("tabby", "*\\t*");
-    Preferences.setString("removeMe","please");
+    Preferences.setString("removeMe", "please");
+    Preferences.setString("a", "\\n");
+    Preferences.setString("b", "\\f");
+    Preferences.setString("c", "\\r");
+    Preferences.setString("d", "\\\\");
+    Preferences.setString("e", "=");
+    Preferences.setString("f", ":");
+    Preferences.setString("g", "#");
+    Preferences.setString("h", "!");
     Preferences.removeProperty("removeMe", false);
     assertFalse(Preferences.propertyExists("removeMe", false));
     Preferences.saveSettingsToFile = false;
@@ -494,12 +505,12 @@ class PreferencesTest {
 
   @Test
   public void exerciseGetStringVariant() {
-    String name = "makeMineAlso"; //makeAndTestUserProperty using the same name breaks
+    String name = "makeMineAlso"; // makeAndTestUserProperty using the same name breaks
     String value = "the P Funk";
     String userName = KoLCharacter.getUserName();
     Preferences.setString(userName, name, value);
     assertEquals(value, Preferences.getString(name, false));
-    name = "lastUsername"; //global
+    name = "lastUsername"; // global
     value = "Bootsy";
     Preferences.setString(name, value);
     assertEquals(value, Preferences.getString(name, true));

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -1,14 +1,13 @@
 package net.sourceforge.kolmafia.preferences;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 import java.util.TreeMap;
 import net.sourceforge.kolmafia.KoLCharacter;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 class PreferencesTest {
+
   // Convert to the new way of doing things...
   @BeforeAll
   protected static void initAll() {
@@ -43,7 +42,7 @@ class PreferencesTest {
 
     Preferences.removeProperty("ATestProperty", false);
     result = Preferences.propertyExists("ATestProperty", false);
-    assertFalse(result, "Property Remove but stll found.");
+    assertFalse(result, "Property Remove but still found.");
   }
 
   @Test
@@ -92,7 +91,7 @@ class PreferencesTest {
     String PrefName = "aBooleanPref";
     Preferences.setBoolean(PrefName, true);
 
-    Boolean checkPref = Preferences.getBoolean(PrefName);
+    boolean checkPref = Preferences.getBoolean(PrefName);
     assertTrue(checkPref, "Boolean Pref failed");
     Preferences.setBoolean(PrefName, false);
 
@@ -159,13 +158,13 @@ class PreferencesTest {
   @Test
   void IncrementPref() {
     String prefName = "anIntegerPref";
-    Integer prefValue = 73;
+    int prefValue = 73;
     String prefString = "aStringPref";
 
     Preferences.setInteger(prefName, prefValue);
     Preferences.increment(prefName);
     Integer checkIncrement = Preferences.getInteger(prefName);
-    assertEquals(prefValue + 1, checkIncrement, "Increement by one failed");
+    assertEquals(prefValue + 1, checkIncrement, "Increment by one failed");
 
     Preferences.increment(prefName, 9);
     checkIncrement = Preferences.getInteger(prefName);
@@ -188,7 +187,7 @@ class PreferencesTest {
   @Test
   void DecrementPref() {
     String prefName = "anIntegerPref";
-    Integer prefValue = 73;
+    int prefValue = 73;
     String prefString = "aStringPref";
 
     Preferences.setInteger(prefName, prefValue);
@@ -218,7 +217,7 @@ class PreferencesTest {
 
     Preferences.setString(userName, propName, propValue);
     String result = Preferences.getString(userName, propName);
-    assertEquals(propValue, result, "Could not set and retrieve per-user string prefe");
+    assertEquals(propValue, result, "Could not set and retrieve per-user string pref");
   }
 
   @Test
@@ -289,7 +288,7 @@ class PreferencesTest {
     String globalProp = "dailyDeedsVersion";
     Integer globalIntProp = 13;
     Integer globalIntValue = 44;
-    Float userPropFloat = 22.2f;
+    float userPropFloat = 22.2f;
     Float propDefaultValue = 1.0f;
 
     TreeMap<String, String> globalMap = Preferences.getMap(true, false);
@@ -307,7 +306,7 @@ class PreferencesTest {
     // override values and re-check
     Preferences.setFloat(propName, userPropFloat);
     Preferences.setInteger(globalProp, globalIntValue);
-    // get the maps again, becuase this is a snapshot of a moment-in-time
+    // get the maps again, because this is a snapshot of a moment-in-time
     globalMap = Preferences.getMap(true, false);
     userMap = Preferences.getMap(true, true);
 
@@ -321,7 +320,7 @@ class PreferencesTest {
         Integer.valueOf(globalMap.get(globalProp)),
         "Global default map value not equal to default value after setting");
 
-    // dfaults == fale means the these are the actual set values.
+    // defaults == false means the these are the actual set values.
     TreeMap<String, String> userDefaultsMap = Preferences.getMap(false, true);
     TreeMap<String, String> globalDefaultsMap = Preferences.getMap(false, false);
 

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -2,7 +2,6 @@ package net.sourceforge.kolmafia.preferences;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.File;
 import java.util.TreeMap;
 import net.sourceforge.kolmafia.KoLCharacter;
 import org.junit.jupiter.api.*;

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -17,6 +17,10 @@ class PreferencesTest {
   }
 
   @Test
+  //This test fails when another test sets Preferences.saveSettingsToFile = true;
+  //The comment about restoring from disk is concerning since there is nothing
+  //to restore from (AFAIK) when the setting is false;  But if the other test
+  //restores the value to false, this test passes.
   void ResetClearsPrefs() {
     String propName = "aTestProp";
     Preferences.setBoolean(propName, true);
@@ -485,6 +489,20 @@ class PreferencesTest {
     Preferences.setString("removeMe","please");
     Preferences.removeProperty("removeMe", false);
     assertFalse(Preferences.propertyExists("removeMe", false));
+    Preferences.saveSettingsToFile = false;
+  }
+
+  @Test
+  public void exerciseGetStringVariant() {
+    String name = "makeMineAlso"; //makeAndTestUserProperty using the same name breaks
+    String value = "the P Funk";
+    String userName = KoLCharacter.getUserName();
+    Preferences.setString(userName, name, value);
+    assertEquals(value, Preferences.getString(name, false));
+    name = "lastUsername"; //global
+    value = "Bootsy";
+    Preferences.setString(name, value);
+    assertEquals(value, Preferences.getString(name, true));
   }
 }
 

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -17,18 +17,6 @@ class PreferencesTest {
     Preferences.saveSettingsToFile = false;
   }
 
-  @AfterAll
-  protected static void cleanUpGlobalSettings() {
-    File file = new File("settings/GLOBAL_aliases.txt");
-    if (file.exists()) {
-      file.deleteOnExit();
-    }
-    file = new File("settings/GLOBAL_prefs.txt");
-    if (file.exists()) {
-      file.deleteOnExit();
-    }
-  }
-
   @Test
   void ResetClearsPrefs() {
     String propName = "aTestProp";

--- a/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
@@ -17,7 +17,7 @@ public class AscensionHistoryRequestTest extends RequestTestBase {
     KoLCharacter.reset("the Tristero");
     KoLCharacter.setUserId(177122);
   }
- 
+
   @Test
   public void checkUserName() {
     assertEquals("the Tristero", KoLCharacter.getUserName());

--- a/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
@@ -17,12 +17,7 @@ public class AscensionHistoryRequestTest extends RequestTestBase {
     KoLCharacter.reset("the Tristero");
     KoLCharacter.setUserId(177122);
   }
-  /*
-    @AfterAll
-    protected static void cleanUp() {
-      // exists to trigger hooked routine
-    }
-  */
+ 
   @Test
   public void checkUserName() {
     assertEquals("the Tristero", KoLCharacter.getUserName());

--- a/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
@@ -18,12 +18,12 @@ public class AscensionHistoryRequestTest extends RequestTestBase {
     KoLCharacter.reset("the Tristero");
     KoLCharacter.setUserId(177122);
   }
-
+/*
   @AfterAll
   protected static void cleanUp() {
     // exists to trigger hooked routine
   }
-
+*/
   @Test
   public void checkUserName() {
     assertEquals("the Tristero", KoLCharacter.getUserName());

--- a/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
@@ -7,7 +7,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.preferences.Preferences;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -18,12 +17,12 @@ public class AscensionHistoryRequestTest extends RequestTestBase {
     KoLCharacter.reset("the Tristero");
     KoLCharacter.setUserId(177122);
   }
-/*
-  @AfterAll
-  protected static void cleanUp() {
-    // exists to trigger hooked routine
-  }
-*/
+  /*
+    @AfterAll
+    protected static void cleanUp() {
+      // exists to trigger hooked routine
+    }
+  */
   @Test
   public void checkUserName() {
     assertEquals("the Tristero", KoLCharacter.getUserName());

--- a/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
@@ -21,7 +21,7 @@ public class AscensionHistoryRequestTest extends RequestTestBase {
 
   @AfterAll
   protected static void cleanUp() {
-    //exists to trigger hooked routine
+    // exists to trigger hooked routine
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
@@ -7,6 +7,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -18,8 +19,13 @@ public class AscensionHistoryRequestTest extends RequestTestBase {
     KoLCharacter.setUserId(177122);
   }
 
+  @AfterAll
+  protected static void cleanUp() {
+    //exists to trigger hooked routine
+  }
+
   @Test
-  public void checkUserName() throws IOException {
+  public void checkUserName() {
     assertEquals("the Tristero", KoLCharacter.getUserName());
   }
 

--- a/test/net/sourceforge/kolmafia/request/UseItemRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/UseItemRequestTest.java
@@ -11,9 +11,15 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 class UseItemRequestTest extends RequestTestBase {
+
+  @AfterAll
+  protected static void cleanUp() {
+    //exists to trigger hooked routine
+  }
 
   // We don't use @BeforeEach here because it's specific to milk-related tests.
   private void milkSetup() {

--- a/test/net/sourceforge/kolmafia/request/UseItemRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/UseItemRequestTest.java
@@ -18,7 +18,7 @@ class UseItemRequestTest extends RequestTestBase {
 
   @AfterAll
   protected static void cleanUp() {
-    //exists to trigger hooked routine
+    // exists to trigger hooked routine
   }
 
   // We don't use @BeforeEach here because it's specific to milk-related tests.

--- a/test/net/sourceforge/kolmafia/request/UseItemRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/UseItemRequestTest.java
@@ -11,7 +11,6 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 class UseItemRequestTest extends RequestTestBase {

--- a/test/net/sourceforge/kolmafia/request/UseItemRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/UseItemRequestTest.java
@@ -16,11 +16,6 @@ import org.junit.jupiter.api.Test;
 
 class UseItemRequestTest extends RequestTestBase {
 
-  @AfterAll
-  protected static void cleanUp() {
-    // exists to trigger hooked routine
-  }
-
   // We don't use @BeforeEach here because it's specific to milk-related tests.
   private void milkSetup() {
     // Simulate logging out and back in again.


### PR DESCRIPTION
Lint, typos and cleanup so root\settings remains empty after tests.  Cleanup should happen automatically but tests that create multiple preferences files may have to do additional work.  A human who wants to examine a preference file after a test is probably not going to be happy.  Draft status as I ponder these things.