### PR TITLE
Chat highlighting improvements

### DIFF
--- a/src/net/sourceforge/kolmafia/chat/ChatFormatter.java
+++ b/src/net/sourceforge/kolmafia/chat/ChatFormatter.java
@@ -1,7 +1,10 @@
 package net.sourceforge.kolmafia.chat;
 
 import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
@@ -325,11 +328,19 @@ public class ChatFormatter {
         InputFieldUtilities.input(
             "What word/phrase would you like to highlight?", KoLCharacter.getUserName());
 
+    addHighlighting(highlight);
+  }
+
+  public static final void addHighlighting(String highlight) {
+    addHighlighting(highlight, ChatFormatter.getRandomColor());
+  }
+
+  public static final void addHighlighting(String highlight, Color color) {
     if (highlight == null || highlight.length() == 0) {
       return;
     }
 
-    Color color = ChatFormatter.getRandomColor();
+    removeHightlighting(highlight);
 
     String newSetting =
         Preferences.getString("highlightList")
@@ -359,30 +370,40 @@ public class ChatFormatter {
       return;
     }
 
+    removeHightlighting(selectedValue);
+  }
+
+  public static Collection<String> getHighlights() {
+    String[] split = Preferences.getString("highlightList").split("\n");
+    List<String> highlights = new ArrayList<>();
+
+    for (int i = 0; i < split.length; i += 2) {
+      highlights.add(split[i] + "\n" + split[i + 1]);
+    }
+
+    return highlights;
+  }
+
+  public static void removeHightlighting(String selectedValue) {
+    selectedValue = selectedValue.toLowerCase();
+
+    String[] patterns = StyledChatBuffer.searchStrings.toArray(new String[0]);
+
     for (int i = 0; i < patterns.length; ++i) {
-      if (patterns[i].equals(selectedValue)) {
-        String settingString = StyledChatBuffer.removeHighlight(i);
-
-        String oldSetting = Preferences.getString("highlightList");
-        int startIndex = oldSetting.indexOf(settingString);
-        int endIndex = startIndex + settingString.length();
-
-        StringBuffer newSetting = new StringBuffer();
-
-        if (startIndex != -1) {
-          newSetting.append(oldSetting, 0, startIndex);
-
-          if (endIndex < oldSetting.length()) {
-            newSetting.append(oldSetting.substring(endIndex));
-          }
-        }
-
-        String cleanString = newSetting.toString();
-        cleanString = ChatFormatter.MULTILINE_PATTERN.matcher(cleanString).replaceAll("\n");
-        cleanString = cleanString.trim();
-
-        Preferences.setString("highlightList", cleanString);
+      if (!patterns[i].equals(selectedValue)) {
+        continue;
       }
+
+      Collection<String> highlights = getHighlights();
+      String settingString = StyledChatBuffer.removeHighlight(i);
+
+      highlights.remove(settingString);
+
+      String cleanString = String.join("\n", highlights);
+      cleanString = ChatFormatter.MULTILINE_PATTERN.matcher(cleanString).replaceAll("\n");
+      cleanString = cleanString.trim();
+
+      Preferences.setString("highlightList", cleanString);
     }
   }
 }

--- a/src/net/sourceforge/kolmafia/chat/ChatFormatter.java
+++ b/src/net/sourceforge/kolmafia/chat/ChatFormatter.java
@@ -340,7 +340,7 @@ public class ChatFormatter {
       return;
     }
 
-    removeHightlighting(highlight);
+    removeHighlighting(highlight);
 
     String newSetting =
         Preferences.getString("highlightList")
@@ -370,7 +370,7 @@ public class ChatFormatter {
       return;
     }
 
-    removeHightlighting(selectedValue);
+    removeHighlighting(selectedValue);
   }
 
   public static Collection<String> getHighlights() {
@@ -384,7 +384,7 @@ public class ChatFormatter {
     return highlights;
   }
 
-  public static void removeHightlighting(String selectedValue) {
+  public static void removeHighlighting(String selectedValue) {
     selectedValue = selectedValue.toLowerCase();
 
     String[] patterns = StyledChatBuffer.searchStrings.toArray(new String[0]);

--- a/src/net/sourceforge/kolmafia/chat/StyledChatBuffer.java
+++ b/src/net/sourceforge/kolmafia/chat/StyledChatBuffer.java
@@ -23,13 +23,16 @@ public class StyledChatBuffer extends ChatBuffer {
   }
 
   public static final boolean initializeHighlights() {
+    StyledChatBuffer.highlightCount = 0;
+    StyledChatBuffer.searchStrings.clear();
+    StyledChatBuffer.colorStrings.clear();
+
     String highlights = Preferences.getString("highlightList").trim();
 
     if (highlights.length() == 0) {
       return false;
     }
 
-    StyledChatBuffer.highlightCount = 0;
     String[] highlightList = highlights.split("\n+");
 
     for (int i = 0; i < highlightList.length; ++i) {

--- a/test/net/sourceforge/kolmafia/chat/ChatFormatterTest.java
+++ b/test/net/sourceforge/kolmafia/chat/ChatFormatterTest.java
@@ -54,7 +54,7 @@ public class ChatFormatterTest {
     // A message added on, to prove that it doesn't wipe out following highlights
     ChatFormatter.addHighlighting("another test", color);
 
-    ChatFormatter.removeHightlighting("test");
+    ChatFormatter.removeHighlighting("test");
     String expected =
         "test case\n#000000\na test\n#000000\na test with a long message\n#000000\nanother test\n#000000";
 

--- a/test/net/sourceforge/kolmafia/chat/ChatFormatterTest.java
+++ b/test/net/sourceforge/kolmafia/chat/ChatFormatterTest.java
@@ -18,15 +18,15 @@ public class ChatFormatterTest {
   public void addHightlightTest() {
     Color color = Color.BLACK;
 
-    ChatFormatter.addHighlighting("john of arc", color);
-    ChatFormatter.addHighlighting("prince john", color);
-    ChatFormatter.addHighlighting("john", color);
-    ChatFormatter.addHighlighting("prince john and the three stooges", color);
-    ChatFormatter.addHighlighting("john", color);
-    ChatFormatter.addHighlighting("king john", color);
+    ChatFormatter.addHighlighting("test case", color);
+    ChatFormatter.addHighlighting("a test", color);
+    ChatFormatter.addHighlighting("test", color);
+    ChatFormatter.addHighlighting("a test with a long message", color);
+    ChatFormatter.addHighlighting("test", color);
+    ChatFormatter.addHighlighting("the test", color);
 
     String expected =
-        "john of arc\n#000000\nprince john\n#000000\nprince john and the three stooges\n#000000\njohn\n#000000\nking john\n#000000";
+        "test case\n#000000\na test\n#000000\na test with a long message\n#000000\ntest\n#000000\nthe test\n#000000";
 
     assertEquals(expected, Preferences.getString("highlightList"));
   }
@@ -35,14 +35,14 @@ public class ChatFormatterTest {
   public void removeHighlightTest() {
     Color color = Color.BLACK;
 
-    ChatFormatter.addHighlighting("john of arc", color);
-    ChatFormatter.addHighlighting("prince john", color);
-    ChatFormatter.addHighlighting("prince john and the three stooges", color);
-    ChatFormatter.addHighlighting("john", color);
-    ChatFormatter.addHighlighting("king john", color);
+    ChatFormatter.addHighlighting("test case", color);
+    ChatFormatter.addHighlighting("a test", color);
+    ChatFormatter.addHighlighting("a test with a long message", color);
+    ChatFormatter.addHighlighting("test", color);
+    ChatFormatter.addHighlighting("another test", color);
 
-    ChatFormatter.removeHightlighting("john");
-    String expected = "john of arc\n#000000\nprince john\n#000000\nprince john and the three stooges\n#000000\nking john\n#000000";
+    ChatFormatter.removeHightlighting("test");
+    String expected = "test case\n#000000\na test\n#000000\na test with a long message\n#000000\nanother test\n#000000";
 
     assertEquals(expected, Preferences.getString("highlightList"));
   }

--- a/test/net/sourceforge/kolmafia/chat/ChatFormatterTest.java
+++ b/test/net/sourceforge/kolmafia/chat/ChatFormatterTest.java
@@ -1,0 +1,44 @@
+package net.sourceforge.kolmafia.chat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.awt.Color;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ChatFormatterTest {
+  @BeforeEach
+  public void resetHighlights() {
+    Preferences.setString("highlightList", "");
+    StyledChatBuffer.initializeHighlights();
+  }
+
+  @Test
+  public void addHightlightTest() {
+    Color color = Color.BLACK;
+
+    ChatFormatter.addHighlighting("john of arc", color);
+    ChatFormatter.addHighlighting("john", color);
+    ChatFormatter.addHighlighting("prince john and the three stooges", color);
+
+    String expected =
+        "john of arc\n#000000\njohn\n#000000\nprince john and the three stooges\n#000000";
+
+    assertEquals(expected, Preferences.getString("highlightList"));
+  }
+
+  @Test
+  public void removeHighlightTest() {
+    Color color = Color.BLACK;
+
+    ChatFormatter.addHighlighting("john of arc", color);
+    ChatFormatter.addHighlighting("john", color);
+    ChatFormatter.addHighlighting("prince john and the three stooges", color);
+
+    ChatFormatter.removeHightlighting("john");
+    String expected = "john of arc\n#000000\nprince john and the three stooges\n#000000";
+
+    assertEquals(expected, Preferences.getString("highlightList"));
+  }
+}

--- a/test/net/sourceforge/kolmafia/chat/ChatFormatterTest.java
+++ b/test/net/sourceforge/kolmafia/chat/ChatFormatterTest.java
@@ -19,11 +19,14 @@ public class ChatFormatterTest {
     Color color = Color.BLACK;
 
     ChatFormatter.addHighlighting("john of arc", color);
+    ChatFormatter.addHighlighting("prince john", color);
     ChatFormatter.addHighlighting("john", color);
     ChatFormatter.addHighlighting("prince john and the three stooges", color);
+    ChatFormatter.addHighlighting("john", color);
+    ChatFormatter.addHighlighting("king john", color);
 
     String expected =
-        "john of arc\n#000000\njohn\n#000000\nprince john and the three stooges\n#000000";
+        "john of arc\n#000000\nprince john\n#000000\nprince john and the three stooges\n#000000\njohn\n#000000\nking john\n#000000";
 
     assertEquals(expected, Preferences.getString("highlightList"));
   }
@@ -33,11 +36,13 @@ public class ChatFormatterTest {
     Color color = Color.BLACK;
 
     ChatFormatter.addHighlighting("john of arc", color);
-    ChatFormatter.addHighlighting("john", color);
+    ChatFormatter.addHighlighting("prince john", color);
     ChatFormatter.addHighlighting("prince john and the three stooges", color);
+    ChatFormatter.addHighlighting("john", color);
+    ChatFormatter.addHighlighting("king john", color);
 
     ChatFormatter.removeHightlighting("john");
-    String expected = "john of arc\n#000000\nprince john and the three stooges\n#000000";
+    String expected = "john of arc\n#000000\nprince john\n#000000\nprince john and the three stooges\n#000000\nking john\n#000000";
 
     assertEquals(expected, Preferences.getString("highlightList"));
   }

--- a/test/net/sourceforge/kolmafia/chat/ChatFormatterTest.java
+++ b/test/net/sourceforge/kolmafia/chat/ChatFormatterTest.java
@@ -16,17 +16,24 @@ public class ChatFormatterTest {
 
   @Test
   public void addHightlightTest() {
-    Color color = Color.BLACK;
+    Color black = Color.BLACK;
+    Color white = Color.WHITE;
 
-    ChatFormatter.addHighlighting("test case", color);
-    ChatFormatter.addHighlighting("a test", color);
-    ChatFormatter.addHighlighting("test", color);
-    ChatFormatter.addHighlighting("a test with a long message", color);
-    ChatFormatter.addHighlighting("test", color);
-    ChatFormatter.addHighlighting("the test", color);
+    // Here we're testing if the messages are added correctly
+    ChatFormatter.addHighlighting("test case", black);
+    // The first highlight, this is intended to be overwritten
+    ChatFormatter.addHighlighting("a test", black);
+    // The second highlight, this is also intended to be overwritten
+    ChatFormatter.addHighlighting("test", black);
+    ChatFormatter.addHighlighting("a test with a long message", black);
+    // This should remove the second highlight and replace it
+    ChatFormatter.addHighlighting("a test", black);
+    // This should remove the first highlight and replace it with white
+    ChatFormatter.addHighlighting("test", white);
+    ChatFormatter.addHighlighting("the test", black);
 
     String expected =
-        "test case\n#000000\na test\n#000000\na test with a long message\n#000000\ntest\n#000000\nthe test\n#000000";
+        "test case\n#000000\na test with a long message\n#000000\na test\n#000000\ntest\n#ffffff\nthe test\n#000000";
 
     assertEquals(expected, Preferences.getString("highlightList"));
   }
@@ -35,14 +42,21 @@ public class ChatFormatterTest {
   public void removeHighlightTest() {
     Color color = Color.BLACK;
 
+    // Here we're checking if the highlight is removed from the preferences correctly
+    // The first message starts with the name of the highlight
     ChatFormatter.addHighlighting("test case", color);
+    // This ends with the name of the highlight
     ChatFormatter.addHighlighting("a test", color);
+    // This simply contains the highlight message
     ChatFormatter.addHighlighting("a test with a long message", color);
+    // This is the highlight we intend to remove
     ChatFormatter.addHighlighting("test", color);
+    // A message added on, to prove that it doesn't wipe out following highlights
     ChatFormatter.addHighlighting("another test", color);
 
     ChatFormatter.removeHightlighting("test");
-    String expected = "test case\n#000000\na test\n#000000\na test with a long message\n#000000\nanother test\n#000000";
+    String expected =
+        "test case\n#000000\na test\n#000000\na test with a long message\n#000000\nanother test\n#000000";
 
     assertEquals(expected, Preferences.getString("highlightList"));
   }


### PR DESCRIPTION
Highlighting could be loaded multiple times, yet would not be unloaded.
This is generally a non-issue until you remove a chat highlight after reopening mafia's chat relay.

It was also possible to highlight the same string multiple times, the old string is now removed.

Previously, it was possible that highlights that are similar could be removed.

The code was confusing to read, and has been cleaned up a little.