### PR TITLE
Use getMallPrice() in InventoryManager without maxAge for exact results

### DIFF
--- a/src/net/sourceforge/kolmafia/session/InventoryManager.java
+++ b/src/net/sourceforge/kolmafia/session/InventoryManager.java
@@ -1147,7 +1147,9 @@ public abstract class InventoryManager {
       }
     }
 
-    int mallPrice = (exact ? StoreManager.getMallPrice(item) : StoreManager.getMallPrice(item, 7.0f)) * quantity;
+    int mallPrice =
+        (exact ? StoreManager.getMallPrice(item) : StoreManager.getMallPrice(item, 7.0f))
+            * quantity;
     if (mallPrice <= 0) {
       mallPrice = Integer.MAX_VALUE;
     } else {

--- a/src/net/sourceforge/kolmafia/session/InventoryManager.java
+++ b/src/net/sourceforge/kolmafia/session/InventoryManager.java
@@ -1108,7 +1108,7 @@ public abstract class InventoryManager {
     factor -= 1.0f;
     lower = upper;
 
-    int mall = StoreManager.getMallPrice(item, exact ? 0.0f : 7.0f);
+    int mall = exact ? StoreManager.getMallPrice(item) : StoreManager.getMallPrice(item, 7.0f);
     if (mall > Math.max(100, 2 * Math.abs(autosell))) {
       upper = Math.max(lower, mall);
     }
@@ -1147,7 +1147,7 @@ public abstract class InventoryManager {
       }
     }
 
-    int mallPrice = StoreManager.getMallPrice(item, exact ? 0.0f : 7.0f) * quantity;
+    int mallPrice = (exact ? StoreManager.getMallPrice(item) : StoreManager.getMallPrice(item, 7.0f)) * quantity;
     if (mallPrice <= 0) {
       mallPrice = Integer.MAX_VALUE;
     } else {


### PR DESCRIPTION
Resolves https://kolmafia.us/threads/retrieve_item-appears-to-be-searching-the-mall-multiple-times-per-ingredient.27103/

Update the mall searches in InventoryManager to used the cached mall price if an exact value is desired, instead of passing in 0 as the maxAge which causes the cache to get purged. This prevents repeated unnecessary mall searches.

New output:
```
> ash retrieve_item($item[single entendre]);

Searching for "double entendre"...
Search complete.
Searching for "bottle of tequila"...
Search complete.
Searching for "bottle of anís"...
Search complete.
Searching for "single entendre"...
Search complete.
Searching for "lemon"...
Search complete.
Verifying ingredients for single entendre (1)...
Verifying ingredients for double entendre (1)...
Using cached search results for bottle of anís...
Purchasing bottle of anís (1 @ 25,000) from #1970014...
Purchases complete.
Creating double entendre (1)...
You acquire an item: double entendre
Successfully created double entendre (1)
Using cached search results for lemon...
Purchasing lemon (1 @ 100) from #1053259...
Purchases complete.
Creating single entendre (1)...
You acquire an item: single entendre
Successfully created single entendre (1)
Returned: true
```