### PR TITLE
BUFFED_HP and BUFFED_MP have a different formula in Grey You

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -1282,6 +1282,10 @@ public abstract class KoLCharacter {
     return ascensionClass == AscensionClass.VAMPYRE;
   }
 
+  public static final boolean isGreyGoo() {
+    return ascensionClass == AscensionClass.GREY_GOO;
+  }
+
   public static final boolean isMoxieClass() {
     return ascensionClass != null && ascensionClass.getPrimeStatIndex() == 2;
   }

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -1092,6 +1092,10 @@ public class Modifiers {
       hpbase = 30;
       hp = hpbase + (int) this.get(Modifiers.HP);
       buffedHP = hp;
+    } else if (KoLCharacter.isGreyGoo()) {
+      hpbase = (int) KoLCharacter.getBaseMaxHP();
+      hp = hpbase + (int) this.get(Modifiers.HP);
+      buffedHP = hp;
     } else {
       hpbase = rv[Modifiers.BUFFED_MUS] + 3;
       double C = KoLCharacter.isMuscleClass() ? 1.5 : 1.0;
@@ -1101,15 +1105,26 @@ public class Modifiers {
     }
     rv[Modifiers.BUFFED_HP] = buffedHP;
 
-    int mpbase = rv[Modifiers.BUFFED_MYS];
-    if (this.getBoolean(Modifiers.MOXIE_CONTROLS_MP)
-        || (this.getBoolean(Modifiers.MOXIE_MAY_CONTROL_MP) && rv[Modifiers.BUFFED_MOX] > mpbase)) {
-      mpbase = rv[Modifiers.BUFFED_MOX];
+    int mpbase;
+    int mp;
+    int buffedMP;
+    if (KoLCharacter.isGreyGoo()) {
+      mpbase = (int) KoLCharacter.getBaseMaxMP();
+      mp = mpbase + (int) this.get(Modifiers.MP);
+      buffedMP = mp;
+    } else {
+      mpbase = rv[Modifiers.BUFFED_MYS];
+      if (this.getBoolean(Modifiers.MOXIE_CONTROLS_MP)
+          || (this.getBoolean(Modifiers.MOXIE_MAY_CONTROL_MP)
+              && rv[Modifiers.BUFFED_MOX] > mpbase)) {
+        mpbase = rv[Modifiers.BUFFED_MOX];
+      }
+      double C = KoLCharacter.isMysticalityClass() ? 1.5 : 1.0;
+      double mpPercent = this.get(Modifiers.MP_PCT);
+      mp = (int) Math.ceil(mpbase * (C + mpPercent / 100.0)) + (int) this.get(Modifiers.MP);
+      buffedMP = Math.max(mp, mys);
     }
-    double C = KoLCharacter.isMysticalityClass() ? 1.5 : 1.0;
-    double mpPercent = this.get(Modifiers.MP_PCT);
-    int mp = (int) Math.ceil(mpbase * (C + mpPercent / 100.0)) + (int) this.get(Modifiers.MP);
-    rv[Modifiers.BUFFED_MP] = Math.max(mp, mys);
+    rv[Modifiers.BUFFED_MP] = buffedMP;
 
     return rv;
   }

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -34,6 +34,7 @@ public class ItemPool {
   public static final int SPIDER_WEB = 27;
   public static final int BIG_ROCK = 30;
   public static final int BJORNS_HAMMER = 32;
+  public static final int VIKING_HELMET = 37;
   public static final int CASINO_PASS = 40;
   public static final int SCHLITZ = 41;
   public static final int HERMIT_PERMIT = 42;
@@ -667,6 +668,7 @@ public class ItemPool {
   public static final int BETTER_THAN_CUDDLING_CAKE = 2332;
   public static final int STUFFED_NINJA_SNOWMAN = 2333;
   public static final int HOLY_MACGUFFIN = 2334;
+  public static final int REINFORCED_BEADED_HEADBAND = 2337;
   public static final int BLACK_PUDDING = 2338;
   public static final int BLACKFLY_CHARDONNAY = 2339;
   public static final int FILTHWORM_QUEEN_HEART = 2347;
@@ -3341,6 +3343,7 @@ public class ItemPool {
   public static final int CATHERINE_WHEEL = 10770;
   public static final int ROCKET_BOOTS = 10771;
   public static final int OVERSIZED_SPARKLER = 10772;
+  public static final int EXTRA_WIDE_HEAD_CANDLE = 10783;
   public static final int BLART = 10790;
   public static final int RAINPROOF_BARREL_CAULK = 10794;
   public static final int PUMP_GREASE = 10795;

--- a/src/net/sourceforge/kolmafia/swingui/panel/CompactSidePane.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/CompactSidePane.java
@@ -1167,7 +1167,9 @@ public class CompactSidePane extends JPanel implements Runnable {
         return;
       }
 
-      this.setToolTipText(effective.getRace());
+      int baseWeight = current.getWeight();
+      this.setToolTipText(
+          effective.getRace() + " (" + baseWeight + (baseWeight == 1 ? " lb" : " lbs") + ")");
       this.setIcon(KoLCharacter.getFamiliarImage());
 
       StringBuffer anno = CharPaneDecorator.getFamiliarAnnotation();

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -171,6 +171,18 @@ public class Player {
     return new Cleanups(() -> setStats(0, 0, 0));
   }
 
+  public static Cleanups setHP(long current, long maximum, long base) {
+    KoLCharacter.setHP(current, maximum, base);
+    KoLCharacter.recalculateAdjustments();
+    return new Cleanups(() -> setHP(0, 0, 0));
+  }
+
+  public static Cleanups setMP(long current, long maximum, long base) {
+    KoLCharacter.setMP(current, maximum, base);
+    KoLCharacter.recalculateAdjustments();
+    return new Cleanups(() -> setMP(0, 0, 0));
+  }
+
   public static Cleanups isClass(AscensionClass ascensionClass) {
     var old = KoLCharacter.getAscensionClass();
     KoLCharacter.setAscensionClass(ascensionClass);

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -307,8 +307,6 @@ public class ModifiersTest {
         stats = mods.predict();
         assertEquals(100, stats[Modifiers.BUFFED_MUS]);
         assertEquals(30, stats[Modifiers.BUFFED_HP]);
-
-        EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
       }
     }
 
@@ -348,8 +346,6 @@ public class ModifiersTest {
         stats = mods.predict();
         assertEquals(100, stats[Modifiers.BUFFED_MUS]);
         assertEquals(176, stats[Modifiers.BUFFED_HP]);
-
-        EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
       }
     }
   }
@@ -399,8 +395,6 @@ public class ModifiersTest {
         stats = mods.predict();
         assertEquals(106, stats[Modifiers.BUFFED_MYS]);
         assertEquals(229, stats[Modifiers.BUFFED_MP]);
-
-        EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
       }
     }
 
@@ -442,8 +436,6 @@ public class ModifiersTest {
         stats = mods.predict();
         assertEquals(106, stats[Modifiers.BUFFED_MYS]);
         assertEquals(176, stats[Modifiers.BUFFED_MP]);
-
-        EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
       }
     }
 
@@ -485,8 +477,6 @@ public class ModifiersTest {
         stats = mods.predict();
         assertEquals(106, stats[Modifiers.BUFFED_MYS]);
         assertEquals(126, stats[Modifiers.BUFFED_MP]);
-
-        EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
       }
     }
 
@@ -540,8 +530,6 @@ public class ModifiersTest {
         stats = mods.predict();
         assertEquals(156, stats[Modifiers.BUFFED_MOX]);
         assertEquals(259, stats[Modifiers.BUFFED_MP]);
-
-        EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
       }
     }
   }

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -17,38 +17,16 @@ import java.util.GregorianCalendar;
 import java.util.Map.Entry;
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
-import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.session.EquipmentManager;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class ModifiersTest {
-
-  @BeforeAll
-  private static void beforeAll() {
-    // Simulate logging out and back in again.
-    KoLCharacter.reset("");
-    KoLCharacter.reset("modifier user");
-    Preferences.saveSettingsToFile = false;
-  }
-
-  @AfterAll
-  private static void afterAll() {
-    Preferences.saveSettingsToFile = true;
-  }
-
-  @BeforeEach
-  private void beforeEach() {
-    KoLCharacter.reset(true);
-    KoLConstants.inventory.clear();
-    EquipmentManager.resetEquipment();
-  }
 
   @Test
   public void patriotShieldClassModifiers() {
@@ -172,374 +150,399 @@ public class ModifiersTest {
     assertEquals(-30, mod.get(Modifiers.COMBAT_RATE));
   }
 
-  @Test
-  public void correctlyCalculatesMaximumHP() {
-
-    var cleanups1 = new Cleanups(isClass(AscensionClass.SEAL_CLUBBER), setStats(100, 100, 100));
-    try (cleanups1) {
-      // Buffed MUS = Base MUS + mod(MUS) + ceiling(Base MUS * mod(MUS_PCT)/100.0)
-      // Base HP = Buffed MUS + 3
-      // C = 1.5 if MUS class, otherwise 1.0
-      // Buffed HP = ceiling(Base HP * (C + mod(HP_PCT)/100.0) + mod(HP))
-
-      Modifiers mods = KoLCharacter.getCurrentModifiers();
-      KoLCharacter.recalculateAdjustments(false);
-      int[] stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(155, stats[Modifiers.BUFFED_HP]);
-
-      // viking helmet: (+1 muscle)
-      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(101, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(156, stats[Modifiers.BUFFED_HP]);
-
-      // reinforced beaded headband (+40 HP)
-      EquipmentManager.setEquipment(
-          EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(195, stats[Modifiers.BUFFED_HP]);
-
-      // extra-wide head candle (+100% HP)
-      EquipmentManager.setEquipment(
-          EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(258, stats[Modifiers.BUFFED_HP]);
-
-      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+  @Nested
+  class BuffedHP {
+    @AfterEach
+    private void afterEach() {
+      EquipmentManager.resetEquipment();
     }
 
-    var cleanups2 = new Cleanups(isClass(AscensionClass.PASTAMANCER), setStats(100, 100, 100));
-    try (cleanups2) {
-      // Buffed MUS = Base MUS + mod(MUS) + ceiling(Base MUS * mod(MUS_PCT)/100.0)
-      // Base HP = Buffed MUS + 3
-      // C = 1.5 if MUS class, otherwise 1.0
-      // Buffed HP = ceiling(Base HP * (C + mod(HP_PCT)/100.0) + mod(HP))
+    @Test
+    public void correctlyCalculatesSealClubberMaximumHP() {
+      var cleanups = new Cleanups(isClass(AscensionClass.SEAL_CLUBBER), setStats(100, 100, 100));
+      try (cleanups) {
+        // Buffed MUS = Base MUS + mod(MUS) + ceiling(Base MUS * mod(MUS_PCT)/100.0)
+        // Base HP = Buffed MUS + 3
+        // C = 1.5 if MUS class, otherwise 1.0
+        // Buffed HP = ceiling(Base HP * (C + mod(HP_PCT)/100.0) + mod(HP))
 
-      Modifiers mods = KoLCharacter.getCurrentModifiers();
-      KoLCharacter.recalculateAdjustments(false);
-      int[] stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(103, stats[Modifiers.BUFFED_HP]);
+        Modifiers mods = KoLCharacter.getCurrentModifiers();
+        KoLCharacter.recalculateAdjustments(false);
+        int[] stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(155, stats[Modifiers.BUFFED_HP]);
 
-      // viking helmet: (+1 muscle)
-      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(101, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(104, stats[Modifiers.BUFFED_HP]);
+        // viking helmet: (+1 muscle)
+        EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(101, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(156, stats[Modifiers.BUFFED_HP]);
 
-      // reinforced beaded headband (+40 HP)
-      EquipmentManager.setEquipment(
-          EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(143, stats[Modifiers.BUFFED_HP]);
+        // reinforced beaded headband (+40 HP)
+        EquipmentManager.setEquipment(
+            EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(195, stats[Modifiers.BUFFED_HP]);
 
-      // extra-wide head candle (+100% HP)
-      EquipmentManager.setEquipment(
-          EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(206, stats[Modifiers.BUFFED_HP]);
-
-      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+        // extra-wide head candle (+100% HP)
+        EquipmentManager.setEquipment(
+            EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(258, stats[Modifiers.BUFFED_HP]);
+      }
     }
 
-    var cleanups3 = new Cleanups(isClass(AscensionClass.VAMPYRE), setStats(100, 100, 100));
-    try (cleanups3) {
-      // Base HP = Base MUS
-      // Buffed HP = max(Base MUS, Base HP + mod(HP))
+    public void correctlyCalculatesPastamancerMaximumHP() {
+      var cleanups = new Cleanups(isClass(AscensionClass.PASTAMANCER), setStats(100, 100, 100));
+      try (cleanups) {
+        // Buffed MUS = Base MUS + mod(MUS) + ceiling(Base MUS * mod(MUS_PCT)/100.0)
+        // Base HP = Buffed MUS + 3
+        // C = 1.5 if MUS class, otherwise 1.0
+        // Buffed HP = ceiling(Base HP * (C + mod(HP_PCT)/100.0) + mod(HP))
 
-      Modifiers mods = KoLCharacter.getCurrentModifiers();
-      KoLCharacter.recalculateAdjustments(false);
-      int[] stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(100, stats[Modifiers.BUFFED_HP]);
+        Modifiers mods = KoLCharacter.getCurrentModifiers();
+        KoLCharacter.recalculateAdjustments(false);
+        int[] stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(103, stats[Modifiers.BUFFED_HP]);
 
-      // viking helmet: (+1 muscle)
-      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(101, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(100, stats[Modifiers.BUFFED_HP]);
+        // viking helmet: (+1 muscle)
+        EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(101, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(104, stats[Modifiers.BUFFED_HP]);
 
-      // reinforced beaded headband (+40 HP)
-      EquipmentManager.setEquipment(
-          EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(140, stats[Modifiers.BUFFED_HP]);
+        // reinforced beaded headband (+40 HP)
+        EquipmentManager.setEquipment(
+            EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(143, stats[Modifiers.BUFFED_HP]);
 
-      // extra-wide head candle (+100% HP)
-      EquipmentManager.setEquipment(
-          EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(100, stats[Modifiers.BUFFED_HP]);
-
-      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+        // extra-wide head candle (+100% HP)
+        EquipmentManager.setEquipment(
+            EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(206, stats[Modifiers.BUFFED_HP]);
+      }
     }
 
-    var cleanups4 = new Cleanups(inPath(Path.YOU_ROBOT), setStats(100, 100, 100));
-    try (cleanups4) {
-      // Base HP = 30
-      // Buffed HP = Base HP + mod(HP)
+    public void correctlyCalculatesVampyreMaximumHP() {
+      var cleanups = new Cleanups(isClass(AscensionClass.VAMPYRE), setStats(100, 100, 100));
+      try (cleanups) {
+        // Base HP = Base MUS
+        // Buffed HP = max(Base MUS, Base HP + mod(HP))
 
-      Modifiers mods = KoLCharacter.getCurrentModifiers();
-      KoLCharacter.recalculateAdjustments(false);
-      int[] stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(30, stats[Modifiers.BUFFED_HP]);
+        Modifiers mods = KoLCharacter.getCurrentModifiers();
+        KoLCharacter.recalculateAdjustments(false);
+        int[] stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(100, stats[Modifiers.BUFFED_HP]);
 
-      // viking helmet: (+1 muscle)
-      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(101, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(30, stats[Modifiers.BUFFED_HP]);
+        // viking helmet: (+1 muscle)
+        EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(101, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(100, stats[Modifiers.BUFFED_HP]);
 
-      // reinforced beaded headband (+40 HP)
-      EquipmentManager.setEquipment(
-          EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(70, stats[Modifiers.BUFFED_HP]);
+        // reinforced beaded headband (+40 HP)
+        EquipmentManager.setEquipment(
+            EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(140, stats[Modifiers.BUFFED_HP]);
 
-      // extra-wide head candle (+100% HP)
-      EquipmentManager.setEquipment(
-          EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(30, stats[Modifiers.BUFFED_HP]);
-
-      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+        // extra-wide head candle (+100% HP)
+        EquipmentManager.setEquipment(
+            EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(100, stats[Modifiers.BUFFED_HP]);
+      }
     }
 
-    var cleanups5 =
-        new Cleanups(
-            isClass(AscensionClass.GREY_GOO), setStats(100, 100, 100), setHP(176, 176, 176));
-    try (cleanups5) {
-      // Base HP = (starting value + absorptions)
-      // Buffed HP = Base HP + mod(HP)
+    public void correctlyCalculatesYouRobotMaximumHP() {
+      var cleanups = new Cleanups(inPath(Path.YOU_ROBOT), setStats(100, 100, 100));
+      try (cleanups) {
+        // Base HP = 30
+        // Buffed HP = Base HP + mod(HP)
 
-      Modifiers mods = KoLCharacter.getCurrentModifiers();
-      KoLCharacter.recalculateAdjustments(false);
-      int[] stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(176, stats[Modifiers.BUFFED_HP]);
+        Modifiers mods = KoLCharacter.getCurrentModifiers();
+        KoLCharacter.recalculateAdjustments(false);
+        int[] stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(30, stats[Modifiers.BUFFED_HP]);
 
-      // viking helmet: (+1 muscle)
-      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(101, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(176, stats[Modifiers.BUFFED_HP]);
+        // viking helmet: (+1 muscle)
+        EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(101, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(30, stats[Modifiers.BUFFED_HP]);
 
-      // reinforced beaded headband (+40 HP)
-      EquipmentManager.setEquipment(
-          EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(216, stats[Modifiers.BUFFED_HP]);
+        // reinforced beaded headband (+40 HP)
+        EquipmentManager.setEquipment(
+            EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(70, stats[Modifiers.BUFFED_HP]);
 
-      // extra-wide head candle (+100% HP)
-      EquipmentManager.setEquipment(
-          EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(176, stats[Modifiers.BUFFED_HP]);
+        // extra-wide head candle (+100% HP)
+        EquipmentManager.setEquipment(
+            EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(30, stats[Modifiers.BUFFED_HP]);
 
-      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+        EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+      }
+    }
+
+    public void correctlyCalculatesGreyYouMaximumHP() {
+      var cleanups =
+          new Cleanups(
+              isClass(AscensionClass.GREY_GOO), setStats(100, 100, 100), setHP(176, 176, 176));
+      try (cleanups) {
+        // Base HP = (starting value + absorptions)
+        // Buffed HP = Base HP + mod(HP)
+
+        Modifiers mods = KoLCharacter.getCurrentModifiers();
+        KoLCharacter.recalculateAdjustments(false);
+        int[] stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(176, stats[Modifiers.BUFFED_HP]);
+
+        // viking helmet: (+1 muscle)
+        EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(101, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(176, stats[Modifiers.BUFFED_HP]);
+
+        // reinforced beaded headband (+40 HP)
+        EquipmentManager.setEquipment(
+            EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(216, stats[Modifiers.BUFFED_HP]);
+
+        // extra-wide head candle (+100% HP)
+        EquipmentManager.setEquipment(
+            EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+        assertEquals(176, stats[Modifiers.BUFFED_HP]);
+
+        EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+      }
     }
   }
 
-  @Test
-  public void correctlyCalculatesMaximumMP() {
-
-    var cleanups1 = new Cleanups(isClass(AscensionClass.SAUCEROR), setStats(100, 100, 100));
-    try (cleanups1) {
-      // Buffed MYS = Base MYS + mod(MYS) + ceiling(Base MYS * mod(MYS_PCT)/100.0)
-      // Base MP = Buffed MYS
-      // C = 1.5 if MYS class, otherwise 1.0
-      // Buffed MP = ceiling(Base MP * (C + mod(MP_PCT)/100.0) + mod(MP))
-
-      Modifiers mods = KoLCharacter.getCurrentModifiers();
-      KoLCharacter.recalculateAdjustments(false);
-      int[] stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(150, stats[Modifiers.BUFFED_MP]);
-
-      // fuzzy earmuffs: (+11 myst)
-      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.FUZZY_EARMUFFS));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(111, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(167, stats[Modifiers.BUFFED_MP]);
-
-      // beer helmet (+40 MP)
-      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(190, stats[Modifiers.BUFFED_MP]);
-
-      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
-
-      // Cargo Cultist Shorts (+6 myst, +66% MP)
-      EquipmentManager.setEquipment(
-          EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(106, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(229, stats[Modifiers.BUFFED_MP]);
-
-      EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
+  @Nested
+  class BuffedMP {
+    @AfterEach
+    private void afterEach() {
+      EquipmentManager.resetEquipment();
     }
 
-    var cleanups2 = new Cleanups(isClass(AscensionClass.TURTLE_TAMER), setStats(100, 100, 100));
-    try (cleanups2) {
-      // Buffed MYS = Base MYS + mod(MYS) + ceiling(Base MYS * mod(MYS_PCT)/100.0)
-      // Base MP = Buffed MYS
-      // C = 1.5 if MYS class, otherwise 1.0
-      // Buffed MP = ceiling(Base MP * (C + mod(MP_PCT)/100.0) + mod(MP))
+    @Test
+    public void correctlyCalculatesSaucerorMaximumMP() {
+      var cleanups = new Cleanups(isClass(AscensionClass.SAUCEROR), setStats(100, 100, 100));
+      try (cleanups) {
+        // Buffed MYS = Base MYS + mod(MYS) + ceiling(Base MYS * mod(MYS_PCT)/100.0)
+        // Base MP = Buffed MYS
+        // C = 1.5 if MYS class, otherwise 1.0
+        // Buffed MP = ceiling(Base MP * (C + mod(MP_PCT)/100.0) + mod(MP))
 
-      Modifiers mods = KoLCharacter.getCurrentModifiers();
-      KoLCharacter.recalculateAdjustments(false);
-      int[] stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(100, stats[Modifiers.BUFFED_MP]);
+        Modifiers mods = KoLCharacter.getCurrentModifiers();
+        KoLCharacter.recalculateAdjustments(false);
+        int[] stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MYS]);
+        assertEquals(150, stats[Modifiers.BUFFED_MP]);
 
-      // fuzzy earmuffs: (+11 myst)
-      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.FUZZY_EARMUFFS));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(111, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(111, stats[Modifiers.BUFFED_MP]);
+        // fuzzy earmuffs: (+11 myst)
+        EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.FUZZY_EARMUFFS));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(111, stats[Modifiers.BUFFED_MYS]);
+        assertEquals(167, stats[Modifiers.BUFFED_MP]);
 
-      // beer helmet (+40 MP)
-      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(140, stats[Modifiers.BUFFED_MP]);
+        // beer helmet (+40 MP)
+        EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MYS]);
+        assertEquals(190, stats[Modifiers.BUFFED_MP]);
 
-      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+        EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
 
-      // Cargo Cultist Shorts (+6 myst, +66% MP)
-      EquipmentManager.setEquipment(
-          EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(106, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(176, stats[Modifiers.BUFFED_MP]);
+        // Cargo Cultist Shorts (+6 myst, +66% MP)
+        EquipmentManager.setEquipment(
+            EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(106, stats[Modifiers.BUFFED_MYS]);
+        assertEquals(229, stats[Modifiers.BUFFED_MP]);
 
-      EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
+        EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
+      }
     }
 
-    var cleanups3 =
-        new Cleanups(
-            isClass(AscensionClass.GREY_GOO), setStats(100, 100, 100), setMP(126, 126, 126));
-    try (cleanups3) {
-      // Base MP = (starting value + absorptions)
-      // Buffed MP = Base MP + mod(MP)
+    @Test
+    public void correctlyCalculatesTurtleTamerMaximumMP() {
+      var cleanups = new Cleanups(isClass(AscensionClass.TURTLE_TAMER), setStats(100, 100, 100));
+      try (cleanups) {
+        // Buffed MYS = Base MYS + mod(MYS) + ceiling(Base MYS * mod(MYS_PCT)/100.0)
+        // Base MP = Buffed MYS
+        // C = 1.5 if MYS class, otherwise 1.0
+        // Buffed MP = ceiling(Base MP * (C + mod(MP_PCT)/100.0) + mod(MP))
 
-      Modifiers mods = KoLCharacter.getCurrentModifiers();
-      KoLCharacter.recalculateAdjustments(false);
-      int[] stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(126, stats[Modifiers.BUFFED_MP]);
+        Modifiers mods = KoLCharacter.getCurrentModifiers();
+        KoLCharacter.recalculateAdjustments(false);
+        int[] stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MYS]);
+        assertEquals(100, stats[Modifiers.BUFFED_MP]);
 
-      // fuzzy earmuffs: (+11 myst)
-      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.FUZZY_EARMUFFS));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(111, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(126, stats[Modifiers.BUFFED_MP]);
+        // fuzzy earmuffs: (+11 myst)
+        EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.FUZZY_EARMUFFS));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(111, stats[Modifiers.BUFFED_MYS]);
+        assertEquals(111, stats[Modifiers.BUFFED_MP]);
 
-      // beer helmet (+40 MP)
-      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(100, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(166, stats[Modifiers.BUFFED_MP]);
+        // beer helmet (+40 MP)
+        EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MYS]);
+        assertEquals(140, stats[Modifiers.BUFFED_MP]);
 
-      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+        EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
 
-      // Cargo Cultist Shorts (+6 myst, +66% MP)
-      EquipmentManager.setEquipment(
-          EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(106, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(126, stats[Modifiers.BUFFED_MP]);
+        // Cargo Cultist Shorts (+6 myst, +66% MP)
+        EquipmentManager.setEquipment(
+            EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(106, stats[Modifiers.BUFFED_MYS]);
+        assertEquals(176, stats[Modifiers.BUFFED_MP]);
 
-      EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
+        EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
+      }
     }
 
-    // moxie magnet: Moxie Controls MP
-    var cleanups4 =
-        new Cleanups(
-            isClass(AscensionClass.DISCO_BANDIT),
-            setStats(100, 100, 150),
-            equip(EquipmentManager.ACCESSORY1, "moxie magnet"));
-    try (cleanups4) {
-      // Buffed MOX = Base MOX + mod(MOX) + ceiling(Base MOX * mod(MOX_PCT)/100.0)
-      // Base MP = Buffed MUS
-      // C = 1.5 if MYS class, otherwise 1.0
-      // Buffed MP = ceiling(Base MP * (C + mod(MP_PCT)/100.0) + mod(MP))
+    @Test
+    public void correctlyCalculatesGreyYouMaximumMP() {
+      var cleanups =
+          new Cleanups(
+              isClass(AscensionClass.GREY_GOO), setStats(100, 100, 100), setMP(126, 126, 126));
+      try (cleanups) {
+        // Base MP = (starting value + absorptions)
+        // Buffed MP = Base MP + mod(MP)
 
-      Modifiers mods = KoLCharacter.getCurrentModifiers();
-      KoLCharacter.recalculateAdjustments(false);
-      int[] stats = mods.predict();
-      assertEquals(150, stats[Modifiers.BUFFED_MOX]);
-      assertEquals(150, stats[Modifiers.BUFFED_MP]);
+        Modifiers mods = KoLCharacter.getCurrentModifiers();
+        KoLCharacter.recalculateAdjustments(false);
+        int[] stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MYS]);
+        assertEquals(126, stats[Modifiers.BUFFED_MP]);
 
-      // Disco 'Fro Pick (+11 mox)
-      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.DISCO_FRO_PICK));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(161, stats[Modifiers.BUFFED_MOX]);
-      assertEquals(161, stats[Modifiers.BUFFED_MP]);
+        // fuzzy earmuffs: (+11 myst)
+        EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.FUZZY_EARMUFFS));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(111, stats[Modifiers.BUFFED_MYS]);
+        assertEquals(126, stats[Modifiers.BUFFED_MP]);
 
-      // beer helmet (+40 MP)
-      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(150, stats[Modifiers.BUFFED_MOX]);
-      assertEquals(190, stats[Modifiers.BUFFED_MP]);
+        // beer helmet (+40 MP)
+        EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(100, stats[Modifiers.BUFFED_MYS]);
+        assertEquals(166, stats[Modifiers.BUFFED_MP]);
 
-      // training helmet: (+25% mox)
-      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.TRAINING_HELMET));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(188, stats[Modifiers.BUFFED_MOX]);
-      assertEquals(188, stats[Modifiers.BUFFED_MP]);
+        EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
 
-      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+        // Cargo Cultist Shorts (+6 myst, +66% MP)
+        EquipmentManager.setEquipment(
+            EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(106, stats[Modifiers.BUFFED_MYS]);
+        assertEquals(126, stats[Modifiers.BUFFED_MP]);
 
-      // Cargo Cultist Shorts (+6 mox, +66% MP)
-      EquipmentManager.setEquipment(
-          EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
-      KoLCharacter.recalculateAdjustments(false);
-      stats = mods.predict();
-      assertEquals(156, stats[Modifiers.BUFFED_MOX]);
-      assertEquals(259, stats[Modifiers.BUFFED_MP]);
+        EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
+      }
+    }
 
-      EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
+    @Test
+    public void correctlyCalculatesMoxieControlledMaximumMP() {
+      // moxie magnet: Moxie Controls MP
+      var cleanups =
+          new Cleanups(
+              isClass(AscensionClass.DISCO_BANDIT),
+              setStats(100, 100, 150),
+              equip(EquipmentManager.ACCESSORY1, "moxie magnet"));
+      try (cleanups) {
+        // Buffed MOX = Base MOX + mod(MOX) + ceiling(Base MOX * mod(MOX_PCT)/100.0)
+        // Base MP = Buffed MUS
+        // C = 1.5 if MYS class, otherwise 1.0
+        // Buffed MP = ceiling(Base MP * (C + mod(MP_PCT)/100.0) + mod(MP))
+
+        Modifiers mods = KoLCharacter.getCurrentModifiers();
+        KoLCharacter.recalculateAdjustments(false);
+        int[] stats = mods.predict();
+        assertEquals(150, stats[Modifiers.BUFFED_MOX]);
+        assertEquals(150, stats[Modifiers.BUFFED_MP]);
+
+        // Disco 'Fro Pick (+11 mox)
+        EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.DISCO_FRO_PICK));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(161, stats[Modifiers.BUFFED_MOX]);
+        assertEquals(161, stats[Modifiers.BUFFED_MP]);
+
+        // beer helmet (+40 MP)
+        EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(150, stats[Modifiers.BUFFED_MOX]);
+        assertEquals(190, stats[Modifiers.BUFFED_MP]);
+
+        // training helmet: (+25% mox)
+        EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.TRAINING_HELMET));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(188, stats[Modifiers.BUFFED_MOX]);
+        assertEquals(188, stats[Modifiers.BUFFED_MP]);
+
+        EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+
+        // Cargo Cultist Shorts (+6 mox, +66% MP)
+        EquipmentManager.setEquipment(
+            EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
+        KoLCharacter.recalculateAdjustments(false);
+        stats = mods.predict();
+        assertEquals(156, stats[Modifiers.BUFFED_MOX]);
+        assertEquals(259, stats[Modifiers.BUFFED_MP]);
+
+        EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
+      }
     }
   }
 }

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -1,20 +1,54 @@
 package net.sourceforge.kolmafia;
 
+import static internal.helpers.Player.inPath;
 import static internal.helpers.Player.isClass;
 import static internal.helpers.Player.isDay;
+import static internal.helpers.Player.setHP;
+import static internal.helpers.Player.setMP;
+import static internal.helpers.Player.setStats;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import internal.helpers.Cleanups;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Map.Entry;
+import net.sourceforge.kolmafia.AscensionPath.Path;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.EquipmentRequest;
+import net.sourceforge.kolmafia.session.EquipmentManager;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class ModifiersTest {
+
+  @BeforeAll
+  private static void beforeAll() {
+    // Simulate logging out and back in again.
+    KoLCharacter.reset("");
+    KoLCharacter.reset("modifier user");
+    Preferences.saveSettingsToFile = false;
+  }
+
+  @AfterAll
+  private static void afterAll() {
+    Preferences.saveSettingsToFile = true;
+  }
+
+  @BeforeEach
+  private void beforeEach() {
+    KoLCharacter.reset(true);
+    KoLConstants.inventory.clear();
+    EquipmentManager.resetEquipment();
+  }
+
   @Test
   public void patriotShieldClassModifiers() {
     // Wide-reaching unit test for getModifiers
@@ -135,5 +169,328 @@ public class ModifiersTest {
     assertEquals(-28, mod.get(Modifiers.COMBAT_RATE));
     mod.add(Modifiers.COMBAT_RATE, -9, "-50");
     assertEquals(-30, mod.get(Modifiers.COMBAT_RATE));
+  }
+
+  @Test
+  public void correctlyCalculatesMaximumHP() {
+
+    var cleanups1 = new Cleanups(isClass(AscensionClass.SEAL_CLUBBER), setStats(100, 100, 100));
+    try (cleanups1) {
+      // Buffed MUS = Base MUS + mod(MUS) + ceiling(Base MUS * mod(MUS_PCT)/100.0)
+      // Base HP = Buffed MUS + 3
+      // C = 1.5 if MUS class, otherwise 1.0
+      // Buffed HP = ceiling(Base HP * (C + mod(HP_PCT)/100.0) + mod(HP))
+
+      Modifiers mods = KoLCharacter.getCurrentModifiers();
+      KoLCharacter.recalculateAdjustments(false);
+      int[] stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(155, stats[Modifiers.BUFFED_HP]);
+
+      // viking helmet: (+1 muscle)
+      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(101, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(156, stats[Modifiers.BUFFED_HP]);
+
+      // reinforced beaded headband (+40 HP)
+      EquipmentManager.setEquipment(
+          EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(195, stats[Modifiers.BUFFED_HP]);
+
+      // extra-wide head candle (+100% HP)
+      EquipmentManager.setEquipment(
+          EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(258, stats[Modifiers.BUFFED_HP]);
+
+      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+    }
+
+    var cleanups2 = new Cleanups(isClass(AscensionClass.PASTAMANCER), setStats(100, 100, 100));
+    try (cleanups2) {
+      // Buffed MUS = Base MUS + mod(MUS) + ceiling(Base MUS * mod(MUS_PCT)/100.0)
+      // Base HP = Buffed MUS + 3
+      // C = 1.5 if MUS class, otherwise 1.0
+      // Buffed HP = ceiling(Base HP * (C + mod(HP_PCT)/100.0) + mod(HP))
+
+      Modifiers mods = KoLCharacter.getCurrentModifiers();
+      KoLCharacter.recalculateAdjustments(false);
+      int[] stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(103, stats[Modifiers.BUFFED_HP]);
+
+      // viking helmet: (+1 muscle)
+      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(101, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(104, stats[Modifiers.BUFFED_HP]);
+
+      // reinforced beaded headband (+40 HP)
+      EquipmentManager.setEquipment(
+          EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(143, stats[Modifiers.BUFFED_HP]);
+
+      // extra-wide head candle (+100% HP)
+      EquipmentManager.setEquipment(
+          EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(206, stats[Modifiers.BUFFED_HP]);
+
+      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+    }
+
+    var cleanups3 = new Cleanups(isClass(AscensionClass.VAMPYRE), setStats(100, 100, 100));
+    try (cleanups3) {
+      // Base HP = Base MUS
+      // Buffed HP = max(Base MUS, Base HP + mod(HP))
+
+      Modifiers mods = KoLCharacter.getCurrentModifiers();
+      KoLCharacter.recalculateAdjustments(false);
+      int[] stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(100, stats[Modifiers.BUFFED_HP]);
+
+      // viking helmet: (+1 muscle)
+      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(101, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(100, stats[Modifiers.BUFFED_HP]);
+
+      // reinforced beaded headband (+40 HP)
+      EquipmentManager.setEquipment(
+          EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(140, stats[Modifiers.BUFFED_HP]);
+
+      // extra-wide head candle (+100% HP)
+      EquipmentManager.setEquipment(
+          EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(100, stats[Modifiers.BUFFED_HP]);
+
+      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+    }
+
+    var cleanups4 = new Cleanups(inPath(Path.YOU_ROBOT), setStats(100, 100, 100));
+    try (cleanups4) {
+      // Base HP = 30
+      // Buffed HP = Base HP + mod(HP)
+
+      Modifiers mods = KoLCharacter.getCurrentModifiers();
+      KoLCharacter.recalculateAdjustments(false);
+      int[] stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(30, stats[Modifiers.BUFFED_HP]);
+
+      // viking helmet: (+1 muscle)
+      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(101, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(30, stats[Modifiers.BUFFED_HP]);
+
+      // reinforced beaded headband (+40 HP)
+      EquipmentManager.setEquipment(
+          EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(70, stats[Modifiers.BUFFED_HP]);
+
+      // extra-wide head candle (+100% HP)
+      EquipmentManager.setEquipment(
+          EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(30, stats[Modifiers.BUFFED_HP]);
+
+      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+    }
+
+    var cleanups5 =
+        new Cleanups(
+            isClass(AscensionClass.GREY_GOO), setStats(100, 100, 100), setHP(176, 176, 176));
+    try (cleanups5) {
+      // Base HP = (starting value + absorptions)
+      // Buffed HP = Base HP + mod(HP)
+
+      long baseHP = KoLCharacter.getBaseMaxHP();
+
+      Modifiers mods = KoLCharacter.getCurrentModifiers();
+      KoLCharacter.recalculateAdjustments(false);
+      int[] stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(baseHP, stats[Modifiers.BUFFED_HP]);
+
+      // viking helmet: (+1 muscle)
+      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(101, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(baseHP, stats[Modifiers.BUFFED_HP]);
+
+      // reinforced beaded headband (+40 HP)
+      EquipmentManager.setEquipment(
+          EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(baseHP + 40, stats[Modifiers.BUFFED_HP]);
+
+      // extra-wide head candle (+100% HP)
+      EquipmentManager.setEquipment(
+          EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MUS]);
+      assertEquals(baseHP, stats[Modifiers.BUFFED_HP]);
+
+      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+    }
+  }
+
+  @Test
+  public void correctlyCalculatesMaximumMP() {
+
+    var cleanups1 = new Cleanups(isClass(AscensionClass.SAUCEROR), setStats(100, 100, 100));
+    try (cleanups1) {
+      // Buffed MYS = Base MYS + mod(MYS) + ceiling(Base MYS * mod(MYS_PCT)/100.0)
+      // Base MP = Buffed MUS
+      // C = 1.5 if MYS class, otherwise 1.0
+      // Buffed MP = ceiling(Base MP * (C + mod(MP_PCT)/100.0) + mod(MP))
+
+      Modifiers mods = KoLCharacter.getCurrentModifiers();
+      KoLCharacter.recalculateAdjustments(false);
+      int[] stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MYS]);
+      assertEquals(150, stats[Modifiers.BUFFED_MP]);
+
+      // fuzzy earmuffs: (+11 myst)
+      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.FUZZY_EARMUFFS));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(111, stats[Modifiers.BUFFED_MYS]);
+      assertEquals(167, stats[Modifiers.BUFFED_MP]);
+
+      // beer helmet (+40 MP)
+      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MYS]);
+      assertEquals(190, stats[Modifiers.BUFFED_MP]);
+
+      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+
+      // Cargo Cultist Shorts (+6 myst, +66% MP)
+      EquipmentManager.setEquipment(
+          EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(106, stats[Modifiers.BUFFED_MYS]);
+      assertEquals(229, stats[Modifiers.BUFFED_MP]);
+
+      EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
+    }
+
+    var cleanups2 = new Cleanups(isClass(AscensionClass.DISCO_BANDIT), setStats(100, 100, 100));
+    try (cleanups2) {
+      // Buffed MYS = Base MYS + mod(MYS) + ceiling(Base MYS * mod(MYS_PCT)/100.0)
+      // Base MP = Buffed MUS
+      // C = 1.5 if MYS class, otherwise 1.0
+      // Buffed MP = ceiling(Base MP * (C + mod(MP_PCT)/100.0) + mod(MP))
+
+      Modifiers mods = KoLCharacter.getCurrentModifiers();
+      KoLCharacter.recalculateAdjustments(false);
+      int[] stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MYS]);
+      assertEquals(100, stats[Modifiers.BUFFED_MP]);
+
+      // fuzzy earmuffs: (+11 myst)
+      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.FUZZY_EARMUFFS));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(111, stats[Modifiers.BUFFED_MYS]);
+      assertEquals(111, stats[Modifiers.BUFFED_MP]);
+
+      // beer helmet (+40 MP)
+      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MYS]);
+      assertEquals(140, stats[Modifiers.BUFFED_MP]);
+
+      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+
+      // Cargo Cultist Shorts (+6 myst, +66% MP)
+      EquipmentManager.setEquipment(
+          EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(106, stats[Modifiers.BUFFED_MYS]);
+      assertEquals(176, stats[Modifiers.BUFFED_MP]);
+
+      EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
+    }
+
+    var cleanups3 =
+        new Cleanups(
+            isClass(AscensionClass.GREY_GOO), setStats(100, 100, 100), setMP(126, 126, 126));
+    try (cleanups3) {
+      // Base MP = (starting value + absorptions)
+      // Buffed MP = Base MP + mod(MP)
+
+      long baseMP = KoLCharacter.getBaseMaxMP();
+
+      Modifiers mods = KoLCharacter.getCurrentModifiers();
+      KoLCharacter.recalculateAdjustments(false);
+      int[] stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MYS]);
+      assertEquals(baseMP, stats[Modifiers.BUFFED_MP]);
+
+      // fuzzy earmuffs: (+11 myst)
+      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.FUZZY_EARMUFFS));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(111, stats[Modifiers.BUFFED_MYS]);
+      assertEquals(baseMP, stats[Modifiers.BUFFED_MP]);
+
+      // beer helmet (+40 MP)
+      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(100, stats[Modifiers.BUFFED_MYS]);
+      assertEquals(baseMP + 40, stats[Modifiers.BUFFED_MP]);
+
+      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+
+      // Cargo Cultist Shorts (+6 myst, +66% MP)
+      EquipmentManager.setEquipment(
+          EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(106, stats[Modifiers.BUFFED_MYS]);
+      assertEquals(baseMP, stats[Modifiers.BUFFED_MP]);
+
+      EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia;
 
+import static internal.helpers.Player.equip;
 import static internal.helpers.Player.inPath;
 import static internal.helpers.Player.isClass;
 import static internal.helpers.Player.isDay;
@@ -333,20 +334,18 @@ public class ModifiersTest {
       // Base HP = (starting value + absorptions)
       // Buffed HP = Base HP + mod(HP)
 
-      long baseHP = KoLCharacter.getBaseMaxHP();
-
       Modifiers mods = KoLCharacter.getCurrentModifiers();
       KoLCharacter.recalculateAdjustments(false);
       int[] stats = mods.predict();
       assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(baseHP, stats[Modifiers.BUFFED_HP]);
+      assertEquals(176, stats[Modifiers.BUFFED_HP]);
 
       // viking helmet: (+1 muscle)
       EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
       KoLCharacter.recalculateAdjustments(false);
       stats = mods.predict();
       assertEquals(101, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(baseHP, stats[Modifiers.BUFFED_HP]);
+      assertEquals(176, stats[Modifiers.BUFFED_HP]);
 
       // reinforced beaded headband (+40 HP)
       EquipmentManager.setEquipment(
@@ -354,7 +353,7 @@ public class ModifiersTest {
       KoLCharacter.recalculateAdjustments(false);
       stats = mods.predict();
       assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(baseHP + 40, stats[Modifiers.BUFFED_HP]);
+      assertEquals(216, stats[Modifiers.BUFFED_HP]);
 
       // extra-wide head candle (+100% HP)
       EquipmentManager.setEquipment(
@@ -362,7 +361,7 @@ public class ModifiersTest {
       KoLCharacter.recalculateAdjustments(false);
       stats = mods.predict();
       assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-      assertEquals(baseHP, stats[Modifiers.BUFFED_HP]);
+      assertEquals(176, stats[Modifiers.BUFFED_HP]);
 
       EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
     }
@@ -374,7 +373,7 @@ public class ModifiersTest {
     var cleanups1 = new Cleanups(isClass(AscensionClass.SAUCEROR), setStats(100, 100, 100));
     try (cleanups1) {
       // Buffed MYS = Base MYS + mod(MYS) + ceiling(Base MYS * mod(MYS_PCT)/100.0)
-      // Base MP = Buffed MUS
+      // Base MP = Buffed MYS
       // C = 1.5 if MYS class, otherwise 1.0
       // Buffed MP = ceiling(Base MP * (C + mod(MP_PCT)/100.0) + mod(MP))
 
@@ -411,10 +410,10 @@ public class ModifiersTest {
       EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
     }
 
-    var cleanups2 = new Cleanups(isClass(AscensionClass.DISCO_BANDIT), setStats(100, 100, 100));
+    var cleanups2 = new Cleanups(isClass(AscensionClass.TURTLE_TAMER), setStats(100, 100, 100));
     try (cleanups2) {
       // Buffed MYS = Base MYS + mod(MYS) + ceiling(Base MYS * mod(MYS_PCT)/100.0)
-      // Base MP = Buffed MUS
+      // Base MP = Buffed MYS
       // C = 1.5 if MYS class, otherwise 1.0
       // Buffed MP = ceiling(Base MP * (C + mod(MP_PCT)/100.0) + mod(MP))
 
@@ -458,27 +457,25 @@ public class ModifiersTest {
       // Base MP = (starting value + absorptions)
       // Buffed MP = Base MP + mod(MP)
 
-      long baseMP = KoLCharacter.getBaseMaxMP();
-
       Modifiers mods = KoLCharacter.getCurrentModifiers();
       KoLCharacter.recalculateAdjustments(false);
       int[] stats = mods.predict();
       assertEquals(100, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(baseMP, stats[Modifiers.BUFFED_MP]);
+      assertEquals(126, stats[Modifiers.BUFFED_MP]);
 
       // fuzzy earmuffs: (+11 myst)
       EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.FUZZY_EARMUFFS));
       KoLCharacter.recalculateAdjustments(false);
       stats = mods.predict();
       assertEquals(111, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(baseMP, stats[Modifiers.BUFFED_MP]);
+      assertEquals(126, stats[Modifiers.BUFFED_MP]);
 
       // beer helmet (+40 MP)
       EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
       KoLCharacter.recalculateAdjustments(false);
       stats = mods.predict();
       assertEquals(100, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(baseMP + 40, stats[Modifiers.BUFFED_MP]);
+      assertEquals(166, stats[Modifiers.BUFFED_MP]);
 
       EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
 
@@ -488,7 +485,59 @@ public class ModifiersTest {
       KoLCharacter.recalculateAdjustments(false);
       stats = mods.predict();
       assertEquals(106, stats[Modifiers.BUFFED_MYS]);
-      assertEquals(baseMP, stats[Modifiers.BUFFED_MP]);
+      assertEquals(126, stats[Modifiers.BUFFED_MP]);
+
+      EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
+    }
+
+    // moxie magnet: Moxie Controls MP
+    var cleanups4 =
+        new Cleanups(
+            isClass(AscensionClass.DISCO_BANDIT),
+            setStats(100, 100, 150),
+            equip(EquipmentManager.ACCESSORY1, "moxie magnet"));
+    try (cleanups4) {
+      // Buffed MOX = Base MOX + mod(MOX) + ceiling(Base MOX * mod(MOX_PCT)/100.0)
+      // Base MP = Buffed MUS
+      // C = 1.5 if MYS class, otherwise 1.0
+      // Buffed MP = ceiling(Base MP * (C + mod(MP_PCT)/100.0) + mod(MP))
+
+      Modifiers mods = KoLCharacter.getCurrentModifiers();
+      KoLCharacter.recalculateAdjustments(false);
+      int[] stats = mods.predict();
+      assertEquals(150, stats[Modifiers.BUFFED_MOX]);
+      assertEquals(150, stats[Modifiers.BUFFED_MP]);
+
+      // Disco 'Fro Pick (+11 mox)
+      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.DISCO_FRO_PICK));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(161, stats[Modifiers.BUFFED_MOX]);
+      assertEquals(161, stats[Modifiers.BUFFED_MP]);
+
+      // beer helmet (+40 MP)
+      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(150, stats[Modifiers.BUFFED_MOX]);
+      assertEquals(190, stats[Modifiers.BUFFED_MP]);
+
+      // training helmet: (+25% mox)
+      EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.TRAINING_HELMET));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(188, stats[Modifiers.BUFFED_MOX]);
+      assertEquals(188, stats[Modifiers.BUFFED_MP]);
+
+      EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
+
+      // Cargo Cultist Shorts (+6 mox, +66% MP)
+      EquipmentManager.setEquipment(
+          EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
+      KoLCharacter.recalculateAdjustments(false);
+      stats = mods.predict();
+      assertEquals(156, stats[Modifiers.BUFFED_MOX]);
+      assertEquals(259, stats[Modifiers.BUFFED_MP]);
 
       EquipmentManager.setEquipment(EquipmentManager.PANTS, EquipmentRequest.UNEQUIP);
     }


### PR DESCRIPTION
Per Kasekopf's report in kolmafia.us, on the Grey You path:

- your maximum HP and MP start with a particular value
- they improve by absorbing certain monsters and consumables
- they are unaffected by Muscle or Mysticality
- the only enchantments that affect them are +HP or +MP; no percentages or stats improvements