### PR TITLE
Show limits even if they're equal to or higher than quantity

### DIFF
--- a/src/net/sourceforge/kolmafia/request/MallPurchaseRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MallPurchaseRequest.java
@@ -152,7 +152,8 @@ public class MallPurchaseRequest extends PurchaseRequest {
 
     this.quantity = quantity;
     this.price = price;
-    this.limit = Math.min(quantity, limit);
+    this.storeLimit = limit;
+    this.limit = limit == 0 ? quantity : Math.min(quantity, limit);
     this.canPurchase = canPurchase;
 
     this.addFormField("whichstore", String.valueOf(shopId));

--- a/src/net/sourceforge/kolmafia/request/MallSearchRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MallSearchRequest.java
@@ -328,7 +328,7 @@ public class MallSearchRequest extends GenericRequest {
 
         int itemId = StringUtilities.parseInt(priceId.substring(0, priceId.length() - 9));
         int quantity = StringUtilities.parseInt(priceMatcher.group(3));
-        int limit = quantity;
+        int limit = 0;
 
         Matcher limitMatcher = MallSearchRequest.STORELIMIT_PATTERN.matcher(priceMatcher.group(4));
         if (limitMatcher.find()) {
@@ -393,7 +393,7 @@ public class MallSearchRequest extends GenericRequest {
           quantity = StringUtilities.parseInt(quantityMatcher.group(1));
         }
 
-        int limit = quantity;
+        int limit = 0;
         boolean canPurchase = true;
 
         Matcher limitMatcher = MallSearchRequest.LISTLIMIT_PATTERN.matcher(linkText);

--- a/src/net/sourceforge/kolmafia/request/PurchaseRequest.java
+++ b/src/net/sourceforge/kolmafia/request/PurchaseRequest.java
@@ -20,6 +20,7 @@ public abstract class PurchaseRequest extends GenericRequest
   protected int quantity;
   protected int price;
   protected int limit;
+  protected int storeLimit;
 
   protected boolean canPurchase;
   protected long timestamp;
@@ -112,6 +113,14 @@ public abstract class PurchaseRequest extends GenericRequest
     this.limit = Math.min(this.quantity, limit);
   }
 
+  public void setStoreLimit(final int storeLimit) {
+    this.storeLimit = storeLimit;
+  }
+
+  public int getStoreLimit() {
+    return this.storeLimit;
+  }
+
   /** Converts this request into a readable string. */
   @Override
   public String toString() {
@@ -135,9 +144,9 @@ public abstract class PurchaseRequest extends GenericRequest
     } else {
       buffer.append(KoLConstants.COMMA_FORMAT.format(this.quantity));
 
-      if (this.limit < this.quantity) {
+      if (this.storeLimit > 0) {
         buffer.append(" limit ");
-        buffer.append(KoLConstants.COMMA_FORMAT.format(this.limit));
+        buffer.append(KoLConstants.COMMA_FORMAT.format(this.storeLimit));
       }
     }
 

--- a/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
@@ -119,9 +119,9 @@ public class ListCellRendererFactory {
       } else {
         buffer.append(KoLConstants.COMMA_FORMAT.format(value.getQuantity()));
 
-        if (value.getLimit() < value.getQuantity()) {
+        if (value.getStoreLimit() > 0) {
           buffer.append(" limit ");
-          buffer.append(KoLConstants.COMMA_FORMAT.format(value.getLimit()));
+          buffer.append(KoLConstants.COMMA_FORMAT.format(value.getStoreLimit()));
         }
       }
 


### PR DESCRIPTION
This is stored in a separate field and the original "limit" field left mostly untouched.

To do otherwise would result in a large refactor over tens of classes. Either for renaming, for in correcting logic.

This allows limits to display even when the quantity in store is equal to, or lower than the store's limit.

![image](https://user-images.githubusercontent.com/1419679/147035132-6f1915a3-4959-4eb9-9915-029f0c0b5678.png)
