### PR TITLE
add Site Alpha Primary Lab and massive goo construct

### DIFF
--- a/src/data/adventures.txt
+++ b/src/data/adventures.txt
@@ -312,6 +312,7 @@ Tammy's Offshore Platform	adventure=538	Env: underwater Stat: 0	The Impenetrable
 Crimbo21	adventure=554	Env: indoor Stat: 0	Site Alpha Dormitory
 Crimbo21	adventure=555	Env: indoor Stat: 0	Site Alpha Greenhouse
 Crimbo21	adventure=556	Env: outdoor Stat: 0	Site Alpha Quarry
+Crimbo21	adventure=557	Env: indoor Stat: 0	Site Alpha Primary Lab
 
 Crimbo18	adventure=529	Env: outdoor Stat: 0	The Canadian Wildlife Preserve
 

--- a/src/data/combats.txt
+++ b/src/data/combats.txt
@@ -214,6 +214,7 @@ Sinister Dodecahedron	100	death ray in a pear tree: 1	turtle mech: 2	Swiss hen: 
 Site Alpha Dormitory	100	gooified elf-thing	gooified dog-thing
 Site Alpha Greenhouse	100	gooified flower	gooified tree
 Site Alpha Quarry	100	gooified rock slab
+Site Alpha Primary Lab	100	massive goo construct
 Sleaziest Adventurer Contest	100	Grease Trapper	Ham Shaman	Porkpocket	Leonard: 0
 Sloppy Seconds Diner	100	Sloppy Seconds Sundae	Sloppy Seconds Burger	Sloppy Seconds Cocktail
 Smartest Adventurer Contest	100	Accountant-Barbarian	Metaphysical Gastronomist	Kleptobrainiac	The Mastermind: 0

--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -2188,6 +2188,7 @@ gooified dog-thing	2222	goo_dog.gif	Atk: 150 Def: 150 HP: 200 Init: 200 P: beast
 gooified flower	2223	goo_flower.gif	Atk: 180 Def: 180 HP: 300 Init: -10000 P: plant	gooified vegetable matter (100)	gooified vegetable matter (100)	gooified vegetable matter (100)
 gooified tree	2224	goo_tree.gif	Atk: 150 Def: 50 HP: 1000 Init: -10000 P: plant	gooified vegetable matter (10)	gooified vegetable matter (10)	gooified vegetable matter (10)	gooified vegetable matter (10)	gooified vegetable matter (10)
 gooified rock slab	2225	goo_slab1.gif,goo_slab2.gif,goo_slab3.gif	Atk: 250 Def: 250 HP: 500 Init: -10000 P: elemental	gooified mineral matter (100)	gooified mineral matter (100)
+massive goo construct	2226		Init: -10000 P: construct	gooified animal matter (100)	gooified vegetable matter (100)	gooified mineral matter (100)
 
 # Old Events
 


### PR DESCRIPTION
This is the December 24 adventure zone and monster.
There is also an Advent Calendar item, but I am not adding it, since it has no modifiers. Seems like an oversight.
The monster is confusing. Manuel has nothing much to say about it.
It also has multiple names and an image composed of multiple images.

This is a start, at least, and lets you automate adventures.