### PR TITLE
feat: add parameter to not steal familiar equipment

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FamiliarRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FamiliarRequest.java
@@ -43,7 +43,7 @@ public class FamiliarRequest extends GenericRequest {
   private FamiliarData changeTo;
   private final AdventureResult item;
   private final boolean locking;
-  private boolean enthrone, bjornify;
+  private boolean enthrone, bjornify, stealItem;
 
   public FamiliarRequest() {
     super("familiar.php");
@@ -52,9 +52,14 @@ public class FamiliarRequest extends GenericRequest {
     this.locking = false;
     this.enthrone = false;
     this.bjornify = false;
+    this.stealItem = true;
   }
 
   public FamiliarRequest(final FamiliarData changeTo) {
+    this(changeTo, true);
+  }
+
+  public FamiliarRequest(final FamiliarData changeTo, boolean stealItem) {
     super("familiar.php");
 
     this.changeTo = changeTo == null ? FamiliarData.NO_FAMILIAR : changeTo;
@@ -62,6 +67,7 @@ public class FamiliarRequest extends GenericRequest {
     this.locking = false;
     this.enthrone = false;
     this.bjornify = false;
+    this.stealItem = stealItem;
 
     if (this.changeTo == FamiliarData.NO_FAMILIAR) {
       this.addFormField("action", "putback");
@@ -80,6 +86,7 @@ public class FamiliarRequest extends GenericRequest {
     this.locking = false;
     this.enthrone = false;
     this.bjornify = false;
+    this.stealItem = true;
 
     if (this.item != EquipmentRequest.UNEQUIP) {
       this.addFormField("action", "equip");
@@ -100,6 +107,7 @@ public class FamiliarRequest extends GenericRequest {
     this.locking = true;
     this.enthrone = false;
     this.bjornify = false;
+    this.stealItem = true;
     this.addFormField("ajax", "1");
   }
 
@@ -281,13 +289,16 @@ public class FamiliarRequest extends GenericRequest {
 
     super.run();
 
-    // If we didn't have a familiar before or don't have one now,
+    // If we didn't have a familiar before,
+    // don't have one now,
+    // or have chosen not to change equipment
     // leave equipment alone.
 
     if (this.enthrone
         || this.bjornify
         || familiar == FamiliarData.NO_FAMILIAR
-        || this.changeTo == FamiliarData.NO_FAMILIAR) {
+        || this.changeTo == FamiliarData.NO_FAMILIAR
+        || !this.stealItem) {
       return;
     }
 

--- a/src/net/sourceforge/kolmafia/request/SummoningChamberRequest.java
+++ b/src/net/sourceforge/kolmafia/request/SummoningChamberRequest.java
@@ -14,6 +14,7 @@ import net.sourceforge.kolmafia.persistence.PocketDatabase;
 import net.sourceforge.kolmafia.persistence.PocketDatabase.Pocket;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.ClanManager;
+import net.sourceforge.kolmafia.session.FamiliarManager;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.session.ResultProcessor;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
@@ -43,8 +44,7 @@ public class SummoningChamberRequest extends GenericRequest {
       // This should never happen if you don't have an Intergnat
       // unless you are manually setting demonName12 to break things
       currentFam = KoLCharacter.getFamiliar();
-      RequestThread.postRequest(
-          new FamiliarRequest(KoLCharacter.findFamiliar(FamiliarPool.INTERGNAT)));
+      FamiliarManager.changeFamiliar(FamiliarPool.INTERGNAT, false);
     }
 
     KoLmafia.updateDisplay("Summoning " + this.demon + "...");

--- a/src/net/sourceforge/kolmafia/session/BreakfastManager.java
+++ b/src/net/sourceforge/kolmafia/session/BreakfastManager.java
@@ -799,10 +799,10 @@ public class BreakfastManager {
 
     FamiliarData currentFam = KoLCharacter.getFamiliar();
 
-    RequestThread.postRequest(new FamiliarRequest(jellyfish));
+    FamiliarManager.changeFamiliar(jellyfish, false);
     RequestThread.postRequest(new PlaceRequest("thesea", "thesea_left2", false));
     RequestThread.postRequest(new GenericRequest("choice.php?whichchoice=1219&option=1"));
-    RequestThread.postRequest(new FamiliarRequest(currentFam));
+    FamiliarManager.changeFamiliar(currentFam);
 
     KoLmafia.forceContinue();
   }

--- a/src/net/sourceforge/kolmafia/session/BreakfastManager.java
+++ b/src/net/sourceforge/kolmafia/session/BreakfastManager.java
@@ -29,7 +29,6 @@ import net.sourceforge.kolmafia.request.ClanRumpusRequest;
 import net.sourceforge.kolmafia.request.ClosetRequest;
 import net.sourceforge.kolmafia.request.CoinMasterRequest;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
-import net.sourceforge.kolmafia.request.FamiliarRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.request.GenieRequest;
 import net.sourceforge.kolmafia.request.HermitRequest;

--- a/src/net/sourceforge/kolmafia/session/FamiliarManager.java
+++ b/src/net/sourceforge/kolmafia/session/FamiliarManager.java
@@ -8,6 +8,7 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestThread;
+import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.FamiliarDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -18,6 +19,22 @@ import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
 
 public abstract class FamiliarManager {
+  public static void changeFamiliar(int famId) {
+    changeFamiliar(famId, true);
+  }
+
+  public static void changeFamiliar(int famId, boolean stealEquipment) {
+    changeFamiliar(KoLCharacter.findFamiliar(famId), stealEquipment);
+  }
+
+  public static void changeFamiliar(FamiliarData familiar) {
+    changeFamiliar(familiar, true);
+  }
+
+  public static void changeFamiliar(FamiliarData familiar, boolean stealEquipment) {
+    RequestThread.postRequest(new FamiliarRequest(familiar, stealEquipment));
+  }
+
   public static void equipAllFamiliars() {
     KoLmafia.updateDisplay("Equipping familiars...");
 

--- a/src/net/sourceforge/kolmafia/session/FamiliarManager.java
+++ b/src/net/sourceforge/kolmafia/session/FamiliarManager.java
@@ -8,7 +8,6 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestThread;
-import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.FamiliarDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -6246,8 +6246,7 @@ public abstract class RuntimeLibrary {
       throw controller.runtimeException("You don't have a Cat Burglar");
     }
     FamiliarData current = KoLCharacter.getFamiliar();
-    RequestThread.postRequest(
-        new FamiliarRequest(KoLCharacter.findFamiliar(FamiliarPool.CAT_BURGLAR)));
+    FamiliarManager.changeFamiliar(FamiliarPool.CAT_BURGLAR, false);
 
     MapValue returnValue = new MapValue(HeistType);
     var heistData = new HeistManager().getHeistTargets();
@@ -6262,7 +6261,7 @@ public abstract class RuntimeLibrary {
       returnValue.aset(DataTypes.makeMonsterValue(monster.id, false), value);
     }
 
-    RequestThread.postRequest(new FamiliarRequest(current));
+    FamiliarManager.changeFamiliar(current);
     return returnValue;
   }
 
@@ -6271,13 +6270,12 @@ public abstract class RuntimeLibrary {
       throw controller.runtimeException("You don't have a Cat Burglar");
     }
     FamiliarData current = KoLCharacter.getFamiliar();
-    RequestThread.postRequest(
-        new FamiliarRequest(KoLCharacter.findFamiliar(FamiliarPool.CAT_BURGLAR)));
+    FamiliarManager.changeFamiliar(FamiliarPool.CAT_BURGLAR, false);
 
     int itemId = (int) item.intValue();
     var heisted = new HeistManager().heist(itemId);
 
-    RequestThread.postRequest(new FamiliarRequest(current));
+    FamiliarManager.changeFamiliar(current);
     return DataTypes.makeBooleanValue(heisted);
   }
 

--- a/src/net/sourceforge/kolmafia/textui/command/HeistCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/HeistCommand.java
@@ -5,10 +5,8 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestLogger;
-import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
-import net.sourceforge.kolmafia.request.FamiliarRequest;
 import net.sourceforge.kolmafia.session.FamiliarManager;
 import net.sourceforge.kolmafia.session.HeistManager;
 

--- a/src/net/sourceforge/kolmafia/textui/command/HeistCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/HeistCommand.java
@@ -9,6 +9,7 @@ import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.request.FamiliarRequest;
+import net.sourceforge.kolmafia.session.FamiliarManager;
 import net.sourceforge.kolmafia.session.HeistManager;
 
 public class HeistCommand extends AbstractCommand {
@@ -24,9 +25,7 @@ public class HeistCommand extends AbstractCommand {
     }
 
     FamiliarData current = KoLCharacter.getFamiliar();
-
-    RequestThread.postRequest(
-        new FamiliarRequest(KoLCharacter.findFamiliar(FamiliarPool.CAT_BURGLAR)));
+    FamiliarManager.changeFamiliar(FamiliarPool.CAT_BURGLAR, false);
 
     parameter = parameter.trim();
 
@@ -35,7 +34,7 @@ public class HeistCommand extends AbstractCommand {
     } else {
       heistItem(parameter);
     }
-    RequestThread.postRequest(new FamiliarRequest(current));
+    FamiliarManager.changeFamiliar(current);
   }
 
   private void showAllItems() {


### PR DESCRIPTION
There are certain cases where Mafia switches to a familiar, not so that it can be used in adventuring, but so you can do something involving the familiar. In those cases, don't steal the familiar equipment (and then steal it back immediately after).

These are:
* using the Space Jellyfish in Breakfast to grab sea jelly
* using the Intergnat to summon a demon
* using the Cat Burglar to heist an item