### PR TITLE
If the client isn't static, neither should the AtomicInteger be

### DIFF
--- a/src/net/sourceforge/kolmafia/utilities/ResettingHttpClient.java
+++ b/src/net/sourceforge/kolmafia/utilities/ResettingHttpClient.java
@@ -9,7 +9,7 @@ import java.util.function.Supplier;
 
 public class ResettingHttpClient {
 
-  private static final AtomicInteger clientRequestsSent = new AtomicInteger();
+  private final AtomicInteger clientRequestsSent = new AtomicInteger();
   /**
    * At 10k client requests, the server will send a GOAWAY exception. We recreate the HttpClient
    * before that to avoid the problem.


### PR DESCRIPTION
If the client isn't static, neither should the AtomicInteger be.

Received a GOAWAY just earlier.

It could be the case that this entire fix doesn't actually work. But it can easily be that the wrong client was reset.

And yes, it was on an up to date build.

I think actually testing this would mean spamming KOL ten thousand times, which for obvious reasons isn't really something I'd want to do.