### PR TITLE
ConsequenceManager raw types

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ConsequenceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ConsequenceManager.java
@@ -30,7 +30,7 @@ public abstract class ConsequenceManager {
   private static final HashMap<String, Consequence> itemDescs = new HashMap<String, Consequence>();
   private static final HashMap<String, Consequence> effectDescs =
       new HashMap<String, Consequence>();
-  private static final HashMap<String, Consequence> skillDescs = new HashMap<String, Consequence>();
+  private static final HashMap<Integer, Consequence> skillDescs = new HashMap<Integer, Consequence>();
   private static final ArrayList<String> descriptions = new ArrayList<String>();
   private static final HashMap<String, Consequence> monsters = new HashMap<String, Consequence>();
   private static final ArrayList<Consequence> accomplishments = new ArrayList<Consequence>();
@@ -181,8 +181,8 @@ public abstract class ConsequenceManager {
       return this.patt.matcher(text);
     }
 
-    public void register(Map map, Object key) {
-      this.next = (Consequence) map.get(key);
+    public <K> void register(Map<K, Consequence> map, K key) {
+      this.next = map.get(key);
       map.put(key, this);
     }
 

--- a/src/net/sourceforge/kolmafia/session/ConsequenceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ConsequenceManager.java
@@ -30,7 +30,8 @@ public abstract class ConsequenceManager {
   private static final HashMap<String, Consequence> itemDescs = new HashMap<String, Consequence>();
   private static final HashMap<String, Consequence> effectDescs =
       new HashMap<String, Consequence>();
-  private static final HashMap<Integer, Consequence> skillDescs = new HashMap<Integer, Consequence>();
+  private static final HashMap<Integer, Consequence> skillDescs =
+      new HashMap<Integer, Consequence>();
   private static final ArrayList<String> descriptions = new ArrayList<String>();
   private static final HashMap<String, Consequence> monsters = new HashMap<String, Consequence>();
   private static final ArrayList<Consequence> accomplishments = new ArrayList<Consequence>();


### PR DESCRIPTION
Not part of https://github.com/kolmafia/kolmafia/pull/150 because of how it changes ConsequenceManager.skillDescs's type (even though it's only the Generic).

Said type was advertised as HashMap<String, Consequence>, but was actually HashMap<Integer, Consequence>, unnoticed because of type erasure.