### PR TITLE
Fix Daily Malware usage not detected

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -10045,7 +10045,7 @@ public class FightRequest extends GenericRequest {
         break;
 
       case ItemPool.DAILY_DUNGEON_MALWARE:
-        if (responseText.contains("It's a UNIX System")
+        if (responseText.contains("It's a UNIX system")
             || responseText.contains("You attempt to hack the monster")) {
           Preferences.setBoolean("_dailyDungeonMalwareUsed", true);
         }


### PR DESCRIPTION
Usage is with a lowercase "system" as shown here: https://kol.coldfront.net/thekolwiki/index.php/Daily_dungeon_malware
