### PR TITLE
feat: retry transient IOExceptions on requests

### DIFF
--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -1595,6 +1595,14 @@ public class GenericRequest implements Runnable {
         StaticEntity.printStackTrace(e, message);
       }
 
+      if (errorMessage != null
+          && (errorMessage.contains("GOAWAY")
+              || errorMessage.contains("parser received no bytes"))) {
+        ++this.timeoutCount;
+        if (this.timeoutCount < TIMEOUT_LIMIT) {
+          return this.sendRequest();
+        }
+      }
       RequestLogger.printLine(MafiaState.ERROR, message);
       this.timeoutCount = TIMEOUT_LIMIT;
       return true;


### PR DESCRIPTION
Detect, by error message, certain errors as transient and treat them as timeouts.

Related to https://kolmafia.us/threads/ioexception-goaway-received.27397/.