### PR TITLE
rationalize availableCombatSkills

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -3905,9 +3905,7 @@ public abstract class KoLCharacter {
 
   /** Adds a single skill to the list of skills temporarily possessed by this character. */
   public static final void addAvailableCombatSkill(final int skillId) {
-    if (!KoLConstants.availableCombatSkillsSet.contains(skillId)) {
-      KoLConstants.availableCombatSkillsSet.add(skillId);
-    }
+    KoLConstants.availableCombatSkillsSet.add(skillId);
   }
 
   public static final void addAvailableCombatSkill(final String skillName) {
@@ -3916,9 +3914,7 @@ public abstract class KoLCharacter {
   }
 
   public static final void removeAvailableCombatSkill(final int skillId) {
-    if (KoLConstants.availableCombatSkillsSet.contains(skillId)) {
-      KoLConstants.availableCombatSkillsSet.remove(skillId);
-    }
+    KoLConstants.availableCombatSkillsSet.remove(skillId);
   }
 
   public static final void removeAvailableCombatSkill(final String skillName) {
@@ -4068,16 +4064,8 @@ public abstract class KoLCharacter {
   }
 
   /** Utility methods which looks up whether or not the character has a particular skill. */
-  public static final boolean hasAvailableSkill(final int skillId) {
-    return KoLConstants.availableSkillsSet.contains(skillId);
-  }
-
-  public static final boolean hasCombatSkill(final int skillId) {
-    return KoLConstants.availableCombatSkillsSet.contains(skillId);
-  }
-
   public static final boolean hasSkill(final int skillId) {
-    return hasAvailableSkill(skillId);
+    return KoLConstants.availableSkillsSet.contains(skillId);
   }
 
   public static final boolean hasSkill(final String skillName) {
@@ -4086,7 +4074,7 @@ public abstract class KoLCharacter {
     return KoLCharacter.hasSkill(skillId);
   }
 
-  public static final boolean availableCombatSkill(final int skillId) {
+  public static final boolean hasCombatSkill(final int skillId) {
     return KoLConstants.availableCombatSkillsSet.contains(skillId);
   }
 

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -430,9 +430,8 @@ public abstract class KoLCharacter {
     KoLConstants.expressionSkills.clear();
     KoLConstants.walkSkills.clear();
     KoLConstants.availableSkills.clear();
-    KoLConstants.availableSkillsMap.clear();
-    KoLConstants.availableCombatSkills.clear();
-    KoLConstants.availableCombatSkillsMap.clear();
+    KoLConstants.availableSkillsSet.clear();
+    KoLConstants.availableCombatSkillsSet.clear();
     KoLConstants.combatSkills.clear();
 
     // All characters get the option to
@@ -3713,14 +3712,14 @@ public abstract class KoLCharacter {
     KoLCharacter.addAvailableSkill(UseSkillRequest.getUnmodifiedInstance(skillId), checkTrendy);
   }
 
-  public static final void addAvailableSkill(final String name) {
+  public static final void addAvailableSkill(final String skillName) {
     // *** Skills can have ambiguous names. Best to use the methods that deal with skill id
-    KoLCharacter.addAvailableSkill(name, false);
+    KoLCharacter.addAvailableSkill(skillName, false);
   }
 
-  public static final void addAvailableSkill(final String name, final boolean checkTrendy) {
+  public static final void addAvailableSkill(final String skillName, final boolean checkTrendy) {
     // *** Skills can have ambiguous names. Best to use the methods that deal with skill id
-    KoLCharacter.addAvailableSkill(UseSkillRequest.getUnmodifiedInstance(name), checkTrendy);
+    KoLCharacter.addAvailableSkill(SkillDatabase.getSkillId(skillName), checkTrendy);
   }
 
   public static final void addAvailableSkill(final UseSkillRequest skill) {
@@ -3732,7 +3731,8 @@ public abstract class KoLCharacter {
       return;
     }
 
-    if (KoLConstants.availableSkillsMap.containsKey(skill)) {
+    int skillId = skill.getSkillId();
+    if (KoLConstants.availableSkillsSet.contains(skillId)) {
       return;
     }
 
@@ -3757,13 +3757,13 @@ public abstract class KoLCharacter {
     }
 
     KoLConstants.availableSkills.add(skill);
-    KoLConstants.availableSkillsMap.put(skill, null);
+    KoLConstants.availableSkillsSet.add(skillId);
     PreferenceListenerRegistry.firePreferenceChanged("(skill)");
 
-    switch (SkillDatabase.getSkillType(skill.getSkillId())) {
+    switch (SkillDatabase.getSkillType(skillId)) {
       case SkillDatabase.PASSIVE:
         {
-          switch (skill.getSkillId()) {
+          switch (skillId) {
             case SkillPool.FLAVOUR_OF_MAGIC:
               // Flavour of Magic gives you access to five other
               // castable skills
@@ -3905,47 +3905,25 @@ public abstract class KoLCharacter {
 
   /** Adds a single skill to the list of skills temporarily possessed by this character. */
   public static final void addAvailableCombatSkill(final int skillId) {
-    KoLCharacter.addAvailableCombatSkill(UseSkillRequest.getUnmodifiedInstance(skillId));
+    if (!KoLConstants.availableCombatSkillsSet.contains(skillId)) {
+      KoLConstants.availableCombatSkillsSet.add(skillId);
+    }
   }
 
   public static final void addAvailableCombatSkill(final String skillName) {
     // *** Skills can have ambiguous names. Best to use the methods that deal with skill id
-    KoLCharacter.addAvailableCombatSkill(UseSkillRequest.getUnmodifiedInstance(skillName));
-  }
-
-  private static void addAvailableCombatSkill(final UseSkillRequest skill) {
-    if (skill == null) {
-      return;
-    }
-
-    if (KoLConstants.availableCombatSkillsMap.containsKey(skill)) {
-      return;
-    }
-
-    KoLConstants.availableCombatSkills.add(skill);
-    KoLConstants.availableCombatSkillsMap.put(skill, null);
+    KoLCharacter.addAvailableCombatSkill(SkillDatabase.getSkillId(skillName));
   }
 
   public static final void removeAvailableCombatSkill(final int skillId) {
-    KoLCharacter.removeAvailableCombatSkill(UseSkillRequest.getUnmodifiedInstance(skillId));
+    if (KoLConstants.availableCombatSkillsSet.contains(skillId)) {
+      KoLConstants.availableCombatSkillsSet.remove(skillId);
+    }
   }
 
-  public static final void removeAvailableCombatSkill(final String name) {
+  public static final void removeAvailableCombatSkill(final String skillName) {
     // *** Skills can have ambiguous names. Best to use the methods that deal with skill id
-    KoLCharacter.removeAvailableCombatSkill(UseSkillRequest.getUnmodifiedInstance(name));
-  }
-
-  private static void removeAvailableCombatSkill(final UseSkillRequest skill) {
-    if (skill == null) {
-      return;
-    }
-
-    if (!KoLConstants.availableCombatSkillsMap.containsKey(skill)) {
-      return;
-    }
-
-    KoLConstants.availableCombatSkills.remove(skill);
-    KoLConstants.availableCombatSkillsMap.remove(skill);
+    KoLCharacter.removeAvailableCombatSkill(SkillDatabase.getSkillId(skillName));
   }
 
   private static void addCombatSkill(final String name) {
@@ -3965,9 +3943,8 @@ public abstract class KoLCharacter {
     }
 
     UseSkillRequest skill = UseSkillRequest.getUnmodifiedInstance(skillId);
-
     KoLConstants.availableSkills.remove(skill);
-    KoLConstants.availableSkillsMap.remove(skill);
+    KoLConstants.availableSkillsSet.remove(skillId);
     KoLConstants.usableSkills.remove(skill);
     KoLConstants.summoningSkills.remove(skill);
     KoLConstants.usableSkills.remove(skill);
@@ -4090,54 +4067,27 @@ public abstract class KoLCharacter {
     return KoLCharacter.hasSkill("Amphibian Sympathy");
   }
 
-  /** Utility method which looks up whether or not the character has a skill of the given name. */
+  /** Utility methods which looks up whether or not the character has a particular skill. */
+  public static final boolean hasAvailableSkill(final int skillId) {
+    return KoLConstants.availableSkillsSet.contains(skillId);
+  }
+
+  public static final boolean hasCombatSkill(final int skillId) {
+    return KoLConstants.availableCombatSkillsSet.contains(skillId);
+  }
+
   public static final boolean hasSkill(final int skillId) {
-    UseSkillRequest skill = UseSkillRequest.getUnmodifiedInstance(skillId);
-    return KoLCharacter.hasSkill(skill);
+    return hasAvailableSkill(skillId);
   }
 
   public static final boolean hasSkill(final String skillName) {
     // *** Skills can have ambiguous names. Best to use the methods that deal with skill id
-    UseSkillRequest skill = UseSkillRequest.getUnmodifiedInstance(skillName);
-    return KoLCharacter.hasSkill(skill);
-  }
-
-  public static final boolean hasSkill(final String skillName, final List<UseSkillRequest> list) {
-    // *** Skills can have ambiguous names. Best to use the methods that deal with skill id
-    UseSkillRequest skill = UseSkillRequest.getUnmodifiedInstance(skillName);
-    return KoLCharacter.hasSkill(skill, list);
-  }
-
-  public static final boolean hasSkill(final UseSkillRequest skill) {
-    return KoLCharacter.hasSkill(skill, KoLConstants.availableSkills);
-  }
-
-  public static final boolean hasSkill(
-      final UseSkillRequest skill, final List<UseSkillRequest> list) {
-    if (skill == null) {
-      return false;
-    }
-
-    if (list == KoLConstants.availableSkills) {
-      return KoLConstants.availableSkillsMap.containsKey(skill);
-    }
-    if (list == KoLConstants.availableCombatSkills) {
-      return KoLConstants.availableCombatSkillsMap.containsKey(skill);
-    }
-    return list.contains(skill);
+    int skillId = SkillDatabase.getSkillId(skillName);
+    return KoLCharacter.hasSkill(skillId);
   }
 
   public static final boolean availableCombatSkill(final int skillId) {
-    UseSkillRequest skill = UseSkillRequest.getUnmodifiedInstance(skillId);
-    return KoLCharacter.availableCombatSkill(skill);
-  }
-
-  public static final boolean availableCombatSkill(final UseSkillRequest skill) {
-    if (skill == null) {
-      return false;
-    }
-
-    return KoLConstants.availableCombatSkillsMap.containsKey(skill);
+    return KoLConstants.availableCombatSkillsSet.contains(skillId);
   }
 
   /**
@@ -4670,14 +4620,16 @@ public abstract class KoLCharacter {
 
     if (thrall == PastaThrallData.NO_THRALL) {
       UseSkillRequest skill = UseSkillRequest.getUnmodifiedInstance("Dismiss Pasta Thrall");
+      int skillId = skill.getSkillId();
       KoLConstants.availableSkills.remove(skill);
-      KoLConstants.availableSkillsMap.remove(skill);
+      KoLConstants.availableSkillsSet.remove(skillId);
       KoLConstants.usableSkills.remove(skill);
       KoLConstants.summoningSkills.remove(skill);
     } else if (KoLCharacter.currentPastaThrall == PastaThrallData.NO_THRALL) {
       UseSkillRequest skill = UseSkillRequest.getUnmodifiedInstance("Dismiss Pasta Thrall");
+      int skillId = skill.getSkillId();
       KoLConstants.availableSkills.add(skill);
-      KoLConstants.availableSkillsMap.put(skill, null);
+      KoLConstants.availableSkillsSet.add(skillId);
       KoLConstants.usableSkills.add(skill);
       LockableListFactory.sort(KoLConstants.usableSkills);
       KoLConstants.summoningSkills.add(skill);

--- a/src/net/sourceforge/kolmafia/KoLConstants.java
+++ b/src/net/sourceforge/kolmafia/KoLConstants.java
@@ -7,10 +7,11 @@ import java.text.DecimalFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.IdentityHashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
+import java.util.Set;
 import java.util.regex.Pattern;
 import net.java.dev.spellcast.utilities.UtilityConstants;
 import net.sourceforge.kolmafia.chat.StyledChatBuffer;
@@ -577,10 +578,10 @@ public interface KoLConstants extends UtilityConstants {
   List<UseSkillRequest> expressionSkills = LockableListFactory.getInstance(UseSkillRequest.class);
   List<UseSkillRequest> walkSkills = LockableListFactory.getInstance(UseSkillRequest.class);
   List<UseSkillRequest> availableSkills = LockableListFactory.getInstance(UseSkillRequest.class);
-  IdentityHashMap<UseSkillRequest, Object> availableSkillsMap = new IdentityHashMap<>();
-  List<UseSkillRequest> availableCombatSkills =
-      LockableListFactory.getInstance(UseSkillRequest.class);
-  IdentityHashMap<UseSkillRequest, Object> availableCombatSkillsMap = new IdentityHashMap<>();
+  Set<Integer> availableSkillsSet = new HashSet<>();
+  // The list of combat skills displayed in skills dropdown from the current (last) fight.php
+  List<Integer> availableCombatSkillsList = new ArrayList<>();
+  Set<Integer> availableCombatSkillsSet = new HashSet<>();
   List<UseSkillRequest> permedSkills = LockableListFactory.getInstance(UseSkillRequest.class);
   List<UseSkillRequest> combatSkills = LockableListFactory.getInstance(UseSkillRequest.class);
 

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -2649,7 +2649,7 @@ public class Modifiers {
 
     for (int i = Modifiers.passiveSkills.size() - 1; i >= 0; --i) {
       UseSkillRequest skill = Modifiers.passiveSkills.get(i);
-      if (KoLCharacter.hasSkill(skill)) {
+      if (KoLCharacter.hasSkill(skill.getSkillId())) {
         String name = skill.getSkillName();
 
         // G-Lover shows passives on the char sheet,

--- a/src/net/sourceforge/kolmafia/combat/Macrofier.java
+++ b/src/net/sourceforge/kolmafia/combat/Macrofier.java
@@ -416,7 +416,7 @@ public class Macrofier {
         // your skills.
 
         if ((KoLCharacter.inBadMoon() && !KoLCharacter.skillsRecalled())
-            || !KoLCharacter.availableCombatSkill(SkillPool.OLFACTION)) { // ignore
+            || !KoLCharacter.hasCombatSkill(SkillPool.OLFACTION)) { // ignore
         } else {
           Macrofier.macroSkill(macro, skillId);
         }

--- a/src/net/sourceforge/kolmafia/request/DrinkItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/DrinkItemRequest.java
@@ -517,7 +517,7 @@ public class DrinkItemRequest extends UseItemRequest {
     UseSkillRequest ode = UseSkillRequest.getInstance("The Ode to Booze");
     boolean canOde =
         !KoLCharacter.inGLover()
-            && KoLCharacter.hasAvailableSkill(SkillPool.ODE_TO_BOOZE)
+            && KoLCharacter.hasSkill(SkillPool.ODE_TO_BOOZE)
             && UseSkillRequest.hasAccordion();
     boolean shouldOde = canOde && KoLCharacter.canInteract();
 

--- a/src/net/sourceforge/kolmafia/request/DrinkItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/DrinkItemRequest.java
@@ -517,7 +517,7 @@ public class DrinkItemRequest extends UseItemRequest {
     UseSkillRequest ode = UseSkillRequest.getInstance("The Ode to Booze");
     boolean canOde =
         !KoLCharacter.inGLover()
-            && KoLConstants.availableSkills.contains(ode)
+            && KoLCharacter.hasAvailableSkill(SkillPool.ODE_TO_BOOZE)
             && UseSkillRequest.hasAccordion();
     boolean shouldOde = canOde && KoLCharacter.canInteract();
 

--- a/src/net/sourceforge/kolmafia/request/EatItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/EatItemRequest.java
@@ -468,8 +468,7 @@ public class EatItemRequest extends UseItemRequest {
     }
 
     // See if the character can cast Song of the Glorious Lunch
-    boolean canLunch =
-        KoLCharacter.inAxecore() && KoLCharacter.hasAvailableSkill(SkillPool.GLORIOUS_LUNCH);
+    boolean canLunch = KoLCharacter.inAxecore() && KoLCharacter.hasSkill(SkillPool.GLORIOUS_LUNCH);
 
     // See if the character has (or can buy) a milk of magnesium.
     boolean canMilk = InventoryManager.itemAvailable(ItemPool.MILK_OF_MAGNESIUM);

--- a/src/net/sourceforge/kolmafia/request/EatItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/EatItemRequest.java
@@ -468,8 +468,8 @@ public class EatItemRequest extends UseItemRequest {
     }
 
     // See if the character can cast Song of the Glorious Lunch
-    UseSkillRequest lunch = UseSkillRequest.getInstance("Song of the Glorious Lunch");
-    boolean canLunch = KoLCharacter.inAxecore() && KoLConstants.availableSkills.contains(lunch);
+    boolean canLunch =
+        KoLCharacter.inAxecore() && KoLCharacter.hasAvailableSkill(SkillPool.GLORIOUS_LUNCH);
 
     // See if the character has (or can buy) a milk of magnesium.
     boolean canMilk = InventoryManager.itemAvailable(ItemPool.MILK_OF_MAGNESIUM);

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -768,7 +768,7 @@ public class FightRequest extends GenericRequest {
   public static final boolean canOlfact() {
     return FightRequest.canOlfact
         && !KoLCharacter.inGLover()
-        && KoLCharacter.availableCombatSkill(SkillPool.OLFACTION);
+        && KoLCharacter.hasCombatSkill(SkillPool.OLFACTION);
   }
 
   public static final boolean isSourceAgent() {
@@ -1370,7 +1370,7 @@ public class FightRequest extends GenericRequest {
         // your skills.
 
         if ((KoLCharacter.inBadMoon() && !KoLCharacter.skillsRecalled())
-            || !KoLCharacter.availableCombatSkill(SkillPool.OLFACTION)) {
+            || !KoLCharacter.hasCombatSkill(SkillPool.OLFACTION)) {
           this.skipRound();
           return;
         }

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -4676,8 +4676,9 @@ public class FightRequest extends GenericRequest {
       return;
     }
 
-    KoLConstants.availableCombatSkills.clear();
-    KoLConstants.availableCombatSkillsMap.clear();
+    // The following is for the benefit of Stationary Buttons
+    KoLConstants.availableCombatSkillsList.clear();
+    KoLConstants.availableCombatSkillsSet.clear();
 
     Matcher m =
         FightRequest.AVAILABLE_COMBATSKILL_PATTERN.matcher(
@@ -4692,10 +4693,11 @@ public class FightRequest extends GenericRequest {
       // If Grey Goose skills are present, they may not actually be available;
       // KoL erroneously leaves them in the dropdown after you have cast them
       // and thereby deleveled your Grey Goose. Bug Reported.
-      if (skillId >= 7408 && skillId <= 7413) {
+      if (skillId >= 7408 && skillId <= 7413 && KoLCharacter.getFamiliar().getWeight() < 6) {
         continue;
       }
       KoLCharacter.addAvailableCombatSkill(skillId);
+      KoLConstants.availableCombatSkillsList.add(skillId);
       // If lovebug skills present, they've been unlocked
       if (skillId >= 7245 && skillId <= 7247) {
         Preferences.setBoolean("lovebugsUnlocked", true);

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -5842,12 +5842,12 @@ public abstract class RuntimeLibrary {
   public static Value have_skill(ScriptRuntime controller, final Value arg) {
     int skillId = (int) arg.intValue();
     return DataTypes.makeBooleanValue(
-        KoLCharacter.hasAvailableSkill(skillId) || KoLCharacter.hasCombatSkill(skillId));
+        KoLCharacter.hasSkill(skillId) || KoLCharacter.hasCombatSkill(skillId));
   }
 
   public static Value combat_skill_available(ScriptRuntime controller, final Value arg) {
     int skillId = (int) arg.intValue();
-    return DataTypes.makeBooleanValue(KoLCharacter.availableCombatSkill(skillId));
+    return DataTypes.makeBooleanValue(KoLCharacter.hasCombatSkill(skillId));
   }
 
   public static Value mp_cost(ScriptRuntime controller, final Value skill) {

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -5841,10 +5841,8 @@ public abstract class RuntimeLibrary {
 
   public static Value have_skill(ScriptRuntime controller, final Value arg) {
     int skillId = (int) arg.intValue();
-    UseSkillRequest skill = UseSkillRequest.getUnmodifiedInstance(skillId);
     return DataTypes.makeBooleanValue(
-        KoLCharacter.hasSkill(skill, KoLConstants.availableSkills)
-            || KoLCharacter.hasSkill(skill, KoLConstants.availableCombatSkills));
+        KoLCharacter.hasAvailableSkill(skillId) || KoLCharacter.hasCombatSkill(skillId));
   }
 
   public static Value combat_skill_available(ScriptRuntime controller, final Value arg) {

--- a/src/net/sourceforge/kolmafia/webui/StationaryButtonDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/StationaryButtonDecorator.java
@@ -17,7 +17,6 @@ import net.sourceforge.kolmafia.persistence.SkillDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.FightRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
-import net.sourceforge.kolmafia.request.UseSkillRequest;
 import net.sourceforge.kolmafia.session.ChoiceManager;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import net.sourceforge.kolmafia.session.InventoryManager;
@@ -425,8 +424,7 @@ public class StationaryButtonDecorator {
     // those skills which are usable against them.
     if (KoLCharacter.inTheSource() && FightRequest.isSourceAgent()) {
       StationaryButtonDecorator.addScriptButton(urlString, actionBuffer, true);
-      for (UseSkillRequest skill : KoLConstants.availableCombatSkills) {
-        int skillId = skill.getSkillId();
+      for (int skillId : KoLConstants.availableCombatSkillsList) {
         if (SkillDatabase.sourceAgentSkill(skillId)) {
           StationaryButtonDecorator.addFightButton(actionBuffer, String.valueOf(skillId), true);
         }
@@ -498,11 +496,9 @@ public class StationaryButtonDecorator {
     }
 
     int classStunId = SkillDatabase.getSkillId(classStun);
-    if (!inBirdForm && KoLCharacter.hasSkill(classStun)) {
-      UseSkillRequest stunRequest = UseSkillRequest.getUnmodifiedInstance(classStun);
+    if (!inBirdForm && KoLCharacter.hasSkill(classStunId)) {
       boolean enabled =
-          FightRequest.getCurrentRound() > 0
-              && KoLConstants.availableCombatSkills.contains(stunRequest);
+          FightRequest.getCurrentRound() > 0 && KoLCharacter.availableCombatSkill(classStunId);
       // Only enable Club Foot when character has Fury, as it's only a stun then.
       enabled &= !(classStun.equals("Club Foot") && KoLCharacter.getFury() == 0);
       // Only enable Soul Bubble when character has 5 Soulsauce, as it's only a stun then.
@@ -584,16 +580,13 @@ public class StationaryButtonDecorator {
           actionBuffer, action, FightRequest.getCurrentRound() > 0);
     }
 
-    // Add conditionally available combat skills
-    // parsed from the fight page
+    // Add conditionally available combat skills parsed from the fight page
+    // They are in the order that KoL had them in the dropdown.
 
-    for (int i = 0; i < KoLConstants.availableCombatSkills.size(); ++i) {
-      UseSkillRequest current = KoLConstants.availableCombatSkills.get(i);
-      int actionId = current.getSkillId();
+    for (int actionId : KoLConstants.availableCombatSkillsList) {
       if (actionId >= 7000 && actionId < 8000 && actionId != classStunId && actionId != 7201) {
-        String action = String.valueOf(actionId);
         StationaryButtonDecorator.addFightButton(
-            actionBuffer, action, FightRequest.getCurrentRound() > 0);
+            actionBuffer, String.valueOf(actionId), FightRequest.getCurrentRound() > 0);
       }
     }
 
@@ -709,9 +702,8 @@ public class StationaryButtonDecorator {
       actionBuffer.append("skill&whichskill=");
       actionBuffer.append(action);
       int skillID = StringUtilities.parseInt(action);
-      UseSkillRequest actionRequest = UseSkillRequest.getUnmodifiedInstance(skillID);
-      isEnabled &= KoLConstants.availableCombatSkills.contains(actionRequest);
-      // Some skills cannot be used by KOL does not remove them
+      isEnabled &= KoLCharacter.availableCombatSkill(skillID);
+      // Some skills cannot be used but KoL does not remove them
       switch (skillID) {
         case SkillPool.LASH_OF_COBRA:
           isEnabled = !Preferences.getBoolean("edUsedLash");

--- a/src/net/sourceforge/kolmafia/webui/StationaryButtonDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/StationaryButtonDecorator.java
@@ -498,7 +498,7 @@ public class StationaryButtonDecorator {
     int classStunId = SkillDatabase.getSkillId(classStun);
     if (!inBirdForm && KoLCharacter.hasSkill(classStunId)) {
       boolean enabled =
-          FightRequest.getCurrentRound() > 0 && KoLCharacter.availableCombatSkill(classStunId);
+          FightRequest.getCurrentRound() > 0 && KoLCharacter.hasCombatSkill(classStunId);
       // Only enable Club Foot when character has Fury, as it's only a stun then.
       enabled &= !(classStun.equals("Club Foot") && KoLCharacter.getFury() == 0);
       // Only enable Soul Bubble when character has 5 Soulsauce, as it's only a stun then.
@@ -702,7 +702,7 @@ public class StationaryButtonDecorator {
       actionBuffer.append("skill&whichskill=");
       actionBuffer.append(action);
       int skillID = StringUtilities.parseInt(action);
-      isEnabled &= KoLCharacter.availableCombatSkill(skillID);
+      isEnabled &= KoLCharacter.hasCombatSkill(skillID);
       // Some skills cannot be used but KoL does not remove them
       switch (skillID) {
         case SkillPool.LASH_OF_COBRA:

--- a/test/net/sourceforge/kolmafia/FamiliarDataTest.java
+++ b/test/net/sourceforge/kolmafia/FamiliarDataTest.java
@@ -51,34 +51,34 @@ public class FamiliarDataTest {
     assertTrue(fam.isActive());
 
     // Verify that no combat skills are available
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.RE_PROCESS_MATTER));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.MEATIFY_MATTER));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.EMIT_MATTER_DUPLICATING_DRONES));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.CONVERT_MATTER_TO_PROTEIN));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.CONVERT_MATTER_TO_ENERGY));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.CONVERT_MATTER_TO_POMADE));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.RE_PROCESS_MATTER));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.MEATIFY_MATTER));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.EMIT_MATTER_DUPLICATING_DRONES));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_PROTEIN));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_ENERGY));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_POMADE));
 
     // Make it level 6
     fam.setWeight(6);
 
     // Verify that non-Grey You combat skills are available
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.RE_PROCESS_MATTER));
-    assertTrue(KoLCharacter.availableCombatSkill(SkillPool.MEATIFY_MATTER));
-    assertTrue(KoLCharacter.availableCombatSkill(SkillPool.EMIT_MATTER_DUPLICATING_DRONES));
-    assertTrue(KoLCharacter.availableCombatSkill(SkillPool.CONVERT_MATTER_TO_PROTEIN));
-    assertTrue(KoLCharacter.availableCombatSkill(SkillPool.CONVERT_MATTER_TO_ENERGY));
-    assertTrue(KoLCharacter.availableCombatSkill(SkillPool.CONVERT_MATTER_TO_POMADE));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.RE_PROCESS_MATTER));
+    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.MEATIFY_MATTER));
+    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.EMIT_MATTER_DUPLICATING_DRONES));
+    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_PROTEIN));
+    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_ENERGY));
+    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_POMADE));
 
     // Reset it to level 5
     fam.setWeight(5);
 
     // Verify that no combat skills are available
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.RE_PROCESS_MATTER));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.MEATIFY_MATTER));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.EMIT_MATTER_DUPLICATING_DRONES));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.CONVERT_MATTER_TO_PROTEIN));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.CONVERT_MATTER_TO_ENERGY));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.CONVERT_MATTER_TO_POMADE));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.RE_PROCESS_MATTER));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.MEATIFY_MATTER));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.EMIT_MATTER_DUPLICATING_DRONES));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_PROTEIN));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_ENERGY));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_POMADE));
 
     // Go into Grey You
     KoLCharacter.setPath(Path.GREY_YOU);
@@ -87,12 +87,12 @@ public class FamiliarDataTest {
     fam.setWeight(6);
 
     // Verify that all combat skills are available
-    assertTrue(KoLCharacter.availableCombatSkill(SkillPool.RE_PROCESS_MATTER));
-    assertTrue(KoLCharacter.availableCombatSkill(SkillPool.MEATIFY_MATTER));
-    assertTrue(KoLCharacter.availableCombatSkill(SkillPool.EMIT_MATTER_DUPLICATING_DRONES));
-    assertTrue(KoLCharacter.availableCombatSkill(SkillPool.CONVERT_MATTER_TO_PROTEIN));
-    assertTrue(KoLCharacter.availableCombatSkill(SkillPool.CONVERT_MATTER_TO_ENERGY));
-    assertTrue(KoLCharacter.availableCombatSkill(SkillPool.CONVERT_MATTER_TO_POMADE));
+    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.RE_PROCESS_MATTER));
+    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.MEATIFY_MATTER));
+    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.EMIT_MATTER_DUPLICATING_DRONES));
+    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_PROTEIN));
+    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_ENERGY));
+    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_POMADE));
 
     // Reset it to level 5
     fam.setWeight(5);
@@ -104,18 +104,18 @@ public class FamiliarDataTest {
     fam.setWeight(6);
 
     // Verify that Meatify Matter is no longer available
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.MEATIFY_MATTER));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.MEATIFY_MATTER));
 
     // Deactivate it. (i.e., put back into the terrarium)
     fam.deactivate();
     assertFalse(fam.isActive());
 
     // Verify that no combat skills are available
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.RE_PROCESS_MATTER));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.MEATIFY_MATTER));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.EMIT_MATTER_DUPLICATING_DRONES));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.CONVERT_MATTER_TO_PROTEIN));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.CONVERT_MATTER_TO_ENERGY));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.CONVERT_MATTER_TO_POMADE));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.RE_PROCESS_MATTER));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.MEATIFY_MATTER));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.EMIT_MATTER_DUPLICATING_DRONES));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_PROTEIN));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_ENERGY));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_POMADE));
   }
 }

--- a/test/net/sourceforge/kolmafia/session/YouRobotManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/YouRobotManagerTest.java
@@ -124,14 +124,14 @@ public class YouRobotManagerTest {
     assertTrue(YouRobotManager.canEquip(KoLConstants.EQUIP_FAMILIAR));
 
     // Install a Pea Shooter as your Top Attachment.
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.SHOOT_PEA));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
     YouRobotManager.testInstallUpgrade(RobotUpgrade.PEA_SHOOTER);
     assertEquals(1, Preferences.getInteger("youRobotTop"));
-    assertTrue(KoLCharacter.availableCombatSkill(SkillPool.SHOOT_PEA));
+    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
 
     // Install a Bird Cage as your Top Attachment.
     YouRobotManager.testInstallUpgrade(RobotUpgrade.BIRD_CAGE);
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.SHOOT_PEA));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
     assertTrue(YouRobotManager.canUseFamiliars());
 
     // Install a Mannequin Head as your Top Attachment.
@@ -293,7 +293,7 @@ public class YouRobotManagerTest {
     assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_SHIRT));
 
     // Verify that our Pea Shooter is active.
-    assertTrue(KoLCharacter.availableCombatSkill(SkillPool.SHOOT_PEA));
+    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
   }
 
   @Test
@@ -418,8 +418,8 @@ public class YouRobotManagerTest {
   public void canTrackChangesInCombatSkills() throws IOException {
     // Start with no known combat skills.
 
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.SHOOT_PEA));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.TESLA_BLAST));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.TESLA_BLAST));
     assertEquals(0, Preferences.getInteger("youRobotTop"));
 
     // Look at Top Attachments
@@ -439,7 +439,7 @@ public class YouRobotManagerTest {
     ChoiceManager.lastChoice = 1445;
     YouRobotManager.postChoice1(urlString, request);
     assertEquals(1, Preferences.getInteger("youRobotTop"));
-    assertTrue(KoLCharacter.availableCombatSkill(SkillPool.SHOOT_PEA));
+    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
 
     // Install Tesla Blaster, lose Shoot Pea, gain Tesla Blast
     urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=7";
@@ -449,8 +449,8 @@ public class YouRobotManagerTest {
     ChoiceManager.lastChoice = 1445;
     YouRobotManager.postChoice1(urlString, request);
     assertEquals(7, Preferences.getInteger("youRobotTop"));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.SHOOT_PEA));
-    assertTrue(KoLCharacter.availableCombatSkill(SkillPool.TESLA_BLAST));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
+    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.TESLA_BLAST));
 
     // Install Solar Panel, lost Tesla Blast
     urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=3";
@@ -460,7 +460,7 @@ public class YouRobotManagerTest {
     ChoiceManager.lastChoice = 1445;
     YouRobotManager.postChoice1(urlString, request);
     assertEquals(3, Preferences.getInteger("youRobotTop"));
-    assertFalse(KoLCharacter.availableCombatSkill(SkillPool.TESLA_BLAST));
+    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.TESLA_BLAST));
   }
 
   @Test


### PR DESCRIPTION
KoLConstants.availableCombatSkills was a LockableListModel of UseSkillRequests.
It was never used in a JList, so need not be a ListModel.
Combat skills cannot be cast using a UseSkillRequest.
Its ONLY use is to pass the list of skillIds from the fight.php skill dropdown to StationaryButtonDecorator.
KoLConstants.availableCombatSkillsMap was an IdentityMap of skillIds.
KoLConstants.availableSkillsMap was an IdentityMap of skillIds.
They could simply be sets.
KoLCharacter.hasSkill is ONLY used to look up skills in availableSkills.
KoLCharacter.availableCombatSkills is ONLY used to look up combat skills.
In both cases, UseSkillRequests were generated and passed to a method which looked up skillIds in the skill Maps.

1) KoLConstants.availableSkillsMap is now KoLConstants.availableSkillsSet
KoLConstants.availableCombatSkillsMap is now KoLConstants.availableCombatSkillsSet
2) KoLCharacter.hasSkill and KoLCharacter.availableCombatSkill now only have variants that take an int skillId or a String skillName. They go straight to the appropriate set of skillIds
3) KoLCharacter.addAvailableSkill and KoLCharacter.removeAvailableSkill still have variants which takes a UseSkillRequest, since KoLConstants.availableSkills is still a list of such.
4) KoLCharacter.addAvailableCombatSkill and KoLCharacter.removeAvailableCombatSkill now only add or remove a value to KoLConstants.avaliableCombatSkillSet. No need to manipulate KoLConstants.availableCombatSkillList.
5) FightRequest and StationaryButtonDecorator manipulate KoLConstants.availableCombatSkillList, whose only purpose is to communicate between those two modules.
6) The handful of places in KoLmafia which looked directly at KoLConstants.availableSkills now call KoLCharacter.hasSkill.
7) The handful of places in KoLmafia which create a UseSkillRequest in order to call KoLCharacter.hasSkill now call the variant with a skillId. Some of them no longer actually need a UseSkillRequest. Some - like the Maximizer - want to maintain a list of UseSkillRequests as a way to cache a skillName/skillId pair. I did not refactor that code, although I find the Maximizer's use of UseSkillRequests ONLY to cache Passive skills not exactly clean.
