### PR TITLE
Extend what it means for a build to be "dirty".

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,22 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  tag:
-    if: github.repository == 'kolmafia/kolmafia'
-    name: Publish Artifacts
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Retrieve version and tag
-        run: |
-          KOLMAFIA_VERSION=$(git rev-list --count $GITHUB_SHA)
-          git tag "r$KOLMAFIA_VERSION"
   bin:
-    needs: [tag]
     if: github.repository == 'kolmafia/kolmafia'
     name: Build Binaries
     runs-on: ${{ matrix.os }}
@@ -59,7 +44,6 @@ jobs:
             build/releases/*.dmg
 
   jar:
-    needs: [tag]
     if: github.repository == 'kolmafia/kolmafia'
     name: Build Release
     runs-on: ubuntu-latest
@@ -102,9 +86,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Retrieve version
+      - name: Retrieve version and tag
         run: |
           KOLMAFIA_VERSION=$(git rev-list --count $GITHUB_SHA)
+          git tag "r$KOLMAFIA_VERSION"
           echo "KOLMAFIA_VERSION=$KOLMAFIA_VERSION" >> $GITHUB_ENV
 
       - name: Download binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,22 @@ on:
   workflow_dispatch:
 
 jobs:
+  tag:
+    if: github.repository == 'kolmafia/kolmafia'
+    name: Publish Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Retrieve version and tag
+        run: |
+          KOLMAFIA_VERSION=$(git rev-list --count $GITHUB_SHA)
+          git tag "r$KOLMAFIA_VERSION"
   bin:
+    needs: [tag]
     if: github.repository == 'kolmafia/kolmafia'
     name: Build Binaries
     runs-on: ${{ matrix.os }}
@@ -44,6 +59,7 @@ jobs:
             build/releases/*.dmg
 
   jar:
+    needs: [tag]
     if: github.repository == 'kolmafia/kolmafia'
     name: Build Release
     runs-on: ubuntu-latest
@@ -86,10 +102,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Retrieve version and tag
+      - name: Retrieve version
         run: |
           KOLMAFIA_VERSION=$(git rev-list --count $GITHUB_SHA)
-          git tag "r$KOLMAFIA_VERSION"
           echo "KOLMAFIA_VERSION=$KOLMAFIA_VERSION" >> $GITHUB_ENV
 
       - name: Download binaries

--- a/build.gradle
+++ b/build.gradle
@@ -326,7 +326,7 @@ shadowJar.dependsOn pruneDist
 jacocoTestReport.dependsOn test
 
 def isDirty() {
-	return versioning.info.dirty || localCommits(findProperty(findProperty('commit') ?: 'HEAD')) > 0
+	return versioning.info.dirty || localCommits(findProperty('commit') ?: 'HEAD') > 0
 }
 
 def localCommits(commit) {

--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ task pruneDist(type: Delete) {
 	doLast {
 		file('dist').eachFile(groovy.io.FileType.FILES) { File file ->
 			if (file.name.startsWith('KoLmafia-') && file.name.endsWith('.jar')) {
-				if (!file.name.contains(project.getVersion().toString()) || (versioning.info.dirty != file.name.endsWith('-M.jar'))) {
+				if (!file.name.contains(project.getVersion().toString()) || (isDirty() != file.name.endsWith('-M.jar'))) {
 					delete file
 				}
 			}
@@ -173,7 +173,7 @@ jar {
 				'Build-Revision'  : new Object() { String toString() { project.getVersion() } },
 				'Build-Branch'    : versioning.info.branchId,
 				'Build-Build'     : versioning.info.build,
-				'Build-Dirty'     : versioning.info.dirty,
+				'Build-Dirty'     : isDirty(),
 				'Build-Jdk'       : "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
 				'Build-OS'        : "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
 				)
@@ -185,13 +185,13 @@ jar {
 	duplicatesStrategy = 'exclude'
 	destinationDirectory = file('dist/')
 	archiveBaseName.set('KoLmafia')
-	archiveClassifier.set("${versioning.info.dirty ? 'M' : ''}")
+	archiveClassifier.set("${isDirty() ? 'M' : ''}")
 }
 
 shadowJar {
 	duplicatesStrategy = 'exclude'
 	destinationDirectory = file('dist/')
-	archiveClassifier.set("${versioning.info.dirty ? 'M' : ''}")
+	archiveClassifier.set("${isDirty() ? 'M' : ''}")
 }
 
 task getRevision() {
@@ -209,7 +209,7 @@ task getRevision() {
 		file('build/revision.txt').text = revision.toString().trim()
 		// Update the version to the new revision
 		project.setVersion(revision.toString().trim())
-		def revString = versioning.info.dirty ? project.getVersion() +'-M': project.getVersion()
+		def revString = isDirty() ? project.getVersion() +'-M': project.getVersion()
 		println '\nRevision: ' + revString
 
 	}
@@ -226,7 +226,7 @@ task gitUpdate() {
 			println 'Already up-to-date, nothing to do.'
 			return
 		}
-		def dirty = versioning.info.dirty
+		def dirty = isDirty()
 		if (dirty) {
 			// This pollutes the reflog, but there's no stash functionality in
 			// grgit...
@@ -287,7 +287,7 @@ tasks.jpackage {
 	doFirst {
 		mainJar = tasks.shadowJar.archiveFileName.get()
 		appVersion += '.' + version
-		appName = 'KoLmafia-r' + version + "${versioning.info.dirty ? 'M' : ''}"
+		appName = 'KoLmafia-r' + version + "${isDirty() ? 'M' : ''}"
 		println 'Packaging app ' + appName + '...'
 		if (System.properties['os.name'] != 'Linux') {
 			return
@@ -325,6 +325,10 @@ jar.dependsOn pruneDist
 shadowJar.dependsOn pruneDist
 
 jacocoTestReport.dependsOn test
+
+def isDirty() {
+	return versioning.info.dirty || versioning.info.tag != 'r' + lastRevision();
+}
 
 def lastRevision() {
 	def revisionFile = file('build/revision.txt')

--- a/build.gradle
+++ b/build.gradle
@@ -198,20 +198,19 @@ task getRevision() {
 	onlyIf {
 		file('.git').exists()
 	}
-	def commit = findProperty('commit') ?: 'origin/main'
+	def commit = findProperty('commit') ?: 'HEAD'
 	inputs.dir('.git')
 	inputs.property('commit', commit)
 	outputs.files file('build/revision.txt')
 
 	doLast {
-		def revision = grgit.log(includes:[commit]).size()
+		def revision = grgit.log(includes:[commit]).size() - localCommits(commit)
 		logger.info('Commit: {} Revision: {}', commit, revision)
 		file('build/revision.txt').text = revision.toString().trim()
 		// Update the version to the new revision
 		project.setVersion(revision.toString().trim())
 		def revString = isDirty() ? project.getVersion() +'-M': project.getVersion()
 		println '\nRevision: ' + revString
-
 	}
 }
 
@@ -327,7 +326,11 @@ shadowJar.dependsOn pruneDist
 jacocoTestReport.dependsOn test
 
 def isDirty() {
-	return versioning.info.dirty || versioning.info.tag != 'r' + lastRevision();
+	return versioning.info.dirty || localCommits(findProperty(findProperty('commit') ?: 'HEAD')) > 0
+}
+
+def localCommits(commit) {
+	return grgit.log(includes:[commit], excludes:['origin/main']).size()
 }
 
 def lastRevision() {


### PR DESCRIPTION
~In particular, consider it to be dirty if it's not tagged with the
corresponding revision.~ Consider a build to be dirty if it has
any changes not in origin/main. 

This should be more flexible than just checking the HEAD of
origin/main, since it'll continue to work if you build an old
revision.

~We also need to make sure that we're tagging revisions before building
jars / binaries for distribution, so they're not all marked as
"dirty".~

This PR also fixes revision detection for old builds, which previously just
used "whatever origin/main is at". Now we count the total number of
revisions, minus those that are not present upstream. (It would be nice if
grgit supported git merge-base, but this works well enough.)