### PR TITLE
Language Server - error locations - String

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/Line.java
+++ b/src/net/sourceforge/kolmafia/textui/Line.java
@@ -203,28 +203,23 @@ public final class Line {
       }
 
       final int offset;
+
+      if (!Line.this.tokens.isEmpty()) {
+        offset = Line.this.tokens.getLast().restOfLineStart;
+      } else {
+        offset = Line.this.offset;
+      }
+
       final String lineRemainder;
 
       if (Line.this.content == null) {
         // At end of file
-        if (Line.this.previousLine != null && !Line.this.previousLine.tokens.isEmpty()) {
-          offset = Line.this.previousLine.tokens.getLast().restOfLineStart;
-        } else {
-          offset = Line.this.offset;
-        }
-
         this.content = ";";
         // Going forward, we can just assume lineRemainder is an
         // empty string.
         lineRemainder = "";
         tokenLength = 0;
       } else {
-        if (!Line.this.tokens.isEmpty()) {
-          offset = Line.this.tokens.getLast().restOfLineStart;
-        } else {
-          offset = Line.this.offset;
-        }
-
         final String lineRemainderWithToken = Line.this.substring(offset);
 
         this.content = lineRemainderWithToken.substring(0, tokenLength);

--- a/src/net/sourceforge/kolmafia/textui/Line.java
+++ b/src/net/sourceforge/kolmafia/textui/Line.java
@@ -48,7 +48,10 @@ public final class Line {
       // We are the "end of file" (or there was an IOException when reading)
       this.content = null;
       this.lineNumber = this.previousLine != null ? this.previousLine.lineNumber : 1;
-      this.offset = this.previousLine != null ? this.previousLine.offset : 0;
+      this.offset =
+          this.previousLine != null
+              ? this.previousLine.offset + this.previousLine.content.length()
+              : 0;
       return;
     }
 

--- a/test/net/sourceforge/kolmafia/textui/LineTest.java
+++ b/test/net/sourceforge/kolmafia/textui/LineTest.java
@@ -98,7 +98,9 @@ public class LineTest {
     assertEquals(1, line1BOM.offset);
     assertEquals(0, line2Empty.offset);
     assertEquals(5, line3SurroundingWhitespace.offset);
-    assertEquals(line3SurroundingWhitespace.offset, endOfFile.offset);
+    assertEquals(
+        line3SurroundingWhitespace.offset + line3SurroundingWhitespace.content.length(),
+        endOfFile.offset);
   }
 
   /** Trimmed line content */
@@ -279,7 +281,9 @@ public class LineTest {
     assertEquals(line3Token2.restOfLineStart, line3Token3.getStart().getCharacter());
     assertEquals(line3Token3.restOfLineStart, line3Token4.getStart().getCharacter());
 
-    assertEquals(line3SurroundingWhitespace.offset, endOfFileToken.getStart().getCharacter());
+    assertEquals(
+        line3SurroundingWhitespace.offset + line3SurroundingWhitespace.content.length(),
+        endOfFileToken.getStart().getCharacter());
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/textui/LineTest.java
+++ b/test/net/sourceforge/kolmafia/textui/LineTest.java
@@ -279,7 +279,7 @@ public class LineTest {
     assertEquals(line3Token2.restOfLineStart, line3Token3.getStart().getCharacter());
     assertEquals(line3Token3.restOfLineStart, line3Token4.getStart().getCharacter());
 
-    assertEquals(line3Token4.restOfLineStart, endOfFileToken.getStart().getCharacter());
+    assertEquals(line3SurroundingWhitespace.offset, endOfFileToken.getStart().getCharacter());
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/textui/parsetree/EscapeSequenceTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/EscapeSequenceTest.java
@@ -64,7 +64,7 @@ public class EscapeSequenceTest {
             "'\\u1'",
             "Unicode character escape requires 4 digits",
             "char 2 to char 6"),
-        invalid("string with escaped eof", "'\\", "No closing ' found"));
+        invalid("string with escaped eof", "'\\", "No closing ' found", "char 1 to char 3"));
   }
 
   @ParameterizedTest

--- a/test/net/sourceforge/kolmafia/textui/parsetree/StringTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/StringTest.java
@@ -15,7 +15,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class StringTest {
   public static Stream<ScriptData> data() {
     return Stream.of(
-        invalid("Multiline string, end of line not escaped", "'\n'", "No closing ' found"),
+        invalid(
+            "Multiline string, end of line not escaped",
+            "'\n'",
+            "No closing ' found",
+            "char 1 to char 2"),
         valid(
             "Multiline string, end of line properly escaped",
             "'\\\n'",
@@ -46,7 +50,8 @@ public class StringTest {
         invalid(
             "Multiline string, end of line properly escaped + empty lines + comment",
             "'\\\n\n\n//Comment\n\n'",
-            "No closing ' found"));
+            "No closing ' found",
+            "char 1 to line 4, char 10"));
   }
 
   @ParameterizedTest

--- a/test/net/sourceforge/kolmafia/textui/parsetree/TemplateStringTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/TemplateStringTest.java
@@ -19,15 +19,18 @@ public class TemplateStringTest {
             "Unterminated string template",
             "`{`",
             // The parser tries to start a new string template inside the expression
-            "No closing ` found"),
+            "No closing ` found",
+            "char 3 to char 4"),
         invalid(
             "Abruptly unterminated string template, expecting expression",
             "`{",
-            "Expression expected"),
+            "Expression expected",
+            "char 3"),
         invalid(
             "Abruptly unterminated string template, parsed expression",
             "`{1",
-            "Expected }, found end of file"),
+            "Expected }, found end of file",
+            "char 4"),
         valid(
             "basic template string",
             "`this is some math: {4 + 7}`",
@@ -56,7 +59,8 @@ public class TemplateStringTest {
         invalid(
             "template string with unclosed comment",
             "`this is some math: {7 // what determines the end?}`",
-            "Expected }, found end of file"),
+            "Expected }, found end of file",
+            "char 53"),
         valid(
             "template string with terminated comment",
             "`this is some math: {7 // turns out you need a newline\r\n\t}`",


### PR DESCRIPTION
Additionally, fixes a behavior regarding the relation between `currentIndex` and the end of file:

When moving to the next line, we would set `currentIndex` to the value of `currentLine.offset`.
However, the "end of file" line's offset is the same as the previous line.
This means that calling `getCurrentPosition()` would yield a Position that seemingly came *earlier* in the final line.