### PR TITLE
In Ronin, you can only pull one of an item

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/ItemManageFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/ItemManageFrame.java
@@ -476,6 +476,9 @@ public class ItemManageFrame extends GenericFrame {
     public void addMovers() {
       if (!this.isEquipmentOnly) {
         super.addMovers();
+        if (KoLCharacter.inRonin()) {
+          this.movers[3].setSelected(true);
+        }
       }
     }
 


### PR DESCRIPTION
When creating the Storage panel for the Item Manager, if you are in Ronin, set the "movers" radio button to "exactly one" rather than the default "multiple".