### PR TITLE
Process multipart choices with spade script

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -15327,12 +15327,12 @@ public abstract class ChoiceManager {
         break;
     }
 
+    SpadingManager.processChoice(urlString, text);
+
     if (ChoiceManager.handlingChoice) {
       ChoiceManager.visitChoice(request);
       return;
     }
-
-    SpadingManager.processChoice(urlString, text);
 
     if (text.contains("charpane.php")) {
       // Since a charpane refresh was requested, a turn might have been spent


### PR DESCRIPTION
Run SpadingManager.processChoice before ChoiceManager.visitChoice() and the function returns, so choices that still need to be handled can be spaded.

@gausie this should be fine right? I'm trying to make a spading script to pull data from a multi-choice adventure where I need access to the urlString at every step.