### PR TITLE
feat: stop zero meaning all for meat

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
@@ -615,7 +615,7 @@ public class ItemFinder {
             amount = StringUtilities.parseInt(amountString);
           }
 
-          if (amount <= 0) {
+          if (amount < 0 || amountString.equals("*")) {
             amount +=
                 sourceList == KoLConstants.storage
                     ? KoLCharacter.getStorageMeat()

--- a/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
@@ -336,12 +336,13 @@ public class ItemFinder {
 
     // Find the item id
 
+    boolean returnAll = false;
     int itemCount = 1;
     int itemId = -1;
 
     // Allow the person to ask for all of the item from the source
     if (parameters.charAt(0) == '*') {
-      itemCount = 0;
+      returnAll = true;
       parameters = parameters.substring(1).trim();
     }
 
@@ -482,6 +483,11 @@ public class ItemFinder {
     } else {
       firstMatch = ItemPool.get(itemName, itemCount);
     }
+
+    // if the user asked for zero, give them zero
+    if (itemCount == 0) return firstMatch;
+
+    if (returnAll) itemCount = 0;
 
     // The result also depends on the number of items which
     // are available in the given match area.

--- a/test/net/sourceforge/kolmafia/persistence/ItemFinderTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/ItemFinderTest.java
@@ -744,6 +744,14 @@ public class ItemFinderTest {
     assertTrue(results[0].isMeat());
     assertEquals(results[0].getCount(), 2000);
 
+    // 0 Meat
+    results = ItemFinder.getMatchingItemList("0 meat", null);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertEquals(results.length, 1);
+    assertTrue(results[0].isMeat());
+    assertEquals(results[0].getCount(), 0);
+
     // All available Meat from inventory
     results = ItemFinder.getMatchingItemList("* meat", KoLConstants.inventory);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
@@ -759,6 +767,14 @@ public class ItemFinderTest {
     assertEquals(results.length, 1);
     assertTrue(results[0].isMeat());
     assertEquals(results[0].getCount(), 2000);
+
+    // 0 Meat from inventory
+    results = ItemFinder.getMatchingItemList("0 meat", KoLConstants.inventory);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertEquals(results.length, 1);
+    assertTrue(results[0].isMeat());
+    assertEquals(results[0].getCount(), 0);
 
     // Add meat to closet
     KoLCharacter.setClosetMeat(20_000);
@@ -779,6 +795,14 @@ public class ItemFinderTest {
     assertTrue(results[0].isMeat());
     assertEquals(results[0].getCount(), 10000);
 
+    // 0 Meat from closet
+    results = ItemFinder.getMatchingItemList("0 meat", KoLConstants.closet);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertEquals(results.length, 1);
+    assertTrue(results[0].isMeat());
+    assertEquals(results[0].getCount(), 0);
+
     // Add meat to storage
     KoLCharacter.setStorageMeat(1_000_000);
 
@@ -790,13 +814,21 @@ public class ItemFinderTest {
     assertTrue(results[0].isMeat());
     assertEquals(results[0].getCount(), 1000000);
 
-    // All but 10000 Meat from closet
+    // All but 10000 Meat from storage
     results = ItemFinder.getMatchingItemList("-10000 meat", KoLConstants.storage);
     assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
     assertTrue(results != null);
     assertEquals(results.length, 1);
     assertTrue(results[0].isMeat());
     assertEquals(results[0].getCount(), 990000);
+
+    // 0 Meat from storage
+    results = ItemFinder.getMatchingItemList("0 meat", KoLConstants.storage);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(results != null);
+    assertEquals(results.length, 1);
+    assertTrue(results[0].isMeat());
+    assertEquals(results[0].getCount(), 0);
 
     // There is no Meat in the freepulls list
 

--- a/test/net/sourceforge/kolmafia/persistence/ItemFinderTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/ItemFinderTest.java
@@ -294,6 +294,13 @@ public class ItemFinderTest {
     assertEquals(item.getItemId(), ItemPool.TOILET_PAPER);
     assertEquals(item.getCount(), 1);
 
+    // Zero
+    item = ItemFinder.getFirstMatchingItem("0 toilet paper", false, null, Match.ANY);
+    assertEquals(StaticEntity.getContinuationState(), MafiaState.CONTINUE);
+    assertTrue(item != null);
+    assertEquals(item.getItemId(), ItemPool.TOILET_PAPER);
+    assertEquals(item.getCount(), 0);
+
     // All available (using inventory)
     item =
         ItemFinder.getFirstMatchingItem("* toilet paper", false, KoLConstants.inventory, Match.ANY);


### PR DESCRIPTION
Relates to https://kolmafia.us/threads/csend-with-commas-acts-unexpectedly-when-sending-meat.27447/

"0 meat" now parses as no meat, instead of all your meat. * continues to be all. -X continues to be all but X.