### PR TITLE
Use image caching in GCLI

### DIFF
--- a/src/net/sourceforge/kolmafia/ImageCachingEditorKit.java
+++ b/src/net/sourceforge/kolmafia/ImageCachingEditorKit.java
@@ -20,7 +20,7 @@ public class ImageCachingEditorKit extends HTMLEditorKit {
     return ImageCachingEditorKit.DEFAULT_FACTORY;
   }
 
-  private static class ImageCachingViewFactory extends HTMLFactory {
+  protected static class ImageCachingViewFactory extends HTMLFactory {
     @Override
     public View create(final Element elem) {
       if (elem.getAttributes().getAttribute(StyleConstants.NameAttribute) == HTML.Tag.IMG) {

--- a/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
@@ -8,15 +8,15 @@ import javax.swing.*;
 import javax.swing.text.*;
 import javax.swing.text.html.HTML;
 import javax.swing.text.html.HTMLDocument;
-import javax.swing.text.html.HTMLEditorKit;
 import javax.swing.text.html.HTMLWriter;
 import javax.swing.text.html.InlineView;
+import net.sourceforge.kolmafia.ImageCachingEditorKit;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class RequestPane extends JEditorPane {
-  static class WrappedHtmlEditorKit extends HTMLEditorKit {
+  static class WrappedHtmlEditorKit extends ImageCachingEditorKit {
     private final ViewFactory viewFactory;
 
     public WrappedHtmlEditorKit() {
@@ -29,7 +29,7 @@ public class RequestPane extends JEditorPane {
       return this.viewFactory;
     }
 
-    private static class WrappedHtmlFactory extends HTMLEditorKit.HTMLFactory {
+    private static class WrappedHtmlFactory extends ImageCachingViewFactory {
       @Override
       public View create(Element elem) {
         View view = super.create(elem);


### PR DESCRIPTION
I had a chat with @cdmoyer who noticed that for some reason the top 3 resource requests (by a huge margin) were to the images for hp, new age healing crystals and gold nuggets. I realised that said images show up in the GCLI when you are volcano farming with preference logging activated.

GCLI was not using the cached image renderer and I think every time it was redrawn it was pulling images from the KoL servers for all the images it was displaying. This PR should fix that.