### PR TITLE
tests: only extend requesttestbase where used

### DIFF
--- a/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
@@ -10,7 +10,7 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class AscensionHistoryRequestTest extends RequestTestBase {
+public class AscensionHistoryRequestTest {
 
   @BeforeAll
   protected static void init() {

--- a/test/net/sourceforge/kolmafia/request/MallPurchaseRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/MallPurchaseRequestTest.java
@@ -10,7 +10,7 @@ import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import org.junit.jupiter.api.Test;
 
-public class MallPurchaseRequestTest extends RequestTestBase {
+public class MallPurchaseRequestTest {
   private MallPurchaseRequest mallPurchaseRequestSetup(AdventureResult item) {
     // Simulate logging out and back in again.
     KoLCharacter.reset("");

--- a/test/net/sourceforge/kolmafia/request/ProcessAcquiredItemsTest.java
+++ b/test/net/sourceforge/kolmafia/request/ProcessAcquiredItemsTest.java
@@ -13,7 +13,7 @@ import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import org.junit.jupiter.api.Test;
 
-public class ProcessAcquiredItemsTest extends RequestTestBase {
+public class ProcessAcquiredItemsTest {
 
   // This package tests acquisition of items from either a Mall purchase or from pulling from your
   // store.

--- a/test/net/sourceforge/kolmafia/request/ScrapheapRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/ScrapheapRequestTest.java
@@ -12,7 +12,7 @@ import net.sourceforge.kolmafia.session.ChoiceManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ScrapheapRequestTest extends RequestTestBase {
+public class ScrapheapRequestTest {
 
   @BeforeEach
   protected void initEach() {

--- a/test/net/sourceforge/kolmafia/request/StorageRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/StorageRequestTest.java
@@ -24,7 +24,7 @@ import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import org.junit.jupiter.api.Test;
 
-public class StorageRequestTest extends RequestTestBase {
+public class StorageRequestTest {
 
   private Set<Integer> pulledItemSet = new HashSet<>();
   private String pulledItemProperty = "";


### PR DESCRIPTION
https://kolmafia.us/threads/migration-from-http-1-1-to-http-2-0.27303/ will involve redoing some of the base class, better to have it used in fewer places.