### PR TITLE
Add svn_list() ash function

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -2397,6 +2397,10 @@ public abstract class RuntimeLibrary {
     params = new Type[] {DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("svn_at_head", DataTypes.BOOLEAN_TYPE, params));
 
+    params = new Type[] {};
+    functions.add(
+        new LibraryFunction("svn_list", new AggregateType(DataTypes.STRING_TYPE, 0), params));
+
     params = new Type[] {DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("svn_info", svnInfoRec, params));
 
@@ -8432,6 +8436,21 @@ public abstract class RuntimeLibrary {
           || dropType > '9') { // leave as an empty string if no special type was given
         rec.aset(2, new Value(String.valueOf(dropType)), null);
       }
+    }
+
+    return value;
+  }
+
+  public static Value svn_list(ScriptRuntime controller) {
+    String[] projects = KoLConstants.SVN_LOCATION.list();
+
+    int projectCount = projects != null ? projects.length : 0;
+
+    AggregateType type = new AggregateType(DataTypes.STRING_TYPE, projectCount);
+    ArrayValue value = new ArrayValue(type);
+
+    for (int i = 0; i < projectCount; ++i) {
+      value.aset(new Value(i), new Value(projects[i]));
     }
 
     return value;


### PR DESCRIPTION
Add a function to get the list of installed svn scripts, returning the same results as `svn list`.

```
> svn list

Ezandora-Bastille-branches-Release
Ezandora-Briefcase-branches-Release
Ezandora-Choice-Override-branches-Release
Ezandora-Far-Future-branches-Release
Ezandora-Gain-branches-Release
Loathing-Associates-Scripting-Society-combo-branches-release
Loathing-Associates-Scripting-Society-garbage-collector-branches-release
Loathing-Associates-Scripting-Society-KoL-MineVolcano-branches-master-RELEASE
therazekolmafia-canadv
zlib

> ash svn_list()

Returned: aggregate string [10]
0 => Ezandora-Bastille-branches-Release
1 => Ezandora-Briefcase-branches-Release
2 => Ezandora-Choice-Override-branches-Release
3 => Ezandora-Far-Future-branches-Release
4 => Ezandora-Gain-branches-Release
5 => Loathing-Associates-Scripting-Society-combo-branches-release
6 => Loathing-Associates-Scripting-Society-garbage-collector-branches-release
7 => Loathing-Associates-Scripting-Society-KoL-MineVolcano-branches-master-RELEASE
8 => therazekolmafia-canadv
9 => zlib
```