### PR TITLE
AutoFilterTextField case sensitivity

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/widget/AutoFilterTextField.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/AutoFilterTextField.java
@@ -174,7 +174,7 @@ public class AutoFilterTextField<E> extends AutoHighlightTextField
       return ((Script) element).getScriptName().toLowerCase();
     }
 
-    return element.toString();
+    return element.toString().toLowerCase();
   }
 
   public static final int getResultPrice(final Object element) {

--- a/test/net/sourceforge/kolmafia/swingui/widget/AutoFilterTextFieldTest.java
+++ b/test/net/sourceforge/kolmafia/swingui/widget/AutoFilterTextFieldTest.java
@@ -1,0 +1,18 @@
+package net.sourceforge.kolmafia.swingui.widget;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.java.dev.spellcast.utilities.LockableListModel;
+import org.junit.jupiter.api.Test;
+
+public class AutoFilterTextFieldTest {
+  @Test
+  public void upperCaseStringIsVisible() {
+    AutoFilterTextField<String> autoFilterTextField =
+        new AutoFilterTextField<>(new LockableListModel<>());
+
+    autoFilterTextField.setText("a");
+
+    assertTrue(autoFilterTextField.isVisible("ALPHA"));
+  }
+}


### PR DESCRIPTION
I was trying out something with InputFieldUtilities and a bunch of strings and noticed weird behavior in AutoFilterTextField, where it was skipping over any upper case letters in the match. I'm pretty sure this was an accident back when it was written, but I admit to not knowing whether anything relies on this odd case-sensitive behavior now.