### PR TITLE
decrement beGregariousFightsLeft only when the gregarity text is present

### DIFF
--- a/src/net/sourceforge/kolmafia/session/EncounterManager.java
+++ b/src/net/sourceforge/kolmafia/session/EncounterManager.java
@@ -285,16 +285,7 @@ public abstract class EncounterManager {
 
   public static final boolean isGregariousEncounter(
       final String responseText, final boolean checkMonster) {
-    if (responseText.contains("Looks like it's that friend you gregariously made")) {
-      return true;
-    }
-
-    if (Preferences.getInteger("beGregariousFightsLeft") < 1) {
-      return false;
-    }
-
-    String monsterName = MonsterStatusTracker.getLastMonsterName();
-    return monsterName.equalsIgnoreCase(Preferences.getString("beGregariousMonster"));
+    return responseText.contains("Looks like it's that friend you gregariously made");
   }
 
   public static final boolean isWanderingMonster(String encounter) {


### PR DESCRIPTION
right now, mafia is incorrectly decrementing the `beGregariousFightsLeft` on time-spinner, envyfish, and other definitely non-gregarious encounters. This ensures that mafia decrements the property only when the gregarity message is present.