### PR TITLE
Add missing zap groups

### DIFF
--- a/src/data/zapgroups.txt
+++ b/src/data/zapgroups.txt
@@ -17,7 +17,9 @@ asparagus lo mein, Knob lo mein, Knoll lo mein, olive lo mein, spooky lo mein
 cold hi mein, hot hi mein, sleazy hi mein, spooky hi mein, stinky hi mein
 cool mushroom casserole, cream of pointy mushroom soup, spicy mushroom quesadilla
 goat cheese pizza, mushroom pizza, sausage pizza
-fettucini Inconnu, gnocchetti di Nietzsche, Hell ramen, spaghetti with Skullheads
+devil hair pasta, Hell ramen, spagecialetti
+fettucini Inconnu, linguini immondizia bianco, shells a la shellfish
+gnocchetti di Nietzsche, spaghetti with Skullheads
 asparagus stir-fry, Knob stir-fry, Knoll stir-fry, olive stir-fry, spooky stir-fry
 bat wing stir-fry, Knob sausage stir-fry, pr0n stir-fry, rat appendix stir-fry, tofu stir-fry
 long pork, displaced fish, Filet of tangy gnat ("fotelif")

--- a/src/data/zapgroups.txt
+++ b/src/data/zapgroups.txt
@@ -196,7 +196,6 @@ miming beret, miming boots, miming corduroys, miming gloves, miming shirt
 Fettris, fusillocybin, prescription noodles
 libertagliatelle, linguini of the sea, turkish mostaccioli
 veiny spore pod, hard spore pod, glowing spore pod, hot spore pod, cool spore pod, jingling spore pod
-fettucini Inconnu, linguini immondizia bianco, shells a la shellfish
 fusilli marrownarrow, ghuol guolash, suggestive strozzapreti
 agnolotti arboli, crudles, spaghetti with ghost balls
 Brogre bucket hat, Brogre brolo shirt, Brogre brorts

--- a/src/data/zapgroups.txt
+++ b/src/data/zapgroups.txt
@@ -183,3 +183,34 @@ spearfish fishing spear, waders, lucky rabbitfish fin
 cursed tricorn hat, cursed pirate cutlass, cursed swash buckle
 Guzzlr hat, Guzzlr shoes, Guzzlr pants
 brilliant oyster egg, gleaming oyster egg, glistening oyster egg, lustrous oyster egg, magnificent oyster egg, pearlescent oyster egg, scintillating oyster egg
+waterlogged cloth, waterlogged leather, waterlogged metal, waterlogged stuffing, waterlogged wood
+meteorite earring, meteorite necklace, meteorite ring
+Egnaro berry, Glum berry, Jamocha berry, Keese berry, Nadsat berry, Sitrep berry, Snarf berry, Tapioc berry
+Mysterious Blue Box, Mysterious Green Box, Mysterious Red Box
+eaves droppers, heart cozy, Lolsipop, personal graffiti kit
+tonic o' Banderas, Bettie page, Fabiotion, heather graham cracker
+Swedish massage fish, heart-shaped candy whetstone, Bustle Hustler, Third Base
+miming beret, miming boots, miming corduroys, miming gloves, miming shirt
+Fettris, fusillocybin, prescription noodles
+libertagliatelle, linguini of the sea, turkish mostaccioli
+veiny spore pod, hard spore pod, glowing spore pod, hot spore pod, cool spore pod, jingling spore pod
+fettucini Inconnu, linguini immondizia bianco, shells a la shellfish
+fusilli marrownarrow, ghuol guolash, suggestive strozzapreti
+agnolotti arboli, crudles, spaghetti with ghost balls
+Brogre bucket hat, Brogre brolo shirt, Brogre brorts
+Gene Tonic: Beast, Gene Tonic: Constellation, Gene Tonic: Construct, Gene Tonic: Demon, Gene Tonic: Dude, Gene Tonic: Elemental, Gene Tonic: Elf, Gene Tonic: Fish, Gene Tonic: Goblin, Gene Tonic: Hippy, Gene Tonic: Hobo, Gene Tonic: Horror, Gene Tonic: Humanoid, Gene Tonic: Insect, Gene Tonic: Mer-kin, Gene Tonic: Orc, Gene Tonic: Penguin, Gene Tonic: Pirate, Gene Tonic: Plant, Gene Tonic: Slime, Gene Tonic: Undead, Gene Tonic: Weird
+tiny die-cast Rudolphus of Crimborg, tiny die-cast Father Crimborg, tiny die-cast Don Crimbo, tiny die-cast Uncle Hobo, tiny die-cast Father Crimbo
+bag of W&Ws, box of Dweebs, Milk Studs, PEEZ dispenser, Swizzler
+folder (cyan), folder (magenta), folder (yellow)
+folder (blue), folder (green), folder (red)
+Dreadsylvanian hot toddy, Dreadsylvanian grimlet, Dreadsylvanian cold-fashioned, Dreadsylvanian dank and stormy, Dreadsylvanian slithery nipple
+Dreadsylvanian hot pocket, Dreadsylvanian spooky pocket, Dreadsylvanian cold pocket, Dreadsylvanian sleaze pocket, Dreadsylvanian stink pocket
+Taco Dan's Taco Stand Taco, Taco Dan's Taco Stand Chillacious Churro, Taco Dan's Taco Stand Chimichangarita
+tiny plastic mumblebee, tiny plastic moneybee, tiny plastic beebee gunners, tiny plastic beebee queue, tiny plastic buzzerker, tiny plastic bee swarm, tiny plastic batbugbear, tiny plastic bugaboo, tiny plastic Ancient Unspeakable Bugbear, tiny plastic black ops bugbear, tiny plastic hypodermic bugbear, tiny plastic cavebugbear, tiny plastic Norville Rogers, tiny plastic Scott the Miner, tiny plastic angry space marine, tiny plastic Charity the Zombie Hunter, tiny plastic Father McGruber, tiny plastic Hank North, Photojournalist, tiny plastic blazing bat
+tiny plastic Beebee King, tiny plastic Queen Bee, tiny plastic Wu Tang the Betrayer, tiny plastic Clancy the Minstrel, tiny plastic Battlesuit Bugbear Type, tiny plastic spiderbugbear, tiny plastic peacannon, tiny plastic the Free Man, tiny plastic fire servant
+tiny plastic Bugbear Captain, tiny plastic Rene C. Corman, tiny plastic Lord Flameface
+crappy brain, decent brain, good brain
+fancy tophat, fancy tuxedo pants, fancy black tie
+bow staff, bowlegged pants, bowler
+bätzle, menudo ravioli, ratini
+boring spaghetti, Knob stroganoff, Knob stuffed shells


### PR DESCRIPTION
Wiki suggests "devil hair pasta, Hell ramen, spagecialetti" yet this is already somewhat defined. Not sure who is accurate.

This list is compiled from individual wiki pages, the zapping page on wiki still needs updating.