### PR TITLE
Fix text filtering in SkillBuffFrame.

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/SkillBuffFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/SkillBuffFrame.java
@@ -316,7 +316,9 @@ public class SkillBuffFrame extends GenericFrame {
       }
     }
 
+    @Override
     public void update() {
+      super.update();
       this.clearDisabledItems();
 
       for (int i = 0; i < DAILY_LIMITED_SKILLS.length; ++i) {


### PR DESCRIPTION
Some time back, we refactored AutoFilterComboBox. In doing so, we
changed its update() method from private to protected to expose it to
a subclass. What we didn't realize was that we were subsequently
shadowing this method in SkillSelectComboBox.

Thanks Veracity for [reporting this](https://kolmafia.us/threads/26961).