### PR TITLE
refactor: remove spotless workaround

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,5 @@
 org.gradle.caching=true
 org.gradle.parallel=true
-org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
 javaSourceCompatibility=17
 javaTargetCompatibility=17


### PR DESCRIPTION
Now that we're on at least 6.7.2, we should be able to remove the
`add-exports` calls.

See

https://github.com/diffplug/spotless/blob/d71bc1812f9fbcabb5cda3e82dac11d7da45e1d5/plugin-gradle/CHANGES.md#671---2022-06-10