### PR TITLE
tests: add test for item trace

### DIFF
--- a/src/net/sourceforge/kolmafia/listener/ItemListenerRegistry.java
+++ b/src/net/sourceforge/kolmafia/listener/ItemListenerRegistry.java
@@ -4,17 +4,19 @@ public class ItemListenerRegistry extends ListenerRegistry {
   // The registry of listeners:
   private static final ListenerRegistry INSTANCE = new ListenerRegistry();
 
-  public static final void registerItemListener(final int itemId, final Listener listener) {
+  public static void registerItemListener(final int itemId, final Listener listener) {
     if (itemId < 1) {
       return;
     }
 
-    Integer key = itemId;
-    ItemListenerRegistry.INSTANCE.registerListener(key, listener);
+    ItemListenerRegistry.INSTANCE.registerListener(itemId, listener);
   }
 
-  public static final void fireItemChanged(final int itemId) {
-    Integer key = itemId;
-    ItemListenerRegistry.INSTANCE.fireListener(key);
+  public static void unregisterItemListener(final int itemId, final Listener listener) {
+    ItemListenerRegistry.INSTANCE.unregisterListener(itemId, listener);
+  }
+
+  public static void fireItemChanged(final int itemId) {
+    ItemListenerRegistry.INSTANCE.fireListener(itemId);
   }
 }

--- a/src/net/sourceforge/kolmafia/listener/ListenerRegistry.java
+++ b/src/net/sourceforge/kolmafia/listener/ListenerRegistry.java
@@ -79,6 +79,22 @@ public class ListenerRegistry {
     }
   }
 
+  public final void unregisterListener(final Object key, final Listener listener) {
+    ArrayList<WeakReference<Listener>> listenerList;
+
+    synchronized (this.listenerMap) {
+      listenerList = this.listenerMap.get(key);
+    }
+
+    if (listenerList == null) {
+      return;
+    }
+
+    synchronized (listenerList) {
+      listenerList.removeIf(ref -> listener.equals(ref.get()));
+    }
+  }
+
   public final void fireListener(final Object key) {
     ArrayList<WeakReference<Listener>> listenerList = null;
 

--- a/src/net/sourceforge/kolmafia/listener/PreferenceListenerRegistry.java
+++ b/src/net/sourceforge/kolmafia/listener/PreferenceListenerRegistry.java
@@ -8,15 +8,19 @@ public class PreferenceListenerRegistry extends ListenerRegistry {
     PreferenceListenerRegistry.INSTANCE.deferListeners(deferring);
   }
 
-  public static final void registerPreferenceListener(final String name, final Listener listener) {
+  public static void registerPreferenceListener(final String name, final Listener listener) {
     PreferenceListenerRegistry.INSTANCE.registerListener(name, listener);
   }
 
-  public static final void firePreferenceChanged(final String name) {
+  public static void unregisterPreferenceListener(String name, final Listener listener) {
+    PreferenceListenerRegistry.INSTANCE.unregisterListener(name, listener);
+  }
+
+  public static void firePreferenceChanged(final String name) {
     PreferenceListenerRegistry.INSTANCE.fireListener(name);
   }
 
-  public static final void fireAllPreferencesChanged() {
+  public static void fireAllPreferencesChanged() {
     PreferenceListenerRegistry.INSTANCE.fireAllListeners();
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/command/ItemTraceCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ItemTraceCommand.java
@@ -10,7 +10,7 @@ import net.sourceforge.kolmafia.listener.Listener;
 import net.sourceforge.kolmafia.persistence.ItemFinder;
 
 public class ItemTraceCommand extends AbstractCommand {
-  private static ArrayList<Listener> audience = null; // keeps listeners from being GC'd
+  private static final ArrayList<Listener> audience = new ArrayList<>(); // keeps listeners from being GC'd
 
   public ItemTraceCommand() {
     this.usage = " <item> [, <item>]... - watch changes to inventory count of items";
@@ -18,8 +18,8 @@ public class ItemTraceCommand extends AbstractCommand {
 
   @Override
   public synchronized void run(String command, final String parameters) {
-    if (audience != null) {
-      audience = null;
+    if (audience.size() != 0) {
+      audience.clear();
       RequestLogger.printLine("Previously watched items have been cleared.");
     }
 
@@ -27,8 +27,7 @@ public class ItemTraceCommand extends AbstractCommand {
       return;
     }
 
-    AdventureResult[] items = ItemFinder.getMatchingItemList(parameters, KoLConstants.inventory);
-    audience = new ArrayList<Listener>();
+    AdventureResult[] items = ItemFinder.getMatchingItemList(parameters);
     for (AdventureResult item : items) {
       audience.add(new ItemListener(item));
     }

--- a/src/net/sourceforge/kolmafia/textui/command/ItemTraceCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ItemTraceCommand.java
@@ -10,7 +10,8 @@ import net.sourceforge.kolmafia.listener.Listener;
 import net.sourceforge.kolmafia.persistence.ItemFinder;
 
 public class ItemTraceCommand extends AbstractCommand {
-  private static final ArrayList<Listener> audience = new ArrayList<>(); // keeps listeners from being GC'd
+  private static final ArrayList<Listener> audience =
+      new ArrayList<>(); // keeps listeners from being GC'd
 
   public ItemTraceCommand() {
     this.usage = " <item> [, <item>]... - watch changes to inventory count of items";

--- a/src/net/sourceforge/kolmafia/textui/command/ItemTraceCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ItemTraceCommand.java
@@ -10,7 +10,7 @@ import net.sourceforge.kolmafia.listener.Listener;
 import net.sourceforge.kolmafia.persistence.ItemFinder;
 
 public class ItemTraceCommand extends AbstractCommand {
-  private static final ArrayList<Listener> audience =
+  private static final ArrayList<ItemListener> audience =
       new ArrayList<>(); // keeps listeners from being GC'd
 
   public ItemTraceCommand() {
@@ -20,6 +20,9 @@ public class ItemTraceCommand extends AbstractCommand {
   @Override
   public synchronized void run(String command, final String parameters) {
     if (audience.size() != 0) {
+      for (ItemListener listener : audience) {
+        listener.unregister();
+      }
       audience.clear();
       RequestLogger.printLine("Previously watched items have been cleared.");
     }
@@ -41,6 +44,10 @@ public class ItemTraceCommand extends AbstractCommand {
       this.item = item;
       ItemListenerRegistry.registerItemListener(item.getItemId(), this);
       this.update();
+    }
+
+    public void unregister() {
+      ItemListenerRegistry.unregisterItemListener(item.getItemId(), this);
     }
 
     @Override

--- a/src/net/sourceforge/kolmafia/textui/command/PrefTraceCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/PrefTraceCommand.java
@@ -8,7 +8,8 @@ import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
 import net.sourceforge.kolmafia.preferences.Preferences;
 
 public class PrefTraceCommand extends AbstractCommand {
-  private static ArrayList<Listener> audience = null; // keeps listeners from being GC'd
+  private static final ArrayList<PreferenceListener> audience =
+      new ArrayList<>(); // keeps listeners from being GC'd
 
   public PrefTraceCommand() {
     this.usage = " <name> [, <name>]... - watch changes to indicated preferences";
@@ -16,8 +17,11 @@ public class PrefTraceCommand extends AbstractCommand {
 
   @Override
   public synchronized void run(String command, final String parameters) {
-    if (audience != null) {
-      audience = null;
+    if (audience.size() != 0) {
+      for (PreferenceListener listener : audience) {
+        listener.unregister();
+      }
+      audience.clear();
       RequestLogger.printLine("Previously watched prefs have been cleared.");
     }
 
@@ -26,9 +30,8 @@ public class PrefTraceCommand extends AbstractCommand {
     }
 
     String[] prefList = parameters.split("\\s*,\\s*");
-    audience = new ArrayList<Listener>();
-    for (int i = 0; i < prefList.length; ++i) {
-      audience.add(new PreferenceListener(prefList[i]));
+    for (String pref : prefList) {
+      audience.add(new PreferenceListener(pref));
     }
   }
 
@@ -39,6 +42,10 @@ public class PrefTraceCommand extends AbstractCommand {
       this.name = name;
       PreferenceListenerRegistry.registerPreferenceListener(name, this);
       this.update();
+    }
+
+    public void unregister() {
+      PreferenceListenerRegistry.unregisterPreferenceListener(name, this);
     }
 
     @Override

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -20,6 +20,7 @@ import net.sourceforge.kolmafia.persistence.EffectDatabase;
 import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
 import net.sourceforge.kolmafia.persistence.HolidayDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
+import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.CampgroundRequest;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
@@ -222,6 +223,12 @@ public class Player {
   public static Cleanups addCampgroundItem(int id) {
     CampgroundRequest.setCampgroundItem(id, 1);
     return new Cleanups(() -> CampgroundRequest.removeCampgroundItem(ItemPool.get(id, 1)));
+  }
+
+  public static Cleanups setProperty(String key, String value) {
+    var oldValue = Preferences.getString(key);
+    Preferences.setString(key, value);
+    return new Cleanups(() -> Preferences.setString(key, oldValue));
   }
 
   public static Cleanups setupFakeResponse(int code, String response) {

--- a/test/internal/helpers/RequestLoggerOutput.java
+++ b/test/internal/helpers/RequestLoggerOutput.java
@@ -17,5 +17,4 @@ public class RequestLoggerOutput {
     RequestLogger.closeCustom();
     return baos.toString();
   }
-
 }

--- a/test/internal/helpers/RequestLoggerOutput.java
+++ b/test/internal/helpers/RequestLoggerOutput.java
@@ -1,0 +1,21 @@
+package internal.helpers;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import net.sourceforge.kolmafia.RequestLogger;
+
+public class RequestLoggerOutput {
+
+  private static ByteArrayOutputStream baos;
+
+  public static void startStream() {
+    baos = new ByteArrayOutputStream();
+    RequestLogger.openCustom(new PrintStream(baos));
+  }
+
+  public static String stopStream() {
+    RequestLogger.closeCustom();
+    return baos.toString();
+  }
+
+}

--- a/test/net/sourceforge/kolmafia/persistence/DebugDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/DebugDatabaseTest.java
@@ -2,6 +2,7 @@ package net.sourceforge.kolmafia.persistence;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import internal.helpers.RequestLoggerOutput;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
@@ -438,13 +439,12 @@ public class DebugDatabaseTest {
 
   @Test
   public void itShouldFindSVNDuplicatesSimple() {
-    var outputStream = new ByteArrayOutputStream();
-    RequestLogger.openCustom(new PrintStream(outputStream));
+    RequestLoggerOutput.startStream();
     File svnRoot = mockSimpleSystem();
     DebugDatabase.checkLocalSVNRepository(svnRoot);
     String expected = "Found 1 repo files." + LS;
-    assertEquals(expected, outputStream.toString(), "Output off");
-    RequestLogger.closeCustom();
+    String output = RequestLoggerOutput.stopStream();
+    assertEquals(expected, output, "Output off");
   }
 
   private File mockSimpleSystem() {
@@ -457,13 +457,12 @@ public class DebugDatabaseTest {
 
   @Test
   public void itShouldFindSVNDuplicatesMoreComplex() {
-    var outputStream = new ByteArrayOutputStream();
-    RequestLogger.openCustom(new PrintStream(outputStream));
+    RequestLoggerOutput.startStream();
     File svnRoot = mockMoreComplexSystem();
     DebugDatabase.checkLocalSVNRepository(svnRoot);
     String expected = "Found 3 repo files." + LS;
-    assertEquals(expected, outputStream.toString(), "Output off");
-    RequestLogger.closeCustom();
+    String output = RequestLoggerOutput.stopStream();
+    assertEquals(expected, output, "Output off");
   }
 
   private File mockMoreComplexSystem() {
@@ -488,14 +487,13 @@ public class DebugDatabaseTest {
 
   @Test
   public void itShouldFindSVNDuplicatesWhenThereAreSome() {
-    var outputStream = new ByteArrayOutputStream();
-    RequestLogger.openCustom(new PrintStream(outputStream));
+    RequestLoggerOutput.startStream();
     File svnRoot = mockDupes();
     DebugDatabase.checkLocalSVNRepository(svnRoot);
     String expected =
         "Found 2 repo files." + LS + "***" + LS + "test.ash" + LS + "test.ash" + LS + "***" + LS;
-    assertEquals(expected, outputStream.toString(), "Output off");
-    RequestLogger.closeCustom();
+    String output = RequestLoggerOutput.stopStream();
+    assertEquals(expected, output, "Output off");
   }
 
   private File mockDupes() {

--- a/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTestBase.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTestBase.java
@@ -2,11 +2,9 @@ package net.sourceforge.kolmafia.textui.command;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
+import internal.helpers.RequestLoggerOutput;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafiaCLI;
-import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.StaticEntity;
 
 public abstract class AbstractCommandTestBase {
@@ -17,14 +15,12 @@ public abstract class AbstractCommandTestBase {
   }
 
   public String execute(final String params, final boolean check) {
-    var outputStream = new ByteArrayOutputStream();
-    RequestLogger.openCustom(new PrintStream(outputStream));
+    RequestLoggerOutput.startStream();
     var cli = new KoLmafiaCLI(System.in);
     KoLmafiaCLI.isExecutingCheckOnlyCommand = check;
     cli.executeCommand(this.command, params);
     KoLmafiaCLI.isExecutingCheckOnlyCommand = false;
-    RequestLogger.closeCustom();
-    return outputStream.toString();
+    return RequestLoggerOutput.stopStream();
   }
 
   public static void assertState(final MafiaState state) {

--- a/test/net/sourceforge/kolmafia/textui/command/ItemTraceCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ItemTraceCommandTest.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.textui.command;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.StringContains.containsString;
 
 import internal.helpers.Cleanups;
@@ -32,5 +33,12 @@ public class ItemTraceCommandTest extends AbstractCommandTestBase {
     String output = execute("");
 
     assertThat(output, containsString("Previously watched items have been cleared"));
+
+    RequestLoggerOutput.startStream();
+    Cleanups cleanups = Player.addItem("hair spray");
+    try (cleanups) {
+      var text = RequestLoggerOutput.stopStream();
+      assertThat(text, not(containsString("itrace")));
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/command/ItemTraceCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ItemTraceCommandTest.java
@@ -37,5 +37,4 @@ public class ItemTraceCommandTest extends AbstractCommandTestBase {
 
     assertThat(output, containsString("Previously watched items have been cleared"));
   }
-
 }

--- a/test/net/sourceforge/kolmafia/textui/command/ItemTraceCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ItemTraceCommandTest.java
@@ -5,9 +5,7 @@ import static org.hamcrest.core.StringContains.containsString;
 
 import internal.helpers.Cleanups;
 import internal.helpers.Player;
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import net.sourceforge.kolmafia.RequestLogger;
+import internal.helpers.RequestLoggerOutput;
 import org.junit.jupiter.api.Test;
 
 public class ItemTraceCommandTest extends AbstractCommandTestBase {
@@ -20,12 +18,10 @@ public class ItemTraceCommandTest extends AbstractCommandTestBase {
   public void tracesItemsAddedToInventory() {
     execute("hair spray");
 
-    var outputStream = new ByteArrayOutputStream();
-    RequestLogger.openCustom(new PrintStream(outputStream));
+    RequestLoggerOutput.startStream();
     Cleanups cleanups = Player.addItem("hair spray");
     try (cleanups) {
-      RequestLogger.closeCustom();
-      var text = outputStream.toString();
+      var text = RequestLoggerOutput.stopStream();
       assertThat(text, containsString("itrace: hair spray = 1"));
     }
   }

--- a/test/net/sourceforge/kolmafia/textui/command/ItemTraceCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ItemTraceCommandTest.java
@@ -16,6 +16,21 @@ public class ItemTraceCommandTest extends AbstractCommandTestBase {
   }
 
   @Test
+  public void doesNotTraceFakeItems() {
+    execute("beefy nigiri");
+
+    RequestLoggerOutput.startStream();
+    Cleanups cleanups = Player.addItem("beefy nigiri");
+    try (cleanups) {
+      var text = RequestLoggerOutput.stopStream();
+      assertThat(text, not(containsString("itrace")));
+    }
+
+    String output = execute("");
+    assertThat(output, containsString("Previously watched items have been cleared"));
+  }
+
+  @Test
   public void tracesItemsAddedToInventory() {
     execute("hair spray");
 

--- a/test/net/sourceforge/kolmafia/textui/command/ItemTraceCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ItemTraceCommandTest.java
@@ -1,0 +1,41 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+
+import internal.helpers.Cleanups;
+import internal.helpers.Player;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import net.sourceforge.kolmafia.RequestLogger;
+import org.junit.jupiter.api.Test;
+
+public class ItemTraceCommandTest extends AbstractCommandTestBase {
+
+  public ItemTraceCommandTest() {
+    this.command = "itrace";
+  }
+
+  @Test
+  public void tracesItemsAddedToInventory() {
+    execute("hair spray");
+
+    var outputStream = new ByteArrayOutputStream();
+    RequestLogger.openCustom(new PrintStream(outputStream));
+    Cleanups cleanups = Player.addItem("hair spray");
+    try (cleanups) {
+      RequestLogger.closeCustom();
+      var text = outputStream.toString();
+      assertThat(text, containsString("itrace: hair spray = 1"));
+    }
+  }
+
+  @Test
+  public void clearsPreviousItems() {
+    execute("hair spray");
+    String output = execute("");
+
+    assertThat(output, containsString("Previously watched items have been cleared"));
+  }
+
+}

--- a/test/net/sourceforge/kolmafia/textui/command/PrefTraceCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/PrefTraceCommandTest.java
@@ -1,0 +1,53 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.StringContains.containsString;
+
+import internal.helpers.Cleanups;
+import internal.helpers.Player;
+import internal.helpers.RequestLoggerOutput;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PrefTraceCommandTest extends AbstractCommandTestBase {
+
+  public PrefTraceCommandTest() {
+    this.command = "ptrace";
+  }
+
+  @BeforeEach
+  public void setup() {
+    KoLCharacter.reset("ptrace");
+    Preferences.reset("ptrace");
+  }
+
+  @Test
+  public void tracesPreferencesChanged() {
+    execute("_VYKEACompanionType");
+
+    RequestLoggerOutput.startStream();
+    Cleanups cleanups = Player.setProperty("_VYKEACompanionType", "couch");
+    try (cleanups) {
+      var text = RequestLoggerOutput.stopStream();
+      assertThat(text, containsString("ptrace: _VYKEACompanionType = couch"));
+    }
+  }
+
+  @Test
+  public void clearsPreviousItems() {
+    execute("_VYKEACompanionType");
+    String output = execute("");
+
+    assertThat(output, containsString("Previously watched prefs have been cleared"));
+
+    RequestLoggerOutput.startStream();
+    Cleanups cleanups = Player.setProperty("_VYKEACompanionType", "couch");
+    try (cleanups) {
+      var text = RequestLoggerOutput.stopStream();
+      assertThat(text, not(containsString("ptrace")));
+    }
+  }
+}


### PR DESCRIPTION
I changed it so you can trace any item, not just those currently in your inventory.

Item Trace had some interesting behaviour: cancelling a previous trace didn't take effect until garbage collection ran. I fixed this too.