### PR TITLE
tests: speed up maximizer tests

### DIFF
--- a/test/internal/helpers/Cleanups.java
+++ b/test/internal/helpers/Cleanups.java
@@ -1,0 +1,35 @@
+package internal.helpers;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class Cleanups {
+  private final List<Runnable> cleanups = new ArrayList<>();
+
+  public Cleanups() {}
+
+  public Cleanups(Runnable r) {
+    cleanups.add(r);
+  }
+
+  public Cleanups(Collection<Runnable> r) {
+    this.addAll(r);
+  }
+
+  public void add(Runnable r) {
+    cleanups.add(r);
+  }
+
+  public void add(Cleanups c) {
+    this.addAll(c.cleanups);
+  }
+
+  public void addAll(Collection<Runnable> r) {
+    cleanups.addAll(r);
+  }
+
+  public void run() {
+    cleanups.forEach(Runnable::run);
+  }
+}

--- a/test/internal/helpers/Cleanups.java
+++ b/test/internal/helpers/Cleanups.java
@@ -1,10 +1,11 @@
 package internal.helpers;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-public class Cleanups {
+public class Cleanups implements Closeable {
   private final List<Runnable> cleanups = new ArrayList<>();
 
   public Cleanups() {}
@@ -31,5 +32,10 @@ public class Cleanups {
 
   public void run() {
     cleanups.forEach(Runnable::run);
+  }
+
+  @Override
+  public void close() {
+    run();
   }
 }

--- a/test/internal/helpers/Maximizer.java
+++ b/test/internal/helpers/Maximizer.java
@@ -1,0 +1,54 @@
+package internal.helpers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+import net.sourceforge.kolmafia.AdventureResult;
+import net.sourceforge.kolmafia.Modifiers;
+import net.sourceforge.kolmafia.maximizer.Boost;
+
+public class Maximizer {
+
+  public static boolean maximize(String maximizerString) {
+    return net.sourceforge.kolmafia.maximizer.Maximizer.maximize(maximizerString, 0, 0, true);
+  }
+
+  public static double modFor(String modifier) {
+    return Modifiers.getNumericModifier("Generated", "_spec", modifier);
+  }
+
+  public static Optional<AdventureResult> getSlot(int slot) {
+    var boost =
+        net.sourceforge.kolmafia.maximizer.Maximizer.boosts.stream()
+            .filter(Boost::isEquipment)
+            .filter(b -> b.getSlot() == slot)
+            .findAny();
+    return boost.map(Boost::getItem);
+  }
+
+  public static void recommendedSlotIs(int slot, String item) {
+    Optional<AdventureResult> equipment = getSlot(slot);
+    assertTrue(equipment.isPresent(), "Expected " + item + " to be recommended, but it was not");
+    assertEquals(AdventureResult.parseResult(item), equipment.get());
+  }
+
+  public static void recommendedSlotIsEmpty(int slot) {
+    Optional<AdventureResult> equipment = getSlot(slot);
+    assertTrue(equipment.isEmpty(), "Expected empty slot " + slot + ", but it was not");
+  }
+
+  public static void recommends(String item) {
+    Optional<Boost> found =
+        net.sourceforge.kolmafia.maximizer.Maximizer.boosts.stream()
+            .filter(Boost::isEquipment)
+            .filter(b -> item.equals(b.getItem().getName()))
+            .findAny();
+    assertTrue(found.isPresent(), "Expected " + item + " to be recommended, but it was not");
+  }
+
+  public static boolean someBoostIs(Predicate<Boost> predicate) {
+    return net.sourceforge.kolmafia.maximizer.Maximizer.boosts.stream().anyMatch(predicate);
+  }
+}

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
@@ -1,0 +1,128 @@
+package net.sourceforge.kolmafia.maximizer;
+
+import static internal.helpers.Maximizer.*;
+import static internal.helpers.Player.canUse;
+import static internal.helpers.Player.equip;
+import static internal.helpers.Player.setStats;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.sourceforge.kolmafia.FamiliarData;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.objectpool.FamiliarPool;
+import net.sourceforge.kolmafia.session.EquipmentManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MaximizerRegressionTest {
+  @BeforeEach
+  public void init() {
+    KoLCharacter.reset(true);
+  }
+
+  // https://kolmafia.us/threads/maximizer-reduces-score-with-combat-chance-at-soft-limit-failing-test-included.25672/
+  @Test
+  public void maximizeShouldNotRemoveEquipmentThatCanNoLongerBeEquipped() {
+    // slippers have a Moxie requirement of 125
+    equip(EquipmentManager.ACCESSORY1, "Fuzzy Slippers of Hatred");
+    // get our Moxie below 125 (e.g. basic hot dogs, stat limiting effects)
+    setStats(0, 0, 0);
+    assertFalse(
+        EquipmentManager.canEquip("Fuzzy Slippers of Hatred"),
+        "Can still equip Fuzzy Slippers of Hatred");
+    assertTrue(
+        maximize("-combat -hat -weapon -offhand -back -shirt -pants -familiar -acc1 -acc2 -acc3"));
+    assertEquals(5, -modFor("Combat Rate"), 0.01, "Base score is 5");
+    assertTrue(maximize("-combat"));
+    assertEquals(5, -modFor("Combat Rate"), 0.01, "Maximizing should not reduce score");
+  }
+
+  // https://kolmafia.us/threads/maximizer-reduces-score-with-combat-chance-at-soft-limit-failing-test-included.25672/
+  @Test
+  public void freshCharacterShouldNotRecommendEverythingWithCurrentScore() {
+    KoLCharacter.setSign("Platypus");
+    assertTrue(maximize("familiar weight"));
+    assertEquals(5, modFor("Familiar Weight"), 0.01, "Base score is 5");
+    // monorail buff should always be available, but should not improve familiar weight.
+    // so are friars, but I don't know why and that might be a bug
+    assertEquals(1, Maximizer.boosts.size());
+    Boost ar = Maximizer.boosts.get(0);
+    assertEquals("", ar.getCmd());
+  }
+
+  // Sample test for https://kolmafia.us/showthread.php?23648&p=151903#post151903.
+  @Test
+  public void noTieCanLeaveSlotsEmpty() {
+    canUse("helmet turtle");
+    assertTrue(maximize("mys -tie"));
+    assertEquals(0, modFor("Buffed Muscle"), 0.01);
+  }
+
+  // Tests for https://kolmafia.us/threads/26413
+  @Test
+  public void keepBjornInhabitantEvenWhenUseless() {
+    canUse("Buddy Bjorn");
+    KoLCharacter.setBjorned(new FamiliarData(FamiliarPool.HAPPY_MEDIUM));
+
+    assertTrue(maximize("+25 bonus buddy bjorn -tie"));
+
+    // Actually equipped the buddy bjorn with its current inhabitant.
+    assertEquals(25, modFor("Meat Drop"), 0.01);
+  }
+
+  // Tests for https://kolmafia.us/threads/26413
+  @Test
+  public void actuallyEquipsBonusBjorn() {
+    canUse("Buddy Bjorn");
+    KoLCharacter.setBjorned(new FamiliarData(FamiliarPool.HAPPY_MEDIUM));
+    // +10 to all attributes. Should not be equipped.
+    KoLCharacter.addFamiliar(new FamiliarData(FamiliarPool.DICE));
+
+    // +7 Muscle
+    equip(EquipmentManager.CONTAINER, "barskin cloak");
+
+    assertTrue(maximize("mus -buddy-bjorn +25 bonus buddy bjorn -tie"));
+    // Unequipped the barskin cloak
+    assertEquals(0, modFor("Buffed Muscle"), 0.01);
+    // Actually equipped the buddy bjorn
+    assertEquals(25, modFor("Meat Drop"), 0.01);
+  }
+
+  @Test
+  public void keepsBonusBjornUnchanged() {
+    canUse("Buddy Bjorn");
+    canUse("Crown of Thrones");
+    KoLCharacter.setBjorned(new FamiliarData(FamiliarPool.HAPPY_MEDIUM));
+    // +10 to all attributes. Worse than current hat.
+    KoLCharacter.addFamiliar(new FamiliarData(FamiliarPool.DICE));
+
+    // +7 Muscle
+    equip(EquipmentManager.CONTAINER, "barskin cloak");
+    // +25 Muscle
+    equip(EquipmentManager.HAT, "wreath of laurels");
+
+    assertTrue(maximize("mus -buddy-bjorn +25 bonus buddy bjorn -tie"));
+    // Unequipped the barskin cloak, still have wreath of laurels equipped.
+    assertEquals(25, modFor("Buffed Muscle"), 0.01);
+    // Actually equipped the buddy bjorn
+    assertEquals(25, modFor("Meat Drop"), 0.01);
+  }
+
+  // https://kolmafia.us/threads/27073/
+  @Test
+  public void noTiePrefersCurrentGear() {
+    // Drops items, but otherwise irrelevant.
+    canUse("Camp Scout backpack");
+    // +1 mys, +2 mox; 7 mox required; Maximizer needs to recommend changes in order to create a
+    // speculation.
+    canUse("basic meat fez");
+    // +7 mus; 75 mys required
+    equip(EquipmentManager.CONTAINER, "barskin cloak");
+    assertTrue(maximize("mys -tie"));
+    recommendedSlotIs(EquipmentManager.HAT, "basic meat fez");
+    // No back change recommended.
+    assertFalse(getSlot(EquipmentManager.CONTAINER).isPresent());
+    assertEquals(7, modFor("Buffed Muscle"), 0.01);
+  }
+}

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -1,40 +1,47 @@
 package net.sourceforge.kolmafia.maximizer;
 
+import static internal.helpers.Maximizer.*;
 import static internal.helpers.Player.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Optional;
-import java.util.function.Predicate;
-import net.sourceforge.kolmafia.AdventureResult;
+import internal.helpers.Cleanups;
+import java.util.ArrayList;
+import java.util.List;
 import net.sourceforge.kolmafia.AscensionPath.Path;
-import net.sourceforge.kolmafia.FamiliarData;
-import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.session.EquipmentManager;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class MaximizerTest {
+  private List<Cleanups> cleanups;
+
   @BeforeEach
   public void init() {
-    KoLCharacter.reset(true);
+    cleanups = new ArrayList<>();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    cleanups.forEach(Cleanups::run);
   }
 
   // basic
 
   @Test
   public void changesGear() {
-    canUse("helmet turtle");
+    cleanups.add(canUse("helmet turtle"));
     assertTrue(maximize("mus"));
     assertEquals(1, modFor("Buffed Muscle"), 0.01);
   }
 
   @Test
   public void equipsItemsOnlyIfHasStats() {
-    canUse("helmet turtle");
-    addItem("wreath of laurels");
+    cleanups.add(canUse("helmet turtle"));
+    cleanups.add(addItem("wreath of laurels"));
     assertTrue(maximize("mus"));
     assertEquals(1, modFor("Buffed Muscle"), 0.01);
     recommendedSlotIs(EquipmentManager.HAT, "helmet turtle");
@@ -42,7 +49,7 @@ public class MaximizerTest {
 
   @Test
   public void nothingBetterThanSomething() {
-    canUse("helmet turtle");
+    cleanups.add(canUse("helmet turtle"));
     assertTrue(maximize("-mus"));
     assertEquals(0, modFor("Buffed Muscle"), 0.01);
   }
@@ -51,9 +58,9 @@ public class MaximizerTest {
 
   @Test
   public void maxKeywordStopsCountingBeyondTarget() {
-    canUse("hardened slime hat");
-    canUse("bounty-hunting helmet");
-    addSkill("Refusal to Freeze");
+    cleanups.add(canUse("hardened slime hat"));
+    cleanups.add(canUse("bounty-hunting helmet"));
+    cleanups.add(addSkill("Refusal to Freeze"));
     assertTrue(maximize("cold res 3 max, 0.1 item drop"));
 
     assertEquals(3, modFor("Cold Resistance"), 0.01);
@@ -64,9 +71,9 @@ public class MaximizerTest {
 
   @Test
   public void startingMaxKeywordTerminatesEarlyIfConditionMet() {
-    canUse("hardened slime hat");
-    canUse("bounty-hunting helmet");
-    addSkill("Refusal to Freeze");
+    cleanups.add(canUse("hardened slime hat"));
+    cleanups.add(canUse("bounty-hunting helmet"));
+    cleanups.add(addSkill("Refusal to Freeze"));
     maximize("3 max, cold res");
 
     assertTrue(
@@ -79,7 +86,7 @@ public class MaximizerTest {
 
   @Test
   public void minKeywordFailsMaximizationIfNotHit() {
-    canUse("helmet turtle");
+    cleanups.add(canUse("helmet turtle"));
     assertFalse(maximize("mus 2 min"));
     // still provides equipment
     recommendedSlotIs(EquipmentManager.HAT, "helmet turtle");
@@ -87,13 +94,13 @@ public class MaximizerTest {
 
   @Test
   public void minKeywordPassesMaximizationIfHit() {
-    canUse("wreath of laurels");
+    cleanups.add(canUse("wreath of laurels"));
     assertTrue(maximize("mus 2 min"));
   }
 
   @Test
   public void startingMinKeywordFailsMaximizationIfNotHit() {
-    canUse("helmet turtle");
+    cleanups.add(canUse("helmet turtle"));
     assertFalse(maximize("2 min, mus"));
     // still provides equipment
     recommendedSlotIs(EquipmentManager.HAT, "helmet turtle");
@@ -101,7 +108,7 @@ public class MaximizerTest {
 
   @Test
   public void startingMinKeywordPassesMaximizationIfHit() {
-    canUse("wreath of laurels");
+    cleanups.add(canUse("wreath of laurels"));
     assertTrue(maximize("2 min, mus"));
   }
 
@@ -109,7 +116,7 @@ public class MaximizerTest {
 
   @Test
   public void clownosityTriesClownEquipment() {
-    canUse("clown wig");
+    cleanups.add(canUse("clown wig"));
     assertFalse(maximize("clownosity -tie"));
     // still provides equipment
     recommendedSlotIs(EquipmentManager.HAT, "clown wig");
@@ -118,8 +125,8 @@ public class MaximizerTest {
 
   @Test
   public void clownositySucceedsWithEnoughEquipment() {
-    canUse("clown wig");
-    canUse("polka-dot bow tie");
+    cleanups.add(canUse("clown wig"));
+    cleanups.add(canUse("polka-dot bow tie"));
     assertTrue(maximize("clownosity -tie"));
     recommendedSlotIs(EquipmentManager.HAT, "clown wig");
     recommendedSlotIs(EquipmentManager.ACCESSORY1, "polka-dot bow tie");
@@ -130,9 +137,9 @@ public class MaximizerTest {
 
   @Test
   public void raveosityTriesRaveEquipment() {
-    canUse("rave visor");
-    canUse("baggy rave pants");
-    canUse("rave whistle");
+    cleanups.add(canUse("rave visor"));
+    cleanups.add(canUse("baggy rave pants"));
+    cleanups.add(canUse("rave whistle"));
     assertFalse(maximize("raveosity -tie"));
     // still provides equipment
     recommendedSlotIs(EquipmentManager.HAT, "rave visor");
@@ -143,11 +150,11 @@ public class MaximizerTest {
 
   @Test
   public void raveositySucceedsWithEnoughEquipment() {
-    canUse("blue glowstick");
-    canUse("glowstick on a string");
-    canUse("teddybear backpack");
-    canUse("rave visor");
-    canUse("baggy rave pants");
+    cleanups.add(canUse("blue glowstick"));
+    cleanups.add(canUse("glowstick on a string"));
+    cleanups.add(canUse("teddybear backpack"));
+    cleanups.add(canUse("rave visor"));
+    cleanups.add(canUse("baggy rave pants"));
     assertTrue(maximize("raveosity -tie"));
     recommendedSlotIs(EquipmentManager.HAT, "rave visor");
     recommendedSlotIs(EquipmentManager.PANTS, "baggy rave pants");
@@ -160,12 +167,12 @@ public class MaximizerTest {
 
   @Test
   public void surgeonosityTriesSurgeonEquipment() {
-    canUse("head mirror");
-    canUse("bloodied surgical dungarees");
-    canUse("surgical apron");
-    canUse("surgical mask");
-    canUse("half-size scalpel");
-    addSkill("Torso Awareness");
+    cleanups.add(canUse("head mirror"));
+    cleanups.add(canUse("bloodied surgical dungarees"));
+    cleanups.add(canUse("surgical apron"));
+    cleanups.add(canUse("surgical mask"));
+    cleanups.add(canUse("half-size scalpel"));
+    cleanups.add(addSkill("Torso Awareness"));
     assertTrue(maximize("surgeonosity -tie"));
     recommendedSlotIs(EquipmentManager.PANTS, "bloodied surgical dungarees");
     recommends("head mirror");
@@ -179,23 +186,23 @@ public class MaximizerTest {
 
   @Test
   public void itemsCanHaveAtMostTwoBeesByDefault() {
-    inPath(Path.BEES_HATE_YOU);
-    canUse("bubblewrap bottlecap turtleban");
+    cleanups.add(inPath(Path.BEES_HATE_YOU));
+    cleanups.add(canUse("bubblewrap bottlecap turtleban"));
     maximize("mys");
     recommendedSlotIsEmpty(EquipmentManager.HAT);
   }
 
   @Test
   public void itemsCanHaveAtMostBeeosityBees() {
-    inPath(Path.BEES_HATE_YOU);
-    canUse("bubblewrap bottlecap turtleban");
+    cleanups.add(inPath(Path.BEES_HATE_YOU));
+    cleanups.add(canUse("bubblewrap bottlecap turtleban"));
     maximize("mys, 5beeosity");
     recommendedSlotIs(EquipmentManager.HAT, "bubblewrap bottlecap turtleban");
   }
 
   @Test
   public void beeosityDoesntApplyOutsideBeePath() {
-    canUse("bubblewrap bottlecap turtleban");
+    cleanups.add(canUse("bubblewrap bottlecap turtleban"));
     maximize("mys");
     recommendedSlotIs(EquipmentManager.HAT, "bubblewrap bottlecap turtleban");
   }
@@ -203,9 +210,9 @@ public class MaximizerTest {
   // proof for the next test
   @Test
   public void canCrownFamiliarsWithBeesOutsideBeecore() {
-    canUse("Crown of Thrones");
-    hasFamiliar(FamiliarPool.LOBSTER); // 15% spell damage
-    hasFamiliar(FamiliarPool.GALLOPING_GRILL); // 10% spell damage
+    cleanups.add(canUse("Crown of Thrones"));
+    cleanups.add(hasFamiliar(FamiliarPool.LOBSTER)); // 15% spell damage
+    cleanups.add(hasFamiliar(FamiliarPool.GALLOPING_GRILL)); // 10% spell damage
 
     maximize("spell dmg");
 
@@ -215,10 +222,10 @@ public class MaximizerTest {
 
   @Test
   public void cannotCrownFamiliarsWithBeesInBeecore() {
-    inPath(Path.BEES_HATE_YOU);
-    canUse("Crown of Thrones");
-    hasFamiliar(FamiliarPool.LOBSTER); // 15% spell damage
-    hasFamiliar(FamiliarPool.GALLOPING_GRILL); // 10% spell damage
+    cleanups.add(inPath(Path.BEES_HATE_YOU));
+    cleanups.add(canUse("Crown of Thrones"));
+    cleanups.add(hasFamiliar(FamiliarPool.LOBSTER)); // 15% spell damage
+    cleanups.add(hasFamiliar(FamiliarPool.GALLOPING_GRILL)); // 10% spell damage
 
     maximize("spell dmg");
 
@@ -229,7 +236,7 @@ public class MaximizerTest {
   // proof for the next test
   @Test
   public void canUsePotionsWithBeesOutsideBeecore() {
-    addItem("baggie of powdered sugar");
+    cleanups.add(addItem("baggie of powdered sugar"));
 
     maximize("meat drop");
 
@@ -238,8 +245,8 @@ public class MaximizerTest {
 
   @Test
   public void cannotUsePotionsWithBeesInBeecore() {
-    inPath(Path.BEES_HATE_YOU);
-    addItem("baggie of powdered sugar");
+    cleanups.add(inPath(Path.BEES_HATE_YOU));
+    cleanups.add(addItem("baggie of powdered sugar"));
 
     maximize("meat drop");
 
@@ -250,7 +257,7 @@ public class MaximizerTest {
 
   @Test
   public void plumberCommandsErrorOutsidePlumber() {
-    inPath(Path.AVATAR_OF_BORIS);
+    cleanups.add(inPath(Path.AVATAR_OF_BORIS));
 
     assertFalse(maximize("plumber"));
     assertFalse(maximize("cold plumber"));
@@ -258,9 +265,9 @@ public class MaximizerTest {
 
   @Test
   public void plumberCommandForcesSomePlumberItem() {
-    inPath(Path.PATH_OF_THE_PLUMBER);
-    canUse("work boots");
-    canUse("shiny ring", 3);
+    cleanups.add(inPath(Path.PATH_OF_THE_PLUMBER));
+    cleanups.add(canUse("work boots"));
+    cleanups.add(canUse("shiny ring", 3));
 
     assertTrue(maximize("plumber, mox"));
     recommends("work boots");
@@ -268,11 +275,11 @@ public class MaximizerTest {
 
   @Test
   public void coldPlumberCommandForcesFlowerAndFrostyButton() {
-    inPath(Path.PATH_OF_THE_PLUMBER);
-    canUse("work boots");
-    canUse("bonfire flower");
-    canUse("frosty button");
-    canUse("shiny ring", 3);
+    cleanups.add(inPath(Path.PATH_OF_THE_PLUMBER));
+    cleanups.add(canUse("work boots"));
+    cleanups.add(canUse("bonfire flower"));
+    cleanups.add(canUse("frosty button"));
+    cleanups.add(canUse("shiny ring", 3));
 
     assertTrue(maximize("cold plumber, mox"));
     recommends("bonfire flower");
@@ -283,10 +290,10 @@ public class MaximizerTest {
 
   @Test
   public void clubModifierDoesntAffectOffhand() {
-    addSkill("Double-Fisted Skull Smashing");
-    canUse("flaming crutch", 2);
-    canUse("white sword", 2);
-    canUse("dense meat sword");
+    cleanups.add(addSkill("Double-Fisted Skull Smashing"));
+    cleanups.add(canUse("flaming crutch", 2));
+    cleanups.add(canUse("white sword", 2));
+    cleanups.add(canUse("dense meat sword"));
     assertTrue(EquipmentManager.canEquip("white sword"), "Can equip white sword");
     assertTrue(EquipmentManager.canEquip("flaming crutch"), "Can equip flaming crutch");
     assertTrue(maximize("mus, club"));
@@ -299,8 +306,8 @@ public class MaximizerTest {
 
   @Test
   public void swordModifierFavorsSword() {
-    canUse("sweet ninja sword");
-    canUse("spiked femur");
+    cleanups.add(canUse("sweet ninja sword"));
+    cleanups.add(canUse("spiked femur"));
     assertTrue(maximize("spooky dmg, sword"));
     recommendedSlotIs(EquipmentManager.WEAPON, "sweet ninja sword");
   }
@@ -309,11 +316,11 @@ public class MaximizerTest {
 
   @Test
   public void maximizeGiveBestScoreWithEffectsAtNoncombatLimit() {
-    canUse("Space Trip safety headphones");
-    canUse("Krampus horn");
+    cleanups.add(canUse("Space Trip safety headphones"));
+    cleanups.add(canUse("Krampus horn"));
     // get ourselves to -25 combat
-    addEffect("Shelter of Shed");
-    addEffect("Smooth Movements");
+    cleanups.add(addEffect("Shelter of Shed"));
+    cleanups.add(addEffect("Smooth Movements"));
     assertTrue(
         EquipmentManager.canEquip("Space Trip safety headphones"),
         "Cannot equip Space Trip safety headphones");
@@ -334,8 +341,8 @@ public class MaximizerTest {
 
   @Test
   public void aboveWaterZonesDoNotCheckUnderwaterNegativeCombat() {
-    inLocation("Noob Cave");
-    canUse("Mer-kin sneakmask");
+    cleanups.add(inLocation("Noob Cave"));
+    cleanups.add(canUse("Mer-kin sneakmask"));
     assertTrue(maximize("-combat -tie"));
     assertEquals(0, modFor("Combat Rate"), 0.01);
 
@@ -344,8 +351,8 @@ public class MaximizerTest {
 
   @Test
   public void underwaterZonesCheckUnderwaterNegativeCombat() {
-    inLocation("The Ice Hole");
-    canUse("Mer-kin sneakmask");
+    cleanups.add(inLocation("The Ice Hole"));
+    cleanups.add(canUse("Mer-kin sneakmask"));
     assertEquals(AdventureDatabase.getEnvironment(Modifiers.currentLocation), "underwater");
     assertTrue(maximize("-combat -tie"));
 
@@ -356,8 +363,8 @@ public class MaximizerTest {
 
   @Test
   public void considersOutfitsIfHelpful() {
-    canUse("eldritch hat");
-    canUse("eldritch pants");
+    cleanups.add(canUse("eldritch hat"));
+    cleanups.add(canUse("eldritch pants"));
     assertTrue(maximize("item -tie"));
 
     assertEquals(50, modFor("Item Drop"), 0.01);
@@ -367,9 +374,9 @@ public class MaximizerTest {
 
   @Test
   public void avoidsOutfitsIfOtherItemsBetter() {
-    canUse("eldritch hat");
-    canUse("eldritch pants");
-    canUse("Team Avarice cap");
+    cleanups.add(canUse("eldritch hat"));
+    cleanups.add(canUse("eldritch pants"));
+    cleanups.add(canUse("Team Avarice cap"));
     assertTrue(maximize("item -tie"));
 
     assertEquals(100, modFor("Item Drop"), 0.01);
@@ -378,11 +385,11 @@ public class MaximizerTest {
 
   @Test
   public void forcingOutfitRequiresThatOutfit() {
-    canUse("bounty-hunting helmet");
-    canUse("bounty-hunting rifle");
-    canUse("bounty-hunting pants");
-    canUse("eldritch hat");
-    canUse("eldritch pants");
+    cleanups.add(canUse("bounty-hunting helmet"));
+    cleanups.add(canUse("bounty-hunting rifle"));
+    cleanups.add(canUse("bounty-hunting pants"));
+    cleanups.add(canUse("eldritch hat"));
+    cleanups.add(canUse("eldritch pants"));
     assertTrue(maximize("item -tie"));
 
     assertEquals(70, modFor("Item Drop"), 0.01);
@@ -405,162 +412,12 @@ public class MaximizerTest {
 
   @Test
   public void considersOutfitPartsIfHelpful() {
-    canUse("Brimstone Beret");
-    canUse("Brimstone Boxers");
+    cleanups.add(canUse("Brimstone Beret"));
+    cleanups.add(canUse("Brimstone Boxers"));
     assertTrue(maximize("ml -tie"));
 
     assertEquals(4, modFor("Monster Level"), 0.01);
     recommendedSlotIs(EquipmentManager.HAT, "Brimstone Beret");
     recommendedSlotIs(EquipmentManager.PANTS, "Brimstone Boxers");
-  }
-
-  // regression
-
-  // https://kolmafia.us/threads/maximizer-reduces-score-with-combat-chance-at-soft-limit-failing-test-included.25672/
-  @Test
-  public void maximizeShouldNotRemoveEquipmentThatCanNoLongerBeEquipped() {
-    // slippers have a Moxie requirement of 125
-    equip(EquipmentManager.ACCESSORY1, "Fuzzy Slippers of Hatred");
-    // get our Moxie below 125 (e.g. basic hot dogs, stat limiting effects)
-    setStats(0, 0, 0);
-    assertFalse(
-        EquipmentManager.canEquip("Fuzzy Slippers of Hatred"),
-        "Can still equip Fuzzy Slippers of Hatred");
-    assertTrue(
-        maximize("-combat -hat -weapon -offhand -back -shirt -pants -familiar -acc1 -acc2 -acc3"));
-    assertEquals(5, -modFor("Combat Rate"), 0.01, "Base score is 5");
-    assertTrue(maximize("-combat"));
-    assertEquals(5, -modFor("Combat Rate"), 0.01, "Maximizing should not reduce score");
-  }
-
-  // https://kolmafia.us/threads/maximizer-reduces-score-with-combat-chance-at-soft-limit-failing-test-included.25672/
-  @Test
-  public void freshCharacterShouldNotRecommendEverythingWithCurrentScore() {
-    KoLCharacter.setSign("Platypus");
-    assertTrue(maximize("familiar weight"));
-    assertEquals(5, modFor("Familiar Weight"), 0.01, "Base score is 5");
-    // monorail buff should always be available, but should not improve familiar weight.
-    // so are friars, but I don't know why and that might be a bug
-    assertEquals(1, Maximizer.boosts.size());
-    Boost ar = Maximizer.boosts.get(0);
-    assertEquals("", ar.getCmd());
-  }
-
-  // Sample test for https://kolmafia.us/showthread.php?23648&p=151903#post151903.
-  @Test
-  public void noTieCanLeaveSlotsEmpty() {
-    canUse("helmet turtle");
-    assertTrue(maximize("mys -tie"));
-    assertEquals(0, modFor("Buffed Muscle"), 0.01);
-  }
-
-  // Tests for https://kolmafia.us/threads/26413
-  @Test
-  public void keepBjornInhabitantEvenWhenUseless() {
-    canUse("Buddy Bjorn");
-    KoLCharacter.setBjorned(new FamiliarData(FamiliarPool.HAPPY_MEDIUM));
-
-    assertTrue(maximize("+25 bonus buddy bjorn -tie"));
-
-    // Actually equipped the buddy bjorn with its current inhabitant.
-    assertEquals(25, modFor("Meat Drop"), 0.01);
-  }
-
-  // Tests for https://kolmafia.us/threads/26413
-  @Test
-  public void actuallyEquipsBonusBjorn() {
-    canUse("Buddy Bjorn");
-    KoLCharacter.setBjorned(new FamiliarData(FamiliarPool.HAPPY_MEDIUM));
-    // +10 to all attributes. Should not be equipped.
-    KoLCharacter.addFamiliar(new FamiliarData(FamiliarPool.DICE));
-
-    // +7 Muscle
-    equip(EquipmentManager.CONTAINER, "barskin cloak");
-
-    assertTrue(maximize("mus -buddy-bjorn +25 bonus buddy bjorn -tie"));
-    // Unequipped the barskin cloak
-    assertEquals(0, modFor("Buffed Muscle"), 0.01);
-    // Actually equipped the buddy bjorn
-    assertEquals(25, modFor("Meat Drop"), 0.01);
-  }
-
-  @Test
-  public void keepsBonusBjornUnchanged() {
-    canUse("Buddy Bjorn");
-    canUse("Crown of Thrones");
-    KoLCharacter.setBjorned(new FamiliarData(FamiliarPool.HAPPY_MEDIUM));
-    // +10 to all attributes. Worse than current hat.
-    KoLCharacter.addFamiliar(new FamiliarData(FamiliarPool.DICE));
-
-    // +7 Muscle
-    equip(EquipmentManager.CONTAINER, "barskin cloak");
-    // +25 Muscle
-    equip(EquipmentManager.HAT, "wreath of laurels");
-
-    assertTrue(maximize("mus -buddy-bjorn +25 bonus buddy bjorn -tie"));
-    // Unequipped the barskin cloak, still have wreath of laurels equipped.
-    assertEquals(25, modFor("Buffed Muscle"), 0.01);
-    // Actually equipped the buddy bjorn
-    assertEquals(25, modFor("Meat Drop"), 0.01);
-  }
-
-  // https://kolmafia.us/threads/27073/
-  @Test
-  public void noTiePrefersCurrentGear() {
-    // Drops items, but otherwise irrelevant.
-    canUse("Camp Scout backpack");
-    // +1 mys, +2 mox; 7 mox required; Maximizer needs to recommend changes in order to create a
-    // speculation.
-    canUse("basic meat fez");
-    // +7 mus; 75 mys required
-    equip(EquipmentManager.CONTAINER, "barskin cloak");
-    assertTrue(maximize("mys -tie"));
-    recommendedSlotIs(EquipmentManager.HAT, "basic meat fez");
-    // No back change recommended.
-    assertFalse(getSlot(EquipmentManager.CONTAINER).isPresent());
-    assertEquals(7, modFor("Buffed Muscle"), 0.01);
-  }
-
-  // helper methods
-
-  private boolean maximize(String maximizerString) {
-    return Maximizer.maximize(maximizerString, 0, 0, true);
-  }
-
-  private double modFor(String modifier) {
-    return Modifiers.getNumericModifier("Generated", "_spec", modifier);
-  }
-
-  private Optional<AdventureResult> getSlot(int slot) {
-    var boost =
-        Maximizer.boosts.stream()
-            .filter(Boost::isEquipment)
-            .filter(b -> b.getSlot() == slot)
-            .findAny();
-    return boost.map(Boost::getItem);
-  }
-
-  private void recommendedSlotIs(int slot, String item) {
-    Optional<AdventureResult> equipment = getSlot(slot);
-    assertTrue(equipment.isPresent(), "Expected " + item + " to be recommended, but it was not");
-    assertEquals(AdventureResult.parseResult(item), equipment.get());
-  }
-
-  private void recommendedSlotIsEmpty(int slot) {
-    Optional<AdventureResult> equipment = getSlot(slot);
-    assertTrue(equipment.isEmpty(), "Expected empty slot " + slot + ", but it was not");
-  }
-
-  private void recommends(String item) {
-    Optional<Boost> found =
-        Maximizer.boosts.stream()
-            .filter(Boost::isEquipment)
-            .filter(b -> item.equals(b.getItem().getName()))
-            .findAny();
-    assertTrue(found.isPresent(), "Expected " + item + " to be recommended, but it was not");
-  }
-
-  private boolean someBoostIs(Predicate<Boost> predicate) {
-    return Maximizer.boosts.stream().anyMatch(predicate);
   }
 }

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -4,420 +4,519 @@ import static internal.helpers.Maximizer.*;
 import static internal.helpers.Player.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import internal.helpers.Cleanups;
-import java.util.ArrayList;
-import java.util.List;
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.session.EquipmentManager;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class MaximizerTest {
-  private List<Cleanups> cleanups;
-
-  @BeforeEach
-  public void init() {
-    cleanups = new ArrayList<>();
-  }
-
-  @AfterEach
-  public void tearDown() {
-    cleanups.forEach(Cleanups::run);
-  }
-
   // basic
 
   @Test
   public void changesGear() {
-    cleanups.add(canUse("helmet turtle"));
-    assertTrue(maximize("mus"));
-    assertEquals(1, modFor("Buffed Muscle"), 0.01);
+    final var c1 = canUse("helmet turtle");
+    try (c1) {
+      assertTrue(maximize("mus"));
+      assertEquals(1, modFor("Buffed Muscle"), 0.01);
+    }
   }
 
   @Test
   public void equipsItemsOnlyIfHasStats() {
-    cleanups.add(canUse("helmet turtle"));
-    cleanups.add(addItem("wreath of laurels"));
-    assertTrue(maximize("mus"));
-    assertEquals(1, modFor("Buffed Muscle"), 0.01);
-    recommendedSlotIs(EquipmentManager.HAT, "helmet turtle");
+    final var c1 = canUse("helmet turtle");
+    final var c2 = addItem("wreath of laurels");
+    try (c1;
+        c2) {
+      assertTrue(maximize("mus"));
+      assertEquals(1, modFor("Buffed Muscle"), 0.01);
+      recommendedSlotIs(EquipmentManager.HAT, "helmet turtle");
+    }
   }
 
   @Test
   public void nothingBetterThanSomething() {
-    cleanups.add(canUse("helmet turtle"));
-    assertTrue(maximize("-mus"));
-    assertEquals(0, modFor("Buffed Muscle"), 0.01);
+    final var c1 = canUse("helmet turtle");
+    try (c1) {
+      assertTrue(maximize("-mus"));
+      assertEquals(0, modFor("Buffed Muscle"), 0.01);
+    }
   }
 
   // max
 
   @Test
   public void maxKeywordStopsCountingBeyondTarget() {
-    cleanups.add(canUse("hardened slime hat"));
-    cleanups.add(canUse("bounty-hunting helmet"));
-    cleanups.add(addSkill("Refusal to Freeze"));
-    assertTrue(maximize("cold res 3 max, 0.1 item drop"));
+    final var c1 = canUse("hardened slime hat");
+    final var c2 = canUse("bounty-hunting helmet");
+    final var c3 = addSkill("Refusal to Freeze");
+    try (c1;
+        c2;
+        c3) {
+      assertTrue(maximize("cold res 3 max, 0.1 item drop"));
 
-    assertEquals(3, modFor("Cold Resistance"), 0.01);
-    assertEquals(20, modFor("Item Drop"), 0.01);
+      assertEquals(3, modFor("Cold Resistance"), 0.01);
+      assertEquals(20, modFor("Item Drop"), 0.01);
 
-    recommendedSlotIs(EquipmentManager.HAT, "bounty-hunting helmet");
+      recommendedSlotIs(EquipmentManager.HAT, "bounty-hunting helmet");
+    }
   }
 
   @Test
   public void startingMaxKeywordTerminatesEarlyIfConditionMet() {
-    cleanups.add(canUse("hardened slime hat"));
-    cleanups.add(canUse("bounty-hunting helmet"));
-    cleanups.add(addSkill("Refusal to Freeze"));
-    maximize("3 max, cold res");
+    final var c1 = canUse("hardened slime hat");
+    final var c2 = canUse("bounty-hunting helmet");
+    final var c3 = addSkill("Refusal to Freeze");
+    try (c1;
+        c2;
+        c3) {
+      maximize("3 max, cold res");
 
-    assertTrue(
-        Maximizer.boosts.stream()
-            .anyMatch(
-                b -> b.toString().contains("(maximum achieved, no further combinations checked)")));
+      assertTrue(
+          Maximizer.boosts.stream()
+              .anyMatch(
+                  b ->
+                      b.toString()
+                          .contains("(maximum achieved, no further combinations checked)")));
+    }
   }
 
   // min
 
   @Test
   public void minKeywordFailsMaximizationIfNotHit() {
-    cleanups.add(canUse("helmet turtle"));
-    assertFalse(maximize("mus 2 min"));
-    // still provides equipment
-    recommendedSlotIs(EquipmentManager.HAT, "helmet turtle");
+    final var c1 = canUse("helmet turtle");
+    try (c1) {
+      assertFalse(maximize("mus 2 min"));
+      // still provides equipment
+      recommendedSlotIs(EquipmentManager.HAT, "helmet turtle");
+    }
   }
 
   @Test
   public void minKeywordPassesMaximizationIfHit() {
-    cleanups.add(canUse("wreath of laurels"));
-    assertTrue(maximize("mus 2 min"));
+    final var c1 = canUse("wreath of laurels");
+    try (c1) {
+      assertTrue(maximize("mus 2 min"));
+    }
   }
 
   @Test
   public void startingMinKeywordFailsMaximizationIfNotHit() {
-    cleanups.add(canUse("helmet turtle"));
-    assertFalse(maximize("2 min, mus"));
-    // still provides equipment
-    recommendedSlotIs(EquipmentManager.HAT, "helmet turtle");
+    final var c1 = canUse("helmet turtle");
+    try (c1) {
+      assertFalse(maximize("2 min, mus"));
+      // still provides equipment
+      recommendedSlotIs(EquipmentManager.HAT, "helmet turtle");
+    }
   }
 
   @Test
   public void startingMinKeywordPassesMaximizationIfHit() {
-    cleanups.add(canUse("wreath of laurels"));
-    assertTrue(maximize("2 min, mus"));
+    final var c1 = canUse("wreath of laurels");
+    try (c1) {
+      assertTrue(maximize("2 min, mus"));
+    }
   }
 
   // clownosity
 
   @Test
   public void clownosityTriesClownEquipment() {
-    cleanups.add(canUse("clown wig"));
-    assertFalse(maximize("clownosity -tie"));
-    // still provides equipment
-    recommendedSlotIs(EquipmentManager.HAT, "clown wig");
-    assertEquals(50, modFor("Clowniness"), 0.01);
+    final var c1 = canUse("clown wig");
+    try (c1) {
+      assertFalse(maximize("clownosity -tie"));
+      // still provides equipment
+      recommendedSlotIs(EquipmentManager.HAT, "clown wig");
+      assertEquals(50, modFor("Clowniness"), 0.01);
+    }
   }
 
   @Test
   public void clownositySucceedsWithEnoughEquipment() {
-    cleanups.add(canUse("clown wig"));
-    cleanups.add(canUse("polka-dot bow tie"));
-    assertTrue(maximize("clownosity -tie"));
-    recommendedSlotIs(EquipmentManager.HAT, "clown wig");
-    recommendedSlotIs(EquipmentManager.ACCESSORY1, "polka-dot bow tie");
-    assertEquals(125, modFor("Clowniness"), 0.01);
+    final var c1 = canUse("clown wig");
+    final var c2 = canUse("polka-dot bow tie");
+    try (c1;
+        c2) {
+      assertTrue(maximize("clownosity -tie"));
+      recommendedSlotIs(EquipmentManager.HAT, "clown wig");
+      recommendedSlotIs(EquipmentManager.ACCESSORY1, "polka-dot bow tie");
+      assertEquals(125, modFor("Clowniness"), 0.01);
+    }
   }
 
   // raveosity
 
   @Test
   public void raveosityTriesRaveEquipment() {
-    cleanups.add(canUse("rave visor"));
-    cleanups.add(canUse("baggy rave pants"));
-    cleanups.add(canUse("rave whistle"));
-    assertFalse(maximize("raveosity -tie"));
-    // still provides equipment
-    recommendedSlotIs(EquipmentManager.HAT, "rave visor");
-    recommendedSlotIs(EquipmentManager.PANTS, "baggy rave pants");
-    recommendedSlotIs(EquipmentManager.WEAPON, "rave whistle");
-    assertEquals(5, modFor("Raveosity"), 0.01);
+    final var c1 = canUse("rave visor");
+    final var c2 = canUse("baggy rave pants");
+    final var c3 = canUse("rave whistle");
+    try (c1;
+        c2;
+        c3) {
+      assertFalse(maximize("raveosity -tie"));
+      // still provides equipment
+      recommendedSlotIs(EquipmentManager.HAT, "rave visor");
+      recommendedSlotIs(EquipmentManager.PANTS, "baggy rave pants");
+      recommendedSlotIs(EquipmentManager.WEAPON, "rave whistle");
+      assertEquals(5, modFor("Raveosity"), 0.01);
+    }
   }
 
   @Test
   public void raveositySucceedsWithEnoughEquipment() {
-    cleanups.add(canUse("blue glowstick"));
-    cleanups.add(canUse("glowstick on a string"));
-    cleanups.add(canUse("teddybear backpack"));
-    cleanups.add(canUse("rave visor"));
-    cleanups.add(canUse("baggy rave pants"));
-    assertTrue(maximize("raveosity -tie"));
-    recommendedSlotIs(EquipmentManager.HAT, "rave visor");
-    recommendedSlotIs(EquipmentManager.PANTS, "baggy rave pants");
-    recommendedSlotIs(EquipmentManager.CONTAINER, "teddybear backpack");
-    recommendedSlotIs(EquipmentManager.OFFHAND, "glowstick on a string");
-    assertEquals(7, modFor("Raveosity"), 0.01);
+    final var c1 = canUse("blue glowstick");
+    final var c2 = canUse("glowstick on a string");
+    final var c3 = canUse("teddybear backpack");
+    final var c4 = canUse("rave visor");
+    final var c5 = canUse("baggy rave pants");
+    try (c1;
+        c2;
+        c3;
+        c4;
+        c5) {
+      assertTrue(maximize("raveosity -tie"));
+      recommendedSlotIs(EquipmentManager.HAT, "rave visor");
+      recommendedSlotIs(EquipmentManager.PANTS, "baggy rave pants");
+      recommendedSlotIs(EquipmentManager.CONTAINER, "teddybear backpack");
+      recommendedSlotIs(EquipmentManager.OFFHAND, "glowstick on a string");
+      assertEquals(7, modFor("Raveosity"), 0.01);
+    }
   }
 
   // surgeonosity
 
   @Test
   public void surgeonosityTriesSurgeonEquipment() {
-    cleanups.add(canUse("head mirror"));
-    cleanups.add(canUse("bloodied surgical dungarees"));
-    cleanups.add(canUse("surgical apron"));
-    cleanups.add(canUse("surgical mask"));
-    cleanups.add(canUse("half-size scalpel"));
-    cleanups.add(addSkill("Torso Awareness"));
-    assertTrue(maximize("surgeonosity -tie"));
-    recommendedSlotIs(EquipmentManager.PANTS, "bloodied surgical dungarees");
-    recommends("head mirror");
-    recommends("surgical mask");
-    recommends("half-size scalpel");
-    recommendedSlotIs(EquipmentManager.SHIRT, "surgical apron");
-    assertEquals(5, modFor("Surgeonosity"), 0.01);
+    final var c1 = canUse("head mirror");
+    final var c2 = canUse("bloodied surgical dungarees");
+    final var c3 = canUse("surgical apron");
+    final var c4 = canUse("surgical mask");
+    final var c5 = canUse("half-size scalpel");
+    final var c6 = addSkill("Torso Awareness");
+    try (c1;
+        c2;
+        c3;
+        c4;
+        c5;
+        c6) {
+      assertTrue(maximize("surgeonosity -tie"));
+      recommendedSlotIs(EquipmentManager.PANTS, "bloodied surgical dungarees");
+      recommends("head mirror");
+      recommends("surgical mask");
+      recommends("half-size scalpel");
+      recommendedSlotIs(EquipmentManager.SHIRT, "surgical apron");
+      assertEquals(5, modFor("Surgeonosity"), 0.01);
+    }
   }
 
   // beecore
 
   @Test
   public void itemsCanHaveAtMostTwoBeesByDefault() {
-    cleanups.add(inPath(Path.BEES_HATE_YOU));
-    cleanups.add(canUse("bubblewrap bottlecap turtleban"));
-    maximize("mys");
-    recommendedSlotIsEmpty(EquipmentManager.HAT);
+    final var c1 = inPath(Path.BEES_HATE_YOU);
+    final var c2 = canUse("bubblewrap bottlecap turtleban");
+    try (c1;
+        c2) {
+      maximize("mys");
+      recommendedSlotIsEmpty(EquipmentManager.HAT);
+    }
   }
 
   @Test
   public void itemsCanHaveAtMostBeeosityBees() {
-    cleanups.add(inPath(Path.BEES_HATE_YOU));
-    cleanups.add(canUse("bubblewrap bottlecap turtleban"));
-    maximize("mys, 5beeosity");
-    recommendedSlotIs(EquipmentManager.HAT, "bubblewrap bottlecap turtleban");
+    final var c1 = inPath(Path.BEES_HATE_YOU);
+    final var c2 = canUse("bubblewrap bottlecap turtleban");
+    try (c1;
+        c2) {
+      maximize("mys, 5beeosity");
+      recommendedSlotIs(EquipmentManager.HAT, "bubblewrap bottlecap turtleban");
+    }
   }
 
   @Test
   public void beeosityDoesntApplyOutsideBeePath() {
-    cleanups.add(canUse("bubblewrap bottlecap turtleban"));
-    maximize("mys");
-    recommendedSlotIs(EquipmentManager.HAT, "bubblewrap bottlecap turtleban");
+    final var c1 = canUse("bubblewrap bottlecap turtleban");
+    try (c1) {
+      maximize("mys");
+      recommendedSlotIs(EquipmentManager.HAT, "bubblewrap bottlecap turtleban");
+    }
   }
 
   // proof for the next test
   @Test
   public void canCrownFamiliarsWithBeesOutsideBeecore() {
-    cleanups.add(canUse("Crown of Thrones"));
-    cleanups.add(hasFamiliar(FamiliarPool.LOBSTER)); // 15% spell damage
-    cleanups.add(hasFamiliar(FamiliarPool.GALLOPING_GRILL)); // 10% spell damage
+    final var c1 = canUse("Crown of Thrones");
+    final var c2 = hasFamiliar(FamiliarPool.LOBSTER); // 15% spell damage
+    final var c3 = hasFamiliar(FamiliarPool.GALLOPING_GRILL); // 10% spell damage
 
-    maximize("spell dmg");
+    try (c1;
+        c2;
+        c3) {
+      maximize("spell dmg");
 
-    // used the lobster in the throne.
-    assertTrue(someBoostIs(x -> x.getCmd().startsWith("enthrone Rock Lobster")));
+      // used the lobster in the throne.
+      assertTrue(someBoostIs(x -> x.getCmd().startsWith("enthrone Rock Lobster")));
+    }
   }
 
   @Test
   public void cannotCrownFamiliarsWithBeesInBeecore() {
-    cleanups.add(inPath(Path.BEES_HATE_YOU));
-    cleanups.add(canUse("Crown of Thrones"));
-    cleanups.add(hasFamiliar(FamiliarPool.LOBSTER)); // 15% spell damage
-    cleanups.add(hasFamiliar(FamiliarPool.GALLOPING_GRILL)); // 10% spell damage
+    final var c1 = inPath(Path.BEES_HATE_YOU);
+    final var c2 = canUse("Crown of Thrones");
+    final var c3 = hasFamiliar(FamiliarPool.LOBSTER); // 15% spell damage
+    final var c4 = hasFamiliar(FamiliarPool.GALLOPING_GRILL); // 10% spell damage
 
-    maximize("spell dmg");
+    try (c1;
+        c2;
+        c3;
+        c4) {
+      maximize("spell dmg");
 
-    // used the grill in the throne.
-    assertTrue(someBoostIs(x -> x.getCmd().startsWith("enthrone Galloping Grill")));
+      // used the grill in the throne.
+      assertTrue(someBoostIs(x -> x.getCmd().startsWith("enthrone Galloping Grill")));
+    }
   }
 
   // proof for the next test
   @Test
   public void canUsePotionsWithBeesOutsideBeecore() {
-    cleanups.add(addItem("baggie of powdered sugar"));
+    final var c1 = addItem("baggie of powdered sugar");
 
-    maximize("meat drop");
+    try (c1) {
+      maximize("meat drop");
 
-    assertTrue(someBoostIs(x -> x.getCmd().startsWith("use 1 baggie of powdered sugar")));
+      assertTrue(someBoostIs(x -> x.getCmd().startsWith("use 1 baggie of powdered sugar")));
+    }
   }
 
   @Test
   public void cannotUsePotionsWithBeesInBeecore() {
-    cleanups.add(inPath(Path.BEES_HATE_YOU));
-    cleanups.add(addItem("baggie of powdered sugar"));
+    final var c1 = inPath(Path.BEES_HATE_YOU);
+    final var c2 = addItem("baggie of powdered sugar");
 
-    maximize("meat drop");
+    try (c1;
+        c2) {
+      maximize("meat drop");
 
-    assertFalse(someBoostIs(x -> x.getCmd().startsWith("use 1 baggie of powdered sugar")));
+      assertFalse(someBoostIs(x -> x.getCmd().startsWith("use 1 baggie of powdered sugar")));
+    }
   }
 
   // plumber
 
   @Test
   public void plumberCommandsErrorOutsidePlumber() {
-    cleanups.add(inPath(Path.AVATAR_OF_BORIS));
+    final var c1 = inPath(Path.AVATAR_OF_BORIS);
 
-    assertFalse(maximize("plumber"));
-    assertFalse(maximize("cold plumber"));
+    try (c1) {
+      assertFalse(maximize("plumber"));
+      assertFalse(maximize("cold plumber"));
+    }
   }
 
   @Test
   public void plumberCommandForcesSomePlumberItem() {
-    cleanups.add(inPath(Path.PATH_OF_THE_PLUMBER));
-    cleanups.add(canUse("work boots"));
-    cleanups.add(canUse("shiny ring", 3));
+    final var c1 = inPath(Path.PATH_OF_THE_PLUMBER);
+    final var c2 = canUse("work boots");
+    final var c3 = canUse("shiny ring", 3);
 
-    assertTrue(maximize("plumber, mox"));
-    recommends("work boots");
+    try (c1;
+        c2;
+        c3) {
+      assertTrue(maximize("plumber, mox"));
+      recommends("work boots");
+    }
   }
 
   @Test
   public void coldPlumberCommandForcesFlowerAndFrostyButton() {
-    cleanups.add(inPath(Path.PATH_OF_THE_PLUMBER));
-    cleanups.add(canUse("work boots"));
-    cleanups.add(canUse("bonfire flower"));
-    cleanups.add(canUse("frosty button"));
-    cleanups.add(canUse("shiny ring", 3));
+    final var c1 = inPath(Path.PATH_OF_THE_PLUMBER);
+    final var c2 = canUse("work boots");
+    final var c3 = canUse("bonfire flower");
+    final var c4 = canUse("frosty button");
+    final var c5 = canUse("shiny ring", 3);
 
-    assertTrue(maximize("cold plumber, mox"));
-    recommends("bonfire flower");
-    recommends("frosty button");
+    try (c1;
+        c2;
+        c3;
+        c4;
+        c5) {
+      assertTrue(maximize("cold plumber, mox"));
+      recommends("bonfire flower");
+      recommends("frosty button");
+    }
   }
 
   // club
 
   @Test
   public void clubModifierDoesntAffectOffhand() {
-    cleanups.add(addSkill("Double-Fisted Skull Smashing"));
-    cleanups.add(canUse("flaming crutch", 2));
-    cleanups.add(canUse("white sword", 2));
-    cleanups.add(canUse("dense meat sword"));
-    assertTrue(EquipmentManager.canEquip("white sword"), "Can equip white sword");
-    assertTrue(EquipmentManager.canEquip("flaming crutch"), "Can equip flaming crutch");
-    assertTrue(maximize("mus, club"));
-    // Should equip 1 flaming crutch, 1 white sword.
-    recommendedSlotIs(EquipmentManager.WEAPON, "flaming crutch");
-    recommendedSlotIs(EquipmentManager.OFFHAND, "white sword");
+    final var c1 = addSkill("Double-Fisted Skull Smashing");
+    final var c2 = canUse("flaming crutch", 2);
+    final var c3 = canUse("white sword", 2);
+    final var c4 = canUse("dense meat sword");
+    try (c1;
+        c2;
+        c3;
+        c4) {
+      assertTrue(EquipmentManager.canEquip("white sword"), "Can equip white sword");
+      assertTrue(EquipmentManager.canEquip("flaming crutch"), "Can equip flaming crutch");
+      assertTrue(maximize("mus, club"));
+      // Should equip 1 flaming crutch, 1 white sword.
+      recommendedSlotIs(EquipmentManager.WEAPON, "flaming crutch");
+      recommendedSlotIs(EquipmentManager.OFFHAND, "white sword");
+    }
   }
 
   // sword
 
   @Test
   public void swordModifierFavorsSword() {
-    cleanups.add(canUse("sweet ninja sword"));
-    cleanups.add(canUse("spiked femur"));
-    assertTrue(maximize("spooky dmg, sword"));
-    recommendedSlotIs(EquipmentManager.WEAPON, "sweet ninja sword");
+    final var c1 = canUse("sweet ninja sword");
+    final var c2 = canUse("spiked femur");
+    try (c1;
+        c2) {
+      assertTrue(maximize("spooky dmg, sword"));
+      recommendedSlotIs(EquipmentManager.WEAPON, "sweet ninja sword");
+    }
   }
 
   // effect limits
 
   @Test
   public void maximizeGiveBestScoreWithEffectsAtNoncombatLimit() {
-    cleanups.add(canUse("Space Trip safety headphones"));
-    cleanups.add(canUse("Krampus horn"));
+    final var c1 = canUse("Space Trip safety headphones");
+    final var c2 = canUse("Krampus horn");
     // get ourselves to -25 combat
-    cleanups.add(addEffect("Shelter of Shed"));
-    cleanups.add(addEffect("Smooth Movements"));
-    assertTrue(
-        EquipmentManager.canEquip("Space Trip safety headphones"),
-        "Cannot equip Space Trip safety headphones");
-    assertTrue(EquipmentManager.canEquip("Krampus horn"), "Cannot equip Krampus Horn");
-    assertTrue(
-        maximize(
-            "cold res,-combat -hat -weapon -offhand -back -shirt -pants -familiar -acc1 -acc2 -acc3"));
-    assertEquals(25, modFor("Cold Resistance") - modFor("Combat Rate"), 0.01, "Base score is 25");
-    assertTrue(maximize("cold res,-combat -acc2 -acc3"));
-    assertEquals(
-        27,
-        modFor("Cold Resistance") - modFor("Combat Rate"),
-        0.01,
-        "Maximizing one slot should reach 27");
+    final var c3 = addEffect("Shelter of Shed");
+    final var c4 = addEffect("Smooth Movements");
+    try (c1;
+        c2;
+        c3;
+        c4) {
+      assertTrue(
+          EquipmentManager.canEquip("Space Trip safety headphones"),
+          "Cannot equip Space Trip safety headphones");
+      assertTrue(EquipmentManager.canEquip("Krampus horn"), "Cannot equip Krampus Horn");
+      assertTrue(
+          maximize(
+              "cold res,-combat -hat -weapon -offhand -back -shirt -pants -familiar -acc1 -acc2 -acc3"));
+      assertEquals(25, modFor("Cold Resistance") - modFor("Combat Rate"), 0.01, "Base score is 25");
+      assertTrue(maximize("cold res,-combat -acc2 -acc3"));
+      assertEquals(
+          27,
+          modFor("Cold Resistance") - modFor("Combat Rate"),
+          0.01,
+          "Maximizing one slot should reach 27");
 
-    recommendedSlotIs(EquipmentManager.ACCESSORY1, "Krampus horn");
+      recommendedSlotIs(EquipmentManager.ACCESSORY1, "Krampus horn");
+    }
   }
 
   @Test
   public void aboveWaterZonesDoNotCheckUnderwaterNegativeCombat() {
-    cleanups.add(inLocation("Noob Cave"));
-    cleanups.add(canUse("Mer-kin sneakmask"));
-    assertTrue(maximize("-combat -tie"));
-    assertEquals(0, modFor("Combat Rate"), 0.01);
+    final var c1 = inLocation("Noob Cave");
+    final var c2 = canUse("Mer-kin sneakmask");
+    try (c1;
+        c2) {
+      assertTrue(maximize("-combat -tie"));
+      assertEquals(0, modFor("Combat Rate"), 0.01);
 
-    recommendedSlotIsEmpty(EquipmentManager.HAT);
+      recommendedSlotIsEmpty(EquipmentManager.HAT);
+    }
   }
 
   @Test
   public void underwaterZonesCheckUnderwaterNegativeCombat() {
-    cleanups.add(inLocation("The Ice Hole"));
-    cleanups.add(canUse("Mer-kin sneakmask"));
-    assertEquals(AdventureDatabase.getEnvironment(Modifiers.currentLocation), "underwater");
-    assertTrue(maximize("-combat -tie"));
+    final var c1 = inLocation("The Ice Hole");
+    final var c2 = canUse("Mer-kin sneakmask");
+    try (c1;
+        c2) {
+      assertEquals(AdventureDatabase.getEnvironment(Modifiers.currentLocation), "underwater");
+      assertTrue(maximize("-combat -tie"));
 
-    recommendedSlotIs(EquipmentManager.HAT, "Mer-kin sneakmask");
+      recommendedSlotIs(EquipmentManager.HAT, "Mer-kin sneakmask");
+    }
   }
 
   // outfits
 
   @Test
   public void considersOutfitsIfHelpful() {
-    cleanups.add(canUse("eldritch hat"));
-    cleanups.add(canUse("eldritch pants"));
-    assertTrue(maximize("item -tie"));
+    final var c1 = canUse("eldritch hat");
+    final var c2 = canUse("eldritch pants");
+    try (c1;
+        c2) {
+      assertTrue(maximize("item -tie"));
 
-    assertEquals(50, modFor("Item Drop"), 0.01);
-    recommendedSlotIs(EquipmentManager.HAT, "eldritch hat");
-    recommendedSlotIs(EquipmentManager.PANTS, "eldritch pants");
+      assertEquals(50, modFor("Item Drop"), 0.01);
+      recommendedSlotIs(EquipmentManager.HAT, "eldritch hat");
+      recommendedSlotIs(EquipmentManager.PANTS, "eldritch pants");
+    }
   }
 
   @Test
   public void avoidsOutfitsIfOtherItemsBetter() {
-    cleanups.add(canUse("eldritch hat"));
-    cleanups.add(canUse("eldritch pants"));
-    cleanups.add(canUse("Team Avarice cap"));
-    assertTrue(maximize("item -tie"));
+    final var c1 = canUse("eldritch hat");
+    final var c2 = canUse("eldritch pants");
+    final var c3 = canUse("Team Avarice cap");
+    try (c1;
+        c2;
+        c3) {
+      assertTrue(maximize("item -tie"));
 
-    assertEquals(100, modFor("Item Drop"), 0.01);
-    recommendedSlotIs(EquipmentManager.HAT, "Team Avarice cap");
+      assertEquals(100, modFor("Item Drop"), 0.01);
+      recommendedSlotIs(EquipmentManager.HAT, "Team Avarice cap");
+    }
   }
 
   @Test
   public void forcingOutfitRequiresThatOutfit() {
-    cleanups.add(canUse("bounty-hunting helmet"));
-    cleanups.add(canUse("bounty-hunting rifle"));
-    cleanups.add(canUse("bounty-hunting pants"));
-    cleanups.add(canUse("eldritch hat"));
-    cleanups.add(canUse("eldritch pants"));
-    assertTrue(maximize("item -tie"));
+    final var c1 = canUse("bounty-hunting helmet");
+    final var c2 = canUse("bounty-hunting rifle");
+    final var c3 = canUse("bounty-hunting pants");
+    final var c4 = canUse("eldritch hat");
+    final var c5 = canUse("eldritch pants");
+    try (c1;
+        c2;
+        c3;
+        c4;
+        c5) {
+      assertTrue(maximize("item -tie"));
 
-    assertEquals(70, modFor("Item Drop"), 0.01);
-    recommendedSlotIs(EquipmentManager.HAT, "bounty-hunting helmet");
-    recommendedSlotIs(EquipmentManager.WEAPON, "bounty-hunting rifle");
-    recommendedSlotIs(EquipmentManager.PANTS, "bounty-hunting pants");
+      assertEquals(70, modFor("Item Drop"), 0.01);
+      recommendedSlotIs(EquipmentManager.HAT, "bounty-hunting helmet");
+      recommendedSlotIs(EquipmentManager.WEAPON, "bounty-hunting rifle");
+      recommendedSlotIs(EquipmentManager.PANTS, "bounty-hunting pants");
 
-    assertTrue(maximize("item, +outfit Eldritch Equipage -tie"));
-    assertEquals(65, modFor("Item Drop"), 0.01);
-    recommendedSlotIs(EquipmentManager.HAT, "eldritch hat");
-    recommendedSlotIs(EquipmentManager.WEAPON, "bounty-hunting rifle");
-    recommendedSlotIs(EquipmentManager.PANTS, "eldritch pants");
+      assertTrue(maximize("item, +outfit Eldritch Equipage -tie"));
+      assertEquals(65, modFor("Item Drop"), 0.01);
+      recommendedSlotIs(EquipmentManager.HAT, "eldritch hat");
+      recommendedSlotIs(EquipmentManager.WEAPON, "bounty-hunting rifle");
+      recommendedSlotIs(EquipmentManager.PANTS, "eldritch pants");
 
-    assertTrue(maximize("item, -outfit Bounty-Hunting Rig -tie"));
-    assertEquals(65, modFor("Item Drop"), 0.01);
-    recommendedSlotIs(EquipmentManager.HAT, "eldritch hat");
-    recommendedSlotIs(EquipmentManager.WEAPON, "bounty-hunting rifle");
-    recommendedSlotIs(EquipmentManager.PANTS, "eldritch pants");
+      assertTrue(maximize("item, -outfit Bounty-Hunting Rig -tie"));
+      assertEquals(65, modFor("Item Drop"), 0.01);
+      recommendedSlotIs(EquipmentManager.HAT, "eldritch hat");
+      recommendedSlotIs(EquipmentManager.WEAPON, "bounty-hunting rifle");
+      recommendedSlotIs(EquipmentManager.PANTS, "eldritch pants");
+    }
   }
 
   @Test
   public void considersOutfitPartsIfHelpful() {
-    cleanups.add(canUse("Brimstone Beret"));
-    cleanups.add(canUse("Brimstone Boxers"));
-    assertTrue(maximize("ml -tie"));
+    final var c1 = canUse("Brimstone Beret");
+    final var c2 = canUse("Brimstone Boxers");
+    try (c1;
+        c2) {
+      assertTrue(maximize("ml -tie"));
 
-    assertEquals(4, modFor("Monster Level"), 0.01);
-    recommendedSlotIs(EquipmentManager.HAT, "Brimstone Beret");
-    recommendedSlotIs(EquipmentManager.PANTS, "Brimstone Boxers");
+      assertEquals(4, modFor("Monster Level"), 0.01);
+      recommendedSlotIs(EquipmentManager.HAT, "Brimstone Beret");
+      recommendedSlotIs(EquipmentManager.PANTS, "Brimstone Boxers");
+    }
   }
 }


### PR DESCRIPTION
`KoLCharacter.reset(true)` is pretty slow (in part due to `KoLCharacter.currentModifiers.resetModifiers()`, which parses the entire `modifiers.txt` file again).

For maximizer tests (the ones I work on the most), do a more targeted teardown, focusing on restoring exactly what was set up to the baseline.

Also split out the regression tests to a different file.