### PR TITLE
Make reading effect_desc, outfit_desc, and skill_desc thread safe.

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -1672,17 +1672,15 @@ public class DebugDatabase {
     DebugDatabase.outfits.put(name, text);
   }
 
-  private static final GenericRequest DESC_OUTFIT_REQUEST = new GenericRequest("desc_outfit.php");
-
   public static final String outfitDescriptionText(final int outfitId) {
     return DebugDatabase.outfitDescriptionText(DebugDatabase.rawOutfitDescriptionText(outfitId));
   }
 
   public static final String readOutfitDescriptionText(final int outfitId) {
-    DebugDatabase.DESC_OUTFIT_REQUEST.clearDataFields();
-    DebugDatabase.DESC_OUTFIT_REQUEST.addFormField("whichoutfit", String.valueOf(outfitId));
-    RequestThread.postRequest(DebugDatabase.DESC_OUTFIT_REQUEST);
-    return DebugDatabase.DESC_OUTFIT_REQUEST.responseText;
+    GenericRequest request = new GenericRequest("desc_outfit.php");
+    request.addFormField("whichoutfit", String.valueOf(outfitId));
+    RequestThread.postRequest(request);
+    return request.responseText;
   }
 
   public static final String rawOutfitDescriptionText(final int outfitId) {
@@ -1892,8 +1890,6 @@ public class DebugDatabase {
     return matcher.find() ? matcher.group(1) : "";
   }
 
-  private static final GenericRequest DESC_EFFECT_REQUEST = new GenericRequest("desc_effect.php");
-
   public static final String effectDescriptionText(final int effectId) {
     return DebugDatabase.effectDescriptionText(DebugDatabase.rawEffectDescriptionText(effectId));
   }
@@ -1907,10 +1903,10 @@ public class DebugDatabase {
   }
 
   public static final String readEffectDescriptionText(final String descId) {
-    DebugDatabase.DESC_EFFECT_REQUEST.clearDataFields();
-    DebugDatabase.DESC_EFFECT_REQUEST.addFormField("whicheffect", descId);
-    RequestThread.postRequest(DebugDatabase.DESC_EFFECT_REQUEST);
-    return DebugDatabase.DESC_EFFECT_REQUEST.responseText;
+    GenericRequest request = new GenericRequest("desc_effect.php");
+    request.addFormField("whicheffect", descId);
+    RequestThread.postRequest(request);
+    return request.responseText;
   }
 
   private static String rawEffectDescriptionText(final int effectId) {
@@ -2155,18 +2151,16 @@ public class DebugDatabase {
     return matcher.find() ? StringUtilities.parseInt(matcher.group(1)) : 0;
   }
 
-  private static final GenericRequest DESC_SKILL_REQUEST = new GenericRequest("desc_skill.php");
-
   public static final String skillDescriptionText(final int skillId) {
     return DebugDatabase.skillDescriptionText(DebugDatabase.rawSkillDescriptionText(skillId));
   }
 
   public static final String readSkillDescriptionText(final int skillId) {
-    DebugDatabase.DESC_SKILL_REQUEST.clearDataFields();
-    DebugDatabase.DESC_SKILL_REQUEST.addFormField("whichskill", String.valueOf(skillId));
-    DebugDatabase.DESC_SKILL_REQUEST.addFormField("self", "true");
-    RequestThread.postRequest(DebugDatabase.DESC_SKILL_REQUEST);
-    return DebugDatabase.DESC_SKILL_REQUEST.responseText;
+    GenericRequest request = new GenericRequest("desc_skill.php");
+    request.addFormField("whichskill", String.valueOf(skillId));
+    request.addFormField("self", "true");
+    RequestThread.postRequest(request);
+    return request.responseText;
   }
 
   private static String rawSkillDescriptionText(final int skillId) {


### PR DESCRIPTION
do not use/reuse static global request objects for fetching skill, outfit, and effect descriptions

We used to do that for desc_item calls, but fixed it when we had multiple threads trying to read item descriptions and they were stomping on each other.

Make the same fix for effect, skill,, and outfit descriptions.