### PR TITLE
Add autoForbidIgnoringStores property

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -191,6 +191,7 @@ user	armoryUnlocked	false
 user	autoAbortThreshold	-0.05
 user	autoAntidote	0
 user	autoBuyPriceLimit	20000
+user	autoForbidIgnoringStores	true
 user	autoCraft	true
 user	autoQuest	true
 user	autoEntangle	false
@@ -607,6 +608,7 @@ user	flickeringPixel6	false
 user	flickeringPixel7	false
 user	flickeringPixel8	false
 user	flyeredML	0
+user	forbiddenStores
 user	fossilB	0
 user	fossilD	0
 user	fossilN	0


### PR DESCRIPTION
Revision 20900 added a "forbiddenStores" property which is a list of stores this user will not attempt to buy from.

This change adds that property to defaults.txt (default is empty).

Also add a "autoForbidIgnoringStores" property (default true) to add any store that has you on its ignore list to that property. Simply detecting that a store is ignoring you will suppress purchasing for the rest of the session, but adding it to the forbidden list will cause it to be ignored in future sessions, as well, without having to attempt a purchase and learn - again - that you are ignored.

I suppose some stores might choose to un-ignore you eventually, but we have no way of knowing when that will happen, and until then, their presence in you mall search results will skew mall price calculations for you.