### PR TITLE
fix: avoid unexpected error in error case with no stream

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -204,7 +204,15 @@ public class Parser {
   }
 
   public String getStringUri() {
-    return this.fileUri != null ? this.fileUri.toString() : this.istream.toString();
+    if (this.fileUri != null) {
+      return this.fileUri.toString();
+    }
+
+    if (this.istream != null) {
+      return this.istream.toString();
+    }
+
+    return "";
   }
 
   public String getScriptName() {


### PR DESCRIPTION
Relates to https://kolmafia.us/threads/starting-mafia-with-a-script-on-the-command-line.27442/#post-167643

This should allow the error message to be printed to the screen.