### PR TITLE
New items, familiar. fix path images. Arena parameters

### DIFF
--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -311,5 +311,6 @@
 282	Ghost of Crimbo Commerce	cghost_commerce.gif	meat0,other0	greedy ghostling		0	0	0	0	eyes,undead
 283	Shorter-Order Cook	shortchef.gif	combat0,combat1,delevel,drop	shortest-order cook	blue plate	3	3	1	1	animal,clothes,eyes,hot,hands
 284	Vampire Vintner	vampvint.gif	combat0,hp0,drop	bottled Vampire Vintner	French-Transylvanian Dictionary	2	3	2	3	undead
-285	Arachnelf	arachnelf.gif	none	festive egg sac	Site Alpha ID badge	0	0	0	0
+285	Arachnelf	arachnelf.gif	none	festive egg sac	Site Alpha ID badge	3	1	3	1
 286	Synthetic Rock	synthrock.gif	none	synthetic rock		0	0	0	0
+287	Grey Goose	greygoose.gif	item0	grey gosling	grey down vest	1	2	3	3

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -10918,3 +10918,6 @@
 10891	cosmic bowling ball	119596776	cosmicball2.gif	none, combat		0
 10892	combat lover's locket lockbox	237536213	lovelocketbox.gif	usable	t	0
 10893	combat lover's locket	634036450	lovelocket.gif	accessory		0
+10894	Thwaitgold protozoa statuette	575626986	thwaitprotozoa.gif	none		0
+10895	grey gosling	802522606	greygosling.gif	grow	t	0
+10896	grey down vest	994210569	greygoovest.gif	familiar	t,d	75

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -4192,6 +4192,7 @@ Item	God Lobster's Rod	Equips On: "God Lobster", Familiar Effect: "whelp"
 Item	God Lobster's Scepter	Leprechaun: 0.5, Fairy: 0.5, Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
 Item	golden banana	Familiar Weight: +5
 Item	green pixie spog	Familiar Weight: +5
+Item	grey down vest	Experience (familiar): +2
 Item	Grim Brothers' story book	Familiar Weight: +5
 Item	grimstone galoshes	Familiar Weight: +5
 Item	guard turtle collar	Familiar Damage: +10, Generic
@@ -11018,6 +11019,7 @@ Item	green face paint	Free Pull
 # green pixel potion: Restores 40-60 HP and 30-40 MP
 # green smoke bomb: Lets you escape from combat without spending an Adventure
 # green smoke bomb: (Probably)
+Item	grey gosling	Free Pull
 # grizzled bearskin Adds +50% Muscle to your cowboy boots
 # grody jug: Deals a Buttload of <font color=green>Stench Damage</font>
 # grogpagne: Restores 30-50 MP

--- a/src/net/sourceforge/kolmafia/AscensionClass.java
+++ b/src/net/sourceforge/kolmafia/AscensionClass.java
@@ -27,7 +27,7 @@ public enum AscensionClass {
   GELATINOUS_NOOB("Gelatinous Noob", 23, "gelatinousicon", 2),
   VAMPYRE("Vampyre", 24, "vampirefangs", 1, "Chill of the Tomb"),
   PLUMBER("Plumber", 25, "mario_hammer2", -1),
-  GREY_GOO("Grey Goo", 27, "goovatar", -1);
+  GREY_GOO("Grey Goo", 27, "greygooring", -1);
 
   public static final List<AscensionClass> standardClasses =
       Arrays.asList(

--- a/src/net/sourceforge/kolmafia/AscensionPath.java
+++ b/src/net/sourceforge/kolmafia/AscensionPath.java
@@ -55,7 +55,7 @@ public class AscensionPath {
     YOU_ROBOT("You, Robot", 41, false, "robobattery", "a", "youRobotPoints", 37, false),
     QUANTUM("Quantum Terrarium", 42, false, "quantum", "a", "quantumPoints", 11, false),
     WILDFIRE("Wildfire", 43, false, "brushfire", "a"),
-    GREY_YOU("Grey You", 44, true, "greygoo", "a", "greyYouPoints", 11, false),
+    GREY_YOU("Grey You", 44, true, "greygooring", "a", "greyYouPoints", 11, false),
     // A "sign" rather than a "path" for some reason
     BAD_MOON("Bad Moon", 999, false, "badmoon", null),
     ;


### PR DESCRIPTION
1) grey gosling hatches into a Grey Goose
2) Thwaitgold protozoa statuette. "Not yet implemented", but we know item Id and desc id
3) Correct the class and path images on the Ascension History.
     This fixes the NPE when looking at your ascension history
4) Derive Arena parameters for Grey Goose
5) Derive Arena parameters for Arachnelf

(I found something useful to do in Grey You aftercore. :)