### PR TITLE
rationalize data types in Concoction and ConcoctionDatabase

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/Concoction.java
+++ b/src/net/sourceforge/kolmafia/objectpool/Concoction.java
@@ -3,8 +3,8 @@ package net.sourceforge.kolmafia.objectpool;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import net.java.dev.spellcast.utilities.LockableListModel;
-import net.java.dev.spellcast.utilities.SortedListModel;
+import java.util.Set;
+import java.util.TreeSet;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
@@ -84,6 +84,9 @@ public class Concoction implements Comparable<Concoction> {
   private String effectName;
   private double mainstatGain;
 
+  private static final Set<String> steelOrgans =
+      Set.of("steel margarita", "steel lasagna", "steel-scented air freshener");
+
   public Concoction(
       final AdventureResult concoction,
       final CraftingType mixingMethod,
@@ -131,11 +134,7 @@ public class Concoction implements Comparable<Concoction> {
     this.price = -1;
     this.property = null;
     this.special = false;
-    this.steelOrgan =
-        this.name != null
-            && (this.name.equals("steel margarita")
-                || this.name.equals("steel lasagna")
-                || this.name.equals("steel-scented air freshener"));
+    this.steelOrgan = steelOrgans.contains(this.name);
 
     this.resetCalculations();
   }
@@ -605,15 +604,15 @@ public class Concoction implements Comparable<Concoction> {
   }
 
   public void queue(
-      final LockableListModel<AdventureResult> globalChanges,
-      final ArrayList<AdventureResult> localChanges,
+      final List<AdventureResult> globalChanges,
+      final List<AdventureResult> localChanges,
       final int amount) {
     this.queue(globalChanges, localChanges, amount, true);
   }
 
   public void queue(
-      final LockableListModel<AdventureResult> globalChanges,
-      final ArrayList<AdventureResult> localChanges,
+      final List<AdventureResult> globalChanges,
+      final List<AdventureResult> localChanges,
       final int amount,
       boolean adjust) {
     if (amount <= 0) {
@@ -776,9 +775,9 @@ public class Concoction implements Comparable<Concoction> {
   public void addIngredient(final AdventureResult ingredient) {
     int itemId = ingredient.getItemId();
     if (itemId >= 0) {
-      SortedListModel<AdventureResult> uses = ConcoctionDatabase.knownUses.get(itemId);
+      Set<AdventureResult> uses = ConcoctionDatabase.knownUses.get(itemId);
       if (uses == null) {
-        uses = new SortedListModel<>();
+        uses = new TreeSet<>();
         ConcoctionDatabase.knownUses.put(ingredient.getItemId(), uses);
       }
 

--- a/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
@@ -6,8 +6,10 @@ import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Stack;
 import net.java.dev.spellcast.utilities.LockableListModel;
 import net.java.dev.spellcast.utilities.SortedListModel;
@@ -75,12 +77,10 @@ public class ConcoctionDatabase {
     }
   }
 
-  private static final SortedListModel<AdventureResult> EMPTY_LIST =
-      new SortedListModel<AdventureResult>();
-  private static final SortedListModel<CreateItemRequest> creatableList =
-      new SortedListModel<CreateItemRequest>();
-  private static final LockableListModel<Concoction> usableList =
-      new LockableListModel<Concoction>();
+  private static final Set<AdventureResult> EMPTY_SET = new HashSet<>();
+  private static final LockableListModel<CreateItemRequest> creatableList =
+      new LockableListModel<>();
+  private static final LockableListModel<Concoction> usableList = new LockableListModel<>();
 
   public static String excuse; // reason why creation is impossible
 
@@ -141,7 +141,7 @@ public class ConcoctionDatabase {
       new Concoction(null, CraftingType.NOCREATE);
   public static final Concoction meatLimit = new Concoction(null, CraftingType.NOCREATE);
 
-  public static final Map<Integer, SortedListModel<AdventureResult>> knownUses = new HashMap<>();
+  public static final Map<Integer, Set<AdventureResult>> knownUses = new HashMap<>();
 
   public static final EnumSet<CraftingType> PERMIT_METHOD = EnumSet.noneOf(CraftingType.class);
   public static final Map<CraftingType, Integer> ADVENTURE_USAGE =
@@ -208,12 +208,10 @@ public class ConcoctionDatabase {
       StaticEntity.printStackTrace(e);
     }
 
-    // Add all concoctions to usable list
-
-    for (Concoction item : ConcoctionPool.concoctions()) {
-      ConcoctionDatabase.usableList.add(item);
-    }
-
+    // Construct the usable list from all known concoctions.
+    // This includes all items
+    ConcoctionDatabase.usableList.clear();
+    ConcoctionDatabase.usableList.addAll(ConcoctionPool.concoctions());
     ConcoctionDatabase.usableList.sort();
   }
 
@@ -346,12 +344,12 @@ public class ConcoctionDatabase {
     return mixingMethod == CraftingType.SUSHI || mixingMethod == CraftingType.VYKEA;
   }
 
-  public static final SortedListModel<AdventureResult> getKnownUses(final int itemId) {
-    SortedListModel<AdventureResult> uses = ConcoctionDatabase.knownUses.get(itemId);
-    return uses == null ? ConcoctionDatabase.EMPTY_LIST : uses;
+  public static final Set<AdventureResult> getKnownUses(final int itemId) {
+    Set<AdventureResult> uses = ConcoctionDatabase.knownUses.get(itemId);
+    return uses == null ? ConcoctionDatabase.EMPTY_SET : uses;
   }
 
-  public static final SortedListModel<AdventureResult> getKnownUses(final AdventureResult item) {
+  public static final Set<AdventureResult> getKnownUses(final AdventureResult item) {
     return ConcoctionDatabase.getKnownUses(item.getItemId());
   }
 
@@ -797,7 +795,7 @@ public class ConcoctionDatabase {
     return ConcoctionDatabase.usableList;
   }
 
-  public static final SortedListModel<CreateItemRequest> getCreatables() {
+  public static final LockableListModel<CreateItemRequest> getCreatables() {
     return ConcoctionDatabase.creatableList;
   }
 

--- a/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
@@ -4,9 +4,9 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import net.java.dev.spellcast.utilities.SortedListModel;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.KoLCharacter;
@@ -362,7 +362,7 @@ public abstract class UseLinkDecorator {
     }
 
     // Retrieve the known ingredient uses for the item.
-    SortedListModel<AdventureResult> creations = ConcoctionDatabase.getKnownUses(itemId);
+    Set<AdventureResult> creations = ConcoctionDatabase.getKnownUses(itemId);
     if (creations.isEmpty()) {
       return CraftingType.NOCREATE;
     }
@@ -414,8 +414,7 @@ public abstract class UseLinkDecorator {
         break;
     }
 
-    for (int i = 0; i < creations.size(); ++i) {
-      AdventureResult creation = creations.get(i);
+    for (AdventureResult creation : creations) {
       CraftingType mixingMethod = ConcoctionDatabase.getMixingMethod(creation);
       EnumSet<CraftingRequirements> requirements =
           ConcoctionDatabase.getRequirements(creation.getItemId());


### PR DESCRIPTION
When I was looking at how ConcoctionDatabase.usableList was implemented, I noted some unnecessarily specify datatypes.

1) Concoction.queue() took two List parameters. They were specified to be a LockableListModel and an ArrayList - only because the caller of that in ConcoctionDatabase just happened to have data of those particular types. queue() cares only that it receives a List. Change the parameter types to such.

2) ConcoctionDatabase.usableList is a LockableListModel<Concoction>.
That is fine, since a LockableListModel can be used as the model in a JList.
ConcoctionDatabase.creatableList was a SortedListModel<Concoction>
A SortedListModel is a LockableListModel that is re-sorted every time it changes.
That's expensive, but if you want your list to be sorted, OK, I guess.
It turns out that refreshConcoctionsNow iterates over all concoctions and adds or removes them to creatableList - and after it has processed them all, it sorts creatableList.
What a waste of CPU. creatableList is now a LockableListModel.

3) ConcoctionDatabase.knownUses was a Map from Integer to SortedListModel<AdventureResult>.
The Integer is the itemId. The SortedListModel contained items that this was in ingredient for.
knownUses is never used in a GUI element. The items are not ordered - except by name.
I made the SortedListModel be a TreeSet<AdventureResult>.
I made the api that returns it give a Set, since the only user is UseLinkDecoration, which really shouldn't care.

4) usablesList was initialized by iterating over ConcoctionPool.concoctions - a Collection - and adding them one at a time to the list. It now simply clears the list and does an addAll().