### PR TITLE
Language Server - Outer Shell (StateCheckWrappers)

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/langserver/AshLanguageServer.java
+++ b/src/net/sourceforge/kolmafia/textui/langserver/AshLanguageServer.java
@@ -1,0 +1,134 @@
+package net.sourceforge.kolmafia.textui.langserver;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.textui.langserver.textdocumentservice.AshTextDocumentService;
+import net.sourceforge.kolmafia.textui.langserver.workspaceservice.AshWorkspaceService;
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.ServerInfo;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.launch.LSPLauncher;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageClientAware;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.eclipse.lsp4j.services.TextDocumentService;
+import org.eclipse.lsp4j.services.WorkspaceService;
+
+/**
+ * The thread in charge of listening for the client's messages. Its methods all quickly delegate to
+ * other threads, because we want to avoid blocking the reading of new messages.
+ *
+ * <p>Was made abstract, because the actual class to use is {@link
+ * StateCheckWrappers.AshLanguageServer}.
+ */
+public abstract class AshLanguageServer implements LanguageClientAware, LanguageServer {
+
+  /* The Launcher */
+
+  public static AshLanguageServer launch(final InputStream in, final OutputStream out) {
+    final AshLanguageServer server = new StateCheckWrappers.AshLanguageServer();
+
+    final Launcher<LanguageClient> launcher =
+        LSPLauncher.createServerLauncher(server, in, out, server.executor, null);
+    server.connect(launcher.getRemoteProxy());
+
+    // TODO find a way to rename the thread that will be created by startListening()
+    Future<Void> connectionListener = launcher.startListening();
+
+    server.listenForEarlyConnectionTermination(connectionListener);
+
+    return server;
+  }
+
+  /* The server */
+
+  public LanguageClient client;
+  public ClientCapabilities clientCapabilities;
+
+  public final AshTextDocumentService textDocumentService =
+      new StateCheckWrappers.AshTextDocumentService(this);
+  public final AshWorkspaceService workspaceService =
+      new StateCheckWrappers.AshWorkspaceService(this);
+
+  public final ExecutorService executor = Executors.newCachedThreadPool();
+
+  @Override
+  public void connect(LanguageClient client) {
+    this.client = client;
+  }
+
+  @Override
+  public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
+    this.clientCapabilities = params.getCapabilities();
+
+    return CompletableFuture.supplyAsync(
+        () -> {
+          final ServerCapabilities capabilities = new ServerCapabilities();
+
+          this.textDocumentService.setCapabilities(capabilities);
+          this.workspaceService.setCapabilities(capabilities);
+
+          final ServerInfo info = new ServerInfo(StaticEntity.getVersion());
+
+          return new InitializeResult(capabilities, info);
+        },
+        this.executor);
+  }
+
+  @Override
+  public CompletableFuture<Object> shutdown() {
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public void exit() {
+    this.executor.shutdownNow();
+  }
+
+  /**
+   * Creates a thread running in parallel with the Language Server for its whole existence, with the
+   * task of listening for the early termination of the thread listening to the client.
+   *
+   * <p>An early termination is defined as the server's input stream being closed before receiving
+   * the {@code exit} notification.
+   *
+   * <p>This makes sure that {@link #exit} still gets called, preventing this process becoming a
+   * zombie process.
+   */
+  private void listenForEarlyConnectionTermination(final Future<Void> connectionListener) {
+    this.executor.execute(
+        () -> {
+          final String previousThreadName = Thread.currentThread().getName();
+          Thread.currentThread().setName("Language Server early connection termination listener");
+
+          try {
+            connectionListener.get();
+          } catch (InterruptedException | ExecutionException | CancellationException e) {
+          } finally {
+            this.exit();
+
+            Thread.currentThread().setName(previousThreadName);
+          }
+        });
+  }
+
+  @Override
+  public TextDocumentService getTextDocumentService() {
+    return this.textDocumentService;
+  }
+
+  @Override
+  public WorkspaceService getWorkspaceService() {
+    return this.workspaceService;
+  }
+}

--- a/src/net/sourceforge/kolmafia/textui/langserver/StateCheckWrappers.java
+++ b/src/net/sourceforge/kolmafia/textui/langserver/StateCheckWrappers.java
@@ -1,0 +1,480 @@
+package net.sourceforge.kolmafia.textui.langserver;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.lsp4j.*;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
+
+/**
+ * Wrappers for {@link net.sourceforge.kolmafia.textui.langserver.AshLanguageServer
+ * AshLanguageServer}.
+ *
+ * <p>Takes care of checking and/or setting the server's state before every request and notification
+ * according to the LSP specifications of <a href=
+ * https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#initialize>
+ * initialize</a> and <a href=
+ * https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#shutdown>
+ * shutdown</a>, which dictate how a server should have a "pre-initialize" and "post-shutdown"
+ * behavior.
+ *
+ * <p>Up-to-date with <a
+ * href=https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/>3.16</a>
+ */
+abstract class StateCheckWrappers {
+  static class AshLanguageServer
+      extends net.sourceforge.kolmafia.textui.langserver.AshLanguageServer {
+
+    private ServerState state = ServerState.STARTED;
+
+    private enum ServerState {
+      STARTED,
+      INITIALIZED,
+      SHUTDOWN
+    }
+
+    private boolean notInitialized() {
+      return this.state == ServerState.STARTED;
+    }
+
+    private boolean wasShutdown() {
+      return this.state == ServerState.SHUTDOWN;
+    }
+
+    /** To use with @JsonNotifications. They are simply ignored if we are not initialized. */
+    private boolean isActive() {
+      return this.state == ServerState.INITIALIZED;
+    }
+
+    private void initializeCheck() {
+      if (this.notInitialized()) {
+        ResponseError error =
+            new ResponseError(
+                ResponseErrorCode.serverNotInitialized, "Server was not initialized", null);
+        throw new ResponseErrorException(error);
+      }
+    }
+
+    private void shutdownCheck() {
+      if (this.wasShutdown()) {
+        ResponseError error =
+            new ResponseError(ResponseErrorCode.InvalidRequest, "Server was shut down", null);
+        throw new ResponseErrorException(error);
+      }
+    }
+
+    /** To use with @JsonRequests. They must throw an error if we are not initialized. */
+    private void stateCheck() {
+      this.initializeCheck();
+      this.shutdownCheck();
+    }
+
+    // LanguageServer
+
+    @Override
+    public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
+      this.shutdownCheck();
+      this.state = ServerState.INITIALIZED;
+      return super.initialize(params);
+    }
+
+    @Override
+    public void initialized(InitializedParams params) {
+      // https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#initialized
+      // The protocol specifies that this notification "may only be sent once", but... doesn't
+      // specify what to do if it is sent multiple times...
+      if (this.isActive()) {
+        super.initialized(params);
+      }
+    }
+
+    @Override
+    public CompletableFuture<Object> shutdown() {
+      this.initializeCheck();
+      this.state = ServerState.SHUTDOWN;
+      return super.shutdown();
+    }
+
+    @Override
+    public void exit() {
+      // https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#exit
+      // exit() gets processed regardless
+      super.exit();
+      // In case there is a local reference to us
+      this.state = ServerState.SHUTDOWN;
+    }
+
+    @Override
+    public void cancelProgress(WorkDoneProgressCancelParams params) {
+      if (this.isActive()) {
+        super.cancelProgress(params);
+      }
+    }
+  }
+
+  static class AshTextDocumentService
+      extends net.sourceforge.kolmafia.textui.langserver.textdocumentservice
+          .AshTextDocumentService {
+    AshTextDocumentService(
+        final net.sourceforge.kolmafia.textui.langserver.AshLanguageServer parent) {
+      super(parent);
+    }
+
+    @Override
+    public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(
+        CompletionParams position) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.completion(position);
+    }
+
+    @Override
+    public CompletableFuture<CompletionItem> resolveCompletionItem(CompletionItem unresolved) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.resolveCompletionItem(unresolved);
+    }
+
+    @Override
+    public CompletableFuture<Hover> hover(HoverParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.hover(params);
+    }
+
+    @Override
+    public CompletableFuture<SignatureHelp> signatureHelp(SignatureHelpParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.signatureHelp(params);
+    }
+
+    @Override
+    public CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>>
+        declaration(DeclarationParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.declaration(params);
+    }
+
+    @Override
+    public CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>>
+        definition(DefinitionParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.definition(params);
+    }
+
+    @Override
+    public CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>>
+        typeDefinition(TypeDefinitionParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.typeDefinition(params);
+    }
+
+    @Override
+    public CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>>
+        implementation(ImplementationParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.implementation(params);
+    }
+
+    @Override
+    public CompletableFuture<List<? extends Location>> references(ReferenceParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.references(params);
+    }
+
+    @Override
+    public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(
+        DocumentHighlightParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.documentHighlight(params);
+    }
+
+    @Override
+    public CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> documentSymbol(
+        DocumentSymbolParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.documentSymbol(params);
+    }
+
+    @Override
+    public CompletableFuture<List<Either<Command, CodeAction>>> codeAction(
+        CodeActionParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.codeAction(params);
+    }
+
+    @Override
+    public CompletableFuture<CodeAction> resolveCodeAction(CodeAction unresolved) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.resolveCodeAction(unresolved);
+    }
+
+    @Override
+    public CompletableFuture<List<? extends CodeLens>> codeLens(CodeLensParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.codeLens(params);
+    }
+
+    @Override
+    public CompletableFuture<CodeLens> resolveCodeLens(CodeLens unresolved) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.resolveCodeLens(unresolved);
+    }
+
+    @Override
+    public CompletableFuture<List<? extends TextEdit>> formatting(DocumentFormattingParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.formatting(params);
+    }
+
+    @Override
+    public CompletableFuture<List<? extends TextEdit>> rangeFormatting(
+        DocumentRangeFormattingParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.rangeFormatting(params);
+    }
+
+    @Override
+    public CompletableFuture<List<? extends TextEdit>> onTypeFormatting(
+        DocumentOnTypeFormattingParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.onTypeFormatting(params);
+    }
+
+    @Override
+    public CompletableFuture<WorkspaceEdit> rename(RenameParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.rename(params);
+    }
+
+    @Override
+    public CompletableFuture<LinkedEditingRanges> linkedEditingRange(
+        LinkedEditingRangeParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.linkedEditingRange(params);
+    }
+
+    @Override
+    public void didOpen(DidOpenTextDocumentParams params) {
+      if (((AshLanguageServer) this.parent).isActive()) {
+        super.didOpen(params);
+      }
+    }
+
+    @Override
+    public void didChange(DidChangeTextDocumentParams params) {
+      if (((AshLanguageServer) this.parent).isActive()) {
+        super.didChange(params);
+      }
+    }
+
+    @Override
+    public void didClose(DidCloseTextDocumentParams params) {
+      if (((AshLanguageServer) this.parent).isActive()) {
+        super.didClose(params);
+      }
+    }
+
+    @Override
+    public void didSave(DidSaveTextDocumentParams params) {
+      if (((AshLanguageServer) this.parent).isActive()) {
+        super.didSave(params);
+      }
+    }
+
+    @Override
+    public void willSave(WillSaveTextDocumentParams params) {
+      if (((AshLanguageServer) this.parent).isActive()) {
+        super.willSave(params);
+      }
+    }
+
+    @Override
+    public CompletableFuture<List<TextEdit>> willSaveWaitUntil(WillSaveTextDocumentParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.willSaveWaitUntil(params);
+    }
+
+    @Override
+    public CompletableFuture<List<DocumentLink>> documentLink(DocumentLinkParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.documentLink(params);
+    }
+
+    @Override
+    public CompletableFuture<DocumentLink> documentLinkResolve(DocumentLink params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.documentLinkResolve(params);
+    }
+
+    @Override
+    public CompletableFuture<List<ColorInformation>> documentColor(DocumentColorParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.documentColor(params);
+    }
+
+    @Override
+    public CompletableFuture<List<ColorPresentation>> colorPresentation(
+        ColorPresentationParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.colorPresentation(params);
+    }
+
+    @Override
+    public CompletableFuture<List<FoldingRange>> foldingRange(FoldingRangeRequestParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.foldingRange(params);
+    }
+
+    @Override
+    public CompletableFuture<Either<Range, PrepareRenameResult>> prepareRename(
+        PrepareRenameParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.prepareRename(params);
+    }
+
+    @Override
+    public CompletableFuture<TypeHierarchyItem> typeHierarchy(TypeHierarchyParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.typeHierarchy(params);
+    }
+
+    @Override
+    public CompletableFuture<TypeHierarchyItem> resolveTypeHierarchy(
+        ResolveTypeHierarchyItemParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.resolveTypeHierarchy(params);
+    }
+
+    @Override
+    public CompletableFuture<List<CallHierarchyItem>> prepareCallHierarchy(
+        CallHierarchyPrepareParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.prepareCallHierarchy(params);
+    }
+
+    @Override
+    public CompletableFuture<List<CallHierarchyIncomingCall>> callHierarchyIncomingCalls(
+        CallHierarchyIncomingCallsParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.callHierarchyIncomingCalls(params);
+    }
+
+    @Override
+    public CompletableFuture<List<CallHierarchyOutgoingCall>> callHierarchyOutgoingCalls(
+        CallHierarchyOutgoingCallsParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.callHierarchyOutgoingCalls(params);
+    }
+
+    @Override
+    public CompletableFuture<List<SelectionRange>> selectionRange(SelectionRangeParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.selectionRange(params);
+    }
+
+    @Override
+    public CompletableFuture<SemanticTokens> semanticTokensFull(SemanticTokensParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.semanticTokensFull(params);
+    }
+
+    @Override
+    public CompletableFuture<Either<SemanticTokens, SemanticTokensDelta>> semanticTokensFullDelta(
+        SemanticTokensDeltaParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.semanticTokensFullDelta(params);
+    }
+
+    @Override
+    public CompletableFuture<SemanticTokens> semanticTokensRange(SemanticTokensRangeParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.semanticTokensRange(params);
+    }
+
+    @Override
+    public CompletableFuture<List<Moniker>> moniker(MonikerParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.moniker(params);
+    }
+  }
+
+  static class AshWorkspaceService
+      extends net.sourceforge.kolmafia.textui.langserver.workspaceservice.AshWorkspaceService {
+    AshWorkspaceService(final net.sourceforge.kolmafia.textui.langserver.AshLanguageServer parent) {
+      super(parent);
+    }
+
+    @Override
+    public CompletableFuture<Object> executeCommand(ExecuteCommandParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.executeCommand(params);
+    }
+
+    @Override
+    public CompletableFuture<List<? extends SymbolInformation>> symbol(
+        WorkspaceSymbolParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.symbol(params);
+    }
+
+    @Override
+    public void didChangeConfiguration(DidChangeConfigurationParams params) {
+      if (((AshLanguageServer) this.parent).isActive()) {
+        super.didChangeConfiguration(params);
+      }
+    }
+
+    @Override
+    public void didChangeWatchedFiles(DidChangeWatchedFilesParams params) {
+      if (((AshLanguageServer) this.parent).isActive()) {
+        super.didChangeWatchedFiles(params);
+      }
+    }
+
+    @Override
+    public void didChangeWorkspaceFolders(DidChangeWorkspaceFoldersParams params) {
+      if (((AshLanguageServer) this.parent).isActive()) {
+        super.didChangeWorkspaceFolders(params);
+      }
+    }
+
+    @Override
+    public CompletableFuture<WorkspaceEdit> willCreateFiles(CreateFilesParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.willCreateFiles(params);
+    }
+
+    @Override
+    public void didCreateFiles(CreateFilesParams params) {
+      if (((AshLanguageServer) this.parent).isActive()) {
+        super.didCreateFiles(params);
+      }
+    }
+
+    @Override
+    public CompletableFuture<WorkspaceEdit> willRenameFiles(RenameFilesParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.willRenameFiles(params);
+    }
+
+    @Override
+    public void didRenameFiles(RenameFilesParams params) {
+      if (((AshLanguageServer) this.parent).isActive()) {
+        super.didRenameFiles(params);
+      }
+    }
+
+    @Override
+    public CompletableFuture<WorkspaceEdit> willDeleteFiles(DeleteFilesParams params) {
+      ((AshLanguageServer) this.parent).stateCheck();
+      return super.willDeleteFiles(params);
+    }
+
+    @Override
+    public void didDeleteFiles(DeleteFilesParams params) {
+      if (((AshLanguageServer) this.parent).isActive()) {
+        super.didDeleteFiles(params);
+      }
+    }
+  }
+}

--- a/src/net/sourceforge/kolmafia/textui/langserver/textdocumentservice/AshTextDocumentService.java
+++ b/src/net/sourceforge/kolmafia/textui/langserver/textdocumentservice/AshTextDocumentService.java
@@ -1,0 +1,31 @@
+package net.sourceforge.kolmafia.textui.langserver.textdocumentservice;
+
+import net.sourceforge.kolmafia.textui.langserver.AshLanguageServer;
+import org.eclipse.lsp4j.DidChangeTextDocumentParams;
+import org.eclipse.lsp4j.DidCloseTextDocumentParams;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.DidSaveTextDocumentParams;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.services.TextDocumentService;
+
+public abstract class AshTextDocumentService implements TextDocumentService {
+  protected final AshLanguageServer parent;
+
+  public AshTextDocumentService(final AshLanguageServer parent) {
+    this.parent = parent;
+  }
+
+  public final void setCapabilities(final ServerCapabilities capabilities) {}
+
+  @Override
+  public void didOpen(DidOpenTextDocumentParams params) {}
+
+  @Override
+  public void didChange(DidChangeTextDocumentParams params) {}
+
+  @Override
+  public void didClose(DidCloseTextDocumentParams params) {}
+
+  @Override
+  public void didSave(DidSaveTextDocumentParams params) {}
+}

--- a/src/net/sourceforge/kolmafia/textui/langserver/workspaceservice/AshWorkspaceService.java
+++ b/src/net/sourceforge/kolmafia/textui/langserver/workspaceservice/AshWorkspaceService.java
@@ -1,0 +1,23 @@
+package net.sourceforge.kolmafia.textui.langserver.workspaceservice;
+
+import net.sourceforge.kolmafia.textui.langserver.AshLanguageServer;
+import org.eclipse.lsp4j.DidChangeConfigurationParams;
+import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.services.WorkspaceService;
+
+public abstract class AshWorkspaceService implements WorkspaceService {
+  protected final AshLanguageServer parent;
+
+  public AshWorkspaceService(final AshLanguageServer parent) {
+    this.parent = parent;
+  }
+
+  public final void setCapabilities(final ServerCapabilities capabilities) {}
+
+  @Override
+  public void didChangeConfiguration(DidChangeConfigurationParams params) {}
+
+  @Override
+  public void didChangeWatchedFiles(DidChangeWatchedFilesParams params) {}
+}

--- a/test/net/sourceforge/kolmafia/textui/langserver/AshLanguageServerTest.java
+++ b/test/net/sourceforge/kolmafia/textui/langserver/AshLanguageServerTest.java
@@ -1,0 +1,58 @@
+package net.sourceforge.kolmafia.textui.langserver;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.launch.LSPLauncher;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+public class AshLanguageServerTest {
+  private final Closeable[] streams = new Closeable[4];
+
+  // The two "true" endpoints.
+  LanguageClient client;
+  AshLanguageServer trueServer;
+
+  // The way the client has to access the server through the LSP4J implementation
+  LanguageServer proxyServer;
+
+  @BeforeEach
+  final void setup() throws IOException {
+    PipedOutputStream serverOut = (PipedOutputStream) (streams[0] = new PipedOutputStream());
+    PipedOutputStream clientOut = (PipedOutputStream) (streams[1] = new PipedOutputStream());
+    PipedInputStream serverIn = (PipedInputStream) (streams[2] = new PipedInputStream(clientOut));
+    PipedInputStream clientIn = (PipedInputStream) (streams[3] = new PipedInputStream(serverOut));
+
+    trueServer = launchServer(serverIn, serverOut);
+
+    client = launchClientAndSetProxy(clientIn, clientOut);
+  }
+
+  @AfterEach
+  final void tearDown() throws IOException {
+    for (Closeable stream : streams) {
+      stream.close();
+    }
+  }
+
+  AshLanguageServer launchServer(InputStream in, OutputStream out) {
+    return AshLanguageServer.launch(in, out);
+  }
+
+  LanguageClient launchClientAndSetProxy(InputStream in, OutputStream out) {
+    LanguageClient client = new TestLanguageClient();
+
+    final Launcher<LanguageServer> launcher = LSPLauncher.createClientLauncher(client, in, out);
+    proxyServer = launcher.getRemoteProxy();
+    launcher.startListening();
+
+    return client;
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/langserver/StateCheckWrappersTest.java
+++ b/test/net/sourceforge/kolmafia/textui/langserver/StateCheckWrappersTest.java
@@ -1,0 +1,422 @@
+package net.sourceforge.kolmafia.textui.langserver;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.StringJoiner;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import net.sourceforge.kolmafia.utilities.PauseObject;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InitializedParams;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
+import org.eclipse.lsp4j.jsonrpc.services.JsonDelegate;
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import org.eclipse.lsp4j.launch.LSPLauncher;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.ThrowingSupplier;
+
+public class StateCheckWrappersTest extends AshLanguageServerTest {
+
+  private final PauseObject pauser = new PauseObject();
+
+  private static class AshLanguageServerNotingIgnoredNotifications
+      extends StateCheckWrappers.AshLanguageServer {
+    private boolean ignoredNotification;
+
+    @Override
+    boolean isActive() {
+      if (super.isActive()) {
+        return true;
+      }
+
+      this.ignoredNotification = true;
+      return false;
+    }
+  }
+
+  @Override
+  AshLanguageServer launchServer(InputStream in, OutputStream out) {
+    final AshLanguageServer server = new AshLanguageServerNotingIgnoredNotifications();
+
+    final Launcher<LanguageClient> launcher =
+        LSPLauncher.createServerLauncher(server, in, out, server.executor, null);
+    server.connect(launcher.getRemoteProxy());
+    launcher.startListening();
+
+    return server;
+  }
+
+  private static Map<Method[], List<Method>> getRequestsAndNotifications() {
+    Map<Method[], List<Method>> map = new HashMap<>();
+    populateRequestsAndNotifications(map, LanguageServer.class.getMethods(), new Method[0]);
+    return map;
+  }
+
+  private static void populateRequestsAndNotifications(
+      Map<Method[], List<Method>> map, Method[] currentMethods, Method[] currentDelegates) {
+    List<Method> lspMethods = new LinkedList<>();
+
+    for (Method method : currentMethods) {
+      if (isStateRelatedMethod(method) || method.getAnnotation(Deprecated.class) != null) {
+        // Ignore
+      } else if (method.getAnnotation(JsonRequest.class) != null
+          || method.getAnnotation(JsonNotification.class) != null) {
+        lspMethods.add(method);
+      } else if (method.getAnnotation(JsonDelegate.class) != null) {
+        Method[] newDelegates = new Method[currentDelegates.length + 1];
+        System.arraycopy(currentDelegates, 0, newDelegates, 0, currentDelegates.length);
+        newDelegates[currentDelegates.length] = method;
+
+        populateRequestsAndNotifications(map, method.getReturnType().getMethods(), newDelegates);
+      }
+    }
+
+    map.put(currentDelegates, lspMethods);
+  }
+
+  private static boolean isStateRelatedMethod(Method method) {
+    return methodEquals(method, "initialize", InitializeParams.class)
+        || methodEquals(method, "initialized", InitializedParams.class)
+        || methodEquals(method, "initialized")
+        || methodEquals(method, "shutdown")
+        || methodEquals(method, "exit");
+  }
+
+  private static boolean methodEquals(Method method, String name, Class<?>... parameterTypes) {
+    try {
+      return method.equals(LanguageServer.class.getMethod(name, parameterTypes));
+    } catch (NoSuchMethodException e) {
+      return false;
+    }
+  }
+
+  private static Object makeSimplestInstancePossible(final Class<?> clazz) {
+    // Try with the version with no arguments
+    try {
+      return clazz.getConstructor().newInstance();
+    } catch (NoSuchMethodException
+        | InstantiationException
+        | InvocationTargetException
+        | IllegalAccessException e) {
+      // No luck
+      // Breadth-first would probably be better, but implementing it here seems like a pain...
+      for (Constructor<?> constructor : clazz.getConstructors()) {
+        Class<?>[] parameters = constructor.getParameterTypes();
+        Object[] arguments = new Object[parameters.length];
+
+        for (int i = 0; i < parameters.length; i++) {
+          arguments[i] = makeSimplestInstancePossible(parameters[i]);
+        }
+
+        try {
+          return constructor.newInstance(arguments);
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException ex) {
+        }
+      }
+    }
+
+    // Our efforts were fruitless. Last chance is that null works
+    return null;
+  }
+
+  private static Object invokeWithDefaultParameters(Method method, Object obj)
+      throws IllegalAccessException, InvocationTargetException, NoSuchMethodException,
+          InstantiationException {
+    Object[] params;
+    Class<?>[] paramTypes = method.getParameterTypes();
+
+    if (paramTypes.length == 0) {
+      params = new Object[0];
+    } else {
+      // LSP4J methods have at most 1 parameter (a single object grouping every "actual" parameter)
+      // These parameter classes always have a default constructor
+      // ...or so I thought. Damn.
+      params = new Object[1];
+
+      params[0] = makeSimplestInstancePossible(paramTypes[0]);
+    }
+
+    return method.invoke(obj, params);
+  }
+
+  private void clearIgnoredNotification() {
+    ((AshLanguageServerNotingIgnoredNotifications) trueServer).ignoredNotification = false;
+  }
+
+  private boolean ignoredNotification() {
+    return ((AshLanguageServerNotingIgnoredNotifications) trueServer).ignoredNotification;
+  }
+
+  public void testWithAllMethods(
+      BiConsumer<String, Supplier<CompletableFuture<?>>> requestConsumer,
+      BiConsumer<String, Runnable> notificationConsumer)
+      throws IllegalAccessException, InvocationTargetException {
+    for (final Entry<Method[], List<Method>> entry : getRequestsAndNotifications().entrySet()) {
+      final Method[] delegateMethods = entry.getKey();
+      final List<Method> methods = entry.getValue();
+
+      Object delegate = proxyServer;
+
+      for (final Method delegateMethod : delegateMethods) {
+        delegate = delegateMethod.invoke(delegate, new Object[0]);
+      }
+
+      final Object finalDelegate = delegate;
+
+      for (final Method method : methods) {
+        clearIgnoredNotification();
+
+        // Prepare a short method name for the error messages
+        StringBuilder s = new StringBuilder(method.getDeclaringClass().getSimpleName());
+        s.append(".");
+        s.append(method.getName());
+        StringJoiner params = new StringJoiner(", ", "(", ")");
+        for (Class<?> param : method.getParameterTypes()) {
+          params.add(param.getSimpleName());
+        }
+        s.append(params.toString());
+
+        String methodName = s.toString();
+
+        if (method.getAnnotation(JsonRequest.class) != null) {
+          requestConsumer.accept(
+              methodName,
+              () -> {
+                try {
+                  return (CompletableFuture<?>) invokeWithDefaultParameters(method, finalDelegate);
+                } catch (Throwable e) {
+                  Assertions.fail("Access to " + methodName + " failed", e);
+                  return null;
+                }
+              });
+        } else {
+          notificationConsumer.accept(
+              methodName,
+              () -> {
+                try {
+                  invokeWithDefaultParameters(method, finalDelegate);
+                } catch (Throwable e) {
+                  Assertions.fail("Access to " + methodName + " failed", e);
+                }
+
+                pauser.pause(100);
+              });
+        }
+      }
+    }
+  }
+
+  @Test
+  public void preInitializationTest() throws IllegalAccessException, InvocationTargetException {
+    testWithAllMethods(
+        (methodName, requestCaller) -> {
+          // Pre-initialization requests should complete exceptionally with
+          // serverNotInitialized
+          ExecutionException error =
+              Assertions.assertThrows(
+                  ExecutionException.class, requestCaller.get()::get, methodName);
+
+          ResponseErrorException response =
+              Assertions.assertInstanceOf(
+                  ResponseErrorException.class, error.getCause(), methodName);
+
+          Assertions.assertEquals("Server was not initialized", response.getMessage(), methodName);
+          Assertions.assertEquals(
+              ResponseErrorCode.serverNotInitialized.getValue(),
+              response.getResponseError().getCode(),
+              methodName);
+        },
+        (methodName, notificationRunner) -> {
+          // Pre-initialization notifications should simply be ignored
+          notificationRunner.run();
+          pauser.pause(100);
+
+          Assertions.assertTrue(ignoredNotification(), methodName);
+        });
+
+    // State-related methods
+
+    // initialize(InitializeParams) is expected. Would change the state.
+
+    // initialized(InitializedParams) acts like any other notification pre-initialization
+    clearIgnoredNotification();
+    proxyServer.initialized(new InitializedParams());
+    pauser.pause(100);
+
+    Assertions.assertTrue(ignoredNotification());
+
+    // shutdown() acts like any other request pre-initialization
+    ExecutionException error =
+        Assertions.assertThrows(ExecutionException.class, proxyServer.shutdown()::get);
+
+    ResponseErrorException response =
+        Assertions.assertInstanceOf(ResponseErrorException.class, error.getCause());
+
+    Assertions.assertEquals("Server was not initialized", response.getMessage());
+    Assertions.assertEquals(
+        ResponseErrorCode.serverNotInitialized.getValue(), response.getResponseError().getCode());
+
+    // exit() is always accepted
+    clearIgnoredNotification();
+    proxyServer.exit();
+    pauser.pause(100);
+
+    Assertions.assertFalse(ignoredNotification());
+
+    Assertions.assertTrue(trueServer.executor.isShutdown());
+  }
+
+  @Test
+  public void postInitializationTest() throws IllegalAccessException, InvocationTargetException {
+    Assertions.assertDoesNotThrow(
+        (ThrowingSupplier<InitializeResult>) proxyServer.initialize(new InitializeParams())::get,
+        "Initialization failed");
+
+    testWithAllMethods(
+        (methodName, requestCaller) -> {
+          // Post-initialization requests should be accepted
+          try {
+            requestCaller.get().get();
+          } catch (InterruptedException e) {
+            Assertions.fail("We were interrupted during " + methodName);
+          } catch (ExecutionException e) {
+            ResponseErrorException exception =
+                Assertions.assertInstanceOf(ResponseErrorException.class, e.getCause());
+            ResponseError response = exception.getResponseError();
+
+            Assertions.assertNotEquals(
+                ResponseErrorCode.serverNotInitialized.getValue(), response.getCode(), methodName);
+            Assertions.assertNotEquals(
+                "Server was already initialized", response.getMessage(), methodName);
+            Assertions.assertNotEquals("Server was shut down", response.getMessage(), methodName);
+          }
+        },
+        (methodName, notificationRunner) -> {
+          // Post-initialization notifications should be accepted
+          notificationRunner.run();
+          pauser.pause(100);
+
+          Assertions.assertFalse(ignoredNotification(), methodName);
+        });
+
+    // State-related methods
+
+    // initialize(InitializeParams) may only be sent once
+    ExecutionException error =
+        Assertions.assertThrows(
+            ExecutionException.class, proxyServer.initialize(new InitializeParams())::get);
+
+    ResponseErrorException response =
+        Assertions.assertInstanceOf(ResponseErrorException.class, error.getCause());
+
+    Assertions.assertEquals("Server was already initialized", response.getMessage());
+    Assertions.assertEquals(
+        ResponseErrorCode.InvalidRequest.getValue(), response.getResponseError().getCode());
+
+    // initialized(InitializedParams) should only be accepted if the first notification after
+    // initialize(InitializeParams). Our implementation currently doesn't do that, so skip
+
+    // shutdown() is expected. Would change the state.
+
+    // exit() is always accepted
+    clearIgnoredNotification();
+    proxyServer.exit();
+    pauser.pause(100);
+
+    Assertions.assertFalse(ignoredNotification());
+
+    Assertions.assertTrue(trueServer.executor.isShutdown());
+  }
+
+  @Test
+  public void postShutdownTest() throws IllegalAccessException, InvocationTargetException {
+    Assertions.assertDoesNotThrow(
+        (ThrowingSupplier<InitializeResult>) proxyServer.initialize(new InitializeParams())::get,
+        "Initialization failed");
+
+    Assertions.assertDoesNotThrow(
+        (ThrowingSupplier<Object>) proxyServer.shutdown()::get, "Shutdown failed");
+
+    testWithAllMethods(
+        (methodName, requestCaller) -> {
+          // Post-shutdown requests should complete exceptionally with InvalidRequest
+          ExecutionException error =
+              Assertions.assertThrows(
+                  ExecutionException.class, requestCaller.get()::get, methodName);
+
+          ResponseErrorException response =
+              Assertions.assertInstanceOf(
+                  ResponseErrorException.class, error.getCause(), methodName);
+
+          Assertions.assertEquals("Server was shut down", response.getMessage(), methodName);
+          Assertions.assertEquals(
+              ResponseErrorCode.InvalidRequest.getValue(),
+              response.getResponseError().getCode(),
+              methodName);
+        },
+        (methodName, notificationRunner) -> {
+          // Post-shutdown notifications should simply be ignored
+          notificationRunner.run();
+          pauser.pause(100);
+
+          Assertions.assertTrue(ignoredNotification(), methodName);
+        });
+
+    // State-related methods
+
+    // initialize(InitializeParams) acts like any other requests post-shutdown
+    ExecutionException error =
+        Assertions.assertThrows(
+            ExecutionException.class, proxyServer.initialize(new InitializeParams())::get);
+
+    ResponseErrorException response =
+        Assertions.assertInstanceOf(ResponseErrorException.class, error.getCause());
+
+    Assertions.assertEquals("Server was shut down", response.getMessage());
+    Assertions.assertEquals(
+        ResponseErrorCode.InvalidRequest.getValue(), response.getResponseError().getCode());
+
+    // initialized(InitializedParams) acts like any other notification post-shutdown
+    clearIgnoredNotification();
+    proxyServer.initialized(new InitializedParams());
+    pauser.pause(100);
+
+    Assertions.assertTrue(ignoredNotification());
+
+    // shutdown() acts like any other request post-shutdown
+    error = Assertions.assertThrows(ExecutionException.class, proxyServer.shutdown()::get);
+
+    response = Assertions.assertInstanceOf(ResponseErrorException.class, error.getCause());
+
+    Assertions.assertEquals("Server was shut down", response.getMessage());
+    Assertions.assertEquals(
+        ResponseErrorCode.InvalidRequest.getValue(), response.getResponseError().getCode());
+
+    // exit() is always accepted
+    clearIgnoredNotification();
+    proxyServer.exit();
+    pauser.pause(100);
+
+    Assertions.assertFalse(ignoredNotification());
+
+    Assertions.assertTrue(trueServer.executor.isShutdown());
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/langserver/TestLanguageClient.java
+++ b/test/net/sourceforge/kolmafia/textui/langserver/TestLanguageClient.java
@@ -1,0 +1,31 @@
+package net.sourceforge.kolmafia.textui.langserver;
+
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.services.LanguageClient;
+
+// Using Mockito.mock(LanguageClient.class) doesn't seem to work, as Mockito seems to makes a
+// duplicate of every single method, including their annotation, which LSP4J disapproves of
+
+public class TestLanguageClient implements LanguageClient {
+  @Override
+  public void telemetryEvent(Object object) {}
+
+  @Override
+  public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {}
+
+  @Override
+  public void showMessage(MessageParams messageParams) {}
+
+  @Override
+  public CompletableFuture<MessageActionItem> showMessageRequest(
+      ShowMessageRequestParams requestParams) {
+    return null;
+  }
+
+  @Override
+  public void logMessage(MessageParams message) {}
+}


### PR DESCRIPTION
The skeleton of the Language Server, as well as StateCheckWrappers, which, like the name suggests, is a wrapper for the server, which takes care of accepting the messages in function of the server's state.

I thought making the tests for it would be simple. HAH. HAHAH. HAHAHAH. I laugh.

HAAAHAHAHA. I laugh some more.

HAAAAAAAAAAAAHHHAHAHAHA.
Kill me.