### PR TITLE
Guard calls to Desktop.getDesktop().

### DIFF
--- a/lib/net/java/dev/spellcast/utilities/LicenseDisplay.java
+++ b/lib/net/java/dev/spellcast/utilities/LicenseDisplay.java
@@ -265,6 +265,10 @@ public class LicenseDisplay
 	{
 		public void hyperlinkUpdate( final HyperlinkEvent e )
 		{
+			if (!Desktop.isDesktopSupported())
+			{
+				return;
+			}
 			if ( e.getEventType() == HyperlinkEvent.EventType.ACTIVATED )
 			{
 				String location = e.getDescription();

--- a/src/net/sourceforge/kolmafia/CreateFrameRunnable.java
+++ b/src/net/sourceforge/kolmafia/CreateFrameRunnable.java
@@ -258,6 +258,10 @@ public class CreateFrameRunnable implements Runnable {
   }
 
   private static void addMenuItems() {
+    if (!Desktop.isDesktopSupported()) {
+      return;
+    }
+
     Desktop desktop = Desktop.getDesktop();
 
     DesktopHandler handler = new DesktopHandler();


### PR DESCRIPTION
In situations where !Desktop.isDesktopSupported(), these will throw
exceptions. That's not great, as we should degrade gracefully.