### PR TITLE
Keep appearance rate calculation DRY

### DIFF
--- a/src/net/sourceforge/kolmafia/AreaCombatData.java
+++ b/src/net/sourceforge/kolmafia/AreaCombatData.java
@@ -1,8 +1,11 @@
 package net.sourceforge.kolmafia;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import net.sourceforge.kolmafia.KoLConstants.Stat;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
@@ -43,9 +46,9 @@ public class AreaCombatData {
   // Parallel lists: monsters and encounter weighting
   private final List<MonsterData> monsters;
   private final List<MonsterData> superlikelyMonsters;
-  private final List<Integer> baseWeightings;
-  private final List<Integer> currentWeightings;
-  private final List<Integer> rejection;
+  private final Map<MonsterData, Integer> baseWeightings;
+  private final Map<MonsterData, Integer> currentWeightings;
+  private final Map<MonsterData, Integer> rejection;
 
   private final String zone;
 
@@ -62,9 +65,9 @@ public class AreaCombatData {
     this.zone = zone;
     this.monsters = new ArrayList<>();
     this.superlikelyMonsters = new ArrayList<>();
-    this.baseWeightings = new ArrayList<>();
-    this.currentWeightings = new ArrayList<>();
-    this.rejection = new ArrayList<>();
+    this.baseWeightings = new HashMap<>();
+    this.currentWeightings = new HashMap<>();
+    this.rejection = new HashMap<>();
     this.combats = combats;
     this.weights = 0.0;
     this.minHit = Integer.MAX_VALUE;
@@ -83,16 +86,15 @@ public class AreaCombatData {
     this.jumpChance = 100;
 
     double weights = 0.0;
-    List<Integer> currentWeightings = new ArrayList<>();
+    Map<MonsterData, Integer> currentWeightings = new HashMap<>();
 
-    for (int i = 0; i < this.monsters.size(); ++i) {
+    for (MonsterData monster : monsters) {
       // Weighting has two low bits which represent odd or even ascension restriction
       // Strip them out now and restore them at the end
-      int baseWeighting = this.baseWeightings.get(i);
+      int baseWeighting = this.baseWeightings.get(monster);
       int flags = baseWeighting & 3;
       baseWeighting = baseWeighting >> WEIGHT_SHIFT;
 
-      MonsterData monster = this.getMonster(i);
       String monsterName = monster.getName();
       Phylum monsterPhylum = monster.getPhylum();
 
@@ -173,24 +175,22 @@ public class AreaCombatData {
         currentWeighting = -4;
       }
 
-      currentWeightings.add((currentWeighting << WEIGHT_SHIFT) | flags);
+      currentWeightings.put(monster, (currentWeighting << WEIGHT_SHIFT) | flags);
 
       // Omit currently 0% chance, banished (-3), impossible (-2) and ultra-rare (-1) monsters
       if (currentWeighting < 0) {
         continue;
       }
 
-      weights += currentWeighting * (1 - (double) this.getRejection(i) / 100);
+      weights += currentWeighting * (1 - (double) this.getRejection(monster) / 100);
       this.addMonsterStats(monster);
     }
     this.weights = weights;
-    Collections.copy(this.currentWeightings, currentWeightings);
+    this.currentWeightings.putAll(currentWeightings);
 
     // Take into account superlikely monsters if they have a non zero chance to appear
-    for (int i = 0; i < this.superlikelyMonsters.size(); ++i) {
-      MonsterData monster = this.getMonster(i);
-      String monsterName = monster.getName();
-      if (AreaCombatData.superlikelyChance(monsterName) > 0) {
+    for (MonsterData monster : superlikelyMonsters) {
+      if (AreaCombatData.superlikelyChance(monster) > 0) {
         this.addMonsterStats(monster);
       }
     }
@@ -303,9 +303,9 @@ public class AreaCombatData {
       this.superlikelyMonsters.add(monster);
     } else {
       this.monsters.add(monster);
-      this.baseWeightings.add(IntegerPool.get((weighting << WEIGHT_SHIFT) | flags));
-      this.currentWeightings.add(IntegerPool.get((weighting << WEIGHT_SHIFT) | flags));
-      this.rejection.add(IntegerPool.get(rejection));
+      this.baseWeightings.put(monster, IntegerPool.get((weighting << WEIGHT_SHIFT) | flags));
+      this.currentWeightings.put(monster, IntegerPool.get((weighting << WEIGHT_SHIFT) | flags));
+      this.rejection.put(monster, IntegerPool.get(rejection));
     }
 
     this.poison = Math.min(this.poison, monster.getPoison());
@@ -377,23 +377,12 @@ public class AreaCombatData {
   }
 
   public int getAvailableMonsterCount() {
-    int count = 0;
-    int size = this.monsters.size();
-    for (int i = 0; i < size; ++i) {
-      int weighting = this.getWeighting(i);
-      if (weighting > 0) {
-        count++;
-      }
-    }
-    size = this.superlikelyMonsters.size();
-    for (int i = 0; i < size; ++i) {
-      MonsterData monster = this.superlikelyMonsters.get(i);
-      String monsterName = monster.getName();
-      if (AreaCombatData.superlikelyChance(monsterName) > 0) {
-        count++;
-      }
-    }
-    return count;
+    return (int)
+        Stream.concat(
+                monsters.stream().map(m -> getWeighting(m) > 0),
+                superlikelyMonsters.stream().map(m -> superlikelyChance(m) > 0))
+            .filter(p -> p)
+            .count();
   }
 
   public MonsterData getMonster(final int i) {
@@ -419,16 +408,16 @@ public class AreaCombatData {
     return this.superlikelyMonsters.indexOf(monster);
   }
 
-  public int getWeighting(final int i) {
-    int raw = (this.currentWeightings.get(i)).intValue();
+  public int getWeighting(final MonsterData monster) {
+    int raw = (this.currentWeightings.getOrDefault(monster, 0)).intValue();
     if (((raw >> (KoLCharacter.getAscensions() & 1)) & 1) == 0) {
       return -2; // impossible this ascension
     }
     return raw >> WEIGHT_SHIFT;
   }
 
-  public int getRejection(final int i) {
-    return this.rejection.get(i);
+  public int getRejection(final MonsterData monster) {
+    return this.rejection.get(monster);
   }
 
   public double totalWeighting() {
@@ -464,28 +453,42 @@ public class AreaCombatData {
     return AreaCombatData.hitPercent(hitStat, this.minHit()) > 0.0;
   }
 
+  public int getJumpChance() {
+    return getJumpChance(m -> m.getJumpChance());
+  }
+
+  public int getJumpChance(int initiative, int ml) {
+    return getJumpChance(m -> m.getJumpChance(initiative, ml));
+  }
+
+  public int getJumpChance(int initiative) {
+    return getJumpChance(m -> m.getJumpChance(initiative));
+  }
+
+  public int getJumpChance(Function<MonsterData, Integer> fn) {
+    return getMonsterData(true).entrySet().stream()
+        .filter(e -> e.getValue() > 0)
+        .mapToInt(e -> fn.apply(e.getKey()))
+        .min()
+        .orElse(0);
+  }
+
   public double getAverageML() {
-    double averageML = 0.0;
-
-    for (int i = 0; i < this.monsters.size(); ++i) {
-      int weighting = this.getWeighting(i);
-
-      // Omit impossible (-2), ultra-rare (-1) and special/banished (0) monsters
-      if (weighting < 1) {
-        continue;
-      }
-
-      MonsterData monster = this.getMonster(i);
-      double weight =
-          (double) weighting * (1 - (double) this.getRejection(i) / 100) / this.totalWeighting();
-      averageML += weight * monster.getAttack();
-    }
+    double averageML =
+        monsters.stream()
+            .filter(m -> getWeighting(m) > 0)
+            .map(
+                m ->
+                    (double) getWeighting(m)
+                        * (1 - (double) this.getRejection(m) / 100)
+                        / this.totalWeighting())
+            .reduce(0.0, Double::sum);
 
     double averageSuperlikelyML = 0.0;
     double superlikelyChance = 0.0;
+
     for (MonsterData monster : this.superlikelyMonsters) {
-      String monsterName = monster.getName();
-      double chance = AreaCombatData.superlikelyChance(monsterName);
+      double chance = AreaCombatData.superlikelyChance(monster);
       if (chance > 0) {
         averageSuperlikelyML += chance * monster.getAttack();
         superlikelyChance += chance;
@@ -516,7 +519,7 @@ public class AreaCombatData {
 
     this.getSummary(buffer, fullString);
     this.getEncounterData(buffer);
-    this.getMonsterData(buffer, fullString);
+    this.appendMonsterData(buffer, fullString);
 
     buffer.append("</body></html>");
     return buffer.toString();
@@ -550,17 +553,18 @@ public class AreaCombatData {
     // Iterate once through monsters to calculate average statGain
     double averageExperience = 0.0;
 
-    for (int i = 0; i < this.monsters.size(); ++i) {
-      int weighting = this.getWeighting(i);
+    for (MonsterData monster : monsters) {
+      int weighting = this.getWeighting(monster);
 
       // Omit impossible (-2), ultra-rare (-1) and special/banished (0) monsters
       if (weighting < 1) {
         continue;
       }
 
-      MonsterData monster = this.getMonster(i);
       double weight =
-          (double) weighting * (1 - (double) this.getRejection(i) / 100) / this.totalWeighting();
+          (double) weighting
+              * (1 - (double) this.getRejection(monster) / 100)
+              / this.totalWeighting();
       int ml = monster.ML();
       averageExperience +=
           weight * (monster.getExperience() + experienceAdjustment - ml / (ml > 0 ? 6.0 : 8.0));
@@ -608,48 +612,68 @@ public class AreaCombatData {
     }
   }
 
-  public void getMonsterData(final StringBuffer buffer, final boolean fullString) {
-    int moxie = KoLCharacter.getAdjustedMoxie();
-    int hitstat = EquipmentManager.getAdjustedHitStat();
-    double combatFactor = this.areaCombatPercent() / 100.0;
-    double superlikelyChance = 0.0;
+  public Map<MonsterData, Double> getMonsterData() {
+    return getMonsterData(false);
+  }
 
-    for (int i = 0; i < this.superlikelyMonsters.size(); ++i) {
-      MonsterData monster = this.superlikelyMonsters.get(i);
-      String monsterName = monster.getName();
-      double chance = AreaCombatData.superlikelyChance(monsterName);
-      buffer.append("<br><br>");
-      buffer.append(
-          this.getMonsterString(
-              this.getSuperlikelyMonster(i),
-              moxie,
-              hitstat,
-              0,
-              0,
-              combatFactor,
-              chance,
-              fullString));
-      superlikelyChance += chance;
+  public Map<MonsterData, Double> getMonsterData(boolean stateful) {
+    Map monsterData = new HashMap<>();
+
+    if (stateful) {
+      recalculate();
     }
 
-    for (int i = 0; i < this.monsters.size(); ++i) {
-      int weighting = this.getWeighting(i);
-      int rejection = this.getRejection(i);
+    double totalSuperlikelyChance = 0.0;
+
+    for (MonsterData monster : superlikelyMonsters) {
+      double chance = superlikelyChance(monster);
+      monsterData.put(monster, chance);
+      totalSuperlikelyChance += chance;
+    }
+
+    double combatFactor = this.areaCombatPercent(stateful) / 100.0;
+
+    for (MonsterData monster : monsters) {
+      int weighting = getWeighting(monster);
+
       if (weighting == -2) {
         continue;
       }
 
-      buffer.append("<br><br>");
-      buffer.append(
-          this.getMonsterString(
-              this.getMonster(i),
-              moxie,
-              hitstat,
-              weighting,
-              rejection,
-              combatFactor,
-              superlikelyChance,
-              fullString));
+      // Negative weight will set this to zero (which is good!)
+      double chance =
+          Math.max(
+              0,
+              100.0
+                  * combatFactor
+                  * (1 - totalSuperlikelyChance / 100)
+                  * weighting
+                  * (1 - (double) getRejection(monster) / 100));
+
+      if (stateful) {
+        chance = AdventureQueueDatabase.applyQueueEffects(chance, monster, this);
+      } else {
+        chance = chance / totalWeighting();
+      }
+
+      monsterData.put(monster, chance);
+    }
+
+    return monsterData;
+  }
+
+  public void appendMonsterData(final StringBuffer buffer, final boolean fullString) {
+    int moxie = KoLCharacter.getAdjustedMoxie();
+    int hitstat = EquipmentManager.getAdjustedHitStat();
+
+    for (Map.Entry<MonsterData, Double> entry : getMonsterData(true).entrySet()) {
+      MonsterData monster = entry.getKey();
+      double chance = entry.getValue();
+      buffer
+          .append("<br><br>")
+          .append(
+              this.getMonsterString(
+                  monster, moxie, hitstat, getWeighting(monster), chance, fullString));
     }
   }
 
@@ -742,38 +766,52 @@ public class AreaCombatData {
   }
 
   public double areaCombatPercent() {
-    // Some areas have fixed non-combats, if we're tracking this, handle them here.
-    if (this.zone.equals("The Defiled Alcove")
-        && Preferences.getInteger("cyrptAlcoveEvilness") <= 25) {
-      return 100;
-    }
-    if (this.zone.equals("The Defiled Cranny")
-        && Preferences.getInteger("cyrptCrannyEvilness") <= 25) {
-      return 100;
-    }
-    if (this.zone.equals("The Defiled Niche")
-        && Preferences.getInteger("cyrptNicheEvilness") <= 25) {
-      return 100;
-    }
-    if (this.zone.equals("The Defiled Nook") && Preferences.getInteger("cyrptNookEvilness") <= 25) {
-      return 100;
-    }
+    return areaCombatPercent(true);
+  }
 
-    if (this.zone.equals("Barf Mountain")) {
-      return Preferences.getBoolean("dinseyRollercoasterNext") ? 0 : 100;
-    }
+  public double areaCombatPercent(boolean stateful) {
+    if (stateful) {
+      // Some situations can force combats
+      if (EncounterManager.isSaberForceZone(this.getZone())) {
+        return 100;
+      }
 
-    if (this.zone.equals("Investigating a Plaintive Telegram")) {
-      return Preferences.getInteger("lttQuestStageCount") == 9
-              || QuestDatabase.isQuestStep(Quest.TELEGRAM, QuestDatabase.STARTED)
-          ? 0
-          : 100;
-    }
-
-    if (this.zone.equals("The Dripping Trees")) {
-      // Non-Combat on turn 16, 31, 46, ...
-      int advs = Preferences.getInteger("drippingTreesAdventuresSinceAscension");
-      return (advs > 0 && (advs % 15) == 0) ? 0 : 100;
+      // Some areas have fixed non-combats, if we're tracking this, handle them here.
+      switch (zone) {
+        case "The Defiled Alcove":
+          if (Preferences.getInteger("cyrptAlcoveEvilness") <= 25) {
+            return 100;
+          }
+          break;
+        case "The Defiled Cranny":
+          if (Preferences.getInteger("cyrptCrannyEvilness") <= 25) {
+            return 100;
+          }
+          break;
+        case "The Defiled Niche":
+          if (Preferences.getInteger("cyrptNicheEvilness") <= 25) {
+            return 100;
+          }
+          break;
+        case "The Defiled Nook":
+          if (Preferences.getInteger("cyrptNookEvilness") <= 25) {
+            return 100;
+          }
+          break;
+        case "The Smut Orc Logging Camp":
+          return Preferences.getInteger("smutOrcNoncombatProgress") < 15 ? 100 : 0;
+        case "Barf Mountain":
+          return Preferences.getBoolean("dinseyRollercoasterNext") ? 0 : 100;
+        case "Investigating a Plaintive Telegram":
+          return Preferences.getInteger("lttQuestStageCount") == 9
+                  || QuestDatabase.isQuestStep(Quest.TELEGRAM, QuestDatabase.STARTED)
+              ? 0
+              : 100;
+        case "The Dripping Trees":
+          // Non-Combat on turn 16, 31, 46, ...
+          int advs = Preferences.getInteger("drippingTreesAdventuresSinceAscension");
+          return (advs > 0 && (advs % 15) == 0) ? 0 : 100;
+      }
     }
 
     // If we don't have the data, pretend it's all combat
@@ -786,7 +824,12 @@ public class AreaCombatData {
       return this.combats;
     }
 
-    double pct = this.combats + KoLCharacter.getCombatRateAdjustment();
+    double pct = this.combats;
+
+    if (stateful) {
+      pct += KoLCharacter.getCombatRateAdjustment();
+    }
+
     return Math.max(0.0, Math.min(100.0, pct));
   }
 
@@ -840,9 +883,7 @@ public class AreaCombatData {
       final int moxie,
       final int hitstat,
       final int weighting,
-      final int rejection,
-      final double combatFactor,
-      final double superlikelyChance,
+      final double chance,
       final boolean fullString) {
     // moxie and hitstat NOT adjusted for monster level, since monster stats now are
 
@@ -874,9 +915,7 @@ public class AreaCombatData {
     buffer.append(name);
     buffer.append("</b></font> (");
 
-    if (EncounterManager.isSuperlikelyMonster(name)) {
-      buffer.append(this.format(superlikelyChance) + "%");
-    } else if (EncounterManager.isSaberForceMonster(name, this.getZone())) {
+    if (EncounterManager.isSaberForceMonster(name, this.getZone())) {
       buffer.append("forced by the saber");
     } else if (EncounterManager.isCrystalBallMonster(name, this.getZone())) {
       buffer.append("predicted by crystal ball");
@@ -889,17 +928,7 @@ public class AreaCombatData {
     } else if (weighting == 0) {
       buffer.append("special");
     } else {
-      buffer.append(
-          this.format(
-                  AdventureQueueDatabase.applyQueueEffects(
-                      100.0
-                          * combatFactor
-                          * (1 - superlikelyChance / 100)
-                          * weighting
-                          * (1 - (double) rejection / 100),
-                      monster,
-                      this))
-              + "%");
+      buffer.append(this.format(chance) + "%");
     }
 
     buffer.append(")<br>Hit: <font color=" + AreaCombatData.elementColor(ed) + ">");
@@ -1603,6 +1632,10 @@ public class AreaCombatData {
       }
     }
     return weighting;
+  }
+
+  public static final double superlikelyChance(MonsterData monster) {
+    return superlikelyChance(monster.getName());
   }
 
   public static final double superlikelyChance(String monster) {

--- a/src/net/sourceforge/kolmafia/persistence/AdventureQueueDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/AdventureQueueDatabase.java
@@ -22,6 +22,7 @@ import net.sourceforge.kolmafia.MonsterData;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.FightRequest;
+import net.sourceforge.kolmafia.session.EncounterManager;
 import net.sourceforge.kolmafia.utilities.RollingLinkedList;
 
 /*
@@ -259,7 +260,15 @@ public class AdventureQueueDatabase implements Serializable {
   public static double applyQueueEffects(
       double numerator, MonsterData monster, AreaCombatData data) {
     String zone = data.getZone();
-    RollingLinkedList<String> zoneQueue = COMBAT_QUEUE.get(zone);
+    RollingLinkedList<String> zoneQueue = getZoneQueue(zone);
+
+    if (EncounterManager.isSaberForceZone(zone)) {
+      return EncounterManager.isSaberForceMonster(monster, zone) ? 100.0 : 0.0;
+    }
+
+    if (EncounterManager.isCrystalBallZone(zone)) {
+      return EncounterManager.isCrystalBallMonster(monster, zone) ? data.areaCombatPercent() : 0;
+    }
 
     double denominator = data.totalWeighting();
 
@@ -282,14 +291,13 @@ public class AdventureQueueDatabase implements Serializable {
     int queueWeight = 0;
     for (String mon : zoneSet) {
       MonsterData queueMonster = MonsterDatabase.findMonster(mon);
-      int index = data.getMonsterIndex(queueMonster);
       boolean olfacted =
           queueMonster != null
               && ((Preferences.getString("olfactedMonster").equals(queueMonster.getName())
                       && KoLConstants.activeEffects.contains(FightRequest.ONTHETRAIL))
                   || Preferences.getString("longConMonster").equals(queueMonster.getName()));
-      if (index != -1 && data.getWeighting(index) > 0 && !olfacted) {
-        queueWeight += data.getWeighting(index);
+      if (queueMonster != null && data.getWeighting(queueMonster) > 0 && !olfacted) {
+        queueWeight += data.getWeighting(queueMonster);
       }
     }
 

--- a/src/net/sourceforge/kolmafia/session/EncounterManager.java
+++ b/src/net/sourceforge/kolmafia/session/EncounterManager.java
@@ -256,6 +256,10 @@ public abstract class EncounterManager {
     return isSaberForceZone(Preferences.getString("_saberForceMonster"), zone);
   }
 
+  public static final boolean isSaberForceMonster(MonsterData monster, String zone) {
+    return isSaberForceMonster(monster.getName(), zone);
+  }
+
   public static final boolean isSaberForceMonster(String monsterName, String zone) {
     if (!isSaberForceZone(monsterName, zone)) {
       return false;
@@ -285,11 +289,19 @@ public abstract class EncounterManager {
         MonsterStatusTracker.getLastMonsterName(), Preferences.getString("nextAdventure"));
   }
 
+  public static final boolean isCrystalBallZone(String zone) {
+    return zone.equalsIgnoreCase(Preferences.getString("crystalBallLocation"));
+  }
+
+  public static final boolean isCrystalBallMonster(MonsterData monster, String zone) {
+    return isCrystalBallMonster(monster.getName(), zone);
+  }
+
   public static final boolean isCrystalBallMonster(String monster, String zone) {
     // There's no message to check for so assume the correct monster in the correct zone is from the
     // crystal ball
     return monster.equalsIgnoreCase(Preferences.getString("crystalBallMonster"))
-        && zone.equalsIgnoreCase(Preferences.getString("crystalBallLocation"));
+        && isCrystalBallZone(zone);
   }
 
   public static final boolean isGregariousEncounter(

--- a/src/net/sourceforge/kolmafia/textui/command/MonsterDataCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/MonsterDataCommand.java
@@ -25,7 +25,7 @@ public class MonsterDataCommand extends AbstractCommand {
     StringBuffer buffer = new StringBuffer();
 
     buffer.append("<html>");
-    data.getMonsterData(buffer, false);
+    data.appendMonsterData(buffer, false);
     buffer.append("</html>");
 
     KoLmafiaCLI.showHTML(buffer.toString());

--- a/test/net/sourceforge/kolmafia/AreaCombatDataTest.java
+++ b/test/net/sourceforge/kolmafia/AreaCombatDataTest.java
@@ -1,0 +1,139 @@
+package net.sourceforge.kolmafia;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Map;
+import net.sourceforge.kolmafia.objectpool.EffectPool;
+import net.sourceforge.kolmafia.persistence.AdventureDatabase;
+import net.sourceforge.kolmafia.persistence.AdventureQueueDatabase;
+import net.sourceforge.kolmafia.persistence.MonsterDatabase;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class AreaCombatDataTest {
+  static final AreaCombatData SMUT_ORC_CAMP =
+      AdventureDatabase.getAreaCombatData("The Smut Orc Logging Camp");
+  static final MonsterData JACKER = MonsterDatabase.findMonster("smut orc jacker");
+  static final MonsterData NAILER = MonsterDatabase.findMonster("smut orc nailer");
+  static final MonsterData PIPELAYER = MonsterDatabase.findMonster("smut orc pipelayer");
+  static final MonsterData SCREWER = MonsterDatabase.findMonster("smut orc screwer");
+  static final MonsterData PERVERT = MonsterDatabase.findMonster("smut orc pervert");
+  static final MonsterData SNAKE = MonsterDatabase.findMonster("The Frattlesnake");
+  static final MonsterData GHOST = MonsterDatabase.findMonster("The ghost of Richard Cockingham");
+
+  @BeforeAll
+  public static void beforeAll() {
+    Preferences.saveSettingsToFile = false;
+  }
+
+  @BeforeEach
+  public void beforeEach() {
+    KoLCharacter.reset("fakeUserName");
+  }
+
+  @Test
+  public void nonstatefulData() {
+    Map<MonsterData, Double> appearanceRates = SMUT_ORC_CAMP.getMonsterData();
+
+    assertThat(
+        appearanceRates,
+        allOf(
+            aMapWithSize(7),
+            hasEntry(JACKER, 25.0),
+            hasEntry(NAILER, 25.0),
+            hasEntry(PIPELAYER, 25.0),
+            hasEntry(SCREWER, 25.0),
+            hasEntry(PERVERT, 0.0),
+            hasEntry(SNAKE, 0.0),
+            hasEntry(GHOST, 0.0)));
+  }
+
+  @Test
+  public void saberCopy() {
+    Preferences.setString("_saberForceMonster", "smut orc screwer");
+    Preferences.setInteger("_saberForceMonsterCount", 3);
+
+    // Should override a crystal ball prediction
+    Preferences.setString("crystalBallMonster", "smut orc jacker");
+    Preferences.setString("crystalBallLocation", SMUT_ORC_CAMP.getZone());
+
+    Map<MonsterData, Double> appearanceRates = SMUT_ORC_CAMP.getMonsterData(true);
+
+    assertThat(
+        appearanceRates,
+        allOf(
+            aMapWithSize(7),
+            hasEntry(JACKER, 0.0),
+            hasEntry(NAILER, 0.0),
+            hasEntry(PIPELAYER, 0.0),
+            hasEntry(SCREWER, 100.0),
+            hasEntry(PERVERT, 0.0),
+            hasEntry(SNAKE, 0.0),
+            hasEntry(GHOST, 0.0)));
+  }
+
+  @Test
+  public void crystalBallPrediction() {
+    Preferences.setString("crystalBallMonster", "smut orc nailer");
+    Preferences.setString("crystalBallLocation", SMUT_ORC_CAMP.getZone());
+
+    Map<MonsterData, Double> appearanceRates = SMUT_ORC_CAMP.getMonsterData(true);
+
+    assertThat(
+        appearanceRates,
+        allOf(
+            aMapWithSize(7),
+            hasEntry(JACKER, 0.0),
+            hasEntry(NAILER, 100.0),
+            hasEntry(PIPELAYER, 0.0),
+            hasEntry(SCREWER, 0.0),
+            hasEntry(PERVERT, 0.0),
+            hasEntry(SNAKE, 0.0),
+            hasEntry(GHOST, 0.0)));
+  }
+
+  @Test
+  public void crystalBallPredictionWhenNCIsUp() {
+    Preferences.setString("crystalBallMonster", "smut orc nailer");
+    Preferences.setString("crystalBallLocation", SMUT_ORC_CAMP.getZone());
+    Preferences.setInteger("smutOrcNoncombatProgress", 15);
+
+    Map<MonsterData, Double> appearanceRates = SMUT_ORC_CAMP.getMonsterData(true);
+
+    assertThat(
+        appearanceRates,
+        allOf(
+            aMapWithSize(7),
+            hasEntry(JACKER, 0.0),
+            hasEntry(NAILER, 0.0),
+            hasEntry(PIPELAYER, 0.0),
+            hasEntry(SCREWER, 0.0),
+            hasEntry(PERVERT, 0.0),
+            hasEntry(SNAKE, 0.0),
+            hasEntry(GHOST, 0.0)));
+  }
+
+  @Test
+  public void olfaction() {
+    AdventureQueueDatabase.resetQueue();
+    KoLConstants.activeEffects.add(EffectPool.get(EffectPool.ON_THE_TRAIL));
+    Preferences.setString("olfactedMonster", "smut orc pipelayer");
+
+    Map<MonsterData, Double> appearanceRates = SMUT_ORC_CAMP.getMonsterData(true);
+
+    assertThat(
+        appearanceRates,
+        allOf(
+            aMapWithSize(7),
+            hasEntry(JACKER, 400 / 28.0),
+            hasEntry(NAILER, 400 / 28.0),
+            hasEntry(PIPELAYER, 1600 / 28.0),
+            hasEntry(SCREWER, 400 / 28.0),
+            hasEntry(PERVERT, 0.0),
+            hasEntry(SNAKE, 0.0),
+            hasEntry(GHOST, 0.0)));
+  }
+}

--- a/test/net/sourceforge/kolmafia/AreaCombatDataTest.java
+++ b/test/net/sourceforge/kolmafia/AreaCombatDataTest.java
@@ -32,6 +32,7 @@ public class AreaCombatDataTest {
   @BeforeEach
   public void beforeEach() {
     KoLCharacter.reset("fakeUserName");
+    Preferences.reset("fakeUsername");
   }
 
   @Test


### PR DESCRIPTION
This is primarily in advance of implementing Be Gregarious to our queue management. We have our queue management logic in multiple different places, so this combines them and makes it easier to support more queuey things in future.

I did this tests-first, so it shouldn't have an effect on any behaviour