### PR TITLE
Stop indents being applied to selected text

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
@@ -127,18 +127,20 @@ public class RequestPane extends JEditorPane {
     StringWriter sw = new StringWriter();
 
     try {
-      // Provides a workaround for the writer normally trying to indent the text after 80 characters.
+      // Provides a workaround for the writer normally trying to indent the text after 80
+      // characters.
       // This results in weird text like "Example    goes here"
       if (this.getDocument() instanceof HTMLDocument) {
-        HTMLWriter w = new HTMLWriter(
-            sw,
-            (HTMLDocument) this.getDocument(),
-            this.getSelectionStart(),
-            this.getSelectionEnd() - this.getSelectionStart()) {
-          {
-            setLineLength(999_999);
-          }
-        };
+        HTMLWriter w =
+            new HTMLWriter(
+                sw,
+                (HTMLDocument) this.getDocument(),
+                this.getSelectionStart(),
+                this.getSelectionEnd() - this.getSelectionStart()) {
+              {
+                setLineLength(999_999);
+              }
+            };
         w.write();
       } else {
         this.getEditorKit()

--- a/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
@@ -9,6 +9,7 @@ import javax.swing.text.*;
 import javax.swing.text.html.HTML;
 import javax.swing.text.html.HTMLDocument;
 import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.HTMLWriter;
 import javax.swing.text.html.InlineView;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -126,12 +127,27 @@ public class RequestPane extends JEditorPane {
     StringWriter sw = new StringWriter();
 
     try {
-      this.getEditorKit()
-          .write(
-              sw,
-              this.getDocument(),
-              this.getSelectionStart(),
-              this.getSelectionEnd() - this.getSelectionStart());
+      // Provides a workaround for the writer normally trying to indent the text after 80 characters.
+      // This results in weird text like "Example    goes here"
+      if (this.getDocument() instanceof HTMLDocument) {
+        HTMLWriter w = new HTMLWriter(
+            sw,
+            (HTMLDocument) this.getDocument(),
+            this.getSelectionStart(),
+            this.getSelectionEnd() - this.getSelectionStart()) {
+          {
+            setLineLength(999_999);
+          }
+        };
+        w.write();
+      } else {
+        this.getEditorKit()
+            .write(
+                sw,
+                this.getDocument(),
+                this.getSelectionStart(),
+                this.getSelectionEnd() - this.getSelectionStart());
+      }
     } catch (Exception e) {
       // In the event that an exception happens, return
       // an empty string.


### PR DESCRIPTION
HTMLWriter has a default maximum line limit of 80, although I think lines with no spaces bypasses this.

What this commit does is adds a check if we're using an HTML Document, and applies a large maximum line limit.

This means lines are no longer indented.
This commit could perhaps be improved further with a proper class declaration, instead of an anonymous class.
setLineLength is a protected method you see.

Quick example of the indention follows, a straight copy/paste from the Mafia CLI display. Just a bunch of "test" with a space in between.

```
test test test test test test test test test test test test test test test     test test test test test test test test test test test test test test test     test test test test test test test test test test test test test test test     test test test test test test test test test test
```
