### PR TITLE
"enum constant needs a corresponding case label"

### DIFF
--- a/src/net/sourceforge/kolmafia/AscensionClass.java
+++ b/src/net/sourceforge/kolmafia/AscensionClass.java
@@ -114,9 +114,9 @@ public enum AscensionClass {
         return ItemPool.DISCO_BALL;
       case ACCORDION_THIEF:
         return ItemPool.STOLEN_ACCORDION;
+      default:
+        return -1;
     }
-
-    return -1;
   }
 
   public final int getPrimeStatIndex() {

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -2801,7 +2801,7 @@ public abstract class KoLCharacter {
 
     switch (oldPath) {
       case AVATAR_OF_WEST_OF_LOATHING:
-        String pref = null;
+        final String pref;
         switch (ascensionClass) {
           case BEANSLINGER:
             pref = "awolPointsBeanslinger";
@@ -2811,6 +2811,9 @@ public abstract class KoLCharacter {
             break;
           case SNAKE_OILER:
             pref = "awolPointsSnakeoiler";
+            break;
+          default:
+            pref = null;
             break;
         }
         if (pref != null) {

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -1293,8 +1293,9 @@ public class Modifiers {
         return Modifiers.SPOOKY_RESISTANCE;
       case STENCH:
         return Modifiers.STENCH_RESISTANCE;
+      default:
+        return -1;
     }
-    return -1;
   }
 
   public static List<AdventureResult> getPotentialChanges(final int index) {

--- a/src/net/sourceforge/kolmafia/objectpool/Concoction.java
+++ b/src/net/sourceforge/kolmafia/objectpool/Concoction.java
@@ -203,7 +203,7 @@ public class Concoction implements Comparable<Concoction> {
   }
 
   public void setStatGain() {
-    String range = "+0.0";
+    final String range;
     switch (KoLCharacter.mainStat()) {
       case MUSCLE:
         range = ConsumablesDatabase.getMuscleRange(this.name);
@@ -213,6 +213,9 @@ public class Concoction implements Comparable<Concoction> {
         break;
       case MOXIE:
         range = ConsumablesDatabase.getMoxieRange(this.name);
+        break;
+      default:
+        range = "+0.0";
         break;
     }
     this.mainstatGain = StringUtilities.parseDouble(range);

--- a/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
@@ -215,8 +215,9 @@ public class MonsterDatabase {
         return element2 == Element.HOT || element2 == Element.STENCH;
       case STENCH:
         return element2 == Element.SLEAZE || element2 == Element.COLD;
+      default:
+        return false;
     }
-    return false;
   }
 
   private static void addMapping(Map<MonsterData, MonsterData> map, String name1, String name2) {

--- a/src/net/sourceforge/kolmafia/request/AscensionHistoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AscensionHistoryRequest.java
@@ -164,7 +164,7 @@ public class AscensionHistoryRequest extends GenericRequest
     for (Entry<AscensionClass, Integer> entry : challengeClassPoints.entrySet()) {
       int points = entry.getValue();
 
-      String pref = null;
+      final String pref;
 
       switch (entry.getKey()) {
         case COWPUNCHER:
@@ -176,10 +176,8 @@ public class AscensionHistoryRequest extends GenericRequest
         case SNAKE_OILER:
           pref = "awolPointsSnakeoiler";
           break;
-      }
-
-      if (pref == null) {
-        continue;
+        default:
+          continue;
       }
 
       if (points > Preferences.getInteger(pref)) {

--- a/src/net/sourceforge/kolmafia/request/CreateItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CreateItemRequest.java
@@ -1216,9 +1216,10 @@ public class CreateItemRequest extends GenericRequest implements Comparable<Crea
 
       case MIX_FANCY:
         return KoLCharacter.hasBartender() ? 0 : 1;
-    }
 
-    return 0;
+      default:
+        return 0;
+    }
   }
 
   private static int getAdventuresUsed(final CraftingType mixingMethod, final int quantityNeeded) {
@@ -1235,9 +1236,10 @@ public class CreateItemRequest extends GenericRequest implements Comparable<Crea
       case COOK_FANCY:
       case MIX_FANCY:
         return Math.max(0, (quantityNeeded - ConcoctionDatabase.getFreeCraftingTurns()));
-    }
 
-    return 0;
+      default:
+        return 0;
+    }
   }
 
   public static final boolean registerRequest(final boolean isExternal, final String urlString) {

--- a/src/net/sourceforge/kolmafia/request/GuildRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GuildRequest.java
@@ -35,9 +35,9 @@ public class GuildRequest extends GenericRequest {
         return "The League of Chef-Magi";
       case MOXIE:
         return "The Department of Shadowy Arts and Crafts";
+      default:
+        return "None";
     }
-
-    return "None";
   }
 
   public static String getStoreName() {
@@ -48,9 +48,9 @@ public class GuildRequest extends GenericRequest {
         return "Gouda's Grimoire and Grocery";
       case MOXIE:
         return "The Shadowy Store";
+      default:
+        return "Nowhere";
     }
-
-    return "Nowhere";
   }
 
   public static String getImplementName() {
@@ -59,9 +59,9 @@ public class GuildRequest extends GenericRequest {
         return "The Malus of Forethought";
       case MOXIE:
         return "Nash Crosby's Still";
+      default:
+        return "Nothing";
     }
-
-    return "Nothing";
   }
 
   public static String getMasterName() {
@@ -72,9 +72,9 @@ public class GuildRequest extends GenericRequest {
         return "Gorgonzola, the Chief Chef";
       case MOXIE:
         return "Shifty, the Thief Chief";
+      default:
+        return "Nobody";
     }
-
-    return "Nobody";
   }
 
   public static String getTrainerName() {
@@ -85,9 +85,9 @@ public class GuildRequest extends GenericRequest {
         return "Brie, the Trainer";
       case MOXIE:
         return "Lefty, the Trainer";
+      default:
+        return "Nobody";
     }
-
-    return "Nobody";
   }
 
   public static String getPacoName() {
@@ -98,9 +98,9 @@ public class GuildRequest extends GenericRequest {
         return "Blaine";
       case MOXIE:
         return "Izzy the Lizard";
+      default:
+        return "Nobody";
     }
-
-    return "Nobody";
   }
 
   public static String getSCGName() {
@@ -117,9 +117,9 @@ public class GuildRequest extends GenericRequest {
         return "Duncan Drisorderly, the Disco Bandit";
       case ACCORDION_THIEF:
         return "Stradella, the Accordion Thief";
+      default:
+        return "Nobody";
     }
-
-    return "Nobody";
   }
 
   public static String getOCGName() {
@@ -136,9 +136,9 @@ public class GuildRequest extends GenericRequest {
         return "Stradella, the Accordion Thief";
       case ACCORDION_THIEF:
         return "Duncan Drisorderly, the Disco Bandit";
+      default:
+        return "Nobody";
     }
-
-    return "Nobody";
   }
 
   public static String getNPCName(final String place) {

--- a/src/net/sourceforge/kolmafia/request/HeyDezeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/HeyDezeRequest.java
@@ -13,8 +13,8 @@ import net.sourceforge.kolmafia.session.ResultProcessor;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class HeyDezeRequest extends GenericRequest {
-  private int effectId = 0;
-  private String desc = "";
+  private final int effectId;
+  private final String desc;
 
   private static final Pattern ID_PATTERN = Pattern.compile("whichbuff=(\\d+)");
 
@@ -39,11 +39,13 @@ public class HeyDezeRequest extends GenericRequest {
         this.effectId = 448;
         this.desc = "smoother";
         break;
+      default:
+        this.effectId = 0;
+        this.desc = "";
+        return;
     }
 
-    if (this.effectId != 0) {
-      this.addFormField("whichbuff", String.valueOf(this.effectId));
-    }
+    this.addFormField("whichbuff", String.valueOf(this.effectId));
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/request/KOLHSRequest.java
+++ b/src/net/sourceforge/kolmafia/request/KOLHSRequest.java
@@ -26,17 +26,22 @@ public class KOLHSRequest extends CreateItemRequest {
         return "kolhs_art";
       case SHOPCLASS:
         return "kolhs_shop";
+      default:
+        return "";
     }
-
-    return "";
   }
 
   private static String shopIDToClassName(final String shopID) {
-    return shopID.equals("kolhs_chem")
-        ? "Chemistry Class"
-        : shopID.equals("kolhs_art")
-            ? "Art Class"
-            : shopID.equals("kolhs_shop") ? "Shop Class" : shopID;
+    switch (shopID) {
+      case "kolhs_chem":
+        return "Chemistry Class";
+      case "kolhs_art":
+        return "Art Class";
+      case "kolhs_shop":
+        return "Shop Class";
+      default:
+        return shopID;
+    }
   }
 
   public KOLHSRequest(final Concoction conc) {

--- a/src/net/sourceforge/kolmafia/request/VolcanoIslandRequest.java
+++ b/src/net/sourceforge/kolmafia/request/VolcanoIslandRequest.java
@@ -57,8 +57,9 @@ public class VolcanoIslandRequest extends GenericRequest {
         return "a Protestor";
       case SAUCEROR:
         return "a Boat";
+      default:
+        return null;
     }
-    return null;
   }
 
   private static String visitNPC(final String urlString) {

--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -17728,7 +17728,7 @@ public abstract class ChoiceManager {
           // The only one that has more than one option is the initial riddle.
           // The option numbers are randomized each time, although the correct
           // answer remains the same.
-          String answer = null;
+          final String answer;
           switch (KoLCharacter.getAscensionClass()) {
             case SEAL_CLUBBER:
               answer = "Boredom.";
@@ -17748,12 +17748,10 @@ public abstract class ChoiceManager {
             case ACCORDION_THIEF:
               answer = "Music.";
               break;
-          }
-
-          // Only standard classes can join the guild, so we
-          // should not fail. But, if we do, cope.
-          if (answer == null) {
-            return "0";
+            default:
+              // Only standard classes can join the guild, so we
+              // should not fail. But, if we do, cope.
+              return "0";
           }
 
           // Iterate over the option strings and find the one
@@ -17775,7 +17773,7 @@ public abstract class ChoiceManager {
           return "1";
         }
 
-        String answer = null;
+        final String answer;
         switch (KoLCharacter.getAscensionClass()) {
           case SEAL_CLUBBER:
             answer = "Freak the hell out like a wrathful wolverine.";
@@ -17795,12 +17793,10 @@ public abstract class ChoiceManager {
           case ACCORDION_THIEF:
             answer = "Bash the wall with your accordion.";
             break;
-        }
-
-        // Only standard classes can join the guild, so we
-        // should not fail. But, if we do, cope.
-        if (answer == null) {
-          return "0";
+          default:
+            // Only standard classes can join the guild, so we
+            // should not fail. But, if we do, cope.
+            return "0";
         }
 
         // Iterate over the option strings and find the one

--- a/src/net/sourceforge/kolmafia/swingui/GearChangeFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/GearChangeFrame.java
@@ -1204,8 +1204,9 @@ public class GearChangeFrame extends GenericFrame {
         return this.weaponTypes[1].isSelected();
       case RANGED:
         return this.weaponTypes[2].isSelected();
+      default:
+        return false;
     }
-    return false;
   }
 
   private boolean filterOffhand(final AdventureResult offhand, int consumption) {

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -8474,8 +8474,9 @@ public abstract class RuntimeLibrary {
         return new Value(DataTypes.ELEMENT_TYPE, "spooky", element);
       case SLEAZE:
         return new Value(DataTypes.ELEMENT_TYPE, "sleaze", element);
+      default:
+        return DataTypes.ELEMENT_INIT;
     }
-    return DataTypes.ELEMENT_INIT;
   }
 
   public static Value unusual_construct_disc(ScriptRuntime controller) {

--- a/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
@@ -586,9 +586,10 @@ public abstract class UseLinkDecorator {
       case COOK:
       case COOK_FANCY:
         return new UseLink(itemId, itemCount, "cook", "craft.php?mode=cook&a=");
-    }
 
-    return null;
+      default:
+        return null;
+    }
   }
 
   private static UseLink getCouncilLink(int itemId) {


### PR DESCRIPTION
I remember seeing that having an empty "default" case was disliked, so instead, this only focuses on default cases which can immediately be inferred.
For example, if every case ends with a "return", this moves what's outside of the switch into the default case.

This cuts the "missing enum case" warnings by roughly half (~400 -> ~200)