### PR TITLE
Extract EquipmentRequirement, more maximizer tests

### DIFF
--- a/src/net/sourceforge/kolmafia/session/EquipmentManager.java
+++ b/src/net/sourceforge/kolmafia/session/EquipmentManager.java
@@ -32,7 +32,6 @@ import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.swingui.GearChangeFrame;
 import net.sourceforge.kolmafia.textui.command.ConditionsCommand;
 import net.sourceforge.kolmafia.utilities.LockableListFactory;
-import net.sourceforge.kolmafia.utilities.StringUtilities;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -2244,18 +2243,22 @@ public class EquipmentManager {
       return false;
     }
 
-    EquipmentRequirement req = new EquipmentRequirement(EquipmentDatabase.getEquipRequirement(itemId));
+    EquipmentRequirement req =
+        new EquipmentRequirement(EquipmentDatabase.getEquipRequirement(itemId));
 
     if (req.isMuscle()) {
-      return KoLCharacter.getBaseMuscle() >= req.getAmount() || KoLCharacter.muscleTrigger(req.getAmount(), itemId);
+      return KoLCharacter.getBaseMuscle() >= req.getAmount()
+          || KoLCharacter.muscleTrigger(req.getAmount(), itemId);
     }
 
     if (req.isMysticality()) {
-      return KoLCharacter.getBaseMysticality() >= req.getAmount() || KoLCharacter.mysticalityTrigger(req.getAmount(), itemId);
+      return KoLCharacter.getBaseMysticality() >= req.getAmount()
+          || KoLCharacter.mysticalityTrigger(req.getAmount(), itemId);
     }
 
     if (req.isMoxie()) {
-      return KoLCharacter.getBaseMoxie() >= req.getAmount() || KoLCharacter.moxieTrigger(req.getAmount(), itemId);
+      return KoLCharacter.getBaseMoxie() >= req.getAmount()
+          || KoLCharacter.moxieTrigger(req.getAmount(), itemId);
     }
 
     return true;

--- a/src/net/sourceforge/kolmafia/session/EquipmentManager.java
+++ b/src/net/sourceforge/kolmafia/session/EquipmentManager.java
@@ -2244,23 +2244,18 @@ public class EquipmentManager {
       return false;
     }
 
-    String requirement = EquipmentDatabase.getEquipRequirement(itemId);
-    int req;
+    EquipmentRequirement req = new EquipmentRequirement(EquipmentDatabase.getEquipRequirement(itemId));
 
-    if (requirement.startsWith("Mus:")) {
-      req = StringUtilities.parseInt(requirement.substring(5));
-      return KoLCharacter.getBaseMuscle() >= req || KoLCharacter.muscleTrigger(req, itemId);
+    if (req.isMuscle()) {
+      return KoLCharacter.getBaseMuscle() >= req.getAmount() || KoLCharacter.muscleTrigger(req.getAmount(), itemId);
     }
 
-    if (requirement.startsWith("Mys:")) {
-      req = StringUtilities.parseInt(requirement.substring(5));
-      return KoLCharacter.getBaseMysticality() >= req
-          || KoLCharacter.mysticalityTrigger(req, itemId);
+    if (req.isMysticality()) {
+      return KoLCharacter.getBaseMysticality() >= req.getAmount() || KoLCharacter.mysticalityTrigger(req.getAmount(), itemId);
     }
 
-    if (requirement.startsWith("Mox:")) {
-      req = StringUtilities.parseInt(requirement.substring(5));
-      return KoLCharacter.getBaseMoxie() >= req || KoLCharacter.moxieTrigger(req, itemId);
+    if (req.isMoxie()) {
+      return KoLCharacter.getBaseMoxie() >= req.getAmount() || KoLCharacter.moxieTrigger(req.getAmount(), itemId);
     }
 
     return true;

--- a/src/net/sourceforge/kolmafia/session/EquipmentRequirement.java
+++ b/src/net/sourceforge/kolmafia/session/EquipmentRequirement.java
@@ -1,0 +1,46 @@
+package net.sourceforge.kolmafia.session;
+
+import net.sourceforge.kolmafia.KoLConstants.Stat;
+import net.sourceforge.kolmafia.utilities.StringUtilities;
+
+public class EquipmentRequirement {
+    private Stat stat = Stat.NONE;
+    private int amount;
+
+  public EquipmentRequirement(String requirement) {
+    if (requirement.startsWith("Mus:")) {
+      stat = Stat.MUSCLE;
+      amount = StringUtilities.parseInt(requirement.substring(5));
+    }
+
+    if (requirement.startsWith("Mys:")) {
+      stat = Stat.MYSTICALITY;
+      amount = StringUtilities.parseInt(requirement.substring(5));
+    }
+
+    if (requirement.startsWith("Mox:")) {
+      stat = Stat.MOXIE;
+      amount = StringUtilities.parseInt(requirement.substring(5));
+    }
+  }
+
+  public boolean isMuscle() {
+    return stat == Stat.MUSCLE;
+  }
+
+  public boolean isMysticality() {
+    return stat == Stat.MYSTICALITY;
+  }
+
+  public boolean isMoxie() {
+    return stat == Stat.MOXIE;
+  }
+
+  public Stat getStat() {
+    return stat;
+  }
+
+  public int getAmount() {
+    return amount;
+  }
+}

--- a/src/net/sourceforge/kolmafia/session/EquipmentRequirement.java
+++ b/src/net/sourceforge/kolmafia/session/EquipmentRequirement.java
@@ -4,8 +4,8 @@ import net.sourceforge.kolmafia.KoLConstants.Stat;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class EquipmentRequirement {
-    private Stat stat = Stat.NONE;
-    private int amount;
+  private Stat stat = Stat.NONE;
+  private int amount;
 
   public EquipmentRequirement(String requirement) {
     if (requirement.startsWith("Mus:")) {

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -331,8 +331,7 @@ public class MaximizerTest {
     setStats(
         Math.max(req.isMuscle() ? req.getAmount() : 0, KoLCharacter.getBaseMuscle()),
         Math.max(req.isMysticality() ? req.getAmount() : 0, KoLCharacter.getBaseMysticality()),
-        Math.max(req.isMoxie() ? req.getAmount() : 0, KoLCharacter.getBaseMoxie())
-    );
+        Math.max(req.isMoxie() ? req.getAmount() : 0, KoLCharacter.getBaseMoxie()));
   }
 
   private void setStats(int muscle, int mysticality, int moxie) {
@@ -369,10 +368,11 @@ public class MaximizerTest {
   }
 
   private void recommends(String item) {
-    Optional<Boost> found = Maximizer.boosts.stream()
-        .filter(Boost::isEquipment)
-        .filter(b -> item.equals(b.getItem().getName()))
-        .findAny();
+    Optional<Boost> found =
+        Maximizer.boosts.stream()
+            .filter(Boost::isEquipment)
+            .filter(b -> item.equals(b.getItem().getName()))
+            .findAny();
     assertTrue(found.isPresent(), "Expected " + item + " to be recommended, but it was not");
   }
 }

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -126,6 +126,35 @@ public class MaximizerTest {
     recommendedSlotIs(EquipmentManager.ACCESSORY1, "polka-dot bow tie");
   }
 
+  // raveosity
+
+  @Test
+  public void raveosityTriesRaveEquipment() {
+    canUse("rave visor");
+    canUse("baggy rave pants");
+    canUse("rave whistle");
+    assertFalse(maximize("raveosity"));
+    // still provides equipment
+    recommendedSlotIs(EquipmentManager.HAT, "rave visor");
+    recommendedSlotIs(EquipmentManager.PANTS, "baggy rave pants");
+    recommendedSlotIs(EquipmentManager.WEAPON, "rave whistle");
+  }
+
+  @Test
+  public void raveositySucceedsWithEnoughEquipment() {
+    canUse("blue glowstick");
+    canUse("glowstick on a string");
+    canUse("teddybear backpack");
+    canUse("rave visor");
+    canUse("baggy rave pants");
+    assertTrue(maximize("raveosity"));
+    recommendedSlotIs(EquipmentManager.HAT, "rave visor");
+    recommendedSlotIs(EquipmentManager.PANTS, "baggy rave pants");
+    recommendedSlotIs(EquipmentManager.CONTAINER, "teddybear backpack");
+    recommendedSlotIs(EquipmentManager.OFFHAND, "glowstick on a string");
+    recommends("blue glowstick");
+  }
+
   // club
 
   @Test
@@ -335,7 +364,15 @@ public class MaximizerTest {
 
   private void recommendedSlotIs(int slot, String item) {
     Optional<AdventureResult> equipment = getSlot(slot);
-    assertTrue(equipment.isPresent());
+    assertTrue(equipment.isPresent(), "Expected " + item + " to be recommended, but it was not");
     assertEquals(equipment.get(), AdventureResult.parseResult(item));
+  }
+
+  private void recommends(String item) {
+    Optional<Boost> found = Maximizer.boosts.stream()
+        .filter(Boost::isEquipment)
+        .filter(b -> item.equals(b.getItem().getName()))
+        .findAny();
+    assertTrue(found.isPresent(), "Expected " + item + " to be recommended, but it was not");
   }
 }


### PR DESCRIPTION
Extracted `EquipmentRequirement` (the equipment requiring parsing code) from `EquipmentManager` because I wanted to re-use it in the tests to set stats appropriately.

Refactored, reordered and added a few more maximizer tests.