### PR TITLE
cli: add ability to autoconfirm sending spading data

### DIFF
--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -216,8 +216,9 @@ public class LoginManager {
     if (Preferences.getString("spadingData").length() > 10) {
       KoLmafia.updateDisplay(
           "Some data has been collected that may be of interest to others. "
-              + "Please type `spade' to examine and submit or delete this data. If you have a lot, "
-              + "typing `spade autoconfirm' will send all of it without prompting you for each bit.");
+              + "Please type `spade' to examine and optionally submit the data or `spade autoconfirm'"
+              + " to submit all of the spaded data. Either way the data will be deleted whether shared"
+              + " or not.");
     }
 
     // Rebuild Scripts menu if needed

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -215,8 +215,9 @@ public class LoginManager {
 
     if (Preferences.getString("spadingData").length() > 10) {
       KoLmafia.updateDisplay(
-          "Some data has been collected that may be of interest "
-              + "to others.  Please type `spade' to examine and submit or delete this data.");
+          "Some data has been collected that may be of interest to others. "
+              + "Please type `spade' to examine and submit or delete this data. If you have a lot, "
+              + "typing `spade autoconfirm' will send all of it without prompting you for each bit.");
     }
 
     // Rebuild Scripts menu if needed

--- a/src/net/sourceforge/kolmafia/textui/command/SubmitSpadeDataCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/SubmitSpadeDataCommand.java
@@ -9,7 +9,7 @@ import net.sourceforge.kolmafia.utilities.InputFieldUtilities;
 
 public class SubmitSpadeDataCommand extends AbstractCommand {
   public SubmitSpadeDataCommand() {
-    this.usage = " [prices <URL>] - submit automatically gathered data.";
+    this.usage = " [autoconfirm | prices <URL>] - submit automatically gathered data.";
   }
 
   @Override
@@ -18,6 +18,8 @@ public class SubmitSpadeDataCommand extends AbstractCommand {
       MallPriceDatabase.submitPrices(parameters.substring(6).trim());
       return;
     }
+
+    boolean autoconfirm = parameters.startsWith("autoconfirm");
 
     String[] data = Preferences.getString("spadingData").split("\\|");
     if (data.length < 3) {
@@ -29,13 +31,14 @@ public class SubmitSpadeDataCommand extends AbstractCommand {
       String contents = data[i];
       String recipient = data[i + 1];
       String explanation = data[i + 2];
-      if (InputFieldUtilities.confirm(
-          "Would you like to send the data \""
-              + contents
-              + "\" to "
-              + recipient
-              + "?\nThis information will be used "
-              + explanation)) {
+      if (autoconfirm
+          || InputFieldUtilities.confirm(
+              "Would you like to send the data \""
+                  + contents
+                  + "\" to "
+                  + recipient
+                  + "?\nThis information will be used "
+                  + explanation)) {
         RequestThread.postRequest(new SendMailRequest(recipient, contents));
       }
     }


### PR DESCRIPTION
If you have a lot of spading data, confirming each time is a bit annoying. This adds a command to confirm everything pre-emptively.