### PR TITLE
Serialize build.yml executions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: build-and-tag-release
+
 jobs:
   bin:
     if: github.repository == 'kolmafia/kolmafia'


### PR DESCRIPTION
I think this might eliminate the case where multiple releases end up
with the same summary data if they're merged in quick succession,
although it's possible the problem is deeper than that.

(I'm really not sure on this one, caveat lector.)