### PR TITLE
Revisit Security

### DIFF
--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -530,17 +530,14 @@ public class Preferences {
     }
   }
 
-  private static void loadUserPreferences(final String username) {
-    String lusername;
+  private static void loadUserPreferences(String username) {
     // Apparently the CodeQL security scan requires this as a fix...
     if ((username != null) && (username.contains(".."))) {
-      lusername = null;
-    } else {
-      lusername = username;
+      username = null;
     }
     File file =
         new File(
-            KoLConstants.SETTINGS_LOCATION, Preferences.baseUserName(lusername) + "_prefs.txt");
+            KoLConstants.SETTINGS_LOCATION, Preferences.baseUserName(username) + "_prefs.txt");
     Preferences.userPropertiesFile = file;
 
     Properties p = Preferences.loadPreferences(file);

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -536,8 +536,7 @@ public class Preferences {
       username = null;
     }
     File file =
-        new File(
-            KoLConstants.SETTINGS_LOCATION, Preferences.baseUserName(username) + "_prefs.txt");
+        new File(KoLConstants.SETTINGS_LOCATION, Preferences.baseUserName(username) + "_prefs.txt");
     Preferences.userPropertiesFile = file;
 
     Properties p = Preferences.loadPreferences(file);

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -531,12 +531,16 @@ public class Preferences {
   }
 
   private static void loadUserPreferences(final String username) {
+    String lusername;
     // Apparently the CodeQL security scan requires this as a fix...
     if ((username != null) && (username.contains(".."))) {
-      return;
+      lusername = null;
+    } else {
+      lusername = username;
     }
     File file =
-        new File(KoLConstants.SETTINGS_LOCATION, Preferences.baseUserName(username) + "_prefs.txt");
+        new File(
+            KoLConstants.SETTINGS_LOCATION, Preferences.baseUserName(lusername) + "_prefs.txt");
     Preferences.userPropertiesFile = file;
 
     Properties p = Preferences.loadPreferences(file);

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -551,10 +551,50 @@ class PreferencesTest {
   }
 
   @Test
-  public void exerciseReset() {
+  public void exerciseResetNull() {
+    // Allow files to be written
+    Preferences.saveSettingsToFile = true;
+    // Global preferences name
+    String globalName = "settings/" + "GLOBAL" + "_prefs.txt";
+    File globalfile = new File(globalName);
+    if (globalfile.exists()) {
+      globalfile.delete();
+    }
+    assertFalse(globalfile.exists());
+    // Reset should save global.
     Preferences.reset(null);
+    assertTrue(globalfile.exists());
+  }
+
+  @Test
+  public void exerciseResetEmpty() {
+    // Allow files to be written
+    Preferences.saveSettingsToFile = true;
+    // Global preferences name
+    String globalName = "settings/" + "GLOBAL" + "_prefs.txt";
+    File globalfile = new File(globalName);
+    if (globalfile.exists()) {
+      globalfile.delete();
+    }
+    assertFalse(globalfile.exists());
+    // Reset should save global.
     Preferences.reset("");
+    assertTrue(globalfile.exists());
+  }
+
+  @Test
+  public void exerciseResetDots() {
+    // Allow files to be written
+    Preferences.saveSettingsToFile = true;
+    // Global preferences name
+    String globalName = "settings/" + "GLOBAL" + "_prefs.txt";
+    File globalfile = new File(globalName);
+    if (globalfile.exists()) {
+      globalfile.delete();
+    }
+    assertFalse(globalfile.exists());
+    // Reset should save global.
     Preferences.reset("dot_is_....not_good");
-    assertTrue(true);
+    assertTrue(globalfile.exists());
   }
 }

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -522,12 +522,12 @@ class PreferencesTest {
   @Test
   public void actuallySaveFileToIncreaseCoverage() {
     Preferences.saveSettingsToFile = true;
-    Preferences.setString("tabby", "*\\t*");
+    Preferences.setString("tabby", "*\t*");
     Preferences.setString("removeMe", "please");
-    Preferences.setString("a", "\\n");
-    Preferences.setString("b", "\\f");
-    Preferences.setString("c", "\\r");
-    Preferences.setString("d", "\\\\");
+    Preferences.setString("a", "\n");
+    Preferences.setString("b", "\f");
+    Preferences.setString("c", "\r");
+    Preferences.setString("d", "\\");
     Preferences.setString("e", "=");
     Preferences.setString("f", ":");
     Preferences.setString("g", "#");
@@ -548,5 +548,13 @@ class PreferencesTest {
     value = "Bootsy";
     Preferences.setString(name, value);
     assertEquals(value, Preferences.getString(name, true));
+  }
+
+  @Test
+    public void exerciseReset() {
+      Preferences.reset(null);
+      Preferences.reset("");
+      Preferences.reset("dot_is_....not_good");
+      assertTrue(true);
   }
 }

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -551,10 +551,10 @@ class PreferencesTest {
   }
 
   @Test
-    public void exerciseReset() {
-      Preferences.reset(null);
-      Preferences.reset("");
-      Preferences.reset("dot_is_....not_good");
-      assertTrue(true);
+  public void exerciseReset() {
+    Preferences.reset(null);
+    Preferences.reset("");
+    Preferences.reset("dot_is_....not_good");
+    assertTrue(true);
   }
 }

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -30,7 +30,7 @@ class PreferencesTest {
     Preferences.saveSettingsToFile = false;
     AbstractCommand.clear();
     KoLmafiaCLI.registerCommands();
-    KoLmafia.lastMessage = "";
+    KoLmafia.lastMessage = " ";
     KoLmafia.forceContinue();
   }
 

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -2,25 +2,59 @@ package net.sourceforge.kolmafia.preferences;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.File;
 import java.util.TreeMap;
 import net.sourceforge.kolmafia.KoLCharacter;
-import org.junit.jupiter.api.*;
+import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.KoLmafiaCLI;
+import net.sourceforge.kolmafia.textui.command.AbstractCommand;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class PreferencesTest {
-
-  // Convert to the new way of doing things...
-  @BeforeAll
-  protected static void initAll() {
+  @BeforeEach
+  public void initializeCharPrefs() {
     KoLCharacter.reset("fakePrefUser");
     KoLCharacter.reset(true);
     Preferences.saveSettingsToFile = false;
   }
 
+  @AfterEach
+  public void removePrefs() {
+    deleteUserPrefsAndMoodsFiles(KoLCharacter.baseUserName());
+    deleteGlobals();
+    KoLCharacter.reset("");
+    KoLCharacter.reset(true);
+    KoLCharacter.setUserId(0);
+    Preferences.saveSettingsToFile = false;
+    AbstractCommand.clear();
+    KoLmafiaCLI.registerCommands();
+    KoLmafia.lastMessage = "";
+    KoLmafia.forceContinue();
+  }
+
+  public static void deleteUserPrefsAndMoodsFiles(String user) {
+    String begin = "settings/" + user;
+    File file = new File(begin + "_prefs.txt");
+    if (file.exists()) {
+      file.deleteOnExit();
+    }
+    file = new File(begin + "_moods.txt");
+    if (file.exists()) {
+      file.deleteOnExit();
+    }
+  }
+
+  public static void deleteGlobals() {
+    deleteUserPrefsAndMoodsFiles("GLOBAL");
+    File file = new File("settings/GLOBAL_aliases.txt");
+    if (file.exists()) {
+      file.deleteOnExit();
+    }
+  }
+
   @Test
-  // This test fails when another test sets Preferences.saveSettingsToFile = true;
-  // The comment about restoring from disk is concerning since there is nothing
-  // to restore from (AFAIK) when the setting is false;  But if the other test
-  // restores the value to false, this test passes.
   void ResetClearsPrefs() {
     String propName = "aTestProp";
     Preferences.setBoolean(propName, true);
@@ -516,6 +550,3 @@ class PreferencesTest {
     assertEquals(value, Preferences.getString(name, true));
   }
 }
-
-// Generated with love by TestMe :) Please report issues and submit feature requests at:
-// http://weirddev.com/forum#!/testme


### PR DESCRIPTION
Previous attempt to make security scanner happy didn't.  Try this.

New Preferences tests kept breaking old ones.  Decided to move the setup and cleanup into Before/After Each instead of All.  Seems to work much better.  Might be willing and able to deprecate ClearSharedState but for the moment just duplicated code from there instead.

 