### PR TITLE
getForbiddenStores returns a mutable list with no empty elements

### DIFF
--- a/src/net/sourceforge/kolmafia/request/MallPurchaseRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MallPurchaseRequest.java
@@ -49,21 +49,22 @@ public class MallPurchaseRequest extends PurchaseRequest {
   }
 
   public static List<String> getForbiddenStores() {
-    return Arrays.asList(Preferences.getString("forbiddenStores").split("\\s*,\\s*"));
+    // We want to return a mutable list.
+    // String.split returns a fixed-size list
+    // String.split returns a list with an empty element if the input string is empty
+    String input = Preferences.getString("forbiddenStores").trim();
+    if (input.equals("")) {
+      return new ArrayList<String>();
+    }
+    return new ArrayList(Arrays.asList(input.split("\\s*,\\s*")));
   }
 
   public static void addForbiddenStore(int shopId) {
     List<String> forbidden = MallPurchaseRequest.getForbiddenStores();
     String shopIdString = String.valueOf(shopId);
     if (!forbidden.contains(shopIdString)) {
-      // forbidden is a fixed-sized list
-      ArrayList<String> list = new ArrayList<>(forbidden);
-      // An empty string splits into an array with a single empty element.
-      if (list.size() == 1 && list.get(0).equals("")) {
-        list.remove(0);
-      }
-      list.add(shopIdString);
-      Preferences.setString("forbiddenStores", String.join(",", list));
+      forbidden.add(shopIdString);
+      Preferences.setString("forbiddenStores", String.join(",", forbidden));
     }
   }
 


### PR DESCRIPTION
I notice there is a pending PR which manipulates the forbiddenStores setting. Cool!
Simplify MallPurchaseRequest.getForbiddenStores.

It now returns a mutable list.
If the forbiddenStores property is empty, return an empty list

Therefore, you can add and remove elements from the List and not worry about having an empty element present if the property has no stores in it.