### PR TITLE
Parse Meat as a long in mall purchase request. Allow purchasing way too many raffle tickets.

### DIFF
--- a/src/net/sourceforge/kolmafia/request/MallPurchaseRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MallPurchaseRequest.java
@@ -460,7 +460,7 @@ public class MallPurchaseRequest extends PurchaseRequest {
 
     int cost = StringUtilities.parseInt(meatMatcher.group(1));
     if (meatMatcher.group(2) != null) {
-      int balance = StringUtilities.parseInt(meatMatcher.group(3));
+      long balance = StringUtilities.parseLong(meatMatcher.group(3));
       KoLCharacter.setStorageMeat(balance);
     } else {
       ResultProcessor.processMeat(-cost);

--- a/src/net/sourceforge/kolmafia/request/RaffleRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RaffleRequest.java
@@ -96,7 +96,7 @@ public class RaffleRequest extends GenericRequest {
     }
 
     int quantity = StringUtilities.parseInt(matcher.group(1));
-    int cost = 10000 * quantity;
+    long cost = 10000 * quantity;
 
     if (where.equals(RaffleSource.STORAGE.toString())) {
       KoLCharacter.setStorageMeat(KoLCharacter.getStorageMeat() - cost);


### PR DESCRIPTION
Mall Purchase using Meat from storage tells you your balance. Parse it as a long.
You can purchase raffle tickets using Meat from Storage. Allow total cost to exceed an int. Fool.