### PR TITLE
Updating references to Ed the Undying to fix my_class()

### DIFF
--- a/src/net/sourceforge/kolmafia/AscensionClass.java
+++ b/src/net/sourceforge/kolmafia/AscensionClass.java
@@ -44,7 +44,7 @@ public enum AscensionClass {
 
   public static AscensionClass nameToClass(String name) {
     for (AscensionClass ascensionClass : AscensionClass.values()) {
-      if (name.equalsIgnoreCase(ascensionClass.getName())) {
+      if (ascensionClass.getName().toLowerCase().contains(name.toLowerCase())) {
         return ascensionClass;
       }
     }

--- a/src/net/sourceforge/kolmafia/AscensionClass.java
+++ b/src/net/sourceforge/kolmafia/AscensionClass.java
@@ -19,7 +19,7 @@ public enum AscensionClass {
   ZOMBIE_MASTER("Zombie Master", 12, "tombstone", 0, "Corpse Pile"),
   AVATAR_OF_JARLSBERG("Avatar of Jarlsberg", 14, "path12icon", 1, "Blend"),
   AVATAR_OF_SNEAKY_PETE("Avatar of Sneaky Pete", 15, "bigglasses", 2, "Snap Fingers"),
-  ED("Ed", 17, "thoth", 1, "Curse of Indecision"),
+  ED("Ed the Undying", 17, "thoth", 1, "Curse of Indecision"),
   COWPUNCHER("Cow Puncher", 18, "darkcow", 0),
   BEANSLINGER("Beanslinger", 19, "beancan", 1),
   SNAKE_OILER("Snake Oiler", 20, "tinysnake", 2),

--- a/src/net/sourceforge/kolmafia/AscensionClass.java
+++ b/src/net/sourceforge/kolmafia/AscensionClass.java
@@ -43,6 +43,10 @@ public enum AscensionClass {
   private final String stun;
 
   public static AscensionClass nameToClass(String name) {
+    if (name.equals("")) {
+      return null;
+    }
+
     for (AscensionClass ascensionClass : AscensionClass.values()) {
       if (ascensionClass.getName().toLowerCase().contains(name.toLowerCase())) {
         return ascensionClass;

--- a/src/net/sourceforge/kolmafia/persistence/SkillDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/SkillDatabase.java
@@ -52,7 +52,7 @@ public class SkillDatabase {
   private static final String AVATAR_OF_JARLSBERG = "Avatar of Jarlsberg";
   private static final String AVATAR_OF_SNEAKY_PETE = "Avatar of Sneaky Pete";
   private static final String HEAVY_RAINS = "Heavy Rains";
-  private static final String ED = "Ed";
+  private static final String ED = "Ed the Undying";
   private static final String COWPUNCHER = "Cow Puncher";
   private static final String BEANSLINGER = "Beanslinger";
   private static final String SNAKE_OILER = "Snake Oiler";

--- a/src/net/sourceforge/kolmafia/request/AfterLifeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AfterLifeRequest.java
@@ -356,7 +356,7 @@ public class AfterLifeRequest extends GenericRequest {
           builder.append("Avatar of Sneaky Pete");
           break;
         case 17:
-          builder.append("Ed");
+          builder.append("Ed the Undying");
           break;
         case 18:
           builder.append("Cow Puncher");

--- a/test/root/expected/test_class.ash.out
+++ b/test/root/expected/test_class.ash.out
@@ -1,2 +1,4 @@
+Changing "Ed" to "Ed the Undying" would get rid of this message. (test_class.ash, line 6)
 comparison true
 primestat true
+true

--- a/test/root/scripts/test_class.ash
+++ b/test/root/scripts/test_class.ash
@@ -3,3 +3,4 @@ ok = ($class[Avatar of Sneaky Pete] == $class[Avatar of Sneaky Pete]);
 print("comparison " + to_string(ok));
 ok = ($class[Gelatinous Noob].primestat == $stat[Moxie]);
 print("primestat " + to_string(ok));
+print($class[Ed] == $class[Ed the Undying]);


### PR DESCRIPTION
This is a partial fix for https://kolmafia.us/threads/my_class-returning-void-for-actually-ed-the-undying.26728/

It now returns:
```
> ash my_class()

Returned: Ed the Undying
primestat => Mysticality
```

This still would break compatibility for all other scripts that still refer to the path as Ed. I'm not sure how to alias it or anything otherwise.