### PR TITLE
fix: strange potential NPE

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
@@ -706,7 +706,8 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> {
         }
 
         // no create
-        if (UseItemEnqueuePanel.this.filters[0].isSelected()
+        if (UseItemEnqueuePanel.this.filters != null
+            && UseItemEnqueuePanel.this.filters[0].isSelected()
             && item.getCount(KoLConstants.inventory) == 0) {
           return false;
         }


### PR DESCRIPTION
Occured when doing something in the relay browser while having the consumables pop-up open, once.

"strange" because I can't see how this could happen -- the null field is non-static and populated in the constructor, and you can't only have the filter field without the rest of it... I think?

Anyway, checking for null should make it no longer happen.
```
Unexpected error, debug log printed.
class java.lang.NullPointerException: Cannot load from object array because "this.this$0.filters" is null
java.lang.NullPointerException: Cannot load from object array because "this.this$0.filters" is null
	at net.sourceforge.kolmafia.swingui.panel.UseItemEnqueuePanel$ConsumableFilterField.isVisible(UseItemEnqueuePanel.java:709)
	at net.java.dev.spellcast.utilities.LockableListModel.updateSingleFilter(LockableListModel.java:828)
	at net.java.dev.spellcast.utilities.LockableListModel.updateFilter(LockableListModel.java:801)
	at net.sourceforge.kolmafia.persistence.ConcoctionDatabase.refreshConcoctionsNow(ConcoctionDatabase.java:1332)
	at net.sourceforge.kolmafia.persistence.ConcoctionDatabase.refreshConcoctions(ConcoctionDatabase.java:1179)
	at net.sourceforge.kolmafia.request.GenericRequest.execute(GenericRequest.java:1353)
	at net.sourceforge.kolmafia.request.GenericRequest.run(GenericRequest.java:1105)
	at net.sourceforge.kolmafia.request.RelayRequest.run(RelayRequest.java:3252)
	at net.sourceforge.kolmafia.RequestThread.postRequest(RequestThread.java:243)
	at net.sourceforge.kolmafia.RequestThread.postRequest(RequestThread.java:208)
	at net.sourceforge.kolmafia.textui.RuntimeLibrary.visit_url(RuntimeLibrary.java:3027)
	at jdk.internal.reflect.GeneratedMethodAccessor174.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at net.sourceforge.kolmafia.textui.parsetree.LibraryFunction.execute(LibraryFunction.java:63)
	at net.sourceforge.kolmafia.textui.parsetree.FunctionCall.execute(FunctionCall.java:113)
	at net.sourceforge.kolmafia.textui.parsetree.Variable.getValue(Variable.java:42)
	at net.sourceforge.kolmafia.textui.parsetree.VariableReference.execute(VariableReference.java:41)
	at net.sourceforge.kolmafia.textui.parsetree.FunctionCall.execute(FunctionCall.java:68)
	at net.sourceforge.kolmafia.textui.parsetree.Variable.getValue(Variable.java:42)
	at net.sourceforge.kolmafia.textui.parsetree.VariableReference.execute(VariableReference.java:41)
	at net.sourceforge.kolmafia.textui.parsetree.FunctionCall.execute(FunctionCall.java:68)
	at net.sourceforge.kolmafia.textui.parsetree.BasicScope.execute(BasicScope.java:423)
	at net.sourceforge.kolmafia.textui.parsetree.UserDefinedFunction.execute(UserDefinedFunction.java:87)
	at net.sourceforge.kolmafia.textui.AshRuntime.executeScope(AshRuntime.java:254)
	at net.sourceforge.kolmafia.textui.AshRuntime.execute(AshRuntime.java:182)
	at net.sourceforge.kolmafia.KoLmafiaASH.getClientHTML(KoLmafiaASH.java:147)
	at net.sourceforge.kolmafia.KoLmafiaASH.getClientHTML(KoLmafiaASH.java:115)
	at net.sourceforge.kolmafia.KoLmafiaASH.getClientHTML(KoLmafiaASH.java:89)
	at net.sourceforge.kolmafia.request.RelayRequest.run(RelayRequest.java:3162)
	at net.sourceforge.kolmafia.RequestThread.postRequest(RequestThread.java:243)
	at net.sourceforge.kolmafia.RequestThread.postRequest(RequestThread.java:208)
	at net.sourceforge.kolmafia.webui.RelayAgent.readServerResponse(RelayAgent.java:455)
	at net.sourceforge.kolmafia.webui.RelayAgent.performRelay(RelayAgent.java:103)
	at net.sourceforge.kolmafia.webui.RelayAgent.run(RelayAgent.java:82)
```