### PR TITLE
a finally clause is allowed to do a function return

### DIFF
--- a/test/root/expected/test_finally_return.ash.out
+++ b/test/root/expected/test_finally_return.ash.out
@@ -4,3 +4,4 @@ I received 50
 You gave me 100
 I prefer 101
 I received 101
+No way!

--- a/test/root/expected/test_finally_return.ash.out
+++ b/test/root/expected/test_finally_return.ash.out
@@ -1,0 +1,6 @@
+You gave me 50
+Good enough!
+I received 50
+You gave me 100
+I prefer 101
+I received 101

--- a/test/root/expected/test_finally_return.ash.out
+++ b/test/root/expected/test_finally_return.ash.out
@@ -4,4 +4,5 @@ I received 50
 You gave me 100
 I prefer 101
 I received 101
+You gave me 200
 No way!

--- a/test/root/scripts/test_finally_return.ash
+++ b/test/root/scripts/test_finally_return.ash
@@ -8,6 +8,9 @@ int test( int input )
             print("I prefer " + output);
             return output;
         }
+	if (input == 200) {
+	    abort("No way!");
+	}
     }
     print("Good enough!");
     return input;
@@ -15,3 +18,4 @@ int test( int input )
 
 print("I received " + test(50));
 print("I received " + test(100));
+print("I received " + test(200));

--- a/test/root/scripts/test_finally_return.ash
+++ b/test/root/scripts/test_finally_return.ash
@@ -1,0 +1,17 @@
+int test( int input )
+{
+    try {
+        print("You gave me " + input);
+    } finally {
+        if (input == 100) {
+            int output = input + 1;
+            print("I prefer " + output);
+            return output;
+        }
+    }
+    print("Good enough!");
+    return input;
+}
+
+print("I received " + test(50));
+print("I received " + test(100));


### PR DESCRIPTION
```
int test( int input )
{
    try {
        print("You gave me " + input);
    } finally {
        if (input == 100) {
            int output = input + 1;
            print("I prefer " + output);
            return output;
        }
    }
    print("Good enough!");
    return input;
}

print("I received " + test(50));
print("I received " + test(100));
```
yields
```
> finally.ash

You gave me 50
Good enough!
I received 50
You gave me 100
I prefer 101
Good enough!
I received 100
```

I don't like that. Now it yields
```
> finally.ash

You gave me 50
Good enough!
I received 50
You gave me 100
I prefer 101
I received 101
```
which is what I expected, when I wrote that code.