### PR TITLE
Add tests for recipe command, improve consistency between `recipe` and `ingredients`

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/command/RecipeCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/RecipeCommand.java
@@ -38,7 +38,7 @@ public class RecipeCommand extends AbstractCommand {
       String name = item.getName();
       String startNumber = "";
       if (concoctions.length > 1) {
-        startNumber =  (i + 1) + ". ";
+        startNumber = (i + 1) + ". ";
       }
 
       if (ConcoctionDatabase.getMixingMethod(itemId) == CraftingType.NOCREATE) {

--- a/src/net/sourceforge/kolmafia/textui/command/RecipeCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/RecipeCommand.java
@@ -26,7 +26,7 @@ public class RecipeCommand extends AbstractCommand {
       return;
     }
 
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
 
     for (int i = 0; i < concoctions.length; ++i) {
       AdventureResult item = ItemFinder.getFirstMatchingItem(concoctions[i]);
@@ -58,7 +58,7 @@ public class RecipeCommand extends AbstractCommand {
     }
   }
 
-  private static void getIngredients(final AdventureResult ar, final StringBuffer sb) {
+  private static void getIngredients(final AdventureResult ar, final StringBuilder sb) {
     sb.append("<b>");
     sb.append(ar.getInstance(ConcoctionDatabase.getYield(ar.getItemId())).toString());
     sb.append("</b>: ");
@@ -82,7 +82,7 @@ public class RecipeCommand extends AbstractCommand {
       first = false;
 
       if (missing < 1) {
-        sb.append(ingredient.toString());
+        sb.append(ingredient);
         continue;
       }
 
@@ -99,8 +99,7 @@ public class RecipeCommand extends AbstractCommand {
   private static List<AdventureResult> getFlattenedIngredients(
       AdventureResult ar, List<AdventureResult> list, boolean deep) {
     AdventureResult[] ingredients = ConcoctionDatabase.getIngredients(ar.getItemId());
-    for (int i = 0; i < ingredients.length; ++i) {
-      AdventureResult ingredient = ingredients[i];
+    for (AdventureResult ingredient : ingredients) {
       if (ConcoctionDatabase.getMixingMethod(ingredient.getItemId()) != CraftingType.NOCREATE) {
         int have = InventoryManager.getAccessibleCount(ingredient);
         if (!RecipeCommand.isRecursing(ar, ingredient) && (deep || have == 0)) {
@@ -125,8 +124,8 @@ public class RecipeCommand extends AbstractCommand {
     }
 
     AdventureResult[] ingredients = ConcoctionDatabase.getIngredients(child.getItemId());
-    for (int i = 0; i < ingredients.length; ++i) {
-      if (ingredients[i].equals(parent)) {
+    for (AdventureResult ingredient : ingredients) {
+      if (ingredient.equals(parent)) {
         return true;
       }
     }
@@ -134,12 +133,10 @@ public class RecipeCommand extends AbstractCommand {
     return false;
   }
 
-  private static void getRecipe(final AdventureResult ar, final StringBuffer sb, final int depth) {
+  private static void getRecipe(final AdventureResult ar, final StringBuilder sb, final int depth) {
     if (depth > 0) {
       sb.append("<br>");
-      for (int i = 0; i < depth; i++) {
-        sb.append("\u00a0\u00a0\u00a0");
-      }
+      sb.append("\u00a0\u00a0\u00a0".repeat(depth));
     }
 
     int itemId = ar.getItemId();
@@ -164,8 +161,7 @@ public class RecipeCommand extends AbstractCommand {
         sb.append(ingredient.toString());
       }
 
-      for (int i = 0; i < ingredients.length; ++i) {
-        AdventureResult ingredient = ingredients[i];
+      for (AdventureResult ingredient : ingredients) {
         if (RecipeCommand.isRecursing(ar, ingredient)) {
           continue;
         }

--- a/src/net/sourceforge/kolmafia/textui/command/RecipeCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/RecipeCommand.java
@@ -36,16 +36,19 @@ public class RecipeCommand extends AbstractCommand {
 
       int itemId = item.getItemId();
       String name = item.getName();
+      String startNumber = "";
+      if (concoctions.length > 1) {
+        startNumber =  (i + 1) + ". ";
+      }
 
       if (ConcoctionDatabase.getMixingMethod(itemId) == CraftingType.NOCREATE) {
-        RequestLogger.printLine("This item cannot be created: <b>" + name + "</b>");
+        RequestLogger.printLine(startNumber + "This item cannot be created: <b>" + name + "</b>");
         continue;
       }
 
       buffer.setLength(0);
       if (concoctions.length > 1) {
-        buffer.append((i + 1));
-        buffer.append(". ");
+        buffer.append(startNumber);
       }
 
       if (cmd.equals("ingredients")) {
@@ -148,7 +151,7 @@ public class RecipeCommand extends AbstractCommand {
     CraftingType mixingMethod = ConcoctionDatabase.getMixingMethod(itemId);
     EnumSet<CraftingRequirements> requirements = ConcoctionDatabase.getRequirements(itemId);
     if (mixingMethod != CraftingType.NOCREATE) {
-      sb.append("<b>:</b> <i>[");
+      sb.append(": <i>[");
       sb.append(ConcoctionDatabase.mixingMethodDescription(mixingMethod, requirements));
       sb.append("]</i> ");
 

--- a/test/net/sourceforge/kolmafia/textui/command/IngredientsCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/IngredientsCommandTest.java
@@ -1,0 +1,48 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static internal.helpers.Player.addItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import internal.helpers.Cleanups;
+import org.junit.jupiter.api.Test;
+
+public class IngredientsCommandTest extends AbstractCommandTestBase {
+
+  public IngredientsCommandTest() {
+    this.command = "ingredients";
+  }
+
+  @Test
+  public void simpleIngredientsCase() {
+    String output = execute("one-winged stab bat");
+
+    assertThat(output, containsString("<b>one-winged stab bat</b>: <i>bat wing (0/1)</i>, <i>batblade (0/1)</i>"));
+  }
+
+  @Test
+  public void presentIngredientsHaveNoItalics() {
+    var cleanups = new Cleanups(addItem("batblade"), addItem("bat wing"));
+    try (cleanups) {
+      String output = execute("one-winged stab bat");
+
+      assertThat(output, containsString("<b>one-winged stab bat</b>: bat wing, batblade"));
+    }
+  }
+
+  @Test
+  public void multipleRecursiveIngredients() {
+    String output = execute("stick of firewood, bundle of firewood");
+
+    assertThat(output, containsString("1. <b>stick of firewood (10)</b>: <i>bundle of firewood (0/1)</i>"));
+    assertThat(output, containsString("2. <b>bundle of firewood</b>: <i>stick of firewood (0/10)</i>"));
+  }
+
+  @Test
+  public void errorCaseIsNumbered() {
+    String output = execute("stick of firewood, wad of Crovacite");
+
+    assertThat(output, containsString("2. This item cannot be created: <b>wad of Crovacite</b>"));
+  }
+
+}

--- a/test/net/sourceforge/kolmafia/textui/command/IngredientsCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/IngredientsCommandTest.java
@@ -17,7 +17,9 @@ public class IngredientsCommandTest extends AbstractCommandTestBase {
   public void simpleIngredientsCase() {
     String output = execute("one-winged stab bat");
 
-    assertThat(output, containsString("<b>one-winged stab bat</b>: <i>bat wing (0/1)</i>, <i>batblade (0/1)</i>"));
+    assertThat(
+        output,
+        containsString("<b>one-winged stab bat</b>: <i>bat wing (0/1)</i>, <i>batblade (0/1)</i>"));
   }
 
   @Test
@@ -34,8 +36,11 @@ public class IngredientsCommandTest extends AbstractCommandTestBase {
   public void multipleRecursiveIngredients() {
     String output = execute("stick of firewood, bundle of firewood");
 
-    assertThat(output, containsString("1. <b>stick of firewood (10)</b>: <i>bundle of firewood (0/1)</i>"));
-    assertThat(output, containsString("2. <b>bundle of firewood</b>: <i>stick of firewood (0/10)</i>"));
+    assertThat(
+        output,
+        containsString("1. <b>stick of firewood (10)</b>: <i>bundle of firewood (0/1)</i>"));
+    assertThat(
+        output, containsString("2. <b>bundle of firewood</b>: <i>stick of firewood (0/10)</i>"));
   }
 
   @Test
@@ -44,5 +49,4 @@ public class IngredientsCommandTest extends AbstractCommandTestBase {
 
     assertThat(output, containsString("2. This item cannot be created: <b>wad of Crovacite</b>"));
   }
-
 }

--- a/test/net/sourceforge/kolmafia/textui/command/RecipeCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/RecipeCommandTest.java
@@ -1,0 +1,63 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+public class RecipeCommandTest extends AbstractCommandTestBase {
+
+  public RecipeCommandTest() {
+    this.command = "recipe";
+  }
+
+  @Test
+  public void errorsIfNoItems() {
+    String output = execute("");
+
+    assertThat(output, containsString("Need to provide an item to match"));
+  }
+
+  @Test
+  public void errorsIfCannotBeCreated() {
+    String output = execute("wad of Crovacite");
+
+    assertThat(output, containsString("This item cannot be created: <b>wad of Crovacite</b>"));
+  }
+
+  @Test
+  public void ignoresInvalidItems() {
+    String output = execute("foobar, plain pizza");
+
+    assertThat(output, containsString("2. <b>plain pizza</b>"));
+  }
+
+  @Test
+  public void simpleRecipe() {
+    String output = execute("one-winged stab bat");
+
+    assertThat(output, containsString("<b>one-winged stab bat</b>: <i>[Meatpasting]</i> batblade + bat wing"));
+  }
+
+  @Test
+  public void pizzaRecipe() {
+    String output = execute("plain pizza");
+
+    assertThat(output, containsString("<b>plain pizza</b>: <i>[Cooking]</i> wad of dough + tomato<br>\u00a0\u00a0\u00a0<b>wad of dough</b>: <i>[rolling pin/unrolling pin]</i> flat dough<br>\u00a0\u00a0\u00a0<b>tomato</b>"));
+  }
+
+  @Test
+  public void multipleRecursiveRecipes() {
+    String output = execute("stick of firewood, bundle of firewood");
+
+    assertThat(output, containsString("1. <b>stick of firewood (10)</b>: <i>[single-use]</i> bundle of firewood"));
+    assertThat(output, containsString("2. <b>bundle of firewood</b>: <i>[Coin Master purchase]</i> stick of firewood (10)"));
+  }
+
+  @Test
+  public void errorCaseIsNumbered() {
+    String output = execute("stick of firewood, wad of Crovacite");
+
+    assertThat(output, containsString("2. This item cannot be created: <b>wad of Crovacite</b>"));
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/command/RecipeCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/RecipeCommandTest.java
@@ -36,22 +36,32 @@ public class RecipeCommandTest extends AbstractCommandTestBase {
   public void simpleRecipe() {
     String output = execute("one-winged stab bat");
 
-    assertThat(output, containsString("<b>one-winged stab bat</b>: <i>[Meatpasting]</i> batblade + bat wing"));
+    assertThat(
+        output,
+        containsString("<b>one-winged stab bat</b>: <i>[Meatpasting]</i> batblade + bat wing"));
   }
 
   @Test
   public void pizzaRecipe() {
     String output = execute("plain pizza");
 
-    assertThat(output, containsString("<b>plain pizza</b>: <i>[Cooking]</i> wad of dough + tomato<br>\u00a0\u00a0\u00a0<b>wad of dough</b>: <i>[rolling pin/unrolling pin]</i> flat dough<br>\u00a0\u00a0\u00a0<b>tomato</b>"));
+    assertThat(
+        output,
+        containsString(
+            "<b>plain pizza</b>: <i>[Cooking]</i> wad of dough + tomato<br>\u00a0\u00a0\u00a0<b>wad of dough</b>: <i>[rolling pin/unrolling pin]</i> flat dough<br>\u00a0\u00a0\u00a0<b>tomato</b>"));
   }
 
   @Test
   public void multipleRecursiveRecipes() {
     String output = execute("stick of firewood, bundle of firewood");
 
-    assertThat(output, containsString("1. <b>stick of firewood (10)</b>: <i>[single-use]</i> bundle of firewood"));
-    assertThat(output, containsString("2. <b>bundle of firewood</b>: <i>[Coin Master purchase]</i> stick of firewood (10)"));
+    assertThat(
+        output,
+        containsString("1. <b>stick of firewood (10)</b>: <i>[single-use]</i> bundle of firewood"));
+    assertThat(
+        output,
+        containsString(
+            "2. <b>bundle of firewood</b>: <i>[Coin Master purchase]</i> stick of firewood (10)"));
   }
 
   @Test


### PR DESCRIPTION
Consistently don't bold the colon, and add a number to the start of the list even in the "uncreatable" condition.