### PR TITLE
All 9 June cleaver choices are now configurable in GUI

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -2906,6 +2906,15 @@ user	choiceAdventure1434	0
 user	choiceAdventure1436	0
 user	choiceAdventure1460	8
 user	choiceAdventure1461	4
+user	choiceAdventure1467	0
+user	choiceAdventure1468	0
+user	choiceAdventure1469	0
+user	choiceAdventure1470	0
+user	choiceAdventure1471	0
+user	choiceAdventure1472	0
+user	choiceAdventure1473	0
+user	choiceAdventure1474	0
+user	choiceAdventure1475	0
 user	lockedItem4637	true
 user	lockedItem4638	true
 user	lockedItem4639	true

--- a/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
@@ -6100,7 +6100,7 @@ public abstract class ChoiceAdventures {
         new Option("Grab the cheer core. Just do it!", 5));
 
     // Poetic Justice
-    new ChoiceSpoiler(
+    new ChoiceAdventure(
         1467,
         "Item-Driven",
         "June cleaver",
@@ -6111,7 +6111,7 @@ public abstract class ChoiceAdventures {
         new Option("Do nothing", 4));
 
     // Aunts not Ants
-    new ChoiceSpoiler(
+    new ChoiceAdventure(
         1468,
         "Item-Driven",
         "June cleaver",
@@ -6122,7 +6122,7 @@ public abstract class ChoiceAdventures {
         new Option("Do nothing", 4));
 
     // Beware of Alligator
-    new ChoiceSpoiler(
+    new ChoiceAdventure(
         1469,
         "Item-Driven",
         "June cleaver",
@@ -6133,7 +6133,7 @@ public abstract class ChoiceAdventures {
         new Option("Do nothing", 4));
 
     // Teacher's Pet
-    new ChoiceSpoiler(
+    new ChoiceAdventure(
         1470,
         "Item-Driven",
         "June cleaver",
@@ -6144,7 +6144,7 @@ public abstract class ChoiceAdventures {
         new Option("Do nothing", 4));
 
     // Lost and Found
-    new ChoiceSpoiler(
+    new ChoiceAdventure(
         1471,
         "Item-Driven",
         "June cleaver",
@@ -6155,7 +6155,7 @@ public abstract class ChoiceAdventures {
         new Option("Do nothing", 4));
 
     // Summer Days
-    new ChoiceSpoiler(
+    new ChoiceAdventure(
         1472,
         "Item-Driven",
         "June cleaver",
@@ -6166,7 +6166,7 @@ public abstract class ChoiceAdventures {
         new Option("Do nothing", 4));
 
     // Bath Time
-    new ChoiceSpoiler(
+    new ChoiceAdventure(
         1473,
         "Item-Driven",
         "June cleaver",
@@ -6177,7 +6177,7 @@ public abstract class ChoiceAdventures {
         new Option("Do nothing", 4));
 
     // Delicious Sprouts
-    new ChoiceSpoiler(
+    new ChoiceAdventure(
         1474,
         "Item-Driven",
         "June cleaver",
@@ -6188,7 +6188,7 @@ public abstract class ChoiceAdventures {
         new Option("Do nothing", 4));
 
     // Hypnotic Master
-    new ChoiceSpoiler(
+    new ChoiceAdventure(
         1475,
         "Item-Driven",
         "June cleaver",


### PR DESCRIPTION
There's a query on kolmafia.us about how the June cleaver choice adventures stop automation and there is no way to configure them. Somebody responded by instructing them to figure out which choice adventures they are, what the various options do, and then to manually set properties in the gCLI.

We considered making those configurable, but you are required to put a default into defaults.txt.
We punted on that since there is not an obvious "best default".

There are two possibilities.

Default of 4 means "skip this choice". If we choose that, you can automate right out the box without having to think about what you want. But you will miss a lot of free stats/adventures/meat/items.

Default of 0 means "show in browser". (You don't actually have to do that; you can do "choice X" in the gCLI to submit the choice.) This will stop automation, but it will remind you that maybe you want to configure June cleaver choices. You can do that, get out of the choice (browser or gCLI "choice" command), and restart automation.

I decided that default of 0 is better. It will force you - once - to set the choices to suit your tastes, rather than simply getting nothing. Heck, you may choose to set (some) of the adventures to "Do Nothing" since you only want to react to others. But that will be the user's decision.