### PR TITLE
register absorptions after a won fight

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -669,6 +669,7 @@ user	goreCollected	0
 user	gourdItemCount	5
 user	grabCloversHardcore	false
 user	grabCloversSoftcore	true
+user	greyYouPoints	0
 user	grimoire1Summons	0
 user	grimoire2Summons	0
 user	grimoire3Summons	0

--- a/src/net/sourceforge/kolmafia/AscensionPath.java
+++ b/src/net/sourceforge/kolmafia/AscensionPath.java
@@ -56,7 +56,7 @@ public class AscensionPath {
     // Not yet implemented
     QUANTUM("Quantum Terrarium", 42, false, "quantum", "a", "quantumPoints", 11, false),
     WILDFIRE("Wildfire", 43, false, "brushfire", "a"),
-    GREY_YOU("Grey You", 44, true, "greygoo", "a"),
+    GREY_YOU("Grey You", 44, true, "greygoo", "a", "greyYouPoints", 11, false),
     // A "sign" rather than a "path" for some reason
     BAD_MOON("Bad Moon", 999, false, "badmoon", null),
     ;

--- a/src/net/sourceforge/kolmafia/AscensionPath.java
+++ b/src/net/sourceforge/kolmafia/AscensionPath.java
@@ -53,7 +53,6 @@ public class AscensionPath {
     LOWKEY("Low Key Summer", 39, false, "littlelock", "a"),
     GREY_GOO("Grey Goo", 40, false, "greygooball", "a"),
     YOU_ROBOT("You, Robot", 41, false, "robobattery", "a", "youRobotPoints", 37, false),
-    // Not yet implemented
     QUANTUM("Quantum Terrarium", 42, false, "quantum", "a", "quantumPoints", 11, false),
     WILDFIRE("Wildfire", 43, false, "brushfire", "a"),
     GREY_YOU("Grey You", 44, true, "greygoo", "a", "greyYouPoints", 11, false),

--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -2188,6 +2188,9 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
     {
       "extreme cold makes it impossible", "You need more cold resistance.",
     },
+    {
+      "This zone is too old to visit on this path.", "That zone is out of Standard.",
+    },
   };
 
   private static Pattern CRIMBO21_COLD_RES =

--- a/src/net/sourceforge/kolmafia/persistence/AscensionSnapshot.java
+++ b/src/net/sourceforge/kolmafia/persistence/AscensionSnapshot.java
@@ -585,6 +585,7 @@ public class AscensionSnapshot {
       case GELATINOUS_NOOB:
       case DARK_GYFFTE:
       case PATH_OF_THE_PLUMBER:
+      case GREY_YOU:
         break;
       case AVATAR_OF_WEST_OF_LOATHING:
         strbuf.append(

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -305,6 +305,7 @@ public class Preferences {
         "nextQuantumFamiliarTurn",
         "nextSpookyravenElizabethRoom",
         "nextSpookyravenStephenRoom",
+	"noobDeferredPoints",
         "nosyNoseMonster",
         "optimisticCandleProgress",
         "parasolUsed",
@@ -1103,14 +1104,6 @@ public class Preferences {
   }
 
   public static void resetPerAscension() {
-    // Most prefs that get reset on ascension just return to their default value
-    for (String pref : resetOnAscension) {
-      resetToDefault(pref);
-    }
-
-    // Some need special treatment
-    MonorailManager.resetMuffinOrder();
-
     // Deferred ascension rewards
     Preferences.setInteger(
         "yearbookCameraUpgrades", Preferences.getInteger("yearbookCameraAscensions"));
@@ -1121,6 +1114,14 @@ public class Preferences {
     Preferences.increment(
         "awolPointsSnakeoiler", Preferences.getInteger("awolDeferredPointsSnakeoiler"));
     Preferences.increment("noobPoints", Preferences.getInteger("noobDeferredPoints"));
+
+    // Most prefs that get reset on ascension just return to their default value
+    for (String pref : resetOnAscension) {
+      resetToDefault(pref);
+    }
+
+    // Some need special treatment
+    MonorailManager.resetMuffinOrder();
   }
 
   public static void resetDailies() {

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -305,7 +305,7 @@ public class Preferences {
         "nextQuantumFamiliarTurn",
         "nextSpookyravenElizabethRoom",
         "nextSpookyravenStephenRoom",
-	"noobDeferredPoints",
+        "noobDeferredPoints",
         "nosyNoseMonster",
         "optimisticCandleProgress",
         "parasolUsed",

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -72,6 +72,7 @@ import net.sourceforge.kolmafia.session.DreadScrollManager;
 import net.sourceforge.kolmafia.session.EncounterManager;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import net.sourceforge.kolmafia.session.GoalManager;
+import net.sourceforge.kolmafia.session.GreyYouManager;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.session.IslandManager;
 import net.sourceforge.kolmafia.session.Limitmode;
@@ -3168,6 +3169,10 @@ public class FightRequest extends GenericRequest {
     String locationName = (location != null) ? location.getAdventureName() : null;
 
     FamiliarData familiar = KoLCharacter.getEffectiveFamiliar();
+
+    if (won && KoLCharacter.inGreyYou()) {
+      GreyYouManager.absorbMonster(monster);
+    }
 
     // Increment stinky cheese counter
     int stinkyCount = EquipmentManager.getStinkyCheeseLevel();

--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -15216,6 +15216,7 @@ public abstract class ChoiceManager {
         // Your Quest is Over
         ChoiceManager.handleAfterAvatar();
         break;
+
       case 1449:
         // If you change the mode with the item equipped, you need to un-equip and re-equip it to
         // get the modifiers
@@ -15307,6 +15308,11 @@ public abstract class ChoiceManager {
             Preferences.setBoolean("primaryLabCheerCoreGrabbed", true);
             break;
         }
+        break;
+
+      case 1465:
+        // No More Grey You
+        ChoiceManager.handleAfterAvatar();
         break;
     }
 

--- a/src/net/sourceforge/kolmafia/textui/command/AbsorptionsCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AbsorptionsCommand.java
@@ -71,8 +71,6 @@ public class AbsorptionsCommand extends AbstractCommand {
       }
     }
 
-    GreyYouManager.refreshAbsorptions();
-
     StringBuilder output = new StringBuilder();
     output.append("<table border=2 cols=4>");
     output.append("<tr>");

--- a/test/net/sourceforge/kolmafia/session/GreyYouManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/GreyYouManagerTest.java
@@ -104,7 +104,7 @@ public class GreyYouManagerTest {
     String name2 = "Baiowulf";
     MonsterData monster2 = MonsterDatabase.findMonster(name2);
     assertNotNull(monster2);
-    GreyYouManager.absorbMonster(monster1);
+    GreyYouManager.absorbMonster(monster2);
     assertEquals(1, GreyYouManager.absorbedMonsters.size());
     assertFalse(GreyYouManager.absorbedMonsters.contains(monster2.getId()));
   }

--- a/test/net/sourceforge/kolmafia/session/GreyYouManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/GreyYouManagerTest.java
@@ -1,6 +1,8 @@
 package net.sourceforge.kolmafia.session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -8,6 +10,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.MonsterData;
+import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -66,5 +70,42 @@ public class GreyYouManagerTest {
     assertEquals(GreyYouManager.unknownAbsorptions.get(1800), "5 adventures");
     assertTrue(GreyYouManager.unknownAbsorptions.containsKey(231));
     assertEquals(GreyYouManager.unknownAbsorptions.get(231), "100 adventures");
+  }
+
+  @Test
+  public void canParseCharsheetOnlyInGreyYou() throws IOException {
+    String responseText = loadHTMLResponse("request/test_grey_you_charsheet.html");
+
+    // This is the method that CharSheetResponse calls
+    GreyYouManager.parseAbsorptions(responseText);
+    assertEquals(140, GreyYouManager.absorbedMonsters.size());
+    assertEquals(0, GreyYouManager.unknownAbsorptions.size());
+    assertEquals(49, GreyYouManager.learnedSkills.size());
+
+    // Exit Grey You and try again
+    KoLCharacter.setPath(Path.NONE);
+    GreyYouManager.parseAbsorptions(responseText);
+    assertEquals(0, GreyYouManager.absorbedMonsters.size());
+    assertEquals(0, GreyYouManager.unknownAbsorptions.size());
+    assertEquals(0, GreyYouManager.learnedSkills.size());
+  }
+
+  @Test
+  public void canRegisterAbsorptionAfterFight() throws IOException {
+    // This is the method that FightRequest calls
+    String name1 = "oil baron";
+    MonsterData monster1 = MonsterDatabase.findMonster(name1);
+    assertNotNull(monster1);
+    assertEquals(0, GreyYouManager.absorbedMonsters.size());
+    GreyYouManager.absorbMonster(monster1);
+    assertEquals(1, GreyYouManager.absorbedMonsters.size());
+    assertTrue(GreyYouManager.absorbedMonsters.contains(monster1.getId()));
+
+    String name2 = "Baiowulf";
+    MonsterData monster2 = MonsterDatabase.findMonster(name2);
+    assertNotNull(monster2);
+    GreyYouManager.absorbMonster(monster1);
+    assertEquals(1, GreyYouManager.absorbedMonsters.size());
+    assertFalse(GreyYouManager.absorbedMonsters.contains(monster2.getId()));
   }
 }


### PR DESCRIPTION
Minor cleanups.

1) When in Grey You, after a fight which you win, register the monster absorption, as needed.
2) In the following cases, log a message both to gCLI and session log:
- Learned an unknown Grey You skill
- A Grey Goo "passive" skill does not have an entry in modifiers.txt 
- Found an unknown "significant" Grey Goo absorption on the charsheet

These all require a KoLmafia fix.

3) Don't need to refresh absorptions in "absorptions" command, since we read them from char sheet and update them appropriately when we absorb a monster.
4) When you try to visit a zone which is too old (per Standard restrictions), recognize that and don't count it as a visited location.
5) When free king after Grey You, you go through a choice adventure to choose a new class. Handle it in the usual way for Avatar paths.
6) Grey You ascensions tracked in greyYouPoints