### PR TITLE
refactor: remove unused allowSocketTimeout preference

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -7,7 +7,6 @@ global	allowNegativeTally	true
 global	allowNonMoodBurning	true
 global	allowSummonBurning	true
 global	autoLogin
-global	allowSocketTimeout	false
 global	autoHighlightOnFocus	true
 global	broadcastEvents	true
 global	browserBookmarks

--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -189,17 +189,8 @@ public class GenericRequest implements Runnable {
 
     GenericRequest.setLoginServer(GenericRequest.SERVERS[useDevProxyServer ? 0 : 1]);
 
-    // Disable this, since it causes unrecoverable problems in
-    // situations of lag, rather than simply slowing things down
-    boolean allowSocketTimeout = false; // Preferences.getBoolean( "allowSocketTimeout" );
-
-    if (allowSocketTimeout) {
-      systemProperties.put("sun.net.client.defaultConnectTimeout", "10000");
-      systemProperties.put("sun.net.client.defaultReadTimeout", "120000");
-    } else {
-      systemProperties.remove("sun.net.client.defaultConnectTimeout");
-      systemProperties.remove("sun.net.client.defaultReadTimeout");
-    }
+    systemProperties.remove("sun.net.client.defaultConnectTimeout");
+    systemProperties.remove("sun.net.client.defaultReadTimeout");
 
     if (Preferences.getBoolean("useNaiveSecureLogin")
         || Preferences.getBoolean("connectViaAddress")) {

--- a/src/net/sourceforge/kolmafia/swingui/LoginFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/LoginFrame.java
@@ -384,8 +384,7 @@ public class LoginFrame extends GenericFrame {
     private final String[][] options = {
       {"useDevProxyServer", "Use devproxy.kingdomofloathing.com to login"},
       {"connectViaAddress", "Use IP address to connect instead of host name"},
-      {"useNaiveSecureLogin", "Do not have Java try to validate SSL certificates"},
-      {"allowSocketTimeout", "Forcibly time-out laggy requests"}
+      {"useNaiveSecureLogin", "Do not have Java try to validate SSL certificates"}
     };
 
     public ConnectionOptionsPanel() {


### PR DESCRIPTION
Instead of being read, it was always false, so don't store it or allow it to change.