### PR TITLE
A couple of SVN messages

### DIFF
--- a/src/net/sourceforge/kolmafia/svn/SVNManager.java
+++ b/src/net/sourceforge/kolmafia/svn/SVNManager.java
@@ -1166,8 +1166,9 @@ public class SVNManager {
     try {
       SVN_LOCK.lock();
       if (!SVNWCUtil.isWorkingCopyRoot(f)) {
-        RequestLogger.printLine(f.getPath() +
-                " selected for repository operation but may not have corresponding remote");
+        RequestLogger.printLine(
+            f.getPath()
+                + " selected for repository operation but may not have corresponding remote");
         return false;
       }
 
@@ -1563,7 +1564,8 @@ public class SVNManager {
     while (it.hasNext()) {
       SVNURL url = it.next();
       if (validateRepo(url, false)) {
-        RequestLogger.printLine("Dependency at " + url + " failed validation.  Won't be processed.");
+        RequestLogger.printLine(
+            "Dependency at " + url + " failed validation.  Won't be processed.");
         it.remove();
       }
     }

--- a/src/net/sourceforge/kolmafia/svn/SVNManager.java
+++ b/src/net/sourceforge/kolmafia/svn/SVNManager.java
@@ -1166,6 +1166,8 @@ public class SVNManager {
     try {
       SVN_LOCK.lock();
       if (!SVNWCUtil.isWorkingCopyRoot(f)) {
+        RequestLogger.printLine(f.getPath() +
+                " selected for repository operation but may not have corresponding remote");
         return false;
       }
 

--- a/src/net/sourceforge/kolmafia/svn/SVNManager.java
+++ b/src/net/sourceforge/kolmafia/svn/SVNManager.java
@@ -1560,8 +1560,8 @@ public class SVNManager {
     Iterator<SVNURL> it = installMe.iterator();
     while (it.hasNext()) {
       SVNURL url = it.next();
-      if (validateRepo(url, true)) {
-        RequestLogger.printLine("bogus dependency: " + url);
+      if (validateRepo(url, false)) {
+        RequestLogger.printLine("Dependency at " + url + " failed validation.  Won't be processed.");
         it.remove();
       }
     }


### PR DESCRIPTION
"bogus dependency" stopped being useful when it started happening.

The other message might never be seen because SVN throws exceptions but logging something is better than silence.