### PR TITLE
Fix miscellaneous small data errors

### DIFF
--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -10853,10 +10853,10 @@
 10825	Doc's Smartifying Wine	747053412	rxwine.gif	drink	t,d	10	bottles of Doc's Smartifying Wine
 10826	Doc's Limbering Wine	975820765	rxwine.gif	drink	t,d	10	bottles of Doc's Limbering Wine
 10827	Doc's Medical-Grade Wine	237098811	rxwine.gif	drink	t,d	10	bottles of Doc's Medical-Grade Wine
-10828	Homebodyl&trade;	972999798	pill3.gif	spleen, usable	t,d	10
-10829	Extrovermectin&trade;	411068914	stimpill.gif	spleen, usable	t,d	10
-10830	Breathitin&trade;	910011561	pill2.gif	spleen, usable	t,d	10
-10831	Fleshazole&trade;	711958772	meatpill.gif	spleen, usable	t,d	10
+10828	Homebodyl&trade;	972999798	pill3.gif	spleen, multiple	t,d	10
+10829	Extrovermectin&trade;	411068914	stimpill.gif	spleen, multiple	t,d	10
+10830	Breathitin&trade;	910011561	pill2.gif	spleen, multiple	t,d	10
+10831	Fleshazole&trade;	711958772	meatpill.gif	spleen, multiple	t,d	10
 10832	anti-burn cream	912342957	creamtube.gif	potion, usable	t,d	10
 10833	anti-freeze cream	866330910	creamtube.gif	potion, usable	t,d	10
 10834	anti-goosebump cream	287944320	creamtube.gif	potion, usable	t,d	10

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -7833,7 +7833,8 @@ Skill	Gnomish Hardigness	Maximum HP Percent: +5
 Skill	Golgi Apparatus	Absorb Stats: +25
 # Good Singing Voice: Doubles duration of Boris songs
 # Gourmand: Increases adventures from food
-Skill	Gravitational Compression	Item Drop: [min(floor(basemys/5)+1,100)] Item Drops from Monsters (Scales with your Mysticality)
+# Gravitational Compression: +100% Item Drops from Monsters (Scales with your Mysticality)
+Skill	Gravitational Compression	Item Drop: [min(ceil(basemys/5),100)]
 # Hammer Throw: Level 1: Briefly stun your foe and reduce their stats by 10%
 # Hammer Throw: Level 2: Reduction increased to 15%
 # Hammer Throw: Level 3: Reduction increased to 20%
@@ -7848,6 +7849,7 @@ Skill	Hide of the Walrus	Damage Absorption: +50
 Skill	High Water Content	Hot Resistance: +2
 Skill	His Master's Voice	Familiar Weight: +5
 # Hivemindedness: Regenerate 100 MP per Adventure (Scales with your Mysticality)
+Skill	Hivemindedness	MP Regen Min: [min(ceil(basemys/10),100)], MP Regen Max: [min(ceil(basemys/10),100)]
 # Hollow Leg: +1 Liver Capacity
 Skill	Hot Headedness	Hot Damage: +11
 Skill	Hungry Eyes	Food Drop: +100

--- a/src/data/statuseffects.txt
+++ b/src/data/statuseffects.txt
@@ -2697,6 +2697,6 @@
 2696	Sluggish	slug.gif	f07d57053c4ed45f8523a4ae8dd95495	neutral	none
 2697	Drained	downarrow.gif	661a324f81137062fc3a484a00a7861a	neutral	none
 2698	Cosmic Ball in the Air	bowlup.gif	48f47e7233cc46a1f5e666d429b488bc	neutral	none
-2699	Shifted Phase	goocon31.gif	ab69049d57f4169be06e7eede432c728	neutral	none
-2700	Hooooooooonk!	goocon32.gif	30aa72118d7cd78067cbbf56bc6ef240	neutral	none
-2701	Darkened Photons	goocon45.gif	7bb8929bf51b4629e9ccb113b3cdefff	neutral	none
+2699	Shifted Phase	goocon31.gif	ab69049d57f4169be06e7eede432c728	neutral	none	cast 1 Phase Shift
+2700	Hooooooooonk!	goocon32.gif	30aa72118d7cd78067cbbf56bc6ef240	neutral	none	cast 1 Piezoelectric Honk
+2701	Darkened Photons	goocon45.gif	7bb8929bf51b4629e9ccb113b3cdefff	neutral	none	cast 1 Photonic Shroud

--- a/src/net/sourceforge/kolmafia/request/AfterLifeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AfterLifeRequest.java
@@ -376,6 +376,9 @@ public class AfterLifeRequest extends GenericRequest {
         case 25:
           builder.append("Plumber");
           break;
+        case 27:
+          builder.append("Grey Goo");
+          break;
         default:
           builder.append("(Class ");
           builder.append(pclass);

--- a/src/net/sourceforge/kolmafia/request/SpleenItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/SpleenItemRequest.java
@@ -284,7 +284,7 @@ public class SpleenItemRequest extends UseItemRequest {
 
       case ItemPool.HOMEBODYL:
         if (responseText.contains("You pop the pill and feel an immediate desire")) {
-          Preferences.increment("homebodylCharges", 11);
+          Preferences.increment("homebodylCharges", 11 * count);
         }
         break;
 
@@ -296,7 +296,7 @@ public class SpleenItemRequest extends UseItemRequest {
 
       case ItemPool.BREATHITIN:
         if (responseText.contains("You pop the pill in your mouth")) {
-          Preferences.increment("breathitinCharges", 5);
+          Preferences.increment("breathitinCharges", 5 * count);
         }
         break;
     }

--- a/src/net/sourceforge/kolmafia/textui/command/GooSkillsCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/GooSkillsCommand.java
@@ -25,13 +25,12 @@ public class GooSkillsCommand extends AbstractCommand {
 
   public static final GooSkill[] GOO_SKILLS = {
     new GooSkill(SkillPool.PSEUDOPOD_SLAP, "", "Deals 10 damage"),
-    new GooSkill(SkillPool.HARDSLAB, "remaindered skeleton", "Deals Muscle in physical damage"),
-    new GooSkill(
-        SkillPool.TELEKINETIC_MURDER, "cr&ecirc;ep", "Deals Mysticality in physical damage"),
+    new GooSkill(SkillPool.HARDSLAB, "remaindered skeleton", "Deals Mus in physical damage"),
+    new GooSkill(SkillPool.TELEKINETIC_MURDER, "cr&ecirc;ep", "Deals Mys in physical damage"),
     new GooSkill(
         SkillPool.SNAKESMACK,
         "sewer snake with a sewer snake in it",
-        "Deals Moxie in physical damage"),
+        "Deals Mox in physical damage"),
     new GooSkill(SkillPool.IRE_PROOF, "raging bull"),
     new GooSkill(SkillPool.NANOFUR, "ratbat"),
     new GooSkill(SkillPool.AUTOVAMPIRISM_ROUTINES, "spooky vampire"),
@@ -69,18 +68,19 @@ public class GooSkillsCommand extends AbstractCommand {
     new GooSkill(SkillPool.HIVEMINDEDNESS, "mind flayer"),
     new GooSkill(SkillPool.PONZI_APPARATUS, "anglerbush"),
     new GooSkill(SkillPool.FLUID_DYNAMICS_SIMULATION, "Carnivorous Moxie Weed"),
-    new GooSkill(SkillPool.NANTLERS, "stuffed moose head", "Deals Muscle in damage + bonus damage"),
+    new GooSkill(SkillPool.NANTLERS, "stuffed moose head", "Deals Mus in damage + bonus damage"),
+    new GooSkill(SkillPool.NANOSHOCK, "Jacob's adder", "Deals Mys in damage + bonus damage"),
+    new GooSkill(SkillPool.AUDIOCLASM, "spooky music box", "Deals Mox in damage + bonus damage"),
     new GooSkill(
-        SkillPool.NANOSHOCK, "Jacob's adder", "Deals Mysticality in damage + bonus damage"),
-    new GooSkill(SkillPool.AUDIOCLASM, "spooky music box", "Deals Moxie in damage + bonus damage"),
-    new GooSkill(
-        SkillPool.SYSTEM_SWEEP, "pygmy janitor", "Deals Muscle in physical damage & banish"),
+        SkillPool.SYSTEM_SWEEP, "pygmy janitor", "Deals Mus in physical damage & banish on win"),
     new GooSkill(
         SkillPool.DOUBLE_NANOVISION,
         "drunk pygmy",
-        "Deals Mysticality in physical damage, +100% Item Drop"),
+        "Deals Mys in physical damage & +100% Item Drop on win"),
     new GooSkill(
-        SkillPool.INFINITE_LOOP, "pygmy witch lawyer", "Deals Muscle in physical damage & +3 exp"),
+        SkillPool.INFINITE_LOOP,
+        "pygmy witch lawyer",
+        "Deals Mus in physical damage & +3 exp on win"),
     new GooSkill(
         SkillPool.PHOTONIC_SHROUD,
         "black panther",
@@ -120,7 +120,7 @@ public class GooSkillsCommand extends AbstractCommand {
     String[] params = parameters.trim().split("\\s+");
 
     boolean all = true;
-    String order = "id";
+    String order = "name";
 
     for (String keyword : params) {
       switch (keyword) {
@@ -343,7 +343,7 @@ public class GooSkillsCommand extends AbstractCommand {
         throw new NullPointerException();
       }
 
-      return o1.name.compareTo(o2.name);
+      return o1.name.compareToIgnoreCase(o2.name);
     }
 
     @Override


### PR DESCRIPTION
1) Cold Medicine Cabinet spleen items are all multi-usable
2) Therefore, when use more than one, charges multiply by count of pills used
3) Fix modifier formulae for Gravitational Compression and Hivemindedness
4) When ascend into Grey You run, you are a Grey Goo, not (Class 27)
5) Default sort order for gooskills command is now item, not id
6) Ignore case when comparing Goo Skills by name