### PR TITLE
refactor: use shared test methods in more places

### DIFF
--- a/test/internal/helpers/Networking.java
+++ b/test/internal/helpers/Networking.java
@@ -1,0 +1,44 @@
+package internal.helpers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import internal.network.RequestBodyReader;
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Assertions;
+
+public class Networking {
+  public static String html(String path) {
+    try {
+      return Files.readString(Paths.get(path)).trim();
+    } catch (IOException e) {
+      Assertions.fail("Failed to load HTML file: " + path);
+    }
+
+    return null;
+  }
+
+  public static void assertGetRequest(HttpRequest request, String path) {
+    assertGetRequest(request, path, null);
+  }
+
+  public static void assertGetRequest(HttpRequest request, String path, String query) {
+    assertThat(request.method(), equalTo("GET"));
+    var uri = request.uri();
+    assertThat(uri.getPath(), equalTo(path));
+    assertThat(uri.getQuery(), equalTo(query));
+  }
+
+  public static void assertPostRequest(HttpRequest request, String path, String body) {
+    assertThat(request.method(), equalTo("POST"));
+    var uri = request.uri();
+    assertThat(uri.getPath(), equalTo(path));
+    var reqBody = new RequestBodyReader().bodyAsString(request);
+    assertThat(URLDecoder.decode(reqBody, StandardCharsets.UTF_8), equalTo(body));
+  }
+}

--- a/test/internal/helpers/Networking.java
+++ b/test/internal/helpers/Networking.java
@@ -18,9 +18,8 @@ public class Networking {
       return Files.readString(Paths.get(path)).trim();
     } catch (IOException e) {
       Assertions.fail("Failed to load HTML file: " + path);
+      throw new AssertionError(e);
     }
-
-    return null;
   }
 
   public static void assertGetRequest(HttpRequest request, String path) {

--- a/test/net/sourceforge/kolmafia/MonsterExpressionTest.java
+++ b/test/net/sourceforge/kolmafia/MonsterExpressionTest.java
@@ -1,14 +1,12 @@
 package net.sourceforge.kolmafia;
 
+import static internal.helpers.Networking.html;
 import static internal.helpers.Player.equip;
 import static internal.helpers.Player.inPath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import net.sourceforge.kolmafia.combat.MonsterStatusTracker;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
@@ -80,21 +78,20 @@ public class MonsterExpressionTest {
   }
 
   @Test
-  public void canDetectBasementLevel() throws IOException {
-    BasementRequest.checkBasement(
-        Files.readString(Path.of("request/test_basement_level_1234.html")));
+  public void canDetectBasementLevel() {
+    BasementRequest.checkBasement(html("request/test_basement_level_1234.html"));
     var exp = new MonsterExpression("BL", "Basement Level");
     assertThat(exp.eval(), is(1234.0));
   }
 
   @Test
-  public void canDetectKissesInDreadWoods() throws IOException {
+  public void canDetectKissesInDreadWoods() {
     KoLAdventure.setLastAdventure(AdventureDatabase.getAdventure("Dreadsylvanian Woods"));
     MonsterStatusTracker.setNextMonster(MonsterDatabase.findMonster("stench bugbear"));
 
     var req = new GenericRequest("fight.php");
     req.setHasResult(true);
-    req.responseText = Files.readString(Path.of("request/test_fight_stench_bugbear_4_kisses.html"));
+    req.responseText = html("request/test_fight_stench_bugbear_4_kisses.html");
     req.processResponse();
 
     var exp = new MonsterExpression("KW", "Kisses in Dread Woods");
@@ -102,13 +99,13 @@ public class MonsterExpressionTest {
   }
 
   @Test
-  public void canDetectKissesInDreadVillage() throws IOException {
+  public void canDetectKissesInDreadVillage() {
     KoLAdventure.setLastAdventure(AdventureDatabase.getAdventure("Dreadsylvanian Village"));
     MonsterStatusTracker.setNextMonster(MonsterDatabase.findMonster("spooky zombie"));
 
     var req = new GenericRequest("fight.php");
     req.setHasResult(true);
-    req.responseText = Files.readString(Path.of("request/test_fight_spooky_zombie_1_kiss.html"));
+    req.responseText = html("request/test_fight_spooky_zombie_1_kiss.html");
     req.processResponse();
 
     var exp = new MonsterExpression("KV", "Kisses in Dread Village");
@@ -116,13 +113,13 @@ public class MonsterExpressionTest {
   }
 
   @Test
-  public void canDetectKissesInDreadCastle() throws IOException {
+  public void canDetectKissesInDreadCastle() {
     KoLAdventure.setLastAdventure(AdventureDatabase.getAdventure("Dreadsylvanian Castle"));
     MonsterStatusTracker.setNextMonster(MonsterDatabase.findMonster("stench vampire"));
 
     var req = new GenericRequest("fight.php");
     req.setHasResult(true);
-    req.responseText = Files.readString(Path.of("request/test_fight_stench_vampire_2_kisses.html"));
+    req.responseText = html("request/test_fight_stench_vampire_2_kisses.html");
     req.processResponse();
 
     var exp = new MonsterExpression("KC", "Kisses in Dread Castle");

--- a/test/net/sourceforge/kolmafia/RequestEditorKitTest.java
+++ b/test/net/sourceforge/kolmafia/RequestEditorKitTest.java
@@ -1,23 +1,16 @@
 package net.sourceforge.kolmafia;
 
+import static internal.helpers.Networking.html;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 public class RequestEditorKitTest {
 
-  static String loadHTML(String path) throws IOException {
-    // Load the text from saved HTML file
-    return Files.readString(Paths.get(path)).trim();
-  }
-
   @Test
-  public void willSuppressRedundantCharPaneRefreshes() throws IOException {
+  public void willSuppressRedundantCharPaneRefreshes() {
     // Obsolete usage: put script into HTML comment.
     //
     // <script language=Javascript>
@@ -40,7 +33,7 @@ public class RequestEditorKitTest {
 
     // No charpane refresh requested
     String location = "fight.php?ireallymeanit=1652976032";
-    String html = loadHTML("request/test_feature_rich_html_charpane_refreshes_0.html");
+    String html = html("request/test_feature_rich_html_charpane_refreshes_0.html");
     StringBuffer buffer = new StringBuffer(html);
     Matcher matcher = CHARPANE_REFRESH_PATTERN.matcher(buffer);
     assertEquals(0, matcher.results().count());
@@ -50,7 +43,7 @@ public class RequestEditorKitTest {
 
     // Only "obsolete" usage.
     location = "fight.php?action=steal";
-    html = loadHTML("request/test_feature_rich_html_charpane_refreshes_1.html");
+    html = html("request/test_feature_rich_html_charpane_refreshes_1.html");
     buffer = new StringBuffer(html);
     matcher = CHARPANE_REFRESH_PATTERN.matcher(buffer);
     assertEquals(1, matcher.results().count());
@@ -60,7 +53,7 @@ public class RequestEditorKitTest {
 
     // Only "current" usage.
     location = "fight.php?action=attack";
-    html = loadHTML("request/test_feature_rich_html_charpane_refreshes_1a.html");
+    html = html("request/test_feature_rich_html_charpane_refreshes_1a.html");
     buffer = new StringBuffer(html);
     matcher = CHARPANE_REFRESH_PATTERN.matcher(buffer);
     assertEquals(1, matcher.results().count());
@@ -70,7 +63,7 @@ public class RequestEditorKitTest {
 
     // Both "obsolete" and "current" usage.
     location = "choice.php?pwd&whichchoice=28&option=2";
-    html = loadHTML("request/test_feature_rich_html_charpane_refreshes_2.html");
+    html = html("request/test_feature_rich_html_charpane_refreshes_2.html");
     buffer = new StringBuffer(html);
     matcher = CHARPANE_REFRESH_PATTERN.matcher(buffer);
     assertEquals(2, matcher.results().count());

--- a/test/net/sourceforge/kolmafia/persistence/AdventureSpentDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/AdventureSpentDatabaseTest.java
@@ -1,10 +1,8 @@
 package net.sourceforge.kolmafia.persistence;
 
+import static internal.helpers.Networking.html;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
@@ -51,13 +49,8 @@ public class AdventureSpentDatabaseTest {
     KoLConstants.inventory.clear();
   }
 
-  static String loadHTMLResponse(String path) throws IOException {
-    // Load the responseText from saved HTML file
-    return Files.readString(Paths.get(path)).trim();
-  }
-
   @Test
-  public void canCountFightChoiceFightInHauntedBedroom() throws IOException {
+  public void canCountFightChoiceFightInHauntedBedroom() {
     // Every encounter in The Haunted Bedroom is a fight followed by a choice adventure.
     // The fight takes a turn.
     // One of the choice/options leads to a fight - which costs another turn.
@@ -73,7 +66,7 @@ public class AdventureSpentDatabaseTest {
 
     // In fight, about to administer killing blow. charpane.php
     String urlString = "charpane.php";
-    String responseText = loadHTMLResponse("request/test_adventures_spent_fight_1_0.html");
+    String responseText = html("request/test_adventures_spent_fight_1_0.html");
     CharPaneRequest.processResults(responseText);
     assertEquals(1332325, KoLCharacter.getTurnsPlayed());
     assertEquals(1332325, KoLCharacter.getCurrentRun());
@@ -82,7 +75,7 @@ public class AdventureSpentDatabaseTest {
 
     // In-fight, final round. fight.php
     urlString = "fight.php?action=attack";
-    responseText = loadHTMLResponse("request/test_adventures_spent_fight_1_1.html");
+    responseText = html("request/test_adventures_spent_fight_1_1.html");
     FightRequest.currentRound = 2;
     FightRequest.registerRequest(true, urlString);
     FightRequest.updateCombatData(null, null, responseText);
@@ -92,7 +85,7 @@ public class AdventureSpentDatabaseTest {
 
     // Won fight. charpane.php
     urlString = "charpane.php";
-    responseText = loadHTMLResponse("request/test_adventures_spent_fight_1_2.html");
+    responseText = html("request/test_adventures_spent_fight_1_2.html");
     CharPaneRequest.processResults(responseText);
     assertEquals(1332326, KoLCharacter.getTurnsPlayed());
     assertEquals(1332326, KoLCharacter.getCurrentRun());
@@ -101,7 +94,7 @@ public class AdventureSpentDatabaseTest {
 
     // Investigate fallen foe. choice.php
     urlString = "choice.php";
-    responseText = loadHTMLResponse("request/test_adventures_spent_fight_1_3.html");
+    responseText = html("request/test_adventures_spent_fight_1_3.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -111,7 +104,7 @@ public class AdventureSpentDatabaseTest {
 
     // In choice adventure. charpane.php
     urlString = "charpane.php";
-    responseText = loadHTMLResponse("request/test_adventures_spent_fight_1_4.html");
+    responseText = html("request/test_adventures_spent_fight_1_4.html");
     CharPaneRequest.processResults(responseText);
     assertEquals(1332326, KoLCharacter.getTurnsPlayed());
     assertEquals(1332326, KoLCharacter.getCurrentRun());
@@ -122,7 +115,7 @@ public class AdventureSpentDatabaseTest {
     // urlString = "choice.php?pwd&whichchoice=879&option=3";
     // This redirects into a fight.
     urlString = "fight.php?ireallymeanit=1652726190";
-    responseText = loadHTMLResponse("request/test_adventures_spent_fight_1_5.html");
+    responseText = html("request/test_adventures_spent_fight_1_5.html");
     FightRequest.preFight(true);
     FightRequest.registerRequest(true, urlString);
     FightRequest.updateCombatData(null, null, responseText);
@@ -134,7 +127,7 @@ public class AdventureSpentDatabaseTest {
 
     // In fight. Round 1.
     urlString = "fight.php?action=attack";
-    responseText = loadHTMLResponse("request/test_adventures_spent_fight_1_6.html");
+    responseText = html("request/test_adventures_spent_fight_1_6.html");
     FightRequest.registerRequest(true, urlString);
     FightRequest.updateCombatData(null, null, responseText);
     assertEquals(1332326, KoLCharacter.getTurnsPlayed());
@@ -145,7 +138,7 @@ public class AdventureSpentDatabaseTest {
 
     // Won fight. charpane.php
     urlString = "charpane.php";
-    responseText = loadHTMLResponse("request/test_adventures_spent_fight_1_7.html");
+    responseText = html("request/test_adventures_spent_fight_1_7.html");
     CharPaneRequest.processResults(responseText);
     assertEquals(1332327, KoLCharacter.getTurnsPlayed());
     assertEquals(1332327, KoLCharacter.getCurrentRun());
@@ -154,7 +147,7 @@ public class AdventureSpentDatabaseTest {
   }
 
   @Test
-  public void canCountFightChoiceInHauntedBedroom() throws IOException {
+  public void canCountFightChoiceInHauntedBedroom() {
     // Every encounter in The Haunted Bedroom is a fight followed by a choice adventure.
     // The fight takes a turn.
     // One of the choice/options leads to a fight - which costs another turn.
@@ -170,7 +163,7 @@ public class AdventureSpentDatabaseTest {
 
     // In fight, about to administer killing blow. charpane.php
     String urlString = "charpane.php";
-    String responseText = loadHTMLResponse("request/test_adventures_spent_fight_2_0.html");
+    String responseText = html("request/test_adventures_spent_fight_2_0.html");
     CharPaneRequest.processResults(responseText);
     assertEquals(1332327, KoLCharacter.getTurnsPlayed());
     assertEquals(1332327, KoLCharacter.getCurrentRun());
@@ -179,7 +172,7 @@ public class AdventureSpentDatabaseTest {
 
     // In-fight, final round. fight.php
     urlString = "fight.php?action=attack";
-    responseText = loadHTMLResponse("request/test_adventures_spent_fight_2_1.html");
+    responseText = html("request/test_adventures_spent_fight_2_1.html");
     FightRequest.currentRound = 2;
     FightRequest.registerRequest(true, urlString);
     FightRequest.updateCombatData(null, null, responseText);
@@ -189,7 +182,7 @@ public class AdventureSpentDatabaseTest {
 
     // Won fight. charpane.php
     urlString = "charpane.php";
-    responseText = loadHTMLResponse("request/test_adventures_spent_fight_2_2.html");
+    responseText = html("request/test_adventures_spent_fight_2_2.html");
     CharPaneRequest.processResults(responseText);
     assertEquals(1332328, KoLCharacter.getTurnsPlayed());
     assertEquals(1332328, KoLCharacter.getCurrentRun());
@@ -198,7 +191,7 @@ public class AdventureSpentDatabaseTest {
 
     // Investigate fallen foe. choice.php
     urlString = "choice.php";
-    responseText = loadHTMLResponse("request/test_adventures_spent_fight_2_3.html");
+    responseText = html("request/test_adventures_spent_fight_2_3.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -209,7 +202,7 @@ public class AdventureSpentDatabaseTest {
 
     // In choice adventure. charpane.php
     urlString = "charpane.php";
-    responseText = loadHTMLResponse("request/test_adventures_spent_fight_2_4.html");
+    responseText = html("request/test_adventures_spent_fight_2_4.html");
     CharPaneRequest.processResults(responseText);
     assertEquals(1332328, KoLCharacter.getTurnsPlayed());
     assertEquals(1332328, KoLCharacter.getCurrentRun());
@@ -218,7 +211,7 @@ public class AdventureSpentDatabaseTest {
 
     // Select choice.
     urlString = "choice.php?pwd&whichchoice=879&option=1";
-    responseText = loadHTMLResponse("request/test_adventures_spent_fight_2_5.html");
+    responseText = html("request/test_adventures_spent_fight_2_5.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -229,7 +222,7 @@ public class AdventureSpentDatabaseTest {
 
     // In choice adventure. charpane.php
     urlString = "charpane.php";
-    responseText = loadHTMLResponse("request/test_adventures_spent_fight_2_6.html");
+    responseText = html("request/test_adventures_spent_fight_2_6.html");
     CharPaneRequest.processResults(responseText);
     assertEquals(1332328, KoLCharacter.getTurnsPlayed());
     assertEquals(1332328, KoLCharacter.getCurrentRun());
@@ -238,7 +231,7 @@ public class AdventureSpentDatabaseTest {
   }
 
   @Test
-  public void canCountBinderClipInHiddenOfficeBuilding() throws IOException {
+  public void canCountBinderClipInHiddenOfficeBuilding() {
     KoLAdventure location = AdventureDatabase.getAdventure("The Hidden Office Building");
     KoLAdventure.setLastAdventure(location);
     KoLCharacter.setTurnsPlayed(59404);
@@ -266,7 +259,7 @@ public class AdventureSpentDatabaseTest {
     // adventure.php?snarfblat=343
     // redirect -> choice.php?forceoption=0
     String urlString = "choice.php?forceoption=0";
-    String responseText = loadHTMLResponse("request/test_adventures_spent_binder_clip_1.html");
+    String responseText = html("request/test_adventures_spent_binder_clip_1.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -276,7 +269,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(ChoiceManager.lastDecision, 0);
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_binder_clip_2.json");
+    responseText = html("request/test_adventures_spent_binder_clip_2.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(59404, KoLCharacter.getTurnsPlayed());
     assertEquals(622, KoLCharacter.getCurrentRun());
@@ -284,7 +277,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(622, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "choice.php?whichchoice=786&option=2&pwd";
-    responseText = loadHTMLResponse("request/test_adventures_spent_binder_clip_3.html");
+    responseText = html("request/test_adventures_spent_binder_clip_3.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     request.setHasResult(true);
@@ -304,7 +297,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(urlString, creator.getURLString());
     SingleUseRequest.registerRequest(urlString);
 
-    responseText = loadHTMLResponse("request/test_adventures_spent_binder_clip_4.html");
+    responseText = html("request/test_adventures_spent_binder_clip_4.html");
     creator.responseText = responseText;
     creator.setHasResult(true);
     creator.processResponse();
@@ -317,7 +310,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(1, InventoryManager.getCount(MCCLUSKY_FILE));
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_binder_clip_5.json");
+    responseText = html("request/test_adventures_spent_binder_clip_5.json");
     ApiRequest.parseResponse(urlString, responseText);
     // The total turn and current run counts advanced
     assertEquals(59405, KoLCharacter.getTurnsPlayed());
@@ -330,7 +323,7 @@ public class AdventureSpentDatabaseTest {
   }
 
   @Test
-  public void canCountBeehiveInBlackForest() throws IOException {
+  public void canCountBeehiveInBlackForest() {
     KoLAdventure location = AdventureDatabase.getAdventure("The Black Forest");
     KoLAdventure.setLastAdventure(location);
     KoLCharacter.setTurnsPlayed(988140);
@@ -342,7 +335,7 @@ public class AdventureSpentDatabaseTest {
 
     // About to adventure in The Black Forest
     String urlString = "charpane.php";
-    String responseText = loadHTMLResponse("request/test_adventures_spent_beehive_0.html");
+    String responseText = html("request/test_adventures_spent_beehive_0.html");
     CharPaneRequest.processResults(responseText);
     assertEquals(988140, KoLCharacter.getTurnsPlayed());
     assertEquals(988140, KoLCharacter.getCurrentRun());
@@ -352,7 +345,7 @@ public class AdventureSpentDatabaseTest {
     // adventure.php?snarfblat=405
     // redirect -> choice.php?forceoption=0
     urlString = "choice.php?forceoption=0";
-    responseText = loadHTMLResponse("request/test_adventures_spent_beehive_1.html");
+    responseText = html("request/test_adventures_spent_beehive_1.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -362,7 +355,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(ChoiceManager.lastDecision, 0);
 
     urlString = "charpane.php";
-    responseText = loadHTMLResponse("request/test_adventures_spent_beehive_2.html");
+    responseText = html("request/test_adventures_spent_beehive_2.html");
     CharPaneRequest.processResults(responseText);
     assertEquals(988140, KoLCharacter.getTurnsPlayed());
     assertEquals(988140, KoLCharacter.getCurrentRun());
@@ -371,7 +364,7 @@ public class AdventureSpentDatabaseTest {
 
     // Choose to visit cobbler
     urlString = "choice.php?pwd&whichchoice=923&option=1";
-    responseText = loadHTMLResponse("request/test_adventures_spent_beehive_3.html");
+    responseText = html("request/test_adventures_spent_beehive_3.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -383,7 +376,7 @@ public class AdventureSpentDatabaseTest {
 
     // Head towards buzzing
     urlString = "choice.php?pwd&whichchoice=924&option=3";
-    responseText = loadHTMLResponse("request/test_adventures_spent_beehive_4.html");
+    responseText = html("request/test_adventures_spent_beehive_4.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -393,7 +386,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(988140, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "charpane.php";
-    responseText = loadHTMLResponse("request/test_adventures_spent_beehive_5.html");
+    responseText = html("request/test_adventures_spent_beehive_5.html");
     CharPaneRequest.processResults(responseText);
     assertEquals(988141, KoLCharacter.getTurnsPlayed());
     assertEquals(988141, KoLCharacter.getCurrentRun());
@@ -403,7 +396,7 @@ public class AdventureSpentDatabaseTest {
 
     // Keep going
     urlString = "choice.php?pwd&whichchoice=1018&option=1";
-    responseText = loadHTMLResponse("request/test_adventures_spent_beehive_6.html");
+    responseText = html("request/test_adventures_spent_beehive_6.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -413,7 +406,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(988141, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "charpane.php";
-    responseText = loadHTMLResponse("request/test_adventures_spent_beehive_7.html");
+    responseText = html("request/test_adventures_spent_beehive_7.html");
     CharPaneRequest.processResults(responseText);
     assertEquals(988142, KoLCharacter.getTurnsPlayed());
     assertEquals(988142, KoLCharacter.getCurrentRun());
@@ -423,7 +416,7 @@ public class AdventureSpentDatabaseTest {
 
     // Almost... there...
     urlString = "choice.php?pwd&whichchoice=1019&option=1";
-    responseText = loadHTMLResponse("request/test_adventures_spent_beehive_8.html");
+    responseText = html("request/test_adventures_spent_beehive_8.html");
     request = new GenericRequest(urlString);
     request.setHasResult(true);
     request.responseText = responseText;
@@ -435,7 +428,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(988142, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "charpane.php";
-    responseText = loadHTMLResponse("request/test_adventures_spent_beehive_9.html");
+    responseText = html("request/test_adventures_spent_beehive_9.html");
     CharPaneRequest.processResults(responseText);
     assertEquals(988143, KoLCharacter.getTurnsPlayed());
     assertEquals(988143, KoLCharacter.getCurrentRun());
@@ -445,7 +438,7 @@ public class AdventureSpentDatabaseTest {
   }
 
   @Test
-  public void canCountZeroTurnChoiceChain() throws IOException {
+  public void canCountZeroTurnChoiceChain() {
     KoLAdventure location = AdventureDatabase.getAdventure("The Spooky Forest");
     KoLAdventure.setLastAdventure(location);
     KoLCharacter.setTurnsPlayed(988527);
@@ -456,7 +449,7 @@ public class AdventureSpentDatabaseTest {
     // redirect -> choice.php?forceoption=0
     // Arboreal respite
     String urlString = "choice.php?forceoption=0";
-    String responseText = loadHTMLResponse("request/test_adventures_spent_spooky_forest_1_1.html");
+    String responseText = html("request/test_adventures_spent_spooky_forest_1_1.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -467,7 +460,7 @@ public class AdventureSpentDatabaseTest {
 
     // Explore the Stream
     urlString = "choice.php?whichchoice=502&option=2&pwd";
-    responseText = loadHTMLResponse("request/test_adventures_spent_spooky_forest_1_2.html");
+    responseText = html("request/test_adventures_spent_spooky_forest_1_2.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -479,7 +472,7 @@ public class AdventureSpentDatabaseTest {
 
     // Squeeze into the cave
     urlString = "choice.php?whichchoice=505&option=2&pwd";
-    responseText = loadHTMLResponse("request/test_adventures_spent_spooky_forest_1_3.html");
+    responseText = html("request/test_adventures_spent_spooky_forest_1_3.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -492,7 +485,7 @@ public class AdventureSpentDatabaseTest {
   }
 
   @Test
-  public void canCountOneTurnChoiceChain() throws IOException {
+  public void canCountOneTurnChoiceChain() {
     KoLAdventure location = AdventureDatabase.getAdventure("The Spooky Forest");
     KoLAdventure.setLastAdventure(location);
     KoLCharacter.setTurnsPlayed(988527);
@@ -503,7 +496,7 @@ public class AdventureSpentDatabaseTest {
     // redirect -> choice.php?forceoption=0
     // Arboreal respite
     String urlString = "choice.php?forceoption=0";
-    String responseText = loadHTMLResponse("request/test_adventures_spent_spooky_forest_2_1.html");
+    String responseText = html("request/test_adventures_spent_spooky_forest_2_1.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -516,7 +509,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(988527, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_spooky_forest_2_2.json");
+    responseText = html("request/test_adventures_spent_spooky_forest_2_2.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(988527, KoLCharacter.getTurnsPlayed());
     assertEquals(988527, KoLCharacter.getCurrentRun());
@@ -526,7 +519,7 @@ public class AdventureSpentDatabaseTest {
 
     // Brave the dark thicket
     urlString = "choice.php?whichchoice=502&option=3&pwd";
-    responseText = loadHTMLResponse("request/test_adventures_spent_spooky_forest_2_3.html");
+    responseText = html("request/test_adventures_spent_spooky_forest_2_3.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -538,7 +531,7 @@ public class AdventureSpentDatabaseTest {
 
     // Follow the even darker path
     urlString = "choice.php?whichchoice=506&option=1&pwd";
-    responseText = loadHTMLResponse("request/test_adventures_spent_spooky_forest_2_4.html");
+    responseText = html("request/test_adventures_spent_spooky_forest_2_4.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -551,7 +544,7 @@ public class AdventureSpentDatabaseTest {
 
     // Take the scorched path
     urlString = "choice.php?whichchoice=26&option=2&pwd";
-    responseText = loadHTMLResponse("request/test_adventures_spent_spooky_forest_2_5.html");
+    responseText = html("request/test_adventures_spent_spooky_forest_2_5.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -564,7 +557,7 @@ public class AdventureSpentDatabaseTest {
 
     // Investigate the smoking crater
     urlString = "choice.php?whichchoice=28&option=2&pwd";
-    responseText = loadHTMLResponse("request/test_adventures_spent_spooky_forest_2_6.html");
+    responseText = html("request/test_adventures_spent_spooky_forest_2_6.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -576,7 +569,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(0, AdventureSpentDatabase.getTurns(location, true));
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_spooky_forest_2_7.json");
+    responseText = html("request/test_adventures_spent_spooky_forest_2_7.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(988528, KoLCharacter.getTurnsPlayed());
     assertEquals(988528, KoLCharacter.getCurrentRun());
@@ -586,7 +579,7 @@ public class AdventureSpentDatabaseTest {
   }
 
   @Test
-  public void canCountHiddenTempleTurns() throws IOException {
+  public void canCountHiddenTempleTurns() {
     KoLAdventure location = AdventureDatabase.getAdventure("The Hidden Temple");
     KoLAdventure.setLastAdventure(location);
     KoLCharacter.setTurnsPlayed(60387);
@@ -600,7 +593,7 @@ public class AdventureSpentDatabaseTest {
     // adventure.php?snarfblat=280
     // redirect -> choice.php?forceoption=0 -> Fitting In
     String urlString = "choice.php?forceoption=0";
-    String responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_1.html");
+    String responseText = html("request/test_adventures_spent_hidden_temple_1.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -610,7 +603,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(ChoiceManager.lastDecision, 0);
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_2.json");
+    responseText = html("request/test_adventures_spent_hidden_temple_2.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(60387, KoLCharacter.getTurnsPlayed());
     assertEquals(559, KoLCharacter.getCurrentRun());
@@ -619,7 +612,7 @@ public class AdventureSpentDatabaseTest {
 
     // Poke around the ground floor -> The Hidden Heart of the Hidden Temple
     urlString = "choice.php?whichchoice=582&option=2&pwd";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_3.html");
+    responseText = html("request/test_adventures_spent_hidden_temple_3.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -633,7 +626,7 @@ public class AdventureSpentDatabaseTest {
 
     // Go down the stairs -> Unconfusing Buttons
     urlString = "choice.php?whichchoice=580&option=2&pwd";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_4.html");
+    responseText = html("request/test_adventures_spent_hidden_temple_4.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -646,7 +639,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(559, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_5.json");
+    responseText = html("request/test_adventures_spent_hidden_temple_5.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(60387, KoLCharacter.getTurnsPlayed());
     assertEquals(559, KoLCharacter.getCurrentRun());
@@ -656,7 +649,7 @@ public class AdventureSpentDatabaseTest {
     // The one with the cute little lightning-tailed guy on it -> The Hidden Heart of the Hidden
     // Temple
     urlString = "choice.php?whichchoice=584&option=4&pwd";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_6.html");
+    responseText = html("request/test_adventures_spent_hidden_temple_6.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     request.setHasResult(true);
@@ -672,7 +665,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(559, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_7.json");
+    responseText = html("request/test_adventures_spent_hidden_temple_7.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(60387, KoLCharacter.getTurnsPlayed());
     assertEquals(559, KoLCharacter.getCurrentRun());
@@ -681,7 +674,7 @@ public class AdventureSpentDatabaseTest {
 
     // Go through the door (3 Adventures) -> At Least It's Not Full Of Trash
     urlString = "choice.php?whichchoice=580&option=1&pwd";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_8.html");
+    responseText = html("request/test_adventures_spent_hidden_temple_8.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -695,7 +688,7 @@ public class AdventureSpentDatabaseTest {
 
     // Raise your hands up toward the heavens -> Now What?
     urlString = "choice.php?whichchoice=123&option=2&pwd";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_9.html");
+    responseText = html("request/test_adventures_spent_hidden_temple_9.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -708,7 +701,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(559, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_10.json");
+    responseText = html("request/test_adventures_spent_hidden_temple_10.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(60388, KoLCharacter.getTurnsPlayed());
     assertEquals(560, KoLCharacter.getCurrentRun());
@@ -719,7 +712,7 @@ public class AdventureSpentDatabaseTest {
     // choice.php
     // redirect -> tiles.php -> Beginning at the Beginning of Beginning
     urlString = "tiles.php";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_11.html");
+    responseText = html("request/test_adventures_spent_hidden_temple_11.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     request.setHasResult(true);
@@ -730,7 +723,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(560, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_12.json");
+    responseText = html("request/test_adventures_spent_hidden_temple_12.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(60388, KoLCharacter.getTurnsPlayed());
     assertEquals(560, KoLCharacter.getCurrentRun());
@@ -739,7 +732,7 @@ public class AdventureSpentDatabaseTest {
 
     // Give me a B!
     urlString = "tiles.php?action=jump&whichtile=4";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_13.html");
+    responseText = html("request/test_adventures_spent_hidden_temple_13.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     request.setHasResult(true);
@@ -749,7 +742,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(560, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_14.json");
+    responseText = html("request/test_adventures_spent_hidden_temple_14.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(60388, KoLCharacter.getTurnsPlayed());
     assertEquals(560, KoLCharacter.getCurrentRun());
@@ -758,7 +751,7 @@ public class AdventureSpentDatabaseTest {
 
     // Give me an A!
     urlString = "tiles.php?action=jump&whichtile=6";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_15.html");
+    responseText = html("request/test_adventures_spent_hidden_temple_15.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     request.setHasResult(true);
@@ -768,7 +761,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(560, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_16.json");
+    responseText = html("request/test_adventures_spent_hidden_temple_16.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(60388, KoLCharacter.getTurnsPlayed());
     assertEquals(560, KoLCharacter.getCurrentRun());
@@ -777,7 +770,7 @@ public class AdventureSpentDatabaseTest {
 
     // Give me an N!
     urlString = "tiles.php?action=jump&whichtile=3";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_17.html");
+    responseText = html("request/test_adventures_spent_hidden_temple_17.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     request.setHasResult(true);
@@ -787,7 +780,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(560, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_18.json");
+    responseText = html("request/test_adventures_spent_hidden_temple_18.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(60388, KoLCharacter.getTurnsPlayed());
     assertEquals(560, KoLCharacter.getCurrentRun());
@@ -796,7 +789,7 @@ public class AdventureSpentDatabaseTest {
 
     // Give me an A!
     urlString = "tiles.php?action=jump&whichtile=6";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_19.html");
+    responseText = html("request/test_adventures_spent_hidden_temple_19.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     request.setHasResult(true);
@@ -806,7 +799,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(560, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_20.json");
+    responseText = html("request/test_adventures_spent_hidden_temple_20.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(60388, KoLCharacter.getTurnsPlayed());
     assertEquals(560, KoLCharacter.getCurrentRun());
@@ -815,7 +808,7 @@ public class AdventureSpentDatabaseTest {
 
     // Give me an N!
     urlString = "tiles.php?action=jump&whichtile=7";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_21.html");
+    responseText = html("request/test_adventures_spent_hidden_temple_21.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     request.setHasResult(true);
@@ -825,7 +818,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(560, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_22.json");
+    responseText = html("request/test_adventures_spent_hidden_temple_22.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(60388, KoLCharacter.getTurnsPlayed());
     assertEquals(560, KoLCharacter.getCurrentRun());
@@ -834,7 +827,7 @@ public class AdventureSpentDatabaseTest {
 
     // Give me an A!
     urlString = "tiles.php?action=jump&whichtile=6";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_23.html");
+    responseText = html("request/test_adventures_spent_hidden_temple_23.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     request.setHasResult(true);
@@ -844,7 +837,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(560, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_24.json");
+    responseText = html("request/test_adventures_spent_hidden_temple_24.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(60388, KoLCharacter.getTurnsPlayed());
     assertEquals(560, KoLCharacter.getCurrentRun());
@@ -856,7 +849,7 @@ public class AdventureSpentDatabaseTest {
     // What's that spell? BANANAS!
     // redirect -> choice.php?forceoption=0 -> No Visible Means of Support
     urlString = "choice.php?forceoption=0";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_25.html");
+    responseText = html("request/test_adventures_spent_hidden_temple_25.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -867,7 +860,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(ChoiceManager.lastDecision, 0);
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_26.json");
+    responseText = html("request/test_adventures_spent_hidden_temple_26.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(60389, KoLCharacter.getTurnsPlayed());
     assertEquals(561, KoLCharacter.getCurrentRun());
@@ -876,7 +869,7 @@ public class AdventureSpentDatabaseTest {
 
     // Do nothing
     urlString = "choice.php?whichchoice=125&option=3&pwd";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_27.html");
+    responseText = html("request/test_adventures_spent_hidden_temple_27.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.preChoice(request);
@@ -889,7 +882,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(561, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_hidden_temple_28.json");
+    responseText = html("request/test_adventures_spent_hidden_temple_28.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(60390, KoLCharacter.getTurnsPlayed());
     assertEquals(562, KoLCharacter.getCurrentRun());
@@ -898,7 +891,7 @@ public class AdventureSpentDatabaseTest {
   }
 
   @Test
-  public void canTrackAutomatedAirshipChoiceFight() throws IOException {
+  public void canTrackAutomatedAirshipChoiceFight() {
     KoLAdventure location = AdventureDatabase.getAdventure("The Penultimate Fantasy Airship");
     KoLAdventure.setLastAdventure(location);
     KoLCharacter.setTurnsPlayed(61853);
@@ -912,7 +905,7 @@ public class AdventureSpentDatabaseTest {
     // adventure.php?snarfblat=81
     // redirect -> fight.php?ireallymeanit=1653112277
     String urlString = "fight.php?ireallymeanit=1653112277";
-    String responseText = loadHTMLResponse("request/test_adventures_spent_airship_1.html");
+    String responseText = html("request/test_adventures_spent_airship_1.html");
     FightRequest.preFight(true);
     FightRequest.registerRequest(true, urlString);
     fight.responseText = responseText;
@@ -923,7 +916,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(985, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_airship_2.json");
+    responseText = html("request/test_adventures_spent_airship_2.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(61853, KoLCharacter.getTurnsPlayed());
     assertEquals(985, KoLCharacter.getCurrentRun());
@@ -931,7 +924,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(985, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "fight.php?action=macro&macrotext=mark+mafiafinal%0Aattack%0Agoto+mafiafinal";
-    responseText = loadHTMLResponse("request/test_adventures_spent_airship_3.html");
+    responseText = html("request/test_adventures_spent_airship_3.html");
     FightRequest.registerRequest(true, urlString);
     fight.responseText = responseText;
     fight.setHasResult(true);
@@ -941,7 +934,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(985, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_airship_4.json");
+    responseText = html("request/test_adventures_spent_airship_4.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(61854, KoLCharacter.getTurnsPlayed());
     assertEquals(986, KoLCharacter.getCurrentRun());
@@ -951,7 +944,7 @@ public class AdventureSpentDatabaseTest {
     // adventure.php?snarfblat=81
     // redirect -> choice.php?forceoption=0
     urlString = "choice.php?forceoption=0";
-    responseText = loadHTMLResponse("request/test_adventures_spent_airship_5.html");
+    responseText = html("request/test_adventures_spent_airship_5.html");
     choice.responseText = responseText;
     choice.setHasResult(true);
     ChoiceManager.preChoice(choice);
@@ -961,7 +954,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(ChoiceManager.lastDecision, 0);
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_airship_6.json");
+    responseText = html("request/test_adventures_spent_airship_6.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(61854, KoLCharacter.getTurnsPlayed());
     assertEquals(986, KoLCharacter.getCurrentRun());
@@ -974,7 +967,7 @@ public class AdventureSpentDatabaseTest {
     choice.setHasResult(true);
     ChoiceManager.preChoice(choice);
     urlString = "fight.php?ireallymeanit=1653112281";
-    responseText = loadHTMLResponse("request/test_adventures_spent_airship_7.html");
+    responseText = html("request/test_adventures_spent_airship_7.html");
     FightRequest.preFight(true);
     FightRequest.registerRequest(true, urlString);
     fight.responseText = responseText;
@@ -985,7 +978,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(986, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_airship_8.json");
+    responseText = html("request/test_adventures_spent_airship_8.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(61854, KoLCharacter.getTurnsPlayed());
     assertEquals(986, KoLCharacter.getCurrentRun());
@@ -994,7 +987,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(986, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "fight.php?action=macro&macrotext=mark+mafiafinal%0Aattack%0Agoto+mafiafinal";
-    responseText = loadHTMLResponse("request/test_adventures_spent_airship_9.html");
+    responseText = html("request/test_adventures_spent_airship_9.html");
     FightRequest.registerRequest(true, urlString);
     fight.responseText = responseText;
     fight.setHasResult(true);
@@ -1004,7 +997,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(986, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_airship_10.json");
+    responseText = html("request/test_adventures_spent_airship_10.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(61855, KoLCharacter.getTurnsPlayed());
     assertEquals(987, KoLCharacter.getCurrentRun());
@@ -1015,7 +1008,7 @@ public class AdventureSpentDatabaseTest {
     // adventure.php?snarfblat=81
     // redirect -> choice.php?forceoption=0
     urlString = "choice.php?forceoption=0";
-    responseText = loadHTMLResponse("request/test_adventures_spent_airship_11.html");
+    responseText = html("request/test_adventures_spent_airship_11.html");
     choice.responseText = responseText;
     choice.setHasResult(true);
     ChoiceManager.preChoice(choice);
@@ -1025,7 +1018,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(ChoiceManager.lastDecision, 0);
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_airship_12.json");
+    responseText = html("request/test_adventures_spent_airship_12.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(61855, KoLCharacter.getTurnsPlayed());
     assertEquals(987, KoLCharacter.getCurrentRun());
@@ -1038,7 +1031,7 @@ public class AdventureSpentDatabaseTest {
     choice.setHasResult(true);
     ChoiceManager.preChoice(choice);
     urlString = "fight.php?ireallymeanit=1653112283";
-    responseText = loadHTMLResponse("request/test_adventures_spent_airship_13.html");
+    responseText = html("request/test_adventures_spent_airship_13.html");
     FightRequest.preFight(true);
     FightRequest.registerRequest(true, urlString);
     fight.responseText = responseText;
@@ -1049,7 +1042,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(987, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "fight.php?action=macro&macrotext=mark+mafiafinal%0Aattack%0Agoto+mafiafinal";
-    responseText = loadHTMLResponse("request/test_adventures_spent_airship_14.html");
+    responseText = html("request/test_adventures_spent_airship_14.html");
     FightRequest.registerRequest(true, urlString);
     fight.responseText = responseText;
     fight.setHasResult(true);
@@ -1059,7 +1052,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(987, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_airship_15.json");
+    responseText = html("request/test_adventures_spent_airship_15.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(61856, KoLCharacter.getTurnsPlayed());
     assertEquals(988, KoLCharacter.getCurrentRun());
@@ -1069,7 +1062,7 @@ public class AdventureSpentDatabaseTest {
   }
 
   @Test
-  public void canTrackAutomatedOfficeChoiceFight() throws IOException {
+  public void canTrackAutomatedOfficeChoiceFight() {
     KoLAdventure location = AdventureDatabase.getAdventure("The Hidden Office Building");
     KoLAdventure.setLastAdventure(location);
     KoLCharacter.setTurnsPlayed(1333901);
@@ -1083,7 +1076,7 @@ public class AdventureSpentDatabaseTest {
     // adventure.php?snarfblat=343
     // redirect -> fight.php?ireallymeanit=1653112277
     String urlString = "fight.php?ireallymeanit=1653163461";
-    String responseText = loadHTMLResponse("request/test_adventures_spent_office_1.html");
+    String responseText = html("request/test_adventures_spent_office_1.html");
     FightRequest.preFight(true);
     FightRequest.registerRequest(false, urlString);
     fight.responseText = responseText;
@@ -1094,7 +1087,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(1333901, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_office_2.json");
+    responseText = html("request/test_adventures_spent_office_2.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(1333901, KoLCharacter.getTurnsPlayed());
     assertEquals(1333901, KoLCharacter.getCurrentRun());
@@ -1103,7 +1096,7 @@ public class AdventureSpentDatabaseTest {
 
     urlString =
         "fight.php?action=macro&macrotext=pickpocket%0Aif+hasskill+6032%0Askill+6032%0Aendif%0Amark+mafiafinal%0Aattack%0Agoto+mafiafinal";
-    responseText = loadHTMLResponse("request/test_adventures_spent_office_3.html");
+    responseText = html("request/test_adventures_spent_office_3.html");
     FightRequest.registerRequest(true, urlString);
     fight.responseText = responseText;
     fight.setHasResult(true);
@@ -1113,7 +1106,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(1333901, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_office_4.json");
+    responseText = html("request/test_adventures_spent_office_4.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(1333902, KoLCharacter.getTurnsPlayed());
     assertEquals(1333902, KoLCharacter.getCurrentRun());
@@ -1123,7 +1116,7 @@ public class AdventureSpentDatabaseTest {
     // adventure.php?snarfblat=343
     // redirect -> choice.php?forceoption=0
     urlString = "choice.php?forceoption=0";
-    responseText = loadHTMLResponse("request/test_adventures_spent_office_5.html");
+    responseText = html("request/test_adventures_spent_office_5.html");
     choice.responseText = responseText;
     choice.setHasResult(true);
     ChoiceManager.preChoice(choice);
@@ -1133,7 +1126,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(ChoiceManager.lastDecision, 0);
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_office_6.json");
+    responseText = html("request/test_adventures_spent_office_6.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(1333902, KoLCharacter.getTurnsPlayed());
     assertEquals(1333902, KoLCharacter.getCurrentRun());
@@ -1146,7 +1139,7 @@ public class AdventureSpentDatabaseTest {
     choice.setHasResult(true);
     ChoiceManager.preChoice(choice);
     urlString = "fight.php?ireallymeanit=1653163462";
-    responseText = loadHTMLResponse("request/test_adventures_spent_office_7.html");
+    responseText = html("request/test_adventures_spent_office_7.html");
     FightRequest.preFight(true);
     FightRequest.registerRequest(true, urlString);
     fight.responseText = responseText;
@@ -1157,7 +1150,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(1333902, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_office_8.json");
+    responseText = html("request/test_adventures_spent_office_8.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(1333902, KoLCharacter.getTurnsPlayed());
     assertEquals(1333902, KoLCharacter.getCurrentRun());
@@ -1167,7 +1160,7 @@ public class AdventureSpentDatabaseTest {
 
     urlString =
         "fight.php?action=macro&macrotext=pickpocket%0Aif+hasskill+6032%0Askill+6032%0Aendif%0Amark+mafiafinal%0Aattack%0Agoto+mafiafinal";
-    responseText = loadHTMLResponse("request/test_adventures_spent_office_9.html");
+    responseText = html("request/test_adventures_spent_office_9.html");
     FightRequest.registerRequest(true, urlString);
     fight.responseText = responseText;
     fight.setHasResult(true);
@@ -1177,7 +1170,7 @@ public class AdventureSpentDatabaseTest {
     assertEquals(1333902, AdventureSpentDatabase.getLastTurnUpdated());
 
     urlString = "api.php?what=status&for=KoLmafia";
-    responseText = loadHTMLResponse("request/test_adventures_spent_office_10.json");
+    responseText = html("request/test_adventures_spent_office_10.json");
     ApiRequest.parseResponse(urlString, responseText);
     assertEquals(1333903, KoLCharacter.getTurnsPlayed());
     assertEquals(1333903, KoLCharacter.getCurrentRun());

--- a/test/net/sourceforge/kolmafia/request/AdventureRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AdventureRequestTest.java
@@ -1,13 +1,11 @@
 package net.sourceforge.kolmafia.request;
 
+import static internal.helpers.Networking.html;
 import static internal.helpers.Player.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
@@ -49,13 +47,13 @@ public class AdventureRequestTest {
   }
 
   @Test
-  public void gregariousMonstersAreQueued() throws IOException {
+  public void gregariousMonstersAreQueued() {
     KoLAdventure.setLastAdventure(AdventureDatabase.getAdventure("Barf Mountain"));
     MonsterStatusTracker.setNextMonster(MonsterDatabase.findMonster("Knob Goblin Embezzler"));
 
     var req = new GenericRequest("fight.php");
     req.setHasResult(true);
-    req.responseText = Files.readString(Path.of("request/test_fight_gregarious_monster.html"));
+    req.responseText = html("request/test_fight_gregarious_monster.html");
     req.processResponse();
 
     assertThat(

--- a/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
@@ -1,10 +1,8 @@
 package net.sourceforge.kolmafia.request;
 
+import static internal.helpers.Networking.html;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import org.junit.jupiter.api.BeforeAll;
@@ -24,8 +22,8 @@ public class AscensionHistoryRequestTest {
   }
 
   @Test
-  public void parseAscensionHistory() throws IOException {
-    String html = Files.readString(Paths.get("request/test_ascensionhistory.html"));
+  public void parseAscensionHistory() {
+    String html = html("request/test_ascensionhistory.html");
 
     AscensionHistoryRequest.parseResponse("ascensionhistory.php?who=177122", html);
 

--- a/test/net/sourceforge/kolmafia/request/CampAwayRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/CampAwayRequestTest.java
@@ -1,11 +1,9 @@
 package net.sourceforge.kolmafia.request;
 
+import static internal.helpers.Networking.html;
 import static internal.helpers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,19 +17,18 @@ public class CampAwayRequestTest {
   }
 
   @Test
-  void canDetectUnlockedByVisiting() throws IOException {
+  void canDetectUnlockedByVisiting() {
     var request = new CampAwayRequest();
-    request.responseText = Files.readString(Path.of("request/test_place_campaway_visit.html"));
+    request.responseText = html("request/test_place_campaway_visit.html");
     request.processResults();
 
     assertThat("getawayCampsiteUnlocked", isSetTo(true));
   }
 
   @Test
-  void doesNotUnlockIfVisitingIsRejected() throws IOException {
+  void doesNotUnlockIfVisitingIsRejected() {
     var request = new CampAwayRequest();
-    request.responseText =
-        Files.readString(Path.of("request/test_place_campaway_dont_have_access.html"));
+    request.responseText = html("request/test_place_campaway_dont_have_access.html");
     request.processResults();
 
     assertThat("getawayCampsiteUnlocked", isSetTo(false));

--- a/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
@@ -1,10 +1,8 @@
 package net.sourceforge.kolmafia.request;
 
+import static internal.helpers.Networking.html;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -19,9 +17,8 @@ public class CampgroundRequestTest {
   }
 
   @Test
-  void canDetectExhaustedMedicineCabinet() throws IOException {
-    String html =
-        Files.readString(Path.of("request/test_campground_medicine_cabinet_out_of_consults.html"));
+  void canDetectExhaustedMedicineCabinet() {
+    String html = html("request/test_campground_medicine_cabinet_out_of_consults.html");
     CampgroundRequest.parseResponse("campground.php?action=workshed", html);
     assertEquals(
         CampgroundRequest.getCurrentWorkshedItem().getItemId(), ItemPool.COLD_MEDICINE_CABINET);

--- a/test/net/sourceforge/kolmafia/request/CharSheetRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/CharSheetRequestTest.java
@@ -1,12 +1,10 @@
 package net.sourceforge.kolmafia.request;
 
+import static internal.helpers.Networking.html;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import javax.xml.parsers.ParserConfigurationException;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.ZodiacSign;
@@ -28,8 +26,8 @@ public class CharSheetRequestTest {
   }
 
   @Test
-  public void parseSkills() throws IOException, ParserConfigurationException {
-    String html = Files.readString(Paths.get("request/test_charsheet_normal.html"));
+  public void parseSkills() throws ParserConfigurationException {
+    String html = html("request/test_charsheet_normal.html");
 
     HtmlCleaner cleaner = HTMLParserUtils.configureDefaultParser();
     DomSerializer domSerializer = new DomSerializer(cleaner.getProperties());
@@ -119,8 +117,8 @@ public class CharSheetRequestTest {
 
   @ParameterizedTest
   @CsvSource({"normal, 123", "unbuffed_stats, 1199739", "grey_you, 2395753"})
-  public void parsePlayerId(String page, String expected) throws IOException {
-    String html = Files.readString(Paths.get("request/test_charsheet_" + page + ".html"));
+  public void parsePlayerId(String page, String expected) {
+    String html = html("request/test_charsheet_" + page + ".html");
     CharSheetRequest.parseStatus(html);
 
     assertThat(KoLCharacter.getPlayerId(), equalTo(expected));
@@ -129,9 +127,8 @@ public class CharSheetRequestTest {
   @ParameterizedTest
   @CsvSource({"normal, 394, 394, 394", "unbuffed_stats, 162, 243, 243", "grey_you, 25, 25, 25"})
   public void parseHP(
-      String page, String expectedCurrentHP, String expectedMaxHP, String expectedBaseMaxHP)
-      throws IOException {
-    String html = Files.readString(Paths.get("request/test_charsheet_" + page + ".html"));
+      String page, String expectedCurrentHP, String expectedMaxHP, String expectedBaseMaxHP) {
+    String html = html("request/test_charsheet_" + page + ".html");
     CharSheetRequest.parseStatus(html);
 
     assertThat(KoLCharacter.getCurrentHP(), equalTo(Long.parseLong(expectedCurrentHP)));
@@ -142,9 +139,8 @@ public class CharSheetRequestTest {
   @ParameterizedTest
   @CsvSource({"normal, 359, 1221, 1221", "unbuffed_stats, 225, 225, 225", "grey_you, 5, 5, 5"})
   public void parseMP(
-      String page, String expectedCurrentMP, String expectedMaxMP, String expectedBaseMaxMP)
-      throws IOException {
-    String html = Files.readString(Paths.get("request/test_charsheet_" + page + ".html"));
+      String page, String expectedCurrentMP, String expectedMaxMP, String expectedBaseMaxMP) {
+    String html = html("request/test_charsheet_" + page + ".html");
     CharSheetRequest.parseStatus(html);
 
     assertThat(KoLCharacter.getCurrentMP(), equalTo(Long.parseLong(expectedCurrentMP)));
@@ -153,8 +149,8 @@ public class CharSheetRequestTest {
   }
 
   @Test
-  public void parseUnbuffedStats() throws IOException {
-    String html = Files.readString(Paths.get("request/test_charsheet_unbuffed_stats.html"));
+  public void parseUnbuffedStats() {
+    String html = html("request/test_charsheet_unbuffed_stats.html");
     CharSheetRequest.parseStatus(html);
 
     assertThat(KoLCharacter.getTotalMuscle(), equalTo(25313L));
@@ -166,8 +162,8 @@ public class CharSheetRequestTest {
   }
 
   @Test
-  public void parseBuffedStats() throws IOException {
-    String html = Files.readString(Paths.get("request/test_charsheet_normal.html"));
+  public void parseBuffedStats() {
+    String html = html("request/test_charsheet_normal.html");
     CharSheetRequest.parseStatus(html);
 
     assertThat(KoLCharacter.getTotalMuscle(), equalTo(29492L));
@@ -179,8 +175,8 @@ public class CharSheetRequestTest {
   }
 
   @Test
-  public void parseGreyYouStats() throws IOException {
-    String html = Files.readString(Paths.get("request/test_charsheet_grey_you.html"));
+  public void parseGreyYouStats() {
+    String html = html("request/test_charsheet_grey_you.html");
     CharSheetRequest.parseStatus(html);
 
     assertThat(KoLCharacter.getTotalMuscle(), equalTo(9L));
@@ -193,8 +189,8 @@ public class CharSheetRequestTest {
 
   @ParameterizedTest
   @CsvSource({"normal, 44", "unbuffed_stats, 494", "grey_you, 20"})
-  public void parseAscensions(String page, String expected) throws IOException {
-    String html = Files.readString(Paths.get("request/test_charsheet_" + page + ".html"));
+  public void parseAscensions(String page, String expected) {
+    String html = html("request/test_charsheet_" + page + ".html");
     CharSheetRequest.parseStatus(html);
 
     assertThat(KoLCharacter.getAscensions(), equalTo(Integer.parseInt(expected)));
@@ -202,8 +198,8 @@ public class CharSheetRequestTest {
 
   @ParameterizedTest
   @CsvSource({"normal, 8621947", "unbuffed_stats, 593", "grey_you, 0"})
-  public void parseAvailableMeat(String page, String expected) throws IOException {
-    String html = Files.readString(Paths.get("request/test_charsheet_" + page + ".html"));
+  public void parseAvailableMeat(String page, String expected) {
+    String html = html("request/test_charsheet_" + page + ".html");
     CharSheetRequest.parseStatus(html);
 
     assertThat(KoLCharacter.getAvailableMeat(), equalTo(Long.parseLong(expected)));
@@ -211,8 +207,8 @@ public class CharSheetRequestTest {
 
   @ParameterizedTest
   @CsvSource({"normal, 2979", "unbuffed_stats, 30", "grey_you, 0"})
-  public void parseCurrentRun(String page, String expected) throws IOException {
-    String html = Files.readString(Paths.get("request/test_charsheet_" + page + ".html"));
+  public void parseCurrentRun(String page, String expected) {
+    String html = html("request/test_charsheet_" + page + ".html");
     CharSheetRequest.parseStatus(html);
 
     assertThat(KoLCharacter.getCurrentRun(), equalTo(Integer.parseInt(expected)));
@@ -220,8 +216,8 @@ public class CharSheetRequestTest {
 
   @ParameterizedTest
   @CsvSource({"normal, 14", "unbuffed_stats, 5", "grey_you, 1"})
-  public void parseCurrentDays(String page, String expected) throws IOException {
-    String html = Files.readString(Paths.get("request/test_charsheet_" + page + ".html"));
+  public void parseCurrentDays(String page, String expected) {
+    String html = html("request/test_charsheet_" + page + ".html");
     CharSheetRequest.parseStatus(html);
 
     assertThat(KoLCharacter.getCurrentDays(), equalTo(Integer.parseInt(expected)));
@@ -229,8 +225,8 @@ public class CharSheetRequestTest {
 
   @ParameterizedTest
   @CsvSource({"normal, Mongoose", "unbuffed_stats, Mongoose", "grey_you, Vole"})
-  public void parseSign(String page, String expected) throws IOException {
-    String html = Files.readString(Paths.get("request/test_charsheet_" + page + ".html"));
+  public void parseSign(String page, String expected) {
+    String html = html("request/test_charsheet_" + page + ".html");
     CharSheetRequest.parseStatus(html);
 
     assertThat(KoLCharacter.getSign(), equalTo(expected));
@@ -238,8 +234,8 @@ public class CharSheetRequestTest {
 
   @ParameterizedTest
   @CsvSource({"normal, false", "unbuffed_stats, false", "grey_you, false"})
-  public void parseHardcore(String page, String expected) throws IOException {
-    String html = Files.readString(Paths.get("request/test_charsheet_" + page + ".html"));
+  public void parseHardcore(String page, String expected) {
+    String html = html("request/test_charsheet_" + page + ".html");
     CharSheetRequest.parseStatus(html);
 
     assertThat(KoLCharacter.isHardcore(), equalTo(Boolean.parseBoolean(expected)));
@@ -247,16 +243,16 @@ public class CharSheetRequestTest {
 
   @ParameterizedTest
   @CsvSource({"normal, 0", "unbuffed_stats, 970", "grey_you, 1000"})
-  public void parseRonin(String page, String expected) throws IOException {
-    String html = Files.readString(Paths.get("request/test_charsheet_" + page + ".html"));
+  public void parseRonin(String page, String expected) {
+    String html = html("request/test_charsheet_" + page + ".html");
     CharSheetRequest.parseStatus(html);
 
     assertThat(KoLCharacter.roninLeft(), equalTo(Integer.parseInt(expected)));
   }
 
   @Test
-  public void unascendedCharacterHasNoPathOrSign() throws IOException {
-    String html = Files.readString(Paths.get("request/test_charsheet_unascended.html"));
+  public void unascendedCharacterHasNoPathOrSign() {
+    String html = html("request/test_charsheet_unascended.html");
     CharSheetRequest.parseStatus(html);
 
     assertThat(KoLCharacter.getAscensions(), equalTo(0));
@@ -264,8 +260,8 @@ public class CharSheetRequestTest {
   }
 
   @Test
-  public void parsesDrunkenness() throws IOException {
-    String html = Files.readString(Paths.get("request/test_charsheet_unascended.html"));
+  public void parsesDrunkenness() {
+    String html = html("request/test_charsheet_unascended.html");
     CharSheetRequest.parseStatus(html);
 
     assertThat(KoLCharacter.getInebriety(), equalTo(3));

--- a/test/net/sourceforge/kolmafia/request/ClanLoungeRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/ClanLoungeRequestTest.java
@@ -1,15 +1,12 @@
 package net.sourceforge.kolmafia.request;
 
+import static internal.helpers.Networking.html;
 import static internal.helpers.Player.setupFakeResponse;
 import static internal.helpers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.preferences.Preferences;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -21,16 +18,6 @@ public class ClanLoungeRequestTest {
     Preferences.reset("ClanLoungeRequestTest");
     // don't try to visit the fireworks shop
     Preferences.setBoolean("_fireworksShop", true);
-  }
-
-  static String html(String path) {
-    try {
-      return Files.readString(Paths.get(path)).trim();
-    } catch (IOException e) {
-      Assertions.fail("Failed to load HTML file: " + path);
-    }
-
-    return null;
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/request/FightRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FightRequestTest.java
@@ -1,12 +1,10 @@
 package net.sourceforge.kolmafia.request;
 
+import static internal.helpers.Networking.html;
 import static internal.helpers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLAdventure;
@@ -47,16 +45,16 @@ public class FightRequestTest {
     KoLCharacter.setFamiliar(FamiliarData.NO_FAMILIAR);
   }
 
-  private void parseCombatData(String path, String location, String encounter) throws IOException {
-    String html = Files.readString(Paths.get(path)).trim();
+  private void parseCombatData(String path, String location, String encounter) {
+    String html = html(path);
     FightRequest.updateCombatData(location, encounter, html);
   }
 
-  private void parseCombatData(String path, String location) throws IOException {
+  private void parseCombatData(String path, String location) {
     parseCombatData(path, location, null);
   }
 
-  private void parseCombatData(String path) throws IOException {
+  private void parseCombatData(String path) {
     parseCombatData(path, null);
   }
 
@@ -111,7 +109,7 @@ public class FightRequestTest {
   }
 
   @Test
-  public void commerceGhostIncrementsByOneOnFight() throws IOException {
+  public void commerceGhostIncrementsByOneOnFight() {
     FamiliarData fam = new FamiliarData(FamiliarPool.GHOST_COMMERCE);
     KoLCharacter.setFamiliar(fam);
     assertEquals(0, Preferences.getInteger("commerceGhostCombats"));
@@ -146,7 +144,7 @@ public class FightRequestTest {
   }
 
   @Test
-  public void gnomeAdv() throws IOException {
+  public void gnomeAdv() {
     var familiar = FamiliarData.registerFamiliar(FamiliarPool.REAGNIMATED_GNOME, 1);
     KoLCharacter.setFamiliar(familiar);
     EquipmentManager.setEquipment(EquipmentManager.FAMILIAR, ItemPool.get(ItemPool.GNOMISH_KNEE));
@@ -157,7 +155,7 @@ public class FightRequestTest {
   }
 
   @Test
-  public void mafiaThumbRingAdvs() throws IOException {
+  public void mafiaThumbRingAdvs() {
     assertEquals(0, Preferences.getInteger("_mafiaThumbRingAdvs"));
     parseCombatData("request/test_fight_mafia_thumb_ring.html");
     assertEquals(1, Preferences.getInteger("_mafiaThumbRingAdvs"));
@@ -167,7 +165,7 @@ public class FightRequestTest {
   }
 
   @Test
-  public void crystalBallPredictions() throws IOException {
+  public void crystalBallPredictions() {
     assertEquals("", Preferences.getString("crystalBallPredictions"));
 
     KoLAdventure.setLastAdventure(AdventureDatabase.getAdventure("The Neverending Party"));
@@ -196,14 +194,14 @@ public class FightRequestTest {
   }
 
   @Test
-  public void voidMonsterIncrementationTest() throws IOException {
+  public void voidMonsterIncrementationTest() {
     MonsterStatusTracker.setNextMonster(MonsterDatabase.findMonster("void slab"));
     parseCombatData("request/test_fight_void_monster.html");
     assertEquals(5, Preferences.getInteger("_voidFreeFights"));
   }
 
   @Test
-  public void cursedMagnifyingGlassTest() throws IOException {
+  public void cursedMagnifyingGlassTest() {
     EquipmentManager.setEquipment(
         EquipmentManager.OFFHAND, ItemPool.get(ItemPool.CURSED_MAGNIFYING_GLASS));
     Preferences.setInteger("cursedMagnifyingGlassCount", 13);
@@ -217,7 +215,7 @@ public class FightRequestTest {
   }
 
   @Test
-  public void daylightShavingTest() throws IOException {
+  public void daylightShavingTest() {
     EquipmentManager.setEquipment(
         EquipmentManager.HAT, ItemPool.get(ItemPool.DAYLIGHT_SHAVINGS_HELMET));
     parseCombatData("request/test_fight_daylight_shavings_buff.html");
@@ -225,7 +223,7 @@ public class FightRequestTest {
   }
 
   @Test
-  public void luckyGoldRingVolcoinoDropRecorded() throws IOException {
+  public void luckyGoldRingVolcoinoDropRecorded() {
     assertFalse(Preferences.getBoolean("_luckyGoldRingVolcoino"));
     parseCombatData("request/test_fight_lucky_gold_ring_volcoino.html");
     assertTrue(Preferences.getBoolean("_luckyGoldRingVolcoino"));
@@ -233,7 +231,7 @@ public class FightRequestTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"alielf", "Black Crayon Crimbo Elf"})
-  public void registersLocketFight(String monsterName) throws IOException {
+  public void registersLocketFight(String monsterName) {
     var monster = MonsterDatabase.findMonster(monsterName);
     MonsterStatusTracker.setNextMonster(monster);
     parseCombatData("request/test_fight_start_locket_fight_with_" + monster.getPhylum() + ".html");
@@ -242,7 +240,7 @@ public class FightRequestTest {
   }
 
   @Test
-  public void rememberNewMonsterForLocket() throws IOException {
+  public void rememberNewMonsterForLocket() {
     assertFalse(LocketManager.remembersMonster(1568));
 
     MonsterStatusTracker.setNextMonster(MonsterDatabase.findMonster("Sloppy Seconds Sundae"));
@@ -252,7 +250,7 @@ public class FightRequestTest {
   }
 
   @Test
-  public void updatesListIfMonsterWasAlreadyInLocket() throws IOException {
+  public void updatesListIfMonsterWasAlreadyInLocket() {
     assertFalse(LocketManager.remembersMonster(155));
 
     MonsterStatusTracker.setNextMonster(MonsterDatabase.findMonster("Knob Goblin Barbecue Team"));
@@ -262,7 +260,7 @@ public class FightRequestTest {
   }
 
   @Test
-  public void dontIncrementWitchessIfFromLocket() throws IOException {
+  public void dontIncrementWitchessIfFromLocket() {
     assertEquals(Preferences.getInteger("_witchessFights"), 0);
 
     MonsterStatusTracker.setNextMonster(MonsterDatabase.findMonster("Witchess Knight"));
@@ -271,15 +269,10 @@ public class FightRequestTest {
     assertEquals(Preferences.getInteger("_witchessFights"), 0);
   }
 
-  static String loadHTMLResponse(String path) throws IOException {
-    // Load the responseText from saved HTML file
-    return Files.readString(Paths.get(path)).trim();
-  }
-
   // Grey Goose Tests
   @Test
-  public void shouldWorkAroundGreyGooseKoLBug() throws IOException {
-    String html = loadHTMLResponse("request/test_fight_grey_goose_combat_skills.html");
+  public void shouldWorkAroundGreyGooseKoLBug() {
+    String html = html("request/test_fight_grey_goose_combat_skills.html");
     FightRequest.currentRound = 1;
     FamiliarData fam = new FamiliarData(FamiliarPool.GREY_GOOSE);
     KoLCharacter.setFamiliar(fam);
@@ -296,8 +289,8 @@ public class FightRequestTest {
   }
 
   @Test
-  public void canTrackMeatifyMatterCast() throws IOException {
-    String html = loadHTMLResponse("request/test_fight_meatify_matter.html");
+  public void canTrackMeatifyMatterCast() {
+    String html = html("request/test_fight_meatify_matter.html");
     FamiliarData fam = new FamiliarData(FamiliarPool.GREY_GOOSE);
     KoLCharacter.setFamiliar(fam);
     KoLCharacter.getFamiliar().setWeight(6);
@@ -318,69 +311,69 @@ public class FightRequestTest {
   // into an exact replica. That was the last drone.
 
   @Test
-  public void canTrackGooseDrones() throws IOException {
+  public void canTrackGooseDrones() {
     FamiliarData fam = new FamiliarData(FamiliarPool.GREY_GOOSE);
     KoLCharacter.setFamiliar(fam);
     KoLCharacter.getFamiliar().setWeight(6);
 
     assertEquals(0, Preferences.getInteger("gooseDronesRemaining"));
 
-    String html = loadHTMLResponse("request/test_fight_goose_drones_1.html");
+    String html = html("request/test_fight_goose_drones_1.html");
     MonsterStatusTracker.setNextMonster(MonsterDatabase.findMonster("angry tourist"));
     FightRequest.registerRequest(true, "fight.php?action=skill&whichskill=7410");
     FightRequest.currentRound = 1;
     FightRequest.updateCombatData(null, null, html);
     assertEquals(6, Preferences.getInteger("gooseDronesRemaining"));
 
-    html = loadHTMLResponse("request/test_fight_goose_drones_2.html");
+    html = html("request/test_fight_goose_drones_2.html");
     FightRequest.registerRequest(true, "fight.php?action=attack");
     FightRequest.currentRound = 2;
     FightRequest.updateCombatData(null, null, html);
     assertEquals(5, Preferences.getInteger("gooseDronesRemaining"));
 
-    html = loadHTMLResponse("request/test_fight_goose_drones_3.html");
+    html = html("request/test_fight_goose_drones_3.html");
     FightRequest.registerRequest(true, "fight.php?action=skill&whichskill=7410");
     FightRequest.currentRound = 1;
     FightRequest.updateCombatData(null, null, html);
     assertEquals(9, Preferences.getInteger("gooseDronesRemaining"));
 
-    html = loadHTMLResponse("request/test_fight_goose_drones_4.html");
+    html = html("request/test_fight_goose_drones_4.html");
     FightRequest.registerRequest(true, "fight.php?action=attack");
     FightRequest.currentRound = 2;
     FightRequest.updateCombatData(null, null, html);
     assertEquals(7, Preferences.getInteger("gooseDronesRemaining"));
 
-    html = loadHTMLResponse("request/test_fight_goose_drones_5.html");
+    html = html("request/test_fight_goose_drones_5.html");
     FightRequest.registerRequest(true, "fight.php?action=attack");
     FightRequest.currentRound = 1;
     FightRequest.updateCombatData(null, null, html);
     assertEquals(6, Preferences.getInteger("gooseDronesRemaining"));
 
-    html = loadHTMLResponse("request/test_fight_goose_drones_6.html");
+    html = html("request/test_fight_goose_drones_6.html");
     FightRequest.registerRequest(true, "fight.php?action=attack");
     FightRequest.currentRound = 1;
     FightRequest.updateCombatData(null, null, html);
     assertEquals(4, Preferences.getInteger("gooseDronesRemaining"));
 
-    html = loadHTMLResponse("request/test_fight_goose_drones_7.html");
+    html = html("request/test_fight_goose_drones_7.html");
     FightRequest.registerRequest(true, "fight.php?action=attack");
     FightRequest.currentRound = 1;
     FightRequest.updateCombatData(null, null, html);
     assertEquals(3, Preferences.getInteger("gooseDronesRemaining"));
 
-    html = loadHTMLResponse("request/test_fight_goose_drones_8.html");
+    html = html("request/test_fight_goose_drones_8.html");
     FightRequest.registerRequest(true, "fight.php?action=attack");
     FightRequest.currentRound = 1;
     FightRequest.updateCombatData(null, null, html);
     assertEquals(2, Preferences.getInteger("gooseDronesRemaining"));
 
-    html = loadHTMLResponse("request/test_fight_goose_drones_9.html");
+    html = html("request/test_fight_goose_drones_9.html");
     FightRequest.registerRequest(true, "fight.php?action=attack");
     FightRequest.currentRound = 1;
     FightRequest.updateCombatData(null, null, html);
     assertEquals(1, Preferences.getInteger("gooseDronesRemaining"));
 
-    html = loadHTMLResponse("request/test_fight_goose_drones_10.html");
+    html = html("request/test_fight_goose_drones_10.html");
     FightRequest.registerRequest(true, "fight.php?action=attack");
     FightRequest.currentRound = 1;
     FightRequest.updateCombatData(null, null, html);
@@ -388,13 +381,13 @@ public class FightRequestTest {
   }
 
   @Test
-  public void canFindItemsAfterSlayTheDead() throws IOException {
+  public void canFindItemsAfterSlayTheDead() {
     FamiliarData fam = new FamiliarData(FamiliarPool.GREY_GOOSE);
     KoLCharacter.setFamiliar(fam);
 
     KoLConstants.inventory.clear();
 
-    String html = loadHTMLResponse("request/test_fight_slay_the_dead.html");
+    String html = html("request/test_fight_slay_the_dead.html");
     String url =
         "fight.php?action=macro&macrotext=abort+hppercentbelow+20%3B+abort+pastround+25%3B+skill+Slay+the+Dead%3B+use+beehive%3B+skill+Double+Nanovision%3B+repeat%3B+mark+eof%3B+";
     MonsterStatusTracker.setNextMonster(MonsterDatabase.findMonster("toothy sklelton"));
@@ -408,10 +401,10 @@ public class FightRequestTest {
   }
 
   @Test
-  public void canFindItemsWithGravyBoat() throws IOException {
+  public void canFindItemsWithGravyBoat() {
     KoLConstants.inventory.clear();
 
-    String html = loadHTMLResponse("request/test_fight_gravy_boat_1.html");
+    String html = html("request/test_fight_gravy_boat_1.html");
     String url = "fight.php?action=skill&whichskill=27043";
     MonsterStatusTracker.setNextMonster(MonsterDatabase.findMonster("spiny skelelton"));
     FightRequest.registerRequest(true, url);
@@ -426,10 +419,10 @@ public class FightRequestTest {
   }
 
   @Test
-  public void canFindItemsWithGravyBoatAndSlayTheDead() throws IOException {
+  public void canFindItemsWithGravyBoatAndSlayTheDead() {
     KoLConstants.inventory.clear();
 
-    String html = loadHTMLResponse("request/test_fight_gravy_boat_2.html");
+    String html = html("request/test_fight_gravy_boat_2.html");
     String url = "fight.php?action=skill&whichskill=7348";
     MonsterStatusTracker.setNextMonster(MonsterDatabase.findMonster("toothy sklelton"));
     FightRequest.registerRequest(true, url);
@@ -442,19 +435,19 @@ public class FightRequestTest {
   }
 
   @Test
-  public void canTrackDramederyActions() throws IOException {
+  public void canTrackDramederyActions() {
     FamiliarData fam =
         new FamiliarData(FamiliarPool.MELODRAMEDARY, "Gogarth", 1, EquipmentRequest.UNEQUIP);
     KoLCharacter.setFamiliar(fam);
 
-    String html = loadHTMLResponse("request/test_fight_drama_drones_1.html");
+    String html = html("request/test_fight_drama_drones_1.html");
     FightRequest.registerRequest(true, "fight.php?action=attack");
     FightRequest.currentRound = 1;
     Preferences.setInteger("camelSpit", 60);
     FightRequest.updateCombatData(null, null, html);
     assertEquals(63, Preferences.getInteger("camelSpit"));
 
-    html = loadHTMLResponse("request/test_fight_drama_spit_1.html");
+    html = html("request/test_fight_drama_spit_1.html");
     FightRequest.registerRequest(true, "fight.php?action=skill&whichskill=7340");
     FightRequest.currentRound = 1;
     Preferences.setInteger("camelSpit", 1000);
@@ -463,11 +456,11 @@ public class FightRequestTest {
   }
 
   @Test
-  public void canTrackDronesWithDramedery() throws IOException {
+  public void canTrackDronesWithDramedery() {
     FamiliarData fam = new FamiliarData(FamiliarPool.MELODRAMEDARY);
     KoLCharacter.setFamiliar(fam);
 
-    String html = loadHTMLResponse("request/test_fight_drama_drones_1.html");
+    String html = html("request/test_fight_drama_drones_1.html");
     FightRequest.registerRequest(true, "fight.php?action=attack");
     FightRequest.currentRound = 1;
     Preferences.setInteger("gooseDronesRemaining", 2);
@@ -476,7 +469,7 @@ public class FightRequestTest {
   }
 
   @Test
-  public void canTrackGreyYouAbsorptions() throws IOException {
+  public void canTrackGreyYouAbsorptions() {
     FamiliarData fam = new FamiliarData(FamiliarPool.GREY_GOOSE);
     KoLCharacter.setFamiliar(fam);
     KoLCharacter.getFamiliar().setExperience(36);
@@ -486,7 +479,7 @@ public class FightRequestTest {
 
     // Initial absorption of an albino bat
     String urlString = "fight.php?action=skill&whichskill=27000";
-    String html = loadHTMLResponse("request/test_fight_goo_absorption_1.html");
+    String html = html("request/test_fight_goo_absorption_1.html");
     MonsterData monster = MonsterDatabase.findMonster("albino bat");
     int monsterId = monster.getId();
     MonsterStatusTracker.setNextMonster(monster);
@@ -501,7 +494,7 @@ public class FightRequestTest {
 
     // Subsequent absorption of an albino bat via Re-Process Matter
     urlString = "fight.php?action=skill&whichskill=7408";
-    html = loadHTMLResponse("request/test_fight_goo_absorption_2.html");
+    html = html("request/test_fight_goo_absorption_2.html");
     FightRequest.currentRound = 2;
     FightRequest.registerRequest(true, urlString);
     assertEquals("", Preferences.getString("gooseReprocessed"));
@@ -514,7 +507,7 @@ public class FightRequestTest {
 
     // Absorbing a Passive Skill
     urlString = "fight.php?action=skill&whichskill=27000";
-    html = loadHTMLResponse("request/test_fight_goo_absorption_3.html");
+    html = html("request/test_fight_goo_absorption_3.html");
     monster = MonsterDatabase.findMonster("rushing bum");
     monsterId = monster.getId();
     MonsterStatusTracker.setNextMonster(monster);
@@ -529,7 +522,7 @@ public class FightRequestTest {
 
     // Absorbing a non-special monster
     urlString = "fight.php?action=skill&whichskill=27000";
-    html = loadHTMLResponse("request/test_fight_goo_absorption_4.html");
+    html = html("request/test_fight_goo_absorption_4.html");
     monster = MonsterDatabase.findMonster("regular old bat");
     monsterId = monster.getId();
     MonsterStatusTracker.setNextMonster(monster);
@@ -540,7 +533,7 @@ public class FightRequestTest {
   }
 
   @Test
-  public void canReabsorbMultipleMonsters() throws IOException {
+  public void canReabsorbMultipleMonsters() {
     FamiliarData fam = new FamiliarData(FamiliarPool.GREY_GOOSE);
     KoLCharacter.setFamiliar(fam);
     KoLCharacter.getFamiliar().setExperience(36);
@@ -550,7 +543,7 @@ public class FightRequestTest {
 
     // Absorption of an albino bat via Re-Process Matter
     String urlString = "fight.php?action=skill&whichskill=7408";
-    String html = loadHTMLResponse("request/test_fight_goo_absorption_2.html");
+    String html = html("request/test_fight_goo_absorption_2.html");
     FightRequest.currentRound = 2;
     FightRequest.registerRequest(true, urlString);
     assertEquals("", Preferences.getString("gooseReprocessed"));
@@ -560,7 +553,7 @@ public class FightRequestTest {
     // Second absorption of a model skeleton via Re-Process Matter
     KoLCharacter.getFamiliar().setExperience(36);
     urlString = "fight.php?action=skill&whichskill=7408";
-    html = loadHTMLResponse("request/test_fight_goo_absorption_5.html");
+    html = html("request/test_fight_goo_absorption_5.html");
     FightRequest.currentRound = 2;
     FightRequest.registerRequest(true, urlString);
     assertEquals("41", Preferences.getString("gooseReprocessed"));
@@ -570,7 +563,7 @@ public class FightRequestTest {
     // Third absorption of a model skeleton via Re-Process Matter
     KoLCharacter.getFamiliar().setExperience(36);
     urlString = "fight.php?action=skill&whichskill=7408";
-    html = loadHTMLResponse("request/test_fight_goo_absorption_5.html");
+    html = html("request/test_fight_goo_absorption_5.html");
     FightRequest.currentRound = 2;
     FightRequest.registerRequest(true, urlString);
     assertEquals("41,1547", Preferences.getString("gooseReprocessed"));
@@ -580,39 +573,39 @@ public class FightRequestTest {
 
   // Cosmic Bowling Ball Tests
   @Test
-  public void canTrackCosmicBowlingBall() throws IOException {
+  public void canTrackCosmicBowlingBall() {
     FightRequest.currentRound = 1;
 
     // Off in the distance, you hear your cosmic bowling ball rattling around in the ball return
     // system.
-    String html = loadHTMLResponse("request/test_fight_bowling_ball_1.html");
+    String html = html("request/test_fight_bowling_ball_1.html");
     FightRequest.parseAvailableCombatSkills(html);
     assertFalse(KoLCharacter.hasCombatSkill(SkillPool.BOWL_STRAIGHT_UP));
 
     // You hear your cosmic bowling ball rattling around in the ball return system.
-    html = loadHTMLResponse("request/test_fight_bowling_ball_2.html");
+    html = html("request/test_fight_bowling_ball_2.html");
     FightRequest.parseAvailableCombatSkills(html);
     assertFalse(KoLCharacter.hasCombatSkill(SkillPool.BOWL_STRAIGHT_UP));
 
     // You hear your cosmic bowling ball rattling around in the ball return system nearby.
-    html = loadHTMLResponse("request/test_fight_bowling_ball_3.html");
+    html = html("request/test_fight_bowling_ball_3.html");
     FightRequest.parseAvailableCombatSkills(html);
     assertFalse(KoLCharacter.hasCombatSkill(SkillPool.BOWL_STRAIGHT_UP));
 
     // You hear your cosmic bowling ball approaching.
-    html = loadHTMLResponse("request/test_fight_bowling_ball_4.html");
+    html = html("request/test_fight_bowling_ball_4.html");
     FightRequest.parseAvailableCombatSkills(html);
     assertFalse(KoLCharacter.hasCombatSkill(SkillPool.BOWL_STRAIGHT_UP));
 
     // Your cosmic bowling ball clatters into the closest ball return and you grab it.
-    html = loadHTMLResponse("request/test_fight_bowling_ball_5.html");
+    html = html("request/test_fight_bowling_ball_5.html");
     FightRequest.parseAvailableCombatSkills(html);
     assertTrue(KoLCharacter.hasCombatSkill(SkillPool.BOWL_STRAIGHT_UP));
   }
 
   // Robort drop tracking preference tests
   @Test
-  public void canTrackRoboDrops() throws IOException {
+  public void canTrackRoboDrops() {
     FamiliarData fam = new FamiliarData(FamiliarPool.ROBORTENDER);
     KoLCharacter.setFamiliar(fam);
 
@@ -628,14 +621,14 @@ public class FightRequestTest {
   }
 
   @Test
-  public void canDetectMaydaySupplyPackage() throws IOException {
+  public void canDetectMaydaySupplyPackage() {
     assertFalse(Preferences.getBoolean("_maydayDropped"));
     parseCombatData("request/test_fight_mayday_contract.html");
     assertTrue(Preferences.getBoolean("_maydayDropped"));
   }
 
   @Test
-  public void canTrackJuneCleaverPrefs() throws IOException {
+  public void canTrackJuneCleaverPrefs() {
     EquipmentManager.setEquipment(EquipmentManager.WEAPON, ItemPool.get(ItemPool.JUNE_CLEAVER));
     parseCombatData("request/test_fight_june_cleaver.html");
     assertEquals(Preferences.getInteger("_juneCleaverSleaze"), 2);
@@ -643,7 +636,7 @@ public class FightRequestTest {
   }
 
   @Test
-  public void canTrackBellydancerPickpocket() throws IOException {
+  public void canTrackBellydancerPickpocket() {
     assertEquals(0, Preferences.getInteger("_bellydancerPickpockets"));
 
     parseCombatData("request/test_fight_bellydancing_pickpocket_1.html");

--- a/test/net/sourceforge/kolmafia/request/GenericRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/GenericRequestTest.java
@@ -1,13 +1,11 @@
 package net.sourceforge.kolmafia.request;
 
+import static internal.helpers.Networking.html;
 import static internal.helpers.Player.*;
 import static internal.helpers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -25,7 +23,7 @@ public class GenericRequestTest {
   }
 
   @Test
-  public void hallowienerVolcoinoNotPickedUpByLuckyGoldRing() throws IOException {
+  public void hallowienerVolcoinoNotPickedUpByLuckyGoldRing() {
     assertEquals("", Preferences.getString("lastEncounter"));
     equip(EquipmentManager.ACCESSORY1, "lucky gold ring");
     assertEquals(false, Preferences.getBoolean("_luckyGoldRingVolcoino"));
@@ -34,9 +32,7 @@ public class GenericRequestTest {
 
     GenericRequest request = new GenericRequest("adventure.php?snarfblat=451");
     request.setHasResult(true);
-    request.responseText =
-        Files.readString(
-            Paths.get("request/test_adventure_hallowiener_volcoino_lucky_gold_ring.html"));
+    request.responseText = html("request/test_adventure_hallowiener_volcoino_lucky_gold_ring.html");
 
     request.processResponse();
 
@@ -45,12 +41,11 @@ public class GenericRequestTest {
   }
 
   @Test
-  public void seeingEmptySpookyPuttyMonsterSetsProperty() throws IOException {
+  public void seeingEmptySpookyPuttyMonsterSetsProperty() {
     Preferences.setString("spookyPuttyMonster", "zmobie");
 
     var req = new GenericRequest("desc_item.php?whichitem=324375100");
-    req.responseText =
-        Files.readString(Paths.get("request/test_desc_item_spooky_putty_monster_empty.html"));
+    req.responseText = html("request/test_desc_item_spooky_putty_monster_empty.html");
     req.processResponse();
 
     assertThat("spookyPuttyMonster", isSetTo(""));
@@ -58,11 +53,9 @@ public class GenericRequestTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"beast", "elf"})
-  public void learnLocketPhylumFromLocketDescription(String phylum) throws IOException {
+  public void learnLocketPhylumFromLocketDescription(String phylum) {
     var req = new GenericRequest("desc_item.php?whichitem=634036450");
-    req.responseText =
-        Files.readString(
-            Paths.get("request/test_desc_item_combat_lovers_locket_" + phylum + ".html"));
+    req.responseText = html("request/test_desc_item_combat_lovers_locket_" + phylum + ".html");
     req.processResponse();
 
     assertThat("locketPhylum", isSetTo(phylum));

--- a/test/net/sourceforge/kolmafia/request/GuildRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/GuildRequestTest.java
@@ -1,11 +1,11 @@
 package net.sourceforge.kolmafia.request;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static internal.helpers.Networking.html;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import internal.helpers.Player;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
@@ -45,16 +45,11 @@ public class GuildRequestTest {
     Preferences.saveSettingsToFile = true;
   }
 
-  static String loadHTMLResponse(String path) throws IOException {
-    // Load the responseText from saved HTML file
-    return Files.readString(Paths.get(path)).trim();
-  }
-
   @Test
-  public void canTrackWizardOfEgoQuest() throws IOException {
+  public void canTrackWizardOfEgoQuest() {
     // First talk with "ocg"
     GuildRequest request = new GuildRequest("ocg");
-    String responseText = loadHTMLResponse("request/test_guild_quest_ego_intro.html");
+    String responseText = html("request/test_guild_quest_ego_intro.html");
     request.responseText = responseText;
     request.setHasResult(true);
     request.processResponse();
@@ -62,7 +57,7 @@ public class GuildRequestTest {
 
     // Second talk with "ocg"
     request = new GuildRequest("ocg");
-    responseText = loadHTMLResponse("request/test_guild_quest_ego_started.html");
+    responseText = html("request/test_guild_quest_ego_started.html");
     request.responseText = responseText;
     request.setHasResult(true);
     request.processResponse();
@@ -71,7 +66,7 @@ public class GuildRequestTest {
     // Talk after turning in key and getting next step
     AdventureResult key = ItemPool.get(ItemPool.FERNSWARTHYS_KEY);
     request = new GuildRequest("ocg");
-    responseText = loadHTMLResponse("request/test_guild_quest_ego_step2.html");
+    responseText = html("request/test_guild_quest_ego_step2.html");
     request.responseText = responseText;
     request.setHasResult(true);
     request.processResponse();
@@ -82,7 +77,7 @@ public class GuildRequestTest {
     AdventureResult dusty = ItemPool.get(ItemPool.DUSTY_BOOK);
     AdventureResult manual = ItemPool.get(ItemPool.MOX_MANUAL);
     request = new GuildRequest("ocg");
-    responseText = loadHTMLResponse("request/test_guild_quest_ego_finished.html");
+    responseText = html("request/test_guild_quest_ego_finished.html");
     request.responseText = responseText;
     request.setHasResult(true);
     request.processResponse();
@@ -93,7 +88,7 @@ public class GuildRequestTest {
   }
 
   @Test
-  public void canDetectWhiteCitadelQuestStarted() throws IOException {
+  public void canDetectWhiteCitadelQuestStarted() {
     // You have completed the Meatcar and visited "paco",
     // You visit "paco" again and they give the White Citadel Quest.
     //
@@ -109,7 +104,7 @@ public class GuildRequestTest {
     try (cleanups) {
       // talk with "ocg"
       GenericRequest request = new GenericRequest("choice.php?forceoption=0");
-      String responseText = loadHTMLResponse("request/test_guild_quest_citadel_started_0.html");
+      String responseText = html("request/test_guild_quest_citadel_started_0.html");
       request.responseText = responseText;
       request.setHasResult(true);
       ChoiceManager.preChoice(request);
@@ -117,7 +112,7 @@ public class GuildRequestTest {
       assertEquals(QuestDatabase.UNSTARTED, QuestDatabase.getQuest(Quest.CITADEL));
 
       request = new GenericRequest("choice.php?pwd&whichchoice=930&option=1");
-      responseText = loadHTMLResponse("request/test_guild_quest_citadel_started_1.html");
+      responseText = html("request/test_guild_quest_citadel_started_1.html");
       request.responseText = responseText;
       request.setHasResult(true);
       ChoiceManager.preChoice(request);
@@ -127,7 +122,7 @@ public class GuildRequestTest {
   }
 
   @Test
-  public void canDetectWhiteCitadelQuestFinished() throws IOException {
+  public void canDetectWhiteCitadelQuestFinished() {
     // You have visited White Citadel and been given a White Citadel Satisfaction Satchel
     // Quest.CITADEL is at "step10"
     // You return to the guild and speak to "paco"
@@ -145,7 +140,7 @@ public class GuildRequestTest {
     try (cleanups) {
       // talk with "ocg"
       GenericRequest request = new GenericRequest("choice.php?forceoption=0");
-      String responseText = loadHTMLResponse("request/test_guild_quest_citadel_finished.html");
+      String responseText = html("request/test_guild_quest_citadel_finished.html");
       request.responseText = responseText;
       request.setHasResult(true);
       ChoiceManager.preChoice(request);

--- a/test/net/sourceforge/kolmafia/request/ProcessAcquiredItemsTest.java
+++ b/test/net/sourceforge/kolmafia/request/ProcessAcquiredItemsTest.java
@@ -1,10 +1,8 @@
 package net.sourceforge.kolmafia.request;
 
+import static internal.helpers.Networking.html;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
@@ -32,8 +30,7 @@ public class ProcessAcquiredItemsTest {
 
   // *** Here are tests for pull items out of your store
 
-  private ManageStoreRequest manageStoreRequestSetup(AdventureResult item, String path)
-      throws IOException {
+  private ManageStoreRequest manageStoreRequestSetup(AdventureResult item, String path) {
     // Simulate logging out and back in again.
     KoLCharacter.reset("");
     KoLCharacter.reset("transfer items user");
@@ -51,15 +48,14 @@ public class ProcessAcquiredItemsTest {
     KoLConstants.freepulls.clear();
 
     // Load the responseText from saved HTML file
-    String html = Files.readString(Paths.get("request/" + path)).trim();
-    request.responseText = html;
+    request.responseText = html("request/" + path);
 
     // Voila! we are ready to test
     return request;
   }
 
   @Test
-  public void itMovesFromStoreToInventory() throws IOException {
+  public void itMovesFromStoreToInventory() {
 
     // Load up our request/response
     AdventureResult item = ItemPool.get(ItemPool.REAGENT, 1);
@@ -81,7 +77,7 @@ public class ProcessAcquiredItemsTest {
   }
 
   @Test
-  public void itMovesFromStoreToStorage() throws IOException {
+  public void itMovesFromStoreToStorage() {
 
     // Load up our request/response
     AdventureResult item = ItemPool.get(ItemPool.SUMP_M_SUMP_M, 2);
@@ -104,7 +100,7 @@ public class ProcessAcquiredItemsTest {
   }
 
   @Test
-  public void itMovesFromStoreToFreepulls() throws IOException {
+  public void itMovesFromStoreToFreepulls() {
 
     // Load up our request/response
     AdventureResult item = ItemPool.get(ItemPool.TOILET_PAPER, 2);
@@ -129,7 +125,7 @@ public class ProcessAcquiredItemsTest {
   // *** Here are tests for buying items from the mall
 
   private MallPurchaseRequest mallPurchaseRequestSetup(
-      AdventureResult item, int shopId, int price, String path) throws IOException {
+      AdventureResult item, int shopId, int price, String path) {
     // Simulate logging out and back in again.
     KoLCharacter.reset("");
     KoLCharacter.reset("transfer items user");
@@ -149,15 +145,14 @@ public class ProcessAcquiredItemsTest {
     KoLConstants.freepulls.clear();
 
     // Load the responseText from saved HTML file
-    String html = Files.readString(Paths.get("request/" + path)).trim();
-    request.responseText = html;
+    request.responseText = html("request/" + path);
 
     // Voila! we are ready to test
     return request;
   }
 
   @Test
-  public void itMovesFromMallToInventory() throws IOException {
+  public void itMovesFromMallToInventory() {
 
     // Load up our request/response
     AdventureResult item = ItemPool.get(ItemPool.MILK_OF_MAGNESIUM, 1);
@@ -180,7 +175,7 @@ public class ProcessAcquiredItemsTest {
   }
 
   @Test
-  public void itMovesFromMallToStorage() throws IOException {
+  public void itMovesFromMallToStorage() {
 
     // Load up our request/response
     AdventureResult item = ItemPool.get(ItemPool.MILK_OF_MAGNESIUM, 1);
@@ -203,7 +198,7 @@ public class ProcessAcquiredItemsTest {
   }
 
   @Test
-  public void itMovesFromMallToFreepulls() throws IOException {
+  public void itMovesFromMallToFreepulls() {
 
     // Load up our request/response
     AdventureResult item = ItemPool.get(ItemPool.TOILET_PAPER, 1);

--- a/test/net/sourceforge/kolmafia/request/ScrapheapRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/ScrapheapRequestTest.java
@@ -1,12 +1,10 @@
 package net.sourceforge.kolmafia.request;
 
+import static internal.helpers.Networking.html;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.ChoiceManager;
@@ -32,8 +30,8 @@ public class ScrapheapRequestTest {
     Preferences.saveSettingsToFile = true;
   }
 
-  private int parseActivations(String path) throws IOException {
-    String html = Files.readString(Paths.get(path));
+  private int parseActivations(String path) {
+    String html = html(path);
     var req = new ScrapheapRequest("sh_chrono");
     req.responseText = html;
     req.processResults();
@@ -41,7 +39,7 @@ public class ScrapheapRequestTest {
   }
 
   @Test
-  public void parseChronolith1() throws IOException {
+  public void parseChronolith1() {
     KoLCharacter.setYouRobotEnergy(1000);
     int cost = 16;
     Preferences.setInteger("_chronolithNextCost", cost);
@@ -51,7 +49,7 @@ public class ScrapheapRequestTest {
   }
 
   @Test
-  public void parseChronolith37() throws IOException {
+  public void parseChronolith37() {
     KoLCharacter.setYouRobotEnergy(1000);
     int cost = 138;
     Preferences.setInteger("_chronolithNextCost", cost);
@@ -61,7 +59,7 @@ public class ScrapheapRequestTest {
   }
 
   @Test
-  public void parseChronolith69() throws IOException {
+  public void parseChronolith69() {
     KoLCharacter.setYouRobotEnergy(1000);
     int cost = 890;
     Preferences.setInteger("_chronolithNextCost", cost);
@@ -71,8 +69,8 @@ public class ScrapheapRequestTest {
   }
 
   @Test
-  public void parseCPUUpgrades() throws IOException {
-    String html = Files.readString(Paths.get("request/test_scrapheap_cpu_upgrades.html"));
+  public void parseCPUUpgrades() {
+    String html = html("request/test_scrapheap_cpu_upgrades.html");
 
     var req = new GenericRequest("choice.php?whichchoice=1445&show=cpus");
     req.responseText = html;

--- a/test/net/sourceforge/kolmafia/request/StorageRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/StorageRequestTest.java
@@ -1,12 +1,10 @@
 package net.sourceforge.kolmafia.request;
 
+import static internal.helpers.Networking.html;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -900,7 +898,7 @@ public class StorageRequestTest {
 
   // *** Here are tests for StorageRequest.transferItems()
 
-  private StorageRequest storageTransferItemsSetup() throws IOException {
+  private StorageRequest storageTransferItemsSetup() {
     // Simulate logging out and back in again.
     KoLCharacter.reset("");
     KoLCharacter.reset("transfer items user");
@@ -953,7 +951,7 @@ public class StorageRequestTest {
 
     // Load the responseText from saved HTML file
     String path = "request/test_request_storage_pulls.html";
-    String html = Files.readString(Paths.get(path)).trim();
+    String html = html(path);
     request.responseText = html;
 
     // Voila! we are ready to test
@@ -961,7 +959,7 @@ public class StorageRequestTest {
   }
 
   @Test
-  public void itShouldNonBulkTransferItems() throws IOException {
+  public void itShouldNonBulkTransferItems() {
 
     // Load up our request/response
     StorageRequest request = storageTransferItemsSetup();
@@ -993,7 +991,7 @@ public class StorageRequestTest {
   }
 
   @Test
-  public void itShouldBulkTransferItems() throws IOException {
+  public void itShouldBulkTransferItems() {
 
     // Load up our request/response
     StorageRequest request = storageTransferItemsSetup();

--- a/test/net/sourceforge/kolmafia/session/BanishManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/BanishManagerTest.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.session;
 
+import static internal.helpers.Networking.html;
 import static internal.helpers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
@@ -9,9 +10,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.MonsterData;
 import net.sourceforge.kolmafia.combat.MonsterStatusTracker;
@@ -398,13 +396,13 @@ class BanishManagerTest {
   }
 
   @Test
-  void canDiscoverIceHouseMonsterFromNoncombat() throws IOException {
+  void canDiscoverIceHouseMonsterFromNoncombat() {
     KoLCharacter.setCurrentRun(128);
     assertThat("banishedMonsters", isSetTo(""));
     BanishManager.loadBanishedMonsters();
 
     var request = new GenericRequest("choice.php?forceoption=0");
-    request.responseText = Files.readString(Path.of("request/test_museum_ice_house.html"));
+    request.responseText = html("request/test_museum_ice_house.html");
     ChoiceManager.visitChoice(request);
 
     var ice = BanishManager.getBanishedMonster(Banisher.ICE_HOUSE);

--- a/test/net/sourceforge/kolmafia/session/BastilleBattalionManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/BastilleBattalionManagerTest.java
@@ -1,13 +1,11 @@
 package net.sourceforge.kolmafia.session;
 
+import static internal.helpers.Networking.html;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
@@ -47,11 +45,6 @@ public class BastilleBattalionManagerTest {
     ChoiceManager.lastDecision = 0;
   }
 
-  static String loadHTMLResponse(String path) throws IOException {
-    // Load the responseText from saved HTML file
-    return Files.readString(Paths.get(path)).trim();
-  }
-
   @Test
   public void canLoadStats() {
     String value = "";
@@ -74,7 +67,7 @@ public class BastilleBattalionManagerTest {
   }
 
   @Test
-  public void canDetectBoosts() throws IOException {
+  public void canDetectBoosts() {
     BastilleBattalionManager.logBoosts();
     assertEquals("", Preferences.getString("_bastilleBoosts"));
     AdventureResult.addResultToList(
@@ -92,12 +85,12 @@ public class BastilleBattalionManagerTest {
   }
 
   @Test
-  public void canConfigureAllUpgrades() throws IOException {
+  public void canConfigureAllUpgrades() {
     // Test all of the configuration options from the main page.
     // Cycle through every upgrade in every upgrade location.
 
     String urlString = "choice.php?forceoption=0";
-    String responseText = loadHTMLResponse("request/test_bastille_configure_0.html");
+    String responseText = html("request/test_bastille_configure_0.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
@@ -111,7 +104,7 @@ public class BastilleBattalionManagerTest {
     String expected = "Decorating the Barbican";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_configure_1.html");
+    responseText = html("request/test_bastille_configure_1.html");
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
     ChoiceManager.lastDecision = 1;
@@ -125,7 +118,7 @@ public class BastilleBattalionManagerTest {
     expected = "Decorating the Barbican";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_configure_2.html");
+    responseText = html("request/test_bastille_configure_2.html");
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
     ChoiceManager.lastDecision = 1;
@@ -138,7 +131,7 @@ public class BastilleBattalionManagerTest {
     expected = "Decorating the Barbican";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_configure_3.html");
+    responseText = html("request/test_bastille_configure_3.html");
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
     ChoiceManager.lastDecision = 1;
@@ -152,7 +145,7 @@ public class BastilleBattalionManagerTest {
     expected = "Changing the Drawbridge";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_configure_4.html");
+    responseText = html("request/test_bastille_configure_4.html");
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
     ChoiceManager.lastDecision = 2;
@@ -166,7 +159,7 @@ public class BastilleBattalionManagerTest {
     expected = "Changing the Drawbridge";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_configure_5.html");
+    responseText = html("request/test_bastille_configure_5.html");
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
     ChoiceManager.lastDecision = 2;
@@ -180,7 +173,7 @@ public class BastilleBattalionManagerTest {
     expected = "Changing the Drawbridge";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_configure_6.html");
+    responseText = html("request/test_bastille_configure_6.html");
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
     ChoiceManager.lastDecision = 2;
@@ -194,7 +187,7 @@ public class BastilleBattalionManagerTest {
     expected = "Sizing the Murder Holes";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_configure_7.html");
+    responseText = html("request/test_bastille_configure_7.html");
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
     ChoiceManager.lastDecision = 3;
@@ -208,7 +201,7 @@ public class BastilleBattalionManagerTest {
     expected = "Sizing the Murder Holes";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_configure_8.html");
+    responseText = html("request/test_bastille_configure_8.html");
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
     ChoiceManager.lastDecision = 3;
@@ -222,7 +215,7 @@ public class BastilleBattalionManagerTest {
     expected = "Sizing the Murder Holes";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_configure_9.html");
+    responseText = html("request/test_bastille_configure_9.html");
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
     ChoiceManager.lastDecision = 3;
@@ -236,7 +229,7 @@ public class BastilleBattalionManagerTest {
     expected = "Filling the Moat";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_configure_10.html");
+    responseText = html("request/test_bastille_configure_10.html");
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
     ChoiceManager.lastDecision = 4;
@@ -250,7 +243,7 @@ public class BastilleBattalionManagerTest {
     expected = "Filling the Moat";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_configure_11.html");
+    responseText = html("request/test_bastille_configure_11.html");
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
     ChoiceManager.lastDecision = 4;
@@ -264,7 +257,7 @@ public class BastilleBattalionManagerTest {
     expected = "Filling the Moat";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_configure_12.html");
+    responseText = html("request/test_bastille_configure_12.html");
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
     ChoiceManager.lastDecision = 4;
@@ -276,12 +269,12 @@ public class BastilleBattalionManagerTest {
   }
 
   @Test
-  public void canProcessGame() throws IOException {
+  public void canProcessGame() {
     // This is 12-turn game, ending in a loss.
 
     // Enter the control console
     String urlString = "choice.php?forceoption=0";
-    String responseText = loadHTMLResponse("request/test_bastille_game1_0.html");
+    String responseText = html("request/test_bastille_game1_0.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
@@ -292,7 +285,7 @@ public class BastilleBattalionManagerTest {
     String expected = "Starting game #1";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_0_1.html");
+    responseText = html("request/test_bastille_game1_0_1.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;
@@ -317,7 +310,7 @@ public class BastilleBattalionManagerTest {
     expected = "Turn #1: Improving offense.";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_1.html");
+    responseText = html("request/test_bastille_game1_1.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1314;
@@ -340,7 +333,7 @@ public class BastilleBattalionManagerTest {
     expected = "Adopt the radical combat style";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_1_2.html");
+    responseText = html("request/test_bastille_game1_1_2.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1317;
@@ -366,7 +359,7 @@ public class BastilleBattalionManagerTest {
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
     request.constructURLString(urlString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_2.html");
+    responseText = html("request/test_bastille_game1_2.html");
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1314;
     ChoiceManager.lastDecision = 1;
@@ -388,7 +381,7 @@ public class BastilleBattalionManagerTest {
     expected = "Draft those artists";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_2_3.html");
+    responseText = html("request/test_bastille_game1_2_3.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1317;
@@ -413,7 +406,7 @@ public class BastilleBattalionManagerTest {
     expected = "Turn #3: Charge!";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_3_4.html");
+    responseText = html("request/test_bastille_game1_3_4.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1315;
@@ -441,7 +434,7 @@ public class BastilleBattalionManagerTest {
     expected = "Turn #4: Focusing on defense.";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_4.html");
+    responseText = html("request/test_bastille_game1_4.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1314;
@@ -464,7 +457,7 @@ public class BastilleBattalionManagerTest {
     expected = "Convert the galleries";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_4_5.html");
+    responseText = html("request/test_bastille_game1_4_5.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1318;
@@ -489,7 +482,7 @@ public class BastilleBattalionManagerTest {
     expected = "Turn #5: Focusing on defense.";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_5.html");
+    responseText = html("request/test_bastille_game1_5.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1314;
@@ -512,7 +505,7 @@ public class BastilleBattalionManagerTest {
     expected = "Repurpose the statues";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_5_6.html");
+    responseText = html("request/test_bastille_game1_5_6.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1318;
@@ -537,7 +530,7 @@ public class BastilleBattalionManagerTest {
     expected = "Turn #6: Charge!";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_6_7.html");
+    responseText = html("request/test_bastille_game1_6_7.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1315;
@@ -565,7 +558,7 @@ public class BastilleBattalionManagerTest {
     expected = "Turn #7: Improving offense.";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_7.html");
+    responseText = html("request/test_bastille_game1_7.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1314;
@@ -588,7 +581,7 @@ public class BastilleBattalionManagerTest {
     expected = "Build the memorial";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_7_8.html");
+    responseText = html("request/test_bastille_game1_7_8.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1317;
@@ -613,7 +606,7 @@ public class BastilleBattalionManagerTest {
     expected = "Turn #8: Improving offense.";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_8.html");
+    responseText = html("request/test_bastille_game1_8.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1314;
@@ -636,7 +629,7 @@ public class BastilleBattalionManagerTest {
     expected = "Approve the retrofit";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_8_9.html");
+    responseText = html("request/test_bastille_game1_8_9.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1317;
@@ -661,7 +654,7 @@ public class BastilleBattalionManagerTest {
     expected = "Turn #9: Charge!";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_9_10.html");
+    responseText = html("request/test_bastille_game1_9_10.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1315;
@@ -689,7 +682,7 @@ public class BastilleBattalionManagerTest {
     expected = "Turn #10: Improving offense.";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_10.html");
+    responseText = html("request/test_bastille_game1_10.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1314;
@@ -712,7 +705,7 @@ public class BastilleBattalionManagerTest {
     expected = "Strengthen the walls";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_10_11.html");
+    responseText = html("request/test_bastille_game1_10_11.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1317;
@@ -737,7 +730,7 @@ public class BastilleBattalionManagerTest {
     expected = "Turn #11: Looking for cheese.";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_11.html");
+    responseText = html("request/test_bastille_game1_11.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1314;
@@ -760,7 +753,7 @@ public class BastilleBattalionManagerTest {
     expected = "Raid the cave";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_11_12.html");
+    responseText = html("request/test_bastille_game1_11_12.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1319;
@@ -785,7 +778,7 @@ public class BastilleBattalionManagerTest {
     expected = "Turn #12: Charge!";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_game1_12_loss.html");
+    responseText = html("request/test_bastille_game1_12_loss.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1315;
@@ -802,7 +795,7 @@ public class BastilleBattalionManagerTest {
     // GAME OVER
     urlString = "choice.php?whichchoice=1316&option=3";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
-    responseText = loadHTMLResponse("request/test_bastille_game1_done.html");
+    responseText = html("request/test_bastille_game1_done.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1316;
@@ -825,7 +818,7 @@ public class BastilleBattalionManagerTest {
   }
 
   @Test
-  public void thatStartingNewGameResetsStats() throws IOException {
+  public void thatStartingNewGameResetsStats() {
     // When you lose a battle, the game ends and your stats are reset to
     // only what your upgrades provide to you.
 
@@ -844,7 +837,7 @@ public class BastilleBattalionManagerTest {
     String expected = "Make the soldiers masons";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    String responseText = loadHTMLResponse("request/test_bastille_end_game_start_game_1.html");
+    String responseText = html("request/test_bastille_end_game_start_game_1.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1318;
@@ -866,7 +859,7 @@ public class BastilleBattalionManagerTest {
     expected = "Turn #6: Charge!";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_end_game_start_game_2.html");
+    responseText = html("request/test_bastille_end_game_start_game_2.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1315;
@@ -894,7 +887,7 @@ public class BastilleBattalionManagerTest {
     urlString = "choice.php?whichchoice=1316&option=2";
     // We don't log returning to the console
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
-    responseText = loadHTMLResponse("request/test_bastille_end_game_start_game_3.html");
+    responseText = html("request/test_bastille_end_game_start_game_3.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1316;
@@ -910,7 +903,7 @@ public class BastilleBattalionManagerTest {
     expected = "Starting game #2";
     assertTrue(BastilleBattalionManager.registerRequest(urlString));
     assertEquals(expected, RequestLogger.previousUpdateString);
-    responseText = loadHTMLResponse("request/test_bastille_end_game_start_game_4.html");
+    responseText = html("request/test_bastille_end_game_start_game_4.html");
     request.constructURLString(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1313;

--- a/test/net/sourceforge/kolmafia/session/ChoiceManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/ChoiceManagerTest.java
@@ -1,10 +1,8 @@
 package net.sourceforge.kolmafia.session;
 
+import static internal.helpers.Networking.html;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Map;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.KoLCharacter;
@@ -38,13 +36,8 @@ public class ChoiceManagerTest {
     ChoiceManager.lastDecision = 0;
   }
 
-  static String loadHTMLResponse(String path) throws IOException {
-    // Load the responseText from saved HTML file
-    return Files.readString(Paths.get(path)).trim();
-  }
-
   @Test
-  public void thatUnknownTombDynamicChoicesWork() throws IOException {
+  public void thatUnknownTombDynamicChoicesWork() {
     // There is a riddle and three possible answers. These are based on your character class.
     // The order of the answers is shuffled every time the choice page is reloaded.
     // One answer is right and two are wrong.
@@ -57,7 +50,7 @@ public class ChoiceManagerTest {
 
     KoLCharacter.setAscensionClass(AscensionClass.ACCORDION_THIEF);
 
-    String responseText = loadHTMLResponse("request/test_choice_manager_unknown_tomb_1.html");
+    String responseText = html("request/test_choice_manager_unknown_tomb_1.html");
     int choice = ChoiceUtilities.extractChoice(responseText);
     assertEquals(1049, choice);
     Map<Integer, String> choices = ChoiceUtilities.parseChoices(responseText);
@@ -67,7 +60,7 @@ public class ChoiceManagerTest {
     String option = ChoiceManager.specialChoiceDecision1(choice, "", 0, responseText);
     assertEquals("1", option);
 
-    responseText = loadHTMLResponse("request/test_choice_manager_unknown_tomb_2.html");
+    responseText = html("request/test_choice_manager_unknown_tomb_2.html");
     choice = ChoiceUtilities.extractChoice(responseText);
     assertEquals(1049, choice);
     choices = ChoiceUtilities.parseChoices(responseText);
@@ -77,7 +70,7 @@ public class ChoiceManagerTest {
     option = ChoiceManager.specialChoiceDecision1(choice, "", 0, responseText);
     assertEquals("2", option);
 
-    responseText = loadHTMLResponse("request/test_choice_manager_unknown_tomb_3.html");
+    responseText = html("request/test_choice_manager_unknown_tomb_3.html");
     choice = ChoiceUtilities.extractChoice(responseText);
     assertEquals(1049, choice);
     choices = ChoiceUtilities.parseChoices(responseText);

--- a/test/net/sourceforge/kolmafia/session/CrystalBallManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/CrystalBallManagerTest.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.session;
 
+import static internal.helpers.Networking.html;
 import static internal.helpers.Player.equip;
 import static internal.helpers.Player.setFamiliar;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -7,9 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import internal.helpers.Cleanups;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.MonsterData;
 import net.sourceforge.kolmafia.combat.MonsterStatusTracker;
@@ -96,15 +94,15 @@ public class CrystalBallManagerTest {
   }
 
   @Test
-  public void canParsePonder() throws IOException {
-    String html = Files.readString(Path.of("request/test_ponder_orb_one_prediction.html"));
+  public void canParsePonder() {
+    String html = html("request/test_ponder_orb_one_prediction.html");
     CrystalBallManager.parsePonder(html);
     assertEquals("0:Twin Peak:Creepy Ginger Twin", Preferences.getString("crystalBallPredictions"));
   }
 
   @Test
-  public void canParsePonderWithMultiple() throws IOException {
-    String html = Files.readString(Path.of("request/test_ponder_orb_two_predictions.html"));
+  public void canParsePonderWithMultiple() {
+    String html = html("request/test_ponder_orb_two_predictions.html");
     CrystalBallManager.parsePonder(html);
     assertEquals(
         "0:A-Boo Peak:Dusken Raider Ghost|0:Twin Peak:Creepy Ginger Twin",
@@ -113,16 +111,16 @@ public class CrystalBallManagerTest {
   }
 
   @Test
-  public void canParsePonderWithArticles() throws IOException {
-    String html = Files.readString(Path.of("request/test_ponder_orb_some_article.html"));
+  public void canParsePonderWithArticles() {
+    String html = html("request/test_ponder_orb_some_article.html");
     CrystalBallManager.parsePonder(html);
     assertEquals(
         "0:The Haunted Ballroom:zombie waltzers", Preferences.getString("crystalBallPredictions"));
   }
 
   @Test
-  public void canParsePonderWithNameStartingWithArticle() throws IOException {
-    String html = Files.readString(Path.of("request/test_ponder_orb_the_gunk.html"));
+  public void canParsePonderWithNameStartingWithArticle() {
+    String html = html("request/test_ponder_orb_the_gunk.html");
     CrystalBallManager.parsePonder(html);
     assertEquals(
         "0:The Haunted Laboratory:the gunk", Preferences.getString("crystalBallPredictions"));

--- a/test/net/sourceforge/kolmafia/session/DisplayCaseManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/DisplayCaseManagerTest.java
@@ -1,9 +1,8 @@
 package net.sourceforge.kolmafia.session;
 
+import static internal.helpers.Networking.html;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,11 +30,7 @@ class DisplayCaseManagerTest {
     // This file is managecollectionshelves.php with no shelves.
     String displayCase = null;
     String fileName = "request/test_displaycollection_no_shelves.html";
-    try {
-      displayCase = Files.readString(Path.of(fileName));
-    } catch (Exception e) {
-      fail("Exception " + e);
-    }
+    displayCase = html(fileName);
     assertNotNull(displayCase, "Could not read case data.");
     assertTrue(displayCase.length() > 0, "Case data is empty.");
     DisplayCaseManager.update(displayCase);
@@ -49,11 +44,7 @@ class DisplayCaseManagerTest {
     // This file is managecollectionshelves.php with two shelves.
     String displayCase = null;
     String fileName = "request/test_displaycollection_shelves.html";
-    try {
-      displayCase = Files.readString(Path.of(fileName));
-    } catch (Exception e) {
-      fail("Exception " + e);
-    }
+    displayCase = html(fileName);
     assertNotNull(displayCase, "Could not read case data.");
     assertTrue(displayCase.length() > 0, "Case data is empty.");
     DisplayCaseManager.update(displayCase);

--- a/test/net/sourceforge/kolmafia/session/EncounterManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/EncounterManagerTest.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.session;
 
+import static internal.helpers.Networking.html;
 import static internal.helpers.Player.addEffect;
 import static internal.helpers.Player.addItem;
 import static internal.helpers.Player.equip;
@@ -20,9 +21,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 
 import internal.helpers.Cleanups;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import net.sourceforge.kolmafia.AscensionPath;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
@@ -209,8 +207,8 @@ class EncounterManagerTest {
   }
 
   @Test
-  void isRomanticEncounterBasedOnResponseText() throws IOException {
-    String html = Files.readString(Path.of("request/test_fight_romantic_monster.html"));
+  void isRomanticEncounterBasedOnResponseText() {
+    String html = html("request/test_fight_romantic_monster.html");
 
     boolean actual = EncounterManager.isRomanticEncounter(html, false);
 
@@ -218,12 +216,12 @@ class EncounterManagerTest {
   }
 
   @Test
-  void isRomanticEncounterBasedOnMonster() throws IOException {
+  void isRomanticEncounterBasedOnMonster() {
     TurnCounter.startCounting(10, "Romantic Monster window end loc=* type=wander", "rparen.gif");
     KoLAdventure.setNextAdventure("The Deep Machine Tunnels");
     Preferences.setString("romanticTarget", "Witchess Knight");
     MonsterStatusTracker.setNextMonster(MonsterDatabase.findMonster("Witchess Knight"));
-    String html = Files.readString(Path.of("request/test_fight_witchess_knight_in_dmt.html"));
+    String html = html("request/test_fight_witchess_knight_in_dmt.html");
 
     boolean actual = EncounterManager.isRomanticEncounter(html, true);
 
@@ -232,8 +230,8 @@ class EncounterManagerTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void noRomanticEncounterFalsePositive(boolean checkMonster) throws IOException {
-    String html = Files.readString(Path.of("request/test_fight_oil_baron.html"));
+  void noRomanticEncounterFalsePositive(boolean checkMonster) {
+    String html = html("request/test_fight_oil_baron.html");
 
     boolean actual = EncounterManager.isRomanticEncounter(html, checkMonster);
 
@@ -242,8 +240,8 @@ class EncounterManagerTest {
 
   @Disabled("Need some HTML")
   @Test
-  void isEnamorangEncounterBasedOnResponseText() throws IOException {
-    String html = Files.readString(Path.of("request/test_fight_enamorang_monster.html"));
+  void isEnamorangEncounterBasedOnResponseText() {
+    String html = html("request/test_fight_enamorang_monster.html");
 
     boolean actual = EncounterManager.isEnamorangEncounter(html, false);
 
@@ -251,14 +249,14 @@ class EncounterManagerTest {
   }
 
   @Test
-  void isEnamorangEncounterBasedOnMonster() throws IOException {
+  void isEnamorangEncounterBasedOnMonster() {
     KoLCharacter.setCurrentRun(0);
     TurnCounter.startCounting(1, "Enamorang Monster loc=* type=wander", "watch.gif");
     KoLCharacter.setCurrentRun(1);
     KoLAdventure.setNextAdventure("The Deep Machine Tunnels");
     Preferences.setString("enamorangMonster", "Witchess Knight");
     MonsterStatusTracker.setNextMonster(MonsterDatabase.findMonster("Witchess Knight"));
-    String html = Files.readString(Path.of("request/test_fight_witchess_knight_in_dmt.html"));
+    String html = html("request/test_fight_witchess_knight_in_dmt.html");
 
     boolean actual = EncounterManager.isEnamorangEncounter(html, true);
 
@@ -267,8 +265,8 @@ class EncounterManagerTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void noEnamorangEncounterFalsePositive(boolean checkMonster) throws IOException {
-    String html = Files.readString(Path.of("request/test_fight_oil_baron.html"));
+  void noEnamorangEncounterFalsePositive(boolean checkMonster) {
+    String html = html("request/test_fight_oil_baron.html");
 
     boolean actual = EncounterManager.isEnamorangEncounter(html, checkMonster);
 
@@ -276,8 +274,8 @@ class EncounterManagerTest {
   }
 
   @Test
-  void isDigitizedEncounterBasedOnResponseText() throws IOException {
-    String html = Files.readString(Path.of("request/test_fight_digitized_monster.html"));
+  void isDigitizedEncounterBasedOnResponseText() {
+    String html = html("request/test_fight_digitized_monster.html");
 
     boolean actual = EncounterManager.isDigitizedEncounter(html, false);
 
@@ -285,14 +283,14 @@ class EncounterManagerTest {
   }
 
   @Test
-  void isDigitizedEncounterBasedOnMonster() throws IOException {
+  void isDigitizedEncounterBasedOnMonster() {
     KoLCharacter.setCurrentRun(0);
     TurnCounter.startCounting(1, "Digitize Monster loc=* type=wander", "watch.gif");
     KoLCharacter.setCurrentRun(1);
     KoLAdventure.setNextAdventure("The Deep Machine Tunnels");
     Preferences.setString("_sourceTerminalDigitizeMonster", "Witchess Knight");
     MonsterStatusTracker.setNextMonster(MonsterDatabase.findMonster("Witchess Knight"));
-    String html = Files.readString(Path.of("request/test_fight_witchess_knight_in_dmt.html"));
+    String html = html("request/test_fight_witchess_knight_in_dmt.html");
 
     boolean actual = EncounterManager.isDigitizedEncounter(html, true);
 
@@ -301,8 +299,8 @@ class EncounterManagerTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void noDigitizedEncounterFalsePositive(boolean checkMonster) throws IOException {
-    String html = Files.readString(Path.of("request/test_fight_oil_baron.html"));
+  void noDigitizedEncounterFalsePositive(boolean checkMonster) {
+    String html = html("request/test_fight_oil_baron.html");
 
     boolean actual = EncounterManager.isDigitizedEncounter(html, checkMonster);
 
@@ -415,8 +413,8 @@ class EncounterManagerTest {
 
   @ParameterizedTest
   @CsvSource({"gregarious_monster, true", "oil_slick, false"})
-  void isGregariousEncounter(String file, String expected) throws IOException {
-    String html = Files.readString(Path.of("request/test_fight_" + file + ".html"));
+  void isGregariousEncounter(String file, String expected) {
+    String html = html("request/test_fight_" + file + ".html");
 
     boolean actual = EncounterManager.isGregariousEncounter(html);
 
@@ -481,8 +479,8 @@ class EncounterManagerTest {
   }
 
   @Test
-  void canRegisterNewEncounter() throws IOException {
-    String html = Files.readString(Path.of("request/test_fight_oil_slick.html"));
+  void canRegisterNewEncounter() {
+    String html = html("request/test_fight_oil_slick.html");
     EncounterManager.registerEncounter("oil slick", "Combat", html);
 
     assertThat(KoLConstants.encounterList, hasSize(1));
@@ -490,8 +488,8 @@ class EncounterManagerTest {
   }
 
   @Test
-  void canRegisterRepeatEncounter() throws IOException {
-    String html = Files.readString(Path.of("request/test_fight_oil_slick.html"));
+  void canRegisterRepeatEncounter() {
+    String html = html("request/test_fight_oil_slick.html");
     EncounterManager.registerEncounter("oil slick", "Combat", html);
     EncounterManager.registerEncounter("oil slick", "Combat", html);
 
@@ -500,10 +498,10 @@ class EncounterManagerTest {
   }
 
   @Test
-  void canAddDifferentEncounterToList() throws IOException {
-    String oilSlickHtml = Files.readString(Path.of("request/test_fight_oil_slick.html"));
+  void canAddDifferentEncounterToList() {
+    String oilSlickHtml = html("request/test_fight_oil_slick.html");
     EncounterManager.registerEncounter("oil slick", "Combat", oilSlickHtml);
-    String oilCartelHtml = Files.readString(Path.of("request/test_fight_oil_slick.html"));
+    String oilCartelHtml = html("request/test_fight_oil_slick.html");
     EncounterManager.registerEncounter("oil cartel", "Combat", oilCartelHtml);
 
     assertThat(KoLConstants.encounterList, hasSize(2));
@@ -515,9 +513,9 @@ class EncounterManagerTest {
   }
 
   @Test
-  void canAddEarlierEncounterToList() throws IOException {
-    String oilSlickHtml = Files.readString(Path.of("request/test_fight_oil_slick.html"));
-    String oilCartelHtml = Files.readString(Path.of("request/test_fight_oil_slick.html"));
+  void canAddEarlierEncounterToList() {
+    String oilSlickHtml = html("request/test_fight_oil_slick.html");
+    String oilCartelHtml = html("request/test_fight_oil_slick.html");
 
     EncounterManager.registerEncounter("oil slick", "Combat", oilSlickHtml);
     EncounterManager.registerEncounter("oil cartel", "Combat", oilCartelHtml);
@@ -543,8 +541,8 @@ class EncounterManagerTest {
   }
 
   @Test
-  void rainManMonsterIgnoresSpecialMonsters() throws IOException {
-    String html = Files.readString(Path.of("request/test_fight_rainman_monster.html"));
+  void rainManMonsterIgnoresSpecialMonsters() {
+    String html = html("request/test_fight_rainman_monster.html");
 
     var cleanups = inPath(AscensionPath.Path.HEAVY_RAINS);
 

--- a/test/net/sourceforge/kolmafia/session/GreyYouManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/GreyYouManagerTest.java
@@ -1,13 +1,11 @@
 package net.sourceforge.kolmafia.session;
 
+import static internal.helpers.Networking.html;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.MonsterData;
@@ -31,11 +29,6 @@ public class GreyYouManagerTest {
     GreyYouManager.resetAbsorptions();
   }
 
-  static String loadHTMLResponse(String path) throws IOException {
-    // Load the responseText from saved HTML file
-    return Files.readString(Paths.get(path)).trim();
-  }
-
   static void printSizes() {
     System.out.println(
         "absorbed monsters: "
@@ -47,8 +40,8 @@ public class GreyYouManagerTest {
   }
 
   @Test
-  public void canFindAbsorptionsOnCharSheet() throws IOException {
-    String responseText = loadHTMLResponse("request/test_grey_you_charsheet.html");
+  public void canFindAbsorptionsOnCharSheet() {
+    String responseText = html("request/test_grey_you_charsheet.html");
     GreyYouManager.parseMonsterAbsorptions(responseText);
     assertEquals(92, GreyYouManager.absorbedMonsters.size());
     assertEquals(0, GreyYouManager.unknownAbsorptions.size());
@@ -61,8 +54,8 @@ public class GreyYouManagerTest {
   }
 
   @Test
-  public void canFindUnknownAbsorptionsOnCharSheet() throws IOException {
-    String responseText = loadHTMLResponse("request/test_grey_you_unknown_absorptions.html");
+  public void canFindUnknownAbsorptionsOnCharSheet() {
+    String responseText = html("request/test_grey_you_unknown_absorptions.html");
     GreyYouManager.parseMonsterAbsorptions(responseText);
     assertEquals(0, GreyYouManager.absorbedMonsters.size());
     assertEquals(2, GreyYouManager.unknownAbsorptions.size());
@@ -73,8 +66,8 @@ public class GreyYouManagerTest {
   }
 
   @Test
-  public void canParseCharsheetOnlyInGreyYou() throws IOException {
-    String responseText = loadHTMLResponse("request/test_grey_you_charsheet.html");
+  public void canParseCharsheetOnlyInGreyYou() {
+    String responseText = html("request/test_grey_you_charsheet.html");
 
     // This is the method that CharSheetResponse calls
     GreyYouManager.parseAbsorptions(responseText);
@@ -91,7 +84,7 @@ public class GreyYouManagerTest {
   }
 
   @Test
-  public void canRegisterAbsorptionAfterFight() throws IOException {
+  public void canRegisterAbsorptionAfterFight() {
     // This is the method that FightRequest calls
     String name1 = "oil baron";
     MonsterData monster1 = MonsterDatabase.findMonster(name1);

--- a/test/net/sourceforge/kolmafia/session/HeistManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/HeistManagerTest.java
@@ -1,14 +1,12 @@
 package net.sourceforge.kolmafia.session;
 
+import static internal.helpers.Networking.html;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
@@ -53,11 +51,7 @@ public class HeistManagerTest {
   static class FakeHeistManager extends HeistManager {
     @Override
     protected String heistRequest() {
-      try {
-        return Files.readString(Paths.get("request/test_heist_command.html"));
-      } catch (IOException e) {
-        throw new RuntimeException("could not find test HTML");
-      }
+      return html("request/test_heist_command.html");
     }
   }
 }

--- a/test/net/sourceforge/kolmafia/session/LocketManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/LocketManagerTest.java
@@ -1,12 +1,10 @@
 package net.sourceforge.kolmafia.session;
 
+import static internal.helpers.Networking.html;
 import static internal.helpers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -21,29 +19,29 @@ public class LocketManagerTest {
   }
 
   @Test
-  public void canHandleLargeListOfMonsters() throws IOException {
-    String html = Files.readString(Path.of("request/test_choice_reminisce_full.html"));
+  public void canHandleLargeListOfMonsters() {
+    String html = html("request/test_choice_reminisce_full.html");
     LocketManager.parseMonsters(html);
     assertThat(LocketManager.getMonsters(), hasSize(276));
   }
 
   @Test
-  public void addsFightToMonsterList() throws IOException {
+  public void addsFightToMonsterList() {
     Preferences.setString("_locketMonstersFought", "5");
 
     var monster = MonsterDatabase.findMonster("alielf");
-    var html = Files.readString(Path.of("request/test_fight_start_locket_fight_with_horror.html"));
+    var html = html("request/test_fight_start_locket_fight_with_horror.html");
     LocketManager.parseFight(monster, html);
 
     assertThat("_locketMonstersFought", isSetTo("5,1092"));
   }
 
   @Test
-  public void addsFightToMonsterListWithoutDuplicating() throws IOException {
+  public void addsFightToMonsterListWithoutDuplicating() {
     Preferences.setString("_locketMonstersFought", "5,1092");
 
     var monster = MonsterDatabase.findMonster("alielf");
-    var html = Files.readString(Path.of("request/test_fight_start_locket_fight_with_horror.html"));
+    var html = html("request/test_fight_start_locket_fight_with_horror.html");
     LocketManager.parseFight(monster, html);
 
     assertThat("_locketMonstersFought", isSetTo("5,1092"));

--- a/test/net/sourceforge/kolmafia/session/MallPriceManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/MallPriceManagerTest.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.session;
 
+import static internal.helpers.Networking.html;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -9,9 +10,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 
 import internal.helpers.Cleanups;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -550,13 +548,8 @@ public class MallPriceManagerTest {
 
   // *** Need tests for getMallPrice(AdventureResult item, float maxAge)
 
-  static String loadHTMLResponse(String path) throws IOException {
-    // Load the responseText from saved HTML file
-    return Files.readString(Paths.get(path)).trim();
-  }
-
   @Test
-  public void canGetMallPricesViaMallSearch() throws IOException {
+  public void canGetMallPricesViaMallSearch() {
 
     // Test with Hell ramen.
     AdventureResult item = ItemPool.get(ItemPool.HELL_RAMEN);
@@ -564,7 +557,7 @@ public class MallPriceManagerTest {
     // Make a mocked MallSearchResponse with the responseText preloaded
 
     MallSearchRequest request = new MockMallSearchRequest("Hell ramen", 0);
-    request.responseText = loadHTMLResponse("request/test_mall_search_hell_ramen.html");
+    request.responseText = html("request/test_mall_search_hell_ramen.html");
 
     try (var cleanups = mockMallSearchRequest(request)) {
       long timestamp = 1_000_000;
@@ -578,12 +571,12 @@ public class MallPriceManagerTest {
   }
 
   @Test
-  public void canGetMallPricesByCategory() throws IOException {
+  public void canGetMallPricesByCategory() {
     // Test with category = "unlockers" since that only has two pages of results
     MallSearchRequest request = new MockMallSearchRequest("unlockers", "");
     request.setResponseTexts(
-        loadHTMLResponse("request/test_mall_search_unlockers_page_1.html"),
-        loadHTMLResponse("request/test_mall_search_unlockers_page_2.html"));
+        html("request/test_mall_search_unlockers_page_1.html"),
+        html("request/test_mall_search_unlockers_page_2.html"));
 
     try (var cleanups = mockMallSearchRequest(request)) {
       long timestamp = 1_000_000;
@@ -598,13 +591,13 @@ public class MallPriceManagerTest {
   }
 
   @Test
-  public void canSearchMallStore() throws IOException {
+  public void canSearchMallStore() {
     // Not actually used in MallPriceManager, but may as well test the fourth
     // (last) form of a MallSearchRequest
 
     // This is Clerk's - one of the bigger stores. :)
     MallSearchRequest request = new MockMallSearchRequest(1053259);
-    request.setResponseTexts(loadHTMLResponse("request/test_mall_search_store.html"));
+    request.setResponseTexts(html("request/test_mall_search_store.html"));
 
     try (var cleanups = mockMallSearchRequest(request)) {
       long timestamp = 1_000_000;

--- a/test/net/sourceforge/kolmafia/session/MonsterManuelManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/MonsterManuelManagerTest.java
@@ -1,12 +1,10 @@
 package net.sourceforge.kolmafia.session;
 
+import static internal.helpers.Networking.html;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import internal.helpers.Cleanups;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import net.sourceforge.kolmafia.MonsterData;
@@ -43,14 +41,9 @@ public class MonsterManuelManagerTest {
     return cleanups;
   }
 
-  static String loadHTMLResponse(String path) throws IOException {
-    // Load the responseText from saved HTML file
-    return Files.readString(Paths.get(path)).trim();
-  }
-
   @Test
-  public void thatCanDetectNewMonster() throws IOException {
-    String text = loadHTMLResponse("request/test_monster_manuel_monster1.html");
+  public void thatCanDetectNewMonster() {
+    String text = html("request/test_monster_manuel_monster1.html");
     MonsterData monster = MonsterDatabase.findMonster("ancient unspeakable bugbear");
     int monsterId = monster.getId();
     var cleanups = unregisterMonster(monster);
@@ -65,8 +58,8 @@ public class MonsterManuelManagerTest {
   }
 
   @Test
-  public void thatCanDetectNewScalingMonster() throws IOException {
-    String text = loadHTMLResponse("request/test_monster_manuel_monster2.html");
+  public void thatCanDetectNewScalingMonster() {
+    String text = html("request/test_monster_manuel_monster2.html");
     MonsterData monster = MonsterDatabase.findMonster("Adventurer echo");
     int monsterId = monster.getId();
     var cleanups = unregisterMonster(monster);
@@ -80,8 +73,8 @@ public class MonsterManuelManagerTest {
   }
 
   @Test
-  public void thatCanDetectNewArticle() throws IOException {
-    String text = loadHTMLResponse("request/test_monster_manuel_monster3.html");
+  public void thatCanDetectNewArticle() {
+    String text = html("request/test_monster_manuel_monster3.html");
     MonsterData monster = MonsterDatabase.findMonster("pygmy orderlies");
     int monsterId = monster.getId();
     assertEquals("some", monster.getArticle());

--- a/test/net/sourceforge/kolmafia/session/QuestManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/QuestManagerTest.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.session;
 
+import static internal.helpers.Networking.html;
 import static internal.helpers.Player.addItem;
 import static internal.helpers.Player.countItem;
 import static internal.helpers.Player.equip;
@@ -13,9 +14,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -46,10 +44,9 @@ public class QuestManagerTest {
    * Council
    */
   @Test
-  public void canParseABigBusyCouncilPage() throws IOException {
+  public void canParseABigBusyCouncilPage() {
     var request = new GenericRequest("council.php");
-    request.responseText =
-        Files.readString(Path.of("request/test_council_first_visit_level_13.html"));
+    request.responseText = html("request/test_council_first_visit_level_13.html");
     QuestManager.handleQuestChange(request);
 
     Set<Quest> started =
@@ -75,11 +72,11 @@ public class QuestManagerTest {
   }
 
   @Test
-  public void canParseLarvaReturn() throws IOException {
+  public void canParseLarvaReturn() {
     addItem("mosquito larva");
 
     var request = new GenericRequest("council.php");
-    request.responseText = Files.readString(Path.of("request/test_council_hand_in_larva.html"));
+    request.responseText = html("request/test_council_hand_in_larva.html");
     QuestManager.handleQuestChange(request);
 
     assertThat(Quest.LARVA, isFinished());
@@ -90,12 +87,12 @@ public class QuestManagerTest {
    * Kingdom-Wide Unlocks
    */
   @Test
-  public void seeingTheIslandMarksItAsUnlocked() throws IOException {
+  public void seeingTheIslandMarksItAsUnlocked() {
     var ascension = 50;
     KoLCharacter.setAscensions(ascension);
     assertThat("lastIslandUnlock", hasIntegerValue(lessThan(ascension)));
     var request = new GenericRequest("main.php");
-    request.responseText = Files.readString(Path.of("request/test_main_island.html"));
+    request.responseText = html("request/test_main_island.html");
     QuestManager.handleQuestChange(request);
     assertThat("lastIslandUnlock", isSetTo(ascension));
   }
@@ -125,29 +122,26 @@ public class QuestManagerTest {
    * Citadel Quest
    */
   @Test
-  void canDetectCitadelStep1InGrove() throws IOException {
+  void canDetectCitadelStep1InGrove() {
     var request = new GenericRequest("adventure.php?snarfblat=100");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_whiteys_grove_its_a_sign.html"));
+    request.responseText = html("request/test_adventure_whiteys_grove_its_a_sign.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.CITADEL, isStep(1));
   }
 
   @Test
-  void canDetectCitadelStep2InWhiteCitadel() throws IOException {
+  void canDetectCitadelStep2InWhiteCitadel() {
     var request = new GenericRequest("adventure.php?snarfblat=413");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_white_citadel_they_arent_blind.html"));
+    request.responseText = html("request/test_adventure_white_citadel_they_arent_blind.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.CITADEL, isStep(2));
   }
 
   @Test
-  void canDetectCitadelStep3InWhiteCitadel() throws IOException {
+  void canDetectCitadelStep3InWhiteCitadel() {
     var request = new GenericRequest("adventure.php?snarfblat=413");
     request.responseText =
-        Files.readString(
-            Path.of("request/test_adventure_white_citadel_existential_blues_brothers.html"));
+        html("request/test_adventure_white_citadel_existential_blues_brothers.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.CITADEL, isStep(3));
   }
@@ -156,38 +150,34 @@ public class QuestManagerTest {
    * Clancy Quest
    */
   @Test
-  void canDetectClancyStep1InBarroom() throws IOException {
+  void canDetectClancyStep1InBarroom() {
     var request = new GenericRequest("adventure.php?snarfblat=233");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_barroom_brawl_jackin_the_jukebox.html"));
+    request.responseText = html("request/test_adventure_barroom_brawl_jackin_the_jukebox.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.CLANCY, isStep(1));
   }
 
   @Test
-  void canDetectClancyStep3InKnobShaft() throws IOException {
+  void canDetectClancyStep3InKnobShaft() {
     var request = new GenericRequest("adventure.php?snarfblat=101");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_knob_shaft_a_miner_variation.html"));
+    request.responseText = html("request/test_adventure_knob_shaft_a_miner_variation.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.CLANCY, isStep(3));
   }
 
   @Test
-  void canDetectClancyStep7InIcyPeak() throws IOException {
+  void canDetectClancyStep7InIcyPeak() {
     var request = new GenericRequest("adventure.php?snarfblat=110");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_icy_peak_mercury_rising.html"));
+    request.responseText = html("request/test_adventure_icy_peak_mercury_rising.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.CLANCY, isStep(7));
   }
 
   @Test
-  void canDetectClancyFinishInMiddleChamber() throws IOException {
+  void canDetectClancyFinishInMiddleChamber() {
     var request = new GenericRequest("adventure.php?snarfblat=407");
     request.responseText =
-        Files.readString(
-            Path.of("request/test_adventure_middle_chamber_dont_you_know_who_i_am.html"));
+        html("request/test_adventure_middle_chamber_dont_you_know_who_i_am.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.CLANCY, isFinished());
   }
@@ -196,19 +186,19 @@ public class QuestManagerTest {
    * Garbage Quest
    */
   @Test
-  void canDetectGarbageStep1InPlains() throws IOException {
+  void canDetectGarbageStep1InPlains() {
     var request = new GenericRequest("place.php?whichplace=plains");
-    request.responseText = Files.readString(Path.of("request/test_place_plains_beanstalk.html"));
+    request.responseText = html("request/test_place_plains_beanstalk.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.GARBAGE, isStep(1));
   }
 
   @Test
-  public void deductsEnchantedBeanWhenPlanting() throws IOException {
+  public void deductsEnchantedBeanWhenPlanting() {
     addItem("enchanted bean");
     assertEquals(1, countItem("enchanted bean"));
     var request = new GenericRequest("place.php?whichplace=plains");
-    request.responseText = Files.readString(Path.of("request/test_place_plains_beanstalk.html"));
+    request.responseText = html("request/test_place_plains_beanstalk.html");
     QuestManager.handleQuestChange(request);
     assertEquals(0, countItem("enchanted bean"));
   }
@@ -222,10 +212,9 @@ public class QuestManagerTest {
   }
 
   @Test
-  public void canDetectGarbageStep2InAirship() throws IOException {
+  public void canDetectGarbageStep2InAirship() {
     var request = new GenericRequest("adventure.php?snarfblat=81");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_airship_beginning_of_the_end.html"));
+    request.responseText = html("request/test_adventure_airship_beginning_of_the_end.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.GARBAGE, isStep(2));
   }
@@ -239,13 +228,12 @@ public class QuestManagerTest {
   }
 
   @Test
-  public void canDetectGarbageStep8InCastleBasement() throws IOException {
+  public void canDetectGarbageStep8InCastleBasement() {
     var ascension = 50;
     KoLCharacter.setAscensions(ascension);
     assertThat("lastCastleGroundUnlock", hasIntegerValue(lessThan(ascension)));
     var request = new GenericRequest("adventure.php?snarfblat=322");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_castle_basement_unlock_ground.html"));
+    request.responseText = html("request/test_adventure_castle_basement_unlock_ground.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.GARBAGE, isStep(8));
     assertThat("lastCastleGroundUnlock", isSetTo(ascension));
@@ -260,24 +248,22 @@ public class QuestManagerTest {
   }
 
   @Test
-  public void canDetectGarbageStep9InCastleFirstFloor() throws IOException {
+  public void canDetectGarbageStep9InCastleFirstFloor() {
     var ascension = 50;
     KoLCharacter.setAscensions(ascension);
     assertThat("lastCastleTopUnlock", hasIntegerValue(lessThan(ascension)));
     var request = new GenericRequest("adventure.php?snarfblat=323");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_castle_first_top_of_the_castle_ma.html"));
+    request.responseText = html("request/test_adventure_castle_first_top_of_the_castle_ma.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.GARBAGE, isStep(9));
     assertThat("lastCastleTopUnlock", isSetTo(ascension));
   }
 
   @Test
-  public void failingToAdventureInCastleTopFloorDoesNotAdvanceStep9() throws IOException {
+  public void failingToAdventureInCastleTopFloorDoesNotAdvanceStep9() {
     QuestDatabase.setQuestIfBetter(Quest.GARBAGE, "step8");
     var request = new GenericRequest("adventure.php?snarfblat=323");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_castle_top_floor_walk_before_fly.html"));
+    request.responseText = html("request/test_adventure_castle_top_floor_walk_before_fly.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.GARBAGE, isStep(8));
   }
@@ -295,18 +281,17 @@ public class QuestManagerTest {
   }
 
   @Test
-  void canDetectPalindomeStartedInPlains() throws IOException {
+  void canDetectPalindomeStartedInPlains() {
     var request = new GenericRequest("place.php?whichplace=plains");
-    request.responseText = Files.readString(Path.of("request/test_place_plains_palindome.html"));
+    request.responseText = html("request/test_place_plains_palindome.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.PALINDOME, isStarted());
   }
 
   @Test
-  void canDetectPalindomeStep3InPalindome() throws IOException {
+  void canDetectPalindomeStep3InPalindome() {
     var request = new GenericRequest("place.php?whichplace=palindome&action=pal_mr");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_palindome_meet_mr_alarm.html"));
+    request.responseText = html("request/test_place_palindome_meet_mr_alarm.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.PALINDOME, isStep(3));
   }
@@ -315,10 +300,9 @@ public class QuestManagerTest {
    * Pirate Quest
    */
   @Test
-  void canDetectPirateFinishedInPoopDeck() throws IOException {
+  void canDetectPirateFinishedInPoopDeck() {
     var request = new GenericRequest("adventure.php?snarfblat=159");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_poop_deck_its_always_swordfish.html"));
+    request.responseText = html("request/test_adventure_poop_deck_its_always_swordfish.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.PIRATE, isFinished());
   }
@@ -327,29 +311,27 @@ public class QuestManagerTest {
    * Pyramid Quest
    */
   @Test
-  void canDetectPyramidStartedFromBeach() throws IOException {
+  void canDetectPyramidStartedFromBeach() {
     var request = new GenericRequest("place.php?whichplace=desertbeach&action=db_pyramid1");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_desert_beach_uncover_pyramid.html"));
+    request.responseText = html("request/test_place_desert_beach_uncover_pyramid.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.PYRAMID, isStarted());
   }
 
   @Test
-  void justBeingInPyramidIsPyramidStarted() throws IOException {
+  void justBeingInPyramidIsPyramidStarted() {
     var request = new GenericRequest("place.php?whichplace=pyramid");
-    request.responseText = Files.readString(Path.of("request/test_place_pyramid_first_visit.html"));
+    request.responseText = html("request/test_place_pyramid_first_visit.html");
     QuestManager.handleQuestChange(request);
 
     assertThat(Quest.PYRAMID, isStarted());
   }
 
   @Test
-  void canDetectPyramidStep1FromUpperChamber() throws IOException {
+  void canDetectPyramidStep1FromUpperChamber() {
     var request = new GenericRequest("adventure.php?snarfblat=406");
     request.responseText =
-        Files.readString(
-            Path.of("request/test_adventure_upper_chamber_down_dooby_doo_down_down.html"));
+        html("request/test_adventure_upper_chamber_down_dooby_doo_down_down.html");
     QuestManager.handleQuestChange(request);
 
     assertThat(Quest.PYRAMID, isStep(1));
@@ -367,10 +349,9 @@ public class QuestManagerTest {
   }
 
   @Test
-  void canDetectPyramidStep1FromPyramid() throws IOException {
+  void canDetectPyramidStep1FromPyramid() {
     var request = new GenericRequest("place.php?whichplace=pyramid");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_pyramid_unlocked_middle_chamber.html"));
+    request.responseText = html("request/test_place_pyramid_unlocked_middle_chamber.html");
     QuestManager.handleQuestChange(request);
 
     assertThat(Quest.PYRAMID, isStep(1));
@@ -380,11 +361,10 @@ public class QuestManagerTest {
   }
 
   @Test
-  void canDetectPyramidStep2FromMiddleChamber() throws IOException {
+  void canDetectPyramidStep2FromMiddleChamber() {
     var request = new GenericRequest("adventure.php?snarfblat=407");
     request.responseText =
-        Files.readString(
-            Path.of("request/test_adventure_middle_chamber_further_down_dooby_doo_down_down.html"));
+        html("request/test_adventure_middle_chamber_further_down_dooby_doo_down_down.html");
     QuestManager.handleQuestChange(request);
 
     assertThat(Quest.PYRAMID, isStep(2));
@@ -392,10 +372,9 @@ public class QuestManagerTest {
   }
 
   @Test
-  void canDetectPyramidStep2FromPyramid() throws IOException {
+  void canDetectPyramidStep2FromPyramid() {
     var request = new GenericRequest("place.php?whichplace=pyramid");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_pyramid_unlocked_lower_chamber.html"));
+    request.responseText = html("request/test_place_pyramid_unlocked_lower_chamber.html");
     QuestManager.handleQuestChange(request);
 
     assertThat(Quest.PYRAMID, isStep(2));
@@ -405,10 +384,9 @@ public class QuestManagerTest {
   }
 
   @Test
-  void canDetectPyramidStep3FromMiddleChamber() throws IOException {
+  void canDetectPyramidStep3FromMiddleChamber() {
     var request = new GenericRequest("adventure.php?snarfblat=407");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_middle_chamber_under_control.html"));
+    request.responseText = html("request/test_adventure_middle_chamber_under_control.html");
     QuestManager.handleQuestChange(request);
 
     assertThat(Quest.PYRAMID, isStep(3));
@@ -417,10 +395,9 @@ public class QuestManagerTest {
   }
 
   @Test
-  void canDetectPyramidStep3FromPyramid() throws IOException {
+  void canDetectPyramidStep3FromPyramid() {
     var request = new GenericRequest("place.php?whichplace=pyramid");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_pyramid_unlocked_control_room.html"));
+    request.responseText = html("request/test_place_pyramid_unlocked_control_room.html");
     QuestManager.handleQuestChange(request);
 
     assertThat(Quest.PYRAMID, isStep(3));
@@ -446,29 +423,27 @@ public class QuestManagerTest {
         "rubble_and_vending_machine",
         "vending_machine_and_rats"
       })
-  void canDetectPyramidPositionFromPyramid(String pyramidState) throws IOException {
+  void canDetectPyramidPositionFromPyramid(String pyramidState) {
     var request = new GenericRequest("place.php?whichplace=pyramid");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_pyramid_" + pyramidState + ".html"));
+    request.responseText = html("request/test_place_pyramid_" + pyramidState + ".html");
     QuestManager.handleQuestChange(request);
 
     assertThat("pyramidPosition", isSetTo(PYRAMID_POSITIONS.get(pyramidState)));
   }
 
   @Test
-  void canDetectPyramidBombUsedFromPyramidAction() throws IOException {
+  void canDetectPyramidBombUsedFromPyramidAction() {
     var request = new GenericRequest("place.php?whichplace=pyramid&action=pyramid_state1");
-    request.responseText = Files.readString(Path.of("request/test_place_pyramid_bomb_rubble.html"));
+    request.responseText = html("request/test_place_pyramid_bomb_rubble.html");
     QuestManager.handleQuestChange(request);
 
     assertThat("pyramidBombUsed", isSetTo(true));
   }
 
   @Test
-  void canDetectPyramidBombUsedFromPyramid() throws IOException {
+  void canDetectPyramidBombUsedFromPyramid() {
     var request = new GenericRequest("place.php?whichplace=pyramid");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_pyramid_unlocked_tomb.html"));
+    request.responseText = html("request/test_place_pyramid_unlocked_tomb.html");
     QuestManager.handleQuestChange(request);
 
     assertThat("pyramidBombUsed", isSetTo(true));
@@ -486,20 +461,18 @@ public class QuestManagerTest {
   }
 
   @Test
-  public void canDetectRonStep2InProtestors() throws IOException {
+  public void canDetectRonStep2InProtestors() {
     var request = new GenericRequest("adventure.php?snarfblat=384");
     request.responseText =
-        Files.readString(
-            Path.of("request/test_adventure_protestors_not_so_much_with_the_humanity.html"));
+        html("request/test_adventure_protestors_not_so_much_with_the_humanity.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.RON, isStep(2));
   }
 
   @Test
-  public void seeingClearedProtestorsSetsRonStep2() throws IOException {
+  public void seeingClearedProtestorsSetsRonStep2() {
     var request = new GenericRequest("place.php?whichplace=zeppelin");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_zeppelin_cleared_protestors.html"));
+    request.responseText = html("request/test_place_zeppelin_cleared_protestors.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.RON, isStep(2));
   }
@@ -513,10 +486,9 @@ public class QuestManagerTest {
   }
 
   @Test
-  public void canDetectRonStep3InZeppelin() throws IOException {
+  public void canDetectRonStep3InZeppelin() {
     var request = new GenericRequest("adventure.php?snarfblat=385");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_zeppelin_zeppelintro.html"));
+    request.responseText = html("request/test_adventure_zeppelin_zeppelintro.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.RON, isStep(3));
   }
@@ -525,39 +497,34 @@ public class QuestManagerTest {
    * Spookyraven Dance Quest
    */
   @Test
-  public void canDetectSpookyravenDanceStep1TalkingToLadyS() throws IOException {
+  public void canDetectSpookyravenDanceStep1TalkingToLadyS() {
     var request = new GenericRequest("place.php?whichplace=manor2&action=manor2_ladys");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_spookyraven_second_floor_talk_to_ladys.html"));
+    request.responseText = html("request/test_place_spookyraven_second_floor_talk_to_ladys.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.SPOOKYRAVEN_DANCE, isStep(1));
   }
 
   @Test
-  public void canDetectSpookyravenDanceStep3InSpookyravenSecondFloor() throws IOException {
+  public void canDetectSpookyravenDanceStep3InSpookyravenSecondFloor() {
     var request = new GenericRequest("place.php?whichplace=manor2");
     request.responseText =
-        Files.readString(
-            Path.of("request/test_place_spookyraven_second_floor_ballroom_unlocked.html"));
+        html("request/test_place_spookyraven_second_floor_ballroom_unlocked.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.SPOOKYRAVEN_DANCE, isStep(3));
   }
 
   @Test
-  public void canDetectSpookyravenDanceStepFinishedInBallroom() throws IOException {
+  public void canDetectSpookyravenDanceStepFinishedInBallroom() {
     var request = new GenericRequest("adventure.php?snarfblat=395");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_spookyraven_ballroom_having_a_ball.html"));
+    request.responseText = html("request/test_adventure_spookyraven_ballroom_having_a_ball.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.SPOOKYRAVEN_DANCE, isFinished());
   }
 
   @Test
-  public void canDetectSpookyravenDanceStepFinishedFromStairsToAttic() throws IOException {
+  public void canDetectSpookyravenDanceStepFinishedFromStairsToAttic() {
     var request = new GenericRequest("place.php?whichplace=manor2");
-    request.responseText =
-        Files.readString(
-            Path.of("request/test_place_spookyraven_second_floor_attic_unlocked.html"));
+    request.responseText = html("request/test_place_spookyraven_second_floor_attic_unlocked.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.SPOOKYRAVEN_DANCE, isFinished());
   }
@@ -566,19 +533,17 @@ public class QuestManagerTest {
    * Spookyraven Necklace Quest
    */
   @Test
-  public void canDetectSpookyravenNecklaceStartedInSpookyravenFirstFloor() throws IOException {
+  public void canDetectSpookyravenNecklaceStartedInSpookyravenFirstFloor() {
     var request = new GenericRequest("place.php?whichplace=manor1");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_spookyraven_first_floor_quest_started.html"));
+    request.responseText = html("request/test_place_spookyraven_first_floor_quest_started.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.SPOOKYRAVEN_NECKLACE, isStarted());
   }
 
   @Test
-  public void canDetectSpookyravenNecklaceStep2InBilliardsRoom() throws IOException {
+  public void canDetectSpookyravenNecklaceStep2InBilliardsRoom() {
     var request = new GenericRequest("adventure.php?snarfblat=391");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_billiards_room_thats_your_cue.html"));
+    request.responseText = html("request/test_adventure_billiards_room_thats_your_cue.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.SPOOKYRAVEN_NECKLACE, isStep(2));
   }
@@ -612,33 +577,29 @@ public class QuestManagerTest {
   }
 
   @Test
-  public void canDetectSpookyravenNecklaceFinishedTalkingToLadyS() throws IOException {
+  public void canDetectSpookyravenNecklaceFinishedTalkingToLadyS() {
     var request = new GenericRequest("place.php?whichplace=manor1&action=manor1_ladys");
-    request.responseText =
-        Files.readString(
-            Path.of("request/test_place_spookyraven_first_floor_receive_necklace.html"));
+    request.responseText = html("request/test_place_spookyraven_first_floor_receive_necklace.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.SPOOKYRAVEN_NECKLACE, isFinished());
   }
 
   @Test
-  public void canDetectSpookyravenNecklaceFinishedInSpookyravenFirstFloor() throws IOException {
+  public void canDetectSpookyravenNecklaceFinishedInSpookyravenFirstFloor() {
     var request = new GenericRequest("place.php?whichplace=manor1");
     request.responseText =
-        Files.readString(
-            Path.of("request/test_place_spookyraven_first_floor_second_floor_unlocked.html"));
+        html("request/test_place_spookyraven_first_floor_second_floor_unlocked.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.SPOOKYRAVEN_NECKLACE, isFinished());
   }
 
   @Test
-  public void justBeingInSpookyravenSecondFloorIsSpookyravenNecklaceFinished() throws IOException {
+  public void justBeingInSpookyravenSecondFloorIsSpookyravenNecklaceFinished() {
     var ascension = 50;
     KoLCharacter.setAscensions(ascension);
     assertThat("lastSecondFloorUnlock", hasIntegerValue(lessThan(ascension)));
     var request = new GenericRequest("place.php?whichplace=manor1");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_spookyraven_second_floor_first_visit.html"));
+    request.responseText = html("request/test_place_spookyraven_second_floor_first_visit.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.SPOOKYRAVEN_NECKLACE, isFinished());
     assertThat("lastSecondFloorUnlock", isSetTo(ascension));
@@ -648,10 +609,10 @@ public class QuestManagerTest {
    * Swamp Quest
    */
   @Test
-  public void canDetectSwapStartedInCanadia() throws IOException {
+  public void canDetectSwapStartedInCanadia() {
     assertThat(Quest.SWAMP, isUnstarted());
     var request = new GenericRequest("place.php?whichplace=canadia&action=lc_marty");
-    request.responseText = Files.readString(Path.of("request/test_canadia_start_quest.html"));
+    request.responseText = html("request/test_canadia_start_quest.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.SWAMP, isStarted());
   }
@@ -660,83 +621,78 @@ public class QuestManagerTest {
    * Topping Quest
    */
   @Test
-  public void canDetectToppingStep1InChasm() throws IOException {
+  public void canDetectToppingStep1InChasm() {
     var request = new GenericRequest("place.php?whichplace=orc_chasm");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_orc_chasm_bridge_built.html"));
+    request.responseText = html("request/test_place_orc_chasm_bridge_built.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.TOPPING, isStep(1));
   }
 
   @Test
-  public void canDetectToppingStep2InHighlands() throws IOException {
+  public void canDetectToppingStep2InHighlands() {
     var request = new GenericRequest("place.php?whichplace=highlands&action=highlands_dude");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_highlands_meet_highland_lord.html"));
+    request.responseText = html("request/test_place_highlands_meet_highland_lord.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.TOPPING, isStep(2));
   }
 
   @Test
-  public void canTrackOilPeakProgressFightingSlick() throws IOException {
-    String responseText = Files.readString(Path.of("request/test_fight_oil_slick.html"));
+  public void canTrackOilPeakProgressFightingSlick() {
+    String responseText = html("request/test_fight_oil_slick.html");
     QuestManager.updateQuestData(responseText, "oil slick");
     assertThat("oilPeakProgress", isSetTo(304.32f));
   }
 
   @Test
-  public void canTrackOilPeakProgressFightingTycoon() throws IOException {
-    String responseText = Files.readString(Path.of("request/test_fight_oil_tycoon.html"));
+  public void canTrackOilPeakProgressFightingTycoon() {
+    String responseText = html("request/test_fight_oil_tycoon.html");
     QuestManager.updateQuestData(responseText, "oil tycoon");
     assertThat("oilPeakProgress", isSetTo(291.64f));
   }
 
   @Test
-  public void canTrackOilPeakProgressFightingBaron() throws IOException {
-    String responseText = Files.readString(Path.of("request/test_fight_oil_baron.html"));
+  public void canTrackOilPeakProgressFightingBaron() {
+    String responseText = html("request/test_fight_oil_baron.html");
     QuestManager.updateQuestData(responseText, "oil baron");
     assertThat("oilPeakProgress", isSetTo(278.96f));
   }
 
   @Test
-  public void canTrackOilPeakProgressFightingCartel() throws IOException {
-    String responseText = Files.readString(Path.of("request/test_fight_oil_cartel.html"));
+  public void canTrackOilPeakProgressFightingCartel() {
+    String responseText = html("request/test_fight_oil_cartel.html");
     QuestManager.updateQuestData(responseText, "oil cartel");
     assertThat("oilPeakProgress", isSetTo(247.26f));
   }
 
   @Test
-  public void canTrackOilPeakProgressWearingDressPants() throws IOException {
+  public void canTrackOilPeakProgressWearingDressPants() {
     equip(EquipmentManager.PANTS, "dress pants");
-    String responseText = Files.readString(Path.of("request/test_fight_oil_tycoon.html"));
+    String responseText = html("request/test_fight_oil_tycoon.html");
     QuestManager.updateQuestData(responseText, "oil tycoon");
     assertThat("oilPeakProgress", isSetTo(285.3f));
   }
 
   @Test
-  public void canTrackOilPeakProgressWithLoveOilBeetle() throws IOException {
-    String responseText =
-        Files.readString(Path.of("request/test_fight_oil_slick_love_oil_beetle_proc.html"));
+  public void canTrackOilPeakProgressWithLoveOilBeetle() {
+    String responseText = html("request/test_fight_oil_slick_love_oil_beetle_proc.html");
     QuestManager.updateQuestData(responseText, "oil slick");
     assertThat("oilPeakProgress", isSetTo(297.98f));
   }
 
   @Test
-  public void canDetectOilPeakFinishedInOilPeak() throws IOException {
+  public void canDetectOilPeakFinishedInOilPeak() {
     var request = new GenericRequest("adventure.php?snarfblat=298");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_oil_peak_unimpressed_with_pressure.html"));
-    Files.readString(Path.of("request/test_adventure_oil_peak_unimpressed_with_pressure.html"));
+    request.responseText = html("request/test_adventure_oil_peak_unimpressed_with_pressure.html");
+    html("request/test_adventure_oil_peak_unimpressed_with_pressure.html");
     QuestManager.handleQuestChange(request);
     assertThat("oilPeakProgress", isSetTo(0f));
     assertThat("oilPeakLit", isSetTo(true));
   }
 
   @Test
-  public void canDetectOilPeakFinishedInHighlands() throws IOException {
+  public void canDetectOilPeakFinishedInHighlands() {
     var request = new GenericRequest("place.php?whichplace=highlands");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_highlands_oil_peak_lit.html"));
+    request.responseText = html("request/test_place_highlands_oil_peak_lit.html");
     QuestManager.handleQuestChange(request);
     assertThat("oilPeakProgress", isSetTo(0f));
     assertThat("oilPeakLit", isSetTo(true));
@@ -757,40 +713,36 @@ public class QuestManagerTest {
   }
 
   @Test
-  public void canDetectBooPeakFinishedInBooPeak() throws IOException {
+  public void canDetectBooPeakFinishedInBooPeak() {
     var request = new GenericRequest("adventure.php?snarfblat=296");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_boo_peak_come_on_ghostly.html"));
+    request.responseText = html("request/test_adventure_boo_peak_come_on_ghostly.html");
     QuestManager.handleQuestChange(request);
     assertThat("booPeakProgress", isSetTo(0));
     assertThat("booPeakLit", isSetTo(true));
   }
 
   @Test
-  public void canDetectBooPeakFinishedInHighlands() throws IOException {
+  public void canDetectBooPeakFinishedInHighlands() {
     var request = new GenericRequest("place.php?whichplace=highlands");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_highlands_boo_peak_lit.html"));
+    request.responseText = html("request/test_place_highlands_boo_peak_lit.html");
     QuestManager.handleQuestChange(request);
     assertThat("booPeakProgress", isSetTo(0));
     assertThat("booPeakLit", isSetTo(true));
   }
 
   @Test
-  public void canDetectToppingStep3InHighlands() throws IOException {
+  public void canDetectToppingStep3InHighlands() {
     var request = new GenericRequest("place.php?whichplace=highlands");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_highlands_all_fires_lit.html"));
+    request.responseText = html("request/test_place_highlands_all_fires_lit.html");
     QuestManager.handleQuestChange(request);
     assertThat("twinPeakProgress", isSetTo(15));
     assertThat(Quest.TOPPING, isStep(3));
   }
 
   @Test
-  public void canDetectToppingFinishedInHighlands() throws IOException {
+  public void canDetectToppingFinishedInHighlands() {
     var request = new GenericRequest("place.php?whichplace=highlands&action=highlands_dude");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_highlands_revisit_highland_lord.html"));
+    request.responseText = html("request/test_place_highlands_revisit_highland_lord.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.TOPPING, isFinished());
   }
@@ -799,19 +751,17 @@ public class QuestManagerTest {
    * Trapper Quest
    */
   @Test
-  public void canDetectTrapperStep1InMcLargeHuge() throws IOException {
+  public void canDetectTrapperStep1InMcLargeHuge() {
     var request = new GenericRequest("place.php?whichplace=mclargehuge&action=trappercabin");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_mclargehuge_trapper_give_quest.html"));
+    request.responseText = html("request/test_place_mclargehuge_trapper_give_quest.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.TRAPPER, isStep(1));
   }
 
   @Test
-  public void canDetectTrapperStep2InMcLargeHuge() throws IOException {
+  public void canDetectTrapperStep2InMcLargeHuge() {
     var request = new GenericRequest("place.php?whichplace=mclargehuge&action=trappercabin");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_mclargehuge_trapper_get_cheese_and_ore.html"));
+    request.responseText = html("request/test_place_mclargehuge_trapper_get_cheese_and_ore.html");
     QuestManager.handleQuestChange(request);
     assertThat(Quest.TRAPPER, isStep(2));
   }
@@ -819,21 +769,19 @@ public class QuestManagerTest {
   @ParameterizedTest
   @ValueSource(
       strings = {"discovering_your_extremity", "2_exxtreme_4_u", "3_exxxtreme_4ever_6pack"})
-  public void canDetectExtremityInExtremeSlope(String nonCombat) throws IOException {
+  public void canDetectExtremityInExtremeSlope(String nonCombat) {
     var request = new GenericRequest("adventure.php?snarfblat=273");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_extreme_slope_" + nonCombat + ".html"));
+    request.responseText = html("request/test_adventure_extreme_slope_" + nonCombat + ".html");
     QuestManager.handleQuestChange(request);
     assertThat("currentExtremity", isSetTo(1));
   }
 
   @Test
-  public void canDetectTrapperStep3ViaExtremeInMcLargeHuge() throws IOException {
+  public void canDetectTrapperStep3ViaExtremeInMcLargeHuge() {
     Preferences.setInteger("currentExtremity", 3);
 
     var request = new GenericRequest("place.php?whichplace=mclargehuge&action=cloudypeak");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_mclargehuge_extreme_peak.html"));
+    request.responseText = html("request/test_place_mclargehuge_extreme_peak.html");
     QuestManager.handleQuestChange(request);
 
     assertThat(Quest.TRAPPER, isStep(3));
@@ -841,11 +789,10 @@ public class QuestManagerTest {
   }
 
   @Test
-  public void canDetectTrapperStep3ViaNinjaInMcLargeHuge() throws IOException {
+  public void canDetectTrapperStep3ViaNinjaInMcLargeHuge() {
     Preferences.setInteger("currentExtremity", 2);
     var request = new GenericRequest("place.php?whichplace=mclargehuge&action=cloudypeak");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_mclargehuge_ninja_peak.html"));
+    request.responseText = html("request/test_place_mclargehuge_ninja_peak.html");
     QuestManager.handleQuestChange(request);
 
     assertThat(Quest.TRAPPER, isStep(3));
@@ -860,15 +807,14 @@ public class QuestManagerTest {
   }
 
   @Test
-  public void canDetectTrapperFinishedInMcLargeHuge() throws IOException {
+  public void canDetectTrapperFinishedInMcLargeHuge() {
     var ascension = 50;
     KoLCharacter.setAscensions(ascension);
     addItem("groar's fur");
     assertThat("lastTr4pz0rQuest", hasIntegerValue(lessThan(ascension)));
 
     var request = new GenericRequest("place.php?whichplace=mclargehuge&action=trappercabin");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_mclargehuge_trapper_give_fur.html"));
+    request.responseText = html("request/test_place_mclargehuge_trapper_give_fur.html");
     QuestManager.handleQuestChange(request);
 
     assertThat("lastTr4pz0rQuest", isSetTo(ascension));
@@ -893,10 +839,9 @@ public class QuestManagerTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"timbarrrr", "plant_a_tree"})
-  void doesNotTrackArrrborDayNonCombats(String nonCombat) throws IOException {
+  void doesNotTrackArrrborDayNonCombats(String nonCombat) {
     var request = new GenericRequest("adventure.php?snarfblat=174");
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_arrrboretum_" + nonCombat + ".html"));
+    request.responseText = html("request/test_adventure_arrrboretum_" + nonCombat + ".html");
     QuestManager.handleQuestChange(request);
     assertThat("_saplingsPlanted", isSetTo(0));
   }
@@ -941,13 +886,12 @@ public class QuestManagerTest {
 
   @ParameterizedTest
   @MethodSource("provideAirportsAndZones")
-  void canParseAFullAirport(String element, int[] zones) throws IOException {
+  void canParseAFullAirport(String element, int[] zones) {
     assertThat(element + "AirportAlways", isSetTo(false));
     assertThat("_" + element + "AirportToday", isSetTo(false));
 
     var request = new GenericRequest("place.php?whichplace=airport");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_airport_all_charters.html"));
+    request.responseText = html("request/test_place_airport_all_charters.html");
     QuestManager.handleQuestChange(request);
 
     assertThat("_" + element + "AirportToday", isSetTo(true));
@@ -985,21 +929,19 @@ public class QuestManagerTest {
 
   @ParameterizedTest
   @MethodSource("provideAirportsAndZones")
-  void beingDeniedAccessToAirportLocationDoesNotMeanDaypass(String element, int[] snarfblats)
-      throws IOException {
+  void beingDeniedAccessToAirportLocationDoesNotMeanDaypass(String element, int[] snarfblats) {
     assertThat(element + "AirportAlways", isSetTo(false));
     assertThat("_" + element + "AirportToday", isSetTo(false));
 
     var request = new GenericRequest("adventure.php?snarfblat=" + snarfblats[0]);
-    request.responseText =
-        Files.readString(Path.of("request/test_adventure_that_isnt_a_place.html"));
+    request.responseText = html("request/test_adventure_that_isnt_a_place.html");
     QuestManager.handleQuestChange(request);
 
     assertThat(element, "_" + element + "AirportToday", isSetTo(false));
   }
 
   @Test
-  void canDetectUnlockingArmoryInSpookyBunker() throws IOException {
+  void canDetectUnlockingArmoryInSpookyBunker() {
     addItem("armory keycard");
     assertThat("armoryUnlocked", isSetTo(false));
     assertThat("canteenUnlocked", isSetTo(false));
@@ -1007,8 +949,7 @@ public class QuestManagerTest {
 
     var request =
         new GenericRequest("place.php?whichplace=airport_spooky_bunker&action=si_shop3locked");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_airport_spooky_bunker_unlocking_armory.html"));
+    request.responseText = html("request/test_place_airport_spooky_bunker_unlocking_armory.html");
     QuestManager.handleQuestChange(request);
 
     assertEquals(0, countItem("armory keycard"));
@@ -1018,7 +959,7 @@ public class QuestManagerTest {
   }
 
   @Test
-  void canDetectUnlockingCanteenInSpookyBunker() throws IOException {
+  void canDetectUnlockingCanteenInSpookyBunker() {
     addItem("bottle-opener keycard");
     assertThat("armoryUnlocked", isSetTo(false));
     assertThat("canteenUnlocked", isSetTo(false));
@@ -1026,9 +967,7 @@ public class QuestManagerTest {
 
     var request =
         new GenericRequest("place.php?whichplace=airport_spooky_bunker&action=si_shop2locked");
-    request.responseText =
-        Files.readString(
-            Path.of("request/test_place_airport_spooky_bunker_unlocking_canteen.html"));
+    request.responseText = html("request/test_place_airport_spooky_bunker_unlocking_canteen.html");
     QuestManager.handleQuestChange(request);
 
     assertEquals(0, countItem("bottle-opener keycard"));
@@ -1038,7 +977,7 @@ public class QuestManagerTest {
   }
 
   @Test
-  void canDetectUnlockingShawarmaInSpookyBunker() throws IOException {
+  void canDetectUnlockingShawarmaInSpookyBunker() {
     addItem("SHAWARMA Initiative Keycard");
     assertThat("armoryUnlocked", isSetTo(false));
     assertThat("canteenUnlocked", isSetTo(false));
@@ -1046,9 +985,7 @@ public class QuestManagerTest {
 
     var request =
         new GenericRequest("place.php?whichplace=airport_spooky_bunker&action=si_shop1locked");
-    request.responseText =
-        Files.readString(
-            Path.of("request/test_place_airport_spooky_bunker_unlocking_shawarma.html"));
+    request.responseText = html("request/test_place_airport_spooky_bunker_unlocking_shawarma.html");
     QuestManager.handleQuestChange(request);
 
     assertEquals(0, countItem("SHAWARMA Initiative keycard"));
@@ -1058,15 +995,14 @@ public class QuestManagerTest {
   }
 
   @Test
-  void canDetectEverythingUnlockedInSpookyBunker() throws IOException {
+  void canDetectEverythingUnlockedInSpookyBunker() {
     assertThat("armoryUnlocked", isSetTo(false));
     assertThat("canteenUnlocked", isSetTo(false));
     assertThat("SHAWARMAInitiativeUnlocked", isSetTo(false));
 
     var request = new GenericRequest("place.php?whichplace=airport_spooky_bunker");
     request.responseText =
-        Files.readString(
-            Path.of("request/test_place_airport_spooky_bunker_everything_unlocked.html"));
+        html("request/test_place_airport_spooky_bunker_everything_unlocked.html");
     QuestManager.handleQuestChange(request);
 
     assertThat("armoryUnlocked", isSetTo(true));
@@ -1075,14 +1011,13 @@ public class QuestManagerTest {
   }
 
   @Test
-  void canDetectNothingUnlockedInSpookyBunker() throws IOException {
+  void canDetectNothingUnlockedInSpookyBunker() {
     Preferences.setBoolean("armoryUnlocked", true);
     Preferences.setBoolean("canteenUnlocked", true);
     Preferences.setBoolean("SHAWARMAInitiativeUnlocked", true);
 
     var request = new GenericRequest("place.php?whichplace=airport_spooky_bunker");
-    request.responseText =
-        Files.readString(Path.of("request/test_place_airport_spooky_bunker_nothing_unlocked.html"));
+    request.responseText = html("request/test_place_airport_spooky_bunker_nothing_unlocked.html");
     QuestManager.handleQuestChange(request);
 
     assertThat("armoryUnlocked", isSetTo(false));
@@ -1122,10 +1057,9 @@ public class QuestManagerTest {
   @ParameterizedTest
   @ValueSource(
       strings = {"choice.php?forceoption=0", "place.php?whichplace=spacegate&action=sg_Terminal"})
-  void canParseSpacegateTerminal(String url) throws IOException {
+  void canParseSpacegateTerminal(String url) {
     var request = new GenericRequest(url);
-    request.responseText =
-        Files.readString(Path.of("request/test_spacegate_terminal_earddyk.html"));
+    request.responseText = html("request/test_spacegate_terminal_earddyk.html");
     QuestManager.handleQuestChange(request);
 
     assertThat("_spacegatePlanetName", isSetTo("Diverticulus Isaacson IX"));

--- a/test/net/sourceforge/kolmafia/session/YouRobotManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/YouRobotManagerTest.java
@@ -1,12 +1,10 @@
 package net.sourceforge.kolmafia.session;
 
+import static internal.helpers.Networking.html;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -168,11 +166,6 @@ public class YouRobotManagerTest {
     assertTrue(YouRobotManager.canUsePotions());
   }
 
-  static String loadHTMLResponse(String path) throws IOException {
-    // Load the responseText from saved HTML file
-    return Files.readString(Paths.get(path)).trim();
-  }
-
   private void verifyNoAvatarOrProperties() {
     assertEquals(0, Preferences.getInteger("statbotUses"));
     assertEquals(0, Preferences.getInteger("youRobotTop"));
@@ -222,8 +215,8 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void canFindAvatarOnCharSheet() throws IOException {
-    String responseText = loadHTMLResponse("request/test_scrapheap_charsheet.html");
+  public void canFindAvatarOnCharSheet() {
+    String responseText = html("request/test_scrapheap_charsheet.html");
 
     // Verify that the properties and avatar are not set
     verifyNoAvatarOrProperties();
@@ -235,8 +228,8 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void canFindAvatarOnCharPane() throws IOException {
-    String responseText = loadHTMLResponse("request/test_scrapheap_charpane.html");
+  public void canFindAvatarOnCharPane() {
+    String responseText = html("request/test_scrapheap_charpane.html");
 
     // Verify that the properties and avatar are not set
     verifyNoAvatarOrProperties();
@@ -249,8 +242,8 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void canFindAvatarOnReassemblyStationVisit() throws IOException {
-    String responseText = loadHTMLResponse("request/test_scrapheap_reassembly_station.html");
+  public void canFindAvatarOnReassemblyStationVisit() {
+    String responseText = html("request/test_scrapheap_reassembly_station.html");
 
     // Verify that the properties and avatar are not set
     verifyNoAvatarOrProperties();
@@ -265,9 +258,9 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void canHandleThreePartAvatar() throws IOException {
+  public void canHandleThreePartAvatar() {
     // This is a newly ascended Accordion Thief
-    String responseText = loadHTMLResponse("request/test_scrapheap_three_part_avatar.html");
+    String responseText = html("request/test_scrapheap_three_part_avatar.html");
 
     // Verify that the properties and avatar are not set
     verifyNoAvatarOrProperties();
@@ -297,9 +290,9 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void canDiscoverStatbotCostOnVisit() throws IOException {
+  public void canDiscoverStatbotCostOnVisit() {
     String urlString = "choice.php?forceoption=0";
-    String responseText = loadHTMLResponse("request/test_scrapheap_visit_statbot.html");
+    String responseText = html("request/test_scrapheap_visit_statbot.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1447;
@@ -309,9 +302,9 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void canDiscoverStatbotCostOnActivation() throws IOException {
+  public void canDiscoverStatbotCostOnActivation() {
     String urlString = "choice.php?pwd&whichchoice=1447&option=3";
-    String responseText = loadHTMLResponse("request/test_scrapheap_activate_statbot.html");
+    String responseText = html("request/test_scrapheap_activate_statbot.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1447;
@@ -321,9 +314,9 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void canDiscoverStatbotCostOnFailedActivation() throws IOException {
+  public void canDiscoverStatbotCostOnFailedActivation() {
     String urlString = "choice.php?pwd&whichchoice=1447&option=3";
-    String responseText = loadHTMLResponse("request/test_scrapheap_activate_statbot_fails.html");
+    String responseText = html("request/test_scrapheap_activate_statbot_fails.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1447;
@@ -333,7 +326,7 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void canRegisterRequests() throws IOException {
+  public void canRegisterRequests() {
     String urlString = "choice.php?whichchoice=1445&show=cpus";
     String expected = "Inspecting CPU Upgrade options at the Reassembly Station.";
     assertTrue(YouRobotManager.registerRequest(urlString));
@@ -392,13 +385,13 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void canPayUpgradeCosts() throws IOException {
+  public void canPayUpgradeCosts() {
     KoLCharacter.setYouRobotEnergy(100);
     KoLCharacter.setYouRobotScraps(100);
 
     // Install Tesla Blaster, lose Shoot Pea, gain Tesla Blast
     String urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=7";
-    String responseText = loadHTMLResponse("request/test_scrapheap_add_skill.html");
+    String responseText = html("request/test_scrapheap_add_skill.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1445;
@@ -406,7 +399,7 @@ public class YouRobotManagerTest {
     assertEquals(70, KoLCharacter.getYouRobotScraps());
 
     urlString = "choice.php?pwd&whichchoice=1445&part=cpus&show=cpus&option=2&p=robot_resist";
-    responseText = loadHTMLResponse("request/test_scrapheap_cpu_upgrade.html");
+    responseText = html("request/test_scrapheap_cpu_upgrade.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1445;
@@ -415,7 +408,7 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void canTrackChangesInCombatSkills() throws IOException {
+  public void canTrackChangesInCombatSkills() {
     // Start with no known combat skills.
 
     assertFalse(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
@@ -424,7 +417,7 @@ public class YouRobotManagerTest {
 
     // Look at Top Attachments
     String urlString = "choice.php?whichchoice=1445&show=top";
-    String responseText = loadHTMLResponse("request/test_scrapheap_show_top.html");
+    String responseText = html("request/test_scrapheap_show_top.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1445;
@@ -433,7 +426,7 @@ public class YouRobotManagerTest {
 
     // Install Pea Shooter, learn Shoot Pea
     urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=1";
-    responseText = loadHTMLResponse("request/test_scrapheap_add_skill.html");
+    responseText = html("request/test_scrapheap_add_skill.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1445;
@@ -443,7 +436,7 @@ public class YouRobotManagerTest {
 
     // Install Tesla Blaster, lose Shoot Pea, gain Tesla Blast
     urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=7";
-    responseText = loadHTMLResponse("request/test_scrapheap_add_skill_lose_skill.html");
+    responseText = html("request/test_scrapheap_add_skill_lose_skill.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1445;
@@ -454,7 +447,7 @@ public class YouRobotManagerTest {
 
     // Install Solar Panel, lost Tesla Blast
     urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=3";
-    responseText = loadHTMLResponse("request/test_scrapheap_lose_skill.html");
+    responseText = html("request/test_scrapheap_lose_skill.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1445;
@@ -464,10 +457,10 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void willUnequipWhenSwapOutEquipPart() throws IOException {
+  public void willUnequipWhenSwapOutEquipPart() {
     // Look at Top Attachments
     String urlString = "choice.php?whichchoice=1445&show=top";
-    String responseText = loadHTMLResponse("request/test_scrapheap_show_top.html");
+    String responseText = html("request/test_scrapheap_show_top.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1445;
@@ -484,7 +477,7 @@ public class YouRobotManagerTest {
 
     // Install Pea Shooter
     urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=1";
-    responseText = loadHTMLResponse("request/test_scrapheap_add_skill.html");
+    responseText = html("request/test_scrapheap_add_skill.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1445;
@@ -495,10 +488,10 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void willUnsetFamiliarWhenUnequipBirdCage() throws IOException {
+  public void willUnsetFamiliarWhenUnequipBirdCage() {
     // Look at Top Attachments
     String urlString = "choice.php?whichchoice=1445&show=top";
-    String responseText = loadHTMLResponse("request/test_scrapheap_show_top_bird_cage.html");
+    String responseText = html("request/test_scrapheap_show_top_bird_cage.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1445;
@@ -515,7 +508,7 @@ public class YouRobotManagerTest {
 
     // Install Mannequin Head
     urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=4";
-    responseText = loadHTMLResponse("request/test_scrapheap_unequip_bird_cage.html");
+    responseText = html("request/test_scrapheap_unequip_bird_cage.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1445;
@@ -527,10 +520,10 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void willAddCPUUpgrades() throws IOException {
+  public void willAddCPUUpgrades() {
     // Look at CPU Upgrades
     String urlString = "choice.php?whichchoice=1445&show=cpus";
-    String responseText = loadHTMLResponse("request/test_scrapheap_show_cpus.html");
+    String responseText = html("request/test_scrapheap_show_cpus.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1445;
@@ -549,7 +542,7 @@ public class YouRobotManagerTest {
 
     // Buy a CPU Upgrade
     urlString = "choice.php?pwd&whichchoice=1445&part=cpus&show=cpus&option=2&p=robot_resist";
-    responseText = loadHTMLResponse("request/test_scrapheap_cpu_upgrade.html");
+    responseText = html("request/test_scrapheap_cpu_upgrade.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1445;
@@ -576,7 +569,7 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void willAllowPotionUsage() throws IOException {
+  public void willAllowPotionUsage() {
     TestListener potionListener = new TestListener("(potions)");
 
     // Start with no CPU upgrades. We cannot use potions.
@@ -593,7 +586,7 @@ public class YouRobotManagerTest {
 
     // Look at CPU Upgrades
     String urlString = "choice.php?whichchoice=1445&show=cpus";
-    String responseText = loadHTMLResponse("request/test_scrapheap_show_cpus.html");
+    String responseText = html("request/test_scrapheap_show_cpus.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1445;
@@ -617,7 +610,7 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void canSetAvatarAndGetSignal() throws IOException {
+  public void canSetAvatarAndGetSignal() {
     TestListener avatarListener = new TestListener("(avatar)");
 
     // We started out with an avatar = ""
@@ -630,7 +623,7 @@ public class YouRobotManagerTest {
     assertEquals(1, avatarListener.getCalls());
 
     // Load a 3-part robot
-    String responseText = loadHTMLResponse("request/test_scrapheap_three_part_avatar.html");
+    String responseText = html("request/test_scrapheap_three_part_avatar.html");
 
     ChoiceManager.lastChoice = 1445;
     GenericRequest request = new GenericRequest("choice.php?forceoption=0");
@@ -645,7 +638,7 @@ public class YouRobotManagerTest {
     assertEquals(2, avatarListener.getCalls());
 
     // Load a 4-part robot
-    responseText = loadHTMLResponse("request/test_scrapheap_reassembly_station.html");
+    responseText = html("request/test_scrapheap_reassembly_station.html");
     ChoiceManager.lastChoice = 1445;
     request = new GenericRequest("choice.php?forceoption=0");
     request.responseText = responseText;
@@ -664,11 +657,11 @@ public class YouRobotManagerTest {
   }
 
   @Test
-  public void canTrackStatbotEnergyCost() throws IOException {
+  public void canTrackStatbotEnergyCost() {
     KoLCharacter.setYouRobotEnergy(100);
 
     String urlString = "choice.php?forceoption=0";
-    String responseText = loadHTMLResponse("request/test_scrapheap_visit_statbot.html");
+    String responseText = html("request/test_scrapheap_visit_statbot.html");
     GenericRequest request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1447;
@@ -677,7 +670,7 @@ public class YouRobotManagerTest {
     assertEquals(10, Preferences.getInteger("statbotUses"));
 
     urlString = "choice.php?pwd&whichchoice=1447&option=1";
-    responseText = loadHTMLResponse("request/test_scrapheap_activate_statbot.html");
+    responseText = html("request/test_scrapheap_activate_statbot.html");
     request = new GenericRequest(urlString);
     request.responseText = responseText;
     ChoiceManager.lastChoice = 1447;

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -1,14 +1,12 @@
 package net.sourceforge.kolmafia.textui;
 
+import static internal.helpers.Networking.html;
 import static internal.helpers.Player.addItem;
 import static internal.helpers.Player.setupFakeResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
 
 import internal.helpers.Cleanups;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.CharSheetRequest;
@@ -47,9 +45,8 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
   }
 
   @Test
-  void getPermedSkills() throws IOException {
-    CharSheetRequest.parseStatus(
-        Files.readString(Paths.get("request/test_charsheet_normal.html")).trim());
+  void getPermedSkills() {
+    CharSheetRequest.parseStatus(html("request/test_charsheet_normal.html"));
 
     String outputHardcore = execute("get_permed_skills()[$skill[Nimble Fingers]]");
 
@@ -90,13 +87,11 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
   }
 
   @Test
-  void floundryLocations() throws IOException {
+  void floundryLocations() {
     // don't try to visit the fireworks shop
     Preferences.setBoolean("_fireworksShop", true);
 
-    var cleanups =
-        setupFakeResponse(
-            200, Files.readString(Paths.get(("request/test_clan_floundry.html"))).trim());
+    var cleanups = setupFakeResponse(200, html("request/test_clan_floundry.html"));
 
     try (cleanups) {
       String output = execute("get_fishing_locations()");

--- a/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTestBase.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTestBase.java
@@ -1,14 +1,8 @@
 package net.sourceforge.kolmafia.textui.command;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import internal.helpers.RequestLoggerOutput;
-import internal.network.RequestBodyReader;
-import java.net.URLDecoder;
-import java.net.http.HttpRequest;
-import java.nio.charset.StandardCharsets;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafiaCLI;
 import net.sourceforge.kolmafia.StaticEntity;
@@ -39,20 +33,5 @@ public abstract class AbstractCommandTestBase {
 
   public static void assertErrorState() {
     assertState(MafiaState.ERROR);
-  }
-
-  public static void assertGetRequest(HttpRequest request, String path, String query) {
-    assertThat(request.method(), equalTo("GET"));
-    var uri = request.uri();
-    assertThat(uri.getPath(), equalTo(path));
-    assertThat(uri.getQuery(), equalTo(query));
-  }
-
-  public static void assertPostRequest(HttpRequest request, String path, String body) {
-    assertThat(request.method(), equalTo("POST"));
-    var uri = request.uri();
-    assertThat(uri.getPath(), equalTo(path));
-    var reqBody = new RequestBodyReader().bodyAsString(request);
-    assertThat(URLDecoder.decode(reqBody, StandardCharsets.UTF_8), equalTo(body));
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/command/AsdonMartinCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AsdonMartinCommandTest.java
@@ -1,19 +1,18 @@
 package net.sourceforge.kolmafia.textui.command;
 
 import static internal.helpers.HttpClientWrapper.getRequests;
-import static internal.helpers.Player.*;
+import static internal.helpers.Networking.assertPostRequest;
+import static internal.helpers.Player.addEffect;
+import static internal.helpers.Player.addItem;
+import static internal.helpers.Player.setWorkshed;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 
 import internal.helpers.Cleanups;
 import internal.helpers.HttpClientWrapper;
-import internal.network.RequestBodyReader;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -100,14 +99,8 @@ public class AsdonMartinCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, not(empty()));
-      var request = requests.get(0);
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/campground.php"));
-      assertThat(request.method(), equalTo("POST"));
-      var body = new RequestBodyReader().bodyAsString(request);
-      assertThat(
-          URLDecoder.decode(body, StandardCharsets.UTF_8),
-          equalTo("preaction=undrive&stop=Stop+Driving+Obnoxiously"));
+      assertPostRequest(
+          requests.get(0), "/campground.php", "preaction=undrive&stop=Stop+Driving+Obnoxiously");
     }
   }
 
@@ -142,13 +135,7 @@ public class AsdonMartinCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, not(empty()));
-      var request = requests.get(0);
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/campground.php"));
-      assertThat(request.method(), equalTo("POST"));
-      var body = new RequestBodyReader().bodyAsString(request);
-      assertThat(
-          URLDecoder.decode(body, StandardCharsets.UTF_8), equalTo("preaction=drive&whichdrive=0"));
+      assertPostRequest(requests.get(0), "/campground.php", "preaction=drive&whichdrive=0");
     }
   }
 
@@ -164,14 +151,10 @@ public class AsdonMartinCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, not(empty()));
-      var request = requests.get(0);
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/campground.php"));
-      assertThat(request.method(), equalTo("POST"));
-      var body = new RequestBodyReader().bodyAsString(request);
-      assertThat(
-          URLDecoder.decode(body, StandardCharsets.UTF_8),
-          equalTo("preaction=drive&whichdrive=0&more=Drive+More+Obnoxiously"));
+      assertPostRequest(
+          requests.get(0),
+          "/campground.php",
+          "preaction=drive&whichdrive=0&more=Drive+More+Obnoxiously");
     }
   }
 
@@ -187,22 +170,9 @@ public class AsdonMartinCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, hasSize(2));
-      var first = requests.get(0);
-      var uri = first.uri();
-      assertThat(uri.getPath(), equalTo("/campground.php"));
-      assertThat(first.method(), equalTo("POST"));
-      var body = new RequestBodyReader().bodyAsString(first);
-      assertThat(
-          URLDecoder.decode(body, StandardCharsets.UTF_8),
-          equalTo("preaction=undrive&stop=Stop+Driving+Obnoxiously"));
-
-      var second = requests.get(1);
-      uri = second.uri();
-      assertThat(uri.getPath(), equalTo("/campground.php"));
-      assertThat(second.method(), equalTo("POST"));
-      body = new RequestBodyReader().bodyAsString(second);
-      assertThat(
-          URLDecoder.decode(body, StandardCharsets.UTF_8), equalTo("preaction=drive&whichdrive=7"));
+      assertPostRequest(
+          requests.get(0), "/campground.php", "preaction=undrive&stop=Stop+Driving+Obnoxiously");
+      assertPostRequest(requests.get(1), "/campground.php", "preaction=drive&whichdrive=7");
     }
   }
 
@@ -239,14 +209,7 @@ public class AsdonMartinCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, not(empty()));
-      var request = requests.get(0);
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/campground.php"));
-      assertThat(request.method(), equalTo("POST"));
-      var body = new RequestBodyReader().bodyAsString(request);
-      assertThat(
-          URLDecoder.decode(body, StandardCharsets.UTF_8),
-          equalTo("action=fuelconvertor&qty=10&iid=8195"));
+      assertPostRequest(requests.get(0), "/campground.php", "action=fuelconvertor&qty=10&iid=8195");
     }
   }
 

--- a/test/net/sourceforge/kolmafia/textui/command/AutoSellCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AutoSellCommandTest.java
@@ -1,15 +1,14 @@
 package net.sourceforge.kolmafia.textui.command;
 
 import static internal.helpers.HttpClientWrapper.getRequests;
+import static internal.helpers.Networking.assertPostRequest;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
 import internal.helpers.Cleanups;
 import internal.helpers.HttpClientWrapper;
 import internal.helpers.Player;
-import internal.network.RequestBodyReader;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.StaticEntity;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,12 +37,8 @@ public class AutoSellCommandTest extends AbstractCommandTestBase {
     var requests = getRequests();
 
     assertThat(requests, not(empty()));
-    var request = requests.get(0);
-    var uri = request.uri();
-    assertThat(uri.getPath(), equalTo("/sellstuff.php"));
-    assertThat(request.method(), equalTo("POST"));
-    var body = new RequestBodyReader().bodyAsString(request);
-    assertThat(body, equalTo("action=sell&ajax=1&type=quant&howmany=1&whichitem[]=2"));
+    assertPostRequest(
+        requests.get(0), "/sellstuff.php", "action=sell&ajax=1&type=quant&howmany=1&whichitem[]=2");
   }
 
   @Test
@@ -57,12 +52,10 @@ public class AutoSellCommandTest extends AbstractCommandTestBase {
     var requests = getRequests();
 
     assertThat(requests, not(empty()));
-    var request = requests.get(0);
-    var uri = request.uri();
-    assertThat(uri.getPath(), equalTo("/sellstuff.php"));
-    assertThat(request.method(), equalTo("POST"));
-    var body = new RequestBodyReader().bodyAsString(request);
-    assertThat(body, equalTo("action=sell&ajax=1&type=all&howmany=1&whichitem[]=2&whichitem[]=3"));
+    assertPostRequest(
+        requests.get(0),
+        "/sellstuff.php",
+        "action=sell&ajax=1&type=all&howmany=1&whichitem[]=2&whichitem[]=3");
   }
 
   @Test
@@ -111,11 +104,9 @@ public class AutoSellCommandTest extends AbstractCommandTestBase {
     var requests = getRequests();
 
     assertThat(requests, not(empty()));
-    var request = requests.get(0);
-    var uri = request.uri();
-    assertThat(uri.getPath(), equalTo("/sellstuff.php"));
-    assertThat(request.method(), equalTo("POST"));
-    var body = new RequestBodyReader().bodyAsString(request);
-    assertThat(body, equalTo("action=sell&ajax=1&type=allbutone&howmany=1&whichitem[]=2"));
+    assertPostRequest(
+        requests.get(0),
+        "/sellstuff.php",
+        "action=sell&ajax=1&type=allbutone&howmany=1&whichitem[]=2");
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/command/ClanStashCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ClanStashCommandTest.java
@@ -2,15 +2,14 @@ package net.sourceforge.kolmafia.textui.command;
 
 import static internal.helpers.HttpClientWrapper.getLastRequest;
 import static internal.helpers.HttpClientWrapper.getRequests;
+import static internal.helpers.Networking.assertPostRequest;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
 import internal.helpers.Cleanups;
 import internal.helpers.HttpClientWrapper;
 import internal.helpers.Player;
-import internal.network.RequestBodyReader;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.session.ClanManager;
@@ -63,12 +62,8 @@ public class ClanStashCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, not(empty()));
-      var request = getLastRequest();
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/clan_stash.php"));
-      assertThat(request.method(), equalTo("POST"));
-      var body = new RequestBodyReader().bodyAsString(request);
-      assertThat(body, equalTo("action=addgoodies&ajax=1&item1=2&qty1=1"));
+      assertPostRequest(
+          getLastRequest(), "/clan_stash.php", "action=addgoodies&ajax=1&item1=2&qty1=1");
     }
 
     @Test
@@ -82,12 +77,10 @@ public class ClanStashCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, not(empty()));
-      var request = getLastRequest();
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/clan_stash.php"));
-      assertThat(request.method(), equalTo("POST"));
-      var body = new RequestBodyReader().bodyAsString(request);
-      assertThat(body, equalTo("action=addgoodies&ajax=1&item1=2&qty1=1&item2=3&qty2=1"));
+      assertPostRequest(
+          getLastRequest(),
+          "/clan_stash.php",
+          "action=addgoodies&ajax=1&item1=2&qty1=1&item2=3&qty2=1");
     }
 
     @Test
@@ -123,12 +116,8 @@ public class ClanStashCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, not(empty()));
-      var request = getLastRequest();
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/clan_stash.php"));
-      assertThat(request.method(), equalTo("POST"));
-      var body = new RequestBodyReader().bodyAsString(request);
-      assertThat(body, equalTo("action=addgoodies&ajax=1&howmuch=100"));
+      assertPostRequest(
+          getLastRequest(), "/clan_stash.php", "action=addgoodies&ajax=1&howmuch=100");
     }
 
     @Test
@@ -142,12 +131,8 @@ public class ClanStashCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, not(empty()));
-      var request = getLastRequest();
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/clan_stash.php"));
-      assertThat(request.method(), equalTo("POST"));
-      var body = new RequestBodyReader().bodyAsString(request);
-      assertThat(body, equalTo("action=addgoodies&ajax=1&howmuch=3000000000"));
+      assertPostRequest(
+          getLastRequest(), "/clan_stash.php", "action=addgoodies&ajax=1&howmuch=3000000000");
     }
 
     @Test
@@ -177,12 +162,8 @@ public class ClanStashCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, not(empty()));
-      var request = getLastRequest();
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/clan_stash.php"));
-      assertThat(request.method(), equalTo("POST"));
-      var body = new RequestBodyReader().bodyAsString(request);
-      assertThat(body, equalTo("action=takegoodies&ajax=1&whichitem=2&quantity=1"));
+      assertPostRequest(
+          getLastRequest(), "/clan_stash.php", "action=takegoodies&ajax=1&whichitem=2&quantity=1");
     }
 
     @Test

--- a/test/net/sourceforge/kolmafia/textui/command/ClosetCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ClosetCommandTest.java
@@ -1,6 +1,8 @@
 package net.sourceforge.kolmafia.textui.command;
 
 import static internal.helpers.HttpClientWrapper.getRequests;
+import static internal.helpers.Networking.assertGetRequest;
+import static internal.helpers.Networking.assertPostRequest;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -12,7 +14,6 @@ import internal.helpers.Cleanups;
 import internal.helpers.HttpClientWrapper;
 import internal.helpers.Player;
 import internal.listeners.FakeListener;
-import internal.network.RequestBodyReader;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
@@ -100,10 +101,7 @@ public class ClosetCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, not(empty()));
-      var request = requests.get(0);
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/closet.php"));
-      assertThat(request.method(), equalTo("POST"));
+      assertPostRequest(requests.get(0), "/closet.php", "action=pullallcloset");
     }
   }
 
@@ -120,10 +118,8 @@ public class ClosetCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, not(empty()));
-      var request = requests.get(0);
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/inventory.php"));
-      assertThat(uri.getQuery(), equalTo("action=closetpush&ajax=1&whichitem=2&qty=1"));
+      assertGetRequest(
+          requests.get(0), "/inventory.php", "action=closetpush&ajax=1&whichitem=2&qty=1");
     }
 
     @Test
@@ -138,14 +134,10 @@ public class ClosetCommandTest extends AbstractCommandTestBase {
 
       assertThat(requests, not(empty()));
       assertThat(requests.size(), equalTo(2));
-      var request = requests.get(0);
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/inventory.php"));
-      assertThat(uri.getQuery(), equalTo("action=closetpush&ajax=1&whichitem=2&qty=1"));
-      request = requests.get(1);
-      uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/inventory.php"));
-      assertThat(uri.getQuery(), equalTo("action=closetpush&ajax=1&whichitem=3&qty=1"));
+      assertGetRequest(
+          requests.get(0), "/inventory.php", "action=closetpush&ajax=1&whichitem=2&qty=1");
+      assertGetRequest(
+          requests.get(1), "/inventory.php", "action=closetpush&ajax=1&whichitem=3&qty=1");
     }
 
     @Test
@@ -181,12 +173,8 @@ public class ClosetCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, not(empty()));
-      var request = requests.get(0);
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/closet.php"));
-      assertThat(request.method(), equalTo("POST"));
-      var body = new RequestBodyReader().bodyAsString(request);
-      assertThat(body, equalTo("action=addtakeclosetmeat&addtake=add&quantity=100"));
+      assertPostRequest(
+          requests.get(0), "/closet.php", "action=addtakeclosetmeat&addtake=add&quantity=100");
     }
 
     @Test
@@ -200,12 +188,10 @@ public class ClosetCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, not(empty()));
-      var request = requests.get(0);
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/closet.php"));
-      assertThat(request.method(), equalTo("POST"));
-      var body = new RequestBodyReader().bodyAsString(request);
-      assertThat(body, equalTo("action=addtakeclosetmeat&addtake=add&quantity=3000000000"));
+      assertPostRequest(
+          requests.get(0),
+          "/closet.php",
+          "action=addtakeclosetmeat&addtake=add&quantity=3000000000");
     }
 
     @Test
@@ -235,10 +221,8 @@ public class ClosetCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, not(empty()));
-      var request = requests.get(0);
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/inventory.php"));
-      assertThat(uri.getQuery(), equalTo("action=closetpull&ajax=1&whichitem=2&qty=1"));
+      assertGetRequest(
+          requests.get(0), "/inventory.php", "action=closetpull&ajax=1&whichitem=2&qty=1");
     }
 
     @Test
@@ -265,12 +249,8 @@ public class ClosetCommandTest extends AbstractCommandTestBase {
       var requests = getRequests();
 
       assertThat(requests, not(empty()));
-      var request = requests.get(0);
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/closet.php"));
-      assertThat(request.method(), equalTo("POST"));
-      var body = new RequestBodyReader().bodyAsString(request);
-      assertThat(body, equalTo("action=addtakeclosetmeat&addtake=take&quantity=100"));
+      assertPostRequest(
+          requests.get(0), "/closet.php", "action=addtakeclosetmeat&addtake=take&quantity=100");
     }
 
     @Test

--- a/test/net/sourceforge/kolmafia/textui/command/HeistCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/HeistCommandTest.java
@@ -1,11 +1,9 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import static internal.helpers.Networking.html;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
@@ -120,11 +118,7 @@ public class HeistCommandTest extends AbstractCommandTestBase {
       class HeistManagerFakeRequest extends HeistManager {
         @Override
         protected String heistRequest() {
-          try {
-            return Files.readString(Paths.get("request/test_heist_command.html"));
-          } catch (IOException e) {
-            throw new RuntimeException("could not find test HTML");
-          }
+          return html("request/test_heist_command.html");
         }
       }
       return new HeistManagerFakeRequest();

--- a/test/net/sourceforge/kolmafia/textui/command/RefreshStatusCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/RefreshStatusCommandTest.java
@@ -2,10 +2,10 @@ package net.sourceforge.kolmafia.textui.command;
 
 import static internal.helpers.HttpClientWrapper.getLastRequest;
 import static internal.helpers.HttpClientWrapper.getRequests;
+import static internal.helpers.Networking.assertGetRequest;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
 import internal.helpers.HttpClientWrapper;
@@ -42,8 +42,6 @@ public class RefreshStatusCommandTest extends AbstractCommandTestBase {
 
     var requests = getRequests();
     assertThat(requests, not(empty()));
-    var request = getLastRequest();
-    var uri = request.uri();
-    assertThat(uri.getPath(), equalTo("/clan_stash.php"));
+    assertGetRequest(getLastRequest(), "/clan_stash.php");
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/command/SendMessageCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/SendMessageCommandTest.java
@@ -1,17 +1,16 @@
 package net.sourceforge.kolmafia.textui.command;
 
 import static internal.helpers.HttpClientWrapper.getRequests;
+import static internal.helpers.Networking.assertPostRequest;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mockStatic;
 
 import internal.helpers.Cleanups;
 import internal.helpers.HttpClientWrapper;
 import internal.helpers.Player;
-import internal.network.RequestBodyReader;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.StaticEntity;
@@ -108,15 +107,10 @@ class SendMessageCommandTest extends AbstractCommandTestBase {
       assertContinueState();
       var requests = getRequests();
       assertThat(requests, not(empty()));
-      var request = requests.get(0);
-      var uri = request.uri();
-      assertThat(uri.getPath(), equalTo("/sendmessage.php"));
-      assertThat(request.method(), equalTo("POST"));
-      var body = new RequestBodyReader().bodyAsString(request);
-      assertThat(
-          body,
-          equalTo(
-              "action=send&towho=buffy&message=Keep+the+contents+of+this+message+top-sekrit%2C+ultra+hush-hush.&whichitem1=2&howmany1=1"));
+      assertPostRequest(
+          requests.get(0),
+          "/sendmessage.php",
+          "action=send&towho=buffy&message=Keep the contents of this message top-sekrit, ultra hush-hush.&whichitem1=2&howmany1=1");
     }
   }
 
@@ -169,15 +163,10 @@ class SendMessageCommandTest extends AbstractCommandTestBase {
     assertContinueState();
     var requests = getRequests();
     assertThat(requests, not(empty()));
-    var request = requests.get(0);
-    var uri = request.uri();
-    assertThat(uri.getPath(), equalTo("/sendmessage.php"));
-    assertThat(request.method(), equalTo("POST"));
-    var body = new RequestBodyReader().bodyAsString(request);
-    assertThat(
-        body,
-        equalTo(
-            "action=send&towho=buffy&message=Keep+the+contents+of+this+message+top-sekrit%2C+ultra+hush-hush.&sendmeat=1000000"));
+    assertPostRequest(
+        requests.get(0),
+        "/sendmessage.php",
+        "action=send&towho=buffy&message=Keep the contents of this message top-sekrit, ultra hush-hush.&sendmeat=1000000");
   }
 
   @Test
@@ -191,16 +180,10 @@ class SendMessageCommandTest extends AbstractCommandTestBase {
     assertContinueState();
     var requests = getRequests();
     assertThat(requests, not(empty()));
-    var request = requests.get(0);
-    var uri = request.uri();
-    assertThat(uri.getPath(), equalTo("/sendmessage.php"));
-    assertThat(request.method(), equalTo("POST"));
-    var body = new RequestBodyReader().bodyAsString(request);
-    // Note - the message is sent but not the meat
-    assertThat(
-        body,
-        equalTo(
-            "action=send&towho=buffy&message=Keep+the+contents+of+this+message+top-sekrit%2C+ultra+hush-hush."));
+    assertPostRequest(
+        requests.get(0),
+        "/sendmessage.php",
+        "action=send&towho=buffy&message=Keep the contents of this message top-sekrit, ultra hush-hush.");
   }
 
   @Test
@@ -214,15 +197,10 @@ class SendMessageCommandTest extends AbstractCommandTestBase {
     assertContinueState();
     var requests = getRequests();
     assertThat(requests, not(empty()));
-    var request = requests.get(0);
-    var uri = request.uri();
-    assertThat(uri.getPath(), equalTo("/sendmessage.php"));
-    assertThat(request.method(), equalTo("POST"));
-    var body = new RequestBodyReader().bodyAsString(request);
-    assertThat(
-        body,
-        equalTo(
-            "action=send&towho=buffy&message=Keep+the+contents+of+this+message+top-sekrit%2C+ultra+hush-hush.&sendmeat=3000000000"));
+    assertPostRequest(
+        requests.get(0),
+        "/sendmessage.php",
+        "action=send&towho=buffy&message=Keep the contents of this message top-sekrit, ultra hush-hush.&sendmeat=3000000000");
   }
 
   // I wasn't expecting this to work since it is sending more meat than present.
@@ -238,15 +216,10 @@ class SendMessageCommandTest extends AbstractCommandTestBase {
     assertContinueState();
     var requests = getRequests();
     assertThat(requests, not(empty()));
-    var request = requests.get(0);
-    var uri = request.uri();
-    assertThat(uri.getPath(), equalTo("/sendmessage.php"));
-    assertThat(request.method(), equalTo("POST"));
-    var body = new RequestBodyReader().bodyAsString(request);
-    assertThat(
-        body,
-        equalTo(
-            "action=send&towho=buffy&message=Keep+the+contents+of+this+message+top-sekrit%2C+ultra+hush-hush.&sendmeat=1000000"));
+    assertPostRequest(
+        requests.get(0),
+        "/sendmessage.php",
+        "action=send&towho=buffy&message=Keep the contents of this message top-sekrit, ultra hush-hush.&sendmeat=1000000");
   }
 
   @Test
@@ -292,14 +265,10 @@ class SendMessageCommandTest extends AbstractCommandTestBase {
     assertContinueState();
     var requests = getRequests();
     assertThat(requests, not(empty()));
-    var request = requests.get(0);
-    var uri = request.uri();
-    assertThat(uri.getPath(), equalTo("/sendmessage.php"));
-    assertThat(request.method(), equalTo("POST"));
-    var body = new RequestBodyReader().bodyAsString(request);
-    assertThat(
-        body,
-        equalTo("action=send&towho=buffy+&message=This+is+Blackmail%21%21%21&sendmeat=3000000000"));
+    assertPostRequest(
+        requests.get(0),
+        "/sendmessage.php",
+        "action=send&towho=buffy &message=This is Blackmail!!!&sendmeat=3000000000");
   }
 
   @Test
@@ -313,15 +282,10 @@ class SendMessageCommandTest extends AbstractCommandTestBase {
     assertContinueState();
     var requests = getRequests();
     assertThat(requests, not(empty()));
-    var request = requests.get(0);
-    var uri = request.uri();
-    assertThat(uri.getPath(), equalTo("/sendmessage.php"));
-    assertThat(request.method(), equalTo("POST"));
-    var body = new RequestBodyReader().bodyAsString(request);
-    assertThat(
-        body,
-        equalTo(
-            "action=send&towho=buffy&message=Keep+the+contents+of+this+message+top-sekrit%2C+ultra+hush-hush.&whichitem1=2&howmany1=1"));
+    assertPostRequest(
+        requests.get(0),
+        "/sendmessage.php",
+        "action=send&towho=buffy&message=Keep the contents of this message top-sekrit, ultra hush-hush.&whichitem1=2&howmany1=1");
   }
 
   @Test
@@ -335,15 +299,10 @@ class SendMessageCommandTest extends AbstractCommandTestBase {
     assertContinueState();
     var requests = getRequests();
     assertThat(requests, not(empty()));
-    var request = requests.get(0);
-    var uri = request.uri();
-    assertThat(uri.getPath(), equalTo("/sendmessage.php"));
-    assertThat(request.method(), equalTo("POST"));
-    var body = new RequestBodyReader().bodyAsString(request);
-    assertThat(
-        body,
-        equalTo(
-            "action=send&towho=buffy&message=Keep+the+contents+of+this+message+top-sekrit%2C+ultra+hush-hush.&whichitem1=2&howmany1=1"));
+    assertPostRequest(
+        requests.get(0),
+        "/sendmessage.php",
+        "action=send&towho=buffy&message=Keep the contents of this message top-sekrit, ultra hush-hush.&whichitem1=2&howmany1=1");
   }
 
   @Test
@@ -421,15 +380,10 @@ class SendMessageCommandTest extends AbstractCommandTestBase {
     assertContinueState();
     var requests = getRequests();
     assertThat(requests, not(empty()));
-    var request = requests.get(0);
-    var uri = request.uri();
-    assertThat(uri.getPath(), equalTo("/sendmessage.php"));
-    assertThat(request.method(), equalTo("POST"));
-    var body = new RequestBodyReader().bodyAsString(request);
-    assertThat(
-        body,
-        equalTo(
-            "action=send&towho=buffy+&message=Signed.++Sealed.++Delivered.&whichitem1=2&howmany1=1&whichitem2=1&howmany2=1"));
+    assertPostRequest(
+        requests.get(0),
+        "/sendmessage.php",
+        "action=send&towho=buffy &message=Signed.  Sealed.  Delivered.&whichitem1=2&howmany1=1&whichitem2=1&howmany2=1");
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/textui/command/SkeletonCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/SkeletonCommandTest.java
@@ -1,16 +1,15 @@
 package net.sourceforge.kolmafia.textui.command;
 
 import static internal.helpers.HttpClientWrapper.getRequests;
+import static internal.helpers.Networking.assertPostRequest;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 
 import internal.helpers.HttpClientWrapper;
 import internal.helpers.Player;
-import internal.network.RequestBodyReader;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -64,16 +63,7 @@ public class SkeletonCommandTest extends AbstractCommandTestBase {
     var requests = getRequests();
     assertThat(requests, not(empty()));
     assertThat(requests, hasSize(2));
-    var first = requests.get(0);
-    var uri = first.uri();
-    assertThat(uri.getPath(), equalTo("/inv_use.php"));
-    var body = new RequestBodyReader().bodyAsString(first);
-    assertThat(body, equalTo("which=3&whichitem=5881"));
-
-    var second = requests.get(1);
-    uri = second.uri();
-    assertThat(uri.getPath(), equalTo("/choice.php"));
-    body = new RequestBodyReader().bodyAsString(second);
-    assertThat(body, equalTo("whichchoice=603&option=5"));
+    assertPostRequest(requests.get(0), "/inv_use.php", "which=3&whichitem=5881");
+    assertPostRequest(requests.get(1), "/choice.php", "whichchoice=603&option=5");
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/command/UntinkerCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/UntinkerCommandTest.java
@@ -2,6 +2,7 @@ package net.sourceforge.kolmafia.textui.command;
 
 import static internal.helpers.HttpClientWrapper.fakeClientBuilder;
 import static internal.helpers.HttpClientWrapper.getRequests;
+import static internal.helpers.Networking.assertPostRequest;
 import static internal.helpers.Player.addItem;
 import static internal.helpers.Player.isSign;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/test/net/sourceforge/kolmafia/textui/command/ZapCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ZapCommandTest.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.textui.command;
 
 import static internal.helpers.HttpClientWrapper.getRequests;
+import static internal.helpers.Networking.assertPostRequest;
 import static internal.helpers.Player.addItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -9,7 +10,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import internal.helpers.Cleanups;
 import internal.helpers.HttpClientWrapper;
-import internal.network.RequestBodyReader;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.StaticEntity;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,12 +72,7 @@ public class ZapCommandTest extends AbstractCommandTestBase {
 
     var requests = getRequests();
     assertThat(requests.size(), equalTo(1));
-    var request = requests.get(0);
-    var uri = request.uri();
-    assertThat(uri.getPath(), equalTo("/wand.php"));
-    assertThat(request.method(), equalTo("POST"));
-    var body = new RequestBodyReader().bodyAsString(request);
-    assertThat(body, equalTo("action=zap&whichwand=1270&whichitem=169"));
+    assertPostRequest(requests.get(0), "/wand.php", "action=zap&whichwand=1270&whichitem=169");
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/webui/CharPaneDecoratorTest.java
+++ b/test/net/sourceforge/kolmafia/webui/CharPaneDecoratorTest.java
@@ -1,10 +1,8 @@
 package net.sourceforge.kolmafia.webui;
 
+import static internal.helpers.Networking.html;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
@@ -32,16 +30,14 @@ public class CharPaneDecoratorTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"basic", "compact"})
-  public void decorateEffects(final String displayMode) throws IOException {
+  public void decorateEffects(final String displayMode) {
     KoLCharacter.addAvailableSkill(SkillPool.ODE_TO_BOOZE);
     Preferences.setString("olfactedMonster", "novelty tropical skeleton");
 
-    String input = Files.readString(Paths.get("request/test_charpane_" + displayMode + ".html"));
+    String input = html("request/test_charpane_" + displayMode + ".html");
     CharPaneRequest.processResults(input);
 
-    var expected =
-        Files.readString(
-            Paths.get("request/test_charpane_" + displayMode + "_decorated_effects.html"));
+    var expected = html("request/test_charpane_" + displayMode + "_decorated_effects.html");
     var actual =
         CharPaneDecorator.decorateIntrinsics(
                 CharPaneDecorator.decorateEffects(new StringBuffer(input)))


### PR DESCRIPTION
Follow-up to #823: use `html` and `assertPostRequest` where interior code was used.