### PR TITLE
Close substantial memory leak in EnumeratedWrapperPrototype.

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/javascript/EnumeratedWrapperPrototype.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/EnumeratedWrapperPrototype.java
@@ -16,9 +16,6 @@ import org.mozilla.javascript.ScriptableObject;
 public class EnumeratedWrapperPrototype extends ScriptableObject {
   private static final long serialVersionUID = 1L;
 
-  private static final Map<Scriptable, TreeMap<Type, EnumeratedWrapperPrototype>> registry =
-      new HashMap<>();
-
   private final Class<?> recordValueClass;
   private final Type type;
 
@@ -78,11 +75,6 @@ public class EnumeratedWrapperPrototype extends ScriptableObject {
     }
 
     sealObject();
-
-    if (!registry.containsKey(scope)) {
-      registry.put(scope, new TreeMap<>());
-    }
-    registry.get(scope).put(type, this);
   }
 
   public static EnumeratedWrapperPrototype getPrototypeInstance(Scriptable scope, Type type) {

--- a/src/net/sourceforge/kolmafia/textui/javascript/EnumeratedWrapperPrototype.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/EnumeratedWrapperPrototype.java
@@ -1,9 +1,6 @@
 package net.sourceforge.kolmafia.textui.javascript;
 
 import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeMap;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.textui.parsetree.Type;


### PR DESCRIPTION
We were caching EnumeratedWrapperPrototypes based on their scope and never cleaning them up, which in turn meant we held a reference to the entire scope of a defunct JS interpreter. This meant every JS script run held on to all the relevant information forever.

There is no actual reason for us to cache this information (we were never looking it up later). I think it was vestigial from earlier work on the JS interpreter. So the solution is just to remove the cache altogether.