### PR TITLE
Clean up disk state

### DIFF
--- a/test/net/sourceforge/kolmafia/extensions/ClearSharedStateAfter.java
+++ b/test/net/sourceforge/kolmafia/extensions/ClearSharedStateAfter.java
@@ -9,15 +9,10 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import net.sourceforge.kolmafia.*;
-import net.sourceforge.kolmafia.preferences.Preferences;
-import net.sourceforge.kolmafia.request.GenericRequest;
-import net.sourceforge.kolmafia.textui.command.AbstractCommand;
 import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class ClearSharedStateAfter implements AfterAllCallback {
-
 
   // Prevents leakage of shared state across test classes.
 
@@ -35,16 +30,18 @@ public class ClearSharedStateAfter implements AfterAllCallback {
     // Get list of things in test\root and iterate, deleting as appropriate
     File root = KoLConstants.ROOT_LOCATION;
     String[] contents = root.list();
-    for (String content : contents) {
-      if (!keepersList.contains(content)) {
-        Path pathToBeDeleted = new File(root, content).toPath();
-        try {
-          Files.walk(pathToBeDeleted)
-              .sorted(Comparator.reverseOrder())
-              .map(Path::toFile)
-              .forEach(File::delete);
-        } catch (IOException e) {
-          e.printStackTrace();
+    if (contents != null) {
+      for (String content : contents) {
+        if (!keepersList.contains(content)) {
+          Path pathToBeDeleted = new File(root, content).toPath();
+          try {
+            Files.walk(pathToBeDeleted)
+                .sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(File::delete);
+          } catch (IOException e) {
+            e.printStackTrace();
+          }
         }
       }
     }

--- a/test/net/sourceforge/kolmafia/extensions/ClearSharedStateAfter.java
+++ b/test/net/sourceforge/kolmafia/extensions/ClearSharedStateAfter.java
@@ -1,0 +1,52 @@
+package net.sourceforge.kolmafia.extensions;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import net.sourceforge.kolmafia.*;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.GenericRequest;
+import net.sourceforge.kolmafia.textui.command.AbstractCommand;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class ClearSharedStateAfter implements AfterAllCallback {
+
+
+  // Prevents leakage of shared state across test classes.
+
+  @Override
+  public void afterAll(ExtensionContext context) {
+    deleteDirectoriesAndContents();
+  }
+
+  public void deleteDirectoriesAndContents() {
+    // These are the directories and files in test\root that are under git control.  Everything
+    // else is fair game for deletion after testing.  Keep relay as well since at least one test
+    // assumes relay had content created when mafia starts up.
+    String[] keepersArray = {"ccs", "data", "expected", "request", "relay", "scripts", "README"};
+    List<String> keepersList = new ArrayList<>(Arrays.asList(keepersArray));
+    // Get list of things in test\root and iterate, deleting as appropriate
+    File root = KoLConstants.ROOT_LOCATION;
+    String[] contents = root.list();
+    for (String content : contents) {
+      if (!keepersList.contains(content)) {
+        Path pathToBeDeleted = new File(root, content).toPath();
+        try {
+          Files.walk(pathToBeDeleted)
+              .sorted(Comparator.reverseOrder())
+              .map(Path::toFile)
+              .forEach(File::delete);
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
+      }
+    }
+  }
+}

--- a/test/net/sourceforge/kolmafia/extensions/ClearSharedStateBefore.java
+++ b/test/net/sourceforge/kolmafia/extensions/ClearSharedStateBefore.java
@@ -15,7 +15,7 @@ import net.sourceforge.kolmafia.textui.command.AbstractCommand;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class ClearSharedState implements BeforeAllCallback {
+public class ClearSharedStateBefore implements BeforeAllCallback {
 
   // Prevents leakage of shared state across test classes.
 

--- a/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,2 +1,3 @@
 net.sourceforge.kolmafia.extensions.ForbidNetworkAccess
-net.sourceforge.kolmafia.extensions.ClearSharedState
+net.sourceforge.kolmafia.extensions.ClearSharedStateBefore
+net.sourceforge.kolmafia.extensions.ClearSharedStateAfter


### PR DESCRIPTION
A test was leaking files into root\settings.  I could not find it so went for the nuclear option of cleaning out the directory after all tests.  An argument could be made that cleaning the directories before and after tests is inefficient but it provides a stronger guarantee of state.