### PR TITLE
increasing combat rate in friar zones

### DIFF
--- a/src/data/combats.txt
+++ b/src/data/combats.txt
@@ -277,9 +277,9 @@ The Cursed Village	100	cursed villager
 The Cursed Village Thieves' Guild	100	regular thief
 The Daily Dungeon	-1	apathetic lizardman	dairy ooze	dodecapede	giant giant moth	mayonnaise wasp	pencil golem	sabre-toothed lime	tonic water elemental	vampire clam
 The Dark and Spooky Swamp	-1	smell-o-the-wisp	swamp entity	swamp hag
-The Dark Elbow of the Woods	90	Demoninja	G imp	L imp
-The Dark Heart of the Woods	90	Fallen Archfiend	G imp	P imp
-The Dark Neck of the Woods	90	Hellion	P imp	W imp
+The Dark Elbow of the Woods	95	Demoninja	G imp	L imp
+The Dark Heart of the Woods	95	Fallen Archfiend	G imp	P imp
+The Dark Neck of the Woods	95	Hellion	P imp	W imp
 The Deep Dark Jungle	100	bigface	Mercenary of Fortune	smoke monster	Venus mantrap
 The Deep Machine Tunnels	-1	Performer of Actions	Thinker of Thoughts	Perceiver of Sensations
 The Defiled Alcove	85	corpulent zobmie	grave rober zmobie	modern zmobie: 0	conjoined zmombie: 0


### PR DESCRIPTION
I'm hoping to boost the combat rate in friar zones to match a change in the game.

According to the wiki:

> On January 1, 2020, {Olive My Love To You, Oh. | I, Martin | A Secret, But Not the Secret You're Looking For} was added, the combat rate was increased from 90% to 95%, and the superlikely adventures were changed to occur 5 turns after the previous one rather than spending a flat number of turns in the zone overall (thus improving consistency).