### PR TITLE
Refactor AbstractCommand: avoid raw types

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
+++ b/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
@@ -497,7 +497,7 @@ public class KoLmafiaCLI {
     return this.elseRuns;
   }
 
-  static {
+  public static void registerCommands() {
     new AbortCommand().register("abort");
     new AbsorbCommand().register("absorb");
     new AccordionsCommand().register("accordions");
@@ -819,6 +819,10 @@ public class KoLmafiaCLI {
     new CommandAlias("skills", "passive").register("pass").register("passive");
     new CommandAlias("skills", "self").register("self");
     new CommandAlias("skills", "combat").register("combat");
+  }
+
+  static {
+    registerCommands();
   }
 
   public static void showHTML(final String text) {

--- a/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
+++ b/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
@@ -312,7 +312,7 @@ public class KoLmafiaCLI {
         lcommand = lcommand.substring(0, length - 1);
       }
 
-      AbstractCommand handler = (AbstractCommand) AbstractCommand.lookup.get(lcommand);
+      AbstractCommand handler = AbstractCommand.lookup.get(lcommand);
       int flags = handler == null ? 0 : handler.flags;
       if (flags == KoLmafiaCLI.FULL_LINE_CMD && !line.equals("")) {
         // parameters are un-trimmed original
@@ -371,7 +371,7 @@ public class KoLmafiaCLI {
         if (command.endsWith("?")) {
           command = command.substring(0, command.length() - 1);
         }
-        AbstractCommand handler = (AbstractCommand) AbstractCommand.lookup.get(command);
+        AbstractCommand handler = AbstractCommand.lookup.get(command);
         int flags = handler == null ? 0 : handler.flags;
         if (flags == KoLmafiaCLI.FULL_LINE_CMD) {
           break;
@@ -440,7 +440,7 @@ public class KoLmafiaCLI {
       lcommand = command = "refresh";
     }
 
-    AbstractCommand handler = (AbstractCommand) AbstractCommand.lookup.get(lcommand);
+    AbstractCommand handler = AbstractCommand.lookup.get(lcommand);
 
     if (handler == null) {
       handler = AbstractCommand.getSubstringMatch(lcommand);

--- a/src/net/sourceforge/kolmafia/textui/command/AbstractCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AbstractCommand.java
@@ -1,7 +1,8 @@
 package net.sourceforge.kolmafia.textui.command;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLmafiaCLI;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
@@ -102,8 +103,7 @@ public abstract class AbstractCommand {
   public AbstractCommand registerSubstring(String substring) {
     // For commands that are parsed as indexOf(...)!=-1.  Use sparingly!
     substring = substring.toLowerCase();
-    AbstractCommand.substringLookup.add(substring);
-    AbstractCommand.substringLookup.add(this);
+    AbstractCommand.substringLookup.put(substring, this);
 
     // Make it visible in the normal lookup map:
     AbstractCommand.lookup.putExact("*" + substring + "*", this);
@@ -114,14 +114,14 @@ public abstract class AbstractCommand {
   // Internal implementation thingies:
 
   public static final PrefixMap lookup = new PrefixMap();
-  public static final ArrayList substringLookup = new ArrayList();
+  public static final Map<String, AbstractCommand> substringLookup = new TreeMap<>();
   public static String fullLineCmds = "";
   public static String flowControlCmds = "";
 
   public static AbstractCommand getSubstringMatch(final String cmd) {
-    for (int i = 0; i < AbstractCommand.substringLookup.size(); i += 2) {
-      if (cmd.indexOf((String) AbstractCommand.substringLookup.get(i)) != -1) {
-        return (AbstractCommand) AbstractCommand.substringLookup.get(i + 1);
+    for (String key : AbstractCommand.substringLookup.keySet()) {
+      if (cmd.contains(key)) {
+        return AbstractCommand.substringLookup.get(key);
       }
     }
     return null;

--- a/src/net/sourceforge/kolmafia/textui/command/AbstractCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AbstractCommand.java
@@ -113,7 +113,7 @@ public abstract class AbstractCommand {
 
   // Internal implementation thingies:
 
-  public static final PrefixMap lookup = new PrefixMap();
+  public static final PrefixMap<AbstractCommand> lookup = new PrefixMap<>();
   public static final Map<String, AbstractCommand> substringLookup = new TreeMap<>();
   public static String fullLineCmds = "";
   public static String flowControlCmds = "";

--- a/src/net/sourceforge/kolmafia/textui/command/AbstractCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AbstractCommand.java
@@ -127,6 +127,11 @@ public abstract class AbstractCommand {
     return null;
   }
 
+  public static void clear() {
+    AbstractCommand.lookup.clear();
+    AbstractCommand.substringLookup.clear();
+  }
+
   private void registerFlags(final String name) {
     if (this.flags == KoLmafiaCLI.FULL_LINE_CMD) {
       AbstractCommand.fullLineCmds +=

--- a/src/net/sourceforge/kolmafia/textui/command/CliRefCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/CliRefCommand.java
@@ -74,15 +74,15 @@ public class CliRefCommand extends AbstractCommand {
     boolean anymatches = false;
     HashMap<String, String> alreadySeen =
         new HashMap<>(); // usage => name of cmd already printed out
-    Iterator<Map.Entry<String, Object>> i = AbstractCommand.lookup.entrySet().iterator();
+    Iterator<Map.Entry<String, AbstractCommand>> i = AbstractCommand.lookup.entrySet().iterator();
     while (i.hasNext()) {
-      Map.Entry<String, Object> e = i.next();
+      Map.Entry<String, AbstractCommand> e = i.next();
       String name = e.getKey();
       int type = AbstractCommand.lookup.getKeyType(name);
       if (type == PrefixMap.NOT_A_KEY) {
         continue;
       }
-      AbstractCommand handler = (AbstractCommand) e.getValue();
+      AbstractCommand handler = e.getValue();
       if (handler == null) // shouldn't happen
       {
         continue;

--- a/src/net/sourceforge/kolmafia/utilities/PrefixMap.java
+++ b/src/net/sourceforge/kolmafia/utilities/PrefixMap.java
@@ -118,7 +118,7 @@ public class PrefixMap<T> extends TreeMap<String, T> {
   // The following TreeMap methods cannot be used with PrefixMap:
   //
   // All constructors that specify a Comparator (normal string ordering is assumed).
-  // All comstructors that load initial values (which key type would they be?).
+  // All constructors that load initial values (which key type would they be?).
   // containsKey( Object key ) - harmless, but the result is meaningless.
   // put( Object key, Object value ) - must use putExact or putPrefix instead.
   // putAll( Map map ) - would need some way to indicate which type of keys to use

--- a/src/net/sourceforge/kolmafia/utilities/PrefixMap.java
+++ b/src/net/sourceforge/kolmafia/utilities/PrefixMap.java
@@ -42,7 +42,7 @@ be removed if no longer key that matches that prefix has been added to the
 map.
 */
 
-public class PrefixMap extends TreeMap<String, Object> {
+public class PrefixMap<T> extends TreeMap<String, T> {
   // Return values for getKeyType
   public static final int NOT_A_KEY = 0;
   public static final int EXACT_KEY = 1;
@@ -55,7 +55,7 @@ public class PrefixMap extends TreeMap<String, Object> {
     super();
   }
 
-  public Object get(String key) {
+  public T get(String key) {
     try {
       return super.get(super.headMap(key + EXACT_SUFFIX).lastKey());
     } catch (NoSuchElementException e) {
@@ -64,7 +64,7 @@ public class PrefixMap extends TreeMap<String, Object> {
   }
 
   // This returns the value that would be found if the key didn't exist.
-  private Object getBelow(String key) {
+  private T getBelow(String key) {
     try {
       return super.get(super.headMap(key).lastKey());
     } catch (NoSuchElementException e) {
@@ -72,20 +72,20 @@ public class PrefixMap extends TreeMap<String, Object> {
     }
   }
 
-  public void putExact(String key, Object value) {
+  public void putExact(String key, T value) {
     this.putRange(key, key + EXACT_SUFFIX, value);
   }
 
-  public void putPrefix(String key, Object value) {
+  public void putPrefix(String key, T value) {
     this.putRange(key, key + PREFIX_SUFFIX, value);
   }
 
-  private void putRange(String startKey, String endKey, Object value) {
+  private void putRange(String startKey, String endKey, T value) {
     super.put(startKey, value);
     super.put(endKey, this.getBelow(startKey));
   }
 
-  public Object remove(String key) {
+  public T remove(String key) {
     super.remove(key + EXACT_SUFFIX);
     super.remove(key + PREFIX_SUFFIX);
     return super.remove(key);

--- a/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
+++ b/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
@@ -2,7 +2,9 @@ package net.sourceforge.kolmafia.extensions;
 
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.KoLmafiaCLI;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.textui.command.AbstractCommand;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -19,6 +21,10 @@ public class ClearSharedState implements AfterAllCallback {
     KoLCharacter.setUserId(0);
     // If you explicitly want saveSettingsToFile to be true, then set it yourself.
     Preferences.saveSettingsToFile = false;
+
+    // re-register default commands
+    AbstractCommand.clear();
+    KoLmafiaCLI.registerCommands();
 
     KoLmafia.lastMessage = "";
     KoLmafia.forceContinue();

--- a/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTest.java
@@ -11,8 +11,7 @@ import org.junit.jupiter.api.Test;
 public class AbstractCommandTest {
   @BeforeEach
   public void initEach() {
-    AbstractCommand.lookup.clear();
-    AbstractCommand.substringLookup.clear();
+    AbstractCommand.clear();
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTest.java
@@ -1,35 +1,46 @@
 package net.sourceforge.kolmafia.textui.command;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
-import net.sourceforge.kolmafia.KoLmafiaCLI;
-import net.sourceforge.kolmafia.RequestLogger;
-import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.KoLmafia;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public abstract class AbstractCommandTest {
-  protected String command = "abort";
-
-  public String execute(final String params) {
-    var outputStream = new ByteArrayOutputStream();
-    RequestLogger.openCustom(new PrintStream(outputStream));
-    var cli = new KoLmafiaCLI(System.in);
-    cli.executeCommand(this.command, params);
-    RequestLogger.closeCustom();
-    return outputStream.toString();
+public class AbstractCommandTest {
+  @BeforeEach
+  public void initEach() {
+    AbstractCommand.lookup.clear();
+    AbstractCommand.substringLookup.clear();
   }
 
-  public static void assertState(final MafiaState state) {
-    assertEquals(state, StaticEntity.getContinuationState());
+  @Test
+  void unregisteredCommandIsNotFound() {
+    assertNull(AbstractCommand.lookup.get("fake"));
+    assertNull(AbstractCommand.getSubstringMatch("fake"));
   }
 
-  public static void assertContinueState() {
-    assertState(MafiaState.CONTINUE);
+  @Test
+  void registeredCommandIsFound() {
+    AbstractCommand command = new FakeCommand().register("fake");
+    assertEquals(command, AbstractCommand.lookup.get("fake"));
+    assertNull(AbstractCommand.getSubstringMatch("fake"));
   }
 
-  public static void assertErrorState() {
-    assertState(MafiaState.ERROR);
+  @Test
+  void registerSubstringFindsCommand() {
+    AbstractCommand command = new FakeCommand().registerSubstring("fake");
+    assertNull(AbstractCommand.lookup.get("fake"));
+    assertEquals(command, AbstractCommand.getSubstringMatch("fake"));
+    assertEquals(command, AbstractCommand.getSubstringMatch("morefake"));
+  }
+}
+
+class FakeCommand extends AbstractCommand {
+
+  @Override
+  public void run(String cmd, String parameters) {
+    KoLmafia.updateDisplay(MafiaState.CONTINUE, "Fake command was run");
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTestBase.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTestBase.java
@@ -1,0 +1,35 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import net.sourceforge.kolmafia.KoLConstants.MafiaState;
+import net.sourceforge.kolmafia.KoLmafiaCLI;
+import net.sourceforge.kolmafia.RequestLogger;
+import net.sourceforge.kolmafia.StaticEntity;
+
+public abstract class AbstractCommandTestBase {
+  protected String command = "abort";
+
+  public String execute(final String params) {
+    var outputStream = new ByteArrayOutputStream();
+    RequestLogger.openCustom(new PrintStream(outputStream));
+    var cli = new KoLmafiaCLI(System.in);
+    cli.executeCommand(this.command, params);
+    RequestLogger.closeCustom();
+    return outputStream.toString();
+  }
+
+  public static void assertState(final MafiaState state) {
+    assertEquals(state, StaticEntity.getContinuationState());
+  }
+
+  public static void assertContinueState() {
+    assertState(MafiaState.CONTINUE);
+  }
+
+  public static void assertErrorState() {
+    assertState(MafiaState.ERROR);
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTestBase.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTestBase.java
@@ -15,7 +15,6 @@ public abstract class AbstractCommandTestBase {
   public String execute(final String params) {
     var outputStream = new ByteArrayOutputStream();
     RequestLogger.openCustom(new PrintStream(outputStream));
-    KoLmafiaCLI.registerCommands();
     var cli = new KoLmafiaCLI(System.in);
     cli.executeCommand(this.command, params);
     RequestLogger.closeCustom();

--- a/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTestBase.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTestBase.java
@@ -15,6 +15,7 @@ public abstract class AbstractCommandTestBase {
   public String execute(final String params) {
     var outputStream = new ByteArrayOutputStream();
     RequestLogger.openCustom(new PrintStream(outputStream));
+    KoLmafiaCLI.registerCommands();
     var cli = new KoLmafiaCLI(System.in);
     cli.executeCommand(this.command, params);
     RequestLogger.closeCustom();

--- a/test/net/sourceforge/kolmafia/textui/command/SaberCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/SaberCommandTest.java
@@ -12,7 +12,7 @@ import net.sourceforge.kolmafia.request.GenericRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class SaberCommandTest extends AbstractCommandTest {
+public class SaberCommandTest extends AbstractCommandTestBase {
   @BeforeEach
   public void initEach() {
     KoLCharacter.reset("testUser");

--- a/test/net/sourceforge/kolmafia/textui/command/SnapperCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/SnapperCommandTest.java
@@ -11,7 +11,7 @@ import net.sourceforge.kolmafia.request.GenericRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class SnapperCommandTest extends AbstractCommandTest {
+public class SnapperCommandTest extends AbstractCommandTestBase {
   @BeforeEach
   public void initEach() {
     KoLCharacter.reset("testUser");

--- a/test/net/sourceforge/kolmafia/textui/command/SpoonCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/SpoonCommandTest.java
@@ -13,7 +13,7 @@ import net.sourceforge.kolmafia.request.GenericRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class SpoonCommandTest extends AbstractCommandTest {
+public class SpoonCommandTest extends AbstractCommandTestBase {
   @BeforeEach
   public void initEach() {
     KoLCharacter.reset("testUser");


### PR DESCRIPTION
`AbstractCommand` had two instances of imprecise types: one in `AbstractCommand.lookup`, where `Object` was used instead of `AbstractCommand`, and one in `AbstractCommand.substringLookup`, which was a `List` that alternated `String`s and `AbstractCommand`s.

The former was generified and `AbstractCommand` used. The latter was replaced by a `Map` of `String` to `AbstractCommand`: the Map has the additional restriction that no key can appear twice, but looking at the implementation that is desired anyway (in fact, an even stricter requirement is desired: no key can strictly contain another).

Tests have been added. I renamed the existing `AbstractCommandTest` because it was used as an abstract base class for the other tests, instead of a test for the `AbstractCommand` methods.