### PR TITLE
keep limeglass icon if not windows. Fix a comment

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -395,15 +395,17 @@ public abstract class KoLmafia {
       SystemTrayFrame.addTrayIcon();
     }
 
+    boolean isWindows = System.getProperty("os.name").startsWith("Win");
+
     if (Taskbar.isTaskbarSupported()) {
       Taskbar taskbar = Taskbar.getTaskbar();
       if (taskbar.isSupported(Taskbar.Feature.ICON_IMAGE)) {
-        taskbar.setIconImage(JComponentUtilities.getImage("app_icon256.png").getImage());
+        String image = isWindows ? "app_icon256.png" : "limeglass.gif";
+        taskbar.setIconImage(JComponentUtilities.getImage(image).getImage());
       }
     }
 
-    if (System.getProperty("os.name").startsWith("Win")
-        || lookAndFeel.equals(UIManager.getCrossPlatformLookAndFeelClassName())) {
+    if (isWindows || lookAndFeel.equals(UIManager.getCrossPlatformLookAndFeelClassName())) {
       UIManager.put("ProgressBar.foreground", Color.black);
       UIManager.put("ProgressBar.selectionForeground", Color.lightGray);
 

--- a/src/net/sourceforge/kolmafia/session/BastilleBattalionManager.java
+++ b/src/net/sourceforge/kolmafia/session/BastilleBattalionManager.java
@@ -1503,8 +1503,8 @@ public abstract class BastilleBattalionManager {
   // {
   //     int round;             // I don't think this affects yield, but...
   //     string name;           // Name of the cheese-granting encounter
-  //     int stat_name;         // Each encounter is affected by a stat
-  //     int stat_value;        // Each encounter is affected by a stat
+  //     string stat_name;      // Name of relevant stat
+  //     int stat_value;        // Value of relevant stat
   //     boolean potion;        // true if appropriate potion in effect
   //     int cheese;            // How much cheese you looted
   // };


### PR DESCRIPTION
A recent PR "Enabled icon images for Windows".

Unfortunately, it changed the Dock icon image on Macs from the friendly and familiar limeglass to a black & white sword and martini guy.

This PR uses the new icon only for Windows, as the other PR seems to intend.

I also fixed a comment in another file.