### PR TITLE
fix: rare NPE in getCount

### DIFF
--- a/src/net/sourceforge/kolmafia/AdventureResult.java
+++ b/src/net/sourceforge/kolmafia/AdventureResult.java
@@ -1077,7 +1077,10 @@ public class AdventureResult implements Comparable<AdventureResult>, Cloneable {
    */
   public int getCount(final List<AdventureResult> list) {
     int index = list.indexOf(this);
-    return index == -1 ? 0 : list.get(index).getCount();
+    if (index == -1) return 0;
+    AdventureResult item = list.get(index);
+    if (item == null) return 0;
+    return item.getCount();
   }
 
   public static AdventureResult findItem(final int itemId, final List<AdventureResult> list) {

--- a/test/net/sourceforge/kolmafia/AdventureResultTest.java
+++ b/test/net/sourceforge/kolmafia/AdventureResultTest.java
@@ -22,5 +22,4 @@ public class AdventureResultTest {
     var count = helm.getCount(List.of(AdventureResult.tallyItem("seal-skull helmet", 5, true)));
     assertThat(count, equalTo(5));
   }
-
 }

--- a/test/net/sourceforge/kolmafia/AdventureResultTest.java
+++ b/test/net/sourceforge/kolmafia/AdventureResultTest.java
@@ -1,0 +1,26 @@
+package net.sourceforge.kolmafia;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.List;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import org.junit.jupiter.api.Test;
+
+public class AdventureResultTest {
+
+  @Test
+  public void getCountReturnsZeroIfNotInList() {
+    var bean = AdventureResult.tallyItem("enchanted bean");
+    var count = bean.getCount(List.of());
+    assertThat(count, equalTo(0));
+  }
+
+  @Test
+  public void getCountReturnsNumberIfInList() {
+    var helm = ItemPool.get(ItemPool.SEAL_HELMET, 1);
+    var count = helm.getCount(List.of(AdventureResult.tallyItem("seal-skull helmet", 5, true)));
+    assertThat(count, equalTo(5));
+  }
+
+}


### PR DESCRIPTION
Don't know what causes this, probably a threading issue where `KoLConstants.inventory` is changing out from under `getCount`.