### PR TITLE
Bastille stats are provided by sets of styles.

### DIFF
--- a/test/net/sourceforge/kolmafia/session/BastilleBattalionManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/BastilleBattalionManagerTest.java
@@ -103,8 +103,7 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1313;
     BastilleBattalionManager.visitChoice(request);
     assertEquals(
-        "BARBERSHOP,DRAFTSMAN,GESTURE,TRUTH_SERUM",
-        Preferences.getString("_bastilleCurrentStyles"));
+        "BARBERSHOP,DRAFTSMAN,GESTURE,TRUTH", Preferences.getString("_bastilleCurrentStyles"));
     assertEquals("MA=0,MD=3,CA=2,CD=4,PA=4,PD=8", Preferences.getString("_bastilleStats"));
     assertTrue(BastilleBattalionManager.checkPredictions());
 
@@ -118,7 +117,7 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastDecision = 1;
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals(
-        "BARBECUE,DRAFTSMAN,GESTURE,TRUTH_SERUM", Preferences.getString("_bastilleCurrentStyles"));
+        "BARBECUE,DRAFTSMAN,GESTURE,TRUTH", Preferences.getString("_bastilleCurrentStyles"));
     assertEquals("MA=3,MD=5,CA=2,CD=4,PA=2,PD=5", Preferences.getString("_bastilleStats"));
     assertTrue(BastilleBattalionManager.checkPredictions());
 
@@ -131,8 +130,7 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastChoice = 1313;
     ChoiceManager.lastDecision = 1;
     BastilleBattalionManager.postChoice1(urlString, request);
-    assertEquals(
-        "BABAR,DRAFTSMAN,GESTURE,TRUTH_SERUM", Preferences.getString("_bastilleCurrentStyles"));
+    assertEquals("BABAR,DRAFTSMAN,GESTURE,TRUTH", Preferences.getString("_bastilleCurrentStyles"));
     assertEquals("MA=0,MD=3,CA=4,CD=7,PA=2,PD=5", Preferences.getString("_bastilleStats"));
     assertTrue(BastilleBattalionManager.checkPredictions());
 
@@ -146,8 +144,7 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastDecision = 1;
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals(
-        "BARBERSHOP,DRAFTSMAN,GESTURE,TRUTH_SERUM",
-        Preferences.getString("_bastilleCurrentStyles"));
+        "BARBERSHOP,DRAFTSMAN,GESTURE,TRUTH", Preferences.getString("_bastilleCurrentStyles"));
     assertEquals("MA=0,MD=3,CA=2,CD=4,PA=4,PD=8", Preferences.getString("_bastilleStats"));
     assertTrue(BastilleBattalionManager.checkPredictions());
 
@@ -161,8 +158,7 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastDecision = 2;
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals(
-        "BARBERSHOP,ART_NOUVEAU,GESTURE,TRUTH_SERUM",
-        Preferences.getString("_bastilleCurrentStyles"));
+        "BARBERSHOP,NOUVEAU,GESTURE,TRUTH", Preferences.getString("_bastilleCurrentStyles"));
     assertEquals("MA=0,MD=0,CA=2,CD=1,PA=6,PD=7", Preferences.getString("_bastilleStats"));
     assertTrue(BastilleBattalionManager.checkPredictions());
 
@@ -176,8 +172,7 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastDecision = 2;
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals(
-        "BARBERSHOP,BRUTALIST,GESTURE,TRUTH_SERUM",
-        Preferences.getString("_bastilleCurrentStyles"));
+        "BARBERSHOP,BRUTALIST,GESTURE,TRUTH", Preferences.getString("_bastilleCurrentStyles"));
     assertEquals("MA=2,MD=0,CA=3,CD=1,PA=6,PD=5", Preferences.getString("_bastilleStats"));
     assertTrue(BastilleBattalionManager.checkPredictions());
 
@@ -191,8 +186,7 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastDecision = 2;
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals(
-        "BARBERSHOP,DRAFTSMAN,GESTURE,TRUTH_SERUM",
-        Preferences.getString("_bastilleCurrentStyles"));
+        "BARBERSHOP,DRAFTSMAN,GESTURE,TRUTH", Preferences.getString("_bastilleCurrentStyles"));
     assertEquals("MA=0,MD=3,CA=2,CD=4,PA=4,PD=8", Preferences.getString("_bastilleStats"));
     assertTrue(BastilleBattalionManager.checkPredictions());
 
@@ -206,7 +200,7 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastDecision = 3;
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals(
-        "BARBERSHOP,DRAFTSMAN,CANNON,TRUTH_SERUM", Preferences.getString("_bastilleCurrentStyles"));
+        "BARBERSHOP,DRAFTSMAN,CANNON,TRUTH", Preferences.getString("_bastilleCurrentStyles"));
     assertEquals("MA=2,MD=4,CA=2,CD=3,PA=3,PD=8", Preferences.getString("_bastilleStats"));
     assertTrue(BastilleBattalionManager.checkPredictions());
 
@@ -220,8 +214,7 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastDecision = 3;
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals(
-        "BARBERSHOP,DRAFTSMAN,CATAPULT,TRUTH_SERUM",
-        Preferences.getString("_bastilleCurrentStyles"));
+        "BARBERSHOP,DRAFTSMAN,CATAPULT,TRUTH", Preferences.getString("_bastilleCurrentStyles"));
     assertEquals("MA=0,MD=4,CA=3,CD=4,PA=3,PD=7", Preferences.getString("_bastilleStats"));
     assertTrue(BastilleBattalionManager.checkPredictions());
 
@@ -235,8 +228,7 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastDecision = 3;
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals(
-        "BARBERSHOP,DRAFTSMAN,GESTURE,TRUTH_SERUM",
-        Preferences.getString("_bastilleCurrentStyles"));
+        "BARBERSHOP,DRAFTSMAN,GESTURE,TRUTH", Preferences.getString("_bastilleCurrentStyles"));
     assertEquals("MA=0,MD=3,CA=2,CD=4,PA=4,PD=8", Preferences.getString("_bastilleStats"));
     assertTrue(BastilleBattalionManager.checkPredictions());
 
@@ -278,8 +270,7 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastDecision = 4;
     BastilleBattalionManager.postChoice1(urlString, request);
     assertEquals(
-        "BARBERSHOP,DRAFTSMAN,GESTURE,TRUTH_SERUM",
-        Preferences.getString("_bastilleCurrentStyles"));
+        "BARBERSHOP,DRAFTSMAN,GESTURE,TRUTH", Preferences.getString("_bastilleCurrentStyles"));
     assertEquals("MA=0,MD=3,CA=2,CD=4,PA=4,PD=8", Preferences.getString("_bastilleStats"));
     assertTrue(BastilleBattalionManager.checkPredictions());
   }


### PR DESCRIPTION
Not by simply summing the stats from each included style.
That often works, but there are plenty of style sets where this or that stat is tweaked.

This is not just a matter of not having the exact bonuses provided for each style: there are plenty of cases when swapping back and forth between two styles adds or subtracts 1 from a stat, but with a different group of three other styles, switching those two styles will add or subtract 2.

There are 4 castle upgrades, each with 3 styles, so there are 3 ^ 4 = 81 style sets.
I recorded, checked, input, and checked again in game all 81 of those.

When we see (or change) styles before starting a game, we check the real set of stats to what we predict the selected styles will provide - and log differences. I checked all 81 sets in-game and no errors were logged.

This is interesting data for comparing stat bonuses from various style sets. It will be useful for experimenting with how the various stat bonus boosts actually work out in play. That's outside of the purview of KoLmafia itself. But, we may as well save - and share - the data somewhere.