### PR TITLE
chore: ignore blame rev for spotless

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# spotless
+fbfd2252d01c76a8b52d01d14a8f23573646e162


### PR DESCRIPTION
GitHub offers [a standardized file to ignore certain revisions when running blame](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view).

Ignore the mass application of spotless.