### PR TITLE
fix: ignore pseudo-headers

### DIFF
--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -416,6 +416,11 @@ public class RelayRequest extends PasswordHashRequest {
           continue;
         }
 
+        // ignore psuedo-headers
+        if (key.startsWith(":")) {
+          continue;
+        }
+
         // KoL is known to send back CONTENT-LENGTH headers.
         // Since there is no built-in startsWithIgnoreCase,
         // upper-case the key when using startsWith.


### PR DESCRIPTION
HTTP/2 requests made under HttpClient may return pseudo-headers (e.g. ":status", ":version").

When proxying headers from KoL, don't include these headers.