### PR TITLE
Fix hiccup

### DIFF
--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -3370,7 +3370,7 @@ public class RelayRequest extends PasswordHashRequest {
     String limitmode = KoLCharacter.getLimitmode();
 
     // If we are playing Spelunky, a specialized set of warnings are relevant
-    if (limitmode.equals(Limitmode.SPELUNKY)) {
+    if ((limitmode != null) && limitmode.equals(Limitmode.SPELUNKY)) {
       return this.sendSpelunkyWarning(adventure);
     }
 


### PR DESCRIPTION
Lint saw a comparison between what was declared as two strings and suggested it be replaced by .equals

I did so but it turns out the first string can be legitimately null.  Fixed that.