### PR TITLE
Do not finish Q5 with Goblin Water unless in Heavy Rains

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -2066,7 +2066,8 @@ public class ResultProcessor {
         break;
 
       case ItemPool.GOBLIN_WATER:
-        if (adventureResults) {
+        if (adventureResults
+            && KoLCharacter.inRaincore()) { // because you can now get the Goblin Water otherwise...
           QuestDatabase.setQuestProgress(Quest.GOBLIN, QuestDatabase.FINISHED);
         }
         break;


### PR DESCRIPTION
 Mr. Cheeng's spectacles can cause Goblin Water to drop, causing the ResultProcessor to finish the Goblin King quest.  Without fixing it comepletely, I closed the hole for all other paths.