### PR TITLE
fix: use try-with-resources for closing non-finally-closed BufferedReaders

### DIFF
--- a/src/net/sourceforge/kolmafia/StaticEntity.java
+++ b/src/net/sourceforge/kolmafia/StaticEntity.java
@@ -532,16 +532,15 @@ public abstract class StaticEntity {
       command[1] = pid;
 
       Process process = runtime.exec(command);
-      BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+      try (BufferedReader reader =
+          new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+        String line;
 
-      String line;
-
-      while ((line = reader.readLine()) != null) {
-        sb.append(line);
-        sb.append(KoLConstants.LINE_BREAK);
+        while ((line = reader.readLine()) != null) {
+          sb.append(line);
+          sb.append(KoLConstants.LINE_BREAK);
+        }
       }
-
-      reader.close();
     } catch (IOException e) {
       e.printStackTrace();
     }
@@ -611,16 +610,15 @@ public abstract class StaticEntity {
 
       Process process = runtime.exec(command, new String[0], KoLConstants.ROOT_LOCATION);
 
-      BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+      try (BufferedReader reader =
+          new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+        String line;
 
-      String line;
-
-      while ((line = reader.readLine()) != null) {
-        sb.append(line);
-        sb.append(KoLConstants.LINE_BREAK);
+        while ((line = reader.readLine()) != null) {
+          sb.append(line);
+          sb.append(KoLConstants.LINE_BREAK);
+        }
       }
-
-      reader.close();
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/src/net/sourceforge/kolmafia/combat/CombatActionManager.java
+++ b/src/net/sourceforge/kolmafia/combat/CombatActionManager.java
@@ -97,16 +97,9 @@ public abstract class CombatActionManager {
       ostream.close();
     }
 
-    try {
-      BufferedReader reader = FileUtilities.getReader(file);
-
+    try (BufferedReader reader = FileUtilities.getReader(file)) {
       CombatActionManager.strategyLookup.load(reader);
-
-      reader.close();
     } catch (IOException e1) {
-      // This should not happen.  Therefore, print
-      // a stack trace for debug purposes.
-
       StaticEntity.printStackTrace(e1);
     }
 

--- a/src/net/sourceforge/kolmafia/moods/MoodManager.java
+++ b/src/net/sourceforge/kolmafia/moods/MoodManager.java
@@ -591,7 +591,7 @@ public abstract class MoodManager {
     loadSettings(FileUtilities.getReader(getFile()));
   }
 
-  public static void loadSettings(BufferedReader reader) {
+  public static void loadSettings(final BufferedReader reader) {
     MoodManager.availableMoods.clear();
 
     Mood mood = new Mood("apathetic");
@@ -602,7 +602,7 @@ public abstract class MoodManager {
 
     if (reader != null) {
 
-      try {
+      try (reader) {
         String line;
 
         while ((line = reader.readLine()) != null) {
@@ -629,8 +629,6 @@ public abstract class MoodManager {
           MoodManager.availableMoods.remove(mood);
           MoodManager.availableMoods.add(mood);
         }
-
-        reader.close();
 
         MoodManager.setMood(Preferences.getString("currentMood"));
       } catch (IOException e) {

--- a/src/net/sourceforge/kolmafia/persistence/Aliases.java
+++ b/src/net/sourceforge/kolmafia/persistence/Aliases.java
@@ -2,6 +2,7 @@ package net.sourceforge.kolmafia.persistence;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Iterator;
 import java.util.Map.Entry;
@@ -37,21 +38,18 @@ public class Aliases {
 
     Aliases.aliasMap.clear();
 
-    BufferedReader reader = FileUtilities.getReader(Aliases.ALIAS_FILE);
-    if (reader != null) {
-      String[] data;
+    try (BufferedReader reader = FileUtilities.getReader(Aliases.ALIAS_FILE)) {
+      if (reader != null) {
+        String[] data;
 
-      while ((data = FileUtilities.readData(reader)) != null) {
-        if (data.length >= 2) {
-          Aliases.aliasMap.put(" " + data[0] + " ", " " + data[1] + " ");
+        while ((data = FileUtilities.readData(reader)) != null) {
+          if (data.length >= 2) {
+            Aliases.aliasMap.put(" " + data[0] + " ", " " + data[1] + " ");
+          }
         }
       }
-
-      try {
-        reader.close();
-      } catch (Exception e) {
-        StaticEntity.printStackTrace(e);
-      }
+    } catch (IOException e) {
+      StaticEntity.printStackTrace(e);
     }
 
     Aliases.aliasSet = Aliases.aliasMap.entrySet();

--- a/src/net/sourceforge/kolmafia/persistence/BountyDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/BountyDatabase.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.persistence;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -49,31 +50,28 @@ public class BountyDatabase {
   }
 
   private static void readData() {
-    BufferedReader reader =
-        FileUtilities.getVersionedReader("bounty.txt", KoLConstants.BOUNTY_VERSION);
+    try (BufferedReader reader =
+        FileUtilities.getVersionedReader("bounty.txt", KoLConstants.BOUNTY_VERSION)) {
 
-    String[] data;
+      String[] data;
 
-    while ((data = FileUtilities.readData(reader)) != null) {
-      if (data.length < 7) {
-        continue;
+      while ((data = FileUtilities.readData(reader)) != null) {
+        if (data.length < 7) {
+          continue;
+        }
+
+        String name = data[0];
+        BountyDatabase.bountyNames.add(name);
+        BountyDatabase.bountyByPlural.put(data[1], name);
+        BountyDatabase.pluralByName.put(name, data[1]);
+        BountyDatabase.typeByName.put(name, data[2]);
+        BountyDatabase.imageByName.put(name, data[3]);
+        BountyDatabase.numberByName.put(name, data[4]);
+        BountyDatabase.monsterByName.put(name, data[5]);
+        BountyDatabase.nameByMonster.put(data[5], name);
+        BountyDatabase.locationByName.put(name, data[6]);
       }
-
-      String name = data[0];
-      BountyDatabase.bountyNames.add(name);
-      BountyDatabase.bountyByPlural.put(data[1], name);
-      BountyDatabase.pluralByName.put(name, data[1]);
-      BountyDatabase.typeByName.put(name, data[2]);
-      BountyDatabase.imageByName.put(name, data[3]);
-      BountyDatabase.numberByName.put(name, data[4]);
-      BountyDatabase.monsterByName.put(name, data[5]);
-      BountyDatabase.nameByMonster.put(data[5], name);
-      BountyDatabase.locationByName.put(name, data[6]);
-    }
-
-    try {
-      reader.close();
-    } catch (Exception e) {
+    } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
   }

--- a/src/net/sourceforge/kolmafia/persistence/BuffBotDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/BuffBotDatabase.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.persistence;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
@@ -50,22 +51,19 @@ public class BuffBotDatabase {
 
     if (!BuffBotDatabase.hasNameList) {
       String[] data;
-      BufferedReader reader =
-          FileUtilities.getVersionedReader("buffbots.txt", KoLConstants.BUFFBOTS_VERSION);
+      try (BufferedReader reader =
+          FileUtilities.getVersionedReader("buffbots.txt", KoLConstants.BUFFBOTS_VERSION)) {
 
-      while ((data = FileUtilities.readData(reader)) != null) {
-        if (data.length >= 2) {
-          ContactManager.registerPlayerId(data[0], data[1]);
+        while ((data = FileUtilities.readData(reader)) != null) {
+          if (data.length >= 2) {
+            ContactManager.registerPlayerId(data[0], data[1]);
 
-          BuffBotDatabase.nameList.add(data[0].toLowerCase());
-          BuffBotDatabase.buffDataMap.put(data[0].toLowerCase(), data);
+            BuffBotDatabase.nameList.add(data[0].toLowerCase());
+            BuffBotDatabase.buffDataMap.put(data[0].toLowerCase(), data);
+          }
         }
-      }
-      BuffBotDatabase.hasNameList = true;
-
-      try {
-        reader.close();
-      } catch (Exception e) {
+        BuffBotDatabase.hasNameList = true;
+      } catch (IOException e) {
         StaticEntity.printStackTrace(e);
       }
     }
@@ -225,18 +223,15 @@ public class BuffBotDatabase {
     KoLmafia.updateDisplay("Configuring dynamic buff prices...");
 
     String[] data = null;
-    BufferedReader reader =
-        FileUtilities.getVersionedReader("buffbots.txt", KoLConstants.BUFFBOTS_VERSION);
+    try (BufferedReader reader =
+        FileUtilities.getVersionedReader("buffbots.txt", KoLConstants.BUFFBOTS_VERSION)) {
 
-    while ((data = FileUtilities.readData(reader)) != null) {
-      if (data.length == 3) {
-        RequestThread.postRequest(new DynamicBotFetcher(data));
+      while ((data = FileUtilities.readData(reader)) != null) {
+        if (data.length == 3) {
+          RequestThread.postRequest(new DynamicBotFetcher(data));
+        }
       }
-    }
-
-    try {
-      reader.close();
-    } catch (Exception e) {
+    } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
 

--- a/src/net/sourceforge/kolmafia/persistence/CafeDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/CafeDatabase.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.persistence;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -37,17 +38,13 @@ public class CafeDatabase {
   }
 
   private static void readCafeData(String filename, int version, Map<Integer, String> map) {
-    BufferedReader reader = FileUtilities.getVersionedReader(filename, version);
+    try (BufferedReader reader = FileUtilities.getVersionedReader(filename, version)) {
+      String[] data;
 
-    String[] data;
-
-    while ((data = FileUtilities.readData(reader)) != null) {
-      CafeDatabase.saveCafeItem(data, map);
-    }
-
-    try {
-      reader.close();
-    } catch (Exception e) {
+      while ((data = FileUtilities.readData(reader)) != null) {
+        CafeDatabase.saveCafeItem(data, map);
+      }
+    } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
   }

--- a/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.persistence;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.EnumSet;
@@ -177,20 +178,14 @@ public class ConcoctionDatabase {
     // examined and float-referenced: once in the name-lookup,
     // and again in the Id lookup.
 
-    BufferedReader reader =
-        FileUtilities.getVersionedReader("concoctions.txt", KoLConstants.CONCOCTIONS_VERSION);
-    String[] data;
+    try (BufferedReader reader =
+        FileUtilities.getVersionedReader("concoctions.txt", KoLConstants.CONCOCTIONS_VERSION)) {
+      String[] data;
 
-    while ((data = FileUtilities.readData(reader)) != null) {
-      ConcoctionDatabase.addConcoction(data);
-    }
-
-    try {
-      reader.close();
-    } catch (Exception e) {
-      // This should not happen.  Therefore, print
-      // a stack trace for debug purposes.
-
+      while ((data = FileUtilities.readData(reader)) != null) {
+        ConcoctionDatabase.addConcoction(data);
+      }
+    } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
 

--- a/src/net/sourceforge/kolmafia/persistence/ConsumablesDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConsumablesDatabase.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.persistence;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Calendar;
 import java.util.HashMap;
@@ -173,16 +174,13 @@ public class ConsumablesDatabase {
   private static void readConsumptionData(String filename, int version, Map<String, Integer> map) {
     map.clear();
 
-    BufferedReader reader = FileUtilities.getVersionedReader(filename, version);
-    String[] data;
+    try (BufferedReader reader = FileUtilities.getVersionedReader(filename, version)) {
+      String[] data;
 
-    while ((data = FileUtilities.readData(reader)) != null) {
-      ConsumablesDatabase.saveConsumptionValues(data, map);
-    }
-
-    try {
-      reader.close();
-    } catch (Exception e) {
+      while ((data = FileUtilities.readData(reader)) != null) {
+        ConsumablesDatabase.saveConsumptionValues(data, map);
+      }
+    } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
   }
@@ -272,28 +270,24 @@ public class ConsumablesDatabase {
   }
 
   private static void readNonfillingData() {
-    BufferedReader reader =
-        FileUtilities.getVersionedReader("nonfilling.txt", KoLConstants.NONFILLING_VERSION);
+    try (BufferedReader reader =
+        FileUtilities.getVersionedReader("nonfilling.txt", KoLConstants.NONFILLING_VERSION)) {
+      String[] data;
 
-    String[] data;
+      while ((data = FileUtilities.readData(reader)) != null) {
+        if (data.length < 2) continue;
 
-    while ((data = FileUtilities.readData(reader)) != null) {
-      if (data.length < 2) continue;
+        String name = data[0];
+        ConsumablesDatabase.levelReqByName.put(name, Integer.valueOf(data[1]));
 
-      String name = data[0];
-      ConsumablesDatabase.levelReqByName.put(name, Integer.valueOf(data[1]));
+        if (data.length < 3) continue;
 
-      if (data.length < 3) continue;
-
-      String notes = data[2];
-      if (notes.length() > 0) {
-        ConsumablesDatabase.notesByName.put(name, notes);
+        String notes = data[2];
+        if (notes.length() > 0) {
+          ConsumablesDatabase.notesByName.put(name, notes);
+        }
       }
-    }
-
-    try {
-      reader.close();
-    } catch (Exception e) {
+    } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
   }

--- a/src/net/sourceforge/kolmafia/persistence/DailyLimitDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DailyLimitDatabase.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.persistence;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -145,27 +146,24 @@ public class DailyLimitDatabase {
   }
 
   public static void reset() {
-    BufferedReader reader =
-        FileUtilities.getVersionedReader("dailylimits.txt", KoLConstants.DAILYLIMITS_VERSION);
-    String[] data;
     boolean error = false;
+    try (BufferedReader reader =
+        FileUtilities.getVersionedReader("dailylimits.txt", KoLConstants.DAILYLIMITS_VERSION)) {
+      String[] data;
 
-    while ((data = FileUtilities.readData(reader)) != null) {
-      if (data.length >= 2) {
-        String tag = data[0];
+      while ((data = FileUtilities.readData(reader)) != null) {
+        if (data.length >= 2) {
+          String tag = data[0];
 
-        DailyLimitType type = DailyLimitDatabase.tagToDailyLimitType.get(tag.toLowerCase());
-        DailyLimit dailyLimit = parseDailyLimit(type, data);
-        if (dailyLimit == null) {
-          RequestLogger.printLine("Daily Limit: " + data[0] + " " + data[1] + " is bogus");
-          error = true;
+          DailyLimitType type = DailyLimitDatabase.tagToDailyLimitType.get(tag.toLowerCase());
+          DailyLimit dailyLimit = parseDailyLimit(type, data);
+          if (dailyLimit == null) {
+            RequestLogger.printLine("Daily Limit: " + data[0] + " " + data[1] + " is bogus");
+            error = true;
+          }
         }
       }
-    }
-
-    try {
-      reader.close();
-    } catch (Exception e) {
+    } catch (IOException e) {
       StaticEntity.printStackTrace(e);
       error = true;
     }

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -2265,27 +2265,26 @@ public class DebugDatabase {
 
       String currentLine;
       StringBuilder currentHTML = new StringBuilder();
-      BufferedReader reader = FileUtilities.getReader(saveData);
-      int lines = 0;
+      try (BufferedReader reader = FileUtilities.getReader(saveData)) {
+        int lines = 0;
 
-      while ((currentLine = reader.readLine()) != null && !currentLine.equals("")) {
-        lines += 1;
-        currentHTML.setLength(0);
-        int currentId = StringUtilities.parseInt(currentLine);
+        while ((currentLine = reader.readLine()) != null && !currentLine.equals("")) {
+          lines += 1;
+          currentHTML.setLength(0);
+          int currentId = StringUtilities.parseInt(currentLine);
 
-        do {
-          currentLine = reader.readLine();
-          currentHTML.append(currentLine);
-          currentHTML.append(KoLConstants.LINE_BREAK);
-        } while (!currentLine.equals("</html>"));
+          do {
+            currentLine = reader.readLine();
+            currentHTML.append(currentLine);
+            currentHTML.append(KoLConstants.LINE_BREAK);
+          } while (!currentLine.equals("</html>"));
 
-        if (array.get(currentId).equals("")) {
-          array.set(currentId, currentHTML.toString());
+          if (array.get(currentId).equals("")) {
+            array.set(currentId, currentHTML.toString());
+          }
+          reader.readLine();
         }
-        reader.readLine();
       }
-
-      reader.close();
     } catch (Exception e) {
       // This shouldn't happen, but if it does, go ahead and
       // fall through.  You're done parsing.

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -2,6 +2,7 @@ package net.sourceforge.kolmafia.persistence;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,35 +59,29 @@ public class EffectDatabase {
   public static void reset() {
     EffectDatabase.newEffects = false;
 
-    BufferedReader reader =
-        FileUtilities.getVersionedReader("statuseffects.txt", KoLConstants.STATUSEFFECTS_VERSION);
-    String[] data;
+    try (BufferedReader reader =
+        FileUtilities.getVersionedReader("statuseffects.txt", KoLConstants.STATUSEFFECTS_VERSION)) {
+      String[] data;
 
-    while ((data = FileUtilities.readData(reader)) != null) {
-      if (data.length >= 3) {
-        Integer effectId = Integer.valueOf(data[0]);
-        if (effectId.intValue() < 0) {
-          continue;
+      while ((data = FileUtilities.readData(reader)) != null) {
+        if (data.length >= 3) {
+          Integer effectId = Integer.valueOf(data[0]);
+          if (effectId.intValue() < 0) {
+            continue;
+          }
+
+          String name = data[1];
+          String image = data[2];
+          String descId = data.length > 3 ? data[3] : null;
+          String quality = data[4];
+          String attributes = data[5];
+          String defaultAction = data.length > 6 ? data[6] : null;
+
+          EffectDatabase.addToDatabase(
+              effectId, name, image, descId, quality, attributes, defaultAction);
         }
-
-        String name = data[1];
-        String image = data[2];
-        String descId = data.length > 3 ? data[3] : null;
-        String quality = data[4];
-        String attributes = data[5];
-        String defaultAction = data.length > 6 ? data[6] : null;
-
-        EffectDatabase.addToDatabase(
-            effectId, name, image, descId, quality, attributes, defaultAction);
       }
-    }
-
-    try {
-      reader.close();
-    } catch (Exception e) {
-      // This should not happen.  Therefore, print
-      // a stack trace for debug purposes.
-
+    } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
 

--- a/src/net/sourceforge/kolmafia/persistence/FaxBotDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/FaxBotDatabase.java
@@ -61,22 +61,16 @@ public class FaxBotDatabase {
   private static void readFaxbotConfig() {
     FaxBotDatabase.botData.clear();
 
-    BufferedReader reader =
-        FileUtilities.getVersionedReader("faxbots.txt", KoLConstants.FAXBOTS_VERSION);
-    String[] data;
+    try (BufferedReader reader =
+        FileUtilities.getVersionedReader("faxbots.txt", KoLConstants.FAXBOTS_VERSION)) {
+      String[] data;
 
-    while ((data = FileUtilities.readData(reader)) != null) {
-      if (data.length > 1) {
-        FaxBotDatabase.botData.add(new BotData(data[0].trim().toLowerCase(), data[1].trim()));
+      while ((data = FileUtilities.readData(reader)) != null) {
+        if (data.length > 1) {
+          FaxBotDatabase.botData.add(new BotData(data[0].trim().toLowerCase(), data[1].trim()));
+        }
       }
-    }
-
-    try {
-      reader.close();
-    } catch (Exception e) {
-      // This should not happen.  Therefore, print
-      // a stack trace for debug purposes.
-
+    } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
   }

--- a/src/net/sourceforge/kolmafia/persistence/FlaggedItems.java
+++ b/src/net/sourceforge/kolmafia/persistence/FlaggedItems.java
@@ -248,12 +248,10 @@ public class FlaggedItems {
     }
 
     AdventureResult item;
-    BufferedReader reader = DataUtilities.getReader(FlaggedItems.itemFlagsFile);
+    try (BufferedReader reader = DataUtilities.getReader(FlaggedItems.itemFlagsFile)) {
+      String line;
+      List<AdventureResult> model = null;
 
-    String line;
-    List<AdventureResult> model = null;
-
-    try {
       while ((line = reader.readLine()) != null) {
         if (line.equals("")) {
           continue;
@@ -287,14 +285,6 @@ public class FlaggedItems {
         }
       }
     } catch (IOException e) {
-    }
-
-    try {
-      reader.close();
-    } catch (IOException e) {
-      // This should not happen.  Therefore, print
-      // a stack trace for debug purposes.
-
       StaticEntity.printStackTrace(e);
     }
   }

--- a/src/net/sourceforge/kolmafia/persistence/MallPriceDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/MallPriceDatabase.java
@@ -3,6 +3,7 @@ package net.sourceforge.kolmafia.persistence;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
@@ -39,56 +40,53 @@ public class MallPriceDatabase {
   private MallPriceDatabase() {}
 
   private static int updatePrices(String filename, boolean allowOverride) {
-    BufferedReader reader = FileUtilities.getReader(filename, allowOverride);
-
-    String line = FileUtilities.readLine(reader);
-    if (line == null) {
-      RequestLogger.printLine("(file not found)");
-      return 0;
-    }
-
-    if (StringUtilities.parseInt(line) != KoLConstants.MALLPRICES_VERSION) {
-      RequestLogger.printLine("(incompatible price file format)");
-      return 0;
-    }
-
-    String[] data;
     int count = 0;
-    long now = System.currentTimeMillis() / 1000L;
+    try (BufferedReader reader = FileUtilities.getReader(filename, allowOverride)) {
 
-    while ((data = FileUtilities.readData(reader)) != null) {
-      if (data.length < 3) {
-        continue;
+      String line = FileUtilities.readLine(reader);
+      if (line == null) {
+        RequestLogger.printLine("(file not found)");
+        return 0;
       }
 
-      int id = StringUtilities.parseInt(data[0]);
-      long timestamp = Math.min(now, Long.parseLong(data[1]));
-      int price = StringUtilities.parseInt(data[2]);
-      if (id < 1
-          || id > ItemDatabase.maxItemId()
-          || price < 1
-          || price > 999999999
-          || timestamp <= 0) { // Something's fishy with this file...
-        continue;
+      if (StringUtilities.parseInt(line) != KoLConstants.MALLPRICES_VERSION) {
+        RequestLogger.printLine("(incompatible price file format)");
+        return 0;
       }
 
-      if (!ItemDatabase.isTradeable(id)) continue;
-      Price p = MallPriceDatabase.prices.get(id);
-      if (p == null) {
-        MallPriceDatabase.prices.set(id, new Price(price, timestamp));
-        ++count;
-        ++MallPriceDatabase.modCount;
-      } else if (timestamp > p.timestamp) {
-        p.price = price;
-        p.timestamp = timestamp;
-        ++count;
-        ++MallPriceDatabase.modCount;
-      }
-    }
+      String[] data;
+      long now = System.currentTimeMillis() / 1000L;
 
-    try {
-      reader.close();
-    } catch (Exception e) {
+      while ((data = FileUtilities.readData(reader)) != null) {
+        if (data.length < 3) {
+          continue;
+        }
+
+        int id = StringUtilities.parseInt(data[0]);
+        long timestamp = Math.min(now, Long.parseLong(data[1]));
+        int price = StringUtilities.parseInt(data[2]);
+        if (id < 1
+            || id > ItemDatabase.maxItemId()
+            || price < 1
+            || price > 999999999
+            || timestamp <= 0) { // Something's fishy with this file...
+          continue;
+        }
+
+        if (!ItemDatabase.isTradeable(id)) continue;
+        Price p = MallPriceDatabase.prices.get(id);
+        if (p == null) {
+          MallPriceDatabase.prices.set(id, new Price(price, timestamp));
+          ++count;
+          ++MallPriceDatabase.modCount;
+        } else if (timestamp > p.timestamp) {
+          p.price = price;
+          p.timestamp = timestamp;
+          ++count;
+          ++MallPriceDatabase.modCount;
+        }
+      }
+    } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
     return count;

--- a/src/net/sourceforge/kolmafia/persistence/QuestDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/QuestDatabase.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.persistence;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.regex.Matcher;
@@ -180,39 +181,32 @@ public class QuestDatabase {
   }
 
   public static void reset() {
-    BufferedReader reader =
-        FileUtilities.getVersionedReader("questslog.txt", KoLConstants.QUESTSLOG_VERSION);
+    try (BufferedReader reader =
+        FileUtilities.getVersionedReader("questslog.txt", KoLConstants.QUESTSLOG_VERSION)) {
+      ArrayList<String[]> quests = new ArrayList<String[]>();
+      String[] data;
 
-    ArrayList<String[]> quests = new ArrayList<String[]>();
-    String[] data;
+      while ((data = FileUtilities.readData(reader)) != null) {
+        data[1] = data[1].replaceAll("<Player\\sName>", KoLCharacter.getUserName());
+        quests.add(data);
+      }
 
-    while ((data = FileUtilities.readData(reader)) != null) {
-      data[1] = data[1].replaceAll("<Player\\sName>", KoLCharacter.getUserName());
-      quests.add(data);
-    }
-
-    questLogData = quests.toArray(new String[quests.size()][]);
-
-    try {
-      reader.close();
-    } catch (Exception e) {
+      questLogData = quests.toArray(new String[quests.size()][]);
+    } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
 
-    reader =
-        FileUtilities.getVersionedReader("questscouncil.txt", KoLConstants.QUESTSCOUNCIL_VERSION);
+    try (BufferedReader reader =
+        FileUtilities.getVersionedReader("questscouncil.txt", KoLConstants.QUESTSCOUNCIL_VERSION)) {
+      ArrayList<String[]> quests = new ArrayList<String[]>();
+      String[] data;
 
-    quests = new ArrayList<String[]>();
+      while ((data = FileUtilities.readData(reader)) != null) {
+        quests.add(data);
+      }
 
-    while ((data = FileUtilities.readData(reader)) != null) {
-      quests.add(data);
-    }
-
-    councilData = quests.toArray(new String[quests.size()][]);
-
-    try {
-      reader.close();
-    } catch (Exception e) {
+      councilData = quests.toArray(new String[quests.size()][]);
+    } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
   }

--- a/src/net/sourceforge/kolmafia/persistence/RestoresDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/RestoresDatabase.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.persistence;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -52,42 +53,38 @@ public class RestoresDatabase {
   }
 
   private static void readData() {
-    BufferedReader reader =
-        FileUtilities.getVersionedReader("restores.txt", KoLConstants.RESTORES_VERSION);
+    try (BufferedReader reader =
+        FileUtilities.getVersionedReader("restores.txt", KoLConstants.RESTORES_VERSION)) {
+      String[] data;
 
-    String[] data;
+      while ((data = FileUtilities.readData(reader)) != null) {
+        if (data.length < 7) {
+          continue;
+        }
 
-    while ((data = FileUtilities.readData(reader)) != null) {
-      if (data.length < 7) {
-        continue;
+        String name = data[0];
+        RestoresDatabase.restoreNames.add(name);
+        RestoresDatabase.typeByName.put(name, data[1]);
+        RestoresDatabase.hpMinByName.put(name, data[2]);
+        RestoresDatabase.hpMaxByName.put(name, data[3]);
+        RestoresDatabase.mpMinByName.put(name, data[4]);
+        RestoresDatabase.mpMaxByName.put(name, data[5]);
+        int advCost = StringUtilities.parseInt(data[6]);
+        RestoresDatabase.advCostByName.put(name, IntegerPool.get(advCost));
+
+        if (data.length > 7) {
+          RestoresDatabase.usesLeftByName.put(name, data[7]);
+        } else {
+          RestoresDatabase.usesLeftByName.put(name, "unlimited");
+        }
+
+        if (data.length > 8) {
+          RestoresDatabase.notesByName.put(name, data[8]);
+        } else {
+          RestoresDatabase.notesByName.put(name, "");
+        }
       }
-
-      String name = data[0];
-      RestoresDatabase.restoreNames.add(name);
-      RestoresDatabase.typeByName.put(name, data[1]);
-      RestoresDatabase.hpMinByName.put(name, data[2]);
-      RestoresDatabase.hpMaxByName.put(name, data[3]);
-      RestoresDatabase.mpMinByName.put(name, data[4]);
-      RestoresDatabase.mpMaxByName.put(name, data[5]);
-      int advCost = StringUtilities.parseInt(data[6]);
-      RestoresDatabase.advCostByName.put(name, IntegerPool.get(advCost));
-
-      if (data.length > 7) {
-        RestoresDatabase.usesLeftByName.put(name, data[7]);
-      } else {
-        RestoresDatabase.usesLeftByName.put(name, "unlimited");
-      }
-
-      if (data.length > 8) {
-        RestoresDatabase.notesByName.put(name, data[8]);
-      } else {
-        RestoresDatabase.notesByName.put(name, "");
-      }
-    }
-
-    try {
-      reader.close();
-    } catch (Exception e) {
+    } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
   }

--- a/src/net/sourceforge/kolmafia/persistence/SkillDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/SkillDatabase.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.persistence;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.util.*;
 import java.util.Map.Entry;
 import net.sourceforge.kolmafia.*;
@@ -158,31 +159,25 @@ public class SkillDatabase {
       SkillDatabase.skillsByCategory.put(category, new ArrayList<>());
     }
 
-    BufferedReader reader =
-        FileUtilities.getVersionedReader("classskills.txt", KoLConstants.CLASSSKILLS_VERSION);
-    String[] data;
+    try (BufferedReader reader =
+        FileUtilities.getVersionedReader("classskills.txt", KoLConstants.CLASSSKILLS_VERSION)) {
+      String[] data;
 
-    while ((data = FileUtilities.readData(reader)) != null) {
-      if (data.length < 6) {
-        continue;
+      while ((data = FileUtilities.readData(reader)) != null) {
+        if (data.length < 6) {
+          continue;
+        }
+
+        Integer skillId = Integer.valueOf(data[0]);
+        String name = data[1];
+        String image = data[2];
+        Integer type = Integer.valueOf(data[3]);
+        Long mp = Long.valueOf(data[4]);
+        Integer duration = Integer.valueOf(data[5]);
+        Integer level = (data.length > 6) ? Integer.valueOf(data[6]) : null;
+        SkillDatabase.addSkill(skillId, name, image, type, mp, duration, level);
       }
-
-      Integer skillId = Integer.valueOf(data[0]);
-      String name = data[1];
-      String image = data[2];
-      Integer type = Integer.valueOf(data[3]);
-      Long mp = Long.valueOf(data[4]);
-      Integer duration = Integer.valueOf(data[5]);
-      Integer level = (data.length > 6) ? Integer.valueOf(data[6]) : null;
-      SkillDatabase.addSkill(skillId, name, image, type, mp, duration, level);
-    }
-
-    try {
-      reader.close();
-    } catch (Exception e) {
-      // This should not happen.  Therefore, print
-      // a stack trace for debug purposes.
-
+    } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
 

--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -536,14 +536,12 @@ public class RelayRequest extends PasswordHashRequest {
       return contentBuffer;
     }
 
-    try {
+    try (reader) {
       String line;
       while ((line = reader.readLine()) != null) {
         contentBuffer.append(line);
         contentBuffer.append(KoLConstants.LINE_BREAK);
       }
-
-      reader.close();
     } catch (IOException e) {
     }
 

--- a/src/net/sourceforge/kolmafia/session/BuffBotManager.java
+++ b/src/net/sourceforge/kolmafia/session/BuffBotManager.java
@@ -2,6 +2,7 @@ package net.sourceforge.kolmafia.session;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -80,34 +81,30 @@ public abstract class BuffBotManager {
     BuffBotManager.sendList.clear();
 
     String[] currentBuff;
-    BufferedReader reader =
+    try (BufferedReader reader =
         FileUtilities.getReader(
-            new File(KoLConstants.BUFFBOT_LOCATION, KoLCharacter.baseUserName() + ".txt"));
-
-    if (reader == null) {
-      BuffBotManager.isInitializing = false;
-      BuffBotManager.saveBuffs();
-      return;
-    }
-
-    // It's possible the person is starting from an older release
-    // of KoLmafia.  If that's the case, reload the data from the
-    // properties file, clear it out, and continue.
-
-    while ((currentBuff = FileUtilities.readData(reader)) != null) {
-      if (currentBuff.length < 3) {
-        continue;
+            new File(KoLConstants.BUFFBOT_LOCATION, KoLCharacter.baseUserName() + ".txt"))) {
+      if (reader == null) {
+        BuffBotManager.isInitializing = false;
+        BuffBotManager.saveBuffs();
+        return;
       }
 
-      BuffBotManager.addBuff(
-          SkillDatabase.getSkillName(StringUtilities.parseInt(currentBuff[0])),
-          StringUtilities.parseInt(currentBuff[1]),
-          StringUtilities.parseInt(currentBuff[2]));
-    }
+      // It's possible the person is starting from an older release
+      // of KoLmafia.  If that's the case, reload the data from the
+      // properties file, clear it out, and continue.
 
-    try {
-      reader.close();
-    } catch (Exception e) {
+      while ((currentBuff = FileUtilities.readData(reader)) != null) {
+        if (currentBuff.length < 3) {
+          continue;
+        }
+
+        BuffBotManager.addBuff(
+            SkillDatabase.getSkillName(StringUtilities.parseInt(currentBuff[0])),
+            StringUtilities.parseInt(currentBuff[1]),
+            StringUtilities.parseInt(currentBuff[2]));
+      }
+    } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
 

--- a/src/net/sourceforge/kolmafia/session/MushroomManager.java
+++ b/src/net/sourceforge/kolmafia/session/MushroomManager.java
@@ -552,10 +552,9 @@ public abstract class MushroomManager {
     // the text file which was generated automatically.
 
     int dayIndex = 0;
-    BufferedReader reader =
-        FileUtilities.getReader(new File(KoLConstants.PLOTS_LOCATION, filename + ".txt"));
 
-    try {
+    try (BufferedReader reader =
+        FileUtilities.getReader(new File(KoLConstants.PLOTS_LOCATION, filename + ".txt"))) {
       String line = "";
       String[][] arrayData = new String[4][4];
 
@@ -617,19 +616,9 @@ public abstract class MushroomManager {
       }
     } catch (Exception e) {
       StaticEntity.printStackTrace(e);
-      return Math.max(dayIndex, 2);
     }
 
-    // Make sure to close the reader after you're done reading
-    // all the data in the file.
-
-    try {
-      reader.close();
-      return Math.max(dayIndex, 2);
-    } catch (Exception e) {
-      StaticEntity.printStackTrace(e);
-      return Math.max(dayIndex, 2);
-    }
+    return Math.max(dayIndex, 2);
   }
 
   private static void copyMushroomImage(final String location) {

--- a/src/net/sourceforge/kolmafia/svn/SVNManager.java
+++ b/src/net/sourceforge/kolmafia/svn/SVNManager.java
@@ -16,6 +16,7 @@ package net.sourceforge.kolmafia.svn;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1605,9 +1606,8 @@ public class SVNManager {
    * @return a <code>Set</code> of <code>SVNURL</code>s that are dependencies
    */
   private static Set<SVNURL> readDependencies(File dep) {
-    BufferedReader reader = FileUtilities.getReader(dep);
     Set<SVNURL> depURLs = new HashSet<>();
-    try {
+    try (BufferedReader reader = FileUtilities.getReader(dep)) {
       String[] data;
       while ((data = FileUtilities.readData(reader)) != null) {
         // turn it into an SVNURL
@@ -1619,12 +1619,8 @@ public class SVNManager {
           break;
         }
       }
-    } finally {
-      try {
-        reader.close();
-      } catch (Exception e) {
-        StaticEntity.printStackTrace(e);
-      }
+    } catch (IOException e) {
+      StaticEntity.printStackTrace(e);
     }
     return depURLs;
   }

--- a/src/net/sourceforge/kolmafia/swingui/panel/CustomCombatPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/CustomCombatPanel.java
@@ -110,25 +110,23 @@ public class CustomCombatPanel extends JPanel {
   public void refreshCombatEditor() {
     try {
       String script = (String) this.availableScripts.getSelectedItem();
-      BufferedReader reader =
-          FileUtilities.getReader(CombatActionManager.getStrategyLookupFile(script));
+      try (BufferedReader reader =
+          FileUtilities.getReader(CombatActionManager.getStrategyLookupFile(script))) {
 
-      if (reader == null) {
-        return;
+        if (reader == null) {
+          return;
+        }
+
+        StringBuffer buffer = new StringBuffer();
+        String line;
+
+        while ((line = reader.readLine()) != null) {
+          buffer.append(line);
+          buffer.append('\n');
+        }
+
+        this.combatEditor.setText(buffer.toString());
       }
-
-      StringBuffer buffer = new StringBuffer();
-      String line;
-
-      while ((line = reader.readLine()) != null) {
-        buffer.append(line);
-        buffer.append('\n');
-      }
-
-      reader.close();
-      reader = null;
-
-      this.combatEditor.setText(buffer.toString());
     } catch (Exception e) {
       // This should not happen.  Therefore, print
       // a stack trace for debug purposes.

--- a/test/net/sourceforge/kolmafia/DataFileMechanicsTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileMechanicsTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.util.stream.Stream;
 import net.sourceforge.kolmafia.utilities.FileUtilities;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -84,23 +85,21 @@ public class DataFileMechanicsTest {
     // to be edited.
     assertTrue(precheck(lowCount, highCount), fname + " failed precheck.");
     // FileUtilities will log "errors" but tries very hard to return a reader no matter what.
-    BufferedReader reader = FileUtilities.getVersionedReader(fname, version);
-    String[] fields;
-    boolean noLines = true;
-    while ((fields = FileUtilities.readData(reader)) != null) {
-      noLines = false;
-      int fieldsRead = fields.length;
-      if (skipMe(fieldsRead)) continue;
-      String msg = fname + " " + fields[0];
-      // Line has too many or too few fields.
-      assertThat(
-          msg, fieldsRead, allOf(greaterThanOrEqualTo(lowCount), lessThanOrEqualTo(highCount)));
-    }
-    // No lines is sometimes a symptom caused by a bad file name.
-    assertFalse(noLines, "No lines in " + fname);
-    try {
-      reader.close();
-    } catch (Exception e) {
+    try (BufferedReader reader = FileUtilities.getVersionedReader(fname, version)) {
+      String[] fields;
+      boolean noLines = true;
+      while ((fields = FileUtilities.readData(reader)) != null) {
+        noLines = false;
+        int fieldsRead = fields.length;
+        if (skipMe(fieldsRead)) continue;
+        String msg = fname + " " + fields[0];
+        // Line has too many or too few fields.
+        assertThat(
+            msg, fieldsRead, allOf(greaterThanOrEqualTo(lowCount), lessThanOrEqualTo(highCount)));
+      }
+      // No lines is sometimes a symptom caused by a bad file name.
+      assertFalse(noLines, "No lines in " + fname);
+    } catch (IOException e) {
       fail("Exception in tearing down reader:" + e.toString());
     }
   }


### PR DESCRIPTION
Where a `BufferedReader` was closed, but a `finally` block was not used, there is the possibility of the reader not being closed if an exception occurs in the middle of execution.

Change almost everywhere that closes a reader to use a try-with-resources block. Leave places that return a `BufferedReader`, places that do nothing but close the reader, and `RuntimeLibrary` (which both does something more complicated and correctly uses the finally block).

Some places don't close readers at all (e.g. `TCRSDatabase.load`). Those were untouched, but should probably change in a future PR.

This changeset should be easier to read if you download the branch and use `git show --ignore-all-space` (which ignores the indentation changes). There might be a way of doing this in GitHub but I don't know it.