### PR TITLE
fix: parse and store Last-Modified headers in English

### DIFF
--- a/src/net/sourceforge/kolmafia/utilities/StringUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/StringUtilities.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.WeakHashMap;
 import java.util.regex.Matcher;
@@ -38,7 +39,7 @@ public class StringUtilities {
               + "under|up|upon|with|within|without)\\b");
 
   private static final SimpleDateFormat DATE_FORMAT =
-      new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
+      new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH);
 
   static {
     DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));

--- a/test/net/sourceforge/kolmafia/utilities/StringUtilitiesTest.java
+++ b/test/net/sourceforge/kolmafia/utilities/StringUtilitiesTest.java
@@ -1,11 +1,28 @@
 package net.sourceforge.kolmafia.utilities;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import org.junit.jupiter.api.Test;
 
 class StringUtilitiesTest {
+  @Test
+  void formatsDateFitForLastModified() {
+    var formatted = StringUtilities.formatDate(0L);
+    assertEquals("Thu, 01 Jan 1970 00:00:00 GMT", formatted);
+  }
+
+  @Test
+  void readsLastModifiedDate() {
+    var parsed = StringUtilities.parseDate("Wed, 21 Oct 2015 07:28:00 GMT");
+    var date = ZonedDateTime.of(2015, 10, 21, 7, 28, 0, 0, ZoneId.of("GMT"));
+    assertEquals(Instant.from(date).toEpochMilli(), parsed);
+  }
+
   @Test
   void isVowel() {
     assertTrue(StringUtilities.isVowel('a'));


### PR DESCRIPTION
Hopefully fixes https://kolmafia.us/threads/item-manager-doesnt-work.27370/#post-167323. Last-Modified HTTP headers need to be in English.

The only non-header use of parseDate / formatDate was in `CacheCommand`. I figured it was easier to just always make it use English.