### PR TITLE
Language Server - error locations - AggregateLiteral + string tweak

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -1091,18 +1091,23 @@ public class Parser {
       // yet ensured we are reading a MapLiteral, allow any
       // type of Value as the "key"
       Type dataType = data.getBaseType();
+
       if (this.currentToken().equals("{")) {
         if (!isArray && !arrayAllowed) {
           // We know this is a map, but they placed
           // an aggregate literal as a key
           throw this.parseException(
+              this.currentToken(),
               "Expected a key of type " + index.toString() + ", found an aggregate");
         }
 
         if (dataType instanceof AggregateType) {
           lhs = this.parseAggregateLiteral(scope, (AggregateType) dataType);
         } else {
+          Location errorLocation = this.makeLocation(this.currentToken());
+
           throw this.parseException(
+              errorLocation,
               "Expected an element of type " + dataType.toString() + ", found an aggregate");
         }
       } else {
@@ -1110,7 +1115,10 @@ public class Parser {
       }
 
       if (lhs == null) {
-        throw this.parseException("Script parsing error");
+        Location errorLocation = this.makeLocation(this.currentToken());
+
+        throw this.parseException(
+            errorLocation, "Script parsing error; couldn't figure out value of aggregate key");
       }
 
       Token delim = this.currentToken();
@@ -1131,7 +1139,12 @@ public class Parser {
           // The value must have the correct data type
           lhs = this.autoCoerceValue(data, lhs, scope);
           if (!Operator.validCoercion(dataType, lhs.getType(), "assign")) {
-            throw this.parseException("Invalid array literal");
+            throw this.parseException(
+                lhs.getLocation(),
+                "Invalid array literal; cannot assign type "
+                    + dataType.toString()
+                    + " to type "
+                    + lhs.getType().toString());
           }
 
           values.add(lhs);
@@ -1161,7 +1174,8 @@ public class Parser {
         if (data.equals(DataTypes.INT_TYPE)) {
           // If so, this is an int[int] aggregate. They could have done something like
           // {0, 1, 2, 3:3, 4:4, 5:5}
-          throw this.parseException("Cannot include keys when making an array literal");
+          throw this.parseException(
+              lhs.getLocation(), "Cannot include keys when making an array literal");
         } else {
           // If not, we can't tell why there's a colon here.
           throw this.parseException(", or }", delim);
@@ -1174,7 +1188,10 @@ public class Parser {
         if (dataType instanceof AggregateType) {
           rhs = this.parseAggregateLiteral(scope, (AggregateType) dataType);
         } else {
+          Location errorLocation = this.makeLocation(this.currentToken());
+
           throw this.parseException(
+              errorLocation,
               "Expected a value of type " + dataType.toString() + ", found an aggregate");
         }
       } else {
@@ -1182,15 +1199,32 @@ public class Parser {
       }
 
       if (rhs == null) {
-        throw this.parseException("Script parsing error");
+        Location errorLocation = this.makeLocation(this.currentToken());
+
+        throw this.parseException(
+            errorLocation, "Script parsing error; couldn't figure out value of aggregate value");
       }
 
       // Check that each type is valid via validCoercion
       lhs = this.autoCoerceValue(index, lhs, scope);
       rhs = this.autoCoerceValue(data, rhs, scope);
-      if (!Operator.validCoercion(index, lhs.getType(), "assign")
-          || !Operator.validCoercion(data, rhs.getType(), "assign")) {
-        throw this.parseException("Invalid map literal");
+
+      if (!Operator.validCoercion(index, lhs.getType(), "assign")) {
+        throw this.parseException(
+            lhs.getLocation(),
+            "Invalid map literal; cannot assign type "
+                + index.toString()
+                + " to key of type "
+                + lhs.getType().toString());
+      }
+
+      if (!Operator.validCoercion(data, rhs.getType(), "assign")) {
+        throw this.parseException(
+            rhs.getLocation(),
+            "Invalid map literal; cannot assign type "
+                + dataType.toString()
+                + " to value of type "
+                + rhs.getType().toString());
       }
 
       keys.add(lhs);
@@ -1211,6 +1245,7 @@ public class Parser {
       int size = aggr.getSize();
       if (size > 0 && size < values.size()) {
         throw this.parseException(
+            aggregateLiteralLocation,
             "Array has " + size + " elements but " + values.size() + " initializers.");
       }
     }
@@ -3176,9 +3211,9 @@ public class Parser {
             this.currentLine.makeToken(i + 1); // + 1 to get rid of stop character token
         this.readToken();
 
-        Evaluable result =
-            Value.locate(
-                this.makeLocation(stringStartPosition), new Value(resultString.toString()));
+        Location resultLocation =
+            this.makeLocation(stringStartPosition, this.peekPreviousToken().getEnd());
+        Evaluable result = Value.locate(resultLocation, new Value(resultString.toString()));
 
         if (conc == null) {
           return result;
@@ -4137,6 +4172,10 @@ public class Parser {
 
   private Location makeLocation(final Position start) {
     return this.makeLocation(this.rangeToHere(start));
+  }
+
+  private Location makeLocation(final Position start, final Position end) {
+    return this.makeLocation(new Range(start, end));
   }
 
   private Location makeLocation(final Range start, final Range end) {

--- a/test/net/sourceforge/kolmafia/textui/parsetree/AggregateLiteralTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/AggregateLiteralTest.java
@@ -43,8 +43,16 @@ public class AggregateLiteralTest {
             Arrays.asList(
                 "1-1", "1-4", "1-5", "1-9", "1-11", "1-13", "1-14", "1-18", "1-19", "1-37", "1-38",
                 "1-40", "1-41", "1-43", "1-44", "1-48", "1-49", "1-62", "1-63", "1-65", "1-66")),
-        invalid("Unterminated aggregate literal", "int[int] {", "Expected }, found end of file"),
-        invalid("Interrupted map literal", "int[int] {:", "Script parsing error"),
+        invalid(
+            "Unterminated aggregate literal",
+            "int[int] {",
+            "Expected }, found end of file",
+            "char 11"),
+        invalid(
+            "Interrupted map literal",
+            "int[int] {:",
+            "Script parsing error; couldn't figure out value of aggregate key",
+            "char 11 to char 12"),
         valid(
             "Simple array literal",
             "int[5] { 1, 2, 3, 4, 5}",
@@ -73,12 +81,14 @@ public class AggregateLiteralTest {
             // We ought to check for this case too, but we don't...
             "Array literal not enough elements",
             "int[10] { 1, 2, 3, 4, 5}",
-            "Array has 10 elements but 5 initializers."),
+            "Array has 10 elements but 5 initializers.",
+            "char 9 to char 25"),
         */
         invalid(
             "Array literal too many elements",
             "int[1] { 1, 2, 3, 4, 5 }",
-            "Array has 1 elements but 5 initializers."),
+            "Array has 1 elements but 5 initializers.",
+            "char 8 to char 25"),
         valid(
             "Empty multidimensional map literal",
             "int[int, int]{}",
@@ -105,33 +115,59 @@ public class AggregateLiteralTest {
         invalid(
             "Interrupted multidimensional map literal",
             "int[int, int] {1:",
-            "Script parsing error"),
-        invalid("Invalid array literal coercion", "int[int]{ 'foo' }", "Invalid array literal"),
-        invalid("Invalid map literal coercion", "int[int]{ 'foo':'bar' }", "Invalid map literal"),
+            "Script parsing error; couldn't figure out value of aggregate value",
+            "char 18"),
+        invalid(
+            "Invalid array literal coercion",
+            "int[int]{ 'foo' }",
+            "Invalid array literal; cannot assign type int to type string",
+            "char 11 to char 16"),
+        invalid(
+            "Invalid map literal coercion",
+            "boolean[int]{ 'foo':true }",
+            "Invalid map literal; cannot assign type int to key of type string",
+            "char 15 to char 20"),
+        invalid(
+            "Invalid map literal coercion 2",
+            "boolean[int]{ 2:'bar' }",
+            "Invalid map literal; cannot assign type boolean to value of type string",
+            "char 17 to char 22"),
         invalid(
             "Ambiguity between array and map literal",
             "boolean[5]{ 0:true, 1:true, 2:false, true, 4:false }",
-            "Expected :, found ,"),
+            "Expected :, found ,",
+            "char 42 to char 43"),
         invalid(
             "Ambiguity between array and map literal 2: index and data are both integers",
             "int[5]{ 0, 1, 2, 3:3, 4 }",
-            "Cannot include keys when making an array literal"),
+            "Cannot include keys when making an array literal",
+            "char 18 to char 19"),
         invalid(
             "Ambiguity between array and map literal 3: that can't be a key",
             "string[5]{ '0', '1', '2', '3':'3', '4' }",
-            "Expected , or }, found :"),
+            "Expected , or }, found :",
+            "char 30 to char 31"),
         invalid(
             "Unexpected aggregate in array literal",
             "boolean[5]{ true, true, false, {true}, false }",
-            "Expected an element of type boolean, found an aggregate"),
+            "Expected an element of type boolean, found an aggregate",
+            // we currently can't read past the "{" before throwing the exception
+            // "char 32 to char 38"),
+            "char 32 to char 33"),
         invalid(
             "Unexpected aggregate in map literal: as a key",
             "boolean[5]{ 0:true, 1:true, 2:false, {3}:true, 4:false }",
-            "Expected a key of type int, found an aggregate"),
+            "Expected a key of type int, found an aggregate",
+            // we currently can't read past the "{" before throwing the exception
+            // "char 38 to char 41"),
+            "char 38 to char 39"),
         invalid(
             "Unexpected aggregate in map literal: as a value",
             "boolean[5]{ 0:true, 1:true, 2:false, 3:{true}, 4:false }",
-            "Expected a value of type boolean, found an aggregate"),
+            "Expected a value of type boolean, found an aggregate",
+            // we currently can't read past the "{" before throwing the exception
+            // "char 40 to char 46"),
+            "char 40 to char 41"),
         valid(
             // This... exercises a different code path.
             "Parenthesized map literal",
@@ -143,7 +179,11 @@ public class AggregateLiteralTest {
             "int[1] x { 1 };",
             Arrays.asList("int", "[", "1", "]", "x", "{", "1", "}", ";"),
             Arrays.asList("1-1", "1-4", "1-5", "1-6", "1-8", "1-10", "1-12", "1-14", "1-15")),
-        invalid("aggregate literal without braces", "(int[])", "Expected {, found )"));
+        invalid(
+            "aggregate literal without braces",
+            "(int[])",
+            "Expected {, found )",
+            "char 7 to char 8"));
   }
 
   @ParameterizedTest

--- a/test/net/sourceforge/kolmafia/textui/parsetree/StringTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/StringTest.java
@@ -32,6 +32,17 @@ public class StringTest {
             "'\\\n\n   \n\n\n'",
             Arrays.asList("'\\", "'"),
             Arrays.asList("1-1", "6-1")),
+        valid(
+            "Trailing spaces after string",
+            "'foobar'    //",
+            Arrays.asList("'foobar'", "//"),
+            Arrays.asList("1-1", "1-13"),
+            scope -> {
+              List<Command> commands = scope.getCommandList();
+
+              Value.Constant string = assertInstanceOf(Value.Constant.class, commands.get(0));
+              ParserTest.assertLocationEquals(1, 1, 1, 9, string.getLocation());
+            }),
         invalid(
             "Multiline string, end of line properly escaped + empty lines + comment",
             "'\\\n\n\n//Comment\n\n'",


### PR DESCRIPTION
1- also adds additional details to some of the error messages
2- also unearthed a mistake with string locations, where their location would include any whitespace immediately following them.