### PR TITLE
Actually verify that it is a number before trying to parse to an item id

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
@@ -365,7 +365,7 @@ public class ItemFinder {
       String name = parameters;
 
       // If the pilcrow character is first, it is followed by an item ID
-      if (name.startsWith("\u00B6")) {
+      if (name.startsWith("\u00B6") && parameters.substring(1).trim().matches("^[-+]?[0-9]+$")) {
         itemId = StringUtilities.parseInt(parameters.substring(1));
       } else if (name.startsWith("[")) {
         int index = name.indexOf("]");


### PR DESCRIPTION
In this scenario, you will be sending 6 imp ales to yourself.

```
kmail 1 ¶ 470, 1 ¶ 470, 1 ¶ 470, 1 ¶ 470, 1 ¶ 470 to YourNameGoesHere
```

You will receive a harmless error before it sends the kmail as expected.

```
4701470147014701470 is out of range, returning 0
Sending kmail to Irrat...
Message sent to Irrat
```

The issue in question is that after verifying that it starts with a ¶, it doesn't bother checking if it's even a comma delimited list and just blindly attempts to parse the entire string to a number.

This in turn reveals a new problem, in which if you attempt to use

```
kmail ¶1, ¶2 to YourNameGoesHere
```

It will attempt to send item no. 12, mariachi pants. Instead of Seal Clubbing Club & Seal Tooth.