### PR TITLE
fix: when getting bytes, always specify an encoding

### DIFF
--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,7 +38,8 @@ public class Preferences {
 
   private static final Object lock = new Object(); // used to synch io
 
-  private static final byte[] LINE_BREAK_AS_BYTES = KoLConstants.LINE_BREAK.getBytes();
+  private static final byte[] LINE_BREAK_AS_BYTES =
+      KoLConstants.LINE_BREAK.getBytes(StandardCharsets.UTF_8);
 
   private static final String[] characterMap = new String[65536];
 
@@ -1069,7 +1071,7 @@ public class Preferences {
         for (Entry<String, Object> current : data.entrySet()) {
           ostream.write(
               Preferences.encodeProperty(current.getKey(), current.getValue().toString())
-                  .getBytes());
+                  .getBytes(StandardCharsets.UTF_8));
           ostream.write(LINE_BREAK_AS_BYTES);
         }
       } catch (IOException e) {

--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -1436,7 +1436,7 @@ public class GenericRequest implements Runnable {
     if (!this.data.isEmpty()) {
       if (this.dataChanged) {
         this.dataChanged = false;
-        this.dataString = this.getDataString().getBytes();
+        this.dataString = this.getDataString().getBytes(StandardCharsets.UTF_8);
       }
 
       requestBuilder.header("Content-Type", "application/x-www-form-urlencoded");

--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -1924,8 +1924,8 @@ public class Parser {
       final String line = this.restOfLine();
 
       try {
-        ostream.write(line.getBytes());
-        ostream.write(KoLConstants.LINE_BREAK.getBytes());
+        ostream.write(line.getBytes(StandardCharsets.UTF_8));
+        ostream.write(KoLConstants.LINE_BREAK.getBytes(StandardCharsets.UTF_8));
       } catch (Exception e) {
         // Byte array output streams do not throw errors,
         // other than out of memory errors.

--- a/src/net/sourceforge/kolmafia/textui/command/AshMultiLineCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AshMultiLineCommand.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import java.nio.charset.StandardCharsets;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
@@ -20,8 +21,8 @@ public class AshMultiLineCommand extends AbstractCommand {
 
     while (currentLine != null && !currentLine.equals("</inline-ash-script>")) {
       try {
-        ostream.write(currentLine.getBytes());
-        ostream.write(KoLConstants.LINE_BREAK.getBytes());
+        ostream.write(currentLine.getBytes(StandardCharsets.UTF_8));
+        ostream.write(KoLConstants.LINE_BREAK.getBytes(StandardCharsets.UTF_8));
       } catch (Exception e) {
         // Byte array output streams do not throw errors,
         // other than out of memory errors.

--- a/src/net/sourceforge/kolmafia/textui/command/AshSingleLineCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AshSingleLineCommand.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.textui.command;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.KoLmafiaCLI;
@@ -22,7 +23,8 @@ public class AshSingleLineCommand extends AbstractCommand {
     }
 
     ByteArrayInputStream istream =
-        new ByteArrayInputStream((parameters + KoLConstants.LINE_BREAK).getBytes());
+        new ByteArrayInputStream(
+            (parameters + KoLConstants.LINE_BREAK).getBytes(StandardCharsets.UTF_8));
 
     AshRuntime interpreter = new AshRuntime();
     interpreter.validate(null, istream);

--- a/src/net/sourceforge/kolmafia/textui/langserver/Script.java
+++ b/src/net/sourceforge/kolmafia/textui/langserver/Script.java
@@ -3,6 +3,7 @@ package net.sourceforge.kolmafia.textui.langserver;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -59,7 +60,7 @@ public final class Script {
       return null;
     }
 
-    return new ByteArrayInputStream(this.text.getBytes());
+    return new ByteArrayInputStream(this.text.getBytes(StandardCharsets.UTF_8));
   }
 
   /**

--- a/src/net/sourceforge/kolmafia/utilities/FileUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/FileUtilities.java
@@ -250,7 +250,7 @@ public class FileUtilities {
         byte[] bytes = ByteBufferUtilities.read(istream);
         String text = new String(bytes);
         text = StringUtilities.globalStringReplace(text, "location.hostname", "location.host");
-        ostream.write(text.getBytes());
+        ostream.write(text.getBytes(StandardCharsets.UTF_8));
       } else if (remote.endsWith(".gif")) {
         byte[] bytes = ByteBufferUtilities.read(istream);
         String signature = new String(bytes, 0, 3);


### PR DESCRIPTION
Inspired by https://kolmafia.us/threads/java-bug-on-some-versions-of-java-weird-things-happen-to-strings-with-special-characters.27531/#post-167950

Fixes 
```
string x = "™"; print(x)
```
printing � (unicode replacement character) on Windows.