### PR TITLE
feat: blank content types to avoid a Rhino problem

### DIFF
--- a/src/data/content-types.properties
+++ b/src/data/content-types.properties
@@ -1,0 +1,1 @@
+# Don't recognise any content types

--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -13,6 +13,7 @@ import java.io.RandomAccessFile;
 import java.math.BigInteger;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -111,6 +112,7 @@ import net.sourceforge.kolmafia.swingui.SystemTrayFrame;
 import net.sourceforge.kolmafia.swingui.listener.LicenseDisplayListener;
 import net.sourceforge.kolmafia.swingui.panel.GenericPanel;
 import net.sourceforge.kolmafia.textui.AshRuntime;
+import net.sourceforge.kolmafia.utilities.FileUtilities;
 import net.sourceforge.kolmafia.utilities.LockableListFactory;
 import net.sourceforge.kolmafia.utilities.LogStream;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
@@ -130,11 +132,23 @@ public abstract class KoLmafia {
     System.setProperty("com.apple.mrj.application.live-resize", "true");
     System.setProperty("com.apple.mrj.application.growbox.intrudes", "false");
     System.setProperty("java.net.preferIPv4Stack", "true");
+    // override content types to avoid a Rhino problem
+    // see https://github.com/mozilla/rhino/issues/1232
+    ensureContentTypes();
 
     if (SwinglessUIUtils.isSwingAvailable()) {
       JEditorPane.registerEditorKitForContentType("text/html", RequestEditorKit.class.getName());
     }
     System.setProperty("apple.laf.useScreenMenuBar", "true");
+  }
+
+  private static void ensureContentTypes() {
+    var contentTypesFile = KoLConstants.DATA_LOCATION.toPath().resolve("content-types.properties");
+    if (!Files.exists(contentTypesFile)) {
+      FileUtilities.loadLibrary(
+          KoLConstants.DATA_LOCATION, KoLConstants.DATA_DIRECTORY, "content-types.properties");
+    }
+    System.setProperty("content.types.user.table", contentTypesFile.toString());
   }
 
   public static String currentIterationString = "";

--- a/test/root/expected/content-type-encoding.js.out
+++ b/test/root/expected/content-type-encoding.js.out
@@ -1,0 +1,1 @@
+Our Daily Candles&trade; order form

--- a/test/root/scripts/content-type-encoding.js
+++ b/test/root/scripts/content-type-encoding.js
@@ -1,0 +1,1 @@
+module.exports.main = function() { var k = require("kolmafia"); k.print(k.Item.get("Our Daily Candles™ order form")) }


### PR DESCRIPTION
Relates to https://kolmafia.us/threads/java-bug-on-some-versions-of-java-weird-things-happen-to-strings-with-special-characters.27531

Requires testing on non-Windows platforms.

Uses a blank content-types property file to avoid licensing problems: the [version of the file prior to the introduction of text/javascript](https://github.com/adoptium/jdk/blob/3789983e89c9de252ef546a1b98a732a7d066650/src/java.base/windows/classes/sun/net/www/content-types.properties) is distributed under GPLv2 without the classpath exception: as such, bringing it into KoLMafia would make this a derived work, and the combination would also have to be distributed under GPLv2. Using our own file (with no content) avoids this problem.

After https://github.com/mozilla/rhino/issues/1232 is fixed in some way and the fix released, this code can be removed.