### PR TITLE
Add coat of paint to mafia defaults

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1571,6 +1571,7 @@ user	_clipartSummons	0
 user	_cloudTalkMessage
 user	_cloudTalkSmoker
 user	_coalPaperweightUsed	false
+user	_coatOfPaintModifier	
 user	_cocoaDispenserUsed	false
 user	_cocktailShakerUsed	false
 user	_coldAirportToday	false


### PR DESCRIPTION
Not sure if this is "normal" or a one off tbh. 

To properly check this, would probably need to find every string matching some regex to find every preference set in the code. Then check if it exists in mafia's defaults.