### PR TITLE
Language Server - End-of-file token tweak

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/Line.java
+++ b/src/net/sourceforge/kolmafia/textui/Line.java
@@ -203,23 +203,28 @@ public final class Line {
       }
 
       final int offset;
-
-      if (!Line.this.tokens.isEmpty()) {
-        offset = Line.this.tokens.getLast().restOfLineStart;
-      } else {
-        offset = Line.this.offset;
-      }
-
       final String lineRemainder;
 
       if (Line.this.content == null) {
         // At end of file
+        if (Line.this.previousLine != null && !Line.this.previousLine.tokens.isEmpty()) {
+          offset = Line.this.previousLine.tokens.getLast().restOfLineStart;
+        } else {
+          offset = Line.this.offset;
+        }
+
         this.content = ";";
         // Going forward, we can just assume lineRemainder is an
         // empty string.
         lineRemainder = "";
         tokenLength = 0;
       } else {
+        if (!Line.this.tokens.isEmpty()) {
+          offset = Line.this.tokens.getLast().restOfLineStart;
+        } else {
+          offset = Line.this.offset;
+        }
+
         final String lineRemainderWithToken = Line.this.substring(offset);
 
         this.content = lineRemainderWithToken.substring(0, tokenLength);

--- a/test/net/sourceforge/kolmafia/textui/LineTest.java
+++ b/test/net/sourceforge/kolmafia/textui/LineTest.java
@@ -279,7 +279,7 @@ public class LineTest {
     assertEquals(line3Token2.restOfLineStart, line3Token3.getStart().getCharacter());
     assertEquals(line3Token3.restOfLineStart, line3Token4.getStart().getCharacter());
 
-    assertEquals(line3SurroundingWhitespace.offset, endOfFileToken.getStart().getCharacter());
+    assertEquals(line3Token4.restOfLineStart, endOfFileToken.getStart().getCharacter());
   }
 
   @Test


### PR DESCRIPTION
Now that I'm looking into writing more tests involving locations, I realize that I forgot to make it so that the end-of-file token's position matches the actual end of the file... whups