### PR TITLE
Add Sauce Spell Damage modifier

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -7838,7 +7838,7 @@ Skill	Inner Sauce	MP Regen Min: [1+2*class(Sauceror)], MP Regen Max: [1+3*class(
 # Insatiable Hunger: +5 Stomach Capacity
 # Intimidating Aura: Gain more blood from the Blood Bank each day
 Skill	Intimidating Aura	Maximum HP: -30
-Skill	Intrinsic Spiciness	Spell Damage: [min(L,10)]
+Skill	Intrinsic Spiciness	Sauce Spell Damage: [min(L,10)]
 Skill	Introspection	Mysticality: +20
 # Ire of the Orca: Fury capacity increases to 5 gallons
 Skill	Irrepressible Spunk	Maximum HP Percent: +5, Maximum MP Percent: +5

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -215,6 +215,7 @@ public class Modifiers {
   public static final int WATER = 140;
   public static final int SPLEEN_DROP = 141;
   public static final int POTION_DROP = 142;
+  public static final int SAUCE_SPELL_DAMAGE = 143;
   public static final String EXPR = "(?:([-+]?[\\d.]+)|\\[([^]]+)\\])";
 
   private static final Object[][] doubleModifiers = {
@@ -806,6 +807,13 @@ public class Modifiers {
       "Potion Drop",
       Pattern.compile("([+-]\\d+)% Potion Drops? [Ff]rom Monsters$"),
       Pattern.compile("Potion Drop: " + EXPR)
+    },
+    {
+      "Sauce Spell Damage",
+      new Object[] {
+        Pattern.compile("Sauce Spell Damage ([+-]\\d+)$"), Pattern.compile("([+-]\\d+) Sauce Spell Damage"),
+      },
+      Pattern.compile("(?:^|, )Sauce Spell Damage: " + EXPR)
     },
   };
 

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -811,7 +811,8 @@ public class Modifiers {
     {
       "Sauce Spell Damage",
       new Object[] {
-        Pattern.compile("Sauce Spell Damage ([+-]\\d+)$"), Pattern.compile("([+-]\\d+) Sauce Spell Damage"),
+        Pattern.compile("Sauce Spell Damage ([+-]\\d+)$"),
+        Pattern.compile("([+-]\\d+) Sauce Spell Damage"),
       },
       Pattern.compile("(?:^|, )Sauce Spell Damage: " + EXPR)
     },

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -50,4 +50,15 @@ public class ModifiersTest {
       assertEquals(manualMask, mask, name);
     }
   }
+
+  @Test
+  public void intrinsicSpicinessModifiers() {
+    KoLCharacter.setAscensionClass(AscensionClass.SAUCEROR);
+    for (int i = 1; i <= 11; i++) {
+      int myst = (i == 1) ? 0 : (i - 1) * (i - 1) + 4;
+      KoLCharacter.setStatPoints(0, 0, myst, myst * myst, 0, 0);
+      Modifiers mods = Modifiers.getModifiers("Skill", "Intrinsic Spiciness");
+      assertEquals(Math.min(i, 10), mods.get(Modifiers.SAUCE_SPELL_DAMAGE));
+    }
+  }
 }


### PR DESCRIPTION
Make a new modifier for Sauce Spell Damage, this currently only applies to Intrinsic Spiciness.

<img width="879" alt="image" src="https://user-images.githubusercontent.com/1320480/149648388-e6f4bc5a-b0a8-48f3-ba0f-f9252dfe62e7.png">
