### PR TITLE
restore (accidentally deleted) factor in getAdverageML

### DIFF
--- a/src/net/sourceforge/kolmafia/AreaCombatData.java
+++ b/src/net/sourceforge/kolmafia/AreaCombatData.java
@@ -480,7 +480,8 @@ public class AreaCombatData {
             .filter(m -> getWeighting(m) > 0)
             .map(
                 m ->
-                    (double) getWeighting(m)
+                    (double) m.getAttack()
+                        * (double) getWeighting(m)
                         * (1 - (double) this.getRejection(m) / 100)
                         / this.totalWeighting())
             .reduce(0.0, Double::sum);


### PR DESCRIPTION
A for loop was replaced by a stream in PR 326.
It's pretty, but it dropped a factor in the calculation.
This restores it.