### PR TITLE
Add some tests to the maximizer

### DIFF
--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -29,6 +29,15 @@ public class MaximizerTest {
   }
 
   @Test
+  public void equipsItemsOnlyIfHasStats() {
+    addItem("helmet turtle");
+    addItem("wreath of laurels");
+    assertTrue(maximize("mus"));
+    assertEquals(1, modFor("Buffed Muscle"), 0.01);
+    recommendedSlotIs(EquipmentManager.HAT, "helmet turtle");
+  }
+
+  @Test
   public void nothingBetterThanSomething() {
     addItem("helmet turtle");
     assertTrue(maximize("-mus"));
@@ -77,9 +86,8 @@ public class MaximizerTest {
         modFor("Cold Resistance") - modFor("Combat Rate"),
         0.01,
         "Maximizing one slot should reach 27");
-    Optional<AdventureResult> acc1 = getSlot(EquipmentManager.ACCESSORY1);
-    assertTrue(acc1.isPresent());
-    assertEquals(acc1.get(), AdventureResult.parseResult("Krampus horn"));
+
+    recommendedSlotIs(EquipmentManager.ACCESSORY1, "Krampus horn");
   }
 
   @Test
@@ -180,9 +188,7 @@ public class MaximizerTest {
     assertEquals(3, modFor("Cold Resistance"), 0.01);
     assertEquals(20, modFor("Item Drop"), 0.01);
 
-    Optional<AdventureResult> hat = getSlot(EquipmentManager.HAT);
-    assertTrue(hat.isPresent());
-    assertEquals(hat.get(), AdventureResult.parseResult("bounty-hunting helmet"));
+    recommendedSlotIs(EquipmentManager.HAT, "bounty-hunting helmet");
   }
 
   @Test
@@ -191,6 +197,25 @@ public class MaximizerTest {
     assertFalse(maximize("mus 2 min"));
     // still provides equipment
     assertEquals(1, modFor("Buffed Muscle"), 0.01);
+  }
+
+  @Test
+  public void clownosityTriesClownEquipment() {
+    addItem("clown wig");
+    setStats(0, 0, 10);
+    assertFalse(maximize("clownosity"));
+    // still provides equipment
+    recommendedSlotIs(EquipmentManager.HAT, "clown wig");
+  }
+
+  @Test
+  public void clownositySucceedsWithEnoughEquipment() {
+    addItem("clown wig");
+    addItem("polka-dot bow tie");
+    setStats(0, 10, 10);
+    assertTrue(maximize("clownosity"));
+    recommendedSlotIs(EquipmentManager.HAT, "clown wig");
+    recommendedSlotIs(EquipmentManager.ACCESSORY1, "polka-dot bow tie");
   }
 
   private void equip(int slot, String item) {
@@ -240,5 +265,11 @@ public class MaximizerTest {
             .filter(b -> b.getSlot() == slot)
             .map(Boost::getItem)
             .findAny();
+  }
+
+  private void recommendedSlotIs(int slot, String item) {
+    Optional<AdventureResult> hat = getSlot(slot);
+    assertTrue(hat.isPresent());
+    assertEquals(hat.get(), AdventureResult.parseResult(item));
   }
 }

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -10,10 +10,8 @@ import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
+import net.sourceforge.kolmafia.persistence.EffectDatabase;
 import net.sourceforge.kolmafia.session.EquipmentManager;
-import net.sourceforge.kolmafia.session.InventoryManager;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,16 +23,14 @@ public class MaximizerTest {
 
   @Test
   public void changesGear() {
-    // 1 helmet turtle.
-    loadInventory("{\"3\": \"1\"}");
+    addItem("helmet turtle");
     assertTrue(maximize("mus"));
     assertEquals(1, modFor("Buffed Muscle"), 0.01);
   }
 
   @Test
   public void nothingBetterThanSomething() {
-    // 1 helmet turtle.
-    loadInventory("{\"3\": \"1\"}");
+    addItem("helmet turtle");
     assertTrue(maximize("-mus"));
     assertEquals(0, modFor("Buffed Muscle"), 0.01);
   }
@@ -43,12 +39,14 @@ public class MaximizerTest {
   public void clubModifierDoesntAffectOffhand() {
     KoLCharacter.addAvailableSkill("Double-Fisted Skull Smashing");
     // 15 base + buffed mus.
-    KoLCharacter.setStatPoints(15, 225, 0, 0, 0, 0);
+    setStats(15, 0, 0);
     // 2 flaming crutch, 2 white sword, 1 dense meat sword.
     // Max required muscle to equip any of these is 15.
-    loadInventory("{\"473\": \"2\", \"269\": \"2\", \"1728\": \"1\"}");
-    assertTrue(EquipmentManager.canEquip(269), "Can equip white sword");
-    assertTrue(EquipmentManager.canEquip(473), "Can equip flaming crutch");
+    addItem("flaming crutch", 2);
+    addItem("white sword", 2);
+    addItem("dense meat sword");
+    assertTrue(EquipmentManager.canEquip("white sword"), "Can equip white sword");
+    assertTrue(EquipmentManager.canEquip("flaming crutch"), "Can equip flaming crutch");
     assertTrue(maximize("mus, club"));
     // Should equip 1 flaming crutch, 1 white sword.
     assertEquals(2, modFor("Muscle"), 0.01, "Muscle as expected.");
@@ -58,16 +56,17 @@ public class MaximizerTest {
   @Test
   public void maximizeGiveBestScoreWithEffectsAtNoncombatLimit() {
     // space trip safety headphones, Krampus horn
-    loadInventory("{\"4639\": \"1\", \"9274\": \"1\"}");
+    addItem("Space Trip safety headphones");
+    addItem("Krampus horn");
     // get ourselves to -25 combat
-    KoLConstants.activeEffects.clear();
-    KoLConstants.activeEffects.add(EffectPool.get(1798)); // Shelter of Shed
-    KoLConstants.activeEffects.add(EffectPool.get(165)); // Smooth Movements
+    addEffect("Shelter of Shed");
+    addEffect("Smooth Movements");
     // check we can equip everything
-    KoLCharacter.setStatPoints(0, 0, 40, 1600, 125, 15625);
-    KoLCharacter.recalculateAdjustments();
-    assertTrue(EquipmentManager.canEquip(4639), "Cannot equip space trip safety headphones");
-    assertTrue(EquipmentManager.canEquip(9274), "Cannot equip Krampus Horn");
+    setStats(0, 40, 125);
+    assertTrue(
+        EquipmentManager.canEquip("Space Trip safety headphones"),
+        "Cannot equip Space Trip safety headphones");
+    assertTrue(EquipmentManager.canEquip("Krampus horn"), "Cannot equip Krampus Horn");
     assertTrue(
         maximize(
             "cold res,-combat -hat -weapon -offhand -back -shirt -pants -familiar -acc1 -acc2 -acc3"));
@@ -85,18 +84,18 @@ public class MaximizerTest {
             .map(Boost::getItem)
             .findAny();
     assertTrue(acc1.isPresent());
-    assertEquals(acc1.get().getItemId(), 9274);
+    assertEquals(acc1.get(), AdventureResult.parseResult("Krampus horn"));
   }
 
   @Test
   public void maximizeShouldNotRemoveEquipmentThatCanNoLongerBeEquipped() {
     // slippers have a Moxie requirement of 125
-    EquipmentManager.setEquipment(
-        EquipmentManager.ACCESSORY1, AdventureResult.parseResult("Fuzzy Slippers of Hatred"));
+    equip(EquipmentManager.ACCESSORY1, "Fuzzy Slippers of Hatred");
     // get our Moxie below 125 (e.g. basic hot dogs, stat limiting effects)
-    KoLCharacter.setStatPoints(0, 0, 0, 0, 0, 0);
-    KoLCharacter.recalculateAdjustments();
-    assertFalse(EquipmentManager.canEquip(4307), "Can still equip Fuzzy Slippers of Hatred");
+    setStats(0, 0, 0);
+    assertFalse(
+        EquipmentManager.canEquip("Fuzzy Slippers of Hatred"),
+        "Can still equip Fuzzy Slippers of Hatred");
     assertTrue(
         maximize("-combat -hat -weapon -offhand -back -shirt -pants -familiar -acc1 -acc2 -acc3"));
     assertEquals(5, -modFor("Combat Rate"), 0.01, "Base score is 5");
@@ -120,7 +119,7 @@ public class MaximizerTest {
   @Test
   public void noTieCanLeaveSlotsEmpty() {
     // 1 helmet turtle.
-    loadInventory("{\"3\": \"1\"}");
+    addItem("helmet turtle");
     assertTrue(maximize("mys -tie"));
     assertEquals(0, modFor("Buffed Muscle"), 0.01);
   }
@@ -180,15 +179,28 @@ public class MaximizerTest {
   }
 
   private void addItem(String item) {
-    AdventureResult.addResultToList(KoLConstants.inventory, AdventureResult.parseResult(item));
+    addItem(item, 1);
   }
 
-  private void loadInventory(String jsonInventory) {
-    try {
-      InventoryManager.parseInventory(new JSONObject(jsonInventory));
-    } catch (JSONException e) {
-      fail("Inventory parsing failed.");
+  private void addItem(String item, int count) {
+    for (int i = 0; i < count; i++) {
+      AdventureResult.addResultToList(KoLConstants.inventory, AdventureResult.parseResult(item));
     }
+  }
+
+  private void addEffect(String effect) {
+    KoLConstants.activeEffects.add(EffectPool.get(EffectDatabase.getEffectId(effect)));
+  }
+
+  private void setStats(int muscle, int mysticality, int moxie) {
+    KoLCharacter.setStatPoints(
+        muscle,
+        (long) muscle * muscle,
+        mysticality,
+        (long) mysticality * mysticality,
+        moxie,
+        (long) moxie * moxie);
+    KoLCharacter.recalculateAdjustments();
   }
 
   private boolean maximize(String maximizerString) {

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -199,8 +199,10 @@ public class MaximizerTest {
     setStats(0, 0, 200);
     maximize("3 max, cold res");
 
-    assertTrue(Maximizer.boosts.stream()
-        .anyMatch(b -> b.toString().contains("(maximum achieved, no further combinations checked)")));
+    assertTrue(
+        Maximizer.boosts.stream()
+            .anyMatch(
+                b -> b.toString().contains("(maximum achieved, no further combinations checked)")));
   }
 
   @Test
@@ -273,10 +275,10 @@ public class MaximizerTest {
 
   private Optional<AdventureResult> getSlot(int slot) {
     return Maximizer.boosts.stream()
-            .filter(Boost::isEquipment)
-            .filter(b -> b.getSlot() == slot)
-            .map(Boost::getItem)
-            .findAny();
+        .filter(Boost::isEquipment)
+        .filter(b -> b.getSlot() == slot)
+        .map(Boost::getItem)
+        .findAny();
   }
 
   private void recommendedSlotIs(int slot, String item) {

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -47,9 +47,7 @@ public class MaximizerTest {
   @Test
   public void clubModifierDoesntAffectOffhand() {
     addSkill("Double-Fisted Skull Smashing");
-    // 15 base + buffed mus.
     setStats(15, 0, 0);
-    // 2 flaming crutch, 2 white sword, 1 dense meat sword.
     // Max required muscle to equip any of these is 15.
     addItem("flaming crutch", 2);
     addItem("white sword", 2);
@@ -64,7 +62,6 @@ public class MaximizerTest {
 
   @Test
   public void maximizeGiveBestScoreWithEffectsAtNoncombatLimit() {
-    // space trip safety headphones, Krampus horn
     addItem("Space Trip safety headphones");
     addItem("Krampus horn");
     // get ourselves to -25 combat
@@ -121,7 +118,6 @@ public class MaximizerTest {
   // Sample test for https://kolmafia.us/showthread.php?23648&p=151903#post151903.
   @Test
   public void noTieCanLeaveSlotsEmpty() {
-    // 1 helmet turtle.
     addItem("helmet turtle");
     assertTrue(maximize("mys -tie"));
     assertEquals(0, modFor("Buffed Muscle"), 0.01);
@@ -282,8 +278,8 @@ public class MaximizerTest {
   }
 
   private void recommendedSlotIs(int slot, String item) {
-    Optional<AdventureResult> hat = getSlot(slot);
-    assertTrue(hat.isPresent());
-    assertEquals(hat.get(), AdventureResult.parseResult(item));
+    Optional<AdventureResult> equipment = getSlot(slot);
+    assertTrue(equipment.isPresent());
+    assertEquals(equipment.get(), AdventureResult.parseResult(item));
   }
 }

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -192,6 +192,18 @@ public class MaximizerTest {
   }
 
   @Test
+  public void startingMaxKeywordTerminatesEarlyIfConditionMet() {
+    addItem("hardened slime hat");
+    addItem("bounty-hunting helmet");
+    addSkill("Refusal to Freeze");
+    setStats(0, 0, 200);
+    maximize("3 max, cold res");
+
+    assertTrue(Maximizer.boosts.stream()
+        .anyMatch(b -> b.toString().contains("(maximum achieved, no further combinations checked)")));
+  }
+
+  @Test
   public void minKeywordFailsMaximizationIfNotHit() {
     addItem("helmet turtle");
     assertFalse(maximize("mus 2 min"));


### PR DESCRIPTION
The maximizer is very big and complicated, and a good target for additional tests before refactoring (or in general).

I refactored the tests a bit to prefer using names to ids; I feel it reads better.

I added tests for max and min (inside modifiers, or starting for max), stat restrictions and clownosity. The documentation says that max and min at the start of an expression should apply to the entire expression, but I tried this and I don't think it works that way for min. It looks like "min" fails the maximization if the _current_ character items / effects don't meet the minimum.