### PR TITLE
refactor: skeleton command

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/command/SkeletonCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/SkeletonCommand.java
@@ -8,6 +8,24 @@ import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.InventoryManager;
 
+class Skeleton {
+  private final String name;
+  private final int num;
+
+  public Skeleton(String name, int num) {
+    this.name = name;
+    this.num = num;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getNum() {
+    return num;
+  }
+}
+
 public class SkeletonCommand extends AbstractCommand {
   public SkeletonCommand() {
     this.usage = " warrior | cleric | wizard | rogue | buddy";
@@ -19,21 +37,19 @@ public class SkeletonCommand extends AbstractCommand {
   public static final int ROGUE = 4;
   public static final int BUDDY = 5;
 
-  public static final Object[][] SKELETONS =
-      new Object[][] {
-        {"warrior", WARRIOR},
-        {"cleric", CLERIC},
-        {"wizard", WIZARD},
-        {"rogue", ROGUE},
-        {"buddy", BUDDY},
+  public static final Skeleton[] SKELETONS =
+      new Skeleton[] {
+        new Skeleton("warrior", WARRIOR),
+        new Skeleton("cleric", CLERIC),
+        new Skeleton("wizard", WIZARD),
+        new Skeleton("rogue", ROGUE),
+        new Skeleton("buddy", BUDDY),
       };
 
   public static final int findSkeleton(final String name) {
-    for (int i = 0; i < SKELETONS.length; ++i) {
-      String skeleton = (String) SKELETONS[i][0];
-      if (name.equals(skeleton)) {
-        Integer index = (Integer) SKELETONS[i][1];
-        return index.intValue();
+    for (Skeleton skeleton : SKELETONS) {
+      if (name.equals(skeleton.getName())) {
+        return skeleton.getNum();
       }
     }
 

--- a/src/net/sourceforge/kolmafia/textui/command/SkeletonCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/SkeletonCommand.java
@@ -15,15 +15,16 @@ public class SkeletonCommand extends AbstractCommand {
     this.usage = " warrior | cleric | wizard | rogue | buddy";
   }
 
-  private static final Map<String, Integer> skeletons = new HashMap<>() {
-    {
-      put("warrior", 1);
-      put("cleric", 2);
-      put("wizard", 3);
-      put("rogue", 4);
-      put("buddy", 5);
-    }
-  };
+  private static final Map<String, Integer> skeletons =
+      new HashMap<>() {
+        {
+          put("warrior", 1);
+          put("cleric", 2);
+          put("wizard", 3);
+          put("rogue", 4);
+          put("buddy", 5);
+        }
+      };
 
   public static int findSkeleton(final String name) {
     return skeletons.getOrDefault(name, 0);

--- a/src/net/sourceforge/kolmafia/textui/command/SkeletonCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/SkeletonCommand.java
@@ -8,11 +8,17 @@ import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.InventoryManager;
 
-class Skeleton {
+enum Skeleton {
+  WARRIOR("warrior", 1),
+  CLERIC("cleric", 2),
+  WIZARD("wizard", 3),
+  ROGUE("rogue", 4),
+  BUDDY("buddy", 5);
+
   private final String name;
   private final int num;
 
-  public Skeleton(String name, int num) {
+  Skeleton(String name, int num) {
     this.name = name;
     this.num = num;
   }
@@ -31,23 +37,8 @@ public class SkeletonCommand extends AbstractCommand {
     this.usage = " warrior | cleric | wizard | rogue | buddy";
   }
 
-  public static final int WARRIOR = 1;
-  public static final int CLERIC = 2;
-  public static final int WIZARD = 3;
-  public static final int ROGUE = 4;
-  public static final int BUDDY = 5;
-
-  public static final Skeleton[] SKELETONS =
-      new Skeleton[] {
-        new Skeleton("warrior", WARRIOR),
-        new Skeleton("cleric", CLERIC),
-        new Skeleton("wizard", WIZARD),
-        new Skeleton("rogue", ROGUE),
-        new Skeleton("buddy", BUDDY),
-      };
-
   public static final int findSkeleton(final String name) {
-    for (Skeleton skeleton : SKELETONS) {
+    for (Skeleton skeleton : Skeleton.values()) {
       if (name.equals(skeleton.getName())) {
         return skeleton.getNum();
       }

--- a/src/net/sourceforge/kolmafia/textui/command/SkeletonCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/SkeletonCommand.java
@@ -1,5 +1,7 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import java.util.HashMap;
+import java.util.Map;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestLogger;
@@ -8,43 +10,23 @@ import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.InventoryManager;
 
-enum Skeleton {
-  WARRIOR("warrior", 1),
-  CLERIC("cleric", 2),
-  WIZARD("wizard", 3),
-  ROGUE("rogue", 4),
-  BUDDY("buddy", 5);
-
-  private final String name;
-  private final int num;
-
-  Skeleton(String name, int num) {
-    this.name = name;
-    this.num = num;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public int getNum() {
-    return num;
-  }
-}
-
 public class SkeletonCommand extends AbstractCommand {
   public SkeletonCommand() {
     this.usage = " warrior | cleric | wizard | rogue | buddy";
   }
 
-  public static final int findSkeleton(final String name) {
-    for (Skeleton skeleton : Skeleton.values()) {
-      if (name.equals(skeleton.getName())) {
-        return skeleton.getNum();
-      }
+  private static final Map<String, Integer> skeletons = new HashMap<>() {
+    {
+      put("warrior", 1);
+      put("cleric", 2);
+      put("wizard", 3);
+      put("rogue", 4);
+      put("buddy", 5);
     }
+  };
 
-    return 0;
+  public static int findSkeleton(final String name) {
+    return skeletons.getOrDefault(name, 0);
   }
 
   @Override

--- a/test/net/sourceforge/kolmafia/textui/command/SkeletonCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/SkeletonCommandTest.java
@@ -1,0 +1,91 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+
+import internal.helpers.Player;
+import internal.network.FakeHttpClientBuilder;
+import internal.network.RequestBodyReader;
+import java.net.http.HttpRequest;
+import java.util.List;
+import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.request.GenericRequest;
+import net.sourceforge.kolmafia.utilities.HttpUtilities;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SkeletonCommandTest extends AbstractCommandTestBase {
+
+  public SkeletonCommandTest() {
+    this.command = "skeleton";
+  }
+
+  private final FakeHttpClientBuilder fakeClientBuilder = new FakeHttpClientBuilder();
+
+  private List<HttpRequest> getRequests() {
+    return fakeClientBuilder.client.getRequests();
+  }
+
+  @BeforeEach
+  public void initializeState() {
+    GenericRequest.sessionId = "skeleton";
+    HttpUtilities.setClientBuilder(() -> fakeClientBuilder);
+    GenericRequest.resetClient();
+    fakeClientBuilder.client.clear();
+    StaticEntity.setContinuationState(KoLConstants.MafiaState.CONTINUE);
+  }
+
+  @Test
+  void providesUsageIfNoParameters() {
+    String output = execute("");
+
+    assertThat(output, containsString("Usage: skeleton warrior | cleric | wizard | rogue | buddy"));
+  }
+
+  @Test
+  void questionsIfInvalidSkeleton() {
+    String output = execute("drunk");
+
+    assertErrorState();
+    assertThat(output, containsString("I don't understand what a 'drunk' skeleton is"));
+  }
+
+  @Test
+  void errorsIfNoSkeletons() {
+    String output = execute("buddy");
+
+    assertErrorState();
+    assertThat(output, containsString("You have no skeletons"));
+  }
+
+  @Test
+  void sendsRequestsIfSkeleton() {
+    var cleanups = Player.addItem(ItemPool.SKELETON);
+
+    try (cleanups) {
+      execute("buddy");
+    }
+
+    assertContinueState();
+    var requests = getRequests();
+    assertThat(requests, not(empty()));
+    assertThat(requests, hasSize(2));
+    var first = requests.get(0);
+    var uri = first.uri();
+    assertThat(uri.getPath(), equalTo("/inv_use.php"));
+    var body = new RequestBodyReader().bodyAsString(first);
+    assertThat(body, equalTo("which=3&whichitem=5881"));
+
+    var second = requests.get(1);
+    uri = second.uri();
+    assertThat(uri.getPath(), equalTo("/choice.php"));
+    body = new RequestBodyReader().bodyAsString(second);
+    assertThat(body, equalTo("whichchoice=603&option=5"));
+  }
+}


### PR DESCRIPTION
Similar to #714, this is a proof of concept for what I'd eventually like `Modifiers` to look like: only allowing enum values instead of ints or strings.

Avoid casts by moving away from `Object[][]`.