### PR TITLE
Language Server - Locations - VariableReference (...mostly)

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -688,7 +688,7 @@ public class Parser {
         }
       }
 
-      variableReferences.add(new VariableReference(param));
+      variableReferences.add(new VariableReference(param.getLocation(), param));
     }
 
     // Add the function to the parent scope before we parse the
@@ -747,7 +747,7 @@ public class Parser {
       }
 
       parentScope.addVariable(v);
-      VariableReference lhs = new VariableReference(v);
+      VariableReference lhs = new VariableReference(v.getLocation(), v);
       Evaluable rhs;
 
       if (this.currentToken().equals("=")) {
@@ -2046,7 +2046,7 @@ public class Parser {
 
       Variable keyvar = new Variable(name, itype, location);
       varList.add(keyvar);
-      variableReferences.add(new VariableReference(keyvar));
+      variableReferences.add(new VariableReference(keyvar.getLocation(), keyvar));
     }
 
     // Parse the scope with the list of keyVars
@@ -2137,7 +2137,7 @@ public class Parser {
     return new ForLoop(
         forLocation,
         scope,
-        new VariableReference(indexvar),
+        new VariableReference(indexvar.getLocation(), indexvar),
         initial,
         last,
         increment,
@@ -2197,7 +2197,7 @@ public class Parser {
 
       this.readToken(); // name
 
-      VariableReference lhs = new VariableReference(variable);
+      VariableReference lhs = new VariableReference(variable.getLocation(), variable);
       Evaluable rhs = null;
 
       if (this.currentToken().equals("=")) {
@@ -3535,6 +3535,8 @@ public class Parser {
     }
 
     Token name = this.currentToken();
+    Location variableLocation = this.makeLocation(name);
+
     Variable var = scope.findVariable(name.content, true);
 
     if (var == null) {
@@ -3543,7 +3545,7 @@ public class Parser {
 
     this.readToken(); // read name
 
-    return this.parseVariableReference(scope, new VariableReference(var));
+    return this.parseVariableReference(scope, new VariableReference(variableLocation, var));
   }
 
   /**

--- a/src/net/sourceforge/kolmafia/textui/parsetree/LibraryFunction.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/LibraryFunction.java
@@ -24,7 +24,7 @@ public class LibraryFunction extends Function {
     // function will not use them, so that tracing works
     for (int i = 1; i <= params.length; ++i) {
       Variable variable = new Variable(params[i - 1]);
-      this.variableReferences.add(new VariableReference(variable));
+      this.variableReferences.add(new VariableReference(null, variable));
       args[i] = Value.class;
     }
 

--- a/src/net/sourceforge/kolmafia/textui/parsetree/VariableReference.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/VariableReference.java
@@ -3,11 +3,18 @@ package net.sourceforge.kolmafia.textui.parsetree;
 import java.io.PrintStream;
 import java.util.List;
 import net.sourceforge.kolmafia.textui.AshRuntime;
+import org.eclipse.lsp4j.Location;
 
 public class VariableReference extends Evaluable implements Comparable<VariableReference> {
   public final Variable target;
 
+  // TEMPORARY
   public VariableReference(final Variable target) {
+    this(null, target);
+  }
+
+  public VariableReference(final Location location, final Variable target) {
+    super(location);
     this.target = target;
   }
 

--- a/test/net/sourceforge/kolmafia/textui/parsetree/AssignmentTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/AssignmentTest.java
@@ -5,6 +5,7 @@ import static net.sourceforge.kolmafia.textui.ScriptData.valid;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.Arrays;
 import java.util.List;
@@ -37,7 +38,18 @@ public class AssignmentTest {
             scope -> {
               List<Command> commands = scope.getCommandList();
 
+              Assignment declaration = assertInstanceOf(Assignment.class, commands.get(0));
               Assignment assignment = assertInstanceOf(Assignment.class, commands.get(1));
+
+              // Variable + VariableReference location test
+              VariableReference varRef1 = declaration.getLeftHandSide();
+              VariableReference varRef2 = assignment.getLeftHandSide();
+              ParserTest.assertLocationEquals(1, 5, 1, 6, varRef1.getLocation());
+              ParserTest.assertLocationEquals(1, 8, 1, 9, varRef2.getLocation());
+              ParserTest.assertLocationEquals(1, 5, 1, 6, varRef1.target.getLocation());
+              assertSame(varRef1.target, varRef2.target);
+
+              // Operator location test
               Operator oper = assignment.getOperator();
               // Assignment.oper is the operator to use *before* doing the assignment (i.e. the "=")
               assertEquals("+", oper.toString());

--- a/test/net/sourceforge/kolmafia/textui/parsetree/ForEachLoopTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/ForEachLoopTest.java
@@ -4,6 +4,7 @@ import static net.sourceforge.kolmafia.textui.ScriptData.invalid;
 import static net.sourceforge.kolmafia.textui.ScriptData.valid;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
@@ -70,12 +71,23 @@ public class ForEachLoopTest {
               Scope loopScope = forLoop.getScope();
               ParserTest.assertLocationEquals(1, 34, 1, 36, loopScope.getLocation());
 
-              // Variable location test
+              // Variable + VariableReference location test
               Iterator<Variable> variables = loopScope.getVariables().iterator();
+              List<VariableReference> references = forLoop.getVariableReferences();
+              // key
               assertTrue(variables.hasNext());
-              ParserTest.assertLocationEquals(1, 9, 1, 12, variables.next().getLocation());
+              Variable var = variables.next();
+              VariableReference varRef = references.get(0);
+              ParserTest.assertLocationEquals(1, 9, 1, 12, var.getLocation());
+              ParserTest.assertLocationEquals(1, 9, 1, 12, varRef.getLocation());
+              assertSame(var, varRef.target);
+              // value
               assertTrue(variables.hasNext());
-              ParserTest.assertLocationEquals(1, 14, 1, 19, variables.next().getLocation());
+              var = variables.next();
+              varRef = references.get(1);
+              ParserTest.assertLocationEquals(1, 14, 1, 19, var.getLocation());
+              ParserTest.assertLocationEquals(1, 14, 1, 19, varRef.getLocation());
+              assertSame(var, varRef.target);
               assertFalse(variables.hasNext());
             }),
         invalid(

--- a/test/net/sourceforge/kolmafia/textui/parsetree/ForLoopTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/ForLoopTest.java
@@ -4,6 +4,7 @@ import static net.sourceforge.kolmafia.textui.ScriptData.invalid;
 import static net.sourceforge.kolmafia.textui.ScriptData.valid;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
@@ -57,10 +58,14 @@ public class ForLoopTest {
               Scope loopScope = forLoop.getScope();
               ParserTest.assertLocationEquals(1, 29, 1, 30, loopScope.getLocation());
 
-              // Variable location test
+              // Variable + VariableReference location test
               Iterator<Variable> variables = loopScope.getVariables().iterator();
               assertTrue(variables.hasNext());
-              ParserTest.assertLocationEquals(1, 5, 1, 6, variables.next().getLocation());
+              Variable var = variables.next();
+              VariableReference varRef = forLoop.getVariable();
+              ParserTest.assertLocationEquals(1, 5, 1, 6, var.getLocation());
+              ParserTest.assertLocationEquals(1, 5, 1, 6, varRef.getLocation());
+              assertSame(var, varRef.target);
               assertFalse(variables.hasNext());
             }),
         valid(

--- a/test/net/sourceforge/kolmafia/textui/parsetree/UserDefinedFunctionTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/UserDefinedFunctionTest.java
@@ -81,8 +81,16 @@ public class UserDefinedFunctionTest {
               UserDefinedFunction f = assertInstanceOf(UserDefinedFunction.class, functions.next());
               assertFalse(functions.hasNext());
 
+              // VariableReference location test
               List<VariableReference> parameters = f.getVariableReferences();
+              VariableReference a = parameters.get(0);
+              ParserTest.assertLocationEquals(1, 12, 1, 13, a.getLocation());
+              VariableReference b = parameters.get(1);
+              ParserTest.assertLocationEquals(1, 22, 1, 23, b.getLocation());
               VariableReference c = parameters.get(2);
+              ParserTest.assertLocationEquals(1, 34, 1, 35, c.getLocation());
+
+              // VarArgType location test
               VarArgType varArg = assertInstanceOf(VarArgType.class, c.getType());
               // The type's location + the three dots (here: "float...")
               ParserTest.assertLocationEquals(1, 25, 1, 33, varArg.getLocation());


### PR DESCRIPTION
Setting aside those that I prepared for when https://github.com/kolmafia/kolmafia/pull/224 will be merged, a large portion of what's left is composed of classes who look at other Evaluables to determine/update their Location.

Those will obviously need to all be submitted at the same time, so in order to reduce the cognitive load induced by this last patch/batch/PR, I'll do my best to work around those.
Do bear in mind that it means a few more of those "TEMPORARY" constructors, though... (they'll all be removed at the same time)


For this PR, those ignored/avoided are variable references made from expressions/function call (e.g. "foo().field"), and composite references.