### PR TITLE
Remove improper handling for the refresh command

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
+++ b/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
@@ -435,11 +435,6 @@ public class KoLmafiaCLI {
       return;
     }
 
-    if (parameters.equals("refresh")) {
-      parameters = lcommand;
-      lcommand = command = "refresh";
-    }
-
     AbstractCommand handler = AbstractCommand.lookup.get(lcommand);
 
     if (handler == null) {

--- a/test/net/sourceforge/kolmafia/textui/command/HelpCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/HelpCommandTest.java
@@ -23,9 +23,6 @@ public class HelpCommandTest extends AbstractCommandTestBase {
     String output = execute("refresh");
 
     assertContinueState();
-    assertThat(
-        output,
-        containsString(
-            "refresh all | [status | effects] | [gear | equip | outfit] | inv | camp | storage | [familiar | terarrium] | stickers | quests | shop - resynchronize with KoL."));
+    assertThat(output, containsString("refresh all |"));
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/command/HelpCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/HelpCommandTest.java
@@ -1,0 +1,31 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import java.beans.Transient;
+
+import net.sourceforge.kolmafia.request.GenericRequest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class HelpCommandTest extends AbstractCommandTestBase {
+    @BeforeEach
+    public void initEach() {
+      // Stop requests from actually running
+      GenericRequest.sessionId = null;
+    }
+
+    public HelpCommandTest() {
+        this.command = "help";
+    }
+
+    @Test
+    void Refresh() {
+        String output = execute("refresh");
+
+        assertContinueState();
+        assertThat(output, containsString("refresh all | [status | effects] | [gear | equip | outfit] | inv | camp | storage | [familiar | terarrium] | stickers | quests | shop - resynchronize with KoL."));
+    }
+}

--- a/test/net/sourceforge/kolmafia/textui/command/HelpCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/HelpCommandTest.java
@@ -1,7 +1,7 @@
 package net.sourceforge.kolmafia.textui.command;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
 
 import net.sourceforge.kolmafia.request.GenericRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +23,6 @@ public class HelpCommandTest extends AbstractCommandTestBase {
     String output = execute("refresh");
 
     assertContinueState();
-    assertThat(output, containsString("refresh all |"));
+    assertThat(output, startsWith("refresh all |"));
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/command/HelpCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/HelpCommandTest.java
@@ -3,29 +3,29 @@ package net.sourceforge.kolmafia.textui.command;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
-import java.beans.Transient;
-
 import net.sourceforge.kolmafia.request.GenericRequest;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class HelpCommandTest extends AbstractCommandTestBase {
-    @BeforeEach
-    public void initEach() {
-      // Stop requests from actually running
-      GenericRequest.sessionId = null;
-    }
+  @BeforeEach
+  public void initEach() {
+    // Stop requests from actually running
+    GenericRequest.sessionId = null;
+  }
 
-    public HelpCommandTest() {
-        this.command = "help";
-    }
+  public HelpCommandTest() {
+    this.command = "help";
+  }
 
-    @Test
-    void Refresh() {
-        String output = execute("refresh");
+  @Test
+  void Refresh() {
+    String output = execute("refresh");
 
-        assertContinueState();
-        assertThat(output, containsString("refresh all | [status | effects] | [gear | equip | outfit] | inv | camp | storage | [familiar | terarrium] | stickers | quests | shop - resynchronize with KoL."));
-    }
+    assertContinueState();
+    assertThat(
+        output,
+        containsString(
+            "refresh all | [status | effects] | [gear | equip | outfit] | inv | camp | storage | [familiar | terarrium] | stickers | quests | shop - resynchronize with KoL."));
+  }
 }


### PR DESCRIPTION
Currently, typing `help refresh` does not work as expected. These lines of code improperly intercept the keyword refresh and alter the inputted command in undesirable ways for all other commands as well such that any command of the form `command refresh` will attempt to run the refresh command instead.

Currently:
```
> help refresh

help cannot be refreshed.

> genie refresh

genie cannot be refreshed.
```

With this change:
```
> help refresh

refresh all | [status | effects] | [gear | equip | outfit] | inv | camp | storage | [familiar | terarrium] | stickers | quests | shop - resynchronize with KoL.

> refresh genie

genie cannot be refreshed.

> genie refresh

(no output)
```