### PR TITLE
remove base mixers from _roboDrops pref

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -4163,12 +4163,7 @@ public class FightRequest extends GenericRequest {
                 "Freshen Your Drink, Sir or Madam",
                 "Have One For The Road",
                 "I Hope I Am Not Enabling Any Addictions You Might Have",
-                "It's Always Happy Hour Somewhere",
-                "practices a complex cocktail juggling move",
-                "gives you a thumbs-up with a special thumb attachment",
-                "Have One On The House",
-                "Please Enjoy A Complimentary Snack",
-                "How About This Weather We're Having, Eh"
+                "It's Always Happy Hour Somewhere"
               };
 
           for (String s : roboDropMessages) {


### PR DESCRIPTION
In trying to spade the decay rate, we noticed the data didn't make any sense. It was confirmed by a dev (cannonfire40) that the base mixers operate on a completely separate roll, and should not count as a drop for the purposes of this. I have removed those familiar messages accordingly.