### PR TITLE
Allow -tie to affect hardcoded tiebreakers.

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -851,6 +851,10 @@ public class Evaluator {
     return this.tiebreaker.getScore(mods);
   }
 
+  boolean isUsingTiebreaker() {
+    return !this.noTiebreaker;
+  }
+
   int checkConstraints(Modifiers mods) {
     // Return value:
     //	-1: item violates a constraint, don't use it

--- a/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
+++ b/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
@@ -137,18 +137,18 @@ public class MaximizerSpeculation extends Speculation
       if (mods.getBoolean(Modifiers.DROPS_MEAT)) countOtherDropsMeat++;
     }
     // Prefer item droppers
-    if (countThisDropsItems != countOtherDropsItems) {
+    if (Maximizer.eval.isUsingTiebreaker() && countThisDropsItems != countOtherDropsItems) {
       return countThisDropsItems > countOtherDropsItems ? 1 : -1;
     }
     // Prefer meat droppers
-    if (countThisDropsMeat != countOtherDropsMeat) {
+    if (Maximizer.eval.isUsingTiebreaker() && countThisDropsMeat != countOtherDropsMeat) {
       return countThisDropsMeat > countOtherDropsMeat ? 1 : -1;
     }
     // Prefer higher tiebreaker account (unless -tie used)
     rv = Double.compare(this.getTiebreaker(), other.getTiebreaker());
     if (rv != 0) return rv;
     // Prefer rollover effects
-    if (countThisEffects != countOtherEffects) {
+    if (Maximizer.eval.isUsingTiebreaker() && countThisEffects != countOtherEffects) {
       return countThisEffects > countOtherEffects ? 1 : -1;
     }
     // Prefer unbreakables

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -366,6 +366,23 @@ public class MaximizerTest {
     assertEquals(25, modFor("Meat Drop"), 0.01);
   }
 
+  // https://kolmafia.us/threads/27073/
+  @Test
+  public void noTiePrefersCurrentGear() {
+    // Drops items, but otherwise irrelevant.
+    canUse("Camp Scout backpack");
+    // +1 mys, +2 mox; 7 mox required; Maximizer needs to recommend changes in order to create a
+    // speculation.
+    canUse("basic meat fez");
+    // +7 mus; 75 mys required
+    equip(EquipmentManager.CONTAINER, "barskin cloak");
+    assertTrue(maximize("mys -tie"));
+    recommendedSlotIs(EquipmentManager.HAT, "basic meat fez");
+    // No back change recommended.
+    assertFalse(getSlot(EquipmentManager.CONTAINER).isPresent());
+    assertEquals(7, modFor("Buffed Muscle"), 0.01);
+  }
+
   // helper methods
 
   private boolean maximize(String maximizerString) {


### PR DESCRIPTION
In particular, this affects item droppers / meat droppers / rollover
effects, but not Bs in Bees Hate You or breakables (although could
control those cases too; I figured those were generally desirable
though).

Context: https://kolmafia.us/threads/the-maximizer-ignores-tie.27073/