### PR TITLE
fix: count ml percent when maximizing exp

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -645,6 +645,7 @@ public class Evaluator {
     // Make sure indirect sources have at least a little weight;
     double fudge = this.weight[Modifiers.EXPERIENCE] * 0.0001f;
     this.weight[Modifiers.MONSTER_LEVEL] += fudge;
+    this.weight[Modifiers.MONSTER_LEVEL_PERCENT] += fudge;
     this.weight[Modifiers.MUS_EXPERIENCE] += fudge;
     this.weight[Modifiers.MYS_EXPERIENCE] += fudge;
     this.weight[Modifiers.MOX_EXPERIENCE] += fudge;
@@ -794,7 +795,10 @@ public class Evaluator {
           }
           break;
         case Modifiers.EXPERIENCE:
-          double baseExp = KoLCharacter.estimatedBaseExp(mods.get(Modifiers.MONSTER_LEVEL));
+          double baseExp =
+              KoLCharacter.estimatedBaseExp(
+                  mods.get(Modifiers.MONSTER_LEVEL)
+                      * (1 + mods.get(Modifiers.MONSTER_LEVEL_PERCENT) / 100));
           double expPct =
               mods.get(Modifiers.MUS_EXPERIENCE_PCT + KoLCharacter.getPrimeIndex()) / 100.0f;
           double exp = mods.get(Modifiers.MUS_EXPERIENCE + KoLCharacter.getPrimeIndex());

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -755,4 +755,32 @@ public class MaximizerTest {
       recommendedSlotIs(EquipmentManager.OFFHAND, "umbrella broken");
     }
   }
+
+  @Test
+  public void expShouldSuggestUmbrella() {
+    final var cleanups =
+        new Cleanups(
+            canUse("unbreakable umbrella"),
+            equip(EquipmentManager.PANTS, "old patched suit-pants"),
+            canUse("Microplushie: Hipsterine"));
+    Preferences.setString("umbrellaState", "cocoon");
+    try (cleanups) {
+      assertTrue(maximize("exp"));
+      recommendedSlotIs(EquipmentManager.OFFHAND, "umbrella broken");
+    }
+  }
+
+  @Test
+  public void expShouldNotSuggestUmbrellaIfBetterInSlot() {
+    final var cleanups =
+        new Cleanups(
+            canUse("unbreakable umbrella"),
+            equip(EquipmentManager.PANTS, "old patched suit-pants"),
+            canUse("vinyl shield"));
+    Preferences.setString("umbrellaState", "cocoon");
+    try (cleanups) {
+      assertTrue(maximize("exp"));
+      recommendedSlotIs(EquipmentManager.OFFHAND, "vinyl shield");
+    }
+  }
 }


### PR DESCRIPTION
Improve maximizing exp by suggesting the umbrella when ML % offers more exp than anything else.

Might take multiple maximizations to be right because maximizer doesn't consider combinations of equipment (i.e. ML + ML%) properly. Should stabilize after you have some ML to start with though.