### PR TITLE
Don't show RequestSynchFrame when headless

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/RequestSynchFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/RequestSynchFrame.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.swingui;
 
 import net.sourceforge.kolmafia.RequestEditorKit;
+import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.request.GenericRequest;
 
 public class RequestSynchFrame extends RequestFrame {
@@ -16,6 +17,10 @@ public class RequestSynchFrame extends RequestFrame {
   }
 
   public static final void showRequest(final GenericRequest request) {
+    if (StaticEntity.isHeadless()) {
+      return;
+    }
+
     if (RequestSynchFrame.INSTANCE == null) {
       GenericFrame.createDisplay(RequestSynchFrame.class);
     }


### PR DESCRIPTION
Creating the request display when headless causes an exception so there's no benefit