### PR TITLE
tests: hopefully fix jenkins build

### DIFF
--- a/test/net/sourceforge/kolmafia/request/ScrapheapRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/ScrapheapRequestTest.java
@@ -46,10 +46,9 @@ public class ScrapheapRequestTest extends RequestTestBase {
   public void parseCPUUpgrades() throws IOException {
     String html = Files.readString(Paths.get("request/test_scrapheap_cpu_upgrades.html"));
 
-    ChoiceManager.handlingChoice = true;
     var req = new GenericRequest("choice.php?whichchoice=1445&show=cpus");
     req.responseText = html;
-    req.processResponse();
+    ChoiceManager.visitChoice(req);
 
     var expected =
         new String[] {


### PR DESCRIPTION
[Jenkins](https://ci.kolmafia.us/job/Kolmafia/) is currently failing after the banish PR. Looks like an action-at-a-distance test issue.

Use the choice manager in the currently failing test instead of just setting a property on it.