### PR TITLE
Add [experimental crimbo spleen] and Chem Lab

### DIFF
--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -10873,3 +10873,4 @@
 10846	gooified mineral matter	933889078	goo_min.gif	none	t	0
 10847	[experimental crimbo food]	268310979	confused.gif	food	q,d	11
 10848	[experimental crimbo booze]	222544926	coffeecup.gif	drink	q,d	11
+10849	[experimental crimbo spleen]	489345410	potion10.gif	spleen, usable	q,d	11

--- a/src/data/spleenhit.txt
+++ b/src/data/spleenhit.txt
@@ -4,6 +4,7 @@
 
 # Item	Spleenhit	Level Req	Quality	Adv	Musc	Myst	Moxie
 
+[experimental crimbo spleen]	2	1		0	0	0	0	Unspaded
 a bug's lymph	1	1	awesome	0	0	0	0	Unspaded 60 A Bug's Life (+100% HP, +8-10 HP Regen)
 abstraction: action	1	1	decent	0	0	0	0	50 Action (+100% mus)
 abstraction: category	1	1	decent	0	0	0	0	50 Category (+25% mys experience)

--- a/src/net/sourceforge/kolmafia/request/PlaceRequest.java
+++ b/src/net/sourceforge/kolmafia/request/PlaceRequest.java
@@ -576,6 +576,8 @@ public class PlaceRequest extends GenericRequest {
         message = "Entering the Food Lab";
       } else if (action.equals("np_boozelab")) {
         message = "Entering the Nog Lab";
+      } else if (action.equals("np_spleenlab")) {
+        message = "Entering the Chem Lab";
       }
     } else if (place.equals("orc_chasm")) {
       if (action.startsWith("bridge") || action.equals("label1") || action.equals("label2")) {

--- a/test/net/sourceforge/kolmafia/DataFileTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileTest.java
@@ -64,7 +64,7 @@ public class DataFileTest {
               ".+", // name
               "\\d+", // fullness
               "\\d+", // level
-              "(crappy|decent|good|awesome|EPIC)", // quality
+              "(|crappy|decent|good|awesome|EPIC)", // quality
               "-?\\d+(-\\d+)?", // adv
               "-?\\d+(-\\d+)?", // mus
               "-?\\d+(-\\d+)?", // mys


### PR DESCRIPTION
new item, new place

Also: Data File test failed because there was no "quality" listed for the spleen item.
That is allowed, as a result of KoL change:

"December 02 - Spleen items no longer show an often misleading quality rating, if they don't give adventures."

I did not remove qualities from existing spleen items, but I fixed the test to not require a quality.