### PR TITLE
Add "letter" keyword to maximizer (to prefer longer equipment names)

### DIFF
--- a/src/data/maximizer-help.html
+++ b/src/data/maximizer-help.html
@@ -26,6 +26,8 @@ The only bitmap modifiers that currently appear useful for maximization are Clow
 String modifiers are not currently meaningful for maximization.
 <p>
 The 'Bees Hate You' challenge path adds a <b>beeosity</b> keyword, which specifies the maximum number of 'B's allowed in the names of your equipment items (each of which causes 10% of your maximum HP in damage at the start of every combat).  The default is 2 at the moment.  The value you specify will automatically be increased if you use a <b>+equip</b> or <b>+outfit</b> keyword (described below) that requires more 'B's to satisfy.
+<p>
+Some extra provided keywords are useful in PvP minigames. <b>number</b> increases score by the number of numbers in a piece of equipment's name. <b>letter</b> increases score by the number of letters in the name, and <b>letter <i>X</i></b> can be used to count the number of Xs.
 <h3>Equipment</h3>
 Slot names can be used as keywords:
 <br><b>hat</b>, <b>weapon</b>, <b>offhand</b>, <b>shirt</b>, <b>pants</b>, <b>acc1</b>, <b>acc2</b>, <b>acc3</b>, <b>familiar</b> (stickers and fake hands are not currently planned.)

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -2363,14 +2363,7 @@ public abstract class KoLCharacter {
   private static final Pattern B_PATTERN = Pattern.compile("[Bb]");
 
   public static final int getBeeosity(String name) {
-    int bees = 0;
-
-    Matcher bMatcher = KoLCharacter.B_PATTERN.matcher(name);
-    while (bMatcher.find()) {
-      bees++;
-    }
-
-    return bees;
+    return (int) KoLCharacter.B_PATTERN.matcher(name).results().count();
   }
 
   public static final boolean hasBeeosity(String name) {

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -6,7 +6,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import net.java.dev.spellcast.utilities.LockableListModel;

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -11,6 +11,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.AdventureResult;
@@ -91,6 +92,7 @@ public class Evaluator {
   private final Set<AdventureResult> negEquip = new HashSet<>();
   private final Set<AdventureResult> uniques = new HashSet<>();
   private final Map<AdventureResult, Double> bonuses = new HashMap<>();
+  private final List<Function<AdventureResult, Double>> bonusFunc = new ArrayList<>();
 
   private static final String TIEBREAKER =
       "1 familiar weight, 1 familiar experience, 1 initiative, 5 exp, 1 item, 1 meat, 0.1 DA 1000 max, 1 DR, 0.5 all res, -10 mana cost, 1.0 mus, 0.5 mys, 1.0 mox, 1.5 mainstat, 1 HP, 1 MP, 1 weapon damage, 1 ranged damage, 1 spell damage, 1 cold damage, 1 hot damage, 1 sleaze damage, 1 spooky damage, 1 stench damage, 1 cold spell damage, 1 hot spell damage, 1 sleaze spell damage, 1 spooky spell damage, 1 stench spell damage, -1 fumble, 1 HP regen max, 3 MP regen max, 1 critical hit percent, 0.1 food drop, 0.1 booze drop, 0.1 hat drop, 0.1 weapon drop, 0.1 offhand drop, 0.1 shirt drop, 0.1 pants drop, 0.1 accessory drop, 1 DB combat damage, 0.1 sixgun damage";
@@ -381,6 +383,22 @@ public class Evaluator {
           return;
         }
         this.bonuses.put(match, weight);
+        continue;
+      }
+
+      if (keyword.startsWith("letter")) {
+        keyword = keyword.substring(6).trim();
+        if (keyword.equals("")) { // no keyword counts letters
+          this.bonusFunc.add(LetterBonus::letterBonus);
+        } else {
+          String finalKeyword = keyword;
+          this.bonusFunc.add(ar -> LetterBonus.letterBonus(ar, finalKeyword));
+        }
+        continue;
+      }
+
+      if (keyword.equals("number")) {
+        this.bonusFunc.add(LetterBonus::numberBonus);
         continue;
       }
 
@@ -780,6 +798,13 @@ public class Evaluator {
       for (AdventureResult item : equipment) {
         if (this.bonuses.containsKey(item)) {
           score += this.bonuses.get(item);
+        }
+      }
+    }
+    if (!this.bonusFunc.isEmpty()) {
+      for (Function<AdventureResult, Double> func : this.bonusFunc) {
+        for (AdventureResult item : equipment) {
+          score += func.apply(item);
         }
       }
     }

--- a/src/net/sourceforge/kolmafia/maximizer/LetterBonus.java
+++ b/src/net/sourceforge/kolmafia/maximizer/LetterBonus.java
@@ -8,10 +8,13 @@ public class LetterBonus {
   static final Pattern NUMBER_PATTERN = Pattern.compile("[0-9]");
 
   static double letterBonus(AdventureResult item) {
+    if (item == null) return 0;
     return item.getName().length();
   }
 
   static double letterBonus(AdventureResult item, String letter) {
+    if (item == null) return 0;
+
     Pattern letterPattern = Pattern.compile(letter, Pattern.CASE_INSENSITIVE);
 
     int letters = 0;
@@ -24,6 +27,8 @@ public class LetterBonus {
   }
 
   static double numberBonus(AdventureResult item) {
+    if (item == null) return 0;
+
     int numbers = 0;
     Matcher matcher = NUMBER_PATTERN.matcher(item.getName());
     while (matcher.find()) {

--- a/src/net/sourceforge/kolmafia/maximizer/LetterBonus.java
+++ b/src/net/sourceforge/kolmafia/maximizer/LetterBonus.java
@@ -1,0 +1,35 @@
+package net.sourceforge.kolmafia.maximizer;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.sourceforge.kolmafia.AdventureResult;
+
+public class LetterBonus {
+  static final Pattern NUMBER_PATTERN = Pattern.compile("[0-9]");
+
+  static double letterBonus(AdventureResult item) {
+    return item.getName().length();
+  }
+
+  static double letterBonus(AdventureResult item, String letter) {
+    Pattern letterPattern = Pattern.compile(letter, Pattern.CASE_INSENSITIVE);
+
+    int letters = 0;
+    Matcher matcher = letterPattern.matcher(item.getName());
+    while (matcher.find()) {
+      letters++;
+    }
+
+    return letters;
+  }
+
+  static double numberBonus(AdventureResult item) {
+    int numbers = 0;
+    Matcher matcher = NUMBER_PATTERN.matcher(item.getName());
+    while (matcher.find()) {
+      numbers++;
+    }
+
+    return numbers;
+  }
+}

--- a/src/net/sourceforge/kolmafia/maximizer/LetterBonus.java
+++ b/src/net/sourceforge/kolmafia/maximizer/LetterBonus.java
@@ -1,6 +1,5 @@
 package net.sourceforge.kolmafia.maximizer;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.AdventureResult;
 
@@ -17,24 +16,12 @@ public class LetterBonus {
 
     Pattern letterPattern = Pattern.compile(letter, Pattern.CASE_INSENSITIVE);
 
-    int letters = 0;
-    Matcher matcher = letterPattern.matcher(item.getName());
-    while (matcher.find()) {
-      letters++;
-    }
-
-    return letters;
+    return letterPattern.matcher(item.getName()).results().count();
   }
 
   static double numberBonus(AdventureResult item) {
     if (item == null) return 0;
 
-    int numbers = 0;
-    Matcher matcher = NUMBER_PATTERN.matcher(item.getName());
-    while (matcher.find()) {
-      numbers++;
-    }
-
-    return numbers;
+    return NUMBER_PATTERN.matcher(item.getName()).results().count();
   }
 }

--- a/src/net/sourceforge/kolmafia/maximizer/LetterBonus.java
+++ b/src/net/sourceforge/kolmafia/maximizer/LetterBonus.java
@@ -7,12 +7,12 @@ public class LetterBonus {
   static final Pattern NUMBER_PATTERN = Pattern.compile("[0-9]");
 
   static double letterBonus(AdventureResult item) {
-    if (item == null) return 0;
+    if (item == null || item.getItemId() < 0) return 0;
     return item.getName().length();
   }
 
   static double letterBonus(AdventureResult item, String letter) {
-    if (item == null) return 0;
+    if (item == null || item.getItemId() < 0) return 0;
 
     Pattern letterPattern = Pattern.compile(letter, Pattern.CASE_INSENSITIVE);
 
@@ -20,7 +20,7 @@ public class LetterBonus {
   }
 
   static double numberBonus(AdventureResult item) {
-    if (item == null) return 0;
+    if (item == null || item.getItemId() < 0) return 0;
 
     return NUMBER_PATTERN.matcher(item.getName()).results().count();
   }

--- a/src/net/sourceforge/kolmafia/maximizer/LetterBonus.java
+++ b/src/net/sourceforge/kolmafia/maximizer/LetterBonus.java
@@ -4,6 +4,8 @@ import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.AdventureResult;
 
 public class LetterBonus {
+  private LetterBonus() {}
+
   static final Pattern NUMBER_PATTERN = Pattern.compile("[0-9]");
 
   static double letterBonus(AdventureResult item) {

--- a/test/net/sourceforge/kolmafia/maximizer/LetterBonusTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/LetterBonusTest.java
@@ -7,6 +7,13 @@ import org.junit.jupiter.api.Test;
 
 public class LetterBonusTest {
   @Test
+  public void dealsWithNulls() {
+    assertEquals(0, LetterBonus.letterBonus(null));
+    assertEquals(0, LetterBonus.letterBonus(null, "X"));
+    assertEquals(0, LetterBonus.numberBonus(null));
+  }
+
+  @Test
   public void letterBonusCountsLettersInItem() {
     AdventureResult item = AdventureResult.tallyItem("spiked femur");
     assertEquals(12, LetterBonus.letterBonus(item));

--- a/test/net/sourceforge/kolmafia/maximizer/LetterBonusTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/LetterBonusTest.java
@@ -1,0 +1,26 @@
+package net.sourceforge.kolmafia.maximizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import net.sourceforge.kolmafia.AdventureResult;
+import org.junit.jupiter.api.Test;
+
+public class LetterBonusTest {
+  @Test
+  public void letterBonusCountsLettersInItem() {
+    AdventureResult item = AdventureResult.tallyItem("spiked femur");
+    assertEquals(12, LetterBonus.letterBonus(item));
+  }
+
+  @Test
+  public void letterBonusCountsSpecificLettersInItem() {
+    AdventureResult item = AdventureResult.tallyItem("spiked femur");
+    assertEquals(2, LetterBonus.letterBonus(item, "e"));
+  }
+
+  @Test
+  public void numberBonusCountsNumbersInItem() {
+    AdventureResult item = AdventureResult.tallyItem("X-37 gun");
+    assertEquals(2, LetterBonus.numberBonus(item));
+  }
+}

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -439,12 +439,14 @@ public class MaximizerTest {
           new Cleanups(
               canUse("asparagus knife"),
               canUse("sweet ninja sword"),
-              canUse("Fourth of May Cosplay Saber"));
+              canUse("Fourth of May Cosplay Saber"),
+              canUse("old sweatpants"));
 
       try (cleanups) {
         maximize("letter n");
 
         recommendedSlotIs(EquipmentManager.WEAPON, "sweet ninja sword");
+        recommendedSlotIs(EquipmentManager.PANTS, "old sweatpants");
       }
     }
 

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -421,6 +421,46 @@ public class MaximizerTest {
   }
 
   @Nested
+  class Letter {
+    @Test
+    public void equipLongestItems() {
+      final var cleanups = new Cleanups(canUse("spiked femur"), canUse("sweet ninja sword"));
+
+      try (cleanups) {
+        maximize("letter");
+
+        recommendedSlotIs(EquipmentManager.WEAPON, "sweet ninja sword");
+      }
+    }
+
+    @Test
+    public void equipMostLetterItems() {
+      final var cleanups =
+          new Cleanups(
+              canUse("asparagus knife"),
+              canUse("sweet ninja sword"),
+              canUse("Fourth of May Cosplay Saber"));
+
+      try (cleanups) {
+        maximize("letter n");
+
+        recommendedSlotIs(EquipmentManager.WEAPON, "sweet ninja sword");
+      }
+    }
+
+    @Test
+    public void equipMostNumberItems() {
+      final var cleanups = new Cleanups(canUse("X-37 gun"), canUse("sweet ninja sword"));
+
+      try (cleanups) {
+        maximize("number");
+
+        recommendedSlotIs(EquipmentManager.WEAPON, "X-37 gun");
+      }
+    }
+  }
+
+  @Nested
   class WeaponModifiers {
     @Test
     public void clubModifierDoesntAffectOffhand() {


### PR DESCRIPTION
Various PvP minigames relate to properties of equipment like power and letters in the name. This PR starts off by adding a "letter" keyword that can count various letters in the name.

Unfortunately it doesn't work:
* it recommends all potions in inventory with the same score under circumstances I've not been able to figure out
* it doesn't recommend items not in inventory (I think it uses "modifiers" to determine the items checked, and "letter" is not)

Hopefully after I add more tests I'll be able to understand more about how Maximizer works so I can add features like this.