### PR TITLE
feat: take elemental attacks from the wiki

### DIFF
--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -12,9 +12,9 @@
 
 # Regular monsters
 
-1335 HaXx0r	141	1335.gif	Atk: 81 Def: 72 HP: 71 Init: 50 Meat: 30 P: dude Article: a	334 scroll (20)	Dyspepsi-Cola (70)	1337 7r0uZ0RZ (15)	Accordion of Jordion (a0)
+1335 HaXx0r	141	1335.gif	Atk: 81 Def: 72 HP: 71 Init: 50 Meat: 30 P: dude EA: "bad spelling" Article: a	334 scroll (20)	Dyspepsi-Cola (70)	1337 7r0uZ0RZ (15)	Accordion of Jordion (a0)
 7-Foot Dwarf Foreman	98	foreman.gif	LUCKY Atk: 57 Def: 51 HP: 50 Init: 80 Meat: 60 P: humanoid Article: a	miner's helmet (30)	miner's pants (30)	7-Foot Dwarven mattock (30)
-A.M.C. gremlin	554	gremlinamc.gif	Atk: 170 Def: 153 HP: 170 Init: 60 Meat: 50 P: humanoid Article: an	gremlin juice (3)
+A.M.C. gremlin	554	gremlinamc.gif	Atk: 170 Def: 153 HP: 170 Init: 60 Meat: 50 P: humanoid EA: hot Article: an	gremlin juice (3)
 acid blob	220	lower_b.gif	Atk: 58 Def: 52 HP: 70 Init: 40 P: slime Article: an	magic whistle (15)	blob of acid (c0)
 acoustic electric eel	736	electriceel.gif	Atk: 400 Def: 360 HP: 500 Init: 200 Meat: 240 P: fish Article: an	dull fish scale (n15)	eel battery (c9)	eel sauce (c10)	eel skin (n4)
 albino bat	41	whitebat.gif	Atk: 12 Def: 12 HP: 8 Init: 60 Meat: 20 P: beast Article: an	batgut (10)	bat guano (10)
@@ -37,9 +37,9 @@ angry bugbear	256	angbugbear.gif	Atk: 15 Def: 14 HP: 12 Init: 50 P: beast Articl
 angry pi&ntilde;ata	269	pinata.gif	Atk: 22 Def: 19 HP: 20 Init: 50 P: construct Article: an	pile of candy (100)
 angry mushroom guy	1800	mush_angry.gif	Atk: 30 Def: 25 HP: 20 Init: 75 P: plant Article: an	fizzing spore pod (70)	Knob mushroom (20)
 animated mahogany nightstand	1541	nightstand2.gif	Atk: 55 Def: 55 HP: 60 Init: -10000 P: construct Article: an
-animated ornate nightstand	1542	nightstand4.gif	Atk: 60 Def: 45 HP: 55 Init: -10000 P: construct Article: an
+animated ornate nightstand	1542	nightstand4.gif	Atk: 60 Def: 45 HP: 55 Init: -10000 P: construct EA: spooky Article: an
 animated rustic nightstand	1543	nightstand3.gif	Atk: 55 Def: 50 HP: 60 Init: -10000 P: construct Article: an
-Anime Smiley	139	smiley.gif	Atk: 77 Def: 69 HP: 67 Init: 60 P: horror Article: an	334 scroll (30)	Tasty Fun Good rice candy (40)	caret (p5)
+Anime Smiley	139	smiley.gif	Atk: 77 Def: 69 HP: 67 Init: 60 P: horror EA: "bad spelling" Article: an	334 scroll (30)	Tasty Fun Good rice candy (40)	caret (p5)
 annoying spooky gravy fairy	259	annoyfairy.gif	Atk: 20 Def: 18 HP: 20 Init: 70 P: plant E: spooky Article: an	annoying pitchfork (100)
 armored mushroom guy	1803	mush_armor.gif	Atk: 20 Def: 35 HP: 20 Init: 25 P: plant Article: an	hard spore pod (0)	warm mushroom (0)
 Astronomer	184	astronomer.gif	Atk: 168 Def: 151 HP: 150 Init: 70 P: constellation EA: hot Article: The	star chart (100)
@@ -48,125 +48,125 @@ Axe Wound	543	axewound.gif	Atk: 163 Def: 146 HP: 150 Init: 70 P: constellation E
 Baa'baa'bu'ran	1163	stone_serpent.gif	LUCKY Scale: 10 Cap: 100 Floor: 20 Init: -10000 P: construct	stone wool (100)	stone wool (50)	stone wool (20)
 baa-relief sheep	1160	stone_sheep.gif	Scale: 0 Cap: 50 Floor: 7 Init: -10000 P: construct Article: a	stone wool (25)
 Bad ASCII Art	426	badascii.gif	LUCKY Atk: 85 Def: 76 HP: 75 Init: 50 P: construct Article: Some	ASCII shirt (c100)	30669 scroll (100)	33398 scroll (100)	334 scroll (100)	334 scroll (100)
-baguette lady	1748	baglady.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: construct Article: a	magical baguette (0)	wad of dough (0)
-Bailey's Beetle	576	warhipmo.gif	Atk: 195 Def: 175 HP: 210 Init: 70 P: hippy E: stench Article: a	green clay bead (30)	floorboard cruft (30)	battered hubcap (30)	communications windchimes (10)	reinforced beaded headband (1)	round purple sunglasses (2)	bullet-proof corduroys (4)
+baguette lady	1748	baglady.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: construct EA: sleaze EA: spooky Article: a	magical baguette (0)	wad of dough (0)
+Bailey's Beetle	576	warhipmo.gif	Atk: 195 Def: 175 HP: 210 Init: 70 P: hippy ED: stench EA: hot EA: stench Article: a	green clay bead (30)	floorboard cruft (30)	battered hubcap (30)	communications windchimes (10)	reinforced beaded headband (1)	round purple sunglasses (2)	bullet-proof corduroys (4)
 Baiowulf	231	baiowulf.gif	NOCOPY NOMANUEL ULTRARARE Atk: 15 Def: 13 HP: 20 Init: 10000 P: dude	Talisman of Baio (100)
-banshee librarian	388	banshee.gif	Atk: 28 Def: 25 HP: 30 Init: -10000 P: undead GHOST ED: spooky Article: a	disintegrating quill pen (20)	killing jar (10)
+banshee librarian	388	banshee.gif	Atk: 28 Def: 25 HP: 30 Init: -10000 P: undead GHOST E: spooky Article: a	disintegrating quill pen (20)	killing jar (10)
 bar	202	bar.gif	Atk: 3 Def: 2 HP: 5 Init: 50 Meat: 15 P: beast Article: a	bar skin (35)	baritone accordion (a0)
 Baron von Ratsworth	286	ratsworth.gif	BOSS NOCOPY Atk: [MOX+min(13,3+A)] Def: [MUS+min(13,3+A)] HP: [HP*1.25] Init: 80 P: beast	Baron von Ratsworth's monocle (c100)	Baron von Ratsworth's money clip (c100)	Baron von Ratsworth's tophat (c100)
 baseball bat	43	ballbat.gif	Atk: 15 Def: 13 HP: 9 Init: 60 Meat: 20 P: beast Article: a	baseball (30)	sonar-in-a-biscuit (10)
 BASIC Elemental	87	basicgolem.gif	Atk: 50 Def: 45 HP: 40 Init: 60 P: elemental Article: a	GOTO (30)
 basic lihc	2153	lich.gif	Atk: 55 Def: 50 HP: 54 Init: 50 P: undead E: spooky Article: a	bottle of vodka (30)	boxed wine (30)
 batrat	150	batrat.gif	Atk: 23 Def: 20 HP: 20 Init: 60 Meat: 22 P: beast Article: a	bat wing (15)	bat guano (15)	batgut (15)	sonar-in-a-biscuit (15)
-Battlie Knight Ghost	1257	aboo_wars.gif	Atk: 76 Def: 64 HP: 40 Init: -10000 P: undead GHOST Phys: 100 E: spooky Article: a	A-Boo clue (c15)	Battlie Light Saver (15)	Whoompa Fur Pants (5)	ectoplasmic orbs (10)
-batwinged gremlin	548	gremlinbat.gif	Atk: 169 Def: 153 HP: 170 Init: 60 Meat: 50 P: humanoid Article: a	gremlin juice (3)
+Battlie Knight Ghost	1257	aboo_wars.gif	Atk: 76 Def: 64 HP: 40 Init: -10000 P: undead GHOST Phys: 100 ED: spooky EA: hot Article: a	A-Boo clue (c15)	Battlie Light Saver (15)	Whoompa Fur Pants (5)	ectoplasmic orbs (10)
+batwinged gremlin	548	gremlinbat.gif	Atk: 169 Def: 153 HP: 170 Init: 60 Meat: 50 P: humanoid EA: stench Article: a	gremlin juice (3)
 batwinged gremlin (tool)	549	gremlinbat.gif	Atk: 169 Def: 153 HP: 170 Init: 60 Meat: 50 P: humanoid Article: a Manuel: "batwinged gremlin" Wiki: "batwinged gremlin (quest)"	gremlin juice (3)	molybdenum hammer (c0)
 bazookafish	724	bazookafish.gif	Atk: 375 Def: 292 HP: 500 Init: 100 Meat: 220 P: fish Article: a	bazookafish bubble gum (42)	bazookafish bubble gum (8)	dull fish scale (n15)	fish bazooka (n2)
 beanbat	48	beanbat.gif	Atk: 21 Def: 18 HP: 18 Init: 60 Meat: 34 P: beast Article: a	enchanted bean (50)	sonar-in-a-biscuit (10)
-bearpig topiary animal	1246	topi2.gif	Atk: 85 Def: 80 HP: 90 Init: 50 P: beast Article: a	rusty hedge trimmers (15)	pestopiary (15)
+bearpig topiary animal	1246	topi2.gif	Atk: 85 Def: 80 HP: 90 Init: 50 P: beast EA: sleaze Article: a	rusty hedge trimmers (15)	pestopiary (15)
 Beaver	539	beaver.gif	Atk: 162 Def: 145 HP: 150 Init: 70 P: constellation ED: sleaze EA: hot Article: The	line (30)	star (30)	star (30)
 beefy bodyguard bat	571	beefybat.gif	NOBANISH Atk: 25 Def: 22 HP: 25 Init: 50 Meat: 250 P: beast Article: a	beefy pill (0)
 Beer Bongadier	422	warfratbg.gif	Atk: 180 Def: 175 HP: 210 Init: 50 P: orc E: sleaze Article: a	beer bong (20)	beer helmet (1)	bejeweled pledge pin (1)	distressed denim pants (1)	kick-ass kicks (2)	PADL Phone (3)
 biclops	1579	biclops.gif	NOCOPY Atk: 38 Def: 33 HP: 30 Init: 25 Meat: 30 P: humanoid Article: a	duonoculars (c100)
 big creepy spider	156	spider1.gif	Atk: 1 Def: 0 HP: 1 Init: 40 Meat: 5 P: bug Article: a Poison: "Hardly Poisoned at All"	spider web (25)	spider web (25)
-big swarm of ghuol whelps	1073	whelps2.gif	Atk: 50 Def: 45 HP: 150 Init: 300 Group: 15 P: undead E: spooky Article: a
+big swarm of ghuol whelps	1073	whelps2.gif	Atk: 50 Def: 45 HP: 150 Init: 300 Group: 15 P: undead ED: spooky Article: a
 Big Wheelin' Twins	1241	twins_bigwheel.gif	Atk: 92 Def: 85 HP: 105 Init: 60 Meat: 70 Group: 2 P: dude Article: the	badge of authority (5)	vial of The Glistening (15)
 bizarre construct	665	vib2.gif	Atk: 300 Def: 270 HP: 300 Init: 30 P: construct Article: a	El Vibrato punchcard (97 holes) (1)	El Vibrato punchcard (216 holes) (1)
 bizarre construct (translated)	671	vib2.gif	Atk: 300 Def: 270 HP: 300 Init: 30 P: construct Article: a Manuel: "bizarre construct" Wiki: "bizarre construct"	El Vibrato punchcard (97 holes) (1)	El Vibrato punchcard (216 holes) (1)
-BL Imp	980	blimp.gif	Atk: 65 Def: 58 HP: 65 Init: 30 Meat: 40 P: demon E: hot Article: a	imp air (20)
+BL Imp	980	blimp.gif	Atk: 65 Def: 58 HP: 65 Init: 30 Meat: 40 P: demon ED: hot EA: stench Article: a	imp air (20)
 black adder	414	blackadder.gif	Atk: 129 Def: 114 HP: 124 Init: 50 Meat: 100 P: beast SNAKE Article: a Poison: "Really Quite Poisoned"	adder bladder (30)	black snake skin (15)	sunken eyes (c50)
 black friar	1577	blackfriar.gif	Atk: 130 Def: 111 HP: 122 Init: 75 P: dude Article: a	black label (15)	Mornington crescent roll (15)	black cloak (5)	black friar's tonsure (c15)
 black magic woman	1576	witchywoman.gif	Atk: 131 Def: 113 HP: 125 Init: 50 Meat: 100 P: dude Article: a	black eye shadow (20)	little black book (5)	black magic powder (c15)
-black panther	416	panther.gif	Atk: 133 Def: 112 HP: 128 Init: 50 Meat: 150 P: beast Article: a	Black No. 2 (20)	broken wings (c50)
+black panther	416	panther.gif	Atk: 133 Def: 112 HP: 128 Init: 50 Meat: 150 P: beast EA: sleaze Article: a	Black No. 2 (20)	broken wings (c50)
 black pudding	476	blpudding.gif	NOCOPY Atk: 50 Def: 45 HP: 40 Init: 10000 P: slime EA: sleaze Article: a	black pudding (100)	black pudding (100)
-black widow	415	blackwidow.gif	Atk: 132 Def: 110 HP: 121 Init: 50 Meat: 50 P: bug Article: a Poison: "Really Quite Poisoned"	black pension check (30)	black picnic basket (15)
+black widow	415	blackwidow.gif	Atk: 132 Def: 110 HP: 121 Init: 50 Meat: 50 P: bug EA: sleaze Article: a Poison: "Really Quite Poisoned"	black pension check (30)	black picnic basket (15)
 blackberry bush	418	blackbush.gif	Atk: 126 Def: 114 HP: 136 Init: 30 P: plant Article: a	blackberry (20)	blackberry (20)	blackberry (20)
-blind snake	2122	pr_snake.gif	Atk: 35 Def: 40 HP: 50 Init: 50 Meat: 250 P: beast Article: a
+blind snake	2122	pr_snake.gif	Atk: 35 Def: 40 HP: 50 Init: 50 Meat: 250 P: beast EA: sleaze EA: stench Article: a
 Blooper	118	squid.gif	Atk: 25 Def: 22 HP: 15 Init: 60 P: beast Article: a	white pixel (80)	white pixel (70)	white pixel (60)
-Blue Oyster cultist	1528	bluecultist.gif	Atk: 135 Def: 135 HP: 130 Init: 50 Meat: 100 P: dude Elem: 75 Article: a	fire of unknown origin (15)	black blade (5)	cigarette lighter (15)	blue oyster badge (c0)
+Blue Oyster cultist	1528	bluecultist.gif	Atk: 135 Def: 135 HP: 130 Init: 50 Meat: 100 P: dude Elem: 75 EA: hot Article: a	fire of unknown origin (15)	black blade (5)	cigarette lighter (15)	blue oyster badge (c0)
 blur	460	blur.gif	Atk: 136 Def: 126 HP: 141 Init: 40 Meat: 120 P: dude Article: a	drum machine (30)	palm frond (10)	hot date (5)	carbonated water lily (10)	Hugo's Weaving Manual (c100)
 boaraffe	568	boaraffe.gif	Atk: 145 Def: 130 HP: 145 Init: 50 Meat: 100 P: beast Article: a	long pork (30)
 Bob Racecar	132	naskar2.gif	Atk: 138 Def: 129 HP: 139 Init: 80 Meat: 120 P: dude	ketchup hound (35)	leather chaps (15)	mesh cap (15)	stunt nuts (30)	a butt tuba (0)	folder (D-Team) (c0)
-bog leech	1345	bogleech.gif	Atk: 44 Def: 50 HP: 60 Init: 20 Meat: 30 P: bug Article: a	delicious swamp muck (0)	leechknife (0)
-bog skeleton	1346	bogskeleton.gif	Atk: 50 Def: 52 HP: 50 Init: 25 Meat: 10 P: undead E: spooky Article: a	delicious swamp muck (0)	skeleton bone (0)
+bog leech	1345	bogleech.gif	Atk: 44 Def: 50 HP: 60 Init: 20 Meat: 30 P: bug EA: stench Article: a	delicious swamp muck (0)	leechknife (0)
+bog skeleton	1346	bogskeleton.gif	Atk: 50 Def: 52 HP: 50 Init: 25 Meat: 10 P: undead ED: spooky EA: spooky EA: stench Article: a	delicious swamp muck (0)	skeleton bone (0)
 bogart	1348	bogart.gif	Atk: 54 Def: 48 HP: 48 Init: 70 Meat: 30 P: humanoid Article: a	fine aged cheddarwurst (0)	stolen meatpouch (0)
 Bonerdagon	198	foss_wyrm.gif	BOSS NOCOPY Atk: 90 Def: 81 HP: 120 Init: 90 P: undead E: spooky Item: 25 Skill: 50 Article: The	skull of the Bonerdagon (n100)	chest of the Bonerdagon (n100)
 bookbat	387	bookbat.gif	Atk: 26 Def: 24 HP: 26 Init: 70 P: construct Article: a	tattered scrap of paper (15)
 booty crab	634	bootycrab.gif	NOCOPY Atk: 100 Def: 90 HP: 70 Init: 10000 Meat: 300 P: beast Phys: 25 E: sleaze Article: a	Cap'm Caronch's nasty booty (100)
 Booze Giant	95	boozegiant.gif	Atk: 76 Def: 68 HP: 66 Init: 80 P: humanoid Article: a	bottle of gin (15)	bottle of rum (15)	bottle of tequila (15)	bottle of vodka (15)	bottle of whiskey (15)	boxed wine (15)	giant breath mint (c0)
 Boss Bat	49	bigbossbat.gif	BOSS NOBANISH NOCOPY Atk: 33 Def: 29 HP: 40 Init: 60 P: beast Article: The	batskin belt (100)	dense Meat stack (100)	Boss Bat britches (c100)	boss Bat bling (c100)
-Box	535	box.gif	Atk: 150 Def: 135 HP: 150 Init: 70 P: constellation E: sleaze Article: The	line (30)	line (30)	line (30)
+Box	535	box.gif	Atk: 150 Def: 135 HP: 150 Init: 70 P: constellation ED: sleaze EA: hot EA: sleaze Article: The	line (30)	line (30)	line (30)
 Brainsweeper	34	broombrain.gif	Atk: 18 Def: 16 HP: 9 Init: 60 Meat: 36 P: construct Article: a	disembodied brain (30)
-Bram the Stoker	1559	bram.gif	LUCKY Atk: 164 Def: 148 HP: 170 Init: 50 Meat: 250 P: undead	Bram's choker (100)
+Bram the Stoker	1559	bram.gif	LUCKY Atk: 164 Def: 148 HP: 170 Init: 50 Meat: 250 P: undead EA: hot	Bram's choker (100)
 Bread Golem	35	breadgolem.gif	Atk: 16 Def: 14 HP: 8 Init: 60 Meat: 32 P: construct Article: a	wad of dough (30)	eldritch dough (c0)
 briefcase bat	46	casebat.gif	Atk: 17 Def: 15 HP: 11 Init: 60 Meat: 28 P: beast Article: a	bat guano (10)	briefcase (40)	sonar-in-a-biscuit (10)
 broodling seal	794	babyseal.gif	NOCOPY FREE Atk: 80 Def: 90 HP: 100 Init: -10000 P: demon Article: a	severed flipper (35)
 Brutus, the toga-clad lout	518	togafrat.gif	NOCOPY Atk: 200 Def: 180 HP: 280 Init: 60 Meat: 250 P: orc E: sleaze	wreath of laurels (100)	white class ring (30)	kick-ass kicks (0)
-Bubblemint Twins	1240	twins_bubble.gif	Atk: 93 Def: 83 HP: 90 Init: 40 Meat: 65 Group: 2 P: dude Article: the	dress pants (5)	that gum you like (25)
+Bubblemint Twins	1240	twins_bubble.gif	Atk: 93 Def: 83 HP: 90 Init: 40 Meat: 65 Group: 2 P: dude EA: sleaze EA: stench Article: the	dress pants (5)	that gum you like (25)
 bugbear-in-the-box	108	binbox.gif	Atk: 16 Def: 16 HP: 11 Init: 70 Meat: 15 P: beast Article: a	box (20)	bugbear beanie (10)	bugbear bungguard (10)
 bugged bugbear	258	bugbugbear.gif	Atk: 17 Def: 16 HP: 14 Init: 50 P: beast Article: a	gnoll teeth (30)	gnoll lips (30)	software glitch (p25)
 Bullet Bill	121	bulletbill.gif	Atk: 25 Def: 22 HP: 15 Init: 60 P: construct Article: a	black pixel (70)	black pixel (70)	black pixel (70)
-bunch of drunken rats	995	ratbunch.gif	Atk: 20 Def: 18 HP: 16 Init: 80 Meat: 20 Group: 3 P: beast Article: a	rat whisker (0)	rat whisker (0)	rat appendix (0)	rat appendix (0)	rat appendix (0)
+bunch of drunken rats	995	ratbunch.gif	Atk: 20 Def: 18 HP: 16 Init: 80 Meat: 20 Group: 3 P: beast EA: sleaze Article: a	rat whisker (0)	rat whisker (0)	rat appendix (0)	rat appendix (0)	rat appendix (0)
 Burly Sidekick	166	sidekick.gif	Atk: 100 Def: 90 HP: 100 Init: 80 Meat: 130 P: dude Article: a	armgun (9)	cocoa eggshell fragment (30)	Mohawk wig (10)	tiny house (30)
 Burrowing Bishop	351	bishop.gif	Atk: 163 Def: 146 HP: 150 Init: 70 P: constellation E: sleaze Article: The	line (30)	line (30)	star (30)
 Bush	537	bush.gif	Atk: 156 Def: 140 HP: 150 Init: 70 P: constellation ED: sleaze EA: hot Article: The	star (30)	star (30)	star (30)
 business hippy	335	bushippy.gif	Atk: 35 Def: 34 HP: 25 Init: -10000 Meat: 50 P: hippy E: stench Article: a	filthy corduroys (10)	filthy knitted dread sack (10)	herbs (20)	reodorant (10)
 Buzzy Beetle	273	buzzy.gif	Atk: 20 Def: 18 HP: 15 Init: 60 P: bug Article: a	black pixel (50)	white pixel (50)	red pixel (65)
-C.A.R.N.I.V.O.R.E. Operative	514	carnivore.gif	NOCOPY Atk: 210 Def: 189 HP: 320 Init: 80 Meat: 300 P: hippy ED: stench	C.A.R.N.I.V.O.R.E. button (100)	green clay bead (30)	Lockenstock&trade; sandals (0)
+C.A.R.N.I.V.O.R.E. Operative	514	carnivore.gif	NOCOPY Atk: 210 Def: 189 HP: 320 Init: 80 Meat: 300 P: hippy ED: stench EA: sleaze	C.A.R.N.I.V.O.R.E. button (100)	green clay bead (30)	Lockenstock&trade; sandals (0)
 cabinet of Dr. Limpieza	1561	laundrycabinet.gif	Atk: 142 Def: 148 HP: 150 Init: 25 P: undead Article: the	fabric softener (15)	bottle of laundry sherry (15)	bloodstain stick (20)	fabric hardener (15)	blasting soda (c0)
 cactuary	465	cactuary.gif	Atk: 137 Def: 126 HP: 139 Init: 10 Meat: 100 P: plant Article: a	bit-o-cactus (27)	giant cactus quill (5)	cactus fruit (20)	handful of sand (20)
-Cake Lord	1756	cakelord.gif	NOCOPY Atk: 5 Def: 5 HP: 10 Init: -10000 P: construct Article: the
+Cake Lord	1756	cakelord.gif	NOCOPY Atk: 5 Def: 5 HP: 10 Init: -10000 P: construct EA: hot Article: the
 Camel's Toe	541	cameltoe.gif	Atk: 158 Def: 142 HP: 150 Init: 70 P: constellation ED: sleaze EA: hot Article: The	line (30)	line (30)	star (30)	star (30)
-Carbuncle Top	985	carbuncletop.gif	BOSS NOCOPY Atk: 70 Def: 63 HP: 70 Init: 50 P: demon	hilarious comedy prop (100)
+Carbuncle Top	985	carbuncletop.gif	BOSS NOCOPY Atk: 70 Def: 63 HP: 70 Init: 50 P: demon EA: hot EA: sleaze	hilarious comedy prop (100)
 cargo crab	743	cargocrab.gif	Atk: 450 Def: 360 HP: 500 Init: 150 Meat: 200 P: fish Article: a	imitation crab crate (n30)
 Carnivorous Moxie Weed	92	carniv.gif	Atk: 66 Def: 59 HP: 56 Init: 80 P: plant Article: a	moxie weed (30)	giant moxie weed (15)	giant moxie weed (15)
-caveman frat boy	451	cavefrat.gif	Atk: 235 Def: 225 HP: 290 Init: 20 Meat: 50 P: orc E: sleaze Article: a	ovoid leather thing (20)	chunk of rock salt (20)	stone baseball cap (10)
-caveman frat pledge	470	cavefrat.gif	Atk: 255 Def: 207 HP: 220 Init: 75 Meat: 40 P: orc E: sleaze Article: a	stone baseball cap (5)	cup of primitive beer (10)	chunk of rock salt (20)	ovoid leather thing (10)
+caveman frat boy	451	cavefrat.gif	Atk: 235 Def: 225 HP: 290 Init: 20 Meat: 50 P: orc ED: sleaze Article: a	ovoid leather thing (20)	chunk of rock salt (20)	stone baseball cap (10)
+caveman frat pledge	470	cavefrat.gif	Atk: 255 Def: 207 HP: 220 Init: 75 Meat: 40 P: orc ED: sleaze Article: a	stone baseball cap (5)	cup of primitive beer (10)	chunk of rock salt (20)	ovoid leather thing (10)
 caveman hippy	471	cavehippy.gif	Atk: 240 Def: 216 HP: 280 Init: 20 P: hippy E: stench Article: a	stone frisbee (20)	dreadlock whip (10)	handful of pine needles (20)	Spanish fly (c25)
-caveman sorority girl	452	cavesorority.gif	Atk: 230 Def: 225 HP: 240 Init: 25 Meat: 50 P: orc E: sleaze Article: a	cup of primitive beer (25)
-cavewomyn hippy	472	cavewomyn.gif	Atk: 250 Def: 207 HP: 260 Init: 25 P: hippy E: stench Article: a	handful of pine needles (20)	handful of nuts and berries (20)	Spanish fly (c25)
+caveman sorority girl	452	cavesorority.gif	Atk: 230 Def: 225 HP: 240 Init: 25 Meat: 50 P: orc ED: sleaze Article: a	cup of primitive beer (25)
+cavewomyn hippy	472	cavewomyn.gif	Atk: 250 Def: 207 HP: 260 Init: 25 P: hippy ED: stench EA: hot EA: stench Article: a	handful of pine needles (20)	handful of nuts and berries (20)	Spanish fly (c25)
 Centurion of Sparky	795	centurion.gif	NOCOPY FREE Atk: 150 Def: 180 HP: 200 Init: -10000 P: horror Article: a	ingot of seal-iron (35)
 CH Imp	981	chimp.gif	Atk: 62 Def: 55 HP: 62 Init: 60 Meat: 30 P: demon ED: hot EA: spooky EA: stench Article: a	imp air (25)
 chalkdust wraith	383	chalkdust.gif	Atk: 25 Def: 23 HP: 25 Init: 50 P: undead GHOST Phys: 100 ED: spooky Article: a	handful of hand chalk (100)
-chatty pirate	624	pirate2.gif	Atk: 100 Def: 90 HP: 90 Init: 50 Meat: 63 P: pirate Article: a
+chatty pirate	624	pirate2.gif	Atk: 100 Def: 90 HP: 90 Init: 50 Meat: 63 P: pirate EA: cold Article: a
 Chowder Golem	39	soupgolem.gif	Atk: 18 Def: 16 HP: 9 Init: 60 Meat: 36 P: construct EA: hot Article: a
 clan of cave bars	1162	cavebars.gif	NOCOPY Scale: 20 Cap: 200 Floor: 30 MLMult: 5 Init: -10000 Meat: 400 Group: 10 P: beast Article: a
 claw-foot bathtub	400	bathtub.gif	Atk: 57 Def: 47 HP: 55 Init: 30 P: construct Article: a	bottle of Monsieur Bubble (25)	fancy bath salts (35)
 Claybender Sorcerer Ghost	1254	aboo_wiz.gif	Atk: 70 Def: 70 HP: 40 Init: -10000 P: undead GHOST Phys: 100 E: spooky Article: a	A-Boo clue (c15)	Polysniff Perfume (15)	Claybender glasses (5)	folder (wizard) (c0)
 cleanly pirate	621	cleanpirate.gif	Atk: 100 Def: 90 HP: 90 Init: 50 Meat: 60 P: pirate Article: a	Swabbie&trade; swab (20)	Tom's of the Spanish Main Toothpaste (20)	rigging shampoo (c30)
 clingy pirate (female)	626	girlpirate.gif	Atk: 100 Def: 90 HP: 90 Init: 50 Meat: 65 P: pirate Article: a Manuel: "clingy pirate"	bit of clingfilm (11)
-clingy pirate (male)	627	pirate2.gif	Atk: 100 Def: 90 HP: 90 Init: 50 Meat: 65 P: pirate Article: a Manuel: "clingy pirate"	bit of clingfilm (11)
+clingy pirate (male)	627	pirate2.gif	Atk: 100 Def: 90 HP: 90 Init: 50 Meat: 65 P: pirate EA: cold Article: a Manuel: "clingy pirate"	bit of clingfilm (11)
 Cloaca-Cola Catapult Engineer	295	colaoff1.gif	Atk: 30 Def: 27 HP: 40 Init: 50 P: dude Article: a	Cloaca-Cola (15)	Cloaca-Cola (15)	Cloaca-Cola c-rations (5)	Cloaca grenade (5)
 Cloaca-Cola Footsoldier	294	colasol1.gif	Atk: 30 Def: 27 HP: 35 Init: 50 P: dude Article: a	Cloaca-Cola (15)	Cloaca-Cola (15)	Cloaca grenade (5)
 Cloaca-Cola Soldier	292	colasol1.gif	Atk: 30 Def: 27 HP: 30 Init: 50 P: dude Article: a	Cloaca-Cola (15)	Cloaca-Cola (15)	Cloaca grenade (5)	lucky lighter (p5)
 cloud of disembodied whiskers	226	whiskers.gif	Atk: 2 Def: 2 HP: 3 Init: 45 Group: 20 P: weird Article: a	shaving cream (20)
 clubfish	725	clubfish.gif	Atk: 350 Def: 360 HP: 600 Init: 100 Meat: 220 P: fish Article: a	dull fish scale (n15)	fish stick (n2)
-coaltergeist	1558	coaltergeist.gif	Atk: 152 Def: 138 HP: 150 Init: 25 P: undead Article: a	coal dust (15)	hot coal (10)	hot coal (10)	coal shovel (5)
+coaltergeist	1558	coaltergeist.gif	Atk: 152 Def: 138 HP: 150 Init: 25 P: undead EA: hot Article: a	coal dust (15)	hot coal (10)	hot coal (10)	coal shovel (5)
 Cobb's Knob oven	1060	kg_oven.gif	Atk: 20 Def: 18 HP: 20 Init: 50 P: construct E: hot Article: a	oven mitts (5)	overcookie (20)
 completely different spider	157	spider2.gif	Atk: 1 Def: 0 HP: 1 Init: 40 Meat: 5 P: bug Article: a Poison: "Hardly Poisoned at All"	spider web (25)	spider web (25)
 confused goth music student	376	lilgoth.gif	Atk: 24 Def: 21 HP: 24 Init: 50 P: dude EA: spooky Article: a	pocket theremin (10)	clove-flavored lip balm (c0)
 conjoined zmombie	197	2zombies.gif	BOSS NOCOPY Atk: 73 Def: 63 HP: 120 Exp: [53+ML/3] Init: 60 Meat: 300 P: undead E: spooky Article: a	cranberries (29)	cranberries (8)	loose teeth (8)
-conservationist hippy	597	conhippy.gif	BOSS NOCOPY Atk: 64 Def: 68 HP: 70 Init: 40 Meat: 40 P: hippy E: stench Article: a	branch from the Great Tree (c100)	super-strong air freshener (c100)
+conservationist hippy	597	conhippy.gif	BOSS NOCOPY Atk: 64 Def: 68 HP: 70 Init: 40 Meat: 40 P: hippy ED: stench Article: a	branch from the Great Tree (c100)	super-strong air freshener (c100)
 cooler wino	1751	coolerwino.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: hobo Article: a	unflavored wine cooler (0)	unflavored wine cooler (0)	mostly-broken sunglasses (0)	handful of stubble (c0)
-Copperhead Club bartender	1510	coppertender.gif	Atk: 140 Def: 140 HP: 150 Init: 25 Meat: 100 P: dude	handful of tips (20)	unnamed cocktail (15)	unrequired jacket (0)	electric copperhead potion (c0)
+Copperhead Club bartender	1510	coppertender.gif	Atk: 140 Def: 140 HP: 150 Init: 25 Meat: 100 P: dude EA: cold EA: hot	handful of tips (20)	unnamed cocktail (15)	unrequired jacket (0)	electric copperhead potion (c0)
 corpulent zobmie	196	fatzombie.gif	Atk: 54 Def: 49 HP: 50 Init: 50 Meat: 75 P: undead E: spooky Article: a	cranberries (25)	cranberries (15)	loose teeth (10)	Grateful Undead T-shirt (c1)	paranormal ricotta (c0)
-cosmetics wraith	1545	makeupwraith.gif	NOCOPY Atk: 65 Def: 55 HP: 65 Init: 50 P: undead E: spooky Article: a	Lady Spookyraven's powder puff (c100)	old eyebrow pencil (0)	old rosewater cream (0)	old bronzer (0)
+cosmetics wraith	1545	makeupwraith.gif	NOCOPY Atk: 65 Def: 55 HP: 65 Init: 50 P: undead ED: spooky EA: sleaze Article: a	Lady Spookyraven's powder puff (c100)	old eyebrow pencil (0)	old rosewater cream (0)	old bronzer (0)
 Count Bakula	348	bakula.gif	NOCOPY NOMANUEL ULTRARARE Atk: 80 Def: 72 HP: 80 Init: 10000 P: dude	Talisman of Bakula (100)
 crate	992	crate.gif	Atk: 0 Def: 0 HP: 1 Init: -10000 P: construct Article: a
 craven carven raven	1161	stone_raven.gif	Scale: 0 Cap: 50 Floor: 7 Init: -10000 P: construct Article: a	shiny stones (100)
 crazy bastard	229	bastard.gif	NOCOPY NOMANUEL ULTRARARE Atk: 20 Def: 18 HP: 25 P: dude	crazy bastard sword (100)
-creamy pirate	622	pirate2.gif	Atk: 100 Def: 90 HP: 90 Init: 50 Meat: 60 P: pirate Article: a	creamsicle (20)	cream stout (20)	Oil of Parrrlay (15)	ball polish (c30)
+creamy pirate	622	pirate2.gif	Atk: 100 Def: 90 HP: 90 Init: 50 Meat: 60 P: pirate EA: cold EA: hot EA: sleaze EA: stench Article: a	creamsicle (20)	cream stout (20)	Oil of Parrrlay (15)	ball polish (c30)
 cr&ecirc;ep	1747	creep.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: construct E: spooky Article: a Manuel: "crêep"	cr&ecirc;epy mask (0)	wad of dough (0)
 creepy clown	112	clown.gif	Atk: 20 Def: 18 HP: 16 Init: 85 Meat: 30 P: horror E: spooky Article: a	acid-squirting flower (10)	clown shoes (10)	foolscap fool's cap (10)	clown skin (10)	big bass drum (4)	polka-dot bow tie (p5)
 creepy doll	1549	creepydoll.gif	Atk: 88 Def: 76 HP: 75 Init: 25 P: construct E: spooky Article: a	droopy doll eye (10)	creepy doll head (5)	creepy voice box (5)
-Creepy Ginger Twin	1243	twins_ginger.gif	Atk: 95 Def: 86 HP: 95 Init: 30 Meat: 55 P: dude Article: a	creepy ginger ale (15)	stolen necklace (5)	fireclutch (c30)
+Creepy Ginger Twin	1243	twins_ginger.gif	Atk: 95 Def: 86 HP: 95 Init: 30 Meat: 55 P: dude EA: hot Article: a	creepy ginger ale (15)	stolen necklace (5)	fireclutch (c30)
 crusty hippy	54	hippy3.gif	Atk: 41 Def: 36 HP: 30 Init: 60 P: hippy E: stench Article: a	filthy corduroys (5)	filthy knitted dread sack (5)	windchimes (30)	reodorant (5)	hippy bongo (5)	Spanish fly (c25)
 crusty hippy jewelry maker	60	hippy3.gif	Atk: 41 Def: 36 HP: 30 Init: 70 P: hippy E: stench Article: a	hemp string (30)	filthy knitted dread sack (3)	reodorant (5)	filthy corduroys (2)	phat turquoise bead (10)	beach glass bead (10)	clay peace-sign bead (10)	hippy bongo (5)	Spanish fly (c25)
 crusty hippy Vegan chef	57	hippy3.gif	Atk: 41 Def: 36 HP: 30 Init: 70 P: hippy E: stench Article: a	filthy corduroys (3)	filthy knitted dread sack (5)	filthy pestle (10)	herbs (30)	reodorant (5)	hippy bongo (5)	Spanish fly (c25)
 crusty pirate	625	crustpirate.gif	Atk: 100 Def: 90 HP: 90 Init: 50 Meat: 65 P: pirate ED: stench Article: a	barrrnacle (15)	tarrrnish charrrm (10)
 cubist bull	393	cubistbull.gif	Atk: 56 Def: 50 HP: 55 Init: 50 Meat: 75 P: beast Article: a	broken sword (5)	4-dimensional guitar (5)	non-Euclidean non-accordion (a0)
 curmudgeonly pirate	623	curmpirate.gif	Atk: 100 Def: 90 HP: 90 Init: 50 Meat: 62 P: pirate Article: a	all-purpose cleaner (25)	curmudgel (5)	grumpy old man charrrm (10)	handful of sawdust (30)	mizzenmast mop (c30)
-Dad Sea Monkee	1379	dad_machine.gif	BOSS NOCOPY Atk: 42000 Def: 42000 HP: 4200 Init: 10000 P: horror
+Dad Sea Monkee	1379	dad_machine.gif	BOSS NOCOPY Atk: 42000 Def: 42000 HP: 4200 Init: 10000 P: horror EA: cold EA: hot EA: sleaze EA: spooky EA: stench
 dairy goat	83	biggoat.gif	Atk: 68 Def: 61 HP: 50 Init: 80 Meat: 50 P: beast EA: sleaze Article: a	glass of goat's milk (20)	goat cheese (40)	Shivering Ch&egrave;vre (c0)
 dancing mushroom guy	1806	mush_dancing.gif	Atk: 20 Def: 35 HP: 20 Init: 100 P: plant Article: a	cool spore pod (0)	cool mushroom (0)
 Danglin' Chad	519	chad.gif	NOCOPY Atk: 210 Def: 189 HP: 320 Init: 80 Meat: 300 P: orc E: sleaze	Danglin' Chad's loincloth (100)	white class ring (30)	beer helmet (0)	bejeweled pledge pin (0)	distressed denim pants (0)	kick-ass kicks (0)
@@ -175,12 +175,12 @@ decent white shark	735	whiteshark.gif	Atk: 425 Def: 337 HP: 600 Init: 150 Meat: 
 demonic icebox	373	demfridge.gif	Atk: 21 Def: 19 HP: 21 Init: 50 Meat: 5 P: demon EA: cold EA: hot EA: stench Article: a	accidental cider (0)	ancient frozen dinner (30)	dire fudgesicle (0)	leftovers of indeterminate origin (40)	hand grenegg (p20)
 Demoninja	126	demoninja.gif	Atk: 48 Def: 27 HP: 48 Init: 75 Meat: 50 P: demon E: hot Article: a	demon skin (15)	hot katana blade (30)	ninja hot pants (5)
 dense liana	1426	liana.gif	Atk: 144 Def: 140 HP: 150 Init: -10000 P: plant Article: a	exotic jungle fruit (0)
-dinner troll	1749	dinnertroll.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: construct Article: a	wad of dough (0)	wad of dough (0)
+dinner troll	1749	dinnertroll.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: construct EA: spooky Article: a	wad of dough (0)	wad of dough (0)
 dire pigeon	1753	direpigeon.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: beast Article: a	jaunty feather (0)	pigeon egg (0)
 dirty hippy	53	hippy2.gif	Atk: 40 Def: 36 HP: 30 Init: 70 P: hippy E: stench Article: a	Feng Shui for Big Dumb Idiots (30)	filthy corduroys (5)	reodorant (5)	filthy knitted dread sack (2)	hippy bongo (5)	Spanish fly (c25)
 dirty hippy jewelry maker	59	hippy2.gif	Atk: 40 Def: 36 HP: 30 Init: 70 P: hippy E: stench Article: a	beach glass bead (10)	clay peace-sign bead (10)	filthy corduroys (5)	filthy knitted dread sack (2)	hemp string (30)	hippy bongo (5)	phat turquoise bead (10)	reodorant (5)	Spanish fly (c25)
 dirty hippy Vegan chef	56	hippy2.gif	Atk: 40 Def: 36 HP: 30 Init: 70 P: hippy E: stench Article: a	carob chunks (30)	double-barreled sling (5)	filthy knitted dread sack (5)	Uncle Jick's Brownie Mix (30)	reodorant (5)	filthy corduroys (2)	filthy pestle (5)	Spanish fly (c25)
-dirty old lihc	1071	dirtyoldlihc.gif	Atk: 60 Def: 54 HP: 50 Init: 50 P: undead E: spooky Article: a	salacious crumbs (25)
+dirty old lihc	1071	dirtyoldlihc.gif	Atk: 60 Def: 54 HP: 50 Init: 50 P: undead ED: spooky EA: sleaze Article: a	salacious crumbs (25)
 dirty thieving brigand	475	bandit.gif	NOCOPY Atk: 169 Def: 153 HP: 185 Init: 50 Meat: 1000 P: dude Article: a	brigand brittle (c0)
 disease-in-the-box	110	dinbox.gif	Atk: 18 Def: 16 HP: 14 Init: 80 P: construct Article: a	box (30)	disease (40)
 diving belle	762	divingbelle.gif	Atk: 400 Def: 450 HP: 750 Init: 50 P: undead E: spooky Article: a	diving muff (n3)	salinated mint julep (32)	water-polo mitt (c0)	comb jelly (0)
@@ -193,18 +193,18 @@ drippy bat	2163	drippybat.gif	NOCOPY Atk: [200] Def: [200] HP: [120] Init: 100 P
 drippy reveler	2176	drippyreveler.gif	NOCOPY Atk: [200] Def: [200] HP: [150] Init: 100 P: humanoid DRIPPY Phys: 100 Elem: 100 Article: a	Driplet (n0)	drippy stein (n0)
 drippy tree	2162	drippytree.gif	NOCOPY Atk: [150] Def: [150] HP: [100] Init: -10000 P: plant DRIPPY Phys: 100 Elem: 100 Article: a	Driplet (n0)
 drowned sailor	744	drownedsailor.gif	Atk: 400 Def: 405 HP: 700 Init: 50 Meat: 150 P: undead E: spooky Article: a	moist sailor's cap (n2)	rusty compass (n2)	rusty speargun (n2)	salt water taffy (c0)
-drunk duck	566	ducknicedrunk.gif	Atk: 165 Def: 157 HP: 170 Init: 40 Meat: 200 P: beast Article: a	bottle of gin (0)	bottle of rum (0)	bottle of tequila (0)	bottle of vodka (0)	bottle of whiskey (0)	boxed wine (0)	duct tape (0)
+drunk duck	566	ducknicedrunk.gif	Atk: 165 Def: 157 HP: 170 Init: 40 Meat: 200 P: beast EA: stench Article: a	bottle of gin (0)	bottle of rum (0)	bottle of tequila (0)	bottle of vodka (0)	bottle of whiskey (0)	boxed wine (0)	duct tape (0)
 drunk goat	82	drunkgoat.gif	Atk: 68 Def: 61 HP: 50 Init: 70 Meat: 45 P: beast Article: a	bottle of whiskey (25)	goat beard (5)
-drunk pygmy	1431	pyg_drunk.gif	Atk: 150 Def: 130 HP: 160 Init: 20 Meat: 100 P: dude Article: a	cold water bottle (0)	gold Boozehounds Anonymous token (0)	pygmy phone number (0)	pygmy concertinette (a0)
-drunken 7-foot dwarf	998	drunkminer.gif	Atk: 8 Def: 9 HP: 7 Init: 40 Meat: 20 P: humanoid Article: a	bottle of whiskey (20)	bottle of whiskey (20)
+drunk pygmy	1431	pyg_drunk.gif	Atk: 150 Def: 130 HP: 160 Init: 20 Meat: 100 P: dude EA: hot EA: sleaze Article: a	cold water bottle (0)	gold Boozehounds Anonymous token (0)	pygmy phone number (0)	pygmy concertinette (a0)
+drunken 7-foot dwarf	998	drunkminer.gif	Atk: 8 Def: 9 HP: 7 Init: 40 Meat: 20 P: humanoid EA: hot Article: a	bottle of whiskey (20)	bottle of whiskey (20)
 drunken half-orc hobo	158	hobo.gif	Atk: 1 Def: 0 HP: 1 Init: 40 P: hobo E: stench Article: a	dirty hobo gloves (32)	Mad Train wine (60)	moxie weed (15)	Boozehounds Anonymous token (p10)	beer-battered accordion (a0)
 drunken rat	51	rat.gif	Atk: 10 Def: 9 HP: 8 Init: 60 Meat: 10 P: beast Article: a	rat whisker (100)	rat appendix (20)	furry pill (0)
-drunken rat king	996	ratking.gif	NOCOPY Atk: 40 Def: 36 HP: 32 Init: 100 Meat: 40 P: beast Article: a	rat whisker (100)	rat whisker (100)	rat whisker (100)	rat whisker (100)	rat appendix (20)	rat appendix (20)	rat appendix (20)	tangle of rat tails (100)
-Dusken Raider Ghost	1255	aboo_dipshit.gif	Atk: 72 Def: 68 HP: 40 Init: -10000 P: undead GHOST Phys: 100 E: spooky Article: a	A-Boo clue (c15)	Duskwalker syringe (15)	Duskwalker fangs (5)	ectoplasmic orbs (10)
+drunken rat king	996	ratking.gif	NOCOPY Atk: 40 Def: 36 HP: 32 Init: 100 Meat: 40 P: beast EA: sleaze Article: a	rat whisker (100)	rat whisker (100)	rat whisker (100)	rat whisker (100)	rat appendix (20)	rat appendix (20)	rat appendix (20)	tangle of rat tails (100)
+Dusken Raider Ghost	1255	aboo_dipshit.gif	Atk: 72 Def: 68 HP: 40 Init: -10000 P: undead GHOST Phys: 100 ED: spooky EA: sleaze Article: a	A-Boo clue (c15)	Duskwalker syringe (15)	Duskwalker fangs (5)	ectoplasmic orbs (10)
 Dyspepsi-Cola General	293	colaoff2.gif	Atk: 30 Def: 27 HP: 40 Init: 50 P: dude Article: a	Dyspepsi-Cola (15)	Dyspepsi-Cola (15)	Dyspepsi-Cola d-rations (5)	Dyspepsi grenade (5)
 Dyspepsi-Cola Knight	291	colasol2.gif	Atk: 30 Def: 27 HP: 35 Init: 50 P: dude Article: a	Dyspepsi-Cola (15)	Dyspepsi-Cola (15)	Dyspepsi grenade (5)
 Dyspepsi-Cola Soldier	290	colasol2.gif	Atk: 30 Def: 27 HP: 30 Init: 50 P: dude Article: a	Dyspepsi-Cola (15)	Dyspepsi-Cola (15)	Dyspepsi grenade (5)	lucky lighter (p5)
-eagle	1529	eagle.gif	Atk: 145 Def: 135 HP: 140 Init: 75 P: beast Article: an	eagle's milk (20)	eagle feather (15)
+eagle	1529	eagle.gif	Atk: 145 Def: 135 HP: 140 Init: 75 P: beast EA: spooky Article: an	eagle's milk (20)	eagle feather (15)
 Ed the Undying	473	ed.gif,ed2.gif,ed3.gif,ed4.gif,ed5.gif,ed6.gif,ed7.gif	BOSS NOCOPY Atk: 180 Def: 162 HP: 1 Init: -10000 P: undead
 Ed the Undying (1)	0	ed.gif	BOSS NOCOPY NOMANUEL Atk: 180 Def: 162 HP: 256 Exp: [75+ML/3] Init: 10000 P: undead
 Ed the Undying (2)	0	ed2.gif	BOSS NOCOPY NOMANUEL Atk: 180 Def: 162 HP: 256 Exp: [75+ML/3] Init: -10000 P: undead
@@ -222,15 +222,15 @@ erudite gremlin	546	gremlinglasses.gif	Atk: 171 Def: 152 HP: 170 Init: 60 Meat: 
 erudite gremlin (tool)	547	gremlinglasses.gif	Atk: 171 Def: 152 HP: 170 Init: 60 Meat: 50 P: humanoid Article: an Manuel: "erudite gremlin" Wiki: "erudite gremlin (quest)"	gremlin juice (3)	molybdenum crescent wrench (c0)
 evil cultist	833	cultist.gif	Atk: 60 Def: 45 HP: 70 Init: 40 P: dude Article: an	memory of a cultist's robe (0)
 Evil Olive	136	oliveevil.gif	Atk: 145 Def: 130 HP: 140 Init: 50 P: beast Article: an	bottle of gin (30)	olive (40)	jumbo olive (10)
-evil spaghetti cult priest	657	spagcult2k.gif	NOCOPY Atk: 24 Def: 21 HP: 21 Init: 40 P: dude Article: an	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)	evil noodles (0)
+evil spaghetti cult priest	657	spagcult2k.gif	NOCOPY Atk: 24 Def: 21 HP: 21 Init: 40 P: dude EA: hot EA: sleaze Article: an	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)	evil noodles (0)
 evil spaghetti cultist	656	spagcult1k.gif	NOCOPY Atk: 21 Def: 18 HP: 18 Init: 20 P: dude Article: an	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)
-evil trumpet-playing mariachi	663	trumpetmariachi.gif	NOCOPY Atk: 21 Def: 18 HP: 18 Init: 20 P: dude Article: an	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)
+evil trumpet-playing mariachi	663	trumpetmariachi.gif	NOCOPY Atk: 21 Def: 18 HP: 18 Init: 20 P: dude EA: sleaze Article: an	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)
 evil vihuela-playing mariachi	662	vihuelamariachi.gif	NOCOPY Atk: 24 Def: 21 HP: 21 Init: 40 P: dude Article: an	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)	evil vihuela (0)
 eXtreme cross-country hippy	1154	skihippy.gif	Atk: 73 Def: 65 HP: 65 Init: 60 P: hippy E: stench Article: an	eXtreme scarf (10)	Mountain Stream soda (30)	enchanted handwarmer (p5)	enchanted muesli (c0)
 eXtreme Orcish snowboarder	1155	fratboard.gif	Atk: 74 Def: 66 HP: 65 Init: 60 Meat: 40 P: orc E: sleaze Article: an	Mountain Stream soda (30)	snowboarder pants (10)	enchanted handwarmer (p5)	eXtreme Bi-Polar Fleece Vest (c5)
-extremely annoyed witch	1581	witchy2.gif	NOCOPY Atk: 36 Def: 32 HP: 32 Init: 25 Meat: 40 P: dude Article: an	wand of pigification (c100)
+extremely annoyed witch	1581	witchy2.gif	NOCOPY Atk: 36 Def: 32 HP: 32 Init: 25 Meat: 40 P: dude EA: hot EA: stench Article: an	wand of pigification (c100)
 eye in the darkness	1373	darkeye.gif	Atk: 600 Def: 650 HP: 700 Init: 200 P: horror E: spooky Article: an	black tear (n50)
-factory-irregular skeleton	1744	badskel1.gif,badskel2.gif,badskel3.gif,badskel4.gif,badskel5.gif,badskel6.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: undead E: spooky Article: a	really thick spine (0)	oversized skullcap (0)	three-legged pants (0)	skeleton bone (0)	loose teeth (0)	alien autoautopsy kit (c0)
+factory-irregular skeleton	1744	badskel1.gif,badskel2.gif,badskel3.gif,badskel4.gif,badskel5.gif,badskel6.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: undead ED: spooky Article: a	really thick spine (0)	oversized skullcap (0)	three-legged pants (0)	skeleton bone (0)	loose teeth (0)	alien autoautopsy kit (c0)
 Fallen Archfiend	127	archfiend.gif	Atk: 50 Def: 45 HP: 50 Init: 80 Meat: 45 P: demon E: hot Article: a	demon skin (15)	evil golden arch (30)	infernal insoles (10)	pink slime (0)	heavy-duty bendy straw (c0)
 Family Jewels	180	jewels.gif	Atk: 156 Def: 140 HP: 150 Init: 70 Group: 2 P: constellation E: sleaze Article: The	star (30)	star (30)	star (30)
 fan dancer	1532	fandancer.gif	Atk: 145 Def: 140 HP: 145 Init: 150 Meat: 100 P: dude Article: a	blowdart (20)	red silk skirt (5)	combat fan (5)	dancing fan (c0)
@@ -248,8 +248,8 @@ fire-breathing duck	559	duckfirebreath.gif	Atk: 177 Def: 154 HP: 185 Init: 50 Me
 fisherfish	764	fisherfish.gif	Atk: 550 Def: 427 HP: 650 Init: 100 Meat: 300 P: fish Article: a	glowing esca (n3)	halibut (c3)	rough fish scale (n3)
 Fitness Giant	1332	giant_fitness.gif	Atk: 150 Def: 140 HP: 200 Init: 40 Meat: 100 P: humanoid Article: a	giant gym membership card (10)	giant jar of protein powder (15)	pec oil (25)	Squat-Thrust Magazine (10)	Fitspiration&trade; poster (c15)
 flame-broiled meat blob	148	meatblob.gif	Atk: 2 Def: 1 HP: 2 Init: 60 Meat: 20 P: slime E: hot Article: a	meat paste (40)	meat paste (40)	meat paste (40)
-Flaming Troll	142	flametroll.gif	Atk: 83 Def: 74 HP: 73 Init: 60 Meat: 40 P: humanoid EA: hot Article: a	flaming talons (10)	Trollhouse cookies (40)
-Flange	538	flange.gif	Atk: 159 Def: 143 HP: 150 Init: 70 P: constellation E: sleaze Article: The	line (30)	line (30)	star (30)
+Flaming Troll	142	flametroll.gif	Atk: 83 Def: 74 HP: 73 Init: 60 Meat: 40 P: humanoid EA: hot EA: "bad spelling" Article: a	flaming talons (10)	Trollhouse cookies (40)
+Flange	538	flange.gif	Atk: 159 Def: 143 HP: 150 Init: 70 P: constellation ED: sleaze EA: hot EA: sleaze Article: The	line (30)	line (30)	star (30)
 fleet woodsman	1527	woodsman.gif	Atk: 150 Def: 130 HP: 150 Init: 100 Meat: 75 P: dude Article: a	fleetwood chain (20)	Green Manalishi (20)	flask of rainwater (c0)
 floating platter of hors d'oeuvres	404	horstray.gif	Atk: 65 Def: 55 HP: 70 Init: -10000 P: construct ED: spooky Article: a	dehydrated caviar (30)	desiccated apricot (30)	flute of flat champagne (30)	hors d'oeuvre tray (4)
 Flock of Stab-bats	133	stabbats.gif	Atk: 155 Def: 133 HP: 155 Init: 90 Meat: 160 Group: 4 P: beast Article: a	bat wing (30)	batblade (25)	batgut (30)
@@ -261,7 +261,7 @@ freaked-out mushroom guy	1801	mush_freaked.gif	Atk: 25 Def: 25 HP: 20 Init: 75 P
 frog	332	frog.gif	NOCOPY Atk: [3] Def: [2] HP: [3] Init: -10000 Meat: 10 P: beast Article: a	squashed frog (100)	frog lip-print (c0)
 frozen duck	556	duckfrozen.gif	Atk: 170 Def: 160 HP: 180 Init: 50 Meat: 150 P: beast E: cold Article: a	frozen feather (10)	duct tape (5)
 Fruit Golem	89	fruitgolem.gif	Atk: 56 Def: 50 HP: 46 Init: 80 P: construct Article: a	cherry (15)	orange (15)	lime (15)
-full-length mirror	1553	bigmirror.gif	NOCOPY LUCKY Scale: 0 Cap: ? Init: 50 P: construct Article: a
+full-length mirror	1553	bigmirror.gif	NOCOPY LUCKY Scale: 0 Cap: ? Init: 50 P: construct EA: hot EA: spooky Article: a
 funk sole brother	719	solebrother.gif	Atk: 300 Def: 315 HP: 400 Init: 150 Meat: 200 P: fish Article: a	dull fish scale (n15)	slick fish meat (n5)
 Furry Giant	172	giant_furry.gif	Atk: 135 Def: 121 HP: 150 Init: 40 Meat: 150 P: humanoid EA: sleaze Article: a	furry fur (35)	disturbing fanfic (25)	wolf mask (10)
 G imp	125	gimp.gif	Atk: 46 Def: 41 HP: 46 Init: 60 Meat: 30 P: demon E: hot Article: a	hot wing (30)	Imp Ale (30)	leather mask (5)	vitamin G pill (0)
@@ -274,17 +274,17 @@ generic duck	544	duckgeneric.gif	Atk: 167 Def: 154 HP: 180 Init: 40 Meat: 75 P: 
 Georgepaul, the Balldodger	879	merkinballer2.gif	BOSS NOCOPY Atk: 1200 Def: 1150 HP: 1400 Init: 100 Meat: 100 P: mer-kin
 ghastly organist	403	phantom.gif	Atk: 65 Def: 55 HP: 70 Init: 50 Meat: 50 P: undead EA: hot EA: spooky Article: a	opera mask (20)
 ghost miner	370	ghostminer.gif	Atk: 30 Def: 27 HP: 31 Init: 50 P: undead GHOST Phys: 100 E: spooky Article: a	bubblewrap ore (10)	bubblewrap ore (10)	cardboard ore (10)	cardboard ore (10)	styrofoam ore (10)	styrofoam ore (10)
-ghost of Elizabeth Spookyraven	1564	elizabeth.gif	NOCOPY Scale: 5 Cap: 300 Init: 100 P: undead GHOST Phys: 100 Article: the	Elizabeth's Dollie (100)	Elizabeth's paintbrush (100)
-ghuol	30	ghuol_reg.gif	Atk: 19 Def: 17 HP: 10 Init: 60 Meat: 34 P: undead E: spooky Article: a	ghuol egg (25)	ghuol ears (25)
+ghost of Elizabeth Spookyraven	1564	elizabeth.gif	NOCOPY Scale: 5 Cap: 300 Init: 100 P: undead GHOST Phys: 100 EA: hot EA: spooky Article: the	Elizabeth's Dollie (100)	Elizabeth's paintbrush (100)
+ghuol	30	ghuol_reg.gif	Atk: 19 Def: 17 HP: 10 Init: 60 Meat: 34 P: undead ED: spooky EA: sleaze EA: spooky Article: a	ghuol egg (25)	ghuol ears (25)
 giant giant giant centipede	462	centipede.gif	Atk: 142 Def: 124 HP: 142 Init: 50 Meat: 150 P: bug Article: a	centipede eggs (20)	handful of sand (25)	handful of sand (15)
-giant mob of baby spiders	1584	manyspiders.gif	Atk: 36 Def: 31 HP: 37 Init: 50 Meat: 20 P: bug Article: a
-giant rubber spider	1622	rubberspider.gif	NOCOPY FREE Scale: 3 Cap: 1000 Init: -10000 P: bug Article: a	rubber nubbin (100)
+giant mob of baby spiders	1584	manyspiders.gif	Atk: 36 Def: 31 HP: 37 Init: 50 Meat: 20 P: bug EA: spooky Article: a
+giant rubber spider	1622	rubberspider.gif	NOCOPY FREE Scale: 3 Cap: 1000 Init: -10000 P: bug EA: stench Article: a	rubber nubbin (100)
 giant sandworm	458	sandworm.gif	NOCOPY Atk: 175 Def: 166 HP: 200 Init: 60 Meat: 250 P: bug Article: a	spices (10)	spices (10)	spices (10)	spice melange (n0)
 giant skeelton	187	giantskel.gif	BOSS NOCOPY Atk: 71 Def: 65 HP: 120 Exp: [53+ML/3] Init: 60 P: undead E: spooky Article: a	skeleton bone (0)	skeleton bone (0)	skeleton bone (0)
 giant squid	763	giantsquid.gif	Atk: 500 Def: 405 HP: 800 Init: 75 Meat: 300 P: fish Article: a	ink bladder (n30)	inky squid sauce (0)
-giant swarm of ghuol whelps	1074	whelps3.gif	Atk: 50 Def: 45 HP: 250 Init: 300 Group: 45 P: undead E: spooky Article: a
+giant swarm of ghuol whelps	1074	whelps3.gif	Atk: 50 Def: 45 HP: 250 Init: 300 Group: 45 P: undead ED: spooky Article: a
 gingerbread murderer	1750	gingerbreadman.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: construct Article: a	glob of enchanted icing (0)	ginger snaps (0)
-Glass of Orange Juice	515	juiceglass.gif	NOCOPY Atk: 220 Def: 198 HP: 350 Init: 100 Meat: 400 P: hippy E: stench Article: a	green clay bead (30)	orange peel hat (100)	bullet-proof corduroys (0)	Lockenstock&trade; sandals (0)	round purple sunglasses (0)
+Glass of Orange Juice	515	juiceglass.gif	NOCOPY Atk: 220 Def: 198 HP: 350 Init: 100 Meat: 400 P: hippy ED: stench EA: hot EA: sleaze EA: stench Article: a	green clay bead (30)	orange peel hat (100)	bullet-proof corduroys (0)	Lockenstock&trade; sandals (0)	round purple sunglasses (0)
 gluttonous ghuol	189	ghuol_fat.gif	Atk: 55 Def: 50 HP: 50 Init: 50 Meat: 60 P: undead E: spooky Article: a	ghuol ears (10)	ghuol egg (10)	ghuol guolash (20)	huge spoon (5)
 gnarly gnome	249	gnarlgnome.gif	Atk: 35 Def: 31 HP: 35 Init: 50 P: humanoid Article: a	clockwork key (n5)	clockwork key (n5)	flange (5)
 gnasty gnome	248	gnasgnome.gif	Atk: 35 Def: 31 HP: 35 Init: 50 P: humanoid Article: a	clockwork key (n5)	clockwork key (n5)	flange (5)
@@ -294,7 +294,7 @@ Gnollish Crossdresser	19	dk_cross.gif	Atk: 11 Def: 9 HP: 5 Init: 60 Meat: 22 P: 
 Gnollish Flyslayer	11	dk_swatter.gif	Atk: 10 Def: 9 HP: 5 Init: 60 Meat: 20 P: humanoid Article: a	gnoll teeth (5)	gnoll lips (5)	Gnollish flyswatter (25)	Enchanted Flyswatter (c0)
 Gnollish Gearhead	12	dk_gearhead.gif	Atk: 10 Def: 9 HP: 5 Init: 60 Meat: 20 P: humanoid Article: a	Gnollish toolbox (75)	gnoll lips (5)	folder (Knight Writer) (c0)	Gearhead Goo (c0)
 Gnollish Piebaker	27	dk_piechef.gif	Atk: 13 Def: 11 HP: 6 Init: 60 Meat: 26 P: humanoid Article: a	Gnollish pie server (25)	Gnollish pie tin (50)	wad of dough (50)	skewer (50)
-Gnollish Plungermaster	9	dk_plunger.gif	Atk: 13 Def: 11 HP: 6 Init: 60 Meat: 26 P: humanoid Article: a	Gnollish plunger (25)	gnoll lips (5)	gnoll teeth (5)	Enchanted Plunger (c0)
+Gnollish Plungermaster	9	dk_plunger.gif	Atk: 13 Def: 11 HP: 6 Init: 60 Meat: 26 P: humanoid EA: sleaze Article: a	Gnollish plunger (25)	gnoll lips (5)	gnoll teeth (5)	Enchanted Plunger (c0)
 Gnollish Tirejuggler	20	dk_juggler.gif	Atk: 12 Def: 10 HP: 6 Init: 60 Meat: 24 P: humanoid Article: a	gnoll teeth (5)	gnoll lips (5)	tires (100)
 Gnollish War Chef	211	dk_warchef.gif	Atk: 14 Def: 13 HP: 9 Init: 60 Meat: 24 P: humanoid Article: a	Gnollish slotted spoon (28)	Knoll mushroom (50)	Knoll mushroom (50)	skewer (50)
 Gnomester Blomester	251	gnomester.gif	Atk: 35 Def: 31 HP: 35 Init: 50 P: humanoid	cog (15)	spring (15)	flange (5)
@@ -307,7 +307,7 @@ grave rober	61	rober.gif	Atk: 22 Def: 19 HP: 12 Init: 80 P: dude Article: a	coff
 grave rober zmobie	195	zomshovel.gif	Atk: 58 Def: 53 HP: 50 Init: 50 Meat: 50 P: undead E: spooky Article: a	coffin lid (3)	dead guy's watch (10)	loose teeth (10)	rusty grave robbing shovel (10)	paranormal ricotta (c0)
 greasy duck	560	duckgreasy.gif	Atk: 173 Def: 162 HP: 185 Init: 70 Meat: 150 P: beast E: sleaze Article: a	flirtatious feather (10)	duct tape (5)
 Green Ops Soldier	492	warhipgr.gif	Atk: 200 Def: 180 HP: 250 Init: 100 P: hippy E: stench Article: a Poison: "Toad In The Hole"	communications windchimes (3)	gas balloon (10)	gas balloon (10)	green clay bead (30)	green smoke bomb (5)	henna face paint (10)	round green sunglasses (5)
-gritty pirate	614	gritpirate.gif	Atk: 140 Def: 126 HP: 120 Init: 50 Meat: 105 P: pirate Article: a	true grit (30)	keel-haulin' knife (0)
+gritty pirate	614	gritpirate.gif	Atk: 140 Def: 126 HP: 120 Init: 50 Meat: 105 P: pirate EA: hot Article: a	true grit (30)	keel-haulin' knife (0)
 Groar	1157	wingedyeti.gif	BOSS NOCOPY Atk: 120 Def: 108 HP: 250 Init: 50 P: beast E: cold	Groar's fur (100)	dense meat stack (100)	dense meat stack (100)	dense meat stack (100)	dense meat stack (100)	dense meat stack (100)
 groovy pirate	613	pirate2.gif	Atk: 140 Def: 126 HP: 120 Init: 50 Meat: 100 P: pirate Article: a	buoybottoms (10)
 grouper groupie	734	groupie.gif	Atk: 350 Def: 405 HP: 500 Init: 40 P: fish Article: a	groupie bra (0)	groupie lipstick (0)	groupie spangles (c0)
@@ -317,10 +317,10 @@ Guard Bugbear	28	haiku2.gif	Atk: 12 Def: 10 HP: 6 Init: 60 Meat: 24 P: beast EA:
 Guy Made Of Bees	424	beeguy.gif	BOSS NOCOPY Atk: 99999 Def: 89999 HP: [99999] Exp: 40 Init: -10000 P: horror Article: The	guy made of bee pollen (100)	handful of bees (p10)
 guy with a pitchfork, and his wife	394	gothic.gif	Atk: 58 Def: 52 HP: 60 Init: 50 Meat: 50 Group: 2 P: dude Article: a	pitchfork (5)
 handsome mariachi	270	mariachi1.gif	Atk: 17 Def: 15 HP: 15 Init: 50 Meat: 5 P: dude Article: a	bottle of tequila (30)	chorizo taco (20)	handsomeness potion (20)
-haunted skullabra	1347	skullabra.gif	Atk: 48 Def: 52 HP: 50 Init: 30 P: undead E: spooky Article: a	moonberry wine cooler (0)	big dribbly candle (0)	haunted flame (c0)
-haunted soup tureen	655	tureen.gif	NOCOPY Atk: 24 Def: 21 HP: 21 Init: 40 P: undead Article: a	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)	turtle soup (0)
-heat seal	800	heatseal.gif	NOCOPY FREE Atk: 175 Def: 157 HP: 200 Init: -10000 P: demon Article: a	Abyssal ember (5)	sizzling seal fat (35)
-Heavy Kegtank	504	warfratar2.gif	Atk: 180 Def: 162 HP: 300 Init: 20 P: orc Phys: 50 E: sleaze Article: a	meat engine (5)	PADL Phone (5)	sake bomb (10)	sake bomb (5)
+haunted skullabra	1347	skullabra.gif	Atk: 48 Def: 52 HP: 50 Init: 30 P: undead ED: spooky EA: hot EA: spooky Article: a	moonberry wine cooler (0)	big dribbly candle (0)	haunted flame (c0)
+haunted soup tureen	655	tureen.gif	NOCOPY Atk: 24 Def: 21 HP: 21 Init: 40 P: undead EA: hot Article: a	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)	turtle soup (0)
+heat seal	800	heatseal.gif	NOCOPY FREE Atk: 175 Def: 157 HP: 200 Init: -10000 P: demon EA: hot Article: a	Abyssal ember (5)	sizzling seal fat (35)
+Heavy Kegtank	504	warfratar2.gif	Atk: 180 Def: 162 HP: 300 Init: 20 P: orc Phys: 50 ED: sleaze EA: hot EA: sleaze Article: a	meat engine (5)	PADL Phone (5)	sake bomb (10)	sake bomb (5)
 Hellion	128	hellion.gif	Atk: 52 Def: 46 HP: 52 Init: 90 P: demon E: hot Article: a	hellion cube (30)	unstable quark (p20)	accord ion (a0)
 hermetic seal	796	hermeticseal.gif	NOCOPY FREE Atk: 110 Def: 180 HP: 150 Init: -10000 P: demon Article: a	powdered sealbone (100)
 hockey elemental	274	hockeyelem.gif	NOCOPY NOMANUEL ULTRARARE Atk: 55 Def: 49 HP: 80 Init: 100 P: elemental	hockey stick of furious angry rage (100)
@@ -335,25 +335,25 @@ hung-over half-orc hobo	281	hobo.gif	Atk: 1 Def: 0 HP: 1 Init: 40 P: hobo E: ste
 hustled spectre	809	poolghost.gif	LUCKY Atk: 25 Def: 22 HP: 35 Init: 100 P: undead GHOST Article: a	cube of billiard chalk (100)
 Hypnotist of Hey Deze	232	hypnotist.gif	NOCOPY NOMANUEL ULTRARARE Atk: 85 Def: 115 HP: 85 Init: 10000 P: dude	hypnodisk (100)
 ice skate	731	iceskate.gif	Atk: 400 Def: 450 HP: 600 Init: 75 Meat: 100 P: fish Article: an	collapsible baton (0)	skate blade (0)	skate skin (0)	spangly unitard (0)
-Iiti Kitty	572	mummycat.gif	Atk: 165 Def: 148 HP: 150 Init: 75 P: undead	leathery cat skin (30)	unidentified jerky (10)	ancient Magi-Wipes (50)	ancient vinyl coin purse (20)	mummy wrapping (20)	Iiti Kitty phone charm (10)	crumbling rat skull (c0)	Iiti Kitty Gumdrop (c0)
+Iiti Kitty	572	mummycat.gif	Atk: 165 Def: 148 HP: 150 Init: 75 P: undead EA: spooky	leathery cat skin (30)	unidentified jerky (10)	ancient Magi-Wipes (50)	ancient vinyl coin purse (20)	mummy wrapping (20)	Iiti Kitty phone charm (10)	crumbling rat skull (c0)	Iiti Kitty Gumdrop (c0)
 industrious construct	666	vib3.gif	Atk: 350 Def: 270 HP: 300 Init: 50 P: construct Article: an	El Vibrato punchcard (129 holes) (1)	El Vibrato punchcard (88 holes) (1)
 industrious construct (translated)	672	vib3.gif	Atk: 350 Def: 270 HP: 300 Init: 50 P: construct Article: an Manuel: "industrious construct" Wiki: "industrious construct"	El Vibrato punchcard (129 holes) (1)	El Vibrato punchcard (88 holes) (1)
 infernal seal larva	652	seal_larva.gif	NOCOPY Atk: 21 Def: 18 HP: 18 Init: 20 P: demon Article: an	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)
 infernal seal spawn	653	seal_baby.gif	NOCOPY Atk: 24 Def: 21 HP: 21 Init: 40 P: demon Article: an	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)	seal eyeball (0)
 infinite meat bug	230	meatbug.gif	NOCOPY NOMANUEL ULTRARARE Atk: 45 Def: 40 HP: 30 Init: 10000 Meat: 10000 P: bug	incredibly dense meat gem (100)
-inkubus	978	inkubus.gif	Atk: 58 Def: 52 HP: 58 Init: 40 Meat: 50 P: demon E: hot Article: an	bus pass (15)
+inkubus	978	inkubus.gif	Atk: 58 Def: 52 HP: 58 Init: 40 Meat: 50 P: demon ED: hot Article: an	bus pass (15)
 irate mariachi	268	mariachi2.gif	Atk: 20 Def: 18 HP: 17 Init: 50 Meat: 5 P: dude Article: an	bottle of tequila (35)	irate sombrero (20)	mariachi G-string (30)	half-sized guitar (20)
 Irritating Series of Random Encounters	167	encount.gif	Atk: 105 Def: 94 HP: 110 Init: 80 Meat: 140 Group: 20 P: beast Article: an	cocoa eggshell fragment (20)	soft green echo eyedrop antidote (20)	tiny house (20)
-Jacob's adder	1546	jacobsadder.gif	Atk: 84 Def: 76 HP: 75 Init: 60 P: beast Article: a	electric snakebite (0)	haunted battery (0)	Jacob's rung (0)
+Jacob's adder	1546	jacobsadder.gif	Atk: 84 Def: 76 HP: 75 Init: 60 P: beast EA: hot Article: a	electric snakebite (0)	haunted battery (0)	Jacob's rung (0)
 jamfish	759	jamfish.gif	Atk: 400 Def: 360 HP: 750 Init: -10000 P: fish Article: a Poison: "Majorly Poisoned"	jamfish jam (n5)	jellyfish gel (c10)	seaweed (n5)	jam band (n5)
 Jefferson pilot	1530	pilot.gif	Atk: 140 Def: 140 HP: 145 Init: 25 Meat: 125 P: dude Article: a	one pill (25)	Jefferson wings (5)	plastic Jefferson wings (c0)
 Johnringo, the Netdragger	880	merkindragger2.gif	BOSS NOCOPY Atk: 1250 Def: 1200 HP: 1500 Init: 100 Meat: 100 P: mer-kin
 Junk	181	thejunk.gif	Atk: 159 Def: 143 HP: 150 Init: 70 P: constellation E: sleaze Article: The	line (30)	line (30)	star (30)
-junksprite bender	1437	js_bender.gif	Atk: 32 Def: 33 HP: 25 Init: -10000 P: humanoid Article: a	funky junk key (0)	bent scrap metal (15)	Worse Homes and Gardens (c0)
-junksprite melter	1438	js_melter.gif	Atk: 37 Def: 32 HP: 21 Init: -10000 P: humanoid Article: a	funky junk key (0)	molten scrap metal (15)	Worse Homes and Gardens (c0)
+junksprite bender	1437	js_bender.gif	Atk: 32 Def: 33 HP: 25 Init: -10000 P: humanoid EA: stench Article: a	funky junk key (0)	bent scrap metal (15)	Worse Homes and Gardens (c0)
+junksprite melter	1438	js_melter.gif	Atk: 37 Def: 32 HP: 21 Init: -10000 P: humanoid EA: hot Article: a	funky junk key (0)	molten scrap metal (15)	Worse Homes and Gardens (c0)
 junksprite sharpener	1436	js_sharpener.gif	Atk: 37 Def: 30 HP: 22 Init: -10000 P: humanoid Article: a	funky junk key (0)	jagged scrap metal (15)	Worse Homes and Gardens (c0)
 Keese	119	keese.gif	Atk: 25 Def: 22 HP: 15 Init: 60 P: beast Article: a	blue pixel (80)	blue pixel (70)	blue pixel (60)
-killer clownfish	767	clownfish.gif	Atk: 500 Def: 450 HP: 700 Init: 75 Meat: 300 P: horror E: sleaze Article: a	high-pressure seltzer bottle (n25)	midget clownfish (c1)	rough fish scale (n5)
+killer clownfish	767	clownfish.gif	Atk: 500 Def: 450 HP: 700 Init: 75 Meat: 300 P: horror ED: sleaze EA: sleaze EA: spooky Article: a	high-pressure seltzer bottle (n25)	midget clownfish (c1)	rough fish scale (n5)
 knight (Snake)	398	snaknight.gif	Atk: 115 Def: 103 HP: 130 Init: 50 P: dude EA: spooky Article: a Manuel: "knight"	serpentine sword (5)	snake shield (5)
 knight (Wolf)	397	wolfknight.gif	Atk: 115 Def: 103 HP: 130 Init: 50 P: dude EA: spooky Article: a Manuel: "knight"	lupine sword (5)	snarling wolf shield (5)
 Knight in White Satin	68	knight.gif	Atk: 38 Def: 33 HP: 21 Init: 70 Meat: 30 P: dude Article: a	white sword (15)	white satin pants (15)	white satin shield (8)	white page (5)
@@ -365,35 +365,35 @@ Knob Goblin Bean Counter	80	kg_beancounter.gif	Atk: 24 Def: 21 HP: 20 Init: 80 M
 Knob Goblin Elite Guard	1057	kg_guard.gif	Atk: 25 Def: 27 HP: 30 Init: -10000 Meat: 50 P: goblin Article: a	Cobb's Knob Wurstbrau (15)	Knob Goblin elite helm (10)	Knob Goblin elite pants (10)	Knob Goblin elite shirt (10)	knob bugle (10)
 Knob Goblin Elite Guard Captain	263	kg_guardcaptain.gif	LUCKY Atk: 30 Def: 27 HP: 35 Init: -10000 Meat: 300 P: goblin Article: a	Knob Goblin elite helm (100)	Knob Goblin elite pants (100)	Knob Goblin elite polearm (100)
 Knob Goblin Embezzler	530	kg_embezzler.gif	LUCKY Atk: 24 Def: 21 HP: 20 Init: 80 Meat: 1000 P: goblin Article: a	Knob Goblin visor (0)	meat stack (0)	meat stack (0)	meat stack (0)	meat stack (0)	embezzler's oil (c0)
-Knob Goblin Harem Girl	78	kg_haremgirl.gif	Atk: 25 Def: 22 HP: 20 Init: 80 P: goblin E: sleaze Article: a	disease (10)	Knob Goblin harem veil (20)	Knob Goblin harem pants (20)	finger cymbals (5)	harem girl t-shirt (c2)
+Knob Goblin Harem Girl	78	kg_haremgirl.gif	Atk: 25 Def: 22 HP: 20 Init: 80 P: goblin ED: sleaze EA: hot EA: sleaze Article: a	disease (10)	Knob Goblin harem veil (20)	Knob Goblin harem pants (20)	finger cymbals (5)	harem girl t-shirt (c2)
 Knob Goblin Harem Guard	1061	kg_haremguard.gif	Atk: 25 Def: 22 HP: 20 Init: 50 P: goblin Article: a	Knob Goblin deluxe scimitar (10)	Knob nuts (15)	excitement pill (0)
 Knob Goblin King	81	kg_king.gif	BOSS NOCOPY Atk: 53 Def: 47 HP: 50 Exp: [66+ML/3] Init: 100 P: goblin Article: The
 Knob Goblin Mad Scientist	85	kg_madsci.gif	Atk: 40 Def: 36 HP: 25 Init: 70 Meat: 40 P: goblin Article: a	Knob Goblin love potion (10)	Knob Goblin seltzer (15)	Knob Goblin steroids (10)
-Knob Goblin Madam	1062	kg_madam.gif	Atk: 30 Def: 22 HP: 30 Init: 50 P: goblin Article: a	Knob Goblin perfume (25)	whalebone corset (15)
+Knob Goblin Madam	1062	kg_madam.gif	Atk: 30 Def: 22 HP: 30 Init: 50 P: goblin EA: sleaze Article: a	Knob Goblin perfume (25)	whalebone corset (15)
 Knob Goblin Master Chef	77	kg_masterchef.gif	Atk: 22 Def: 19 HP: 20 Init: 70 Meat: 30 P: goblin Article: a	dry noodles (15)	Knob Goblin spatula (15)	Knob mushroom (15)	spices (15)
 Knob Goblin MBA	1064	kg_mba.gif	Atk: 25 Def: 22 HP: 20 Init: 75 Meat: 70 P: goblin Article: a	baggie of powdered sugar (15)	meat stack (25)	meat stack (5)
 Knob Goblin Mutant	88	kg_mutant.gif	Atk: 53 Def: 47 HP: 43 Init: 70 Meat: 55 P: goblin Article: a
 Knob Goblin poseur	533	kg_poseur.gif	Atk: 4 Def: 3 HP: 5 Init: 50 Meat: 20 P: goblin Article: a	dope gangsta bling-bling (10)	out-of-tune biwa (10)	terrible poem (20)
-Knob Goblin Sous Chef	76	kg_souschef.gif	Atk: 20 Def: 18 HP: 15 Init: 60 Meat: 20 P: goblin Article: a	Knob Goblin spatula (7)	Knob sausage (15)	tomato (15)	wad of dough (15)
+Knob Goblin Sous Chef	76	kg_souschef.gif	Atk: 20 Def: 18 HP: 15 Init: 60 Meat: 20 P: goblin EA: hot Article: a	Knob Goblin spatula (7)	Knob sausage (15)	tomato (15)	wad of dough (15)
 Knob Goblin Very Mad Scientist	86	kg_verymadsci.gif	Atk: 45 Def: 40 HP: 30 Init: 70 Meat: 45 P: goblin Article: a	Knob Goblin melon baller (5)	Knob Goblin seltzer (15)	Knob Goblin superseltzer (15)	scrumptious reagent (25)	bunch of square grapes (c19)	smudged alchemical recipe (p5)	Cobb's Knob Menagerie key (c0)	Subject 37 file (c0)
-Knott Slanding	617	slanding.gif	NOCOPY NOMANUEL ULTRARARE Atk: 150 Def: 135 HP: 150 Init: 10000 Meat: 970-1342 P: beast E: cold	Dallas Dynasty Falcon Crest shield (100)
+Knott Slanding	617	slanding.gif	NOCOPY NOMANUEL ULTRARARE Atk: 150 Def: 135 HP: 150 Init: 10000 Meat: 970-1342 P: beast ED: cold	Dallas Dynasty Falcon Crest shield (100)
 Knott Yeti	99	yeti.gif	Atk: 105 Def: 92 HP: 90 Init: 60 Meat: 200 P: beast E: cold Article: a	yeti fur (30)
 Koopa Troopa	116	koopa.gif	Atk: 20 Def: 18 HP: 15 Init: 60 P: beast Article: a	black pixel (50)	green pixel (80)	white pixel (50)
 L imp	124	limp.gif	Atk: 44 Def: 39 HP: 44 Init: 60 Meat: 30 P: demon E: hot Article: an	Imp Ale (30)	cast (30)	flaming crutch (30)
-Lamz0r N00b	140	n00b.gif	Atk: 79 Def: 71 HP: 69 Init: 70 Meat: 30 P: dude Article: a	33398 scroll (30)	draggin' ball hat (10)	plastic guitar (10)	Nardz energy beverage (p30)
+Lamz0r N00b	140	n00b.gif	Atk: 79 Def: 71 HP: 69 Init: 70 Meat: 30 P: dude EA: "bad spelling" Article: a	33398 scroll (30)	draggin' ball hat (10)	plastic guitar (10)	Nardz energy beverage (p30)
 large kobold	224	lower_k.gif	Atk: 57 Def: 49 HP: 60 Init: 45 P: humanoid Article: a	ring of aggravate monster (15)	small box (40)	kobold kibble (c0)
 Larry of the Field of Signs	984	larrysignfield.gif	BOSS NOCOPY Atk: 70 Def: 63 HP: 70 Init: 50 P: demon	observational glasses (100)
 larval filthworm	477	filthworm1.gif	NOCOPY Atk: 165 Def: 148 HP: 180 Init: 50 Meat: 50 P: bug E: stench Article: a	filthworm hatchling scent gland (10)
 lemon-in-the-box	109	linbox.gif	Atk: 17 Def: 15 HP: 12 Init: 75 P: construct Article: a	box (20)	lemon (50)
 Lesser Fruit Golem	284	lfruitgol.gif	Atk: 17 Def: 15 HP: 9 Init: 50 P: construct Article: a	grapefruit (15)	grapes (15)	lemon (15)	orange (15)	strawberry (15)
 lihc	32	lich.gif	Atk: 20 Def: 18 HP: 11 Init: 60 Meat: 36 P: undead ED: spooky EA: sleaze EA: spooky Article: a	lihc eye (30)
-Little Man in the Canoe	540	canoeman.gif	Atk: 165 Def: 148 HP: 150 Init: 70 P: constellation E: sleaze Article: The	line (30)	star (30)	star (30)
+Little Man in the Canoe	540	canoeman.gif	Atk: 165 Def: 148 HP: 150 Init: 70 P: constellation ED: sleaze EA: hot EA: sleaze Article: The	line (30)	star (30)	star (30)
 lobsterfrogman	529	lobsterman.gif	Atk: 171 Def: 152 HP: 190 Init: 40 Meat: 60 P: beast Article: a	barrel of gunpowder (n100)
 lonely construct	668	vib5.gif	Atk: 300 Def: 315 HP: 350 Init: 80 P: construct Article: a	El Vibrato punchcard (213 holes) (1)	El Vibrato punchcard (182 holes) (1)
 lonely construct (translated)	674	vib5.gif	Atk: 300 Def: 315 HP: 350 Init: 80 P: construct Article: a Manuel: "lonely construct" Wiki: "lonely construct"	El Vibrato punchcard (213 holes) (1)	El Vibrato punchcard (182 holes) (1)
 Lord Spookyraven	464	lordspooky.gif	BOSS NOCOPY Atk: 165 Def: 148 HP: 200 Exp: [120+ML/3] Init: 10000 P: undead ED: spooky EA: cold EA: hot EA: sleaze EA: spooky EA: stench	Eye of Ed (n100)	Lord Spookyraven's ear trumpet (n100)
-Lot's Wife	1757	lotswife.gif	NOCOPY Atk: 3 Def: 3 HP: 10 Init: -10000 P: beast Article: the	The Lot's engagement ring (n100)
-lounge lizardfish	770	lizardfish.gif	Atk: 400 Def: 630 HP: 550 Init: 100 Meat: 200 P: fish Article: a	amber aviator shades (n5)	hair of the fish (c7)	rough fish scale (n4)	slug of shochu (21)
+Lot's Wife	1757	lotswife.gif	NOCOPY Atk: 3 Def: 3 HP: 10 Init: -10000 P: beast EA: stench Article: the	The Lot's engagement ring (n100)
+lounge lizardfish	770	lizardfish.gif	Atk: 400 Def: 630 HP: 550 Init: 100 Meat: 200 P: fish EA: stench Article: a	amber aviator shades (n5)	hair of the fish (c7)	rough fish scale (n4)	slug of shochu (21)
 lowercase B	934	lower_b.gif	Atk: 58 Def: 52 HP: 70 Init: 40 P: slime Article: a	left parenthesis (15)
 lowercase H	936	lower_h.gif	Atk: 59 Def: 54 HP: 77 Init: 75 P: horror Article: a	left bracket (15)	left parenthesis (20)	percent sign (25)
 lowercase K	938	lower_k.gif	Atk: 57 Def: 49 HP: 60 Init: 45 P: humanoid Article: a	equal sign (15)	left parenthesis (40)
@@ -403,75 +403,75 @@ lumberjuan	235	lumberjuan.gif	Atk: 35 Def: 31 HP: 35 Init: 60 Meat: 20 P: dude A
 lynyrd	1533	lynyrd.gif	Atk: 150 Def: 150 HP: 155 Init: 10000 P: beast Article: a	lynyrd skin (0)
 lynyrd skinner	1526	skinner.gif	Atk: 140 Def: 130 HP: 135 Init: 50 Meat: 125 P: dude Article: a	sweet roll Alabama (25)	Saturday Night Special (5)	lynyrd snare (15)	lynyrd musk (25)	lynyrd skinner toothblack (c0)
 mad bugbears	257	madbugbear.gif	Atk: 16 Def: 15 HP: 13 Init: 50 Group: 3 P: beast
-mad wino	1563	madwino.gif	Atk: 148 Def: 141 HP: 150 Init: 50 Meat: 50 P: hobo Article: a	pie man was not meant to eat (10)	crazy hobo notebook (10)	Psychotic Train wine (10)	page of the Necrohobocon (c15)
-magic dragonfish	758	dragonfish.gif	Atk: 500 Def: 360 HP: 750 Init: 50 Meat: 200 P: fish Article: a	rough fish scale (n4)	seaweed (n5)	dragonfish caviar (n5)
-magical fruit bat	2156	fruitbat1.gif	Atk: 19 Def: 19 HP: 20 Init: 50 Meat: 40 P: beast Article: a	sonar-in-a-biscuit (10)	lemon (10)	orange (50)	strawberry (20)
+mad wino	1563	madwino.gif	Atk: 148 Def: 141 HP: 150 Init: 50 Meat: 50 P: hobo EA: spooky Article: a	pie man was not meant to eat (10)	crazy hobo notebook (10)	Psychotic Train wine (10)	page of the Necrohobocon (c15)
+magic dragonfish	758	dragonfish.gif	Atk: 500 Def: 360 HP: 750 Init: 50 Meat: 200 P: fish EA: cold EA: hot EA: sleaze EA: spooky EA: stench Article: a	rough fish scale (n4)	seaweed (n5)	dragonfish caviar (n5)
+magical fruit bat	2156	fruitbat1.gif	Atk: 19 Def: 19 HP: 20 Init: 50 Meat: 40 P: beast EA: hot EA: stench Article: a	sonar-in-a-biscuit (10)	lemon (10)	orange (50)	strawberry (20)
 MagiMechTech MechaMech	175	mech.gif	Atk: 120 Def: 108 HP: 100 Init: 80 P: construct Article: a	photoprotoneutron torpedo (30)	metallic A (30)	glowing red eye (16)	oversized pizza cutter (8)	magilaser blastercannon (10)
 malevolent hair clog	389	hairclog.gif	Atk: 59 Def: 48 HP: 50 Init: 50 P: horror ED: spooky Article: a	gob of wet hair (40)
 malt liquor golem	1754	maltliquorgolem.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: construct Article: a	premium malt liquor (0)	premium malt liquor (0)	brown paper bag mask (0)	brown paper pants (0)
 man with the red buttons	1520	redbuttons.gif	Atk: 160 Def: 150 HP: 170 Init: 50 Meat: 150 P: dude Article: the	red box (15)	red button (0)	big red button (n1)	button rouge (c0)
 man-eating plant	382	audrey.gif	Atk: 22 Def: 21 HP: 25 Init: 50 P: plant Article: a
 mariachi calavera	272	mariachi3.gif	Atk: 22 Def: 19 HP: 30 Init: 50 P: undead EA: hot Article: a	bottle of tequila (30)	marzipan skull (30)	calavera concertina (p5)
-me4t begZ0r	144	beggar.gif	Atk: 87 Def: 78 HP: 77 Init: 50 P: dude Article: a	meat vortex (100)
+me4t begZ0r	144	beggar.gif	Atk: 87 Def: 78 HP: 77 Init: 50 P: dude EA: "bad spelling" Article: a	meat vortex (100)
 medium-sized barrel mimic	288	mimic3.gif	Atk: 25 Def: 22 HP: 35 Init: 90 P: weird Article: a
-mean drunk duck	567	duckmeandrunk.gif	Atk: 180 Def: 157 HP: 190 Init: 50 Meat: 200 P: beast Article: a	bottle of vodka (20)	bottle of tequila (20)	bottle of whiskey (20)	duct tape (5)
-mega frog	1342	megafrog.gif	Atk: 14 Def: 16 HP: 20 Init: 10 Meat: 15 P: beast Article: a	delicious swamp muck (0)	swamp lolly (0)
+mean drunk duck	567	duckmeandrunk.gif	Atk: 180 Def: 157 HP: 190 Init: 50 Meat: 200 P: beast EA: sleaze Article: a	bottle of vodka (20)	bottle of tequila (20)	bottle of whiskey (20)	duct tape (5)
+mega frog	1342	megafrog.gif	Atk: 14 Def: 16 HP: 20 Init: 10 Meat: 15 P: beast EA: stench Article: a	delicious swamp muck (0)	swamp lolly (0)
 menacing construct	664	vib1.gif	Atk: 400 Def: 315 HP: 400 Init: 65 P: construct Article: a	El Vibrato punchcard (115 holes) (1)	El Vibrato punchcard (142 holes) (1)
 menacing construct (translated)	670	vib1.gif	Atk: 400 Def: 315 HP: 400 Init: 65 P: construct Article: a Manuel: "menacing construct" Wiki: "menacing construct"	El Vibrato punchcard (115 holes) (1)	El Vibrato punchcard (142 holes) (1)
 Mer-kin alphabetizer	850	merkinalphabet.gif	Atk: 750 Def: 800 HP: 900 Init: 100 Meat: 80 P: mer-kin Article: a	Mer-kin smartjuice (0)	Mer-kin worktea (0)
 Mer-kin balldodger	842	merkinballer.gif	NOCOPY Atk: [820+30*pref(lastColosseumRoundWon)] Def: [770+30*pref(lastColosseumRoundWon)] HP: [750+50*pref(lastColosseumRoundWon)] Init: -10000 Meat: 50 P: mer-kin Article: a
 Mer-kin bladeswitcher	844	merkinswitcher.gif	NOCOPY Atk: [820+30*pref(lastColosseumRoundWon)] Def: [770+30*pref(lastColosseumRoundWon)] HP: [750+50*pref(lastColosseumRoundWon)] Init: -10000 Meat: 50 P: mer-kin Article: a
 Mer-kin burglar	772	merkinburglar.gif	Atk: 650 Def: 720 HP: 650 Init: 150 Meat: 250 P: mer-kin Article: a	Mer-kin foodbucket (n6)	Mer-kin hidepaint (n10)	Mer-kin sneakmask (n2)	Mer-kin takebag (n2)
-Mer-kin diver	761	merkindiver.gif	Atk: 475 Def: 427 HP: 700 Init: 75 Meat: 200 P: mer-kin Article: a	Mer-kin foodbucket (n15)	Mer-kin hookspear (n2)	Mer-kin pressureglobe (n9)	Mer-kin thingpouch (n25)
+Mer-kin diver	761	merkindiver.gif	Atk: 475 Def: 427 HP: 700 Init: 75 Meat: 200 P: mer-kin EA: hot Article: a	Mer-kin foodbucket (n15)	Mer-kin hookspear (n2)	Mer-kin pressureglobe (n9)	Mer-kin thingpouch (n25)
 Mer-kin drifter	851	merkindrifter.gif	Atk: 850 Def: 800 HP: 1000 Init: 25 P: mer-kin Article: a	Mer-kin knucklebone (0)	Mer-kin begsign (0)	Mer-kin cooljuice (0)
-Mer-kin healer	773	merkinhealer.gif	Atk: 650 Def: 585 HP: 600 Init: 75 Meat: 150 P: mer-kin Article: a	Mer-kin foodbucket (n5)	Mer-kin healscroll (n25)	Mer-kin prayerbeads (n5)	Mer-kin thingpouch (n15)
+Mer-kin healer	773	merkinhealer.gif	Atk: 650 Def: 585 HP: 600 Init: 75 Meat: 150 P: mer-kin EA: hot Article: a	Mer-kin foodbucket (n5)	Mer-kin healscroll (n25)	Mer-kin prayerbeads (n5)	Mer-kin thingpouch (n15)
 Mer-kin juicer	853	merkinjuicer.gif	Atk: 780 Def: 650 HP: 900 Init: 50 Meat: 50 P: mer-kin Article: a	Mer-kin dragbelt (0)	Mer-kin ragejuice (0)
 Mer-kin miner	765	merkinminer.gif	Atk: 450 Def: 405 HP: 750 Init: 50 Meat: 200 P: mer-kin Article: a	Mer-kin foodbucket (n5)	Mer-kin digpick (n10)	Mer-kin thingpouch (n25)
 Mer-kin monitor	852	merkinmonitor.gif	Atk: 650 Def: 650 HP: 750 Init: 100 Meat: 80 P: mer-kin Article: a	Mer-kin cheatsheet (0)	Mer-kin eyeglasses (0)	Mer-kin hallpass (0)
 Mer-kin netdragger	843	merkindragger.gif	NOCOPY Atk: [820+30*pref(lastColosseumRoundWon)] Def: [770+30*pref(lastColosseumRoundWon)] HP: [750+50*pref(lastColosseumRoundWon)] Init: -10000 Meat: 50 P: mer-kin Article: a
 Mer-kin poseur	849	merkinposeur.gif	Atk: 720 Def: 750 HP: 750 Init: 125 Meat: 100 P: mer-kin Article: a	Mer-kin fitbrine (0)	Mer-kin gutgirdle (0)
 Mer-kin punisher	839	merkinpunisher.gif	Atk: 700 Def: 600 HP: 800 Init: 75 Meat: 50 P: mer-kin Article: a	Mer-kin mouthsoap (0)	Mer-kin finpaddle (0)	Mer-kin hallpass (0)
-Mer-kin raider	771	merkinraider.gif	Atk: 750 Def: 585 HP: 800 Init: 50 Meat: 250 P: mer-kin Article: a	Mer-kin breastplate (c2)	Mer-kin foodbucket (n10)	Mer-kin hookspear (n2)	Mer-kin roundshield (n2)
+Mer-kin raider	771	merkinraider.gif	Atk: 750 Def: 585 HP: 800 Init: 50 Meat: 250 P: mer-kin EA: sleaze Article: a	Mer-kin breastplate (c2)	Mer-kin foodbucket (n10)	Mer-kin hookspear (n2)	Mer-kin roundshield (n2)
 Mer-kin researcher	840	merkinresearcher.gif	Atk: 800 Def: 750 HP: 900 Init: 75 Meat: 65 P: mer-kin Article: a	Mer-kin healscroll (0)	Mer-kin killscroll (0)	Mer-kin darkbook (0)
-Mer-kin rustler	777	merkinspear.gif	Atk: 700 Def: 675 HP: 750 Init: 100 Meat: 200 P: mer-kin Article: a	Mer-kin thingpouch (n15)	Mer-kin foodbucket (n10)	Mer-kin hookspear (n2)
+Mer-kin rustler	777	merkinspear.gif	Atk: 700 Def: 675 HP: 750 Init: 100 Meat: 200 P: mer-kin EA: hot Article: a	Mer-kin thingpouch (n15)	Mer-kin foodbucket (n10)	Mer-kin hookspear (n2)
 Mer-kin scavenger	742	merkinscav.gif	Atk: 450 Def: 405 HP: 600 Init: 100 Meat: 200 P: mer-kin Article: a	Mer-kin hookspear (n2)	Mer-kin takebag (n4)	Mer-kin thingpouch (n25)
-Mer-kin specter	1372	merkinghost.gif	Atk: 750 Def: 600 HP: 600 Init: 100 P: undead GHOST Phys: 100 E: spooky Article: a
+Mer-kin specter	1372	merkinghost.gif	Atk: 750 Def: 600 HP: 600 Init: 100 P: undead GHOST Phys: 100 ED: spooky EA: cold EA: hot EA: sleaze EA: spooky EA: stench Article: a
 Mer-kin teacher	838	merkinteacher.gif	Atk: 600 Def: 700 HP: 700 Init: 50 Meat: 50 P: mer-kin Article: a	Mer-kin lipstick (0)	Mer-kin bunwig (0)	Mer-kin hallpass (0)	folder (catfish) (c0)
 Mer-kin tippler	768	merkintippler.gif	Atk: 600 Def: 360 HP: 750 Init: 25 Meat: 200 P: mer-kin Article: a	Alewife&trade; Ale (40)	Mer-kin foodbucket (n5)	Mer-kin pinkslip (n5)	slug of vodka (21)	Mer-kin weaksauce (0)
 Mer-kin trainer	841	merkintrainer.gif	Atk: 750 Def: 700 HP: 800 Init: 75 P: mer-kin Article: a	Mer-kin strongjuice (0)	Mer-kin stopwatch (0)
 mimic	283	lowerm.gif	BOSS NOCOPY Atk: 45 Def: 40 HP: 50 Init: 70 P: weird Article: a Wiki: "mimic (Cloak)"	dead mimic (n100)
 mind flayer	222	lower_h.gif	Atk: 59 Def: 54 HP: 77 Init: 75 P: horror Article: a	mind flayer corpse (25)	cornuthaum (15)	large box (20)	flayed mind (c0)
 mine crab	746	minecrab.gif	Atk: 700 Def: 540 HP: 850 Init: 50 Meat: 250 P: fish Article: a	live nautical mine (n20)
-Mismatched Twins	1242	twins_mism.gif	Atk: 91 Def: 85 HP: 100 Init: 50 Meat: 60 Group: 2 P: dude Article: some	artisanal limoncello (15)	giant motorcycle boots (5)
+Mismatched Twins	1242	twins_mism.gif	Atk: 91 Def: 85 HP: 100 Init: 50 Meat: 60 Group: 2 P: dude EA: spooky Article: some	artisanal limoncello (15)	giant motorcycle boots (5)
 Mob Penguin Capo	1511	mobcapo.gif	Atk: 155 Def: 145 HP: 160 Init: 50 Meat: 200 P: penguin Article: the	tommy gun (5)	drum of tommy ammo (30)	drum of tommy ammo (20)
-Mobile Armored Sweat Lodge	488	warhipar2.gif	Atk: 180 Def: 162 HP: 300 Init: 20 P: hippy Phys: 50 E: stench Article: a	communications windchimes (3)	didgeridooka (33)	gas balloon (20)
-model skeleton	1547	modelskeleton.gif	Atk: 76 Def: 81 HP: 85 Init: 25 P: construct GHOST E: spooky Article: a	synthetic marrow (0)	rubber ribcage (0)	funny bone (0)
-modern zmobie	1070	modernzombie.gif	SUPERLIKELY Atk: 60 Def: 54 HP: 50 Init: 300 Meat: 60 P: undead E: spooky Article: a
-moister oyster	1371	moyster.gif	NOCOPY LUCKY Atk: 1100 Def: 1300 HP: 1500 Init: 50 Meat: 100 P: fish Phys: 25 Elem: 25 Article: a	giant pearl (n100)
+Mobile Armored Sweat Lodge	488	warhipar2.gif	Atk: 180 Def: 162 HP: 300 Init: 20 P: hippy Phys: 50 ED: stench EA: hot EA: stench Article: a	communications windchimes (3)	didgeridooka (33)	gas balloon (20)
+model skeleton	1547	modelskeleton.gif	Atk: 76 Def: 81 HP: 85 Init: 25 P: construct GHOST ED: spooky Article: a	synthetic marrow (0)	rubber ribcage (0)	funny bone (0)
+modern zmobie	1070	modernzombie.gif	SUPERLIKELY Atk: 60 Def: 54 HP: 50 Init: 300 Meat: 60 P: undead ED: spooky Article: a
+moister oyster	1371	moyster.gif	NOCOPY LUCKY Atk: 1100 Def: 1300 HP: 1500 Init: 50 Meat: 100 P: fish Phys: 25 Elem: 25 EA: hot EA: sleaze Article: a	giant pearl (n100)
 monstrous boiler	1556	boiler.gif	Atk: 134 Def: 144 HP: 160 Init: -10000 P: construct Elem: 5 E: hot Article: a	chunk of hot iron (5)	red-hot boilermaker (5)	miniature boiler (5)
 Monty Basingstoke-Pratt, IV	517	monty.gif	NOCOPY Atk: 195 Def: 175 HP: 240 Init: 40 Meat: 200 P: orc E: sleaze	natty blue ascot (100)	white class ring (30)	distressed denim pants (0)	bejeweled pledge pin (0)	kick-ass kicks (0)
 mud turtle	1351	swampturtle.gif	Atk: 48 Def: 56 HP: 56 Init: 20 Meat: 30 P: beast Article: a	fine aged cheddarwurst (0)	muddy pirate hat (0)	turtle mud (c0)
-Muff	536	muff.gif	Atk: 153 Def: 137 HP: 150 Init: 70 P: constellation E: sleaze Article: The	line (30)	line (30)	star (30)
+Muff	536	muff.gif	Atk: 153 Def: 137 HP: 150 Init: 70 P: constellation ED: sleaze EA: hot EA: sleaze Article: The	line (30)	line (30)	star (30)
 musical fruit bat	2155	fruitbat2.gif	Atk: 19 Def: 20 HP: 18 Init: 60 Meat: 30 P: beast Article: a	sonar-in-a-biscuit (10)	grapefruit (20)	grapes (20)	lemon
 muscular mushroom guy	1802	mush_beefy.gif	Atk: 30 Def: 30 HP: 20 Init: 25 P: plant Article: a	veiny spore pod (50)	stinky mushroom (20)
 Naughty Sorceress	243	sorcform1.gif	BOSS NOCOPY Atk: 190 Def: 171 HP: 400 Exp: 0 Init: 10000 P: dude Item: 25 Skill: 50 Article: The
 Naughty Sorceress (2)	244	sorcblob.gif	BOSS NOCOPY Atk: 205 Def: 184 HP: 600 Exp: 0 Init: 10000 P: dude Item: 25 Skill: 50 Article: The
 Naughty Sorceress (3)	245	bigsaus.gif	BOSS NOCOPY Atk: 9999999 Def: 8999999 HP: 9999999 Exp: 500 Init: 10000 P: dude Article: The	Instant Karma (c100)
 Naughty Sorority Nurse	510	warfratmd2.gif	Atk: 180 Def: 166 HP: 160 Init: 30 P: orc ED: sleaze Article: a	energy drink IV (27)	gauze garter (25)	gauze garter (20)	kick-ass kicks (2)	PADL Phone (3)
-navy seal	801	navyseal.gif	NOCOPY FREE Atk: 175 Def: 157 HP: 200 Init: -10000 P: demon Article: a	frost-rimed seal hide (35)	frozen seal spine (5)
+navy seal	801	navyseal.gif	NOCOPY FREE Atk: 175 Def: 157 HP: 200 Init: -10000 P: demon EA: cold Article: a	frost-rimed seal hide (35)	frozen seal spine (5)
 Neckbeard Giant	1333	giant_neckbeard.gif	Atk: 125 Def: 120 HP: 150 Init: 40 Meat: 150 P: humanoid Article: a	giant penguin keychain (10)	O'RLY manual (15)	open sauce (25)	giant neckbeard (c15)
 Neil	512	neil.gif	NOCOPY Atk: 195 Def: 175 HP: 240 Init: 40 Meat: 200 P: hippy ED: stench	longhaired hippy wig (100)	green clay bead (30)	Lockenstock&trade; sandals (0)	reinforced beaded headband (0)	bullet-proof corduroys (0)
-Neptune flytrap	740	flytrap.gif	Atk: 450 Def: 360 HP: 700 Init: 125 P: plant Article: a Poison: "Really Quite Poisoned"	flytrap pellet (n30)	water-polo cap (c0)	wriggling flytrap pellet (c0)
-newt	333	newt.gif	NOCOPY Atk: [3] Def: [2] HP: [3] Init: -10000 Meat: 10 P: beast Article: a	eye of newt (100)
+Neptune flytrap	740	flytrap.gif	Atk: 450 Def: 360 HP: 700 Init: 125 P: plant EA: sleaze Article: a Poison: "Really Quite Poisoned"	flytrap pellet (n30)	water-polo cap (c0)	wriggling flytrap pellet (c0)
+newt	333	newt.gif	NOCOPY Atk: [3] Def: [2] HP: [3] Init: -10000 Meat: 10 P: beast EA: sleaze Article: a	eye of newt (100)
 Next-generation Frat Boy	516	emofrat.gif	NOCOPY Atk: 190 Def: 171 HP: 200 Init: 20 Meat: 150 P: orc E: sleaze Article: a	beaten-up Chucks (100)	white class ring (30)	beer helmet (0)	distressed denim pants (0)	kick-ass kicks (0)
 ninja dressed as a waiter	1512	ninjawaiter.gif	Atk: 150 Def: 150 HP: 155 Init: 100 P: dude Article: a	crappy waiter disguise (30)	throwing knife (10)	throwing fork (10)	throwing spoon (10)	ninja fear powder (c0)
 Ninja Snowman (Chopsticks)	338	ninjarice.gif	Atk: 85 Def: 76 HP: 70 Init: 60 P: elemental ED: cold Article: a Manuel: "Ninja Snowman"	frigid ninja stars (20)	rice bowl (5)	chopsticks (5)	pentatonic accordion (a0)
 Ninja Snowman (Hilt)	137	snowman.gif	Atk: 85 Def: 76 HP: 70 Init: 60 P: elemental E: cold Article: a Manuel: "Ninja Snowman"	frigid ninja stars (20)	frozen nunchaku (5)	icy katana hilt (15)
 Ninja Snowman (Mask)	100	snowman.gif	Atk: 85 Def: 76 HP: 70 Init: 60 P: elemental E: cold Article: a Manuel: "Ninja Snowman"	cold ninja mask (10)	frigid ninja stars (20)	frozen nunchaku (5)
-ninja snowman assassin	1185	ninja_ass.gif	SUPERLIKELY Atk: 150 Def: 135 HP: 10 Init: 150 P: elemental E: cold Article: a	ninja rope (n100)	ninja crampons (n100)	ninja carabiner (n100)
+ninja snowman assassin	1185	ninja_ass.gif	SUPERLIKELY Atk: 150 Def: 135 HP: 10 Init: 150 P: elemental ED: cold Article: a	ninja rope (n100)	ninja crampons (n100)	ninja carabiner (n100)
 Ninja Snowman Janitor	339	ninjamop.gif	Atk: 80 Def: 81 HP: 70 Init: 60 P: elemental ED: cold Article: a	frigid ninja stars (20)	ninja mop (5)	pail (10)
 Ninja Snowman Weaponmaster	340	ninjacloud.gif	Atk: 90 Def: 81 HP: 80 Init: 75 P: elemental ED: cold Article: a	ridiculously overelaborate ninja weapon (5)	frigid ninja stars (20)	frozen nunchaku (5)	frigid hanky&#363; (0)	frigid mote (p5)
-novelty tropical skeleton	1746	tropicalskel.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: undead E: spooky Article: a	cherry (0)	cherry (0)	grapefruit (0)	grapefruit (0)	orange (0)	orange (0)	strawberry (0)	strawberry (0)	lemon (0)	lemon (0)	novelty fruit hat (c0)
+novelty tropical skeleton	1746	tropicalskel.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: undead ED: spooky Article: a	cherry (0)	cherry (0)	grapefruit (0)	grapefruit (0)	orange (0)	orange (0)	strawberry (0)	strawberry (0)	lemon (0)	lemon (0)	novelty fruit hat (c0)
 nurse shark	769	nurseshark.gif	Atk: 450 Def: 405 HP: 800 Init: 50 Meat: 200 P: fish Article: a	blank prescription sheet (c11)	nurse's hat (n5)	sea salt scrubs (c5)	slug of rum (21)
 oasis monster	459	whirlwind.gif	Atk: 132 Def: 123 HP: 139 Init: 40 Meat: 100 P: elemental Article: an	displaced fish (20)	palm frond (10)	Supernova Champagne (20)	wonderwall shield (4)	carbonated water lily (10)	hot date (5)
 octopus gardener	738	octopus.gif	Atk: 425 Def: 360 HP: 600 Init: 200 Meat: 100 P: fish Article: an	octopus's spade (n2)	sea radish (c3)	soggy seed packet (n30)	straw hat (n2)
@@ -481,54 +481,54 @@ oil baron	1237	oilbaron.gif	Atk: 85 Def: 77 HP: 60 Init: 80 P: slime Elem: 50 E:
 oil cartel	1238	oilcartel2.gif	Atk: 85 Def: 77 HP: 60 Init: 90 Group: 3 P: slime Elem: 25 E: sleaze Article: an	bubblin' crude (100)	bubblin' crude (30)	bubblin' crude (10)
 oil slick	1235	oilslick.gif	Atk: 85 Def: 77 HP: 60 Init: 50 P: slime E: sleaze Article: an	bubblin' crude (100)
 oil tycoon	1236	oiltycoon.gif	Atk: 85 Def: 77 HP: 60 Init: 65 P: slime Elem: 25 E: sleaze Article: an	bubblin' crude (100)	bubblin' crude (10)
-one-eyed Gnoll	18	dk_oneeye.gif	Atk: 11 Def: 9 HP: 5 Init: 60 Meat: 22 P: humanoid Article: a	eyepatch (5)	gnoll teeth (5)	glass gnoll eye (p5)	Missing Eye Simulation Device (c0)
-One-Eyed Willie	178	oneeyed.gif	Atk: 150 Def: 135 HP: 150 Init: 70 P: constellation E: sleaze	line (30)	line (30)	star (30)
+one-eyed Gnoll	18	dk_oneeye.gif	Atk: 11 Def: 9 HP: 5 Init: 60 Meat: 22 P: humanoid EA: sleaze Article: a	eyepatch (5)	gnoll teeth (5)	glass gnoll eye (p5)	Missing Eye Simulation Device (c0)
+One-Eyed Willie	178	oneeyed.gif	Atk: 150 Def: 135 HP: 150 Init: 70 P: constellation ED: sleaze EA: hot EA: sleaze	line (30)	line (30)	star (30)
 Orcish Frat Boy (Music Lover)	62	fratboy.gif	Atk: 39 Def: 35 HP: 30 Init: 60 Meat: 30 P: orc E: sleaze Article: an Manuel: "Orcish Frat Boy"	ice-cold Sir Schlitz (20)	ice-cold fotie (20)	Orcish baseball cap (5)	deodorant (5)	shingle (25)	packet of beer nuts (p15)
 Orcish Frat Boy (Paddler)	63	fratboy.gif	Atk: 40 Def: 36 HP: 30 Init: 60 Meat: 30 P: orc E: sleaze Article: an Manuel: "Orcish Frat Boy"	bottle of gin (20)	ice-cold Sir Schlitz (20)	Orcish cargo shorts (5)	deodorant (5)	packet of beer nuts (p15)
 Orcish Frat Boy (Pledge)	64	fratskirt.gif	Atk: 41 Def: 36 HP: 30 Init: 60 Meat: 30 P: orc E: sleaze Article: an Manuel: "Orcish Frat Boy"	bottle of vodka (20)	Orcish frat-paddle (5)	ice-cold Sir Schlitz (20)	deodorant (5)	frilly skirt (0)	packet of beer nuts (p15)
-Orcish Frat Boy Spy	409	fratbong.gif	Atk: 165 Def: 153 HP: 180 Init: 60 P: orc E: sleaze Article: an	beer helmet (30)	distressed denim pants (30)	bejeweled pledge pin (30)
+Orcish Frat Boy Spy	409	fratbong.gif	Atk: 165 Def: 153 HP: 180 Init: 60 P: orc ED: sleaze Article: an	beer helmet (30)	distressed denim pants (30)	bejeweled pledge pin (30)
 overdone flame-broiled meat blob	282	meatblob.gif	Atk: 4 Def: 1 HP: 2 Init: 60 Meat: 20 P: slime E: hot Article: an	meat paste (40)	meat paste (40)	meat paste (40)
-P imp	123	pimp.gif	Atk: 42 Def: 37 HP: 42 Init: 60 Meat: 30 P: demon E: hot Article: a	Imp Ale (30)	hot wing (30)	diamond-studded cane (5)
-pair of burnouts	1578	stonebros.gif	Atk: 34 Def: 30 HP: 25 Init: -10000 Meat: 15 P: dude Article: a	poppy (30)	poppy (10)
-panicking Knott Yeti	1228	yeti.gif	NOCOPY Atk: 105 Def: 92 HP: 90 Init: 60 Meat: 200 P: beast E: cold Article: a	yeti fur (30)
+P imp	123	pimp.gif	Atk: 42 Def: 37 HP: 42 Init: 60 Meat: 30 P: demon ED: hot EA: hot EA: sleaze Article: a	Imp Ale (30)	hot wing (30)	diamond-studded cane (5)
+pair of burnouts	1578	stonebros.gif	Atk: 34 Def: 30 HP: 25 Init: -10000 Meat: 15 P: dude EA: hot Article: a	poppy (30)	poppy (10)
+panicking Knott Yeti	1228	yeti.gif	NOCOPY Atk: 105 Def: 92 HP: 90 Init: 60 Meat: 200 P: beast ED: cold EA: cold EA: stench Article: a	yeti fur (30)
 Panty Raider Frat Boy	421	warfratpr.gif	Atk: 200 Def: 180 HP: 250 Init: 100 P: orc E: sleaze Article: a	chloroform rag (12)	chloroform rag (7)	depantsing bomb (18)	depantsing bomb (3)	Elmley shades (6)	PADL Phone (3)	panty raider camouflage (10)	white class ring (30)
 paper towelgeist	374	ptowels.gif	Atk: 21 Def: 18 HP: 22 Init: 30 P: undead Article: a	cardboard katana (5)
-party skelteon	2154	partyskeleton.gif	Atk: 52 Def: 49 HP: 55 Init: 50 P: undead E: spooky Article: a	skeleton bone	loose teeth	margarita	martini	monkey wrench	salty dog	screwdriver	strawberry daiquiri	strawberry wine	tequila sunrise	vodka martini	whiskey and soda	whiskey sour	wine spritzer
+party skelteon	2154	partyskeleton.gif	Atk: 52 Def: 49 HP: 55 Init: 50 P: undead ED: spooky EA: cold EA: hot EA: sleaze EA: spooky Article: a	skeleton bone	loose teeth	margarita	martini	monkey wrench	salty dog	screwdriver	strawberry daiquiri	strawberry wine	tequila sunrise	vodka martini	whiskey and soda	whiskey sour	wine spritzer
 Peanut	1376	peanut.gif	NOCOPY Atk: 650 Def: 700 HP: 1200 Init: 75 P: horror Elem: 25	peanut sauce (0)
 pernicious puddle of pesto	659	pestopuddle.gif	NOCOPY Atk: 21 Def: 18 HP: 18 Init: 20 P: slime Article: a	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)
 perpendicular bat	47	perpbat.gif	Atk: 18 Def: 16 HP: 12 Init: 60 Meat: 30 P: beast Article: a	batgut (15)	bat wing (15)	sonar-in-a-biscuit (10)	perpendicular guano (c0)	guancertina (a0)
 pig	1591	somepig.gif	NOCOPY Atk: [6] Def: [7] HP: [8] Init: -10000 Meat: 5 P: beast Article: a	ham steak (0)	piggy tattoo (c0)
 pine bat	149	pinebat.gif	Atk: 14 Def: 10 HP: 8 Init: 60 Meat: 22 P: beast EA: stench Article: a	bat wing (15)	Pine-Fresh air freshener (15)	batgut (15)
 piranha plant	2175	piranhaplant.gif	NOCOPY Scale: 20 Cap: 1000 Floor: 30 Init: -10000 P: plant Article: a	piranha pollen (0)
-plaid ghost	1560	plaidghost.gif	Atk: 137 Def: 136 HP: 160 Init: 50 P: undead GHOST Article: a	plaid swatch (20)
+plaid ghost	1560	plaidghost.gif	Atk: 137 Def: 136 HP: 160 Init: 50 P: undead GHOST EA: sleaze Article: a	plaid swatch (20)
 plaque of locusts	457	plaque.gif	Atk: 134 Def: 124 HP: 140 Init: 30 Meat: 25 P: bug Article: a	bronzed locust (20)	honey-dipped locust (20)	handful of sand (20)
-plastered frat orc	994	drunkfrat.gif	Atk: 10 Def: 7 HP: 7 Init: 40 Meat: 25 P: orc Article: a	ice-cold fotie (20)	ice-cold Sir Schlitz (20)	ice-cold Willer (20)	flask flops (0)
+plastered frat orc	994	drunkfrat.gif	Atk: 10 Def: 7 HP: 7 Init: 40 Meat: 25 P: orc EA: sleaze Article: a	ice-cold fotie (20)	ice-cold Sir Schlitz (20)	ice-cold Willer (20)	flask flops (0)
 pooltergeist	386	poolter.gif	Atk: 25 Def: 23 HP: 27 Init: 70 P: undead Article: a	1-ball (3)	2-ball (3)	3-ball (3)	4-ball (3)	5-ball (3)	6-ball (3)	7-ball (3)	8-ball (15)
 pooltergeist (ultra-rare)	425	poolter2.gif	NOCOPY NOMANUEL ULTRARARE Atk: 55 Def: 48 HP: 50 Init: 70 P: undead Wiki: "pooltergeist (Ultra-Rare)"	17-ball (100)
 Pork Sword	182	porksword.gif	Atk: 162 Def: 145 HP: 150 Init: 70 P: constellation E: sleaze Article: The	line (30)	star (30)	star (30)
 Portly Abomination	94	abom.gif	Atk: 73 Def: 65 HP: 63 Init: 70 Meat: 75 P: horror Article: a	abominable blubber (0)
 possessed can of tomatoes	145	tomatosoup.gif	Atk: 1 Def: 0 HP: 1 Init: 50 Meat: 3 P: undead Article: a	razor-sharp can lid (45)	tomato (60)	possessed tomato (p15)	folder (yellow) (c0)
-possessed laundry press	1562	mangler.gif	Atk: 158 Def: 129 HP: 145 Init: -10000 P: construct Article: a	extra-flat panini (15)	industrial strength starch (15)	mangled finger (5)
+possessed laundry press	1562	mangler.gif	Atk: 158 Def: 129 HP: 145 Init: -10000 P: construct EA: hot Article: a	extra-flat panini (15)	industrial strength starch (15)	mangled finger (5)
 possessed silverware drawer	372	silverware.gif	Atk: 22 Def: 18 HP: 22 Init: 50 P: undead Article: a	antique packet of ketchup (0)	corn holder (15)	eggbeater (4)
-possessed toy chest	1550	toybox.gif	Atk: 76 Def: 84 HP: 85 Init: -10000 P: weird Article: a	haunted paddle-ball (5)	spooky sound effects record (15)	spooky alphabet block (20)
-possessed wine rack	713	winerack.gif	Atk: 158 Def: 146 HP: 165 Init: 40 P: construct E: spooky Article: a	actual tapas (0)	bottle of Chateau de Vinegar (c0)
+possessed toy chest	1550	toybox.gif	Atk: 76 Def: 84 HP: 85 Init: -10000 P: weird EA: sleaze Article: a	haunted paddle-ball (5)	spooky sound effects record (15)	spooky alphabet block (20)
+possessed wine rack	713	winerack.gif	Atk: 158 Def: 146 HP: 165 Init: 40 P: construct ED: spooky Article: a	actual tapas (0)	bottle of Chateau de Vinegar (c0)
 Possibility Giant	171	question.gif	Atk: 130 Def: 117 HP: 150 Init: 40 Meat: 150 P: humanoid Article: a	chaos butterfly (20)	plot hole (15)	probability potion (25)
 poutine ooze	225	pouooze.gif	Atk: 3 Def: 1 HP: 3 Init: 30 P: slime Article: a	poutine (40)
-Pr Imp	979	primp.gif	Atk: 60 Def: 54 HP: 60 Init: 50 Meat: 50 P: demon E: hot Article: a	imp air (15)
+Pr Imp	979	primp.gif	Atk: 60 Def: 54 HP: 60 Init: 50 Meat: 50 P: demon ED: hot Article: a	imp air (15)
 Procrastination Giant	170	giant_procrast.gif	Atk: 125 Def: 112 HP: 150 Init: -10000 Meat: 150 P: humanoid Article: a	procrastination potion (25)
 Protagonist	160	protag.gif	Atk: 100 Def: 90 HP: 80 Init: 80 Meat: 100 P: dude Article: a	phonics down (40)	ridiculously huge sword (10)	super-spiky hair gel (20)	ocarina of space (5)
-Protector Spectre	450	protspect.gif	NOCOPY Atk: 164 Def: 151 HP: 100 Init: 30 P: undead GHOST Phys: 100 Article: a	ancient amulet (n100)	spectre scepter (n100)
-psychedelic fur	661	carpet.gif	NOCOPY Atk: 21 Def: 18 HP: 18 Init: 20 P: weird Article: a	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)
+Protector Spectre	450	protspect.gif	NOCOPY Atk: 164 Def: 151 HP: 100 Init: 30 P: undead GHOST Phys: 100 EA: hot EA: spooky Article: a	ancient amulet (n100)	spectre scepter (n100)
+psychedelic fur	661	carpet.gif	NOCOPY Atk: 21 Def: 18 HP: 18 Init: 20 P: weird EA: spooky Article: a	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)
 pufferfish	757	pufferfish.gif	Atk: 400 Def: 450 HP: 750 Init: 100 Meat: 200 P: fish Article: a	pufferfish spine (n5)	rough fish scale (n4)	seaweed (n5)
 pumped-up bass	718	pumpedbass.gif	Atk: 330 Def: 270 HP: 500 Init: 100 Meat: 200 P: fish Article: a	dull fish scale (n15)	beefy fish meat (n5)
 Punk Rock Giant	1336	giant_punk.gif	Atk: 150 Def: 140 HP: 150 Init: 50 Meat: 50 P: humanoid Article: a	giant safety pin (10)	punk rock jacket (10)	stolen sushi (30)	folder (smiley face) (c0)	punk patch (c15)
-pygmy assault squad	448	pyg_squad.gif	Atk: 152 Def: 136 HP: 148 Init: 50 Meat: 125 Group: 2 P: dude Article: a	bottle of alcohol (40)	pygmy pygment (25)	pygmy spear (5)	jungle drum (10)
+pygmy assault squad	448	pyg_squad.gif	Atk: 152 Def: 136 HP: 148 Init: 50 Meat: 125 Group: 2 P: dude EA: hot Article: a	bottle of alcohol (40)	pygmy pygment (25)	pygmy spear (5)	jungle drum (10)
 pygmy blowgunner	449	pyg_blowgunner.gif	Atk: 156 Def: 130 HP: 147 Init: 90 Meat: 100 P: dude Article: a	big bad voodoo mask (5)	pygmy blowgun (30)	pygmy nose-bone (10)	pygmy dart (c10)
-pygmy bowler	1432	pyg_bowler.gif	Atk: 154 Def: 135 HP: 155 Init: 30 Meat: 125 P: dude Article: a	bowling ball (40)	imitation White Russian (25)	tiny bowler (5)
-pygmy headhunter	447	pyg_headhunter.gif	Atk: 146 Def: 138 HP: 150 Init: 30 Meat: 175 P: dude E: sleaze Article: a	briefcase (60)	headhunter necktie (5)	pointed stick (10)	world's smallest violin (5)	pygmy papers (c20)
-pygmy janitor	1427	pyg_janitor.gif	Atk: 142 Def: 150 HP: 155 Init: 10 Meat: 90 P: dude Article: a	all-purpose cleaner (10)	book of matches (20)	jungle floor wax (25)	short-handled mop (10)
+pygmy bowler	1432	pyg_bowler.gif	Atk: 154 Def: 135 HP: 155 Init: 30 Meat: 125 P: dude EA: sleaze Article: a	bowling ball (40)	imitation White Russian (25)	tiny bowler (5)
+pygmy headhunter	447	pyg_headhunter.gif	Atk: 146 Def: 138 HP: 150 Init: 30 Meat: 175 P: dude ED: sleaze Article: a	briefcase (60)	headhunter necktie (5)	pointed stick (10)	world's smallest violin (5)	pygmy papers (c20)
+pygmy janitor	1427	pyg_janitor.gif	Atk: 142 Def: 150 HP: 155 Init: 10 Meat: 90 P: dude EA: sleaze EA: stench Article: a	all-purpose cleaner (10)	book of matches (20)	jungle floor wax (25)	short-handled mop (10)
 pygmy orderlies	1435	pyg_orderlies.gif	Atk: 152 Def: 142 HP: 158 Init: 20 Meat: 200 P: dude Article: some	compression stocking (15)	midriff scrubs (5)	pill cup (25)
-pygmy shaman	1428	pyg_shaman.gif	Atk: 148 Def: 140 HP: 150 Init: 40 Meat: 125 P: dude Article: a	colorful toad (20)	crude voodoo doll (5)	smirking shrunken head (15)	voodoo glowskull (c0)
+pygmy shaman	1428	pyg_shaman.gif	Atk: 148 Def: 140 HP: 150 Init: 40 Meat: 125 P: dude EA: hot EA: sleaze Article: a	colorful toad (20)	crude voodoo doll (5)	smirking shrunken head (15)	voodoo glowskull (c0)
 pygmy witch accountant	1430	pyg_acct.gif	Atk: 150 Def: 138 HP: 148 Init: 50 Meat: 150 P: dude Article: a	adder (20)	bone abacus (5)	short calculator (5)	McClusky file (page 1) (c100)	McClusky file (page 2) (c100)	McClusky file (page 3) (c100)	McClusky file (page 4) (c100)	McClusky file (page 5) (c100)	pygmy adder oil (c0)
 pygmy witch lawyer	1434	pyg_lawyer.gif	Atk: 150 Def: 142 HP: 145 Init: 40 Meat: 175 P: dude Article: a	attorney's badge (15)	short writ of habeas corpus (5)	pygmy briefs (5)	short deposition (c0)
 pygmy witch nurse	1433	pyg_nurse.gif	Atk: 148 Def: 148 HP: 148 Init: 60 Meat: 100 P: dude Article: a	tongue depressor (5)	bag of pygmy blood (20)	sphygmomanometer (20)	pygmy witchhazel (c0)
@@ -543,16 +543,16 @@ rampaging adding machine	570	adding.gif	Atk: 80 Def: 72 HP: 70 Init: 50 P: const
 ratbat	151	ratbat.gif	Atk: 25 Def: 22 HP: 22 Init: 60 Meat: 22 P: beast EA: sleaze Article: a	rat appendix (15)	ratgut (15)	ratarang (p5)	sonar-in-a-biscuit (15)
 rattlin' duck	563	duckrattle.gif	Atk: 175 Def: 155 HP: 190 Init: 60 Meat: 150 P: beast E: stench Article: a	fetid feather (10)	duct tape (5)
 Raver Giant	173	giant_raver.gif	Atk: 140 Def: 126 HP: 150 Init: 40 Meat: 150 P: humanoid Article: a	Angry Farmer candy (20)	giant needle (20)	Mick's IcyVapoHotness Rub (20)	rave whistle (5)
-red butler	1522	redbutler.gif	Atk: 150 Def: 155 HP: 160 Init: 50 Meat: 75 P: dude Article: a	red box (15)	glark cable (30)
+red butler	1522	redbutler.gif	Atk: 150 Def: 155 HP: 160 Init: 50 Meat: 75 P: dude EA: hot Article: a	red box (15)	glark cable (30)
 Red Fox	1525	redfox.gif	LUCKY Atk: 166 Def: 155 HP: 170 Init: 200 Meat: 200 P: dude Article: The	red foxglove (100)	Red Fox glove (1)
 Red Herring	1523	redherring.gif	Atk: 149 Def: 152 HP: 166 Init: 37 Meat: 125 P: dude Article: a	red box (20)
-red skeleton	1521	redskeleton.gif	Atk: 145 Def: 160 HP: 155 Init: 25 P: undead E: spooky Article: a	red box (15)	red blood cells (25)	red eye (5)	Red Army camouflage kit (c0)
+red skeleton	1521	redskeleton.gif	Atk: 145 Def: 160 HP: 155 Init: 25 P: undead ED: spooky Article: a	red box (15)	red blood cells (25)	red eye (5)	Red Army camouflage kit (c0)
 Red Snapper	1524	redsnapper.gif	Atk: 155 Def: 157 HP: 150 Init: 75 Meat: 125 P: dude Article: a	red box (30)
 regular old bat	44	regbat.gif	Atk: 13 Def: 11 HP: 8 Init: 60 Meat: 22 P: beast Article: a	bat guano (15)	batgut (15)	bat wing (15)
-remaindered skeleton	1745	headlessskel.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: undead E: spooky Article: a	skeleton bone (0)	remaindered axe (0)	low-budget shield (0)
+remaindered skeleton	1745	headlessskel.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: undead ED: spooky Article: a	skeleton bone (0)	remaindered axe (0)	low-budget shield (0)
 remains of a jilted mistress	396	mistress.gif	Atk: 65 Def: 60 HP: 65 Init: 50 P: undead ED: spooky Article: the	antique hand mirror (40)	gilt perfume bottle (c0)
 Remarkable Elba Kramer	1966	elbakramer.gif	NOCOPY NOMANUEL ULTRARARE Atk: 220 Def: 200 HP: 240 Init: 10000	repaid diaper (n100)
-Renaissance Giant	1335	giant_renfair.gif	Atk: 125 Def: 110 HP: 150 Init: 40 Meat: 100 P: humanoid Article: a	giant turkey leg (10)	Ye Olde Bawdy Limerick (25)	Ye Olde Meade (15)	Ye Olde Medieval Insult (25)
+Renaissance Giant	1335	giant_renfair.gif	Atk: 125 Def: 110 HP: 150 Init: 40 Meat: 100 P: humanoid EA: hot Article: a	giant turkey leg (10)	Ye Olde Bawdy Limerick (25)	Ye Olde Meade (15)	Ye Olde Medieval Insult (25)
 revolting bugbear	254	angbugbear.gif	Atk: 13 Def: 12 HP: 10 Init: 50 P: beast E: stench Article: a
 revolving bugbear	255	revbugbear.gif	Atk: 14 Def: 13 HP: 11 Init: 50 P: beast Article: a
 Ringogeorge, the Bladeswitcher	881	merkinswitcher2.gif	BOSS NOCOPY Atk: 1300 Def: 1250 HP: 1600 Init: 100 Meat: 100 P: mer-kin
@@ -561,7 +561,7 @@ roller skate	730	rollerskate.gif	Atk: 450 Def: 360 HP: 700 Init: 30 Meat: 100 P:
 rolling stone	574	rollingstone.gif	Atk: 137 Def: 126 HP: 135 Init: 50 P: elemental Article: a	palm frond (10)	handful of moss (20)	brown sugar cane (20)	mother's little helper (10)	Tuesday's ruby (5)	hot date (5)
 Ron "The Weasel" Copperhead	1531	roncopper.gif	BOSS NOCOPY Atk: 165 Def: 170 HP: 180 Init: 100 Meat: 250 P: dude	Copperhead Charm (rampant) (n100)
 rotten dolphin thief	810	realdolphin.gif	NOCOPY Atk: 400 Def: 360 HP: 600 Init: 100 P: fish Article: a
-rotund duck	561	duckfat.gif	Atk: 175 Def: 157 HP: 195 Init: 40 Meat: 300 P: beast Article: a	duct tape (6)
+rotund duck	561	duckfat.gif	Atk: 175 Def: 157 HP: 195 Init: 40 Meat: 300 P: beast EA: sleaze Article: a	duct tape (6)
 rushing bum	159	bum.gif	Atk: 1 Def: 0 HP: 1 Init: 40 P: hobo Article: a	bum cheek (32)	Mad Train wine (30)	moxie weed (15)	dented harmonica (15)	cheap cigar butt (p60)	folder (magenta) (c0)
 sabre-toothed ferret	474	ferret.gif	Atk: 250 Def: 198 HP: 200 Init: 75 Meat: 200 P: beast E: stench Article: a	sabre teeth (25)	Spanish fly (c25)
 sabre-toothed goat	84	toothgoat.gif	Atk: 68 Def: 61 HP: 50 Init: 80 Meat: 55 P: beast Article: a	goat beard (5)	sabre teeth (5)
@@ -574,22 +574,22 @@ school of wizardfish	717	wizardfish.gif	Atk: 300 Def: 270 HP: 400 Init: 100 Meat
 scimitarfish	723	scimitarfish.gif	Atk: 400 Def: 292 HP: 550 Init: 200 Meat: 220 P: fish Article: a	dull fish scale (n15)	fish scimitar (n2)
 scorched duck	558	duckscorch.gif	Atk: 170 Def: 156 HP: 185 Init: 50 Meat: 150 P: beast E: hot Article: a	flaming feather (10)	duct tape (5)
 screambat	1010	screambat.gif	SUPERLIKELY Atk: 18 Def: 16 HP: 15 Init: 50 P: beast Article: a
-sea cow	775	seacow.gif	Atk: 600 Def: 675 HP: 900 Init: 25 Meat: 300 P: fish Article: a	sea cowbell (n10)	sea leather (n20)
+sea cow	775	seacow.gif	Atk: 600 Def: 675 HP: 900 Init: 25 Meat: 300 P: fish EA: stench Article: a	sea cowbell (n10)	sea leather (n20)
 sea cowboy	776	seacowboy.gif	Atk: 750 Def: 585 HP: 700 Init: 50 Meat: 200 P: fish Article: a	sea lasso (n30)	deep six-shooter (n8)
 senile lihc	192	lich.gif	Atk: 56 Def: 51 HP: 50 Init: 50 P: undead E: spooky Article: a	lihc eye (20)	lihc face (9)	shimmering tendrils (c5)
 serialbus	982	serialbus.gif	Atk: 60 Def: 54 HP: 60 Init: 50 Meat: 30 P: demon E: hot Article: a	bus pass (25)
-Servant of Grodstank	799	grodseal.gif	NOCOPY FREE Atk: 175 Def: 157 HP: 200 Init: -10000 P: horror Article: a	fustulent seal grulch (35)	infernal toilet brush (5)
+Servant of Grodstank	799	grodseal.gif	NOCOPY FREE Atk: 175 Def: 157 HP: 200 Init: -10000 P: horror EA: stench Article: a	fustulent seal grulch (35)	infernal toilet brush (5)
 sewer snake with a sewer snake in it	1752	sewersnake.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: beast SNAKE E: stench Article: a	carton of snake milk (100)	carton of snake milk (30)	sewer snake (30)
-shadow of Black Bubbles	798	shadowseal.gif	NOCOPY FREE Atk: 175 Def: 157 HP: 200 Init: -10000 P: horror Article: a	scrap of shadow (35)	shadowy seal eye (5)
-shady pirate	107	pirate1.gif	Atk: 67 Def: 60 HP: 57 Init: 75 Meat: 30 P: pirate Article: a	safarrri hat (10)
+shadow of Black Bubbles	798	shadowseal.gif	NOCOPY FREE Atk: 175 Def: 157 HP: 200 Init: -10000 P: horror EA: spooky Article: a	scrap of shadow (35)	shadowy seal eye (5)
+shady pirate	107	pirate1.gif	Atk: 67 Def: 60 HP: 57 Init: 75 Meat: 30 P: pirate EA: sleaze Article: a	safarrri hat (10)
 shaky clown	285	clown.gif	Atk: 19 Def: 17 HP: 16 Init: 80 Meat: 20 P: horror E: sleaze Article: a	bloody clown pants (15)	big red clown nose (15)	bottle of gin (10)	bottle of rum (10)	bottle of tequila (10)	bottle of whiskey (10)	bottle of vodka (10)	boxed wine (10)	clown skin (10)	polka-dot bow tie (p5)
 sheet ghost	1555	sheetghost.gif	Atk: 79 Def: 81 HP: 75 Init: 50 P: undead GHOST Article: a	ghost key (15)	sheet cake (15)	ghost toga (5)
 shifty pirate	129	pirate2.gif	Atk: 69 Def: 62 HP: 59 Init: 60 Meat: 45 P: pirate Article: a	arrrgyle socks (10)	flaregun (30)	sunken chest (30)
 Shub-Jigguwatt, Elder God of Violence	1377	shub-jigguwatt.gif	BOSS NOCOPY Atk: 4000 Def: 4000 HP: 10000 Init: 10000 P: horror Elem: 95
 sk8 gnome	1156	sk8gnome.gif	Atk: 75 Def: 67 HP: 65 Init: 60 Meat: 70 P: humanoid Article: a	eXtreme mittens (0)	Mountain Stream soda (0)	gr8ps (40)	sk8board (5)	t8r tots (40)	folder (space skeleton) (c0)
 Skate Board member	732	boardskate.gif	Atk: 450 Def: 450 HP: 750 Init: 50 Meat: 150 P: fish Article: a	S.A.V.E. flyer (0)	skate board (0)	skate skin (0)
-skeletal cat	379	catskel.gif	Atk: 24 Def: 21 HP: 23 Init: 50 P: undead ED: spooky Article: a	pile of dusty animal bones (100)
-skeletal hamster	375	hamskel.gif	Atk: 23 Def: 20 HP: 22 Init: 50 P: undead ED: spooky Article: a	pile of dusty animal bones (100)	tiny canopic jar (c0)
+skeletal cat	379	catskel.gif	Atk: 24 Def: 21 HP: 23 Init: 50 P: undead E: spooky Article: a	pile of dusty animal bones (100)
+skeletal hamster	375	hamskel.gif	Atk: 23 Def: 20 HP: 22 Init: 50 P: undead E: spooky Article: a	pile of dusty animal bones (100)	tiny canopic jar (c0)
 skeletal monkey	380	monkeyskel.gif	Atk: 24 Def: 21 HP: 23 Init: 300 P: undead ED: spooky Article: a	pile of dusty animal bones (100)	skeletal banana (c0)
 skeletal sommelier	714	steward.gif	Atk: 168 Def: 142 HP: 162 Init: 65 Meat: 100 P: undead ED: spooky Article: a	tarnished tastevin (3)	sommelier's towel (3)	wine-soaked bone chips (c0)	ghost accordion (a0)
 skeleton with a mop	999	mopskeleton.gif	Atk: 8 Def: 7 HP: 7 Init: 50 P: undead Article: a	beer-soaked mop (10)	ice-cold Willer (30)	ice-cold Willer (30)
@@ -597,13 +597,13 @@ Skelter Butleton, the Butler Skeleton	408	buttleton.gif	NOCOPY Atk: 170 Def: 153
 Skinflute	353	skinflute.gif	Atk: 158 Def: 142 HP: 150 Init: 70 P: constellation E: sleaze Article: The	star (30)	star (30)	line (30)	line (30)
 skleleton	29	skeleton.gif	Atk: 18 Def: 16 HP: 10 Init: 60 P: undead E: spooky Article: a	loose teeth (30)	skeleton bone (40)	skeleton bone (20)
 skullbat	45	skullbat.gif	Atk: 16 Def: 14 HP: 10 Init: 60 Meat: 28 P: beast EA: spooky Article: a	broken skull (40)	loose teeth (20)	sonar-in-a-biscuit (15)	smoking talon (c0)
-skulldozer	1239	skulldozer.gif	NOCOPY Scale: 5 Cap: 10000 Floor: 300 Init: -10000 P: undead E: spooky Article: a	skulldozer egg (0)
-skullery maid	377	skullery.gif	Atk: 20 Def: 18 HP: 20 Init: 50 Meat: 5 P: undead E: spooky Article: a	bottle of popskull (30)	dishrag (5)	Skullery Maid's Knee (c0)
+skulldozer	1239	skulldozer.gif	NOCOPY Scale: 5 Cap: 10000 Floor: 300 Init: -10000 P: undead ED: spooky EA: sleaze Article: a	skulldozer egg (0)
+skullery maid	377	skullery.gif	Atk: 20 Def: 18 HP: 20 Init: 50 Meat: 5 P: undead ED: spooky Article: a	bottle of popskull (30)	dishrag (5)	Skullery Maid's Knee (c0)
 sleeping Knob Goblin Guard	152	kg_sleepingguard.gif	Atk: 0 Def: 0 HP: 1 Init: -10000 Meat: 5 P: goblin Article: a	viking helmet (32)	Knob Goblin pants (8)	Knob Goblin scimitar (32)
 sleepy 7-Foot Dwarf	1149	dwarf_sleepy.gif	Atk: 53 Def: 47 HP: 40 Init: -10000 Meat: 40 P: humanoid Article: a	miner's pants (9)
 slick lihc	193	lich.gif	Atk: 59 Def: 54 HP: 50 Init: 50 P: undead E: spooky Article: a	lihc eye (20)	lihc face (7)	shimmering tendrils (c5)
-slithering hollandaise glob	658	holglob.gif	NOCOPY Atk: 24 Def: 21 HP: 21 Init: 40 P: slime Article: a	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)	nauseating reagent (0)
-slithering thing	1375	slithering.gif	Atk: 600 Def: 675 HP: 700 Init: 50 Meat: 50 P: horror Elem: 25 Article: a	grisly shell fragment (0)	grisly shell fragment (0)
+slithering hollandaise glob	658	holglob.gif	NOCOPY Atk: 24 Def: 21 HP: 21 Init: 40 P: slime EA: sleaze Article: a	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)	nauseating reagent (0)
+slithering thing	1375	slithering.gif	Atk: 600 Def: 675 HP: 700 Init: 50 Meat: 50 P: horror Elem: 25 EA: sleaze Article: a	grisly shell fragment (0)	grisly shell fragment (0)
 Slow Talkin' Elliot	511	eliot.gif	NOCOPY Atk: 190 Def: 171 HP: 200 Init: 20 Meat: 150 P: hippy E: stench	Slow Talkin' Elliot's dogtags (100)	green clay bead (30)	bullet-proof corduroys (0)	Lockenstock&trade; sandals (0)
 small barrel mimic	287	mimic2.gif	Atk: 15 Def: 13 HP: 25 Init: 90 P: weird Article: a
 smarmy pirate	106	pirate1.gif	Atk: 65 Def: 58 HP: 55 Init: 70 Meat: 27 P: pirate E: sleaze Article: a	bottle of rum (50)	eyepatch (10)	flaregun (30)	Jolly Roger charrrm bracelet (20)
@@ -612,13 +612,13 @@ smell-o-the-wisp	1343	smellothewisp.gif	Atk: 28 Def: 35 HP: 35 Init: 50 P: eleme
 smut orc jacker	1230	smutorc_jacker.gif	Atk: 69 Def: 69 HP: 69 Init: 50 Meat: 30 P: orc Article: a	orcish hand lotion (0)	orc wrist (0)	long hard screw (0)	messy butt joint (0)	morningwood plank (0)	raging hardwood plank (0)	thick caulk (0)	weirdwood plank (0)
 smut orc nailer	1232	smutorc_nailer.gif	Atk: 69 Def: 69 HP: 69 Init: 50 Meat: 30 P: orc Article: a	orcish nailing lube (0)	orcish stud-finder	long hard screw (0)	messy butt joint (0)	morningwood plank (0)	raging hardwood plank (0)	thick caulk (0)	weirdwood plank (0)
 smut orc pervert	1234	smutorc_pervert.gif	NOCOPY Atk: 69 Def: 69 HP: 69 Init: 50 P: orc E: sleaze Article: a	smut orc keepsake box (n100)	smut orc sunglasses (c0)
-smut orc pipelayer	1231	smutorc_layer.gif	Atk: 69 Def: 69 HP: 69 Init: 50 Meat: 35 P: orc Article: a	orcish rubber (0)	freshwater pearl necklace (0)	long hard screw (0)	messy butt joint (0)	morningwood plank (0)	raging hardwood plank (0)	thick caulk (0)	weirdwood plank (0)
+smut orc pipelayer	1231	smutorc_layer.gif	Atk: 69 Def: 69 HP: 69 Init: 50 Meat: 35 P: orc EA: stench Article: a	orcish rubber (0)	freshwater pearl necklace (0)	long hard screw (0)	messy butt joint (0)	morningwood plank (0)	raging hardwood plank (0)	thick caulk (0)	weirdwood plank (0)
 smut orc screwer	1233	smutorc_screwer.gif	Atk: 69 Def: 69 HP: 69 Init: 50 Meat: 35 P: orc Article: a	backwoods screwdriver (0)	screwing pooch (0)	long hard screw (0)	messy butt joint (0)	morningwood plank (0)	raging hardwood plank (0)	thick caulk (0)	weirdwood plank (0)
 Snow Queen	385	snowqueen.gif	Atk: 107 Def: 94 HP: 70 Init: 60 P: elemental Phys: 100 E: cold Article: a	crazy little Turkish delight (25)	ga-ga radio (5)	Snow Queen Crown (5)
 Sorority Nurse	508	warfratmd.gif	Atk: 170 Def: 157 HP: 200 Init: 30 P: orc E: sleaze Article: a	energy drink IV (18)	gauze garter (20)	gauze garter (7)	kick-ass kicks (2)	PADL Phone (3)	scrunchie tourniquet (c0)
 Sorority Operator	509	warfratcm.gif	Atk: 185 Def: 162 HP: 200 Init: 80 P: orc E: sleaze Article: a	beer helmet (1)	bejeweled pledge pin (1)	distressed denim pants (1)	kick-ass kicks (2)	PADL Phone (18)	PADL Phone (18)	PADL Phone (18)	white class ring (30)
-Space Tourist Explorer Ghost	1256	aboo_trek.gif	Atk: 74 Def: 66 HP: 40 Init: -10000 P: undead GHOST Phys: 100 E: spooky Article: a	A-Boo clue (c15)	Space Tours Tripple (15)	Space Tourist Phaser (5)	ectoplasmic orbs (10)
-Spam Witch	143	spamwitch.gif	Atk: 85 Def: 76 HP: 75 Init: 70 Meat: 30 P: dude EA: sleaze Article: a	30669 scroll (30)	Spam Witch sammich (50)
+Space Tourist Explorer Ghost	1256	aboo_trek.gif	Atk: 74 Def: 66 HP: 40 Init: -10000 P: undead GHOST Phys: 100 ED: spooky EA: cold EA: hot EA: sleaze Article: a	A-Boo clue (c15)	Space Tours Tripple (15)	Space Tourist Phaser (5)	ectoplasmic orbs (10)
+Spam Witch	143	spamwitch.gif	Atk: 85 Def: 76 HP: 75 Init: 70 Meat: 30 P: dude EA: "bad spelling" Article: a	30669 scroll (30)	Spam Witch sammich (50)
 Spawn of Wally	793	wretchedseal.gif	NOCOPY FREE Atk: 10 Def: 9 HP: 15 Init: -10000 P: horror Article: a	tainted seal's blood (100)
 Spectral Jellyfish	93	jellyfish.gif	Atk: 70 Def: 63 HP: 60 Init: 60 P: beast Article: a Poison: "Somewhat Poisoned"	spectral jelly (p1)
 spider (duck?) topiary animal	1245	topi1.gif	Atk: 85 Def: 80 HP: 90 Init: 50 P: beast Article: a	rusty hedge trimmers (15)	pestopiary (15)
@@ -630,36 +630,36 @@ sponge	739	sponge.gif	Atk: 350 Def: 405 HP: 1000 Init: 50 P: fish Article: a	san
 spooky gravy fairy guard	260	sgguard.gif	Atk: 55 Def: 49 HP: 45 Init: 60 P: plant E: spooky Article: a	spooky mushroom (40)	halfberd (5)	small leather glove (10)
 spooky gravy fairy ninja	262	sgninja.gif	Atk: 65 Def: 58 HP: 55 Init: 100 P: plant E: spooky Article: a	spooky mushroom (40)	teeny-tiny ninja stars (5)	tiny ninja sword (5)
 spooky gravy fairy warlock	261	sgwarlock.gif	Atk: 60 Def: 54 HP: 50 Init: 60 P: plant E: spooky Article: a	spooky mushroom (40)	enchanted toothpick (5)	spooky gravy fairy warlock hat (c0)
-spooky mummy	201	mummy.gif	Atk: 4 Def: 3 HP: 3 Init: 50 Meat: 10 P: undead E: spooky Article: a	dried face (10)	spooky shrunken head (20)	ancient pills (0)
+spooky mummy	201	mummy.gif	Atk: 4 Def: 3 HP: 3 Init: 50 Meat: 10 P: undead ED: spooky EA: spooky EA: stench Article: a	dried face (10)	spooky shrunken head (20)	ancient pills (0)
 spooky music box	1551	musicbox.gif	Atk: 79 Def: 81 HP: 80 Init: 25 P: construct E: spooky Article: a	spooky music box mechanism (5)	tiny dancer (15)
 spooky vampire	1	vampire.gif	Atk: 3 Def: 3 HP: 2 Init: 50 Meat: 5 P: undead E: spooky Article: a Wiki: "spooky vampire (Spooky Forest)"	vampire heart (c100)	vampire collar (c4)
 Spunky Princess	165	princess.gif	Atk: 90 Def: 81 HP: 75 Init: 90 Meat: 110 P: dude Article: a	cocoa eggshell fragment (30)	tiny house (30)	titanium assault umbrella (10)
 steam elemental	1557	steamelemental.gif	Atk: 160 Def: 137 HP: 140 Init: 75 P: elemental E: hot Article: a
-Steampunk Giant	1337	giant_steampunk.gif	Atk: 145 Def: 135 HP: 150 Init: 40 Meat: 100 P: humanoid Article: a	brass gear (25)	brown felt tophat (10)	autocalliope (a0)	steampunk potion (c15)
+Steampunk Giant	1337	giant_steampunk.gif	Atk: 145 Def: 135 HP: 150 Init: 40 Meat: 100 P: humanoid EA: hot EA: sleaze Article: a	brass gear (25)	brown felt tophat (10)	autocalliope (a0)	steampunk potion (c15)
 Stephen Spookyraven	1565	steven.gif	NOCOPY Scale: 5 Cap: 300 Init: 100 Meat: 500 P: undead Elem: 66	Stephen's secret formula (100)	Stephen's lab coat (100)
-sticky mummy	1583	stickymummy.gif	Atk: 35 Def: 34 HP: 34 Init: -10000 P: undead Article: a
+sticky mummy	1583	stickymummy.gif	Atk: 35 Def: 34 HP: 34 Init: -10000 P: undead EA: spooky Article: a
 stone temple pirate	1159	stone_pirate.gif	Scale: 0 Cap: 50 Floor: 7 Init: -10000 P: construct Article: a	ancient poisoned dart (35)	eyepatch (15)
-stranglin' algae	741	algae.gif	Atk: 400 Def: 405 HP: 600 Init: 100 P: plant Article: some	glob of green slime (n30)	sea lace (n30)
+stranglin' algae	741	algae.gif	Atk: 400 Def: 405 HP: 600 Init: 100 P: plant EA: sleaze Article: some	glob of green slime (n30)	sea lace (n30)
 stuffed moose head	1552	moosehead.gif	Atk: 86 Def: 79 HP: 80 Init: -10000 Meat: 100 P: beast E: spooky Article: a	moose antlers (5)	moose chocolate (15)	moose thought (15)
 Sub-Assistant Knob Mad Scientist	154	kg_madsci.gif	Atk: 1 Def: 1 HP: 1 Init: 60 Meat: 6 P: goblin Article: a	Knob Goblin firecracker (100)	Knob Goblin pants (9)	strongness elixir (30)	folder (cyan) (c0)	Knob Goblin Mutagen (c0)
-suckubus	977	suckubus.gif	Atk: 55 Def: 49 HP: 55 Init: 30 Meat: 40 P: demon E: hot Article: a	bus pass (20)	folder (rainbow unicorn) (c0)
+suckubus	977	suckubus.gif	Atk: 55 Def: 49 HP: 55 Init: 30 Meat: 40 P: demon ED: hot EA: hot EA: sleaze Article: a	bus pass (20)	folder (rainbow unicorn) (c0)
 surprised and annoyed witch	1596	witchy1.gif	NOCOPY Atk: 36 Def: 32 HP: 32 Init: -10000 Meat: 40 P: dude Article: a	wand of pigification (c100)	&Uuml;berraschthexengebr&auml;u (c0)
 swamp beaver lumberjack	1349	beav_jack.gif	Atk: 54 Def: 48 HP: 50 Init: 30 Meat: 30 P: beast Article: a	fine aged cheddarwurst (0)	balaclava (0)
-swamp beaver shaman	594	beav_shaman.gif	Atk: 52 Def: 46 HP: 46 Init: 60 Meat: 20 P: beast Article: a	moonberry wine cooler (0)	shamanic beads (0)
+swamp beaver shaman	594	beav_shaman.gif	Atk: 52 Def: 46 HP: 46 Init: 60 Meat: 20 P: beast EA: cold EA: hot Article: a	moonberry wine cooler (0)	shamanic beads (0)
 swamp beaver warrior	593	beav_warrior.gif	Atk: 28 Def: 35 HP: 40 Init: 30 Meat: 30 P: beast Article: a	fine aged cheddarwurst (0)	beaver spear (0)
 swamp duck	562	duckstinky.gif	Atk: 169 Def: 160 HP: 190 Init: 50 Meat: 150 P: beast E: stench Article: a	fetid feather (10)	duct tape (5)
 swamp entity	596	swampentity.gif	Atk: 20 Def: 18 HP: 25 Init: 30 Meat: 20 P: elemental E: stench Article: a	delicious swamp muck (0)	decomposed boot (0)
-swamp gator	595	swampgator.gif	Atk: 36 Def: 32 HP: 32 Init: 40 Meat: 30 P: beast Article: a	fine aged cheddarwurst (0)	seegar butt (0)
-swamp hag	1344	swamphag.gif	Atk: 35 Def: 28 HP: 40 Init: 30 Meat: 25 P: dude E: stench Article: a	moonberry wine cooler (0)	witch wart (0)	vial of swamp vapors (c0)
-swamp owl	1350	swampowl.gif	Atk: 56 Def: 48 HP: 46 Init: 80 Meat: 20 P: beast Article: a	moonberry wine cooler (0)	dilapidated wizard hat (0)
+swamp gator	595	swampgator.gif	Atk: 36 Def: 32 HP: 32 Init: 40 Meat: 30 P: beast EA: hot Article: a	fine aged cheddarwurst (0)	seegar butt (0)
+swamp hag	1344	swamphag.gif	Atk: 35 Def: 28 HP: 40 Init: 30 Meat: 25 P: dude ED: stench EA: spooky Article: a	moonberry wine cooler (0)	witch wart (0)	vial of swamp vapors (c0)
+swamp owl	1350	swampowl.gif	Atk: 56 Def: 48 HP: 46 Init: 80 Meat: 20 P: beast EA: hot Article: a	moonberry wine cooler (0)	dilapidated wizard hat (0)
 swamp skunk	1353	swampskunk.gif	BOSS NOCOPY Atk: 68 Def: 66 HP: 65 Init: 50 Meat: 40 P: beast E: stench Article: a	bouquet of swamp roses (c100)	floral-print skirt (c100)	pogo stick (0)
-swarm of fire ants	461	ants.gif	Atk: 142 Def: 119 HP: 136 Init: 60 Meat: 50 Group: 20 P: bug E: hot Article: a	ant agonist (20)	ant hoe (1)	ant pick (1)	ant pitchfork (1)	ant rake (1)	ant sickle (1)	handful of sand (20)
-swarm of ghuol whelps	1072	whelps1.gif	Atk: 50 Def: 45 HP: 100 Init: 300 Group: 15 P: undead E: spooky Article: a
+swarm of fire ants	461	ants.gif	Atk: 142 Def: 119 HP: 136 Init: 60 Meat: 50 Group: 20 P: bug ED: hot Article: a	ant agonist (20)	ant hoe (1)	ant pick (1)	ant pitchfork (1)	ant rake (1)	ant sickle (1)	handful of sand (20)
+swarm of ghuol whelps	1072	whelps1.gif	Atk: 50 Def: 45 HP: 100 Init: 300 Group: 15 P: undead ED: spooky Article: a
 swarm of killer bees	221	aswarm.gif	Atk: 59 Def: 53 HP: 75 Init: 90 Group: 6 P: bug Article: a Poison: "Somewhat Poisoned"	baby killer bee (5)	royal jelly (25)
 swarm of Knob lice	1059	kg_lice.gif	Atk: 25 Def: 22 HP: 30 Init: 50 Group: 100 P: bug Phys: 50 Article: a
 swarm of lowercase As	935	aswarm.gif	Atk: 59 Def: 53 HP: 75 Init: 90 Group: 6 P: bug Article: a	lowercase a (5)	percent sign (25)
-swarm of scarab beatles	456	beatles.gif	Atk: 136 Def: 117 HP: 131 Init: 50 Meat: 175 Group: 4 P: bug E: spooky Article: a	Colonel Mustard's Lonely Spades Club Jacket (c5)	Corporal Fennel's Lonely Clubs Club Jacket (c5)	General Sage's Lonely Diamonds Club Jacket (c5)	Private Pepper's Lonely Hearts Club Jacket (c5)	savoy truffle (10)	rocky raccoon (40)	mojo filter (5)	Maxwell's Silver Hammer (5)	carbonated water lily (10)	palm frond (c10)	hot date (5)	happiness (5)
-swarm of skulls	1743	skullswarm.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: undead E: spooky Article: a	half of a gold tooth (0)	mouse skull (0)	loose teeth (0)
+swarm of scarab beatles	456	beatles.gif	Atk: 136 Def: 117 HP: 131 Init: 50 Meat: 175 Group: 4 P: bug ED: spooky Article: a	Colonel Mustard's Lonely Spades Club Jacket (c5)	Corporal Fennel's Lonely Clubs Club Jacket (c5)	General Sage's Lonely Diamonds Club Jacket (c5)	Private Pepper's Lonely Hearts Club Jacket (c5)	savoy truffle (10)	rocky raccoon (40)	mojo filter (5)	Maxwell's Silver Hammer (5)	carbonated water lily (10)	palm frond (c10)	hot date (5)	happiness (5)
+swarm of skulls	1743	skullswarm.gif	Atk: 2 Def: 1 HP: 2 Init: -10000 P: undead ED: spooky Article: a	half of a gold tooth (0)	mouse skull (0)	loose teeth (0)
 swarthy pirate	105	pirate1.gif	Atk: 63 Def: 56 HP: 53 Init: 65 Meat: 25 P: pirate EA: sleaze Article: a	leotarrrd (10)	pirate pelvis (20)	stuffed shoulder parrot (10)
 Taco Cat	134	cacotap.gif	Atk: 139 Def: 131 HP: 145 Init: 30 Meat: 100 P: beast Article: a	cat appendix (30)	catgut (30)	taco shell (30)
 talking head	660	kasemhead.gif	NOCOPY Atk: 24 Def: 21 HP: 21 Init: 40 P: weird Article: a	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)	evil paper umbrella (0)
@@ -669,26 +669,26 @@ Tektite	114	tektite.gif	Atk: 20 Def: 18 HP: 15 Init: 60 P: beast EA: sleaze Arti
 tetchy pirate	619	madpirate.gif	Atk: 83 Def: 75 HP: 72 Init: 50 Meat: 40 P: pirate Article: a	bottle of rum (20)	cocktail napkin (10)
 Thanksgolem	1973	thanksgolem.gif	NOCOPY HP: 10000 Scale: 20 Cap: 10000 Floor: 200 Init: -10000 P: construct Phys: 75 Elem: 50 Article: a	leftovers (n100)	leftovers (n100)	leftovers (n100)	leftovers (n100)	leftovers (n100)	leftovers (n100)	giant pilgrim hat (n100)
 The Barrelmech of Diogenes	1840	otherimages/barrelbeast.gif	NOCOPY Atk: 200 Def: 250 HP: 1500 Init: 25 P: construct
-The Big Wisniewski	545	thisdude.gif	BOSS NOCOPY Atk: 250 Def: 225 HP: 2000 Init: 60 P: hippy ED: stench	solid gold bowling ball (100)
-The Clownlord Beelzebozo	569	beelzebozo.gif	BOSS NOCOPY Atk: 27 Def: 27 HP: 40 Init: 85 P: horror
+The Big Wisniewski	545	thisdude.gif	BOSS NOCOPY Atk: 250 Def: 225 HP: 2000 Init: 60 P: hippy E: stench	solid gold bowling ball (100)
+The Clownlord Beelzebozo	569	beelzebozo.gif	BOSS NOCOPY Atk: 27 Def: 27 HP: 40 Init: 85 P: horror EA: sleaze EA: spooky
 the darkness (blind)	0	darkness.gif	NOMANUEL Wiki: "Darkness (Temporary Blindness)"
-the former owner of the Skeleton Store	1755	skelmanager.gif	NOCOPY Atk: 5 Def: 5 HP: 8 Init: -10000 P: undead E: spooky	check to the Meatsmith (c100)	invisibility cream (c0)
+the former owner of the Skeleton Store	1755	skelmanager.gif	NOCOPY Atk: 5 Def: 5 HP: 8 Init: -10000 P: undead ED: spooky	check to the Meatsmith (c100)	invisibility cream (c0)
 the ghost of Phil Bunion	1352	bunionghost.gif	BOSS NOCOPY Atk: 72 Def: 68 HP: 60 Init: 40 Meat: 30 P: undead GHOST Phys: 100 E: spooky	spectral axe (c100)	Phil Bunion's axe (c100)
 the gunk	1548	thegunk.gif	Atk: 81 Def: 81 HP: 80 Init: -10000 Meat: 50 P: slime	gunky chicken (0)	the funk (0)	half-melted spoon (0)
-The Man	555	theman.gif	BOSS NOCOPY Atk: 250 Def: 225 HP: 2000 Init: 60 P: dude ED: sleaze	really dense meat stack (100)
-The Master Of Thieves	371	masterat.gif	NOCOPY NOMANUEL ULTRARARE Atk: 70 Def: 63 HP: 70 Init: 10000 P: dude	Platinum Yendorian Express Card (100)
+The Man	555	theman.gif	BOSS NOCOPY Atk: 250 Def: 225 HP: 2000 Init: 60 P: dude ED: sleaze EA: hot EA: sleaze	really dense meat stack (100)
+The Master Of Thieves	371	masterat.gif	NOCOPY NOMANUEL ULTRARARE Atk: 70 Def: 63 HP: 70 Init: 10000 P: dude EA: sleaze	Platinum Yendorian Express Card (100)
 The Nuge	1534	thenuge.gif	NOCOPY NOMANUEL ULTRARARE Atk: 155 Def: 150 HP: 180 Init: 10000 P: dude	The Nuge's favorite crossbow (100)
 The Temporal Bandit	392	timebandit.gif	NOCOPY NOMANUEL ULTRARARE Atk: 35 Def: 31 HP: 35 Init: 10000 P: dude EA: spooky	Counterclockwise Watch (100)
 The Thing in the Basement	2164	drippything1.gif	NOMANUEL Atk: [300] Def: [300] HP: [320] Init: -10000 P: horror DRIPPY	The Eye of the Thing in the Basement (n100)	The Fingernail of the Thing in the Basement (n100)
 The Unknown Seal Clubber	1775	unknownghost.gif	BOSS NOCOPY Atk: 25 Def: 25 HP: 15 Init: -10000 P: undead GHOST E: spooky	Bjorn's Hammer (100)
 The Unknown Turtle Tamer	1776	unknownghost.gif	BOSS NOCOPY Atk: 25 Def: 25 HP: 15 Init: -10000 P: undead GHOST E: spooky	Mace of the Tortoise (100)
-The Unknown Pastamancer	1777	unknownghost.gif	BOSS NOCOPY Atk: 25 Def: 25 HP: 15 Init: -10000 P: undead GHOST E: spooky	Pasta Spoon of Peril (100)
-The Unknown Sauceror	1778	unknownghost.gif	BOSS NOCOPY Atk: 25 Def: 25 HP: 15 Init: -10000 P: undead GHOST E: spooky	5-Alarm Saucepan (100)
-The Unknown Disco Bandit	1779	unknownghost.gif	BOSS NOCOPY Atk: 25 Def: 25 HP: 15 Init: -10000 P: undead GHOST E: spooky	Disco Banjo (100)
-The Unknown Accordion Thief	1780	unknownghost.gif	BOSS NOCOPY Atk: 25 Def: 25 HP: 15 Init: -10000 P: undead GHOST E: spooky	Rock and Roll Legend (100)
+The Unknown Pastamancer	1777	unknownghost.gif	BOSS NOCOPY Atk: 25 Def: 25 HP: 15 Init: -10000 P: undead GHOST ED: spooky EA: hot	Pasta Spoon of Peril (100)
+The Unknown Sauceror	1778	unknownghost.gif	BOSS NOCOPY Atk: 25 Def: 25 HP: 15 Init: -10000 P: undead GHOST ED: spooky EA: hot	5-Alarm Saucepan (100)
+The Unknown Disco Bandit	1779	unknownghost.gif	BOSS NOCOPY Atk: 25 Def: 25 HP: 15 Init: -10000 P: undead GHOST ED: spooky	Disco Banjo (100)
+The Unknown Accordion Thief	1780	unknownghost.gif	BOSS NOCOPY Atk: 25 Def: 25 HP: 15 Init: -10000 P: undead GHOST ED: spooky	Rock and Roll Legend (100)
 Thinknerd Moving Robot	1537	tnbot1.gif,tnbot2.gif,tnbot3.gif	Scale: 1 Cap: 69 Floor: 4 Init: 50 P: construct Article: a	robot grease (0)	returned Thinknerd package (c0)
 Thinknerd Packing Robot	1538	tnbot1.gif,tnbot2.gif,tnbot3.gif	Scale: 1 Cap: 69 Floor: 4 Init: -10000 P: construct Article: a	robot grease (0)	returned Thinknerd package (c0)
-Thinknerd Sorting Robot	1536	tnbot1.gif,tnbot2.gif,tnbot3.gif	Scale: 1 Cap: 69 Floor: 4 Init: -10000 P: construct Article: a	robot grease (0)	returned Thinknerd package (c0)
+Thinknerd Sorting Robot	1536	tnbot1.gif,tnbot2.gif,tnbot3.gif	Scale: 1 Cap: 69 Floor: 4 Init: -10000 P: construct EA: sleaze Article: a	robot grease (0)	returned Thinknerd package (c0)
 tiny barrel mimic	177	mimic1.gif	Atk: 15 Def: 13 HP: 25 Init: 90 P: weird Article: a
 tipsy pirate	618	tipsypirate.gif	Atk: 80 Def: 72 HP: 70 Init: 50 Meat: 45 P: pirate Article: a	bottle of rum (20)	bottle of rum (15)	cocktail napkin (10)	rum barrel charrrm (5)	tip jar (5)
 toilet papergeist	390	tpgeist.gif	Atk: 55 Def: 47 HP: 60 Init: -10000 P: undead ED: spooky Article: a	cardboard wakizashi (5)	roll of toilet paper (50)
@@ -696,66 +696,66 @@ tomb asp	469	tombasp.gif	Atk: 170 Def: 145 HP: 155 Init: 70 Meat: 100 P: beast S
 tomb bat	575	mummybat.gif	Atk: 175 Def: 157 HP: 180 Init: 50 Meat: 50 P: beast Article: a	leathery bat skin (30)	unidentified jerky (10)	mummy wrapping (20)
 tomb rat	467	tombrat.gif	Atk: 161 Def: 148 HP: 175 Init: 50 Meat: 75 P: beast Article: a	tomb ratchet (c20)	leathery rat skin (30)	unidentified jerky (12)
 tomb rat king	997	tombratking.gif	BOSS NOCOPY Atk: [350] Def: [315] HP: [300] Init: -10000 Meat: 150 P: beast Article: a	tomb ratchet (c20)	tomb ratchet (c20)	tomb ratchet (c20)	leathery rat skin (0)	leathery rat skin (0)	leathery rat skin (0)	unidentified jerky (0)	unidentified jerky (0)	unidentified jerky (0)
-tomb servant	468	tombguy.gif	Atk: 160 Def: 153 HP: 185 Init: 20 Meat: 50 P: undead E: spooky Article: a	canopic jar (30)	ancient protein powder (15)	mummy wrapping (20)	unidentified jerky (12)	ancient ice cream scoop (5)	secret mummy herbs and spices (c10)
+tomb servant	468	tombguy.gif	Atk: 160 Def: 153 HP: 185 Init: 20 Meat: 50 P: undead ED: spooky Article: a	canopic jar (30)	ancient protein powder (15)	mummy wrapping (20)	unidentified jerky (12)	ancient ice cream scoop (5)	secret mummy herbs and spices (c10)
 toothy pirate	620	toothpirate.gif	Atk: 83 Def: 76 HP: 75 Init: 50 Meat: 45 P: pirate Article: a	bottle of rum (20)	cocktail napkin (10)	gold toothbrush (c0)
 toothy sklelton	186	toothskel.gif	Atk: 57 Def: 52 HP: 50 Init: 50 P: undead E: spooky Article: a	loose teeth (20)	loose teeth (20)	skeleton bone (20)	bone flute (10)	evil eye (20)	bone bandoneon (a0)
 towering construct	667	vib4.gif	Atk: 350 Def: 360 HP: 450 Init: 20 P: construct Article: a	El Vibrato punchcard (165 holes) (1)	El Vibrato punchcard (176 holes) (1)
 towering construct (translated)	673	vib4.gif	Atk: 350 Def: 360 HP: 450 Init: 20 P: construct Article: a Manuel: "towering construct" Wiki: "towering construct"	El Vibrato punchcard (165 holes) (1)	El Vibrato punchcard (176 holes) (1)
 triffid	342	triffid.gif	Atk: 5 Def: 4 HP: 6 Init: 70 P: plant Article: a	moxie weed (30)	spooky stick (30)
-Troll Twins	1244	twins_troll.gif	Atk: 94 Def: 82 HP: 98 Init: 40 Meat: 75 Group: 2 P: dude Article: the	incredible pizza (5)	troll britches (5)
+Troll Twins	1244	twins_troll.gif	Atk: 94 Def: 82 HP: 98 Init: 40 Meat: 75 Group: 2 P: dude EA: spooky Article: the	incredible pizza (5)	troll britches (5)
 trophyfish	774	trophyfish.gif	NOCOPY Atk: 5000 Def: 4500 HP: 15000 Init: 200 P: fish Phys: 25 Article: a
 Trouser Snake	179	tsnake.gif	Atk: 153 Def: 137 HP: 150 Init: 70 P: constellation SNAKE E: sleaze Article: The	line (30)	line (30)	line (30)
 tumbleweed	1110	tumbleweed.gif	NOCOPY Atk: 10 Def: 9 HP: 10 Init: -10000 P: plant Article: a
 Twig and Berries	352	twigberry.gif	Atk: 152 Def: 136 HP: 150 Init: 70 Group: 3 P: constellation E: sleaze Article: The	line (30)	star (30)	star (30)
 undead elbow macaroni	147	macaroni.gif	Atk: 1 Def: 1 HP: 1 Init: 50 Meat: 5 P: undead E: spooky Article: an Wiki: "undead elbow macaroni (monster)"	magicalness-in-a-can (25)	quasi-ethereal macaroni fragments (c0)
-unemployed knob goblin	1000	lensgoblin.gif	Atk: 6 Def: 5 HP: 5 Init: -10000 Meat: 15 P: goblin Article: an	beer lens (c25)
+unemployed knob goblin	1000	lensgoblin.gif	Atk: 6 Def: 5 HP: 5 Init: -10000 Meat: 15 P: goblin EA: hot Article: an	beer lens (c25)
 unholy diver	745	unholydiver.gif	Atk: 700 Def: 540 HP: 1000 Init: 100 Meat: 250 P: horror Article: an	glowing syringe (c4)	rusty broken diving helmet (n3)	rusty porthole (n2)	rusty rivet (n10)	rusty rivet (n10)	rusty rivet (n2)	rusty rivet (n1)	unholy water (c0)
-upgraded ram	384	ram.gif	Atk: 106 Def: 93 HP: 95 Init: 50 Meat: 100 P: beast ED: cold Article: an	ram horns (5)	ram stick (5)	Ram's Face Lager (30)
+upgraded ram	384	ram.gif	Atk: 106 Def: 93 HP: 95 Init: 50 Meat: 100 P: beast E: cold Article: an	ram horns (5)	ram stick (5)	Ram's Face Lager (30)
 uppercase Q	937	upper_q.gif	Atk: 61 Def: 51 HP: 81 Init: 80 P: dude Article: an	left parenthesis (40)	right parenthesis (10)	dollar sign (p20)
 urchin urchin	733	urchin.gif	Atk: 400 Def: 315 HP: 600 Init: 20 P: fish Article: an	mermaid's purse (0)	bazookafish bubble gum (0)	underwater slingshot (0)
 vampire bat	350	regbat.gif	Atk: 17 Def: 14 HP: 10 Init: 60 Meat: 40 P: beast EA: hot EA: stench Article: a	bat wing (15)	batgut (15)	sonar-in-a-biscuit (10)
 vampire duck	564	duckvampire.gif	Atk: 175 Def: 153 HP: 190 Init: 50 Meat: 150 P: beast E: spooky Article: a	frightful feather (10)	duct tape (5)	vampire glitter (c0)
 vegetable gremlin	550	gremlinveg.gif	Atk: 168 Def: 154 HP: 170 Init: 60 Meat: 50 P: humanoid Article: a	gremlin juice (3)
 vegetable gremlin (tool)	551	gremlinveg.gif	Atk: 168 Def: 154 HP: 170 Init: 60 Meat: 50 P: humanoid Article: a Manuel: "vegetable gremlin" Wiki: "vegetable gremlin (quest)"	gremlin juice (3)	molybdenum screwdriver (c0)
-vengeful turtle spectre	654	turtleghost.gif	NOCOPY Atk: 21 Def: 18 HP: 18 Init: 20 P: undead Article: a	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)
+vengeful turtle spectre	654	turtleghost.gif	NOCOPY Atk: 21 Def: 18 HP: 18 Init: 20 P: undead EA: hot EA: spooky Article: a	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)
 vicious gnauga	247	gnauga.gif	Atk: 45 Def: 36 HP: 40 Init: 60 P: beast Article: a	gnauga hide (10)
-Victor the Insult Comic Hellhound	983	victor.gif	BOSS NOCOPY Atk: 70 Def: 63 HP: 70 Init: 50 P: demon	Victor, the Insult Comic Hellhound Puppet (100)
-void slab	2227	voidslab.gif	WANDERER Atk: 13 Def: 13 HP: 13 Init: 999 P: horror Article: a
-void spider	2228	voidspider.gif	WANDERER Atk: 13 Def: 13 HP: 13 Init: 999 P: horror Article: a
-void guy	2229	voidguy.gif	WANDERER Atk: 13 Def: 13 HP: 13 Init: 999 P: horror
+Victor the Insult Comic Hellhound	983	victor.gif	BOSS NOCOPY Atk: 70 Def: 63 HP: 70 Init: 50 P: demon EA: hot	Victor, the Insult Comic Hellhound Puppet (100)
+void slab	2227	voidslab.gif	WANDERER Atk: 13 Def: 13 HP: 13 Init: 999 P: horror EA: cold EA: hot EA: spooky Article: a
+void spider	2228	voidspider.gif	WANDERER Atk: 13 Def: 13 HP: 13 Init: 999 P: horror EA: cold Article: a
+void guy	2229	voidguy.gif	WANDERER Atk: 13 Def: 13 HP: 13 Init: 999 P: horror EA: cold EA: spooky
 W imp	122	wimp.gif	Atk: 40 Def: 36 HP: 40 Init: 60 Meat: 30 P: demon E: hot Article: a	Imp Ale (30)	ruby W (30)	wussiness potion (30)	infernal fife (10)
-wacky pirate	630	wackypirate.gif	Atk: 120 Def: 108 HP: 110 Init: 50 Meat: 75 P: pirate Article: a	cannonball charrrm (10)	yohohoyo (5)	pirate cream pie (c0)
+wacky pirate	630	wackypirate.gif	Atk: 120 Def: 108 HP: 110 Init: 50 Meat: 75 P: pirate EA: sleaze Article: a	cannonball charrrm (10)	yohohoyo (5)	pirate cream pie (c0)
 wailing mushroom guy	1807	mush_shrieking.gif	Atk: 25 Def: 25 HP: 20 Init: -10000 P: plant Article: a	jingling spore pod (0)	frozen mushroom (0)
-waiter dressed as a ninja	1513	waiterninja.gif	Atk: 142 Def: 142 HP: 140 Init: 25 Meat: 25 P: dude Article: a	crappy waiter disguise (20)	shuriken salad (15)	breadchucks (10)	ninja eyeblack (c0)
-War Frat 110th Infantryman	498	warfratc.gif	Atk: 172 Def: 154 HP: 185 Init: 40 P: orc E: sleaze Article: a	beer bomb (5)	beer helmet (10)	bejeweled pledge pin (10)	bottle opener belt buckle (10)	distressed denim pants (10)	giant foam finger (10)	keg shield (6)
-War Frat 151st Captain	499	warfrata2.gif	Atk: 180 Def: 166 HP: 205 Init: 50 P: orc E: sleaze Article: a	beer bomb (9)	beer helmet (5)	bejeweled pledge pin (5)	distressed denim pants (5)	keg shield (5)	PADL Phone (3)	perforated battle paddle (15)	red class ring (30)	flask flops (0)
-War Frat 151st Infantryman	423	warfrata.gif	Atk: 170 Def: 157 HP: 185 Init: 40 P: orc E: sleaze Article: a	beer bomb (5)	beer helmet (10)	bejeweled pledge pin (10)	bottle opener belt buckle (10)	flask flops (5)	distressed denim pants (10)	keg shield (5)	perforated battle paddle (10)
+waiter dressed as a ninja	1513	waiterninja.gif	Atk: 142 Def: 142 HP: 140 Init: 25 Meat: 25 P: dude EA: hot Article: a	crappy waiter disguise (20)	shuriken salad (15)	breadchucks (10)	ninja eyeblack (c0)
+War Frat 110th Infantryman	498	warfratc.gif	Atk: 172 Def: 154 HP: 185 Init: 40 P: orc ED: sleaze EA: sleaze EA: stench Article: a	beer bomb (5)	beer helmet (10)	bejeweled pledge pin (10)	bottle opener belt buckle (10)	distressed denim pants (10)	giant foam finger (10)	keg shield (6)
+War Frat 151st Captain	499	warfrata2.gif	Atk: 180 Def: 166 HP: 205 Init: 50 P: orc ED: sleaze EA: hot EA: sleaze Article: a	beer bomb (9)	beer helmet (5)	bejeweled pledge pin (5)	distressed denim pants (5)	keg shield (5)	PADL Phone (3)	perforated battle paddle (15)	red class ring (30)	flask flops (0)
+War Frat 151st Infantryman	423	warfrata.gif	Atk: 170 Def: 157 HP: 185 Init: 40 P: orc ED: sleaze EA: sleaze EA: stench Article: a	beer bomb (5)	beer helmet (10)	bejeweled pledge pin (10)	bottle opener belt buckle (10)	flask flops (5)	distressed denim pants (10)	keg shield (5)	perforated battle paddle (10)
 War Frat 500th Infantrygentleman	497	warfratb.gif	Atk: 175 Def: 153 HP: 185 Init: 40 Meat: 100 P: orc E: sleaze Article: a	beer bomb (5)	beer helmet (10)	bejeweled pledge pin (10)	bottle opener belt buckle (10)	distressed denim pants (10)	keg shield (5)	perforated battle paddle (9)
-War Frat Elite 110th Captain	501	warfratc2.gif	Atk: 190 Def: 171 HP: 215 Init: 50 P: orc E: sleaze Article: a	beer bomb (9)	beer helmet (5)	bejeweled pledge pin (5)	distressed denim pants (5)	giant foam finger (15)	keg shield (5)	PADL Phone (3)	red class ring (30)
-War Frat Elite 500th Captain	500	warfratb2.gif	Atk: 185 Def: 171 HP: 210 Init: 50 Meat: 250 P: orc E: sleaze Article: a	beer bomb (10)	beer helmet (5)	bejeweled pledge pin (5)	distressed denim pants (5)	keg shield (5)	PADL Phone (3)	perforated battle paddle (15)	red class ring (30)
-War Frat Elite Wartender	506	warfratsp2.gif	Atk: 195 Def: 166 HP: 220 Init: 70 P: orc E: sleaze Article: a	beer bomb (20)	beer bomb (10)	beer helmet (1)	bejeweled pledge pin (1)	distressed denim pants (1)	blue class ring (30)	kick-ass kicks (2)	molotov cocktail cocktail (0)	PADL Phone (3)	sake bomb (25)	sake bomb (13)	tequila grenade (0)
-War Frat Grill Sergeant	502	warfratgr.gif	Atk: 190 Def: 148 HP: 100 Init: 50 P: orc E: sleaze Article: a	Frat Army FGF (5)	kick-ass kicks (10)	Monstar energy beverage (20)	PADL Phone (3)	war tongs (17)
+War Frat Elite 110th Captain	501	warfratc2.gif	Atk: 190 Def: 171 HP: 215 Init: 50 P: orc ED: sleaze EA: hot EA: sleaze Article: a	beer bomb (9)	beer helmet (5)	bejeweled pledge pin (5)	distressed denim pants (5)	giant foam finger (15)	keg shield (5)	PADL Phone (3)	red class ring (30)
+War Frat Elite 500th Captain	500	warfratb2.gif	Atk: 185 Def: 171 HP: 210 Init: 50 Meat: 250 P: orc ED: sleaze Article: a	beer bomb (10)	beer helmet (5)	bejeweled pledge pin (5)	distressed denim pants (5)	keg shield (5)	PADL Phone (3)	perforated battle paddle (15)	red class ring (30)
+War Frat Elite Wartender	506	warfratsp2.gif	Atk: 195 Def: 166 HP: 220 Init: 70 P: orc ED: sleaze EA: hot Article: a	beer bomb (20)	beer bomb (10)	beer helmet (1)	bejeweled pledge pin (1)	distressed denim pants (1)	blue class ring (30)	kick-ass kicks (2)	molotov cocktail cocktail (0)	PADL Phone (3)	sake bomb (25)	sake bomb (13)	tequila grenade (0)
+War Frat Grill Sergeant	502	warfratgr.gif	Atk: 190 Def: 148 HP: 100 Init: 50 P: orc ED: sleaze EA: cold EA: hot EA: sleaze Article: a	Frat Army FGF (5)	kick-ass kicks (10)	Monstar energy beverage (20)	PADL Phone (3)	war tongs (17)
 War Frat Kegrider	420	warfratar.gif	Atk: 170 Def: 153 HP: 300 Init: 20 P: orc Phys: 25 E: sleaze Article: a	beer bong (5)	beer helmet (1)	bejeweled pledge pin (1)	distressed denim pants (1)	furniture dolly (15)	PADL Phone (5)
-War Frat Mobile Grill Unit	577	warfratmo.gif	Atk: 180 Def: 162 HP: 190 Init: 70 P: orc Phys: 25 E: sleaze Article: a	beer helmet (2)	bejeweled pledge pin (2)	distressed denim pants (2)	Frat Army FGF (5)	PADL Phone (10)	sausage bomb (40)	shiny hood ornament (25)	white class ring (30)
-War Frat Senior Grill Sergeant	503	warfratgr2.gif	Atk: 210 Def: 153 HP: 120 Init: 50 P: orc E: sleaze Article: a	asbestos apron (c0)	Frat Army FGF (20)	kick-ass kicks (15)	Monstar energy beverage (30)	PADL Phone (3)	war tongs (19)
+War Frat Mobile Grill Unit	577	warfratmo.gif	Atk: 180 Def: 162 HP: 190 Init: 70 P: orc Phys: 25 ED: sleaze EA: hot Article: a	beer helmet (2)	bejeweled pledge pin (2)	distressed denim pants (2)	Frat Army FGF (5)	PADL Phone (10)	sausage bomb (40)	shiny hood ornament (25)	white class ring (30)
+War Frat Senior Grill Sergeant	503	warfratgr2.gif	Atk: 210 Def: 153 HP: 120 Init: 50 P: orc ED: sleaze EA: cold EA: hot EA: sleaze EA: spooky Article: a	asbestos apron (c0)	Frat Army FGF (20)	kick-ass kicks (15)	Monstar energy beverage (30)	PADL Phone (3)	war tongs (19)
 War Frat Streaker	520	streaker.gif	NOCOPY Atk: 220 Def: 198 HP: 350 Init: 100 Meat: 400 P: orc E: sleaze Article: A	tube sock (100)	white class ring (30)	distressed denim pants (0)	beer helmet (0)	kick-ass kicks (0)
-War Frat Wartender	505	warfratsp.gif	Atk: 185 Def: 157 HP: 200 Init: 70 P: orc E: sleaze Article: a	beer bomb (14)	beer bomb (7)	beer helmet (1)	bejeweled pledge pin (1)	distressed denim pants (1)	kick-ass kicks (3)	molotov cocktail cocktail (0)	PADL Phone (3)	red class ring (30)	sake bomb (22)	sake bomb (22)	tequila grenade (0)
+War Frat Wartender	505	warfratsp.gif	Atk: 185 Def: 157 HP: 200 Init: 70 P: orc ED: sleaze EA: hot Article: a	beer bomb (14)	beer bomb (7)	beer helmet (1)	bejeweled pledge pin (1)	distressed denim pants (1)	kick-ass kicks (3)	molotov cocktail cocktail (0)	PADL Phone (3)	red class ring (30)	sake bomb (22)	sake bomb (22)	tequila grenade (0)
 War Hippy (space) cadet	481	warhipb.gif	Atk: 165 Def: 148 HP: 180 Init: 40 P: hippy E: stench Article: a	round purple sunglasses (5)	reinforced beaded headband (5)	bullet-proof corduroys (5)	peace accordion (a0)
-War Hippy Airborne Commander	489	warhipac2.gif	Atk: 195 Def: 166 HP: 220 Init: 70 P: hippy E: stench Article: a	bullet-proof corduroys (1)	communications windchimes (3)	ferret bait (20)	ferret bait (20)	Lockenstock&trade; sandals (2)	purple clay bead (30)	reinforced beaded headband (1)	round purple sunglasses (1)	water pipe bomb (15)	water pipe bomb (15)	exploding hacky-sack (20)	patchouli oil bomb (20)
-War Hippy Baker	483	warhipb.gif	Atk: 175 Def: 153 HP: 185 Init: 40 P: hippy E: stench Article: a	bullet-proof corduroys (10)	hippy protest button (10)	oversized pipe (10)	reinforced beaded headband (10)	round purple sunglasses (10)	water pipe bomb (20)	wicker shield (5)
+War Hippy Airborne Commander	489	warhipac2.gif	Atk: 195 Def: 166 HP: 220 Init: 70 P: hippy ED: stench EA: hot Article: a	bullet-proof corduroys (1)	communications windchimes (3)	ferret bait (20)	ferret bait (20)	Lockenstock&trade; sandals (2)	purple clay bead (30)	reinforced beaded headband (1)	round purple sunglasses (1)	water pipe bomb (15)	water pipe bomb (15)	exploding hacky-sack (20)	patchouli oil bomb (20)
+War Hippy Baker	483	warhipb.gif	Atk: 175 Def: 153 HP: 185 Init: 40 P: hippy ED: stench EA: hot EA: stench Article: a	bullet-proof corduroys (10)	hippy protest button (10)	oversized pipe (10)	reinforced beaded headband (10)	round purple sunglasses (10)	water pipe bomb (20)	wicker shield (5)
 War Hippy Dread Squad	410	warhipar.gif	Atk: 170 Def: 153 HP: 300 Init: 20 Group: 2 P: hippy Phys: 25 E: stench Article: a	bullet-proof corduroys (2)	communications windchimes (3)	didgeridooka (20)	Lockenstock&trade; sandals (2)	reinforced beaded headband (2)	round purple sunglasses (2)	tube of dread wax (15)
 War Hippy drill sergeant	482	warhipds.gif	Atk: 175 Def: 157 HP: 200 Init: 60 P: hippy E: stench Article: a	round purple sunglasses (10)	reinforced beaded headband (10)	bullet-proof corduroys (10)
-War Hippy Elder Shaman	495	warhipsh2.gif	Atk: 210 Def: 153 HP: 120 Init: 20 P: hippy E: stench Article: a	carbonated soy milk (30)	communications windchimes (3)	flowing hippy skirt (5)	funky dried mushroom (20)	Gaia beads (20)	Lockenstock&trade; sandals (15)
+War Hippy Elder Shaman	495	warhipsh2.gif	Atk: 210 Def: 153 HP: 120 Init: 20 P: hippy ED: stench EA: cold EA: spooky EA: stench Article: a	carbonated soy milk (30)	communications windchimes (3)	flowing hippy skirt (5)	funky dried mushroom (20)	Gaia beads (20)	Lockenstock&trade; sandals (15)
 War Hippy Elite Fire Spinner	496	warhipfs2.gif	Atk: 190 Def: 184 HP: 230 Init: 50 P: hippy ED: stench EA: hot Article: a	bullet-proof corduroys (1)	communications windchimes (3)	fire poi (30)	Lockenstock&trade; sandals (2)	reinforced beaded headband (1)	round purple sunglasses (1)
 War Hippy Elite Rigger	487	warhipc2.gif	Atk: 190 Def: 171 HP: 215 Init: 50 P: hippy E: stench Article: a	bullet-proof corduroys (5)	communications windchimes (3)	oversized pipe (17)	pink clay bead (30)	reinforced beaded headband (5)	round purple sunglasses (5)	wicker shield (4)	water pipe bomb (10)
 War Hippy F.R.O.G.	485	warhipa2.gif	Atk: 180 Def: 166 HP: 205 Init: 50 P: hippy E: stench Article: a	bullet-proof corduroys (6)	communications windchimes (3)	oversized pipe (17)	pink clay bead (30)	reinforced beaded headband (6)	round purple sunglasses (6)	wicker shield (6)	water pipe bomb (10)
 War Hippy Fire Spinner	413	warhipfs.gif	Atk: 180 Def: 175 HP: 210 Init: 50 P: hippy ED: stench EA: hot Article: a	bullet-proof corduroys (1)	communications windchimes (3)	fire poi (20)	Lockenstock&trade; sandals (1)	reinforced beaded headband (1)	round purple sunglasses (1)
-War Hippy Green Gourmet	486	warhipb2.gif	Atk: 185 Def: 171 HP: 210 Init: 50 P: hippy E: stench Article: a	bullet-proof corduroys (5)	communications windchimes (3)	Hippy Army MPE (50)	oversized pipe (15)	reinforced beaded headband (5)	round purple sunglasses (5)	water pipe bomb (38)	wicker shield (6)	pink clay bead (30)
+War Hippy Green Gourmet	486	warhipb2.gif	Atk: 185 Def: 171 HP: 210 Init: 50 P: hippy ED: stench EA: hot EA: stench Article: a	bullet-proof corduroys (5)	communications windchimes (3)	Hippy Army MPE (50)	oversized pipe (15)	reinforced beaded headband (5)	round purple sunglasses (5)	water pipe bomb (38)	wicker shield (6)	pink clay bead (30)
 War Hippy Homeopath	490	warhipmd.gif	Atk: 170 Def: 157 HP: 200 Init: 30 P: hippy E: stench Article: a	communications windchimes (3)	filthy poultice (15)	hippy medical kit (18)	Lockenstock&trade; sandals (2)	natural fennel soda (10)	holistic headache remedy (c0)
 War Hippy Infantryman	411	warhipa.gif	Atk: 170 Def: 157 HP: 185 Init: 40 P: hippy E: stench Article: a	bullet-proof corduroys (10)	hippy protest button (10)	oversized pipe (10)	reinforced beaded headband (10)	round purple sunglasses (10)	wicker shield (5)	water pipe bomb (5)
-War Hippy Naturopathic Homeopath	491	warhipmd2.gif	Atk: 180 Def: 166 HP: 220 Init: 30 P: hippy E: stench Article: a	communications windchimes (3)	filthy poultice (20)	hippy medical kit (30)	Lockenstock&trade; sandals (2)	natural fennel soda (30)
-War Hippy Rigger	484	warhipc.gif	Atk: 172 Def: 154 HP: 185 Init: 40 P: hippy E: stench Article: a	bullet-proof corduroys (10)	hippy protest button (10)	oversized pipe (10)	reinforced beaded headband (10)	round purple sunglasses (10)	water pipe bomb (5)	wicker shield (5)
-War Hippy Shaman	494	warhipsh.gif	Atk: 190 Def: 148 HP: 100 Init: 50 P: hippy E: stench Article: a	carbonated soy milk (20)	communications windchimes (3)	funky dried mushroom (15)	Gaia beads (15)	Lockenstock&trade; sandals (10)
+War Hippy Naturopathic Homeopath	491	warhipmd2.gif	Atk: 180 Def: 166 HP: 220 Init: 30 P: hippy ED: stench EA: hot Article: a	communications windchimes (3)	filthy poultice (20)	hippy medical kit (30)	Lockenstock&trade; sandals (2)	natural fennel soda (30)
+War Hippy Rigger	484	warhipc.gif	Atk: 172 Def: 154 HP: 185 Init: 40 P: hippy ED: stench EA: cold EA: stench Article: a	bullet-proof corduroys (10)	hippy protest button (10)	oversized pipe (10)	reinforced beaded headband (10)	round purple sunglasses (10)	water pipe bomb (5)	wicker shield (5)
+War Hippy Shaman	494	warhipsh.gif	Atk: 190 Def: 148 HP: 100 Init: 50 P: hippy ED: stench EA: cold EA: hot EA: sleaze EA: spooky EA: stench Article: a	carbonated soy milk (20)	communications windchimes (3)	funky dried mushroom (15)	Gaia beads (15)	Lockenstock&trade; sandals (10)
 War Hippy Sky Captain	412	warhipac.gif	Atk: 185 Def: 157 HP: 200 Init: 70 P: hippy E: stench Article: a	bullet-proof corduroys (1)	communications windchimes (3)	exploding hacky-sack (20)	ferret bait (20)	Lockenstock&trade; sandals (2)	patchouli oil bomb (20)	reinforced beaded headband (1)	round purple sunglasses (1)	water pipe bomb (10)	water pipe bomb (10)	pink clay bead (30)
 War Hippy Spy	419	hippyspy.gif	Atk: 165 Def: 153 HP: 180 Init: 60 P: hippy E: stench Article: a	bullet-proof corduroys (30)	reinforced beaded headband (30)	round purple sunglasses (30)
 War Hippy Windtalker	493	warhipcm.gif	Atk: 185 Def: 162 HP: 200 Init: 80 P: hippy ED: stench EA: spooky Article: a	bullet-proof corduroys (1)	communications windchimes (18)	communications windchimes (18)	communications windchimes (18)	Lockenstock&trade; sandals (2)	reinforced beaded headband (1)	round purple sunglasses (1)	green clay bead (30)
@@ -764,23 +764,23 @@ Wardr&ouml;b nightstand	1540	nightstand1.gif	Atk: 60 Def: 50 HP: 55 Init: -10000
 warty pirate	632	wartpirate.gif	Atk: 120 Def: 108 HP: 110 Init: 50 Meat: 85 P: pirate Article: a	copper ha'penny charrrm (10)	fish-liver oil (30)	vinegar-soaked lemon slice (30)
 warwelf	199	werewolf.gif	Atk: 4 Def: 2 HP: 2 Init: 50 Meat: 12 P: dude Article: a
 watertight seal	797	waterseal.gif	NOCOPY FREE Atk: 350 Def: 315 HP: 400 Init: -10000 P: demon Article: a	hyperinflated seal lung (100)
-wealthy pirate	631	richpirate.gif	Atk: 120 Def: 108 HP: 110 Init: 50 Meat: 200 P: pirate Article: a	booty chest charrrm (10)	solid gold pegleg (5)	fat wallet (p10)
-werecougar	993	cavewomyn.gif	Atk: 8 Def: 7 HP: 6 Init: 50 Meat: 15 P: dude Article: a	margarita (10)	sangria (10)	strawberry daiquiri (10)	tequila with training wheels (10)	mama's squeezebox (a0)
+wealthy pirate	631	richpirate.gif	Atk: 120 Def: 108 HP: 110 Init: 50 Meat: 200 P: pirate EA: sleaze Article: a	booty chest charrrm (10)	solid gold pegleg (5)	fat wallet (p10)
+werecougar	993	cavewomyn.gif	Atk: 8 Def: 7 HP: 6 Init: 50 Meat: 15 P: dude EA: sleaze Article: a	margarita (10)	sangria (10)	strawberry daiquiri (10)	tequila with training wheels (10)	mama's squeezebox (a0)
 Weremoose	91	weremoose.gif	Atk: 63 Def: 56 HP: 53 Init: 70 Meat: 65 P: beast Article: a	weremoose spit (0)
 Weretaco	37	weretaco.gif	Atk: 16 Def: 14 HP: 8 Init: 60 Meat: 32 P: beast EA: hot Article: a	taco shell (30)	uncooked chorizo (30)
-wet seal	802	wetseal.gif	NOCOPY FREE Atk: 175 Def: 157 HP: 200 Init: -10000 P: demon Article: a	mannequin leg (5)	seal lube (35)
-Whatsian Commando Ghost	1258	aboo_who.gif	Atk: 78 Def: 62 HP: 40 Init: -10000 P: undead GHOST Phys: 100 E: spooky Article: a	A-Boo clue (c15)	T.U.R.D.S. Key (15)	Whatsian Ionic Pliers (5)	ectoplasmic orbs (10)
+wet seal	802	wetseal.gif	NOCOPY FREE Atk: 175 Def: 157 HP: 200 Init: -10000 P: demon EA: sleaze Article: a	mannequin leg (5)	seal lube (35)
+Whatsian Commando Ghost	1258	aboo_who.gif	Atk: 78 Def: 62 HP: 40 Init: -10000 P: undead GHOST Phys: 100 ED: spooky EA: sleaze Article: a	A-Boo clue (c15)	T.U.R.D.S. Key (15)	Whatsian Ionic Pliers (5)	ectoplasmic orbs (10)
 whiny pirate	628	pirate2.gif	Atk: 120 Def: 108 HP: 110 Init: 50 Meat: 80 P: pirate Article: a	bilge wine (30)
 white chocolate golem	67	chocgolem.gif	Atk: 37 Def: 32 HP: 21 Init: 70 P: construct EA: sleaze Article: a	white chocolate chips (50)	mother's secret recipe (p3)	White Chocolate Golem Seeds (c0)
 white elephant	1590	whiteelephant.gif	Atk: 45 Def: 45 HP: 50 Init: 50 Meat: 300 P: beast Article: a	white blood cells (0)	white wine (0)	white elephant gift (0)
 white lion	66	lion.gif	Atk: 36 Def: 31 HP: 21 Init: 60 Meat: 30 P: beast Article: a	catgut (15)	lion oil (25)
 whitesnake	65	whitesnake.gif	Atk: 35 Def: 30 HP: 21 Init: 60 Meat: 10 P: beast SNAKE Article: a Poison: "A Little Bit Poisoned"	white snake skin (30)	bird rib (25)
-wild seahorse	778	seahorse.gif	NOMANUEL Atk: 500 Def: 900000 HP: 1000000 Init: 10000 P: fish Phys: 100
+wild seahorse	778	seahorse.gif	NOMANUEL Atk: 500 Def: 900000 HP: 1000000 Init: 10000 P: fish Phys: 100 EA: spooky EA: stench
 witty pirate	629	pirate2.gif	Atk: 120 Def: 108 HP: 110 Init: 50 Meat: 85 P: pirate Article: a	witty rapier (10)	silver tongue charrrm (10)
 wizardly mushroom guy	1804	mush_wizard.gif	Atk: 35 Def: 25 HP: 15 Init: 50 P: plant Article: a	glowing spore pod (0)	pointy mushroom (0)
 wolfman	200	werewolf.gif	Atk: 3 Def: 2 HP: 2 Init: 50 Meat: 10 P: dude Article: a
 writing desk	405	ravendesk.gif	NOCOPY Atk: 27 Def: 27 HP: 28 Init: 50 P: construct Article: a	disintegrating quill pen (15)	inkwell (30)	snifter of thoroughly aged brandy (30)
-XXX pr0n	138	pr0n.gif	Atk: 75 Def: 67 HP: 68 Init: 60 Meat: 30 P: beast EA: sleaze Article: an	f3d0r4 (15)	lowercase N (30)	pr0n legs (40)
+XXX pr0n	138	pr0n.gif	Atk: 75 Def: 67 HP: 68 Init: 60 Meat: 30 P: beast EA: sleaze EA: "bad spelling" Article: an	f3d0r4 (15)	lowercase N (30)	pr0n legs (40)
 Yeast Beast	36	yeastbeast.gif	Atk: 17 Def: 15 HP: 8 Init: 60 P: construct EA: sleaze Article: a	wad of dough (50)	wad of dough (50)
 Yog-Urt, Elder Goddess of Hatred	1378	yog-urt.gif	BOSS NOCOPY Atk: 400 Def: 400 HP: 750 Init: 10000 P: horror Phys: 100
 Zim Merman	513	zimmerman.gif	NOCOPY Atk: 200 Def: 180 HP: 280 Init: 60 Meat: 250 P: hippy E: stench	Zim Merman's guitar (100)	green clay bead (30)	Lockenstock&trade; sandals (0)
@@ -789,7 +789,7 @@ zobmie	33	zombie.gif	Atk: 19 Def: 17 HP: 10 Init: 60 Meat: 34 P: undead E: spook
 Zol	120	zol.gif	Atk: 25 Def: 22 HP: 15 Init: 60 P: slime Article: a	green pixel (80)	green pixel (70)	green pixel (60)
 zombie chef	378	zombiechef.gif	Atk: 22 Def: 19 HP: 20 Init: 50 Meat: 7 P: undead Article: a	bottle of cooking sherry (30)	chef's hat (5)	fricasseed brains (20)	stale baguette (30)	zombie hollandaise (c0)
 zombie duck	565	duckzombie.gif	Atk: 171 Def: 158 HP: 190 Init: 40 Meat: 150 P: beast E: spooky Article: a	duct tape (5)	frightful feather (10)
-zombie waltzers	401	zomwaltz.gif	Atk: 65 Def: 55 HP: 70 Init: 50 Meat: 50 Group: 2 P: undead E: spooky Article: some	ballroom blintz (15)	dance card (15)
+zombie waltzers	401	zomwaltz.gif	Atk: 65 Def: 55 HP: 70 Init: 50 Meat: 50 Group: 2 P: undead ED: spooky Article: some	ballroom blintz (15)	dance card (15)
 
 # Copperhead Quest
 
@@ -805,7 +805,7 @@ Snakeleton	1519	snakeboss6.gif	NOCOPY Atk: 160 Def: 160 HP: 175 Init: 50 P: beas
 apathetic lizardman	5	lizardman.gif	NOCOPY Atk: 20 Def: 18 HP: 12 Init: 60 Meat: 20 P: humanoid Article: an	flavorless gruel (n100)
 dairy ooze	69	ooze.gif	NOCOPY Atk: 13 Def: 11 HP: 8 Init: 60 Meat: 12 P: slime Phys: 50 Elem: 50 EA: stench Article: a	mana curds (n100)
 dodecapede	3	pede.gif	NOCOPY Atk: 12 Def: 10 HP: 8 Init: 60 Meat: 12 P: bug Article: a Poison: "A Little Bit Poisoned"	clutch of dodecapede eggs (n100)
-giant giant moth	72	moth.gif	NOCOPY Atk: 16 Def: 14 HP: 11 Init: 60 Meat: 16 P: bug Article: a	giant giant moth dust (n100)
+giant giant moth	72	moth.gif	NOCOPY Atk: 16 Def: 14 HP: 11 Init: 60 Meat: 16 P: bug EA: spooky Article: a	giant giant moth dust (n100)
 mayonnaise wasp	73	wasp.gif	NOCOPY Atk: 17 Def: 15 HP: 11 Init: 60 P: bug EA: sleaze Article: a Poison: "A Little Bit Poisoned"	glob of spoiled mayo (n100)
 pencil golem	71	pencil.gif	NOCOPY Atk: 15 Def: 13 HP: 11 Init: 60 P: construct Article: a	pencil stub (n100)
 sabre-toothed lime	70	lime.gif	NOCOPY Atk: 14 Def: 12 HP: 8 Init: 60 Meat: 14 P: beast Article: a	twist of lime (n100)
@@ -815,7 +815,7 @@ vampire clam	75	vampclam.gif	NOCOPY Atk: 40 Def: 17 HP: 14 Init: 60 Meat: 18 P: 
 # Nemesis Quest
 
 menacing thug	680	nemesisthug.gif	NOCOPY WANDERER Atk: 55 Def: 49 HP: 75 Init: 30 Meat: 160 P: dude Article: a
-Mob Penguin hitman	683	pengthug.gif	NOCOPY WANDERER Atk: 75 Def: 67 HP: 90 Init: 40 Meat: 200 P: penguin Article: a	kneecapping stick (0)
+Mob Penguin hitman	683	pengthug.gif	NOCOPY WANDERER Atk: 75 Def: 67 HP: 90 Init: 40 Meat: 200 P: penguin EA: stench Article: a	kneecapping stick (0)
 
 # Seal Clubber
 
@@ -831,7 +831,7 @@ Gorgolok, the Demonic Hellseal	888	1_4a.gif	BOSS NOCOPY Atk: 200 Def: 180 HP: 40
 
 # Turtle Tamer
 
-turtle trapper	685	turtletrapper.gif	NOCOPY WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 Meat: 100 P: dude Article: a
+turtle trapper	685	turtletrapper.gif	NOCOPY WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 Meat: 100 P: dude EA: stench Article: a
 Safari Jack, Small-Game Hunter	702	safarijack.gif	NOCOPY WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 P: dude	secret tropical island volcano lair map (100)	Safari Jack's moustache (100)	untamable turtle (100)
 guard turtle	782	guardturtle1.gif,guardturtle2.gif,guardturtle3.gif,guardturtle4.gif	NOBANISH NOCOPY Atk: 140 Def: 126 HP: 140 Init: 140 P: beast Article: a	guard turtle shell (0)	guard turtle collar (0)
 french guard turtle	783	frenchturtle.gif	NOCOPY Atk: 140 Def: 126 HP: 140 Init: 140 P: beast Article: a Manuel: "guard turtle" Wiki: "guard turtle (french)"	guard turtle shell (0)	guard turtle collar (0)
@@ -849,7 +849,7 @@ evil spaghetti cult middle-manager	806	spagcult3.gif	NOBANISH Atk: 150 Def: 135 
 evil spaghetti cult neophyte	807	spagcult1.gif	NOBANISH Atk: 140 Def: 126 HP: 150 Init: 60 P: dude Article: an	spaghetti cult mask (0)	spaghetti cult rosary (0)
 evil spaghetti cult technician	808	spagcult2.gif	NOBANISH Atk: 140 Def: 126 HP: 150 Init: 60 P: dude Article: an	spaghetti cult mask (0)	spaghetti cult rosary (0)
 evil spaghetti cult zealot	868	spagcult4.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: dude Article: an
-Spaghetti Elemental (Inner Sanctum)	23	3_1.gif	BOSS NOCOPY Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: elemental Article: a Manuel: "Spaghetti Elemental"	Colander of Em-er'il (100)
+Spaghetti Elemental (Inner Sanctum)	23	3_1.gif	BOSS NOCOPY Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: elemental EA: hot Article: a Manuel: "Spaghetti Elemental"	Colander of Em-er'il (100)
 Spaghetti Elemental (The Nemesis' Lair)	874	3_2.gif	BOSS NOCOPY Atk: 170 Def: 153 HP: 220 Init: 80 P: elemental Article: the Manuel: "Spaghetti Elemental"	Angelhair Culottes (100)
 Spaghetti Elemental (Volcanic Cave)	884	3_3.gif	BOSS NOCOPY Atk: 185 Def: 166 HP: 260 Init: 90 P: elemental Article: the Manuel: "Spaghetti Elemental"
 Spaghetti Demon	890	3_4a.gif	BOSS NOCOPY Atk: 200 Def: 180 HP: 600 Init: 100 P: demon Phys: 40 Elem: 40 Article: the	Bandolier of the Spaghetti Elemental (100)	Instant Karma (c100)	heart of the volcano (c100)
@@ -858,14 +858,14 @@ Spaghetti Demon	890	3_4a.gif	BOSS NOCOPY Atk: 200 Def: 180 HP: 600 Init: 100 P: 
 
 b&eacute;arnaise zombie	687	saucezombie.gif	NOCOPY WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 P: slime EA: spooky Article: a Manuel: "béarnaise zombie"
 Heimandatz, Nacho Golem	704	nachogolem.gif	NOCOPY WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 P: construct	secret tropical island volcano lair map (100)	Heimandatz's heart (100)	friendly cheez blob (100)
-booth slime	803	boothslime.gif	NOBANISH Atk: 140 Def: 126 HP: 150 Init: 50 P: slime Article: a	vial of blue slime (f66)
-fan slime	804	fanslime.gif	NOBANISH Atk: 140 Def: 126 HP: 150 Init: 50 P: slime Article: a	vial of yellow slime (f66)
+booth slime	803	boothslime.gif	NOBANISH Atk: 140 Def: 126 HP: 150 Init: 50 P: slime EA: stench Article: a	vial of blue slime (f66)
+fan slime	804	fanslime.gif	NOBANISH Atk: 140 Def: 126 HP: 150 Init: 50 P: slime EA: sleaze Article: a	vial of yellow slime (f66)
 vendor slime	805	vendorslime.gif	NOBANISH Atk: 145 Def: 130 HP: 160 Init: 75 P: slime Article: a	vial of red slime (f66)
 security slime	869	securityslime.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: slime Article: a
 Lumpy, the Sinister Sauceblob (Inner Sanctum)	24	4_1.gif	BOSS NOCOPY Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: slime EA: hot Manuel: "Lumpy, the Sinister Sauceblob"	Ancient Saucehelm (100)
 Lumpy, the Sinister Sauceblob (The Nemesis' Lair)	875	4_2.gif	BOSS NOCOPY Atk: 170 Def: 153 HP: 220 Init: 80 P: slime Manuel: "Lumpy, the Sinister Sauceblob"	Newman's Own Trousers (100)
 Lumpy, the Sinister Sauceblob (Volcanic Cave)	885	4_3.gif	BOSS NOCOPY Atk: 185 Def: 166 HP: 260 Init: 90 P: slime Phys: 25 Elem: 25 Manuel: "Lumpy, the Sinister Sauceblob"
-Lumpy, the Demonic Sauceblob	891	4_4a.gif	BOSS NOCOPY Atk: 200 Def: 180 HP: 500 Init: 100 P: demon Phys: 40 Elem: 40	Gravyskin Belt of the Sauceblob (100)	Instant Karma (c100)	heart of the volcano (c100)
+Lumpy, the Demonic Sauceblob	891	4_4a.gif	BOSS NOCOPY Atk: 200 Def: 180 HP: 500 Init: 100 P: demon Phys: 40 Elem: 40 EA: hot EA: spooky EA: stench	Gravyskin Belt of the Sauceblob (100)	Instant Karma (c100)	heart of the volcano (c100)
 
 # Disco Bandit
 
@@ -873,8 +873,8 @@ flock of seagulls	699	seagulls.gif	NOCOPY WANDERER Atk: 95 Def: 85 HP: 120 Init:
 Jocko Homo	705	jockohomo.gif	NOCOPY WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 P: beast	secret tropical island volcano lair map (100)	Jocko Homo's head (100)	unusual disco ball (100)
 breakdancing raver	855	breakdancer.gif	NOBANISH Atk: 140 Def: 126 HP: 150 Init: 10000 P: dude Article: a	candy necklace (c0)	rave visor (c0)	teddybear backpack (c0)
 pop-and-lock raver	856	popnlocker.gif	NOBANISH Atk: 140 Def: 126 HP: 150 Init: 10000 P: dude Article: a	baggy rave pants (c0)	glowstick on a string (c0)	teddybear backpack (c0)
-running man	857	runningman.gif	NOBANISH Atk: 140 Def: 126 HP: 150 Init: 10000 P: dude Article: a	candy necklace (c0)	glowstick on a string (c0)	pacifier necklace (c0)
-daft punk	870	daftpunk.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: dude Article: a
+running man	857	runningman.gif	NOBANISH Atk: 140 Def: 126 HP: 150 Init: 10000 P: dude EA: sleaze Article: a	candy necklace (c0)	glowstick on a string (c0)	pacifier necklace (c0)
+daft punk	870	daftpunk.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: dude EA: hot Article: a
 Spirit of New Wave (Inner Sanctum)	25	5_1.gif	BOSS NOCOPY Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: undead GHOST Article: the Manuel: "Spirit of New Wave"	Disco 'Fro Pick (100)
 Spirit of New Wave (The Nemesis' Lair)	876	5_2.gif	BOSS NOCOPY Atk: 170 Def: 153 HP: 220 Init: 80 P: undead GHOST Article: the Manuel: "Spirit of New Wave"	Volartta's bellbottoms (100)
 Spirit of New Wave (Volcanic Cave)	886	5_3.gif	BOSS NOCOPY Atk: 185 Def: 166 HP: 260 Init: 90 P: undead GHOST Phys: 25 Elem: 25 Article: the Manuel: "Spirit of New Wave"
@@ -882,13 +882,13 @@ Demon of New Wave	892	5_4a.gif	BOSS NOCOPY Atk: 200 Def: 180 HP: 500 Init: 100 P
 
 # Accordion Thief
 
-mariachi bandolero	700	bandolero.gif	NOCOPY WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 Meat: 50 P: dude Article: a
+mariachi bandolero	700	bandolero.gif	NOCOPY WANDERER Atk: 95 Def: 85 HP: 120 Init: 50 Meat: 50 P: dude EA: hot Article: a
 The Mariachi With No Name	706	darkmariachi.gif	NOCOPY WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 Meat: 50 P: dude	secret tropical island volcano lair map (100)	The Mariachi's guitar case (100)	stray chihuahua (100)
 sleepy mariachi	858	mar_sleepy.gif	NOBANISH Atk: 120 Def: 108 HP: 110 Init: 125 P: dude Article: a	spangly mariachi pants (0)	spangly mariachi vest (0)	spangly sombrero (0)
 surprised mariachi	859	mar_surprised.gif	NOBANISH Atk: 130 Def: 117 HP: 125 Init: 150 P: dude Article: a	spangly mariachi pants (0)	spangly mariachi vest (0)	spangly sombrero (0)
 alert mariachi	860	mar_alert.gif	NOBANISH Atk: 200 Def: 180 HP: 250 Init: 300 P: dude Article: an	spangly mariachi pants (0)	spangly mariachi vest (0)	spangly sombrero (0)	alarm accordion (a0)
 mariachi bruiser	871	mar_bruiser.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: dude Article: a	spangly mariachi pants (0)	spangly mariachi vest (0)	spangly sombrero (0)
-Somerset Lopez, Dread Mariachi (Inner Sanctum)	26	6_1.gif	BOSS NOCOPY Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: dude Manuel: "Somerset Lopez, Dread Mariachi"	El Sombrero De Lopez (100)
+Somerset Lopez, Dread Mariachi (Inner Sanctum)	26	6_1.gif	BOSS NOCOPY Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: dude EA: sleaze Manuel: "Somerset Lopez, Dread Mariachi"	El Sombrero De Lopez (100)
 Somerset Lopez, Dread Mariachi (The Nemesis' Lair)	877	6_2.gif	BOSS NOCOPY Atk: 170 Def: 153 HP: 220 Init: 80 P: dude Manuel: "Somerset Lopez, Dread Mariachi"	Lederhosen of the Night (100)
 Somerset Lopez, Dread Mariachi (Volcanic Cave)	887	6_3.gif	BOSS NOCOPY Atk: 185 Def: 166 HP: 260 Init: 90 P: dude Phys: 25 Elem: 25 Manuel: "Somerset Lopez, Dread Mariachi"
 Somerset Lopez, Demon Mariachi	893	6_4a.gif	BOSS NOCOPY Atk: 200 Def: 180 HP: 1000 Init: 100 P: demon Phys: 40 Elem: 40	La Hebilla del Cintur&oacute;n de Lopez (100)	Instant Karma (c100)	heart of the volcano (c100)
@@ -901,7 +901,7 @@ Somerset Lopez, Demon Mariachi	893	6_4a.gif	BOSS NOCOPY Atk: 200 Def: 180 HP: 10
 # -- Fastest Adventurer
 
 Cheetahman	1670	adv_fast1.gif	NOCOPY Atk: [300-15*max(pref(nsContestants1)-1,0)] Def: [150-5*max(pref(nsContestants1)-1,0)] HP: [300-10*max(pref(nsContestants1)-1,0)] Init: 1000 P: dude Article: a
-Microwave Magus	1671	adv_fast2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants1)-1,0)] Def: [250-10*max(pref(nsContestants1)-1,0)] HP: [200-10*max(pref(nsContestants1)-1,0)] Init: 1000 P: dude Article: a
+Microwave Magus	1671	adv_fast2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants1)-1,0)] Def: [250-10*max(pref(nsContestants1)-1,0)] HP: [200-10*max(pref(nsContestants1)-1,0)] Init: 1000 P: dude EA: hot EA: sleaze EA: spooky EA: stench Article: a
 Kung-Fu Hustler	1672	adv_fast3.gif	NOCOPY Atk: [200-5*max(pref(nsContestants1)-1,0)] Def: [300-15*max(pref(nsContestants1)-1,0)] HP: [250-10*max(pref(nsContestants1)-1,0)] Init: 1000 P: dude Article: a Wiki: "Kung-Fu Hustler (monster)"	hustler shades (c0)
 Tasmanian Dervish	1673	adv_fast4.gif	BOSS NOCOPY Atk: [300] Def: [150] HP: [300] Init: 10000 P: dude Article: The
 
@@ -910,60 +910,60 @@ Tasmanian Dervish	1673	adv_fast4.gif	BOSS NOCOPY Atk: [300] Def: [150] HP: [300]
 # -- Strongest Adventurer
 
 Macho Man	1674	adv_strong1.gif	NOCOPY Atk: [300-15*max(pref(nsContestants2)-1,0)] Def: [150-5*max(pref(nsContestants2)-1,0)] HP: [300-10*max(pref(nsContestants2)-1,0)] Init: -10000 P: dude Article: a	spicy jerky stick (c0)
-Iron Chef	1675	adv_strong2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants2)-1,0)] Def: [250-10*max(pref(nsContestants2)-1,0)] HP: [200-10*max(pref(nsContestants2)-1,0)] Init: -10000 P: dude Article: an
+Iron Chef	1675	adv_strong2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants2)-1,0)] Def: [250-10*max(pref(nsContestants2)-1,0)] HP: [200-10*max(pref(nsContestants2)-1,0)] Init: -10000 P: dude EA: hot Article: an
 Entire Shoplifter	1676	adv_strong3.gif	NOCOPY Atk: [200-5*max(pref(nsContestants2)-1,0)] Def: [300-15*max(pref(nsContestants2)-1,0)] HP: [250-10*max(pref(nsContestants2)-1,0)] Init: -10000 P: dude Article: an	costume rental shop (c0)
 Mr. Loathing	1677	adv_strong4.gif	BOSS NOCOPY Atk: [300] Def: [150] HP: [300] Init: -10000 P: dude	muscle oil (c0)
 
 # -- Smartest Adventurer
 
 Accountant-Barbarian	1678	adv_smart1.gif	NOCOPY Atk: [300-15*max(pref(nsContestants2)-1,0)] Def: [150-5*max(pref(nsContestants2)-1,0)] HP: [300-10*max(pref(nsContestants2)-1,0)] Init: -10000 P: dude Article: an	bottle of Red-Out (c0)
-Metaphysical Gastronomist	1679	adv_smart2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants2)-1,0)] Def: [250-10*max(pref(nsContestants2)-1,0)] HP: [200-10*max(pref(nsContestants2)-1,0)] Init: -10000 P: dude Article: a
+Metaphysical Gastronomist	1679	adv_smart2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants2)-1,0)] Def: [250-10*max(pref(nsContestants2)-1,0)] HP: [200-10*max(pref(nsContestants2)-1,0)] Init: -10000 P: dude EA: cold EA: hot Article: a
 Kleptobrainiac	1680	adv_smart3.gif	NOCOPY Atk: [200-5*max(pref(nsContestants2)-1,0)] Def: [300-15*max(pref(nsContestants2)-1,0)] HP: [250-10*max(pref(nsContestants2)-1,0)] Init: -10000 P: dude Article: a	pickpocket protector (c0)
 The Mastermind	1681	adv_smart4.gif	BOSS NOCOPY Atk: [250] Def: [250] HP: [200] Init: -10000 P: dude	sinister-looking cat (c0)
 
 # -- Smoothest Adventurer
 
 Savage Beatnik	1682	adv_smooth1.gif	NOCOPY Atk: [300-15*max(pref(nsContestants2)-1,0)] Def: [150-5*max(pref(nsContestants2)-1,0)] HP: [300-10*max(pref(nsContestants2)-1,0)] Init: -10000 P: dude Article: a	jazzy cigarette holder (c0)
-Creamweaver	1683	adv_smooth2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants2)-1,0)] Def: [250-10*max(pref(nsContestants2)-1,0)] HP: [200-10*max(pref(nsContestants2)-1,0)] Init: -10000 P: dude Article: a
-Smooth Criminal	1684	adv_smooth3.gif	NOCOPY Atk: [200-5*max(pref(nsContestants2)-1,0)] Def: [300-15*max(pref(nsContestants2)-1,0)] HP: [250-10*max(pref(nsContestants2)-1,0)] Init: -10000 P: dude Article: a Wiki: "Smooth Criminal (monster)"	one glove (c0)
+Creamweaver	1683	adv_smooth2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants2)-1,0)] Def: [250-10*max(pref(nsContestants2)-1,0)] HP: [200-10*max(pref(nsContestants2)-1,0)] Init: -10000 P: dude EA: cold EA: sleaze EA: stench Article: a
+Smooth Criminal	1684	adv_smooth3.gif	NOCOPY Atk: [200-5*max(pref(nsContestants2)-1,0)] Def: [300-15*max(pref(nsContestants2)-1,0)] HP: [250-10*max(pref(nsContestants2)-1,0)] Init: -10000 P: dude EA: sleaze Article: a Wiki: "Smooth Criminal (monster)"	one glove (c0)
 Seannery the Conman	1685	adv_smooth4.gif	BOSS NOCOPY Atk: [200] Def: [300] HP: [250] Init: -10000 P: dude	leather glove (c0)
 
 # - Adventurer Crowd 3
 
 # -- Hottest Adventurer
 
-Fire Fighter	1686	adv_hot1.gif	NOCOPY Atk: [300-15*max(pref(nsContestants3)-1,0)] Def: [150-5*max(pref(nsContestants3)-1,0)] HP: [300-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude Article: a	handful of fire (c0)
-Cereal Arsonist	1687	adv_hot2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants3)-1,0)] Def: [250-10*max(pref(nsContestants3)-1,0)] HP: [200-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude Article: a	Cracklin' Oat Bran (c0)
-Burnglar	1688	adv_hot3.gif	NOCOPY Atk: [200-5*max(pref(nsContestants3)-1,0)] Def: [300-15*max(pref(nsContestants3)-1,0)] HP: [250-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude Article: a	disposable lighter (c0)
-The Lavalier	1689	adv_hot4.gif	BOSS NOCOPY Atk: [300] Def: [150] HP: [300] Init: -10000 P: dude
+Fire Fighter	1686	adv_hot1.gif	NOCOPY Atk: [300-15*max(pref(nsContestants3)-1,0)] Def: [150-5*max(pref(nsContestants3)-1,0)] HP: [300-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude EA: hot Article: a	handful of fire (c0)
+Cereal Arsonist	1687	adv_hot2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants3)-1,0)] Def: [250-10*max(pref(nsContestants3)-1,0)] HP: [200-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude EA: hot Article: a	Cracklin' Oat Bran (c0)
+Burnglar	1688	adv_hot3.gif	NOCOPY Atk: [200-5*max(pref(nsContestants3)-1,0)] Def: [300-15*max(pref(nsContestants3)-1,0)] HP: [250-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude EA: hot Article: a	disposable lighter (c0)
+The Lavalier	1689	adv_hot4.gif	BOSS NOCOPY Atk: [300] Def: [150] HP: [300] Init: -10000 P: dude EA: hot
 
 # -- Coldest Adventurer
 
-Snowbrawler	1690	adv_cold1.gif	NOCOPY Atk: [300-15*max(pref(nsContestants3)-1,0)] Def: [150-5*max(pref(nsContestants3)-1,0)] HP: [300-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude Article: a	coal contact lenses (c0)
-Ice Cream Conjurer	1691	adv_cold2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants3)-1,0)] Def: [250-10*max(pref(nsContestants3)-1,0)] HP: [200-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude Article: an	conjured ice cream (c0)
-Iceberglar	1692	adv_cold3.gif	NOCOPY Atk: [200-5*max(pref(nsContestants3)-1,0)] Def: [300-15*max(pref(nsContestants3)-1,0)] HP: [250-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude Article: an	Iceberglar scarf (c0)
-Mrs. Freeze	1693	adv_cold4.gif	BOSS NOCOPY Atk: [250] Def: [250] HP: [200] Init: -10000 P: dude	icy hairspray (c0)
+Snowbrawler	1690	adv_cold1.gif	NOCOPY Atk: [300-15*max(pref(nsContestants3)-1,0)] Def: [150-5*max(pref(nsContestants3)-1,0)] HP: [300-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude EA: cold Article: a	coal contact lenses (c0)
+Ice Cream Conjurer	1691	adv_cold2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants3)-1,0)] Def: [250-10*max(pref(nsContestants3)-1,0)] HP: [200-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude EA: cold Article: an	conjured ice cream (c0)
+Iceberglar	1692	adv_cold3.gif	NOCOPY Atk: [200-5*max(pref(nsContestants3)-1,0)] Def: [300-15*max(pref(nsContestants3)-1,0)] HP: [250-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude EA: cold Article: an	Iceberglar scarf (c0)
+Mrs. Freeze	1693	adv_cold4.gif	BOSS NOCOPY Atk: [250] Def: [250] HP: [200] Init: -10000 P: dude EA: cold	icy hairspray (c0)
 
 # -- Stinkiest Adventurer
 
-Granola Barbarian	1694	adv_stench1.gif	NOCOPY Atk: [300-15*max(pref(nsContestants3)-1,0)] Def: [150-5*max(pref(nsContestants3)-1,0)] HP: [300-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude Article: a
-Cheese Wizard	1695	adv_stench2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants3)-1,0)] Def: [250-10*max(pref(nsContestants3)-1,0)] HP: [200-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude Article: a	smellbook (c0)
-Assassin	1696	adv_stench3.gif	NOCOPY Atk: [200-5*max(pref(nsContestants3)-1,0)] Def: [300-15*max(pref(nsContestants3)-1,0)] HP: [250-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude Article: an	assassin's cheese knife (c0)
-Odorous Humongous	1697	adv_stench4.gif	BOSS NOCOPY Atk: [300] Def: [150] HP: [300] Init: -10000 P: dude	filthy armor (c0)
+Granola Barbarian	1694	adv_stench1.gif	NOCOPY Atk: [300-15*max(pref(nsContestants3)-1,0)] Def: [150-5*max(pref(nsContestants3)-1,0)] HP: [300-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude EA: stench Article: a
+Cheese Wizard	1695	adv_stench2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants3)-1,0)] Def: [250-10*max(pref(nsContestants3)-1,0)] HP: [200-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude EA: stench Article: a	smellbook (c0)
+Assassin	1696	adv_stench3.gif	NOCOPY Atk: [200-5*max(pref(nsContestants3)-1,0)] Def: [300-15*max(pref(nsContestants3)-1,0)] HP: [250-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude EA: stench Article: an	assassin's cheese knife (c0)
+Odorous Humongous	1697	adv_stench4.gif	BOSS NOCOPY Atk: [300] Def: [150] HP: [300] Init: -10000 P: dude EA: stench	filthy armor (c0)
 
 # -- Spookiest Adventurer
 
-Ghostpuncher	1698	adv_spooky1.gif	NOCOPY Atk: [300-15*max(pref(nsContestants3)-1,0)] Def: [150-5*max(pref(nsContestants3)-1,0)] HP: [300-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude Article: a
-Plague Chef	1699	adv_spooky2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants3)-1,0)] Def: [250-10*max(pref(nsContestants3)-1,0)] HP: [200-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude Article: a	plague pie (c0)
-Batburglar	1700	adv_spooky3.gif	NOCOPY Atk: [200-5*max(pref(nsContestants3)-1,0)] Def: [300-15*max(pref(nsContestants3)-1,0)] HP: [250-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude Article: a	batarang (c0)
-Arthur Frankenstein	1701	adv_spooky4.gif	BOSS NOCOPY Atk: [300] Def: [150] HP: [300] Init: -10000 P: dude	spare neck bolts (c0)
+Ghostpuncher	1698	adv_spooky1.gif	NOCOPY Atk: [300-15*max(pref(nsContestants3)-1,0)] Def: [150-5*max(pref(nsContestants3)-1,0)] HP: [300-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude EA: spooky Article: a
+Plague Chef	1699	adv_spooky2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants3)-1,0)] Def: [250-10*max(pref(nsContestants3)-1,0)] HP: [200-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude EA: spooky Article: a	plague pie (c0)
+Batburglar	1700	adv_spooky3.gif	NOCOPY Atk: [200-5*max(pref(nsContestants3)-1,0)] Def: [300-15*max(pref(nsContestants3)-1,0)] HP: [250-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude EA: spooky Article: a	batarang (c0)
+Arthur Frankenstein	1701	adv_spooky4.gif	BOSS NOCOPY Atk: [300] Def: [150] HP: [300] Init: -10000 P: dude EA: spooky	spare neck bolts (c0)
 
 # -- Sleaziest Adventurer
 
-Grease Trapper	1702	adv_sleaze1.gif	NOCOPY Atk: [300-15*max(pref(nsContestants3)-1,0)] Def: [150-5*max(pref(nsContestants3)-1,0)] HP: [300-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude Article: a	grease trap (c0)
-Ham Shaman	1703	adv_sleaze2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants3)-1,0)] Def: [250-10*max(pref(nsContestants3)-1,0)] HP: [200-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude Article: a	shamanic ham (c0)
-Porkpocket	1704	adv_sleaze3.gif	NOCOPY Atk: [200-5*max(pref(nsContestants3)-1,0)] Def: [300-15*max(pref(nsContestants3)-1,0)] HP: [250-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude Article: a	porkpocket (c0)
-Leonard	1705	adv_sleaze4.gif	BOSS NOCOPY Atk: [200] Def: [300] HP: [250] Init: -10000 P: dude	Leonard's glasses (c0)
+Grease Trapper	1702	adv_sleaze1.gif	NOCOPY Atk: [300-15*max(pref(nsContestants3)-1,0)] Def: [150-5*max(pref(nsContestants3)-1,0)] HP: [300-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude EA: sleaze Article: a	grease trap (c0)
+Ham Shaman	1703	adv_sleaze2.gif	NOCOPY Atk: [250-10*max(pref(nsContestants3)-1,0)] Def: [250-10*max(pref(nsContestants3)-1,0)] HP: [200-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude EA: sleaze Article: a	shamanic ham (c0)
+Porkpocket	1704	adv_sleaze3.gif	NOCOPY Atk: [200-5*max(pref(nsContestants3)-1,0)] Def: [300-15*max(pref(nsContestants3)-1,0)] HP: [250-10*max(pref(nsContestants3)-1,0)] Init: -10000 P: dude EA: sleaze Article: a	porkpocket (c0)
+Leonard	1705	adv_sleaze4.gif	BOSS NOCOPY Atk: [200] Def: [300] HP: [250] Init: -10000 P: dude EA: sleaze	Leonard's glasses (c0)
 
 # - Hedge Maze
 
@@ -975,10 +975,10 @@ topiary kiwi	1713	topiarykiwi.gif	NOCOPY Atk: 350 Def: 350 HP: 350 Init: 150 P: 
 # - Tower
 
 wall of bones	1708	wallofbones.gif	BOSS NOCOPY Atk: 1000 Def: 1000 HP: 20000 Init: -10000 Group: 100 P: undead Article: a
-wall of meat	1706	meatwall1.gif,meatwall2.gif,meatwall3.gif,meatwall4.gif	BOSS NOCOPY Atk: 200 Def: 200 HP: 700 Init: -10000 Meat: 200 P: elemental Phys: 50 Elem: 50 Article: a
-wall of skin	1707	wallofskin.gif	BOSS NOCOPY Atk: 200 Def: 200 HP: [50+150*path(BIG!)] Init: -10000 P: construct Phys: 100 Elem: 100 Article: a
+wall of meat	1706	meatwall1.gif,meatwall2.gif,meatwall3.gif,meatwall4.gif	BOSS NOCOPY Atk: 200 Def: 200 HP: 700 Init: -10000 Meat: 200 P: elemental Phys: 50 Elem: 50 EA: sleaze Article: a
+wall of skin	1707	wallofskin.gif	BOSS NOCOPY Atk: 200 Def: 200 HP: [50+150*path(BIG!)] Init: -10000 P: construct Phys: 100 Elem: 100 EA: cold EA: hot EA: sleaze EA: spooky EA: stench Article: a
 # Manuel name is "(shadow opponent)" with parentheses
-Your Shadow	210	otherimages/shadows/20.gif	BOSS NOCOPY Atk: [150] Def: [89999] HP: [395] Exp: 200 Init: 150 P: dude Article: a Manuel: "(shadow opponent)" Wiki: "Shadow opponent"
+Your Shadow	210	otherimages/shadows/20.gif	BOSS NOCOPY Atk: [150] Def: [89999] HP: [395] Exp: 200 Init: 150 P: dude EA: shadow Article: a Manuel: "(shadow opponent)" Wiki: "Shadow opponent"
 
 # Retired Sorceress Lair
 
@@ -1023,17 +1023,17 @@ X-dimensional horror	592	dimhorror.gif	NOCOPY Atk: [2*ceil(BL^1.4)+ML] Def: [2*c
 
 # Hobopolis
 
-C. H. U. M.	682	chum1.gif,chum2.gif,chum3.gif,chum4.gif,chum5.gif	Atk: 260 Def: 229 HP: 200 Init: -10000 P: humanoid Article: a	bottle of sewage schnapps (15)	C.H.U.M. lantern (1)	C.H.U.M. knife (1)	sewer nuggets (20)	C.H.U.M. chum (p40)
-C. H. U. M. chieftain	715	chumchief.gif	LUCKY Atk: 330 Def: 270 HP: 400 Init: 40 P: humanoid Article: a	C.H.U.M. knife (2)	bottle of sewage schnapps (30)	bottle of sewage schnapps (30)	sewer nuggets (40)	sewer nuggets (40)	C.H.U.M. chum (p40)
-giant zombie goldfish	681	zomfish.gif	Atk: 250 Def: 229 HP: 250 Init: 60 P: undead Article: a	decaying goldfish liver (15)	sewer nuggets (20)	sewer nuggets (20)
+C. H. U. M.	682	chum1.gif,chum2.gif,chum3.gif,chum4.gif,chum5.gif	Atk: 260 Def: 229 HP: 200 Init: -10000 P: humanoid EA: stench Article: a	bottle of sewage schnapps (15)	C.H.U.M. lantern (1)	C.H.U.M. knife (1)	sewer nuggets (20)	C.H.U.M. chum (p40)
+C. H. U. M. chieftain	715	chumchief.gif	LUCKY Atk: 330 Def: 270 HP: 400 Init: 40 P: humanoid EA: stench Article: a	C.H.U.M. knife (2)	bottle of sewage schnapps (30)	bottle of sewage schnapps (30)	sewer nuggets (40)	sewer nuggets (40)	C.H.U.M. chum (p40)
+giant zombie goldfish	681	zomfish.gif	Atk: 250 Def: 229 HP: 250 Init: 60 P: undead EA: stench Article: a	decaying goldfish liver (15)	sewer nuggets (20)	sewer nuggets (20)
 sewer gator	679	sewergator.gif	Atk: 245 Def: 225 HP: 300 Init: 60 Meat: 75 P: beast Article: a	gator skin (15)	sewer nuggets (20)	sewer nuggets (20)
 Normal hobo	651	nhobo1.gif,nhobo2.gif,nhobo3.gif,nhobo4.gif,nhobo5.gif,nhobo6.gif,nhobo7.gif,nhobo8.gif,nhobo9.gif,nhobo10.gif,nhobo11.gif,nhobo12.gif,nhobo13.gif,nhobo14.gif,nhobo15.gif,nhobo16.gif,nhobo17.gif,nhobo18.gif	Atk: 300 Def: 270 HP: 400 Init: 100 P: hobo	hobo nickel (c15)	Mr. Joe's bangles (0)	corncob pipe (0)	panhandle panhandling hat (0)	frayed rope belt (0)	cup of infinite pencils (0)	'WILL WORK FOR BOOZE' sign (0)	lucky bottlecap (0)	rusty piece of rebar (0)
 Cold hobo	690	coldhobo1.gif,coldhobo2.gif,coldhobo3.gif,coldhobo4.gif,coldhobo5.gif,coldhobo6.gif,coldhobo7.gif,coldhobo8.gif	Atk: 350 Def: 315 HP: 500 Init: 100 P: hobo E: cold	hobo nickel (c15)	freezin' bindle (0)	Maxing, Relaxing (0)	Blizzards I Have Died In (0)	frigid air mattress (0)
 Hot hobo	689	hothobo1.gif,hothobo2.gif,hothobo3.gif,hothobo4.gif,hothobo5.gif,hothobo6.gif,hothobo7.gif,hothobo8.gif	Atk: 350 Def: 315 HP: 500 Init: 100 P: hobo E: hot	bed of coals (0)	hobo nickel (c15)	flamin' bindle (0)	Tales from the Fireside (0)	Kissin' Cousins (0)
-Sleaze hobo	693	slhobo1.gif,slhobo2.gif,slhobo3.gif,slhobo4.gif,slhobo5.gif,slhobo6.gif,slhobo7.gif,slhobo8.gif	Atk: 350 Def: 315 HP: 500 Init: 100 P: hobo E: sleaze	hobo nickel (c15)	sleazy bindle (0)	Summer Nights (0)	Sensual Massage for Creeps (0)	stained mattress (0)
+Sleaze hobo	693	slhobo1.gif,slhobo2.gif,slhobo3.gif,slhobo4.gif,slhobo5.gif,slhobo6.gif,slhobo7.gif,slhobo8.gif	Atk: 350 Def: 315 HP: 500 Init: 100 P: hobo ED: sleaze	hobo nickel (c15)	sleazy bindle (0)	Summer Nights (0)	Sensual Massage for Creeps (0)	stained mattress (0)
 Spooky hobo	692	spookyhobo1.gif,spookyhobo2.gif,spookyhobo3.gif,spookyhobo4.gif,spookyhobo5.gif,spookyhobo6.gif,spookyhobo7.gif,spookyhobo8.gif	Atk: 350 Def: 315 HP: 500 Init: 100 P: hobo E: spooky	hobo nickel (c15)	spooky bindle (0)	Asleep in the Cemetery (0)	Let Me Be! (0)	comfy coffin (0)
 Stench hobo	691	stenchhobo1.gif,stenchhobo2.gif,stenchhobo3.gif,stenchhobo4.gif,stenchhobo5.gif,stenchhobo6.gif,stenchhobo7.gif,stenchhobo8.gif	Atk: 350 Def: 315 HP: 500 Init: 100 P: hobo E: stench	hobo nickel (c15)	stinkin' bindle (0)	Biddy Cracker's Old-Fashioned Cookbook (0)	Travels with Jerry (0)	filth-encrusted futon (0)
-gang of hobo muggers	707	muggers.gif	Atk: 800 Def: 900 HP: 3000 Init: 300 P: hobo Article: a
+gang of hobo muggers	707	muggers.gif	Atk: 800 Def: 900 HP: 3000 Init: 300 P: hobo EA: hot Article: a
 
 # Hobopolis Bosses
 
@@ -1042,17 +1042,17 @@ Ol' Scratch	694	olscratch.gif	BOSS NOCOPY Atk: 500 Def: 450 HP: 8000 Init: 150 P
 Oscus	696	oscus.gif	BOSS NOCOPY Atk: 500 Def: 450 HP: 6500 Init: 200 P: hobo E: stench	The Ballad of Richie Thingfinder (0)	jar of fermented pickle juice (0)	Oscus's dumpster waders (0)	Oscus's pelt (0)	Wand of Oscus (0)	Oscus's flypaper pants (f20)	Oscus's garbage can lid (f20)	Oscus's neverending soda (f20)
 Chester	698	chester.gif	BOSS NOCOPY Atk: 500 Def: 450 HP: 8000 Init: 200 P: dude E: sleaze	Chorale of Companionship (0)	extra-greasy slider (0)	Chester's bag of candy (0)	Chester's cutoffs (0)	Chester's moustache (0)	Chester's Aquarius medallion (f20)	Chester's muscle shirt (f20)	Chester's sunglasses (f20)
 Zombo	697	zombo.gif	BOSS NOCOPY Atk: 500 Def: 450 HP: 10000 Init: 200 P: undead E: spooky	Prelude of Precision (0)	voodoo snuff (0)	Zombo's grievous greaves (0)	Zombo's shield (0)	Zombo's skullcap (0)	Zombo's empty eye (f20)	Zombo's shoulder blade (f20)	Zombo's skull ring (f20)
-Hodgman, The Hoboverlord	688	hodgman.gif	BOSS NOCOPY Atk: 750 Def: 675 HP: 25000 Init: 250 P: hobo Phys: 25	Hodgman's bow tie (0)	Hodgman's porkpie hat (0)	Hodgman's lobsterskin pants (0)	Hodgman's almanac (0)	Hodgman's lucky sock (0)	Hodgman's metal detector (0)	Hodgman's varcolac paw (0)	Hodgman's harmonica (0)	Hodgman's garbage sticker (0)	Hodgman's cane (0)	Hodgman's whackin' stick (0)	Hodgman's disgusting technicolor overcoat (0)	Hodgman's imaginary hamster (0)	hobo fortress blueprints (0)	stuffed Hodgman (0)	Hodgman's blanket (0)	tin cup of mulligan stew (0)	Hodgman's journal #1: The Lean Times (0)	Hodgman's journal #2: Entrepreneurythmics (0)	Hodgman's journal #3: Pumping Tin (0)	Hodgman's journal #4: View From The Big Top (0)
+Hodgman, The Hoboverlord	688	hodgman.gif	BOSS NOCOPY Atk: 750 Def: 675 HP: 25000 Init: 250 P: hobo Phys: 25 EA: hot EA: spooky EA: stench	Hodgman's bow tie (0)	Hodgman's porkpie hat (0)	Hodgman's lobsterskin pants (0)	Hodgman's almanac (0)	Hodgman's lucky sock (0)	Hodgman's metal detector (0)	Hodgman's varcolac paw (0)	Hodgman's harmonica (0)	Hodgman's garbage sticker (0)	Hodgman's cane (0)	Hodgman's whackin' stick (0)	Hodgman's disgusting technicolor overcoat (0)	Hodgman's imaginary hamster (0)	hobo fortress blueprints (0)	stuffed Hodgman (0)	Hodgman's blanket (0)	tin cup of mulligan stew (0)	Hodgman's journal #1: The Lean Times (0)	Hodgman's journal #2: Entrepreneurythmics (0)	Hodgman's journal #3: Pumping Tin (0)	Hodgman's journal #4: View From The Big Top (0)
 
 # Slime Tube
-Slime Tube monster	791	noart.gif	Atk: 100 Def: 90 HP: 200 Init: 50 P: slime EA: slime Article: a Wiki: "Slime"
+Slime Tube monster	791	noart.gif	Atk: 100 Def: 90 HP: 200 Init: 50 P: slime EA: cold EA: hot EA: sleaze EA: stench EA: slime Article: a Wiki: "Slime"
 # The above is the single Monster Manuel monster. In the Slime Tube, we can distinguish by image
-Slime	-37	slime1_1.gif,slime1_2.gif,slime1_3.gif,slime1_4.gif,slime1_5.gif,slime1_6.gif,slime1_7.gif,slime1_8.gif	Atk: 100 Def: 90 HP: 200 Init: 50 P: slime EA: slime Manuel: "Slime Tube Monster"	slimy sweetbreads (5)	slimy fermented bile bladder (5)	tiny slimy cyst (n5)	wad of slimy rags (n1)
-Slime Hand	-36	slime2_1.gif,slime2_2.gif,slime2_3.gif,slime2_4.gif,slime2_5.gif,slime2_6.gif,slime2_7.gif,slime2_8.gif	Atk: 100 Def: 90 HP: 200 Init: 50 P: slime EA: slime Manuel: "Slime Tube Monster"	slimy sweetbreads (5)	slimy fermented bile bladder (5)	tiny slimy cyst (n5)
-Slime Mouth	-35	slime3_1.gif,slime3_2.gif,slime3_3.gif,slime3_4.gif,slime3_5.gif,slime3_6.gif,slime3_7.gif,slime3_8.gif	Atk: 100 Def: 90 HP: 200 Init: 50 P: slime EA: slime Manuel: "Slime Tube Monster"	slimy sweetbreads (5)	slimy fermented bile bladder (5)	small slimy cyst (n5)
-Slime Construct	-34	slime4_1.gif,slime4_2.gif,slime4_3.gif,slime4_4.gif,slime4_5.gif,slime4_6.gif,slime4_7.gif,slime4_8.gif	Atk: 100 Def: 90 HP: 200 Init: 50 P: slime EA: slime Manuel: "Slime Tube Monster"	slimy sweetbreads (5)	slimy fermented bile bladder (5)	medium slimy cyst (n2)
-Slime Colossus	-33	slime5_1.gif,slime5_2.gif,slime5_3.gif,slime5_4.gif,slime5_5.gif,slime5_6.gif,slime5_7.gif,slime5_8.gif	Atk: 100 Def: 90 HP: 200 Init: 50 P: slime EA: slime Manuel: "Slime Tube Monster"	slimy sweetbreads (5)	slimy fermented bile bladder (5)	big slimy cyst (n2)
-Mother Slime	792	otherimages/slimetube/stboss.gif	BOSS NOCOPY Atk: 1000 Def: 900 HP: 2950 Init: 300 P: slime EA: slime	hardened slime belt (0)	hardened slime hat (0)	hardened slime pants (0)	slime-soaked brain (0)	slime-soaked hypophysis (0)	slime-soaked sweat gland (0)	slimy alveolus (0)	chamoisole (n5)	caustic slime nodule (0)	caustic slime nodule (0)	squirming Slime larva (0)
+Slime	-37	slime1_1.gif,slime1_2.gif,slime1_3.gif,slime1_4.gif,slime1_5.gif,slime1_6.gif,slime1_7.gif,slime1_8.gif	Atk: 100 Def: 90 HP: 200 Init: 50 P: slime EA: cold EA: hot EA: sleaze EA: stench EA: slime Manuel: "Slime Tube Monster"	slimy sweetbreads (5)	slimy fermented bile bladder (5)	tiny slimy cyst (n5)	wad of slimy rags (n1)
+Slime Hand	-36	slime2_1.gif,slime2_2.gif,slime2_3.gif,slime2_4.gif,slime2_5.gif,slime2_6.gif,slime2_7.gif,slime2_8.gif	Atk: 100 Def: 90 HP: 200 Init: 50 P: slime EA: cold EA: hot EA: sleaze EA: spooky EA: stench EA: slime Manuel: "Slime Tube Monster"	slimy sweetbreads (5)	slimy fermented bile bladder (5)	tiny slimy cyst (n5)
+Slime Mouth	-35	slime3_1.gif,slime3_2.gif,slime3_3.gif,slime3_4.gif,slime3_5.gif,slime3_6.gif,slime3_7.gif,slime3_8.gif	Atk: 100 Def: 90 HP: 200 Init: 50 P: slime EA: sleaze EA: spooky EA: slime Manuel: "Slime Tube Monster"	slimy sweetbreads (5)	slimy fermented bile bladder (5)	small slimy cyst (n5)
+Slime Construct	-34	slime4_1.gif,slime4_2.gif,slime4_3.gif,slime4_4.gif,slime4_5.gif,slime4_6.gif,slime4_7.gif,slime4_8.gif	Atk: 100 Def: 90 HP: 200 Init: 50 P: slime EA: hot EA: sleaze EA: spooky EA: slime Manuel: "Slime Tube Monster"	slimy sweetbreads (5)	slimy fermented bile bladder (5)	medium slimy cyst (n2)
+Slime Colossus	-33	slime5_1.gif,slime5_2.gif,slime5_3.gif,slime5_4.gif,slime5_5.gif,slime5_6.gif,slime5_7.gif,slime5_8.gif	Atk: 100 Def: 90 HP: 200 Init: 50 P: slime EA: cold EA: hot EA: slime Manuel: "Slime Tube Monster"	slimy sweetbreads (5)	slimy fermented bile bladder (5)	big slimy cyst (n2)
+Mother Slime	792	otherimages/slimetube/stboss.gif	BOSS NOCOPY Atk: 1000 Def: 900 HP: 2950 Init: 300 P: slime EA: spooky EA: slime	hardened slime belt (0)	hardened slime hat (0)	hardened slime pants (0)	slime-soaked brain (0)	slime-soaked hypophysis (0)	slime-soaked sweat gland (0)	slimy alveolus (0)	chamoisole (n5)	caustic slime nodule (0)	caustic slime nodule (0)	squirming Slime larva (0)
 
 # Dreadsylvania
 #
@@ -1105,29 +1105,29 @@ stench zombie	1405	dvstenchzom1.gif,dvstenchzom2.gif,dvstenchzom3.gif	NOCOPY Atk
 # Dreadsylvania Bosses
 Count Drunkula	1390	drunkula.gif	NOCOPY Atk: 1000 Def: 1000 HP: 8000 Init: 20 P: undead	Thunkula's drinking cap (c0)	Drunkula's cape (c0)	Drunkula's silky pants (c0)	bottle of Bloodweiser (c0)
 Count Drunkula (Hard Mode)	-89	drunkula_hm.gif	NOCOPY NOMANUEL P: undead	Thunkula's drinking cap (c0)	Drunkula's cape (c0)	Drunkula's silky pants (c0)	Drunkula's ring of haze (c0)	Drunkula's wineglass (c0)	Drunkula's bell (c0)	skull capacitor (100)	bottle of Bloodweiser (c0)
-Falls-From-Sky	1386	fallsfromsky.gif	NOCOPY Atk: 700 Def: 700 HP: 1500 Init: 50 P: beast	Covers-Your-Head (c0)	Drapes-You-Regally (c0)	Warms-Your-Tush (c0)	Gets-You-Drunk (c0)
-Falls-From-Sky (Hard Mode)	-88	fallsfromsky_hm.gif	NOCOPY NOMANUEL P: beast	Covers-Your-Head (c0)	Drapes-You-Regally (c0)	Warms-Your-Tush (c0)	Helps-You-Sleep (c0)	Quiets-Your-Steps (c0)	Protects-Your-Junk (c0)	Gets-You-Drunk (c0)
+Falls-From-Sky	1386	fallsfromsky.gif	NOCOPY Atk: 700 Def: 700 HP: 1500 Init: 50 P: beast EA: cold EA: hot EA: sleaze EA: spooky EA: stench	Covers-Your-Head (c0)	Drapes-You-Regally (c0)	Warms-Your-Tush (c0)	Gets-You-Drunk (c0)
+Falls-From-Sky (Hard Mode)	-88	fallsfromsky_hm.gif	NOCOPY NOMANUEL P: beast EA: cold EA: hot EA: sleaze EA: spooky EA: stench	Covers-Your-Head (c0)	Drapes-You-Regally (c0)	Warms-Your-Tush (c0)	Helps-You-Sleep (c0)	Quiets-Your-Steps (c0)	Protects-Your-Junk (c0)	Gets-You-Drunk (c0)
 Great Wolf of the Air	1387	wolfoftheair.gif	NOCOPY Atk: 1200 Def: 1200 HP: 5000 Init: 10000 P: beast Article: The	Great Wolf's headband (c0)	Great Wolf's left paw (c0)	Great Wolf's right paw (c0)	Hunger&trade; Sauce (c0)
 Great Wolf of the Air (Hard Mode)	-87	wolfoftheair_hm.gif	NOCOPY NOMANUEL P: beast Article: The	Great Wolf's headband (c0)	Great Wolf's left paw (c0)	Great Wolf's right paw (c0)	Great Wolf's rocket launcher (c0)	Great Wolf's beastly trousers (c0)	Great Wolf's lice (c0)	Hunger&trade; Sauce (c0)
-Mayor Ghost	1389	mayorghost.gif	NOCOPY Atk: 1500 Def: 1500 HP: 10000 Init: 200 P: undead GHOST Phys: 100	Mayor Ghost's cloak (c0)	Mayor Ghost's khakis (c0)	Mayor Ghost's toupee (c0)	ghost pepper (c0)
-Mayor Ghost (Hard Mode)	-86	mayorghost_hm.gif	NOCOPY NOMANUEL P: undead GHOST Phys: 100	Mayor Ghost's cloak (c0)	Mayor Ghost's khakis (c0)	Mayor Ghost's toupee (c0)	Mayor Ghost's gavel (c0)	Mayor Ghost's sash (c0)	Mayor Ghost's scissors (c0)	ghost pepper (c0)
+Mayor Ghost	1389	mayorghost.gif	NOCOPY Atk: 1500 Def: 1500 HP: 10000 Init: 200 P: undead GHOST Phys: 100 EA: spooky	Mayor Ghost's cloak (c0)	Mayor Ghost's khakis (c0)	Mayor Ghost's toupee (c0)	ghost pepper (c0)
+Mayor Ghost (Hard Mode)	-86	mayorghost_hm.gif	NOCOPY NOMANUEL P: undead GHOST Phys: 100 EA: spooky	Mayor Ghost's cloak (c0)	Mayor Ghost's khakis (c0)	Mayor Ghost's toupee (c0)	Mayor Ghost's gavel (c0)	Mayor Ghost's sash (c0)	Mayor Ghost's scissors (c0)	ghost pepper (c0)
 The Unkillable Skeleton	1391	ukskeleton.gif	NOCOPY Atk: 500 Def: 500 HP: 500 Init: 200 P: undead	Unkillable Skeleton's breastplate (c0)	Unkillable Skeleton's shinguards (c0)	Unkillable Skeleton's skullcap (c0)	electric Kool-Aid (c0)
 The Unkillable Skeleton (Hard Mode)	-85	ukskeleton_hm.gif	NOCOPY NOMANUEL P: undead	Unkillable Skeleton's breastplate (c0)	Unkillable Skeleton's shinguards (c0)	Unkillable Skeleton's skullcap (c0)	Unkillable Skeleton's sawsword (c0)	Unkillable Skeleton's shield (c0)	Unkillable Skeleton's restless leg (c0)	skull capacitor (100)	electric Kool-Aid (c0)
-Zombie Homeowners' Association	1388	zombiehoa.gif	NOCOPY Atk: 700 Def: 700 HP: 15000 Init: 200 P: undead Article: the	zombie mariachi hat (c0)	zombie accordion (c0)	zombie mariachi pants (c0)	wriggling severed nose (c0)
-Zombie Homeowners' Association (Hard Mode)	-84	zombiehoa_hm.gif	NOCOPY P: undead Article: the	zombie mariachi hat (c0)	zombie accordion (c0)	zombie mariachi pants (c0)	HOA regulation book (c0)	HOA zombie eyes (c0)	HOA citation pad (c0)	wriggling severed nose (c0)
+Zombie Homeowners' Association	1388	zombiehoa.gif	NOCOPY Atk: 700 Def: 700 HP: 15000 Init: 200 P: undead EA: sleaze EA: stench Article: the	zombie mariachi hat (c0)	zombie accordion (c0)	zombie mariachi pants (c0)	wriggling severed nose (c0)
+Zombie Homeowners' Association (Hard Mode)	-84	zombiehoa_hm.gif	NOCOPY P: undead EA: sleaze EA: stench Article: the	zombie mariachi hat (c0)	zombie accordion (c0)	zombie mariachi pants (c0)	HOA regulation book (c0)	HOA zombie eyes (c0)	HOA citation pad (c0)	wriggling severed nose (c0)
 
 # Challenge Paths
 
 # Bees Hate You
 beebee gunners	1077	beebeegunner.gif	NOCOPY WANDERER Scale: 10 Init: -10000 Group: 3 P: bug	handful of honey (0)
-moneybee	1076	moneybee.gif	NOCOPY WANDERER Scale: 10 Init: -10000 P: bug Article: a	handful of honey (0)
+moneybee	1076	moneybee.gif	NOCOPY WANDERER Scale: 10 Init: -10000 P: bug EA: sleaze Article: a	handful of honey (0)
 mumblebee	1075	mumblebee.gif	NOCOPY WANDERER Scale: 10 Init: -10000 P: bug Article: a	handful of honey (0)
 beebee queue	1080	beebeequeue.gif	NOCOPY WANDERER Scale: 20 Init: -10000 Group: 2 P: bug Article: a	handful of honey (0)	handful of honey (0)
 bee swarm	1079	beeswarm.gif	NOCOPY WANDERER Scale: 20 Init: -10000 Group: 3 P: bug Article: a	handful of honey (0)	handful of honey (0)
 buzzerker	1078	buzzerker.gif	NOCOPY WANDERER Scale: 20 Init: -10000 P: bug Article: a	handful of honey (0)	handful of honey (0)
 Beebee King	1082	beebeeking.gif	NOCOPY WANDERER Scale: 40 Init: -10000 P: bug Phys: 50 Article: a	handful of honey (0)	handful of honey (0)	handful of honey (0)
-bee thoven	1081	beethoven.gif	NOCOPY WANDERER Scale: 40 Init: -10000 Group: 3 P: bug Phys: 50 Article: a	handful of honey (0)	handful of honey (0)	handful of honey (0)
-Queen Bee	1083	beequeen.gif	NOCOPY WANDERER Scale: 40 Init: -10000 P: bug Phys: 50 Article: a	handful of honey (0)	handful of honey (0)	handful of honey (0)
+bee thoven	1081	beethoven.gif	NOCOPY WANDERER Scale: 40 Init: -10000 Group: 3 P: bug Phys: 50 EA: hot Article: a	handful of honey (0)	handful of honey (0)	handful of honey (0)
+Queen Bee	1083	beequeen.gif	NOCOPY WANDERER Scale: 40 Init: -10000 P: bug Phys: 50 EA: sleaze Article: a	handful of honey (0)	handful of honey (0)	handful of honey (0)
 
 # Way of the Stunning Fist
 Wu Tang the Betrayer	1100	susguy.gif	NOCOPY Atk: 200 Def: 89999 HP: 500 Init: 150 P: dude	forged identification documents (100)	can of black paint (100)	black cherry soda (0)	black cherry soda (0)	black cherry soda (0)
@@ -1138,41 +1138,41 @@ The Avatar of Sneaky Pete	1158	sneakypete.gif	BOSS NOCOPY Atk: 225 Def: 202 HP: 
 The Luter	1152	theluter.gif	NOCOPY Atk: 75 Def: 67 HP: 100 Init: 50 P: undead Phys: 50 Elem: 50	Clancy's lute (n100)
 
 # Bugbear Invasion
-scavenger bugbear	1165	bb_scav.gif	Atk: 5 Def: 4 HP: 5 Init: 150 P: beast Article: a	BURT (100)
-creepy eye-stalk tentacle monster	1174	dianoga.gif	Atk: 8 Def: 5 HP: 6 Init: 100 P: horror E: stench Article: a	handful of juicy garbage (0)
-grouchy furry monster	1175	grouchewie.gif	Atk: 6 Def: 6 HP: 8 Init: 50 P: beast Article: a	handful of juicy garbage (0)	Osk'r Chow (c0)
+scavenger bugbear	1165	bb_scav.gif	Atk: 5 Def: 4 HP: 5 Init: 150 P: beast EA: stench Article: a	BURT (100)
+creepy eye-stalk tentacle monster	1174	dianoga.gif	Atk: 8 Def: 5 HP: 6 Init: 100 P: horror ED: stench EA: sleaze EA: stench Article: a	handful of juicy garbage (0)
+grouchy furry monster	1175	grouchewie.gif	Atk: 6 Def: 6 HP: 8 Init: 50 P: beast EA: stench Article: a	handful of juicy garbage (0)	Osk'r Chow (c0)
 hypodermic bugbear	1166	bb_vamp.gif	Atk: 8 Def: 7 HP: 8 Init: 100 P: beast Article: a	BURT (100)
 anesthesiologist bugbear	1176	bb_doctor.gif	Atk: 12 Def: 7 HP: 10 Init: 50 P: beast Article: an	BURT (100)
-bugbear robo-surgeon	1177	robosurgeon.gif	NOCOPY Atk: 15 Def: 22 HP: 20 Init: 50 P: construct Article: a
+bugbear robo-surgeon	1177	robosurgeon.gif	NOCOPY Atk: 15 Def: 22 HP: 20 Init: 50 P: construct EA: hot Article: a
 batbugbear	1167	bb_bat.gif	Atk: 25 Def: 22 HP: 25 Init: 100 P: beast Article: a	BURT (100)
-bugbear scientist	1168	bb_science.gif	Atk: 45 Def: 40 HP: 50 Init: 50 P: beast Article: a	BURT (100)
+bugbear scientist	1168	bb_science.gif	Atk: 45 Def: 40 HP: 50 Init: 50 P: beast EA: cold Article: a	BURT (100)
 spiderbugbear	1178	bb_spider.gif	Atk: 55 Def: 49 HP: 50 Init: 75 P: beast Article: a	quantum nanopolymer spider web (0)
-bugaboo	1169	bb_ghost.gif	Atk: 60 Def: 54 HP: 70 Init: 50 P: undead E: spooky Article: a	BURT (100)
-bugbear mortician	1179	bb_mortician.gif	Atk: 65 Def: 76 HP: 60 Init: 25 P: beast Article: a	bugbear autopsy tweezers (100)
+bugaboo	1169	bb_ghost.gif	Atk: 60 Def: 54 HP: 70 Init: 50 P: undead ED: spooky EA: sleaze EA: spooky Article: a	BURT (100)
+bugbear mortician	1179	bb_mortician.gif	Atk: 65 Def: 76 HP: 60 Init: 25 P: beast EA: spooky Article: a	bugbear autopsy tweezers (100)
 Black Ops Bugbear	1170	bb_ninja.gif	Atk: 90 Def: 81 HP: 100 Init: 75 P: beast Phys: 25 Elem: 25 Article: a	BURT (100)
 Battlesuit Bugbear Type	1171	bb_mech.gif	Atk: 125 Def: 112 HP: 150 Init: 50 P: beast Phys: 50 Elem: 50 Article: a	BURT (100)
-bugbear drone	1180	bb_drone.gif	Atk: 135 Def: 121 HP: 150 Init: 75 P: construct Phys: 50 Elem: 50 Article: a	drone self-destruct chip (0)
+bugbear drone	1180	bb_drone.gif	Atk: 135 Def: 121 HP: 150 Init: 75 P: construct Phys: 50 Elem: 50 EA: cold Article: a	drone self-destruct chip (0)
 liquid metal bugbear	1181	bb_liquidmetal.gif	Atk: 140 Def: 162 HP: 175 Init: 150 P: construct Phys: 50 Article: a
-ancient unspeakable bugbear	1172	bb_horror.gif	Atk: 140 Def: 126 HP: 150 Init: 50 P: beast E: spooky Article: an	BURT (100)
-N-space Virtual Assistant	1184	bb_vassist.gif	Atk: 175 Def: 157 HP: 180 Init: 100 P: construct Phys: 60 Elem: 60 Article: an
-trendy bugbear chef	1173	bb_chef.gif	Atk: 200 Def: 180 HP: 250 Init: 50 P: beast Phys: 25 E: stench Article: a	BURT (100)
+ancient unspeakable bugbear	1172	bb_horror.gif	Atk: 140 Def: 126 HP: 150 Init: 50 P: beast ED: spooky Article: an	BURT (100)
+N-space Virtual Assistant	1184	bb_vassist.gif	Atk: 175 Def: 157 HP: 180 Init: 100 P: construct Phys: 60 Elem: 60 EA: sleaze Article: an
+trendy bugbear chef	1173	bb_chef.gif	Atk: 200 Def: 180 HP: 250 Init: 50 P: beast Phys: 25 ED: stench Article: a	BURT (100)
 angry cavebugbear	1183	bb_caveman.gif	Atk: 220 Def: 211 HP: 300 Init: 25 P: beast Phys: 25 Article: an
 Bugbear Captain	1182	bb_captain.gif	NOCOPY Atk: 280 Def: 288 HP: 1337 Init: 200 P: beast Phys: 25 Elem: 30 Article: the
 
 # Zombie Slayer
-Norville Rogers	1214	hunter2.gif	NOCOPY WANDERER Atk: 10 Def: 9 HP: 15 Init: 20 P: dude	hunter brain (n100)	Scuba Snack (c0)
+Norville Rogers	1214	hunter2.gif	NOCOPY WANDERER Atk: 10 Def: 9 HP: 15 Init: 20 P: dude EA: sleaze	hunter brain (n100)	Scuba Snack (c0)
 Peacannon	1215	hunter3.gif	NOCOPY WANDERER Atk: 16 Def: 15 HP: 22 Init: 30 P: plant	hunter brain (n100)
-Scott the Miner	1216	hunter4.gif	NOCOPY WANDERER Atk: 23 Def: 22 HP: 30 Init: 40 P: dude	hunter brain (n100)	grey cube (c0)
-Father McGruber	1217	hunter5.gif	NOCOPY WANDERER Atk: 31 Def: 30 HP: 40 Init: 50 P: dude	hunter brain (n100)	votive candle (c0)
+Scott the Miner	1216	hunter4.gif	NOCOPY WANDERER Atk: 23 Def: 22 HP: 30 Init: 40 P: dude EA: hot	hunter brain (n100)	grey cube (c0)
+Father McGruber	1217	hunter5.gif	NOCOPY WANDERER Atk: 31 Def: 30 HP: 40 Init: 50 P: dude EA: hot	hunter brain (n100)	votive candle (c0)
 Herman East, Relivinator	1218	hunter6.gif	NOCOPY WANDERER Atk: 39 Def: 39 HP: 52 Init: 60 P: dude	hunter brain (n100)
 Angry Space Marine	1219	hunter7.gif	NOCOPY WANDERER Atk: 50 Def: 50 HP: 65 Init: 70 P: dude	hunter brain (n100)
 Deputy Nick Soames & Earl	1220	hunter8.gif	NOCOPY WANDERER Atk: 64 Def: 63 HP: 83 Init: 80 Group: 2 P: dude	hunter brain (n100)
-Father Nikolai Ravonovich	1221	hunter9.gif	NOCOPY WANDERER Atk: 81 Def: 81 HP: 98 Init: 90 P: dude	hunter brain (n100)	booby trap (c0)
+Father Nikolai Ravonovich	1221	hunter9.gif	NOCOPY WANDERER Atk: 81 Def: 81 HP: 98 Init: 90 P: dude EA: hot	hunter brain (n100)	booby trap (c0)
 Charity the Zombie Hunter	1222	hunter10.gif	NOCOPY WANDERER Atk: 100 Def: 99 HP: 121 Init: 100 P: dude	hunter brain (n100)	Charity's choker (c0)
-Special Agent Wallace Burke Corrigan	1223	hunter11.gif	NOCOPY WANDERER Atk: 121 Def: 123 HP: 140 Init: 110 P: dude	hunter brain (n100)	Agent Corrigan's cigarette (c0)
+Special Agent Wallace Burke Corrigan	1223	hunter11.gif	NOCOPY WANDERER Atk: 121 Def: 123 HP: 140 Init: 110 P: dude EA: hot	hunter brain (n100)	Agent Corrigan's cigarette (c0)
 Hank North, Photojournalist	1224	hunter12.gif	NOCOPY WANDERER Atk: 144 Def: 148 HP: 180 Init: 120 P: dude	hunter brain (n100)
 rag-tag band of survivors	1225	hunter13.gif	NOCOPY WANDERER Atk: 169 Def: 171 HP: 223 Init: 130 Group: 4 P: dude Article: a	hunter brain (n100)
-The Free Man	1227	hunter15.gif	NOCOPY WANDERER Atk: 230 Def: 234 HP: 360 Init: 150 P: dude	hunter brain (n100)
+The Free Man	1227	hunter15.gif	NOCOPY WANDERER Atk: 230 Def: 234 HP: 360 Init: 150 P: dude EA: hot	hunter brain (n100)
 Wesley J. "Wes" Campbell	1226	hunter14.gif	NOCOPY WANDERER Atk: 197 Def: 207 HP: 280 Init: 140 P: dude	hunter brain (n100)	good ash (c0)
 zombie-huntin' feller	1213	hunter1.gif	NOCOPY WANDERER Atk: 10 Def: 9 HP: 15 Init: 20 P: dude Article: a	hunter brain (n100)
 Rene C. Corman	1229	reneccorman.gif	NOCOPY Atk: 222 Def: 199 HP: 1000 Init: 200 P: dude Wiki: "Rene C. Corman (Zombie Slayer)"	Thwaitgold maggot statuette (n100)
@@ -1182,83 +1182,83 @@ Clancy	1338	clancy.gif	NOCOPY Atk: 150 Def: 165 HP: 500 Init: 90 P: dude Phys: 2
 The Avatar of Boris	1339	boris.gif	NOCOPY Atk: 230 Def: 190 HP: 1000 Init: 50 P: dude Elem: 50
 
 # KOLHS
-Bunsen burner and beaker	1363	bunsen.gif	Scale: 4 Cap: 200 Init: -10000 P: construct Article: a	mysterious chemical residue (25)	mysterious chemical residue (10)
-clay golem	1368	claygolem.gif	Scale: 3 Cap: 200 Init: -10000 P: construct Article: a	lump of clay (25)	lump of clay (10)
+Bunsen burner and beaker	1363	bunsen.gif	Scale: 4 Cap: 200 Init: -10000 P: construct EA: hot Article: a	mysterious chemical residue (25)	mysterious chemical residue (10)
+clay golem	1368	claygolem.gif	Scale: 3 Cap: 200 Init: -10000 P: construct EA: hot Article: a	lump of clay (25)	lump of clay (10)
 deadly vise	1359	vice.gif	Scale: 3 Cap: 200 Init: -10000 P: construct Article: a	blob of wood glue (25)	blob of wood glue (10)
 demonic jigsaw	1362	jigsaw.gif	Scale: 4 Cap: 200 Init: 20 P: demon Article: a	jigsaw blade (25)	jigsaw blade (10)
 dropped base	1364	dropbase.gif	Scale: 3 Cap: 200 Init: 20 P: slime Article: some	ph balancer (25)	ph balancer (10)
-dweebie	1355	dweebie.gif	Scale: 0 Cap: 200 Init: 20 Meat: 40 P: dude Article: a	Ogres and Oubliettes&trade; module (15)	Mountain Stream Code Black Alert (15)	slide rule (5)	folder (Yedi) (10)	Dweebisol&trade; inhaler (c0)
+dweebie	1355	dweebie.gif	Scale: 0 Cap: 200 Init: 20 Meat: 40 P: dude EA: sleaze Article: a	Ogres and Oubliettes&trade; module (15)	Mountain Stream Code Black Alert (15)	slide rule (5)	folder (Yedi) (10)	Dweebisol&trade; inhaler (c0)
 Fran&ccedil;ois Verte, Art Teacher	1423	artteacher.gif	LUCKY Scale: 6 Cap: 200 Init: 100 Meat: 60 P: dude Manuel: "François Verte, Art Teacher"	lump of clay (100)	angry inch (100)	eraser nubbin (100)	twisted piece of wire (100)	tomato soup poster (c0)
 misproportioned portrait	1369	badportrait.gif	Scale: 3 Cap: 200 Init: -10000 P: construct Article: a	eraser nubbin (25)	eraser nubbin (10)
 motorhead	1357	motorhead.gif	Scale: 1 Cap: 200 Init: 40 Meat: 30 P: dude Article: a	pickelhaube (5)	hair oil (15)	scrap metal (15)	folder (sports car) (10)	Lewd Lemmy Hair Oil (c0)
-Mrs. K, the Chemistry Teacher	1424	chemteacher.gif	LUCKY Scale: 6 Cap: 200 Init: 100 Meat: 60 P: dude	chlorine crystal (100)	ph balancer (100)	mysterious chemical residue (100)	nugget of sodium (100)
+Mrs. K, the Chemistry Teacher	1424	chemteacher.gif	LUCKY Scale: 6 Cap: 200 Init: 100 Meat: 60 P: dude EA: hot	chlorine crystal (100)	ph balancer (100)	mysterious chemical residue (100)	nugget of sodium (100)
 out-of-control bandsaw	1358	bandsaw.gif	Scale: 3 Cap: 200 Init: 20 P: construct Article: an	balsa plank (25)	balsa plank (10)
 possessed eyewashing station	1366	eyewash.gif	Scale: 3 Cap: 200 Init: 20 P: demon Article: a	chlorine crystal (25)	chlorine crystal (10)
-Principal Mooney	1425	chalmers.gif	NOCOPY Atk: 220 Def: 210 HP: 1000 Init: 10000 P: dude
+Principal Mooney	1425	chalmers.gif	NOCOPY Atk: 220 Def: 210 HP: 1000 Init: 10000 P: dude EA: spooky
 rulergheist	1367	rulergolem.gif	Scale: 4 Cap: 200 Init: 20 P: undead Article: a	angry inch (25)	angry inch (10)
 screw golem	1361	screwgolem.gif	Scale: 4 Cap: 200 Init: 40 P: construct Article: a	wood screw (25)	wood screw (10)
-sodium golem	1365	sodium.gif	Scale: 4 Cap: 200 Init: 40 P: construct Article: a	nugget of sodium (25)	nugget of sodium (10)
+sodium golem	1365	sodium.gif	Scale: 4 Cap: 200 Init: 40 P: construct EA: hot Article: a	nugget of sodium (25)	nugget of sodium (10)
 sporto	1356	sporto.gif	Scale: 2 Cap: 200 Init: 60 Meat: 30 P: dude Article: a	surgical tape (15)	folder (sportsballs) (10)	stepmom's booze (15)	twisted-up wet towel (5)
 wastoid	1354	wastoid.gif	Scale: -1 Cap: 200 Init: -10000 Meat: 20 P: dude Article: a	fountain 'soda' (15)	illegal firecracker (15)	metal band T-shirt (5)	folder (heavy metal) (10)	Redeye&trade; Eyedrops (c0)
-wire sculpture	1370	wiresculpture.gif	Scale: 4 Cap: 200 Init: 40 P: construct Article: a	twisted piece of wire (25)	twisted piece of wire (10)
+wire sculpture	1370	wiresculpture.gif	Scale: 4 Cap: 200 Init: 40 P: construct EA: hot Article: a	twisted piece of wire (25)	twisted piece of wire (10)
 X-fingered Shop Teacher	1360	shopteacher.gif	LUCKY Scale: 6 Cap: 200 Init: 100 P: dude Article: the	jigsaw blade (100)	wood screw (100)	balsa plank (100)	blob of wood glue (100)
 
 # Avatar of Sneaky Pete
-The Avatar of Jarlsberg	1535	aojarls.gif	NOCOPY Atk: 240 Def: 180 HP: 600 Init: 100 P: dude Elem: 50
+The Avatar of Jarlsberg	1535	aojarls.gif	NOCOPY Atk: 240 Def: 180 HP: 600 Init: 100 P: dude Elem: 50 EA: hot EA: sleaze
 
 # Heavy Rains
-alley catfish	1600	catfish.gif	WANDERER Scale: -35 Init: 70 Meat: 80 P: fish Article: an	catfish whiskers (0)
-Aquabat	1605	aquabat.gif	BOSS NOCOPY Atk: 36 Def: 34 HP: 36 Init: 50 P: beast Article: the	neoprene skullcap (n100)
+alley catfish	1600	catfish.gif	WANDERER Scale: -35 Init: 70 Meat: 80 P: fish EA: sleaze Article: an	catfish whiskers (0)
+Aquabat	1605	aquabat.gif	BOSS NOCOPY Atk: 36 Def: 34 HP: 36 Init: 50 P: beast EA: spooky Article: the	neoprene skullcap (n100)
 aquaconda	1603	aquaconda.gif	NOCOPY WANDERER Atk: 80 Def: 80 HP: 120 Init: 80 P: beast Article: an	aquaconda brain (n100)
 Aquagoblin	1606	aquagoblin.gif	BOSS NOCOPY Atk: 55 Def: 50 HP: 69 Init: 50 P: goblin Article: the	goblin water (n100)
-Auqadargon	1607	aquadargon.gif	BOSS NOCOPY Atk: 99 Def: 90 HP: 140 Init: 90 P: undead Article: the	chest of the Bonerdagon (n100)
-Big Wisnaqua	1612	aquaniewski.gif	BOSS NOCOPY Atk: 260 Def: 240 HP: 2000 Init: 60 P: dude Article: the	Wet Russian (n100)
+Auqadargon	1607	aquadargon.gif	BOSS NOCOPY Atk: 99 Def: 90 HP: 140 Init: 90 P: undead EA: hot Article: the	chest of the Bonerdagon (n100)
+Big Wisnaqua	1612	aquaniewski.gif	BOSS NOCOPY Atk: 260 Def: 240 HP: 2000 Init: 60 P: dude EA: stench Article: the	Wet Russian (n100)
 Dr. Aquard	1608	aquard.gif	BOSS NOCOPY Atk: 180 Def: 165 HP: 260 Init: -10000 P: dude	Sogg-Os (n100)	dumb mud (n100)
 freshwater bonefish	1599	bonefish.gif	WANDERER Scale: -27 Init: 50 Meat: 60 P: fish Article: a	freshwater fishbone (0)	freshwater fishbone (0)
 giant isopod	1597	isopod.gif	WANDERER Scale: -11 Init: 10 Meat: 20 P: bug Article: a	freshwater fishbone (0)
-giant tardigrade	1604	tardigrade.gif	NOCOPY WANDERER Atk: 40 Def: 40 HP: 60 Init: 40 P: bug Article: a	thunder thigh (n100)	baggie of regular-sized tardigrades (c0)
-gourmet gourami	1598	gourami.gif	WANDERER Scale: -19 Init: 30 Meat: 40 P: fish Article: a	gourmet gourami oil (0)
+giant tardigrade	1604	tardigrade.gif	NOCOPY WANDERER Atk: 40 Def: 40 HP: 60 Init: 40 P: bug EA: sleaze EA: spooky Article: a	thunder thigh (n100)	baggie of regular-sized tardigrades (c0)
+gourmet gourami	1598	gourami.gif	WANDERER Scale: -19 Init: 30 Meat: 40 P: fish EA: sleaze Article: a	gourmet gourami oil (0)
 Gurgle	1611	gurgle.gif	BOSS NOCOPY Atk: 125 Def: 115 HP: 280 Init: 60 P: beast	liquid ice (n100)
-Lord Soggyraven	1609	soggyraven.gif	BOSS NOCOPY Atk: 175 Def: 160 HP: 260 Init: 50 P: undead	Lord Soggyraven's Slippers (n100)
+Lord Soggyraven	1609	soggyraven.gif	BOSS NOCOPY Atk: 175 Def: 160 HP: 260 Init: 50 P: undead EA: cold EA: hot EA: sleaze EA: spooky EA: stench	Lord Soggyraven's Slippers (n100)
 piranhadon	1601	piranhadon.gif	WANDERER Scale: -43 Init: 90 Meat: 100 P: fish Article: a	freshwater fishbone (0)	freshwater fishbone (0)	freshwater fishbone (0)
-Protector Spurt	1610	spurt.gif	BOSS NOCOPY Atk: 170 Def: 160 HP: 140 Init: 50 P: undead Article: a	Ancient Protector Soda (n100)
+Protector Spurt	1610	spurt.gif	BOSS NOCOPY Atk: 170 Def: 160 HP: 140 Init: 50 P: undead EA: hot Article: a	Ancient Protector Soda (n100)
 storm cow	1602	stormcow.gif	NOCOPY WANDERER Atk: 160 Def: 160 HP: 240 Init: 160 P: beast Article: a	lightning milk (n100)
 The Aquaman	1613	theaquaman.gif	BOSS NOCOPY Atk: 260 Def: 240 HP: 2000 Init: 60 P: dude	filet of The Fish (n100)
-The Rain King	1614	rainking.gif	BOSS NOCOPY Atk: 280 Def: 250 HP: 800 Init: 10000 P: dude
+The Rain King	1614	rainking.gif	BOSS NOCOPY Atk: 280 Def: 250 HP: 800 Init: 10000 P: dude EA: spooky
 
 # Actually Ed the Undying
 Boss Bat?	1664	deadbossbat.gif	BOSS NOCOPY Atk: 33 Def: 29 HP: 40 Init: 60 P: undead Article: The
 new Knob Goblin King	1665	kg_king.gif	BOSS NOCOPY Atk: 53 Def: 47 HP: 50 Exp: [66+ML/3] Init: 100 P: goblin Article: The
-Donerbagon	1666	donerbagon.gif	BOSS NOCOPY Atk: 90 Def: 81 HP: 120 Init: 90 P: undead E: spooky Item: 25 Skill: 50 Article: The
+Donerbagon	1666	donerbagon.gif	BOSS NOCOPY Atk: 90 Def: 81 HP: 120 Init: 90 P: undead ED: spooky Item: 25 Skill: 50 Article: The
 Your winged yeti	1667	wingedyeti.gif	BOSS NOCOPY Atk: 120 Def: 108 HP: 250 Init: 50 P: beast E: cold Wiki: "winged yeti"
-hulking bridge troll	1668	bridgetroll.gif	BOSS NOCOPY Atk: 100 Def: 100 HP: 140 Init: 50 Meat: 50 P: humanoid Article: a
+hulking bridge troll	1668	bridgetroll.gif	BOSS NOCOPY Atk: 100 Def: 100 HP: 140 Init: 50 Meat: 50 P: humanoid EA: sleaze Article: a
 You the Adventurer	1669		BOSS NOCOPY Atk: 240 Def: 210 HP: 900 Init: 150 P: dude Wiki: "%playername the Adventurer"
 warehouse guard	1740	warehouseguard.gif	Atk: 210 Def: 230 HP: 250 Init: 50 Meat: 50 P: dude Article: a	warehouse map page (10)	warehouse walkie-talkie (c15)
 warehouse janitor	1741	warehousejanitor.gif	Atk: 230 Def: 230 HP: 230 Init: 150 Meat: 30 P: dude Article: a	janitor sponge (10)	janitor's mop (c15)
 warehouse clerk	1742	warehouseclerk.gif	Atk: 220 Def: 240 HP: 210 Init: 200 Meat: 75 P: dude Article: a	warehouse inventory page (10)	warehouse clerk's glasses (c15)
 
 # Avatar of West of Loathing
-furious cow	1926	awolcow1.gif	WANDERER Scale: 0 Cap: ? Floor: ? Init: -10000 P: demon Article: a
+furious cow	1926	awolcow1.gif	WANDERER Scale: 0 Cap: ? Floor: ? Init: -10000 P: demon EA: hot EA: sleaze Article: a
 furious giant cow	1929	awolcow2.gif	WANDERER Scale: 20 Cap: ? Floor: ? Init: -10000 P: demon Article: a
-ungulith	1932	awolcow3.gif	WANDERER Scale: 40 Cap: ? Floor: ? Init: -10000 P: demon Article: an
+ungulith	1932	awolcow3.gif	WANDERER Scale: 40 Cap: ? Floor: ? Init: -10000 P: demon EA: cold EA: hot EA: sleaze EA: stench Article: an
 
-emaciated rodeo clown	1927	awolclown1.gif	WANDERER Scale: 0 Cap: ? Floor: ? Init: -10000 P: horror Article: an
-menacing rodeo clown	1930	awolclown2.gif	WANDERER Scale: 20 Cap: ? Floor: ? Init: -10000 P: horror Article: a
-grizzled rodeo clown	1933	awolclown3.gif	WANDERER Scale: 40 Cap: ? Floor: ? Init: -10000 P: horror Article: a
+emaciated rodeo clown	1927	awolclown1.gif	WANDERER Scale: 0 Cap: ? Floor: ? Init: -10000 P: horror EA: spooky Article: an
+menacing rodeo clown	1930	awolclown2.gif	WANDERER Scale: 20 Cap: ? Floor: ? Init: -10000 P: horror EA: spooky Article: a
+grizzled rodeo clown	1933	awolclown3.gif	WANDERER Scale: 40 Cap: ? Floor: ? Init: -10000 P: horror EA: spooky EA: stench Article: a
 
 aggressive grass snake	1928	awolsnake1.gif	WANDERER Scale: 0 Cap: ? Floor: ? Init: -10000 P: beast SNAKE Article: an
-prince snake	1931	awolsnake2.gif	WANDERER Scale: 20 Cap: ? Floor: ? Init: -10000 P: beast SNAKE E: sleaze Article: a	snake oil (100)	snake oil (100)
+prince snake	1931	awolsnake2.gif	WANDERER Scale: 20 Cap: ? Floor: ? Init: -10000 P: beast SNAKE ED: sleaze Article: a	snake oil (100)	snake oil (100)
 king snake	1934	awolsnake3.gif	WANDERER Scale: 40 Cap: ? Floor: ? Init: -10000 P: beast SNAKE Article: a	snake oil (100)	snake oil (100)	snake oil (100)
 
 # The Source
-Source Agent	1945	sourceagent.gif	Atk: [30+30*pref(sourceAgentsDefeated)+ML] Def: [30+30*pref(sourceAgentsDefeated)+ML] HP: [40+40*pref(sourceAgentsDefeated)+ML] Exp: [((30+30*pref(sourceAgentsDefeated))/4+ML/3)*15] Init: [25+25*pref(sourceAgentsDefeated)] P: construct
-One Thousand Source Agents	1944	sourceagents.gif	NOCOPY Atk: 500 Def: 500 HP: 700 Init: -10000 P: construct Article: a
+Source Agent	1945	sourceagent.gif	Atk: [30+30*pref(sourceAgentsDefeated)+ML] Def: [30+30*pref(sourceAgentsDefeated)+ML] HP: [40+40*pref(sourceAgentsDefeated)+ML] Exp: [((30+30*pref(sourceAgentsDefeated))/4+ML/3)*15] Init: [25+25*pref(sourceAgentsDefeated)] P: construct EA: cold EA: hot EA: sleaze EA: spooky EA: stench
+One Thousand Source Agents	1944	sourceagents.gif	NOCOPY Atk: 500 Def: 500 HP: 700 Init: -10000 P: construct EA: cold EA: hot EA: sleaze EA: spooky EA: stench Article: a
 
 # License to Adventure (May 2017)
 "Blofeld"	2028	bond_villain5.gif	NOCOPY Atk: 100 Def: 100 HP: 100 Init: 10 P: dude
 Villainous Minion	2024	bond_minion1.gif,bond_minion2.gif,bond_minion3.gif,bond_minion4.gif	Scale: -2 Cap: ? Floor: ? Init: 50 P: dude Article: A
 Villainous Henchperson	2025	bond_sidekick1.gif,bond_sidekick2.gif,bond_sidekick3.gif,bond_sidekick4.gif,bond_sidekick5.gif,bond_sidekick6.gif,bond_sidekick7.gif,bond_sidekick8.gif,bond_sidekick9.gif	NOCOPY Scale: 10 Cap: ? Floor: ? Init: -10000 P: dude Article: The
-Villainous Villain	2026	bond_villain1.gif,bond_villain2.gif,bond_villain3.gif,bond_villain4.gif,bond_villain5.gif,bond_villain6.gif,bond_villain7.gif	NOCOPY Scale: 11 Cap: ? Floor: ? Init: -10000 P: dude
+Villainous Villain	2026	bond_villain1.gif,bond_villain2.gif,bond_villain3.gif,bond_villain4.gif,bond_villain5.gif,bond_villain6.gif,bond_villain7.gif	NOCOPY Scale: 11 Cap: ? Floor: ? Init: -10000 P: dude EA: cold EA: hot EA: stench
 
 # Pocket Familiars
 Jerry Bradford	2050	larryscrote.gif	NOCOPY Atk: 35 Def: 0 HP: 0 Init: -10000 P: dude Wiki: "Jerry Bradford (Boss Bat)"	batskin belt (n100)	dense Meat stack (n100)
@@ -1273,22 +1273,22 @@ Jerry Bradford	2058	larryscrote.gif	NOCOPY Atk: 200 Def: 0 HP: 0 Init: -10000 P:
 Jerry Bradford, Pokéfam World Champion	2059	larryscrote.gif	NOCOPY Atk: 250 Def: 0 HP: 0 Init: -10000 P: dude
 
 # Dark Gyffte
-Steve Belmont	2105	stevebelmont.gif	BOSS NOCOPY Atk: 40 Def: 40 HP: 50 Init: 100 P: dude	white money bag (n100)
+Steve Belmont	2105	stevebelmont.gif	BOSS NOCOPY Atk: 40 Def: 40 HP: 50 Init: 100 P: dude EA: hot	white money bag (n100)
 Ricardo Belmont	2106	ricardobelmont.gif	BOSS NOCOPY Atk: 60 Def: 60 HP: 80 Init: 150 P: dude	white money bag (n100)
-Jayden Belmont	2107	jaydenbelmont.gif	BOSS NOCOPY Atk: 100 Def: 100 HP: 150 Init: 200 P: dude	red money bag (n100)
-Travis Belmont	2108	travisbelmont.gif	BOSS NOCOPY Atk: 200 Def: 200 HP: 250 Init: 250 P: dude	red money bag (n100)	Staff of Fats (n100)
+Jayden Belmont	2107	jaydenbelmont.gif	BOSS NOCOPY Atk: 100 Def: 100 HP: 150 Init: 200 P: dude EA: sleaze EA: spooky	red money bag (n100)
+Travis Belmont	2108	travisbelmont.gif	BOSS NOCOPY Atk: 200 Def: 200 HP: 250 Init: 250 P: dude EA: hot	red money bag (n100)	Staff of Fats (n100)
 Greg Dagreasy	2109	gregdagreasy.gif	BOSS NOCOPY Atk: 200 Def: 300 HP: 200 Init: 250 P: dude	red money bag (n100)	Eye of Ed (100)
-Sylvia Belgrande	2110	sylviabelgrande.gif	BOSS NOCOPY Atk: 200 Def: 200 HP: 200 Init: 250 P: dude	red money bag (n100)	ancient amulet (100)
-Sharona	2111	sharona.gif	BOSS NOCOPY Atk: 150 Def: 150 HP: 250 Init: 150 P: dude	red money bag (n100)
-Jake Norris	2112	jakenorris.gif	BOSS NOCOPY Atk: 250 Def: 250 HP: 2000 Init: 300 P: dude	blue money bag (n100)
-Chad Alacarte	2113	chadalacarte.gif	BOSS NOCOPY Atk: 250 Def: 250 HP: 2000 Init: 300 P: dude	blue money bag (n100)
-%alucard%	2114	reyalpeht.gif	BOSS NOCOPY Atk: 300 Def: 300 HP: 1000 Init: 10000 P: dude
-Your Lack of Reflection	2115	towermirror.gif	BOSS NOCOPY Atk: 100 Def: 100 HP: 3000 Init: -10000 P: horror
+Sylvia Belgrande	2110	sylviabelgrande.gif	BOSS NOCOPY Atk: 200 Def: 200 HP: 200 Init: 250 P: dude EA: cold EA: hot	red money bag (n100)	ancient amulet (100)
+Sharona	2111	sharona.gif	BOSS NOCOPY Atk: 150 Def: 150 HP: 250 Init: 150 P: dude EA: cold	red money bag (n100)
+Jake Norris	2112	jakenorris.gif	BOSS NOCOPY Atk: 250 Def: 250 HP: 2000 Init: 300 P: dude EA: hot EA: stench	blue money bag (n100)
+Chad Alacarte	2113	chadalacarte.gif	BOSS NOCOPY Atk: 250 Def: 250 HP: 2000 Init: 300 P: dude EA: hot EA: stench	blue money bag (n100)
+%alucard%	2114	reyalpeht.gif	BOSS NOCOPY Atk: 300 Def: 300 HP: 1000 Init: 10000 P: dude EA: hot EA: stench
+Your Lack of Reflection	2115	towermirror.gif	BOSS NOCOPY Atk: 100 Def: 100 HP: 3000 Init: -10000 P: horror EA: spooky
 
 # Kingdom of Exploathing
 invader bullet	2137	invaderbullet.gif	WANDERER Scale: 20 Cap: ? Floor: ? Init: 10000 P: construct Article: an
 skeleton astronaut	2136	astroskeleton.gif	WANDERER Atk: 100 Def: 100 HP: 100 Init: 100 P: undead Article: a
-the invader	2138	invader.gif	BOSS NOCOPY Atk: 1000 Def: 1000 HP: 1000 Init: -10000 P: construct
+the invader	2138	invader.gif	BOSS NOCOPY Atk: 1000 Def: 1000 HP: 1000 Init: -10000 P: construct EA: cold EA: hot EA: sleaze EA: spooky EA: stench
 
 # Glitch Season
 %monster%	2140	nopic.gif	NOCOPY Atk: [pref(glitchItemImplementationCount)*5+1] Def: [pref(glitchItemImplementationCount)*5] HP: [pref(glitchItemImplementationCount)*5+1] Init: 1 P: construct Article: a
@@ -1296,13 +1296,13 @@ the invader	2138	invader.gif	BOSS NOCOPY Atk: 1000 Def: 1000 HP: 1000 Init: -100
 # Path of the Plumber
 Koopa Paratroopa	2165	paratroopa.gif	BOSS NOCOPY Atk: 40 Def: 40 HP: 40 Init: 50 P: beast Elem: 50 Article: a
 Hammer Brother	2166	hammerbrother.gif	BOSS NOCOPY Atk: 60 Def: 60 HP: 80 Init: 50 P: beast Article: a
-Very Dry Bones	2167	drybones.gif	BOSS NOCOPY Atk: 100 Def: 100 HP: 150 Init: 50 P: undead Article: a
-Birdo	2168	birdo.gif	BOSS NOCOPY Atk: 180 Def: 180 HP: 300 Init: 50 P: beast	Staff of Fats (n100)
-King Boo	2169	kingboo2.gif	BOSS NOCOPY Atk: 180 Def: 180 HP: 300 Init: 50 P: undead Phys: 100	Eye of Ed (n100)
-Kamek	2170	kamek.gif	BOSS NOCOPY Atk: 180 Def: 180 HP: 200 Init: 50 P: beast Phys: 100	ancient amulet (n100)
-Angry Sun	2171	angrysun.gif	BOSS NOCOPY Atk: 130 Def: 130 HP: 300 Init: 50 P: weird
-Bowser	2172	bowser.gif	BOSS NOCOPY Atk: 300 Def: 300 HP: 400 Init: 50 P: beast Wiki: "Bowser (Hippy Camp)"
-Bowser	2173	bowser.gif	BOSS NOCOPY Atk: 300 Def: 300 HP: 400 Init: 50 P: beast Wiki: "Bowser (Orcish Frat House)"
+Very Dry Bones	2167	drybones.gif	BOSS NOCOPY Atk: 100 Def: 100 HP: 150 Init: 50 P: undead EA: spooky Article: a
+Birdo	2168	birdo.gif	BOSS NOCOPY Atk: 180 Def: 180 HP: 300 Init: 50 P: beast EA: sleaze EA: stench	Staff of Fats (n100)
+King Boo	2169	kingboo2.gif	BOSS NOCOPY Atk: 180 Def: 180 HP: 300 Init: 50 P: undead Phys: 100 EA: spooky	Eye of Ed (n100)
+Kamek	2170	kamek.gif	BOSS NOCOPY Atk: 180 Def: 180 HP: 200 Init: 50 P: beast Phys: 100 EA: hot	ancient amulet (n100)
+Angry Sun	2171	angrysun.gif	BOSS NOCOPY Atk: 130 Def: 130 HP: 300 Init: 50 P: weird EA: hot
+Bowser	2172	bowser.gif	BOSS NOCOPY Atk: 300 Def: 300 HP: 400 Init: 50 P: beast EA: hot Wiki: "Bowser (Hippy Camp)"
+Bowser	2173	bowser.gif	BOSS NOCOPY Atk: 300 Def: 300 HP: 400 Init: 50 P: beast EA: hot Wiki: "Bowser (Orcish Frat House)"
 Wa%playername/lowercase%	2174	waplayer.gif	BOSS NOCOPY Atk: 300 Def: 300 HP: 1000 Init: 10000 P: dude	red coin (n100)
 
 # Grey Goo
@@ -1328,28 +1328,28 @@ grey goo triangle	2179	goo_triangle.gif	NOCOPY Atk: 0 Def: 0 HP: 0 Init: -10000 
 grey gooblin	2189	goo_blin1.gif,goo_blin2.gif,goo_blin3.gif,goo_blin4.gif,goo_blin5.gif	NOCOPY Atk: 0 Def: 0 HP: 0 Init: -10000 P: construct Article: a
 
 # You, Robot
-Boss Bot	2201	roboss_bat.gif	BOSS NOCOPY Atk: 30 Def: 30 HP: 40 Init: 60 P: construct Article: the	robo-battery (n100)
-Gobot King	2202	roboss_goblin.gif	BOSS NOCOPY Atk: 50 Def: 50 HP: 50 Init: 100 P: construct Article: the	robo-battery (n100)
-Robonerdagon	2203	roboss_dagon.gif	BOSS NOCOPY Atk: 90 Def: 80 HP: 120 Init: 90 P: construct Article: the	robo-battery (n100)
+Boss Bot	2201	roboss_bat.gif	BOSS NOCOPY Atk: 30 Def: 30 HP: 40 Init: 60 P: construct EA: hot Article: the	robo-battery (n100)
+Gobot King	2202	roboss_goblin.gif	BOSS NOCOPY Atk: 50 Def: 50 HP: 50 Init: 100 P: construct EA: hot Article: the	robo-battery (n100)
+Robonerdagon	2203	roboss_dagon.gif	BOSS NOCOPY Atk: 90 Def: 80 HP: 120 Init: 90 P: construct EA: cold EA: hot EA: sleaze EA: spooky EA: stench Article: the	robo-battery (n100)
 Tobias J. Saibot	2204	roboss_saibot.gif	BOSS NOCOPY Atk: 180 Def: 160 HP: 200 Init: -10000 P: construct	robo-battery (n100)	Staff of Fats (n100)
-Lord Cyberraven	2205	roboss_spooky.gif	BOSS NOCOPY Atk: 170 Def: 150 HP: 200 Init: 10000 P: construct	robo-battery (n100)	Eye of Ed (n100)
+Lord Cyberraven	2205	roboss_spooky.gif	BOSS NOCOPY Atk: 170 Def: 150 HP: 200 Init: 10000 P: construct EA: hot	robo-battery (n100)	Eye of Ed (n100)
 Protector S. P. E. C. T. R. E.	2206	roboss_spectre.gif	BOSS NOCOPY Atk: 165 Def: 150 HP: 100 Init: 30 P: construct Article: the	robo-battery (n100)	ancient amulet (n100)
-Groarbot	2207	roboss_groar.gif	BOSS NOCOPY Atk: 120 Def: 110 HP: 250 Init: 50 P: construct	robo-battery (n100)
-The Artificial Wisniewski	2208	roboss_dude.gif	BOSS NOCOPY Atk: 250 Def: 230 HP: 2000 Init: 60 P: construct	robo-battery (n100)
+Groarbot	2207	roboss_groar.gif	BOSS NOCOPY Atk: 120 Def: 110 HP: 250 Init: 50 P: construct EA: cold EA: hot	robo-battery (n100)
+The Artificial Wisniewski	2208	roboss_dude.gif	BOSS NOCOPY Atk: 250 Def: 230 HP: 2000 Init: 60 P: construct EA: hot	robo-battery (n100)
 The Android	2209	roboss_man.gif	BOSS NOCOPY Atk: 250 Def: 230 HP: 2000 Init: 60 P: construct	robo-battery (n100)
-Nautomatic Sorceress	2210	roboss_sorc.gif	BOSS NOCOPY Atk: 300 Def: 300 HP: 1000 Init: 10000 P: construct Phys: 50 Elem: 50 Article: the
+Nautomatic Sorceress	2210	roboss_sorc.gif	BOSS NOCOPY Atk: 300 Def: 300 HP: 1000 Init: 10000 P: construct Phys: 50 Elem: 50 EA: hot EA: sleaze Article: the
 
 # Wildfires
 Blaze Bat	2211	firebossbat.gif	BOSS NOCOPY Atk: 33 Def: 29 HP: 40 Init: 60 P: beast E: hot Article: The	batskin belt (100)	dense Meat stack (100)	Boss Bat britches (c100)	boss Bat bling (c100)
 fired-up Knob Goblin King	2212	firegoblinking.gif	BOSS NOCOPY Atk: 53 Def: 47 HP: 50 Init: 100 P: goblin E: hot Article: The	dense meat stack (100)	dense meat stack (100)
-Burnerdagon	2213	burnerdagon.gif	BOSS NOCOPY Atk: 90 Def: 81 HP: 120 Init: 90 P: undead E: hot Article: The	skull of the Bonerdagon (n100)	chest of the Bonerdagon (n100)
+Burnerdagon	2213	burnerdagon.gif	BOSS NOCOPY Atk: 90 Def: 81 HP: 120 Init: 90 P: undead ED: hot EA: spooky Article: The	skull of the Bonerdagon (n100)	chest of the Bonerdagon (n100)
 Dr. Awkward, who is on fire	2214	fireawkward.gif	BOSS NOCOPY Atk: 175 Def: 157 HP: 200 Init: -10000 P: dude E: hot	Drowsy Sword (n100)	Staff of Fats (n100)
 Lord Sootyraven	2215	fireyraven.gif	BOSS NOCOPY Atk: 165 Def: 148 HP: 200 Init: 10000 P: undead E: hot	Eye of Ed (n100)	Lord Spookyraven's ear trumpet (n100)
 Protector Spectre (Wildfire)	2216	firespectre.gif	BOSS NOCOPY Atk: 164 Def: 151 HP: 100 Init: 30 P: undead Phys: 100 E: hot Article: a Manuel: "Protector Spectre"	ancient amulet (n100)	spectre scepter (n100)
-Groar, Except Hot	2217	firegroar.gif	BOSS NOCOPY Atk: 120 Def: 108 HP: 250 Init: 50 P: beast E: hot	Groar's fur (100)	dense meat stack (100)	dense meat stack (100)	dense meat stack (100)	dense meat stack (100)	dense meat stack (100)
+Groar, Except Hot	2217	firegroar.gif	BOSS NOCOPY Atk: 120 Def: 108 HP: 250 Init: 50 P: beast ED: hot EA: cold EA: hot	Groar's fur (100)	dense meat stack (100)	dense meat stack (100)	dense meat stack (100)	dense meat stack (100)	dense meat stack (100)
 The Big Ignatowicz	2218	firethedude.gif	BOSS NOCOPY Atk: 250 Def: 225 HP: 2000 Init: 60 P: hippy E: hot	solid gold bowling ball (100)
 The Man on Fire	2219	firetheman.gif	BOSS NOCOPY Atk: 250 Def: 225 HP: 2000 Init: 60 P: dude E: hot	really dense meat stack (100)
-The Naughty Scorcheress	2220	sorcform1.gif	BOSS NOCOPY Atk: 190 Def: 171 HP: 400 Init: 10000 P: dude E: hot Article: The	Instant Karma (c100)	Thwaitgold maggot statuette (n100)
+The Naughty Scorcheress	2220	sorcform1.gif	BOSS NOCOPY Atk: 190 Def: 171 HP: 400 Init: 10000 P: dude ED: hot Article: The	Instant Karma (c100)	Thwaitgold maggot statuette (n100)
 
 # Items of the Month
 
@@ -1382,25 +1382,25 @@ raven	579	raven.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,M
 usher	578	usher.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 50 P: dude Article: an	patent antipsychotics (20)
 
 # Rogue Windmill (Green Pixie June 2007)
-can-can dancer	587	cancan.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 70 P: dude Article: a	can-can-in-a-can (20)
-courtesan	589	courtesan.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 60 P: dude Article: a	bottle of realpagne (20)
-master of ceremonies	588	promoter.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 60 P: dude Article: the	escargotsicle (20)	Rogue Windmill Rouge (c0)
+can-can dancer	587	cancan.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 70 P: dude EA: sleaze Article: a	can-can-in-a-can (20)
+courtesan	589	courtesan.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 60 P: dude EA: sleaze Article: a	bottle of realpagne (20)
+master of ceremonies	588	promoter.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 60 P: dude EA: sleaze Article: the	escargotsicle (20)	Rogue Windmill Rouge (c0)
 sensitive poet-type	591	sadpoet.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 60 P: dude Article: a	sensitive poetry journal (20)	A muse-bouche (c0)
 voyeuristic artist	590	smallartist.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 50 P: dude Article: a	Bohemian rhapsody (20)
 
 # Stately Pleasure Dome (Green Pixie June 2007)
 Ancient Mariner	582	mariner.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 50 P: dude Article: an	Mariner's Friend cough drops (20)
-angry poet	585	madpoet.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 60 P: dude Article: an	honey-dew (10)	white Xanadian (0)
-Kubla Khan	583	kublakhan.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 60 P: dude
+angry poet	585	madpoet.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 60 P: dude EA: sleaze Article: an	honey-dew (10)	white Xanadian (0)
+Kubla Khan	583	kublakhan.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 60 P: dude EA: cold EA: hot EA: sleaze
 roller-skating Muse	586	muse.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 70 P: dude Article: a	bottled inspiration (20)
-toothless mastiff bitch	584	mastiff.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 50 P: beast Article: a	disintegrating spiky collar (20)
+toothless mastiff bitch	584	mastiff.gif	Atk: [max(min(125,MOX*1.1),5)+max(ML,0)] Def: [max(min(125,MUS),5)+max(ML,0)] HP: [max(min(100,0.8*(min(125,MUS)+max(ML,0))),5)+max(ML,0)*0.75] Exp: [max(min(125,STAT*1.1),5)/4+max(ML,0)/3] Init: 50 P: beast EA: spooky Article: a	disintegrating spiky collar (20)
 
 # Mt. Molehill (Llama Lama June 2008)
 digital underground dweller	709	digitalug.gif	Scale: 0 Cap: 200 Init: -10000 P: humanoid Article: a
 dwarvish gnome	712	dwarfgnome.gif	Scale: 0 Cap: 200 Init: -10000 P: humanoid Article: a
 spelunking astronaut	711	spelastronaut.gif	Scale: 0 Cap: 200 Init: -10000 P: dude Article: a	compressed air canister (c0)
 velvet underground dweller	710	velvetug.gif	Scale: 0 Cap: 200 Init: -10000 P: humanoid Article: a
-weather underground dweller	708	weatherug.gif	Scale: 0 Cap: 200 Init: -10000 P: humanoid Article: a
+weather underground dweller	708	weatherug.gif	Scale: 0 Cap: 200 Init: -10000 P: humanoid EA: cold EA: hot EA: sleaze EA: spooky EA: stench Article: a
 
 # Memories of the Very Beginning (Baby Sandworm June 2009)
 cluster of angry bacteria	814	prim_bact.gif	Atk: 20 Def: 18 HP: 25 Init: 50 P: bug Article: a	memory of an A (20)	memory of a G (20)
@@ -1424,13 +1424,13 @@ wumpus	821	wumpus.gif	NOCOPY Atk: 66 Def: 59 HP: 66 Init: 66 P: beast Article: a
 high priest of Ki'rhuss	829	highpriest.gif	NOCOPY Atk: 110 Def: 99 HP: 110 Init: 50 P: dude Article: a
 
 # Memories of the Distant Future (Baby Sandworm June 2009)
-"Handyman" Jay Android	823	handymanjay.gif	Atk: 150 Def: 135 HP: 150 Init: 80 P: construct Article: a	neurostim pill (0)	physiostim pill (0)	sham champagne (0)	essence of kink (c100)	handyman &quot;hand soap&quot; (c0)
-7-Foot Dwarf Replicant	825	miner.gif	Atk: 145 Def: 130 HP: 155 Init: 60 P: construct Article: a	cyber-mattock (0)	neurostim pill (0)	essence of stench (c100)
-Bangyomaman Warrior	822	bangyomama.gif	Atk: 150 Def: 126 HP: 160 Init: 20 P: dude Article: a	neurostim pill (0)	X-37 gun (0)	essence of heat (c100)	Bangyomaman battle juice (c0)
+"Handyman" Jay Android	823	handymanjay.gif	Atk: 150 Def: 135 HP: 150 Init: 80 P: construct EA: sleaze Article: a	neurostim pill (0)	physiostim pill (0)	sham champagne (0)	essence of kink (c100)	handyman &quot;hand soap&quot; (c0)
+7-Foot Dwarf Replicant	825	miner.gif	Atk: 145 Def: 130 HP: 155 Init: 60 P: construct EA: stench Article: a	cyber-mattock (0)	neurostim pill (0)	essence of stench (c100)
+Bangyomaman Warrior	822	bangyomama.gif	Atk: 150 Def: 126 HP: 160 Init: 20 P: dude EA: hot Article: a	neurostim pill (0)	X-37 gun (0)	essence of heat (c100)	Bangyomaman battle juice (c0)
 cyborg policeman	834	cybercop.gif	Atk: 160 Def: 144 HP: 160 Init: 50 P: construct Article: a	physiostim pill (0)	protein paste (0)	oil-filled donut (c0)
-liquid metal robot	824	liquidmetal.gif	Atk: 140 Def: 144 HP: 150 Init: 100 P: construct Article: a	physiostim pill (0)	pool of liquid metal (0)	essence of cold (c100)
+liquid metal robot	824	liquidmetal.gif	Atk: 140 Def: 144 HP: 150 Init: 100 P: construct EA: cold Article: a	physiostim pill (0)	pool of liquid metal (0)	essence of cold (c100)
 obese tourist	835	tourist.gif	Atk: 140 Def: 135 HP: 200 Init: -10000 P: dude Article: an	cupcake-in-a-cup (0)	neurostim pill (0)
-Space Marine	826	spacemarine.gif	Atk: 160 Def: 135 HP: 140 Init: 40 P: dude Article: a	facehugging alien (0)	physiostim pill (0)	essence of fright (c100)	space marine flash grenade (c0)
+Space Marine	826	spacemarine.gif	Atk: 160 Def: 135 HP: 140 Init: 40 P: dude EA: spooky Article: a	facehugging alien (0)	physiostim pill (0)	essence of fright (c100)	space marine flash grenade (c0)
 terrifying robot	836	terrorbot.gif	Atk: 170 Def: 153 HP: 170 Init: 50 P: construct Article: a	neurostim pill (0)	physiostim pill (0)
 
 # BRICKO Monsters (Libram of BRICKOs February 2010)
@@ -1438,17 +1438,17 @@ BRICKO airship	926	brickoairship.gif	NOCOPY FREE Atk: 550 Def: 495 HP: 10000 Ini
 BRICKO bat	919	brickobat.gif	FREE Atk: 70 Def: 63 HP: 100 Init: 30 P: construct Article: a	BRICKO brick (0)	BRICKO brick (0)	BRICKO brick (0)
 BRICKO cathedral	927	brickocathedral.gif	NOCOPY FREE Atk: 725 Def: 652 HP: 100000 Init: 200 P: construct Phys: 50 Article: a	gilded BRICKO brick (100)
 BRICKO elephant	922	brickoelephant.gif	NOCOPY FREE Atk: 130 Def: 117 HP: 200 Init: 80 P: construct Article: a	BRICKO trunk (40)
-BRICKO gargantuchicken	928	brickogchicken.gif	NOCOPY FREE Atk: 1000 Def: 900 HP: 1000000 Init: 300 P: construct Phys: 50 Article: a	BRICKO egg (100)
+BRICKO gargantuchicken	928	brickogchicken.gif	NOCOPY FREE Atk: 1000 Def: 900 HP: 1000000 Init: 300 P: construct Phys: 50 EA: sleaze Article: a	BRICKO egg (100)
 BRICKO octopus	923	brickoctopus.gif	NOCOPY FREE Atk: 140 Def: 126 HP: 250 Init: 90 P: construct Article: a	BRICKO brick (0)	BRICKO brick (0)	BRICKO brick (0)	BRICKO brick (0)	BRICKO brick (0)	BRICKO brick (0)	BRICKO brick (0)	black BRICKO brick (0)
 BRICKO ooze	918	brickoblob.gif	FREE Atk: 40 Def: 36 HP: 50 Init: 20 P: construct Article: a	BRICKO brick (30)	BRICKO stud (c0)
 BRICKO oyster	920	brickooyster.gif	NOCOPY FREE Atk: 100 Def: 90 HP: 120 Init: 50 P: construct Article: a	BRICKO pearl (0)
 BRICKO python	924	brickopython.gif	NOCOPY FREE Atk: 160 Def: 144 HP: 300 Init: 100 P: construct Article: a	green BRICKO brick (25)	BRICKO brick (0)	BRICKO brick (0)	BRICKO brick (0)	BRICKO brick (0)	BRICKO brick (0)	BRICKO brick (0)	BRICKO brick (0)	BRICKO brick (0)	BRICKO brick (0)
 BRICKO turtle	921	brickoturtle.gif	NOCOPY FREE Atk: 120 Def: 108 HP: 150 Init: 70 P: construct Article: a	BRICKO bulwark (50)
-BRICKO vacuum cleaner	925	brickovacuum.gif	NOCOPY FREE Atk: 400 Def: 360 HP: 2500 Init: 150 P: construct Phys: 10 Article: a	broken BRICKO brick (0)
+BRICKO vacuum cleaner	925	brickovacuum.gif	NOCOPY FREE Atk: 400 Def: 360 HP: 2500 Init: 150 P: construct Phys: 10 EA: hot Article: a	broken BRICKO brick (0)
 
 # The Red Queen's Garden (Clan Looking Glass March 2010)
 beelephant	932	beelephant.gif	NOCOPY Scale: 0 Cap: 200 Init: 50 P: beast Article: a	bucket of honey (20)	elephant stinger (0)	reflection of a map (c10)
-snapdragon	933	snapdragon.gif	NOCOPY Scale: 0 Cap: 200 Init: 50 P: plant Article: a	dragon snaps (20)	snapdragon pistil (0)	reflection of a map (c10)
+snapdragon	933	snapdragon.gif	NOCOPY Scale: 0 Cap: 200 Init: 50 P: plant EA: hot Article: a	dragon snaps (20)	snapdragon pistil (0)	reflection of a map (c10)
 Tiger-lily	930	tigerlily.gif	NOCOPY Scale: 0 Cap: 200 Init: 50 P: plant Article: a	eye of the Tiger-lily (0)	Tiger-lily's milk (20)	reflection of a map (c10)
 wasp in a wig	931	wigwasp.gif	NOCOPY Scale: 0 Cap: 200 Init: 50 P: bug Article: a	powdered donut (20)	powdered wig (0)	reflection of a map (c10)
 croqueteer	929	croqueteer.gif	NOCOPY Scale: 0 Cap: 200 Init: 75 Meat: 50 P: dude Article: a	croquet hedgehog (0)	flamingo mallet (0)
@@ -1461,17 +1461,17 @@ peeved roommate	971	mh_roommate.gif	FREE Scale: 0 Init: -10000 P: dude Article: 
 random scenester	973	mh_scenester.gif	FREE Scale: 0 Init: -10000 P: dude Article: a	ironic jogging shorts (c10)
 
 # Spaaace (Li'l Xenomorph June 2011)
-alielf	1092	alielf.gif	Scale: 10 Cap: 460 Init: 50 P: horror Article: an	elven medi-pack (0)	lunar isotope (0)	lunar isotope (0)	lunar isotope (0)
+alielf	1092	alielf.gif	Scale: 10 Cap: 460 Init: 50 P: horror EA: sleaze Article: an	elven medi-pack (0)	lunar isotope (0)	lunar isotope (0)	lunar isotope (0)
 cat-alien	1090	catalien.gif	Scale: 8 Cap: 450 Init: -10000 P: horror Article: a	elven medi-pack (0)	lunar isotope (0)	lunar isotope (0)
-dog-alien	1091	dogalien.gif	Scale: 8 Cap: 450 Init: -10000 P: horror Article: a	elven magi-pack (0)	lunar isotope (0)	lunar isotope (0)
+dog-alien	1091	dogalien.gif	Scale: 8 Cap: 450 Init: -10000 P: horror EA: sleaze Article: a	elven magi-pack (0)	lunar isotope (0)	lunar isotope (0)
 dogcat	1093	catdog.gif	Scale: 10 Cap: 460 Init: -10000 P: horror Article: a	elven magi-pack (0)	lunar isotope (0)	lunar isotope (0)
-ferrelf	1095	ferrelf.gif	Scale: 7 Cap: 440 Init: -10000 P: horror Article: a	elven magi-pack (0)	lunar isotope (0)	lunar isotope (0)	folder (holographic fractal) (c0)
+ferrelf	1095	ferrelf.gif	Scale: 7 Cap: 440 Init: -10000 P: horror EA: stench Article: a	elven magi-pack (0)	lunar isotope (0)	lunar isotope (0)	folder (holographic fractal) (c0)
 grizzled survivor	1085	surv_grizzled.gif	Scale: 5 Cap: 310 Init: -10000 P: dude Article: a	elven hardtack (25)	elven squeeze (25)	Map to Safety Shelter Grimace Prime (10)	Notes from the Elfpocalypse, Chapter II (15)
 hamsterpus	1094	hamsterpus.gif	Scale: 5 Cap: 430 Init: -10000 P: horror Article: a	elven medi-pack (0)	lunar isotope (0)	lunar isotope (0)	lunar isotope (0)
 overarmed survivor	1088	surv_overarmed.gif	Scale: 5 Cap: 320 Init: -10000 P: dude Article: an	elven hardtack (25)	elven squeeze (25)	Map to Safety Shelter Ronald Prime (10)	Notes from the Elfpocalypse, Chapter V (15)
-primitive survivor	1089	surv_primitive.gif	Scale: 5 Cap: 310 Init: -10000 P: dude Article: a	elven hardtack (25)	elven squeeze (25)	Map to Safety Shelter Ronald Prime (10)	Notes from the Elfpocalypse, Chapter VI (15)
+primitive survivor	1089	surv_primitive.gif	Scale: 5 Cap: 310 Init: -10000 P: dude EA: stench Article: a	elven hardtack (25)	elven squeeze (25)	Map to Safety Shelter Ronald Prime (10)	Notes from the Elfpocalypse, Chapter VI (15)
 unhinged survivor	1084	surv_unhinged.gif	Scale: 5 Cap: 300 Init: -10000 P: dude Article: a	elven hardtack (25)	elven squeeze (25)	Map to Safety Shelter Grimace Prime (10)	Notes from the Elfpocalypse, Chapter I (15)
-unlikely survivor	1087	surv_unlikely.gif	Scale: 0 Cap: 300 Init: -10000 P: dude Article: an	elven hardtack (25)	elven squeeze (25)	Map to Safety Shelter Ronald Prime (10)	Notes from the Elfpocalypse, Chapter IV (15)
+unlikely survivor	1087	surv_unlikely.gif	Scale: 0 Cap: 300 Init: -10000 P: dude EA: sleaze Article: an	elven hardtack (25)	elven squeeze (25)	Map to Safety Shelter Ronald Prime (10)	Notes from the Elfpocalypse, Chapter IV (15)
 whiny survivor	1086	surv_whiny.gif	Scale: -5 Cap: 290 Init: -10000 P: dude Article: a	elven hardtack (25)	elven squeeze (25)	Map to Safety Shelter Grimace Prime (10)	Notes from the Elfpocalypse, Chapter III (15)
 alien hamsterpus	1096	muthamster.gif	Scale: 1 Cap: 5000 Init: 100 P: horror Article: an	elven magi-pack (25)	elven medi-pack (25)	lunar isotope (0)	lunar isotope (0)	lunar isotope (0)
 mutated alielephant	1098	alielephant.gif	Scale: 10 Cap: 5000 Init: -10000 P: horror Article: a	elven magi-pack (25)	elven medi-pack (25)	lunar isotope (0)	lunar isotope (0)	lunar isotope (0)	lunar isotope (0)
@@ -1487,20 +1487,20 @@ The Thorax	1127	thethorax.gif	BOSS NOCOPY Atk: 150 Def: 135 HP: 9500 Init: 100 P
 The Bat in the Spats	1128	batinspats.gif	BOSS NOCOPY Atk: 150 Def: 135 HP: 9500 Init: 100 P: beast	vanity stone (100)
 
 # The Maelstrom of Lovers (Blavious Kloop Year 2012)
-Bettie Barulio	1130	wraith2.gif	Scale: 2 Cap: 150 Init: 50 P: undead GHOST	Barulio's bottle (0)	jar full of wind (0)	jar full of wind (0)
-Marcus Macurgeon	1133	wraith5.gif	Scale: 2 Cap: 150 Init: 50 P: undead GHOST	jar full of wind (0)	jar full of wind (0)	purple prose pen (0)
+Bettie Barulio	1130	wraith2.gif	Scale: 2 Cap: 150 Init: 50 P: undead GHOST EA: sleaze	Barulio's bottle (0)	jar full of wind (0)	jar full of wind (0)
+Marcus Macurgeon	1133	wraith5.gif	Scale: 2 Cap: 150 Init: 50 P: undead GHOST EA: sleaze	jar full of wind (0)	jar full of wind (0)	purple prose pen (0)
 Marvin J. Sunny	1131	wraith3.gif	Scale: 2 Cap: 150 Init: 50 P: undead GHOST	jar full of wind (0)	Marvin's marvelous pill (0)
-Mortimer Strauss	1129	wraith1.gif	Scale: 2 Cap: 150 Init: 50 P: undead GHOST	jar full of wind (0)	jar full of wind (0)	Mortimer's nostrum (0)
-Wonderful Winifred Wongle	1132	wraith4.gif	Scale: 2 Cap: 150 Init: 50 P: undead GHOST	jar full of wind (0)	jar full of wind (0)	Winifred's whistle (0)
+Mortimer Strauss	1129	wraith1.gif	Scale: 2 Cap: 150 Init: 50 P: undead GHOST EA: sleaze	jar full of wind (0)	jar full of wind (0)	Mortimer's nostrum (0)
+Wonderful Winifred Wongle	1132	wraith4.gif	Scale: 2 Cap: 150 Init: 50 P: undead GHOST EA: sleaze	jar full of wind (0)	jar full of wind (0)	Winifred's whistle (0)
 The Terrible Pinch	1134	thepinch.gif	BOSS NOCOPY Atk: 150 Def: 135 HP: 1000 Init: 100 P: humanoid	lecherous stone (100)
 Thug 1 and Thug 2	1135	thug1thug2.gif	BOSS NOCOPY Atk: 150 Def: 135 HP: 1000 Init: 500 P: humanoid	jealousy stone (100)
 
 # The Glacier of Jerks (Blavious Kloop Year 2012)
 Brock "Rocky" Flox	1140	iceguy5.gif	Scale: 2 Cap: 150 Init: 50 P: dude	dangerous jerkcicle (0)	pink-belly slapper (0)
 Dolores D. Smiley	1138	iceguy2.gif	Scale: 2 Cap: 150 Init: 50 P: dude	dangerous jerkcicle (0)	dangerous jerkcicle (0)	desktop zen garden (0)
-Hugo Von Douchington	1136	iceguy1.gif	Scale: 2 Cap: 150 Init: 50 P: dude	dangerous jerkcicle (0)	half-empty carton of milk (0)
-Vivian Vibrian Vumian Varr	1139	iceguy4.gif	Scale: 2 Cap: 150 Init: 50 P: dude	dangerous jerkcicle (0)	dangerous jerkcicle (0)	Vivian's Vitamin (0)
-Wacky Zack Flacky	1137	iceguy3.gif	Scale: 2 Cap: 150 Init: 50 P: dude	dangerous jerkcicle (0)	dangerous jerkcicle (0)	glass of warm water (0)
+Hugo Von Douchington	1136	iceguy1.gif	Scale: 2 Cap: 150 Init: 50 P: dude EA: cold EA: sleaze	dangerous jerkcicle (0)	half-empty carton of milk (0)
+Vivian Vibrian Vumian Varr	1139	iceguy4.gif	Scale: 2 Cap: 150 Init: 50 P: dude EA: hot	dangerous jerkcicle (0)	dangerous jerkcicle (0)	Vivian's Vitamin (0)
+Wacky Zack Flacky	1137	iceguy3.gif	Scale: 2 Cap: 150 Init: 50 P: dude EA: cold	dangerous jerkcicle (0)	dangerous jerkcicle (0)	glass of warm water (0)
 Mammon the Elephant	1142	mammon.gif	BOSS NOCOPY Atk: 150 Def: 135 HP: 50000 Init: 150 P: beast	avarice stone (100)
 The Large-Bellied Snitch	1141	snitch.gif	BOSS NOCOPY Atk: 150 Def: 135 HP: 10000 Init: 150 P: beast	gluttonous stone (100)
 
@@ -1513,62 +1513,62 @@ largish blob of gray goo	1249	grayblob2.gif	NOCOPY Atk: [98] Def: [105] HP: [110
 enormous blob of gray goo	1250	grayblob3.gif	NOCOPY Atk: [230] Def: [240] HP: [250] Init: 150 P: horror Article: an
 
 # Black Crayon Monsters (Artistic Goth Kid June 2012)
-Black Crayon Beast	1187	cray_beast.gif	FREE Scale: 0 Cap: ? Init: -10000 P: beast Article: a	crayon shavings (100)
-Black Crayon Beetle	1191	cray_bug.gif	FREE Scale: 0 Cap: ? Init: -10000 P: bug Article: a	crayon shavings (100)
-Black Crayon Constellation	1206	cray_const.gif	FREE Scale: 0 Cap: ? Init: -10000 P: constellation Article: a	crayon shavings (100)
+Black Crayon Beast	1187	cray_beast.gif	FREE Scale: 0 Cap: ? Init: -10000 P: beast EA: spooky Article: a	crayon shavings (100)
+Black Crayon Beetle	1191	cray_bug.gif	FREE Scale: 0 Cap: ? Init: -10000 P: bug EA: sleaze EA: spooky Article: a	crayon shavings (100)
+Black Crayon Constellation	1206	cray_const.gif	FREE Scale: 0 Cap: ? Init: -10000 P: constellation EA: hot EA: spooky Article: a	crayon shavings (100)
 Black Crayon Crimbo Elf	1201	cray_elf.gif	FREE Scale: 0 Cap: ? Init: -10000 P: elf Article: a	crayon shavings (100)
 Black Crayon Demon	1194	cray_demon.gif	FREE Scale: 0 Cap: ? Init: -10000 P: demon Article: a	crayon shavings (100)
-Black Crayon Elemental	1205	cray_elemental.gif	FREE Scale: 0 Cap: ? Init: -10000 P: elemental Article: a	crayon shavings (100)
+Black Crayon Elemental	1205	cray_elemental.gif	FREE Scale: 0 Cap: ? Init: -10000 P: elemental EA: cold EA: hot EA: spooky Article: a	crayon shavings (100)
 Black Crayon Fish	1196	cray_fish.gif	FREE Scale: 0 Cap: ? Init: -10000 P: fish Article: a	crayon shavings (100)
 Black Crayon Flower	1199	cray_plant.gif	FREE Scale: 0 Cap: ? Init: -10000 P: plant Article: a	crayon shavings (100)
 Black Crayon Frat Orc	1193	cray_orc.gif	FREE Scale: 0 Cap: ? Init: -10000 P: orc Article: a	crayon shavings (100)
 Black Crayon Goblin	1197	cray_goblin.gif	FREE Scale: 0 Cap: ? Init: -10000 P: goblin Article: a	crayon shavings (100)
 Black Crayon Golem	1188	cray_construct.gif	FREE Scale: 0 Cap: ? Init: -10000 P: construct Article: a	crayon shavings (100)
 Black Crayon Hippy	1192	cray_hippy.gif	FREE Scale: 0 Cap: ? Init: -10000 P: hippy Article: a	crayon shavings (100)
-Black Crayon Hobo	1207	cray_hobo.gif	FREE Scale: 0 Cap: ? Init: -10000 P: hobo Article: a	crayon shavings (100)
+Black Crayon Hobo	1207	cray_hobo.gif	FREE Scale: 0 Cap: ? Init: -10000 P: hobo EA: hot Article: a	crayon shavings (100)
 Black Crayon Man	1186	cray_dude.gif	FREE Scale: 0 Cap: ? Init: -10000 P: dude Article: a	crayon shavings (100)
 Black Crayon Manloid	1190	cray_humanoid.gif	FREE Scale: 0 Cap: ? Init: -10000 P: humanoid Article: a	crayon shavings (100)
 Black Crayon Mer-kin	1202	cray_merkin.gif	FREE Scale: 0 Cap: ? Init: -10000 P: mer-kin Article: a	crayon shavings (100)
-Black Crayon Penguin	1204	cray_penguin.gif	FREE Scale: 0 Cap: ? Init: -10000 P: penguin Article: a	crayon shavings (100)
-Black Crayon Pirate	1198	cray_pirate.gif	FREE Scale: 0 Cap: ? Init: -10000 P: pirate Article: a	crayon shavings (100)
-Black Crayon Shambling Monstrosity	1195	cray_horror.gif	FREE Scale: 0 Cap: ? Init: -10000 P: horror Article: a	crayon shavings (100)
-Black Crayon Slime	1203	cray_slime.gif	FREE Scale: 0 Cap: ? Init: -10000 P: slime Article: a	crayon shavings (100)
-Black Crayon Spiraling Shape	1200	cray_weird.gif	FREE Scale: 0 Cap: ? Init: -10000 P: weird	crayon shavings (100)
-Black Crayon Undead Thing	1189	cray_undead.gif	FREE Scale: 0 Cap: ? Init: -10000 P: undead Article: a	crayon shavings (100)
+Black Crayon Penguin	1204	cray_penguin.gif	FREE Scale: 0 Cap: ? Init: -10000 P: penguin EA: sleaze Article: a	crayon shavings (100)
+Black Crayon Pirate	1198	cray_pirate.gif	FREE Scale: 0 Cap: ? Init: -10000 P: pirate EA: spooky Article: a	crayon shavings (100)
+Black Crayon Shambling Monstrosity	1195	cray_horror.gif	FREE Scale: 0 Cap: ? Init: -10000 P: horror EA: sleaze Article: a	crayon shavings (100)
+Black Crayon Slime	1203	cray_slime.gif	FREE Scale: 0 Cap: ? Init: -10000 P: slime EA: sleaze Article: a	crayon shavings (100)
+Black Crayon Spiraling Shape	1200	cray_weird.gif	FREE Scale: 0 Cap: ? Init: -10000 P: weird EA: hot	crayon shavings (100)
+Black Crayon Undead Thing	1189	cray_undead.gif	FREE Scale: 0 Cap: ? Init: -10000 P: undead EA: spooky Article: a	crayon shavings (100)
 
 # Psychoses (Angry Yung Man Year 2013)
 work hat	1273	doubt1.gif	Atk: 30 Def: 40 HP: 30 Init: 50 P: construct Article: a	black pixel (0)	black pixel (0)	white pixel (0)	pixel power cell (0)
 reproachful heart	1274	doubt2.gif	Atk: 30 Def: 40 HP: 25 Init: 70 P: construct Article: a	red pixel (0)	red pixel (0)	white pixel (0)	pixel power cell (0)
 judgmental eye	1275	doubt3.gif	Atk: 45 Def: 35 HP: 40 Init: 50 P: beast Article: a	red pixel (0)	black pixel (0)	white pixel (0)	pixel power cell (0)
-Doubt Man	1272	doubtman.gif	BOSS NOCOPY Atk: 40 Def: 40 HP: 150 Init: 50 P: dude	doubt cannon (100)
+Doubt Man	1272	doubtman.gif	BOSS NOCOPY Atk: 40 Def: 40 HP: 150 Init: 50 P: dude EA: sleaze	doubt cannon (100)
 contemplative ghost	1277	regret1.gif	Atk: 30 Def: 35 HP: 35 Init: 60 P: undead GHOST Phys: 100 Article: a	green pixel (0)	green pixel (0)	green pixel (0)	pixel power cell (0)
 lovesick ghost	1278	regret2.gif	Atk: 30 Def: 40 HP: 50 Init: 30 P: undead GHOST Phys: 100 Article: a	white pixel (0)	black pixel (0)	red pixel (0)	pixel power cell (0)
 ancient ghost	1279	regret3.gif	Atk: 30 Def: 40 HP: 25 Init: 70 P: undead GHOST Phys: 100 Article: an	white pixel (0)	white pixel (0)	black pixel (0)	pixel power cell (0)	cube of ectoplasm (c0)
-Regret Man	1276	regretman.gif	BOSS NOCOPY Atk: 40 Def: 40 HP: 200 Init: 100 P: dude	regret hose (100)
-ticking time bomb	1266	anger2.gif	Atk: 50 Def: 40 HP: 30 Init: 20 P: construct Article: a	black pixel (0)	black pixel (0)	white pixel (0)	pixel power cell (0)
+Regret Man	1276	regretman.gif	BOSS NOCOPY Atk: 40 Def: 40 HP: 200 Init: 100 P: dude EA: cold	regret hose (100)
+ticking time bomb	1266	anger2.gif	Atk: 50 Def: 40 HP: 30 Init: 20 P: construct EA: hot Article: a	black pixel (0)	black pixel (0)	white pixel (0)	pixel power cell (0)
 rage flame	1265	anger1.gif	Atk: 30 Def: 30 HP: 30 Init: 100 P: elemental E: hot Article: a	red pixel (0)	red pixel (0)	white pixel (0)	pixel power cell (0)
-frustrating knight	1267	anger3.gif	Atk: 25 Def: 60 HP: 70 Init: 50 P: dude Article: a	blue pixel (0)	blue pixel (0)	white pixel (0)	pixel power cell (0)
-Anger Man	1264	angerman.gif	BOSS NOCOPY Atk: 50 Def: 40 HP: 200 Init: 100 P: dude	anger blaster (100)
+frustrating knight	1267	anger3.gif	Atk: 25 Def: 60 HP: 70 Init: 50 P: dude EA: hot Article: a	blue pixel (0)	blue pixel (0)	white pixel (0)	pixel power cell (0)
+Anger Man	1264	angerman.gif	BOSS NOCOPY Atk: 50 Def: 40 HP: 200 Init: 100 P: dude EA: hot	anger blaster (100)
 morbid skull	1269	fear1.gif	Atk: 50 Def: 50 HP: 50 Init: 50 P: undead E: spooky Article: a	white pixel (80)	white pixel (70)	white pixel (60)	white pixel (50)	white pixel (40)	pixel power cell (0)
 animated possessions	1270	fear2.gif	Atk: 30 Def: 30 HP: 50 Init: 50 P: construct Article: some	white pixel (0)	black pixel (0)	black pixel (0)	pixel power cell (0)
-natural spider	1271	fear3.gif	Atk: 30 Def: 20 HP: 60 Init: 50 P: bug Article: a	white pixel (0)	red pixel (0)	black pixel (0)	pixel power cell (0)
-Fear Man	1268	fearman.gif	BOSS NOCOPY Atk: 40 Def: 40 HP: 200 Init: 30 P: dude	fear condenser (100)
+natural spider	1271	fear3.gif	Atk: 30 Def: 20 HP: 60 Init: 50 P: bug EA: spooky Article: a	white pixel (0)	red pixel (0)	black pixel (0)	pixel power cell (0)
+Fear Man	1268	fearman.gif	BOSS NOCOPY Atk: 40 Def: 40 HP: 200 Init: 30 P: dude EA: spooky	fear condenser (100)
 Whisk of Misery	1293	pa_whisk.gif	Atk: 9 Def: 11 HP: 12 Init: 50 P: weird Article: a	Artist's Whisk of Misery (0)
 Spatula of Despair	1295	pa_spatula.gif	Atk: 8 Def: 12 HP: 12 Init: 50 P: weird Article: a	Artist's Spatula of Despair (0)
-Butterknife of Regret	1294	pa_knife.gif	Atk: 11 Def: 9 HP: 12 Init: 50 P: weird Article: a	Artist's Butterknife of Regret (0)
+Butterknife of Regret	1294	pa_knife.gif	Atk: 11 Def: 9 HP: 12 Init: 50 P: weird EA: hot Article: a	Artist's Butterknife of Regret (0)
 Cookie Cutter of Loneliness	1296	pa_cutter.gif	Atk: 10 Def: 10 HP: 12 Init: 50 P: weird Article: a	Artist's Cookie Cutter of Loneliness (0)
-Creme Brulee Torch of Fury	1297	pa_torch.gif	Atk: 12 Def: 8 HP: 12 Init: 50 P: weird E: hot Article: a	Artist's Cr&egrave;me Brul&eacute;e Torch of Fury (0)
-bag of Potatoes of Security	1300	pa_potatoes.gif	NOCOPY Atk: 30 Def: 100 HP: 100 Init: 100 P: weird Article: a
+Creme Brulee Torch of Fury	1297	pa_torch.gif	Atk: 12 Def: 8 HP: 12 Init: 50 P: weird ED: hot EA: hot EA: sleaze Article: a	Artist's Cr&egrave;me Brul&eacute;e Torch of Fury (0)
+bag of Potatoes of Security	1300	pa_potatoes.gif	NOCOPY Atk: 30 Def: 100 HP: 100 Init: 100 P: weird EA: hot Article: a
 box of Batter Mix of Hope	1302	pa_muffin.gif	NOCOPY Atk: 30 Def: 100 HP: 100 Init: 100 P: weird Article: a
-carton of Eggs of Confidence	1298	pa_eggs.gif	NOCOPY Atk: 30 Def: 100 HP: 100 Init: 100 P: weird Article: a
+carton of Eggs of Confidence	1298	pa_eggs.gif	NOCOPY Atk: 30 Def: 100 HP: 100 Init: 100 P: weird EA: sleaze Article: a
 loaf of Bread of Wonder	1299	pa_bread.gif	NOCOPY Atk: 30 Def: 100 HP: 100 Init: 100 P: weird Article: a
-bundle of Meat of Happiness	1301	pa_meat.gif	NOCOPY Atk: 30 Def: 100 HP: 100 Init: 100 Meat: 100 P: weird Article: a	the kindest cold cut (c0)
+bundle of Meat of Happiness	1301	pa_meat.gif	NOCOPY Atk: 30 Def: 100 HP: 100 Init: 100 Meat: 100 P: weird EA: hot Article: a	the kindest cold cut (c0)
 groast	1289	groast.gif	Atk: 200 Def: 200 HP: 300 Init: 50 Meat: 250 P: undead E: spooky Article: a	ectoplasm <i>au jus</i> (c0)
 bacon snake	1287	baconsnake.gif	Atk: 220 Def: 200 HP: 300 Init: 75 Meat: 250 P: beast SNAKE E: sleaze Article: a
 pork butterfly	1288	porkbutterfly.gif	Atk: 180 Def: 240 HP: 300 Init: 50 Meat: 250 P: bug E: sleaze Article: a
 salaminder	1290	salaminder.gif	Atk: 200 Def: 200 HP: 300 Init: 100 Meat: 250 P: beast E: hot Article: a
 cold cutter	1291	coldcutter.gif	Atk: 200 Def: 200 HP: 300 Init: 50 Meat: 250 P: construct E: cold Article: a
-The Beefhemoth	1292	beefhemoth.gif	BOSS NOCOPY Atk: 300 Def: 300 HP: 1000 Init: -10000 Meat: 500 P: beast
+The Beefhemoth	1292	beefhemoth.gif	BOSS NOCOPY Atk: 300 Def: 300 HP: 1000 Init: -10000 Meat: 500 P: beast EA: cold EA: stench
 tin can conspirator	1282	gourd_can.gif	NOCOPY Atk: 18 Def: 22 HP: 25 Init: 50 Meat: 10 P: construct Article: a	razor-sharp can lid (0)	razor-sharp can lid (0)	censored can label (c0)	sharp tin strip (0)
 goblin conspirator	1281	gourd_goblin.gif	NOCOPY Atk: 20 Def: 20 HP: 25 Init: 50 Meat: 20 P: goblin Article: a	Knob Goblin firecracker (0)	Knob Goblin firecracker (0)	goblin collarbone (0)	Illuminati earpiece (c0)
 spider conspirator	1280	gourd_spider.gif	NOCOPY Atk: 22 Def: 18 HP: 25 Init: 50 Meat: 15 P: bug Article: a	spider web (0)	spider web (0)	wad of spider silk (0)
@@ -1589,7 +1589,7 @@ yakuza courier	1310	yakcourier.gif	NOCOPY Atk: 70 Def: 70 HP: 85 Init: 65 P: hum
 triad code wizard	1306	triadwizard.gif	Atk: 73 Def: 67 HP: 85 Init: 50 Meat: 20 P: dude Article: a	triad summoning scroll (0)	ASCII fu manchu (c0)
 clean-room daemon	1307	cleanroomdemon.gif	Atk: 70 Def: 70 HP: 85 Init: 50 P: demon Article: a	rubber gloves (0)	demonic surgical gloves (c0)
 fabricator gu&agrave;i	1308	guai.gif	Atk: 67 Def: 73 HP: 90 Init: 40 Meat: 20 P: demon Article: a Manuel: "fabricator guài"	Chinese curse words (0)
-The Sierpinski brothers	1309	sierpinski.gif	NOCOPY Atk: 77 Def: 74 HP: 95 Init: 70 P: dude	triad summoning scroll (0)	triad summoning scroll (0)	triad summoning scroll (0)	cheap Chinese beer (0)	cheap Chinese beer (0)	dead meat bun (0)	magical battery (c1)
+The Sierpinski brothers	1309	sierpinski.gif	NOCOPY Atk: 77 Def: 74 HP: 95 Init: 70 P: dude EA: hot	triad summoning scroll (0)	triad summoning scroll (0)	triad summoning scroll (0)	cheap Chinese beer (0)	cheap Chinese beer (0)	dead meat bun (0)	magical battery (c1)
 security robot	1313	secrobot.gif	Atk: 72 Def: 78 HP: 85 Init: 40 P: construct Article: a	great big capacitor (0)
 salaryninja	1312	salaryninja.gif	Atk: 78 Def: 72 HP: 80 Init: 60 Meat: 15 P: dude Article: a	pencil kunai (0)	pencil kunai (0)	weighted paperclip chain (0)	cheap clip-on ninja tie (c0)
 yakuza guard	1311	yakguard.gif	Atk: 75 Def: 75 HP: 95 Init: 50 Meat: 30 P: humanoid Article: a	butterfly knife (0)	tube of herbal ointment (0)
@@ -1599,10 +1599,10 @@ desperate gold farmer	1315	goldfarmer.gif	Atk: 80 Def: 80 HP: 95 Init: 50 Meat: 
 rabid MMO addict	1316	mmoaddict.gif	Atk: 84 Def: 76 HP: 90 Init: 60 Meat: 20 P: dude Article: a	gold piece (0)	gamer slurry (c0)
 The Server	1318	theserver.gif	NOCOPY Atk: 90 Def: 90 HP: 999999999 Init: 75 P: construct
 White Bone Demon	1319	whitebonedemon.gif	NOCOPY Atk: 100 Def: 100 HP: 180 Init: 100 P: demon	suspicious-looking fedora (100)
-procedurally-generated skeleton	1323	bigskeleton.gif	NOCOPY Init: -10000 P: undead
+procedurally-generated skeleton	1323	bigskeleton.gif	NOCOPY Init: -10000 P: undead EA: cold EA: hot EA: sleaze EA: spooky EA: stench
 
 # Video Game dungeon (GameInformPowerDailyPro magazine February 2013)
-Video Game Boss	1331	faq_boss1.gif,faq_boss2.gif,faq_boss3.gif,faq_boss4.gif,faq_boss5.gif,faq_boss6.gif	NOCOPY Scale: 5 Init: -10000 P: construct
+Video Game Boss	1331	faq_boss1.gif,faq_boss2.gif,faq_boss3.gif,faq_boss4.gif,faq_boss5.gif,faq_boss6.gif	NOCOPY Scale: 5 Init: -10000 P: construct EA: cold EA: hot
 Video Game Miniboss	1330	faq_miniboss1.gif,faq_miniboss2.gif,faq_miniboss3.gif,faq_miniboss4.gif,faq_miniboss5.gif,faq_miniboss6.gif	NOCOPY Scale: 3 Init: -10000 P: construct
 Video Game Minion (moderate)	1328	qmark.gif	NOCOPY Scale: -2 Init: -10000 P: construct Article: a
 Video Game Minion (strong)	1329	qmark.gif	NOCOPY Scale: 1 Init: -10000 P: construct Article: a
@@ -1614,10 +1614,10 @@ Escalatormaster&trade;	1488	stairmaster.gif	NOCOPY Scale: 3 Cap: 1000 Floor: 50 
 Legstrong&trade; stationary bicycle	1489	statbike.gif	NOCOPY Scale: 3 Cap: 1000 Floor: 50 Init: -10000 P: construct Article: a Manuel: "Legstrong™ stationary bicycle"	pint of sweat (0)	Jerks' Health&trade; Magazine (0)	sweatband (0)	gym shorts (0)	ankleweights (0)	sweat socks (0)	Five Second Energy&trade; (0)
 rack of free weights	1486	weightrack.gif	NOCOPY Scale: 3 Cap: 1000 Floor: 50 Init: -10000 P: construct Article: a	pint of sweat (0)	Jerks' Health&trade; Magazine (0)	sweatband (0)	gym shorts (0)	ankleweights (0)	sweat socks (0)	Five Second Energy&trade; (0)
 treadmill	1485	treadmill.gif	NOCOPY Scale: 3 Cap: 1000 Floor: 50 Init: -10000 P: construct Article: a	pint of sweat (0)	Jerks' Health&trade; Magazine (0)	sweatband (0)	gym shorts (0)	ankleweights (0)	sweat socks (0)	Five Second Energy&trade; (0)
-Medieval dung peddler	1507	med_dung.gif	Scale: 3 Cap: 250 Floor: 25 Init: -10000 Meat: 5 P: dude Article: a	leather (0)	leather (0)	straw (0)	straw (0)
-Medieval leather mug salesman	1505	med_mugman.gif	Scale: 0 Cap: 200 Floor: 20 Init: -10000 Meat: 25 P: dude Article: a	leather (0)	leather (0)	leather (0)	leather (0)
-Medieval mug apprentice	1509	med_muggirl.gif	Scale: 3 Cap: 250 Floor: 25 Init: -10000 Meat: 5 P: dude Article: a	clay (0)	clay (0)	leather (0)	leather (0)
-Medieval potter	1506	med_potter.gif	Scale: 0 Cap: 200 Floor: 20 Init: -10000 Meat: 25 P: dude Article: a	clay (0)	clay (0)	clay (0)	clay (0)
+Medieval dung peddler	1507	med_dung.gif	Scale: 3 Cap: 250 Floor: 25 Init: -10000 Meat: 5 P: dude EA: sleaze EA: stench Article: a	leather (0)	leather (0)	straw (0)	straw (0)
+Medieval leather mug salesman	1505	med_mugman.gif	Scale: 0 Cap: 200 Floor: 20 Init: -10000 Meat: 25 P: dude EA: hot Article: a	leather (0)	leather (0)	leather (0)	leather (0)
+Medieval mug apprentice	1509	med_muggirl.gif	Scale: 3 Cap: 250 Floor: 25 Init: -10000 Meat: 5 P: dude EA: hot Article: a	clay (0)	clay (0)	leather (0)	leather (0)
+Medieval potter	1506	med_potter.gif	Scale: 0 Cap: 200 Floor: 20 Init: -10000 Meat: 25 P: dude EA: sleaze Article: a	clay (0)	clay (0)	clay (0)	clay (0)
 Medieval strawman debator	1504	med_strawman.gif	Scale: 0 Cap: 200 Floor: 20 Init: -10000 Meat: 25 P: dude Article: a	straw (0)	straw (0)	straw (0)	straw (0)	straw pole (c0)
 Medieval stucco artisan	1508	med_stucco.gif	Scale: 3 Cap: 250 Floor: 25 Init: -10000 Meat: 10 P: dude Article: a	clay (0)	clay (0)	straw (0)	straw (0)
 gummi plesiosaur	1491	plesio.gif	NOCOPY Scale: ? Cap: ? Floor: ? Init: -10000 P: beast Article: a	small gummi fin (0)	gummi sword (0)
@@ -1629,53 +1629,53 @@ Rock Pop weasel	1493	popweasel.gif	NOCOPY Scale: ? Cap: ? Floor: ? Init: -10000 
 candied pecan tree	1496	pecantree.gif	NOCOPY Scale: ? Cap: ? Floor: ? Init: -10000 P: plant Article: a	candied pecan (0)	candy stick (0)
 licorice snake	1497	licosnake.gif	NOCOPY Scale: ? Cap: ? Floor: ? Init: -10000 P: beast SNAKE Article: a	anise-flavored venom (0)	licorice whip (0)
 tricksy pixie	1498	trixiepixie.gif	NOCOPY Scale: ? Cap: ? Floor: ? Init: -10000 P: humanoid Article: a	sour powder (0)	pixie axie (0)
-fire truck	1499	firetruck.gif	NOCOPY Scale: ? Cap: ? Floor: ? Init: -10000 P: construct Article: a	fireman's lunch (0)	fire hose (0)
+fire truck	1499	firetruck.gif	NOCOPY Scale: ? Cap: ? Floor: ? Init: -10000 P: construct EA: hot Article: a	fireman's lunch (0)	fire hose (0)
 ice cream truck	1500	icecreamtruck.gif	NOCOPY Scale: ? Cap: ? Floor: ? Init: -10000 P: construct Article: an	ice cream sandwich (0)	plain paper hat (0)
-monster hearse	1502	monsterhearse.gif	NOCOPY Scale: ? Cap: ? Floor: ? Init: -10000 P: construct Article: a	nachos of the night (0)	skull gearshift knob (0)
-sewer tanker	1501	sewertruck.gif	NOCOPY Scale: ? Cap: ? Floor: ? Init: -10000 P: construct Article: a	plumber's lunch (0)	&quot;honey&quot; dipper (0)
-sketchy van	1503	sketchyvan.gif	NOCOPY Scale: ? Cap: ? Floor: ? Init: -10000 P: construct Article: a	can of Adultwitch&trade; (0)	Sketcherz&trade; (0)
+monster hearse	1502	monsterhearse.gif	NOCOPY Scale: ? Cap: ? Floor: ? Init: -10000 P: construct EA: spooky Article: a	nachos of the night (0)	skull gearshift knob (0)
+sewer tanker	1501	sewertruck.gif	NOCOPY Scale: ? Cap: ? Floor: ? Init: -10000 P: construct EA: stench Article: a	plumber's lunch (0)	&quot;honey&quot; dipper (0)
+sketchy van	1503	sketchyvan.gif	NOCOPY Scale: ? Cap: ? Floor: ? Init: -10000 P: construct EA: sleaze Article: a	can of Adultwitch&trade; (0)	Sketcherz&trade; (0)
 befouled straw house	1473	straw_stench.gif	NOCOPY FREE Init: -10000 P: construct E: stench Article: a
 brick (suggestive pause) house	1484	brick_sleaze.gif	NOCOPY FREE Init: -10000 P: construct E: sleaze Article: a
 brick icehouse	1481	brick_cold.gif	NOCOPY FREE Init: -10000 P: construct E: cold Article: a
 brick kiln	1480	brick_hot.gif	NOCOPY FREE Init: -10000 P: construct E: hot Article: a
 brick mausoleum	1482	brick_spooky.gif	NOCOPY FREE Init: -10000 P: construct E: spooky Article: a
 brick outhouse	1483	brick_stench.gif	NOCOPY FREE Init: -10000 P: construct E: stench Article: a
-cold ironwood house	1476	wood_cold.gif	NOCOPY FREE Init: -10000 P: construct E: cold Article: a
+cold ironwood house	1476	wood_cold.gif	NOCOPY FREE Init: -10000 P: construct ED: cold Article: a
 Dutch Angle straw house	1472	straw_spooky.gif	NOCOPY FREE Init: -10000 P: construct E: spooky Article: a
 frosty straw house	1471	straw_cold.gif	NOCOPY FREE Init: -10000 P: construct E: cold Article: a
 glowing ash house	1475	wood_hot.gif	NOCOPY FREE Init: -10000 P: construct E: hot Article: a
 oily straw house	1474	straw_sleaze.gif	NOCOPY FREE Init: -10000 P: construct E: sleaze Article: an
 pitch pine house	1478	wood_stench.gif	NOCOPY FREE Init: -10000 P: construct E: stench Article: a
-quaking aspen house	1477	wood_spooky.gif	NOCOPY FREE Init: -10000 P: construct E: spooky Article: a
+quaking aspen house	1477	wood_spooky.gif	NOCOPY FREE Init: -10000 P: construct ED: spooky Article: a
 slippery elm house	1479	wood_sleaze.gif	NOCOPY FREE Init: -10000 P: construct E: sleaze Article: a
 steaming straw house	1470	straw_hot.gif	NOCOPY FREE Init: -10000 P: construct E: hot Article: a
 
 # Spring Break Beach (May 2014)
-Sloppy Seconds Burger	1566	ssd_burger.gif	NOBANISH Scale: 5 Cap: 11111 Init: -10000 Meat: 250 P: weird E: sleaze	Meat-inflating powder (0)
+Sloppy Seconds Burger	1566	ssd_burger.gif	NOBANISH Scale: 5 Cap: 11111 Init: -10000 Meat: 250 P: weird ED: sleaze EA: hot EA: sleaze	Meat-inflating powder (0)
 Sloppy Seconds Cocktail	1567	ssd_cocktail.gif	NOBANISH Scale: 5 Cap: 11111 Init: -10000 P: weird E: sleaze	bottle of vodka (0)	bottle of rum (0)	bottle of tequila (0)
-Sloppy Seconds Sundae	1568	ssd_sundae.gif	NOBANISH Scale: 5 Cap: 11111 Init: -10000 P: weird E: sleaze	possessed sugar cube (0)
-Fun-Guy Playmate	1569	fun-gal1.gif,fun-gal2.gif,fun-gal3.gif,fun-gal4.gif,fun-gal5.gif,fun-gal6.gif	NOCOPY Atk: [30] Def: [30] HP: [30] Exp: 30 Init: -10000 P: plant E: sleaze	sleight-of-hand mushroom (0)	Fun-Guy spore (5)	pencil thin mushroom (c0)
+Sloppy Seconds Sundae	1568	ssd_sundae.gif	NOBANISH Scale: 5 Cap: 11111 Init: -10000 P: weird ED: sleaze EA: cold EA: hot	possessed sugar cube (0)
+Fun-Guy Playmate	1569	fun-gal1.gif,fun-gal2.gif,fun-gal3.gif,fun-gal4.gif,fun-gal5.gif,fun-gal6.gif	NOCOPY Atk: [30] Def: [30] HP: [30] Exp: 30 Init: -10000 P: plant ED: sleaze EA: cold EA: hot EA: sleaze EA: stench	sleight-of-hand mushroom (0)	Fun-Guy spore (5)	pencil thin mushroom (c0)
 broctopus	1571	broctopus.gif	Atk: 375 Def: 300 HP: 500 Init: 50 Meat: 100 P: fish E: sleaze Article: a	BROS Energy Drink (25)	8-billed baseball cap (5)
 cocktail shrimp	1572	cocktailshrimp.gif	Atk: 350 Def: 325 HP: 400 Init: 75 Meat: 50 P: fish Elem: 50 E: sleaze Article: a	giant shrimp fork (5)	shrimp cocktail (25)
-taco fish	1573	tacofish.gif	NOCOPY Atk: 350 Def: 400 HP: 500 Init: 50 Meat: 150 P: fish E: sleaze Article: a
+taco fish	1573	tacofish.gif	NOCOPY Atk: 350 Def: 400 HP: 500 Init: 50 Meat: 150 P: fish ED: sleaze EA: hot Article: a
 wild girl	1570	wildgirl.gif	Atk: 325 Def: 350 HP: 450 Init: 100 Meat: 100 P: dude E: sleaze Article: a	extremely wet T-shirt (5)	go-go potion (25)	string of moist beads (30)
-son of a son of a sailor	1574	sonofsailor.gif	NOCOPY Atk: 350 Def: 350 HP: 600 Init: 50 Meat: 75 P: dude E: sleaze Article: a
-drownedbeat	1575	drownedbeat.gif	NOCOPY Atk: 400 Def: 325 HP: 450 Init: 25 Meat: 25 P: dude E: sleaze Article: a	bike rental broupon (c100)
+son of a son of a sailor	1574	sonofsailor.gif	NOCOPY Atk: 350 Def: 350 HP: 600 Init: 50 Meat: 75 P: dude ED: sleaze Article: a
+drownedbeat	1575	drownedbeat.gif	NOCOPY Atk: 400 Def: 325 HP: 450 Init: 25 Meat: 25 P: dude ED: sleaze Article: a	bike rental broupon (c100)
 
 # The Mansion of Dr. Weirdeaux (Conspiracy Island October 2014)
-one of Doctor Weirdeaux's creations	1632	noart.gif	NOCOPY Init: -10000 P: beast E: spooky	experimental serum P-00 (0)
+one of Doctor Weirdeaux's creations	1632	noart.gif	NOCOPY Init: -10000 P: beast ED: spooky EA: cold EA: hot EA: sleaze EA: spooky EA: stench	experimental serum P-00 (0)
 
 # The Deep Dark Jungle (Conspiracy Island October 2014)
-bigface	1638	bigface.gif	Scale: 5 Cap: 11111 Init: -10000 P: humanoid E: spooky	&quot;meat&quot; stick (15)	Sasq&trade; watch (c0)
-Mercenary of Fortune	1640	mercenary.gif	Scale: 5 Cap: 11111 Init: -10000 P: dude E: spooky Article: a	specialty ammo bandolier (15)	camouflage T-shirt (c0)	Coinspiracy (c0)	mercenary headband (c0)
-smoke monster	1639	smokemonster.gif	Scale: 5 Cap: 11111 Init: -10000 P: weird E: spooky Article: a	transdermal smoke patch (15)	smoker's cloak (c0)
-Venus mantrap	1637	mantrap.gif	Scale: 5 Cap: 11111 Init: -10000 P: plant E: spooky Article: a	the most dangerous bait (15)	pair of plants (c0)
+bigface	1638	bigface.gif	Scale: 5 Cap: 11111 Init: -10000 P: humanoid ED: spooky EA: sleaze EA: spooky	&quot;meat&quot; stick (15)	Sasq&trade; watch (c0)
+Mercenary of Fortune	1640	mercenary.gif	Scale: 5 Cap: 11111 Init: -10000 P: dude ED: spooky EA: hot Article: a	specialty ammo bandolier (15)	camouflage T-shirt (c0)	Coinspiracy (c0)	mercenary headband (c0)
+smoke monster	1639	smokemonster.gif	Scale: 5 Cap: 11111 Init: -10000 P: weird ED: spooky Article: a	transdermal smoke patch (15)	smoker's cloak (c0)
+Venus mantrap	1637	mantrap.gif	Scale: 5 Cap: 11111 Init: -10000 P: plant ED: spooky Article: a	the most dangerous bait (15)	pair of plants (c0)
 
 # The Secret Government Laboratory (Conspiracy Island October 2014)
 creepy little girl	1635	creepygirl.gif	NOBANISH Atk: [200+150*pref(controlPanel5)+150*pref(controlPanel6)+150*pref(controlPanel9)+ML] Def: [200+150*pref(controlPanel5)+150*pref(controlPanel6)+150*pref(controlPanel9)+ML] HP: [150+150*pref(controlPanel5)+150*pref(controlPanel6)+150*pref(controlPanel9)+ML] Exp: [(200+150*pref(controlPanel5)+150*pref(controlPanel6)+150*pref(controlPanel9))/4+ML/3] Init: -10000 P: dude E: spooky Article: a	jangly bracelet (c0)	delicious candy (c0)	cuddly teddy bear (c0)	airborne mutagen (c0)	creepy nursery rhyme (c0)
-government scientist	1633	scientist.gif	NOBANISH Atk: [200+150*pref(controlPanel1)+150*pref(controlPanel2)+150*pref(controlPanel9)+ML] Def: [200+150*pref(controlPanel1)+150*pref(controlPanel2)+150*pref(controlPanel9)+ML] HP: [150+150*pref(controlPanel1)+150*pref(controlPanel2)+150*pref(controlPanel9)+ML] Exp: [(200+150*pref(controlPanel1)+150*pref(controlPanel2)+150*pref(controlPanel9))/4+ML/3] Init: -10000 P: dude E: spooky Article: a	heavy-duty clipboard (c0)	experimental serum G-9 (c15)	battery-powered drill (c0)	airborne mutagen (c0)	grimy lab coat (c0)
-lab monkey	1634	labmonkey.gif	NOBANISH Atk: [200+150*pref(controlPanel3)+150*pref(controlPanel4)+150*pref(controlPanel9)+ML] Def: [200+150*pref(controlPanel3)+150*pref(controlPanel4)+150*pref(controlPanel9)+ML] HP: [150+150*pref(controlPanel3)+150*pref(controlPanel4)+150*pref(controlPanel9)+ML] Exp: [(200+150*pref(controlPanel3)+150*pref(controlPanel4)+150*pref(controlPanel9))/4+ML/3] Init: -10000 P: beast E: spooky Article: a	limp broccoli (c0)	monkey barf (c0)	giant yellow hat (c0)	airborne mutagen (c0)
-super-sized Cola Wars soldier	1636	colasoldier.gif	NOBANISH Atk: [200+150*pref(controlPanel7)+150*pref(controlPanel8)+150*pref(controlPanel9)+ML] Def: [200+150*pref(controlPanel7)+150*pref(controlPanel8)+150*pref(controlPanel9)+ML] HP: [150+150*pref(controlPanel7)+150*pref(controlPanel8)+150*pref(controlPanel9)+ML] Exp: [(200+150*pref(controlPanel7)+150*pref(controlPanel8)+150*pref(controlPanel9))/4+ML/3] Init: -10000 P: dude E: spooky Article: a	ice-cold Cloaca Zero (c0)	first-aid pouch (c0)	khaki duffel bag (c0)	airborne mutagen (c0)	iron torso box (c0)
+government scientist	1633	scientist.gif	NOBANISH Atk: [200+150*pref(controlPanel1)+150*pref(controlPanel2)+150*pref(controlPanel9)+ML] Def: [200+150*pref(controlPanel1)+150*pref(controlPanel2)+150*pref(controlPanel9)+ML] HP: [150+150*pref(controlPanel1)+150*pref(controlPanel2)+150*pref(controlPanel9)+ML] Exp: [(200+150*pref(controlPanel1)+150*pref(controlPanel2)+150*pref(controlPanel9))/4+ML/3] Init: -10000 P: dude ED: spooky EA: hot Article: a	heavy-duty clipboard (c0)	experimental serum G-9 (c15)	battery-powered drill (c0)	airborne mutagen (c0)	grimy lab coat (c0)
+lab monkey	1634	labmonkey.gif	NOBANISH Atk: [200+150*pref(controlPanel3)+150*pref(controlPanel4)+150*pref(controlPanel9)+ML] Def: [200+150*pref(controlPanel3)+150*pref(controlPanel4)+150*pref(controlPanel9)+ML] HP: [150+150*pref(controlPanel3)+150*pref(controlPanel4)+150*pref(controlPanel9)+ML] Exp: [(200+150*pref(controlPanel3)+150*pref(controlPanel4)+150*pref(controlPanel9))/4+ML/3] Init: -10000 P: beast ED: spooky EA: cold EA: stench Article: a	limp broccoli (c0)	monkey barf (c0)	giant yellow hat (c0)	airborne mutagen (c0)
+super-sized Cola Wars soldier	1636	colasoldier.gif	NOBANISH Atk: [200+150*pref(controlPanel7)+150*pref(controlPanel8)+150*pref(controlPanel9)+ML] Def: [200+150*pref(controlPanel7)+150*pref(controlPanel8)+150*pref(controlPanel9)+ML] HP: [150+150*pref(controlPanel7)+150*pref(controlPanel8)+150*pref(controlPanel9)+ML] Exp: [(200+150*pref(controlPanel7)+150*pref(controlPanel8)+150*pref(controlPanel9))/4+ML/3] Init: -10000 P: dude ED: spooky Article: a	ice-cold Cloaca Zero (c0)	first-aid pouch (c0)	khaki duffel bag (c0)	airborne mutagen (c0)	iron torso box (c0)
 E.V.E., the robot zombie	1647	eve.gif	NOBANISH NOCOPY Atk: 300 Def: 300 HP: 500 Init: 150 P: construct Phys: 50 E: spooky
 
 # Tales of Spelunking (Adventurous Spelunker Year 2015)
@@ -1721,31 +1721,31 @@ flashy pirate	1764	flashypirate.gif	NOBANISH Atk: 200 Def: 200 HP: 150 Init: -10
 toxic beastie	1765	toxbeast1.gif,toxbeast2.gif,toxbeast3.gif,toxbeast4.gif	NOCOPY Scale: [5+55*pref(dinseySafetyProtocolsLoose)] Cap: [11111+11111*pref(dinseySafetyProtocolsLoose)] Floor: 50 Init: -10000 P: slime E: stench Article: a	toxic globule (35)	toxic globule (5)	toxic globule (5)
 
 # Uncle Gator's Country Fun-Time Liquid Waste Sluice (Dinseylandfill April 2015)
-C<i>bzzt</i>er the Grisly Bear	1766	animbear.gif	NOBANISH Scale: [5+20*pref(dinseyAudienceEngagement)] Cap: 11111 Floor: 100 MLMult: [3+2*pref(dinseyAudienceEngagement)] Init: -10000 P: construct E: stench Wiki: "Cbzzter the Grisly Bear"	jar of swamp honey (0)	backwoods banjo (c0)
+C<i>bzzt</i>er the Grisly Bear	1766	animbear.gif	NOBANISH Scale: [5+20*pref(dinseyAudienceEngagement)] Cap: 11111 Floor: 100 MLMult: [3+2*pref(dinseyAudienceEngagement)] Init: -10000 P: construct ED: stench EA: spooky EA: stench Wiki: "Cbzzter the Grisly Bear"	jar of swamp honey (0)	backwoods banjo (c0)
 Gurgle the Turgle	1768	animturtle.gif	NOBANISH Scale: [5+20*pref(dinseyAudienceEngagement)] Cap: 11111 Floor: 100 MLMult: [3+2*pref(dinseyAudienceEngagement)] Init: -10000 P: construct E: stench	turtle voicebox (0)	fake washboard (c0)
 Skeezy the Jug Rat	1767	animrat.gif	NOBANISH Scale: [5+20*pref(dinseyAudienceEngagement)] Cap: 11111 Floor: 100 MLMult: [3+2*pref(dinseyAudienceEngagement)] Init: -10000 P: construct E: stench	grody jug (0)	ratskin pajama pants (c0)
 nasty bear	1769	nastybear.gif	NOBANISH NOCOPY Atk: [(150+ML)*(1-pref(dinseyAudienceEngagement))+(max(min(10000,MOX+20),100)+5*max(ML,0))*pref(dinseyAudienceEngagement)] Def: [(150+ML)*(1-pref(dinseyAudienceEngagement))+(max(min(10000,MUS+20),100)+5*max(ML,0))*pref(dinseyAudienceEngagement)] HP: [(1000+ML)*(1-pref(dinseyAudienceEngagement))+(max(min(10000,MUS+20),100)+5*max(ML,0))*pref(dinseyAudienceEngagement)*0.75] Exp: [(150/4+ML/3)*(1-pref(dinseyAudienceEngagement))+(max(min(10000,STAT+20),100)/4+5*max(ML,0)/3)*pref(dinseyAudienceEngagement)] Init: -10000 P: beast E: stench Article: a
 
 # Dinseylandfill (April 2015)
-Wart Dinsey	1770	wartdinsey.gif	BOSS NOCOPY Atk: 700 Def: 700 HP: 1000 Init: 250 P: construct E: stench	Dinsey's brain (0)	brain preservation fluid (c100)	Wart Dinsey: An Afterlife (0)
+Wart Dinsey	1770	wartdinsey.gif	BOSS NOCOPY Atk: 700 Def: 700 HP: 1000 Init: 250 P: construct ED: stench EA: cold EA: hot EA: sleaze EA: spooky EA: stench	Dinsey's brain (0)	brain preservation fluid (c100)	Wart Dinsey: An Afterlife (0)
 
 # Deck of Every Card (July 2015)
 legal alien	1783	illegal_alien.gif	NOCOPY Atk: 50 Def: 50 HP: 100 Init: 50 P: humanoid Article: a
-The Emperor	1782	theemperor.gif	NOCOPY Atk: 100 Def: 100 HP: 100 Init: 100 P: dude	The Emperor's dry cleaning (100)
-The Hermit	1781	otherimages/hermit.gif	NOCOPY NOMANUEL Atk: 100 Def: 100 HP: 100 Init: 100 P: dude Wiki: "Hermit (monster)"	hermit factoid (0)
+The Emperor	1782	theemperor.gif	NOCOPY Atk: 100 Def: 100 HP: 100 Init: 100 P: dude EA: sleaze	The Emperor's dry cleaning (100)
+The Hermit	1781	otherimages/hermit.gif	NOCOPY NOMANUEL Atk: 100 Def: 100 HP: 100 Init: 100 P: dude EA: hot Wiki: "Hermit (monster)"	hermit factoid (0)
 
 # Bubblin' Caldera (That 70s Volcano August 2015)
 basaltamander	1799	basaltamander.gif	Atk: 100 Def: 100 HP: 180 Init: 50 P: beast E: hot Article: a	basaltamander tongue (15)	basaltamander buckler (c0)
 lava lamprey	1797	lavalamprey.gif	Atk: 110 Def: 90 HP: 150 Init: 75 P: fish E: hot Article: a	smelted roe (15)	lavalarva (c0)
 lavatory	1798	lavatory.gif	Atk: 90 Def: 110 HP: 140 Init: 25 P: elemental E: hot Article: a	lavawater (15)	lava balaclava (c0)
-Lavalos	1821	lavalos.gif	BOSS NOCOPY Atk: 250 Def: 200 HP: 500 Init: 50 P: horror	Lavalos core (n100)	Lavalos's shell (n100)
+Lavalos	1821	lavalos.gif	BOSS NOCOPY Atk: 250 Def: 200 HP: 500 Init: 50 P: horror EA: cold	Lavalos core (n100)	Lavalos's shell (n100)
 
 # The SMOOCH Army HQ (That 70s Volcano August 2015)
-SMOOCH private	1794	smoochman1.gif	Scale: 1 Cap: 12345 Init: -10000 P: dude E: hot Article: a	SMOOCH soda (35)	heat-resistant sheet metal (20)
-SMOOCH sergeant	1795	smoochman2.gif	Scale: 15 Cap: 12345 Init: -10000 P: dude E: hot Article: a	SMOOCH soda (35)	heat-resistant sheet metal (20)	heat-resistant sheet metal (20)
-SMOOCH general	1796	smoochman3.gif	Scale: 30 Cap: 12345 Init: -10000 P: dude E: hot Article: a	SMOOCH soda (35)	heat-resistant sheet metal (20)	heat-resistant sheet metal (20)	heat-resistant sheet metal (20)
-Geve Smimmons	1817	smoochboss1.gif	BOSS NOCOPY Atk: 200 Def: 240 HP: 300 Init: 150 P: dude	the tongue of Smimmons (n100)	demon makeup kit (n100)
-Raul Stamley	1818	smoochboss2.gif	BOSS NOCOPY Atk: 180 Def: 220 HP: 300 Init: 75 P: dude	Raul's guitar pick (n100)	love (n100)
+SMOOCH private	1794	smoochman1.gif	Scale: 1 Cap: 12345 Init: -10000 P: dude ED: hot Article: a	SMOOCH soda (35)	heat-resistant sheet metal (20)
+SMOOCH sergeant	1795	smoochman2.gif	Scale: 15 Cap: 12345 Init: -10000 P: dude ED: hot Article: a	SMOOCH soda (35)	heat-resistant sheet metal (20)	heat-resistant sheet metal (20)
+SMOOCH general	1796	smoochman3.gif	Scale: 30 Cap: 12345 Init: -10000 P: dude ED: hot Article: a	SMOOCH soda (35)	heat-resistant sheet metal (20)	heat-resistant sheet metal (20)	heat-resistant sheet metal (20)
+Geve Smimmons	1817	smoochboss1.gif	BOSS NOCOPY Atk: 200 Def: 240 HP: 300 Init: 150 P: dude EA: hot	the tongue of Smimmons (n100)	demon makeup kit (n100)
+Raul Stamley	1818	smoochboss2.gif	BOSS NOCOPY Atk: 180 Def: 220 HP: 300 Init: 75 P: dude EA: hot	Raul's guitar pick (n100)	love (n100)
 Pener Crisp	1819	smoochboss3.gif	BOSS NOCOPY Atk: 200 Def: 220 HP: 400 Init: 75 P: dude	Pener's crisps (n100)	Pener's drumstick (n100)
 Deuce Freshly	1820	smoochboss4.gif	BOSS NOCOPY Atk: 220 Def: 180 HP: 400 Init: 125 P: dude	signed deuce (n100)	little deuce cape (n100)
 
@@ -1755,10 +1755,10 @@ factory overseer (male)	1790	facworker3.gif	Atk: 50 Def: 50 HP: 100 Init: 50 Mea
 factory worker (female)	1789	facworker1.gif	Atk: 50 Def: 50 HP: 100 Init: 50 Meat: 50 P: dude E: hot Article: a Manuel: "factory worker"	heat-resistant gloves (5)	lava-proof pants (5)	very hot lunch (15)
 factory worker (male)	1792	facworker2.gif	Atk: 50 Def: 50 HP: 100 Init: 50 Meat: 50 P: dude E: hot Article: a Manuel: "factory worker"	asbestos thermos (15)	heat-resistant necktie (5)
 lava golem	1793	lavagolem.gif	Atk: 70 Def: 70 HP: 150 Init: 70 P: construct Phys: 75 E: hot Article: a	gooey lava globs (30)	sticky lava globs (30)	viscous lava globs (10)
-Mr. Cheeng	1815	mrcheeng.gif	BOSS NOCOPY Atk: 180 Def: 220 HP: 400 Init: 100 P: dude	Mr. Cheeng's 'stache (n100)	Mr. Cheeng's spectacles (n100)
+Mr. Cheeng	1815	mrcheeng.gif	BOSS NOCOPY Atk: 180 Def: 220 HP: 400 Init: 100 P: dude EA: hot	Mr. Cheeng's 'stache (n100)	Mr. Cheeng's spectacles (n100)
 
 # The Velvet / Gold Mine (That 70s Volcano August 2015)
-healing crystal golem	1788	crystalgolem.gif	Atk: 70 Def: 70 HP: 150 Init: 70 P: construct Phys: 50 E: hot Article: a	glowing New Age crystal (5)	New Age healing crystal (20)	New Age healing crystal (15)
+healing crystal golem	1788	crystalgolem.gif	Atk: 70 Def: 70 HP: 150 Init: 70 P: construct Phys: 50 ED: hot Article: a	glowing New Age crystal (5)	New Age healing crystal (20)	New Age healing crystal (15)
 mine overseer (female)	1787	mineboss2.gif	Atk: 50 Def: 50 HP: 100 Init: 50 P: dude E: hot Article: a Manuel: "mine overseer"	fireproof megaphone (0)	Gold Velvet&trade; whiskey (0)
 mine overseer (male)	1785	mineboss1.gif	Atk: 50 Def: 50 HP: 100 Init: 50 P: dude E: hot Article: a Manuel: "mine overseer"	fireproof megaphone (0)	Gold Velvet&trade; whiskey (0)
 mine worker (female)	1784	mineworker1.gif	Atk: 50 Def: 50 HP: 100 Init: 50 P: dude E: hot Article: a Manuel: "mine worker"	broken high-temperature mining drill (0)	high-temperature mining mask (0)	mineapple (0)
@@ -1770,19 +1770,19 @@ Travoltron	1816	travoltron.gif	BOSS NOCOPY Atk: 240 Def: 180 HP: 500 Init: 75 P:
 
 # The Ice Hotel (The Glaciest November 2015)
 ice bartender	1850	icetender.gif	Atk: 100 Def: 90 HP: 110 Init: 40 Meat: 50 P: dude E: cold Article: an	perfect ice cube (30)
-ice clerk	1854	iceclerk.gif	Atk: 100 Def: 80 HP: 120 Init: 40 P: dude E: cold Article: an	ice hotel bell (0)
-ice concierge	1852	iceconcierge.gif	Atk: 110 Def: 90 HP: 150 Init: 50 Meat: 40 P: dude E: cold Article: an	exotic travel brochure (0)	bag of foreign bribes (0)
+ice clerk	1854	iceclerk.gif	Atk: 100 Def: 80 HP: 120 Init: 40 P: dude ED: cold Article: an	ice hotel bell (0)
+ice concierge	1852	iceconcierge.gif	Atk: 110 Def: 90 HP: 150 Init: 50 Meat: 40 P: dude ED: cold Article: an	exotic travel brochure (0)	bag of foreign bribes (0)
 ice housekeeper	1853	icemaid.gif	Atk: 90 Def: 100 HP: 120 Init: 20 P: dude E: cold Article: an	frozen shampoo-conditioner (0)	hotel minibar key (0)
-ice porter	1851	iceporter.gif	Atk: 90 Def: 100 HP: 160 Init: 10 Meat: 25 P: dude E: cold Article: an	ice porter (0)	bellhop's hat (0)
+ice porter	1851	iceporter.gif	Atk: 90 Def: 100 HP: 160 Init: 10 Meat: 25 P: dude ED: cold Article: an	ice porter (0)	bellhop's hat (0)
 
 # VYKEA (The Glaciest November 2015)
-VYKEA viking (female)	1849	vykfemale1.gif,vykfemale2.gif,vykfemale3.gif	NOCOPY Scale: 10 Cap: 12500 Floor: 85 Init: -10000 P: dude E: cold	VYKEA instructions (0)	VYKEA woadpaint (0)	VYKEA hex key (0)
+VYKEA viking (female)	1849	vykfemale1.gif,vykfemale2.gif,vykfemale3.gif	NOCOPY Scale: 10 Cap: 12500 Floor: 85 Init: -10000 P: dude ED: cold	VYKEA instructions (0)	VYKEA woadpaint (0)	VYKEA hex key (0)
 VYKEA viking (male)	1848	vykmale1.gif,vykmale2.gif,vykmale3.gif	NOCOPY Scale: 6 Cap: 12000 Floor: 85 Init: -10000 P: dude E: cold	VYKEA instructions (0)	VYKEA woadpaint (0)	VYKEA hex key (0)
 
 # The Ice Hole (The Glaciest November 2015)
-Norwhal	1856	norwhal.gif	Atk: 250 Def: 200 HP: 225 Init: 25 P: fish E: cold Article: a	bottle of norwhiskey (0)	norwhal helmet (c0)
-Arctic Octolus	1857	octolus.gif	Atk: 225 Def: 250 HP: 200 Init: 25 P: fish E: cold Article: an	octolus oculus (0)	octolus-skin cloak (c0)
-Tin of Submardines	1855	submardines.gif	Atk: 225 Def: 200 HP: 250 Init: 25 P: fish E: cold Article: a	tin of submardines (0)	sardine can key (c0)
+Norwhal	1856	norwhal.gif	Atk: 250 Def: 200 HP: 225 Init: 25 P: fish ED: cold Article: a	bottle of norwhiskey (0)	norwhal helmet (c0)
+Arctic Octolus	1857	octolus.gif	Atk: 225 Def: 250 HP: 200 Init: 25 P: fish ED: cold Article: an	octolus oculus (0)	octolus-skin cloak (c0)
+Tin of Submardines	1855	submardines.gif	Atk: 225 Def: 200 HP: 250 Init: 25 P: fish ED: cold Article: a	tin of submardines (0)	sardine can key (c0)
 
 # Deep Machine Tunnels (Machine Elf Capsule December 2015)
 Performer of Actions	1859	blank.gif	Scale: 1 Cap: 10000 Floor: 10 Init: -10000 P: weird	abstraction: action (0)	abstraction: purpose (0)
@@ -1790,7 +1790,7 @@ Thinker of Thoughts	1860	blank.gif	Scale: 1 Cap: 10000 Floor: 10 Init: -10000 P:
 Perceiver of Sensations	1861	blank.gif	Scale: 1 Cap: 10000 Floor: 10 Init: -10000 P: weird	abstraction: perception (0)	abstraction: sensation (0)
 
 # The X-32-F Combat Training Snowman (X-32-F snowman crate January 2016)
-X-32-F Combat Training Snowman	1858	blank.gif	NOCOPY NOMANUEL NOWANDER Atk: 1 Def: 1 HP: 1 P: construct E: cold
+X-32-F Combat Training Snowman	1858	blank.gif	NOCOPY NOMANUEL NOWANDER Atk: 1 Def: 1 HP: 1 P: construct ED: cold EA: cold EA: hot EA: sleaze EA: spooky EA: stench
 
 # Investigating a Plaintive Telegram
 
@@ -1806,7 +1806,7 @@ buzzard	1907	vulture.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Cap: 111
 mountain lion	1908	mtlion.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Cap: 11111 Floor: [60*pref(lttQuestDifficulty)] Init: 100 P: beast Article: a	lion musk (0)
 grizzled bear	1909	grizzlebear.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Cap: 11111 Floor: [60*pref(lttQuestDifficulty)] Init: -10000 P: beast Article: a	bear claw (0)
 diamondback rattler	1910	diamondback.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Cap: 11111 Floor: [60*pref(lttQuestDifficulty)] Init: 75 P: beast SNAKE Article: a	rattler gland (0)
-coal snake	1911	coalsnake.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Cap: 11111 Floor: [60*pref(lttQuestDifficulty)] Init: 50 P: beast SNAKE Article: a	half-digested coal (0)
+coal snake	1911	coalsnake.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Cap: 11111 Floor: [60*pref(lttQuestDifficulty)] Init: 50 P: beast SNAKE EA: hot Article: a	half-digested coal (0)
 frontwinder	1912	frontwinder.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Cap: 11111 Floor: [60*pref(lttQuestDifficulty)] Init: 100 P: beast SNAKE Article: a	tightly-wound spine (0)
 caugr	1913	caugr.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Cap: 11111 Floor: [60*pref(lttQuestDifficulty)] Init: -10000 P: demon Article: a	rotting beefsteak (0)
 pyrobove	1914	pyrobove.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Cap: 11111 Floor: [60*pref(lttQuestDifficulty)] Init: 100 P: demon E: hot Article: a	firemilk (0)
@@ -1814,16 +1814,16 @@ spidercow	1915	cowspider.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Cap:
 moomy	1916	moomy.gif	Scale: [max(5,25*pref(lttQuestDifficulty)-25)] Cap: 11111 Floor: [60*pref(lttQuestDifficulty)] Init: -10000 P: demon Elem: [max(min(50*(pref(lttQuestDifficulty)-1),75),0)] E: spooky Article: a	moomy dust (0)
 
 # Bosses
-Jeff the Fancy Skeleton	1917	fancyjeff.gif	NOCOPY Atk: 180 Def: 200 HP: 300 Init: 100 P: undead Phys: 50 Elem: 70 E: spooky	Fancy Jeff's fancy pocket square (n100)
+Jeff the Fancy Skeleton	1917	fancyjeff.gif	NOCOPY Atk: 180 Def: 200 HP: 300 Init: 100 P: undead Phys: 50 Elem: 70 ED: spooky	Fancy Jeff's fancy pocket square (n100)
 Daisy the Unclean	1918	daisy.gif	NOCOPY Atk: 200 Def: 180 HP: 400 Init: 100 P: demon E: stench	Daisy's unclean bloomers (n100)
 Pecos Dave	1919	pecosdave.gif	NOCOPY Atk: 200 Def: 180 HP: 300 Init: 10000 P: dude	Pecos Dave's sixgun (n100)
 
-Pharaoh Amoon-Ra Cowtep	1920	amoonra.gif	NOCOPY HP: 1000 Scale: 30 Cap: 5000 Floor: 300 Init: 10000 P: demon	Amoon-Ra Cowtep's nemes (n100)
+Pharaoh Amoon-Ra Cowtep	1920	amoonra.gif	NOCOPY HP: 1000 Scale: 30 Cap: 5000 Floor: 300 Init: 10000 P: demon EA: spooky	Amoon-Ra Cowtep's nemes (n100)
 Snake-Eyes Glenn	1921	snakeglenn.gif	NOCOPY HP: 1000 Scale: 30 Cap: 5000 Floor: 300 Init: 10000 P: dude	Glenn's golden dice (n100)
 Former Sheriff Dan Driscoll	1922	sheriffdan.gif	NOCOPY HP: 800 Scale: 30 Cap: 5000 Floor: 300 Init: -10000 P: dude	Former Sheriff Dan's tin star (n100)
 
-unusual construct	1923	vib6.gif	NOCOPY HP: 5000 Scale: 60 Cap: 9000 Floor: 500 Init: 10000 P: construct Phys: 50 Elem: 50 Article: an	El Vibrato restraints (n100)
-Clara	1924	clara.gif	NOCOPY HP: 5000 Scale: 60 Cap: 9000 Floor: 500 Init: 300 P: demon	Clara's bell (n100)
+unusual construct	1923	vib6.gif	NOCOPY HP: 5000 Scale: 60 Cap: 9000 Floor: 500 Init: 10000 P: construct Phys: 50 Elem: 50 EA: hot Article: an	El Vibrato restraints (n100)
+Clara	1924	clara.gif	NOCOPY HP: 5000 Scale: 60 Cap: 9000 Floor: 500 Init: 300 P: demon EA: cold EA: hot EA: spooky EA: stench	Clara's bell (n100)
 Granny Hackleton	1925	grannyhack.gif	NOCOPY HP: 3000 Scale: 60 Cap: 9000 Floor: 500 Init: -10000 P: dude	Granny Hackleton's Gatling gun (n100)
 
 # Batfellow Area (Batfellow comic IOTY 2016)
@@ -1836,34 +1836,34 @@ low-level mook	1868	blankmook.gif	NOCOPY HP: 10 Init: -10000 P: dude Article: a
 mid-level mook	1869	blankmook.gif	NOCOPY HP: 20 Init: -10000 P: dude Article: a
 high-level mook	1870	blankmook.gif	NOCOPY HP: 35 Init: -10000 P: dude Article: a
 
-Kudzu	1871	batboss_kudzu.gif	BOSS NOCOPY HP: 20 Init: -10000 P: plant	Kudzu slaw (c100)
+Kudzu	1871	batboss_kudzu.gif	BOSS NOCOPY HP: 20 Init: -10000 P: plant EA: stench	Kudzu slaw (c100)
 Mansquito	1872	batboss_mansq.gif	BOSS NOCOPY HP: 20 Init: -10000 P: dude	Mansquito's blood (c100)
-Miss Graves	1873	batboss_graves.gif	BOSS NOCOPY HP: 20 Init: -10000 P: dude	infrablack lipstick (c100)
-The Plumber	1874	batboss_plumber.gif	BOSS NOCOPY HP: 75 Init: -10000 P: dude	can of drain cleaner (c100)
-The Author	1875	batboss_author.gif	BOSS NOCOPY HP: 75 Init: -10000 P: dude	The Author's inkwell (c100)
+Miss Graves	1873	batboss_graves.gif	BOSS NOCOPY HP: 20 Init: -10000 P: dude EA: spooky	infrablack lipstick (c100)
+The Plumber	1874	batboss_plumber.gif	BOSS NOCOPY HP: 75 Init: -10000 P: dude EA: stench	can of drain cleaner (c100)
+The Author	1875	batboss_author.gif	BOSS NOCOPY HP: 75 Init: -10000 P: dude EA: spooky	The Author's inkwell (c100)
 The Mad Libber	1876	batboss_libber.gif	BOSS NOCOPY HP: 75 Init: -10000 P: dude	bag of random words (c100)
 Doc Clock	1877	batboss_docclock.gif	BOSS NOCOPY HP: 100 Init: -10000 P: dude	tube of pendulum lube (c100)
-Mr. Burns	1878	batboss_mrburns.gif	BOSS NOCOPY HP: 100 Init: -10000 P: dude	red-hot jawbreaker (c100)
+Mr. Burns	1878	batboss_mrburns.gif	BOSS NOCOPY HP: 100 Init: -10000 P: dude EA: hot	red-hot jawbreaker (c100)
 The Inquisitor	1879	batboss_inquis.gif	BOSS NOCOPY HP: 100 Init: -10000 P: dude	question juice (c100)
 
 # Gotpork Conservatory of Flowers
-vine-controlled botanist	1880	botanist.gif	NOCOPY HP: 11 Init: -10000 P: plant Article: a
-vicious plant creature	1881	plantmonster.gif	NOCOPY HP: 11 Init: -10000 P: plant Article: a
+vine-controlled botanist	1880	botanist.gif	NOCOPY HP: 11 Init: -10000 P: plant EA: stench Article: a
+vicious plant creature	1881	plantmonster.gif	NOCOPY HP: 11 Init: -10000 P: plant EA: stench Article: a
 
 # Gotpork Municipal Reservoir
 giant leech	1882	giantleech.gif	NOCOPY HP: 11 Init: -10000 P: bug Article: a
 giant mosquito	1883	giantskeeter.gif	NOCOPY HP: 11 Init: -10000 P: bug Article: a
 
 # Gotpork Gardens Cemetery
-lovestruck goth dude	1884	lovestruckgoth.gif	NOCOPY HP: 11 Init: -10000 P: dude Article: a
-walking skeleton	1885	gothskeleton.gif	NOCOPY HP: 11 Init: -10000 P: undead Article: a
+lovestruck goth dude	1884	lovestruckgoth.gif	NOCOPY HP: 11 Init: -10000 P: dude EA: spooky Article: a
+walking skeleton	1885	gothskeleton.gif	NOCOPY HP: 11 Init: -10000 P: undead EA: spooky Article: a
 
 # Gotpork City Sewers
 liquid plumber	1886	liquidplumber.gif	NOCOPY HP: 25 Init: -10000 P: construct Article: a
-plumber's helper	1887	plumberhelper.gif	NOCOPY HP: 25 Init: -10000 P: dude Article: a
+plumber's helper	1887	plumberhelper.gif	NOCOPY HP: 25 Init: -10000 P: dude EA: stench Article: a
 
 # Porkham Asylum
-former inmate	1888	psychpatient.gif	NOCOPY HP: 25 Init: -10000 P: dude Article: a
+former inmate	1888	psychpatient.gif	NOCOPY HP: 25 Init: -10000 P: dude EA: spooky Article: a
 former guard	1889	blankmook.gif	NOCOPY HP: 25 Init: -10000 P: dude Article: a
 
 # The Old Gotpork Library
@@ -1875,40 +1875,40 @@ time bandit	1892	blankmook.gif	NOCOPY HP: 40 Init: -10000 P: dude Article: a
 clockwork man	1893	clockworkman.gif	NOCOPY HP: 40 Init: -10000 P: dude Article: a
 
 # Gotpork Foundry
-serial arsonist	1894	burnerman.gif	NOCOPY HP: 40 Init: -10000 P: dude Article: a
-burner	1895	blankmook.gif	NOCOPY HP: 40 Init: -10000 P: dude Article: a
+serial arsonist	1894	burnerman.gif	NOCOPY HP: 40 Init: -10000 P: dude EA: hot Article: a
+burner	1895	blankmook.gif	NOCOPY HP: 40 Init: -10000 P: dude EA: hot Article: a
 
 # Trivial Pursuits, LLC
-inquisitee	1896	inquisitee.gif	NOCOPY HP: 40 Init: -10000 P: dude Article: an
+inquisitee	1896	inquisitee.gif	NOCOPY HP: 40 Init: -10000 P: dude EA: spooky Article: an
 trivia researcher	1897	researcher.gif	NOCOPY HP: 40 Init: -10000 P: dude Article: a
 
 # JokesterCo
 The Jokester	1898	jokester.gif	BOSS NOCOPY HP: 200 Init: -10000 P: dude	tube of villain white (c100)
 
 # Witchess set (March 2016)
-Witchess Pawn	1935	chess_bpawn.gif	FREE Scale: 2 Cap: 200 Floor: 10 Init: -10000 P: dude Article: a	armored prawn (n100)
+Witchess Pawn	1935	chess_bpawn.gif	FREE Scale: 2 Cap: 200 Floor: 10 Init: -10000 P: dude EA: hot Article: a	armored prawn (n100)
 Witchess Knight	1936	chess_bknight.gif	FREE Scale: 5 Cap: 400 Floor: 20 Init: -10000 P: dude Article: a	jumping horseradish (n100)
 Witchess Ox	1937	chess_box.gif	FREE Atk: 1 HP: [max(2500,(MUS/4+ML/3)*45)] Scale: 0 Cap: 5000 Floor: 10 Init: -10000 P: beast Phys: 50 Elem: 50 Article: a	ox-head shield (n100)
 Witchess Rook	1938	chess_brook.gif	FREE Scale: 7 Cap: 600 Floor: 25 Init: -10000 P: construct Article: a	Greek Fire (n100)
 Witchess Queen	1939	chess_bqueen.gif	FREE HP: 4000 Scale: 40 Cap: 8000 Floor: 200 Init: -10000 P: dude Phys: 75 Elem: 50 Article: a	very pointy crown (n100)
 Witchess King	1940	chess_bking.gif	FREE HP: 2000 Scale: 20 Cap: 6000 Floor: 100 Init: -10000 P: dude Elem: 50 Article: a	dented scepter (n100)
-Witchess Witch	1941	chess_bwitch.gif	FREE HP: 3000 Scale: 30 Cap: 7000 Floor: 150 Init: -10000 P: dude Phys: 50 Elem: 75 Article: a	battle broom (n100)
+Witchess Witch	1941	chess_bwitch.gif	FREE HP: 3000 Scale: 30 Cap: 7000 Floor: 150 Init: -10000 P: dude Phys: 50 Elem: 75 EA: spooky Article: a	battle broom (n100)
 Witchess Bishop	1942	chess_bbishop.gif	FREE Scale: 7 Cap: 600 Floor: 25 Init: -10000 P: dude Article: a	Sacramento wine (n100)
 
 # Protonic Accelerator Pack (August 2016)
-the ghost of Oily McBindle	1946	ghost_oily.gif	NOCOPY FREE NOWANDER Atk: 3 Def: 2 HP: 10 Init: 5 P: undead GHOST E: spooky	haunted bindle (c100)
+the ghost of Oily McBindle	1946	ghost_oily.gif	NOCOPY FREE NOWANDER Atk: 3 Def: 2 HP: 10 Init: 5 P: undead GHOST ED: spooky EA: sleaze	haunted bindle (c100)
 boneless blobghost	1947	ghost_skin.gif	NOCOPY FREE NOWANDER Atk: 3 Def: 2 HP: 10 Init: 5 P: undead GHOST E: spooky Article: a	fleshy lump (c100)
-the ghost of Monsieur Baguelle	1948	ghost_bagel.gif	NOCOPY FREE NOWANDER Atk: 3 Def: 2 HP: 10 Init: 5 P: undead GHOST E: spooky	smoldering bagel punch (c100)
+the ghost of Monsieur Baguelle	1948	ghost_bagel.gif	NOCOPY FREE NOWANDER Atk: 3 Def: 2 HP: 10 Init: 5 P: undead GHOST ED: spooky EA: hot	smoldering bagel punch (c100)
 The Headless Horseman	1949	ghost_horse.gif	NOCOPY FREE NOWANDER Atk: 12 Def: 10 HP: 12 Init: 15 P: undead GHOST E: spooky	ghostly reins (c100)
-The Icewoman	1950	ghost_icewoman.gif	NOCOPY FREE NOWANDER Atk: 25 Def: 22 HP: 25 Init: 25 P: undead GHOST E: spooky	frigid derringer (c100)
+The Icewoman	1950	ghost_icewoman.gif	NOCOPY FREE NOWANDER Atk: 25 Def: 22 HP: 25 Init: 25 P: undead GHOST ED: spooky EA: cold	frigid derringer (c100)
 The ghost of Ebenoozer Screege	1951	ghost_screege.gif	NOCOPY FREE NOWANDER Atk: 25 Def: 22 HP: 25 Init: 25 P: undead GHOST E: spooky	Mr. Screege's spectacles (c100)
-The ghost of Lord Montague Spookyraven	1952	ghost_sraven.gif	NOCOPY FREE NOWANDER Atk: 32 Def: 28 HP: 32 Init: 30 P: undead GHOST E: spooky	Spookyraven signet (c100)
-The ghost of Vanillica "Trashblossom" Gorton	1953	ghost_hippy.gif	NOCOPY FREE NOWANDER Atk: 32 Def: 28 HP: 32 Init: 30 P: undead GHOST E: spooky	tie-dyed fannypack (c100)
-The ghost of Sam McGee	1954	ghost_flame.gif	NOCOPY FREE NOWANDER Atk: 95 Def: 85 HP: 90 Init: 40 P: undead GHOST E: spooky	burnt snowpants (c100)
+The ghost of Lord Montague Spookyraven	1952	ghost_sraven.gif	NOCOPY FREE NOWANDER Atk: 32 Def: 28 HP: 32 Init: 30 P: undead GHOST ED: spooky EA: stench	Spookyraven signet (c100)
+The ghost of Vanillica "Trashblossom" Gorton	1953	ghost_hippy.gif	NOCOPY FREE NOWANDER Atk: 32 Def: 28 HP: 32 Init: 30 P: undead GHOST ED: spooky EA: stench	tie-dyed fannypack (c100)
+The ghost of Sam McGee	1954	ghost_flame.gif	NOCOPY FREE NOWANDER Atk: 95 Def: 85 HP: 90 Init: 40 P: undead GHOST ED: spooky EA: hot	burnt snowpants (c100)
 The ghost of Richard Cockingham	1955	ghost_censor.gif	NOCOPY FREE NOWANDER Atk: 85 Def: 80 HP: 80 Init: 50 P: undead GHOST E: spooky	standards and practices guide (c100)
-The ghost of Waldo the Carpathian	1956	ghost_waldo.gif	NOCOPY FREE NOWANDER Atk: 70 Def: 65 HP: 70 Init: 60 P: undead GHOST E: spooky	Carpathian longsword (c100)
+The ghost of Waldo the Carpathian	1956	ghost_waldo.gif	NOCOPY FREE NOWANDER Atk: 70 Def: 65 HP: 70 Init: 60 P: undead GHOST ED: spooky EA: hot	Carpathian longsword (c100)
 Emily Koops, a spooky lime	1957	ghost_lime.gif	NOCOPY FREE NOWANDER Atk: 175 Def: 150 HP: 160 Init: 70 P: undead GHOST E: spooky	Liam's mail (c100)
-The ghost of Jim Unfortunato	1958	ghost_fortunado.gif	NOCOPY FREE NOWANDER Atk: 190 Def: 170 HP: 180 Init: 75 P: undead GHOST E: spooky	Unfortunato's foolscap (c100)
+The ghost of Jim Unfortunato	1958	ghost_fortunado.gif	NOCOPY FREE NOWANDER Atk: 190 Def: 170 HP: 180 Init: 75 P: undead GHOST ED: spooky EA: sleaze	Unfortunato's foolscap (c100)
 
 # Time Spinner (September 2016)
 Ancient Skeleton with Skin still on it	1962	skinskeleton.gif	Scale: 3 Cap: ? Floor: 20 Init: -10000 P: undead Phys: 60 Elem: 50 Article: an	compounded experience (c100)	time residue (c0)
@@ -1927,11 +1927,11 @@ gingerbread mad dog	1978	gbdog.gif	NOCOPY Scale: 10 Cap: 1000 Floor: 30 Init: 10
 gingerbread lawyer	1979	gblawyer.gif	NOCOPY Scale: 10 Cap: 1000 Floor: 30 Init: -10000 SprinkleMin: 18 SprinkleMax: 20 P: dude Article: a	candy dress shoes (0)	gingerbread restraining order (0)
 gingerbread vagrant	1980	gbvagrant.gif	NOCOPY Scale: -5 Cap: 1000 Floor: 30 Init: 150 SprinkleMin: 3 SprinkleMax: 5 P: dude Article: a	sprinkle-begging cup (0)
 animal cracker	1981	gbcracker.gif	NOCOPY Scale: 10 Cap: 1000 Floor: 30 Init: 150 SprinkleMin: 8 SprinkleMax: 10 P: beast Article: an	animal part cracker (0)
-gingerbread wino	1982	gbwino.gif	NOCOPY Scale: 10 Cap: 1000 Floor: 30 Init: 100 SprinkleMin: 3 SprinkleMax: 5 P: dude Article: a	gingerbread wine (0)
+gingerbread wino	1982	gbwino.gif	NOCOPY Scale: 10 Cap: 1000 Floor: 30 Init: 100 SprinkleMin: 3 SprinkleMax: 5 P: dude EA: stench Article: a	gingerbread wine (0)
 gingerbread mugger	1983	gbmugger.gif	NOCOPY Scale: 10 Cap: 1000 Floor: 30 Init: 150 SprinkleMin: 16 SprinkleMax: 22 P: dude Article: a	gingerbread mug (0)	gingerbread mask (0)
 gingerbread welder robot	1984	gbwelder.gif	NOCOPY Scale: 10 Cap: 1000 Floor: 30 Init: 200 SprinkleMin: 8 SprinkleMax: 11 P: construct Article: a	gingerservo (0)
 gingerbread mutant	1985	gbmutant.gif	NOCOPY Scale: 10 Cap: 1000 Floor: 30 Init: 150 SprinkleMin: 8 SprinkleMax: 11 P: dude Article: a	tainted icing (0)
-gingerbread gentrifier	1986	gbgentry.gif	NOCOPY Scale: 10 Cap: 1000 Floor: 30 Init: 200 SprinkleMin: 18 SprinkleMax: 22 P: dude Article: a	gingerbread smartphone (0)	gingerbeard (0)
+gingerbread gentrifier	1986	gbgentry.gif	NOCOPY Scale: 10 Cap: 1000 Floor: 30 Init: 200 SprinkleMin: 18 SprinkleMax: 22 P: dude EA: hot Article: a	gingerbread smartphone (0)	gingerbeard (0)
 gingerbread finance bro	1987	gbfinancebro.gif	NOCOPY Scale: 10 Cap: 1000 Floor: 30 Init: 150 SprinkleMin: 28 SprinkleMax: 32 P: dude Article: a	gingerbread smartphone (0)	candy necktie (0)
 gingerbread tech bro	1988	gbtechbro.gif	NOCOPY Scale: 10 Cap: 1000 Floor: 30 Init: -10000 SprinkleMin: 23 SprinkleMax: 27 P: dude Article: a	gingerbread smartphone (0)	gingerbread hoodie (0)
 gingerbread alligator	1989	gbgator.gif	NOCOPY Scale: [10+190*pref(_gingerBiggerAlligators)] Cap: 1000 Floor: 30 Init: 100 SprinkleMin: [28+70*pref(_gingerBiggerAlligators)] SprinkleMax: [30+70*pref(_gingerBiggerAlligators)] P: beast Article: a
@@ -1949,12 +1949,12 @@ hostile plant	2013	sgplanta1.gif,sgplanta2.gif,sgplanta3.gif,sgplanta4.gif,sgpla
 large hostile plant	2014	sgplantb1.gif,sgplantb2.gif,sgplantb3.gif,sgplantb4.gif,sgplantb5.gif,sgplantb6.gif,sgplantb7.gif,sgplantb8.gif,sgplantb9.gif,sgplantb10.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: plant Article: a	edible alien plant bit	edible alien plant bit	alien plant fibers	alien plant fibers	alien plant goo
 exotic hostile plant	2015	sgplantc1.gif,sgplantc2.gif,sgplantc3.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: plant Article: an	edible alien plant bit	edible alien plant bit	edible alien plant bit	alien plant fibers	alien plant fibers	alien plant fibers	alien plant goo	alien plant pod
 small hostile animal	2016	sganimala1.gif,sganimala2.gif,sganimala3.gif,sganimala4.gif,sganimala5.gif,sganimala6.gif,sganimala7.gif,sganimala8.gif,sganimala9.gif,sganimala10.gif,sganimala11.gif,sganimala12.gif,sganimala13.gif,sganimala14.gif,sganimala15.gif,sganimala16.gif,sganimala17.gif,sganimala18.gif,sganimala19.gif,sganimala20.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: beast Article: a	alien meat	alien toenails	alien animal goo
-large hostile animal	2017	sganimalb1.gif,sganimalb2.gif,sganimalb3.gif,sganimalb4.gif,sganimalb5.gif,sganimalb6.gif,sganimalb7.gif,sganimalb8.gif,sganimalb9.gif,sganimalb10.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: beast Article: a	alien meat	alien meat	alien toenails	alien toenails	alien animal goo
-exotic hostile animal	2018	sganimalc1.gif,sganimalc2.gif,sganimalc3.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: beast Article: an	alien meat	alien meat	alien meat	alien toenails	alien toenails	alien toenails	alien animal goo	alien animal milk
-Spant drone	2019	sgspantdrone.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: bug Article: a	spant chitin	spant chitin	spant tendon	spant tendon
-Spant soldier	2020	sgspantwarrior.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: bug Article: a	spant chitin	spant chitin	spant tendon	spant tendon	spant spear
-Murderbot drone	2021	sgmbdrone.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: construct Article: a	murderbot component casing	murderbot monofilament	murderbot monofilament	murderbot power cell	murderbot power cell	murderbot memory chip
-Murderbot soldier	2022	sgmb.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: construct Article: a	murderbot component casing	murderbot component casing	murderbot monofilament	murderbot monofilament	murderbot power cell	murderbot power cell	murderbot memory chip	murderbot memory chip	murderbot memory chip	murderbot plasma rifle
+large hostile animal	2017	sganimalb1.gif,sganimalb2.gif,sganimalb3.gif,sganimalb4.gif,sganimalb5.gif,sganimalb6.gif,sganimalb7.gif,sganimalb8.gif,sganimalb9.gif,sganimalb10.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: beast EA: stench Article: a	alien meat	alien meat	alien toenails	alien toenails	alien animal goo
+exotic hostile animal	2018	sganimalc1.gif,sganimalc2.gif,sganimalc3.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: beast EA: stench Article: an	alien meat	alien meat	alien meat	alien toenails	alien toenails	alien toenails	alien animal goo	alien animal milk
+Spant drone	2019	sgspantdrone.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: bug EA: hot Article: a	spant chitin	spant chitin	spant tendon	spant tendon
+Spant soldier	2020	sgspantwarrior.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: bug EA: stench Article: a	spant chitin	spant chitin	spant tendon	spant tendon	spant spear
+Murderbot drone	2021	sgmbdrone.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: construct EA: cold EA: hot Article: a	murderbot component casing	murderbot monofilament	murderbot monofilament	murderbot power cell	murderbot power cell	murderbot memory chip
+Murderbot soldier	2022	sgmb.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: construct EA: stench Article: a	murderbot component casing	murderbot component casing	murderbot monofilament	murderbot monofilament	murderbot power cell	murderbot power cell	murderbot memory chip	murderbot memory chip	murderbot memory chip	murderbot plasma rifle
 hostile intelligent alien	2023	sgalienb1.gif,sgalienb2.gif,sgalienb3.gif,sgalienb4.gif,sgalienb5.gif,sgalienb6.gif,sgalienb7.gif,sgalienb8.gif,sgalienb9.gif,sgalienb10.gif	NOCOPY Scale: [10+25*pref(_spacegatePlanetIndex)] Cap: 10000 Floor: ? Init: [60+10*pref(_spacegatePlanetIndex)] P: humanoid Article: a
 
 # The following may not actually be a monster, but there is a cycle of images for it
@@ -1971,16 +1971,16 @@ giant amorphous blob	2033	xoblob_big.gif	NOCOPY Atk: 10000 Def: 9000 HP: 20000 I
 fantasy bandit	2060	fr_bandit.gif	Atk: 100 Def: 100 HP: 100 Init: 100 P: dude Article: a	Rubee&trade; (n100)
 fantasy ourk	2061	fr_ourk.gif	Atk: 120 Def: 120 HP: 150 Init: 100 P: dude Phys: 100 Article: a	Rubee&trade; (n100)
 fantasy forest faerie	2062	fr_faerie.gif	Atk: 120 Def: 120 HP: 90 Init: 300 P: dude Article: a	Rubee&trade; (n100)
-swamp monster	2063	fr_swampmonster.gif	Atk: 120 Def: 120 HP: 100 Init: 100 P: dude Phys: 60 Article: a	Rubee&trade; (n100)
-cursed villager	2064	fr_villager.gif	Atk: 130 Def: 130 HP: 30 Init: -10000 P: dude Article: a	Rubee&trade; (n100)
-spooky ghost	2065	fr_ghost.gif	Atk: 130 Def: 130 HP: 150 Init: 200 P: dude GHOST Phys: 100 Article: a Wiki: "Spooky ghost (FantasyRealm)"	Rubee&trade; (n100)
+swamp monster	2063	fr_swampmonster.gif	Atk: 120 Def: 120 HP: 100 Init: 100 P: dude Phys: 60 EA: stench Article: a	Rubee&trade; (n100)
+cursed villager	2064	fr_villager.gif	Atk: 130 Def: 130 HP: 30 Init: -10000 P: dude EA: cold EA: hot Article: a	Rubee&trade; (n100)
+spooky ghost	2065	fr_ghost.gif	Atk: 130 Def: 130 HP: 150 Init: 200 P: dude GHOST Phys: 100 EA: spooky Article: a Wiki: "Spooky ghost (FantasyRealm)"	Rubee&trade; (n100)
 mining grobold	2067	fr_grolblin.gif	Atk: 140 Def: 140 HP: 100 Init: 999 P: construct Article: a	Rubee&trade; (n100)	Rubee&trade; (n100)
 rubber bat	2068	fr_bat.gif	Atk: 140 Def: 140 HP: 150 Init: -10000 P: construct Article: a	Rubee&trade; (n100)	Rubee&trade; (n100)
-quadfaerie	2069	fr_quadfaerie.gif	Atk: 140 Def: 140 HP: 100 Init: 150 P: construct Article: a	Rubee&trade; (n100)	Rubee&trade; (n100)
+quadfaerie	2069	fr_quadfaerie.gif	Atk: 140 Def: 140 HP: 100 Init: 150 P: construct EA: cold EA: hot EA: sleaze EA: spooky EA: stench Article: a	Rubee&trade; (n100)	Rubee&trade; (n100)
 druid plants	2070	fr_druidplant.gif	Atk: 150 Def: 150 HP: 300 Init: -10000 P: plant Article: some	Rubee&trade; (n100)	Rubee&trade; (n100)
 flock of every birds	2071	fr_birds.gif	Atk: 150 Def: 150 HP: 50 Init: 100 P: beast Article: a	Rubee&trade; (n100)	Rubee&trade; (n100)
 plywood cultists	2072	fr_cultist.gif	Atk: 150 Def: 150 HP: 100 Init: -10000 P: construct Article: the	Rubee&trade; (n100)	Rubee&trade; (n100)
-barrow wraith?	2073	darkness.gif	Atk: 150 Def: 150 HP: 99999 Init: 100 P: construct Article: a Wiki: "barrow wraith"	Rubee&trade; (n100)	Rubee&trade; (n100)
+barrow wraith?	2073	darkness.gif	Atk: 150 Def: 150 HP: 99999 Init: 100 P: construct EA: spooky Article: a Wiki: "barrow wraith"	Rubee&trade; (n100)	Rubee&trade; (n100)
 regular thief	2074	fr_thief.gif	Atk: 150 Def: 150 HP: 100 Init: 100 P: dude Article: a	Rubee&trade; (n100)	Rubee&trade; (n100)
 swamp troll	2075	fr_troll.gif	Atk: 150 Def: 150 HP: 300 Init: -10000 P: construct Phys: 100 Article: a	Rubee&trade; (n100)	Rubee&trade; (n100)
 crypt creeper	2076	fr_creeper.gif	Atk: 150 Def: 150 HP: 99999 Init: 1000 P: construct Article: the	Rubee&trade; (n100)	Rubee&trade; (n100)
@@ -1996,45 +1996,45 @@ Ted Schwartz, Master Thief	2085	fr_masterthief.gif	BOSS NOCOPY Atk: 400 Def: 400
 Skeleton Lord	2087	skeletonlord.gif	BOSS NOCOPY Atk: 300 Def: 300 HP: 200 Init: -10000 P: construct Article: the	shield of the Skeleton Lord (c100)	ring of the Skeleton Lord (c100)	scepter of the Skeleton Lord (c100)
 
 # God Lobster (May 2018)
-God Lobster	2088	godlob.gif,godlob_scepter.gif,godlob_ring.gif,godlob_rod.gif,godlob_cape.gif,godlob_crown.gif	NOCOPY FREE Scale: [10*equipped(God Lobster's Scepter)+20*equipped(God Lobster's Ring)+30*equipped(God Lobster's Rod)+40*equipped(God Lobster's Robe)+50*equipped(God Lobster's Crown)] Cap: 1500 Floor: ? Init: 1000 P: horror Phys: [30*equipped(God Lobster's Ring)+50*equipped(God Lobster's Rod)+60*equipped(God Lobster's Robe)+80*equipped(God Lobster's Crown)] Elem: [25*equipped(God Lobster's Rod)+60*equipped(God Lobster's Robe)+90*equipped(God Lobster's Crown)] Article: the Wiki: "God Lobster (monster)"
+God Lobster	2088	godlob.gif,godlob_scepter.gif,godlob_ring.gif,godlob_rod.gif,godlob_cape.gif,godlob_crown.gif	NOCOPY FREE Scale: [10*equipped(God Lobster's Scepter)+20*equipped(God Lobster's Ring)+30*equipped(God Lobster's Rod)+40*equipped(God Lobster's Robe)+50*equipped(God Lobster's Crown)] Cap: 1500 Floor: ? Init: 1000 P: horror Phys: [30*equipped(God Lobster's Ring)+50*equipped(God Lobster's Rod)+60*equipped(God Lobster's Robe)+80*equipped(God Lobster's Crown)] Elem: [25*equipped(God Lobster's Rod)+60*equipped(God Lobster's Robe)+90*equipped(God Lobster's Crown)] EA: hot EA: spooky Article: the Wiki: "God Lobster (monster)"
 
 # Neverending Party (Sept 2018)
-biker	2089	nparty_biker.gif	Scale: [20+100*equipped(PARTY HARD T-shirt)] Cap: 20000 Floor: 21 Init: -10000 Meat: 100 P: dude Phys: 20 Article: a	gas can (0)	Middle of the Road&trade; brand whiskey (0)	neverending wallet chain (0)	pentagram bandana (0)	gold skull ring (c0)
-"plain" girl	2090	nparty_plaingirl.gif	Scale: [-10+100*equipped(PARTY HARD T-shirt)] Cap: 20000 Floor: 10 Init: -10000 Meat: 100 P: dude Article: a	electronics kit (0)	PB&J with the crusts cut off (0)	dorky glasses (0)	ponytail clip (0)	paint palette (c0)
-jock	2091	nparty_jock.gif	Scale: [0+100*equipped(PARTY HARD T-shirt)] Cap: 20000 Floor: 10 Init: -10000 Meat: 150 P: dude Article: a	unremarkable duffel bag (0)	Purple Beast energy drink (0)	cosmetic football (0)	shoe ad T-shirt (0)	pump-up high-tops (c0)
-party girl	2092	nparty_partygirl.gif	Scale: [10+100*equipped(PARTY HARD T-shirt)] Cap: 20000 Floor: 11 Init: -10000 Meat: 100 P: dude Article: a	runproof mascara (0)	very small red dress (0)	noticeable pumps (0)	surprisingly capacious handbag (0)	everfull glass (c0)
-burnout	2093	nparty_burnout.gif	Scale: [-5+100*equipped(PARTY HARD T-shirt)] Cap: 20000 Floor: 10 Init: -10000 Meat: 50 P: dude Article: a	denim jacket (0)	ratty knitted cap (0)	van key (0)	jam band bootleg (0)
+biker	2089	nparty_biker.gif	Scale: [20+100*equipped(PARTY HARD T-shirt)] Cap: 20000 Floor: 21 Init: -10000 Meat: 100 P: dude Phys: 20 EA: hot EA: sleaze EA: stench Article: a	gas can (0)	Middle of the Road&trade; brand whiskey (0)	neverending wallet chain (0)	pentagram bandana (0)	gold skull ring (c0)
+"plain" girl	2090	nparty_plaingirl.gif	Scale: [-10+100*equipped(PARTY HARD T-shirt)] Cap: 20000 Floor: 10 Init: -10000 Meat: 100 P: dude EA: sleaze Article: a	electronics kit (0)	PB&J with the crusts cut off (0)	dorky glasses (0)	ponytail clip (0)	paint palette (c0)
+jock	2091	nparty_jock.gif	Scale: [0+100*equipped(PARTY HARD T-shirt)] Cap: 20000 Floor: 10 Init: -10000 Meat: 150 P: dude EA: sleaze Article: a	unremarkable duffel bag (0)	Purple Beast energy drink (0)	cosmetic football (0)	shoe ad T-shirt (0)	pump-up high-tops (c0)
+party girl	2092	nparty_partygirl.gif	Scale: [10+100*equipped(PARTY HARD T-shirt)] Cap: 20000 Floor: 11 Init: -10000 Meat: 100 P: dude EA: sleaze Article: a	runproof mascara (0)	very small red dress (0)	noticeable pumps (0)	surprisingly capacious handbag (0)	everfull glass (c0)
+burnout	2093	nparty_burnout.gif	Scale: [-5+100*equipped(PARTY HARD T-shirt)] Cap: 20000 Floor: 10 Init: -10000 Meat: 50 P: dude EA: hot EA: stench Article: a	denim jacket (0)	ratty knitted cap (0)	van key (0)	jam band bootleg (0)
 
 # Voter Registration Form (Nov 2018)
 angry ghost	2094	vw_ghost.gif	NOCOPY Scale: 4 Cap: 1000 Floor: 10 Init: -10000 P: undead GHOST Phys: 50 E: spooky Article: an	ghostly ectoplasm (100)	ghostly ectoplasm (10)	ghostly ectoplasm (1)
 annoyed snake	2098	vwsnake.gif	NOCOPY Scale: 3 Cap: 1000 Floor: 10 Init: -10000 Meat: 25 P: beast Elem: 50 Article: an	snake skin (0)
 government bureaucrat	2095	vwgovt.gif	NOCOPY Scale: 1 Cap: 1000 Floor: 10 Init: -10000 Meat: 50 P: dude Article: a	government requisition form (0)	absentee voter ballot (0)
 terrible mutant	2096	vwmutant.gif	NOCOPY Scale: 5 Cap: 1000 Floor: 10 Init: -10000 Meat: 10 P: humanoid Article: a	glob of undifferentiated tissue (0)	glob of undifferentiated tissue (0)	mutant arm (n0)	mutant legs (c0)	mutant crown (c0)
-slime blob	2097	vwslime.gif	NOCOPY Scale: 4 Cap: 1000 Floor: 10 Init: -10000 P: slime Phys: 50 E: sleaze Article: a	green slime glob (20)	orange slime glob (40)	black slime glob (n0)
+slime blob	2097	vwslime.gif	NOCOPY Scale: 4 Cap: 1000 Floor: 10 Init: -10000 P: slime Phys: 50 ED: sleaze Article: a	green slime glob (20)	orange slime glob (40)	black slime glob (n0)
 
 # Kramco Sausage-o-Matic (Jan 2019
-sausage goblin	2104	sausagegoblin.gif	FREE Scale: [1+2*pref(_sausageFights)] Cap: ? Floor: ? Init: -10000 Meat: 69 P: goblin E: sleaze Article: a	magical sausage casing (n100)	red-hot sausage fork (0)	bag of sausage links (n0)
+sausage goblin	2104	sausagegoblin.gif	FREE Scale: [1+2*pref(_sausageFights)] Cap: ? Floor: ? Init: -10000 Meat: 69 P: goblin ED: sleaze EA: hot EA: sleaze Article: a	magical sausage casing (n100)	red-hot sausage fork (0)	bag of sausage links (n0)
 
 # PirateRealm (Apr 2019)
-giant crab	2116	pr_crab.gif	Atk: 25 Def: 25 HP: 30 Init: 50 Meat: 150 P: beast Article: a
-melty army man	2117	pr_armyman.gif	Atk: 30 Def: 20 HP: 30 Init: 50 P: dude E: stench Article: a	melty plastic grenade
-plastic skeleton	2118	pr_skeleton.gif	Atk: 30 Def: 30 HP: 40 Init: 50 P: undead Article: a
+giant crab	2116	pr_crab.gif	Atk: 25 Def: 25 HP: 30 Init: 50 Meat: 150 P: beast EA: sleaze Article: a
+melty army man	2117	pr_armyman.gif	Atk: 30 Def: 20 HP: 30 Init: 50 P: dude ED: stench EA: hot EA: stench Article: a	melty plastic grenade
+plastic skeleton	2118	pr_skeleton.gif	Atk: 30 Def: 30 HP: 40 Init: 50 P: undead EA: spooky Article: a
 plastic pirate	2119	pr_piratefigure.gif	Atk: 35 Def: 30 HP: 30 Init: 75 P: construct Article: a
-translucent monkey	2120	pr_monkey.gif	Atk: 30 Def: 30 HP: 40 Init: 75 P: beast Article: a
-giant giant crab	2121	pr_bosscrab.gif	NOCOPY Atk: 80 Def: 80 HP: 200 Init: 50 Meat: 2000 P: beast Article: a
+translucent monkey	2120	pr_monkey.gif	Atk: 30 Def: 30 HP: 40 Init: 75 P: beast EA: hot EA: stench Article: a
+giant giant crab	2121	pr_bosscrab.gif	NOCOPY Atk: 80 Def: 80 HP: 200 Init: 50 Meat: 2000 P: beast EA: sleaze EA: spooky Article: a
 toy dinosaur	2123	pr_dinosaur.gif	Atk: 50 Def: 50 HP: 60 Init: 75 P: beast Article: a
-cockroach	2124	pr_cockroach.gif	Atk: 40 Def: 80 HP: 60 Init: 50 Meat: 500 P: bug Article: a
-vape ghost	2125	pr_vapeghost.gif	Atk: 60 Def: 30 HP: 60 Init: 30 P: undead Phys: 100 Article: a
+cockroach	2124	pr_cockroach.gif	Atk: 40 Def: 80 HP: 60 Init: 50 Meat: 500 P: bug EA: sleaze Article: a
+vape ghost	2125	pr_vapeghost.gif	Atk: 60 Def: 30 HP: 60 Init: 30 P: undead Phys: 100 EA: cold EA: hot EA: sleaze EA: spooky EA: stench Article: a
 signal	2126	pr_signal.gif	Atk: 90 Def: 90 HP: 100 Init: 200 P: weird Phys: 50 Elem: 50 Article: a	signal fragment
-tiki idol	2127	pr_tiki.gif	Atk: 90 Def: 110 HP: 100 Init: 50 P: construct E: sleaze Article: a	hibiscus petal	huge mint leaf	pineapple slab
+tiki idol	2127	pr_tiki.gif	Atk: 90 Def: 110 HP: 100 Init: 50 P: construct ED: sleaze EA: sleaze EA: spooky Article: a	hibiscus petal	huge mint leaf	pineapple slab
 pewter torsohunter	2128	pr_headhunter.gif	Atk: 120 Def: 80 HP: 100 Init: 80 P: construct Article: a	pewter shavings
 carnivorous plant	2129	pr_plant.gif	Atk: 100 Def: 80 HP: 80 Init: -10000 P: plant Article: a
 strong wind	2130	pr_wind.gif	Atk: 100 Def: 100 HP: 10 Init: 999 P: weird Phys: 100 Elem: 100 Article: a	windicle
 jungle titan	2131	pr_titan.gif	NOCOPY Atk: 90 Def: 90 HP: 1000 Init: 50 P: dude Article: a
-pirate radio	2132	pr_radio.gif	NOCOPY Atk: 100 Def: 100 HP: 500 Init: -10000 P: construct Article: a
-melty freezeface	2133	pr_freezeface.gif	Atk: 80 Def: 80 HP: 100 Init: 100 P: construct E: cold Article: a	oversized ice molecule
+pirate radio	2132	pr_radio.gif	NOCOPY Atk: 100 Def: 100 HP: 500 Init: -10000 P: construct EA: hot Article: a
+melty freezeface	2133	pr_freezeface.gif	Atk: 80 Def: 80 HP: 100 Init: 100 P: construct ED: cold EA: cold EA: stench Article: a	oversized ice molecule
 Red Roger	2134	pr_redroger.gif	NOCOPY Atk: 100 Def: 100 HP: 500 Init: -10000 P: construct	Red Roger's reliquary (n100)
-Glass Jack Hummel	2135	pr_glassjack.gif	NOCOPY Atk: 100 Def: 100 HP: 200 Init: 50 P: construct
+Glass Jack Hummel	2135	pr_glassjack.gif	NOCOPY Atk: 100 Def: 100 HP: 200 Init: 50 P: construct EA: spooky
 
 # Cargo Cultist Shorts (Sep 2020)
 Astrologer of Shub-Jigguwatt	2200	ccs_astrologer.gif	NOCOPY Scale: 15 Init: -10000 P: constellation E: sleaze Article: an	star chart (n100)	star (n30)	star (n10)	line (n30)	line (n10)
@@ -2050,23 +2050,23 @@ family of kobolds	1101	kobolds.gif	NOCOPY Atk: 99999 Def: 89999 HP: 99999 Init: 
 
 # Transmissions from planet Xi (Xi Receiver KoL Con XI)
 holographic army	1629	holoarmy.gif	NOCOPY Scale: 30 Floor: ? Init: -10000 Group: 10 P: weird Elem: 50 Article: a	holo-bomber (0)	holo-platoon (0)	holo-tank (0)
-They	1631	they.gif	Scale: 20 Floor: ? Init: -10000 P: humanoid Article: a	They liver (0)	They liver (0)	BUBBLE GUM (c0)
+They	1631	they.gif	Scale: 20 Floor: ? Init: -10000 P: humanoid EA: spooky Article: a	They liver (0)	They liver (0)	BUBBLE GUM (c0)
 Xiblaxian political prisoner	1630	polprisoner.gif	NOCOPY Scale: 40 Floor: ? Init: -10000 P: weird Elem: 75 Article: an	residual zeal (n100)	little red .epub file (c0)
 
 # Antique Maps
 
 # Landscaper's Lair (antique painting of a landscape March-April 2010)
 menacing lawn gnome	914	lawngnome1.gif	Atk: 50 Def: 45 HP: 75 Init: 50 P: humanoid Article: a	machetito (0)	pointy red hat (0)	stick-on gnome beard (c0)
-mounted lawn gnome	916	lawngnome3.gif	Atk: 60 Def: 54 HP: 95 Init: 85 P: humanoid Article: a	pointy red hat (0)	lawnmower blade (0)	grass clippings (0)
+mounted lawn gnome	916	lawngnome3.gif	Atk: 60 Def: 54 HP: 95 Init: 85 P: humanoid EA: hot Article: a	pointy red hat (0)	lawnmower blade (0)	grass clippings (0)
 mowing lawn gnome	915	lawngnome2.gif	Atk: 55 Def: 49 HP: 85 Init: 50 P: humanoid Article: a	lawnmower blade (0)	grass clippings (0)	pointy red hat (0)
 The Landscaper	917	landscaper.gif	BOSS NOCOPY Atk: 100 Def: 90 HP: 100000 Init: -10000 P: demon Phys: 100 EA: hot	The Landscaper's leafblower (100)
 
 # Professor Jacking's laboratory (antique record album March-April 2010)
 Professor Jacking	939	profjacking.gif	NOCOPY Atk: 85 Def: 76 HP: 200 Init: 85 Meat: 200 P: dude
-Castle in the Clouds in the Sky	943	thecastle.gif	Atk: 75 Def: 81 HP: 200 Init: 10 P: construct Article: the	tiny goth giant (0)
-cruel dust mote	940	dustmote.gif	Atk: 75 Def: 67 HP: 100 Init: 40 P: weird Article: a	boulder (0)
-Fearsome Wacken	946	wacken.gif	NOCOPY Atk: 90 Def: 81 HP: 200 Init: 60 P: beast Article: the	Crazyleg's razor (100)
-funk particle	942	funkparticle.gif	Atk: 85 Def: 67 HP: 80 Init: 30 P: weird Article: a	fat bottom quark (0)
+Castle in the Clouds in the Sky	943	thecastle.gif	Atk: 75 Def: 81 HP: 200 Init: 10 P: construct EA: sleaze Article: the	tiny goth giant (0)
+cruel dust mote	940	dustmote.gif	Atk: 75 Def: 67 HP: 100 Init: 40 P: weird EA: sleaze Article: a	boulder (0)
+Fearsome Wacken	946	wacken.gif	NOCOPY Atk: 90 Def: 81 HP: 200 Init: 60 P: beast EA: spooky Article: the	Crazyleg's razor (100)
+funk particle	942	funkparticle.gif	Atk: 85 Def: 67 HP: 80 Init: 30 P: weird EA: stench Article: a	fat bottom quark (0)
 jungle scabie	947	scabie_jungle.gif	Atk: 90 Def: 81 HP: 100 Init: 60 P: bug Article: a	big glob of skin (0)
 loose coalition of yetis, snowmen, and goats	945	coalition.gif	Atk: 80 Def: 72 HP: 100 Init: 80 P: beast Article: a	six tiny wedges of goat cheese (0)	tiny frozen prehistoric meteorite jawbreaker (c100)
 malevolent magnetic field	941	magfield.gif	Atk: 75 Def: 76 HP: 100 Init: 50 P: weird Article: a	bottle of gin (0)
@@ -2075,42 +2075,42 @@ Spookyraven Manor	944	manor.gif	Atk: 80 Def: 72 HP: 120 Init: 20 P: construct Wi
 The Whole Kingdom	949	wholekingdom.gif	NOCOPY NOMANUEL Atk: 1 Def: 1 HP: 10000000 P: construct Phys: 100
 
 # Kegger in the Woods (antique bottle opener May-June 2010)
-actual orcish frat boy	956	1boy2cups.gif	Atk: 45 Def: 63 HP: 100 Init: 60 Meat: 30 P: orc E: sleaze Article: an	plastic cup of beer (100)	plastic cup of beer (100)
+actual orcish frat boy	956	1boy2cups.gif	Atk: 45 Def: 63 HP: 100 Init: 60 Meat: 30 P: orc ED: sleaze EA: stench Article: an	plastic cup of beer (100)	plastic cup of beer (100)
 jailbait orquette	957	orquette1.gif	Atk: 40 Def: 45 HP: 80 Init: 30 Meat: 5 P: orc E: sleaze Article: a	orquette's phone number (c100)
-juvenile delinquent orquette	958	orquette2.gif	Atk: 50 Def: 45 HP: 100 Init: 75 Meat: 10 P: orc E: sleaze Article: a	orquette's phone number (c100)
+juvenile delinquent orquette	958	orquette2.gif	Atk: 50 Def: 45 HP: 100 Init: 75 Meat: 10 P: orc ED: sleaze Article: a	orquette's phone number (c100)
 orcish frat wannaboy	955	lilfratboy.gif	Atk: 38 Def: 54 HP: 90 Init: 40 Meat: 10 P: orc E: sleaze Article: an	plastic cup of beer (100)
 orcish juvenile delinquent	954	lilfratboy.gif	Atk: 35 Def: 40 HP: 80 Init: 50 Meat: 5 P: orc E: sleaze Article: an	plastic cup of beer (100)
-totally trashed orquette	959	orquette3.gif	Atk: 48 Def: 54 HP: 90 Init: 20 Meat: 20 P: orc E: sleaze Article: a	orquette's phone number (c100)
+totally trashed orquette	959	orquette3.gif	Atk: 48 Def: 54 HP: 90 Init: 20 Meat: 20 P: orc ED: sleaze EA: stench Article: a	orquette's phone number (c100)
 
 # Vanya's Castle (antique 8-bit Power magazine June-July 2010)
 fleaman	951	cvfleaman.gif	Atk: 85 Def: 67 HP: 80 Init: 10000 P: dude Article: a	black pixel (0)	brown pixel (0)	brown pixel (0)
 ghost	950	cvghost.gif	Atk: 75 Def: 67 HP: 80 Init: 50 P: undead GHOST Article: a	white pixel (80)	white pixel (70)	white pixel (60)	white pixel (50)	white pixel (40)
 medusa	952	cvmedusa.gif	Atk: 75 Def: 76 HP: 80 Init: 80 P: horror Article: a	blue pixel (0)	white pixel (0)	white pixel (0)
-Vanya's Creature	953	cvcreature.gif	BOSS NOCOPY Atk: 1000 Def: 900 HP: 3000 Init: -10000 Meat: 1500 P: construct Phys: 50 E: spooky	pixel orb (n100)
+Vanya's Creature	953	cvcreature.gif	BOSS NOCOPY Atk: 1000 Def: 900 HP: 3000 Init: -10000 Meat: 1500 P: construct Phys: 50 ED: spooky EA: hot	pixel orb (n100)
 
 # Magic Commune (antique souvenir drawing July-August 2010)
-Neptune, the Dog that Is a Respected Equal and Not a Pet cast member	962	mc_respect1.gif	Atk: 65 Def: 58 HP: 100 Init: 30 P: beast	respected companion biscuit (0)
+Neptune, the Dog that Is a Respected Equal and Not a Pet cast member	962	mc_respect1.gif	Atk: 65 Def: 58 HP: 100 Init: 30 P: beast EA: sleaze	respected companion biscuit (0)
 Susie Soyburger cast member	961	mc_soy1.gif	Atk: 70 Def: 54 HP: 110 Init: 20 P: dude Article: a	soyburger juice (0)
-Timmy Tofurkey cast member	960	mc_tofu1.gif	Atk: 60 Def: 63 HP: 110 Init: 20 P: dude Article: a	sun-dried tofu (0)
-Neptune, the Dog that Is a Respected Equal and Not a Pet	965	mc_respect2.gif	Atk: 45 Def: 40 HP: 80 Init: 60 P: beast	respected companion biscuit (0)
+Timmy Tofurkey cast member	960	mc_tofu1.gif	Atk: 60 Def: 63 HP: 110 Init: 20 P: dude EA: sleaze Article: a	sun-dried tofu (0)
+Neptune, the Dog that Is a Respected Equal and Not a Pet	965	mc_respect2.gif	Atk: 45 Def: 40 HP: 80 Init: 60 P: beast EA: stench	respected companion biscuit (0)
 Susie Soyburger	964	mc_soy2.gif	Atk: 50 Def: 36 HP: 90 Init: 50 P: humanoid	soyburger juice (0)
-Timmy Tofurkey	963	mc_tofu2.gif	Atk: 40 Def: 45 HP: 90 Init: 50 P: humanoid	sun-dried tofu (0)
-Essence of Interspecies Respect	968	mc_respect3.gif	NOCOPY Atk: 25 Def: 22 HP: 50 Init: 90 P: elemental Article: the	essential cameraderie (0)
+Timmy Tofurkey	963	mc_tofu2.gif	Atk: 40 Def: 45 HP: 90 Init: 50 P: humanoid EA: sleaze EA: spooky	sun-dried tofu (0)
+Essence of Interspecies Respect	968	mc_respect3.gif	NOCOPY Atk: 25 Def: 22 HP: 50 Init: 90 P: elemental EA: sleaze Article: the	essential cameraderie (0)
 Essence of Soy	967	mc_soy3.gif	NOCOPY Atk: 30 Def: 18 HP: 60 Init: 80 P: elemental Article: the	essential soy (0)
 Essence of Tofu	966	mc_tofu3.gif	NOCOPY Atk: 20 Def: 27 HP: 60 Init: 80 P: elemental Article: the	essential tofu (0)
 
 # Ellsbury's Claim (antique pair of blue jeans August-September 2010)
 deadly venomtrout	974	venomtrout.gif	Atk: 130 Def: 117 HP: 150 Init: 50 P: fish Article: a	trout fang (0)	poisonous caviar (0)
 unearthed monstrosity	976	ellsburyboss.gif	BOSS NOCOPY Atk: 200 Def: 180 HP: 500 Init: 10000 P: horror Article: an	Ellsbury's skull (100)	Ellsbury's journal (100)
-water spider	975	waterspider.gif	Atk: 130 Def: 117 HP: 150 Init: 50 P: bug Article: a	wet venom duct (0)
+water spider	975	waterspider.gif	Atk: 130 Def: 117 HP: 150 Init: 50 P: bug EA: hot Article: a	wet venom duct (0)
 
 # PVP Maps
 
 # Kokomo Resort (Feb-Apr 2015 PVP reward)
 Drunken Tropical Vacationer	1772	kok_drunk.gif	Scale: 0 Cap: ? Init: -10000 Meat: 200 P: dude Article: a	Kokomo Resort Brand Suntan Oil (0)	Kokomo Resort Chip (0)	Kokomo Resort Chip (0)	Kokomo Resort Chip (0)	captured boozles (c0)
 Lovestruck Tropical Honeymooners	1771	kok_lovers.gif	Scale: -5 Cap: ? Init: -10000 Meat: 250 P: dude Article: some	Afternoon Delight (0)	Kokomo Resort Chip (0)	Kokomo Resort Chip (0)
-Resort Waiter	1773	kok_waiter.gif	Scale: 5 Cap: ? Init: -10000 Meat: 100 P: dude Article: a	Kokomo Resort Order Pad (0)	Kokomo Resort Chip (0)	Kokomo Resort Chip (0)	drinks tray (c0)
-Brick Mulligan, the Bartender	1774	kok_tender.gif	NOCOPY Scale: 5 Cap: ? Floor: ? Init: -10000 P: dude	lemon (0)	lime (0)	orange (0)	bottle of gin (0)	bottle of vodka (0)	bottle of rum (0)	coconut shell (0)	little paper umbrella (0)	magical ice cubes (0)	eyebrow lifter (c0)
+Resort Waiter	1773	kok_waiter.gif	Scale: 5 Cap: ? Init: -10000 Meat: 100 P: dude EA: hot Article: a	Kokomo Resort Order Pad (0)	Kokomo Resort Chip (0)	Kokomo Resort Chip (0)	drinks tray (c0)
+Brick Mulligan, the Bartender	1774	kok_tender.gif	NOCOPY Scale: 5 Cap: ? Floor: ? Init: -10000 P: dude EA: hot	lemon (0)	lime (0)	orange (0)	bottle of gin (0)	bottle of vodka (0)	bottle of rum (0)	coconut shell (0)	little paper umbrella (0)	magical ice cubes (0)	eyebrow lifter (c0)
 
 # Current Events
 
@@ -2129,7 +2129,7 @@ Stuffing Golem	315	stuffgolem.gif	NOCOPY WANDERER Atk: [MOX-3] Def: [MUS-3] HP: 
 Novia Cad&aacute;ver	635	novia.gif	NOCOPY WANDERER Scale: -3 Init: -10000 P: undead Article: La Manuel: "Novia Cadáver"	red-headed corpse (c100)	corpse on the beach (c100)
 Novio Cad&aacute;ver	636	novio.gif	NOCOPY WANDERER Scale: -3 Init: -10000 P: undead Article: El Manuel: "Novio Cadáver"	kamicorpse-ee (c100)	corpsedriver (c100)
 Padre Cad&aacute;ver	637	elpriest.gif	NOCOPY WANDERER Scale: -3 Init: -10000 P: undead Article: El Manuel: "Padre Cadáver"	purple corpsel (c100)	corpsetini (c100)
-Persona Inocente Cad&aacute;ver	638	bystander.gif	NOCOPY WANDERER Scale: -3 Init: -10000 P: undead Article: La Manuel: "Persona Inocente Cadáver"	corpsebite (c100)	Corpse Island iced tea (c100)	una poca de gracia (c0)
+Persona Inocente Cad&aacute;ver	638	bystander.gif	NOCOPY WANDERER Scale: -3 Init: -10000 P: undead EA: spooky Article: La Manuel: "Persona Inocente Cadáver"	corpsebite (c100)	Corpse Island iced tea (c100)	una poca de gracia (c0)
 
 # The Spectral Pickle Factory
 carnivorous dill plant	215	dillplant.gif	BOSS NOCOPY Atk: 200 Def: 180 HP: 180 Init: 70 P: plant Article: a	dill (50)	dill (20)
@@ -2137,10 +2137,10 @@ ghostly pickle factory worker	214	worker.gif	BOSS NOCOPY Atk: 200 Def: 180 HP: 1
 vine gar	213	gar.gif	BOSS NOCOPY Atk: 200 Def: 180 HP: 180 Init: 70 P: beast Article: a	vinegar (50)	vinegar (20)
 
 # Trick or Treat
-vandal kid	1448	vandalkid.gif	FREE Scale: -3 Cap: 200 Init: 50 P: dude	carton of rotten eggs (15)	slingshot (5)	spray paint (10)
+vandal kid	1448	vandalkid.gif	FREE Scale: -3 Cap: 200 Init: 50 P: dude EA: stench	carton of rotten eggs (15)	slingshot (5)	spray paint (10)
 suburban security civilian	1450	paulblart.gif	FREE Scale: 3 Cap: 300 Init: -10000 P: dude Elem: 50	security flashlight (10)	unused walkie-talkie (1)	Way More Tears&trade; pepper spray (15)
-kid who is too old to be Trick-or-Treating	1449	tooold.gif	FREE Scale: 0 Cap: 250 Init: 50 P: dude Article: a	bottle of whiskey (15)	Effermint&trade; tablets (10)	sturdy cane (5)
-All-Hallow's Steve	1451	steve.gif	NOCOPY NOMANUEL FREE Scale: 30 Init: 90 P: dude Phys: 75 Elem: 75	All-Hallow's Steve's fright wig (n100)
+kid who is too old to be Trick-or-Treating	1449	tooold.gif	FREE Scale: 0 Cap: 250 Init: 50 P: dude EA: spooky Article: a	bottle of whiskey (15)	Effermint&trade; tablets (10)	sturdy cane (5)
+All-Hallow's Steve	1451	steve.gif	NOCOPY NOMANUEL FREE Scale: 30 Init: 90 P: dude Phys: 75 Elem: 75 EA: stench	All-Hallow's Steve's fright wig (n100)
 
 # Twitch 1 - Crashed Space Ship (May 2014)
 Government agent	1585	gov_agent.gif	Scale: -5 Init: 25 Meat: 75 P: dude Article: a	burned government manual fragment (15)	government cheese (20)	pair of government shades (3)	government-issued night-vision goggles (3)	government-issue identification badge (c0)
@@ -2158,41 +2158,41 @@ Caveman Dan	1621	cavedan.gif	NOCOPY NOMANUEL Scale: 10 Cap: 2000 Floor: 25 Init:
 
 # Twitch 3 - 1920's (July 2014)
 Moonshriner	1618	moonshriner.gif	Scale: 1 Cap: 1000 Init: -10000 Meat: 20 P: dude Article: a	throwing candy (20)	4-dimensional fez (2)
-unstill	1619	unstill.gif	Scale: 1 Cap: 1000 Init: -10000 P: construct Article: an	unquiet spirits (20)	super-absorbent tarp (2)
-banjoccultist	1620	banjowizard.gif	Scale: 1 Cap: 1000 Init: -10000 Meat: 10 P: dude Article: a	blue grass (20)	banjo kazoo mount (2)
+unstill	1619	unstill.gif	Scale: 1 Cap: 1000 Init: -10000 P: construct EA: hot Article: an	unquiet spirits (20)	super-absorbent tarp (2)
+banjoccultist	1620	banjowizard.gif	Scale: 1 Cap: 1000 Init: -10000 Meat: 10 P: dude EA: hot EA: spooky Article: a	blue grass (20)	banjo kazoo mount (2)
 hep cat	1616	hepcat.gif	Scale: 1 Cap: 1000 Init: -10000 Meat: 10 P: dude Article: a	jive turkey leg (20)	hep waders (2)	baloney rotgut (c0)
-cigarette girl	1617	ciggirl.gif	Scale: 1 Cap: 1000 Init: -10000 Meat: 25 P: dude Article: a	candy cigarette (20)	birdbone corset (2)	carton of gaspers (c0)
+cigarette girl	1617	ciggirl.gif	Scale: 1 Cap: 1000 Init: -10000 Meat: 25 P: dude EA: hot Article: a	candy cigarette (20)	birdbone corset (2)	carton of gaspers (c0)
 Mob Penguin entrepreneur	1615	peng_ent.gif	Scale: 1 Cap: 1000 Init: -10000 Meat: 40 P: penguin Article: a	legitimate business on the beach (20)	law-abiding citizen cane (2)
 
 # Twitch 4 - The Roman Forum (August 2014)
-hypocritical medicus	1628	medicus.gif	Scale: 0 Cap: 1000 Init: -10000 P: dude Article: a	non-aged vinegar (20)	unsanitized scalpel (2)
-cheap strix	1627	strix.gif	Scale: 1 Cap: 1000 Init: -10000 P: beast Article: a	Strix stix (20)	vampire pellet (2)
+hypocritical medicus	1628	medicus.gif	Scale: 0 Cap: 1000 Init: -10000 P: dude EA: hot Article: a	non-aged vinegar (20)	unsanitized scalpel (2)
+cheap strix	1627	strix.gif	Scale: 1 Cap: 1000 Init: -10000 P: beast EA: spooky Article: a	Strix stix (20)	vampire pellet (2)
 Gladiator	1623	gladiator.gif	Scale: 2 Cap: 1000 Init: 20 Meat: 5 P: dude	salt wages (10)	gladiator tunica (2)	bronze polish (c0)
-Sadiator	1624	sadiator.gif	Scale: 3 Cap: 1000 Init: 30 Meat: 10 P: dude	salt wages (10)	Roman sadnals (2)	crident (c0)
-Madiator	1625	madiator.gif	Scale: 4 Cap: 1000 Init: 40 Meat: 15 P: dude	salt wages (10)	madius (2)
+Sadiator	1624	sadiator.gif	Scale: 3 Cap: 1000 Init: 30 Meat: 10 P: dude EA: sleaze	salt wages (10)	Roman sadnals (2)	crident (c0)
+Madiator	1625	madiator.gif	Scale: 4 Cap: 1000 Init: 40 Meat: 15 P: dude EA: stench	salt wages (10)	madius (2)
 Radiator	1626	radiator.gif	Scale: 5 Cap: 1000 Init: 50 Meat: 20 P: dude	salt wages (10)	radiator heater shield (2)	totally sweet mohawk helmet (c0)
 
 # Twitch 5 - Post Apocalypse (September 2014)
 sentient ATM	1646	atm.gif	NOCOPY Atk: [1] Def: [0] HP: [1] Exp: [1] Init: -10000 P: construct Article: a
 T-9000	1641	t9000.gif	Scale: 5 Cap: 1000 Init: -10000 P: construct Article: a	TI-9000 calculator (40)	tarnished bottlecap (20)	spray chrome (c0)
-damned dirty ape	1642	dirtyape.gif	Scale: 5 Cap: 1000 Init: -10000 P: beast E: stench Article: a	unused soap (40)	tarnished bottlecap (20)	filthy monkey head (c0)
+damned dirty ape	1642	dirtyape.gif	Scale: 5 Cap: 1000 Init: -10000 P: beast ED: stench Article: a	unused soap (40)	tarnished bottlecap (20)	filthy monkey head (c0)
 jet-ski bandit	1643	jetski.gif	Scale: 5 Cap: 1000 Init: -10000 P: dude Article: a	impure gasoline (40)	tarnished bottlecap (20)
 Z-Rex	1644	zrex.gif	Scale: 5 Cap: 1000 Init: -10000 P: undead Article: a	Z-Bone steak (40)	tarnished bottlecap (20)
 superdupervirus	1645	supervirus.gif	Scale: 5 Cap: 1000 Init: -10000 P: horror Article: a	viral DNA (40)	tarnished bottlecap (20)
 
 # Twitch 6 - Western (November 2014)
-animated spittoon	1657	spittoon.gif	Scale: 1 Cap: 1000 Floor: 5 Init: -10000 P: construct Article: an	nastygeist (20)	gold tooth (3)
+animated spittoon	1657	spittoon.gif	Scale: 1 Cap: 1000 Floor: 5 Init: -10000 P: construct EA: stench Article: an	nastygeist (20)	gold tooth (3)
 cowskeleton	1661	cowskeleton.gif	Scale: 1 Cap: 1000 Floor: 5 Init: -10000 P: undead Article: a	spooky lasso (20)	plaid cowboy hat (5)	rusted-out shootin' iron (5)	skeleton beans (c0)
 craggy bartender	1659	craggybart.gif	Scale: 1 Cap: 1000 Floor: 5 Init: -10000 Meat: 40 P: dude Article: a	glass of herbal tequila (15)	shot of mescal (15)	whiskey in a broken glass (15)	damp bar rag (c0)
 gamblin' man	1656	gamblinman.gif	Scale: 1 Cap: 1000 Floor: 5 Init: -10000 Meat: 50 P: dude Article: a	sleeve deuce (20)	pocket ace (5)	hand of cards (c0)
 nest of rattlers	1662	snakenest.gif	Scale: 1 Cap: 1000 Floor: 5 Init: -10000 P: beast Article: a	rattler rattle (40)
 outlaw behind an table	1658	tableoutlaw.gif	Scale: 1 Cap: 1000 Floor: 5 Init: -10000 Meat: 25 P: dude Article: a	portable table (10)	outlaw bandana (5)
-outlaw leader	1663	outlawboss.gif	NOCOPY Scale: 1 Cap: 1000 Floor: 5 Init: -10000 Meat: 100 P: dude	big bag of money (n100)
+outlaw leader	1663	outlawboss.gif	NOCOPY Scale: 1 Cap: 1000 Floor: 5 Init: -10000 Meat: 100 P: dude EA: hot	big bag of money (n100)
 tetched prospector	1660	tetched.gif	Scale: 1 Cap: 1000 Floor: 5 Init: -10000 Meat: 15 P: dude Article: a	minin' dynamite (20)	minin' dynamite (1)	lump of goofball ore (c0)
 
 # Twitch 7 - Shakespeare (October 2015)
-ghost actor	1847	ghostactor.gif	Scale: 3 Cap: 1000 Floor: 10 Init: -10000 P: undead GHOST Phys: 100 Article: a	ghost beer (0)	ghostly dagger (0)
-Groundling	1842	groundling.gif	Scale: 1 Cap: 1000 Floor: 5 Init: -10000 P: dude Article: a	stink-penny (0)
+ghost actor	1847	ghostactor.gif	Scale: 3 Cap: 1000 Floor: 10 Init: -10000 P: undead GHOST Phys: 100 EA: spooky Article: a	ghost beer (0)	ghostly dagger (0)
+Groundling	1842	groundling.gif	Scale: 1 Cap: 1000 Floor: 5 Init: -10000 P: dude EA: stench Article: a	stink-penny (0)
 Hamlet	1843	hamlet.gif	Scale: 3 Cap: 1000 Floor: 10 Init: -10000 P: dude	hawk (0)	hamlet sandwich (0)
 Othello	1844	othello.gif	Scale: 5 Cap: 1000 Floor: 15 Init: -10000 P: dude	bowl of Jeal-O (0)
 Richard X	1841	richardx.gif	Scale: 3 Cap: 1000 Floor: 10 Init: -10000 P: dude	heavy crown (0)	ear poison (0)
@@ -2205,22 +2205,22 @@ board games elemental	1967	boardgamesman.gif	Scale: 3 Init: -10000 P: construct 
 nerd rapper	1968	nerdrapper.gif	Scale: 5 Init: -10000 P: dude Article: a
 stumbling-drunk congoer (female)	1972	congoerf1.gif,congoerf2.gif,congoerf3.gif	Scale: 5 Init: -10000 P: dude
 stumbling-drunk congoer (male)	1969	congoer1.gif,congoer2.gif,congoer3.gif	Scale: 5 Init: -10000 P: dude
-swimming pool monster	1970	poolmonster.gif	Scale: 5 Init: -10000 P: elemental Article: a
+swimming pool monster	1970	poolmonster.gif	Scale: 5 Init: -10000 P: elemental EA: sleaze Article: a
 
 # Crimbo 2018
 wild walrus	2099	c18walrus.gif	Scale: 1 Cap: 10000 Floor: 10 Init: -10000 Meat: 150 P: beast E: cold Article: a	thick walrus blubber (10)	pristine walrus tusk (c0)
-herd of wild lemmings	2100	c18lemmings.gif	Scale: 1 Cap: 10000 Floor: 10 Init: -10000 Meat: 150 P: beast E: cold Article: a	tiny bomb (10)	plastic bazooka (c0)
+herd of wild lemmings	2100	c18lemmings.gif	Scale: 1 Cap: 10000 Floor: 10 Init: -10000 Meat: 150 P: beast ED: cold Article: a	tiny bomb (10)	plastic bazooka (c0)
 wild moose	2101	c18moose.gif	Scale: 1 Cap: 10000 Floor: 10 Init: -10000 Meat: 150 P: beast E: cold Article: a	mooseflank (10)	balanced antler (c0)
 wild beaver	2102	c18beaver.gif	Scale: 1 Cap: 10000 Floor: 10 Init: -10000 Meat: 150 P: beast E: cold Article: a	beavermouth (10)	portable dam (c0)
-wild reindeer	2103	c18reindeer.gif	Scale: 1 Cap: 10000 Floor: 10 Init: -10000 Meat: 150 P: beast E: cold Article: a
+wild reindeer	2103	c18reindeer.gif	Scale: 1 Cap: 10000 Floor: 10 Init: -10000 Meat: 150 P: beast ED: cold Article: a
 
 # Crimbo 2021
-gooified elf-thing	2221	goo_elf1.gif,goo_elf2.gif,goo_elf3.gif	Atk: 130 Def: 130 HP: 150 Init: 100 P: elf Article: a	gooified animal matter (100)	gooified animal matter (20)	gooified animal matter (1)
+gooified elf-thing	2221	goo_elf1.gif,goo_elf2.gif,goo_elf3.gif	Atk: 130 Def: 130 HP: 150 Init: 100 P: elf EA: hot EA: sleaze EA: spooky EA: stench Article: a	gooified animal matter (100)	gooified animal matter (20)	gooified animal matter (1)
 gooified dog-thing	2222	goo_dog.gif	Atk: 150 Def: 150 HP: 200 Init: 200 P: beast Article: a	gooified animal matter (100)	gooified animal matter (50)	gooified animal matter (25)	gooified animal matter (5)	gooified animal matter (1)
 gooified flower	2223	goo_flower.gif	Atk: 180 Def: 180 HP: 300 Init: -10000 P: plant Article: a	gooified vegetable matter (100)	gooified vegetable matter (100)	gooified vegetable matter (100)
 gooified tree	2224	goo_tree.gif	Atk: 150 Def: 50 HP: 1000 Init: -10000 P: plant Article: a	gooified vegetable matter (10)	gooified vegetable matter (10)	gooified vegetable matter (10)	gooified vegetable matter (10)	gooified vegetable matter (10)
 gooified rock slab	2225	goo_slab1.gif,goo_slab2.gif,goo_slab3.gif	Atk: 250 Def: 250 HP: 500 Init: -10000 P: elemental Article: a	gooified mineral matter (100)	gooified mineral matter (100)
-massive goo construct	2226		Atk: 100 Def: 100 HP: 100 Init: -10000 P: construct Article: a	gooified animal matter (100)	gooified vegetable matter (100)	gooified mineral matter (100)
+massive goo construct	2226		Atk: 100 Def: 100 HP: 100 Init: -10000 P: construct EA: hot EA: sleaze Article: a	gooified animal matter (100)	gooified vegetable matter (100)	gooified mineral matter (100)
 
 # Old Events
 
@@ -2233,27 +2233,27 @@ Mob Penguin Soprano	218	pengprano.gif	Atk: 95 Def: 85 HP: 90 Init: 80 Meat: 25 P
 Mob Penguin Thug	217	pengthug.gif	Atk: 95 Def: 85 HP: 80 Init: 80 Meat: 50 P: penguin Article: A	kneecapping stick (0)	penguin skin (0)
 
 # Market Square, 28 Days Later (November 2005)
-drunken zombie half-orc hobo	296	zomhobo.gif	Atk: 1 Def: 0 HP: 1 Init: 40 P: undead E: spooky Article: a	Mad Train wine (0)	dirty hobo gloves (0)	moxie weed (0)	zombie pineal gland (0)
-fiendish zombie can of asparagus	297	asparagus.gif	Atk: 2 Def: 0 HP: 1 Init: 50 P: undead E: spooky Article: a	razor-sharp can lid (0)	asparagus knife (0)	stalk of asparagus (0)	zombie pineal gland (0)
+drunken zombie half-orc hobo	296	zomhobo.gif	Atk: 1 Def: 0 HP: 1 Init: 40 P: undead ED: spooky Article: a	Mad Train wine (0)	dirty hobo gloves (0)	moxie weed (0)	zombie pineal gland (0)
+fiendish zombie can of asparagus	297	asparagus.gif	Atk: 2 Def: 0 HP: 1 Init: 50 P: undead ED: spooky Article: a	razor-sharp can lid (0)	asparagus knife (0)	stalk of asparagus (0)	zombie pineal gland (0)
 Knob Goblin Elite Zombie	300	zomelite.gif	Atk: 30 Def: 25 HP: 30 Init: 90 P: goblin E: spooky Article: a	Knob Goblin elite helm (0)	Knob Goblin elite pants (0)	Knob Goblin elite polearm (0)	Knob Goblin elite shirt (0)	zombie pineal gland (0)
 zombie Gnollish crossdresser	301	zomknoll.gif	Atk: 11 Def: 9 HP: 5 Init: 60 Meat: 22 P: humanoid Article: a	frilly shirt (0)	frilly skirt (0)	gnoll teeth (0)	maiden wig (0)	zombie pineal gland (0)
-Zombie Knob Goblin Assistant Chef	299	zomchef.gif	Atk: 2 Def: 0 HP: 1 Init: 40 Meat: 8 P: goblin E: spooky Article: a	Knob Goblin tongs (0)	Knob Goblin pants (0)	chef's hat (0)	zombie pineal gland (0)
-zombie yeast beast	304	zomyeast.gif	Atk: 17 Def: 15 HP: 8 Init: 60 P: undead E: spooky Article: a	wad of dough (0)	wad of dough (0)	zombie pineal gland (0)
+Zombie Knob Goblin Assistant Chef	299	zomchef.gif	Atk: 2 Def: 0 HP: 1 Init: 40 Meat: 8 P: goblin ED: spooky Article: a	Knob Goblin tongs (0)	Knob Goblin pants (0)	chef's hat (0)	zombie pineal gland (0)
+zombie yeast beast	304	zomyeast.gif	Atk: 17 Def: 15 HP: 8 Init: 60 P: undead ED: spooky Article: a	wad of dough (0)	wad of dough (0)	zombie pineal gland (0)
 
 # The Mall of Loathing, 28 Days Later (November 2005)
-white zombie	308	zombie2.gif	Atk: 38 Def: 33 HP: 21 Init: 70 Meat: 30 P: undead E: spooky Article: a	cranberries (0)	zombie pineal gland (0)	piece of wedding cake (0)
-zombie apathetic lizardman	298	zomlizard.gif	Atk: 20 Def: 18 HP: 12 Init: 60 P: undead E: spooky Article: a	zombie pineal gland (0)
-Zombie Clown	302	zomclown.gif	Atk: 19 Def: 17 HP: 15 Init: 80 Meat: 25 P: horror E: spooky Article: a	bloody clown pants (0)	long skinny balloon (0)	big red clown nose (0)	zombie pineal gland (0)
-zombie frat boy	305	zomfrat.gif	Atk: 41 Def: 36 HP: 30 Init: 60 Meat: 30 P: orc E: sleaze Article: a	ice-cold Sir Schlitz (0)	bottle of tequila (0)	Orcish frat-paddle (0)	zombie pineal gland (0)	deodorant (0)
-zombie hippy	306	zomhippy.gif	Atk: 41 Def: 36 HP: 30 Init: 25 P: hippy E: spooky Article: a	filthy corduroys (0)	filthy knitted dread sack (0)	windchimes (0)	reodorant (0)	zombie pineal gland (0)
-zombie zmobie	303	zombie2.gif	Atk: 20 Def: 18 HP: 11 Init: 60 P: undead E: spooky Article: a	loose teeth (0)	cranberries (0)	zombie pineal gland (0)
+white zombie	308	zombie2.gif	Atk: 38 Def: 33 HP: 21 Init: 70 Meat: 30 P: undead ED: spooky Article: a	cranberries (0)	zombie pineal gland (0)	piece of wedding cake (0)
+zombie apathetic lizardman	298	zomlizard.gif	Atk: 20 Def: 18 HP: 12 Init: 60 P: undead ED: spooky Article: a	zombie pineal gland (0)
+Zombie Clown	302	zomclown.gif	Atk: 19 Def: 17 HP: 15 Init: 80 Meat: 25 P: horror ED: spooky Article: a	bloody clown pants (0)	long skinny balloon (0)	big red clown nose (0)	zombie pineal gland (0)
+zombie frat boy	305	zomfrat.gif	Atk: 41 Def: 36 HP: 30 Init: 60 Meat: 30 P: orc ED: sleaze Article: a	ice-cold Sir Schlitz (0)	bottle of tequila (0)	Orcish frat-paddle (0)	zombie pineal gland (0)	deodorant (0)
+zombie hippy	306	zomhippy.gif	Atk: 41 Def: 36 HP: 30 Init: 25 P: hippy ED: spooky Article: a	filthy corduroys (0)	filthy knitted dread sack (0)	windchimes (0)	reodorant (0)	zombie pineal gland (0)
+zombie zmobie	303	zombie2.gif	Atk: 20 Def: 18 HP: 11 Init: 60 P: undead ED: spooky Article: a	loose teeth (0)	cranberries (0)	zombie pineal gland (0)
 
 # Wrong Side of the Tracks, 28 Days Later (November 2005)
 # scary pirate	307	zompirate.gif
-Zombie eXtreme Snowboarding Orc	310	zomsnow.gif	Atk: 74 Def: 66 HP: 65 Init: 60 Meat: 40 P: undead E: spooky Article: a	snowboarder pants (0)	eXtreme mittens (0)	Mountain Stream soda (0)	zombie pineal gland (0)
-Zombie Goth Giant	312	zomgoth.gif	Atk: 130 Def: 117 HP: 150 Init: 40 Meat: 150 P: undead E: spooky Article: a	thin black candle (0)	Warm Subject gift certificate (0)	awful poetry journal (0)	zombie pineal gland (0)
+Zombie eXtreme Snowboarding Orc	310	zomsnow.gif	Atk: 74 Def: 66 HP: 65 Init: 60 Meat: 40 P: undead ED: spooky Article: a	snowboarder pants (0)	eXtreme mittens (0)	Mountain Stream soda (0)	zombie pineal gland (0)
+Zombie Goth Giant	312	zomgoth.gif	Atk: 130 Def: 117 HP: 150 Init: 40 Meat: 150 P: undead ED: spooky Article: a	thin black candle (0)	Warm Subject gift certificate (0)	awful poetry journal (0)	zombie pineal gland (0)
 Zombie N00b	309	zomnoob.gif	Atk: 79 Def: 71 HP: 69 Init: 70 Meat: 30 P: undead Article: a	draggin' ball hat (0)	33398 scroll (0)	zombie pineal gland (0)
-Zombie Quiet Healer	311	zomhealer.gif	Atk: 95 Def: 85 HP: 90 Init: 80 Meat: 115 P: undead E: spooky Article: a	scroll of drastic healing (0)	amulet of extreme plot significance (0)	soft green echo eyedrop antidote (0)	zombie pineal gland (0)
+Zombie Quiet Healer	311	zomhealer.gif	Atk: 95 Def: 85 HP: 90 Init: 80 Meat: 115 P: undead ED: spooky Article: a	scroll of drastic healing (0)	amulet of extreme plot significance (0)	soft green echo eyedrop antidote (0)	zombie pineal gland (0)
 
 # Crimbo Town Toy Factory (Crimbo 2005)
 Striking Factory-Worker Elf	318	crimboelf.gif	Atk: 0 Def: 0 HP: 0 Init: -10000 P: elf Article: A	felt (10)	wooden block (10)	googly eye (10)	length of string (10)	stuffing (10)	toy wheel (10)
@@ -2274,7 +2274,7 @@ Zeppo, the Reindeer	331	reindeer.gif	Atk: 0 Def: 0 HP: 0 Init: -10000 P: beast
 
 # The Grim Grimacite Site (June 2006)
 Mob Penguin Smasher	600	pengsmasher.gif	P: penguin	chunk of depleted Grimacite (0)	kneecapping stick (0)	penguin skin (0)
-Mob Penguin Smith	599	hazmatpeng.gif	P: penguin	chunk of depleted Grimacite (0)	iron pasta spoon (0)	scroll of pasta summoning (0)
+Mob Penguin Smith	599	hazmatpeng.gif	P: penguin EA: hot	chunk of depleted Grimacite (0)	iron pasta spoon (0)	scroll of pasta summoning (0)
 Mob Penguin Supervisor	598	pengphone.gif	P: penguin	chunk of depleted Grimacite (0)	mafia aria (0)	Mob Penguin cellular phone (0)	support cummerbund (0)
 
 # Simple Tool-Making Cave (Crimbo 2006)
@@ -2310,10 +2310,10 @@ turtle mech	640	turtlemech.gif	Atk: 0 Def: 0 HP: 0 Init: -10000 P: construct Art
 Swiss hen	641	swisshen.gif	Atk: 0 Def: 0 HP: 0 Init: -10000 P: construct Article: a	oversized fish scaler (0)
 killing bird	642	killingbird.gif	Atk: 0 Def: 0 HP: 0 Init: -10000 P: construct Article: a	killing feather (0)	killing feather (0)
 golden ring	643	goldenring.gif	Atk: 0 Def: 0 HP: 0 Init: -10000 P: construct Article: a	golden ring (0)
-goose a-laying	644	goosealaying.gif	Atk: 0 Def: 0 HP: 0 Init: -10000 P: construct Article: a	robotronic egg (0)	robotronic egg (0)
+goose a-laying	644	goosealaying.gif	Atk: 0 Def: 0 HP: 0 Init: -10000 P: construct EA: hot Article: a	robotronic egg (0)	robotronic egg (0)
 swarm a-swarming	645	swarmers.gif	Atk: 0 Def: 0 HP: 0 Init: -10000 P: construct Article: a	rogue swarmer (0)	rogue swarmer (0)
 blade a-spinning	646	sawblade.gif	Atk: 0 Def: 0 HP: 0 Init: -10000 P: construct Article: a	sawblade fragment (0)	sawblade fragment (0)
-laser lancing	647	laser.gif	Atk: 0 Def: 0 HP: 0 Init: -10000 P: construct Article: a	unstable laser battery (0)	unstable laser battery (0)
+laser lancing	647	laser.gif	Atk: 0 Def: 0 HP: 0 Init: -10000 P: construct EA: hot Article: a	unstable laser battery (0)	unstable laser battery (0)
 borg a-beeping	648	borgabeeping.gif	Atk: 0 Def: 0 HP: 0 Init: -10000 P: construct Article: a	vibrating cyborg knife (0)
 strangler strangling	649	strangler.gif	Atk: 0 Def: 0 HP: 0 Init: -10000 P: construct Article: a	immense cyborg hand (0)
 stomper stomping	650	stomper.gif	Atk: 0 Def: 0 HP: 0 Init: -10000 P: construct Article: a	cyborg stompin' boot (0)
@@ -2333,21 +2333,21 @@ Mob Penguin racketeer	754	pengracket.gif	Scale: 6 Init: 75 P: penguin Article: a
 
 # The Atomic Crimbo Town Toy Factory (Crimbo 2008)
 mutant circuit-soldering elf	751	antlerelf.gif	Scale: 8 Floor: ? Init: 150 P: elf Article: a	elven moonshine (0)	miniature antlers (0)
-mutant cookie-baking elf	749	elfblob.gif	Scale: 6 Floor: ? Init: 75 P: elf Article: a	festive holiday hat (0)
+mutant cookie-baking elf	749	elfblob.gif	Scale: 6 Floor: ? Init: 75 P: elf EA: hot Article: a	festive holiday hat (0)
 mutant doll-dressing elf	748	elflimbs.gif	Scale: 6 Floor: ? Init: 75 P: elf Article: a	cheap elven gloves (0)
 mutant gift-wrapping elf	747	elfclaw.gif	Scale: 6 Floor: ? Init: 75 P: elf Article: a	elven socks (0)
 mutant whistle-carving elf	750	elfhulk.gif	Scale: 7 Floor: ? Init: 100 P: elf Article: a	elven <i>limbos</i> gingerbread (0)	elven whittling knife (0)
 
 # Unexplained Tremors (August 2009)
-Crys-Rock	854	crys_rock.gif	NOMANUEL Atk: [min(300,MOX+10)] Def: [min(300,MUS+10)] HP: [min(240,HP*2/3)] Exp: [(min(300,STAT+10))/4] Init: 50 Phys: 50	crystallized memory (100)	control crystal (100)	floaty inverse geode (100)
+Crys-Rock	854	crys_rock.gif	NOMANUEL Atk: [min(300,MOX+10)] Def: [min(300,MUS+10)] HP: [min(240,HP*2/3)] Exp: [(min(300,STAT+10))/4] Init: 50 Phys: 50 EA: cold EA: hot	crystallized memory (100)	control crystal (100)	floaty inverse geode (100)
 clod hopper	847	rock_hopper.gif	WANDERER Atk: 100 Def: 90 HP: 150 Init: 50 P: beast Article: a	floaty sand (15)	floaty sand (15)	floaty sand (15)
-rock homunculus	846	rock_guy.gif	WANDERER Atk: 30 Def: 27 HP: 40 Init: -10000 P: beast Article: a	floaty sand (20)	floaty sand (20)
+rock homunculus	846	rock_guy.gif	WANDERER Atk: 30 Def: 27 HP: 40 Init: -10000 P: beast EA: hot Article: a	floaty sand (20)	floaty sand (20)
 rock snake	845	rock_snake.gif	NOMANUEL WANDERER Atk: 10 Def: 9 HP: 15 SNAKE	floaty sand (25)
 rockfish	848	rock_fish.gif	WANDERER Atk: 300 Def: 270 HP: 400 Init: 50 P: fish Article: a	rockfish stomach (100)
 
 # The Shivering Timbers (Arborween October 2009)
 deadwood tree	864	shiv_dead.gif	Scale: 5 Cap: 200 Floor: ? Init: -10000 P: plant Article: a	petrified wood (5)	spooky bark (10)	spooky sap (5)
-fur tree	862	shiv_fur.gif	Scale: 5 Cap: 200 Floor: ? Init: -10000 P: plant Article: a	petrified wood (5)	spooky bark (10)	spooky sap (5)	wolfman mask (20)
+fur tree	862	shiv_fur.gif	Scale: 5 Cap: 200 Floor: ? Init: -10000 P: plant EA: sleaze Article: a	petrified wood (5)	spooky bark (10)	spooky sap (5)	wolfman mask (20)
 hangman's tree	865	shiv_hangman.gif	Scale: 5 Cap: 200 Floor: ? Init: -10000 P: plant Article: a	petrified wood (5)	spooky bark (10)	spooky sap (5)
 pumpkin tree	863	shiv_pumpkin.gif	Scale: 5 Cap: 200 Floor: ? Init: -10000 P: plant Article: a	petrified wood (5)	pumpkinhead mask (20)	spooky bark (10)	spooky sap (5)
 toilet-papered tree	861	shiv_tp.gif	Scale: 5 Cap: 200 Floor: ? Init: -10000 P: plant Article: a	mummy costume (20)	petrified wood (5)	spooky bark (10)	spooky sap (5)
@@ -2369,7 +2369,7 @@ Edwing Abbidriel	903	edwing.gif	NOMANUEL P: elf	elf resistance button (100)
 Black-and-White-Ops Penguin	911	pengblackop.gif	Scale: 3 Init: -10000 P: penguin Article: a	Crimbuck (0)	grappling hook (c100)	night-vision goggles (0)
 Cement Cobbler Penguin	912	pengcement.gif	Scale: 4 Init: -10000 P: penguin Article: a	cement sandals (0)	chunk of cement (c100)	Crimbuck (0)
 Mesmerizing Penguin	909	pengmesmer.gif	Scale: 2 Init: -10000 P: penguin Article: a	Crimbuck (0)	pocketwatch on a chain (0)	spiraling shape (c100)
-Mob Penguin Arsonist	905	pengarson.gif	Scale: 0 Init: -10000 P: penguin Article: a	Crimbuck	herringcello	penguin focaccia bread
+Mob Penguin Arsonist	905	pengarson.gif	Scale: 0 Init: -10000 P: penguin EA: hot Article: a	Crimbuck	herringcello	penguin focaccia bread
 Mob Penguin Caporegime	907	pengcapo.gif	Scale: 0 Init: -10000 P: penguin Article: a	Crimbuck	herringcello	penguin focaccia bread
 Mob Penguin Demolitionist	908	pengdemo.gif	Scale: 0 Init: -10000 P: penguin Article: a	Crimbuck	herringcello	penguin focaccia bread
 Mob Penguin Goon (2009)	906	penggoon.gif	Scale: 0 Init: -10000 P: penguin Article: a Manuel: "Mob Penguin Goon" Wiki: "Mob Penguin Goon"	Crimbuck	herringcello	penguin focaccia bread
@@ -2378,12 +2378,12 @@ Undercover Penguin	910	pengundercover.gif	Scale: 1 Init: -10000 P: penguin Artic
 Don Crimbo	913	doncrimbo.gif	NOMANUEL Atk: 99999 Def: 89999 HP: 1000000 Init: 100 Phys: 100
 
 # Bigg's Diggg (September 2010)
-reanimated baboon skeleton	988	foss_baboon.gif	Atk: 150 Def: 135 HP: 150 Init: -10000 P: undead Phys: 100 Article: a	fossilized necklace (c100)
+reanimated baboon skeleton	988	foss_baboon.gif	Atk: 150 Def: 135 HP: 150 Init: -10000 P: undead Phys: 100 EA: stench Article: a	fossilized necklace (c100)
 reanimated bat skeleton	986	foss_bat.gif	Atk: 50 Def: 45 HP: 50 Init: -10000 P: undead Phys: 100 Article: a	fossilized necklace (c100)
-reanimated demon skeleton	990	foss_demon.gif	Atk: 250 Def: 225 HP: 250 Init: 50 P: undead Phys: 100 Article: a	fossilized necklace (c100)
-reanimated giant spider skeleton	991	foss_spider.gif	Atk: 300 Def: 270 HP: 300 Init: 50 P: undead Phys: 100 Article: a	fossilized necklace (c100)
+reanimated demon skeleton	990	foss_demon.gif	Atk: 250 Def: 225 HP: 250 Init: 50 P: undead Phys: 100 EA: hot Article: a	fossilized necklace (c100)
+reanimated giant spider skeleton	991	foss_spider.gif	Atk: 300 Def: 270 HP: 300 Init: 50 P: undead Phys: 100 EA: spooky Article: a	fossilized necklace (c100)
 reanimated serpent skeleton	987	foss_serpent.gif	Atk: 100 Def: 90 HP: 100 Init: -10000 P: undead Phys: 100 Article: a	fossilized necklace (c100)
-reanimated wyrm skeleton	989	foss_wyrm.gif	Atk: 200 Def: 180 HP: 200 Init: -10000 P: undead Phys: 100 Article: a	fossilized necklace (c100)
+reanimated wyrm skeleton	989	foss_wyrm.gif	Atk: 200 Def: 180 HP: 200 Init: -10000 P: undead Phys: 100 EA: hot Article: a	fossilized necklace (c100)
 
 # A Skeleton Invasion (October 2010)
 skeleton invader	1001	bigskeleton.gif	Atk: 10 Def: 9 HP: 10 Init: 50 P: undead Article: a	bone chips (30)
@@ -2403,59 +2403,59 @@ your overflowing inbox	1038	c10inbox.gif	NOCOPY NOMANUEL Scale: 0 Init: 100 Wiki
 tedious spreadsheet	1036	c10spreadsheet.gif	NOCOPY NOMANUEL Scale: 0 Init: 100	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)
 unoptimized database	1035	c10database.gif	NOCOPY NOMANUEL Scale: 0 Init: 100	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)
 Book of Faces	1041	c10faces.gif	NOCOPY NOMANUEL Scale: 0 Init: 100	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)
-chatty coworker	1042	c10chatty.gif	NOCOPY NOMANUEL Scale: 0 Init: 100	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)
+chatty coworker	1042	c10chatty.gif	NOCOPY NOMANUEL Scale: 0 Init: 100 EA: sleaze EA: stench	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)
 Tome of Tropes	1043	c10tropes.gif	NOCOPY NOMANUEL Scale: 0 Init: 100	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)
-Totally Malicious 'Zine	1044	c10tmz.gif	NOCOPY NOMANUEL Scale: 0 Init: 100	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)
-water cooler	-66	c10cooler.gif	NOCOPY NOMANUEL Scale: 0 Init: 100	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)
+Totally Malicious 'Zine	1044	c10tmz.gif	NOCOPY NOMANUEL Scale: 0 Init: 100 EA: sleaze EA: stench	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)
+water cooler	-66	c10cooler.gif	NOCOPY NOMANUEL Scale: 0 Init: 100 EA: cold EA: hot	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)	CRIMBCO scrip (n100)
 Best Game Ever	1046	c10bge.gif	NOCOPY NOMANUEL Scale: 0 Init: 100	BGE merchandise order form (n100)
 
 # CRIMBCO WC (Crimbo 2010)
-Elf Hobo	1050	elfhobo1.gif,elfhobo2.gif,elfhobo3.gif,elfhobo4.gif,elfhobo5.gif,elfhobo6.gif,elfhobo7.gif,elfhobo8.gif	Atk: 30 Def: 27 HP: 40 Init: 50 P: hobo Manuel: "Hobelf" Wiki: "Hobelf (WC)"	bindlestocking (0)	bottle of rum (15)	bottle of tequila (15)	bottle of whiskey (15)	candy cane (15)	Crimbo candied pecan (15)	Crimbo fudge (15)	Crimbo peppermint bark (15)	eggnog (15)	Mad Train wine (15)	sleeping stocking (0)	Tales of a Kansas Toymaker (0)	The Joy of Wassailing (0)	white lightning (15)	Wint-O-Fresh mint (15)
+Elf Hobo	1050	elfhobo1.gif,elfhobo2.gif,elfhobo3.gif,elfhobo4.gif,elfhobo5.gif,elfhobo6.gif,elfhobo7.gif,elfhobo8.gif	Atk: 30 Def: 27 HP: 40 Init: 50 P: hobo EA: hot EA: sleaze Manuel: "Hobelf" Wiki: "Hobelf (WC)"	bindlestocking (0)	bottle of rum (15)	bottle of tequila (15)	bottle of whiskey (15)	candy cane (15)	Crimbo candied pecan (15)	Crimbo fudge (15)	Crimbo peppermint bark (15)	eggnog (15)	Mad Train wine (15)	sleeping stocking (0)	Tales of a Kansas Toymaker (0)	The Joy of Wassailing (0)	white lightning (15)	Wint-O-Fresh mint (15)
 
 # Elf Alley (Crimbo 2010)
-Hobelf	1031	elfhobo1.gif,elfhobo2.gif,elfhobo3.gif,elfhobo4.gif,elfhobo5.gif,elfhobo6.gif,elfhobo7.gif,elfhobo8.gif	NOCOPY Atk: 350 Def: 315 HP: 500 Init: 100 P: hobo Wiki: "Hobelf (Elf Alley)"	bindlestocking (0)	hobo nickel (c15)	sleeping stocking (0)	Tales of a Kansas Toymaker (0)	The Joy of Wassailing (0)
-Uncle Hobo	1032	unclehobo.gif	NOMANUEL Atk: 500 Def: 450 HP: 15000 Init: 100 Phys: 100	Uncle Crimbo's Rations (100)	chocolate cigar (0)	Uncle Hobo's gift baggy pants (0)	Uncle Hobo's epic beard (0)	Uncle Hobo's stocking cap (0)	Uncle Hobo's fingerless tinsel gloves (f30)	Uncle Hobo's highest bough (f30)	Uncle Hobo's belt (f30)
+Hobelf	1031	elfhobo1.gif,elfhobo2.gif,elfhobo3.gif,elfhobo4.gif,elfhobo5.gif,elfhobo6.gif,elfhobo7.gif,elfhobo8.gif	NOCOPY Atk: 350 Def: 315 HP: 500 Init: 100 P: hobo EA: hot EA: sleaze Wiki: "Hobelf (Elf Alley)"	bindlestocking (0)	hobo nickel (c15)	sleeping stocking (0)	Tales of a Kansas Toymaker (0)	The Joy of Wassailing (0)
+Uncle Hobo	1032	unclehobo.gif	NOMANUEL Atk: 500 Def: 450 HP: 15000 Init: 100 Phys: 100 EA: hot EA: stench	Uncle Crimbo's Rations (100)	chocolate cigar (0)	Uncle Hobo's gift baggy pants (0)	Uncle Hobo's epic beard (0)	Uncle Hobo's stocking cap (0)	Uncle Hobo's fingerless tinsel gloves (f30)	Uncle Hobo's highest bough (f30)	Uncle Hobo's belt (f30)
 
 # Portable photocopier (Crimbo 2010)
-somebody else's butt	1049	butt.gif	NOCOPY Atk: [1000] Def: [1000] HP: [1000] Init: -10000 P: dude Manuel: "[somebody else's butt]"
-your butt	1048	butt.gif	NOCOPY Scale: 0 Init: -10000 P: dude
+somebody else's butt	1049	butt.gif	NOCOPY Atk: [1000] Def: [1000] HP: [1000] Init: -10000 P: dude EA: sleaze EA: stench Manuel: "[somebody else's butt]"
+your butt	1048	butt.gif	NOCOPY Scale: 0 Init: -10000 P: dude EA: sleaze EA: stench
 
 # Drunksgiving (March 2011)
-Hammered Yam Golem	1066	drunkyam.gif	NOCOPY NOMANUEL WANDERER Scale: -3 MLMult: 0	marshmallow flamb&eacute; (c100)
-Inebriated Tofurkey	1069	drunktofurkey.gif	NOCOPY NOMANUEL WANDERER Scale: -3 MLMult: 0	soy cordial (c100)
+Hammered Yam Golem	1066	drunkyam.gif	NOCOPY NOMANUEL WANDERER Scale: -3 MLMult: 0 EA: hot	marshmallow flamb&eacute; (c100)
+Inebriated Tofurkey	1069	drunktofurkey.gif	NOCOPY NOMANUEL WANDERER Scale: -3 MLMult: 0 EA: sleaze	soy cordial (c100)
 Plastered Can of Cranberry Sauce	1067	drunkcrancan.gif	NOCOPY NOMANUEL WANDERER Scale: -3 MLMult: 0	cranberry schnapps (c100)
-Soused Stuffing Golem	1068	drunkstuffing.gif	NOCOPY NOMANUEL WANDERER Scale: -3 MLMult: 0	breaded beer (c100)
+Soused Stuffing Golem	1068	drunkstuffing.gif	NOCOPY NOMANUEL WANDERER Scale: -3 MLMult: 0 EA: sleaze	breaded beer (c100)
 
 # April Fool's Day (April 2011)
-CDMoyer's butt	-64	butt.gif	NOMANUEL WANDERER Atk: 69 Def: 76 HP: 52	Red Pill (100)
-HotStuff's butt	-63	butt.gif	NOMANUEL WANDERER Atk: 69 Def: 76 HP: 52	obnoxious riddle (100)
-Jick's butt	-62	butt.gif	NOMANUEL WANDERER Atk: 69 Def: 76 HP: 52	handful of numbers (100)
-Mr Skullhead's butt	-61	butt.gif	NOMANUEL WANDERER Atk: 69 Def: 76 HP: 52	Lars the Cyberian (100)
-Multi Czar's butt	-60	butt.gif	NOMANUEL WANDERER Atk: 69 Def: 76 HP: 52	Atomic Comic (100)
-Riff's butt	-59	butt.gif	NOMANUEL WANDERER Atk: 69 Def: 76 HP: 52	intriguing puzzle box (100)
+CDMoyer's butt	-64	butt.gif	NOMANUEL WANDERER Atk: 69 Def: 76 HP: 52 EA: sleaze EA: stench	Red Pill (100)
+HotStuff's butt	-63	butt.gif	NOMANUEL WANDERER Atk: 69 Def: 76 HP: 52 EA: stench	obnoxious riddle (100)
+Jick's butt	-62	butt.gif	NOMANUEL WANDERER Atk: 69 Def: 76 HP: 52 EA: stench	handful of numbers (100)
+Mr Skullhead's butt	-61	butt.gif	NOMANUEL WANDERER Atk: 69 Def: 76 HP: 52 EA: stench	Lars the Cyberian (100)
+Multi Czar's butt	-60	butt.gif	NOMANUEL WANDERER Atk: 69 Def: 76 HP: 52 EA: stench	Atomic Comic (100)
+Riff's butt	-59	butt.gif	NOMANUEL WANDERER Atk: 69 Def: 76 HP: 52 EA: sleaze EA: stench	intriguing puzzle box (100)
 
 # A Pile of Old Servers (June 2011)
 antique database server	1099	spiderserver.gif	Atk: [0] Def: [0] HP: 300 Exp: 60 Init: -10000 P: construct Article: an	corrupted data (10)	squirming egg sac (5)
 
 # The Haunted Sorority House (October 2011)
-sexy sorority ghost	1102	sororghost1.gif,sororghost2.gif,sororghost3.gif	Atk: 50 Def: 45 HP: 100 Init: 50 P: undead GHOST Phys: 100	Haunted Sorority House staff guide (0)	ghostly body paint (0)	Ecto-Cooler (0)	ghost protocol (0)	extra-see-thru nightie (0)
-sexy sorority skeleton	1103	sororeton1.gif,sororeton2.gif,sororeton3.gif	Atk: 50 Def: 45 HP: 100 Init: 50 P: undead	Haunted Sorority House staff guide (0)	press-on ribs (0)	Bone's Farm &quot;wine&quot; (0)	throwing bone (0)	extremely skinny jeans (0)
+sexy sorority ghost	1102	sororghost1.gif,sororghost2.gif,sororghost3.gif	Atk: 50 Def: 45 HP: 100 Init: 50 P: undead GHOST Phys: 100 EA: sleaze EA: spooky	Haunted Sorority House staff guide (0)	ghostly body paint (0)	Ecto-Cooler (0)	ghost protocol (0)	extra-see-thru nightie (0)
+sexy sorority skeleton	1103	sororeton1.gif,sororeton2.gif,sororeton3.gif	Atk: 50 Def: 45 HP: 100 Init: 50 P: undead EA: spooky	Haunted Sorority House staff guide (0)	press-on ribs (0)	Bone's Farm &quot;wine&quot; (0)	throwing bone (0)	extremely skinny jeans (0)
 sexy sorority vampire	1104	sororpire1.gif,sororpire2.gif,sororpire3.gif	Atk: 50 Def: 45 HP: 100 Init: 50 P: undead	Haunted Sorority House staff guide (0)	bite-me-red lipstick (0)	Blood Light (0)	Nightstalker perfume (0)	Mesmereyes&trade; contact lenses (0)
-sexy sorority werewolf	1106	sororwolf1.gif,sororwolf2.gif,sororwolf3.gif	Atk: 50 Def: 45 HP: 100 Init: 50 P: dude Phys: 50	Haunted Sorority House staff guide (0)	whisker pencil (0)	Silver Bullet beer (0)	drum of pomade (0)	cursed scrunchie (0)
-sexy sorority zombie	1105	sororbie1.gif,sororbie2.gif,sororbie3.gif	Atk: 50 Def: 45 HP: 100 Init: 50 P: undead	Haunted Sorority House staff guide (0)	necrotizing body spray (0)	Bartles and BRAAAINS wine cooler (0)	sorority brain (0)	BRAINS shorts (0)
+sexy sorority werewolf	1106	sororwolf1.gif,sororwolf2.gif,sororwolf3.gif	Atk: 50 Def: 45 HP: 100 Init: 50 P: dude Phys: 50 EA: spooky	Haunted Sorority House staff guide (0)	whisker pencil (0)	Silver Bullet beer (0)	drum of pomade (0)	cursed scrunchie (0)
+sexy sorority zombie	1105	sororbie1.gif,sororbie2.gif,sororbie3.gif	Atk: 50 Def: 45 HP: 100 Init: 50 P: undead EA: spooky	Haunted Sorority House staff guide (0)	necrotizing body spray (0)	Bartles and BRAAAINS wine cooler (0)	sorority brain (0)	BRAINS shorts (0)
 
 # Lollipop Forest (Crimbo 2011)
 lollicat	1112	lollicat.gif	Atk: 20 Def: 18 HP: 30 Init: 50 P: beast Article: a	lollipop stick (10)	pearidot (c1)
 lolligator	1113	lolligator.gif	Atk: 20 Def: 18 HP: 30 Init: 50 P: beast Article: a	lollipop stick (10)	tourmalime (c1)
 lollipede	1111	lollipede.gif	Atk: 20 Def: 18 HP: 30 Init: 50 P: bug Article: a	lollipop stick (10)	bananagate (c1)
 lolliphaunt	1114	lolliphaunt.gif	Atk: 40 Def: 36 HP: 50 Init: 50 P: beast Article: a	lollipop stick (25)	kumquartz (c1)
-lolrus	1115	lollirus2.gif	Atk: 60 Def: 54 HP: 70 Init: 50 P: beast Article: a	lollipop stick (20)	lollipop stick (20)	strawberyl (c1)
+lolrus	1115	lollirus2.gif	Atk: 60 Def: 54 HP: 70 Init: 50 P: beast EA: spooky Article: a	lollipop stick (20)	lollipop stick (20)	strawberyl (c1)
 trollipop	1121	trollipop.gif	NOMANUEL Atk: 90 Def: 90 HP: 150 Init: 50	grape troll doll (0)	cinnamon troll doll (0)	blue raspberry troll doll (0)
 The Colollilossus	1147	colollilossus.gif	NOMANUEL Atk: 400 Def: 400 HP: 600 Init: 0	all-year sucker (100)
 
 # Fudge Mountain (Crimbo 2011)
 fudge monkey	1117	fudgemonkey2.gif	Atk: 80 Def: 72 HP: 100 Init: 50 P: beast Article: a	fudgecule (c100)
-fudge oyster	1119	fudgeoyster.gif	Atk: 100 Def: 90 HP: 130 Init: -10000 P: beast Article: a	fudgecule (c100)
+fudge oyster	1119	fudgeoyster.gif	Atk: 100 Def: 90 HP: 130 Init: -10000 P: beast EA: sleaze Article: a	fudgecule (c100)
 fudge poodle	1120	fudgepoodle.gif	Atk: 120 Def: 108 HP: 150 Init: 80 P: beast Article: a	fudgecule (c100)
 fudge vulture	1118	fudgevulture.gif	Atk: 80 Def: 72 HP: 100 Init: 50 P: beast Article: a	fudgecule (c100)
 fudge weasel	1116	fudgeweasel.gif	Atk: 80 Def: 72 HP: 100 Init: 50 P: beast Article: a	fudgecule (c100)
@@ -2467,16 +2467,16 @@ The Abominable Fudgeman	1146	fudgeman.gif	NOMANUEL Atk: 350 Def: 350 HP: 500 Ini
 four-shadowed mime	1164	mime.gif	Scale: -3 Cap: 50 Floor: 3 Init: -10000 P: horror Article: a	mime soul fragment (100)
 
 # A Smoldering Fortress (June 2012)
-brushfire	1208	brushfire.gif	NOMANUEL
+brushfire	1208	brushfire.gif	NOMANUEL EA: hot
 blazing bat	1210	firebat.gif	Atk: 200 Def: 180 HP: 500 Init: 50 P: beast Phys: 100 E: hot Article: a
-snakefire in the grassfire	1209	firesnake.gif	NOMANUEL P: beast SNAKE
+snakefire in the grassfire	1209	firesnake.gif	NOMANUEL P: beast SNAKE EA: hot
 Servant of Lord Flameface	1211	fireservant1.gif,fireservant2.gif,fireservant3.gif,fireservant4.gif,fireservant5.gif	Atk: 100 Def: 90 HP: 150 Init: 50 P: demon Phys: 100 E: hot Wiki: "Servant of Lord Flameface (monster)"	molten brick (c5)
 
 # Crimbo Town Toy Factory (Crimbo 2012)
 sign-twirling Crimbo elf	1261	tacoelf_sign.gif	Scale: 0 Cap: 150 Init: -10000 P: elf Article: a	Taco Dan's Taco Stand Chillacious Churro (0)	Taco Dan's Taco Stand Flier (0)
-tacobuilding elf	1263	tacoelf_cart.gif	Scale: 0 Cap: 150 Init: -10000 P: elf	Taco Dan's Taco Stand Chimichangarita (0)	Taco Dan's Taco Stand Flier (0)
-taco-clad Crimbo elf	1262	tacoelf_taco.gif	Scale: 0 Cap: 150 Init: -10000 P: elf	Taco Dan's Taco Stand Taco (100)	Taco Dan's Taco Stand Flier (0)
-circuit-soldering animelf	1253	animelf3.gif	Scale: 0 Init: -10000 P: elf	electrical thingamabob (50)	electrical thingamabob (10)
+tacobuilding elf	1263	tacoelf_cart.gif	Scale: 0 Cap: 150 Init: -10000 P: elf EA: hot	Taco Dan's Taco Stand Chimichangarita (0)	Taco Dan's Taco Stand Flier (0)
+taco-clad Crimbo elf	1262	tacoelf_taco.gif	Scale: 0 Cap: 150 Init: -10000 P: elf EA: hot	Taco Dan's Taco Stand Taco (100)	Taco Dan's Taco Stand Flier (0)
+circuit-soldering animelf	1253	animelf3.gif	Scale: 0 Init: -10000 P: elf EA: hot	electrical thingamabob (50)	electrical thingamabob (10)
 plastic-extruding animelf	1251	animelf2.gif	Scale: 0 Init: -10000 P: elf	plastic ingot (50)	plastic ingot (10)
 quality control animelf	1259	animelf4.gif	Scale: 0 Init: -10000 P: elf	electrical thingamabob (50)	plastic ingot (10)
 tiny-screwing animelf	1252	animelf1.gif	Scale: 0 Init: -10000 P: elf	electrical thingamabob (50)	plastic ingot (10)
@@ -2485,26 +2485,26 @@ toy assembling animelf	1260	animelf5.gif	Scale: 0 Init: -10000 P: elf	plastic in
 # Abyssal Portals (September 2013)
 scout seal	1440	scoutseal.gif	Atk: 30 Def: 35 HP: 50 Init: 300 P: demon Article: a	foetid seal tear (c30)	crystalline seal eye (c0)
 bulwark bull seal	1441	bullseal.gif	Atk: 50 Def: 55 HP: 100 Init: -10000 P: demon Article: a	cold seal sweat (c30)	studded sealhide shield (c0)	abyssal battle plans (c0)
-official seal	1442	officialseal.gif	Atk: 110 Def: 110 HP: 300 Init: 70 P: demon Article: an	boiling seal blood (c30)	scabrous seal epaulets (c0)	abyssal battle plans (c0)
-general seal	1443	generalseal.gif	NOMANUEL Atk: 300 Def: 300 HP: 1000 Init: -10000 P: demon Wiki: "Infernal Officer"	seal medal (c100)
+official seal	1442	officialseal.gif	Atk: 110 Def: 110 HP: 300 Init: 70 P: demon EA: hot EA: sleaze Article: an	boiling seal blood (c30)	scabrous seal epaulets (c0)	abyssal battle plans (c0)
+general seal	1443	generalseal.gif	NOMANUEL Atk: 300 Def: 300 HP: 1000 Init: -10000 P: demon EA: hot EA: stench Wiki: "Infernal Officer"	seal medal (c100)
 
 # The Space Odyssey Discotheque (October 2013)
 awkward disco dancer	1445	disco_awkward.gif	Scale: 0 Cap: 3000 Init: 100 P: dude Article: an	discocktail (c0)
 flexible disco dancer	1446	disco_flexible.gif	Scale: 0 Cap: 3000 Init: 50 P: dude Article: a	discocktail (c0)
 stiff disco dancer	1444	disco_stiff.gif	Scale: 0 Cap: 3000 Init: -10000 P: construct Article: a	discocktail (c0)
-The Sagittarian	1447	sagittarian.gif	NOMANUEL Atk: 100 Def: 100 HP: 500 Init: 1000 P: dude	The Sagittarian's leisure pants (100)
+The Sagittarian	1447	sagittarian.gif	NOMANUEL Atk: 100 Def: 100 HP: 500 Init: 1000 P: dude EA: cold EA: hot EA: sleaze	The Sagittarian's leisure pants (100)
 
 # Wandering Accordionists (October 2013)
-depressing French accordionist	1452	wanderacc1.gif	WANDERER Scale: -3 Floor: ? Init: -10000 P: dude Article: a	Bal-musette accordion (a0)
-lively Cajun accordionist	1453	wanderacc2.gif	WANDERER Scale: -3 Floor: ? Init: -10000 P: dude Article: a	Cajun accordion (a0)
+depressing French accordionist	1452	wanderacc1.gif	WANDERER Scale: -3 Floor: ? Init: -10000 P: dude EA: hot EA: stench Article: a	Bal-musette accordion (a0)
+lively Cajun accordionist	1453	wanderacc2.gif	WANDERER Scale: -3 Floor: ? Init: -10000 P: dude EA: hot Article: a	Cajun accordion (a0)
 quirky indie-rock accordionist	1454	wanderacc3.gif	WANDERER Scale: -3 Floor: ? Init: -10000 P: dude Article: a	quirky accordion (a0)
 Frank &quot;Skipper&quot; Dan, the Accordion Lord	1455	accboss.gif	NOCOPY NOMANUEL WANDERER Scale: 7 Init: -10000 P: dude	Skipper's accordion (n100)
 
 # The Spirit World (November 2013)
-spirit alarm clock	1460	spiritalclock.gif	NOCOPY NOMANUEL Scale: 5 Cap: 1000 Init: -10000 P: undead	spirit bell (n100)
-spirit bedbug	1456	spiritbug.gif	Scale: -5 Cap: 500 Floor: 20 Init: -10000 P: undead Article: a	spirit gum (5)
-spirit faucet	1458	spiritfaucet.gif	Scale: -5 Cap: 500 Floor: 20 Init: -10000 P: undead Article: a	spirit gum (5)
-spirit pea	1457	spiritpea.gif	Scale: -5 Cap: 500 Floor: 20 Init: -10000 P: undead Article: a	spirit gum (5)
+spirit alarm clock	1460	spiritalclock.gif	NOCOPY NOMANUEL Scale: 5 Cap: 1000 Init: -10000 P: undead EA: spooky	spirit bell (n100)
+spirit bedbug	1456	spiritbug.gif	Scale: -5 Cap: 500 Floor: 20 Init: -10000 P: undead EA: sleaze Article: a	spirit gum (5)
+spirit faucet	1458	spiritfaucet.gif	Scale: -5 Cap: 500 Floor: 20 Init: -10000 P: undead EA: cold EA: hot EA: sleaze Article: a	spirit gum (5)
+spirit pea	1457	spiritpea.gif	Scale: -5 Cap: 500 Floor: 20 Init: -10000 P: undead EA: spooky Article: a	spirit gum (5)
 
 # Peripatetic Pasta (November 2013)
 Possessed Can of Linguine-Os	1461	mystwander1.gif	WANDERER Scale: -3 Cap: 500 Floor: 15 Init: -10000 P: weird Phys: 100 E: hot Article: a	spoonful of Linguine-Os (c0)	spoonful of Linguine-Os (c0)
@@ -2512,25 +2512,25 @@ Possessed Can of Creepy Pasta	1465	mystwander2.gif	WANDERER Scale: -3 Cap: 500 F
 Frozen Bag of Tortellini	1462	mystwander3.gif	WANDERER Scale: -3 Cap: 500 Floor: 15 Init: -10000 P: weird Phys: 100 E: cold Article: a	freezer-burned frost-bitten tortellini (c0)	freezer-burned frost-bitten tortellini (c0)
 Possessed Jar of Alphredo&trade;	1463	mystwander4.gif	WANDERER Scale: -3 Cap: 500 Floor: 15 Init: -10000 P: weird Phys: 100 E: stench Article: a Manuel: "Possessed Jar of Alphredo™"	blob of Alphredo&trade; (c0)	blob of Alphredo&trade; (c0)
 Box of Crafty Dinner	1464	mystwander5.gif	WANDERER Scale: -3 Cap: 500 Floor: 15 Init: -10000 P: weird Phys: 100 E: sleaze Article: a	handful of crafty noodles (c0)	handful of crafty noodles (c0)
-Chef Boy, R&amp;D	1466	chefboy.gif	NOMANUEL WANDERER Scale: 5 Init: -10000 P: dude Phys: 100 Elem: 50
+Chef Boy, R&amp;D	1466	chefboy.gif	NOMANUEL WANDERER Scale: 5 Init: -10000 P: dude Phys: 100 Elem: 50 EA: hot
 
 # The WarBear Fortress (Crimbo 2013)
-Warbear Foot Soldier	1459	warbear11.gif,warbear12.gif,warbear13.gif	Scale: -3 Floor: 20 Init: -10000 P: beast	warbear whosit (n100)
-Warbear Officer	1467	warbear21.gif,warbear22.gif,warbear23.gif	Scale: ? Cap: ? Floor: ? Init: 50 P: beast	warbear whosit (n100)	warbear whosit (n100)	warbear requisition box (f0)	warbear badge (f0)
-High-Ranking Warbear Officer	1468	warbear31.gif,warbear32.gif,warbear33.gif	Scale: ? Cap: ? Floor: ? Init: 100 P: beast	warbear whosit (n100)	warbear whosit (n100)	warbear whosit (n100)	warbear officer requisition box (f0)
+Warbear Foot Soldier	1459	warbear11.gif,warbear12.gif,warbear13.gif	Scale: -3 Floor: 20 Init: -10000 P: beast EA: supercold	warbear whosit (n100)
+Warbear Officer	1467	warbear21.gif,warbear22.gif,warbear23.gif	Scale: ? Cap: ? Floor: ? Init: 50 P: beast EA: supercold	warbear whosit (n100)	warbear whosit (n100)	warbear requisition box (f0)	warbear badge (f0)
+High-Ranking Warbear Officer	1468	warbear31.gif,warbear32.gif,warbear33.gif	Scale: ? Cap: ? Floor: ? Init: 100 P: beast EA: supercold	warbear whosit (n100)	warbear whosit (n100)	warbear whosit (n100)	warbear officer requisition box (f0)
 
 # Halloween 2014
-giant pumpkin-head	1653	headpumpkin.gif	NOMANUEL Scale: 0 Cap: 1000 Floor: 5 Init: -10000 P: horror	Big Punk (n100)	mimeplasm (c100)
-large-headed werewolf	1652	headwolf.gif	NOMANUEL Scale: 0 Cap: 1000 Floor: 5 Init: -10000 P: horror	Moonds (n100)	mimeplasm (c100)
-oddly-proportioned ghost	1651	headghost.gif	NOMANUEL Scale: 0 Cap: 1000 Floor: 5 Init: -10000 P: horror	BOOterfinger (n100)	mimeplasm (c100)
+giant pumpkin-head	1653	headpumpkin.gif	NOMANUEL Scale: 0 Cap: 1000 Floor: 5 Init: -10000 P: horror EA: spooky	Big Punk (n100)	mimeplasm (c100)
+large-headed werewolf	1652	headwolf.gif	NOMANUEL Scale: 0 Cap: 1000 Floor: 5 Init: -10000 P: horror EA: spooky	Moonds (n100)	mimeplasm (c100)
+oddly-proportioned ghost	1651	headghost.gif	NOMANUEL Scale: 0 Cap: 1000 Floor: 5 Init: -10000 P: horror EA: spooky	BOOterfinger (n100)	mimeplasm (c100)
 
 # The Fully Automated Crimbo Factory (Crimbo 2014)
 Crimbomega	-79	crimbomega.gif	NOMANUEL Atk: 100 Def: 100 HP: 300	Crimbomega drive chain (n100)
 
 # The Crimbonium Mining Camp (Crimbo 2014)
-ambulatory robo-minecart	1650	crimbominer3.gif	Scale: 5 Init: -10000 P: elf Article: an	flask of tainted mining oil (15)	cylindrical mold (5)	servo-assisted exo-pants (c1)
-exo-suited miner	1648	crimbominer1.gif	Scale: 5 Init: -10000 P: elf Article: an	flask of tainted mining oil (15)	cylindrical mold (5)	high-energy mining laser (c1)
-semi-autonomous drill unit	1649	crimbominer2.gif	Scale: 5 Init: -10000 P: elf Article: a	flask of tainted mining oil (15)	cylindrical mold (5)	radiation-resistant helmet (c1)
+ambulatory robo-minecart	1650	crimbominer3.gif	Scale: 5 Init: -10000 P: elf EA: cold EA: hot Article: an	flask of tainted mining oil (15)	cylindrical mold (5)	servo-assisted exo-pants (c1)
+exo-suited miner	1648	crimbominer1.gif	Scale: 5 Init: -10000 P: elf EA: hot Article: an	flask of tainted mining oil (15)	cylindrical mold (5)	high-energy mining laser (c1)
+semi-autonomous drill unit	1649	crimbominer2.gif	Scale: 5 Init: -10000 P: elf EA: stench Article: a	flask of tainted mining oil (15)	cylindrical mold (5)	radiation-resistant helmet (c1)
 
 # The Ruins of the Fully Automated Crimbo Factory (Crimbo 2015)
 armored Crimbot	1862	crimbot2.gif	Scale: 1 Cap: 10000 Init: -10000 P: construct Article: an	pitted sheet metal (0)
@@ -2539,12 +2539,12 @@ unstable nuclear Crimbot	1864	crimbot3.gif	Scale: 1 Cap: 10000 Init: -10000 P: c
 
 # Tres de Mayo (May 2016)
 
-Cinco de Mayo reveler	1943	reveler1.gif,reveler2.gif	Scale: 5 Init: -10000 Meat: 100 P: dude Article: a
+Cinco de Mayo reveler	1943	reveler1.gif,reveler2.gif	Scale: 5 Init: -10000 Meat: 100 P: dude EA: sleaze EA: stench Article: a
 
 # Eldritch Incursion (October 2016)
 
 Eldritch Tentacle	1974	eldtentacle.gif	Scale: 7 Cap: 400 Floor: 20 Init: -10000 P: horror Phys: 50 Elem: 50 E: spooky Article: an	eldritch effluvium (0)	eldritch effluvium (0)	eldritch effluvium (0)
-Sssshhsssblllrrggghsssssggggrrgglsssshhssslblgl	2012	eldboss.gif	NOMANUEL Atk: 300 Def: 300 Init: -10000 P: horror Phys: 50 Elem: 50 E: spooky	eldritch effluvium (0)	eldritch effluvium (0)	eldritch mushroom (0)
+Sssshhsssblllrrggghsssssggggrrgglsssshhssslblgl	2012	eldboss.gif	NOMANUEL Atk: 300 Def: 300 Init: -10000 P: horror Phys: 50 Elem: 50 ED: spooky	eldritch effluvium (0)	eldritch effluvium (0)	eldritch mushroom (0)
 
 # Crimbo 2016 (December 2016)
 
@@ -2564,7 +2564,7 @@ angry viking warriors	2002	3vikings.gif	Scale: 7 Cap: 10000 Floor: 40 Init: -100
 bottle of cheap whiskey	2003	whiskey.gif	Scale: 4 Cap: 10000 Floor: 25 Init: -10000 P: weird Article: a	negative lump (0)
 the Crimborg	2004	dodec.gif	Scale: 4 Cap: 10000 Floor: 25 Init: -10000 P: weird	negative lump (0)
 penguin mafioso	2005	pengthug.gif	Scale: 5 Cap: 10000 Floor: 30 Init: -10000 P: weird Article: a	negative lump (0)
-simple hobo	2006	nhobo1.gif	Scale: 5 Cap: 10000 Floor: 30 Init: -10000 P: weird Article: a	negative lump (0)
+simple hobo	2006	nhobo1.gif	Scale: 5 Cap: 10000 Floor: 30 Init: -10000 P: weird EA: stench Article: a	negative lump (0)
 
 Your Brain	2007	brain.gif	NOCOPY NOMANUEL Scale: 6 Cap: 10000 Floor: 40 Init: -10000 P: weird	Third Eye (100)	chakra sludge (100)	chakra sludge (100)	chakra sludge (100)
 The Krampus	2008	krampus.gif	NOCOPY NOMANUEL Scale: 9 Cap: 10000 Floor: 50 Init: -10000 P: weird	Krampus Horn (100)	chakra sludge (100)	chakra sludge (100)	chakra sludge (100)	chakra sludge (100)	chakra sludge (100)	chakra sludge (100)	chakra sludge (100)	chakra sludge (100)
@@ -2576,41 +2576,41 @@ T&iacute;o Cad&aacute;ver	-28	drunkleskel.gif	NOCOPY NOMANUEL WANDERER Scale: -3
 
 # Crimbo 2017
 cheerless mime functionary	2044	mimefunc1.gif,mimefunc2.gif,mimefunc3.gif	Scale: 1 Init: -10000 P: horror Article: a	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)
-cheerless mime scientist	2045	mimesci1.gif,mimesci2.gif,mimesci3.gif	Scale: 15 Init: 100 P: horror Article: a	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)
+cheerless mime scientist	2045	mimesci1.gif,mimesci2.gif,mimesci3.gif	Scale: 15 Init: 100 P: horror EA: cold Article: a	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)
 cheerless mime soldier	2046	mimebat1.gif,mimebat2.gif,mimebat3.gif	Scale: 30 Init: 200 P: horror Article: a	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)
-cheerless mime vizier	2047	mimeseer1.gif,mimeseer2.gif,mimeseer3.gif	Scale: 45 Init: 300 P: horror Article: a	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)
+cheerless mime vizier	2047	mimeseer1.gif,mimeseer2.gif,mimeseer3.gif	Scale: 45 Init: 300 P: horror EA: cold EA: spooky Article: a	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)
 cheerless mime executive	2048	mimeexec1.gif,mimeexec2.gif,mimeexec3.gif	Scale: 60 Init: 400 Meat: 500 P: horror Phys: 100 Article: a	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)	crystalline cheer (n100)	warehouse key (p0)
 The Silent Nightmare	2049	c17_bossguy.gif	BOSS NOCOPY NOMANUEL Atk: 100 Def: 100 HP: 200 Init: 100 P: horror
 mouthless murmur	2043	mimemurmur.gif	WANDERER Scale: -11 Init: -10000 P: weird Phys: 100 Article: a
 silent scream	2042	mimescream.gif	WANDERER Scale: 1 Init: -10000 P: weird Article: a
-voiceless whisper	2041	mimewhisper.gif	WANDERER Scale: -3 Init: 150 P: weird Article: a
+voiceless whisper	2041	mimewhisper.gif	WANDERER Scale: -3 Init: 150 P: weird EA: cold EA: sleaze Article: a
 
 # Monorail Work Site (September 2017)
-Mob Penguin negotiator	2036	penghammer.gif	NOCOPY Scale: 20 Cap: 1200 Floor: 21 Init: 100 Meat: 300 P: penguin Article: a	negotiatin' hammer (0)	mafia pointer finger ring (0)	worksite credentials (p0)
-Mob Penguin organizer	2037	penggoon.gif	NOCOPY Scale: 50 Cap: 1500 Floor: 51 Init: 200 Meat: 500 P: penguin Article: a	mafia filofax (0)	mafia wedding ring (0)	mafia organizer badge (p0)
-Mob Penguin protector	2034	pengthug.gif	NOCOPY Scale: 11 Cap: 1000 Floor: 12 Init: -10000 Meat: 400 P: penguin Article: a	protection stick (0)	mafia thumb ring (0)	roll of meat (p0)
-Mob Penguin steel driver	2035	penghammer.gif	NOCOPY Scale: 15 Cap: 1000 Floor: 16 Init: 100 Meat: 500 P: penguin Article: a	steel drivin' hammer (0)	mafia middle finger ring (0)	little piece of steel (p0)
+Mob Penguin negotiator	2036	penghammer.gif	NOCOPY Scale: 20 Cap: 1200 Floor: 21 Init: 100 Meat: 300 P: penguin EA: sleaze EA: spooky Article: a	negotiatin' hammer (0)	mafia pointer finger ring (0)	worksite credentials (p0)
+Mob Penguin organizer	2037	penggoon.gif	NOCOPY Scale: 50 Cap: 1500 Floor: 51 Init: 200 Meat: 500 P: penguin EA: hot EA: sleaze EA: spooky EA: stench Article: a	mafia filofax (0)	mafia wedding ring (0)	mafia organizer badge (p0)
+Mob Penguin protector	2034	pengthug.gif	NOCOPY Scale: 11 Cap: 1000 Floor: 12 Init: -10000 Meat: 400 P: penguin EA: hot EA: stench Article: a	protection stick (0)	mafia thumb ring (0)	roll of meat (p0)
+Mob Penguin steel driver	2035	penghammer.gif	NOCOPY Scale: 15 Cap: 1000 Floor: 16 Init: 100 Meat: 500 P: penguin EA: hot EA: spooky Article: a	steel drivin' hammer (0)	mafia middle finger ring (0)	little piece of steel (p0)
 Mob Penguin union rail worker	2031	pengthug.gif	NOCOPY Scale: 6 Cap: 1000 Floor: 10 Init: 75 P: penguin Article: a	contract enforcement stick (0)	mafia pinky ring (0)	flask of port (p0)
 tree hugging hippy protestor	2066	limphippy1.gif	NOCOPY Scale: 6 Cap: 1000 Floor: 10 Init: 50 P: hippy E: stench Article: a	&quot;Remember the Trees&quot; Shirt (0)
-tree loving hippy protestor	2086	limphippy2.gif	NOCOPY Scale: 6 Cap: 1000 Floor: 10 Init: 50 Meat: 1 P: hippy E: stench Article: a	deadfall branch (0)
+tree loving hippy protestor	2086	limphippy2.gif	NOCOPY Scale: 6 Cap: 1000 Floor: 10 Init: 50 Meat: 1 P: hippy ED: stench EA: hot Article: a	deadfall branch (0)
 
 # Crimbo 2019 (December 2019)
-gingerbread maw	2141	gingermaw.gif	Atk: 200 Def: 200 HP: 300 Init: 100 P: horror Article: a	salty gumdrop	soggy gingerbread chunk	ribbon candy ascot
-nutmeg anemone	2142	nutmeganemone.gif	Atk: 200 Def: 200 HP: 150 Init: -10000 Meat: 100 P: plant Article: a	intact anemone spike	moist Crimbo spices	anemoney clip
+gingerbread maw	2141	gingermaw.gif	Atk: 200 Def: 200 HP: 300 Init: 100 P: horror EA: spooky Article: a	salty gumdrop	soggy gingerbread chunk	ribbon candy ascot
+nutmeg anemone	2142	nutmeganemone.gif	Atk: 200 Def: 200 HP: 150 Init: -10000 Meat: 100 P: plant EA: stench Article: a	intact anemone spike	moist Crimbo spices	anemoney clip
 icingfish	2143	icingfish.gif	Atk: 200 Def: 200 HP: 100 Init: 300 P: fish Article: an	runny icing	super-sweet fish goo (spoiled)	icing poncho
 Mer-kin baker	2144	merkinbaker.gif	Atk: 200 Def: 200 HP: 400 Init: 200 Meat: 200 P: mer-kin Article: a	glob of salty molasses	Mer-kin cookiestove	Mer-kin rollpin
 dolphin "orphan"	2145	dolphin2.gif	NOCOPY Atk: 300 Def: 300 HP: 500 Init: 200 Meat: 300 P: fish Article: a	waterlogged wood	waterlogged cloth	waterlogged stuffing	waterlogged leather	waterlogged metal
-kelpie (horse form)	2146	kelpiehorse.gif	Atk: 300 Def: 300 HP: 400 Init: 200 Meat: 300 P: beast Article: a	kelp-holly drape (0)
-kelpie (lady form)	2147	kelpielady.gif	Atk: 300 Def: 300 HP: 400 Init: 300 Meat: 200 P: dude Article: a	kelp-holly gun (0)
+kelpie (horse form)	2146	kelpiehorse.gif	Atk: 300 Def: 300 HP: 400 Init: 200 Meat: 300 P: beast EA: cold EA: hot EA: stench Article: a	kelp-holly drape (0)
+kelpie (lady form)	2147	kelpielady.gif	Atk: 300 Def: 300 HP: 400 Init: 300 Meat: 200 P: dude EA: stench Article: a	kelp-holly gun (0)
 Crimbylow	2148	crimbylow.gif	Atk: 500 Def: 400 HP: 50 Init: 300 Meat: 100 P: demon Article: a	green and red bean (0)	Crimbylow-rise jeans (0)
 sea-elf	2149	seaelf.gif	Atk: 300 Def: 300 HP: 400 Init: 200 Meat: 100 P: elf Article: a	salt plum (0)	soggy elf shoes (0)
-peppermint eel	2150	pepperminteel.gif	Atk: 400 Def: 400 HP: 400 Init: 200 Meat: 150 P: fish Article: a	peppermint eel sauce (0)	peppermint spine (0)
+peppermint eel	2150	pepperminteel.gif	Atk: 400 Def: 400 HP: 400 Init: 200 Meat: 150 P: fish EA: cold EA: hot Article: a	peppermint eel sauce (0)	peppermint spine (0)
 Yuleviathan	2151	yuleviathan.gif	Atk: 400 Def: 400 HP: 1000 Init: -10000 Meat: 300 P: fish Article: The	Yuleviathan necklace (0)
-Dolph Bossin, the Boss Dolphin	2152	dolphbossin.gif	NOMANUEL Atk: 500 Def: 450 HP: 800 Init: -10000 P: fish	Dolph Bossin's charity note (100)	Dolph Bossin's Crimbo hat (100)
+Dolph Bossin, the Boss Dolphin	2152	dolphbossin.gif	NOMANUEL Atk: 500 Def: 450 HP: 800 Init: -10000 P: fish EA: stench	Dolph Bossin's charity note (100)	Dolph Bossin's Crimbo hat (100)
 
 # Retired Standard Monsters
-Astronomer (obsolete)	354	astronomer.gif	Atk: 168 Def: 151 HP: 150 Init: 70 P: constellation Article: The Manuel: "Astronomer" Wiki: "Astronomer"	star chart (100)
-possessed wine rack (obsolete)	454	winerack.gif	Atk: 158 Def: 146 HP: 165 Init: 40 P: construct E: spooky Article: a Manuel: "possessed wine rack" Wiki: "possessed wine rack"
+Astronomer (obsolete)	354	astronomer.gif	Atk: 168 Def: 151 HP: 150 Init: 70 P: constellation EA: hot Article: The Manuel: "Astronomer" Wiki: "Astronomer"	star chart (100)
+possessed wine rack (obsolete)	454	winerack.gif	Atk: 158 Def: 146 HP: 165 Init: 40 P: construct ED: spooky Article: a Manuel: "possessed wine rack" Wiki: "possessed wine rack"
 skeletal sommelier (obsolete)	455	steward.gif	Atk: 168 Def: 142 HP: 162 Init: 65 Meat: 100 P: undead ED: spooky Article: a Manuel: "skeletal sommelier" Wiki: "skeletal sommelier"
 
 7-Foot Dwarf (Moiling)	97	miner.gif	NOMANUEL Atk: 53 Def: 47 HP: 40 Meat: 40 P: humanoid	miner's helmet (3)	miner's pants (3)	7-Foot Dwarven mattock (3)
@@ -2620,8 +2620,8 @@ animated nightstand (mahogany combat)	399	darkstand.gif	Atk: 162 Def: 149 HP: 17
 animated nightstand (mahogany noncombat)	407	darkstand.gif	Atk: 162 Def: 149 HP: 170 Init: 30 P: construct Article: an Manuel: "animated nightstand" Wiki: "animated nightstand (Mahogany)"	old coin purse (25)	old leather wallet (25)
 animated nightstand (white combat)	391	nightstand.gif	Atk: 159 Def: 153 HP: 180 Init: 40 P: construct Article: an Manuel: "animated nightstand" Wiki: "animated nightstand (White)"	grouchy restless spirit (80)
 animated nightstand (white noncombat)	406	nightstand.gif	Atk: 159 Def: 153 HP: 180 Init: 40 P: construct Article: an Manuel: "animated nightstand" Wiki: "animated nightstand (White)"	grouchy restless spirit (80)
-Black Knight	417	blknight.gif	Atk: 123 Def: 121 HP: 135 Init: 50 Meat: 90 P: dude Article: The	black greaves (15)	black helmet (15)	black shield (15)	black sword (15)
+Black Knight	417	blknight.gif	Atk: 123 Def: 121 HP: 135 Init: 50 Meat: 90 P: dude EA: sleaze Article: The	black greaves (15)	black helmet (15)	black shield (15)	black sword (15)
 eXtreme Sports Orcs	336	wcorcs.gif	Atk: 39 Def: 34 HP: 30 Init: 60 Meat: 30 Group: 2 P: orc E: sleaze Article: some	eXtreme mittens (4)	Mountain Stream soda (40)	Orcish baseball cap (10)	Orcish cargo shorts (10)	ultimate ultimate frisbee (10)	hang glider (c100)
 giant pair of tweezers	38	tweezers.gif	Atk: 16 Def: 14 HP: 8 Init: 60 P: construct Article: a
-Gnollish Sorceress	17	gnollmage.gif	Atk: 11 Def: 9 HP: 5 Init: 60 Meat: 22 P: humanoid Article: a	gnoll teeth (5)	gnoll lips (5)
+Gnollish Sorceress	17	gnollmage.gif	Atk: 11 Def: 9 HP: 5 Init: 60 Meat: 22 P: humanoid EA: cold EA: hot Article: a	gnoll teeth (5)	gnoll lips (5)
 Knob Goblin Elite Guardsman	79	kg_guardcaptain.gif	Atk: 30 Def: 25 HP: 30 Init: 90 Meat: 50 P: goblin Article: a	Knob Goblin elite helm (5)	Knob Goblin elite pants (5)	Knob Goblin elite polearm (5)	knob bugle (5)	Knob Goblin elite shirt (c5)

--- a/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
+++ b/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
@@ -563,6 +563,7 @@ public class KoLmafiaCLI {
         .register("checkshields")
         .register("checkskills")
         .register("checkwikimonsters")
+        .register("checkwikimonsterelementalattacks")
         .register("checkzapgroups");
     new ChessCommand().register("chess");
     new ChoiceCommand().register("choice");

--- a/src/net/sourceforge/kolmafia/MonsterData.java
+++ b/src/net/sourceforge/kolmafia/MonsterData.java
@@ -535,7 +535,7 @@ public class MonsterData extends AdventureResult {
       } else {
         buf.append(option);
         buf.append(" ");
-        addElement((Element)value, buf);
+        addElement((Element) value, buf);
         buf.append(" ");
       }
     }

--- a/src/net/sourceforge/kolmafia/MonsterData.java
+++ b/src/net/sourceforge/kolmafia/MonsterData.java
@@ -176,7 +176,7 @@ public class MonsterData extends AdventureResult {
             continue;
           case EA:
             if (tokens.hasMoreTokens()) {
-              String next = tokens.nextToken();
+              String next = parseString(tokens.nextToken(), tokens);
               Element element = parseElement(next);
               if (element == Element.NONE) {
                 continue;
@@ -325,7 +325,7 @@ public class MonsterData extends AdventureResult {
 
   private static String parseString(String token, StringTokenizer tokens) {
     if (!token.startsWith("\"")) {
-      return "";
+      return token;
     }
 
     StringBuilder temp = new StringBuilder(token);
@@ -529,15 +529,23 @@ public class MonsterData extends AdventureResult {
         for (Element element : elements) {
           buf.append(option);
           buf.append(" ");
-          buf.append(element);
+          addElement(element, buf);
           buf.append(" ");
         }
       } else {
         buf.append(option);
         buf.append(" ");
-        buf.append(value);
+        addElement((Element)value, buf);
         buf.append(" ");
       }
+    }
+  }
+
+  private static void addElement(Element element, StringBuilder buf) {
+    if (element == Element.BADSPELLING) {
+      buf.append("\"").append(element).append("\"");
+    } else {
+      buf.append(element);
     }
   }
 

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -64,7 +64,7 @@ public class DebugDatabase {
   private static final Pattern WIKI_MONSTER_ID_PATTERN = Pattern.compile("Monster ID - (\\d+)");
 
   private static final Pattern WIKI_ELEMENT_ATTACK_PATTERN =
-      Pattern.compile("\\(<span class=\"element-[^)]+<b>(.+) damage</b>");
+      Pattern.compile("\\(<span class=\"element-[^)]+<b>([^<]+) damage</b>");
 
   private DebugDatabase() {}
 

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -28,7 +28,6 @@ import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.Modifiers.Modifier;
 import net.sourceforge.kolmafia.Modifiers.ModifierList;
 import net.sourceforge.kolmafia.MonsterData;
-import net.sourceforge.kolmafia.MonsterData.Attribute;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.SpecialOutfit;
@@ -3809,8 +3808,13 @@ public class DebugDatabase {
       }
       var mafiaAttacks = monster.getAttackElements();
       Matcher matcher = WIKI_ELEMENT_ATTACK_PATTERN.matcher(wikiData);
-      var wikiAttacks = matcher.results().map(m -> m.group(1)).map(Element::fromString)
-          .collect(Collectors.toCollection(() -> EnumSet.noneOf(MonsterDatabase.Element.class)));
+      var wikiAttacks =
+          matcher
+              .results()
+              .map(m -> m.group(1))
+              .map(Element::fromString)
+              .collect(
+                  Collectors.toCollection(() -> EnumSet.noneOf(MonsterDatabase.Element.class)));
       if (wikiAttacks.contains(Element.NONE)) {
         RequestLogger.printLine("Unrecognised element for monster " + monster.getName());
       }

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -64,12 +64,17 @@ public class DebugDatabase {
 
   /** Takes an item name and constructs the likely Wiki equivalent of that item name. */
   private static String readWikiItemData(final String name, final HttpClient client) {
-    String url = WikiUtilities.getWikiLocation(name, WikiUtilities.ITEM_TYPE);
+    String url = WikiUtilities.getWikiLocation(name, WikiUtilities.ITEM_TYPE, false);
     return DebugDatabase.readWikiData(url, client);
   }
 
   private static String readWikiMonsterData(final MonsterData monster, final HttpClient client) {
-    String url = WikiUtilities.getWikiLocation(monster);
+    return readWikiMonsterData(monster, client, true);
+  }
+
+  private static String readWikiMonsterData(
+      final MonsterData monster, final HttpClient client, boolean dataPage) {
+    String url = WikiUtilities.getWikiLocation(monster, dataPage);
     return DebugDatabase.readWikiData(url, client);
   }
 

--- a/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
@@ -66,7 +66,17 @@ public class MonsterDatabase {
         "supercold",
         "ice.gif",
         "#ADD8E6", // lightblue
-        "is Supercold");
+        "is Supercold."),
+    BADSPELLING(
+        "bad spelling",
+        "cookbook.gif",
+        "#800080", // purple
+        "is Bad Spelling. Bad Spelling is weak against dictionaries."),
+    SHADOW(
+        "shadow",
+        "ice.gif",
+        "#808080", // gray
+        "is Shadow.");
 
     private final String name;
     private final String image;

--- a/src/net/sourceforge/kolmafia/textui/command/CheckDataCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/CheckDataCommand.java
@@ -189,6 +189,12 @@ public class CheckDataCommand extends AbstractCommand {
       return;
     }
 
+    if (command.equals("checkwikimonsterelementalattacks")) {
+      DebugDatabase.checkWikiMonsterElementalAttacks();
+      RequestLogger.printLine("Wiki monster elemental attacks checked.");
+      return;
+    }
+
     if (command.equals("checkwikimonsters")) {
       DebugDatabase.checkWikiMonsters();
       RequestLogger.printLine("Wiki monsters checked.");

--- a/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
@@ -827,7 +827,7 @@ public class TestCommand extends AbstractCommand {
       int index = parameters.indexOf(typeName);
       index = parameters.indexOf(" ", index);
       String name = parameters.substring(index + 1);
-      String location = WikiUtilities.getWikiLocation(name, type);
+      String location = WikiUtilities.getWikiLocation(name, type, false);
 
       RequestLogger.printLine(location);
 

--- a/src/net/sourceforge/kolmafia/utilities/WikiUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/WikiUtilities.java
@@ -26,7 +26,7 @@ public class WikiUtilities {
 
   private WikiUtilities() {}
 
-  public static final String getWikiLocation(String name, int type) {
+  public static final String getWikiLocation(String name, int type, boolean dataPage) {
     boolean checkOtherTables = true;
 
     if (type != ANY_TYPE) {
@@ -98,18 +98,21 @@ public class WikiUtilities {
     // Turn character entities into characters
     name = CharacterEntities.unescape(name);
 
-    if (type == MONSTER_TYPE) {
-      name = StringUtilities.getURLEncode(name);
-      name = StringUtilities.globalStringReplace(name, "%2F", "/");
+    name = StringUtilities.getURLEncode(name);
+    name = StringUtilities.globalStringReplace(name, "%2F", "/");
+
+    if (dataPage) {
       name = "Data:" + name;
-    } else {
-      name = StringUtilities.globalStringReplace(name, "?", "%3F");
     }
 
     return "https://kol.coldfront.net/thekolwiki/index.php/" + name;
   }
 
   public static final String getWikiLocation(Object item) {
+    return getWikiLocation(item, false);
+  }
+
+  public static final String getWikiLocation(Object item, boolean dataPage) {
     if (item == null) {
       return null;
     }
@@ -160,7 +163,7 @@ public class WikiUtilities {
       return null;
     }
 
-    return WikiUtilities.getWikiLocation(name, type);
+    return WikiUtilities.getWikiLocation(name, type, dataPage);
   }
 
   public static final void showWikiDescription(final Object item) {

--- a/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
+++ b/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
@@ -39,7 +39,7 @@ public class ModifierExpressionTest {
   @ParameterizedTest
   @EnumSource(
       value = MonsterDatabase.Element.class,
-      names = {"NONE"},
+      names = {"NONE", "SHADOW", "BADSPELLING"},
       mode = EnumSource.Mode.EXCLUDE)
   public void canReadElementalResistance(MonsterDatabase.Element element) {
     Modifiers.overrideModifier("Generated:_userMods", element.toTitle() + " Resistance: +10");

--- a/test/net/sourceforge/kolmafia/utilities/WikiUtilitiesTest.java
+++ b/test/net/sourceforge/kolmafia/utilities/WikiUtilitiesTest.java
@@ -15,30 +15,37 @@ public class WikiUtilitiesTest {
   @Test
   public void getWikiLocationForMonster() {
     var vampire = MonsterDatabase.findMonster("spooky vampire");
-    String link = WikiUtilities.getWikiLocation(vampire);
+    String link = WikiUtilities.getWikiLocation(vampire, true);
     assertEquals(
         "https://kol.coldfront.net/thekolwiki/index.php/Data:Spooky_vampire_%28Spooky_Forest%29",
         link);
   }
 
   @Test
+  public void getWikiLocationWithQuotes() {
+    var drippyPlum = AdventureResult.tallyItem("\"caramel\" orange");
+    String link = WikiUtilities.getWikiLocation(drippyPlum, true);
+    assertEquals("https://kol.coldfront.net/thekolwiki/index.php/Data:%22caramel%22_orange", link);
+  }
+
+  @Test
   public void getWikiLocationWithQuestionMark() {
     var drippyPlum = AdventureResult.tallyItem("drippy plum(?)");
     String link = WikiUtilities.getWikiLocation(drippyPlum);
-    assertEquals("https://kol.coldfront.net/thekolwiki/index.php/Drippy_plum(%3F)", link);
+    assertEquals("https://kol.coldfront.net/thekolwiki/index.php/Drippy_plum%28%3F%29", link);
   }
 
   @Test
   public void getWikiLocationForItemThatIsAlsoMonster() {
     var flange = AdventureResult.tallyItem("flange");
     String link = WikiUtilities.getWikiLocation(flange);
-    assertEquals("https://kol.coldfront.net/thekolwiki/index.php/Flange_(item)", link);
+    assertEquals("https://kol.coldfront.net/thekolwiki/index.php/Flange_%28item%29", link);
   }
 
   @Test
   public void getWikiLocationForMonsterThatIsAlsoItem() {
     var flange = MonsterDatabase.findMonster("Flange");
-    String link = WikiUtilities.getWikiLocation(flange);
+    String link = WikiUtilities.getWikiLocation(flange, true);
     assertEquals("https://kol.coldfront.net/thekolwiki/index.php/Data:Flange_%28monster%29", link);
   }
 
@@ -46,7 +53,7 @@ public class WikiUtilitiesTest {
   public void icePorterItemHasANonStandardDisambiguation() {
     var icePorter = AdventureResult.tallyItem("ice porter");
     String link = WikiUtilities.getWikiLocation(icePorter);
-    assertEquals("https://kol.coldfront.net/thekolwiki/index.php/Ice_porter_(drink)", link);
+    assertEquals("https://kol.coldfront.net/thekolwiki/index.php/Ice_porter_%28drink%29", link);
   }
 
   @Test
@@ -70,16 +77,16 @@ public class WikiUtilitiesTest {
   @Test
   public void getWikiLocationForBossBatQuestionMark() {
     var edBossBat = MonsterDatabase.findMonster("Boss Bat?");
-    String link = WikiUtilities.getWikiLocation(edBossBat);
-    assertEquals("https://kol.coldfront.net/thekolwiki/index.php/Data:Boss_Bat%3F", link);
+    String link = WikiUtilities.getWikiLocation(edBossBat, false);
+    assertEquals("https://kol.coldfront.net/thekolwiki/index.php/Boss_Bat%3F", link);
   }
 
   @Test
   public void getWikiLocationForWaluigi() {
     var waluigi = MonsterDatabase.findMonster("Wa%playername/lowercase%");
-    String link = WikiUtilities.getWikiLocation(waluigi);
+    String link = WikiUtilities.getWikiLocation(waluigi, false);
     assertEquals(
-        "https://kol.coldfront.net/thekolwiki/index.php/Data:Wa%25playername/lowercase%25", link);
+        "https://kol.coldfront.net/thekolwiki/index.php/Wa%25playername/lowercase%25", link);
   }
 
   private static Stream<Arguments> wikiPages() {
@@ -89,40 +96,42 @@ public class WikiUtilitiesTest {
         Arguments.of("knuckle sandwich", WikiUtilities.ITEM_TYPE, "Knuckle_sandwich"),
         Arguments.of(
             "industrial strength starch", WikiUtilities.ITEM_TYPE, "Industrial_strength_starch"),
-        Arguments.of("black pudding", WikiUtilities.ITEM_TYPE, "Black_pudding_(food)"),
-        Arguments.of("zmobie", WikiUtilities.ITEM_TYPE, "Zmobie_(drink)"),
-        Arguments.of("ice porter", WikiUtilities.ITEM_TYPE, "Ice_porter_(drink)"),
-        Arguments.of("Bulky Buddy Box", WikiUtilities.ITEM_TYPE, "Bulky_Buddy_Box_(hatchling)"),
+        Arguments.of("black pudding", WikiUtilities.ITEM_TYPE, "Black_pudding_%28food%29"),
+        Arguments.of("zmobie", WikiUtilities.ITEM_TYPE, "Zmobie_%28drink%29"),
+        Arguments.of("ice porter", WikiUtilities.ITEM_TYPE, "Ice_porter_%28drink%29"),
+        Arguments.of("Bulky Buddy Box", WikiUtilities.ITEM_TYPE, "Bulky_Buddy_Box_%28hatchling%29"),
         Arguments.of(
-            "The Sword in the Steak", WikiUtilities.ITEM_TYPE, "The_Sword_in_the_Steak_(item)"),
-        Arguments.of("BRICKO bat", WikiUtilities.ITEM_TYPE, "BRICKO_bat_(item)"),
+            "The Sword in the Steak", WikiUtilities.ITEM_TYPE, "The_Sword_in_the_Steak_%28item%29"),
+        Arguments.of("BRICKO bat", WikiUtilities.ITEM_TYPE, "BRICKO_bat_%28item%29"),
         Arguments.of(
-            "Chorale of Companionship", WikiUtilities.ITEM_TYPE, "Chorale_of_Companionship_(item)"),
+            "Chorale of Companionship",
+            WikiUtilities.ITEM_TYPE,
+            "Chorale_of_Companionship_%28item%29"),
         Arguments.of("sonar-in-a-biscuit", WikiUtilities.ITEM_TYPE, "Sonar-in-a-biscuit"),
         Arguments.of(
             "Chorale of Companionship",
             WikiUtilities.SKILL_TYPE,
-            "Chorale_of_Companionship_(skill)"),
-        Arguments.of("Knuckle Sandwich", WikiUtilities.SKILL_TYPE, "Knuckle_Sandwich_(skill)"),
+            "Chorale_of_Companionship_%28skill%29"),
+        Arguments.of("Knuckle Sandwich", WikiUtilities.SKILL_TYPE, "Knuckle_Sandwich_%28skill%29"),
         Arguments.of(
             "Chorale of Companionship",
             WikiUtilities.EFFECT_TYPE,
-            "Chorale_of_Companionship_(effect)"),
+            "Chorale_of_Companionship_%28effect%29"),
         Arguments.of("Sweet Tooth", WikiUtilities.EFFECT_TYPE, "Sweet_Tooth"),
         Arguments.of("Water Wings", WikiUtilities.EFFECT_TYPE, "Water_Wings"),
         Arguments.of(
             "Industrial Strength Starch", WikiUtilities.EFFECT_TYPE, "Industrial_Strength_Starch"),
-        Arguments.of("ice porter", WikiUtilities.MONSTER_TYPE, "Data:Ice_porter"),
+        Arguments.of("ice porter", WikiUtilities.MONSTER_TYPE, "Ice_porter"),
         Arguments.of(
             "undead elbow macaroni",
             WikiUtilities.MONSTER_TYPE,
-            "Data:Undead_elbow_macaroni_%28monster%29"));
+            "Undead_elbow_macaroni_%28monster%29"));
   }
 
   @ParameterizedTest
   @MethodSource("wikiPages")
   public void correctAnswerForWikiPagesOfVariousTypes(String name, int type, String expectedPage) {
-    var link = WikiUtilities.getWikiLocation(name, type);
+    var link = WikiUtilities.getWikiLocation(name, type, false);
     assertEquals("https://kol.coldfront.net/thekolwiki/index.php/" + expectedPage, link);
   }
 }


### PR DESCRIPTION
Make Mafia aware of the elements "shadow" and "bad spelling".

Parse wiki pages for elemental attacks, and update Mafia accordingly.

The parsing picks up "X damage", and so will pick up elemental attacks, auras, thorns etc. Not sure if this is what we want long-term but an elemental aura means you want to defend against that element, so it seems reasonable.