### PR TITLE
Language Server - error locations - ForLoop

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -2095,10 +2095,15 @@ public class Parser {
 
     Token name = this.currentToken();
 
+    Variable indexvar;
+
     if (Parser.isReservedWord(name.content)) {
-      throw this.parseException("Reserved word '" + name + "' cannot be an index variable name");
+      throw this.parseException(
+          name, "Reserved word '" + name + "' cannot be an index variable name");
     } else if (parentScope.findVariable(name.content) != null) {
-      throw this.parseException("Index variable '" + name + "' is already defined");
+      throw this.parseException(name, "Index variable '" + name + "' is already defined");
+    } else {
+      indexvar = new Variable(name.content, DataTypes.INT_TYPE, this.makeLocation(name));
     }
 
     this.readToken(); // name
@@ -2112,27 +2117,32 @@ public class Parser {
     Evaluable initial = this.parseExpression(parentScope);
 
     if (initial == null) {
-      throw this.parseException("Expression for initial value expected");
+      Location errorLocation = this.makeLocation(this.currentToken());
+
+      throw this.parseException(errorLocation, "Expression for initial value expected");
     }
 
     int direction = 0;
 
     if (this.currentToken().equalsIgnoreCase("upto")) {
       direction = 1;
+      this.readToken(); // upto
     } else if (this.currentToken().equalsIgnoreCase("downto")) {
       direction = -1;
+      this.readToken(); // downto
     } else if (this.currentToken().equalsIgnoreCase("to")) {
       direction = 0;
+      this.readToken(); // to
     } else {
       throw this.parseException("to, upto, or downto", this.currentToken());
     }
 
-    this.readToken(); // upto/downto/to
-
     Evaluable last = this.parseExpression(parentScope);
 
     if (last == null) {
-      throw this.parseException("Expression for floor/ceiling value expected");
+      Location errorLocation = this.makeLocation(this.currentToken());
+
+      throw this.parseException(errorLocation, "Expression for floor/ceiling value expected");
     }
 
     Evaluable increment = Value.locate(this.makeZeroWidthLocation(), DataTypes.ONE_VALUE);
@@ -2141,12 +2151,11 @@ public class Parser {
       increment = this.parseExpression(parentScope);
 
       if (increment == null) {
-        throw this.parseException("Expression for increment value expected");
+        Location errorLocation = this.makeLocation(this.currentToken());
+
+        throw this.parseException(errorLocation, "Expression for increment value expected");
       }
     }
-
-    // Create integer index variable
-    Variable indexvar = new Variable(name.content, DataTypes.INT_TYPE, this.makeLocation(name));
 
     // Put index variable onto a list
     VariableList varList = new VariableList();

--- a/test/net/sourceforge/kolmafia/textui/parsetree/ForLoopTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/ForLoopTest.java
@@ -22,15 +22,18 @@ public class ForLoopTest {
         invalid(
             "For loop, no/bad initial expression",
             "for x from",
-            "Expression for initial value expected"),
+            "Expression for initial value expected",
+            "char 11"),
         invalid(
             "For loop, no/bad ceiling expression",
             "for x from 0 to",
-            "Expression for floor/ceiling value expected"),
+            "Expression for floor/ceiling value expected",
+            "char 16"),
         invalid(
             "For loop, no/bad increment expression",
             "for x from 0 to 1 by",
-            "Expression for increment value expected"),
+            "Expression for increment value expected",
+            "char 21"),
         valid(
             "for-from-to",
             "for i from 1 to 10000;",
@@ -86,18 +89,25 @@ public class ForLoopTest {
         invalid(
             "for with reserved index",
             "for int from 1 upto 10;",
-            "Reserved word 'int' cannot be an index variable"),
+            "Reserved word 'int' cannot be an index variable name",
+            "char 5 to char 8"),
         invalid(
             "for with existing index",
             // Oddly, this is unsupported, when other for loops will create
             // a nested scope.
             "int i; for i from 1 upto 10;",
-            "Index variable 'i' is already defined"),
-        invalid("for without from", "for i in range(10):\n  print(i)", "Expected from, found in"),
+            "Index variable 'i' is already defined",
+            "char 12 to char 13"),
+        invalid(
+            "for without from",
+            "for i in range(10):\n  print(i)",
+            "Expected from, found in",
+            "char 7 to char 9"),
         invalid(
             "for with invalid dest keyword",
             "for i from 1 until 10;",
-            "Expected to, upto, or downto, found until"));
+            "Expected to, upto, or downto, found until",
+            "char 14 to char 19"));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Also does 2 small things:

1- creates "indexvar" earlier
2- only reads "upto"/"downto"/"to" in the conditional in which we see it (instead of after)