### PR TITLE
Give full function prototype to all JS function stubs

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/javascript/AshStub.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/AshStub.java
@@ -22,7 +22,9 @@ public abstract class AshStub extends BaseFunction {
   protected final ScriptRuntime controller;
   protected final String ashFunctionName;
 
-  public AshStub(ScriptRuntime controller, String ashFunctionName) {
+  public AshStub(
+      Scriptable scope, Scriptable prototype, ScriptRuntime controller, String ashFunctionName) {
+    super(scope, prototype);
     this.controller = controller;
     this.ashFunctionName = ashFunctionName;
   }

--- a/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
@@ -116,16 +116,19 @@ public class JavascriptRuntime extends AbstractRuntime {
     int permanentReadOnly = ScriptableObject.PERMANENT | ScriptableObject.READONLY;
 
     for (String libraryFunctionName : uniqueFunctionNames) {
+      String jsName = toCamelCase(libraryFunctionName);
       ScriptableObject.defineProperty(
           stdLib,
-          toCamelCase(libraryFunctionName),
-          new LibraryFunctionStub(this, libraryFunctionName),
+          jsName,
+          new LibraryFunctionStub(
+              stdLib, ScriptableObject.getFunctionPrototype(stdLib), this, libraryFunctionName),
           permanentReadOnly);
       if (addToTopScope) {
         ScriptableObject.defineProperty(
             scope,
-            toCamelCase(libraryFunctionName),
-            new LibraryFunctionStub(this, libraryFunctionName),
+            jsName,
+            new LibraryFunctionStub(
+                scope, ScriptableObject.getFunctionPrototype(scope), this, libraryFunctionName),
             ScriptableObject.DONTENUM);
       }
     }

--- a/src/net/sourceforge/kolmafia/textui/javascript/LibraryFunctionStub.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/LibraryFunctionStub.java
@@ -18,8 +18,9 @@ import org.mozilla.javascript.Scriptable;
 public class LibraryFunctionStub extends AshStub {
   private static final long serialVersionUID = 1L;
 
-  public LibraryFunctionStub(ScriptRuntime controller, String ashFunctionName) {
-    super(controller, ashFunctionName);
+  public LibraryFunctionStub(
+      Scriptable scope, Scriptable prototype, ScriptRuntime controller, String ashFunctionName) {
+    super(scope, prototype, controller, ashFunctionName);
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/textui/javascript/SafeRequire.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/SafeRequire.java
@@ -79,7 +79,12 @@ public class SafeRequire extends Require {
         String functionName = userDefinedFunction.getName();
         String functionNameCamelCase = JavascriptRuntime.toCamelCase(functionName);
         if (!ScriptableObject.hasProperty(exports, functionNameCamelCase)) {
-          UserDefinedFunctionStub stub = new UserDefinedFunctionStub(interpreter, functionName);
+          UserDefinedFunctionStub stub =
+              new UserDefinedFunctionStub(
+                  exports,
+                  ScriptableObject.getFunctionPrototype(exports),
+                  interpreter,
+                  functionName);
           int attributes =
               ScriptableObject.DONTENUM | ScriptableObject.PERMANENT | ScriptableObject.READONLY;
           ScriptableObject.defineProperty(exports, functionNameCamelCase, stub, attributes);

--- a/src/net/sourceforge/kolmafia/textui/javascript/UserDefinedFunctionStub.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/UserDefinedFunctionStub.java
@@ -8,12 +8,14 @@ import net.sourceforge.kolmafia.textui.parsetree.Function;
 import net.sourceforge.kolmafia.textui.parsetree.FunctionList;
 import net.sourceforge.kolmafia.textui.parsetree.UserDefinedFunction;
 import net.sourceforge.kolmafia.textui.parsetree.Value;
+import org.mozilla.javascript.Scriptable;
 
 public class UserDefinedFunctionStub extends AshStub {
   private static final long serialVersionUID = 1L;
 
-  public UserDefinedFunctionStub(AshRuntime interpreter, String ashFunctionName) {
-    super(interpreter, ashFunctionName);
+  public UserDefinedFunctionStub(
+      Scriptable scope, Scriptable prototype, AshRuntime interpreter, String ashFunctionName) {
+    super(scope, prototype, interpreter, ashFunctionName);
   }
 
   @Override

--- a/test/root/expected/stdlib_prototype.js.out
+++ b/test/root/expected/stdlib_prototype.js.out
@@ -1,0 +1,6 @@
+constructor: true
+call: true
+apply: true
+bind: true
+toString: true
+toSource: true

--- a/test/root/scripts/item_drops_array.js
+++ b/test/root/scripts/item_drops_array.js
@@ -3,7 +3,6 @@ const { print, toJson, itemDropsArray } = require('kolmafia');
 let monster = Monster.get("beanbat");
 let drops = itemDropsArray(monster);
 
-// Rhino doesn't support template literal strings. Alas.
-print(monster + " has " + drops.length + " drops.");
-print("The first drop is " + drops[0].drop + " with a rate of " + drops[0].rate + ".");
-print("Its image is " + drops[0].drop.image + ".");
+print(`${monster} has ${drops.length} drops.`);
+print(`The first drop is ${drops[0].drop} with a rate of ${drops[0].rate}.`);
+print(`Its image is ${drops[0].drop.image}.`);

--- a/test/root/scripts/stdlib_prototype.js
+++ b/test/root/scripts/stdlib_prototype.js
@@ -1,0 +1,17 @@
+const { print, isTradeable } = require('kolmafia');
+
+const item = Item.get("seal tooth");
+
+const tests = {
+    constructor: () => isTradeable.constructor === Function.prototype.constructor,
+    call: () => isTradeable.call(null, item) === true,
+    apply: () => isTradeable.apply(null, [item]) === true,
+    bind: () => {
+        const bound = isTradeable.bind(null);
+        return bound(item) === true;
+    },
+    toString: () => isTradeable.toString().length > 0,
+    toSource: () => isTradeable.toSource().length > 0,
+}
+
+Object.entries(tests).forEach(([k, v]) => print(`${k}: ${v()}`));


### PR DESCRIPTION
Now you can run `.apply`, `.call` etc on js functions that are generated from ash