### PR TITLE
mark a bunch of monsters NOCOPY based on locket data

### DIFF
--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -18,7 +18,6 @@ A.M.C. gremlin	554	gremlinamc.gif	Atk: 170 Def: 153 HP: 170 Init: 60 Meat: 50 P:
 acid blob	220	lower_b.gif	Atk: 58 Def: 52 Init: 40 HP: 70 P: slime	magic whistle (15)	blob of acid (c0)
 acoustic electric eel	736	electriceel.gif	Atk: 400 Def: 360 HP: 500 Init: 200 Meat: 240 P: fish	dull fish scale (n15)	eel battery (c9)	eel sauce (c10)	eel skin (n4)
 albino bat	41	whitebat.gif	Atk: 12 Def: 12 HP: 8 Init: 60 Meat: 20 P: beast	batgut (10)	bat guano (10)
-alert mariachi	860	mar_alert.gif	HP: 250 Def: 180 Atk: 200 Init: 300 P: dude NOBANISH	spangly mariachi pants (0)	spangly mariachi vest (0)	spangly sombrero (0)	alarm accordion (a0)
 Alphabet Giant	176	giant_alphabet.gif	Atk: 145 Def: 130 HP: 150 Init: 80 Meat: 150 P: humanoid	heavy D (40)	original G (40)
 amateur ninja	716	ninja.gif	Atk: 4 Def: 5 HP: 5 Init: 75 Meat: 20 P: dude	bargain flash powder (20)	cheap plastic blowgun (10)	third-hand nunchaku (10)
 amok putty	1539	amokputty.gif	Scale: 1 Cap: 89 Floor: 6 Init: 100 P: slime	amok pudding (0)	amok putter (0)
@@ -42,13 +41,10 @@ animated ornate nightstand	1542	nightstand4.gif	Atk: 60 Def: 45 HP: 55 Init: -10
 animated rustic nightstand	1543	nightstand3.gif	Atk: 55 Def: 50 HP: 60 Init: -10000 P: construct
 Anime Smiley	139	smiley.gif	Atk: 77 Def: 69 HP: 67 Init: 60 P: horror	334 scroll (30)	Tasty Fun Good rice candy (40)	caret (p5)
 annoying spooky gravy fairy	259	annoyfairy.gif	Atk: 20 Def: 18 HP: 20 Init: 70 E: spooky P: plant	annoying pitchfork (100)
-apathetic lizardman	5	lizardman.gif	NOCOPY Atk: 20 Def: 18 HP: 12 Init: 60 Meat: 20 P: humanoid	flavorless gruel (n100)
-Argarggagarg the Dire Hellseal	701	2headseal.gif	WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 P: demon	secret tropical island volcano lair map (100)	Argarggagarg's fang (100)	adorable seal larva (100)
 armored mushroom guy	1803	mush_armor.gif	Atk: 20 Def: 35 HP: 20 Init: 25 P: plant	hard spore pod (0)	warm mushroom (0)
 Astronomer	184	astronomer.gif	Atk: 168 Def: 151 HP: 150 Init: 70 P: constellation	star chart (100)
 axe handle	227	axehandle.gif	HP: 3 Def: 2 Atk: 3 Init: 40 P: construct	pine tar (20)
 Axe Wound	543	axewound.gif	Atk: 163 Def: 146 HP: 150 Init: 70 E: sleaze P: constellation	line (30)	line (30)	star (30)
-b&eacute;arnaise zombie	687	saucezombie.gif	WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 P: slime Manuel: "béarnaise zombie"
 Baa'baa'bu'ran	1163	stone_serpent.gif	LUCKY Scale: 10 Cap: 100 Floor: 20 Init: -10000 P: construct	stone wool (100)	stone wool (50)	stone wool (20)
 baa-relief sheep	1160	stone_sheep.gif	Scale: 0 Cap: 50 Floor: 7 Init: -10000 P: construct	stone wool (25)
 Bad ASCII Art	426	badascii.gif	LUCKY Atk: 85 Def: 76 HP: 75 Init: 50 P: construct	ASCII shirt (c100)	30669 scroll (100)	33398 scroll (100)	334 scroll (100)	334 scroll (100)
@@ -62,7 +58,6 @@ baseball bat	43	ballbat.gif	Atk: 15 Def: 13 HP: 9 Init: 60 Meat: 20 P: beast	bas
 BASIC Elemental	87	basicgolem.gif	Atk: 50 Def: 45 HP: 40 Init: 60 P: elemental	GOTO (30)
 basic lihc	2153	lich.gif	Atk: 55 Def: 50 HP: 54 Init: 50 E: spooky P: undead	bottle of vodka (30)	boxed wine (30)
 batrat	150	batrat.gif	Atk: 23 Def: 20 HP: 20 Init: 60 Meat: 22 P: beast	bat wing (15)	bat guano (15)	batgut (15)	sonar-in-a-biscuit (15)
-Batsnake	1517	snakeboss5.gif	Atk: 160 Def: 160 HP: 175 Init: 50 P: beast SNAKE E: stench	The Stankara Stone (0)
 Battlie Knight Ghost	1257	aboo_wars.gif	Atk: 76 Def: 64 HP: 40 Init: -10000 Phys: 100 E: spooky P: undead GHOST	A-Boo clue (c15)	Battlie Light Saver (15)	Whoompa Fur Pants (5)	ectoplasmic orbs (10)
 batwinged gremlin	548	gremlinbat.gif	Atk: 169 Def: 153 HP: 170 Init: 60 Meat: 50 P: humanoid	gremlin juice (3)
 batwinged gremlin (tool)	549	gremlinbat.gif	Atk: 169 Def: 153 HP: 170 Init: 60 Meat: 50 P: humanoid Manuel: "batwinged gremlin" Wiki: "batwinged gremlin (quest)"	gremlin juice (3)	molybdenum hammer (c0)
@@ -97,7 +92,6 @@ bog skeleton	1346	bogskeleton.gif	Atk: 50 Def: 52 HP: 50 Init: 25 P: undead E: s
 bogart	1348	bogart.gif	Atk: 54 Def: 48 HP: 48 Init: 70 P: humanoid Meat: 30	fine aged cheddarwurst (0)	stolen meatpouch (0)
 Bonerdagon	198	foss_wyrm.gif	NOCOPY BOSS Atk: 90 Def: 81 HP: 120 Init: 90 Item: 25 Skill: 50 E: spooky P: undead	skull of the Bonerdagon (n100)	chest of the Bonerdagon (n100)
 bookbat	387	bookbat.gif	Atk: 26 Def: 24 HP: 26 Init: 70 P: construct	tattered scrap of paper (15)
-booth slime	803	boothslime.gif	Atk: 140 Def: 126 HP: 150 Init: 50 P: slime NOBANISH	vial of blue slime (f66)
 booty crab	634	bootycrab.gif	NOCOPY Atk: 100 Def: 90 HP: 70 Init: 10000 Meat: 300 E: sleaze Phys: 25 P: beast	Cap'm Caronch's nasty booty (100)
 Booze Giant	95	boozegiant.gif	Atk: 76 Def: 68 HP: 66 Init: 80 P: humanoid	bottle of gin (15)	bottle of rum (15)	bottle of tequila (15)	bottle of vodka (15)	bottle of whiskey (15)	boxed wine (15)	giant breath mint (c0)
 Boss Bat	49	bigbossbat.gif	NOCOPY BOSS Atk: 33 Def: 29 HP: 40 Init: 60 P: beast NOBANISH	batskin belt (100)	dense Meat stack (100)	Boss Bat britches (c100)	boss Bat bling (c100)
@@ -105,7 +99,6 @@ Box	535	box.gif	Atk: 150 Def: 135 HP: 150 E: sleaze Init: 70 P: constellation	li
 Brainsweeper	34	broombrain.gif	Atk: 18 Def: 16 HP: 9 Init: 60 Meat: 36 P: construct	disembodied brain (30)
 Bram the Stoker	1559	bram.gif	LUCKY Atk: 164 Def: 148 HP: 170 Init: 50 Meat: 250 P: undead	Bram's choker (100)
 Bread Golem	35	breadgolem.gif	Atk: 16 Def: 14 HP: 8 Init: 60 Meat: 32 P: construct	wad of dough (30)	eldritch dough (c0)
-breakdancing raver	855	breakdancer.gif	Atk: 140 Def: 126 HP: 150 Init: 10000 P: dude NOBANISH	candy necklace (c0)	rave visor (c0)	teddybear backpack (c0)
 briefcase bat	46	casebat.gif	Atk: 17 Def: 15 HP: 11 Init: 60 Meat: 28 P: beast	bat guano (10)	briefcase (40)	sonar-in-a-biscuit (10)
 broodling seal	794	babyseal.gif	NOCOPY FREE Atk: 80 Def: 90 HP: 100 Init: -10000 P: demon	severed flipper (35)
 Brutus, the toga-clad lout	518	togafrat.gif	NOCOPY Atk: 200 Def: 180 HP: 280 Init: 60 Meat: 250 E: sleaze P: orc	wreath of laurels (100)	white class ring (30)	kick-ass kicks (0)
@@ -115,7 +108,6 @@ bugged bugbear	258	bugbugbear.gif	HP: 14 Def: 16 Atk: 17 Init: 50 P: beast	gnoll
 Bullet Bill	121	bulletbill.gif	Atk: 25 Def: 22 HP: 15 Init: 60 P: construct	black pixel (70)	black pixel (70)	black pixel (70)
 bunch of drunken rats	995	ratbunch.gif	Atk: 20 Def: 18 HP: 16 Init: 80 Meat: 20 P: beast	rat whisker (0)	rat whisker (0)	rat appendix (0)	rat appendix (0)	rat appendix (0)
 Burly Sidekick	166	sidekick.gif	Atk: 100 Def: 90 HP: 100 Init: 80 Meat: 130 P: dude	armgun (9)	cocoa eggshell fragment (30)	Mohawk wig (10)	tiny house (30)
-Burning Snake of Fire	1518	snakeboss4.gif	Atk: 160 Def: 160 HP: 175 Init: 50 P: beast SNAKE E: hot	Murphy's Rancid Black Flag (n100)
 Burrowing Bishop	351	bishop.gif	Atk: 163 Def: 146 HP: 150 Init: 70 E: sleaze P: constellation	line (30)	line (30)	star (30)
 Bush	537	bush.gif	Atk: 156 Def: 140 HP: 150 Init: 70 E: sleaze P: constellation	star (30)	star (30)	star (30)
 business hippy	335	bushippy.gif	Atk: 35 Def: 34 HP: 25 Init: -10000 Meat: 50 E: stench P: hippy	filthy corduroys (10)	filthy knitted dread sack (10)	herbs (20)	reodorant (10)
@@ -175,14 +167,11 @@ crusty pirate	625	crustpirate.gif	Atk: 100 Def: 90 HP: 90 Init: 50 ED: stench Me
 cubist bull	393	cubistbull.gif	Atk: 56 Def: 50 HP: 55 Init: 50 Meat: 75 P: beast	broken sword (5)	4-dimensional guitar (5)	non-Euclidean non-accordion (a0)
 curmudgeonly pirate	623	curmpirate.gif	Atk: 100 Def: 90 HP: 90 Init: 50 P: pirate Meat: 62	all-purpose cleaner (25)	curmudgel (5)	grumpy old man charrrm (10)	handful of sawdust (30)	mizzenmast mop (c30)
 Dad Sea Monkee	1379	dad_machine.gif	BOSS Atk: 42000 Def: 42000 HP: 4200 Init: 10000 P: horror
-daft punk	870	daftpunk.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: dude
 dairy goat	83	biggoat.gif	Atk: 68 Def: 61 HP: 50 Init: 80 Meat: 50 P: beast	glass of goat's milk (20)	goat cheese (40)	Shivering Ch&egrave;vre (c0)
-dairy ooze	69	ooze.gif	Atk: 13 Def: 11 HP: 8 Init: 60 Meat: 12 P: slime	mana curds (n100)
 dancing mushroom guy	1806	mush_dancing.gif	Atk: 20 Def: 35 HP: 20 Init: 100 P: plant	cool spore pod (0)	cool mushroom (0)
 Danglin' Chad	519	chad.gif	NOCOPY Atk: 210 Def: 189 HP: 320 Init: 80 Meat: 300 E: sleaze P: orc	Danglin' Chad's loincloth (100)	white class ring (30)	beer helmet (0)	bejeweled pledge pin (0)	distressed denim pants (0)	kick-ass kicks (0)
 decent lumberjack	233	lumberjack.gif	Atk: 35 Def: 31 HP: 35 Init: 60 Meat: 20 P: dude	poutine (30)	disbelief suspenders (10)	jack flapper (10)	manly bloomers (p15)
 decent white shark	735	whiteshark.gif	Atk: 425 Def: 337 HP: 600 Init: 150 Meat: 240 P: fish	dull fish scale (n15)	shark cartilage (c10)	shark jumper (c3)	shark tooth (n2)	shark tooth (n1)
-Demon of New Wave	892	5_4a.gif	NOCOPY BOSS Atk: 200 Def: 180 HP: 500 Init: 100 Phys: 40 P: demon	Bling of the New Wave (100)	Instant Karma (c100)	heart of the volcano (c100)
 demonic icebox	373	demfridge.gif	Atk: 21 Def: 19 HP: 21 Meat: 5 Init: 50 P: demon	accidental cider (0)	ancient frozen dinner (30)	dire fudgesicle (0)	leftovers of indeterminate origin (40)	hand grenegg (p20)
 Demoninja	126	demoninja.gif	Atk: 48 Def: 27 HP: 48 Init: 75 E: hot Meat: 50 P: demon	demon skin (15)	hot katana blade (30)	ninja hot pants (5)
 dense liana	1426	liana.gif	Atk: 144 Def: 140 HP: 150 Init: -10000 P: plant	exotic jungle fruit (0)
@@ -196,7 +185,6 @@ dirty thieving brigand	475	bandit.gif	Atk: 169 Def: 153 HP: 185 Init: 50 Meat: 1
 disease-in-the-box	110	dinbox.gif	Atk: 18 Def: 16 HP: 14 Init: 80 P: construct	box (30)	disease (40)
 diving belle	762	divingbelle.gif	Atk: 400 Def: 450 HP: 750 Init: 50 E: spooky P: undead	diving muff (n3)	salinated mint julep (32)	water-polo mitt (c0)	comb jelly (0)
 Doctor Oh, the Junksprite Boss	1439	js_oh.gif	Atk: 40 Def: 40 HP: 60 Init: -10000 P: humanoid	eternal car battery (n100)
-dodecapede	3	pede.gif	Atk: 12 Def: 10 HP: 8 Init: 60 "A Little Bit Poisoned" Meat: 12 P: bug	clutch of dodecapede eggs (n100)
 dopey 7-Foot Dwarf	1150	dwarf_dopey.gif	Atk: 53 Def: 47 HP: 40 Init: 50 Meat: 40 P: humanoid	miner's helmet (9)
 doughbat	42	doughbat.gif	Atk: 14 Def: 12 HP: 8 Init: 60 EA: sleaze Meat: 20 P: beast	sonar-in-a-biscuit (10)	wad of dough (30)
 Dr. Awkward	453	drawkward.gif	NOCOPY BOSS Atk: 175 Def: 157 HP: 200 Init: -10000 P: dude	Drowsy Sword (n100)	Staff of Fats (n100)	fumble formula (p5)
@@ -234,12 +222,7 @@ erudite gremlin	546	gremlinglasses.gif	Atk: 171 Def: 152 HP: 170 Init: 60 Meat: 
 erudite gremlin (tool)	547	gremlinglasses.gif	Atk: 171 Def: 152 HP: 170 Init: 60 Meat: 50 P: humanoid Manuel: "erudite gremlin" Wiki: "erudite gremlin (quest)"	gremlin juice (3)	molybdenum crescent wrench (c0)
 evil cultist	833	cultist.gif	Atk: 60 Def: 45 HP: 70 Init: 40 P: dude	memory of a cultist's robe (0)
 Evil Olive	136	oliveevil.gif	Atk: 145 Def: 130 HP: 140 Init: 50 P: beast	bottle of gin (30)	olive (40)	jumbo olive (10)
-evil spaghetti cult assassin	686	spagcult2.gif	NOCOPY WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 P: dude
-evil spaghetti cult middle-manager	806	spagcult3.gif	Atk: 150 Def: 135 HP: 175 Init: 80 P: dude NOBANISH	spaghetti cult mask (0)	spaghetti cult rosary (0)	crystal orb of spirit wrangling (100)	cult memo (100)
-evil spaghetti cult neophyte	807	spagcult1.gif	Atk: 140 Def: 126 HP: 150 Init: 60 P: dude NOBANISH	spaghetti cult mask (0)	spaghetti cult rosary (0)
 evil spaghetti cult priest	657	spagcult2k.gif	Atk: 24 Def: 21 HP: 21 Init: 40 P: dude	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)	evil noodles (0)
-evil spaghetti cult technician	808	spagcult2.gif	Atk: 140 Def: 126 HP: 150 Init: 60 P: dude NOBANISH	spaghetti cult mask (0)	spaghetti cult rosary (0)
-evil spaghetti cult zealot	868	spagcult4.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: dude
 evil spaghetti cultist	656	spagcult1k.gif	Atk: 21 Def: 18 HP: 18 Init: 20 P: dude	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)
 evil trumpet-playing mariachi	663	trumpetmariachi.gif	Atk: 21 Def: 18 HP: 18 Init: 20 P: dude	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)
 evil vihuela-playing mariachi	662	vihuelamariachi.gif	Atk: 24 Def: 21 HP: 21 Init: 40 P: dude	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)	evil vihuela (0)
@@ -251,7 +234,6 @@ factory-irregular skeleton	1744	badskel1.gif,badskel2.gif,badskel3.gif,badskel4.
 Fallen Archfiend	127	archfiend.gif	Atk: 50 Def: 45 HP: 50 Init: 80 E: hot Meat: 45 P: demon	demon skin (15)	evil golden arch (30)	infernal insoles (10)	pink slime (0)	heavy-duty bendy straw (c0)
 Family Jewels	180	jewels.gif	Atk: 156 Def: 140 HP: 150 Init: 70 E: sleaze P: constellation	star (30)	star (30)	star (30)
 fan dancer	1532	fandancer.gif	Atk: 145 Def: 140 HP: 145 Init: 150 P: dude Meat: 100	blowdart (20)	red silk skirt (5)	combat fan (5)	dancing fan (c0)
-fan slime	804	fanslime.gif	Atk: 140 Def: 126 HP: 150 Init: 50 P: slime NOBANISH	vial of yellow slime (f66)
 Felonia, Queen of the Spooky Gravy Fairies	266	felonia.gif	NOCOPY BOSS Atk: 75 Def: 67 HP: 80 Init: 100 E: spooky P: plant
 ferocious bugbear	531	haiku2.gif	Atk: 3 Def: 2 HP: 5 Init: 50 Meat: 20 P: beast	bugbear beanie (20)	bugbear bungguard (20)
 fiendish can of asparagus	146	asparagus.gif	Atk: 2 Def: 0 HP: 1 Init: 50 E: stench Meat: 5 P: undead	asparagus knife (20)	stalk of asparagus (40)	razor-sharp can lid (40)
@@ -270,17 +252,14 @@ Flaming Troll	142	flametroll.gif	Atk: 83 Def: 74 HP: 73 Init: 60 Meat: 40 P: hum
 Flange	538	flange.gif	Atk: 159 Def: 143 HP: 150 Init: 70 E: sleaze P: constellation	line (30)	line (30)	star (30)
 fleet woodsman	1527	woodsman.gif	Atk: 150 Def: 130 HP: 150 Init: 100 P: dude Meat: 75	fleetwood chain (20)	Green Manalishi (20)	flask of rainwater (c0)
 floating platter of hors d'oeuvres	404	horstray.gif	Atk: 65 Def: 55 HP: 70 Init: -10000 ED: spooky P: construct	dehydrated caviar (30)	desiccated apricot (30)	flute of flat champagne (30)	hors d'oeuvre tray (4)
-flock of seagulls	699	seagulls.gif	WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 P: beast
 Flock of Stab-bats	133	stabbats.gif	Atk: 155 Def: 133 HP: 155 Init: 90 Meat: 160 P: beast	bat wing (30)	batblade (25)	batgut (30)
 fluffy bunny	313	bunny.gif	Atk: 1 Def: 0 HP: 1 Init: 50 Meat: 8 P: beast	bunny liver (0)
 Foodie Giant	1334	giant_foodie.gif	Atk: 130 Def: 120 HP: 150 Init: 40 Meat: 100 P: humanoid	chipotle wasabi cilantro aioli (25)	giant artisanal rice peeler (10)	giant heirloom grape tomato (15)	artisanal hand-squeezed wheatgrass juice (c15)
 forest spirit	228	forspirit.gif	Atk: 2 Def: 1 HP: 3 Init: 40 E: spooky P: undead	forest tears (30)	forest spirit rattle (c0)
 Frat Warrior drill sergeant	528	warfrata.gif	Atk: 175 Def: 157 HP: 200 Init: 60 E: sleaze P: orc	distressed denim pants (10)	bejeweled pledge pin (10)	beer helmet (10)	flask flops (0)
 freaked-out mushroom guy	1801	mush_freaked.gif	Atk: 25 Def: 25 HP: 20 Init: 75 P: plant	paisley spore pod (70)	Knoll mushroom (20)
-french guard turtle	783	frenchturtle.gif	NOCOPY Atk: 140 Def: 126 HP: 140 Init: 140 P: beast Manuel: "guard turtle"	guard turtle shell (0)	guard turtle collar (0)
 frog	332	frog.gif	NOCOPY HP: [3] Def: [2] Atk: [3] Init: -10000 Meat: 10 P: beast	squashed frog (100)	frog lip-print (c0)
 frozen duck	556	duckfrozen.gif	Atk: 170 Def: 160 HP: 180 Init: 50 Meat: 150 E: cold P: beast	frozen feather (10)	duct tape (5)
-Frozen Solid Snake	1514	snakeboss1.gif	NOCOPY Atk: 160 Def: 160 HP: 175 Init: 50 P: beast SNAKE E: cold	The First Pizza (n100)
 Fruit Golem	89	fruitgolem.gif	Atk: 56 Def: 50 HP: 46 Init: 80 P: construct	cherry (15)	orange (15)	lime (15)
 full-length mirror	1553	bigmirror.gif	NOCOPY LUCKY Scale: 0 Cap: ? Init: 50 P: construct
 funk sole brother	719	solebrother.gif	Atk: 300 Def: 315 HP: 400 Init: 150 Meat: 200 P: fish	dull fish scale (n15)	slick fish meat (n5)
@@ -299,7 +278,6 @@ ghost of Elizabeth Spookyraven	1564	elizabeth.gif	NOCOPY Scale: 5 Cap: 300 Init:
 ghuol	30	ghuol_reg.gif	Atk: 19 Def: 17 HP: 10 E: spooky Init: 60 Meat: 34 P: undead	ghuol egg (25)	ghuol ears (25)
 giant amorphous blob	2033	xoblob_big.gif	Atk: 10000 Def: 9000 HP: 20000 Init: 500 P: slime
 giant giant giant centipede	462	centipede.gif	Atk: 142 Def: 124 HP: 142 Init: 50 Meat: 150 P: bug	centipede eggs (20)	handful of sand (25)	handful of sand (15)
-giant giant moth	72	moth.gif	Atk: 16 Def: 14 HP: 11 Init: 60 Meat: 16 P: bug	giant giant moth dust (n100)
 giant mob of baby spiders	1584	manyspiders.gif	Atk: 36 Def: 31 HP: 37 Init: 50 P: bug Meat: 20
 giant rubber spider	1622	rubberspider.gif	NOCOPY FREE Scale: 3 Cap: 1000 Init: -10000 P: bug	rubber nubbin (100)
 giant sandworm	458	sandworm.gif	NOCOPY Atk: 175 Def: 166 HP: 200 Init: 60 Meat: 250 P: bug	spices (10)	spices (10)	spices (10)	spice melange (n0)
@@ -323,10 +301,6 @@ Gnollish War Chef	211	dk_warchef.gif	Atk: 14 Def: 13 HP: 9 Init: 60 Meat: 24 P: 
 Gnomester Blomester	251	gnomester.gif	Atk: 35 Def: 31 HP: 35 Init: 50 P: humanoid	cog (15)	spring (15)	flange (5)
 gnu jack gnome	250	gnugnome.gif	Atk: 35 Def: 31 HP: 35 Init: 50 P: humanoid	sprocket (15)	spring (15)	flange (5)
 Goomba	113	goomba.gif	Atk: 20 Def: 18 HP: 15 Init: 60 P: beast	black pixel (50)	red pixel (80)	white pixel (50)
-Gorgolok, the Demonic Hellseal	888	1_4a.gif	NOCOPY BOSS Atk: 200 Def: 180 HP: 400 Init: 100 Phys: 40 P: demon	Claw of the Infernal Seal (100)	Instant Karma (c100)	heart of the volcano (c100)
-Gorgolok, the Infernal Seal (Inner Sanctum)	21	1_1.gif	NOCOPY BOSS Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: demon Manuel: "Gorgolok, the Infernal Seal"	Scalp of Gorgolok (100)
-Gorgolok, the Infernal Seal (The Nemesis' Lair)	872	1_2.gif	NOCOPY BOSS Atk: 170 Def: 153 HP: 220 Init: 80 P: demon Manuel: "Gorgolok, the Infernal Seal"	Krakrox's Loincloth (100)
-Gorgolok, the Infernal Seal (Volcanic Cave)	882	1_3.gif	NOCOPY BOSS Atk: 185 Def: 166 HP: 260 Init: 90 Phys: 25 P: demon Manuel: "Gorgolok, the Infernal Seal"
 Goth Giant	174	giant_goth.gif	Atk: 130 Def: 117 HP: 150 Init: 40 Meat: 150 P: humanoid	awful poetry journal (20)	thin black candle (25)	Warm Subject gift certificate (10)	giant tube of black lipstick (c10)
 Grass Elemental	90	grasselemental.gif	Atk: 60 Def: 54 HP: 50 Init: 60 P: elemental	leaf of grass (0)	folder (Ex-Files) (c0)
 grassy pirate	615	grasspirate.gif	Atk: 140 Def: 126 HP: 120 Init: 50 P: pirate Meat: 95	grassy cutlass (10)
@@ -341,7 +315,6 @@ grouper groupie	734	groupie.gif	Atk: 350 Def: 405 HP: 500 Init: 40 P: fish	group
 grumpy 7-Foot Dwarf	1151	dwarf_grumpy.gif	Atk: 58 Def: 52 HP: 45 Init: 50 Meat: 50 P: humanoid	7-Foot Dwarven mattock (9)
 grungy pirate	616	grungypirate.gif	Atk: 140 Def: 126 HP: 120 Init: 50 P: pirate Meat: 98	acoustic guitarrr (20)	grungy bandana (10)	grungy flannel shirt (c5)
 Guard Bugbear	28	haiku2.gif	Atk: 12 Def: 10 HP: 6 Init: 60 Meat: 24 P: beast	bugbear beanie (25)	bugbear bungguard (25)
-guard turtle	782	guardturtle1.gif,guardturtle2.gif,guardturtle3.gif,guardturtle4.gif	NOCOPY Atk: 140 Def: 126 HP: 140 Init: 140 P: beast NOBANISH	guard turtle shell (0)	guard turtle collar (0)
 Guy Made Of Bees	424	beeguy.gif	NOCOPY BOSS Atk: 99999 Def: 89999 HP: [99999] Init: -10000 Exp: 40 P: horror	guy made of bee pollen (100)	handful of bees (p10)
 guy with a pitchfork, and his wife	394	gothic.gif	Atk: 58 Def: 52 HP: 60 Init: 50 Meat: 50 P: dude	pitchfork (5)
 handsome mariachi	270	mariachi1.gif	Atk: 17 Def: 15 HP: 15 Init: 50 Meat: 5 P: dude	bottle of tequila (30)	chorizo taco (20)	handsomeness potion (20)
@@ -349,10 +322,7 @@ haunted skullabra	1347	skullabra.gif	Atk: 48 Def: 52 HP: 50 Init: 30 P: undead E
 haunted soup tureen	655	tureen.gif	Atk: 24 Def: 21 HP: 21 Init: 40 P: undead	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)	turtle soup (0)
 heat seal	800	heatseal.gif	NOCOPY FREE Atk: 175 Def: 157 HP: 200 Init: -10000 P: demon	Abyssal ember (5)	sizzling seal fat (35)
 Heavy Kegtank	504	warfratar2.gif	Atk: 180 Def: 162 HP: 300 Init: 20 E: sleaze Phys: 50 P: orc	meat engine (5)	PADL Phone (5)	sake bomb (10)	sake bomb (5)
-Heimandatz, Nacho Golem	704	nachogolem.gif	NOCOPY WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 P: construct	secret tropical island volcano lair map (100)	Heimandatz's heart (100)	friendly cheez blob (100)
 Hellion	128	hellion.gif	Atk: 52 Def: 46 HP: 52 Init: 90 E: hot P: demon	hellion cube (30)	unstable quark (p20)	accord ion (a0)
-hellseal guardian	781	sealguard.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: demon	hellseal whisker (0)	hellseal whisker (0)	hellseal claw (0)	hellseal claw (0)
-hellseal pup	779	sealpup.gif	Atk: 85 Def: 76 HP: 85 Init: 85 P: demon NOBANISH	hellseal whisker (0)	hellseal claw (0)
 hermetic seal	796	hermeticseal.gif	NOCOPY FREE Atk: 110 Def: 180 HP: 150 Init: -10000 P: demon	powdered sealbone (100)
 hockey elemental	274	hockeyelem.gif	ULTRARARE NOMANUEL  Atk: 55 Def: 49 HP: 80 Init: 100 P: elemental	hockey stick of furious angry rage (100)
 Honey Pot	542	honeypot.gif	Atk: 152 Def: 136 HP: 150 Init: 70 E: sleaze P: constellation	line (30)	star (30)	star (30)
@@ -363,7 +333,6 @@ huge mosquito	1341	giantmosquito.gif	Atk: 16 Def: 14 HP: 18 Init: 20 P: bug Meat
 hulking construct	669	vib6.gif	Atk: 500 Def: 450 HP: 1000000 Init: -10000 Phys: 100 P: construct	El Vibrato punchcard (104 holes) (1)
 hulking construct (translated)	675	vib6.gif	Atk: 500 Def: 450 HP: 1000000 Init: -10000 Phys: 100 P: construct Manuel: "hulking construct" Wiki: "hulking construct"	El Vibrato punchcard (104 holes) (1)
 hung-over half-orc hobo	281	hobo.gif	Atk: 1 Def: 0 HP: 1 Init: 40 E: stench P: hobo	dirty hobo gloves (32)	Mad Train wine (60)	moxie weed (15)	Boozehounds Anonymous token (p10)
-hunting seal	684	huntingseal.gif	NOCOPY WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 P: demon
 hustled spectre	809	poolghost.gif	Atk: 25 Def: 22 HP: 35 Init: 100 P: undead GHOST LUCKY	cube of billiard chalk (100)
 Hypnotist of Hey Deze	-97	hypnotist.gif	ULTRARARE NOMANUEL Atk: 85 Def: 115 HP: 85 Init: 10000 P: dude	hypnodisk (100)
 ice skate	731	iceskate.gif	Atk: 400 Def: 450 HP: 600 Init: 75 Meat: 100 P: fish	collapsible baton (0)	skate blade (0)	skate skin (0)	spangly unitard (0)
@@ -379,7 +348,6 @@ Irritating Series of Random Encounters	167	encount.gif	Atk: 105 Def: 94 HP: 110 
 Jacob's adder	1546	jacobsadder.gif	Atk: 84 Def: 76 HP: 75 Init: 60 P: beast	electric snakebite (0)	haunted battery (0)	Jacob's rung (0)
 jamfish	759	jamfish.gif	Atk: 400 Def: 360 HP: 750 Init: -10000 "Majorly Poisoned" P: fish	jamfish jam (n5)	jellyfish gel (c10)	seaweed (n5)	jam band (n5)
 Jefferson pilot	1530	pilot.gif	Atk: 140 Def: 140 HP: 145 Init: 25 P: dude Meat: 125	one pill (25)	Jefferson wings (5)	plastic Jefferson wings (c0)
-Jocko Homo	705	jockohomo.gif	NOCOPY WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 P: beast	secret tropical island volcano lair map (100)	Jocko Homo's head (100)	unusual disco ball (100)
 Johnringo, the Netdragger	880	merkindragger2.gif	NOCOPY Atk: 1250 Def: 1200 HP: 1500 Init: 100 Meat: 100 P: mer-kin
 Junk	181	thejunk.gif	Atk: 159 Def: 143 HP: 150 Init: 70 E: sleaze P: constellation	line (30)	line (30)	star (30)
 junksprite bender	1437	js_bender.gif	Atk: 32 Def: 33 HP: 25 Init: -10000 P: humanoid	funky junk key (0)	bent scrap metal (15)	Worse Homes and Gardens (c0)
@@ -433,10 +401,6 @@ lowercase K	938	lower_k.gif	Atk: 57 Def: 49 HP: 60 Init: 45 P: humanoid	equal si
 lumberjack supervisor	236	lumbersup.gif	Atk: 40 Def: 36 HP: 40 Init: 60 Meat: 30 P: dude	balaclava (5)	balaclava baklava (25)
 lumberjill	234	lumberjill.gif	Atk: 36 Def: 32 HP: 36 Init: 60 Meat: 20 P: dude	Blatantly Canadian (30)	maple syrup (30)	supportive bra (c20)
 lumberjuan	235	lumberjuan.gif	Atk: 35 Def: 31 HP: 35 Init: 60 Meat: 20 P: dude	los chinos (5)	leaflet (15)	wooden axe (5)
-Lumpy, the Demonic Sauceblob	891	4_4a.gif	NOCOPY BOSS Atk: 200 Def: 180 HP: 500 Init: 100 Phys: 40 P: demon	Gravyskin Belt of the Sauceblob (100)	Instant Karma (c100)	heart of the volcano (c100)
-Lumpy, the Sinister Sauceblob (Inner Sanctum)	24	4_1.gif	NOCOPY BOSS Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: slime Manuel: "Lumpy, the Sinister Sauceblob"	Ancient Saucehelm (100)
-Lumpy, the Sinister Sauceblob (The Nemesis' Lair)	875	4_2.gif	NOCOPY BOSS Atk: 170 Def: 153 HP: 220 Init: 80 P: slime Manuel: "Lumpy, the Sinister Sauceblob"	Newman's Own Trousers (100)
-Lumpy, the Sinister Sauceblob (Volcanic Cave)	885	4_3.gif	NOCOPY BOSS Atk: 185 Def: 166 HP: 260 Init: 90 Phys: 25 P: slime Manuel: "Lumpy, the Sinister Sauceblob"
 lynyrd	1533	lynyrd.gif	Atk: 150 Def: 150 HP: 155 Init: 10000 P: beast	lynyrd skin (0)
 lynyrd skinner	1526	skinner.gif	Atk: 140 Def: 130 HP: 135 Init: 50 P: dude Meat: 125	sweet roll Alabama (25)	Saturday Night Special (5)	lynyrd snare (15)	lynyrd musk (25)	lynyrd skinner toothblack (c0)
 mad bugbears	257	madbugbear.gif	Atk: 16 Def: 15 HP: 13 Init: 50 P: beast
@@ -448,17 +412,13 @@ malevolent hair clog	389	hairclog.gif	Atk: 59 Def: 48 HP: 50 Init: 50 ED: spooky
 malt liquor golem	1754	maltliquorgolem.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: construct	premium malt liquor (0)	premium malt liquor (0)	brown paper bag mask (0)	brown paper pants (0)
 man with the red buttons	1520	redbuttons.gif	Atk: 160 Def: 150 HP: 170 Init: 50 P: dude Meat: 150	red box (15)	red button (0)	big red button (n1)	button rouge (c0)
 man-eating plant	382	audrey.gif	Atk: 22 Def: 21 HP: 25 Init: 50 P: plant
-mariachi bandolero	700	bandolero.gif	WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 Meat: 50 P: dude
-mariachi bruiser	871	mar_bruiser.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: dude	spangly mariachi pants (0)	spangly mariachi vest (0)	spangly sombrero (0)
 mariachi calavera	272	mariachi3.gif	Atk: 22 Def: 19 HP: 30 Init: 50 P: undead	bottle of tequila (30)	marzipan skull (30)	calavera concertina (p5)
-mayonnaise wasp	73	wasp.gif	Atk: 17 Def: 15 HP: 11 Init: 60 "A Little Bit Poisoned" P: bug	glob of spoiled mayo (n100)
 me4t begZ0r	144	beggar.gif	Atk: 87 Def: 78 HP: 77 Init: 50 P: dude	meat vortex (100)
 medium-sized barrel mimic	288	mimic3.gif	Atk: 25 Def: 22 HP: 35 Init: 90 P: weird
 mean drunk duck	567	duckmeandrunk.gif	Atk: 180 Def: 157 HP: 190 Init: 50 Meat: 200 P: beast	bottle of vodka (20)	bottle of tequila (20)	bottle of whiskey (20)	duct tape (5)
 mega frog	1342	megafrog.gif	Atk: 14 Def: 16 HP: 20 Init: 10 P: beast Meat: 15	delicious swamp muck (0)	swamp lolly (0)
 menacing construct	664	vib1.gif	Atk: 400 Def: 315 HP: 400 Init: 65 P: construct	El Vibrato punchcard (115 holes) (1)	El Vibrato punchcard (142 holes) (1)
 menacing construct (translated)	670	vib1.gif	Atk: 400 Def: 315 HP: 400 Init: 65 P: construct Manuel: "menacing construct" Wiki: "menacing construct"	El Vibrato punchcard (115 holes) (1)	El Vibrato punchcard (142 holes) (1)
-menacing thug	680	nemesisthug.gif	WANDERER Atk: 55 Def: 49 HP: 75 Init: 30 Meat: 160 P: dude
 Mer-kin alphabetizer	850	merkinalphabet.gif	Atk: 750 Def: 800 HP: 900 Init: 100 Meat: 80 P: mer-kin	Mer-kin smartjuice (0)	Mer-kin worktea (0)
 Mer-kin balldodger	842	merkinballer.gif	Atk: [820+30*pref(lastColosseumRoundWon)] Def: [770+30*pref(lastColosseumRoundWon)] HP: [750+50*pref(lastColosseumRoundWon)] Init: -10000 Meat: 50 P: mer-kin
 Mer-kin bladeswitcher	844	merkinswitcher.gif	Atk: [820+30*pref(lastColosseumRoundWon)] Def: [770+30*pref(lastColosseumRoundWon)] HP: [750+50*pref(lastColosseumRoundWon)] Init: -10000 Meat: 50 P: mer-kin
@@ -492,7 +452,6 @@ modern zmobie	1070	modernzombie.gif	SUPERLIKELY Atk: 60 Def: 54 HP: 50 Init: 300
 moister oyster	1371	moyster.gif	NOCOPY LUCKY Atk: 1100 Def: 1300 HP: 1500 Init: 50 Meat: 100 Phys: 25 P: fish	giant pearl (n100)
 monstrous boiler	1556	boiler.gif	Atk: 134 Def: 144 HP: 160 Init: -10000 P: construct E: hot	chunk of hot iron (5)	red-hot boilermaker (5)	miniature boiler (5)
 Monty Basingstoke-Pratt, IV	517	monty.gif	NOCOPY Atk: 195 Def: 175 HP: 240 Init: 40 Meat: 200 E: sleaze P: orc	natty blue ascot (100)	white class ring (30)	distressed denim pants (0)	bejeweled pledge pin (0)	kick-ass kicks (0)
-mother hellseal	780	motherseal.gif	SUPERLIKELY Atk: [150*1.385^pref(_sealScreeches)] Def: [150*1.385^pref(_sealScreeches)] HP: 150 Exp: [150*1.385^pref(_sealScreeches)/4] Init: [150*1.385^pref(_sealScreeches)] P: demon NOBANISH	burst hellseal brain (c0)	shredded hellseal hide (c0)	torn hellseal sinew (c0)	hellseal brain (c0)	hellseal hide (c0)	hellseal sinew (c0)	hellseal whisker (c0)	hellseal claw (c0)
 mud turtle	1351	swampturtle.gif	Atk: 48 Def: 56 HP: 56 Init: 20 P: beast Meat: 30	fine aged cheddarwurst (0)	muddy pirate hat (0)	turtle mud (c0)
 Muff	536	muff.gif	Atk: 153 Def: 137 HP: 150 Init: 70 E: sleaze P: constellation	line (30)	line (30)	star (30)
 musical fruit bat	2155	fruitbat2.gif	Atk: 19 Def: 20 HP: 18 Init: 60 Meat: 30 P: beast	sonar-in-a-biscuit (10)	grapefruit (20)	grapes (20)	lemon
@@ -538,7 +497,6 @@ Panty Raider Frat Boy	421	warfratpr.gif	Atk: 200 Def: 180 HP: 250 Init: 100 E: s
 paper towelgeist	374	ptowels.gif	Atk: 21 Def: 18 HP: 22 Init: 30 P: undead	cardboard katana (5)
 party skelteon	2154	partyskeleton.gif	Atk: 52 Def: 49 HP: 55 Init: 50 E: spooky P: undead	skeleton bone	loose teeth	margarita	martini	monkey wrench	salty dog	screwdriver	strawberry daiquiri	strawberry wine	tequila sunrise	vodka martini	whiskey and soda	whiskey sour	wine spritzer
 Peanut	1376	peanut.gif	NOCOPY Atk: 650 Def: 700 HP: 1200 Init: 75 P: horror	peanut sauce (0)
-pencil golem	71	pencil.gif	Atk: 15 Def: 13 HP: 11 Init: 60 P: construct	pencil stub (n100)
 pernicious puddle of pesto	659	pestopuddle.gif	Atk: 21 Def: 18 HP: 18 Init: 20 P: slime	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)
 perpendicular bat	47	perpbat.gif	Atk: 18 Def: 16 HP: 12 Init: 60 Meat: 30 P: beast	batgut (15)	bat wing (15)	sonar-in-a-biscuit (10)	perpendicular guano (c0)	guancertina (a0)
 pig	1591	somepig.gif	Atk: [6] Def: [7] HP: [8] Init: -10000 Meat: 5 P: beast	ham steak (0)	piggy tattoo (c0)
@@ -549,7 +507,6 @@ plaque of locusts	457	plaque.gif	Atk: 134 Def: 124 HP: 140 Init: 30 P: bug Meat:
 plastered frat orc	994	drunkfrat.gif	Atk: 10 Def: 7 HP: 7 Init: 40 P: orc Meat: 25	ice-cold fotie (20)	ice-cold Sir Schlitz (20)	ice-cold Willer (20)	flask flops (0)
 pooltergeist	386	poolter.gif	Atk: 25 Def: 23 HP: 27 Init: 70 P: undead	1-ball (3)	2-ball (3)	3-ball (3)	4-ball (3)	5-ball (3)	6-ball (3)	7-ball (3)	8-ball (15)
 pooltergeist (ultra-rare)	-94	poolter2.gif	NOCOPY ULTRARARE NOMANUEL Atk: 55 Def: 48 HP: 50 Init: 70 P: undead	17-ball (100)
-pop-and-lock raver	856	popnlocker.gif	Atk: 140 Def: 126 HP: 150 Init: 10000 P: dude NOBANISH	baggy rave pants (c0)	glowstick on a string (c0)	teddybear backpack (c0)
 Pork Sword	182	porksword.gif	Atk: 162 Def: 145 HP: 150 Init: 70 E: sleaze P: constellation	line (30)	star (30)	star (30)
 Portly Abomination	94	abom.gif	Atk: 73 Def: 65 HP: 63 Init: 70 Meat: 75 P: horror	abominable blubber (0)
 possessed can of tomatoes	145	tomatosoup.gif	Atk: 1 Def: 0 HP: 1 Init: 50 Meat: 3 P: undead	razor-sharp can lid (45)	tomato (60)	possessed tomato (p15)	folder (yellow) (c0)
@@ -607,12 +564,9 @@ rolling stone	574	rollingstone.gif	Atk: 137 Def: 126 HP: 135 Init: 50 P: element
 Ron "The Weasel" Copperhead	1531	roncopper.gif	Atk: 165 Def: 170 HP: 180 Init: 100 P: dude Meat: 250	Copperhead Charm (rampant) (n100)
 rotten dolphin thief	810	realdolphin.gif	NOCOPY Atk: 400 Def: 360 HP: 600 Init: 100 P: fish
 rotund duck	561	duckfat.gif	Atk: 175 Def: 157 HP: 195 Init: 40 Meat: 300 P: beast	duct tape (6)
-running man	857	runningman.gif	Atk: 140 Def: 126 HP: 150 Init: 10000 P: dude NOBANISH	candy necklace (c0)	glowstick on a string (c0)	pacifier necklace (c0)
 rushing bum	159	bum.gif	Atk: 1 Def: 0 HP: 1 Init: 40 P: hobo	bum cheek (32)	Mad Train wine (30)	moxie weed (15)	dented harmonica (15)	cheap cigar butt (p60)	folder (magenta) (c0)
 sabre-toothed ferret	474	ferret.gif	Atk: 250 Def: 198 HP: 200 Init: 75 Meat: 200 E: stench P: beast	sabre teeth (25)	Spanish fly (c25)
 sabre-toothed goat	84	toothgoat.gif	Atk: 68 Def: 61 HP: 50 Init: 80 Meat: 55 P: beast	goat beard (5)	sabre teeth (5)
-sabre-toothed lime	70	lime.gif	Atk: 14 Def: 12 HP: 8 Init: 60 P: beast Meat: 14	twist of lime (n100)
-Safari Jack, Small-Game Hunter	702	safarijack.gif	WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 P: dude	secret tropical island volcano lair map (100)	Safari Jack's moustache (100)	untamable turtle (100)
 salamander	334	salamander.gif	NOCOPY HP: [3] Def: [2] Atk: [3] Init: -10000 Meat: 10 P: beast	salamander spleen (100)
 sassy pirate	104	pirate1.gif	Atk: 61 Def: 54 HP: 51 Init: 60 Meat: 20 P: pirate	crowbarrr (10)	flaregun (30)	sunken chest (15)	swashbuckling pants (10)
 scary clown	111	clown.gif	Atk: 19 Def: 17 HP: 15 Init: 80 E: spooky Meat: 25 P: horror	big red clown nose (10)	bloody clown pants (10)	long skinny balloon (40)	big bass drum (4)	clown skin (10)	polka-dot bow tie (p5)
@@ -624,7 +578,6 @@ scorched duck	558	duckscorch.gif	Atk: 170 Def: 156 HP: 185 Init: 50 Meat: 150 E:
 screambat	1010	screambat.gif	SUPERLIKELY Atk: 18 Def: 16 HP: 15 Init: 50 P: beast
 sea cow	775	seacow.gif	Atk: 600 Def: 675 HP: 900 Init: 25 Meat: 300 P: fish	sea cowbell (n10)	sea leather (n20)
 sea cowboy	776	seacowboy.gif	Atk: 750 Def: 585 HP: 700 Init: 50 Meat: 200 P: fish	sea lasso (n30)	deep six-shooter (n8)
-security slime	869	securityslime.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: slime
 senile lihc	192	lich.gif	Atk: 56 Def: 51 HP: 50 Init: 50 E: spooky P: undead	lihc eye (20)	lihc face (9)	shimmering tendrils (c5)
 serialbus	982	serialbus.gif	Atk: 60 Def: 54 HP: 60 Init: 50 E: hot Meat: 30 P: demon	bus pass (25)
 Servant of Grodstank	799	grodseal.gif	FREE Atk: 175 Def: 157 HP: 200 Init: -10000 P: horror	fustulent seal grulch (35)	infernal toilet brush (5)
@@ -650,7 +603,6 @@ skulldozer	1239	skulldozer.gif	NOCOPY Scale: 5 Cap: 10000 Floor: 300 Init: -1000
 skullery maid	377	skullery.gif	Atk: 20 Def: 18 HP: 20 Init: 50 Meat: 5 E: spooky P: undead	bottle of popskull (30)	dishrag (5)	Skullery Maid's Knee (c0)
 sleeping Knob Goblin Guard	152	kg_sleepingguard.gif	Atk: 0 Def: 0 HP: 1 Init: -10000 Meat: 5 P: goblin	viking helmet (32)	Knob Goblin pants (8)	Knob Goblin scimitar (32)
 sleepy 7-Foot Dwarf	1149	dwarf_sleepy.gif	Atk: 53 Def: 47 HP: 40 Init: -10000 Meat: 40 P: humanoid	miner's pants (9)
-sleepy mariachi	858	mar_sleepy.gif	Atk: 120 Def: 108 HP: 110 Init: 125 P: dude NOBANISH	spangly mariachi pants (0)	spangly mariachi vest (0)	spangly sombrero (0)
 slick lihc	193	lich.gif	Atk: 59 Def: 54 HP: 50 Init: 50 E: spooky P: undead	lihc eye (20)	lihc face (7)	shimmering tendrils (c5)
 slithering hollandaise glob	658	holglob.gif	Atk: 24 Def: 21 HP: 21 Init: 40 P: slime	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)	nauseating reagent (0)
 slithering thing	1375	slithering.gif	Atk: 600 Def: 675 HP: 700 Init: 50 Meat: 50 P: horror	grisly shell fragment (0)	grisly shell fragment (0)
@@ -664,19 +616,10 @@ smut orc nailer	1232	smutorc_nailer.gif	Atk: 69 Def: 69 HP: 69 Init: 50 P: orc M
 smut orc pervert	1234	smutorc_pervert.gif	NOCOPY Atk: 69 Def: 69 HP: 69 Init: 50 E: sleaze P: orc	smut orc keepsake box (n100)	smut orc sunglasses (c0)
 smut orc pipelayer	1231	smutorc_layer.gif	Atk: 69 Def: 69 HP: 69 Init: 50 P: orc Meat: 35	orcish rubber (0)	freshwater pearl necklace (0)	long hard screw (0)	messy butt joint (0)	morningwood plank (0)	raging hardwood plank (0)	thick caulk (0)	weirdwood plank (0)
 smut orc screwer	1233	smutorc_screwer.gif	Atk: 69 Def: 69 HP: 69 Init: 50 P: orc Meat: 35	backwoods screwdriver (0)	screwing pooch (0)	long hard screw (0)	messy butt joint (0)	morningwood plank (0)	raging hardwood plank (0)	thick caulk (0)	weirdwood plank (0)
-Snakeleton	1519	snakeboss6.gif	Atk: 160 Def: 160 HP: 175 Init: 50 P: beast SNAKE E: spooky	The Shield of Brook (n100)
 Snow Queen	385	snowqueen.gif	Atk: 107 Def: 94 HP: 70 Init: 60 E: cold Phys: 100 P: elemental	crazy little Turkish delight (25)	ga-ga radio (5)	Snow Queen Crown (5)
-Somerset Lopez, Demon Mariachi	893	6_4a.gif	NOCOPY BOSS Atk: 200 Def: 180 HP: 1000 Init: 100 Phys: 40 P: demon	La Hebilla del Cintur&oacute;n de Lopez (100)	Instant Karma (c100)	heart of the volcano (c100)
-Somerset Lopez, Dread Mariachi (Inner Sanctum)	26	6_1.gif	NOCOPY BOSS Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: dude Manuel: "Somerset Lopez, Dread Mariachi"	El Sombrero De Lopez (100)
-Somerset Lopez, Dread Mariachi (The Nemesis' Lair)	877	6_2.gif	NOCOPY BOSS Atk: 170 Def: 153 HP: 220 Init: 80 P: dude Manuel: "Somerset Lopez, Dread Mariachi"	Lederhosen of the Night (100)
-Somerset Lopez, Dread Mariachi (Volcanic Cave)	887	6_3.gif	NOCOPY BOSS Atk: 185 Def: 166 HP: 260 Init: 90 Phys: 25 P: dude Manuel: "Somerset Lopez, Dread Mariachi"
 Sorority Nurse	508	warfratmd.gif	Atk: 170 Def: 157 HP: 200 Init: 30 E: sleaze P: orc	energy drink IV (18)	gauze garter (20)	gauze garter (7)	kick-ass kicks (2)	PADL Phone (3)	scrunchie tourniquet (c0)
 Sorority Operator	509	warfratcm.gif	Atk: 185 Def: 162 HP: 200 Init: 80 E: sleaze P: orc	beer helmet (1)	bejeweled pledge pin (1)	distressed denim pants (1)	kick-ass kicks (2)	PADL Phone (18)	PADL Phone (18)	PADL Phone (18)	white class ring (30)
 Space Tourist Explorer Ghost	1256	aboo_trek.gif	Atk: 74 Def: 66 HP: 40 Init: -10000 E: spooky P: undead Phys: 100 GHOST	A-Boo clue (c15)	Space Tours Tripple (15)	Space Tourist Phaser (5)	ectoplasmic orbs (10)
-Spaghetti Demon	890	3_4a.gif	NOCOPY BOSS Atk: 200 Def: 180 HP: 600 Init: 100 Phys: 40 P: demon	Bandolier of the Spaghetti Elemental (100)	Instant Karma (c100)	heart of the volcano (c100)
-Spaghetti Elemental (Inner Sanctum)	23	3_1.gif	NOCOPY BOSS Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: elemental Manuel: "Spaghetti Elemental"	Colander of Em-er'il (100)
-Spaghetti Elemental (The Nemesis' Lair)	874	3_2.gif	NOCOPY BOSS Atk: 170 Def: 153 HP: 220 Init: 80 P: elemental Manuel: "Spaghetti Elemental"	Angelhair Culottes (100)
-Spaghetti Elemental (Volcanic Cave)	884	3_3.gif	NOCOPY BOSS Atk: 185 Def: 166 HP: 260 Init: 90 P: elemental Manuel: "Spaghetti Elemental"
 Spam Witch	143	spamwitch.gif	Atk: 85 Def: 76 HP: 75 Init: 70 EA: sleaze Meat: 30 P: dude	30669 scroll (30)	Spam Witch sammich (50)
 Spawn of Wally	793	wretchedseal.gif	NOCOPY FREE Atk: 10 Def: 9 HP: 15 Init: -10000 P: horror	tainted seal's blood (100)
 Spectral Jellyfish	93	jellyfish.gif	Atk: 70 Def: 63 HP: 60 Init: 60 "Somewhat Poisoned" P: beast	spectral jelly (p1)
@@ -685,9 +628,6 @@ spider gremlin	552	gremlinspider.gif	Atk: 172 Def: 151 HP: 170 Init: 60 Meat: 50
 spider gremlin (tool)	553	gremlinspider.gif	Atk: 172 Def: 151 HP: 170 Init: 60 Meat: 50 P: humanoid Manuel: "spider gremlin" Wiki: "spider gremlin (quest)"	gremlin juice (3)	molybdenum pliers (c0)
 spider-legged witch's hut	1580	spiderhut.gif	NOCOPY Atk: 50 Def: 50 HP: 50 Init: 50 P: construct	giant spider leg (c100)
 spiny skelelton	185	spikeskel.gif	Atk: 53 Def: 48 HP: 50 Init: 50 E: spooky P: undead	skeleton bone (40)	smart skull (50)	spiked femur (10)	succulent marrow (25)	evil eye (20)	skelelton spine (c0)
-Spirit of New Wave (Inner Sanctum)	25	5_1.gif	NOCOPY BOSS Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: undead GHOST Manuel: "Spirit of New Wave"	Disco 'Fro Pick (100)
-Spirit of New Wave (The Nemesis' Lair)	876	5_2.gif	NOCOPY BOSS Atk: 170 Def: 153 HP: 220 Init: 80 P: undead GHOST Manuel: "Spirit of New Wave"	Volartta's bellbottoms (100)
-Spirit of New Wave (Volcanic Cave)	886	5_3.gif	NOCOPY BOSS Atk: 185 Def: 166 HP: 260 Init: 90 Phys: 25 P: undead GHOST Manuel: "Spirit of New Wave"
 sponge	739	sponge.gif	Atk: 350 Def: 405 HP: 1000 Init: 50 P: fish	sand dollar (n10)	sand dollar (n9)	sand dollar (n1)	slab of sponge (n5)
 spooky gravy fairy guard	260	sgguard.gif	Atk: 55 Def: 49 HP: 45 Init: 60 E: spooky P: plant	spooky mushroom (40)	halfberd (5)	small leather glove (10)
 spooky gravy fairy ninja	262	sgninja.gif	Atk: 65 Def: 58 HP: 55 Init: 100 E: spooky P: plant	spooky mushroom (40)	teeny-tiny ninja stars (5)	tiny ninja sword (5)
@@ -698,10 +638,6 @@ spooky vampire	1	vampire.gif	Atk: 3 Def: 3 HP: 2 Init: 50 E: spooky Meat: 5 P: u
 Spunky Princess	165	princess.gif	Atk: 90 Def: 81 HP: 75 Init: 90 Meat: 110 P: dude	cocoa eggshell fragment (30)	tiny house (30)	titanium assault umbrella (10)
 steam elemental	1557	steamelemental.gif	Atk: 160 Def: 137 HP: 140 Init: 75 P: elemental E: hot
 Steampunk Giant	1337	giant_steampunk.gif	Atk: 145 Def: 135 HP: 150 Init: 40 Meat: 100 P: humanoid	brass gear (25)	brown felt tophat (10)	autocalliope (a0)	steampunk potion (c15)
-Stella, the Demonic Turtle Poacher	889	2_4a.gif	NOCOPY BOSS Atk: 200 Def: 180 HP: 1000 Init: 100 Phys: 40 P: demon	Garter of the Turtle Poacher (100)	Instant Karma (c100)	heart of the volcano (c100)
-Stella, the Turtle Poacher (Inner Sanctum)	22	2_1.gif	NOCOPY BOSS Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: dude Manuel: "Stella, the Turtle Poacher"	Elder Turtle Shell (100)
-Stella, the Turtle Poacher (The Nemesis' Lair)	873	2_2.gif	NOCOPY BOSS Atk: 170 Def: 153 HP: 220 Init: 80 P: dude Manuel: "Stella, the Turtle Poacher"	Galapagosian Cuisses (100)
-Stella, the Turtle Poacher (Volcanic Cave)	883	2_3.gif	NOCOPY BOSS Atk: 185 Def: 166 HP: 260 Init: 90 Phys: 25 P: dude Manuel: "Stella, the Turtle Poacher"
 Stephen Spookyraven	1565	steven.gif	NOCOPY Scale: 5 Cap: 300 Init: 100 Meat: 500  P: undead	Stephen's secret formula (100)	Stephen's lab coat (100)
 sticky mummy	1583	stickymummy.gif	Atk: 35 Def: 34 HP: 34 Init: -10000 P: undead
 stone temple pirate	1159	stone_pirate.gif	Scale: 0 Cap: 50 Floor: 7 Init: -10000 P: construct	ancient poisoned dart (35)	eyepatch (15)
@@ -710,7 +646,6 @@ stuffed moose head	1552	moosehead.gif	Atk: 86 Def: 79 HP: 80 Init: -10000 Meat: 
 Sub-Assistant Knob Mad Scientist	154	kg_madsci.gif	Atk: 1 Def: 1 HP: 1 Init: 60 Meat: 6 P: goblin	Knob Goblin firecracker (100)	Knob Goblin pants (9)	strongness elixir (30)	folder (cyan) (c0)	Knob Goblin Mutagen (c0)
 suckubus	977	suckubus.gif	Atk: 55 Def: 49 HP: 55 Init: 30 E: hot Meat: 40 P: demon	bus pass (20)	folder (rainbow unicorn) (c0)
 surprised and annoyed witch	1596	witchy1.gif	Atk: 36 Def: 32 HP: 32 Init: -10000 P: dude Meat:  40	wand of pigification (c100)	&Uuml;berraschthexengebr&auml;u (c0)
-surprised mariachi	859	mar_surprised.gif	Atk: 130 Def: 117 HP: 125 Init: 150 P: dude NOBANISH	spangly mariachi pants (0)	spangly mariachi vest (0)	spangly sombrero (0)
 swamp beaver lumberjack	1349	beav_jack.gif	Atk: 54 Def: 48 HP: 50 Init: 30 P: beast Meat: 30	fine aged cheddarwurst (0)	balaclava (0)
 swamp beaver shaman	594	beav_shaman.gif	Atk: 52 Def: 46 HP: 46 Init: 60 P: beast Meat: 20	moonberry wine cooler (0)	shamanic beads (0)
 swamp beaver warrior	593	beav_warrior.gif	Atk: 28 Def: 35 HP: 40 Init: 30 P: beast Meat: 30	fine aged cheddarwurst (0)	beaver spear (0)
@@ -740,14 +675,11 @@ The Big Wisniewski	545	thisdude.gif	NOCOPY BOSS Atk: 250 Def: 225 HP: 2000 Init:
 The Clownlord Beelzebozo	569	beelzebozo.gif	NOCOPY BOSS Atk: 27 Def: 27 HP: 40 Init: 85 P: horror
 the darkness (blind)	0	darkness.gif	NOMANUEL
 the former owner of the Skeleton Store	1755	skelmanager.gif	Atk: 5 Def: 5 HP: 8 Init: -10000 E: spooky P: undead	check to the Meatsmith (c100)	invisibility cream (c0)
-The Frattlesnake	1515	snakeboss2.gif	Atk: 160 Def: 160 HP: 175 P: beast SNAKE E: sleaze Init: 50	The Lacrosse Stick of Lacoronado (n100)
 the ghost of Phil Bunion	1352	bunionghost.gif	Atk: 72 Def: 68 HP: 60 Init: 40 Phys: 100 P: undead E: spooky Meat: 30 GHOST	spectral axe (c100)	Phil Bunion's axe (c100)
 the gunk	1548	thegunk.gif	Atk: 81 Def: 81 HP: 80 Init: -10000 Meat: 50 P: slime	gunky chicken (0)	the funk (0)	half-melted spoon (0)
 The Man	555	theman.gif	NOCOPY BOSS Atk: 250 Def: 225 HP: 2000 Init: 60 ED: sleaze P: dude	really dense meat stack (100)
-The Mariachi With No Name	706	darkmariachi.gif	WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 Meat: 50 P: dude	secret tropical island volcano lair map (100)	The Mariachi's guitar case (100)	stray chihuahua (100)
 The Master Of Thieves	-92	masterat.gif	ULTRARARE NOMANUEL Atk: 70 Def: 63 HP: 70 Init: 10000 P: dude	Platinum Yendorian Express Card (100)
 The Nuge	1534	thenuge.gif	NOCOPY ULTRARARE NOMANUEL Atk: 155 Def: 150 HP: 180 Init: 10000 P: dude	The Nuge's favorite crossbow (100)
-The Snake With Like Ten Heads	1516	snakeboss3.gif	Atk: 160 Def: 160 HP: 175 Init: 50 P: beast SNAKE E: sleaze	The Eye of the Stars (n100)
 The Temporal Bandit	-90	timebandit.gif	NOCOPY ULTRARARE NOMANUEL Atk: 35 Def: 31 HP: 35 Init: 10000 P: dude	Counterclockwise Watch (100)
 The Thing in the Basement	-24	drippything1.gif	NOMANUEL Atk: [300] Def: [300] HP: [320] Init: -10000 P: horror DRIPPY 	The Eye of the Thing in the Basement (n100)	The Fingernail of the Thing in the Basement (n100)
 The Unknown Seal Clubber	1775	unknownghost.gif	Atk: 25 Def: 25 HP: 15 P: undead E: spooky Init: -10000 GHOST	Bjorn's Hammer (100)
@@ -767,7 +699,6 @@ tomb bat	575	mummybat.gif	Atk: 175 Def: 157 HP: 180 Init: 50 Meat: 50 P: beast	l
 tomb rat	467	tombrat.gif	Atk: 161 Def: 148 HP: 175 Init: 50 Meat: 75 P: beast	tomb ratchet (c20)	leathery rat skin (30)	unidentified jerky (12)
 tomb rat king	997	tombratking.gif	NOCOPY BOSS Atk: [350] Def: [315] HP: [300] Init: -10000 Meat: 150 P: beast	tomb ratchet (c20)	tomb ratchet (c20)	tomb ratchet (c20)	leathery rat skin (0)	leathery rat skin (0)	leathery rat skin (0)	unidentified jerky (0)	unidentified jerky (0)	unidentified jerky (0)
 tomb servant	468	tombguy.gif	Atk: 160 Def: 153 HP: 185 Init: 20 Meat: 50 E: spooky P: undead	canopic jar (30)	ancient protein powder (15)	mummy wrapping (20)	unidentified jerky (12)	ancient ice cream scoop (5)	secret mummy herbs and spices (c10)
-tonic water elemental	74	whirlwind.gif	Atk: 18 Def: 16 HP: 14 Init: 60 Meat: 18 P: elemental	tonic djinn (n100)
 toothy pirate	620	toothpirate.gif	Atk: 83 Def: 76 HP: 75 Init: 50 Meat: 45 P: pirate	bottle of rum (20)	cocktail napkin (10)	gold toothbrush (c0)
 toothy sklelton	186	toothskel.gif	Atk: 57 Def: 52 HP: 50 Init: 50 E: spooky P: undead	loose teeth (20)	loose teeth (20)	skeleton bone (20)	bone flute (10)	evil eye (20)	bone bandoneon (a0)
 towering construct	667	vib4.gif	Atk: 350 Def: 360 HP: 450 Init: 20 P: construct	El Vibrato punchcard (165 holes) (1)	El Vibrato punchcard (176 holes) (1)
@@ -777,7 +708,6 @@ Troll Twins	1244	twins_troll.gif	Atk: 94 Def: 82 HP: 98 Init: 40 Meat: 75 P: dud
 trophyfish	774	trophyfish.gif	NOCOPY Atk: 5000 Def: 4500 HP: 15000 Init: 200 Phys: 25 P: fish
 Trouser Snake	179	tsnake.gif	Atk: 153 Def: 137 HP: 150 Init: 70 E: sleaze SNAKE P: constellation	line (30)	line (30)	line (30)
 tumbleweed	1110	tumbleweed.gif	Atk: 10 Def: 9 HP: 10 Init: -10000 P: plant
-turtle trapper	685	turtletrapper.gif	WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 Meat: 100 P: dude
 Twig and Berries	352	twigberry.gif	Atk: 152 Def: 136 HP: 150 Init: 70 E: sleaze P: constellation	line (30)	star (30)	star (30)
 undead elbow macaroni	147	macaroni.gif	Atk: 1 Def: 1 HP: 1 Init: 50 E: spooky Meat: 5 P: undead	magicalness-in-a-can (25)	quasi-ethereal macaroni fragments (c0)
 unemployed knob goblin	1000	lensgoblin.gif	Atk: 6 Def: 5 HP: 5 Init: -10000 P: goblin Meat: 15	beer lens (c25)
@@ -786,11 +716,9 @@ upgraded ram	384	ram.gif	Atk: 106 Def: 93 HP: 95 Init: 50 Meat: 100 ED: cold P: 
 uppercase Q	937	upper_q.gif	Atk: 61 Def: 51 HP: 81 Init: 80 P: dude	left parenthesis (40)	right parenthesis (10)	dollar sign (p20)
 urchin urchin	733	urchin.gif	Atk: 400 Def: 315 HP: 600 Init: 20 P: fish	mermaid's purse (0)	bazookafish bubble gum (0)	underwater slingshot (0)
 vampire bat	350	regbat.gif	Atk: 17 Def: 14 HP: 10 Init: 60 Meat: 40 P: beast	bat wing (15)	batgut (15)	sonar-in-a-biscuit (10)
-vampire clam	75	vampclam.gif	Atk: 40 Def: 17 HP: 14 Init: 60 Meat: 18 P: undead	vampire chowder (100)	vampire pearl (p35)
 vampire duck	564	duckvampire.gif	Atk: 175 Def: 153 HP: 190 Init: 50 Meat: 150 E: spooky P: beast	frightful feather (10)	duct tape (5)	vampire glitter (c0)
 vegetable gremlin	550	gremlinveg.gif	Atk: 168 Def: 154 HP: 170 Init: 60 Meat: 50 P: humanoid	gremlin juice (3)
 vegetable gremlin (tool)	551	gremlinveg.gif	Atk: 168 Def: 154 HP: 170 Init: 60 Meat: 50 P: humanoid Manuel: "vegetable gremlin" Wiki: "vegetable gremlin (quest)"	gremlin juice (3)	molybdenum screwdriver (c0)
-vendor slime	805	vendorslime.gif	Atk: 145 Def: 130 HP: 160 Init: 75 P: slime NOBANISH	vial of red slime (f66)
 vengeful turtle spectre	654	turtleghost.gif	Atk: 21 Def: 18 HP: 18 Init: 20 P: undead	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)
 vicious gnauga	247	gnauga.gif	Atk: 45 Def: 36 HP: 40 Init: 60 P: beast	gnauga hide (10)
 Victor the Insult Comic Hellhound	983	victor.gif	NOCOPY BOSS Atk: 70 Def: 63 HP: 70 Init: 50 P: demon	Victor, the Insult Comic Hellhound Puppet (100)
@@ -835,7 +763,6 @@ War Hippy Spy	419	hippyspy.gif	Atk: 165 Def: 153 HP: 180 Init: 60 E: stench P: h
 War Hippy Windtalker	493	warhipcm.gif	Atk: 185 Def: 162 HP: 200 Init: 80 E: stench P: hippy	bullet-proof corduroys (1)	communications windchimes (18)	communications windchimes (18)	communications windchimes (18)	Lockenstock&trade; sandals (2)	reinforced beaded headband (1)	round purple sunglasses (1)	green clay bead (30)
 War Pledge	527	fratboy.gif	Atk: 165 Def: 148 HP: 180 Init: 40 E: sleaze P: orc	distressed denim pants (5)	bejeweled pledge pin (5)	beer helmet (5)
 Wardr&ouml;b nightstand	1540	nightstand1.gif	Atk: 60 Def: 50 HP: 55 Init: -10000 P: construct Manuel: "Wardröb nightstand"
-warehouse worker	867	warehouseguy.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: dude	crowbar (0)
 warty pirate	632	wartpirate.gif	Atk: 120 Def: 108 HP: 110 Init: 50 Meat: 85 P: pirate	copper ha'penny charrrm (10)	fish-liver oil (30)	vinegar-soaked lemon slice (30)
 warwelf	199	werewolf.gif	Atk: 4 Def: 2 HP: 2 Init: 50 Meat: 12 P: dude
 watertight seal	797	waterseal.gif	FREE Atk: 350 Def: 315 HP: 400 Init: -10000 P: demon	hyperinflated seal lung (100)
@@ -856,7 +783,6 @@ wizardly mushroom guy	1804	mush_wizard.gif	Atk: 35 Def: 25 HP: 15 Init: 50 P: pl
 wolfman	200	werewolf.gif	Atk: 3 Def: 2 HP: 2 Init: 50 Meat: 10 P: dude
 writing desk	405	ravendesk.gif	Atk: 27 Def: 27 HP: 28 Init: 50 P: construct	disintegrating quill pen (15)	inkwell (30)	snifter of thoroughly aged brandy (30)
 XXX pr0n	138	pr0n.gif	Atk: 75 Def: 67 HP: 68 Init: 60 Meat: 30 P: beast	f3d0r4 (15)	lowercase N (30)	pr0n legs (40)
-Yakisoba the Executioner	703	yakisoba.gif	WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 P: dude	secret tropical island volcano lair map (100)	Yakisoba's hat (100)	macaroni duck (100)
 Yeast Beast	36	yeastbeast.gif	Atk: 17 Def: 15 HP: 8 Init: 60 EA: sleaze P: construct	wad of dough (50)	wad of dough (50)
 Yog-Urt, Elder Goddess of Hatred	1378	yog-urt.gif	BOSS Atk: 400 Def: 400 HP: 750 Init: 10000 Phys: 100 P: horror
 Zim Merman	513	zimmerman.gif	NOCOPY Atk: 200 Def: 180 HP: 280 Init: 60 Meat: 250 E: stench P: hippy	Zim Merman's guitar (100)	green clay bead (30)	Lockenstock&trade; sandals (0)
@@ -866,6 +792,109 @@ Zol	120	zol.gif	Atk: 25 Def: 22 HP: 15 Init: 60 P: slime	green pixel (80)	green 
 zombie chef	378	zombiechef.gif	Atk: 22 Def: 19 HP: 20 Init: 50 Meat: 7 P: undead	bottle of cooking sherry (30)	chef's hat (5)	fricasseed brains (20)	stale baguette (30)	zombie hollandaise (c0)
 zombie duck	565	duckzombie.gif	Atk: 171 Def: 158 HP: 190 Init: 40 Meat: 150 E: spooky P: beast	duct tape (5)	frightful feather (10)
 zombie waltzers	401	zomwaltz.gif	Atk: 65 Def: 55 HP: 70 Init: 50 Meat: 50 E: spooky P: undead	ballroom blintz (15)	dance card (15)
+
+# Copperhead Quest
+
+Batsnake	1517	snakeboss5.gif	NOCOPY Atk: 160 Def: 160 HP: 175 Init: 50 P: beast SNAKE E: stench	The Stankara Stone (0)
+Frozen Solid Snake	1514	snakeboss1.gif	NOCOPY Atk: 160 Def: 160 HP: 175 Init: 50 P: beast SNAKE E: cold	The First Pizza (n100)
+Burning Snake of Fire	1518	snakeboss4.gif	NOCOPY Atk: 160 Def: 160 HP: 175 Init: 50 P: beast SNAKE E: hot	Murphy's Rancid Black Flag (n100)
+The Snake With Like Ten Heads	1516	snakeboss3.gif	NOCOPY Atk: 160 Def: 160 HP: 175 Init: 50 P: beast SNAKE E: sleaze	The Eye of the Stars (n100)
+The Frattlesnake	1515	snakeboss2.gif	NOCOPY Atk: 160 Def: 160 HP: 175 P: beast SNAKE E: sleaze Init: 50	The Lacrosse Stick of Lacoronado (n100)
+Snakeleton	1519	snakeboss6.gif	NOCOPY Atk: 160 Def: 160 HP: 175 Init: 50 P: beast SNAKE E: spooky	The Shield of Brook (n100)
+
+# Daily Dungeon
+
+apathetic lizardman	5	lizardman.gif	NOCOPY Atk: 20 Def: 18 HP: 12 Init: 60 Meat: 20 P: humanoid	flavorless gruel (n100)
+dairy ooze	69	ooze.gif	NOCOPY Atk: 13 Def: 11 HP: 8 Init: 60 Meat: 12 P: slime	mana curds (n100)
+dodecapede	3	pede.gif	NOCOPY Atk: 12 Def: 10 HP: 8 Init: 60 "A Little Bit Poisoned" Meat: 12 P: bug	clutch of dodecapede eggs (n100)
+giant giant moth	72	moth.gif	NOCOPY Atk: 16 Def: 14 HP: 11 Init: 60 Meat: 16 P: bug	giant giant moth dust (n100)
+mayonnaise wasp	73	wasp.gif	NOCOPY Atk: 17 Def: 15 HP: 11 Init: 60 "A Little Bit Poisoned" P: bug	glob of spoiled mayo (n100)
+pencil golem	71	pencil.gif	NOCOPY Atk: 15 Def: 13 HP: 11 Init: 60 P: construct	pencil stub (n100)
+sabre-toothed lime	70	lime.gif	NOCOPY Atk: 14 Def: 12 HP: 8 Init: 60 P: beast Meat: 14	twist of lime (n100)
+tonic water elemental	74	whirlwind.gif	NOCOPY Atk: 18 Def: 16 HP: 14 Init: 60 Meat: 18 P: elemental	tonic djinn (n100)
+vampire clam	75	vampclam.gif	NOCOPY Atk: 40 Def: 17 HP: 14 Init: 60 Meat: 18 P: undead	vampire chowder (100)	vampire pearl (p35)
+
+# Nemesis Quest
+
+menacing thug	680	nemesisthug.gif	NOCOPY WANDERER Atk: 55 Def: 49 HP: 75 Init: 30 Meat: 160 P: dude
+Mob Penguin hitman	683	pengthug.gif	NOCOPY WANDERER Atk: 75 Def: 67 HP: 90 Init: 40 Meat: 200 P: penguin	kneecapping stick (0)
+
+# Seal Clubber
+
+hunting seal	684	huntingseal.gif	NOCOPY WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 P: demon
+Argarggagarg the Dire Hellseal	701	2headseal.gif	NOCOPY WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 P: demon	secret tropical island volcano lair map (100)	Argarggagarg's fang (100)	adorable seal larva (100)
+hellseal pup	779	sealpup.gif	Atk: 85 Def: 76 HP: 85 Init: 85 P: demon NOBANISH	hellseal whisker (0)	hellseal claw (0)
+mother hellseal	780	motherseal.gif	SUPERLIKELY Atk: [150*1.385^pref(_sealScreeches)] Def: [150*1.385^pref(_sealScreeches)] HP: 150 Exp: [150*1.385^pref(_sealScreeches)/4] Init: [150*1.385^pref(_sealScreeches)] P: demon NOBANISH	burst hellseal brain (c0)	shredded hellseal hide (c0)	torn hellseal sinew (c0)	hellseal brain (c0)	hellseal hide (c0)	hellseal sinew (c0)	hellseal whisker (c0)	hellseal claw (c0)
+hellseal guardian	781	sealguard.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: demon	hellseal whisker (0)	hellseal whisker (0)	hellseal claw (0)	hellseal claw (0)
+Gorgolok, the Infernal Seal (Inner Sanctum)	21	1_1.gif	NOCOPY BOSS Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: demon Manuel: "Gorgolok, the Infernal Seal"	Scalp of Gorgolok (100)
+Gorgolok, the Infernal Seal (The Nemesis' Lair)	872	1_2.gif	NOCOPY BOSS Atk: 170 Def: 153 HP: 220 Init: 80 P: demon Manuel: "Gorgolok, the Infernal Seal"	Krakrox's Loincloth (100)
+Gorgolok, the Infernal Seal (Volcanic Cave)	882	1_3.gif	NOCOPY BOSS Atk: 185 Def: 166 HP: 260 Init: 90 Phys: 25 P: demon Manuel: "Gorgolok, the Infernal Seal"
+Gorgolok, the Demonic Hellseal	888	1_4a.gif	NOCOPY BOSS Atk: 200 Def: 180 HP: 400 Init: 100 Phys: 40 P: demon	Claw of the Infernal Seal (100)	Instant Karma (c100)	heart of the volcano (c100)
+
+# Turtle Tamer
+
+turtle trapper	685	turtletrapper.gif	NOCOPY WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 Meat: 100 P: dude
+Safari Jack, Small-Game Hunter	702	safarijack.gif	NOCOPY WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 P: dude	secret tropical island volcano lair map (100)	Safari Jack's moustache (100)	untamable turtle (100)
+guard turtle	782	guardturtle1.gif,guardturtle2.gif,guardturtle3.gif,guardturtle4.gif	NOCOPY Atk: 140 Def: 126 HP: 140 Init: 140 P: beast NOBANISH	guard turtle shell (0)	guard turtle collar (0)
+french guard turtle	783	frenchturtle.gif	NOCOPY Atk: 140 Def: 126 HP: 140 Init: 140 P: beast Manuel: "guard turtle"	guard turtle shell (0)	guard turtle collar (0)
+warehouse worker	867	warehouseguy.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: dude	crowbar (0)
+Stella, the Turtle Poacher (Inner Sanctum)	22	2_1.gif	NOCOPY BOSS Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: dude Manuel: "Stella, the Turtle Poacher"	Elder Turtle Shell (100)
+Stella, the Turtle Poacher (The Nemesis' Lair)	873	2_2.gif	NOCOPY BOSS Atk: 170 Def: 153 HP: 220 Init: 80 P: dude Manuel: "Stella, the Turtle Poacher"	Galapagosian Cuisses (100)
+Stella, the Turtle Poacher (Volcanic Cave)	883	2_3.gif	NOCOPY BOSS Atk: 185 Def: 166 HP: 260 Init: 90 Phys: 25 P: dude Manuel: "Stella, the Turtle Poacher"
+Stella, the Demonic Turtle Poacher	889	2_4a.gif	NOCOPY BOSS Atk: 200 Def: 180 HP: 1000 Init: 100 Phys: 40 P: demon	Garter of the Turtle Poacher (100)	Instant Karma (c100)	heart of the volcano (c100)
+
+# Pastamancer
+
+evil spaghetti cult assassin	686	spagcult2.gif	NOCOPY WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 P: dude
+Yakisoba the Executioner	703	yakisoba.gif	NOCOPY WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 P: dude	secret tropical island volcano lair map (100)	Yakisoba's hat (100)	macaroni duck (100)
+evil spaghetti cult middle-manager	806	spagcult3.gif	Atk: 150 Def: 135 HP: 175 Init: 80 P: dude NOBANISH	spaghetti cult mask (0)	spaghetti cult rosary (0)	crystal orb of spirit wrangling (100)	cult memo (100)
+evil spaghetti cult neophyte	807	spagcult1.gif	Atk: 140 Def: 126 HP: 150 Init: 60 P: dude NOBANISH	spaghetti cult mask (0)	spaghetti cult rosary (0)
+evil spaghetti cult technician	808	spagcult2.gif	Atk: 140 Def: 126 HP: 150 Init: 60 P: dude NOBANISH	spaghetti cult mask (0)	spaghetti cult rosary (0)
+evil spaghetti cult zealot	868	spagcult4.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: dude
+Spaghetti Elemental (Inner Sanctum)	23	3_1.gif	NOCOPY BOSS Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: elemental Manuel: "Spaghetti Elemental"	Colander of Em-er'il (100)
+Spaghetti Elemental (The Nemesis' Lair)	874	3_2.gif	NOCOPY BOSS Atk: 170 Def: 153 HP: 220 Init: 80 P: elemental Manuel: "Spaghetti Elemental"	Angelhair Culottes (100)
+Spaghetti Elemental (Volcanic Cave)	884	3_3.gif	NOCOPY BOSS Atk: 185 Def: 166 HP: 260 Init: 90 P: elemental Manuel: "Spaghetti Elemental"
+Spaghetti Demon	890	3_4a.gif	NOCOPY BOSS Atk: 200 Def: 180 HP: 600 Init: 100 Phys: 40 P: demon	Bandolier of the Spaghetti Elemental (100)	Instant Karma (c100)	heart of the volcano (c100)
+
+# Saucerer
+
+b&eacute;arnaise zombie	687	saucezombie.gif	NOCOPY WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 P: slime Manuel: "béarnaise zombie"
+Heimandatz, Nacho Golem	704	nachogolem.gif	NOCOPY WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 P: construct	secret tropical island volcano lair map (100)	Heimandatz's heart (100)	friendly cheez blob (100)
+booth slime	803	boothslime.gif	Atk: 140 Def: 126 HP: 150 Init: 50 P: slime NOBANISH	vial of blue slime (f66)
+fan slime	804	fanslime.gif	Atk: 140 Def: 126 HP: 150 Init: 50 P: slime NOBANISH	vial of yellow slime (f66)
+vendor slime	805	vendorslime.gif	Atk: 145 Def: 130 HP: 160 Init: 75 P: slime NOBANISH	vial of red slime (f66)
+security slime	869	securityslime.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: slime
+Lumpy, the Sinister Sauceblob (Inner Sanctum)	24	4_1.gif	NOCOPY BOSS Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: slime Manuel: "Lumpy, the Sinister Sauceblob"	Ancient Saucehelm (100)
+Lumpy, the Sinister Sauceblob (The Nemesis' Lair)	875	4_2.gif	NOCOPY BOSS Atk: 170 Def: 153 HP: 220 Init: 80 P: slime Manuel: "Lumpy, the Sinister Sauceblob"	Newman's Own Trousers (100)
+Lumpy, the Sinister Sauceblob (Volcanic Cave)	885	4_3.gif	NOCOPY BOSS Atk: 185 Def: 166 HP: 260 Init: 90 Phys: 25 P: slime Manuel: "Lumpy, the Sinister Sauceblob"
+Lumpy, the Demonic Sauceblob	891	4_4a.gif	NOCOPY BOSS Atk: 200 Def: 180 HP: 500 Init: 100 Phys: 40 P: demon	Gravyskin Belt of the Sauceblob (100)	Instant Karma (c100)	heart of the volcano (c100)
+
+# Disco Bandit
+
+flock of seagulls	699	seagulls.gif	NOCOPY WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 P: beast
+Jocko Homo	705	jockohomo.gif	NOCOPY WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 P: beast	secret tropical island volcano lair map (100)	Jocko Homo's head (100)	unusual disco ball (100)
+breakdancing raver	855	breakdancer.gif	Atk: 140 Def: 126 HP: 150 Init: 10000 P: dude NOBANISH	candy necklace (c0)	rave visor (c0)	teddybear backpack (c0)
+pop-and-lock raver	856	popnlocker.gif	Atk: 140 Def: 126 HP: 150 Init: 10000 P: dude NOBANISH	baggy rave pants (c0)	glowstick on a string (c0)	teddybear backpack (c0)
+running man	857	runningman.gif	Atk: 140 Def: 126 HP: 150 Init: 10000 P: dude NOBANISH	candy necklace (c0)	glowstick on a string (c0)	pacifier necklace (c0)
+daft punk	870	daftpunk.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: dude
+Spirit of New Wave (Inner Sanctum)	25	5_1.gif	NOCOPY BOSS Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: undead GHOST Manuel: "Spirit of New Wave"	Disco 'Fro Pick (100)
+Spirit of New Wave (The Nemesis' Lair)	876	5_2.gif	NOCOPY BOSS Atk: 170 Def: 153 HP: 220 Init: 80 P: undead GHOST Manuel: "Spirit of New Wave"	Volartta's bellbottoms (100)
+Spirit of New Wave (Volcanic Cave)	886	5_3.gif	NOCOPY BOSS Atk: 185 Def: 166 HP: 260 Init: 90 Phys: 25 P: undead GHOST Manuel: "Spirit of New Wave"
+Demon of New Wave	892	5_4a.gif	NOCOPY BOSS Atk: 200 Def: 180 HP: 500 Init: 100 Phys: 40 P: demon	Bling of the New Wave (100)	Instant Karma (c100)	heart of the volcano (c100)
+
+# Accordion Thief
+
+mariachi bandolero	700	bandolero.gif	NOCOPY WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 Meat: 50 P: dude
+The Mariachi With No Name	706	darkmariachi.gif	NOCOPY WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 Meat: 50 P: dude	secret tropical island volcano lair map (100)	The Mariachi's guitar case (100)	stray chihuahua (100)
+sleepy mariachi	858	mar_sleepy.gif	Atk: 120 Def: 108 HP: 110 Init: 125 P: dude NOBANISH	spangly mariachi pants (0)	spangly mariachi vest (0)	spangly sombrero (0)
+surprised mariachi	859	mar_surprised.gif	Atk: 130 Def: 117 HP: 125 Init: 150 P: dude NOBANISH	spangly mariachi pants (0)	spangly mariachi vest (0)	spangly sombrero (0)
+alert mariachi	860	mar_alert.gif	HP: 250 Def: 180 Atk: 200 Init: 300 P: dude NOBANISH	spangly mariachi pants (0)	spangly mariachi vest (0)	spangly sombrero (0)	alarm accordion (a0)
+mariachi bruiser	871	mar_bruiser.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: dude	spangly mariachi pants (0)	spangly mariachi vest (0)	spangly sombrero (0)
+Somerset Lopez, Dread Mariachi (Inner Sanctum)	26	6_1.gif	NOCOPY BOSS Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: dude Manuel: "Somerset Lopez, Dread Mariachi"	El Sombrero De Lopez (100)
+Somerset Lopez, Dread Mariachi (The Nemesis' Lair)	877	6_2.gif	NOCOPY BOSS Atk: 170 Def: 153 HP: 220 Init: 80 P: dude Manuel: "Somerset Lopez, Dread Mariachi"	Lederhosen of the Night (100)
+Somerset Lopez, Dread Mariachi (Volcanic Cave)	887	6_3.gif	NOCOPY BOSS Atk: 185 Def: 166 HP: 260 Init: 90 Phys: 25 P: dude Manuel: "Somerset Lopez, Dread Mariachi"
+Somerset Lopez, Demon Mariachi	893	6_4a.gif	NOCOPY BOSS Atk: 200 Def: 180 HP: 1000 Init: 100 Phys: 40 P: demon	La Hebilla del Cintur&oacute;n de Lopez (100)	Instant Karma (c100)	heart of the volcano (c100)
+
 
 # New Sorceress Lair
 
@@ -1044,36 +1073,36 @@ Mother Slime	792	otherimages/slimetube/stboss.gif	Atk: 1000 Def: 900 HP: 2950 In
 # Stench: environmental damage + (K-1) turns of Nauseated
 # Spooky: (K-1) turns of curse
 
-cold bugbear	1393	dvcoldbear1.gif,dvcoldbear2.gif,dvcoldbear3.gif	HP: [600+KW*200+ML] Atk: [400+KW*100+ML] Def: [400+KW*100+ML] Init: [15+KW*10] E: cold P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	snowstick (c0)
-cold ghost	1408	dvcoldghost1.gif,dvcoldghost2.gif,dvcoldghost3.gif	HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: cold P: undead Phys: 100 GHOST	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	BOOtonniere (c0)
-cold skeleton	1418	dvcoldskel1.gif,dvcoldskel2.gif,dvcoldskel3.gif	HP: [1000*2^(KC-1)+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: cold P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	old ball and chain (c0)
-cold vampire	1413	dvcoldvamp1.gif,dvcoldvamp2.gif,dvcoldvamp3.gif	HP: [600+KC*200+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: cold P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	remorseless knife (c0)
-cold werewolf	1398	dvcoldwolf1.gif,dvcoldwolf2.gif,dvcoldwolf3.gif	HP: [max(500,1.25*(MUS+(KW-2)*10))+ML] Atk: [max(400,MOX+(KW-2)*10)+ML] Def: [max(400,MUS+(KW-2)*10)+ML] Exp: [(max(400,STAT+(KW-2)*10))/4+max(ML,0)/3-min(0,ML)/4] Init: [15+KW*10] E: cold P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	drafty drawers (c0)
-cold zombie	1403	dvcoldzom1.gif,dvcoldzom2.gif,dvcoldzom3.gif	HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: cold P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	Thriller Ice (c0)
+cold bugbear	1393	dvcoldbear1.gif,dvcoldbear2.gif,dvcoldbear3.gif	NOCOPY HP: [600+KW*200+ML] Atk: [400+KW*100+ML] Def: [400+KW*100+ML] Init: [15+KW*10] E: cold P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	snowstick (c0)
+cold ghost	1408	dvcoldghost1.gif,dvcoldghost2.gif,dvcoldghost3.gif	NOCOPY HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: cold P: undead Phys: 100 GHOST	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	BOOtonniere (c0)
+cold skeleton	1418	dvcoldskel1.gif,dvcoldskel2.gif,dvcoldskel3.gif	NOCOPY HP: [1000*2^(KC-1)+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: cold P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	old ball and chain (c0)
+cold vampire	1413	dvcoldvamp1.gif,dvcoldvamp2.gif,dvcoldvamp3.gif	NOCOPY HP: [600+KC*200+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: cold P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	remorseless knife (c0)
+cold werewolf	1398	dvcoldwolf1.gif,dvcoldwolf2.gif,dvcoldwolf3.gif	NOCOPY HP: [max(500,1.25*(MUS+(KW-2)*10))+ML] Atk: [max(400,MOX+(KW-2)*10)+ML] Def: [max(400,MUS+(KW-2)*10)+ML] Exp: [(max(400,STAT+(KW-2)*10))/4+max(ML,0)/3-min(0,ML)/4] Init: [15+KW*10] E: cold P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	drafty drawers (c0)
+cold zombie	1403	dvcoldzom1.gif,dvcoldzom2.gif,dvcoldzom3.gif	NOCOPY HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: cold P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	Thriller Ice (c0)
 hot bugbear	1392	dvhotbear1.gif,dvhotbear2.gif,dvhotbear3.gif	NOCOPY HP: [600+KW*200+ML] Atk: [400+KW*100+ML] Def: [400+KW*100+ML] Init: [15+KW*60] E: hot P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	warm fur (c0)
 hot ghost	1407	dvhotghost1.gif,dvhotghost2.gif,dvhotghost3.gif	NOCOPY HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*60] E: hot P: undead Phys: 100 GHOST	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	vengeful spirit (c0)
 hot skeleton	1417	dvhotskel1.gif,dvhotskel2.gif,dvhotskel3.gif	NOCOPY HP: [1000*2^(KC-1)+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: hot P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	frying brainpan (c0)
 hot vampire	1412	dvhotvamp1.gif,dvhotvamp2.gif,dvhotvamp3.gif	NOCOPY HP: [600+KC*200+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*60] E: hot P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	vial of hot blood (c0)
 hot werewolf	1397	dvhotwolf1.gif,dvhotwolf2.gif,dvhotwolf3.gif	NOCOPY HP: [max(500,1.25*(MUS+(KW-2)*10))+ML] Atk: [max(400,MOX+(KW-2)*10)+ML] Def: [max(400,MUS+(KW-2)*10)+ML] Exp: [(max(400,STAT+(KW-2)*10))/4+max(ML,0)/3-min(0,ML)/4] Init: [15+KW*60] E: hot P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	accidental mutton (c0)
 hot zombie	1402	dvhotzom1.gif,dvhotzom2.gif,dvhotzom3.gif	NOCOPY HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*60] E: hot P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	hothammer (c0)
-sleaze bugbear	1396	dvsleazebear1.gif,dvsleazebear2.gif,dvsleazebear3.gif	HP: [600+KW*200+ML] Atk: [400+KW*100+ML] Def: [400+KW*100+ML] Init: [15+KW*10] E: sleaze P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	dubious loincloth (c0)
-sleaze ghost	1411	dvsleazeghost1.gif,dvsleazeghost2.gif,dvsleazeghost3.gif	HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: sleaze P: undead Phys: 100 GHOST	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	transparent pants (c0)
-sleaze skeleton	1421	dvsleazeskel1.gif,dvsleazeskel2.gif,dvsleazeskel3.gif	HP: [1000*2^(KC-1)+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: sleaze P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	tonguebone (c0)
-sleaze vampire	1416	dvsleazevamp1.gif,dvsleazevamp2.gif,dvsleazevamp3.gif	HP: [600+KC*200+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: sleaze P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	blood sausage (c0)
-sleaze werewolf	1401	dvsleazewolf1.gif,dvsleazewolf2.gif,dvsleazewolf3.gif	HP: [max(500,1.25*(MUS+(KW-2)*10))+ML] Atk: [max(400,MOX+(KW-2)*10)+ML] Def: [max(400,MUS+(KW-2)*10)+ML] Exp: [(max(400,STAT+(KW-2)*10))/4+max(ML,0)/3-min(0,ML)/4] Init: [15+KW*10] E: sleaze P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	groping claw (c0)
-sleaze zombie	1406	dvsleazezom1.gif,dvsleazezom2.gif,dvsleazezom3.gif	HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: sleaze P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	antique spyglass (c0)
-spooky bugbear	1394	dvspookybear1.gif,dvspookybear2.gif,dvspookybear3.gif	HP: [600+KW*200+ML] Atk: [400+KW*100+ML] Def: [400+KW*100+ML] Init: [15+KW*10] E: spooky P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	eerie fetish (c0)
-spooky ghost (Dreadsylvanian)	1409	dvspookyghost1.gif,dvspookyghost2.gif,dvspookyghost3.gif	HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: spooky P: undead Phys: 100 GHOST Manuel: "spooky ghost" Wiki: "spooky ghost"	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	ghost thread (c0)
-spooky skeleton	1419	dvspookyskel1.gif,dvspookyskel2.gif,dvspookyskel3.gif	HP: [1000*2^(KC-1)+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: spooky P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	old dry bone (c0)
-spooky vampire (Dreadsylvanian)	1414	dvspookyvamp1.gif,dvspookyvamp2.gif,dvspookyvamp3.gif	HP: [600+KC*200+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: spooky P: undead Manuel: "spooky vampire" Wiki: "spooky vampire (Dreadsylvanian Castle)"	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	intimidating coiffure (c0)
-spooky werewolf	1399	dvspookywolf1.gif,dvspookywolf2.gif,dvspookywolf3.gif	HP: [max(500,1.25*(MUS+(KW-2)*10))+ML] Atk: [max(400,MOX+(KW-2)*10)+ML] Def: [max(400,MUS+(KW-2)*10)+ML] Exp: [(max(400,STAT+(KW-2)*10))/4+max(ML,0)/3-min(0,ML)/4] Init: [15+KW*10] E: spooky P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	wolfskull mask (c0)
-spooky zombie	1404	dvspookyzom1.gif,dvspookyzom2.gif,dvspookyzom3.gif	HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: spooky P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	grandfather watch (c0)
-stench bugbear	1395	dvstenchbear1.gif,dvstenchbear2.gif,dvstenchbear3.gif	HP: [600+KW*200+ML] Atk: [400+KW*100+ML] Def: [400+KW*100+ML] Init: [15+KW*10] E: stench P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	stinkwater (c0)
-stench ghost	1410	dvstenchghost1.gif,dvstenchghost2.gif,dvstenchghost3.gif	HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: stench P: undead Phys: 100 GHOST	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	bag of unfinished business (c0)	folder (Stinky Trash Kid) (c0)
-stench skeleton	1420	dvstenchskel1.gif,dvstenchskel2.gif,dvstenchskel3.gif	HP: [1000*2^(KC-1)+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: stench P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	tailbone shield (c0)
-stench vampire	1415	dvstenchvamp1.gif,dvstenchvamp2.gif,dvstenchvamp3.gif	HP: [600+KC*200+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: stench P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	cod cape (c0)
-stench werewolf	1400	dvstenchwolf1.gif,dvstenchwolf2.gif,dvstenchwolf3.gif	HP: [max(500,1.25*(MUS+(KW-2)*10))+ML] Atk: [max(400,MOX+(KW-2)*10)+ML] Def: [max(400,MUS+(KW-2)*10)+ML] Exp: [(max(400,STAT+(KW-2)*10))/4+max(ML,0)/3-min(0,ML)/4] Init: [15+KW*10] E: stench P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	guts necklace (c0)
-stench zombie	1405	dvstenchzom1.gif,dvstenchzom2.gif,dvstenchzom3.gif	HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: stench P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	muddy skirt (c0)
+sleaze bugbear	1396	dvsleazebear1.gif,dvsleazebear2.gif,dvsleazebear3.gif	NOCOPY HP: [600+KW*200+ML] Atk: [400+KW*100+ML] Def: [400+KW*100+ML] Init: [15+KW*10] E: sleaze P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	dubious loincloth (c0)
+sleaze ghost	1411	dvsleazeghost1.gif,dvsleazeghost2.gif,dvsleazeghost3.gif	NOCOPY HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: sleaze P: undead Phys: 100 GHOST	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	transparent pants (c0)
+sleaze skeleton	1421	dvsleazeskel1.gif,dvsleazeskel2.gif,dvsleazeskel3.gif	NOCOPY HP: [1000*2^(KC-1)+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: sleaze P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	tonguebone (c0)
+sleaze vampire	1416	dvsleazevamp1.gif,dvsleazevamp2.gif,dvsleazevamp3.gif	NOCOPY HP: [600+KC*200+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: sleaze P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	blood sausage (c0)
+sleaze werewolf	1401	dvsleazewolf1.gif,dvsleazewolf2.gif,dvsleazewolf3.gif	NOCOPY HP: [max(500,1.25*(MUS+(KW-2)*10))+ML] Atk: [max(400,MOX+(KW-2)*10)+ML] Def: [max(400,MUS+(KW-2)*10)+ML] Exp: [(max(400,STAT+(KW-2)*10))/4+max(ML,0)/3-min(0,ML)/4] Init: [15+KW*10] E: sleaze P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	groping claw (c0)
+sleaze zombie	1406	dvsleazezom1.gif,dvsleazezom2.gif,dvsleazezom3.gif	NOCOPY HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: sleaze P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	antique spyglass (c0)
+spooky bugbear	1394	dvspookybear1.gif,dvspookybear2.gif,dvspookybear3.gif	NOCOPY HP: [600+KW*200+ML] Atk: [400+KW*100+ML] Def: [400+KW*100+ML] Init: [15+KW*10] E: spooky P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	eerie fetish (c0)
+spooky ghost (Dreadsylvanian)	1409	dvspookyghost1.gif,dvspookyghost2.gif,dvspookyghost3.gif	NOCOPY HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: spooky P: undead Phys: 100 GHOST Manuel: "spooky ghost" Wiki: "spooky ghost"	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	ghost thread (c0)
+spooky skeleton	1419	dvspookyskel1.gif,dvspookyskel2.gif,dvspookyskel3.gif	NOCOPY HP: [1000*2^(KC-1)+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: spooky P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	old dry bone (c0)
+spooky vampire (Dreadsylvanian)	1414	dvspookyvamp1.gif,dvspookyvamp2.gif,dvspookyvamp3.gif	NOCOPY HP: [600+KC*200+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: spooky P: undead Manuel: "spooky vampire" Wiki: "spooky vampire (Dreadsylvanian Castle)"	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	intimidating coiffure (c0)
+spooky werewolf	1399	dvspookywolf1.gif,dvspookywolf2.gif,dvspookywolf3.gif	NOCOPY HP: [max(500,1.25*(MUS+(KW-2)*10))+ML] Atk: [max(400,MOX+(KW-2)*10)+ML] Def: [max(400,MUS+(KW-2)*10)+ML] Exp: [(max(400,STAT+(KW-2)*10))/4+max(ML,0)/3-min(0,ML)/4] Init: [15+KW*10] E: spooky P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	wolfskull mask (c0)
+spooky zombie	1404	dvspookyzom1.gif,dvspookyzom2.gif,dvspookyzom3.gif	NOCOPY HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: spooky P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	grandfather watch (c0)
+stench bugbear	1395	dvstenchbear1.gif,dvstenchbear2.gif,dvstenchbear3.gif	NOCOPY HP: [600+KW*200+ML] Atk: [400+KW*100+ML] Def: [400+KW*100+ML] Init: [15+KW*10] E: stench P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	stinkwater (c0)
+stench ghost	1410	dvstenchghost1.gif,dvstenchghost2.gif,dvstenchghost3.gif	NOCOPY HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: stench P: undead Phys: 100 GHOST	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	bag of unfinished business (c0)	folder (Stinky Trash Kid) (c0)
+stench skeleton	1420	dvstenchskel1.gif,dvstenchskel2.gif,dvstenchskel3.gif	NOCOPY HP: [1000*2^(KC-1)+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: stench P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	tailbone shield (c0)
+stench vampire	1415	dvstenchvamp1.gif,dvstenchvamp2.gif,dvstenchvamp3.gif	NOCOPY HP: [600+KC*200+ML] Atk: [400+KC*100+ML] Def: [400+KC*100+ML] Init: [15+KC*10] E: stench P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	cod cape (c0)
+stench werewolf	1400	dvstenchwolf1.gif,dvstenchwolf2.gif,dvstenchwolf3.gif	NOCOPY HP: [max(500,1.25*(MUS+(KW-2)*10))+ML] Atk: [max(400,MOX+(KW-2)*10)+ML] Def: [max(400,MUS+(KW-2)*10)+ML] Exp: [(max(400,STAT+(KW-2)*10))/4+max(ML,0)/3-min(0,ML)/4] Init: [15+KW*10] E: stench P: beast	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	guts necklace (c0)
+stench zombie	1405	dvstenchzom1.gif,dvstenchzom2.gif,dvstenchzom3.gif	NOCOPY HP: [600+KV*200+ML] Atk: [400+KV*100+ML] Def: [400+KV*100+ML] Init: [15+KV*10] E: stench P: undead	Dreadsylvanian Almanac page (c0)	Freddy Kruegerand (c0)	muddy skirt (c0)
 
 # Dreadsylvania Bosses
 Count Drunkula	1390	drunkula.gif	NOCOPY Atk: 1000 Def: 1000 HP: 8000 Init: 20 P: undead	Thunkula's drinking cap (c0)	Drunkula's cape (c0)	Drunkula's silky pants (c0)	bottle of Bloodweiser (c0)
@@ -1767,36 +1796,36 @@ X-32-F Combat Training Snowman	1858	blank.gif	NOMANUEL NOWANDER NOCOPY Atk: 1 De
 
 # Investigating a Plaintive Telegram
 
-drunk cowpoke	1899	drunkpoke.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: -10000 P: dude	cow poker (0)
-surly gambler	1900	gamblinman.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: -10000 P: dude	poker face paint (0)
-wannabe gunslinger	1901	wannabecowboy.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 50 P: dude	realistic cap gun (0)
-cow cultist	1902	cowcultist.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 50 P: dude	tainted milk (0)
-hired gun	1903	outlawboss.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 75 P: dude	gun parts (0)
-camp cook	1904	campcook.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 50 P: dude	plate of Heimz Fortified Kidney Beans (0)	plate of Mixed Garbanzos and Chickpeas (0)	plate of Tesla's Electroplated Beans (0)
-skeletal gunslinger	1905	cowskeleton.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 75 E: spooky P: undead	triggerfingerbone (0)
-restless ghost	1906	elizabeth.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 50 E: spooky P: undead Phys: 100 GHOST	ghost bit (0)
-buzzard	1907	vulture.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 100 E: stench P: beast	buzzard feather (0)
-mountain lion	1908	mtlion.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 100 P: beast	lion musk (0)
-grizzled bear	1909	grizzlebear.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: -10000 P: beast	bear claw (0)
-diamondback rattler	1910	diamondback.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 75 P: beast SNAKE	rattler gland (0)
-coal snake	1911	coalsnake.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 50 P: beast SNAKE	half-digested coal (0)
-frontwinder	1912	frontwinder.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 100 P: beast SNAKE	tightly-wound spine (0)
-caugr	1913	caugr.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: -10000 P: demon	rotting beefsteak (0)
-pyrobove	1914	pyrobove.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 100 E: hot P: demon	firemilk (0)
-spidercow	1915	cowspider.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 50 E: spooky P: demon	spidercow eye-cluster (0)
-moomy	1916	moomy.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: -10000 E: spooky P: demon	moomy dust (0)
+drunk cowpoke	1899	drunkpoke.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: -10000 P: dude	cow poker (0)
+surly gambler	1900	gamblinman.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: -10000 P: dude	poker face paint (0)
+wannabe gunslinger	1901	wannabecowboy.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 50 P: dude	realistic cap gun (0)
+cow cultist	1902	cowcultist.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 50 P: dude	tainted milk (0)
+hired gun	1903	outlawboss.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 75 P: dude	gun parts (0)
+camp cook	1904	campcook.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 50 P: dude	plate of Heimz Fortified Kidney Beans (0)	plate of Mixed Garbanzos and Chickpeas (0)	plate of Tesla's Electroplated Beans (0)
+skeletal gunslinger	1905	cowskeleton.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 75 E: spooky P: undead	triggerfingerbone (0)
+restless ghost	1906	elizabeth.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 50 E: spooky P: undead Phys: 100 GHOST	ghost bit (0)
+buzzard	1907	vulture.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 100 E: stench P: beast	buzzard feather (0)
+mountain lion	1908	mtlion.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 100 P: beast	lion musk (0)
+grizzled bear	1909	grizzlebear.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: -10000 P: beast	bear claw (0)
+diamondback rattler	1910	NOCOPY diamondback.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 75 P: beast SNAKE	rattler gland (0)
+coal snake	1911	coalsnake.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 50 P: beast SNAKE	half-digested coal (0)
+frontwinder	1912	frontwinder.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 100 P: beast SNAKE	tightly-wound spine (0)
+caugr	1913	caugr.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: -10000 P: demon	rotting beefsteak (0)
+pyrobove	1914	pyrobove.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 100 E: hot P: demon	firemilk (0)
+spidercow	1915	cowspider.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: 50 E: spooky P: demon	spidercow eye-cluster (0)
+moomy	1916	moomy.gif	NOCOPY Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Floor: [60*pref(lttQuestDifficulty)] Cap: 11111 Init: -10000 E: spooky P: demon	moomy dust (0)
 
 # Bosses
-Jeff the Fancy Skeleton	1917	fancyjeff.gif	Atk: 180 Def: 200 HP: 300 Init: 100 E: spooky P: undead	Fancy Jeff's fancy pocket square (n100)
-Daisy the Unclean	1918	daisy.gif	Atk: 200 Def: 180 HP: 400 Init: 100 E: stench P: demon	Daisy's unclean bloomers (n100)
-Pecos Dave	1919	pecosdave.gif	Atk: 200 Def: 180 HP: 300 Init: 10000 P: dude	Pecos Dave's sixgun (n100)
+Jeff the Fancy Skeleton	1917	fancyjeff.gif	NOCOPY Atk: 180 Def: 200 HP: 300 Init: 100 E: spooky P: undead	Fancy Jeff's fancy pocket square (n100)
+Daisy the Unclean	1918	daisy.gif	NOCOPY Atk: 200 Def: 180 HP: 400 Init: 100 E: stench P: demon	Daisy's unclean bloomers (n100)
+Pecos Dave	1919	pecosdave.gif	NOCOPY Atk: 200 Def: 180 HP: 300 Init: 10000 P: dude	Pecos Dave's sixgun (n100)
 
-Pharaoh Amoon-Ra Cowtep	1920	amoonra.gif	Scale: 30 Cap: 5000 Floor: 300 HP: 1000 Init: 10000 P: demon	Amoon-Ra Cowtep's nemes (n100)
-Snake-Eyes Glenn	1921	snakeglenn.gif	Scale: 30 Cap: 5000 Floor: 300 HP: 1000 Init: 10000 P: dude	Glenn's golden dice (n100)
-Former Sheriff Dan Driscoll	1922	sheriffdan.gif	Scale: 30 Cap: 5000 Floor: 300 HP: 800 Init: -10000 P: dude	Former Sheriff Dan's tin star (n100)
+Pharaoh Amoon-Ra Cowtep	1920	amoonra.gif	NOCOPY Scale: 30 Cap: 5000 Floor: 300 HP: 1000 Init: 10000 P: demon	Amoon-Ra Cowtep's nemes (n100)
+Snake-Eyes Glenn	1921	snakeglenn.gif	NOCOPY Scale: 30 Cap: 5000 Floor: 300 HP: 1000 Init: 10000 P: dude	Glenn's golden dice (n100)
+Former Sheriff Dan Driscoll	1922	sheriffdan.gif	NOCOPY Scale: 30 Cap: 5000 Floor: 300 HP: 800 Init: -10000 P: dude	Former Sheriff Dan's tin star (n100)
 
-unusual construct	1923	vib6.gif	Scale: 60 Cap: 9000 Floor: 500 HP: 5000 Init: 10000 P: construct	El Vibrato restraints (n100)
-Clara	1924	clara.gif	Scale: 60 Cap: 9000 Floor: 500 HP: 5000 Init: 300 P: demon	Clara's bell (n100)
+unusual construct	1923	vib6.gif	NOCOPY Scale: 60 Cap: 9000 Floor: 500 HP: 5000 Init: 10000 P: construct	El Vibrato restraints (n100)
+Clara	1924	clara.gif	NOCOPY Scale: 60 Cap: 9000 Floor: 500 HP: 5000 Init: 300 P: demon	Clara's bell (n100)
 Granny Hackleton	1925	grannyhack.gif	NOCOPY Scale: 60 Cap: 9000 Floor: 500 HP: 3000 Init: -10000 P: dude	Granny Hackleton's Gatling gun (n100)
 
 # Batfellow Area (Batfellow comic IOTY 2016)

--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -445,7 +445,6 @@ mind flayer	222	lower_h.gif	Atk: 59 Def: 54 HP: 77 Init: 75 P: horror	mind flaye
 mine crab	746	minecrab.gif	Atk: 700 Def: 540 HP: 850 Init: 50 Meat: 250 P: fish	live nautical mine (n20)
 Mismatched Twins	1242	twins_mism.gif	Atk: 91 Def: 85 HP: 100 Init: 50 Meat: 60 P: dude	artisanal limoncello (15)	giant motorcycle boots (5)
 Mob Penguin Capo	1511	mobcapo.gif	Atk: 155 Def: 145 HP: 160 Init: 50 P: penguin Meat: 200	tommy gun (5)	drum of tommy ammo (30)	drum of tommy ammo (20)
-Mob Penguin hitman	683	pengthug.gif	WANDERER Atk: 75 Def: 67 HP: 90 Init: 40 Meat: 200 P: penguin	kneecapping stick (0)
 Mobile Armored Sweat Lodge	488	warhipar2.gif	Atk: 180 Def: 162 HP: 300 Init: 20 E: stench Phys: 50 P: hippy	communications windchimes (3)	didgeridooka (33)	gas balloon (20)
 model skeleton	1547	modelskeleton.gif	Atk: 76 Def: 81 HP: 85 Init: 25 P: construct E: spooky GHOST	synthetic marrow (0)	rubber ribcage (0)	funny bone (0)
 modern zmobie	1070	modernzombie.gif	SUPERLIKELY Atk: 60 Def: 54 HP: 50 Init: 300 Meat: 60 E: spooky P: undead

--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -115,7 +115,7 @@ Buzzy Beetle	273	buzzy.gif	Atk: 20 Def: 18 HP: 15 Init: 60 P: bug	black pixel (5
 C.A.R.N.I.V.O.R.E. Operative	514	carnivore.gif	NOCOPY Atk: 210 Def: 189 HP: 320 Init: 80 Meat: 300 ED: stench P: hippy	C.A.R.N.I.V.O.R.E. button (100)	green clay bead (30)	Lockenstock&trade; sandals (0)
 cabinet of Dr. Limpieza	1561	laundrycabinet.gif	Atk: 142 Def: 148 HP: 150 Init: 25 P: undead	fabric softener (15)	bottle of laundry sherry (15)	bloodstain stick (20)	fabric hardener (15)	blasting soda (c0)
 cactuary	465	cactuary.gif	Atk: 137 Def: 126 HP: 139 Init: 10 Meat: 100 P: plant	bit-o-cactus (27)	giant cactus quill (5)	cactus fruit (20)	handful of sand (20)
-Cake Lord	1756	cakelord.gif	Atk: 5 Def: 5 HP: 10 Init: -10000 P: construct
+Cake Lord	1756	cakelord.gif	NOCOPY Atk: 5 Def: 5 HP: 10 Init: -10000 P: construct
 Camel's Toe	541	cameltoe.gif	Atk: 158 Def: 142 HP: 150 Init: 70 E: sleaze P: constellation	line (30)	line (30)	star (30)	star (30)
 Carbuncle Top	985	carbuncletop.gif	NOCOPY BOSS Atk: 70 Def: 63 HP: 70 Init: 50 P: demon	hilarious comedy prop (100)
 cargo crab	743	cargocrab.gif	Atk: 450 Def: 360 HP: 500 Init: 150 Meat: 200 P: fish	imitation crab crate (n30)
@@ -184,7 +184,7 @@ dirty old lihc	1071	dirtyoldlihc.gif	Atk: 60 Def: 54 HP: 50 Init: 50 E: spooky P
 dirty thieving brigand	475	bandit.gif	Atk: 169 Def: 153 HP: 185 Init: 50 Meat: 1000 P: dude	brigand brittle (c0)
 disease-in-the-box	110	dinbox.gif	Atk: 18 Def: 16 HP: 14 Init: 80 P: construct	box (30)	disease (40)
 diving belle	762	divingbelle.gif	Atk: 400 Def: 450 HP: 750 Init: 50 E: spooky P: undead	diving muff (n3)	salinated mint julep (32)	water-polo mitt (c0)	comb jelly (0)
-Doctor Oh, the Junksprite Boss	1439	js_oh.gif	Atk: 40 Def: 40 HP: 60 Init: -10000 P: humanoid	eternal car battery (n100)
+Doctor Oh, the Junksprite Boss	1439	js_oh.gif	NOCOPY Atk: 40 Def: 40 HP: 60 Init: -10000 P: humanoid	eternal car battery (n100)
 dopey 7-Foot Dwarf	1150	dwarf_dopey.gif	Atk: 53 Def: 47 HP: 40 Init: 50 Meat: 40 P: humanoid	miner's helmet (9)
 doughbat	42	doughbat.gif	Atk: 14 Def: 12 HP: 8 Init: 60 EA: sleaze Meat: 20 P: beast	sonar-in-a-biscuit (10)	wad of dough (30)
 Dr. Awkward	453	drawkward.gif	NOCOPY BOSS Atk: 175 Def: 157 HP: 200 Init: -10000 P: dude	Drowsy Sword (n100)	Staff of Fats (n100)	fumble formula (p5)
@@ -393,7 +393,7 @@ lobsterfrogman	529	lobsterman.gif	Atk: 171 Def: 152 HP: 190 Init: 40 Meat: 60 P:
 lonely construct	668	vib5.gif	Atk: 300 Def: 315 HP: 350 Init: 80 P: construct	El Vibrato punchcard (213 holes) (1)	El Vibrato punchcard (182 holes) (1)
 lonely construct (translated)	674	vib5.gif	Atk: 300 Def: 315 HP: 350 Init: 80 P: construct Manuel: "lonely construct" Wiki: "lonely construct"	El Vibrato punchcard (213 holes) (1)	El Vibrato punchcard (182 holes) (1)
 Lord Spookyraven	464	lordspooky.gif	NOCOPY BOSS Atk: 165 Def: 148 HP: 200 Exp: [120+ML/3] Init: 10000 ED: spooky P: undead	Eye of Ed (n100)	Lord Spookyraven's ear trumpet (n100)
-Lot's Wife	1757	lotswife.gif	Atk: 3 Def: 3 HP: 10 P: beast Init: -10000	The Lot's engagement ring (n100)
+Lot's Wife	1757	lotswife.gif	NOCOPY Atk: 3 Def: 3 HP: 10 P: beast Init: -10000	The Lot's engagement ring (n100)
 lounge lizardfish	770	lizardfish.gif	Atk: 400 Def: 630 HP: 550 Init: 100 Meat: 200 P: fish	amber aviator shades (n5)	hair of the fish (c7)	rough fish scale (n4)	slug of shochu (21)
 lowercase B	934	lower_b.gif	Atk: 58 Def: 52 HP: 70 Init: 40 P: slime	left parenthesis (15)
 lowercase H	936	lower_h.gif	Atk: 59 Def: 54 HP: 77 Init: 75 P: horror	left bracket (15)	left parenthesis (20)	percent sign (25)
@@ -673,7 +673,7 @@ The Barrelmech of Diogenes	1840	otherimages/barrelbeast.gif	Atk: 200 Def: 250 HP
 The Big Wisniewski	545	thisdude.gif	NOCOPY BOSS Atk: 250 Def: 225 HP: 2000 Init: 60 ED: stench P: hippy	solid gold bowling ball (100)
 The Clownlord Beelzebozo	569	beelzebozo.gif	NOCOPY BOSS Atk: 27 Def: 27 HP: 40 Init: 85 P: horror
 the darkness (blind)	0	darkness.gif	NOMANUEL
-the former owner of the Skeleton Store	1755	skelmanager.gif	Atk: 5 Def: 5 HP: 8 Init: -10000 E: spooky P: undead	check to the Meatsmith (c100)	invisibility cream (c0)
+the former owner of the Skeleton Store	1755	NOCOPY skelmanager.gif	Atk: 5 Def: 5 HP: 8 Init: -10000 E: spooky P: undead	check to the Meatsmith (c100)	invisibility cream (c0)
 the ghost of Phil Bunion	1352	bunionghost.gif	Atk: 72 Def: 68 HP: 60 Init: 40 Phys: 100 P: undead E: spooky Meat: 30 GHOST	spectral axe (c100)	Phil Bunion's axe (c100)
 the gunk	1548	thegunk.gif	Atk: 81 Def: 81 HP: 80 Init: -10000 Meat: 50 P: slime	gunky chicken (0)	the funk (0)	half-melted spoon (0)
 The Man	555	theman.gif	NOCOPY BOSS Atk: 250 Def: 225 HP: 2000 Init: 60 ED: sleaze P: dude	really dense meat stack (100)

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -6951,7 +6951,8 @@ public class FightRequest extends GenericRequest {
     if (image.equals("lovelocket.gif")) {
       boolean added = str.contains("warm light");
       boolean already = str.contains("already a photo");
-      if (added) {
+      boolean scary = str.contains("too painful");
+      if (added || scary) {
         FightRequest.logText(str, status);
       }
       if (added || already) {


### PR DESCRIPTION
... from Crowther and me.

I also made FightRequest notice and log when your locket refuses to copy a monster.
For spading.

I suppose that will be redundant, by and by, but it will let us discover new NOCOPY monsters in the session log, even if you didn't notice it as it was happening.