### PR TITLE
tests: cover closet command, refactor

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
@@ -618,7 +618,7 @@ public class ItemFinder {
           long amount = 0;
 
           if (!amountString.equals("*")) {
-            amount = StringUtilities.parseInt(amountString);
+            amount = StringUtilities.parseLong(amountString);
           }
 
           if (amount < 0 || amountString.equals("*")) {

--- a/src/net/sourceforge/kolmafia/textui/command/ClosetCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ClosetCommand.java
@@ -64,7 +64,8 @@ public class ClosetCommand extends AbstractCommand {
     var items = split.get(false);
 
     if (meat.size() > 0) {
-      int meatCount = meat.stream().map(AdventureResult::getCount).mapToInt(Integer::intValue).sum();
+      int meatCount =
+          meat.stream().map(AdventureResult::getCount).mapToInt(Integer::intValue).sum();
       if (meatCount > 0) {
         int moveType = isTake ? ClosetRequest.MEAT_TO_INVENTORY : ClosetRequest.MEAT_TO_CLOSET;
         RequestThread.postRequest(new ClosetRequest(moveType, meatCount));

--- a/src/net/sourceforge/kolmafia/textui/command/ClosetCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ClosetCommand.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import java.util.Arrays;
 import java.util.List;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLConstants;
@@ -78,6 +79,10 @@ public class ClosetCommand extends AbstractCommand {
     }
 
     if (meatAttachmentCount == itemList.length) {
+      return;
+    }
+
+    if (Arrays.stream(itemList).allMatch(x -> x.getCount() <= 0)) {
       return;
     }
 

--- a/src/net/sourceforge/kolmafia/textui/command/ClosetCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ClosetCommand.java
@@ -64,8 +64,8 @@ public class ClosetCommand extends AbstractCommand {
     var items = split.get(false);
 
     if (meat.size() > 0) {
-      int meatCount =
-          meat.stream().map(AdventureResult::getCount).mapToInt(Integer::intValue).sum();
+      long meatCount =
+          meat.stream().map(AdventureResult::getLongCount).mapToLong(Long::longValue).sum();
       if (meatCount > 0) {
         int moveType = isTake ? ClosetRequest.MEAT_TO_INVENTORY : ClosetRequest.MEAT_TO_CLOSET;
         RequestThread.postRequest(new ClosetRequest(moveType, meatCount));

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.mockStatic;
 
 import internal.network.FakeHttpClientBuilder;
 import java.util.Calendar;
+import java.util.List;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.AscensionPath.Path;
@@ -54,11 +55,22 @@ public class Player {
   }
 
   public static Cleanups addItem(AdventureResult item) {
+    return addToList(item, KoLConstants.inventory);
+  }
+
+  public static Cleanups addItemToCloset(String name) {
+    int count = 1;
+    int itemId = ItemDatabase.getItemId(name, count, false);
+    AdventureResult item = ItemPool.get(itemId, count);
+    return addToList(item, KoLConstants.closet);
+  }
+
+  private static Cleanups addToList(AdventureResult item, List<AdventureResult> list) {
     var cleanups = new Cleanups();
-    AdventureResult.addResultToList(KoLConstants.inventory, item);
-    // Per midglec: "All the cleanups I wrote assume you're reverting back to a reset character"
+    AdventureResult.addResultToList(list, item);
+    // Per midgleyc: "All the cleanups I wrote assume you're reverting back to a reset character"
     // Therefore, simply remove this item from inventory.
-    cleanups.add(() -> AdventureResult.removeResultFromList(KoLConstants.inventory, item));
+    cleanups.add(() -> AdventureResult.removeResultFromList(list, item));
     return cleanups;
   }
 

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -74,6 +74,18 @@ public class Player {
     return cleanups;
   }
 
+  public static Cleanups setMeat(long meat) {
+    var oldMeat = KoLCharacter.getAvailableMeat();
+    KoLCharacter.setAvailableMeat(meat);
+    return new Cleanups(() -> KoLCharacter.setAvailableMeat(oldMeat));
+  }
+
+  public static Cleanups setClosetMeat(long meat) {
+    var oldMeat = KoLCharacter.getClosetMeat();
+    KoLCharacter.setClosetMeat(meat);
+    return new Cleanups(() -> KoLCharacter.setClosetMeat(oldMeat));
+  }
+
   public static int countItem(int itemId) {
     return InventoryManager.getCount(itemId);
   }

--- a/test/internal/listeners/FakeListener.java
+++ b/test/internal/listeners/FakeListener.java
@@ -1,0 +1,17 @@
+package internal.listeners;
+
+import net.sourceforge.kolmafia.listener.Listener;
+
+public class FakeListener implements Listener {
+
+  private int updateCount = 0;
+
+  public int getUpdateCount() {
+    return updateCount;
+  }
+
+  @Override
+  public void update() {
+    updateCount++;
+  }
+}

--- a/test/internal/network/FakeHttpClient.java
+++ b/test/internal/network/FakeHttpClient.java
@@ -14,6 +14,7 @@ import java.net.http.HttpResponse.ResponseInfo;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -26,13 +27,29 @@ import javax.net.ssl.SSLParameters;
 
 public class FakeHttpClient extends HttpClient {
 
-  public HttpRequest request;
-  public int responseCode = 0;
-  public String response = "";
+  private final List<HttpRequest> requests = new ArrayList<>();
+  private int responseCode = 0;
+  private String response = "";
 
   public void setResponse(int responseCode, String response) {
     this.responseCode = responseCode;
     this.response = response;
+  }
+
+  public List<HttpRequest> getRequests() {
+    return requests;
+  }
+
+  public HttpRequest getLastRequest() {
+    if (requests.size() == 0) return null;
+
+    return requests.get(requests.size() - 1);
+  }
+
+  public void clear() {
+    this.requests.clear();
+    this.responseCode = 0;
+    this.response = "";
   }
 
   @Override
@@ -83,7 +100,7 @@ public class FakeHttpClient extends HttpClient {
   @Override
   public <T> HttpResponse<T> send(HttpRequest request, BodyHandler<T> responseBodyHandler)
       throws IOException, InterruptedException {
-    this.request = request;
+    this.requests.add(request);
 
     T body;
 

--- a/test/internal/network/RequestBodyReader.java
+++ b/test/internal/network/RequestBodyReader.java
@@ -1,0 +1,64 @@
+package internal.network;
+
+import java.net.http.HttpRequest;
+import java.nio.ByteBuffer;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+
+public class RequestBodyReader {
+
+  public String bodyAsString(HttpRequest request) {
+    var bodyPublisher = request.bodyPublisher();
+    if (bodyPublisher.isEmpty()) return null;
+
+    var publisher = bodyPublisher.get();
+
+    var subscriber = new BodySubscriber();
+    publisher.subscribe(subscriber);
+
+    var bytes = subscriber.getBytes();
+    return new String(bytes);
+  }
+
+  private static class BodySubscriber implements Subscriber<ByteBuffer> {
+
+    private byte[] bytes = new byte[0];
+
+    public byte[] getBytes() {
+      return bytes;
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+      bytes = new byte[0];
+      subscription.request(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void onNext(ByteBuffer item) {
+      var newBytes = new byte[item.remaining()];
+      item.get(newBytes);
+      bytes = concatArrs(bytes, newBytes);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+
+    }
+
+    @Override
+    public void onComplete() {
+
+    }
+
+    private byte[] concatArrs(byte[] first, byte[] second) {
+      int fal = first.length;
+      int sal = second.length;
+      byte[] result = new byte[fal + sal];
+      System.arraycopy(first, 0, result, 0, fal);
+      System.arraycopy(second, 0, result, fal, sal);
+      return result;
+    }
+  }
+
+}

--- a/test/internal/network/RequestBodyReader.java
+++ b/test/internal/network/RequestBodyReader.java
@@ -42,14 +42,10 @@ public class RequestBodyReader {
     }
 
     @Override
-    public void onError(Throwable throwable) {
-
-    }
+    public void onError(Throwable throwable) {}
 
     @Override
-    public void onComplete() {
-
-    }
+    public void onComplete() {}
 
     private byte[] concatArrs(byte[] first, byte[] second) {
       int fal = first.length;
@@ -60,5 +56,4 @@ public class RequestBodyReader {
       return result;
     }
   }
-
 }

--- a/test/net/sourceforge/kolmafia/persistence/MallPriceDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/MallPriceDatabaseTest.java
@@ -22,7 +22,7 @@ public class MallPriceDatabaseTest {
     MallPriceDatabase.submitPrices("http://example.com");
 
     var fakeClient = fakeClientBuilder.client;
-    var request = fakeClient.request;
+    var request = fakeClient.getLastRequest();
 
     assertThat(request, notNullValue());
     assertThat(request.method(), equalTo("POST"));

--- a/test/net/sourceforge/kolmafia/textui/command/ClosetCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ClosetCommandTest.java
@@ -80,7 +80,8 @@ public class ClosetCommandTest extends AbstractCommandTestBase {
     @Test
     public void listsClosetWithFilter() {
       String output;
-      var cleanups = new Cleanups(Player.addItemToCloset("seal tooth"), Player.addItemToCloset("disco mask"));
+      var cleanups =
+          new Cleanups(Player.addItemToCloset("seal tooth"), Player.addItemToCloset("disco mask"));
 
       try (cleanups) {
         output = execute("list seal");

--- a/test/net/sourceforge/kolmafia/textui/command/ClosetCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ClosetCommandTest.java
@@ -134,6 +134,15 @@ public class ClosetCommandTest extends AbstractCommandTestBase {
     }
 
     @Test
+    public void doesNotStoreItemsNotInInventory() {
+      execute("put 1 seal tooth");
+
+      var requests = getRequests();
+
+      assertThat(requests, empty());
+    }
+
+    @Test
     public void doesNotStoreZeroItemsInCloset() {
       var cleanups = Player.addItem("seal tooth");
 

--- a/test/net/sourceforge/kolmafia/textui/command/ClosetCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ClosetCommandTest.java
@@ -173,6 +173,23 @@ public class ClosetCommandTest extends AbstractCommandTestBase {
     }
 
     @Test
+    public void storesMoreThanIntMaxMeatInCloset() {
+      var cleanups = Player.setMeat(3_000_000_000L);
+
+      try (cleanups) {
+        execute("put 3000000000 meat");
+      }
+
+      var requests = getRequests();
+
+      assertThat(requests, not(empty()));
+      var request = requests.get(0);
+      var uri = request.uri();
+      assertThat(uri.getPath(), equalTo("/closet.php"));
+      assertThat(request.method(), equalTo("POST"));
+    }
+
+    @Test
     public void doesNotStoreZeroMeatInCloset() {
       var cleanups = Player.setMeat(100);
 

--- a/test/net/sourceforge/kolmafia/textui/command/ClosetCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ClosetCommandTest.java
@@ -7,6 +7,7 @@ import internal.helpers.Cleanups;
 import internal.helpers.Player;
 import internal.listeners.FakeListener;
 import internal.network.FakeHttpClientBuilder;
+import internal.network.RequestBodyReader;
 import java.net.http.HttpRequest;
 import java.util.List;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
@@ -170,6 +171,8 @@ public class ClosetCommandTest extends AbstractCommandTestBase {
       var uri = request.uri();
       assertThat(uri.getPath(), equalTo("/closet.php"));
       assertThat(request.method(), equalTo("POST"));
+      var body = new RequestBodyReader().bodyAsString(request);
+      assertThat(body, equalTo("action=addtakeclosetmeat&addtake=add&quantity=100"));
     }
 
     @Test
@@ -187,6 +190,8 @@ public class ClosetCommandTest extends AbstractCommandTestBase {
       var uri = request.uri();
       assertThat(uri.getPath(), equalTo("/closet.php"));
       assertThat(request.method(), equalTo("POST"));
+      var body = new RequestBodyReader().bodyAsString(request);
+      assertThat(body, equalTo("action=addtakeclosetmeat&addtake=add&quantity=3000000000"));
     }
 
     @Test
@@ -250,6 +255,8 @@ public class ClosetCommandTest extends AbstractCommandTestBase {
       var uri = request.uri();
       assertThat(uri.getPath(), equalTo("/closet.php"));
       assertThat(request.method(), equalTo("POST"));
+      var body = new RequestBodyReader().bodyAsString(request);
+      assertThat(body, equalTo("action=addtakeclosetmeat&addtake=take&quantity=100"));
     }
 
     @Test

--- a/test/net/sourceforge/kolmafia/textui/command/ClosetCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ClosetCommandTest.java
@@ -1,13 +1,14 @@
 package net.sourceforge.kolmafia.textui.command;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
 import internal.helpers.Player;
 import internal.network.FakeHttpClientBuilder;
-import net.sourceforge.kolmafia.KoLCharacter;
+import java.net.http.HttpRequest;
+import java.util.List;
+import net.sourceforge.kolmafia.KoLConstants.MafiaState;
+import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.utilities.HttpUtilities;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,31 +16,37 @@ import org.junit.jupiter.api.Test;
 
 public class ClosetCommandTest extends AbstractCommandTestBase {
 
+  private final FakeHttpClientBuilder fakeClientBuilder = new FakeHttpClientBuilder();
+
+  private List<HttpRequest> getRequests() {
+    return fakeClientBuilder.client.getRequests();
+  }
+
   public ClosetCommandTest() {
     this.command = "closet";
   }
 
   @BeforeEach
   public void initializeState() {
-    KoLCharacter.reset("closet");
-    KoLCharacter.reset(true);
     GenericRequest.sessionId = "closet"; // do "send" requests
+    HttpUtilities.setClientBuilder(() -> fakeClientBuilder);
+    GenericRequest.resetClient();
+    fakeClientBuilder.client.clear();
+    StaticEntity.setContinuationState(MafiaState.CONTINUE);
   }
 
   @Test
   public void storesSealToothInCloset() {
-    // setup fake client
-    var fakeClientBuilder = new FakeHttpClientBuilder();
-    HttpUtilities.setClientBuilder(() -> fakeClientBuilder);
+    var cleanups = Player.addItem("seal tooth");
 
-    Player.addItem("seal tooth");
+    try (cleanups) {
+      execute("put 1 seal tooth");
+    }
 
-    execute("put 1 seal tooth");
+    var requests = getRequests();
 
-    var fakeClient = fakeClientBuilder.client;
-    var request = fakeClient.request;
-
-    assertThat(request, notNullValue());
+    assertThat(requests, not(empty()));
+    var request = requests.get(0);
     var uri = request.uri();
     assertThat(uri.getPath(), equalTo("/inventory.php"));
     assertThat(uri.getQuery(), equalTo("action=closetpush&ajax=1&whichitem=2&qty=1"));
@@ -47,15 +54,44 @@ public class ClosetCommandTest extends AbstractCommandTestBase {
 
   @Test
   public void doesNotStoreZeroItemsInCloset() {
-    // setup fake client
-    var fakeClientBuilder = new FakeHttpClientBuilder();
-    HttpUtilities.setClientBuilder(() -> fakeClientBuilder);
+    var cleanups = Player.addItem("seal tooth");
 
-    execute("put 0 seal tooth");
+    try (cleanups) {
+      execute("put 0 seal tooth");
+    }
 
-    var fakeClient = fakeClientBuilder.client;
-    var request = fakeClient.request;
+    var requests = getRequests();
 
-    assertThat(request, nullValue());
+    assertThat(requests, empty());
+  }
+
+  @Test
+  public void takesSealToothFromCloset() {
+    var cleanups = Player.addItemToCloset("seal tooth");
+
+    try (cleanups) {
+      execute("take 1 seal tooth");
+    }
+
+    var requests = getRequests();
+
+    assertThat(requests, not(empty()));
+    var request = requests.get(0);
+    var uri = request.uri();
+    assertThat(uri.getPath(), equalTo("/inventory.php"));
+    assertThat(uri.getQuery(), equalTo("action=closetpull&ajax=1&whichitem=2&qty=1"));
+  }
+
+  @Test
+  public void doesNotTakeZeroItemsFromCloset() {
+    var cleanups = Player.addItemToCloset("seal tooth");
+
+    try (cleanups) {
+      execute("take 0 seal tooth");
+    }
+
+    var requests = getRequests();
+
+    assertThat(requests, empty());
   }
 }


### PR DESCRIPTION
There was a small problem with #699: I didn't reset the client between calls, so somehow it was winding up with different clients. Don't understand that because the builder was instantiated once in the test class (and the client against never reinstantiated), so it should have been the same client, but it wasn't.

That's fixed, enough tests have been added to cover the class (though this doesn't cover all the functionality -- e.g. passing multiple items, meat counts is not done because I haven't yet managed to get the request text, and I need that to write a meaningful test).

Small refactoring to use streams.