### PR TITLE
When checking underwater locations, check environment instead of list

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -2206,8 +2206,7 @@ public abstract class KoLCharacter {
   /** Accessor method to retrieve the total current combat percent adjustment */
   public static final double getCombatRateAdjustment() {
     double rate = KoLCharacter.currentModifiers.get(Modifiers.COMBAT_RATE);
-    if (Modifiers.currentZone.contains("The Sea")
-        || Modifiers.currentLocation.equals("The Sunken Party Yacht")) {
+    if ("underwater".equals(AdventureDatabase.getEnvironment(Modifiers.currentLocation))) {
       rate += KoLCharacter.currentModifiers.get(Modifiers.UNDERWATER_COMBAT_RATE);
     }
     return rate;

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -25,6 +25,7 @@ import net.sourceforge.kolmafia.SpecialOutfit;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
 import net.sourceforge.kolmafia.persistence.FamiliarDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
@@ -560,8 +561,7 @@ public class Evaluator {
           }
         } else if (keyword.startsWith("com")) {
           index = Modifiers.COMBAT_RATE;
-          if (Modifiers.currentZone.equals("The Sea")
-              || Modifiers.currentLocation.equals("The Sunken Party Yacht")) {
+          if ("underwater".equals(AdventureDatabase.getEnvironment(Modifiers.currentLocation))) {
             this.weight[Modifiers.UNDERWATER_COMBAT_RATE] = weight;
           }
         } else if (keyword.startsWith("item")) {

--- a/src/net/sourceforge/kolmafia/request/AdventureRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AdventureRequest.java
@@ -1003,9 +1003,7 @@ public class AdventureRequest extends GenericRequest {
     if (this.adventureId.equals(AdventurePool.THE_SHORE_ID)) {
       return KoLCharacter.inFistcore() ? 5 : 3;
     }
-    String zone = AdventureDatabase.getZone(this.adventureName);
-    if (zone != null
-        && (zone.equals("The Sea") || this.adventureId.equals(AdventurePool.YACHT_ID))) {
+    if ("underwater".equals(AdventureDatabase.getEnvironment(this.adventureName))) {
       return KoLConstants.activeEffects.contains(EffectPool.get(EffectPool.FISHY)) ? 1 : 2;
     }
     return 1;


### PR DESCRIPTION
Several places in the codebase checked only for The Sea and the Party Yacht instead of all underwater locations. This PR changes that, and adds a test for the Maximizer.