### PR TITLE
Use cloudfront for images, take two.

### DIFF
--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -70,7 +70,7 @@ public class FamiliarData implements Comparable<FamiliarData> {
   // 1=id 2=image 3=name 4=race 5=exp 6=kills 7=extra
   private static final Pattern CURRENT_FAMILIAR_PATTERN =
       Pattern.compile(
-          ".*?(?:onClick='fam\\((\\d+)\\)')? .*?src=\"[^>]*?(?:images.kingdomofloathing.com|/images)/(?:item|other)images/([^\"]*?)\".*?<b>(.*?)</b>.*?\\d+-pound (.*?) \\(([\\d,]+) (?:exp|experience|candy|candies)?, ([\\d,]+) kills?\\)(.*?)(?:</form)>");
+          ".*?(?:onClick='fam\\((\\d+)\\)')? .*?src=\"[^>]*?(?:cloudfront.net|images.kingdomofloathing.com|/images)/(?:item|other)images/([^\"]*?)\".*?<b>(.*?)</b>.*?\\d+-pound (.*?) \\(([\\d,]+) (?:exp|experience|candy|candies)?, ([\\d,]+) kills?\\)(.*?)(?:</form)>");
 
   private static final Pattern FROW_PATTERN = Pattern.compile("<tr class=\"frow .*?</tr>");
 

--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -14,6 +14,7 @@ import java.math.BigInteger;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.util.List;
+import java.util.Set;
 import java.util.TimeZone;
 import javax.swing.JEditorPane;
 import javax.swing.JFrame;
@@ -149,20 +150,20 @@ public abstract class KoLmafia {
   public static KoLAdventure currentAdventure;
   public static String statDay = "None";
 
-  public static boolean useAmazonImages = true;
-
-  public static final String AMAZON_IMAGE_SERVER =
-      "https://s3.amazonaws.com/images.kingdomofloathing.com";
-  public static final String AMAZON_IMAGE_SERVER_PATH = AMAZON_IMAGE_SERVER + "/";
-  public static final String KOL_IMAGE_SERVER = "http://images.kingdomofloathing.com";
-  public static final String KOL_IMAGE_SERVER_PATH = KOL_IMAGE_SERVER + "/";
+  private static final String PREFERRED_IMAGE_SERVER = "https://d2uyhvukfffg5a.cloudfront.net";
+  private static final String PREFERRED_IMAGE_SERVER_PATH = PREFERRED_IMAGE_SERVER + "/";
+  public static final Set<String> IMAGE_SERVER_PATHS =
+      Set.of(
+          PREFERRED_IMAGE_SERVER_PATH,
+          "https://s3.amazonaws.com/images.kingdomofloathing.com/",
+          "http://images.kingdomofloathing.com/");
 
   public static String imageServerPrefix() {
-    return KoLmafia.useAmazonImages ? AMAZON_IMAGE_SERVER : KOL_IMAGE_SERVER;
+    return PREFERRED_IMAGE_SERVER;
   }
 
   public static String imageServerPath() {
-    return KoLmafia.useAmazonImages ? AMAZON_IMAGE_SERVER_PATH : KOL_IMAGE_SERVER_PATH;
+    return PREFERRED_IMAGE_SERVER_PATH;
   }
 
   private static boolean acquireFileLock(final String suffix) {

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -1876,7 +1876,7 @@ public class DebugDatabase {
   // http://images.kingdomofloathing.com/otherimages/folders/folder22.gif
   // http://images.kingdomofloathing.com/otherimages/sigils/workouttat.gif
   private static final Pattern IMAGE_PATTERN =
-      Pattern.compile("images.kingdomofloathing.com/(.*?\\.gif)");
+      Pattern.compile("(cloudfront.net|images.kingdomofloathing.com)/(.*?\\.gif)");
 
   public static final String parseImage(final String text) {
     Matcher matcher = DebugDatabase.IMAGE_PATTERN.matcher(text);

--- a/src/net/sourceforge/kolmafia/request/CharPaneRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CharPaneRequest.java
@@ -270,7 +270,8 @@ public class CharPaneRequest extends GenericRequest {
   // width=60 height=100 border=0></a>
 
   public static final Pattern AVATAR_PATTERN =
-      Pattern.compile("<img +src=[^>]*?(?:images.kingdomofloathing.com|/images)/([^>'\"\\s]+)");
+      Pattern.compile(
+          "<img +src=[^>]*?(?:cloudfront.net|images.kingdomofloathing.com|/images)/([^>'\"\\s]+)");
 
   public static final void parseAvatar(final String responseText) {
     Matcher avatarMatcher = CharPaneRequest.AVATAR_PATTERN.matcher(responseText);
@@ -1097,7 +1098,7 @@ public class CharPaneRequest extends GenericRequest {
 
   private static final Pattern PokeFamPattern =
       Pattern.compile(
-          "img align=\"absmiddle\" src=http://images.kingdomofloathing.com/itemimages/(.*?)>&nbsp;(.*?) \\(Lvl (\\d+)\\)",
+          "img align=\"absmiddle\" src=(?:cloudfront.net|images.kingdomofloathing.com)/itemimages/(.*?)>&nbsp;(.*?) \\(Lvl (\\d+)\\)",
           Pattern.DOTALL);
 
   private static void checkPokeFam(final String responseText) {

--- a/src/net/sourceforge/kolmafia/request/CharSheetRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CharSheetRequest.java
@@ -33,7 +33,8 @@ import org.w3c.dom.NodeList;
 public class CharSheetRequest extends GenericRequest {
   private static final Pattern BASE_PATTERN = Pattern.compile(" \\(base: ([\\d,]+)\\)");
   private static final Pattern AVATAR_PATTERN =
-      Pattern.compile("<img src=[^>]*?(?:images.kingdomofloathing.com|/images)/([^>'\"\\s]+)");
+      Pattern.compile(
+          "<img src=[^>]*?(?:cloudfront.net|images.kingdomofloathing.com|/images)/([^>'\"\\s]+)");
 
   private static final HtmlCleaner cleaner = HTMLParserUtils.configureDefaultParser();
   private static final DomSerializer domSerializer = new DomSerializer(cleaner.getProperties());

--- a/src/net/sourceforge/kolmafia/request/DisplayCaseRequest.java
+++ b/src/net/sourceforge/kolmafia/request/DisplayCaseRequest.java
@@ -192,7 +192,7 @@ public class DisplayCaseRequest extends TransferItemRequest {
   // height=100></td><td valign=center>...txt...</td></tr></table>
   public static final Pattern ANNOUNCEMENT_PATTERN =
       Pattern.compile(
-          "<table><tr><td valign=center><img src=[^>]*?(?:images.kingdomofloathing.com|/images)/otherimages/museum/displaycase.gif\" width=100 height=100></td><td[^.]*>(.*?)</td></table>");
+          "<table><tr><td valign=center><img src=[^>]*?(?:cloudfront.net|images.kingdomofloathing.com|/images)/otherimages/museum/displaycase.gif\" width=100 height=100></td><td[^.]*>(.*?)</td></table>");
 
   public static final boolean parseDisplayCase(final String urlString, String responseText) {
     RequestThread.runInParallel(new DisplayCaseParser(responseText), false);

--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -578,11 +578,11 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     for (String filename : IMAGES) {
-      String find1 = KoLmafia.KOL_IMAGE_SERVER_PATH + filename;
-      String find2 = KoLmafia.AMAZON_IMAGE_SERVER_PATH + filename;
       String replace = "/images/" + filename;
-      StringUtilities.globalStringReplace(buffer, find1, replace);
-      StringUtilities.globalStringReplace(buffer, find2, replace);
+      for (String path : KoLmafia.IMAGE_SERVER_PATHS) {
+        String find = path + filename;
+        StringUtilities.globalStringReplace(buffer, find, replace);
+      }
     }
   }
 

--- a/src/net/sourceforge/kolmafia/request/TrophyRequest.java
+++ b/src/net/sourceforge/kolmafia/request/TrophyRequest.java
@@ -9,7 +9,7 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 public class TrophyRequest extends GenericRequest {
   private static final Pattern TROPHY_PATTERN =
       Pattern.compile(
-          "<td><img.*?src=[^>]*?(?:images.kingdomofloathing.com|/images)/(.+?)\".*?<td[^>]*?>(.+?)<.*?name=public(\\d+)\\s*(checked)?\\s*>",
+          "<td><img.*?src=[^>]*?(?:cloudfront.net|images.kingdomofloathing.com|/images)/(.+?)\".*?<td[^>]*?>(.+?)<.*?name=public(\\d+)\\s*(checked)?\\s*>",
           Pattern.DOTALL);
   private ArrayList<Trophy> trophies;
 

--- a/src/net/sourceforge/kolmafia/session/BuffBotManager.java
+++ b/src/net/sourceforge/kolmafia/session/BuffBotManager.java
@@ -60,7 +60,7 @@ public abstract class BuffBotManager {
 
   public static final Pattern MEAT_PATTERN =
       Pattern.compile(
-          "<img src=[^>]*?(?:images.kingdomofloathing.com|/images)/itemimages/meat.gif\" height=30 width=30 alt=\"Meat\">You gain ([\\d,]+) Meat");
+          "<img src=[^>]*?(?:cloudfront.net|images.kingdomofloathing.com|/images)/itemimages/meat.gif\" height=30 width=30 alt=\"Meat\">You gain ([\\d,]+) Meat");
   public static final Pattern GIFT1_PATTERN =
       Pattern.compile(
           "<a class=nounder style='color: blue' href='showplayer.php\\?who=(\\d+)' target=mainpane>");

--- a/src/net/sourceforge/kolmafia/session/MonsterManuelManager.java
+++ b/src/net/sourceforge/kolmafia/session/MonsterManuelManager.java
@@ -316,7 +316,7 @@ public class MonsterManuelManager {
   // width=100></td>
   private static final Pattern IMAGE_PATTERN =
       Pattern.compile(
-          "<td rowspan=4 valign=top width=100><img src=[^>]*?(?:images.kingdomofloathing.com|/images)/(?:(adventureimages|otherimages)/(?:\\.\\./)?)?(.*?\\.gif).*?</td>");
+          "<td rowspan=4 valign=top width=100><img src=[^>]*?(?:cloudfront.net|images.kingdomofloathing.com|/images)/(?:(adventureimages|otherimages)/(?:\\.\\./)?)?(.*?\\.gif).*?</td>");
 
   public static String extractMonsterImage(final String text) {
     Matcher matcher = MonsterManuelManager.IMAGE_PATTERN.matcher(text);

--- a/src/net/sourceforge/kolmafia/utilities/FileUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/FileUtilities.java
@@ -355,6 +355,9 @@ public class FileUtilities {
     }
     String images = ".com";
     int index = filename.lastIndexOf(images);
+    if (index == -1) {
+      index = filename.lastIndexOf(".net");
+    }
     int offset = index == -1 ? 0 : (index + images.length() + 1);
     String localname = offset > 0 ? filename.substring(offset) : filename;
     if (localname.startsWith("albums/")) {

--- a/src/net/sourceforge/kolmafia/webui/BarrelDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/BarrelDecorator.java
@@ -89,7 +89,7 @@ public abstract class BarrelDecorator {
 
   private static final Pattern UNSMASHED =
       Pattern.compile(
-          "smash=(\\d+)&pwd=(\\w+)'><img src=[^>]*?(?:images.kingdomofloathing.com|/images)/otherimages/mountains/smallbarrel.gif'.*?>");
+          "smash=(\\d+)&pwd=(\\w+)'><img src=[^>]*?(?:cloudfront.net|images.kingdomofloathing.com|/images)/otherimages/mountains/smallbarrel.gif'.*?>");
 
   public static final void decorate(final StringBuffer buffer) {
     if (!Preferences.getBoolean("relayShowSpoilers")) {

--- a/src/net/sourceforge/kolmafia/webui/IslandDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/IslandDecorator.java
@@ -342,8 +342,9 @@ public class IslandDecorator {
     }
 
     // Replace all KoL image servers with KoLmafia image cache locations
-    StringUtilities.globalStringReplace(buffer, KoLmafia.AMAZON_IMAGE_SERVER, "/images");
-    StringUtilities.globalStringReplace(buffer, KoLmafia.KOL_IMAGE_SERVER, "/images");
+    for (String path : KoLmafia.IMAGE_SERVER_PATHS) {
+      StringUtilities.globalStringReplace(buffer, path, "/images/");
+    }
 
     // Replace sidequest location images for completed quests
     IslandDecorator.sidequestImage(buffer, "sidequestArenaCompleted", Quest.ARENA);
@@ -504,8 +505,9 @@ public class IslandDecorator {
     IslandDecorator.decorateArena(url, buffer);
 
     // Replace all KoL image servers with KoLmafia image cache locations
-    StringUtilities.globalStringReplace(buffer, KoLmafia.AMAZON_IMAGE_SERVER, "/images");
-    StringUtilities.globalStringReplace(buffer, KoLmafia.KOL_IMAGE_SERVER, "/images");
+    for (String path : KoLmafia.IMAGE_SERVER_PATHS) {
+      StringUtilities.globalStringReplace(buffer, path, "/images/");
+    }
 
     // Replace sidequest location images for completed quests
 

--- a/src/net/sourceforge/kolmafia/webui/RelayAgent.java
+++ b/src/net/sourceforge/kolmafia/webui/RelayAgent.java
@@ -456,20 +456,18 @@ public class RelayAgent extends Thread {
     }
   }
 
-  private static final String NOCACHE_IMAGES = "(/memes|/otherimages/zonefont)?";
+  private static final String NOCACHE_IMAGES = "(memes|otherimages/zonefont)?";
 
   private static final Pattern IMAGE_PATTERN =
       Pattern.compile(
           "("
-              + KoLmafia.AMAZON_IMAGE_SERVER
-              + "|"
-              + KoLmafia.KOL_IMAGE_SERVER
+              + String.join("|", KoLmafia.IMAGE_SERVER_PATHS)
               + "|"
               + "/iii"
               + "|"
-              + "//images.kingdomofloathing.com"
+              + "//images.kingdomofloathing.com/"
               + "|"
-              + "http://pics.communityofloathing.com/albums"
+              + "http://pics.communityofloathing.com/albums/"
               + ")"
               + RelayAgent.NOCACHE_IMAGES);
 
@@ -489,7 +487,7 @@ public class RelayAgent extends Thread {
           if (matcher.group(2) != null) {
             matcher.appendReplacement(responseBuffer, "$0");
           } else {
-            matcher.appendReplacement(responseBuffer, "/images");
+            matcher.appendReplacement(responseBuffer, "/images/");
           }
         }
 

--- a/src/net/sourceforge/kolmafia/webui/StationaryButtonDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/StationaryButtonDecorator.java
@@ -142,9 +142,7 @@ public class StationaryButtonDecorator {
     if (Preferences.getBoolean("serverAddsCustomCombat")) {
       // Apparently KoL is always using the Amazon server for the CAB
       String bufferString =
-          "<td><img src='"
-              + KoLmafia.AMAZON_IMAGE_SERVER_PATH
-              + "itemimages/book3.gif' id='skills'>";
+          "<td><img src='" + KoLmafia.imageServerPath() + "itemimages/book3.gif' id='skills'>";
       int imageIndex = buffer.indexOf(bufferString);
       if (imageIndex != -1) {
         boolean again = FightRequest.getCurrentRound() == 0;


### PR DESCRIPTION
KoL is currently serving a mix of cloudfront / S3 traffic, so we should be
strict about requesting from cloudfront if we originate a request, but lenient
about accepting responses that contain non-cloudfront URLs.

Further, downloadImage() was constrained such that it would look for the last
occurrence of .com, which naturally stopped matching once we moved to
cloudfront.net URLs.

Also also, there were a bunch of regexes that expected image URLs to contain
"images.kingdomofloathing.com", which was true under S3 but is no longer true
with Cloudfront. Many of these are underspecified out of laziness, but I can fix
that if needed.