### PR TITLE
Item finder fixes

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -65,6 +65,7 @@ import net.sourceforge.kolmafia.session.EventManager;
 import net.sourceforge.kolmafia.session.GoalManager;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.session.Limitmode;
+import net.sourceforge.kolmafia.session.LocketManager;
 import net.sourceforge.kolmafia.session.ResultProcessor;
 import net.sourceforge.kolmafia.session.StoreManager;
 import net.sourceforge.kolmafia.session.TurnCounter;
@@ -383,6 +384,7 @@ public abstract class KoLCharacter {
     EquipmentManager.resetCustomOutfits();
     GearChangeFrame.clearFamiliarList();
     InventoryManager.resetInventory();
+    LocketManager.clear();
     SkillDatabase.resetCasts();
     SpecialOutfit.forgetCheckpoints();
     StorageRequest.resetRoninStoragePulls();

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -204,6 +204,7 @@ public class ItemPool {
   public static final int BRIDGE = 535;
   public static final int DICTIONARY = 536;
   public static final int LOWERCASE_N = 539;
+  public static final int ELITE_TROUSERS = 542;
   public static final int SCROLL_334 = 547;
   public static final int SCROLL_668 = 548;
   public static final int SCROLL_30669 = 549;
@@ -1402,6 +1403,7 @@ public class ItemPool {
   public static final int TINY_FLY_GLASSES = 4566;
   public static final int LEGENDARY_BEAT = 4573;
   public static final int BUGGED_BEANIE = 4575;
+  public static final int BUGGED_POTION = 4579;
   public static final int BUGGED_BAIO = 4581;
   public static final int PIXEL_WHIP = 4589;
   public static final int PIXEL_CHAIN_WHIP = 4590;
@@ -1734,6 +1736,7 @@ public class ItemPool {
   public static final int NOTE_FROM_CLANCY = 5682;
   public static final int BURT = 5683;
   public static final int AUTOPSY_TWEEZERS = 5687;
+  public static final int ONE_MEAT = 5697;
   public static final int LOST_GLASSES = 5698;
   public static final int LITTLE_MANNEQUIN = 5702;
   public static final int CRAYON_SHAVINGS = 5703;
@@ -2830,6 +2833,7 @@ public class ItemPool {
   public static final int HOLORECORD_PIGS = 9114;
   public static final int HOLORECORD_DRUNK_UNCLES = 9115;
   public static final int TIME_RESIDUE = 9116;
+  public static final int EARL_GREY = 9122;
   public static final int SCHOOL_OF_HARD_KNOCKS_DIPLOMA = 9123;
   public static final int KOL_COL_13_SNOWGLOBE = 9133;
   public static final int TRICK_TOT_KNIGHT = 9137;

--- a/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
@@ -254,7 +254,7 @@ public class MonsterDatabase {
     MonsterDatabase.addMapping(youRobotMap, "Dr. Awkward", "Tobias J. Saibot");
     MonsterDatabase.addMapping(youRobotMap, "Lord Spookyraven", "Lord Cyberraven");
     MonsterDatabase.addMapping(youRobotMap, "Protector Spectre", "Protector S. P. E. C. T. R. E.");
-    MonsterDatabase.addMapping(youRobotMap, "The Big Wisniewski", "Artificial Wisniewski");
+    MonsterDatabase.addMapping(youRobotMap, "The Big Wisniewski", "The Artificial Wisniewski");
     MonsterDatabase.addMapping(youRobotMap, "The Man", "The Android");
     MonsterDatabase.addMapping(youRobotMap, "Naughty Sorceress", "Nautomatic Sorceress");
     MonsterDatabase.MONSTER_PATH_MAP.put(Path.YOU_ROBOT.getName(), youRobotMap);

--- a/src/net/sourceforge/kolmafia/textui/command/StorageCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/StorageCommand.java
@@ -121,14 +121,8 @@ public class StorageCommand extends AbstractCommand {
       items = needed.toArray(new AdventureResult[0]);
     } else if (inHardcore) {
       items = ItemFinder.getMatchingItemList(parameters, KoLConstants.freepulls);
-    } else if (!inRonin) {
-      items = ItemFinder.getMatchingItemList(parameters, KoLConstants.storage);
     } else {
-      // See if in storage. If not, see if in freepulls.
       items = ItemFinder.getMatchingItemList(parameters, KoLConstants.storage);
-      if (items.length == 0) {
-        items = ItemFinder.getMatchingItemList(parameters, KoLConstants.freepulls);
-      }
     }
 
     if (items.length == 0) {

--- a/test/net/sourceforge/kolmafia/persistence/ItemFinderTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/ItemFinderTest.java
@@ -11,19 +11,27 @@ import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.ItemFinder.Match;
+import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.CharPaneRequest;
+import net.sourceforge.kolmafia.utilities.StringUtilities;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ItemFinderTest {
 
-  @BeforeEach
-  private void itemFinderSetup() {
+  @BeforeAll
+  private static void itemFinderClassSetup() {
     // Simulate logging out and back in again.
     KoLCharacter.reset("");
     KoLCharacter.reset("item finder user");
-    // Reset preferences to defaults.
-    KoLCharacter.reset(true);
+  }
+
+  @BeforeEach
+  private void itemFinderSetup() {
+    // Reset exactly the preferences used by this package to defaults
+    Preferences.setString("_roboDrinks", "");
+    Preferences.setBoolean("autoSatisfyWithNPCs", false);
 
     // Not in error state
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
@@ -138,67 +146,68 @@ public class ItemFinderTest {
     item = ItemFinder.getFirstMatchingItem("toilet paper", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.TOILET_PAPER);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.TOILET_PAPER);
+    assertEquals(item.getCount(), 1);
 
     // Test successful exact match where item name starts with a number
     item = ItemFinder.getFirstMatchingItem("1337 7r0uZ0RZ", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.ELITE_TROUSERS);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.ELITE_TROUSERS);
+    assertEquals(item.getCount(), 1);
 
     // Test successful exact match where item name contains commas
     item = ItemFinder.getFirstMatchingItem("Tea, Earl Grey, Hot", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.EARL_GREY);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.EARL_GREY);
+    assertEquals(item.getCount(), 1);
 
     // Test successful exact match for item specified by pilcrow
     item = ItemFinder.getFirstMatchingItem("¶7961", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == 7961);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), 7961);
+    assertEquals(item.getCount(), 1);
 
     // Test for the item whose name contains a pilcrow - &para;
-    parameter = "Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion";
+    parameter =
+        StringUtilities.getEntityDecode("Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion");
     item = ItemFinder.getFirstMatchingItem(parameter, false, null, Match.ANY);
     assertTrue(item != null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
-    assertTrue(item.getItemId() == ItemPool.BUGGED_POTION);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.BUGGED_POTION);
+    assertEquals(item.getCount(), 1);
 
     // Test successful exact match for item specified by itemId
     item = ItemFinder.getFirstMatchingItem("[7961]", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == 7961);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), 7961);
+    assertEquals(item.getCount(), 1);
 
     // Test successful exact match for item specified by itemId and name
     item = ItemFinder.getFirstMatchingItem("[7961]Staff of Ed", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == 7961);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), 7961);
+    assertEquals(item.getCount(), 1);
 
     // Test successful exact match for item specified by itemId and bogus name
     // *** One could argue this should check that the name agrees with item
     item = ItemFinder.getFirstMatchingItem("[7961]Staff of Edward", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == 7961);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), 7961);
+    assertEquals(item.getCount(), 1);
 
     // Test unambiguous fuzzy matching. Fuzzy matching deserves its own test
     // suite. Elsewhere.
     item = ItemFinder.getFirstMatchingItem("mmj", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.MMJ);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.MMJ);
+    assertEquals(item.getCount(), 1);
   }
 
   @Test
@@ -212,51 +221,51 @@ public class ItemFinderTest {
     item = ItemFinder.getFirstMatchingItem("2 toilet paper", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.TOILET_PAPER);
-    assertTrue(item.getCount() == 2);
+    assertEquals(item.getItemId(), ItemPool.TOILET_PAPER);
+    assertEquals(item.getCount(), 2);
 
     // count + item name starts with a number
     item = ItemFinder.getFirstMatchingItem("2 1337 7r0uZ0RZ", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.ELITE_TROUSERS);
-    assertTrue(item.getCount() == 2);
+    assertEquals(item.getItemId(), ItemPool.ELITE_TROUSERS);
+    assertEquals(item.getCount(), 2);
 
     // count + item name contains commas
     item = ItemFinder.getFirstMatchingItem("2 Tea, Earl Grey, Hot", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.EARL_GREY);
-    assertTrue(item.getCount() == 2);
+    assertEquals(item.getItemId(), ItemPool.EARL_GREY);
+    assertEquals(item.getCount(), 2);
 
     // count + item specified by pilcrow
     item = ItemFinder.getFirstMatchingItem("2 ¶7961", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == 7961);
-    assertTrue(item.getCount() == 2);
+    assertEquals(item.getItemId(), 7961);
+    assertEquals(item.getCount(), 2);
 
     // count + item specified by itemId
     item = ItemFinder.getFirstMatchingItem("2 [7961]", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == 7961);
-    assertTrue(item.getCount() == 2);
+    assertEquals(item.getItemId(), 7961);
+    assertEquals(item.getCount(), 2);
 
     // count + item specified by itemId and name
     item = ItemFinder.getFirstMatchingItem("2 [7961]Staff of Ed", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == 7961);
-    assertTrue(item.getCount() == 2);
+    assertEquals(item.getItemId(), 7961);
+    assertEquals(item.getCount(), 2);
 
     // Single test for fuzzy matching. As I said, that deserves its own test
     // suite. Elsewhere.
     item = ItemFinder.getFirstMatchingItem("10 mmj", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.MMJ);
-    assertTrue(item.getCount() == 10);
+    assertEquals(item.getItemId(), ItemPool.MMJ);
+    assertEquals(item.getCount(), 10);
   }
 
   @Test
@@ -275,23 +284,23 @@ public class ItemFinderTest {
     item = ItemFinder.getFirstMatchingItem("* toilet paper", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.TOILET_PAPER);
-    assertTrue(item.getCount() == 3);
+    assertEquals(item.getItemId(), ItemPool.TOILET_PAPER);
+    assertEquals(item.getCount(), 3);
 
     // All but 2
     item = ItemFinder.getFirstMatchingItem("-2 toilet paper", false, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.TOILET_PAPER);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.TOILET_PAPER);
+    assertEquals(item.getCount(), 1);
 
     // All available (using inventory)
     item =
         ItemFinder.getFirstMatchingItem("* toilet paper", false, KoLConstants.inventory, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.TOILET_PAPER);
-    assertTrue(item.getCount() == 3);
+    assertEquals(item.getItemId(), ItemPool.TOILET_PAPER);
+    assertEquals(item.getCount(), 3);
 
     // All but 2
     item =
@@ -299,12 +308,8 @@ public class ItemFinderTest {
             "-2 toilet paper", false, KoLConstants.inventory, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.TOILET_PAPER);
-    assertTrue(item.getCount() == 1);
-
-    // *** Closet
-    // *** Storage
-    // *** FreePulls
+    assertEquals(item.getItemId(), ItemPool.TOILET_PAPER);
+    assertEquals(item.getCount(), 1);
   }
 
   @Test
@@ -324,7 +329,7 @@ public class ItemFinderTest {
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "Need to provide an item to match.";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
     // Test unsuccessful match for bogus string, no error on failure
@@ -338,7 +343,7 @@ public class ItemFinderTest {
     item = ItemFinder.getFirstMatchingItem("Bogus", true, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
-    assertTrue("[Bogus] has no matches.".equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, "[Bogus] has no matches.");
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
     // Test for bogus item whose name contains a pilcrow - &para;
@@ -347,7 +352,7 @@ public class ItemFinderTest {
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "Unknown item " + parameter;
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
     // Test for item with too many matches
@@ -355,7 +360,7 @@ public class ItemFinderTest {
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "[tea] has too many matches.";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
   }
 
@@ -370,74 +375,74 @@ public class ItemFinderTest {
     item = ItemFinder.getFirstMatchingItem("seal tooth", true, null, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.SEAL_TOOTH);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.SEAL_TOOTH);
+    assertEquals(item.getCount(), 1);
 
     item = ItemFinder.getFirstMatchingItem("Hell ramen", true, null, Match.FOOD);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.HELL_RAMEN);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.HELL_RAMEN);
+    assertEquals(item.getCount(), 1);
 
     item = ItemFinder.getFirstMatchingItem("vesper", true, null, Match.BOOZE);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.VESPER);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.VESPER);
+    assertEquals(item.getCount(), 1);
 
     item = ItemFinder.getFirstMatchingItem("moxie weed", true, null, Match.SPLEEN);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.MOXIE_WEED);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.MOXIE_WEED);
+    assertEquals(item.getCount(), 1);
 
     item = ItemFinder.getFirstMatchingItem("cottage", true, null, Match.USE);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.COTTAGE);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.COTTAGE);
+    assertEquals(item.getCount(), 1);
 
     item = ItemFinder.getFirstMatchingItem("cottage", true, null, Match.CREATE);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.COTTAGE);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.COTTAGE);
+    assertEquals(item.getCount(), 1);
 
     item = ItemFinder.getFirstMatchingItem("cottage", true, null, Match.UNTINKER);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.COTTAGE);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.COTTAGE);
+    assertEquals(item.getCount(), 1);
 
     item = ItemFinder.getFirstMatchingItem("helmet turtle", true, null, Match.EQUIP);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.HELMET_TURTLE);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.HELMET_TURTLE);
+    assertEquals(item.getCount(), 1);
 
     item = ItemFinder.getFirstMatchingItem("fancy chocolate", true, null, Match.CANDY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.FANCY_CHOCOLATE);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.FANCY_CHOCOLATE);
+    assertEquals(item.getCount(), 1);
 
     item = ItemFinder.getFirstMatchingItem("seal tooth", true, null, Match.ABSORB);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.SEAL_TOOTH);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.SEAL_TOOTH);
+    assertEquals(item.getCount(), 1);
 
     item = ItemFinder.getFirstMatchingItem("literal grasshopper", true, null, Match.ROBO);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.LITERAL_GRASSHOPPER);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.LITERAL_GRASSHOPPER);
+    assertEquals(item.getCount(), 1);
 
     item = ItemFinder.getFirstMatchingItem("Hell ramen", true, null, Match.ASDON);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.HELL_RAMEN);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.HELL_RAMEN);
+    assertEquals(item.getCount(), 1);
 
     // *** Test items that don't match each Match type
 
@@ -447,77 +452,77 @@ public class ItemFinderTest {
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "[vesper] cannot be eaten.";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
     item = ItemFinder.getFirstMatchingItem("Hell ramen", true, null, Match.BOOZE);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "[Hell ramen] cannot be drunk.";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
     item = ItemFinder.getFirstMatchingItem("seal tooth", true, null, Match.SPLEEN);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "[seal tooth] cannot be chewed.";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
     item = ItemFinder.getFirstMatchingItem("stolen accordion", true, null, Match.USE);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "[stolen accordion] cannot be used.";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.ERROR);
 
     item = ItemFinder.getFirstMatchingItem("seal tooth", true, null, Match.CREATE);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "[seal tooth] cannot be created.";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
     item = ItemFinder.getFirstMatchingItem("seal tooth", true, null, Match.UNTINKER);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "[seal tooth] cannot be untinkered.";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
     item = ItemFinder.getFirstMatchingItem("Hell ramen", true, null, Match.EQUIP);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "[Hell ramen] cannot be equipped.";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
     item = ItemFinder.getFirstMatchingItem("alien drugs", true, null, Match.CANDY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "[alien drugs] is not candy.";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
     item = ItemFinder.getFirstMatchingItem("spooky sapling", true, null, Match.ABSORB);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "[spooky sapling] cannot be absorbed.";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
     item = ItemFinder.getFirstMatchingItem("pink pony", true, null, Match.ROBO);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "[pink pony] cannot be fed.";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
     item = ItemFinder.getFirstMatchingItem("lemon", true, null, Match.ASDON);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "[lemon] cannot be used as fuel.";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
   }
 
@@ -543,22 +548,22 @@ public class ItemFinderTest {
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "[milk of magnesium] requested, but it's not a Free Pull";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
     // Test for requesting a free pull from freepulLs
     item = ItemFinder.getFirstMatchingItem("toilet paper", true, KoLConstants.freepulls, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.TOILET_PAPER);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.TOILET_PAPER);
+    assertEquals(item.getCount(), 1);
 
     // Test for requesting a free pull from storage
     item = ItemFinder.getFirstMatchingItem("toilet paper", true, KoLConstants.storage, Match.ANY);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(item != null);
-    assertTrue(item.getItemId() == ItemPool.TOILET_PAPER);
-    assertTrue(item.getCount() == 1);
+    assertEquals(item.getItemId(), ItemPool.TOILET_PAPER);
+    assertEquals(item.getCount(), 1);
 
     // Test for requesting too many of an item which is not on a list
     item =
@@ -567,7 +572,7 @@ public class ItemFinderTest {
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "[milk of magnesium] requested, but none available.";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
     // Test for requesting too many of an item which is on a list
@@ -575,7 +580,7 @@ public class ItemFinderTest {
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(item == null);
     message = "[2 seal tooth] requested, but only 1 available.";
-    assertTrue(message.equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, message);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
   }
 
@@ -607,9 +612,17 @@ public class ItemFinderTest {
     results = ItemFinder.getMatchingItemList("toilet paper", null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 1);
-    assertTrue(results[0].getItemId() == ItemPool.TOILET_PAPER);
-    assertTrue(results[0].getCount() == 1);
+    assertEquals(results.length, 1);
+    assertEquals(results[0].getItemId(), ItemPool.TOILET_PAPER);
+    assertEquals(results[0].getCount(), 1);
+
+    // Test failed exact match for entire string.
+    results = ItemFinder.getMatchingItemList("bogus items", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
+    assertEquals(KoLmafia.lastMessage, "[bogus items] has no matches.");
+    assertTrue(results != null);
+    assertEquals(results.length, 0);
+    StaticEntity.setContinuationState(MafiaState.CONTINUE);
   }
 
   // Next, test items preceded by a count - a simple integer
@@ -631,9 +644,9 @@ public class ItemFinderTest {
     results = ItemFinder.getMatchingItemList("2 toilet paper", null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 1);
-    assertTrue(results[0].getItemId() == ItemPool.TOILET_PAPER);
-    assertTrue(results[0].getCount() == 2);
+    assertEquals(results.length, 1);
+    assertEquals(results[0].getItemId(), ItemPool.TOILET_PAPER);
+    assertEquals(results[0].getCount(), 2);
   }
 
   // You can specify meat via "COUNT meat".
@@ -647,26 +660,26 @@ public class ItemFinderTest {
     results = ItemFinder.getMatchingItemList("1000 meat", null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 1);
+    assertEquals(results.length, 1);
     assertTrue(results[0].isMeat());
-    assertTrue(results[0].getCount() == 1000);
+    assertEquals(results[0].getCount(), 1000);
 
     // And the funny special case of the actual item named "1 Meat"
     results = ItemFinder.getMatchingItemList("1 meat", null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 1);
-    assertTrue(results[0].getItemId() == ItemPool.ONE_MEAT);
-    assertTrue(results[0].getCount() == 1);
+    assertEquals(results.length, 1);
+    assertEquals(results[0].getItemId(), ItemPool.ONE_MEAT);
+    assertEquals(results[0].getCount(), 1);
 
     // Meat should be case insensitive
 
     results = ItemFinder.getMatchingItemList("1000 Meat", null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 1);
+    assertEquals(results.length, 1);
     assertTrue(results[0].isMeat());
-    assertTrue(results[0].getCount() == 1000);
+    assertEquals(results[0].getCount(), 1000);
   }
 
   @Test
@@ -684,9 +697,9 @@ public class ItemFinderTest {
     results = ItemFinder.getMatchingItemList("* toilet paper", null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 1);
-    assertTrue(results[0].getItemId() == ItemPool.TOILET_PAPER);
-    assertTrue(results[0].getCount() == 3);
+    assertEquals(results.length, 1);
+    assertEquals(results[0].getItemId(), ItemPool.TOILET_PAPER);
+    assertEquals(results[0].getCount(), 3);
   }
 
   @Test
@@ -701,33 +714,33 @@ public class ItemFinderTest {
     results = ItemFinder.getMatchingItemList("* meat", null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 1);
+    assertEquals(results.length, 1);
     assertTrue(results[0].isMeat());
-    assertTrue(results[0].getCount() == 12000);
+    assertEquals(results[0].getCount(), 12000);
 
     // All but 10000 Meat
     results = ItemFinder.getMatchingItemList("-10000 meat", null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 1);
+    assertEquals(results.length, 1);
     assertTrue(results[0].isMeat());
-    assertTrue(results[0].getCount() == 2000);
+    assertEquals(results[0].getCount(), 2000);
 
     // All available Meat from inventory
     results = ItemFinder.getMatchingItemList("* meat", KoLConstants.inventory);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 1);
+    assertEquals(results.length, 1);
     assertTrue(results[0].isMeat());
-    assertTrue(results[0].getCount() == 12000);
+    assertEquals(results[0].getCount(), 12000);
 
     // All but 10000 Meat from inventory
     results = ItemFinder.getMatchingItemList("-10000 meat", KoLConstants.inventory);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 1);
+    assertEquals(results.length, 1);
     assertTrue(results[0].isMeat());
-    assertTrue(results[0].getCount() == 2000);
+    assertEquals(results[0].getCount(), 2000);
 
     // Add meat to closet
     KoLCharacter.setClosetMeat(20_000);
@@ -736,17 +749,17 @@ public class ItemFinderTest {
     results = ItemFinder.getMatchingItemList("* meat", KoLConstants.closet);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 1);
+    assertEquals(results.length, 1);
     assertTrue(results[0].isMeat());
-    assertTrue(results[0].getCount() == 20000);
+    assertEquals(results[0].getCount(), 20000);
 
     // All but 10000 Meat from closet
     results = ItemFinder.getMatchingItemList("-10000 meat", KoLConstants.closet);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 1);
+    assertEquals(results.length, 1);
     assertTrue(results[0].isMeat());
-    assertTrue(results[0].getCount() == 10000);
+    assertEquals(results[0].getCount(), 10000);
 
     // Add meat to storage
     KoLCharacter.setStorageMeat(1_000_000);
@@ -755,17 +768,17 @@ public class ItemFinderTest {
     results = ItemFinder.getMatchingItemList("* meat", KoLConstants.storage);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 1);
+    assertEquals(results.length, 1);
     assertTrue(results[0].isMeat());
-    assertTrue(results[0].getCount() == 1000000);
+    assertEquals(results[0].getCount(), 1000000);
 
     // All but 10000 Meat from closet
     results = ItemFinder.getMatchingItemList("-10000 meat", KoLConstants.storage);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 1);
+    assertEquals(results.length, 1);
     assertTrue(results[0].isMeat());
-    assertTrue(results[0].getCount() == 990000);
+    assertEquals(results[0].getCount(), 990000);
 
     // There is no Meat in the freepulls list
 
@@ -773,7 +786,7 @@ public class ItemFinderTest {
     results = ItemFinder.getMatchingItemList("* meat", KoLConstants.freepulls);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 0);
+    assertEquals(results.length, 0);
   }
 
   @Test
@@ -786,48 +799,48 @@ public class ItemFinderTest {
         ItemFinder.getMatchingItemList("1 seal tooth, 2 toilet paper, 3 milk of magnesium", null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 3);
-    assertTrue(results[0].getItemId() == ItemPool.SEAL_TOOTH);
-    assertTrue(results[0].getCount() == 1);
-    assertTrue(results[1].getItemId() == ItemPool.TOILET_PAPER);
-    assertTrue(results[1].getCount() == 2);
-    assertTrue(results[2].getItemId() == ItemPool.MILK_OF_MAGNESIUM);
-    assertTrue(results[2].getCount() == 3);
+    assertEquals(results.length, 3);
+    assertEquals(results[0].getItemId(), ItemPool.SEAL_TOOTH);
+    assertEquals(results[0].getCount(), 1);
+    assertEquals(results[1].getItemId(), ItemPool.TOILET_PAPER);
+    assertEquals(results[1].getCount(), 2);
+    assertEquals(results[2].getItemId(), ItemPool.MILK_OF_MAGNESIUM);
+    assertEquals(results[2].getCount(), 3);
 
     // Multiple items, not all valid
     results =
         ItemFinder.getMatchingItemList("1 seal tooth, 2 bogus items, 3 milk of magnesium", null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
-    assertTrue("[bogus items] has no matches.".equals(KoLmafia.lastMessage));
+    assertEquals(KoLmafia.lastMessage, "[bogus items] has no matches.");
     assertTrue(results != null);
-    assertTrue(results.length == 2);
-    assertTrue(results[0].getItemId() == ItemPool.SEAL_TOOTH);
-    assertTrue(results[0].getCount() == 1);
-    assertTrue(results[1].getItemId() == ItemPool.MILK_OF_MAGNESIUM);
-    assertTrue(results[1].getCount() == 3);
+    assertEquals(results.length, 2);
+    assertEquals(results[0].getItemId(), ItemPool.SEAL_TOOTH);
+    assertEquals(results[0].getCount(), 1);
+    assertEquals(results[1].getItemId(), ItemPool.MILK_OF_MAGNESIUM);
+    assertEquals(results[1].getCount(), 3);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
     // Multiple items specified by itemId
     results = ItemFinder.getMatchingItemList("1 ¶1, 2 [2], 3 ¶3, 4 [4]", null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
-    assertTrue(results.length == 4);
-    assertTrue(results[0].getItemId() == 1);
-    assertTrue(results[0].getCount() == 1);
-    assertTrue(results[1].getItemId() == 2);
-    assertTrue(results[1].getCount() == 2);
-    assertTrue(results[2].getItemId() == 3);
-    assertTrue(results[2].getCount() == 3);
-    assertTrue(results[3].getItemId() == 4);
-    assertTrue(results[3].getCount() == 4);
+    assertEquals(results.length, 4);
+    assertEquals(results[0].getItemId(), 1);
+    assertEquals(results[0].getCount(), 1);
+    assertEquals(results[1].getItemId(), 2);
+    assertEquals(results[1].getCount(), 2);
+    assertEquals(results[2].getItemId(), 3);
+    assertEquals(results[2].getCount(), 3);
+    assertEquals(results[3].getItemId(), 4);
+    assertEquals(results[3].getCount(), 4);
 
     // Multiple by name, but one has commas. This should fail.
     results = ItemFinder.getMatchingItemList("seal tooth, A Crimbo Carol, Ch.1", null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
-    assertTrue("[Ch.1] has too many matches.".equals(KoLmafia.lastMessage));
-    assertTrue(results.length == 1);
-    assertTrue(results[0].getItemId() == ItemPool.SEAL_TOOTH);
-    assertTrue(results[0].getCount() == 1);
+    assertEquals(KoLmafia.lastMessage, "[Ch.1] has too many matches.");
+    assertEquals(results.length, 1);
+    assertEquals(results[0].getItemId(), ItemPool.SEAL_TOOTH);
+    assertEquals(results[0].getCount(), 1);
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
   }
 }

--- a/test/net/sourceforge/kolmafia/persistence/ItemFinderTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/ItemFinderTest.java
@@ -1,0 +1,597 @@
+package net.sourceforge.kolmafia.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.sourceforge.kolmafia.AdventureResult;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.MafiaState;
+import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.request.CharPaneRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ItemFinderTest {
+
+  @BeforeEach
+  private void itemFinderSetup() {
+    // Simulate logging out and back in again.
+    KoLCharacter.reset("");
+    KoLCharacter.reset("item finder user");
+    // Reset preferences to defaults.
+    KoLCharacter.reset(true);
+
+    // Not in error state
+    StaticEntity.setContinuationState(MafiaState.CONTINUE);
+
+    // Default is not in Ronin or Hardcore
+    KoLCharacter.setRonin(false);
+    KoLCharacter.setHardcore(false);
+    CharPaneRequest.setCanInteract(true);
+
+    KoLConstants.inventory.clear();
+    KoLConstants.closet.clear();
+    KoLConstants.storage.clear();
+    KoLConstants.freepulls.clear();
+
+    KoLCharacter.setAvailableMeat(0);
+    KoLCharacter.setClosetMeat(0);
+    KoLCharacter.setStorageMeat(0);
+  }
+
+  private void addToInventory(int itemId, int count) {
+    AdventureResult.addResultToList(KoLConstants.inventory, ItemPool.get(itemId, count));
+  }
+
+  private void addToCloset(int itemId, int count) {
+    AdventureResult.addResultToList(KoLConstants.closet, ItemPool.get(itemId, count));
+  }
+
+  private void addToStorage(int itemId, int count) {
+    AdventureResult.addResultToList(KoLConstants.storage, ItemPool.get(itemId, count));
+  }
+
+  private void addToFreePulls(int itemId, int count) {
+    AdventureResult.addResultToList(KoLConstants.freepulls, ItemPool.get(itemId, count));
+  }
+
+  // ItemFinder is the utility which accepts a parameter string (as typed by a
+  // user in the gCLI) and parses it into an array of AdventureResults,
+  //
+  // The string can specify a single item or a comma seperated list of items.
+  //
+  // The user can specify a "count" for each item, including wildcards:
+  // "*" means "all available and "-N" means "all except N"
+
+  // Primitives:
+  //
+  // List<String> getMatchingNames(String)
+  // String getFirstMatchingItemName(List, String, Match)
+  // AdventureResult getFirstMatchingItem(String, boolean, List, Match)
+  // AdventureResult[] getMatchingItemList(String, boolean, List, Match)
+
+  // getMatchingItemList is implemented using getFirstMatchingItem
+  // getFirstMatchingItem is implemented using getFirstMatchingItemName
+  // getFirstMatchingItemName is implemented using getMatchingNames
+
+  // Therefore, this test suite focuses on testing getMatchingItemList
+
+  // The first thing to test is a string containing a single item
+  //
+  // "" -> ERROR
+  // "bogus" -> ERROR
+  // seal tooth
+  // 1 Meat
+  // mmj -> magical mystery juice
+  // 1337 7r0uZ0RZ
+  // Tea, Earl Grey, Hot
+  // [7961]Staff of Ed
+  // [7961]
+  //  ¶7961
+  //
+  // The "pilcrow" character followed by itemID was invented by Jason
+  // Harper to allow ASH RuntimeLibrary methods to call CLI commands
+  // ("but", "closet", etc.) with no ambiguity.
+  //
+  // The [itemId] forms were added later as general disambiguation for
+  // multiple object types in ASH
+  //
+  // Item names can contain a comma. Even though the parameter string can
+  // contain multiple comma-separated items, we do not allow or expect you to
+  // escape the comma. Instead, you can only specify such an item (by name) if
+  // it is the entire parameter string.
+  //
+  // Although the user can specify N of an item, item names can start with a
+  // number. Tricky!
+  //
+  // Lastly notice that we do "fuzzy matching" using ItemDatabase.getMatchingNames(),
+  // which uses StringUtilities.getMatchingNames().
+  // That package deserves its own test suite.
+  //
+  // also:
+  //
+  // 3215 Meat -> MEAT, not an item
+
+  @Test
+  public void itShouldParseSingleItems() {
+
+    // This set of tests will use null as the source list. That means
+    // that it will not restrict its matches to what is available in a
+    // specific list. The only exception is if you use wildcard counts -
+    // * or -N - in which case, it assumes inventory. We'll test wildcard
+    // counts separately.
+
+    AdventureResult[] results = null;
+
+    // Test empty string, no error on failure
+
+    results = ItemFinder.getMatchingItemList("", false, null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 0);
+
+    // Test empty string, error on failure
+
+    results = ItemFinder.getMatchingItemList("", true, null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
+    assertTrue(results != null);
+    assertTrue(results.length == 0);
+    StaticEntity.setContinuationState(MafiaState.CONTINUE);
+
+    // Test unsuccessful exact match for bogus string, no error on failure
+
+    results = ItemFinder.getMatchingItemList("Bogus", false, null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 0);
+
+    // Test unsuccessful exact match for bogus string, error on failure
+
+    results = ItemFinder.getMatchingItemList("Bigfoot", true, null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
+    assertTrue(results != null);
+    assertTrue(results.length == 0);
+    StaticEntity.setContinuationState(MafiaState.CONTINUE);
+
+    // Test successful exact match for entire string.
+
+    results = ItemFinder.getMatchingItemList("toilet paper", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == ItemPool.TOILET_PAPER);
+    assertTrue(results[0].getCount() == 1);
+
+    // Test successful exact match for entire string where item name starts
+    // with a number
+
+    results = ItemFinder.getMatchingItemList("1337 7r0uZ0RZ", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == ItemPool.ELITE_TROUSERS);
+    assertTrue(results[0].getCount() == 1);
+
+    // Test successful exact match for entire string where item name contains
+    // commas
+
+    results = ItemFinder.getMatchingItemList("Tea, Earl Grey, Hot", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == ItemPool.EARL_GREY);
+    assertTrue(results[0].getCount() == 1);
+
+    // Test successful exact match for item specified by pilcrow
+    results = ItemFinder.getMatchingItemList("¶7961", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == 7961);
+    assertTrue(results[0].getCount() == 1);
+
+    // Test for the item whose name contains a pilcrow - &para;
+    results =
+        ItemFinder.getMatchingItemList("Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == ItemPool.BUGGED_POTION);
+    assertTrue(results[0].getCount() == 1);
+
+    // Test successful exact match for item specified by itemId
+    results = ItemFinder.getMatchingItemList("[7961]", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == 7961);
+    assertTrue(results[0].getCount() == 1);
+
+    // Test successful exact match for item specified by itemId and name
+    results = ItemFinder.getMatchingItemList("[7961]Staff of Ed", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == 7961);
+    assertTrue(results[0].getCount() == 1);
+
+    // Test successful exact match for item specified by itemId and bogus name
+    // *** One could argue this should check that the name agrees with item
+    results = ItemFinder.getMatchingItemList("[7961]Staff of Edward", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == 7961);
+    assertTrue(results[0].getCount() == 1);
+
+    // Single test for fuzzy matching. As I said, that deserves its own test
+    // suite. elsewhere.
+    results = ItemFinder.getMatchingItemList("mmj", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == ItemPool.MMJ);
+    assertTrue(results[0].getCount() == 1);
+  }
+
+  // Next, test items preceded by a count - a simple integer
+
+  @Test
+  public void itShouldParseSingleItemsWithCount() {
+
+    // Now test single items with a count + item
+
+    AdventureResult[] results = null;
+
+    // count + item name
+    results = ItemFinder.getMatchingItemList("2 toilet paper", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == ItemPool.TOILET_PAPER);
+    assertTrue(results[0].getCount() == 2);
+
+    // count + item name starts with a number
+
+    results = ItemFinder.getMatchingItemList("2 1337 7r0uZ0RZ", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == ItemPool.ELITE_TROUSERS);
+    assertTrue(results[0].getCount() == 2);
+
+    // count + item name contains commas
+
+    results = ItemFinder.getMatchingItemList("2 Tea, Earl Grey, Hot", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == ItemPool.EARL_GREY);
+    assertTrue(results[0].getCount() == 2);
+
+    // count + item specified by pilcrow
+    results = ItemFinder.getMatchingItemList("2 ¶7961", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == 7961);
+    assertTrue(results[0].getCount() == 2);
+
+    // count + item specified by itemId
+    results = ItemFinder.getMatchingItemList("2 [7961]", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == 7961);
+    assertTrue(results[0].getCount() == 2);
+
+    // count + item specified by itemId and name
+    results = ItemFinder.getMatchingItemList("2 [7961]Staff of Ed", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == 7961);
+    assertTrue(results[0].getCount() == 2);
+
+    // Single test for fuzzy matching. As I said, that deserves its own test
+    // suite. Elsewhere.
+    results = ItemFinder.getMatchingItemList("10 mmj", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == ItemPool.MMJ);
+    assertTrue(results[0].getCount() == 10);
+  }
+
+  // You can specify meat via "COUNT meat".
+
+  @Test
+  public void itShouldParseMeat() {
+
+    AdventureResult[] results = null;
+
+    // Test that you can get a Meat result
+    results = ItemFinder.getMatchingItemList("1000 meat", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].isMeat());
+    assertTrue(results[0].getCount() == 1000);
+
+    // And the funny special case of the actual item named "1 Meat"
+    results = ItemFinder.getMatchingItemList("1 meat", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == ItemPool.ONE_MEAT);
+    assertTrue(results[0].getCount() == 1);
+
+    // Meat should be case insensitive
+
+    // *** This currently fails
+    // results = ItemFinder.getMatchingItemList("1000 Meat", null);
+    // assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    // assertTrue(results != null);
+    // assertTrue(results.length == 1);
+    // assertTrue(results[0].isMeat());
+    // assertTrue(results[0].getCount() == 1000);
+  }
+
+  @Test
+  public void itShouldParseWildcardItems() {
+
+    // Add stuff to inventory
+    addToInventory(ItemPool.SEAL_TOOTH, 1);
+    addToInventory(ItemPool.TOILET_PAPER, 3);
+    addToInventory(ItemPool.MILK_OF_MAGNESIUM, 1);
+
+    AdventureResult[] results = null;
+
+    // All available (using null list == inventory)
+    results = ItemFinder.getMatchingItemList("* toilet paper", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == ItemPool.TOILET_PAPER);
+    assertTrue(results[0].getCount() == 3);
+
+    // All but 2
+    results = ItemFinder.getMatchingItemList("-2 toilet paper", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == ItemPool.TOILET_PAPER);
+    assertTrue(results[0].getCount() == 1);
+
+    // All available (using inventory)
+    results = ItemFinder.getMatchingItemList("* toilet paper", KoLConstants.inventory);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == ItemPool.TOILET_PAPER);
+    assertTrue(results[0].getCount() == 3);
+
+    // All but 2
+    results = ItemFinder.getMatchingItemList("-2 toilet paper", KoLConstants.inventory);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == ItemPool.TOILET_PAPER);
+    assertTrue(results[0].getCount() == 1);
+
+    // *** Closet
+    // *** Storage
+    // *** FreePulls
+  }
+
+  @Test
+  public void itShouldParseWildcardMeat() {
+
+    AdventureResult[] results = null;
+
+    // Add meat to inventory
+    KoLCharacter.setAvailableMeat(12_000);
+
+    // All available Meat from null list (default inventory)
+    results = ItemFinder.getMatchingItemList("* meat", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].isMeat());
+    assertTrue(results[0].getCount() == 12000);
+
+    // All but 10000 Meat
+    results = ItemFinder.getMatchingItemList("-10000 meat", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].isMeat());
+    assertTrue(results[0].getCount() == 2000);
+
+    // All available Meat from inventory
+    results = ItemFinder.getMatchingItemList("* meat", KoLConstants.inventory);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].isMeat());
+    assertTrue(results[0].getCount() == 12000);
+
+    // All but 10000 Meat from inventory
+    results = ItemFinder.getMatchingItemList("-10000 meat", KoLConstants.inventory);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].isMeat());
+    assertTrue(results[0].getCount() == 2000);
+
+    // Add meat to closet
+    KoLCharacter.setClosetMeat(20_000);
+
+    // All available Meat from closet
+    results = ItemFinder.getMatchingItemList("* meat", KoLConstants.closet);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].isMeat());
+    assertTrue(results[0].getCount() == 20000);
+
+    // All but 10000 Meat from closet
+    results = ItemFinder.getMatchingItemList("-10000 meat", KoLConstants.closet);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].isMeat());
+    assertTrue(results[0].getCount() == 10000);
+
+    // Add meat to storage
+    KoLCharacter.setStorageMeat(1_000_000);
+
+    // All available Meat from storage
+    results = ItemFinder.getMatchingItemList("* meat", KoLConstants.storage);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].isMeat());
+    assertTrue(results[0].getCount() == 1000000);
+
+    // All but 10000 Meat from closet
+    results = ItemFinder.getMatchingItemList("-10000 meat", KoLConstants.storage);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].isMeat());
+    assertTrue(results[0].getCount() == 990000);
+
+    // There is no Meat in the freepulls list
+
+    // All available Meat from freepulls
+    results = ItemFinder.getMatchingItemList("* meat", KoLConstants.freepulls);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 0);
+  }
+
+  @Test
+  public void itShouldParseMultipleItems() {
+
+    AdventureResult[] results = null;
+
+    // Multiple items, all valid
+    results = ItemFinder.getMatchingItemList("1 seal tooth, 2 toilet paper, 3 milk of magnesium", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 3);
+    assertTrue(results[0].getItemId() == ItemPool.SEAL_TOOTH);
+    assertTrue(results[0].getCount() == 1);
+    assertTrue(results[1].getItemId() == ItemPool.TOILET_PAPER);
+    assertTrue(results[1].getCount() == 2);
+    assertTrue(results[2].getItemId() == ItemPool.MILK_OF_MAGNESIUM);
+    assertTrue(results[2].getCount() == 3);
+
+    // Multiple items, not all valid
+    results = ItemFinder.getMatchingItemList("1 seal tooth, 2 bogus items, 3 milk of magnesium", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
+    assertTrue(results != null);
+    assertTrue(results.length == 2);
+    assertTrue(results[0].getItemId() == ItemPool.SEAL_TOOTH);
+    assertTrue(results[0].getCount() == 1);
+    assertTrue(results[1].getItemId() == ItemPool.MILK_OF_MAGNESIUM);
+    assertTrue(results[1].getCount() == 3);
+    StaticEntity.setContinuationState(MafiaState.CONTINUE);
+
+    // Multiple items specified by itemId
+    results = ItemFinder.getMatchingItemList("1 ¶1, 2 [2], 3 ¶3, 4 [4]", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertTrue(results.length == 4);
+    assertTrue(results[0].getItemId() == 1);
+    assertTrue(results[0].getCount() == 1);
+    assertTrue(results[1].getItemId() == 2);
+    assertTrue(results[1].getCount() == 2);
+    assertTrue(results[2].getItemId() == 3);
+    assertTrue(results[2].getCount() == 3);
+    assertTrue(results[3].getItemId() == 4);
+    assertTrue(results[3].getCount() == 4);
+
+    // Multiple by name, but one has commas. This should fail.
+    results = ItemFinder.getMatchingItemList("seal tooth, A Crimbo Carol, Ch.1", null );
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
+    assertTrue(results.length == 1);
+    assertTrue(results[0].getItemId() == ItemPool.SEAL_TOOTH);
+    assertTrue(results[0].getCount() == 1);
+    StaticEntity.setContinuationState(MafiaState.CONTINUE);
+  }
+
+  @Test
+  public void itShouldFindItemsInInventory() {
+    // Doesn't matter if we are in Ronin or not
+
+    // Add stuff to inventory
+    addToInventory(ItemPool.SEAL_TOOTH, 1);
+    addToInventory(ItemPool.TOILET_PAPER, 3);
+    addToInventory(ItemPool.MILK_OF_MAGNESIUM, 1);
+
+    // Test with list == KoLConstants.inventory. That affects how we treat item counts.
+
+    AdventureResult[] results = null;
+  }
+
+  @Test
+  public void itShouldFindItemsInCloset() {
+    // Doesn't matter if we are in Ronin or not
+
+    // Add stuff to closet
+    addToCloset(ItemPool.TOILET_PAPER, 8);
+    addToCloset(ItemPool.MILK_OF_MAGNESIUM, 2);
+
+    AdventureResult[] results = null;
+  }
+
+  @Test
+  public void itShouldFindItemsInStorageInteracting() {
+    // Not in Ronin, Not in Hardcore. Pulls are unlimited.
+    KoLCharacter.setRonin(false);
+    KoLCharacter.setHardcore(false);
+    CharPaneRequest.setCanInteract(true);
+
+    // Add stuff to storage
+    addToStorage(ItemPool.SEAL_TOOTH, 6);
+    addToStorage(ItemPool.TOILET_PAPER, 14);
+    addToStorage(ItemPool.MILK_OF_MAGNESIUM, 3);
+
+    AdventureResult[] results = null;
+  }
+
+  @Test
+  public void itShouldFindItemsInStorageInRonin() {
+    // In Ronin, Not in Hardcore. Pulls are limited.
+    KoLCharacter.setRonin(true);
+    KoLCharacter.setHardcore(false);
+    CharPaneRequest.setCanInteract(false);
+
+    // Add stuff to storage
+    KoLCharacter.setStorageMeat(1_000_000);
+    addToStorage(ItemPool.SEAL_TOOTH, 6);
+    addToStorage(ItemPool.MILK_OF_MAGNESIUM, 3);
+
+    // Add stuff to freepulls
+    addToFreePulls(ItemPool.TOILET_PAPER, 14);
+
+    AdventureResult[] results = null;
+  }
+
+  @Test
+  public void itShouldFindItemsInFreepullsInHardcore() {
+    // Not in Ronin, In Hardcore. Only Free Pulls. No Meat.
+    KoLCharacter.setRonin(false);
+    KoLCharacter.setHardcore(true);
+    CharPaneRequest.setCanInteract(false);
+
+    // Add stuff to freepulls
+    addToFreePulls(ItemPool.TOILET_PAPER, 14);
+
+    AdventureResult[] results = null;
+  }
+}

--- a/test/net/sourceforge/kolmafia/persistence/ItemFinderTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/ItemFinderTest.java
@@ -546,6 +546,20 @@ public class ItemFinderTest {
     assertTrue(message.equals(KoLmafia.lastMessage));
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
 
+    // Test for requesting a free pull from freepulLs
+    item = ItemFinder.getFirstMatchingItem("toilet paper", true, KoLConstants.freepulls, Match.ANY);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(item != null);
+    assertTrue(item.getItemId() == ItemPool.TOILET_PAPER);
+    assertTrue(item.getCount() == 1);
+
+    // Test for requesting a free pull from storage
+    item = ItemFinder.getFirstMatchingItem("toilet paper", true, KoLConstants.storage, Match.ANY);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(item != null);
+    assertTrue(item.getItemId() == ItemPool.TOILET_PAPER);
+    assertTrue(item.getCount() == 1);
+
     // Test for requesting too many of an item which is not on a list
     item =
         ItemFinder.getFirstMatchingItem(

--- a/test/net/sourceforge/kolmafia/persistence/ItemFinderTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/ItemFinderTest.java
@@ -479,7 +479,8 @@ public class ItemFinderTest {
     AdventureResult[] results = null;
 
     // Multiple items, all valid
-    results = ItemFinder.getMatchingItemList("1 seal tooth, 2 toilet paper, 3 milk of magnesium", null);
+    results =
+        ItemFinder.getMatchingItemList("1 seal tooth, 2 toilet paper, 3 milk of magnesium", null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
     assertTrue(results.length == 3);
@@ -491,7 +492,8 @@ public class ItemFinderTest {
     assertTrue(results[2].getCount() == 3);
 
     // Multiple items, not all valid
-    results = ItemFinder.getMatchingItemList("1 seal tooth, 2 bogus items, 3 milk of magnesium", null);
+    results =
+        ItemFinder.getMatchingItemList("1 seal tooth, 2 bogus items, 3 milk of magnesium", null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(results != null);
     assertTrue(results.length == 2);
@@ -516,7 +518,7 @@ public class ItemFinderTest {
     assertTrue(results[3].getCount() == 4);
 
     // Multiple by name, but one has commas. This should fail.
-    results = ItemFinder.getMatchingItemList("seal tooth, A Crimbo Carol, Ch.1", null );
+    results = ItemFinder.getMatchingItemList("seal tooth, A Crimbo Carol, Ch.1", null);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.ERROR);
     assertTrue(results.length == 1);
     assertTrue(results[0].getItemId() == ItemPool.SEAL_TOOTH);


### PR DESCRIPTION
I added an extensive test suite for ItemFinder
I may add to it, once coverage runs, and I can see where it falls short.

Fixed ItemFinder issues:

- N meat -- "meat" is no longer case sensitive
- Fix NOOB skill filter
- Remove unreachable code (low level "parse one item name" code no longer worries about receiving a comma separated list of names)
- When temporarily changing a preference, put inside try/finally
- When looking for items in storage, they might be in freepulls

Fixed StorageCommand issue:

- In Hardcore, only search freepulls list
- Otherwise, search storage list - and assume ItemFinder will find it on freepulls, if necessary

