### PR TITLE
Language Server - interruptions

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/AshRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/AshRuntime.java
@@ -133,6 +133,9 @@ public class AshRuntime extends AbstractRuntime {
     try {
       this.parser = new Parser(scriptFile, stream, null);
       this.scope = parser.parse();
+    } catch (InterruptedException e) {
+      // Unlikely, but just in case.
+      return false;
     } catch (Exception e) {
       StaticEntity.printStackTrace(e);
       return false;

--- a/src/net/sourceforge/kolmafia/textui/NamespaceInterpreter.java
+++ b/src/net/sourceforge/kolmafia/textui/NamespaceInterpreter.java
@@ -56,6 +56,9 @@ public class NamespaceInterpreter extends AshRuntime {
           // The user changed the script since it was validated
           KoLmafia.updateDisplay(MafiaState.ERROR, e.getMessage());
           return false;
+        } catch (InterruptedException e) {
+          // Unlikely, but just in case.
+          return false;
         } catch (Exception e) {
           StaticEntity.printStackTrace(e);
           return false;

--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -179,7 +179,7 @@ public class Parser {
     }
   }
 
-  public Scope parse() {
+  public Scope parse() throws InterruptedException {
     if (this.istream == null) {
       throw new RuntimeException(
           "Parser was not properly initialized before parsing was attempted");
@@ -339,11 +339,16 @@ public class Parser {
     return name != null && Parser.reservedWords.contains(name.toLowerCase());
   }
 
-  public Scope importFile(final String fileName, final Scope scope) {
+  public Scope importFile(final String fileName, final Scope scope) throws InterruptedException {
     return this.importFile(fileName, scope, null);
   }
 
-  private Scope importFile(final String fileName, final Scope scope, final Location location) {
+  private Scope importFile(final String fileName, final Scope scope, final Location location)
+      throws InterruptedException {
+    if (Thread.interrupted()) {
+      throw new InterruptedException();
+    }
+
     List<File> matches = KoLmafiaCLI.findScriptFile(fileName);
     if (matches.size() > 1) {
       StringBuilder s = new StringBuilder();
@@ -391,7 +396,8 @@ public class Parser {
     return result;
   }
 
-  private Scope parseCommandOrDeclaration(final Scope result, final Type expectedType) {
+  private Scope parseCommandOrDeclaration(final Scope result, final Type expectedType)
+      throws InterruptedException {
     Type t = this.parseType(result, true);
 
     // If there is no data type, it's a command of some sort
@@ -418,7 +424,7 @@ public class Parser {
     return result;
   }
 
-  private Scope parseFile(final Scope startScope) {
+  private Scope parseFile(final Scope startScope) throws InterruptedException {
     final Scope result =
         startScope == null
             ? new Scope((VariableList) null, Parser.getExistingFunctionScope())
@@ -442,7 +448,8 @@ public class Parser {
       final VariableList variables,
       final BasicScope parentScope,
       final boolean allowBreak,
-      final boolean allowContinue) {
+      final boolean allowContinue)
+      throws InterruptedException {
     Scope result = new Scope(variables, parentScope);
     return this.parseScope(result, expectedType, parentScope, false, allowBreak, allowContinue);
   }
@@ -453,7 +460,8 @@ public class Parser {
       final BasicScope parentScope,
       final boolean wholeFile,
       final boolean allowBreak,
-      final boolean allowContinue) {
+      final boolean allowContinue)
+      throws InterruptedException {
     Directive importDirective;
 
     this.parseScriptName();
@@ -556,7 +564,7 @@ public class Parser {
     return result;
   }
 
-  private Type parseRecord(final BasicScope parentScope) {
+  private Type parseRecord(final BasicScope parentScope) throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("record")) {
       return null;
     }
@@ -691,7 +699,8 @@ public class Parser {
     return rec;
   }
 
-  private Function parseFunction(final Type functionType, final Scope parentScope) {
+  private Function parseFunction(final Type functionType, final Scope parentScope)
+      throws InterruptedException {
     if (!this.parseIdentifier(this.currentToken().content)) {
       return null;
     }
@@ -827,7 +836,8 @@ public class Parser {
     return result;
   }
 
-  private boolean parseVariables(final Type t, final BasicScope parentScope) {
+  private boolean parseVariables(final Type t, final BasicScope parentScope)
+      throws InterruptedException {
     while (true) {
       Variable v = this.parseVariable(t, parentScope);
       if (v == null) {
@@ -863,7 +873,7 @@ public class Parser {
     }
   }
 
-  private Variable parseVariable(final Type t, final BasicScope scope) {
+  private Variable parseVariable(final Type t, final BasicScope scope) throws InterruptedException {
     if (!this.parseIdentifier(this.currentToken().content)) {
       return null;
     }
@@ -892,7 +902,8 @@ public class Parser {
    * Parses the right-hand-side of a variable definition. It is assumed that the caller expects an
    * expression to be found, so this method never returns null.
    */
-  private Evaluable parseInitialization(final VariableReference lhs, final BasicScope scope) {
+  private Evaluable parseInitialization(final VariableReference lhs, final BasicScope scope)
+      throws InterruptedException {
     Evaluable result;
 
     Type t = lhs.target.getType();
@@ -1005,7 +1016,7 @@ public class Parser {
     return params;
   }
 
-  private boolean parseTypedef(final Scope parentScope) {
+  private boolean parseTypedef(final Scope parentScope) throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("typedef")) {
       return false;
     }
@@ -1061,7 +1072,8 @@ public class Parser {
       final BasicScope scope,
       final boolean noElse,
       final boolean allowBreak,
-      final boolean allowContinue) {
+      final boolean allowContinue)
+      throws InterruptedException {
     Command result;
 
     if (this.currentToken().equalsIgnoreCase("break")) {
@@ -1142,7 +1154,8 @@ public class Parser {
     return result;
   }
 
-  private Type parseType(final BasicScope scope, final boolean records) {
+  private Type parseType(final BasicScope scope, final boolean records)
+      throws InterruptedException {
     if (!this.parseIdentifier(this.currentToken().content)) {
       return null;
     }
@@ -1173,7 +1186,8 @@ public class Parser {
    * <p>The presence of the opening bracket "{" is ALWAYS assumed when entering this method, and as
    * such, MUST be checked before calling it. This method will never return null.
    */
-  private Evaluable parseAggregateLiteral(final BasicScope scope, final AggregateType aggr) {
+  private Evaluable parseAggregateLiteral(final BasicScope scope, final AggregateType aggr)
+      throws InterruptedException {
     Token aggregateLiteralStartToken = this.currentToken();
 
     this.readToken(); // read {
@@ -1383,7 +1397,8 @@ public class Parser {
     return Value.locate(aggregateLiteralLocation, result);
   }
 
-  private Type parseAggregateType(Type dataType, final BasicScope scope) {
+  private Type parseAggregateType(Type dataType, final BasicScope scope)
+      throws InterruptedException {
     Token separatorToken = this.currentToken();
 
     this.readToken(); // [ or ,
@@ -1484,7 +1499,8 @@ public class Parser {
     return true;
   }
 
-  private FunctionReturn parseReturn(final Type expectedType, final BasicScope parentScope) {
+  private FunctionReturn parseReturn(final Type expectedType, final BasicScope parentScope)
+      throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("return")) {
       return null;
     }
@@ -1538,7 +1554,8 @@ public class Parser {
       final BasicScope parentScope,
       final boolean noElse,
       final boolean allowBreak,
-      final boolean allowContinue) {
+      final boolean allowContinue)
+      throws InterruptedException {
     Token scopeStartToken = this.currentToken();
     Scope result = new Scope(parentScope);
 
@@ -1566,7 +1583,8 @@ public class Parser {
       final BasicScope parentScope,
       final boolean noElse,
       final boolean allowBreak,
-      final boolean allowContinue) {
+      final boolean allowContinue)
+      throws InterruptedException {
     Scope scope =
         this.parseBlock(functionType, variables, parentScope, noElse, allowBreak, allowContinue);
     if (scope != null) {
@@ -1582,7 +1600,8 @@ public class Parser {
       final BasicScope parentScope,
       final boolean noElse,
       final boolean allowBreak,
-      final boolean allowContinue) {
+      final boolean allowContinue)
+      throws InterruptedException {
     if (!this.currentToken().equals("{")) {
       return null;
     }
@@ -1610,7 +1629,8 @@ public class Parser {
       final BasicScope parentScope,
       final boolean noElse,
       final boolean allowBreak,
-      final boolean allowContinue) {
+      final boolean allowContinue)
+      throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("if")) {
       return null;
     }
@@ -1727,7 +1747,7 @@ public class Parser {
     return result;
   }
 
-  private BasicScript parseBasicScript() {
+  private BasicScript parseBasicScript() throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("cli_execute")) {
       return null;
     }
@@ -1780,7 +1800,8 @@ public class Parser {
     return new BasicScript(basicScriptLocation, ostream);
   }
 
-  private Loop parseWhile(final Type functionType, final BasicScope parentScope) {
+  private Loop parseWhile(final Type functionType, final BasicScope parentScope)
+      throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("while")) {
       return null;
     }
@@ -1825,7 +1846,8 @@ public class Parser {
     return new WhileLoop(whileLocation, scope, condition);
   }
 
-  private Loop parseRepeat(final Type functionType, final BasicScope parentScope) {
+  private Loop parseRepeat(final Type functionType, final BasicScope parentScope)
+      throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("repeat")) {
       return null;
     }
@@ -1877,7 +1899,8 @@ public class Parser {
   }
 
   private Switch parseSwitch(
-      final Type functionType, final BasicScope parentScope, final boolean allowContinue) {
+      final Type functionType, final BasicScope parentScope, final boolean allowContinue)
+      throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("switch")) {
       return null;
     }
@@ -2065,7 +2088,8 @@ public class Parser {
       final Type functionType,
       final BasicScope parentScope,
       final boolean allowBreak,
-      final boolean allowContinue) {
+      final boolean allowContinue)
+      throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("try")) {
       return null;
     }
@@ -2104,7 +2128,8 @@ public class Parser {
       final Type functionType,
       final BasicScope parentScope,
       final boolean allowBreak,
-      final boolean allowContinue) {
+      final boolean allowContinue)
+      throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("catch")) {
       return null;
     }
@@ -2120,7 +2145,7 @@ public class Parser {
     return new Catch(this.makeLocation(catchStartToken, this.peekPreviousToken()), body);
   }
 
-  private Catch parseCatchValue(final BasicScope parentScope) {
+  private Catch parseCatchValue(final BasicScope parentScope) throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("catch")) {
       return null;
     }
@@ -2146,7 +2171,8 @@ public class Parser {
     return new Catch(this.makeLocation(catchStartToken, this.peekPreviousToken()), body);
   }
 
-  private Scope parseStatic(final Type functionType, final BasicScope parentScope) {
+  private Scope parseStatic(final Type functionType, final BasicScope parentScope)
+      throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("static")) {
       return null;
     }
@@ -2177,7 +2203,7 @@ public class Parser {
     return result;
   }
 
-  private SortBy parseSort(final BasicScope parentScope) {
+  private SortBy parseSort(final BasicScope parentScope) throws InterruptedException {
     // sort aggregate by expr
 
     if (!this.currentToken().equalsIgnoreCase("sort")) {
@@ -2246,7 +2272,8 @@ public class Parser {
     return new SortBy(sortLocation, (VariableReference) aggregate, indexvar, valuevar, expr, this);
   }
 
-  private Loop parseForeach(final Type functionType, final BasicScope parentScope) {
+  private Loop parseForeach(final Type functionType, final BasicScope parentScope)
+      throws InterruptedException {
     // foreach key [, key ... ] in aggregate { scope }
 
     if (!this.currentToken().equalsIgnoreCase("foreach")) {
@@ -2366,7 +2393,8 @@ public class Parser {
     return new ForEachLoop(foreachLocation, scope, variableReferences, aggregate, this);
   }
 
-  private Loop parseFor(final Type functionType, final BasicScope parentScope) {
+  private Loop parseFor(final Type functionType, final BasicScope parentScope)
+      throws InterruptedException {
     // for identifier from X [upto|downto|to|] Y [by Z]? {scope }
 
     if (!this.currentToken().equalsIgnoreCase("for")) {
@@ -2472,7 +2500,8 @@ public class Parser {
         this);
   }
 
-  private Loop parseJavaFor(final Type functionType, final BasicScope parentScope) {
+  private Loop parseJavaFor(final Type functionType, final BasicScope parentScope)
+      throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("for")) {
       return null;
     }
@@ -2669,12 +2698,14 @@ public class Parser {
   }
 
   private Scope parseLoopScope(
-      final Type functionType, final VariableList varList, final BasicScope parentScope) {
+      final Type functionType, final VariableList varList, final BasicScope parentScope)
+      throws InterruptedException {
     return this.parseLoopScope(new Scope(varList, parentScope), functionType, parentScope);
   }
 
   private Scope parseLoopScope(
-      final Scope result, final Type functionType, final BasicScope parentScope) {
+      final Scope result, final Type functionType, final BasicScope parentScope)
+      throws InterruptedException {
     Token loopScopeStartToken = this.currentToken();
 
     if (this.currentToken().equals("{")) {
@@ -2709,7 +2740,7 @@ public class Parser {
     return result;
   }
 
-  private Evaluable parseNewRecord(final BasicScope scope) {
+  private Evaluable parseNewRecord(final BasicScope scope) throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("new")) {
       return null;
     }
@@ -2837,11 +2868,12 @@ public class Parser {
     return Value.locate(newRecordLocation, target.initialValueExpression(params));
   }
 
-  private Evaluable parseCall(final BasicScope scope) {
+  private Evaluable parseCall(final BasicScope scope) throws InterruptedException {
     return this.parseCall(scope, null);
   }
 
-  private Evaluable parseCall(final BasicScope scope, final Evaluable firstParam) {
+  private Evaluable parseCall(final BasicScope scope, final Evaluable firstParam)
+      throws InterruptedException {
     if (!"(".equals(this.nextToken())) {
       return null;
     }
@@ -2882,7 +2914,8 @@ public class Parser {
     return this.parsePostCall(scope, call);
   }
 
-  private List<Evaluable> parseParameters(final BasicScope scope, final Evaluable firstParam) {
+  private List<Evaluable> parseParameters(final BasicScope scope, final Evaluable firstParam)
+      throws InterruptedException {
     if (!this.currentToken().equals("(")) {
       return null;
     }
@@ -2939,7 +2972,8 @@ public class Parser {
     return params;
   }
 
-  private Evaluable parsePostCall(final BasicScope scope, FunctionCall call) {
+  private Evaluable parsePostCall(final BasicScope scope, FunctionCall call)
+      throws InterruptedException {
     Evaluable result = call;
     while (result != null && this.currentToken().equals(".")) {
       Variable current = new Variable(result.getType());
@@ -2952,7 +2986,7 @@ public class Parser {
     return result;
   }
 
-  private Evaluable parseInvoke(final BasicScope scope) {
+  private Evaluable parseInvoke(final BasicScope scope) throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("call")) {
       return null;
     }
@@ -3014,7 +3048,8 @@ public class Parser {
     return this.parsePostCall(scope, call);
   }
 
-  private Assignment parseAssignment(final BasicScope scope, final VariableReference lhs) {
+  private Assignment parseAssignment(final BasicScope scope, final VariableReference lhs)
+      throws InterruptedException {
     Token operStr = this.currentToken();
     if (!operStr.equals("=")
         && !operStr.equals("+=")
@@ -3091,7 +3126,7 @@ public class Parser {
     return new Assignment(lhs, rhs, op);
   }
 
-  private Evaluable parseRemove(final BasicScope scope) {
+  private Evaluable parseRemove(final BasicScope scope) throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase("remove")) {
       return null;
     }
@@ -3099,7 +3134,7 @@ public class Parser {
     return this.parseExpression(scope);
   }
 
-  private Evaluable parsePreIncDec(final BasicScope scope) {
+  private Evaluable parsePreIncDec(final BasicScope scope) throws InterruptedException {
     if (this.nextToken() == null) {
       return null;
     }
@@ -3137,7 +3172,7 @@ public class Parser {
     return new IncDec(preIncDecLocation, (VariableReference) lhs, oper);
   }
 
-  private Evaluable parsePostIncDec(final VariableReference lhs) {
+  private Evaluable parsePostIncDec(final VariableReference lhs) throws InterruptedException {
     // [VariableReference]++
     // [VariableReference]--
 
@@ -3161,11 +3196,12 @@ public class Parser {
     return new IncDec(postIncDecLocation, lhs, oper);
   }
 
-  private Evaluable parseExpression(final BasicScope scope) {
+  private Evaluable parseExpression(final BasicScope scope) throws InterruptedException {
     return this.parseExpression(scope, null);
   }
 
-  private Evaluable parseExpression(final BasicScope scope, final Operator previousOper) {
+  private Evaluable parseExpression(final BasicScope scope, final Operator previousOper)
+      throws InterruptedException {
     if (this.currentToken().equals(";")) {
       return null;
     }
@@ -3369,7 +3405,7 @@ public class Parser {
     } while (true);
   }
 
-  private Evaluable parseEvaluable(final BasicScope scope) {
+  private Evaluable parseEvaluable(final BasicScope scope) throws InterruptedException {
     if (this.currentToken().equals(";")) {
       return null;
     }
@@ -3462,7 +3498,7 @@ public class Parser {
     return result;
   }
 
-  private Evaluable parseNumber() {
+  private Evaluable parseNumber() throws InterruptedException {
     Token numberStartToken = this.currentToken();
 
     Value number;
@@ -3531,7 +3567,7 @@ public class Parser {
     return true;
   }
 
-  private Evaluable parseString(final BasicScope scope) {
+  private Evaluable parseString(final BasicScope scope) throws InterruptedException {
     if (!this.currentToken().equals("\"")
         && !this.currentToken().equals("'")
         && !this.currentToken().equals("`")) {
@@ -3818,7 +3854,7 @@ public class Parser {
     return value;
   }
 
-  private Evaluable parseTypedConstant(final BasicScope scope) {
+  private Evaluable parseTypedConstant(final BasicScope scope) throws InterruptedException {
     if (!this.currentToken().equals("$")) {
       return null;
     }
@@ -3960,7 +3996,8 @@ public class Parser {
         this.makeLocation(typedConstantStartToken, this.peekPreviousToken()), result);
   }
 
-  private PluralValue parsePluralConstant(final BasicScope scope, final Type type) {
+  private PluralValue parsePluralConstant(final BasicScope scope, final Type type)
+      throws InterruptedException {
     // Directly work with currentLine - ignore any "tokens" you meet until
     // the string is closed
 
@@ -4120,7 +4157,7 @@ public class Parser {
         || oper.equals("remove");
   }
 
-  private Evaluable parseVariableReference(final BasicScope scope) {
+  private Evaluable parseVariableReference(final BasicScope scope) throws InterruptedException {
     if (!this.parseIdentifier(this.currentToken().content)) {
       return null;
     }
@@ -4150,7 +4187,8 @@ public class Parser {
    *
    * <p>There may also be nothing, in which case the submitted variable reference is returned as is.
    */
-  private Evaluable parseVariableReference(final BasicScope scope, final VariableReference varRef) {
+  private Evaluable parseVariableReference(final BasicScope scope, final VariableReference varRef)
+      throws InterruptedException {
     VariableReference current = varRef;
     Type type = varRef.getType();
     List<Evaluable> indices = new ArrayList<>();
@@ -4277,7 +4315,7 @@ public class Parser {
     }
   }
 
-  private Directive parseDirective(final String directive) {
+  private Directive parseDirective(final String directive) throws InterruptedException {
     if (!this.currentToken().equalsIgnoreCase(directive)) {
       return null;
     }
@@ -4361,21 +4399,21 @@ public class Parser {
     return result;
   }
 
-  private void parseScriptName() {
+  private void parseScriptName() throws InterruptedException {
     Directive scriptDirective = this.parseDirective("script");
     if (this.scriptName == null && scriptDirective != null) {
       this.scriptName = scriptDirective.value;
     }
   }
 
-  private void parseNotify() {
+  private void parseNotify() throws InterruptedException {
     Directive notifyDirective = this.parseDirective("notify");
     if (this.notifyRecipient == null && notifyDirective != null) {
       this.notifyRecipient = notifyDirective.value;
     }
   }
 
-  private void parseSince() {
+  private void parseSince() throws InterruptedException {
     Directive sinceDirective = this.parseDirective("since");
     if (sinceDirective != null) {
       // enforce "since" directives RIGHT NOW at parse time
@@ -4383,7 +4421,7 @@ public class Parser {
     }
   }
 
-  private Directive parseImport() {
+  private Directive parseImport() throws InterruptedException {
     return this.parseDirective("import");
   }
 
@@ -4395,7 +4433,11 @@ public class Parser {
    *
    * <p>Never returns {@code null}.
    */
-  private Token currentToken() {
+  private Token currentToken() throws InterruptedException {
+    if (Thread.interrupted()) {
+      throw new InterruptedException();
+    }
+
     // If we've already parsed a token, return it
     if (this.currentToken != null) {
       return this.currentToken;
@@ -4481,7 +4523,7 @@ public class Parser {
    * @return the content of the next token to come after the token we are currently in front of, or
    *     {@code null} if we are at the end of the file.
    */
-  private String nextToken() {
+  private String nextToken() throws InterruptedException {
     int offset = this.currentToken().restOfLineStart;
     Line line = this.currentLine;
     boolean inMultiLineComment = false;
@@ -4530,7 +4572,7 @@ public class Parser {
   /**
    * Forget every token up to {@code destinationToken}, so that we can resume parsing from there.
    */
-  private void rewindBackTo(final Token destinationToken) {
+  private void rewindBackTo(final Token destinationToken) throws InterruptedException {
     this.currentToken();
 
     while (this.currentToken != destinationToken) {
@@ -4561,7 +4603,7 @@ public class Parser {
    * If we are not at the end of the file, null out {@link #currentToken} (allowing a new one to be
    * gathered next time we call {@link #currentToken()}), and move {@link #currentIndex} forward.
    */
-  private void readToken() {
+  private void readToken() throws InterruptedException {
     // at "end of file"
     if (this.currentToken().getLine().content == null) {
       return;
@@ -4663,7 +4705,7 @@ public class Parser {
    * Calls {@link #currentToken()} in order to skip any comment or whitespace we would be in front
    * of, then return whether or not we reached the end of the file.
    */
-  private boolean atEndOfFile() {
+  private boolean atEndOfFile() throws InterruptedException {
     this.currentToken();
 
     return this.currentLine.content == null;

--- a/test/net/sourceforge/kolmafia/textui/ParserTest.java
+++ b/test/net/sourceforge/kolmafia/textui/ParserTest.java
@@ -122,6 +122,24 @@ public class ParserTest {
   }
 
   @Test
+  public void testInterruption() {
+    assertFalse(Thread.currentThread().isInterrupted());
+
+    Thread.currentThread().interrupt();
+    assertTrue(Thread.currentThread().isInterrupted());
+
+    // Doesn't matter if we use valid() or invalid(); the parsing gets interrupted anyway
+    final ScriptData script = ScriptData.valid("Will not parse", "foobar();", null, null);
+
+    assertNull(script.scope);
+    assertNull(script.errors);
+    assertInstanceOf(InterruptedException.class, script.parsingException);
+
+    // The interrupted state of the thread was cleared
+    assertFalse(Thread.currentThread().isInterrupted());
+  }
+
+  @Test
   public void testMultipleDiagnosticsPerParser() throws InterruptedException {
     final String script =
         "import fake/path"

--- a/test/net/sourceforge/kolmafia/textui/ParserTest.java
+++ b/test/net/sourceforge/kolmafia/textui/ParserTest.java
@@ -122,7 +122,7 @@ public class ParserTest {
   }
 
   @Test
-  public void testMultipleDiagnosticsPerParser() {
+  public void testMultipleDiagnosticsPerParser() throws InterruptedException {
     final String script =
         "import fake/path"
             + "\nstring foobar(string... foo, int bar) {"
@@ -151,7 +151,7 @@ public class ParserTest {
   }
 
   @Test
-  public void testErrorFilter() {
+  public void testErrorFilter() throws InterruptedException {
     final String script = "int a; max(a, b)";
     final ByteArrayInputStream istream =
         new ByteArrayInputStream(script.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
The language server will run the parsing of the various scripts in separate threads.

This allows us to save resources by allowing those threads to be interrupted when we no longer need them (if, for example, a file is modified during parsing).

Is this a behaviour that needs to be tested? Not sure how I'd even test that.