### PR TITLE
Change mall price updates to use Java 9 HttpClient

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -80,7 +80,8 @@ public class DebugDatabase {
       return "";
     }
 
-    var request = HttpRequest.newBuilder(uri).build();
+    var request =
+        HttpRequest.newBuilder(uri).header("User-Agent", GenericRequest.getUserAgent()).build();
     HttpResponse<String> response;
     try {
       response = client.send(request, BodyHandlers.ofString(StandardCharsets.UTF_8));

--- a/src/net/sourceforge/kolmafia/persistence/MallPriceDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/MallPriceDatabase.java
@@ -21,6 +21,7 @@ import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.MallPriceManager;
 import net.sourceforge.kolmafia.utilities.FileUtilities;
 import net.sourceforge.kolmafia.utilities.HttpUtilities;
@@ -202,6 +203,7 @@ public class MallPriceDatabase {
         HttpUtilities.getClientBuilder().connectTimeout(Duration.ofMillis(CONNECT_TIMEOUT)).build();
     HttpRequest req =
         HttpRequest.newBuilder(uri)
+            .header("User-Agent", GenericRequest.getUserAgent())
             .header("Content-Type", "multipart/form-data; boundary=--blahblahfishcakes")
             .POST(BodyPublishers.ofString(getPostData()))
             .build();

--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -2993,6 +2993,10 @@ public class GenericRequest implements Runnable {
     GenericRequest.setUserAgent(agent);
   }
 
+  public static final String getUserAgent() {
+    return GenericRequest.userAgent;
+  }
+
   public static final void setUserAgent(final String agent) {
     if (!agent.equals(GenericRequest.userAgent)) {
       GenericRequest.userAgent = agent;


### PR DESCRIPTION
More HttpClient to prep for https://kolmafia.us/threads/migration-from-http-1-1-to-http-2-0.27303/, again unnecessary as https://kolmafia.us/scripts/updateprices.php doesn't use HTTP/2.

Could do with somebody with access to https://kolmafia.us/scripts/updateprices.php confirming that the calls work completely correctly. I've tested it on a fake server, and it seems to send and receive the right data, but without access to the real server I can't be sure. I have sent some data to the real thing, and got successful responses back.

One more difference found: HttpClient doesn't read `http.agent` for the user agent; it has to be set manually.

On the plus side, the code is slightly neater, and we can choose to read the whole body in case of error, instead of just the first line, more easily.