### PR TITLE
Stabilize appName for packaged builds.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -280,6 +280,7 @@ tasks.jpackage {
 	input = 'dist'
 	destination = 'build/releases'
 	mainClass = mainClassName
+	appName = 'KoLmafia'
 	appVersion = new Date().format('yy.MM')
 	linux {
 		icon = 'util/linux/KoLmafia.ico'
@@ -298,9 +299,8 @@ tasks.jpackage {
 	}
 	doFirst {
 		mainJar = tasks.shadowJar.archiveFileName.get()
-		appVersion += '.' + version
-		appName = 'KoLmafia-r' + version + "${isDirty() ? 'M' : ''}"
-		println 'Packaging app ' + appName + '...'
+		appVersion += '.' + version + "${isDirty() ? 'M' : ''}"
+		println 'Packaging app ' + appName + '-r' + appVersion + '...'
 		if (System.properties['os.name'] != 'Linux') {
 			return
 		}


### PR DESCRIPTION
Users of the .exe should be able to keep their settings across version
upgrades without having to manually copy them over from previous
installs.

https://kolmafia.us/threads/exe-and-dmg-builds-dont-work-anymore.27408/#post-167737
describes my experience with the latest commit. This PR should
address one of my concerns (namely, around the install path / setting
persistence).