### PR TITLE
Split out part of updateCombatData that only applies in a final round

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -3140,10 +3140,30 @@ public class FightRequest extends GenericRequest {
     KoLAdventure.setNextAdventure(KoLAdventure.lastVisitedLocation);
 
     if (stillInBattle) {
-      // The fight is not over, none of the stuff below needs to be checked
+      // The fight is not over, we do not need to update the final round data
       MonsterStatusTracker.applyManuelStats();
       return;
     }
+
+    updateFinalRoundData(responseText, won);
+  }
+
+  // This performs checks that are only applied once combat is finished,
+  // and that aren't (yet) part of the processNormalResults loop.
+  // `responseText` will be a fragment of the page; anything that needs
+  // to check something outside of the round should use
+  // FightRequest.lastResponseText instead.
+  // Note that this is not run if the combat is finished by
+  // rollover-runaway, saber, or similar mechanic.
+  private static void updateFinalRoundData(final String responseText, final boolean won) {
+    MonsterData monster = MonsterStatusTracker.getLastMonster();
+    String monsterName = monster != null ? monster.getName() : "";
+    SpecialMonster special = FightRequest.specialMonsterCategory(monsterName);
+
+    KoLAdventure location = KoLAdventure.lastVisitedLocation();
+    String locationName = (location != null) ? location.getAdventureName() : null;
+
+    FamiliarData familiar = KoLCharacter.getEffectiveFamiliar();
 
     // Increment stinky cheese counter
     int stinkyCount = EquipmentManager.getStinkyCheeseLevel();
@@ -3410,7 +3430,7 @@ public class FightRequest extends GenericRequest {
 
     // Check for worn-out stickers
     int count = 0;
-    m = WORN_STICKER_PATTERN.matcher(responseText);
+    Matcher m = WORN_STICKER_PATTERN.matcher(responseText);
     while (m.find()) {
       ++count;
     }


### PR DESCRIPTION
Scrolling through this long function, it was always unclear whether you were writing code that is run every combat round or only in the final round because that splitting point was achieved by an early return - it was not implied to be conditional by indentation or something similar.

This should result in no difference of behaviour, but just split up a long function and make development easier (for example, my IDE tells me what the name of the function I'm currently editing is)