### PR TITLE
refactor: use standard charsets over charset names

### DIFF
--- a/src/net/sourceforge/kolmafia/RequestEditorKit.java
+++ b/src/net/sourceforge/kolmafia/RequestEditorKit.java
@@ -7,6 +7,7 @@ import java.awt.Frame;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -2516,7 +2517,7 @@ public class RequestEditorKit extends HTMLEditorKit {
         }
 
         formSubmitter.constructURLString(
-            GenericRequest.decodeField(actionString.toString(), "ISO-8859-1"));
+            GenericRequest.decodeField(actionString.toString(), StandardCharsets.ISO_8859_1));
       } else {
         // For normal URLs, the form data can be submitted
         // just like in every other request.

--- a/src/net/sourceforge/kolmafia/persistence/ScriptManager.java
+++ b/src/net/sourceforge/kolmafia/persistence/ScriptManager.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.persistence;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
@@ -11,7 +12,6 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.svn.SVNManager;
 import net.sourceforge.kolmafia.utilities.ByteBufferUtilities;
 import net.sourceforge.kolmafia.utilities.FileUtilities;
-import net.sourceforge.kolmafia.utilities.StringUtilities;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -116,7 +116,7 @@ public class ScriptManager {
     }
 
     byte[] bytes = ByteBufferUtilities.read(repoFile);
-    String string = StringUtilities.getEncodedString(bytes, "UTF-8");
+    String string = new String(bytes, StandardCharsets.UTF_8);
 
     try {
       return new JSONArray(string);

--- a/src/net/sourceforge/kolmafia/request/ChatRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ChatRequest.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.request;
 
+import java.nio.charset.StandardCharsets;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.chat.ChatManager;
 
@@ -59,7 +60,7 @@ public class ChatRequest extends GenericRequest {
     newURLString.append(KoLCharacter.getUserId());
 
     newURLString.append("&graf=");
-    newURLString.append(GenericRequest.encodeURL(graf, "ISO-8859-1"));
+    newURLString.append(GenericRequest.encodeURL(graf, StandardCharsets.ISO_8859_1));
 
     this.constructURLString(newURLString.toString(), false);
 

--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -20,6 +20,7 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpRequest.Builder;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -500,7 +501,7 @@ public class GenericRequest implements Runnable {
   public void addFormField(final String name, final String value, final boolean allowDuplicates) {
     this.dataChanged = true;
 
-    String charset = this.isChatRequest ? "ISO-8859-1" : "UTF-8";
+    Charset charset = this.isChatRequest ? StandardCharsets.ISO_8859_1 : StandardCharsets.UTF_8;
 
     String encodedName = name + "=";
     String encodedValue = value == null ? "" : GenericRequest.encodeURL(value, charset);
@@ -601,10 +602,10 @@ public class GenericRequest implements Runnable {
     if (equalIndex != -1) {
       String name = element.substring(0, equalIndex).trim();
       String value = element.substring(equalIndex + 1).trim();
-      String charset = this.isChatRequest ? "ISO-8859-1" : "UTF-8";
+      Charset charset = this.isChatRequest ? StandardCharsets.ISO_8859_1 : StandardCharsets.UTF_8;
 
       // The name may or may not be encoded.
-      name = GenericRequest.decodeField(name, "UTF-8");
+      name = GenericRequest.decodeField(name, StandardCharsets.UTF_8);
       value = GenericRequest.decodeField(value, charset);
 
       // But we want to always submit value encoded.
@@ -662,7 +663,7 @@ public class GenericRequest implements Runnable {
 
       if (decode) {
         // Chat was encoded as ISO-8859-1, so decode it that way.
-        String charset = this.isChatRequest ? "ISO-8859-1" : "UTF-8";
+        Charset charset = this.isChatRequest ? StandardCharsets.ISO_8859_1 : StandardCharsets.UTF_8;
         return GenericRequest.decodeField(value, charset);
       }
       return value;
@@ -688,35 +689,27 @@ public class GenericRequest implements Runnable {
   }
 
   public static String decodeField(final String urlString) {
-    return GenericRequest.decodeField(urlString, "UTF-8");
+    return GenericRequest.decodeField(urlString, StandardCharsets.UTF_8);
   }
 
-  public static String decodeField(final String value, final String charset) {
+  public static String decodeField(final String value, final Charset charset) {
     if (value == null) {
       return null;
     }
 
-    try {
-      return URLDecoder.decode(value, charset);
-    } catch (IOException e) {
-      return value;
-    }
+    return URLDecoder.decode(value, charset);
   }
 
   public static String encodeURL(final String urlString) {
-    return GenericRequest.encodeURL(urlString, "UTF-8");
+    return GenericRequest.encodeURL(urlString, StandardCharsets.UTF_8);
   }
 
-  public static String encodeURL(final String urlString, final String charset) {
+  public static String encodeURL(final String urlString, final Charset charset) {
     if (urlString == null) {
       return null;
     }
 
-    try {
-      return URLEncoder.encode(urlString, charset);
-    } catch (IOException e) {
-      return urlString;
-    }
+    return URLEncoder.encode(urlString, charset);
   }
 
   public void removeFormField(final String name) {

--- a/src/net/sourceforge/kolmafia/session/BuffBotManager.java
+++ b/src/net/sourceforge/kolmafia/session/BuffBotManager.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -185,8 +186,8 @@ public abstract class BuffBotManager {
     File datafile = new File(KoLConstants.BUFFBOT_LOCATION, KoLCharacter.baseUserName() + ".txt");
     File xmlfile = new File(KoLConstants.BUFFBOT_LOCATION, KoLCharacter.baseUserName() + ".xml");
 
-    PrintStream settings = LogStream.openStream(datafile, true, "ISO-8859-1");
-    PrintStream document = LogStream.openStream(xmlfile, true, "ISO-8859-1");
+    PrintStream settings = LogStream.openStream(datafile, true, StandardCharsets.ISO_8859_1);
+    PrintStream document = LogStream.openStream(xmlfile, true, StandardCharsets.ISO_8859_1);
 
     document.println("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>");
     document.println("<?xml-stylesheet type=\"text/xsl\" href=\"buffbot.xsl\"?>");

--- a/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
@@ -9,6 +9,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.Enumeration;
@@ -43,7 +44,6 @@ import net.sourceforge.kolmafia.swingui.widget.GenericScrollPane;
 import net.sourceforge.kolmafia.swingui.widget.ShowDescriptionList;
 import net.sourceforge.kolmafia.utilities.ByteBufferUtilities;
 import net.sourceforge.kolmafia.utilities.InputFieldUtilities;
-import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class MaximizerFrame extends GenericFrame implements ListSelectionListener {
   public static final JComboBox<String> expressionSelect = new JComboBox<>();
@@ -68,7 +68,7 @@ public class MaximizerFrame extends GenericFrame implements ListSelectionListene
     InputStream stream =
         DataUtilities.getInputStream(KoLConstants.DATA_DIRECTORY, "maximizer-help.html", false);
     byte[] bytes = ByteBufferUtilities.read(stream);
-    MaximizerFrame.HELP_STRING = StringUtilities.getEncodedString(bytes, "UTF-8");
+    MaximizerFrame.HELP_STRING = new String(bytes, StandardCharsets.UTF_8);
   }
 
   public MaximizerFrame() {

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -7975,7 +7976,7 @@ public abstract class RuntimeLibrary {
 
     ByteArrayOutputStream cacheStream = new ByteArrayOutputStream();
 
-    PrintStream writer = LogStream.openStream(cacheStream, "UTF-8");
+    PrintStream writer = LogStream.openStream(cacheStream, StandardCharsets.UTF_8);
     map_variable.dump(writer, "", compact);
     writer.close();
 
@@ -8017,7 +8018,7 @@ public abstract class RuntimeLibrary {
   public static Value file_to_buffer(ScriptRuntime controller, final Value var1) {
     String location = var1.toString();
     byte[] bytes = DataFileCache.getBytes(location);
-    String string = StringUtilities.getEncodedString(bytes, "UTF-8");
+    String string = new String(bytes, StandardCharsets.UTF_8);
     StringBuffer buffer = new StringBuffer(string);
     return new Value(DataTypes.BUFFER_TYPE, "", buffer);
   }
@@ -8025,7 +8026,7 @@ public abstract class RuntimeLibrary {
   public static Value buffer_to_file(ScriptRuntime controller, final Value var1, final Value var2) {
     StringBuffer buffer = (StringBuffer) var1.rawValue();
     String string = buffer.toString();
-    byte[] bytes = StringUtilities.getEncodedBytes(string, "UTF-8");
+    byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
     String location = var2.toString();
     return DataFileCache.printBytes(location, bytes);
   }

--- a/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import net.java.dev.spellcast.utilities.DataUtilities;
@@ -129,7 +130,7 @@ public class TestCommand extends AbstractCommand {
       }
 
       byte[] bytes = ByteBufferUtilities.read(file);
-      String string = StringUtilities.getEncodedString(bytes, "UTF-8");
+      String string = new String(bytes, StandardCharsets.UTF_8);
       TestCommand.contents = string;
 
       KoLmafia.updateDisplay(

--- a/src/net/sourceforge/kolmafia/textui/command/WumpusCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/WumpusCommand.java
@@ -1,13 +1,13 @@
 package net.sourceforge.kolmafia.textui.command;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.session.WumpusManager;
 import net.sourceforge.kolmafia.utilities.ByteBufferUtilities;
-import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class WumpusCommand extends AbstractCommand {
   public WumpusCommand() {
@@ -54,7 +54,7 @@ public class WumpusCommand extends AbstractCommand {
       }
 
       byte[] bytes = ByteBufferUtilities.read(file);
-      String text = StringUtilities.getEncodedString(bytes, "UTF-8");
+      String text = new String(bytes, StandardCharsets.UTF_8);
 
       KoLmafia.updateDisplay(
           "Read "

--- a/src/net/sourceforge/kolmafia/utilities/FileUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/FileUtilities.java
@@ -15,6 +15,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
@@ -302,7 +303,7 @@ public class FileUtilities {
 
     ByteArrayOutputStream ostream = new ByteArrayOutputStream();
     downloadFileToStream(remote, istream, ostream);
-    return new StringBuffer(StringUtilities.getEncodedString(ostream.toByteArray(), "UTF-8"));
+    return new StringBuffer(ostream.toString(StandardCharsets.UTF_8));
   }
 
   private static InputStream getInputStream(HttpResponse<InputStream> response) {

--- a/src/net/sourceforge/kolmafia/utilities/LogStream.java
+++ b/src/net/sourceforge/kolmafia/utilities/LogStream.java
@@ -1,9 +1,10 @@
 package net.sourceforge.kolmafia.utilities;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import javax.swing.SwingUtilities;
 import net.java.dev.spellcast.utilities.DataUtilities;
@@ -20,11 +21,11 @@ public class LogStream extends PrintStream implements Runnable {
   }
 
   public static PrintStream openStream(final File file, final boolean forceNewFile) {
-    return LogStream.openStream(file, forceNewFile, "UTF-8");
+    return LogStream.openStream(file, forceNewFile, StandardCharsets.UTF_8);
   }
 
   public static PrintStream openStream(
-      final File file, final boolean forceNewFile, final String encoding) {
+      final File file, final boolean forceNewFile, final Charset encoding) {
     OutputStream ostream = DataUtilities.getOutputStream(file, !forceNewFile);
     PrintStream pstream = openStream(ostream, encoding);
 
@@ -78,13 +79,8 @@ public class LogStream extends PrintStream implements Runnable {
     return newStream;
   }
 
-  public static PrintStream openStream(final OutputStream ostream, final String encoding) {
-    try {
-      return new LogStream(ostream, encoding);
-    } catch (IOException e) {
-      e.printStackTrace();
-      return System.out;
-    }
+  public static PrintStream openStream(final OutputStream ostream, final Charset encoding) {
+    return new LogStream(ostream, encoding);
   }
 
   @Override
@@ -92,7 +88,7 @@ public class LogStream extends PrintStream implements Runnable {
     KoLDesktop.getInstance().getRootPane().putClientProperty("Window.documentFile", this.proxy);
   }
 
-  private LogStream(final OutputStream ostream, final String encoding) throws IOException {
+  private LogStream(final OutputStream ostream, final Charset encoding) {
     super(ostream, true, encoding);
   }
 }

--- a/src/net/sourceforge/kolmafia/utilities/StringUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/StringUtilities.java
@@ -1,6 +1,5 @@
 package net.sourceforge.kolmafia.utilities;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -69,22 +68,6 @@ public class StringUtilities {
       return StringUtilities.DATE_FORMAT.format(date);
     } catch (Exception e) {
       return "";
-    }
-  }
-
-  public static String getEncodedString(final byte[] bytes, final String encoding) {
-    try {
-      return new String(bytes, encoding);
-    } catch (UnsupportedEncodingException e) {
-      return "";
-    }
-  }
-
-  public static byte[] getEncodedBytes(final String string, final String encoding) {
-    try {
-      return string.getBytes(encoding);
-    } catch (UnsupportedEncodingException e) {
-      return new byte[0];
     }
   }
 

--- a/test/net/sourceforge/kolmafia/utilities/StringUtilitiesTest.java
+++ b/test/net/sourceforge/kolmafia/utilities/StringUtilitiesTest.java
@@ -2,7 +2,6 @@ package net.sourceforge.kolmafia.utilities;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -519,29 +518,6 @@ class StringUtilitiesTest {
     Date testMe = new Date(1445412480000L);
     assertEquals("", StringUtilities.formatDate(null));
     assertEquals("Wed, 21 Oct 2015 07:28:00 GMT", StringUtilities.formatDate(testMe));
-  }
-
-  @Test
-  public void itShouldNotAttemptAnInvalidStringEncoding() {
-    byte[] testMe = new byte[0];
-    assertEquals("", StringUtilities.getEncodedString(testMe, "NotARealEncoding"));
-  }
-
-  @Test
-  public void itShouldNotAttemptAnInvalidByteEncoding() {
-    byte[] result = StringUtilities.getEncodedBytes("Just a string.", "NotARealEncoding");
-    assertEquals(0, result.length);
-  }
-
-  @Test
-  public void itShouldEncodeAValidEncoding() {
-    String test = "Just a string.";
-    byte[] expected = test.getBytes(StandardCharsets.UTF_8);
-    byte[] result = StringUtilities.getEncodedBytes(test, "UTF-8");
-    assertEquals(expected.length, result.length);
-    for (int i = 0; i < expected.length; i++) {
-      assertEquals(expected[i], result[i], "Not a match at element " + i);
-    }
   }
 
   @Test


### PR DESCRIPTION
Eliminate two `StringUtilities` methods that are unnecessary if charsets are used.