### PR TITLE
tests: clear traces after tests

### DIFF
--- a/test/net/sourceforge/kolmafia/textui/command/ItemTraceCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ItemTraceCommandTest.java
@@ -7,12 +7,18 @@ import static org.hamcrest.core.StringContains.containsString;
 import internal.helpers.Cleanups;
 import internal.helpers.Player;
 import internal.helpers.RequestLoggerOutput;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class ItemTraceCommandTest extends AbstractCommandTestBase {
 
   public ItemTraceCommandTest() {
     this.command = "itrace";
+  }
+
+  @AfterEach
+  public void tearDown() {
+    execute("");
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/textui/command/PrefTraceCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/PrefTraceCommandTest.java
@@ -9,6 +9,7 @@ import internal.helpers.Player;
 import internal.helpers.RequestLoggerOutput;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -22,6 +23,11 @@ public class PrefTraceCommandTest extends AbstractCommandTestBase {
   public void setup() {
     KoLCharacter.reset("ptrace");
     Preferences.reset("ptrace");
+  }
+
+  @AfterEach
+  public void tearDown() {
+    execute("");
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #735 based on comments.

`AfterEach` instead of `BeforeEach` as we want to clear the trace from the final test.