### PR TITLE
feat: extend absorb to allow 'absorb X item'

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/command/AbsorbCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AbsorbCommand.java
@@ -38,6 +38,8 @@ public class AbsorbCommand extends AbstractCommand {
 
     AdventureResult match = ItemFinder.getFirstMatchingItem(parameters, Match.ABSORB);
     if (match == null) {
+      // for backwards compatibility: previously no message was displayed, so do not error here
+      KoLmafia.updateDisplay("What item is " + parameters + "?");
       return;
     }
 
@@ -65,5 +67,8 @@ public class AbsorbCommand extends AbstractCommand {
     if (ItemDatabase.isHat(itemId)) {
       PreferenceListenerRegistry.firePreferenceChanged("(hats)");
     }
+
+    KoLmafia.updateDisplay(
+        "Absorbed " + (count > 1 ? count + " " : "") + match.getPluralName());
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/command/AbsorbCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AbsorbCommand.java
@@ -16,7 +16,7 @@ import net.sourceforge.kolmafia.session.InventoryManager;
 
 public class AbsorbCommand extends AbstractCommand {
   public AbsorbCommand() {
-    this.usage = " <item> - absorb item.";
+    this.usage = "[X] <item> - absorb item(s).";
   }
 
   @Override
@@ -42,6 +42,7 @@ public class AbsorbCommand extends AbstractCommand {
     }
 
     int itemId = match.getItemId();
+    int count = match.getCount();
 
     // If not in inventory, try to retrieve it (if it's in inventory, doesn't matter if outside
     // Standard)
@@ -52,9 +53,11 @@ public class AbsorbCommand extends AbstractCommand {
       return;
     }
 
-    // Absorb the item
-    RequestThread.postRequest(
-        new GenericRequest("inventory.php?absorb=" + itemId + "&ajax=1", false));
+    // Absorb the item(s)
+    for (int i = 0; i < count; i++) {
+      RequestThread.postRequest(
+          new GenericRequest("inventory.php?absorb=" + itemId + "&ajax=1", false));
+    }
 
     // Parse the charpane for updated absorb info
     RequestThread.postRequest(new CharPaneRequest());

--- a/src/net/sourceforge/kolmafia/textui/command/AbsorbCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AbsorbCommand.java
@@ -55,10 +55,10 @@ public class AbsorbCommand extends AbstractCommand {
       return;
     }
 
+    var request = new GenericRequest("inventory.php?absorb=" + itemId + "&ajax=1", false);
     // Absorb the item(s)
     for (int i = 0; i < count; i++) {
-      RequestThread.postRequest(
-          new GenericRequest("inventory.php?absorb=" + itemId + "&ajax=1", false));
+      RequestThread.postRequest(request);
     }
 
     // Parse the charpane for updated absorb info

--- a/src/net/sourceforge/kolmafia/textui/command/AbsorbCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AbsorbCommand.java
@@ -68,7 +68,6 @@ public class AbsorbCommand extends AbstractCommand {
       PreferenceListenerRegistry.firePreferenceChanged("(hats)");
     }
 
-    KoLmafia.updateDisplay(
-        "Absorbed " + (count > 1 ? count + " " : "") + match.getPluralName());
+    KoLmafia.updateDisplay("Absorbed " + (count > 1 ? count + " " : "") + match.getPluralName());
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/command/HeistCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/HeistCommand.java
@@ -86,8 +86,7 @@ public class HeistCommand extends AbstractCommand {
       return;
     }
 
-    KoLmafia.updateDisplay(
-        "Heisted " + (count > 1 ? count + " " : "") + item.getPluralName());
+    KoLmafia.updateDisplay("Heisted " + (count > 1 ? count + " " : "") + item.getPluralName());
     KoLCharacter.updateStatus();
   }
 

--- a/src/net/sourceforge/kolmafia/textui/command/HeistCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/HeistCommand.java
@@ -1,7 +1,6 @@
 package net.sourceforge.kolmafia.textui.command;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
@@ -9,6 +8,7 @@ import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
+import net.sourceforge.kolmafia.persistence.ItemFinder;
 import net.sourceforge.kolmafia.session.FamiliarManager;
 import net.sourceforge.kolmafia.session.HeistManager;
 
@@ -16,8 +16,6 @@ public class HeistCommand extends AbstractCommand {
   public HeistCommand() {
     this.usage = " [[N] ITEM] - display all heistable items, or heist some number of items";
   }
-
-  private static final Pattern ITEM_WITH_COUNT = Pattern.compile("(\\d+)\\s+(.*)");
 
   @Override
   public void run(final String cmd, String parameter) {
@@ -70,22 +68,15 @@ public class HeistCommand extends AbstractCommand {
   }
 
   private void heistItem(String parameter) {
-    int id = ItemDatabase.getItemId(parameter);
-    int count = 1;
-    if (id == -1) {
-      // possibly number first
-      Matcher itemMatcher = ITEM_WITH_COUNT.matcher(parameter);
-      if (itemMatcher.matches()) {
-        count = Integer.parseInt(itemMatcher.group(1));
-        String possibleItemName = itemMatcher.group(2);
-        id = ItemDatabase.getItemId(possibleItemName);
-      }
-      if (id == -1) {
-        KoLmafia.updateDisplay(MafiaState.ERROR, "What item is " + parameter + "?");
-        return;
-      }
+    AdventureResult item = ItemFinder.getFirstMatchingItem(parameter);
+
+    if (item == null) {
+      KoLmafia.updateDisplay(MafiaState.ERROR, "What item is " + parameter + "?");
+      return;
     }
 
+    int id = item.getItemId();
+    int count = item.getCount();
     var heistManager = heistManager();
     var success = heistManager.heist(count, id);
 

--- a/src/net/sourceforge/kolmafia/textui/command/HeistCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/HeistCommand.java
@@ -87,7 +87,7 @@ public class HeistCommand extends AbstractCommand {
     }
 
     KoLmafia.updateDisplay(
-        "Heisted " + (count > 1 ? count + " " : "") + ItemDatabase.getItemName(id));
+        "Heisted " + (count > 1 ? count + " " : "") + item.getPluralName());
     KoLCharacter.updateStatus();
   }
 

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -158,4 +158,9 @@ public class Player {
     mocked.when(HolidayDatabase::getDate).thenReturn(cal.getTime());
     return new Cleanups(mocked::close);
   }
+
+  public static Cleanups usedAbsorbs(int absorbs) {
+    KoLCharacter.setAbsorbs(absorbs);
+    return new Cleanups(() -> usedAbsorbs(0));
+  }
 }

--- a/test/net/sourceforge/kolmafia/textui/command/AbsorbCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AbsorbCommandTest.java
@@ -1,0 +1,88 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static internal.helpers.Player.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import internal.helpers.Cleanups;
+import net.sourceforge.kolmafia.AscensionPath.Path;
+import net.sourceforge.kolmafia.request.GenericRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class AbsorbCommandTest extends AbstractCommandTestBase {
+  @BeforeEach
+  public void initEach() {
+    // Stop requests from actually running
+    GenericRequest.sessionId = null;
+  }
+
+  public AbsorbCommandTest() {
+    this.command = "absorb";
+  }
+
+  @Test
+  void mustBeInNoob() {
+    var cleanups = inPath(Path.NONE);
+    try (cleanups) {
+      String output = execute("1 helmet turtle");
+      assertThat(output, containsString("not in a Gelatinous Noob"));
+      assertErrorState();
+    }
+  }
+
+  @Test
+  void mustSpecifyItem() {
+    var cleanups = inPath(Path.GELATINOUS_NOOB);
+    try (cleanups) {
+      String output = execute("");
+
+      assertThat(output, containsString("No items specified"));
+      assertErrorState();
+    }
+  }
+
+  @Test
+  void mustHaveAbsorbs() {
+    var cleanups = new Cleanups(inPath(Path.GELATINOUS_NOOB), usedAbsorbs(100));
+    try (cleanups) {
+      String output = execute("1 helmet turtle");
+
+      assertThat(output, containsString("Cannot absorb items"));
+      assertErrorState();
+    }
+  }
+
+  @Test
+  void mustSpecifyValidItem() {
+    var cleanups = new Cleanups(inPath(Path.GELATINOUS_NOOB));
+    try (cleanups) {
+      String output = execute("invalid item");
+
+      assertThat(output, containsString("What item"));
+      assertContinueState();
+    }
+  }
+
+  @Test
+  void mustHaveItem() {
+    var cleanups = new Cleanups(inPath(Path.GELATINOUS_NOOB));
+    try (cleanups) {
+      String output = execute("1 dirty bottlecap");
+
+      assertThat(output, containsString("Item not accessible"));
+      assertErrorState();
+    }
+  }
+
+  @Test
+  void canAbsorbItems() {
+    var cleanups = new Cleanups(inPath(Path.GELATINOUS_NOOB), addItem("Half a Purse", 15));
+    try (cleanups) {
+      String output = execute("15 Half a Purse");
+
+      assertThat(output, containsString("Absorbed 15 Half Purses"));
+      assertContinueState();
+    }
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/command/HeistCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/HeistCommandTest.java
@@ -28,7 +28,7 @@ public class HeistCommandTest extends AbstractCommandTestBase {
     this.command = "heist";
   }
 
-  static void setCatBurglar() {
+  private static void setCatBurglar() {
     var familiar = FamiliarData.registerFamiliar(FamiliarPool.CAT_BURGLAR, 1);
     KoLCharacter.setFamiliar(familiar);
   }
@@ -100,7 +100,7 @@ public class HeistCommandTest extends AbstractCommandTestBase {
     this.command = "heistFake";
     String output = execute("\"meat\" stick");
 
-    assertThat(output, containsString("Heisted \"meat\" stick"));
+    assertThat(output, containsString("Heisted &quot;meat&quot; stick"));
     assertContinueState();
   }
 
@@ -110,7 +110,7 @@ public class HeistCommandTest extends AbstractCommandTestBase {
     this.command = "heistFake";
     String output = execute("13 Purple Beast");
 
-    assertThat(output, containsString("Heisted 13 Purple Beast energy drink"));
+    assertThat(output, containsString("Heisted 13 Purple Beast energy drinks"));
     assertContinueState();
   }
 


### PR DESCRIPTION
When [farming in Gel Noob](http://forums.kingdomofloathing.com/vb/showthread.php?t=248197) you want to kick off the day by absorbing 15 of a single item. Extend the "absorb" command to allow this (most of the logic was there already).

Use the same item parsing function in `heist`, now that I know what it is.

Tested manually.