### PR TITLE
Increment gold guzzlr quests by 1 on completion

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -13262,8 +13262,7 @@ public abstract class ChoiceManager {
                 // Increment the number of gold or platinum deliveres STARTED today
                 if (!tier.equals("bronze")) {
                   Preferences.increment(
-                      "_guzzlr" + StringUtilities.toTitleCase(tier) + "Deliveries",
-                      tier.equals("gold") ? 3 : 1);
+                      "_guzzlr" + StringUtilities.toTitleCase(tier) + "Deliveries", 1);
                 }
 
                 if (boozeMatcher.find()) {


### PR DESCRIPTION
Prior to #374 this always incremented by 1 because Java matchers return a String. String == string is generally false because they do not exist at the same memory location. This PR is intended to revert to the original behavior that is now expected by users and simplify logic.