### PR TITLE
fix: avoid NPE on start with unwritable folder

### DIFF
--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -600,12 +600,14 @@ public class RelayRequest extends PasswordHashRequest {
 
   private static void clearImageDirectory(File directory, FilenameFilter filter) {
     File[] files = directory.listFiles(filter);
-    for (File file : files) {
-      if (file.isDirectory()) {
-        RelayRequest.clearImageDirectory(file, null);
-      }
+    if (files != null) {
+      for (File file : files) {
+        if (file.isDirectory()) {
+          RelayRequest.clearImageDirectory(file, null);
+        }
 
-      file.delete();
+        file.delete();
+      }
     }
   }
 


### PR DESCRIPTION
From https://kolmafia.us/threads/getting-mafia-started-help-please.27407/#post-167510.

After getting past here, it hits the `System.exit` in [`KoLmafia.java`, line 286](https://github.com/kolmafia/kolmafia/blob/c1b3ad79a1b9126450162b077a2d98aa0f533f77/src/net/sourceforge/kolmafia/KoLmafia.java#L286). This means we get a message "Could not acquire file lock" right at the end, which might be helpful if it happens again in the future?