### PR TITLE
Specify --win-per-user-install for exe builds.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -289,11 +289,11 @@ tasks.jpackage {
 		icon = 'util/macosx/limeglass.icns'
 
 	}
-	windows{
+	windows {
 		type = 'exe'
 		icon = 'util/windows/KoLmafia.ico'
-		winShortcut = 'true'
-		winDirChooser = 'true'
+		winShortcut = true
+		winPerUserInstall = true
 		javaOptions = ["-DuseCWDasROOT=true"]
 	}
 	doFirst {


### PR DESCRIPTION
This should create an install in C:\Users\ instead of C:\Program Files\.

See https://kolmafia.us/threads/exe-and-dmg-builds-dont-work-anymore.27408/#post-167736 for more context.