### PR TITLE
fix: only retry if it's safe, even on GOAWAY

### DIFF
--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -1592,7 +1592,7 @@ public class GenericRequest implements Runnable {
           && (errorMessage.contains("GOAWAY")
               || errorMessage.contains("parser received no bytes"))) {
         ++this.timeoutCount;
-        if (this.timeoutCount < TIMEOUT_LIMIT) {
+        if (this.timeoutCount < TIMEOUT_LIMIT && this.retryOnTimeout()) {
           return this.sendRequest();
         }
       }


### PR DESCRIPTION
Initially, I thought GOAWAY meant that the request wasn't handled at all, but someone on Discord reported accidentally hitting the Chateau twice after the HTTP2 move. While I can't be sure this is GOAWAY, it's safer to only retry if it's safe to do so.