### PR TITLE
track combat usage of cosmic bowling ball

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -440,6 +440,7 @@ user	controlPanelOmega	0
 user	copperheadClubHazard	none
 user	cornucopiasOpened	0
 user	corralUnlocked	false
+user	cosmicBowlingBallActive	false
 user	cozyCounter6332	0
 user	cozyCounter6333	0
 user	cozyCounter6334	0
@@ -1560,6 +1561,7 @@ user	_companionshipCasts	0
 user	_confusingLEDClockUsed	false
 user	_controlPanelUsed	false
 user	_corruptedStardustUsed	false
+user	_cosmicBowlingSkillsUsed	0
 user	_cosmicSixPackConjured	false
 user	_crappyCameraUsed	false
 user	_creepyVoodooDollUsed	false

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -440,7 +440,7 @@ user	controlPanelOmega	0
 user	copperheadClubHazard	none
 user	cornucopiasOpened	0
 user	corralUnlocked	false
-user	cosmicBowlingBallActive	false
+user	cosmicBowlingBallReturnCombats	-1
 user	cozyCounter6332	0
 user	cozyCounter6333	0
 user	cozyCounter6334	0

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3316,6 +3316,7 @@ public class ItemPool {
   public static final int REFURBISHED_AIR_FRYER = 10879;
   public static final int ELEVEN_LEAF_CLOVER = 10881;
   public static final int CURSED_MAGNIFYING_GLASS = 10885;
+  public static final int COSMIC_BOWLING_BALL = 10891;
 
   public static final AdventureResult get(String itemName, int count) {
     int itemId = ItemDatabase.getItemId(itemName, 1, false);

--- a/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
@@ -332,6 +332,10 @@ public class SkillPool {
   public static final int FIRE_EXTINGUISHER__BLAST_THE_AREA = 7389;
   public static final int FIRE_EXTINGUISHER__ZONE_SPECIFIC = 7390;
   public static final int BE_GREGARIOUS = 7391;
+  public static final int BOWL_BACKWARDS = 7404;
+  public static final int BOWL_A_CURVEBALL = 7405;
+  public static final int BOWL_SIDEWAYS = 7406;
+  public static final int BOWL_STRAIGHT_UP = 7407;
   public static final int GOOD_SINGING_VOICE = 11016;
   public static final int BANISHING_SHOUT = 11020;
   public static final int DEMAND_SANDWICH = 11021;

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -164,6 +164,7 @@ public class Preferences {
         "commerceGhostItem",
         "copperheadClubHazard",
         "cornucopiasOpened",
+        "cosmicBowlingBallActive",
         "cozyCounter6332",
         "cozyCounter6333",
         "cozyCounter6334",

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -164,7 +164,7 @@ public class Preferences {
         "commerceGhostItem",
         "copperheadClubHazard",
         "cornucopiasOpened",
-        "cosmicBowlingBallActive",
+        "cosmicBowlingBallReturnCombats",
         "cozyCounter6332",
         "cozyCounter6333",
         "cozyCounter6334",

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -9405,67 +9405,94 @@ public class FightRequest extends GenericRequest {
         break;
 
       case SkillPool.FIRE_EXTINGUISHER__ZONE_SPECIFIC:
-        boolean success = false;
-        KoLAdventure location = KoLAdventure.lastVisitedLocation();
-        switch (location.getZone()) {
-          case "BatHole":
-            if (responseText.contains(
-                    "You squeeze down the nozzle on your fire extinguisher and release a blast")
-                || skillSuccess) {
-              if (!QuestDatabase.isQuestLaterThan(Quest.BAT, "step2")) {
-                QuestDatabase.advanceQuest(Quest.BAT);
+        {
+          boolean success = false;
+          KoLAdventure location = KoLAdventure.lastVisitedLocation();
+          switch (location.getZone()) {
+            case "BatHole":
+              if (responseText.contains(
+                      "You squeeze down the nozzle on your fire extinguisher and release a blast")
+                  || skillSuccess) {
+                if (!QuestDatabase.isQuestLaterThan(Quest.BAT, "step2")) {
+                  QuestDatabase.advanceQuest(Quest.BAT);
+                }
+                Preferences.setBoolean("fireExtinguisherBatHoleUsed", true);
+                success = true;
               }
-              Preferences.setBoolean("fireExtinguisherBatHoleUsed", true);
-              success = true;
-            }
-            break;
-          case "Cyrpt":
-            if (responseText.contains(
-                    "The chill of the refrigerant quickly replaces some of the chill of evil in the air")
-                || skillSuccess) {
-              String setting = getEvilZoneSetting();
-              if (setting != null) {
-                Preferences.decrement(setting, 10, 0);
-                Preferences.decrement("cyrptTotalEvilness", 10, 0);
+              break;
+            case "Cyrpt":
+              if (responseText.contains(
+                      "The chill of the refrigerant quickly replaces some of the chill of evil in the air")
+                  || skillSuccess) {
+                String setting = getEvilZoneSetting();
+                if (setting != null) {
+                  Preferences.decrement(setting, 10, 0);
+                  Preferences.decrement("cyrptTotalEvilness", 10, 0);
+                }
+                Preferences.setBoolean("fireExtinguisherCyrptUsed", true);
+                success = true;
               }
-              Preferences.setBoolean("fireExtinguisherCyrptUsed", true);
-              success = true;
-            }
-            break;
-        }
+              break;
+          }
 
-        switch (location.getAdventureName()) {
-          case "Cobb's Knob Harem":
-            if (responseText.contains("You fill the harem with foam") || skillSuccess) {
-              Preferences.setBoolean("fireExtinguisherHaremUsed", true);
-              success = true;
-            }
-            break;
-          case "The Smut Orc Logging Camp":
-            if (responseText.contains("You wantonly spray the area with your fire extinguisher")
-                || skillSuccess) {
-              Preferences.increment("smutOrcNoncombatProgress", 11, 15, false);
-              Preferences.setBoolean("fireExtinguisherChasmUsed", true);
-              success = true;
-            }
-            break;
-          case "The Arid, Extra-Dry Desert":
-            if (responseText.contains("You aim the nozzle directly into your mouth")
-                || skillSuccess) {
-              Preferences.setBoolean("fireExtinguisherDesertUsed", true);
-              success = true;
-            }
-            break;
-        }
+          switch (location.getAdventureName()) {
+            case "Cobb's Knob Harem":
+              if (responseText.contains("You fill the harem with foam") || skillSuccess) {
+                Preferences.setBoolean("fireExtinguisherHaremUsed", true);
+                success = true;
+              }
+              break;
+            case "The Smut Orc Logging Camp":
+              if (responseText.contains("You wantonly spray the area with your fire extinguisher")
+                  || skillSuccess) {
+                Preferences.increment("smutOrcNoncombatProgress", 11, 15, false);
+                Preferences.setBoolean("fireExtinguisherChasmUsed", true);
+                success = true;
+              }
+              break;
+            case "The Arid, Extra-Dry Desert":
+              if (responseText.contains("You aim the nozzle directly into your mouth")
+                  || skillSuccess) {
+                Preferences.setBoolean("fireExtinguisherDesertUsed", true);
+                success = true;
+              }
+              break;
+          }
 
-        if (success) {
-          Preferences.decrement("_fireExtinguisherCharge", 20);
+          if (success) {
+            Preferences.decrement("_fireExtinguisherCharge", 20);
+          }
         }
+        break;
+
       case SkillPool.BE_GREGARIOUS:
         if (responseText.contains("You decide to put your best foot forward") || skillSuccess) {
           Preferences.setString("beGregariousMonster", monsterName);
           Preferences.decrement("beGregariousCharges", 1, 0);
           Preferences.setInteger("beGregariousFightsLeft", 3);
+        }
+        break;
+
+      case SkillPool.BOWL_BACKWARDS:
+        // You roll the ball behind you as hard as you can. It crashes
+        // into another enemy in the area, knocking something loose
+        // before draining into the ball return system.
+      case SkillPool.BOWL_A_CURVEBALL:
+        // Your ball clatters into the ball return system.
+      case SkillPool.BOWL_SIDEWAYS:
+        // You scream like a lunatic and hurl your cosmic bowling ball
+        // sideways. It starts ricocheting wildly around the area.
+      case SkillPool.BOWL_STRAIGHT_UP:
+        // You launch your cosmic bowling ball straight up into the air
+        // with a dramatic hook. It starts spinning in the air above you,
+        // glowing and illuminating the area around you.
+        if (responseText.contains("into the ball return system")
+            || responseText.contains("You scream like a lunatic")
+            || responseText.contains("You launch your cosmic bowling ball")
+            || skillSuccess) {
+          Preferences.setBoolean("cosmicBowlingBallActive", true);
+          Preferences.increment("_cosmicBowlingSkillsUsed", 1);
+          ResultProcessor.removeItem(ItemPool.COSMIC_BOWLING_BALL);
         }
         break;
     }
@@ -9764,6 +9791,15 @@ public class FightRequest extends GenericRequest {
         if (!usedBasePair) {
           usedBasePair = true;
           QuestManager.updateCyrusAdjective(itemId);
+        }
+        break;
+
+      case ItemPool.COSMIC_BOWLING_BALL:
+        // Since you've got this cosmic bowling ball, you hurl it down
+        // the ancient lanes. You knock over a few pins. You may be
+        // getting the hang of this!
+        if (responseText.contains("you hurl it down the ancient lanes")) {
+          Preferences.increment("hiddenBowlingAlleyProgress", 1);
         }
         break;
     }

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -2690,6 +2690,8 @@ public class FightRequest extends GenericRequest {
       if (KoLCharacter.hasEquipped(ItemPool.MINIATURE_CRYSTAL_BALL, EquipmentManager.FAMILIAR)) {
         CrystalBallManager.parseCrystalBall(responseText);
       }
+
+      Preferences.decrement("cosmicBowlingBallReturnCombats", 1, -1);
     }
 
     // Figure out various things by examining the responseText. Ideally,
@@ -9490,8 +9492,9 @@ public class FightRequest extends GenericRequest {
             || responseText.contains("You scream like a lunatic")
             || responseText.contains("You launch your cosmic bowling ball")
             || skillSuccess) {
-          Preferences.setBoolean("cosmicBowlingBallActive", true);
           Preferences.increment("_cosmicBowlingSkillsUsed", 1);
+          int combats = Preferences.getInteger("_cosmicBowlingSkillsUsed") * 2 + 3;
+          Preferences.setInteger("cosmicBowlingBallReturnCombats", combats);
           ResultProcessor.removeItem(ItemPool.COSMIC_BOWLING_BALL);
         }
         break;
@@ -9798,7 +9801,7 @@ public class FightRequest extends GenericRequest {
         // Since you've got this cosmic bowling ball, you hurl it down
         // the ancient lanes. You knock over a few pins. You may be
         // getting the hang of this!
-        Preferences.setBoolean("cosmicBowlingBallActive", true);
+        Preferences.setInteger("cosmicBowlingBallReturnCombats", 0);
         if (responseText.contains("you hurl it down the ancient lanes")) {
           Preferences.increment("hiddenBowlingAlleyProgress", 1);
         }

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -9798,6 +9798,7 @@ public class FightRequest extends GenericRequest {
         // Since you've got this cosmic bowling ball, you hurl it down
         // the ancient lanes. You knock over a few pins. You may be
         // getting the hang of this!
+        Preferences.setBoolean("cosmicBowlingBallActive", true);
         if (responseText.contains("you hurl it down the ancient lanes")) {
           Preferences.increment("hiddenBowlingAlleyProgress", 1);
         }

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -9493,7 +9493,7 @@ public class FightRequest extends GenericRequest {
             || responseText.contains("You launch your cosmic bowling ball")
             || skillSuccess) {
           Preferences.increment("_cosmicBowlingSkillsUsed", 1);
-          int combats = Preferences.getInteger("_cosmicBowlingSkillsUsed") * 2 + 3;
+          int combats = Preferences.getInteger("_cosmicBowlingSkillsUsed") * 2 + 3 - 1;
           Preferences.setInteger("cosmicBowlingBallReturnCombats", combats);
           ResultProcessor.removeItem(ItemPool.COSMIC_BOWLING_BALL);
         }

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -3239,6 +3239,12 @@ public class ResultProcessor {
       case ItemPool.VAMPIRE_VINTNER_WINE:
         ResultProcessor.updateVintner();
         break;
+
+      case ItemPool.COSMIC_BOWLING_BALL:
+        if (adventureResults) {
+          Preferences.setBoolean("cosmicBowlingBallActive", false);
+        }
+        break;
     }
 
     // Gaining items can achieve goals.

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -3242,7 +3242,7 @@ public class ResultProcessor {
 
       case ItemPool.COSMIC_BOWLING_BALL:
         if (adventureResults) {
-          Preferences.setBoolean("cosmicBowlingBallActive", false);
+          Preferences.setInteger("cosmicBowlingBallReturnCombats", -1);
         }
         break;
     }


### PR DESCRIPTION
- When you throw your cosmic bowling ball in combat, increment hiddenBowlingAlleyProgress
- When you use a bowling skill, remove it from inventory, increment _cosmicBowlingSkillsUsed, and set cosmicBowlingBallActive to true.
- When you receive a cosmic bowling ball in combat, set cosmicBowlingBallActive to false
- When you ascend, set cosmicBowlingBallActive to false

And when I inserted the case block to support the bowling skills in FightRequest.payActionCost, I noticed that the code following the case label for SkillPool.FIRE_EXTINGUISHER__ZONE_SPECIFIC ("Fire Extinguisher: Zone Specific") was a complete mess. Whoever wrote it apparently assumed that the code following the case label was an implicit block - defining local variables and omitting the break statement at the end. The result being, it then fell through the case label for  SkillPool.BE_GREGARIOUS.

I stuck {} around the "implicit block" and added a break;