### PR TITLE
only give error if trying to reminisce more then three times if yoare actually trying to fight a monster

### DIFF
--- a/src/net/sourceforge/kolmafia/request/LocketRequest.java
+++ b/src/net/sourceforge/kolmafia/request/LocketRequest.java
@@ -43,7 +43,14 @@ public class LocketRequest extends GenericRequest {
     }
 
     if (LocketManager.getFoughtMonsters().size() >= 3) {
-      KoLmafia.updateDisplay(KoLConstants.MafiaState.ERROR, "You can only reminisce thrice daily.");
+      // You can't even look at your locket if you've reminisced three times.
+      //
+      // So, don't try - but only generate an error if you are trying to
+      // actually get another monster.
+      if (monster != null) {
+        KoLmafia.updateDisplay(
+            KoLConstants.MafiaState.ERROR, "You can only reminisce thrice daily.");
+      }
       return;
     }
 


### PR DESCRIPTION
As opposed to refreshing session, say. You still can't look at your locket, but it need not abort.

Tested by reminiscing three times and asking for another monster (generating an error) and refreshing session (not generating an error).