### PR TITLE
Don't send empty macros to KoL

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -1040,10 +1040,6 @@ public class FightRequest extends GenericRequest {
   }
 
   private void handleMacroAction(String macro) {
-    FightRequest.nextAction = "macro";
-
-    this.addFormField("action", "macro");
-
     // In case the player continues the script from the relay browser,
     // insert a jump to the next restart point.
 
@@ -1054,8 +1050,21 @@ public class FightRequest extends GenericRequest {
       StringUtilities.singleStringReplace(macro, "#mafiaheader", "#mafiaheader\ngoto " + label);
     }
 
-    this.addFormField(
-        "macrotext", FightRequest.MACRO_COMPACT_PATTERN.matcher(macro).replaceAll("$1"));
+    macro = FightRequest.MACRO_COMPACT_PATTERN.matcher(macro).replaceAll("$1").trim();
+
+    // Sending an empty (or whitespace-only) macro to KoL generates an
+    // "Invalid macro" error.
+    if (macro.isBlank()) {
+      if (RequestLogger.isDebugging()) {
+        RequestLogger.updateDebugLog("Macro optimized down to nothing, not submitting");
+      }
+      return;
+    }
+
+    FightRequest.nextAction = "macro";
+
+    this.addFormField("action", "macro");
+    this.addFormField("macrotext", macro);
   }
 
   public static final String getCurrentKey() {


### PR DESCRIPTION
Sometimes Kolmafia might generate a combat macro which, after optimisation,
constists solely of the placeholders

#mafiaround
#mafiamp
#mafiaheader

handleMacroAction() then further optimises that kind of macro down into a bunch
of newlines, which then cause an "Invalid macro" error when sent to KoL.

With this change, we also check that the macro isn't empty *after* the pro-
cessing done by handleMacroAction(), and only send it on to KoL if it's truly
non-empty.

See also https://kolmafia.us/threads/consult-script-ccs-that-gets-optimised-out-to-nothing-leads-to-invalid-macro-abort.26620/