### PR TITLE
Fix maximizer behavior with force-equipping empty bjorns (and crowns)

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
+++ b/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
@@ -503,7 +503,7 @@ public class MaximizerSpeculation extends Speculation
       List<CheckedItem> possible = possibles.get(EquipmentManager.HAT);
       boolean any = false;
       for (int pos = 0; pos < possible.size(); ++pos) {
-        AdventureResult item = possible.get(pos);
+        CheckedItem item = possible.get(pos);
         int count = item.getCount();
         if (item.equals(this.equipment[EquipmentManager.FAMILIAR])) {
           --count;
@@ -523,7 +523,7 @@ public class MaximizerSpeculation extends Speculation
         if (count <= 0) continue;
         this.equipment[EquipmentManager.HAT] = item;
         if (item.getItemId() == ItemPool.HATSEAT) {
-          if (useCrownFamiliar != FamiliarData.NO_FAMILIAR) {
+          if (useCrownFamiliar != FamiliarData.NO_FAMILIAR || item.requiredFlag) {
             this.setEnthroned(useCrownFamiliar);
             this.tryShirts(possibles, bestCard);
             any = true;

--- a/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
+++ b/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
@@ -368,7 +368,7 @@ public class MaximizerSpeculation extends Speculation
       List<CheckedItem> possible = possibles.get(EquipmentManager.CONTAINER);
       boolean any = false;
       for (int pos = 0; pos < possible.size(); ++pos) {
-        AdventureResult item = possible.get(pos);
+        CheckedItem item = possible.get(pos);
         int count = item.getCount();
         FoldGroup group = ItemDatabase.getFoldGroup(item.getName());
         if (group != null && this.foldables) {
@@ -385,7 +385,7 @@ public class MaximizerSpeculation extends Speculation
         if (count <= 0) continue;
         this.equipment[EquipmentManager.CONTAINER] = item;
         if (item.getItemId() == ItemPool.BUDDY_BJORN) {
-          if (useBjornFamiliar != FamiliarData.NO_FAMILIAR) {
+          if (useBjornFamiliar != FamiliarData.NO_FAMILIAR || item.requiredFlag) {
             this.setBjorned(useBjornFamiliar);
             this.tryAccessories(enthronedFamiliars, possibles, 0, bestCard, useCrownFamiliar);
             any = true;

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
@@ -8,9 +8,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.beans.Transient;
+
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -107,6 +110,15 @@ public class MaximizerRegressionTest {
     assertEquals(25, modFor("Buffed Muscle"), 0.01);
     // Actually equipped the buddy bjorn
     assertEquals(25, modFor("Meat Drop"), 0.01);
+  }
+
+  @Test
+  public void equipBjornWhenEmpty() {
+    equip(EquipmentManager.CONTAINER, "Buddy Bjorn");
+    KoLCharacter.addFamiliar(new FamiliarData(FamiliarPool.MOSQUITO));
+    KoLCharacter.setBjorned(FamiliarData.NO_FAMILIAR);
+    
+    assertTrue(maximize("item, -buddy-bjorn, +equip buddy bjorn"));
   }
 
   // https://kolmafia.us/threads/27073/

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
@@ -113,12 +113,15 @@ public class MaximizerRegressionTest {
   }
 
   @Test
+  @Disabled("Refuses to equip a bjorn without a familiar in it, even when the equip keyword is used.")
   public void equipEmptyBjornNoSlot() {
     equip(EquipmentManager.CONTAINER, "Buddy Bjorn");
     KoLCharacter.addFamiliar(new FamiliarData(FamiliarPool.MOSQUITO));
     KoLCharacter.setBjorned(FamiliarData.NO_FAMILIAR);
     
-    assertTrue(maximize("item, -buddy-bjorn, +equip buddy bjorn"));
+    // Here, buddy-bjorn refers to the slot, while Buddy Bjorn refers to the item associated with that slot.
+    // We've earlier forced that slot to be empty, and here we're asking mafia not to fill it when maximizing, but to still equip the bjorn.
+    assertTrue(maximize("item, -buddy-bjorn, +equip Buddy Bjorn"));
   }
 
   // https://kolmafia.us/threads/27073/

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
@@ -111,8 +111,6 @@ public class MaximizerRegressionTest {
   }
 
   @Test
-  @Disabled(
-      "Refuses to equip a bjorn without a familiar in it, even when the equip keyword is used.")
   public void equipEmptyBjornNoSlot() {
     equip(EquipmentManager.CONTAINER, "Buddy Bjorn");
     KoLCharacter.addFamiliar(new FamiliarData(FamiliarPool.MOSQUITO));

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
@@ -8,12 +8,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.beans.Transient;
-
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
-import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -113,14 +110,17 @@ public class MaximizerRegressionTest {
   }
 
   @Test
-  @Disabled("Refuses to equip a bjorn without a familiar in it, even when the equip keyword is used.")
+  @Disabled(
+      "Refuses to equip a bjorn without a familiar in it, even when the equip keyword is used.")
   public void equipEmptyBjornNoSlot() {
     equip(EquipmentManager.CONTAINER, "Buddy Bjorn");
     KoLCharacter.addFamiliar(new FamiliarData(FamiliarPool.MOSQUITO));
     KoLCharacter.setBjorned(FamiliarData.NO_FAMILIAR);
-    
-    // Here, buddy-bjorn refers to the slot, while Buddy Bjorn refers to the item associated with that slot.
-    // We've earlier forced that slot to be empty, and here we're asking mafia not to fill it when maximizing, but to still equip the bjorn.
+
+    // Here, buddy-bjorn refers to the slot, while Buddy Bjorn refers to the item associated with
+    // that slot.
+    // We've earlier forced that slot to be empty, and here we're asking mafia not to fill it when
+    // maximizing, but to still equip the bjorn.
     assertTrue(maximize("item, -buddy-bjorn, +equip Buddy Bjorn"));
   }
 

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
@@ -113,7 +113,7 @@ public class MaximizerRegressionTest {
   }
 
   @Test
-  public void equipBjornWhenEmpty() {
+  public void equipEmptyBjornNoSlot() {
     equip(EquipmentManager.CONTAINER, "Buddy Bjorn");
     KoLCharacter.addFamiliar(new FamiliarData(FamiliarPool.MOSQUITO));
     KoLCharacter.setBjorned(FamiliarData.NO_FAMILIAR);

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
@@ -14,6 +14,7 @@ import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 
 public class MaximizerRegressionTest {
   @BeforeEach

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
@@ -13,7 +13,6 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class MaximizerRegressionTest {

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
@@ -122,6 +122,15 @@ public class MaximizerRegressionTest {
     assertTrue(maximize("item, -buddy-bjorn, +equip Buddy Bjorn"));
   }
 
+  @Test
+  public void equipEmptyCrownNoSlot() {
+    equip(EquipmentManager.HAT, "Crown of Thrones");
+    KoLCharacter.addFamiliar(new FamiliarData(FamiliarPool.MOSQUITO));
+    KoLCharacter.setEnthroned(FamiliarData.NO_FAMILIAR);
+
+    assertTrue(maximize("item, -crown-of-thrones, +equip Crown of Thrones"));
+  }
+
   // https://kolmafia.us/threads/27073/
   @Test
   public void noTiePrefersCurrentGear() {

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
@@ -13,8 +13,8 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class MaximizerRegressionTest {
   @BeforeEach


### PR DESCRIPTION
For a long time, I've encountered a weird issue involving the buddy bjorn and the maximizer that I've had a hard time describing and duplicating. No longer!

I've also had issues when assigning a bonus value to the buddy bjorn rather than using +equip, although I had a much harder time writing a failing test for that.