### PR TITLE
(slightly) safe(r) cloning

### DIFF
--- a/src/net/sourceforge/kolmafia/AdventureResult.java
+++ b/src/net/sourceforge/kolmafia/AdventureResult.java
@@ -212,8 +212,8 @@ public class AdventureResult implements Comparable<AdventureResult>, Cloneable {
   }
 
   // Need this to retain instance-specific methods
-  protected Object clone() throws CloneNotSupportedException {
-    return super.clone();
+  protected AdventureResult clone() throws CloneNotSupportedException {
+    return (AdventureResult) super.clone();
   }
 
   public void normalizeEffectName() {
@@ -1034,7 +1034,7 @@ public class AdventureResult implements Comparable<AdventureResult>, Cloneable {
 
       AdventureResult item;
       try {
-        item = (AdventureResult) this.clone();
+        item = this.clone();
       } catch (CloneNotSupportedException e) {
         // This should not happen. Hope for the best.
         item = new AdventureResult(AdventureResult.NO_PRIORITY, this.name);
@@ -1049,7 +1049,7 @@ public class AdventureResult implements Comparable<AdventureResult>, Cloneable {
     if (this.isStatusEffect()) {
       AdventureResult effect;
       try {
-        effect = (AdventureResult) this.clone();
+        effect = this.clone();
       } catch (CloneNotSupportedException e) {
         // This should not happen. Hope for the best.
         effect = new AdventureResult(AdventureResult.NO_PRIORITY, this.name);

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -1562,12 +1562,12 @@ public class Evaluator {
           spec.setEnthroned(familiar);
           spec.setUnscored();
           if (spec.compareTo(best) > 0) {
-            secondBest = (MaximizerSpeculation) best.clone();
-            best = (MaximizerSpeculation) spec.clone();
+            secondBest = best.clone();
+            best = spec.clone();
             secondBestCarriedFamiliar = bestCarriedFamiliar;
             bestCarriedFamiliar = familiar;
           } else if (spec.compareTo(secondBest) > 0) {
-            secondBest = (MaximizerSpeculation) spec.clone();
+            secondBest = spec.clone();
             secondBestCarriedFamiliar = familiar;
           }
         }
@@ -1597,7 +1597,7 @@ public class Evaluator {
           spec.equipment[EquipmentManager.OFFHAND] = sleeve;
           spec.equipment[EquipmentManager.CARDSLEEVE] = card;
           if (spec.compareTo(best) > 0) {
-            best = (MaximizerSpeculation) spec.clone();
+            best = spec.clone();
             bestCard = card;
           }
         }
@@ -1632,7 +1632,7 @@ public class Evaluator {
           spec.equipment[EquipmentManager.HAT] = edPiece;
           spec.setEdPiece(animal);
           if (spec.compareTo(best) > 0) {
-            best = (MaximizerSpeculation) spec.clone();
+            best = spec.clone();
             bestEdPiece = animal;
           }
         }
@@ -1662,7 +1662,7 @@ public class Evaluator {
         spec.equipment[EquipmentManager.FAMILIAR] = snowsuit;
         spec.setSnowsuit(decoration);
         if (spec.compareTo(best) > 0) {
-          best = (MaximizerSpeculation) spec.clone();
+          best = spec.clone();
           bestSnowsuit = decoration;
         }
       }
@@ -1699,7 +1699,7 @@ public class Evaluator {
           spec.equipment[EquipmentManager.CONTAINER] = retroCape;
           spec.setRetroCape(config);
           if (spec.compareTo(best) > 0) {
-            best = (MaximizerSpeculation) spec.clone();
+            best = spec.clone();
             bestRetroCape = config;
           }
         }
@@ -1731,7 +1731,7 @@ public class Evaluator {
         spec.equipment[EquipmentManager.ACCESSORY3] = backupCamera;
         spec.setBackupCamera(mode);
         if (spec.compareTo(best) > 0) {
-          best = (MaximizerSpeculation) spec.clone();
+          best = spec.clone();
           bestBackupCamera = mode;
         }
       }

--- a/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
+++ b/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
@@ -33,7 +33,7 @@ public class MaximizerSpeculation extends Speculation
   private boolean foldables = false;
 
   @Override
-  public Object clone() {
+  public MaximizerSpeculation clone() {
     try {
       MaximizerSpeculation copy = (MaximizerSpeculation) super.clone();
       copy.equipment = this.equipment.clone();
@@ -791,7 +791,7 @@ public class MaximizerSpeculation extends Speculation
       throw new MaximizerLimitException();
     }
     if (this.compareTo(Maximizer.best) > 0) {
-      Maximizer.best = (MaximizerSpeculation) this.clone();
+      Maximizer.best = this.clone();
     }
     Maximizer.bestChecked++;
     long t = System.currentTimeMillis();

--- a/src/net/sourceforge/kolmafia/session/RabbitHoleManager.java
+++ b/src/net/sourceforge/kolmafia/session/RabbitHoleManager.java
@@ -514,7 +514,7 @@ public abstract class RabbitHoleManager {
     }
 
     @Override
-    public Object clone() {
+    public Board clone() {
       return new Board(this);
     }
 
@@ -1034,7 +1034,7 @@ public abstract class RabbitHoleManager {
 
   private static Path solve(final Board board) {
     // Attempt to solve by moving the current piece
-    return RabbitHoleManager.solve((Board) board.clone(), new Path());
+    return RabbitHoleManager.solve(board.clone(), new Path());
   }
 
   private static Path solve(final Board board, final Path path) {

--- a/src/net/sourceforge/kolmafia/session/VolcanoMazeManager.java
+++ b/src/net/sourceforge/kolmafia/session/VolcanoMazeManager.java
@@ -926,7 +926,7 @@ public abstract class VolcanoMazeManager {
     }
 
     public Path(final Path prefix, final Integer square) {
-      list = (ArrayList<Integer>) prefix.list.clone();
+      list = new ArrayList<>(prefix.list);
       list.add(square);
     }
 

--- a/src/net/sourceforge/kolmafia/swingui/MuseumFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/MuseumFrame.java
@@ -252,6 +252,8 @@ public class MuseumFrame extends GenericFrame {
 
   public class OrderingPanel extends ItemListManagePanel<String> {
     @SuppressWarnings("unchecked")
+    // LockableListModel (the type of getHeaders())'s clone() method still claims to return an
+    // Object, but we know its internal list has the same elements, so their types definitely match
     public OrderingPanel() {
       super((LockableListModel<String>) DisplayCaseManager.getHeaders().clone());
 

--- a/src/net/sourceforge/kolmafia/swingui/MuseumFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/MuseumFrame.java
@@ -251,6 +251,7 @@ public class MuseumFrame extends GenericFrame {
   }
 
   public class OrderingPanel extends ItemListManagePanel<String> {
+    @SuppressWarnings("unchecked")
     public OrderingPanel() {
       super((LockableListModel<String>) DisplayCaseManager.getHeaders().clone());
 

--- a/src/net/sourceforge/kolmafia/textui/AshRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/AshRuntime.java
@@ -379,9 +379,8 @@ public class AshRuntime extends AbstractRuntime {
     return frame;
   }
 
-  @SuppressWarnings("unchecked")
   public List<CallFrame> getCallFrames() {
-    return (List<CallFrame>) frameStack.clone();
+    return new ArrayList<>(frameStack);
   }
 
   private String getStackTrace() {


### PR DESCRIPTION
For types without a generic: use covariant return types to save some type castings.
(source: http://jtechies.blogspot.com/2012/07/item-11-override-clone-judiciously.html )

For ArrayList: use the copy constructor instead of ArrayList.clone()
(source: https://stackoverflow.com/questions/3410035/how-to-make-a-copy-of-arraylist-object-which-is-type-of-list/3410133#3410133 )

For LockableListModel... ugh... just ignore the warning, I guess...