### PR TITLE
Eliminate a a condition that is always true in a conditional on the presumption it is an error.

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
@@ -45,12 +45,15 @@ public class RequestPane extends JEditorPane {
     // so remove those to find out the remaining HTML.
 
     String selectedText = sw.toString();
-    int beginIndex = selectedText.indexOf("<body>") + 6;
+    int beginIndex = selectedText.indexOf("<body>");
     int endIndex = selectedText.lastIndexOf("</body>");
 
     if (beginIndex == -1 || endIndex == -1) {
       return "";
     }
+
+    // skip over body tag
+    beginIndex = beginIndex + 6;
 
     selectedText = selectedText.substring(beginIndex, endIndex).trim();
     if (Preferences.getBoolean("copyAsHTML")) {


### PR DESCRIPTION
"lint" showed a condition that was always false in a test.

This cleans that up a little.  It gets indices for each tag and bails if either tag is not found.  The old code would contine if the <body> tag was not present.