### PR TITLE
When checking price to make, do not assume quantityPossible > 0

### DIFF
--- a/src/net/sourceforge/kolmafia/session/InventoryManager.java
+++ b/src/net/sourceforge/kolmafia/session/InventoryManager.java
@@ -925,7 +925,7 @@ public abstract class InventoryManager {
 
     if (creator != null && mixingMethod != CraftingType.NOCREATE && !scriptSaysBuy) {
       boolean makeFromComponents = true;
-      if (isAutomated && creator.getQuantityPossible() > 0) {
+      if (isAutomated) {
         // Speculate on how much the items needed to make the creation would cost.
         // Do not retrieve if the average meat spend to make one of the item
         // exceeds the user's autoBuyPriceLimit.
@@ -1087,7 +1087,8 @@ public abstract class InventoryManager {
     }
 
     if (Preferences.getBoolean("debugBuy")) {
-      RequestLogger.printLine("\u262F " + item + " mall=" + mallPrice + " make=" + makePrice);
+      RequestLogger.printLine(
+          "\u262F " + item + " mall=" + priceString(mallPrice) + " make=" + priceString(makePrice));
     }
 
     return mallPrice < makePrice;
@@ -1196,7 +1197,12 @@ public abstract class InventoryManager {
       if (needed == 0) {
         if (Preferences.getBoolean("debugBuy")) {
           RequestLogger.printLine(
-              "\u262F " + item.getInstance(onhand) + " onhand=" + onhand + " price = " + price);
+              "\u262F "
+                  + item.getInstance(onhand)
+                  + " onhand="
+                  + onhand
+                  + " price = "
+                  + priceString(price));
         }
 
         return price;
@@ -1225,10 +1231,15 @@ public abstract class InventoryManager {
     }
 
     if (Preferences.getBoolean("debugBuy")) {
-      RequestLogger.printLine("\u262F " + item + " mall=" + mallPrice + " make=" + makePrice);
+      RequestLogger.printLine(
+          "\u262F " + item + " mall=" + priceString(mallPrice) + " make=" + priceString(makePrice));
     }
 
     return Math.min(mallPrice, makePrice);
+  }
+
+  private static String priceString(long price) {
+    return price == Long.MAX_VALUE ? "\u221E" : String.valueOf(price);
   }
 
   public static long priceToMake(final AdventureResult item, final boolean exact) {


### PR DESCRIPTION
When recursively calculating priceToMake - taking into account the price to buy the ingredients - acquire was assuming that the concoction's quantityPossible was greater than 0. I.e. that you had enough "accessible" ingredients to do the creation.

Considering that we are explicitly assuming we are willing to buy ingredients, this is less than useful.

Especially since this was the place where we compared autoBuyPriceLimit against the total cost of buying all the ingredients.

Removing the quantityPossible > 0 check means we can now get this:

```
> acquire? etched hourglass
...
The average amount of meat spent on components (6,496,048) for one etched hourglass exceeds autoBuyPriceLimit (20,000)
etched hourglass: fail
```

Which is more desirable than buying more than 10,000 grains of sand and making the item, autoBuyPriceLimit be damned.

I also made Long.MAXIMUM_VALUE print as &infin; for debugBuy logging.