### PR TITLE
Snojo monsters are nocopy and add void shard

### DIFF
--- a/src/data/equipment.txt
+++ b/src/data/equipment.txt
@@ -1664,6 +1664,7 @@ velcro paddle ball	200	Mox: 85	1-handed flail
 velour voulge	50	Mus: 0	1-handed polearm
 vibrating cyborg knife	150	Mus: 55	1-handed sword
 villainous scythe	200	Mus: 150	2-handed polearm
+void shard	150	Mus: 25	1-handed knife
 vorpal blade	90	Mus: 30	1-handed sword
 VYKEA hex key	125	Mus: 47	1-handed club
 Wand of Nagamar	30	Mus: 0	1-handed wand

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -10913,6 +10913,6 @@
 10886	void lager	295960773	voidbeer.gif	drink	d	5
 10887	void burger	594078167	voidburger.gif	food	d	5
 10888	void stone	676671920	voidstone.gif	none	d	500
-10889
+10889	void shard	935741344	voidknife.gif	weapon	t	0
 10890	undrilled cosmic bowling ball	276317641	cosmicball.gif	usable	t	0
 10891	cosmic bowling ball	119596776	cosmicball2.gif	none, combat		0

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -1960,6 +1960,7 @@ Item	velcro paddle ball	Moxie Percent: +5, MP Regen Min: 6, MP Regen Max: 12, Ac
 Item	velour voulge	Experience (Muscle): +2, Weapon Drop: +30
 Item	vibrating cyborg knife	Weapon Damage: +20, Fumble: 3
 Item	villainous scythe	Weapon Damage Percent: +30, Critical Hit Percent: +20, Slime Hates It: +2
+Item	void shard	Muscle Percent: +13, Mysticality Percent: +13, Moxie Percent: +13, Item Drop: +13, Monster Level: +13, Spooky Damage: +13
 Item	vorpal blade	Critical Hit Percent: +8
 Item	VYKEA hex key	Muscle: +6, Mysticality: +6, Moxie: +6, HP Regen Min: 6, HP Regen Max: 6, MP Regen Min: 6, MP Regen Max: 6, Weapon Damage: +6
 # Wand of Nagamar

--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -1762,7 +1762,7 @@ Thinker of Thoughts	1860	blank.gif	Scale: 1 Cap: 10000 Floor: 10 Init: -10000 P:
 Perceiver of Sensations	1861	blank.gif	Scale: 1 Cap: 10000 Floor: 10 Init: -10000 P: weird	abstraction: perception (0)	abstraction: sensation (0)
 
 # The X-32-F Combat Training Snowman (X-32-F snowman crate January 2016)
-X-32-F Combat Training Snowman	1858	blank.gif	NOMANUEL NOWANDER Atk: 1 Def: 1 HP: 1 E: cold P: construct
+X-32-F Combat Training Snowman	1858	blank.gif	NOMANUEL NOWANDER NOCOPY Atk: 1 Def: 1 HP: 1 E: cold P: construct
 
 # Investigating a Plaintive Telegram
 


### PR DESCRIPTION
Another place I noticed `lastCopyableMonster` being erroneously updated. Verified by casting Feel Nostalgic and still getting previous monsters drops even on the 3rd Snojo combat and also double checked with the print screen button to ensure it gives the failure to copy message. Log of Snojo combats casting Feel Nostalgic after a smoke monster -> [snojo_lastCopyableMonster_example.txt](https://github.com/kolmafia/kolmafia/files/7878451/snojo_lastCopyableMonster_example.txt)

Void shard is in the mall so I had mafia generate the values by searching for it then copied the entries from my session.log to the appropriate files (so formatting should be correct but if it isn't let me know).

