### PR TITLE
Fix some regressions from the cloudfront change.

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -1876,7 +1876,7 @@ public class DebugDatabase {
   // http://images.kingdomofloathing.com/otherimages/folders/folder22.gif
   // http://images.kingdomofloathing.com/otherimages/sigils/workouttat.gif
   private static final Pattern IMAGE_PATTERN =
-      Pattern.compile("(cloudfront.net|images.kingdomofloathing.com)/(.*?\\.gif)");
+      Pattern.compile("(?:cloudfront.net|images.kingdomofloathing.com)/(.*?\\.gif)");
 
   public static final String parseImage(final String text) {
     Matcher matcher = DebugDatabase.IMAGE_PATTERN.matcher(text);

--- a/src/net/sourceforge/kolmafia/webui/RelayAgent.java
+++ b/src/net/sourceforge/kolmafia/webui/RelayAgent.java
@@ -463,7 +463,7 @@ public class RelayAgent extends Thread {
           "("
               + String.join("|", KoLmafia.IMAGE_SERVER_PATHS)
               + "|"
-              + "/iii"
+              + "/iii/"
               + "|"
               + "//images.kingdomofloathing.com/"
               + "|"


### PR DESCRIPTION
DebugDatabase: a regex inadvertently introduced a new capturing group.

RelayAgent: I moved the trailing slash to the capturing group, as opposed to
having a leading slash in the rest of the pattern, so we could get away with
only exposing "PATH" constants. (Thanks Veracity for catching this)