### PR TITLE
fix: combat rate stacks in non multiples of 5

### DIFF
--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -1468,9 +1468,26 @@ public class Modifiers {
     return damage;
   }
 
+  private double cappedCombatRate() {
+    // Combat Rate has diminishing returns beyond + or - 25%
+    double rate = this.doubles[Modifiers.COMBAT_RATE];
+    if (rate > 25.0) {
+      double extra = rate - 25.0;
+      return 25.0 + Math.floor(extra / 5.0);
+    }
+    if (rate < -25.0) {
+      double extra = rate + 25.0;
+      return -25.0 + Math.ceil(extra / 5.0);
+    }
+    return rate;
+  }
+
   public double get(final int index) {
     if (index == Modifiers.PRISMATIC_DAMAGE) {
       return this.derivePrismaticDamage();
+    }
+    if (index == Modifiers.COMBAT_RATE) {
+      return this.cappedCombatRate();
     }
 
     if (index < 0 || index >= this.doubles.length) {
@@ -1483,6 +1500,9 @@ public class Modifiers {
   public double get(final String name) {
     if (name.equals("Prismatic Damage")) {
       return this.derivePrismaticDamage();
+    }
+    if (name.equals("Combat Rate")) {
+      return this.cappedCombatRate();
     }
 
     int index = Modifiers.findName(Modifiers.doubleModifiers, name);
@@ -1683,26 +1703,6 @@ public class Modifiers {
 
   public void add(final int index, final double mod, final String desc) {
     switch (index) {
-      case COMBAT_RATE:
-        // Combat Rate has diminishing returns beyond + or - 25%
-
-        // Assume that all the sources of Combat Rate modifiers are of + or - 5%,
-        // and start by obtaining the current value without the diminishing returns taken into
-        // account
-        double rate = this.doubles[index];
-        double extra = Math.abs(rate) - 25.0;
-        if (extra > 0.0) {
-          rate = (25.0 + Math.ceil(extra) * 5.0) * (rate < 0.0 ? -1.0 : 1.0);
-        }
-
-        // Add mod and calculate the new value with the diminishing returns taken into account
-        rate += mod;
-        extra = Math.abs(rate) - 25.0;
-        if (extra > 0.0) {
-          rate = (25.0 + Math.floor(extra / 5.0)) * (rate < 0.0 ? -1.0 : 1.0);
-        }
-        this.doubles[index] = rate;
-        break;
       case MANA_COST:
         // Total Mana Cost reduction cannot exceed 3
         this.doubles[index] += mod;

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -115,4 +115,25 @@ public class ModifiersTest {
   public void canParseModifier(String enchantment, String modifier) {
     assertEquals(modifier, Modifiers.parseModifier(enchantment));
   }
+
+  @Test
+  public void correctlyCalculatesCappedCombatRate() {
+    Modifiers mod = new Modifiers();
+    mod.add(Modifiers.COMBAT_RATE, 25, "Start");
+    mod.add(Modifiers.COMBAT_RATE, 7, "32");
+    assertEquals(26, mod.get(Modifiers.COMBAT_RATE));
+    mod.add(Modifiers.COMBAT_RATE, 9, "41");
+    assertEquals(28, mod.get(Modifiers.COMBAT_RATE));
+    mod.add(Modifiers.COMBAT_RATE, 9, "50");
+    assertEquals(30, mod.get(Modifiers.COMBAT_RATE));
+
+    mod = new Modifiers();
+    mod.add(Modifiers.COMBAT_RATE, -25, "Start");
+    mod.add(Modifiers.COMBAT_RATE, -7, "-32");
+    assertEquals(-26, mod.get(Modifiers.COMBAT_RATE));
+    mod.add(Modifiers.COMBAT_RATE, -9, "-41");
+    assertEquals(-28, mod.get(Modifiers.COMBAT_RATE));
+    mod.add(Modifiers.COMBAT_RATE, -9, "-50");
+    assertEquals(-30, mod.get(Modifiers.COMBAT_RATE));
+  }
 }


### PR DESCRIPTION
Relates to https://kolmafia.us/threads/irregular-combat-rate-modifiers-interact-poorly-with-the-soft-cap.27478/

Modifiers incremented capped values one at a time: for example, adding nine twice added one twice when over the soft cap (as 9 // 5 = 1). However, adding nine twice should add three total, as 18 // 5 = 3.

This changes COMBAT_RATE to store the uncapped combat rate, and `get` to return the capped one when called.