### PR TITLE
feat: make zap command aware of counts

### DIFF
--- a/src/net/sourceforge/kolmafia/request/ZapRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ZapRequest.java
@@ -29,7 +29,7 @@ public class ZapRequest extends GenericRequest {
   private static final Pattern OPTION_PATTERN =
       Pattern.compile("<option value=(\\d+) descid='.*?'>.*?</option>");
 
-  private static final Map<Integer, List<String>> zapGroups = new HashMap<Integer, List<String>>();
+  private static final Map<Integer, List<String>> zapGroups = new HashMap<>();
 
   private AdventureResult item;
 
@@ -74,10 +74,10 @@ public class ZapRequest extends GenericRequest {
     }
   }
 
-  public static final LockableListModel<AdventureResult> getZappableItems() {
+  public static LockableListModel<AdventureResult> getZappableItems() {
     ZapRequest.initializeList();
 
-    SortedListModel<AdventureResult> matchingItems = new SortedListModel<AdventureResult>();
+    SortedListModel<AdventureResult> matchingItems = new SortedListModel<>();
     if (Preferences.getBoolean("relayTrimsZapList")) {
       matchingItems.addAll(
           KoLConstants.inventory.stream()
@@ -89,7 +89,7 @@ public class ZapRequest extends GenericRequest {
     return matchingItems;
   }
 
-  public static final List<String> getZapGroup(int itemId) {
+  public static List<String> getZapGroup(int itemId) {
     ZapRequest.initializeList();
 
     return ZapRequest.zapGroups.getOrDefault(itemId, new ArrayList<>());
@@ -126,7 +126,7 @@ public class ZapRequest extends GenericRequest {
 
     // "The Crown of the Goblin King shudders for a moment, but
     // nothing happens."
-    if (this.responseText.indexOf("nothing happens") != -1) {
+    if (this.responseText.contains("nothing happens")) {
       KoLmafia.updateDisplay(MafiaState.ERROR, "The " + this.item.getName() + " is not zappable.");
       return;
     }
@@ -135,17 +135,17 @@ public class ZapRequest extends GenericRequest {
     KoLmafia.updateDisplay(this.item.getName() + " has been transformed.");
   }
 
-  public static final void parseResponse(final String urlString, final String responseText) {
+  public static void parseResponse(final String urlString, final String responseText) {
     if (!urlString.startsWith("wand.php")) {
       return;
     }
 
-    if (responseText.indexOf("nothing happens") != -1) {
+    if (responseText.contains("nothing happens")) {
       return;
     }
 
     // If it blew up, remove wand and zero usages
-    if (responseText.indexOf("abruptly explodes") != -1) {
+    if (responseText.contains("abruptly explodes")) {
       ResultProcessor.processResult(KoLCharacter.getZapper().getNegation());
       // set to -1 because will be incremented below
       Preferences.setInteger("_zapCount", -1);
@@ -166,7 +166,7 @@ public class ZapRequest extends GenericRequest {
     Preferences.increment("_zapCount");
   }
 
-  public static final void decorate(final StringBuffer buffer) {
+  public static void decorate(final StringBuffer buffer) {
     // Don't trim the list if user wants to see all items
     if (!Preferences.getBoolean("relayTrimsZapList")) return;
 
@@ -181,7 +181,7 @@ public class ZapRequest extends GenericRequest {
     buffer.delete(selectIndex, endSelectIndex);
 
     int itemId;
-    StringBuffer zappableOptions = new StringBuffer();
+    StringBuilder zappableOptions = new StringBuilder();
     while (optionMatcher.find()) {
       itemId = Integer.parseInt(optionMatcher.group(1));
       if (itemId == 0 || ZapRequest.zapGroups.containsKey(itemId)) {
@@ -189,7 +189,7 @@ public class ZapRequest extends GenericRequest {
       }
     }
 
-    buffer.insert(selectIndex, zappableOptions.toString());
+    buffer.insert(selectIndex, zappableOptions);
     int pos = buffer.lastIndexOf("</center>");
     buffer.insert(
         pos,
@@ -198,7 +198,7 @@ public class ZapRequest extends GenericRequest {
             + "&notrim=1\">Click here</a> for the full list.");
   }
 
-  public static final boolean registerRequest(final String urlString) {
+  public static boolean registerRequest(final String urlString) {
     if (!urlString.startsWith("wand.php")) {
       return false;
     }

--- a/src/net/sourceforge/kolmafia/textui/command/ZapCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ZapCommand.java
@@ -27,7 +27,10 @@ public class ZapCommand extends AbstractCommand {
     AdventureResult[] items = ItemFinder.getMatchingItemList(parameters, KoLConstants.inventory);
 
     for (AdventureResult item : items) {
-      RequestThread.postRequest(new ZapRequest(item));
+      var request = new ZapRequest(item);
+      for (int i = 0; i < item.getCount(); i++) {
+        RequestThread.postRequest(request);
+      }
     }
   }
 }

--- a/test/internal/helpers/HttpClientWrapper.java
+++ b/test/internal/helpers/HttpClientWrapper.java
@@ -24,5 +24,4 @@ public class HttpClientWrapper {
     GenericRequest.resetClient();
     fakeClientBuilder.client.clear();
   }
-
 }

--- a/test/internal/helpers/HttpClientWrapper.java
+++ b/test/internal/helpers/HttpClientWrapper.java
@@ -1,0 +1,28 @@
+package internal.helpers;
+
+import internal.network.FakeHttpClientBuilder;
+import java.net.http.HttpRequest;
+import java.util.List;
+import net.sourceforge.kolmafia.request.GenericRequest;
+import net.sourceforge.kolmafia.utilities.HttpUtilities;
+
+public class HttpClientWrapper {
+
+  public static FakeHttpClientBuilder fakeClientBuilder = new FakeHttpClientBuilder();
+
+  public static List<HttpRequest> getRequests() {
+    return fakeClientBuilder.client.getRequests();
+  }
+
+  public static HttpRequest getLastRequest() {
+    return fakeClientBuilder.client.getLastRequest();
+  }
+
+  public static void setupFakeClient() {
+    GenericRequest.sessionId = "real"; // do "send" requests
+    HttpUtilities.setClientBuilder(() -> fakeClientBuilder);
+    GenericRequest.resetClient();
+    fakeClientBuilder.client.clear();
+  }
+
+}

--- a/test/net/sourceforge/kolmafia/textui/command/AbsorbCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AbsorbCommandTest.java
@@ -1,20 +1,21 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import static internal.helpers.HttpClientWrapper.getRequests;
 import static internal.helpers.Player.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 import internal.helpers.Cleanups;
+import internal.helpers.HttpClientWrapper;
 import net.sourceforge.kolmafia.AscensionPath.Path;
-import net.sourceforge.kolmafia.request.GenericRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class AbsorbCommandTest extends AbstractCommandTestBase {
   @BeforeEach
   public void initEach() {
-    // Stop requests from actually running
-    GenericRequest.sessionId = null;
+    HttpClientWrapper.setupFakeClient();
   }
 
   public AbsorbCommandTest() {
@@ -84,5 +85,8 @@ public class AbsorbCommandTest extends AbstractCommandTestBase {
       assertThat(output, containsString("Absorbed 15 Half Purses"));
       assertContinueState();
     }
+
+    var requests = getRequests();
+    assertThat(requests.size(), equalTo(16)); // 15 items + 1 charpane
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/command/AutoSellCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AutoSellCommandTest.java
@@ -1,11 +1,13 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import static internal.helpers.HttpClientWrapper.getRequests;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
 import internal.helpers.Cleanups;
+import internal.helpers.HttpClientWrapper;
 import internal.helpers.Player;
 import internal.network.FakeHttpClientBuilder;
 import internal.network.RequestBodyReader;
@@ -20,22 +22,13 @@ import org.junit.jupiter.api.Test;
 
 public class AutoSellCommandTest extends AbstractCommandTestBase {
 
-  private final FakeHttpClientBuilder fakeClientBuilder = new FakeHttpClientBuilder();
-
-  private List<HttpRequest> getRequests() {
-    return fakeClientBuilder.client.getRequests();
-  }
-
   public AutoSellCommandTest() {
     this.command = "autosell";
   }
 
   @BeforeEach
   public void initializeState() {
-    GenericRequest.sessionId = "autosell"; // do "send" requests
-    HttpUtilities.setClientBuilder(() -> fakeClientBuilder);
-    GenericRequest.resetClient();
-    fakeClientBuilder.client.clear();
+    HttpClientWrapper.setupFakeClient();
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
   }
 

--- a/test/net/sourceforge/kolmafia/textui/command/AutoSellCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AutoSellCommandTest.java
@@ -9,14 +9,9 @@ import static org.hamcrest.Matchers.not;
 import internal.helpers.Cleanups;
 import internal.helpers.HttpClientWrapper;
 import internal.helpers.Player;
-import internal.network.FakeHttpClientBuilder;
 import internal.network.RequestBodyReader;
-import java.net.http.HttpRequest;
-import java.util.List;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.StaticEntity;
-import net.sourceforge.kolmafia.request.GenericRequest;
-import net.sourceforge.kolmafia.utilities.HttpUtilities;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/test/net/sourceforge/kolmafia/textui/command/ClanStashCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ClanStashCommandTest.java
@@ -1,36 +1,24 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import static internal.helpers.HttpClientWrapper.getLastRequest;
+import static internal.helpers.HttpClientWrapper.getRequests;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
 import internal.helpers.Cleanups;
+import internal.helpers.HttpClientWrapper;
 import internal.helpers.Player;
-import internal.network.FakeHttpClientBuilder;
 import internal.network.RequestBodyReader;
-import java.net.http.HttpRequest;
-import java.util.List;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.StaticEntity;
-import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.ClanManager;
-import net.sourceforge.kolmafia.utilities.HttpUtilities;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class ClanStashCommandTest extends AbstractCommandTestBase {
-
-  private final FakeHttpClientBuilder fakeClientBuilder = new FakeHttpClientBuilder();
-
-  private List<HttpRequest> getRequests() {
-    return fakeClientBuilder.client.getRequests();
-  }
-
-  private HttpRequest getLastRequest() {
-    return fakeClientBuilder.client.getLastRequest();
-  }
 
   public ClanStashCommandTest() {
     this.command = "stash";
@@ -38,10 +26,7 @@ public class ClanStashCommandTest extends AbstractCommandTestBase {
 
   @BeforeEach
   public void initializeState() {
-    GenericRequest.sessionId = "stash"; // do "send" requests
-    HttpUtilities.setClientBuilder(() -> fakeClientBuilder);
-    GenericRequest.resetClient();
-    fakeClientBuilder.client.clear();
+    HttpClientWrapper.setupFakeClient();
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
     // don't send a GET request to the server to get the stash
     ClanManager.setStashRetrieved();

--- a/test/net/sourceforge/kolmafia/textui/command/ClosetCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ClosetCommandTest.java
@@ -1,31 +1,26 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import static internal.helpers.HttpClientWrapper.getRequests;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 
 import internal.helpers.Cleanups;
+import internal.helpers.HttpClientWrapper;
 import internal.helpers.Player;
 import internal.listeners.FakeListener;
-import internal.network.FakeHttpClientBuilder;
 import internal.network.RequestBodyReader;
-import java.net.http.HttpRequest;
-import java.util.List;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
-import net.sourceforge.kolmafia.request.GenericRequest;
-import net.sourceforge.kolmafia.utilities.HttpUtilities;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class ClosetCommandTest extends AbstractCommandTestBase {
-
-  private final FakeHttpClientBuilder fakeClientBuilder = new FakeHttpClientBuilder();
-
-  private List<HttpRequest> getRequests() {
-    return fakeClientBuilder.client.getRequests();
-  }
 
   public ClosetCommandTest() {
     this.command = "closet";
@@ -33,10 +28,7 @@ public class ClosetCommandTest extends AbstractCommandTestBase {
 
   @BeforeEach
   public void initializeState() {
-    GenericRequest.sessionId = "closet"; // do "send" requests
-    HttpUtilities.setClientBuilder(() -> fakeClientBuilder);
-    GenericRequest.resetClient();
-    fakeClientBuilder.client.clear();
+    HttpClientWrapper.setupFakeClient();
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
   }
 

--- a/test/net/sourceforge/kolmafia/textui/command/RefreshStatusCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/RefreshStatusCommandTest.java
@@ -1,32 +1,20 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import static internal.helpers.HttpClientWrapper.getLastRequest;
+import static internal.helpers.HttpClientWrapper.getRequests;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
-import internal.network.FakeHttpClientBuilder;
-import java.net.http.HttpRequest;
-import java.util.List;
+import internal.helpers.HttpClientWrapper;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.StaticEntity;
-import net.sourceforge.kolmafia.request.GenericRequest;
-import net.sourceforge.kolmafia.utilities.HttpUtilities;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class RefreshStatusCommandTest extends AbstractCommandTestBase {
-
-  private final FakeHttpClientBuilder fakeClientBuilder = new FakeHttpClientBuilder();
-
-  private List<HttpRequest> getRequests() {
-    return fakeClientBuilder.client.getRequests();
-  }
-
-  private HttpRequest getLastRequest() {
-    return fakeClientBuilder.client.getLastRequest();
-  }
 
   public RefreshStatusCommandTest() {
     this.command = "refresh";
@@ -34,10 +22,7 @@ public class RefreshStatusCommandTest extends AbstractCommandTestBase {
 
   @BeforeEach
   public void initializeState() {
-    GenericRequest.sessionId = "refresh"; // do "send" requests
-    HttpUtilities.setClientBuilder(() -> fakeClientBuilder);
-    GenericRequest.resetClient();
-    fakeClientBuilder.client.clear();
+    HttpClientWrapper.setupFakeClient();
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
   }
 

--- a/test/net/sourceforge/kolmafia/textui/command/SendMessageCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/SendMessageCommandTest.java
@@ -1,22 +1,22 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import static internal.helpers.HttpClientWrapper.getRequests;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mockStatic;
 
 import internal.helpers.Cleanups;
+import internal.helpers.HttpClientWrapper;
 import internal.helpers.Player;
-import internal.network.FakeHttpClientBuilder;
 import internal.network.RequestBodyReader;
-import java.net.http.HttpRequest;
-import java.util.List;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.moods.RecoveryManager;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
-import net.sourceforge.kolmafia.request.GenericRequest;
-import net.sourceforge.kolmafia.utilities.HttpUtilities;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -30,18 +30,9 @@ class SendMessageCommandTest extends AbstractCommandTestBase {
     this.command = "csend";
   }
 
-  private final FakeHttpClientBuilder fakeClientBuilder = new FakeHttpClientBuilder();
-
-  private List<HttpRequest> getRequests() {
-    return fakeClientBuilder.client.getRequests();
-  }
-
   @BeforeEach
   public void initializeState() {
-    GenericRequest.sessionId = "csend";
-    HttpUtilities.setClientBuilder(() -> fakeClientBuilder);
-    GenericRequest.resetClient();
-    fakeClientBuilder.client.clear();
+    HttpClientWrapper.setupFakeClient();
     StaticEntity.setContinuationState(KoLConstants.MafiaState.CONTINUE);
   }
 

--- a/test/net/sourceforge/kolmafia/textui/command/SkeletonCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/SkeletonCommandTest.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import static internal.helpers.HttpClientWrapper.getRequests;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -7,16 +8,12 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 
+import internal.helpers.HttpClientWrapper;
 import internal.helpers.Player;
-import internal.network.FakeHttpClientBuilder;
 import internal.network.RequestBodyReader;
-import java.net.http.HttpRequest;
-import java.util.List;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
-import net.sourceforge.kolmafia.request.GenericRequest;
-import net.sourceforge.kolmafia.utilities.HttpUtilities;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -26,18 +23,9 @@ public class SkeletonCommandTest extends AbstractCommandTestBase {
     this.command = "skeleton";
   }
 
-  private final FakeHttpClientBuilder fakeClientBuilder = new FakeHttpClientBuilder();
-
-  private List<HttpRequest> getRequests() {
-    return fakeClientBuilder.client.getRequests();
-  }
-
   @BeforeEach
   public void initializeState() {
-    GenericRequest.sessionId = "skeleton";
-    HttpUtilities.setClientBuilder(() -> fakeClientBuilder);
-    GenericRequest.resetClient();
-    fakeClientBuilder.client.clear();
+    HttpClientWrapper.setupFakeClient();
     StaticEntity.setContinuationState(KoLConstants.MafiaState.CONTINUE);
   }
 

--- a/test/net/sourceforge/kolmafia/textui/command/ZapCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ZapCommandTest.java
@@ -94,7 +94,11 @@ public class ZapCommandTest extends AbstractCommandTestBase {
 
   @Test
   public void zapManyItems() {
-    var cleanups = new Cleanups(addItem("hexagonal wand"), addItem("bugbear beanie"), addItem("cursed swash buckle", 2));
+    var cleanups =
+        new Cleanups(
+            addItem("hexagonal wand"),
+            addItem("bugbear beanie"),
+            addItem("cursed swash buckle", 2));
 
     try (cleanups) {
       execute("1 bugbear beanie, 2 cursed swash buckle");
@@ -103,5 +107,4 @@ public class ZapCommandTest extends AbstractCommandTestBase {
     var requests = getRequests();
     assertThat(requests.size(), equalTo(3));
   }
-
 }

--- a/test/net/sourceforge/kolmafia/textui/command/ZapCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ZapCommandTest.java
@@ -1,0 +1,107 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static internal.helpers.HttpClientWrapper.getRequests;
+import static internal.helpers.Player.addItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+
+import internal.helpers.Cleanups;
+import internal.helpers.HttpClientWrapper;
+import internal.network.RequestBodyReader;
+import net.sourceforge.kolmafia.KoLConstants.MafiaState;
+import net.sourceforge.kolmafia.StaticEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ZapCommandTest extends AbstractCommandTestBase {
+  @BeforeEach
+  public void initEach() {
+    HttpClientWrapper.setupFakeClient();
+    StaticEntity.setContinuationState(MafiaState.CONTINUE);
+  }
+
+  public ZapCommandTest() {
+    this.command = "zap";
+  }
+
+  @Test
+  public void mustSpecifyItem() {
+    String output = execute("");
+
+    assertErrorState();
+    assertThat(output, containsString("Zap what?"));
+  }
+
+  @Test
+  public void cantZapUnmatchedItems() {
+    execute("foo_bar");
+
+    var requests = getRequests();
+    assertThat(requests, empty());
+  }
+
+  @Test
+  public void cantZapItemsNotInInventory() {
+    execute("bugbear beanie");
+
+    var requests = getRequests();
+    assertThat(requests, empty());
+  }
+
+  @Test
+  public void requireWandToZap() {
+    var cleanups = addItem("bugbear beanie");
+
+    try (cleanups) {
+      execute("bugbear beanie");
+    }
+
+    var requests = getRequests();
+    assertThat(requests, empty());
+  }
+
+  @Test
+  public void zapSimpleItem() {
+    var cleanups = new Cleanups(addItem("hexagonal wand"), addItem("bugbear beanie"));
+
+    try (cleanups) {
+      execute("bugbear beanie");
+    }
+
+    var requests = getRequests();
+    assertThat(requests.size(), equalTo(1));
+    var request = requests.get(0);
+    var uri = request.uri();
+    assertThat(uri.getPath(), equalTo("/wand.php"));
+    assertThat(request.method(), equalTo("POST"));
+    var body = new RequestBodyReader().bodyAsString(request);
+    assertThat(body, equalTo("action=zap&whichwand=1270&whichitem=169"));
+  }
+
+  @Test
+  public void zapNoItems() {
+    var cleanups = new Cleanups(addItem("hexagonal wand"), addItem("bugbear beanie"));
+
+    try (cleanups) {
+      execute("0 bugbear beanie");
+    }
+
+    var requests = getRequests();
+    assertThat(requests, empty());
+  }
+
+  @Test
+  public void zapManyItems() {
+    var cleanups = new Cleanups(addItem("hexagonal wand"), addItem("bugbear beanie"), addItem("cursed swash buckle", 2));
+
+    try (cleanups) {
+      execute("1 bugbear beanie, 2 cursed swash buckle");
+    }
+
+    var requests = getRequests();
+    assertThat(requests.size(), equalTo(3));
+  }
+
+}


### PR DESCRIPTION
Make zap command accept counts of items, and not make requests for 0 items.

While doing this, I noticed that the zap command silently fails if the user doesn't have a wand. There's a check in `ZapRequest` that would cover this, but it isn't hit due to an earlier error case being hit. I left it as it was.