### PR TITLE
Cannot use `this` before it is defined (i.e. before super is called)

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/parsetree/RecordType.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/RecordType.java
@@ -184,16 +184,16 @@ public class RecordType extends CompositeType {
 
   @Override
   public RecordType reference(final Location location) {
-    return new RecordTypeReference(location);
+    return new RecordTypeReference(this, location);
   }
 
   private class RecordTypeReference extends RecordType {
-    public RecordTypeReference(final Location location) {
+    public RecordTypeReference(final RecordType recordType, final Location location) {
       super(
-          RecordType.this.name,
-          RecordType.this.fieldNames,
-          RecordType.this.fieldTypes,
-          RecordType.this.fieldIndices,
+          recordType.name,
+          recordType.fieldNames,
+          recordType.fieldTypes,
+          recordType.fieldIndices,
           location);
     }
 

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
@@ -510,12 +510,12 @@ public class Type extends Symbol {
    * @param location the location of the reference
    */
   public Type reference(final Location location) {
-    return new TypeReference(location);
+    return new TypeReference(this, location);
   }
 
   private class TypeReference extends Type {
-    public TypeReference(final Location location) {
-      super(Type.this.name, Type.this.type, location);
+    public TypeReference(Type type, final Location location) {
+      super(type.name, type.type, location);
     }
 
     @Override


### PR DESCRIPTION
Minor issue with the `reference` functions @fredg1 added to Type and RecordType. Unless I'm missing something, these were broken before,.