### PR TITLE
Actually use java version in matrix.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: ${{ matrix.java }}
           cache: "gradle"
 
       - name: Gradle Wrapper Validation


### PR DESCRIPTION
Previously we were inadvertently hard-coding 17 as the Java
version. This was not great for maintaining Java 11 compatibility
as we purported to do.