### PR TITLE
fix: "complete the outfit" leads to NPE

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -1939,7 +1939,7 @@ public abstract class ChoiceManager {
     for (int i = 0; i < options.length; ++i) {
       Option opt = options[i];
       AdventureResult item[] = opt.getItems();
-      if (item == null) {
+      if (item == null || item.length == 0) {
         continue;
       }
 

--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -1939,7 +1939,7 @@ public abstract class ChoiceManager {
     for (int i = 0; i < options.length; ++i) {
       Option opt = options[i];
       AdventureResult item[] = opt.getItems();
-      if (item == null || item.length == 0) {
+      if (item.length == 0) {
         continue;
       }
 


### PR DESCRIPTION
`item` can't ever be null, but can be empty, in which case `item[0]` gives an NPE.

This occurs when a choice (e.g. pirate outfit, mining outfit) is set to 4, "complete the outfit", and the choice is viewed in the relay browser or encountered during `adv`.