### PR TITLE
optionally save battle details in Bastille.battles.txt

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -579,8 +579,6 @@ user	falloutShelterChronoUsed	false
 user	falloutShelterCoolingTankUsed	false
 user	falloutShelterLevel	0
 user	familiarScript
-user	lastBeardBuff	0
-user	lastCopyableMonster
 user	fingernailsClipped	0
 user	fireExtinguisherBatHoleUsed	false
 user	fireExtinguisherChasmUsed	false
@@ -768,6 +766,7 @@ user	lastBangPotion827
 user	lastBangPotionReset	-1
 user	lastBarrelSmashed	0
 user	lastBattlefieldReset	-1
+user	lastBeardBuff	0
 user	lastBreakfast	-1
 user	lastCastleGroundUnlock	-1
 user	lastCastleTopUnlock	-1
@@ -777,6 +776,7 @@ user	lastChanceThreshold	100
 user	lastChessboard
 user	lastChasmReset	-1
 user	lastColosseumRoundWon	0
+user	lastCopyableMonster
 user	lastCouncilVisit	0
 user	lastCounterDay	-1
 user	lastDesertUnlock	-1
@@ -897,6 +897,7 @@ user	libraryCardUsed	false
 user	lightsOutAutomation	1
 user	locketPhylum	mer-kin
 user	lockPicked	false
+user	logBastilleBattalionBattles	false
 user	loginRecoveryHardcore	false
 user	loginRecoverySoftcore	true
 user	longConMonster	
@@ -1501,6 +1502,7 @@ user	_bastilleGames	0
 user	_bastilleGameTurn	0
 user	_bastilleLastBattleResults
 user	_bastilleLastBattleWon	false
+user	_bastilleLastCheese	0
 user	_bastilleStats	
 user	_beachCombing	false
 user	_beachHeadsUsed

--- a/src/net/sourceforge/kolmafia/session/BastilleBattalionManager.java
+++ b/src/net/sourceforge/kolmafia/session/BastilleBattalionManager.java
@@ -1185,52 +1185,37 @@ public abstract class BastilleBattalionManager {
 
   private static final String BATTLE_FILE_NAME = "Bastille.battles.txt";
 
-  private static final String TAB = "\t";
+  private static String joinFields(String separator, String... fields) {
+    return Arrays.stream(fields).collect(Collectors.joining(separator));
+  }
 
   private static String generateKey(int game, int number) {
-    StringBuilder buf = new StringBuilder();
-    buf.append(KoLConstants.DAILY_FORMAT.format(new Date()));
-    buf.append(".");
-    buf.append(KoLCharacter.getPlayerId());
-    buf.append(".");
-    buf.append(game);
-    buf.append(".");
-    buf.append(number);
-    return buf.toString();
+    return joinFields(
+        ".",
+        KoLConstants.DAILY_FORMAT.format(new Date()),
+        KoLCharacter.getPlayerId(),
+        String.valueOf(game),
+        String.valueOf(number));
   }
 
   private static String generateFields(Battle battle) {
-    StringBuilder buf = new StringBuilder();
-    buf.append(battle.number);
-    buf.append(TAB);
-    buf.append(battle.stats.get(Stat.MA));
-    buf.append(TAB);
-    buf.append(battle.stats.get(Stat.MD));
-    buf.append(TAB);
-    buf.append(battle.stats.get(Stat.CA));
-    buf.append(TAB);
-    buf.append(battle.stats.get(Stat.CD));
-    buf.append(TAB);
-    buf.append(battle.stats.get(Stat.PA));
-    buf.append(TAB);
-    buf.append(battle.stats.get(Stat.PD));
-    buf.append(TAB);
-    buf.append(battle.boosts.toString());
-    buf.append(TAB);
-    buf.append(battle.enemy.getPrefix());
-    buf.append(TAB);
-    buf.append(battle.stance.toString());
-    buf.append(TAB);
-    buf.append(battle.results.aggressor);
-    buf.append(TAB);
-    buf.append(battle.results.military);
-    buf.append(TAB);
-    buf.append(battle.results.castle);
-    buf.append(TAB);
-    buf.append(battle.results.psychological);
-    buf.append(TAB);
-    buf.append(battle.cheese);
-    return buf.toString();
+    return joinFields(
+        "\t",
+        String.valueOf(battle.number),
+        String.valueOf(battle.stats.get(Stat.MA)),
+        String.valueOf(battle.stats.get(Stat.MD)),
+        String.valueOf(battle.stats.get(Stat.CA)),
+        String.valueOf(battle.stats.get(Stat.CD)),
+        String.valueOf(battle.stats.get(Stat.PA)),
+        String.valueOf(battle.stats.get(Stat.PD)),
+        battle.boosts.toString(),
+        battle.enemy.getPrefix(),
+        battle.stance.toString(),
+        String.valueOf(battle.results.aggressor),
+        String.valueOf(battle.results.military),
+        String.valueOf(battle.results.castle),
+        String.valueOf(battle.results.psychological),
+        String.valueOf(battle.cheese));
   }
 
   private static void saveBattle(Battle battle) {
@@ -1245,7 +1230,7 @@ public abstract class BastilleBattalionManager {
 
     StringBuilder buf = new StringBuilder();
     buf.append(key);
-    buf.append(TAB);
+    buf.append("\t");
     buf.append(fields);
     String line = buf.toString();
 

--- a/src/net/sourceforge/kolmafia/session/BastilleBattalionManager.java
+++ b/src/net/sourceforge/kolmafia/session/BastilleBattalionManager.java
@@ -1198,9 +1198,10 @@ public abstract class BastilleBattalionManager {
         String.valueOf(number));
   }
 
-  private static String generateFields(Battle battle) {
+  private static String generateFields(String key, Battle battle) {
     return joinFields(
         "\t",
+        key,
         String.valueOf(battle.number),
         String.valueOf(battle.stats.get(Stat.MA)),
         String.valueOf(battle.stats.get(Stat.MD)),
@@ -1225,14 +1226,7 @@ public abstract class BastilleBattalionManager {
 
     int game = Preferences.getInteger("_bastilleGames") + 1;
     int number = battle.number;
-    String key = generateKey(game, number);
-    String fields = generateFields(battle);
-
-    StringBuilder buf = new StringBuilder();
-    buf.append(key);
-    buf.append("\t");
-    buf.append(fields);
-    String line = buf.toString();
+    String line = generateFields(generateKey(game, number), battle);
 
     String path = KoLConstants.DATA_DIRECTORY + BATTLE_FILE_NAME;
     try (PrintStream stream = LogStream.openStream(path, false)) {

--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -9437,6 +9437,17 @@ public abstract class ChoiceManager {
           }
           break;
         }
+
+      case 1313: // Bastille Battalion
+      case 1314: // Bastille Battalion (Master of None)
+      case 1315: // Castle vs. Castle
+      case 1316: // GAME OVER
+      case 1317: // A Hello to Arms (Battalion)
+      case 1318: // Defensive Posturing
+      case 1319: // Cheese Seeking Behavior
+        BastilleBattalionManager.preChoice(urlString, request);
+        break;
+
       case 1451:
         // Fire Captain Hagnk
         WildfireCampRequest.parseCaptain(text);

--- a/test/net/sourceforge/kolmafia/session/BastilleBattalionManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/BastilleBattalionManagerTest.java
@@ -41,6 +41,7 @@ public class BastilleBattalionManagerTest {
   @BeforeEach
   private void beforeEach() {
     BastilleBattalionManager.reset();
+    Preferences.setBoolean("logBastilleBattalionBattles", false);
     KoLConstants.activeEffects.clear();
     ChoiceManager.lastChoice = 0;
     ChoiceManager.lastDecision = 0;
@@ -305,7 +306,7 @@ public class BastilleBattalionManagerTest {
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
     ChoiceManager.lastDecision = 5;
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals("MA=0,MD=3,CA=2,CD=4,PA=3,PD=8", Preferences.getString("_bastilleStats"));
 
@@ -331,8 +332,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1314;
     ChoiceManager.lastDecision = 1;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1314, responseText));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(0, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
 
     // The response is the "visit" to a new choice
@@ -353,8 +355,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1317;
     ChoiceManager.lastDecision = 2;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1314, responseText));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(0, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals("MA=2,MD=1,CA=4,CD=2,PA=5,PD=6", Preferences.getString("_bastilleStats"));
 
@@ -377,8 +380,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1314;
     ChoiceManager.lastDecision = 1;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1314, responseText));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(0, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
 
     // The response is the "visit" to a new choice
@@ -399,8 +403,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1317;
     ChoiceManager.lastDecision = 3;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1314, responseText));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(0, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals("MA=4,MD=1,CA=4,CD=2,PA=5,PD=5", Preferences.getString("_bastilleStats"));
 
@@ -423,7 +428,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1315;
     ChoiceManager.lastDecision = 1;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1315, responseText));
-    BastilleBattalionManager.visitChoice(request);
+    assertEquals(38, Preferences.getInteger("_bastilleLastCheese"));
+    assertEquals(38, Preferences.getInteger("_bastilleCheese"));
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals("MA>MD,CA<CD,PA>PD", Preferences.getString("_bastilleLastBattleResults"));
     assertTrue(Preferences.getBoolean("_bastilleLastBattleWon"));
@@ -431,7 +438,6 @@ public class BastilleBattalionManagerTest {
     // The response is the "visit" to a new choice
     ChoiceManager.lastChoice = 1314;
     BastilleBattalionManager.visitChoice(request);
-    assertEquals(38, Preferences.getInteger("_bastilleCheese"));
     assertEquals(4, Preferences.getInteger("_bastilleGameTurn"));
     assertEquals("Mace Lilly", Preferences.getString("_bastilleEnemyName"));
     assertEquals("berserker", Preferences.getString("_bastilleEnemyCastle"));
@@ -450,8 +456,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1314;
     ChoiceManager.lastDecision = 2;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1314, responseText));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(38, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
 
     // The response is the "visit" to a new choice
@@ -472,8 +479,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1318;
     ChoiceManager.lastDecision = 1;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1318, responseText));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(38, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals("MA=4,MD=2,CA=4,CD=2,PA=5,PD=5", Preferences.getString("_bastilleStats"));
 
@@ -496,8 +504,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1314;
     ChoiceManager.lastDecision = 2;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1314, responseText));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(38, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
 
     // The response is the "visit" to a new choice
@@ -518,13 +527,14 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1318;
     ChoiceManager.lastDecision = 1;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1318, responseText));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(38, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals("MA=4,MD=3,CA=4,CD=3,PA=5,PD=4", Preferences.getString("_bastilleStats"));
 
     // The response is the "visit" to a new choice
-    ChoiceManager.lastChoice = 1314;
+    ChoiceManager.lastChoice = 1315;
     BastilleBattalionManager.visitChoice(request);
     assertEquals(6, Preferences.getInteger("_bastilleGameTurn"));
     assertEquals("", Preferences.getString("_bastilleChoice1"));
@@ -542,7 +552,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1315;
     ChoiceManager.lastDecision = 1;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1315, responseText));
-    BastilleBattalionManager.visitChoice(request);
+    assertEquals(80, Preferences.getInteger("_bastilleLastCheese"));
+    assertEquals(118, Preferences.getInteger("_bastilleCheese"));
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals("MA>MD,CA>CD,PA>PD", Preferences.getString("_bastilleLastBattleResults"));
     assertTrue(Preferences.getBoolean("_bastilleLastBattleWon"));
@@ -550,7 +562,6 @@ public class BastilleBattalionManagerTest {
     // The response is the "visit" to a new choice
     ChoiceManager.lastChoice = 1314;
     BastilleBattalionManager.visitChoice(request);
-    assertEquals(118, Preferences.getInteger("_bastilleCheese"));
     assertEquals(7, Preferences.getInteger("_bastilleGameTurn"));
     assertEquals("Sergeant Ludwig", Preferences.getString("_bastilleEnemyName"));
     assertEquals("barracks", Preferences.getString("_bastilleEnemyCastle"));
@@ -569,8 +580,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1314;
     ChoiceManager.lastDecision = 1;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1314, responseText));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(118, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
 
     // The response is the "visit" to a new choice
@@ -591,8 +603,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1317;
     ChoiceManager.lastDecision = 1;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1317, responseText));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(118, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals("MA=4,MD=3,CA=4,CD=3,PA=6,PD=4", Preferences.getString("_bastilleStats"));
 
@@ -615,8 +628,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1314;
     ChoiceManager.lastDecision = 1;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1314, responseText));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(118, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
 
     // The response is the "visit" to a new choice
@@ -637,13 +651,14 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1317;
     ChoiceManager.lastDecision = 2;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1317, responseText));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(118, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals("MA=4,MD=3,CA=4,CD=3,PA=7,PD=4", Preferences.getString("_bastilleStats"));
 
     // The response is the "visit" to a new choice
-    ChoiceManager.lastChoice = 1314;
+    ChoiceManager.lastChoice = 1315;
     BastilleBattalionManager.visitChoice(request);
     assertEquals(9, Preferences.getInteger("_bastilleGameTurn"));
     assertEquals("", Preferences.getString("_bastilleChoice1"));
@@ -661,7 +676,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1315;
     ChoiceManager.lastDecision = 1;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1315, responseText));
-    BastilleBattalionManager.visitChoice(request);
+    assertEquals(139, Preferences.getInteger("_bastilleLastCheese"));
+    assertEquals(257, Preferences.getInteger("_bastilleCheese"));
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals("MA<MD,CA>CD,PA>PD", Preferences.getString("_bastilleLastBattleResults"));
     assertTrue(Preferences.getBoolean("_bastilleLastBattleWon"));
@@ -669,7 +686,6 @@ public class BastilleBattalionManagerTest {
     // The response is the "visit" to a new choice
     ChoiceManager.lastChoice = 1314;
     BastilleBattalionManager.visitChoice(request);
-    assertEquals(257, Preferences.getInteger("_bastilleCheese"));
     assertEquals(10, Preferences.getInteger("_bastilleGameTurn"));
     assertEquals("Bradley the Samey", Preferences.getString("_bastilleEnemyName"));
     assertEquals("masterofnone", Preferences.getString("_bastilleEnemyCastle"));
@@ -688,8 +704,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1314;
     ChoiceManager.lastDecision = 1;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1314, responseText));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(257, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
 
     // The response is the "visit" to a new choice
@@ -710,8 +727,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1317;
     ChoiceManager.lastDecision = 3;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1317, responseText));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(257, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals("MA=6,MD=3,CA=6,CD=3,PA=5,PD=4", Preferences.getString("_bastilleStats"));
 
@@ -734,8 +752,9 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1314;
     ChoiceManager.lastDecision = 3;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1314, responseText));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(257, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
 
     // The response is the "visit" to a new choice
@@ -756,13 +775,14 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1319;
     ChoiceManager.lastDecision = 1;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1319, responseText));
+    assertEquals(133, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(390, Preferences.getInteger("_bastilleCheese"));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals("MA=6,MD=3,CA=6,CD=3,PA=5,PD=4", Preferences.getString("_bastilleStats"));
 
     // The response is the "visit" to a new choice
-    ChoiceManager.lastChoice = 1314;
+    ChoiceManager.lastChoice = 1315;
     BastilleBattalionManager.visitChoice(request);
     assertEquals(12, Preferences.getInteger("_bastilleGameTurn"));
     assertEquals("", Preferences.getString("_bastilleChoice1"));
@@ -780,7 +800,7 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1315;
     ChoiceManager.lastDecision = 1;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1315, responseText));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals("MA>MD,CA<CD,PA<PD", Preferences.getString("_bastilleLastBattleResults"));
     assertFalse(Preferences.getBoolean("_bastilleLastBattleWon"));
@@ -797,7 +817,7 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1316;
     ChoiceManager.lastDecision = 3;
     assertNull(AdventureRequest.parseChoiceEncounter(urlString, 1316, responseText));
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
 
     // The game is complete and we are no longer in a game
@@ -809,6 +829,7 @@ public class BastilleBattalionManagerTest {
     assertEquals("masterofnone", Preferences.getString("_bastilleEnemyCastle"));
     assertEquals("MA=6,MD=3,CA=6,CD=3,PA=5,PD=4", Preferences.getString("_bastilleStats"));
     assertEquals("MA>MD,CA<CD,PA<PD", Preferences.getString("_bastilleLastBattleResults"));
+    assertEquals(0, Preferences.getInteger("_bastilleLastCheese"));
     assertEquals(390, Preferences.getInteger("_bastilleCheese"));
   }
 
@@ -837,9 +858,17 @@ public class BastilleBattalionManagerTest {
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1318;
     ChoiceManager.lastDecision = 3;
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals("MA=6,MD=5,CA=6,CD=5,PA=3,PD=4", Preferences.getString("_bastilleStats"));
+
+    // The response is the "visit" to a new choice
+    ChoiceManager.lastChoice = 1315;
+    BastilleBattalionManager.visitChoice(request);
+    assertEquals(6, Preferences.getInteger("_bastilleGameTurn"));
+    assertEquals("", Preferences.getString("_bastilleChoice1"));
+    assertEquals("", Preferences.getString("_bastilleChoice2"));
+    assertEquals("", Preferences.getString("_bastilleChoice3"));
 
     // Enter into battle with your foe.
     urlString = "choice.php?whichchoice=1315&option=1";
@@ -851,10 +880,10 @@ public class BastilleBattalionManagerTest {
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1315;
     ChoiceManager.lastDecision = 1;
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
 
-    // We advanced a turn and lost the battle, but have not yet rest stats and
+    // We advanced a turn and lost the battle, but have not yet reset stats and
     // such; a script might want to look at them.
     assertEquals("MA<MD,CA<CD,PA>PD", Preferences.getString("_bastilleLastBattleResults"));
     assertEquals(false, Preferences.getBoolean("_bastilleLastBattleWon"));
@@ -866,6 +895,10 @@ public class BastilleBattalionManagerTest {
     assertEquals("", Preferences.getString("_bastilleChoice3"));
     assertEquals("MA=6,MD=5,CA=6,CD=5,PA=3,PD=4", Preferences.getString("_bastilleStats"));
 
+    // The response is the "visit" to a new choice
+    ChoiceManager.lastChoice = 1316;
+    BastilleBattalionManager.visitChoice(request);
+
     // Choose not to simply Walk Away
     urlString = "choice.php?whichchoice=1316&option=2";
     // We don't log returning to the console
@@ -875,7 +908,7 @@ public class BastilleBattalionManagerTest {
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1316;
     ChoiceManager.lastDecision = 2;
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     // But we do increment games played
     assertEquals(1, Preferences.getInteger("_bastilleGames"));
@@ -891,7 +924,7 @@ public class BastilleBattalionManagerTest {
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
     ChoiceManager.lastDecision = 5;
-    BastilleBattalionManager.visitChoice(request);
+    BastilleBattalionManager.preChoice(urlString, request);
     BastilleBattalionManager.postChoice1(urlString, request);
     // Reset stats, upcoming foe, and turn
     assertEquals(1, Preferences.getInteger("_bastilleGameTurn"));


### PR DESCRIPTION
I've been playing Bastille Battalion with two characters and have been manually recording details of battles: which round, which stance I choose, whther I ended up being offensive or defensive, castle type, and so on.

It would be nice for KoLmafia to save that data for me in a file which I can load into an ASH script to analyze.

Assuming you have set "logBastilleBattalionBattles" to true, "data/Bastille.battles.txt" will be loadable via file_to_map.

```
record battle {
    int number;         // Affects strength of enemy
    int [6] stats;      // MA/MD/CA/CD/PA/PD
    string boosts;      // MCP
    string enemy;       // {frenchcastle,masterofnone,bigcastle,berserker,shieldmaster,barracks}
    string stance;      // {offensive,waiting,defensive}
    boolean aggressor;  // as opposed to defender
    boolean military;   // true if won
    boolean castle;     // true if won
    boolean psych;      // true if won
    int cheese;         // if won
};

battle [string] battles;
file_to_map( "Bastille.battles.txt", battles );
```

The (string) key is: DATE.PLAYERID.GAME.BATTLE

Since a player can have five games with up to 5 battles each, up to 25 entries per day per player.
Yes, all your multis will write to the same file; you don't need to analyze the data player by player.