### PR TITLE
Value for no poison is Integer.MAX_VALUE, not 0. add .poison proxy record field

### DIFF
--- a/src/net/sourceforge/kolmafia/MonsterData.java
+++ b/src/net/sourceforge/kolmafia/MonsterData.java
@@ -663,7 +663,7 @@ public class MonsterData extends AdventureResult {
     this.maxSprinkles = attributes.get(Attribute.SPRINKLE_MAX);
     this.group = (int) attributes.getOrDefault(Attribute.GROUP, 1);
     this.phylum = (Phylum) attributes.getOrDefault(Attribute.PHYLUM, Phylum.NONE);
-    this.poison = (int) attributes.getOrDefault(Attribute.POISON, 0);
+    this.poison = (int) attributes.getOrDefault(Attribute.POISON, Integer.MAX_VALUE);
     this.boss = attributes.containsKey(Attribute.BOSS);
     this.noBanish = attributes.containsKey(Attribute.NOBANISH);
     this.noCopy = attributes.containsKey(Attribute.NOCOPY);

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -1274,6 +1274,7 @@ public class ProxyRecordValue extends RecordValue {
             .add("turns_spent", DataTypes.INT_TYPE)
             .add("kisses", DataTypes.INT_TYPE)
             .add("recommended_stat", DataTypes.INT_TYPE)
+            .add("poison_level", DataTypes.INT_TYPE)
             .add("water_level", DataTypes.INT_TYPE)
             .add("wanderers", DataTypes.BOOLEAN_TYPE)
             .finish("location proxy");
@@ -1386,6 +1387,15 @@ public class ProxyRecordValue extends RecordValue {
 
     public int get_recommended_stat() {
       return this.content != null ? ((KoLAdventure) this.content).getRecommendedStat() : 0;
+    }
+
+    public int get_poison_level() {
+      if (this.content == null) {
+        return 0;
+      }
+
+      AreaCombatData area = ((KoLAdventure) this.content).getAreaSummary();
+      return area == null ? 0 : area.poison();
     }
 
     public int get_water_level() {

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -1391,11 +1391,11 @@ public class ProxyRecordValue extends RecordValue {
 
     public int get_poison() {
       if (this.content == null) {
-        return 0;
+        return Integer.MAX_VALUE;
       }
 
       AreaCombatData area = ((KoLAdventure) this.content).getAreaSummary();
-      return area == null ? 0 : area.poison();
+      return area == null ? Integer.MAX_VALUE : area.poison();
     }
 
     public int get_water_level() {

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -1274,7 +1274,7 @@ public class ProxyRecordValue extends RecordValue {
             .add("turns_spent", DataTypes.INT_TYPE)
             .add("kisses", DataTypes.INT_TYPE)
             .add("recommended_stat", DataTypes.INT_TYPE)
-            .add("poison_level", DataTypes.INT_TYPE)
+            .add("poison", DataTypes.INT_TYPE)
             .add("water_level", DataTypes.INT_TYPE)
             .add("wanderers", DataTypes.BOOLEAN_TYPE)
             .finish("location proxy");
@@ -1389,7 +1389,7 @@ public class ProxyRecordValue extends RecordValue {
       return this.content != null ? ((KoLAdventure) this.content).getRecommendedStat() : 0;
     }
 
-    public int get_poison_level() {
+    public int get_poison() {
       if (this.content == null) {
         return 0;
       }


### PR DESCRIPTION
Monsters with poison have a poison level from 1 to 6.
The lower the level, the more severe.
The value for "no poison" is Integer.MAX_VALUE, not 0.

Added $location.poison proxy record field, which is the most virulent poison a monster in that area has.

This is the issue for the following Bug Report:

https://kolmafia.us/threads/mafia-will-not-adventure-without-acquiring-an-anti-anti-antidote.27628/