### PR TITLE
Language Server - No longer need Stream<Arguments>

### DIFF
--- a/test/net/sourceforge/kolmafia/textui/ParserTest.java
+++ b/test/net/sourceforge/kolmafia/textui/ParserTest.java
@@ -35,7 +35,7 @@ public class ParserTest {
     StaticEntity.overrideRevision(null);
   }
 
-  public static Stream<Arguments> data() {
+  public static Stream<ScriptData> data() {
     /**
      * @return A list containing arrays with the following spec: String description String errorText
      *     A substring of the expected error message. List<String> tokens that are expected for a

--- a/test/net/sourceforge/kolmafia/textui/ScriptData.java
+++ b/test/net/sourceforge/kolmafia/textui/ScriptData.java
@@ -3,7 +3,6 @@ package net.sourceforge.kolmafia.textui;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import org.junit.jupiter.params.provider.Arguments;
 
 public abstract class ScriptData {
   /**
@@ -13,17 +12,17 @@ public abstract class ScriptData {
    * <p>Positions are serialized as {@code "L-C"} where L is the starting line, C is the starting
    * character, and both are 1-indexed.
    */
-  public static Arguments valid(
+  public static ScriptData valid(
       final String desc,
       final String script,
       final List<String> tokens,
       final List<String> positions) {
-    return Arguments.of(new ValidScriptData(desc, script, tokens, positions));
+    return new ValidScriptData(desc, script, tokens, positions);
   }
 
   /** Shortcut method for the creation of an invalid script failing with the given error message. */
-  public static Arguments invalid(final String desc, final String script, final String errorText) {
-    return Arguments.of(new InvalidScriptData(desc, script, errorText));
+  public static ScriptData invalid(final String desc, final String script, final String errorText) {
+    return new InvalidScriptData(desc, script, errorText);
   }
 
   public final String desc;


### PR DESCRIPTION
Arguments is no longer needed for ParserTest.data() since there is a single, consistent class for each element.