### PR TITLE
Track AT songs explicitly, improve user experience around AT songs

### DIFF
--- a/src/data/statuseffects.txt
+++ b/src/data/statuseffects.txt
@@ -59,18 +59,18 @@
 57	Rainy Soul Miasma	raincloud.gif	a47ef21c02a4b8ba3b1da929f4566934	neutral	none	use 1 thin black candle
 58	Teleportitis	confused.gif	cb5404472a27b435aa6fad1ba528b1b8	neutral	nopvp	use 1 potion of teleportitis
 59	Wanged	wang.gif	0f35dcc9f22cd0ee2e6ef690c3512a01	neutral	none	# wang used on you
-60	Aloysius' Antiphon of Aptitude	antiphon.gif	3f875f7c9c4cc7b64f4c7d7b7eea1ef6	good	none	cast 1 Aloysius' Antiphon of Aptitude|cargo effect Aloysius' Antiphon of Aptitude
-61	The Moxious Madrigal	madrigal.gif	c77eb3298c1bcba5e0147eba77a5a802	good	none	cast 1 The Moxious Madrigal
-62	Cletus's Canticle of Celerity	celerity.gif	fe25963fb651fc5d81ed5a098b509030	good	none	cast 1 Cletus's Canticle of Celerity
-63	Polka of Plenty	plenty.gif	c26a911b8ec2c57f7eef57f9ff5fdc24	good	none	cast 1 The Polka of Plenty|cargo effect Polka of Plenty
-64	The Magical Mojomuscular Melody	mojomusc.gif	80224f21d262123e7e370d440ce36937	good	none	cast 1 The Magical Mojomuscular Melody
-65	Power Ballad of the Arrowsmith	arrowsmith.gif	695f24467176d2e76738e7c5e1148a42	good	none	cast 1 The Power Ballad of the Arrowsmith|cargo effect Power Ballad of the Arrowsmith
-66	Brawnee's Anthem of Absorption	brawnees.gif	bcbbb5a02c92d158e45fd9c736950380	good	none	cast 1 Brawnee's Anthem of Absorption|cargo effect Brawnee's Anthem of Absorption
-67	Fat Leon's Phat Loot Lyric	fatleons.gif	63e73adb3ecfb0cbf544db435eeeaf00	good	none	cast 1 Fat Leon's Phat Loot Lyric|cargo effect Fat Leon's Phat Loot Lyric
-68	Psalm of Pointiness	psalm.gif	5abc19b33b53e0cb7749472a07311c6a	good	none	cast 1 The Psalm of Pointiness
-69	Jackasses' Symphony of Destruction	jackasses.gif	fca62260f2f750e32f104f868ed1a3a5	good	none	cast 1 Jackasses' Symphony of Destruction
-70	Stevedave's Shanty of Superiority	superiority.gif	2e5a803cf1be5b3d2aaa897e60f29138	good	none	cast 1 Stevedave's Shanty of Superiority|cargo effect Stevedave's Shanty of Superiority
-71	Ode to Booze	odetobooze.gif	626c8ef76cfc003c6ac2e65e9af5fd7a	good	none	cast 1 The Ode to Booze|cargo effect Ode to Booze
+60	Aloysius' Antiphon of Aptitude	antiphon.gif	3f875f7c9c4cc7b64f4c7d7b7eea1ef6	good	song	cast 1 Aloysius' Antiphon of Aptitude|cargo effect Aloysius' Antiphon of Aptitude
+61	The Moxious Madrigal	madrigal.gif	c77eb3298c1bcba5e0147eba77a5a802	good	song	cast 1 The Moxious Madrigal
+62	Cletus's Canticle of Celerity	celerity.gif	fe25963fb651fc5d81ed5a098b509030	good	song	cast 1 Cletus's Canticle of Celerity
+63	Polka of Plenty	plenty.gif	c26a911b8ec2c57f7eef57f9ff5fdc24	good	song	cast 1 The Polka of Plenty|cargo effect Polka of Plenty
+64	The Magical Mojomuscular Melody	mojomusc.gif	80224f21d262123e7e370d440ce36937	good	song	cast 1 The Magical Mojomuscular Melody
+65	Power Ballad of the Arrowsmith	arrowsmith.gif	695f24467176d2e76738e7c5e1148a42	good	song	cast 1 The Power Ballad of the Arrowsmith|cargo effect Power Ballad of the Arrowsmith
+66	Brawnee's Anthem of Absorption	brawnees.gif	bcbbb5a02c92d158e45fd9c736950380	good	song	cast 1 Brawnee's Anthem of Absorption|cargo effect Brawnee's Anthem of Absorption
+67	Fat Leon's Phat Loot Lyric	fatleons.gif	63e73adb3ecfb0cbf544db435eeeaf00	good	song	cast 1 Fat Leon's Phat Loot Lyric|cargo effect Fat Leon's Phat Loot Lyric
+68	Psalm of Pointiness	psalm.gif	5abc19b33b53e0cb7749472a07311c6a	good	song	cast 1 The Psalm of Pointiness
+69	Jackasses' Symphony of Destruction	jackasses.gif	fca62260f2f750e32f104f868ed1a3a5	good	song	cast 1 Jackasses' Symphony of Destruction
+70	Stevedave's Shanty of Superiority	superiority.gif	2e5a803cf1be5b3d2aaa897e60f29138	good	song	cast 1 Stevedave's Shanty of Superiority|cargo effect Stevedave's Shanty of Superiority
+71	Ode to Booze	odetobooze.gif	626c8ef76cfc003c6ac2e65e9af5fd7a	good	song	cast 1 The Ode to Booze|cargo effect Ode to Booze
 72	Sleeping with the Fishes	sleepy.gif	5285075ac41f4e239008e57f0b11e193	neutral	none	# wearing cement shoes
 73	Ticking Clock	clock.gif	6e54ea1584f2410c94c93032c5a038f0	good	none	use 1 cheap wind-up clock
 74	Fresh Scent	happy.gif	a12c86c626c44ecd48540d1e55bf1204	neutral	none	use either 1 chunk of rock salt, 1 deodorant|cargo effect Fresh Scent
@@ -161,9 +161,9 @@
 159	Spooky Weapon	batblade.gif	d774d576335ec8cc8c061e6891ff41c5	good	none	use 1 spooky nuggets
 160	Stinky Weapon	stench.gif	c927edbace02490d4c66ee8271c64e2e	good	none	use 1 stench nuggets
 161	Sleazy Weapon	dripsword.gif	fe75c03d60169594193a0733c513a853	good	none	use 1 sleaze nuggets
-162	The Sonata of Sneakiness	sonata.gif	b757f23feb7f08bd250f63586e03cf4a	neutral	none	cast 1 The Sonata of Sneakiness|cargo effect The Sonata of Sneakiness
-163	Carlweather's Cantata of Confrontation	cantata.gif	06e123f9b46d3d180c97efc5ab0ad150	neutral	none	cast 1 Carlweather's Cantata of Confrontation|cargo effect Carlweather's Cantata of Confrontation
-164	Ur-Kel's Aria of Annoyance	urkels.gif	59a1ac48440e1ea1f869f2b37753f9cc	neutral	none	cast 1 Ur-Kel's Aria of Annoyance|cargo effect Ur-Kel's Aria of Annoyance
+162	The Sonata of Sneakiness	sonata.gif	b757f23feb7f08bd250f63586e03cf4a	neutral	song	cast 1 The Sonata of Sneakiness|cargo effect The Sonata of Sneakiness
+163	Carlweather's Cantata of Confrontation	cantata.gif	06e123f9b46d3d180c97efc5ab0ad150	neutral	song	cast 1 Carlweather's Cantata of Confrontation|cargo effect Carlweather's Cantata of Confrontation
+164	Ur-Kel's Aria of Annoyance	urkels.gif	59a1ac48440e1ea1f869f2b37753f9cc	neutral	song	cast 1 Ur-Kel's Aria of Annoyance|cargo effect Ur-Kel's Aria of Annoyance
 165	Smooth Movements	footprints.gif	173a9c4b4bbef78643fe4ec1a93b1cfc	neutral	none	cast 1 Smooth Movement
 166	Musk of the Moose	stench.gif	5e788aac76c7451c42ce19d2acf6de18	neutral	none	cast 1 Musk of the Moose
 167	Spirit of Cayenne	flame.gif	050dd88888b1ac9a2192cd71fd175a45	good	nohookah	cast 1 Spirit of Cayenne
@@ -224,7 +224,7 @@
 222	Snarl of the Timberwolf	wolfmask.gif	2968e9397d3aa977b8cb3e9817ad8cdd	good	nohookah	cast 1 Snarl of the Timberwolf
 223	Dreams and Lights	snowflakes.gif	360467118bd69ef869a1af2002117e63	good	none	# adv in Haunted Gallery
 224	Scarysauce	skullshld.gif	f7551a889b9c61510fc3f73f96ecc98e	good	none	cast 1 Scarysauce
-225	Dirge of Dreadfulness	dirge.gif	6121ba486d7ad86165d117ea62794d09	good	none	cast 1 Dirge of Dreadfulness
+225	Dirge of Dreadfulness	dirge.gif	6121ba486d7ad86165d117ea62794d09	good	song	cast 1 Dirge of Dreadfulness
 226	Talking Like a Pirate	piratehead.gif	defbfe64c65b2d495dc0133506223c1f	neutral	none	use 1 can of Binarrrca
 227	The 'Tussin	bseye.gif	295f414c903d22c44ec2f92f789cad71	neutral	none	use 1 bottle of Vangoghbitussin
 228	Pie in the Face	pieface.gif	9c9794f2ff9a0fcb1090c281c2c442f1	neutral	none	# being hit with cream pie
@@ -529,12 +529,12 @@
 527	Carrion' On	bonepile.gif	447b7c96f0e5c93fb9a64f92850f0b3e	good	none	chew 1 glimmering buzzard feather
 528	Melancholy Burden	blackbird1.gif	99d1d6de637d4289842cba0ffc2aec19	good	none	chew 1 glimmering raven feather
 529	The Great Tit's Blessing	wink.gif	429a69b3cdc061390828454dd06b6825	neutral	none	chew 1 glimmering great tit feather
-530	The Ballad of Richie Thingfinder	richie.gif	ff0e9ff0189cea375f60b5860463518d	good	none	cast 1 The Ballad of Richie Thingfinder|use 1 recording of The Ballad of Richie Thingfinder
-531	Benetton's Medley of Diversity	medley.gif	c8d08f07fdafe4308601d97322ca69dd	good	none	cast 1 Benetton's Medley of Diversity|use 1 recording of Benetton's Medley of Diversity
-532	Elron's Explosive Etude	etude.gif	26318ef7c75a6bf1fa80584e2e8941b3	good	none	cast 1 Elron's Explosive Etude|use 1 recording of Elron's Explosive Etude
-533	Chorale of Companionship	chorale.gif	e9227c476b197f54d5fe6be5e52995b5	good	none	cast 1 Chorale of Companionship|use 1 recording of Chorale of Companionship
-534	Prelude of Precision	prelude.gif	3f442b411c8d73c4116db7b89669b852	good	none	cast 1 Prelude of Precision|use 1 recording of Prelude of Precision
-535	Deadly Lampblade	blacksword.gif	32cfd91b38e4cfd44a05d368aec7cf48	good	none	use 1 deadly lampshade
+530	The Ballad of Richie Thingfinder	richie.gif	ff0e9ff0189cea375f60b5860463518d	good	song	cast 1 The Ballad of Richie Thingfinder|use 1 recording of The Ballad of Richie Thingfinder
+531	Benetton's Medley of Diversity	medley.gif	c8d08f07fdafe4308601d97322ca69dd	good	song	cast 1 Benetton's Medley of Diversity|use 1 recording of Benetton's Medley of Diversity
+532	Elron's Explosive Etude	etude.gif	26318ef7c75a6bf1fa80584e2e8941b3	good	song	cast 1 Elron's Explosive Etude|use 1 recording of Elron's Explosive Etude
+533	Chorale of Companionship	chorale.gif	e9227c476b197f54d5fe6be5e52995b5	good	song	cast 1 Chorale of Companionship|use 1 recording of Chorale of Companionship
+534	Prelude of Precision	prelude.gif	3f442b411c8d73c4116db7b89669b852	good	song	cast 1 Prelude of Precision|use 1 recording of Prelude of Precision
+535	Deadly Lampblade	blacksword.gif	32cfd91b38e4cfd44a05d368aec7cf48	good	song	use 1 deadly lampshade
 536	Drenched With Filth	blooddrops.gif	0bae503909ac0e2a21763466adf33d29	good	none	use 1 concentrated garbage juice
 537	Hobonic	hobohead.gif	1a4b9db2f98937c155609f54c14cdf7c	good	none	# resting in Hobo Fortress
 538	Crotchety, Pining	pineneedles.gif	a03720e54550e5757e0e8107c6f842bc	good	none	use 1 handful of Crotchety Pine needles|cargo effect Crotchety, Pining
@@ -613,7 +613,7 @@
 611	Lustful Heart	heart.gif	35a0e93898e18f500d1d0c7eec8e8ef1	good	nohookah	use 1 love song of naughty innuendo
 612	Clumsy	sad.gif	63fa9abd19f2d77636e52d591b54f589	neutral	none	use 1 concoction of clumsiness|cargo effect Clumsy
 613	Spectral	specjelly.gif	810bbc77f3ef220d9d77ed395b9cc70c	neutral	none	use either 1 spectral jelly, 1 ghost protocol
-614	Donho's Bubbly Ballad	bubblyballad.gif	3337ba138b0e4d48f070bca9711139b5	good	none	cast 1 Donho's Bubbly Ballad|use 1 recording of Donho's Bubbly Ballad
+614	Donho's Bubbly Ballad	bubblyballad.gif	3337ba138b0e4d48f070bca9711139b5	good	song	cast 1 Donho's Bubbly Ballad|use 1 recording of Donho's Bubbly Ballad
 615	Antihangover	martini.gif	eadafbbe6d035eb5a36408dfbb1c85cc	good	nohookah	use 1 hair of the fish
 616
 617	Old School Pompadour	pompadour.gif	aff568fdc12724deb962ebcb00e81fb9	good	none	use 1 jellyfish gel|cargo effect Old School Pompadour
@@ -699,7 +699,7 @@
 697	Bruised Jaw	jawbruise.gif	f4959778ae2895efb4c53a2b82a7fe01	neutral	none	eat 1 jawbruiser|cargo effect Bruised Jaw
 698	A Few Extra Pounds	bathroomscale.gif	210aca072eee884be7fe49b03f5098b6	good	none	cast 1 Holiday Weight Gain
 699	Jingle Jangle Jingle	jinglebells.gif	a32acc4a5de83386ae3417140d09bf43	good	none	cast 1 Jingle Bells
-700	Cringle's Curative Carol	curative.gif	943d3ca45c939d9bcd9a92ababb7db08	good	none	cast 1 Cringle's Curative Carol
+700	Cringle's Curative Carol	curative.gif	943d3ca45c939d9bcd9a92ababb7db08	good	song	cast 1 Cringle's Curative Carol
 701	Holiday Bliss	sleepy.gif	31b51f4b07633328937bae282d4baa5f	good	none	use 1 holly-flavored Hob-O
 702	Sugar High	sugarmag.gif	268dcb9173beb3621445fd6931b5a07d	good	none	# elven suicide capsule - 1/3 chance
 703	Sugar Smacks	sugarstr.gif	c78dc8f3ef4be37bcae07851eed778aa	good	none	# elven suicide capsule - 1/3 chance
@@ -715,7 +715,7 @@
 713	Simply Invisible	blank.gif	3563606030d2e7abf29128b1714dc309	neutral	none	use 1 invisibility potion
 714	Simply Irresistible	magnet.gif	cba956179bd0be43eb87e0f80fc6692c	neutral	none	use 1 irresistibility potion
 715	Simply Irritable	angry.gif	78f093b933f55e50f2cf8d8ee23451d6	neutral	none	use 1 irritability potion
-716	Inigo's Incantation of Inspiration	incantation.gif	13a38b36b281484553a9ea836fd3b2d8	good	none	cast 1 Inigo's Incantation of Inspiration|use 1 recording of Inigo's Incantation of Inspiration
+716	Inigo's Incantation of Inspiration	incantation.gif	13a38b36b281484553a9ea836fd3b2d8	good	song	cast 1 Inigo's Incantation of Inspiration|use 1 recording of Inigo's Incantation of Inspiration
 717	Red Misty-Eyed	eyeball.gif	820b089cdb98e5f389fb24448c4d6a37	good	none	use 1 sealhide seal doll
 718	B-b-brr!	sphererough.gif	c7cfec0c1b99f8ab69bdd4dd24dd6735	neutral	none	# snowball
 719	Sealed Brain	realbrain.gif	12fa21a06cde21c7a65f2244cd02dacb	good	none	use 1 seal-brain elixir
@@ -1494,7 +1494,7 @@
 1492	Reassured	reassured.gif	671ff2f265a9a566b00a976180372a3e	good	nohookah	# having Psychokinetic Hug cast on you
 1493	Eyes for Miles	eyes.gif	889ae743a4d0cc14105c135476fa0a66	good	none	use 1 warbear liquid lasers
 1494	New and Improved	light.gif	d09b7ced217029dae850045f1d238d94	good	none	use 1 warbear rejuvenation potion
-1495	Rolando's Rondo of Resisto	resisto.gif	b19edbdc0f692aca0840c72949fefa0b	good	nohookah	use 1 recording of Rolando's Rondo of Resisto
+1495	Rolando's Rondo of Resisto	resisto.gif	b19edbdc0f692aca0840c72949fefa0b	good	song,nohookah	use 1 recording of Rolando's Rondo of Resisto
 1496	Soles of Glass	glassslipper.gif	1b0f0ec668f5f70c96c4f55de8c61fff	good	none	grim init
 1497	Angry like the Wolf	wolfmask.gif	a8f0f79de690532da8d2e80d12b2b83e	good	none	grim hpmp
 1498	Grumpy and Ornery	angry.gif	a7d08fbe7e345a227857cd9135b788a7	good	none	grim damage
@@ -2374,7 +2374,7 @@
 2372	Big	getbig.gif	581c62434820bcc318206d2b26888f60	good	none	cast 1 Get Big
 2373	Inscrutable Gaze	psychicgaze.gif	117aebee9518a532e86e92dcf4aa1175	good	none	cast 1 Inscrutable Gaze
 2374	Tainted Love Potion	potion9.gif	75c1c2a807f9e12f6c9e3e9954586d08	good	nohookah	use 1 Love Potion #XYZ
-2375	Paul's Passionate Pop Song	paulssong.gif	f13ebf735337e1109a0d726c968f134f	good	none	cast 1 Paul's Passionate Pop Song
+2375	Paul's Passionate Pop Song	paulssong.gif	f13ebf735337e1109a0d726c968f134f	good	song	cast 1 Paul's Passionate Pop Song
 2376	Rhinestoned	rhinestones.gif	b87601a22d0736c8c6ed9a08518829e0	good	none	use 1 rhinestone
 2377	Berry Critical	berry3.gif	96f738d3eca639e360cf915cffd81e3d	good	none	use 1 Nadsat berry
 2378	Berry Thorny	berry5.gif	ae0eaee783c12d3e6756b796d17dfc0a	good	none	use 1 Jamocha berry
@@ -2457,7 +2457,7 @@
 2455	Frenzied, Bloody	bloodfrenzy.gif	cc775d86f48fe74196f3f6a6c17cf3a5	good	none	cast 1 Blood Frenzy
 2456	Blood Bond	bloodbond.gif	5e3903ce818e16ddaec9167389fc988d	good	none	cast 1 Blood Bond
 2457	Blood Bubble	jarl_choco.gif	03a2694dd77ef8a08db950e036c9c910	neutral	none	cast 1 Blood Bubble
-2458	Bram's Bloody Bagatelle	bloodsong.gif	03c0d20a0a8facdb7da2bdbd76bec8cc	neutral	none	cast 1 Bram's Bloody Bagatelle
+2458	Bram's Bloody Bagatelle	bloodsong.gif	03c0d20a0a8facdb7da2bdbd76bec8cc	neutral	song	cast 1 Bram's Bloody Bagatelle
 2459	The Best a Pirate Can Get	pr_shavingcream.gif	579f7b8ec468f4120a9e9c4efbe44169	good	none	use 1 pirate shaving cream
 2460	Mint-Condition Breath	pr_mintleaf.gif	41aabe6bd233a3239d32834219e5a658	good	none	use 1 huge mint leaf
 2461	Pewtershot	pr_shavings.gif	2ec98f6b5ba231f82d6cf5d4b24f0082	good	none	chew 1 pewter shavings

--- a/src/net/sourceforge/kolmafia/AdventureResult.java
+++ b/src/net/sourceforge/kolmafia/AdventureResult.java
@@ -710,12 +710,13 @@ public class AdventureResult implements Comparable<AdventureResult>, Cloneable {
           name = name + " [" + monster + "]";
         }
       } else {
+        if (EffectDatabase.isSong(name)) {
+          name = "\u266B " + name;
+        }
+
         String skillName = UneffectRequest.effectToSkill(name);
         if (SkillDatabase.contains(skillName)) {
           int skillId = SkillDatabase.getSkillId(skillName);
-          if (SkillDatabase.isAccordionThiefSong(skillId)) {
-            name = "\u266B " + name;
-          }
           if (SkillDatabase.isExpression(skillId)) {
             name = "\u263A " + name;
           }

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -1009,6 +1009,18 @@ public abstract class KoLCharacter {
     disco_momentum = 0;
   }
 
+  public static final int getMaxSongs() {
+    return (currentBooleanModifier(Modifiers.FOUR_SONGS) ? 4 : 3)
+        + (int) currentNumericModifier(Modifiers.ADDITIONAL_SONG);
+  }
+
+  public static final int getSongs() {
+    return (int)
+        KoLConstants.activeEffects.stream()
+            .filter(e -> EffectDatabase.isSong(e.getEffectId()))
+            .count();
+  }
+
   public static final int getAudience() {
     return KoLCharacter.audience;
   }

--- a/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
@@ -167,6 +167,7 @@ public class SkillPool {
   public static final int DONHOS = 6026;
   public static final int INIGOS = 6028;
   public static final int ACCORDION_BASH = 6032;
+  public static final int MARIACHI_MEMORY = 6043;
   public static final int POP_SONG = 6045;
   public static final int BRAMS_BLOODY_BAGATELLE = 6046;
   public static final int MAGIC_MISSILE = 7009;

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -188,6 +188,14 @@ public class EffectDatabase {
     return (attrs == null) ? false : attrs.contains(attribute);
   }
 
+  public static final boolean isSong(final int effectId) {
+    return EffectDatabase.hasAttribute(effectId, "song");
+  }
+
+  public static final boolean isSong(final String effectName) {
+    return EffectDatabase.hasAttribute(effectName, "song");
+  }
+
   public static final String getDefaultAction(final int effectId) {
     if (effectId == -1) {
       return null;

--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
@@ -27,6 +27,7 @@ import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.persistence.ConsumablesDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
@@ -244,7 +245,7 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> {
       this.buttons[bingeIndex].setEnabled(haveHobo);
 
       // The ode listener is just after the hobo listener
-      boolean haveOde = KoLCharacter.hasSkill("The Ode to Booze");
+      boolean haveOde = KoLCharacter.hasSkill(SkillPool.ODE_TO_BOOZE);
       boolean roomForSong = KoLCharacter.getSongs() < KoLCharacter.getMaxSongs();
       if (!haveOde || !roomForSong) {
         String reason =

--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
@@ -245,7 +245,18 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> {
 
       // The ode listener is just after the hobo listener
       boolean haveOde = KoLCharacter.hasSkill("The Ode to Booze");
-      this.buttons[bingeIndex + 1].setEnabled(haveOde);
+      boolean roomForSong = KoLCharacter.getSongs() < KoLCharacter.getMaxSongs();
+      if (!haveOde || !roomForSong) {
+        String reason =
+            (!haveOde)
+                ? "You do not know The Ode to Booze"
+                : (!roomForSong) ? "You can't remember any more songs" : "";
+        this.buttons[bingeIndex + 1].setToolTipText(reason);
+        this.buttons[bingeIndex + 1].setEnabled(false);
+      } else {
+        this.buttons[bingeIndex + 1].setEnabled(true);
+        this.buttons[bingeIndex + 1].setToolTipText("");
+      }
 
       // The prayer listener is just after the ode listener
       boolean prayerAvailable =

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -1187,6 +1187,7 @@ public class ProxyRecordValue extends RecordValue {
             .add("candy_tier", DataTypes.INT_TYPE)
             .add("quality", DataTypes.STRING_TYPE)
             .add("attributes", DataTypes.STRING_TYPE)
+            .add("song", DataTypes.BOOLEAN_TYPE)
             .finish("effect proxy");
 
     public EffectProxy(Value obj) {
@@ -1233,6 +1234,10 @@ public class ProxyRecordValue extends RecordValue {
 
     public int get_candy_tier() {
       return CandyDatabase.getEffectTier((int) this.contentLong);
+    }
+
+    public boolean get_song() {
+      return EffectDatabase.isSong((int) this.contentLong);
     }
   }
 

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -4,7 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.sourceforge.kolmafia.KoLConstants.ZodiacType;
 import net.sourceforge.kolmafia.KoLConstants.ZodiacZone;
+import net.sourceforge.kolmafia.objectpool.EffectPool;
+import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.session.EquipmentManager;
 import org.junit.jupiter.api.Test;
 
 public class KoLCharacterTest {
@@ -74,5 +77,32 @@ public class KoLCharacterTest {
     assertEquals(0, KoLCharacter.getSignIndex());
     assertEquals(ZodiacType.NONE, KoLCharacter.getSignStat());
     assertEquals(ZodiacZone.NONE, KoLCharacter.getSignZone());
+  }
+
+  @Test
+  public void getSongs() {
+    KoLConstants.activeEffects.add(EffectPool.get(EffectPool.ODE));
+    KoLConstants.activeEffects.add(EffectPool.get(2375)); // Paul's Passionate Pop Song
+    KoLConstants.activeEffects.add(EffectPool.get(1495)); // Rolando's Rondo of Resisto
+    KoLConstants.activeEffects.add(EffectPool.get(3)); // Confused (i.e. not a song)
+
+    assertEquals(3, KoLCharacter.getSongs());
+  }
+
+  private void equip(int slot, String item) {
+    EquipmentManager.setEquipment(slot, AdventureResult.parseResult(item));
+  }
+
+  @Test
+  public void getMaxSongs() {
+    KoLCharacter.setAscensionClass(AscensionClass.ACCORDION_THIEF);
+    equip(EquipmentManager.HAT, "brimstone beret"); // Four Songs (mutex)
+    equip(EquipmentManager.ACCESSORY1, "plexiglass pendant"); // Four Songs (mutex)
+    equip(EquipmentManager.WEAPON, "zombie accordion"); // Additional Song
+    KoLCharacter.addAvailableSkill(SkillPool.MARIACHI_MEMORY); // Additional Song
+
+    KoLCharacter.recalculateAdjustments();
+
+    assertEquals(6, KoLCharacter.getMaxSongs());
   }
 }

--- a/test/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanelTest.java
+++ b/test/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanelTest.java
@@ -6,6 +6,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.objectpool.EffectPool;
+import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import org.json.JSONException;
@@ -75,6 +78,62 @@ public class UseItemEnqueuePanelTest {
         Arrays.stream(panel.buttons)
             .filter(b -> b.getText().equals("universal seasoning"))
             .findFirst();
+    assertTrue(buttonSearch.isPresent());
+    var button = buttonSearch.get();
+    assertFalse(button.isEnabled());
+  }
+
+  @Test
+  public void odeToBoozeDisabledWithNoSkill() {
+    var panel = new UseItemEnqueuePanel(false, true, false, null);
+    var buttonSearch =
+        Arrays.stream(panel.buttons).filter(b -> b.getText().equals("cast ode")).findFirst();
+    assertTrue(buttonSearch.isPresent());
+    var button = buttonSearch.get();
+    assertFalse(button.isEnabled());
+  }
+
+  @Test
+  public void odeToBoozeEnabledWithSkill() {
+    KoLCharacter.addAvailableSkill(SkillPool.ODE_TO_BOOZE);
+
+    var panel = new UseItemEnqueuePanel(false, true, false, null);
+    var buttonSearch =
+        Arrays.stream(panel.buttons).filter(b -> b.getText().equals("cast ode")).findFirst();
+    assertTrue(buttonSearch.isPresent());
+    var button = buttonSearch.get();
+    assertTrue(button.isEnabled());
+  }
+
+  @Test
+  public void odeToBoozeDisabledWithNoRoom() {
+    KoLCharacter.addAvailableSkill(SkillPool.ODE_TO_BOOZE);
+
+    KoLConstants.activeEffects.add(EffectPool.get(530)); // The Ballad of Richie Thingfinder
+    KoLConstants.activeEffects.add(EffectPool.get(531)); // Benetton's Medley of Diversity
+    KoLConstants.activeEffects.add(EffectPool.get(532)); // Elron's Explosive Etude
+
+    System.out.println(KoLCharacter.getSongs());
+    System.out.println(KoLCharacter.getMaxSongs());
+
+    var panel = new UseItemEnqueuePanel(false, true, false, null);
+    var buttonSearch =
+        Arrays.stream(panel.buttons).filter(b -> b.getText().equals("cast ode")).findFirst();
+    assertTrue(buttonSearch.isPresent());
+    var button = buttonSearch.get();
+    assertFalse(button.isEnabled());
+  }
+
+  @Test
+  public void odeToBoozeEnabledWithRoom() {
+    KoLCharacter.addAvailableSkill(SkillPool.ODE_TO_BOOZE);
+
+    KoLConstants.activeEffects.add(EffectPool.get(531)); // Benetton's Medley of Diversity
+    KoLConstants.activeEffects.add(EffectPool.get(532)); // Elron's Explosive Etude
+
+    var panel = new UseItemEnqueuePanel(false, true, false, null);
+    var buttonSearch =
+        Arrays.stream(panel.buttons).filter(b -> b.getText().equals("cast ode")).findFirst();
     assertTrue(buttonSearch.isPresent());
     var button = buttonSearch.get();
     assertFalse(button.isEnabled());

--- a/test/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanelTest.java
+++ b/test/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanelTest.java
@@ -13,13 +13,14 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class UseItemEnqueuePanelTest {
 
-  @BeforeAll
-  private static void injectPreferences() {
+  @BeforeEach
+  private void beforeEach() {
+    KoLCharacter.reset(true);
     KoLCharacter.reset("fakeUserName");
 
     // Now that we have a username set, we can edit preferences and have per-user defaults.
@@ -90,7 +91,8 @@ public class UseItemEnqueuePanelTest {
         Arrays.stream(panel.buttons).filter(b -> b.getText().equals("cast ode")).findFirst();
     assertTrue(buttonSearch.isPresent());
     var button = buttonSearch.get();
-    assertFalse(button.isEnabled());
+    var enabled = button.isEnabled();
+    assertFalse(enabled);
   }
 
   @Test
@@ -113,9 +115,6 @@ public class UseItemEnqueuePanelTest {
     KoLConstants.activeEffects.add(EffectPool.get(531)); // Benetton's Medley of Diversity
     KoLConstants.activeEffects.add(EffectPool.get(532)); // Elron's Explosive Etude
 
-    System.out.println(KoLCharacter.getSongs());
-    System.out.println(KoLCharacter.getMaxSongs());
-
     var panel = new UseItemEnqueuePanel(false, true, false, null);
     var buttonSearch =
         Arrays.stream(panel.buttons).filter(b -> b.getText().equals("cast ode")).findFirst();
@@ -136,6 +135,6 @@ public class UseItemEnqueuePanelTest {
         Arrays.stream(panel.buttons).filter(b -> b.getText().equals("cast ode")).findFirst();
     assertTrue(buttonSearch.isPresent());
     var button = buttonSearch.get();
-    assertFalse(button.isEnabled());
+    assertTrue(button.isEnabled());
   }
 }


### PR DESCRIPTION
We've formerly designated effects as part of the mutex "Songs" if their skill source is a buff in the AT id range. However, `Rolando's Rondo of Resisto` is a song that doesn't meet those criteria. This PR:

- Adds `song` as an attribute in statuseffects
- Appends the musical note based on this new attribute
- Disables the "cast ode" button in the UseItemEnqueuePanel when the player has no free memory for more songs (and explains why in a tooltip)
- Tests the above