### PR TITLE
When we attempt to search mall, always ensure the "Force Sort" option…

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/MallSearchFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/MallSearchFrame.java
@@ -241,6 +241,8 @@ public class MallSearchFrame extends GenericPanelFrame {
       KoLmafiaGUI.constructFrame("MallSearchFrame");
     }
 
+    PurchaseRequest.setUsePriceComparison(INSTANCE.mallSearch.forceSortingCheckBox.isSelected());
+
     MallSearchFrame.results.clear();
     request.setResults(MallSearchFrame.results);
 


### PR DESCRIPTION
… is properly read.

This fixes searching mall from chat, without having searched through the Purchases tab not reading the checkbox.

Aka, checking the box, then attempting to visit someone's store through mafia's chat. Previously, the box would be ignored.