### PR TITLE
Expose JS enumerated types on runtime library.

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/javascript/EnumeratedWrapperPrototype.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/EnumeratedWrapperPrototype.java
@@ -21,7 +21,7 @@ public class EnumeratedWrapperPrototype extends ScriptableObject {
     this.type = type;
   }
 
-  public void initToScope(Context cx, Scriptable scope) {
+  public void initToScope(Context cx, Scriptable scope, Scriptable runtimeLibrary) {
     setPrototype(ScriptableObject.getObjectPrototype(scope));
 
     if (recordValueClass != null) {
@@ -41,6 +41,10 @@ public class EnumeratedWrapperPrototype extends ScriptableObject {
       Method constructorMethod = EnumeratedWrapper.class.getDeclaredMethod("constructDefaultValue");
       FunctionObject constructor = new FunctionObject(getClassName(), constructorMethod, scope);
       constructor.addAsConstructor(scope, this);
+      if (runtimeLibrary != null) {
+        ScriptableObject.defineProperty(
+            runtimeLibrary, getClassName(), constructor, DONTENUM | READONLY | PERMANENT);
+      }
 
       Method getMethod =
           EnumeratedWrapper.class.getDeclaredMethod(

--- a/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
@@ -139,13 +139,17 @@ public class JavascriptRuntime extends AbstractRuntime {
   }
 
   private static void initEnumeratedType(
-      Context cx, Scriptable scope, Class<?> recordValueClass, Type valueType) {
+      Context cx,
+      Scriptable scope,
+      Scriptable runtimeLibrary,
+      Class<?> recordValueClass,
+      Type valueType) {
     EnumeratedWrapperPrototype prototype =
         new EnumeratedWrapperPrototype(recordValueClass, valueType);
-    prototype.initToScope(cx, scope);
+    prototype.initToScope(cx, scope, runtimeLibrary);
   }
 
-  private static void initEnumeratedTypes(Context cx, Scriptable scope) {
+  private static void initEnumeratedTypes(Context cx, Scriptable scope, Scriptable runtimeLibrary) {
     for (Type valueType : DataTypes.enumeratedTypes) {
       String typeName = capitalize(valueType.getName());
       Class<?> proxyRecordValueClass = Value.class;
@@ -155,7 +159,7 @@ public class JavascriptRuntime extends AbstractRuntime {
         }
       }
 
-      initEnumeratedType(cx, scope, proxyRecordValueClass, valueType);
+      initEnumeratedType(cx, scope, runtimeLibrary, proxyRecordValueClass, valueType);
     }
   }
 
@@ -185,7 +189,7 @@ public class JavascriptRuntime extends AbstractRuntime {
     try {
       // If executing from GCLI (and not file), add std lib to top scope.
       currentStdLib = initRuntimeLibrary(cx, scope, scriptFile == null);
-      initEnumeratedTypes(cx, scope);
+      initEnumeratedTypes(cx, scope, currentStdLib);
 
       setState(State.NORMAL);
 


### PR DESCRIPTION
This is in addition to global scope; will allow usage in environments where Element and Location cause conflicts with globally-defined DOM constructors.