### PR TITLE
Language Server - Locations - FunctionInvocation

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -2549,6 +2549,8 @@ public class Parser {
       return null;
     }
 
+    Token invokeStartToken = this.currentToken();
+
     this.readToken(); // call
 
     Type type = this.parseType(scope, false);
@@ -2584,7 +2586,9 @@ public class Parser {
       throw this.parseException("(", this.currentToken());
     }
 
-    FunctionInvocation call = new FunctionInvocation(scope, type, name, params, this);
+    Location invokeLocation = this.makeLocation(invokeStartToken, this.peekPreviousToken());
+    FunctionInvocation call =
+        new FunctionInvocation(invokeLocation, scope, type, name, params, this);
 
     return this.parsePostCall(scope, call);
   }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/FunctionCall.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/FunctionCall.java
@@ -8,6 +8,7 @@ import net.sourceforge.kolmafia.textui.DataTypes;
 import net.sourceforge.kolmafia.textui.Parser;
 import net.sourceforge.kolmafia.textui.Profiler;
 import net.sourceforge.kolmafia.textui.ScriptRuntime;
+import org.eclipse.lsp4j.Location;
 
 public class FunctionCall extends Evaluable {
   protected Function target;
@@ -15,7 +16,17 @@ public class FunctionCall extends Evaluable {
   protected final String fileName;
   protected final int lineNumber;
 
+  // TEMPORARY
   public FunctionCall(final Function target, final List<Evaluable> params, final Parser parser) {
+    this(null, target, params, parser);
+  }
+
+  public FunctionCall(
+      final Location location,
+      final Function target,
+      final List<Evaluable> params,
+      final Parser parser) {
+    super(location);
     this.target = target;
     this.params = params;
     this.fileName = parser.getShortFileName();

--- a/src/net/sourceforge/kolmafia/textui/parsetree/FunctionInvocation.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/FunctionInvocation.java
@@ -6,6 +6,7 @@ import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.textui.AshRuntime;
 import net.sourceforge.kolmafia.textui.Parser;
 import net.sourceforge.kolmafia.textui.ScriptRuntime;
+import org.eclipse.lsp4j.Location;
 
 public class FunctionInvocation extends FunctionCall {
   private final BasicScope scope;
@@ -13,12 +14,13 @@ public class FunctionInvocation extends FunctionCall {
   private final Type type;
 
   public FunctionInvocation(
+      final Location location,
       final BasicScope scope,
       final Type type,
       final Evaluable name,
       final List<Evaluable> params,
       final Parser parser) {
-    super(null, params, parser);
+    super(location, null, params, parser);
     this.scope = scope;
     this.type = type;
     this.name = name;

--- a/test/net/sourceforge/kolmafia/textui/parsetree/FunctionInvocationTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/FunctionInvocationTest.java
@@ -2,8 +2,10 @@ package net.sourceforge.kolmafia.textui.parsetree;
 
 import static net.sourceforge.kolmafia.textui.ScriptData.invalid;
 import static net.sourceforge.kolmafia.textui.ScriptData.valid;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Stream;
 import net.sourceforge.kolmafia.textui.ParserTest;
 import net.sourceforge.kolmafia.textui.ScriptData;
@@ -30,7 +32,14 @@ public class FunctionInvocationTest {
             // ummm this should insist that the variable is a string...
             "int x; call string x('foo')",
             Arrays.asList("int", "x", ";", "call", "string", "x", "(", "'foo'", ")"),
-            Arrays.asList("1-1", "1-5", "1-6", "1-8", "1-13", "1-20", "1-21", "1-22", "1-27")));
+            Arrays.asList("1-1", "1-5", "1-6", "1-8", "1-13", "1-20", "1-21", "1-22", "1-27"),
+            scope -> {
+              List<Command> commands = scope.getCommandList();
+
+              FunctionInvocation invocation = assertInstanceOf(FunctionInvocation.class, commands.get(1));
+              // From the "call" up to the closing ")" of the parameters
+              ParserTest.assertLocationEquals(1, 8, 1, 28, invocation.getLocation());
+            }));
   }
 
   @ParameterizedTest

--- a/test/net/sourceforge/kolmafia/textui/parsetree/FunctionInvocationTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/FunctionInvocationTest.java
@@ -36,7 +36,8 @@ public class FunctionInvocationTest {
             scope -> {
               List<Command> commands = scope.getCommandList();
 
-              FunctionInvocation invocation = assertInstanceOf(FunctionInvocation.class, commands.get(1));
+              FunctionInvocation invocation =
+                  assertInstanceOf(FunctionInvocation.class, commands.get(1));
               // From the "call" up to the closing ")" of the parameters
               ParserTest.assertLocationEquals(1, 8, 1, 28, invocation.getLocation());
             }));


### PR DESCRIPTION
This skips over FunctionCall, because they have multiple instances of looking at another Command/Evaluable's Location, and so will need to be in the very final batch.