### PR TITLE
If we declare world peace, maximizer should abort

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/CheckedItem.java
+++ b/src/net/sourceforge/kolmafia/maximizer/CheckedItem.java
@@ -3,6 +3,7 @@ package net.sourceforge.kolmafia.maximizer;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.ConcoctionPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -184,7 +185,11 @@ public class CheckedItem extends AdventureResult {
         + this.pullBuyable;
   }
 
-  public void validate(int maxPrice, int priceLevel) {
+  public void validate(int maxPrice, int priceLevel) throws MaximizerInterruptedException {
+    if (!KoLmafia.permitsContinue()) {
+      throw new MaximizerInterruptedException();
+    }
+
     if (priceLevel <= 0) {
       return;
     }


### PR DESCRIPTION
This sounds like it should go into the maximizer class itself, but the maximizer class is so messy that it'd need to be rewritten just to make that viable.

This method is called several times in different locations in different orders of logic. It's just simpler and cleaner as it stands to put the check here.