### PR TITLE
Fix html title hover not working as intended

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
@@ -110,7 +110,8 @@ public class RequestPane extends JEditorPane {
     this.setContentType("text/html");
     this.setEditable(false);
 
-    // No need to unregister the component as this only registers variables on this component, not on the shared instance.
+    // No need to unregister the component as this only registers variables on this component, not
+    // on the shared instance.
     ToolTipManager.sharedInstance().registerComponent(this);
 
     HTMLDocument currentHTML = (HTMLDocument) getDocument();

--- a/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
@@ -110,16 +110,11 @@ public class RequestPane extends JEditorPane {
     this.setContentType("text/html");
     this.setEditable(false);
 
+    // No need to unregister the component as this only registers variables on this component, not on the shared instance.
     ToolTipManager.sharedInstance().registerComponent(this);
 
     HTMLDocument currentHTML = (HTMLDocument) getDocument();
     currentHTML.putProperty("multiByte", Boolean.FALSE);
-  }
-
-  @Override
-  public void invalidate() {
-    ToolTipManager.sharedInstance().unregisterComponent(this);
-    super.invalidate();
   }
 
   @Override


### PR DESCRIPTION
The invalidation of the component is not needed, especially as it is called fairly often.

No need to unregister the component, as the component is not saved in a global object that needs to be removed later as originally thought.