### PR TITLE
feat: use HTTPS for hardcoded KOL links

### DIFF
--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -616,7 +616,7 @@ public class RelayRequest extends PasswordHashRequest {
 
   private static String localImagePath(final String filename) {
     return filename.endsWith("favicon.ico")
-        ? "http://www.kingdomofloathing.com/favicon.ico"
+        ? "https://www.kingdomofloathing.com/favicon.ico"
         : filename.startsWith("images")
             ? KoLmafia.imageServerPrefix() + filename.substring(6)
             : filename.startsWith("iii")
@@ -683,7 +683,7 @@ public class RelayRequest extends PasswordHashRequest {
       // If the file is not in the file system, it's probably a KoL
       // file which is not in the image directory for some reason.
       // Download it from KoL.
-      replyBuffer = FileUtilities.downloadFile("http://www.kingdomofloathing.com/" + filename);
+      replyBuffer = FileUtilities.downloadFile("https://www.kingdomofloathing.com/" + filename);
     }
 
     // If it is a KoLmafia built-in file, as opposed to the

--- a/src/net/sourceforge/kolmafia/swingui/ChatFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/ChatFrame.java
@@ -388,7 +388,7 @@ public class ChatFrame extends GenericFrame {
 
         if (message.startsWith("/?") || message.startsWith("/help")) {
           RelayLoader.openSystemBrowser(
-              "http://www.kingdomofloathing.com/doc.php?topic=chat_commands");
+              "https://www.kingdomofloathing.com/doc.php?topic=chat_commands");
           return;
         }
 

--- a/src/net/sourceforge/kolmafia/swingui/menu/GlobalMenuBar.java
+++ b/src/net/sourceforge/kolmafia/swingui/menu/GlobalMenuBar.java
@@ -213,7 +213,7 @@ public class GlobalMenuBar extends JMenuBar {
 
     helperMenu.add(
         new RelayBrowserMenuItem(
-            "The KoL Wiki", "http://kol.coldfront.net/thekolwiki/index.php/Main_Page"));
+            "The KoL Wiki", "https://kol.coldfront.net/thekolwiki/index.php/Main_Page"));
     helperMenu.add(
         new InvocationMenuItem("Violet Fog Mapper", VioletFogManager.class, "showGemelliMap"));
     helperMenu.add(new InvocationMenuItem("Wumpinator", WumpusManager.class, "invokeWumpinator"));


### PR DESCRIPTION
For links that use cached HTTP clients, there should be a tiny speed boost in that we avoid the "try HTTP/2, no it's HTTP/1.1, okay we were redirected to https, now try HTTP/2" malarkey.

For the ones that open in the browser, preferring HTTPS where stable seems good practice.