### PR TITLE
tests: clear preferences in shared state helper

### DIFF
--- a/test/net/sourceforge/kolmafia/extensions/ClearSharedStateBefore.java
+++ b/test/net/sourceforge/kolmafia/extensions/ClearSharedStateBefore.java
@@ -30,6 +30,7 @@ public class ClearSharedStateBefore implements BeforeAllCallback {
     KoLCharacter.reset("");
     // But, if username is already "", then it doesn't do the bulk of resetting state.
     KoLCharacter.reset(true);
+    Preferences.reset("");
     KoLCharacter.setUserId(0);
   }
 


### PR DESCRIPTION
Possibly fix Jenkins. Not sure how it's getting more or less combat chance, but it must be from something leaking from Daily Deeds test, and preferences is all I can see there.