### PR TITLE
InventoryManager.priceToAcquire as retrieve_price

### DIFF
--- a/src/net/sourceforge/kolmafia/session/InventoryManager.java
+++ b/src/net/sourceforge/kolmafia/session/InventoryManager.java
@@ -1122,7 +1122,7 @@ public abstract class InventoryManager {
     return lower + (int) ((upper - lower) * factor);
   }
 
-  private static int priceToAcquire(
+  public static final int priceToAcquire(
       final AdventureResult item,
       int quantity,
       final int level,

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -4628,7 +4628,7 @@ public abstract class RuntimeLibrary {
     int item = countThenItem ? arg2Value : arg1Value;
 
     if (count <= 0) {
-      return RuntimeLibrary.continueValue();
+      return new Value(0);
     }
 
     return new Value(

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -4628,7 +4628,7 @@ public abstract class RuntimeLibrary {
     int item = countThenItem ? arg2Value : arg1Value;
 
     if (count <= 0) {
-      return new Value(0);
+      return DataTypes.ZERO_VALUE;
     }
 
     return new Value(

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -905,6 +905,15 @@ public abstract class RuntimeLibrary {
     params = new Type[] {DataTypes.INT_TYPE, DataTypes.ITEM_TYPE};
     functions.add(new LibraryFunction("retrieve_item", DataTypes.BOOLEAN_TYPE, params));
 
+    params = new Type[] {DataTypes.ITEM_TYPE};
+    functions.add(new LibraryFunction("retrieve_price", DataTypes.INT_TYPE, params));
+
+    params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.INT_TYPE};
+    functions.add(new LibraryFunction("retrieve_price", DataTypes.INT_TYPE, params));
+
+    params = new Type[] {DataTypes.INT_TYPE, DataTypes.ITEM_TYPE};
+    functions.add(new LibraryFunction("retrieve_price", DataTypes.INT_TYPE, params));
+
     params = new Type[] {};
     functions.add(new LibraryFunction("receive_fax", DataTypes.VOID_TYPE, params));
 
@@ -4606,6 +4615,28 @@ public abstract class RuntimeLibrary {
 
   public static Value retrieve_item(ScriptRuntime controller, final Value item) {
     return retrieve_item(controller, DataTypes.ONE_VALUE, item);
+  }
+
+  public static Value retrieve_price(ScriptRuntime controller, final Value arg1, final Value arg2) {
+    int arg1Value = (int) arg1.intValue();
+    int arg2Value = (int) arg2.intValue();
+
+    boolean countThenItem =
+        arg1.getType().equals(DataTypes.INT_TYPE) || arg1.getType().equals(DataTypes.FLOAT_TYPE);
+
+    int count = countThenItem ? arg1Value : arg2Value;
+    int item = countThenItem ? arg2Value : arg1Value;
+
+    if (count <= 0) {
+      return RuntimeLibrary.continueValue();
+    }
+
+    return new Value(
+        InventoryManager.priceToAcquire(ItemPool.get(item, count), count, 0, false, false));
+  }
+
+  public static Value retrieve_price(ScriptRuntime controller, final Value item) {
+    return retrieve_price(controller, DataTypes.ONE_VALUE, item);
   }
 
   public static Value receive_fax(ScriptRuntime controller) {


### PR DESCRIPTION
This will return the price that is used when calling `acquire` or `retrieve_item` for the "cheapest" way to acquire said item.

Some things to be aware of how acquire works:
* `valueOfInventory` is taken into account for items in your inventory that determines how an item in your inventory affects the retrieve price. This is a float value that defaults to 1.8 so you may want to set this to 1.0 so it matches mall price.
* historical price is usually used (7 day max) but it will mall search on occasion if the prices are within a 2x threshold of each other to get a more exact difference.