### PR TITLE
Add mall_price( item, float maxAge ) to ASH

### DIFF
--- a/src/net/sourceforge/kolmafia/session/StoreManager.java
+++ b/src/net/sourceforge/kolmafia/session/StoreManager.java
@@ -758,7 +758,12 @@ public abstract class StoreManager {
   public static int getMallPrice(AdventureResult item, float maxAge) {
     int id = item.getItemId();
     int price = MallPriceDatabase.getPrice(id);
-    if (price <= 0 || MallPriceDatabase.getAge(id) > maxAge) {
+    if (MallPriceDatabase.getAge(id) > maxAge) {
+      StoreManager.flushCache(id);
+      StoreManager.mallPrices.set(id, 0);
+      price = 0;
+    }
+    if (price <= 0) {
       price = StoreManager.getMallPrice(item);
     }
     return price;

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -990,6 +990,9 @@ public abstract class RuntimeLibrary {
     params = new Type[] {DataTypes.ITEM_TYPE};
     functions.add(new LibraryFunction("mall_price", DataTypes.INT_TYPE, params));
 
+    params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.FLOAT_TYPE};
+    functions.add(new LibraryFunction("mall_price", DataTypes.INT_TYPE, params));
+
     params = new Type[] {RuntimeLibrary.ItemSetType};
     functions.add(new LibraryFunction("mall_prices", DataTypes.INT_TYPE, params));
 
@@ -5007,6 +5010,12 @@ public abstract class RuntimeLibrary {
 
   public static Value mall_price(ScriptRuntime controller, final Value item) {
     return new Value(StoreManager.getMallPrice(ItemPool.get((int) item.intValue(), 0)));
+  }
+
+  public static Value mall_price(ScriptRuntime controller, final Value item, final Value maxAge) {
+    return new Value(
+        StoreManager.getMallPrice(
+            ItemPool.get((int) item.intValue(), 0), (float) maxAge.floatValue()));
   }
 
   public static Value mall_prices(ScriptRuntime controller, final Value arg) {


### PR DESCRIPTION
New ASH function:

int mall_price( item it, float maxAge )

This will force a mall search to update the price if the cached price is too old.
Use maxAge of 0 to always force a mall search.

> ash mall_price( $item[ milk of magnesium ] )

Searching for "milk of magnesium"...
Search complete.
Returned: 1195`

> ash mall_price( $item[ milk of magnesium ] )

Returned: 1195

> ash mall_price( $item[ milk of magnesium ], 0 )

Searching for "milk of magnesium"...
Search complete.
Returned: 1195`