### PR TITLE
add available_combat_skill ASH function.

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -4063,6 +4063,19 @@ public abstract class KoLCharacter {
     return list.contains(skill);
   }
 
+  public static final boolean availableCombatSkill(final int skillId) {
+    UseSkillRequest skill = UseSkillRequest.getUnmodifiedInstance(skillId);
+    return KoLCharacter.availableCombatSkill(skill);
+  }
+
+  public static final boolean availableCombatSkill(final UseSkillRequest skill) {
+    if (skill == null) {
+      return false;
+    }
+
+    return KoLConstants.availableCombatSkillsMap.containsKey(skill);
+  }
+
   /**
    * Accessor method to get the current familiar.
    *

--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -6077,7 +6077,7 @@ public abstract class ChoiceManager {
           new Option("return to Site Alpha")
         }),
 
-    // (Unnamed choice adventure)
+    // Hello Knob My Old Friend
     new ChoiceAdventure(
         "Crimbo21",
         "choiceAdventure1461",
@@ -18924,7 +18924,7 @@ public abstract class ChoiceManager {
         return VillainLairDecorator.Symbology(responseText);
 
       case 1461:
-        // Site Alpha Primary Lab
+        // Hello Knob My Old Friend
         // If you can "Grab the Cheer Core!", do it.
         if (responseText.contains("Grab the Cheer Core!")) {
           return "5";

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -1327,6 +1327,9 @@ public abstract class RuntimeLibrary {
     functions.add(new LibraryFunction("have_skill", DataTypes.BOOLEAN_TYPE, params));
 
     params = new Type[] {DataTypes.SKILL_TYPE};
+    functions.add(new LibraryFunction("available_combat_skill", DataTypes.BOOLEAN_TYPE, params));
+
+    params = new Type[] {DataTypes.SKILL_TYPE};
     functions.add(new LibraryFunction("mp_cost", DataTypes.INT_TYPE, params));
 
     params = new Type[] {DataTypes.SKILL_TYPE};
@@ -5762,6 +5765,11 @@ public abstract class RuntimeLibrary {
     return DataTypes.makeBooleanValue(
         KoLCharacter.hasSkill(skill, KoLConstants.availableSkills)
             || KoLCharacter.hasSkill(skill, KoLConstants.availableCombatSkills));
+  }
+
+  public static Value available_combat_skill(ScriptRuntime controller, final Value arg) {
+    int skillId = (int) arg.intValue();
+    return DataTypes.makeBooleanValue(KoLCharacter.availableCombatSkill(skillId));
   }
 
   public static Value mp_cost(ScriptRuntime controller, final Value skill) {

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -1327,7 +1327,7 @@ public abstract class RuntimeLibrary {
     functions.add(new LibraryFunction("have_skill", DataTypes.BOOLEAN_TYPE, params));
 
     params = new Type[] {DataTypes.SKILL_TYPE};
-    functions.add(new LibraryFunction("available_combat_skill", DataTypes.BOOLEAN_TYPE, params));
+    functions.add(new LibraryFunction("combat_skill_available", DataTypes.BOOLEAN_TYPE, params));
 
     params = new Type[] {DataTypes.SKILL_TYPE};
     functions.add(new LibraryFunction("mp_cost", DataTypes.INT_TYPE, params));
@@ -5767,7 +5767,7 @@ public abstract class RuntimeLibrary {
             || KoLCharacter.hasSkill(skill, KoLConstants.availableCombatSkills));
   }
 
-  public static Value available_combat_skill(ScriptRuntime controller, final Value arg) {
+  public static Value combat_skill_available(ScriptRuntime controller, final Value arg) {
     int skillId = (int) arg.intValue();
     return DataTypes.makeBooleanValue(KoLCharacter.availableCombatSkill(skillId));
   }


### PR DESCRIPTION
KoLConstant.availableCombatSkills is maintained by FightRequest; when you are in a fight, it is populated with the skills listed in the skill dropdown. This can change each round.

Added KoLCharacter.availableCombatSkill( skillId ) and KoLCharacter.availableCombatSkill( UseSkillRequest ) to check if the supplied skill is currently available.

Added ASH function: boolean combat_skill_available( skill ) to do the same thing.
Note that this is only accurate while you are in a fight; it is intended for use in consult scripts and combat filters.

Also, KoL has finally given a name to the Choice Adventure in the Site Alpha Primary Lab: Hello Knob My Old Friend
Not that this is useful, but it's nice to have the comments be correct, at least.