### PR TITLE
fire extinguisher increments blech house progress by 11, not 10

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -9417,7 +9417,7 @@ public class FightRequest extends GenericRequest {
           case "The Smut Orc Logging Camp":
             if (responseText.contains("You wantonly spray the area with your fire extinguisher")
                 || skillSuccess) {
-              Preferences.increment("smutOrcNoncombatProgress", 10, 15, false);
+              Preferences.increment("smutOrcNoncombatProgress", 11, 15, false);
               Preferences.setBoolean("fireExtinguisherChasmUsed", true);
               success = true;
             }


### PR DESCRIPTION
Change Blech House progress from 10 to 11 when Fire Extinguisher zone specific skill is used.

Fixes bug:
https://kolmafia.us/threads/fire-extinguisher-effect-in-smut-orc-logging-camp-incorrect.27098/

This is my first Mafia PR - let me know if I should do anything differently! Didn't do any testing as this is a simple change. Happy to run/create a test if you all desire. Will need to be pointed in the right direction. 