### PR TITLE
Set chat caret to last position on key up/down

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/ChatFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/ChatFrame.java
@@ -334,6 +334,7 @@ public class ChatFrame extends GenericFrame {
             text = ChatPanel.this.commandHistory.get(--ChatPanel.this.lastCommandIndex);
           }
           ChatPanel.this.entryField.setText(text);
+          ChatPanel.this.entryField.setCaretPosition(text.length());
         } else if (keyCode == KeyEvent.VK_DOWN) {
           String text;
           if (ChatPanel.this.lastCommandIndex + 1 >= ChatPanel.this.commandHistory.size()) {
@@ -343,6 +344,7 @@ public class ChatFrame extends GenericFrame {
             text = ChatPanel.this.commandHistory.get(++ChatPanel.this.lastCommandIndex);
           }
           ChatPanel.this.entryField.setText(text);
+          ChatPanel.this.entryField.setCaretPosition(text.length());
         } else if (keyCode == KeyEvent.VK_ENTER) {
           this.submitChat();
         }


### PR DESCRIPTION
If you have said something previously, pressing "Up" on your keyboard with the chat input selected, will restore what you had previously said.

However, the position of the caret remains at 0, instead of the last position as expected.

This aims to fix that, by placing the caret at the end of the text after performing the action.