### PR TITLE
Ignore special monsters when time-spinning

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -11783,6 +11783,7 @@ public abstract class ChoiceManager {
         // Travel to a Recent Fight
         if (ChoiceManager.lastDecision == 1 && !urlString.contains("monid=0")) {
           Preferences.increment("_timeSpinnerMinutesUsed", 3);
+          EncounterManager.ignoreSpecialMonsters();
         }
         break;
 


### PR DESCRIPTION
This should fix timespinner considering semirare monsters and goth kid monsters (amongst others) when recording their associated state changes.

Fixes https://kolmafia.us/threads/timespinning-a-knob-goblin-embezzler-resets-the-semirare-counter.26987/