### PR TITLE
Record the turn on which LOV Enamorang is used

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -564,6 +564,7 @@ user	electricKoolAidEaten	0
 user	encountersUntilDMTChoice	5
 user	encountersUntilNEPChoice	7
 user	enamorangMonster
+user    enamorangMonsterTurn
 user	ensorcelee
 user	ensorceleeLevel	0
 user	entauntaunedColdRes	0

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -564,7 +564,7 @@ user	electricKoolAidEaten	0
 user	encountersUntilDMTChoice	5
 user	encountersUntilNEPChoice	7
 user	enamorangMonster
-user    enamorangMonsterTurn
+user	enamorangMonsterTurn
 user	ensorcelee
 user	ensorceleeLevel	0
 user	entauntaunedColdRes	0

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -8167,6 +8167,7 @@ public class FightRequest extends GenericRequest {
             TurnCounter.startCounting(15, "Enamorang Monster loc=* type=wander", "watch.gif");
           }
           Preferences.setString("enamorangMonster", monsterName);
+          Preferences.setInteger("enamorangMonsterTurn", KoLCharacter.getTurnsPlayed());
           Preferences.increment("_enamorangs");
           return true;
         }


### PR DESCRIPTION
In some cases, the enamoranged monster counter can be initialized, or the monster itself encountered without KoLMafia and scripts detecting it. This addition would offer more data to help automation better decide if the enamorangMonster value should be handled or ignored.

Since the monster name property and timers are unset upon encountering an enamorang monster, I left this one alone but it too could be unset if desired.