### PR TITLE
ClearSharedState

### DIFF
--- a/test/net/sourceforge/kolmafia/CustomScriptTest.java
+++ b/test/net/sourceforge/kolmafia/CustomScriptTest.java
@@ -33,7 +33,7 @@ public class CustomScriptTest {
   }
 
   private static Stream<Arguments> data() {
-    return Arrays.asList(KoLConstants.SCRIPT_LOCATION.list(new ScriptNameFilter())).stream()
+    return Arrays.stream(KoLConstants.SCRIPT_LOCATION.list(new ScriptNameFilter()))
         .map(Arguments::of);
   }
 

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -4,15 +4,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.sourceforge.kolmafia.KoLConstants.ZodiacType;
 import net.sourceforge.kolmafia.KoLConstants.ZodiacZone;
-import net.sourceforge.kolmafia.extensions.ClearSharedState;
 import net.sourceforge.kolmafia.preferences.Preferences;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class KoLCharacterTest {
 
   @Test
   public void rejectsUsernameWithTwoPeriods() {
+    KoLCharacter.reset("");
+    KoLCharacter.reset(true);
+    KoLCharacter.setUserId(0);
     KoLCharacter.reset("test..name");
     // Unset value.
     assertEquals("", KoLCharacter.getUserName());
@@ -20,12 +21,18 @@ public class KoLCharacterTest {
 
   @Test
   public void rejectsUsernameWithForwardSlash() {
+    KoLCharacter.reset("");
+    KoLCharacter.reset(true);
+    KoLCharacter.setUserId(0);
     KoLCharacter.reset("test/name");
     assertEquals("", KoLCharacter.getUserName());
   }
 
   @Test
   public void rejectsUsernameWithBackslash() {
+    KoLCharacter.reset("");
+    KoLCharacter.reset(true);
+    KoLCharacter.setUserId(0);
     KoLCharacter.reset("test\\name");
     assertEquals("", KoLCharacter.getUserName());
   }
@@ -67,10 +74,5 @@ public class KoLCharacterTest {
     assertEquals(0, KoLCharacter.getSignIndex());
     assertEquals(ZodiacType.NONE, KoLCharacter.getSignStat());
     assertEquals(ZodiacZone.NONE, KoLCharacter.getSignZone());
-  }
-
-  @AfterEach
-  void resetUsername() {
-    KoLCharacter.reset("");
   }
 }

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -1,10 +1,10 @@
 package net.sourceforge.kolmafia;
 
-import static net.sourceforge.kolmafia.extensions.ClearSharedState.deleteUserPrefsAndMoodsFiles;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.sourceforge.kolmafia.KoLConstants.ZodiacType;
 import net.sourceforge.kolmafia.KoLConstants.ZodiacZone;
+import net.sourceforge.kolmafia.extensions.ClearSharedState;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -71,7 +71,6 @@ public class KoLCharacterTest {
 
   @AfterEach
   void resetUsername() {
-    deleteUserPrefsAndMoodsFiles(KoLCharacter.baseUserName());
     KoLCharacter.reset("");
   }
 }

--- a/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
+++ b/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
@@ -8,11 +8,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLConstants;
-import net.sourceforge.kolmafia.KoLmafia;
-import net.sourceforge.kolmafia.KoLmafiaCLI;
+
+import net.sourceforge.kolmafia.*;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.textui.command.AbstractCommand;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -42,6 +41,8 @@ public class ClearSharedState implements AfterAllCallback {
     KoLmafiaCLI.registerCommands();
     KoLmafia.lastMessage = KoLmafia.NO_MESSAGE;
     KoLmafia.forceContinue();
+    StaticEntity.overrideRevision(null);
+    GenericRequest.sessionId = null;
   }
 
   public void deleteDirectoriesAndContents() {

--- a/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
+++ b/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-
 import net.sourceforge.kolmafia.*;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.GenericRequest;
@@ -47,10 +46,11 @@ public class ClearSharedState implements AfterAllCallback {
 
   public void deleteDirectoriesAndContents() {
     // These are the directories and files in test\root that are under git control.  Everything
-    // else is fair game for deletion after testing.  Keep relay as well.
+    // else is fair game for deletion after testing.  Keep relay as well since at least one test
+    // assumes relay had content created when mafia starts up.
     String[] keepersArray = {"ccs", "data", "expected", "request", "relay", "scripts", "README"};
     List<String> keepersList = new ArrayList<>(Arrays.asList(keepersArray));
-    // Get list of things in test\root and iterate
+    // Get list of things in test\root and iterate, deleting as appropriate
     File root = KoLConstants.ROOT_LOCATION;
     String[] contents = root.list();
     for (String content : contents) {

--- a/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
+++ b/test/net/sourceforge/kolmafia/extensions/ClearSharedState.java
@@ -1,7 +1,15 @@
 package net.sourceforge.kolmafia.extensions;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.KoLmafiaCLI;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -15,18 +23,20 @@ public class ClearSharedState implements AfterAllCallback {
 
   @Override
   public void afterAll(ExtensionContext context) {
-    // Clean up user files
-    deleteUserPrefsAndMoodsFiles(KoLCharacter.baseUserName());
-    // and GLOBALS
-    deleteGlobals();
-    // Among other things, this sets KoLCharacter.username.
+    restoreUserStateToNoUser();
+    restoreOtherStates();
+    deleteDirectoriesAndContents();
+  }
+
+  public void restoreUserStateToNoUser() {
     KoLCharacter.reset("");
     // But, if username is already "", then it doesn't do the bulk of resetting state.
     KoLCharacter.reset(true);
     KoLCharacter.setUserId(0);
-    // If you explicitly want saveSettingsToFile to be true, then set it yourself.
-    Preferences.saveSettingsToFile = false;
+  }
 
+  public void restoreOtherStates() {
+    Preferences.saveSettingsToFile = false;
     // re-register default commands
     AbstractCommand.clear();
     KoLmafiaCLI.registerCommands();
@@ -34,23 +44,26 @@ public class ClearSharedState implements AfterAllCallback {
     KoLmafia.forceContinue();
   }
 
-  public static void deleteUserPrefsAndMoodsFiles(String user) {
-    String begin = "settings/" + user;
-    File file = new File(begin + "_prefs.txt");
-    if (file.exists()) {
-      file.deleteOnExit();
-    }
-    file = new File(begin + "_moods.txt");
-    if (file.exists()) {
-      file.deleteOnExit();
-    }
-  }
-
-  public static void deleteGlobals() {
-    deleteUserPrefsAndMoodsFiles("GLOBAL");
-    File file = new File("settings/GLOBAL_aliases.txt");
-    if (file.exists()) {
-      file.deleteOnExit();
+  public void deleteDirectoriesAndContents() {
+    // These are the directories and files in test\root that are under git control.  Everything
+    // else is fair game for deletion after testing.  Keep relay as well.
+    String[] keepersArray = {"ccs", "data", "expected", "request", "relay", "scripts", "README"};
+    List<String> keepersList = new ArrayList<>(Arrays.asList(keepersArray));
+    // Get list of things in test\root and iterate
+    File root = KoLConstants.ROOT_LOCATION;
+    String[] contents = root.list();
+    for (String content : contents) {
+      if (!keepersList.contains(content)) {
+        Path pathToBeDeleted = new File(root, content).toPath();
+        try {
+          Files.walk(pathToBeDeleted)
+              .sorted(Comparator.reverseOrder())
+              .map(Path::toFile)
+              .forEach(File::delete);
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
+      }
     }
   }
 }

--- a/test/net/sourceforge/kolmafia/objectpool/ConcoctionTest.java
+++ b/test/net/sourceforge/kolmafia/objectpool/ConcoctionTest.java
@@ -21,7 +21,7 @@ public class ConcoctionTest {
   @Test
   public void itShouldSortUsables() {
     LockableListModel<Concoction> usableList = ConcoctionDatabase.getUsables();
-    int thing = usableList.getSize();
+    int thing = usableList.size();
     usableList.sort();
     assertEquals(usableList.size(), thing);
   }

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -5,9 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.File;
 import java.util.TreeMap;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLmafia;
-import net.sourceforge.kolmafia.KoLmafiaCLI;
-import net.sourceforge.kolmafia.textui.command.AbstractCommand;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,37 +18,11 @@ class PreferencesTest {
   }
 
   @AfterEach
-  public void removePrefs() {
-    deleteUserPrefsAndMoodsFiles(KoLCharacter.baseUserName());
-    deleteGlobals();
+  public void resetCharAndPrefs() {
     KoLCharacter.reset("");
     KoLCharacter.reset(true);
     KoLCharacter.setUserId(0);
     Preferences.saveSettingsToFile = false;
-    AbstractCommand.clear();
-    KoLmafiaCLI.registerCommands();
-    KoLmafia.lastMessage = KoLmafia.NO_MESSAGE;
-    KoLmafia.forceContinue();
-  }
-
-  public static void deleteUserPrefsAndMoodsFiles(String user) {
-    String begin = "settings/" + user;
-    File file = new File(begin + "_prefs.txt");
-    if (file.exists()) {
-      file.deleteOnExit();
-    }
-    file = new File(begin + "_moods.txt");
-    if (file.exists()) {
-      file.deleteOnExit();
-    }
-  }
-
-  public static void deleteGlobals() {
-    deleteUserPrefsAndMoodsFiles("GLOBAL");
-    File file = new File("settings/GLOBAL_aliases.txt");
-    if (file.exists()) {
-      file.deleteOnExit();
-    }
   }
 
   @Test
@@ -596,6 +567,5 @@ class PreferencesTest {
     // Reset should save global.
     Preferences.reset("dot_is_....not_good");
     assertTrue(globalfile.exists());
-    deleteUserPrefsAndMoodsFiles("dot_is_....not_good");
   }
 }

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class PreferencesTest {
+
+  // These need to be before and after each because leakage has been observed between tests
+  // in this class.
   @BeforeEach
   public void initializeCharPrefs() {
     KoLCharacter.reset("fakePrefUser");

--- a/test/net/sourceforge/kolmafia/request/BasementRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/BasementRequestTest.java
@@ -6,8 +6,6 @@ import static org.mockito.Mockito.spy;
 import java.util.stream.Stream;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLmafia;
-import net.sourceforge.kolmafia.extensions.ClearSharedState;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -19,11 +17,6 @@ class BasementRequestTest extends RequestTestBase {
   protected static void injectPreferences() {
     // Set a username so we can edit preferences and have per-user defaults.
     KoLCharacter.reset("fakeUserName");
-  }
-
-  @AfterAll
-  protected static void makeFakeGoAway() {
-    ClearSharedState.deleteUserPrefsAndMoodsFiles("fakeUserName");
   }
 
   private static Stream<Arguments> monsterFights() {

--- a/test/net/sourceforge/kolmafia/request/RequestTestBase.java
+++ b/test/net/sourceforge/kolmafia/request/RequestTestBase.java
@@ -2,19 +2,13 @@ package net.sourceforge.kolmafia.request;
 
 import static org.mockito.Mockito.doAnswer;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
 abstract class RequestTestBase {
 
   @BeforeAll
-  static final void setSessionId() {
+  static void setSessionId() {
     GenericRequest.sessionId = "fake session id";
-  }
-
-  @AfterAll
-  static final void cleanSessionId() {
-    GenericRequest.sessionId = null;
   }
 
   // Inject expected success (responseCode = 200) response text.

--- a/test/net/sourceforge/kolmafia/request/ScrapheapRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/ScrapheapRequestTest.java
@@ -7,10 +7,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.extensions.ClearSharedState;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.ChoiceManager;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,11 +26,6 @@ public class ScrapheapRequestTest extends RequestTestBase {
     req.responseText = html;
     req.processResults();
     return Preferences.getInteger("_chronolithActivations");
-  }
-
-  @AfterAll
-  protected static void makeFakeGoAway() {
-    ClearSharedState.deleteUserPrefsAndMoodsFiles("fakeUserName");
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanelTest.java
+++ b/test/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanelTest.java
@@ -6,16 +6,15 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.extensions.ClearSharedState;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class UseItemEnqueuePanelTest {
+
   @BeforeAll
   private static void injectPreferences() {
     KoLCharacter.reset("fakeUserName");
@@ -24,6 +23,7 @@ public class UseItemEnqueuePanelTest {
     // But first, make sure we don't persist anything.
     Preferences.setBoolean("saveSettingsOnSet", false);
   }
+  /*
 
   @AfterAll
   protected static void makeFakeGoAway() {
@@ -35,6 +35,8 @@ public class UseItemEnqueuePanelTest {
     KoLCharacter.reset("");
   }
 
+
+   */
   private void loadInventory(String jsonInventory) {
     try {
       InventoryManager.parseInventory(new JSONObject(jsonInventory));

--- a/test/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanelTest.java
+++ b/test/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanelTest.java
@@ -23,20 +23,7 @@ public class UseItemEnqueuePanelTest {
     // But first, make sure we don't persist anything.
     Preferences.setBoolean("saveSettingsOnSet", false);
   }
-  /*
 
-  @AfterAll
-  protected static void makeFakeGoAway() {
-    ClearSharedState.deleteUserPrefsAndMoodsFiles("fakeUserName");
-  }
-
-  @AfterAll
-  private static void cleanupSession() {
-    KoLCharacter.reset("");
-  }
-
-
-   */
   private void loadInventory(String jsonInventory) {
     try {
       InventoryManager.parseInventory(new JSONObject(jsonInventory));

--- a/test/net/sourceforge/kolmafia/textui/command/UseSkillCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/UseSkillCommandTest.java
@@ -15,9 +15,6 @@ import org.junit.jupiter.api.Test;
 public class UseSkillCommandTest extends AbstractCommandTestBase {
   @BeforeEach
   public void initEach() {
-    KoLCharacter.reset("testUser");
-    KoLCharacter.reset(true);
-
     // Stop requests from actually running
     GenericRequest.sessionId = null;
   }

--- a/test/net/sourceforge/kolmafia/textui/parsetree/DirectiveTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/DirectiveTest.java
@@ -8,7 +8,6 @@ import java.util.stream.Stream;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.textui.ParserTest;
 import net.sourceforge.kolmafia.textui.ScriptData;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -17,11 +16,6 @@ public class DirectiveTest {
   @BeforeEach
   public void setRevision() {
     StaticEntity.overrideRevision(10000);
-  }
-
-  @AfterEach
-  public void clearRevision() {
-    StaticEntity.overrideRevision(null);
   }
 
   public static Stream<ScriptData> data() {


### PR DESCRIPTION
As previously discussed, I have consolidated as many BeforeAll, BeforeEach, AfterEach and AfterAll activities as I could into ClearSharedState.  The remaining uses are for cases where the state must be reset between individual tests contained in the same test class.  Part of my solution was to delete the directories under test\root that are not under git control.

There us some lint cleaned up and a mistake in ConcoctionsTest that was not corrected when it was discovered.  

Everything ran locally with forkEvery at default and 1.