### PR TITLE
Primary lab

### DIFF
--- a/src/data/adventures.txt
+++ b/src/data/adventures.txt
@@ -312,6 +312,7 @@ Tammy's Offshore Platform	adventure=538	Env: underwater Stat: 0	The Impenetrable
 Crimbo21	adventure=554	Env: indoor Stat: 0	Site Alpha Dormitory
 Crimbo21	adventure=555	Env: indoor Stat: 0	Site Alpha Greenhouse
 Crimbo21	adventure=556	Env: outdoor Stat: 0	Site Alpha Quarry
+Crimbo21	adventure=557	Env: indoor Stat: 0	Site Alpha Primary Lab
 
 Crimbo18	adventure=529	Env: outdoor Stat: 0	The Canadian Wildlife Preserve
 

--- a/src/data/combats.txt
+++ b/src/data/combats.txt
@@ -214,6 +214,7 @@ Sinister Dodecahedron	100	death ray in a pear tree: 1	turtle mech: 2	Swiss hen: 
 Site Alpha Dormitory	100	gooified elf-thing	gooified dog-thing
 Site Alpha Greenhouse	100	gooified flower	gooified tree
 Site Alpha Quarry	100	gooified rock slab
+Site Alpha Primary Lab	100	massive goo construct
 Sleaziest Adventurer Contest	100	Grease Trapper	Ham Shaman	Porkpocket	Leonard: 0
 Sloppy Seconds Diner	100	Sloppy Seconds Sundae	Sloppy Seconds Burger	Sloppy Seconds Cocktail
 Smartest Adventurer Contest	100	Accountant-Barbarian	Metaphysical Gastronomist	Kleptobrainiac	The Mastermind: 0

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1047,6 +1047,8 @@ user	prayedForProtection	false
 user	prayedForVigor	false
 user	preAscensionScript
 user	preBlackbirdFamiliar
+user	primaryLabGooIntensity	10
+user	primaryLabCheerCoreGrabbed	false
 user	prismaticSummons	0
 user	procrastinatorLanguageFluency	0
 user	promptAboutCrafting	1
@@ -2845,6 +2847,7 @@ user	choiceAdventure1405	1
 user	choiceAdventure1411	0
 user	choiceAdventure1415	0
 user	choiceAdventure1460	8
+user	choiceAdventure1461	4
 
 user	lockedItem4637	true
 user	lockedItem4638	true

--- a/src/data/equipment.txt
+++ b/src/data/equipment.txt
@@ -2595,7 +2595,7 @@ Iiti Kitty phone charm	165	Mys: 67
 imitation nice watch	100	Mys: 35
 imp unity ring	45	Mys: 15
 incredibly dense meat gem	200	none
-inert grey goo ring	0	none
+ert grey goo ring	0	none
 infernal insoles	60	Mys: 15
 inflatable duck	10	none
 intergalactic pom poms	0	none

--- a/src/data/equipment.txt
+++ b/src/data/equipment.txt
@@ -3201,6 +3201,7 @@ tiny plastic orphan	10	none
 tiny plastic pastamancer	20	none
 tiny plastic peacannon	30	none
 tiny plastic Penny	10	none
+tiny plastic primary lab	10	none
 tiny plastic Professor What	10	none
 tiny plastic Protagonist	10	none
 tiny plastic protector spectre	50	Mys: 10

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -10627,7 +10627,7 @@
 10599	Dripwood slab	429328231	dripwood.gif	none	t	0
 10600	drippy diadem	516307518	dripdiadem.gif	hat		0
 10601	Thwaitgold slug statuette	655416395	thwaitslug.gif	none		0
-10602	inert grey goo ring	613175985	greygooring.gif	accessory	t	0
+10602	ert grey goo ring	613175985	greygooring.gif	accessory	t	0
 10603	fistful of wood shavings	725899167	scpowder.gif	none, combat	t,d	5	fistsful of wood shavings
 10604	Yeg's Motel ashtray	695921497	yeg_ashtray.gif	none, combat	t,d	6
 10605	Yeg's Motel alarm clock	834539301	yeg_clock.gif	usable	t,d	6

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -10837,7 +10837,7 @@
 10809	tiny plastic food lab	612016475	c21tp1.gif	accessory	t	0
 10810	tiny plastic nog lab	678768923	c21tpboo.gif	accessory	t	0
 10811	tiny plastic chem lab	974054842	c21tptres.gif	accessory	t	0
-10812
+10812	tiny plastic primary lab	618163201	c21tpfore.gif	accessory	t	0
 10813
 10814	packaged cold medicine cabinet	394128710	cmcabinet_box.gif	usable	t	0
 10815	cold medicine cabinet	411733473	cmcabinet.gif	usable		0

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -3755,6 +3755,7 @@ Item	tiny plastic orphan	Stench Resistance: +1
 Item	tiny plastic pastamancer	Mysticality: +2, Muscle: +1
 Item	tiny plastic peacannon	Ranged Damage: +5
 Item	tiny plastic Penny	Meat Drop: +10
+Item	tiny plastic primary lab	Single Equip
 Item	tiny plastic Professor What	Monster Level: +1
 Item	tiny plastic Protagonist	Monster Level: +1
 Item	tiny plastic protector spectre	Spooky Damage: +10

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -3061,8 +3061,8 @@ Item	Iiti Kitty phone charm	Spooky Damage: +15, Single Equip
 Item	imitation nice watch	Adventures: +3, Single Equip, Nonstackable Watch
 Item	imp unity ring	Hot Damage: +5, Hot Spell Damage: +5
 Item	incredibly dense meat gem	Meat Drop: +60, Moxie: +5, Maximum MP: +10
-# inert grey goo ring: Definitely Safe
-Item	inert grey goo ring	Maximum HP: +10, Maximum MP: +10
+# ert grey goo ring: Definitely Safe
+Item	ert grey goo ring	Maximum HP: +10, Maximum MP: +10
 Item	infernal insoles	Hot Resistance: +1, Initiative: +10
 # inflatable duck
 Item	intergalactic pom poms	Moxie: +20, Initiative: +30

--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -2188,6 +2188,7 @@ gooified dog-thing	2222	goo_dog.gif	Atk: 150 Def: 150 HP: 200 Init: 200 P: beast
 gooified flower	2223	goo_flower.gif	Atk: 180 Def: 180 HP: 300 Init: -10000 P: plant	gooified vegetable matter (100)	gooified vegetable matter (100)	gooified vegetable matter (100)
 gooified tree	2224	goo_tree.gif	Atk: 150 Def: 50 HP: 1000 Init: -10000 P: plant	gooified vegetable matter (10)	gooified vegetable matter (10)	gooified vegetable matter (10)	gooified vegetable matter (10)	gooified vegetable matter (10)
 gooified rock slab	2225	goo_slab1.gif,goo_slab2.gif,goo_slab3.gif	Atk: 250 Def: 250 HP: 500 Init: -10000 P: elemental	gooified mineral matter (100)	gooified mineral matter (100)
+massive goo construct	2226		Init: -10000 P: construct	gooified animal matter (100)	gooified vegetable matter (100)	gooified mineral matter (100)
 
 # Old Events
 

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3248,6 +3248,7 @@ public class ItemPool {
   public static final int WORMWOOD_WEDDING_RING = 10598;
   public static final int DRIPWOOD_SLAB = 10599;
   public static final int DRIPPY_DIADEM = 10600;
+  public static final int GREY_GOO_RING = 10602;
   public static final int SIZZLING_DESK_BELL = 10617;
   public static final int FROST_RIMED_DESK_BELL = 10618;
   public static final int UNCANNY_DESK_BELL = 10619;

--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -6048,7 +6048,7 @@ public abstract class ChoiceManager {
           new Option("fight a chalkdust wraith", 3)
         }),
 
-    // The Only Thing About Him is the Way That He Walks
+    // Gift Fabrication Lab
     new ChoiceAdventure(
         "Crimbo21",
         "choiceAdventure1460",
@@ -6075,6 +6075,19 @@ public abstract class ChoiceManager {
           new Option("lab-grown meat", "lab-grown meat", "golden fleece", "boxed gumball machine"),
           new Option("cloning kit", "cloning kit", "electric pants", "can of mixed everything"),
           new Option("return to Site Alpha")
+        }),
+
+    // (Unnamed choice adventure)
+    new ChoiceAdventure(
+        "Crimbo21",
+        "choiceAdventure1461",
+        "Site Alpha Primary Lab",
+        new Object[] {
+          new Option("Increase goo intensity", 1),
+          new Option("Decrease goo intensity", 2),
+          new Option("Trade grey goo ring for gooified matter", 3),
+          new Option("Do nothing", 4),
+          new Option("Grab the cheer core. Just do it!", 5),
         }),
   };
 
@@ -15282,6 +15295,27 @@ public abstract class ChoiceManager {
           }
         }
         break;
+
+      case 1461: // Site Alpha Primary Lab
+        switch (ChoiceManager.lastDecision) {
+          case 1:
+            Preferences.increment("primaryLabGooIntensity", 1);
+            break;
+          case 2:
+            Preferences.decrement("primaryLabGooIntensity", 1);
+            break;
+          case 3:
+            ResultProcessor.processItem(ItemPool.GREY_GOO_RING, -1);
+            break;
+          case 4:
+            // Do nothing
+            break;
+          case 5:
+            // Grab the Cheer Core
+            Preferences.setBoolean("primaryLabCheerCoreGrabbed", true);
+            break;
+        }
+        break;
     }
 
     if (ChoiceManager.handlingChoice) {
@@ -18888,6 +18922,14 @@ public abstract class ChoiceManager {
       case 1262:
         // What Setting?
         return VillainLairDecorator.Symbology(responseText);
+
+      case 1461:
+        // Site Alpha Primary Lab
+        // If you can "Grab the Cheer Core!", do it.
+        if (responseText.contains("Grab the Cheer Core!")) {
+          return "5";
+        }
+        return decision;
     }
     return decision;
   }


### PR DESCRIPTION
Add tiny plastic primary lab. It has no visible Enchantments. If they fix that, we'll have to update.
Add support for Choice Adventure 1461 in the Site Alpha Primary Lab.
Note that option #5 is "Grab the Cheer Core". If I recall, you get that once - and it is your only choice.
Therefore, if you are automating and that choice comes up and that option is present, we select it, regardless of how you have the choice configured.
Note also that this choice adventure does not have a blue "Encounter" when you find it.
I bug reported it to KoL. Surely they'd prefer to have something funny, rather than nothing.

Also added two properties:

primaryLabGooIntensity (default 10)
primaryLabCheerCoreGrabbed (default false)
