### PR TITLE
make Combat Rate case insensitive

### DIFF
--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -1498,10 +1498,10 @@ public class Modifiers {
   }
 
   public double get(final String name) {
-    if (name.equals("Prismatic Damage")) {
+    if (name.toLowerCase().equals("prismatic damage")) {
       return this.derivePrismaticDamage();
     }
-    if (name.equals("Combat Rate")) {
+    if (name.toLowerCase().equals("combat rate")) {
       return this.cappedCombatRate();
     }
 

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -1498,10 +1498,10 @@ public class Modifiers {
   }
 
   public double get(final String name) {
-    if (name.toLowerCase().equals("prismatic damage")) {
+    if (name.equalsIgnoreCase("Prismatic Damage")) {
       return this.derivePrismaticDamage();
     }
-    if (name.toLowerCase().equals("combat rate")) {
+    if (name.equalsIgnoreCase("Combat Rate")) {
       return this.cappedCombatRate();
     }
 


### PR DESCRIPTION
Right now,` numericModifier("Combat Rate")` and `numericModifier("combat rate")` return different values when you're past the cap of 25, because we only are special casing the input "Combat Rate".