### PR TITLE
Simplify Panels that handle ConcoctionDatabase.usables

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/Concoction.java
+++ b/src/net/sourceforge/kolmafia/objectpool/Concoction.java
@@ -29,6 +29,14 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
  * actually make the item.
  */
 public class Concoction implements Comparable<Concoction> {
+  // For queueing
+  public static enum ConcoctionType {
+    FOOD,
+    BOOZE,
+    SPLEEN,
+    POTION;
+  }
+
   public static final int FOOD_PRIORITY = 1;
   public static final int BOOZE_PRIORITY = 2;
   public static final int SPLEEN_PRIORITY = 3;

--- a/src/net/sourceforge/kolmafia/swingui/ItemManageFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/ItemManageFrame.java
@@ -28,6 +28,7 @@ import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.listener.Listener;
 import net.sourceforge.kolmafia.listener.NamedListenerRegistry;
 import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
+import net.sourceforge.kolmafia.objectpool.Concoction.ConcoctionType;
 import net.sourceforge.kolmafia.objectpool.IntegerPool;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
@@ -87,12 +88,12 @@ public class ItemManageFrame extends GenericFrame {
     queueTabs = null;
 
     if (Preferences.getBoolean("addCreationQueue")) {
-      dequeuePanel = new UseItemDequeuePanel(true, false, false);
+      dequeuePanel = new UseItemDequeuePanel(ConcoctionType.FOOD);
       foodPanel.add(dequeuePanel, BorderLayout.NORTH);
       queueTabs = dequeuePanel.getQueueTabs();
     }
 
-    foodPanel.add(new UseItemEnqueuePanel(true, false, false, queueTabs), BorderLayout.CENTER);
+    foodPanel.add(new UseItemEnqueuePanel(ConcoctionType.FOOD, queueTabs), BorderLayout.CENTER);
 
     selectorPanel.addPanel(" - Food", foodPanel);
 
@@ -101,12 +102,12 @@ public class ItemManageFrame extends GenericFrame {
     queueTabs = null;
 
     if (Preferences.getBoolean("addCreationQueue")) {
-      dequeuePanel = new UseItemDequeuePanel(false, true, false);
+      dequeuePanel = new UseItemDequeuePanel(ConcoctionType.BOOZE);
       boozePanel.add(dequeuePanel, BorderLayout.NORTH);
       queueTabs = dequeuePanel.getQueueTabs();
     }
 
-    boozePanel.add(new UseItemEnqueuePanel(false, true, false, queueTabs), BorderLayout.CENTER);
+    boozePanel.add(new UseItemEnqueuePanel(ConcoctionType.BOOZE, queueTabs), BorderLayout.CENTER);
 
     selectorPanel.addPanel(" - Booze", boozePanel);
 
@@ -115,12 +116,12 @@ public class ItemManageFrame extends GenericFrame {
     queueTabs = null;
 
     if (Preferences.getBoolean("addCreationQueue")) {
-      dequeuePanel = new UseItemDequeuePanel(false, false, true);
+      dequeuePanel = new UseItemDequeuePanel(ConcoctionType.SPLEEN);
       spleenPanel.add(dequeuePanel, BorderLayout.NORTH);
       queueTabs = dequeuePanel.getQueueTabs();
     }
 
-    spleenPanel.add(new UseItemEnqueuePanel(false, false, true, queueTabs), BorderLayout.CENTER);
+    spleenPanel.add(new UseItemEnqueuePanel(ConcoctionType.SPLEEN, queueTabs), BorderLayout.CENTER);
 
     selectorPanel.addPanel(" - Spleen", spleenPanel);
 
@@ -129,12 +130,12 @@ public class ItemManageFrame extends GenericFrame {
     queueTabs = null;
 
     if (Preferences.getBoolean("addCreationQueue")) {
-      dequeuePanel = new UseItemDequeuePanel(false, false, false);
+      dequeuePanel = new UseItemDequeuePanel(ConcoctionType.POTION);
       potionPanel.add(dequeuePanel, BorderLayout.NORTH);
       queueTabs = dequeuePanel.getQueueTabs();
     }
 
-    potionPanel.add(new UseItemEnqueuePanel(false, false, false, queueTabs), BorderLayout.CENTER);
+    potionPanel.add(new UseItemEnqueuePanel(ConcoctionType.POTION, queueTabs), BorderLayout.CENTER);
 
     selectorPanel.addPanel(" - Potions", potionPanel);
 

--- a/test/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanelTest.java
+++ b/test/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanelTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.util.Arrays;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.objectpool.Concoction.ConcoctionType;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -42,7 +43,7 @@ public class UseItemEnqueuePanelTest {
     Preferences.setInteger("_universalSeasoningsUsed", 0);
     loadInventory("{\"10640\": \"1\"}");
 
-    var panel = new UseItemEnqueuePanel(true, false, false, null);
+    var panel = new UseItemEnqueuePanel(ConcoctionType.FOOD, null);
     var buttonSearch =
         Arrays.stream(panel.buttons)
             .filter(b -> b.getText().equals("universal seasoning"))
@@ -58,7 +59,7 @@ public class UseItemEnqueuePanelTest {
     Preferences.setInteger("_universalSeasoningsUsed", 0);
     loadInventory("{\"10640\": \"0\"}");
 
-    var panel = new UseItemEnqueuePanel(true, false, false, null);
+    var panel = new UseItemEnqueuePanel(ConcoctionType.FOOD, null);
     var buttonSearch =
         Arrays.stream(panel.buttons)
             .filter(b -> b.getText().equals("universal seasoning"))
@@ -74,7 +75,7 @@ public class UseItemEnqueuePanelTest {
     Preferences.setInteger("_universalSeasoningsUsed", 1);
     loadInventory("{\"10640\": \"1\"}");
 
-    var panel = new UseItemEnqueuePanel(true, false, false, null);
+    var panel = new UseItemEnqueuePanel(ConcoctionType.FOOD, null);
     var buttonSearch =
         Arrays.stream(panel.buttons)
             .filter(b -> b.getText().equals("universal seasoning"))
@@ -86,7 +87,7 @@ public class UseItemEnqueuePanelTest {
 
   @Test
   public void odeToBoozeDisabledWithNoSkill() {
-    var panel = new UseItemEnqueuePanel(false, true, false, null);
+    var panel = new UseItemEnqueuePanel(ConcoctionType.BOOZE, null);
     var buttonSearch =
         Arrays.stream(panel.buttons).filter(b -> b.getText().equals("cast ode")).findFirst();
     assertTrue(buttonSearch.isPresent());
@@ -99,7 +100,7 @@ public class UseItemEnqueuePanelTest {
   public void odeToBoozeEnabledWithSkill() {
     KoLCharacter.addAvailableSkill(SkillPool.ODE_TO_BOOZE);
 
-    var panel = new UseItemEnqueuePanel(false, true, false, null);
+    var panel = new UseItemEnqueuePanel(ConcoctionType.BOOZE, null);
     var buttonSearch =
         Arrays.stream(panel.buttons).filter(b -> b.getText().equals("cast ode")).findFirst();
     assertTrue(buttonSearch.isPresent());
@@ -115,7 +116,7 @@ public class UseItemEnqueuePanelTest {
     KoLConstants.activeEffects.add(EffectPool.get(531)); // Benetton's Medley of Diversity
     KoLConstants.activeEffects.add(EffectPool.get(532)); // Elron's Explosive Etude
 
-    var panel = new UseItemEnqueuePanel(false, true, false, null);
+    var panel = new UseItemEnqueuePanel(ConcoctionType.BOOZE, null);
     var buttonSearch =
         Arrays.stream(panel.buttons).filter(b -> b.getText().equals("cast ode")).findFirst();
     assertTrue(buttonSearch.isPresent());
@@ -130,7 +131,7 @@ public class UseItemEnqueuePanelTest {
     KoLConstants.activeEffects.add(EffectPool.get(531)); // Benetton's Medley of Diversity
     KoLConstants.activeEffects.add(EffectPool.get(532)); // Elron's Explosive Etude
 
-    var panel = new UseItemEnqueuePanel(false, true, false, null);
+    var panel = new UseItemEnqueuePanel(ConcoctionType.BOOZE, null);
     var buttonSearch =
         Arrays.stream(panel.buttons).filter(b -> b.getText().equals("cast ode")).findFirst();
     assertTrue(buttonSearch.isPresent());


### PR DESCRIPTION
Refactor GUI panels to have a ConcoctionType enum rather than three mutually exclusive booleans

UseItemEnqueuePanel and UseItemDequeuePanel handle the list of "usables" from ConcoctionDatabase.
Each such panel can (mutually exclusively) be {food, booze, spleen, potions}.

They - and ConctionDatabase - are full of methods like this:

method(boolean food, boolean booze, boolean spleen)

FOOD = true, false, false
BOOZE = false, true, false
SPLEEN = false, false, true
POTION = false, false, false

I made an enum:
```
  public static enum ConcoctionType {
    FOOD,
    BOOZE,
    SPLEEN,
    POTION;
  }
```
and did a mass refactoring for all those methods to simply take one of these as an argument.

I have no idea how to write unit tests for GUI classes.