### PR TITLE
Language Server - error locations - Directive

### DIFF
--- a/test/net/sourceforge/kolmafia/textui/ParserTest.java
+++ b/test/net/sourceforge/kolmafia/textui/ParserTest.java
@@ -34,7 +34,7 @@ public class ParserTest {
 
   private static void testInvalidScript(final InvalidScriptData script) {
     ScriptException e = assertThrows(ScriptException.class, script.parser::parse, script.desc);
-    assertThat(script.desc, e.getMessage(), containsString(script.errorText));
+    assertThat(script.desc, e.getMessage(), startsWith(script.errorText));
 
     if (script.errorLocationString != null) {
       assertThat(script.desc, e.getMessage(), endsWith(" (" + script.errorLocationString + ")"));

--- a/test/net/sourceforge/kolmafia/textui/parsetree/DirectiveTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/DirectiveTest.java
@@ -20,7 +20,8 @@ public class DirectiveTest {
 
   public static Stream<ScriptData> data() {
     return Stream.of(
-        invalid("interrupted script directive", "script", "Expected <, found end of file"),
+        invalid(
+            "interrupted script directive", "script", "Expected <, found end of file", "char 7"),
         valid(
             "empty script directive",
             "script;",
@@ -41,7 +42,21 @@ public class DirectiveTest {
             "script zlib.ash",
             Arrays.asList("script", "zlib.ash"),
             Arrays.asList("1-1", "1-8")),
-        invalid("Unterminated script directive", "script \"zlib.ash", "No closing \" found"),
+        invalid(
+            "Unterminated script directive",
+            "script \"zlib.ash",
+            "No closing \" found",
+            "char 8 to char 17"),
+        invalid(
+            "Unterminated script directive 2",
+            "script \"zlib.ash \n Have I told you about that time when--",
+            "No closing \" found",
+            "char 8 to char 17"),
+        invalid(
+            "Unterminated script directive 3",
+            "script \"zlib.ash ; Have I told you about that time when--",
+            "No closing \" found",
+            "char 8 to char 18"),
         valid(
             "since passes for low revision",
             "since r100;",
@@ -50,15 +65,24 @@ public class DirectiveTest {
         invalid(
             "since fails for high revision",
             "since r2000000000;",
-            "requires revision r2000000000 of kolmafia or higher"),
-        invalid("Invalid since version", "since 10;", "invalid 'since' format"),
+            "'null' requires revision r2000000000 of kolmafia or higher (current: r10000).  Up-to-date builds can be found at https://ci.kolmafia.us/.",
+            "char 1 to char 18"),
+        invalid("Invalid since version", "since 10;", "invalid 'since' format", "char 1 to char 9"),
         valid(
             "since passes for low version",
             "since 1.0;",
             Arrays.asList("since", "1.0", ";"),
             Arrays.asList("1-1", "1-7", "1-10")),
-        invalid("since fails for high version", "since 2000000000.0;", "final point release"),
-        invalid("since fails for not-a-number", "since yesterday;", "invalid 'since' format"));
+        invalid(
+            "since fails for high version",
+            "since 2000000000.0;",
+            "invalid 'since' format (21.09 was the final point release)",
+            "char 1 to char 19"),
+        invalid(
+            "since fails for not-a-number",
+            "since yesterday;",
+            "invalid 'since' format",
+            "char 1 to char 16"));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
1- also removes the `targetIsRevision` boolean parameter of the `sinceException` method, as it was always true since 21.09

2- The matcher used to test invalid script's error message can now be `startsWith` rather than `containsString`