### PR TITLE
fix: pass unbreakable umbrella to boost constructor

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/Boost.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Boost.java
@@ -63,7 +63,8 @@ public class Boost implements Comparable<Boost> {
       String edPiece,
       String snowsuit,
       String retroCape,
-      String backupCamera) {
+      String backupCamera,
+      String unbreakableUmbrella) {
     this(cmd, text, item, boost);
     this.isEquipment = true;
     this.slot = slot;
@@ -73,6 +74,7 @@ public class Boost implements Comparable<Boost> {
     this.snowsuit = snowsuit;
     this.retroCape = retroCape;
     this.backupCamera = backupCamera;
+    this.unbreakableUmbrella = unbreakableUmbrella;
   }
 
   public Boost(String cmd, String text, FamiliarData fam, double boost) {
@@ -89,18 +91,16 @@ public class Boost implements Comparable<Boost> {
 
   @Override
   public int compareTo(Boost o) {
-    if (!(o instanceof Boost)) return -1;
-    Boost other = o;
+    if (o == null) return -1;
 
-    if (this.isEquipment != other.isEquipment) {
+    if (this.isEquipment != o.isEquipment) {
       return this.isEquipment ? -1 : 1;
     }
-    if (this.priority != other.priority) {
+    if (this.priority != o.priority) {
       return this.priority ? -1 : 1;
     }
     if (this.isEquipment) return 0; // preserve order of addition
-    int rv = Double.compare(other.boost, this.boost);
-    return rv;
+    return Double.compare(o.boost, this.boost);
   }
 
   public boolean execute(boolean equipOnly) {

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -1836,7 +1836,8 @@ public class Maximizer {
             edPiece,
             snowsuit,
             retroCape,
-            backupCamera);
+            backupCamera,
+            unbreakableUmbrella);
     if (equipScope == -1) { // called from CLI
       boost.execute(true);
       if (!KoLmafia.permitsContinue()) {


### PR DESCRIPTION
Unbreakable umbrella was never passed into the Boost object, so code inside that class never ran.

Did this break anything? No idea. Perhaps it could have caused the umbrella to be set when it should not have been, under some circumstances? 