### PR TITLE
Default value of a filter type is not true, but is checkbox.selected()

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
@@ -93,7 +93,7 @@ public class MaximizerFrame extends GenericFrame implements ListSelectionListene
       }
     }
     for (KoLConstants.filterType f : KoLConstants.filterType.values()) {
-      activeFilters.put(f, true);
+      activeFilters.put(f, filterButtons.get(f).isSelected());
     }
   }
 


### PR DESCRIPTION
This fixes the exclusive setting of maximizer having checkboxes ticked wrongly