### PR TITLE
Allow known shorthand for the skill/cast command

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/command/UseSkillCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/UseSkillCommand.java
@@ -26,6 +26,24 @@ public class UseSkillCommand extends AbstractCommand {
     ShowDataCommand.show("skills" + (command.equals("cast") ? " cast" : ""));
   }
 
+  /**
+   * For some very commonly used skills, we can safely expand certain shorthand forms for better
+   * ease of use. For example "cast ode" is safely expanded to "cast the ode to booze" rather than
+   * failing because it clashes the "CHEAT CODE: " skills.
+   *
+   * @param skillNameString Skill name provided as a parameter
+   * @return An expanded skill name if the parameter is a recognized shorthand, else the original
+   *     parameter
+   */
+  private static String expandRecognizedShorthand(final String skillNameString) {
+    switch (skillNameString) {
+      case "ode":
+        return "The Ode to Booze";
+    }
+
+    return skillNameString;
+  }
+
   private static void cast(final String parameters) {
     UseSkillCommand.cast(parameters, false);
   }
@@ -46,7 +64,8 @@ public class UseSkillCommand extends AbstractCommand {
       String buffCountString = buffParameters[0];
       String skillNameString = buffParameters[1];
 
-      String skillName = SkillDatabase.getUsableKnownSkillName(skillNameString);
+      String skillName =
+          SkillDatabase.getUsableKnownSkillName(expandRecognizedShorthand(skillNameString));
       if (skillName == null) {
         if (sim) {
           return false;

--- a/test/net/sourceforge/kolmafia/textui/command/UseSkillCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/UseSkillCommandTest.java
@@ -1,0 +1,54 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import net.sourceforge.kolmafia.AdventureResult;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.objectpool.SkillPool;
+import net.sourceforge.kolmafia.request.GenericRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class UseSkillCommandTest extends AbstractCommandTestBase {
+  @BeforeEach
+  public void initEach() {
+    KoLCharacter.reset("testUser");
+    KoLCharacter.reset(true);
+
+    // Stop requests from actually running
+    GenericRequest.sessionId = null;
+  }
+
+  public UseSkillCommandTest() {
+    this.command = "cast";
+  }
+
+  @Test
+  void expandsKnownShorthand() {
+    KoLCharacter.addAvailableSkill(SkillPool.ODE_TO_BOOZE);
+    KoLCharacter.addAvailableSkill("CHEAT CODE: Invisible Avatar");
+    KoLCharacter.addAvailableSkill("CHEAT CODE: Triple Size");
+    AdventureResult.addResultToList(
+        KoLConstants.inventory, ItemPool.get(ItemPool.ANTIQUE_ACCORDION));
+    KoLCharacter.setMP(100, 100, 100);
+
+    String output = execute("ode");
+
+    assertContinueState();
+    assertThat(output, containsString("Casting The Ode to Booze"));
+  }
+
+  @Test
+  void doesNotExpandUnknownShorthand() {
+    KoLCharacter.addAvailableSkill(SkillPool.ODE_TO_BOOZE);
+    KoLCharacter.addAvailableSkill("CHEAT CODE: Invisible Avatar");
+    KoLCharacter.addAvailableSkill("CHEAT CODE: Triple Size");
+    String output = execute("od");
+
+    assertErrorState();
+    assertThat(output, containsString("Possible matches:"));
+  }
+}


### PR DESCRIPTION
This changes the behaviour of the `skill` or `cast` command to recognise a set of well-defined shorthands and avoid asking the user for clarification. Before the powerful glove, `cast ode` was sufficient a command to get Ode to Booze. Since then, such a command would ask for more specifics as "ode" is a substring of "CHEAT CODE".

In the case of `cast ode` (and only in that case, not `cast de`, `cast od`  or indeed `cast booze` etc) this PR will now expand to `cast The Ode To Booze`. It also sets out a framework through which we could add other known shorthands in the future, as well as adding tests.