### PR TITLE
feat: show warning after login for versions less than 17

### DIFF
--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -243,6 +243,8 @@ public class LoginManager {
     if (MailManager.hasNewMessages()) {
       KoLmafia.updateDisplay("You have new mail.");
     }
+
+    printWarningMessages();
   }
 
   public static void showCurrentHoliday() {
@@ -255,5 +257,13 @@ public class LoginManager {
 
   public static boolean isSvnLoginUpdateUnfinished() {
     return svnLoginUpdateNotFinished;
+  }
+
+  private static void printWarningMessages() {
+    var version = Runtime.version();
+    if (version.feature() < 17) {
+      KoLmafia.updateDisplay("Java versions lower than 17 will stop being supported by KoLMafia.");
+      KoLmafia.updateDisplay("You are running a version of Java lower than 17. Visit https://adoptium.net/ to download a newer version of Java.");
+    }
   }
 }

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -263,7 +263,8 @@ public class LoginManager {
     var version = Runtime.version();
     if (version.feature() < 17) {
       KoLmafia.updateDisplay("Java versions lower than 17 will stop being supported by KoLMafia.");
-      KoLmafia.updateDisplay("You are running a version of Java lower than 17. Visit https://adoptium.net/ to download a newer version of Java.");
+      KoLmafia.updateDisplay(
+          "You are running a version of Java lower than 17. Visit https://adoptium.net/ to download a newer version of Java.");
     }
   }
 }


### PR DESCRIPTION
After a user logs in, show a warning if they're running a version less than 17.

This will show in the CLI and also in the adventure frame (the default main frame) until the user takes another action.