### PR TITLE
Use new cloudfront url for KoL images.

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -151,8 +151,7 @@ public abstract class KoLmafia {
 
   public static boolean useAmazonImages = true;
 
-  public static final String AMAZON_IMAGE_SERVER =
-      "https://s3.amazonaws.com/images.kingdomofloathing.com";
+  public static final String AMAZON_IMAGE_SERVER = "https://d2uyhvukfffg5a.cloudfront.net";
   public static final String AMAZON_IMAGE_SERVER_PATH = AMAZON_IMAGE_SERVER + "/";
   public static final String KOL_IMAGE_SERVER = "http://images.kingdomofloathing.com";
   public static final String KOL_IMAGE_SERVER_PATH = KOL_IMAGE_SERVER + "/";


### PR DESCRIPTION
Apparently this changed recently and broke the CAB.

https://kolmafia.us/threads/26911