### PR TITLE
Generic handling for items configurable via preference: Modeables

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -5527,7 +5527,8 @@ public abstract class KoLCharacter {
           var modeable = Modeable.find(itemId);
 
           if (modeable != null) {
-            newModifiers.add(Modifiers.getModifiers(modeable.getModifier(), modeables.get(modeable)));
+            newModifiers.add(
+                Modifiers.getModifiers(modeable.getModifier(), modeables.get(modeable)));
           }
       }
     }

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -1,10 +1,7 @@
 package net.sourceforge.kolmafia;
 
 import java.awt.Taskbar;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
@@ -4899,16 +4896,10 @@ public abstract class KoLCharacter {
             KoLCharacter.effectiveFamiliar,
             KoLCharacter.currentEnthroned,
             KoLCharacter.currentBjorned,
-            Preferences.getString("edPiece"),
-            Preferences.getString("snowsuit"),
             null,
             Preferences.getString("_horsery"),
             Preferences.getString("boomBoxSong"),
-            Preferences.getString("retroCapeSuperhero")
-                + " "
-                + Preferences.getString("retroCapeWashingInstructions"),
-            Preferences.getString("backupCameraMode"),
-            Preferences.getString("umbrellaState"),
+            Modeable.getStateMap(),
             false));
   }
 
@@ -4920,14 +4911,10 @@ public abstract class KoLCharacter {
       FamiliarData familiar,
       FamiliarData enthroned,
       FamiliarData bjorned,
-      String edPiece,
-      String snowsuit,
       String custom,
       String horsery,
       String boomBox,
-      String retroCape,
-      String backupCamera,
-      String unbreakableUmbrella,
+      Map<Modeable, String> modeables,
       boolean speculation) {
     int taoFactor = KoLCharacter.hasSkill("Tao of the Terrapin") ? 2 : 1;
 
@@ -5016,11 +5003,7 @@ public abstract class KoLCharacter {
           equipment,
           enthroned,
           bjorned,
-          edPiece,
-          snowsuit,
-          retroCape,
-          backupCamera,
-          unbreakableUmbrella,
+          modeables,
           speculation,
           taoFactor);
     }
@@ -5420,11 +5403,7 @@ public abstract class KoLCharacter {
       AdventureResult[] equipment,
       FamiliarData enthroned,
       FamiliarData bjorned,
-      String edPiece,
-      String snowsuit,
-      String retroCape,
-      String backupCamera,
-      String unbreakableUmbrella,
+      Map<Modeable, String> modeables,
       boolean speculation,
       int taoFactor) {
     if (item == null || item == EquipmentRequest.UNEQUIP) {
@@ -5544,25 +5523,12 @@ public abstract class KoLCharacter {
           newModifiers.applyVampyricCloakeModifiers();
           break;
 
-        case ItemPool.CROWN_OF_ED:
-          newModifiers.add(Modifiers.getModifiers("Edpiece", edPiece));
-          break;
+        default:
+          var modeable = Modeable.find(itemId);
 
-        case ItemPool.KNOCK_OFF_RETRO_SUPERHERO_CAPE:
-          newModifiers.add(Modifiers.getModifiers("RetroCape", retroCape));
-          break;
-
-        case ItemPool.BACKUP_CAMERA:
-          newModifiers.add(Modifiers.getModifiers("BackupCamera", backupCamera));
-          break;
-
-        case ItemPool.UNBREAKABLE_UMBRELLA:
-          newModifiers.add(Modifiers.getModifiers("UnbreakableUmbrella", unbreakableUmbrella));
-          break;
-
-        case ItemPool.SNOW_SUIT:
-          newModifiers.add(Modifiers.getModifiers("Snowsuit", snowsuit));
-          break;
+          if (modeable != null) {
+            newModifiers.add(Modifiers.getModifiers(modeable.getModifier(), modeables.get(modeable)));
+          }
       }
     }
 

--- a/src/net/sourceforge/kolmafia/Modeable.java
+++ b/src/net/sourceforge/kolmafia/Modeable.java
@@ -1,73 +1,100 @@
 package net.sourceforge.kolmafia;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.textui.command.*;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 public enum Modeable {
-    EDPIECE("edpiece", "edPiece", ItemPool.get(ItemPool.CROWN_OF_ED), "Edpiece", new EdPieceCommand()),
-    RETROCAPE("retrocape", null, ItemPool.get(ItemPool.KNOCK_OFF_RETRO_SUPERHERO_CAPE), "RetroCape", new RetroCapeCommand()),
-    BACKUPCAMERA("backupcamera", "backupCameraMode", ItemPool.get(ItemPool.BACKUP_CAMERA), "BackupCamera", new BackupCameraCommand()),
-    UMBRELLA("umbrella", "umbrellaState", ItemPool.get(ItemPool.UNBREAKABLE_UMBRELLA), "UnbreakableUmbrella", new UmbrellaCommand()),
-    SNOWSUIT("snowsuit", "snowsuit", ItemPool.get(ItemPool.SNOW_SUIT), "Snowsuit", new SnowsuitCommand());
+  EDPIECE(
+      "edpiece", "edPiece", ItemPool.get(ItemPool.CROWN_OF_ED), "Edpiece", new EdPieceCommand()),
+  RETROCAPE(
+      "retrocape",
+      null,
+      ItemPool.get(ItemPool.KNOCK_OFF_RETRO_SUPERHERO_CAPE),
+      "RetroCape",
+      new RetroCapeCommand()),
+  BACKUPCAMERA(
+      "backupcamera",
+      "backupCameraMode",
+      ItemPool.get(ItemPool.BACKUP_CAMERA),
+      "BackupCamera",
+      new BackupCameraCommand()),
+  UMBRELLA(
+      "umbrella",
+      "umbrellaState",
+      ItemPool.get(ItemPool.UNBREAKABLE_UMBRELLA),
+      "UnbreakableUmbrella",
+      new UmbrellaCommand()),
+  SNOWSUIT(
+      "snowsuit", "snowsuit", ItemPool.get(ItemPool.SNOW_SUIT), "Snowsuit", new SnowsuitCommand());
 
-    private final String command;
-    private final String statePref;
-    private final AdventureResult item;
-    private final String modifier;
-    private final AbstractModeCommand commandInstance;
+  private final String command;
+  private final String statePref;
+  private final AdventureResult item;
+  private final String modifier;
+  private final AbstractModeCommand commandInstance;
 
-    Modeable(final String command, final String statePref, final AdventureResult item, final String modifier, final AbstractModeCommand commandInstance) {
-        this.command = command;
-        this.statePref = statePref;
-        this.item = item;
-        this.modifier = modifier;
-        this.commandInstance = commandInstance;
+  Modeable(
+      final String command,
+      final String statePref,
+      final AdventureResult item,
+      final String modifier,
+      final AbstractModeCommand commandInstance) {
+    this.command = command;
+    this.statePref = statePref;
+    this.item = item;
+    this.modifier = modifier;
+    this.commandInstance = commandInstance;
+  }
+
+  public String getCommand() {
+    return this.command;
+  }
+
+  public AdventureResult getItem() {
+    return this.item;
+  }
+
+  public boolean validate(final String command, final String parameters) {
+    return this.commandInstance.validate(command, parameters);
+  }
+
+  public String getState() {
+    if (this == RETROCAPE) {
+      return Preferences.getString("retroCapeSuperhero")
+          + " "
+          + Preferences.getString("retroCapeWashingInstructions");
     }
 
-    public String getCommand() {
-        return this.command;
-    }
+    return Preferences.getString(this.statePref);
+  }
 
-    public AdventureResult getItem() {
-        return this.item;
-    }
+  public String getModifier() {
+    return this.modifier;
+  }
 
-    public boolean validate(final String command, final String parameters) {
-        return this.commandInstance.validate(command, parameters);
-    }
+  public static Modeable find(final String command) {
+    return Arrays.stream(values())
+        .filter(m -> m.getCommand().equalsIgnoreCase(command))
+        .findAny()
+        .orElse(null);
+  }
 
-    public String getState() {
-        if (this == RETROCAPE) {
-            return Preferences.getString("retroCapeSuperhero")
-                    + " "
-                    + Preferences.getString("retroCapeWashingInstructions");
-        }
+  public static Modeable find(final int itemId) {
+    return Arrays.stream(values())
+        .filter(m -> m.getItem().getItemId() == itemId)
+        .findAny()
+        .orElse(null);
+  }
 
-        return Preferences.getString(this.statePref);
-    }
+  public static Map<Modeable, String> getStateMap() {
+    return Arrays.stream(values()).collect(Collectors.toMap(m -> m, Modeable::getState));
+  }
 
-    public String getModifier() {
-        return this.modifier;
-    }
-
-    public static Modeable find(final String command) {
-        return Arrays.stream(values()).filter(m -> m.getCommand().equalsIgnoreCase(command)).findAny().orElse(null);
-    }
-
-    public static Modeable find(final int itemId) {
-        return Arrays.stream(values()).filter(m -> m.getItem().getItemId() == itemId).findAny().orElse(null);
-    }
-
-    public static Map<Modeable, String> getStateMap() {
-        return Arrays.stream(values()).collect(Collectors.toMap(m -> m, Modeable::getState));
-    }
-
-    public static Map<Modeable, Boolean> getBooleanMap() {
-        return Arrays.stream(values()).collect(Collectors.toMap(m -> m, m -> false));
-    }
+  public static Map<Modeable, Boolean> getBooleanMap() {
+    return Arrays.stream(values()).collect(Collectors.toMap(m -> m, m -> false));
+  }
 }

--- a/src/net/sourceforge/kolmafia/Modeable.java
+++ b/src/net/sourceforge/kolmafia/Modeable.java
@@ -1,0 +1,73 @@
+package net.sourceforge.kolmafia;
+
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.textui.command.*;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public enum Modeable {
+    EDPIECE("edpiece", "edPiece", ItemPool.get(ItemPool.CROWN_OF_ED), "Edpiece", new EdPieceCommand()),
+    RETROCAPE("retrocape", null, ItemPool.get(ItemPool.KNOCK_OFF_RETRO_SUPERHERO_CAPE), "RetroCape", new RetroCapeCommand()),
+    BACKUPCAMERA("backupcamera", "backupCameraMode", ItemPool.get(ItemPool.BACKUP_CAMERA), "BackupCamera", new BackupCameraCommand()),
+    UMBRELLA("umbrella", "umbrellaState", ItemPool.get(ItemPool.UNBREAKABLE_UMBRELLA), "UnbreakableUmbrella", new UmbrellaCommand()),
+    SNOWSUIT("snowsuit", "snowsuit", ItemPool.get(ItemPool.SNOW_SUIT), "Snowsuit", new SnowsuitCommand());
+
+    private final String command;
+    private final String statePref;
+    private final AdventureResult item;
+    private final String modifier;
+    private final AbstractModeCommand commandInstance;
+
+    Modeable(final String command, final String statePref, final AdventureResult item, final String modifier, final AbstractModeCommand commandInstance) {
+        this.command = command;
+        this.statePref = statePref;
+        this.item = item;
+        this.modifier = modifier;
+        this.commandInstance = commandInstance;
+    }
+
+    public String getCommand() {
+        return this.command;
+    }
+
+    public AdventureResult getItem() {
+        return this.item;
+    }
+
+    public boolean validate(final String command, final String parameters) {
+        return this.commandInstance.validate(command, parameters);
+    }
+
+    public String getState() {
+        if (this == RETROCAPE) {
+            return Preferences.getString("retroCapeSuperhero")
+                    + " "
+                    + Preferences.getString("retroCapeWashingInstructions");
+        }
+
+        return Preferences.getString(this.statePref);
+    }
+
+    public String getModifier() {
+        return this.modifier;
+    }
+
+    public static Modeable find(final String command) {
+        return Arrays.stream(values()).filter(m -> m.getCommand().equalsIgnoreCase(command)).findAny().orElse(null);
+    }
+
+    public static Modeable find(final int itemId) {
+        return Arrays.stream(values()).filter(m -> m.getItem().getItemId() == itemId).findAny().orElse(null);
+    }
+
+    public static Map<Modeable, String> getStateMap() {
+        return Arrays.stream(values()).collect(Collectors.toMap(m -> m, Modeable::getState));
+    }
+
+    public static Map<Modeable, Boolean> getBooleanMap() {
+        return Arrays.stream(values()).collect(Collectors.toMap(m -> m, m -> false));
+    }
+}

--- a/src/net/sourceforge/kolmafia/Speculation.java
+++ b/src/net/sourceforge/kolmafia/Speculation.java
@@ -1,10 +1,8 @@
 package net.sourceforge.kolmafia;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -16,7 +14,6 @@ import net.sourceforge.kolmafia.persistence.ItemFinder.Match;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.session.EquipmentManager;
-import net.sourceforge.kolmafia.textui.command.RetroCapeCommand;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class Speculation {
@@ -24,9 +21,7 @@ public class Speculation {
   public AdventureResult[] equipment;
   private final ArrayList<AdventureResult> effects;
   private FamiliarData familiar, enthroned, bjorned;
-  private String custom,
-      horsery,
-      boomBox;
+  private String custom, horsery, boomBox;
   protected boolean calculated = false;
   protected Modifiers mods;
   private Map<Modeable, String> modeables;
@@ -265,7 +260,8 @@ public class Speculation {
 
         if (modeable != null) {
           if (!modeable.validate(cmd, params)) {
-            KoLmafia.updateDisplay(MafiaState.ERROR, "Unknown parameter for " + cmd + ": " + params);
+            KoLmafia.updateDisplay(
+                MafiaState.ERROR, "Unknown parameter for " + cmd + ": " + params);
             return true;
           }
 

--- a/src/net/sourceforge/kolmafia/Speculation.java
+++ b/src/net/sourceforge/kolmafia/Speculation.java
@@ -3,6 +3,8 @@ package net.sourceforge.kolmafia;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -22,16 +24,12 @@ public class Speculation {
   public AdventureResult[] equipment;
   private final ArrayList<AdventureResult> effects;
   private FamiliarData familiar, enthroned, bjorned;
-  private String edPiece,
-      snowsuit,
-      custom,
+  private String custom,
       horsery,
-      boomBox,
-      retroCape,
-      backupCamera,
-      unbreakableUmbrella;
+      boomBox;
   protected boolean calculated = false;
   protected Modifiers mods;
+  private Map<Modeable, String> modeables;
 
   public Speculation() {
     this.MCD = KoLCharacter.getMindControlLevel();
@@ -55,17 +53,10 @@ public class Speculation {
     this.familiar = KoLCharacter.currentFamiliar;
     this.enthroned = KoLCharacter.currentEnthroned;
     this.bjorned = KoLCharacter.currentBjorned;
-    this.edPiece = Preferences.getString("edPiece");
-    this.snowsuit = Preferences.getString("snowsuit");
     this.custom = null;
     this.horsery = Preferences.getString("_horsery");
     this.boomBox = Preferences.getString("boomBoxSong");
-    this.retroCape =
-        Preferences.getString("retroCapeSuperhero")
-            + " "
-            + Preferences.getString("retroCapeWashingInstructions");
-    this.backupCamera = Preferences.getString("backupCameraMode");
-    this.unbreakableUmbrella = Preferences.getString("umbrellaState");
+    this.modeables = Modeable.getStateMap();
   }
 
   public void setMindControlLevel(int MCD) {
@@ -84,24 +75,8 @@ public class Speculation {
     this.bjorned = familiar;
   }
 
-  public void setEdPiece(String edPiece) {
-    this.edPiece = edPiece;
-  }
-
-  public void setRetroCape(String retroCape) {
-    this.retroCape = retroCape;
-  }
-
-  public void setBackupCamera(String backupCamera) {
-    this.backupCamera = backupCamera;
-  }
-
-  public void setUnbreakableUmbrella(String unbreakableUmbrella) {
-    this.unbreakableUmbrella = unbreakableUmbrella;
-  }
-
-  public void setSnowsuit(String snowsuit) {
-    this.snowsuit = snowsuit;
+  public void setModeable(Modeable modeable, String value) {
+    this.modeables.put(modeable, value);
   }
 
   public void setCustom(String custom) {
@@ -128,26 +103,6 @@ public class Speculation {
     return this.familiar;
   }
 
-  public String getEdPiece() {
-    return this.edPiece;
-  }
-
-  public String getRetroCape() {
-    return this.retroCape;
-  }
-
-  public String getBackupCamera() {
-    return this.backupCamera;
-  }
-
-  public String getUnbreakableUmbrella() {
-    return this.unbreakableUmbrella;
-  }
-
-  public String getSnowsuit() {
-    return this.snowsuit;
-  }
-
   public String getCustom() {
     return this.custom;
   }
@@ -158,6 +113,10 @@ public class Speculation {
 
   public String getBoomBox() {
     return this.boomBox;
+  }
+
+  public Map<Modeable, String> getModeables() {
+    return this.modeables;
   }
 
   public void equip(int slot, AdventureResult item) {
@@ -192,14 +151,10 @@ public class Speculation {
             this.familiar,
             this.enthroned,
             this.bjorned,
-            this.edPiece,
-            this.snowsuit,
             this.custom,
             this.horsery,
             this.boomBox,
-            this.retroCape,
-            this.backupCamera,
-            this.unbreakableUmbrella,
+            this.modeables,
             true);
     this.calculated = true;
     return this.mods;
@@ -281,58 +236,6 @@ public class Speculation {
         FamiliarData fam = new FamiliarData(id);
         this.setBjorned(fam);
         this.equip(EquipmentManager.CONTAINER, ItemPool.get(ItemPool.BUDDY_BJORN));
-      } else if (cmd.equals("edpiece")) {
-        if (!params.equals("bear")
-            && !params.equals("owl")
-            && !params.equals("puma")
-            && !params.equals("hyena")
-            && !params.equals("mouse")
-            && !params.equals("weasel")) {
-          KoLmafia.updateDisplay(MafiaState.ERROR, "Unknown animal: " + params);
-          return true;
-        }
-        this.setEdPiece(params);
-        this.equip(EquipmentManager.HAT, ItemPool.get(ItemPool.CROWN_OF_ED));
-      } else if (cmd.equals("retrocape")) {
-        String[] parts = params.split(" ");
-        if ((!Arrays.asList(RetroCapeCommand.SUPERHEROS).contains(parts[0]))
-            || (!Arrays.asList(RetroCapeCommand.WASHING_INSTRUCTIONS).contains(parts[1]))) {
-          KoLmafia.updateDisplay(MafiaState.ERROR, "Unknown retro cape configuration: " + params);
-          return true;
-        }
-        this.setRetroCape(params);
-        this.equip(
-            EquipmentManager.CONTAINER, ItemPool.get(ItemPool.KNOCK_OFF_RETRO_SUPERHERO_CAPE));
-      } else if (cmd.equals("backupcamera")) {
-        if (!params.equals("meat") && !params.equals("ml") && !params.equals("init")) {
-          KoLmafia.updateDisplay(MafiaState.ERROR, "Unknown backup camera setting: " + params);
-          return true;
-        }
-        this.setBackupCamera(params);
-        this.equip(EquipmentManager.ACCESSORY3, ItemPool.get(ItemPool.BACKUP_CAMERA));
-      } else if (cmd.equals("umbrella")) {
-        if (!params.equals("broken")
-            && !params.equals("forward-facing")
-            && !params.equals("bucket style")
-            && !params.equals("pitchfork style")
-            && !params.equals("constantly twirling")
-            && !params.equals("cocoon")) {
-          KoLmafia.updateDisplay(
-              MafiaState.ERROR, "Unknown unbreakable umbrella setting:" + params);
-        }
-        this.setUnbreakableUmbrella(params);
-        this.equip(EquipmentManager.OFFHAND, ItemPool.get(ItemPool.UNBREAKABLE_UMBRELLA));
-      } else if (cmd.equals("snowsuit")) {
-        if (!params.equals("eyebrows")
-            && !params.equals("smirk")
-            && !params.equals("nose")
-            && !params.equals("goatee")
-            && !params.equals("hat")) {
-          KoLmafia.updateDisplay(MafiaState.ERROR, "Unknown decoration: " + params);
-          return true;
-        }
-        this.setSnowsuit(params);
-        this.equip(EquipmentManager.FAMILIAR, ItemPool.get(ItemPool.SNOW_SUIT));
       } else if (cmd.equals("up")) {
         List<String> effects = EffectDatabase.getMatchingNames(params);
         if (effects.isEmpty()) {
@@ -358,6 +261,18 @@ public class Speculation {
       } else if (cmd.equals("quiet")) {
         quiet = true;
       } else {
+        var modeable = Modeable.find(cmd);
+
+        if (modeable != null) {
+          if (!modeable.validate(cmd, params)) {
+            KoLmafia.updateDisplay(MafiaState.ERROR, "Unknown parameter for " + cmd + ": " + params);
+            return true;
+          }
+
+          this.setModeable(modeable, params);
+          this.equip(KoLCharacter.equipmentSlot(modeable.getItem()), modeable.getItem());
+        }
+
         KoLmafia.updateDisplay(MafiaState.ERROR, "I don't know how to speculate about " + cmd);
         return true;
       }

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -6,14 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import net.java.dev.spellcast.utilities.LockableListModel;
-import net.sourceforge.kolmafia.AdventureResult;
-import net.sourceforge.kolmafia.FamiliarData;
-import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLConstants;
-import net.sourceforge.kolmafia.KoLmafia;
-import net.sourceforge.kolmafia.KoLmafiaCLI;
-import net.sourceforge.kolmafia.Modifiers;
-import net.sourceforge.kolmafia.RequestLogger;
+import net.sourceforge.kolmafia.*;
 import net.sourceforge.kolmafia.moods.MoodManager;
 import net.sourceforge.kolmafia.objectpool.ConcoctionPool;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
@@ -1543,27 +1536,12 @@ public class Maximizer {
     int itemId = -1;
     FamiliarData enthroned = Maximizer.best.getEnthroned();
     FamiliarData bjorned = Maximizer.best.getBjorned();
-    String edPiece = Maximizer.best.getEdPiece();
-    String snowsuit = Maximizer.best.getSnowsuit();
-    String retroCape = Maximizer.best.getRetroCape();
-    String backupCamera = Maximizer.best.getBackupCamera();
-    String unbreakableUmbrella = Maximizer.best.getUnbreakableUmbrella();
+    var modeables = Maximizer.best.getModeables();
+    var currentModeables = Modeable.getStateMap();
+    var setModeables = Modeable.getBooleanMap();
     AdventureResult curr = EquipmentManager.getEquipment(slot);
     FamiliarData currEnthroned = KoLCharacter.getEnthroned();
     FamiliarData currBjorned = KoLCharacter.getBjorned();
-    String currEdPiece = Preferences.getString("edPiece");
-    Boolean setEdPiece = false;
-    String currSnowsuit = Preferences.getString("snowsuit");
-    Boolean setSnowsuit = false;
-    String currRetroCape =
-        Preferences.getString("retroCapeSuperhero")
-            + " "
-            + Preferences.getString("retroCapeWashingInstructions");
-    Boolean setRetroCape = false;
-    String currBackupCamera = Preferences.getString("backupCameraMode");
-    Boolean setBackupCamera = false;
-    String currUmbrella = Preferences.getString("umbrellaState");
-    Boolean setUmbrella = false;
 
     if (item == null || item.getItemId() == 0) {
       item = EquipmentRequest.UNEQUIP;
@@ -1619,16 +1597,12 @@ public class Maximizer {
       spec.setEnthroned(enthroned);
     } else if (itemId == ItemPool.BUDDY_BJORN) {
       spec.setBjorned(bjorned);
-    } else if (itemId == ItemPool.CROWN_OF_ED) {
-      spec.setEdPiece(edPiece);
-    } else if (itemId == ItemPool.SNOW_SUIT) {
-      spec.setSnowsuit(snowsuit);
-    } else if (itemId == ItemPool.KNOCK_OFF_RETRO_SUPERHERO_CAPE) {
-      spec.setRetroCape(retroCape);
-    } else if (itemId == ItemPool.BACKUP_CAMERA) {
-      spec.setBackupCamera(backupCamera);
-    } else if (itemId == ItemPool.UNBREAKABLE_UMBRELLA) {
-      spec.setUnbreakableUmbrella(unbreakableUmbrella);
+    } else {
+      var modeable = Modeable.find(itemId);
+
+      if (modeable != null) {
+        spec.setModeable(modeable, modeables.get(modeable));
+      }
     }
 
     double delta = spec.getScore() - current;

--- a/src/net/sourceforge/kolmafia/request/UmbrellaRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UmbrellaRequest.java
@@ -2,6 +2,8 @@ package net.sourceforge.kolmafia.request;
 
 import net.sourceforge.kolmafia.preferences.Preferences;
 
+import java.util.Arrays;
+
 public class UmbrellaRequest extends GenericRequest {
   public UmbrellaRequest() {
     super("choice.php");
@@ -35,6 +37,14 @@ public class UmbrellaRequest extends GenericRequest {
 
     public void set() {
       Preferences.setString("umbrellaState", this.name);
+    }
+
+    public static Form find(final String name) {
+      if (name.equals("twirling")) {
+        return Form.TWIRL;
+      }
+
+      return Arrays.stream(values()).filter(f -> f.name.startsWith(name)).findAny().orElse(null);
     }
   }
 

--- a/src/net/sourceforge/kolmafia/request/UmbrellaRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UmbrellaRequest.java
@@ -1,8 +1,7 @@
 package net.sourceforge.kolmafia.request;
 
-import net.sourceforge.kolmafia.preferences.Preferences;
-
 import java.util.Arrays;
+import net.sourceforge.kolmafia.preferences.Preferences;
 
 public class UmbrellaRequest extends GenericRequest {
   public UmbrellaRequest() {

--- a/src/net/sourceforge/kolmafia/textui/command/AbstractModeCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AbstractModeCommand.java
@@ -1,0 +1,25 @@
+package net.sourceforge.kolmafia.textui.command;
+
+public abstract class AbstractModeCommand extends AbstractCommand {
+    /**
+     * Basic side-effect-less command validation
+     * @param command Command string
+     * @param parameters Parameters as a string
+     * @return Whether command is valid
+     */
+    public boolean validate(final String command, final String parameters) {
+        return true;
+    }
+
+    /**
+     * Normalise parameters to the value expected in modifiers.txt
+     *
+     * For example, one might specify "ml" to the "umbrella" command, but the value to compare in
+     * state would be "broken".
+     * @param parameters Input parameters
+     * @return Appropriate state value
+     */
+    public String normalize(final String parameters) {
+        return parameters;
+    }
+}

--- a/src/net/sourceforge/kolmafia/textui/command/AbstractModeCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AbstractModeCommand.java
@@ -1,25 +1,27 @@
 package net.sourceforge.kolmafia.textui.command;
 
 public abstract class AbstractModeCommand extends AbstractCommand {
-    /**
-     * Basic side-effect-less command validation
-     * @param command Command string
-     * @param parameters Parameters as a string
-     * @return Whether command is valid
-     */
-    public boolean validate(final String command, final String parameters) {
-        return true;
-    }
+  /**
+   * Basic side-effect-less command validation
+   *
+   * @param command Command string
+   * @param parameters Parameters as a string
+   * @return Whether command is valid
+   */
+  public boolean validate(final String command, final String parameters) {
+    return true;
+  }
 
-    /**
-     * Normalise parameters to the value expected in modifiers.txt
-     *
-     * For example, one might specify "ml" to the "umbrella" command, but the value to compare in
-     * state would be "broken".
-     * @param parameters Input parameters
-     * @return Appropriate state value
-     */
-    public String normalize(final String parameters) {
-        return parameters;
-    }
+  /**
+   * Normalise parameters to the value expected in modifiers.txt
+   *
+   * <p>For example, one might specify "ml" to the "umbrella" command, but the value to compare in
+   * state would be "broken".
+   *
+   * @param parameters Input parameters
+   * @return Appropriate state value
+   */
+  public String normalize(final String parameters) {
+    return parameters;
+  }
 }

--- a/src/net/sourceforge/kolmafia/textui/command/BackupCameraCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/BackupCameraCommand.java
@@ -6,12 +6,19 @@ import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.InventoryManager;
 
-public class BackupCameraCommand extends AbstractCommand {
+import java.util.Arrays;
+
+public class BackupCameraCommand extends AbstractModeCommand {
   public BackupCameraCommand() {
     this.usage = " [ml | meat | init | (reverser on | off )] - set your backup camera mode";
   }
 
   public static final String[][] MODE = {{"ml", "1"}, {"meat", "2"}, {"init", "3"}};
+
+  @Override
+  public boolean validate(final String command, final String parameters) {
+    return Arrays.stream(MODE).anyMatch(m -> m[0].equals(parameters));
+  }
 
   @Override
   public void run(final String cmd, final String parameters) {

--- a/src/net/sourceforge/kolmafia/textui/command/BackupCameraCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/BackupCameraCommand.java
@@ -1,12 +1,11 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import java.util.Arrays;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.InventoryManager;
-
-import java.util.Arrays;
 
 public class BackupCameraCommand extends AbstractModeCommand {
   public BackupCameraCommand() {

--- a/src/net/sourceforge/kolmafia/textui/command/EdPieceCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/EdPieceCommand.java
@@ -11,7 +11,9 @@ import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 
-public class EdPieceCommand extends AbstractCommand {
+import java.util.Arrays;
+
+public class EdPieceCommand extends AbstractModeCommand {
   public static final String[][] ANIMAL = {
     {"bear", "muscle", "1", "Muscle: +20; +2 Muscle Stats Per Fight"},
     {"owl", "mysticality", "2", "Mysticality: +20; +2 Mysticality Stats Per Fight"},
@@ -30,6 +32,11 @@ public class EdPieceCommand extends AbstractCommand {
   public EdPieceCommand() {
     this.usage =
         "[?] <animal> - place a golden animal on the Crown of Ed (and equip it if unequipped)";
+  }
+
+  @Override
+  public boolean validate(final String command, final String parameters) {
+    return Arrays.stream(ANIMAL).anyMatch(a -> parameters.equalsIgnoreCase(a[0]));
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/textui/command/EdPieceCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/EdPieceCommand.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import java.util.Arrays;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.KoLmafiaCLI;
@@ -10,8 +11,6 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.EquipmentManager;
-
-import java.util.Arrays;
 
 public class EdPieceCommand extends AbstractModeCommand {
   public static final String[][] ANIMAL = {

--- a/src/net/sourceforge/kolmafia/textui/command/RetroCapeCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/RetroCapeCommand.java
@@ -10,13 +10,22 @@ import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import net.sourceforge.kolmafia.session.InventoryManager;
 
-public class RetroCapeCommand extends AbstractCommand {
+import java.util.Arrays;
+
+public class RetroCapeCommand extends AbstractModeCommand {
   public static final String[] SUPERHEROS = {"vampire", "heck", "robot"};
   public static final String[] WASHING_INSTRUCTIONS = {"hold", "thrill", "kiss", "kill"};
 
   public RetroCapeCommand() {
     this.usage =
         " [muscle | mysticality | moxie | vampire | heck | robot] [hold | thrill | kiss | kill]";
+  }
+
+  @Override
+  public boolean validate(final String command, final String parameters) {
+    String[] parts = parameters.split(" ");
+    return Arrays.asList(SUPERHEROS).contains(parts[0])
+            && Arrays.asList(WASHING_INSTRUCTIONS).contains(parts[1]);
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/textui/command/RetroCapeCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/RetroCapeCommand.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import java.util.Arrays;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
@@ -9,8 +10,6 @@ import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import net.sourceforge.kolmafia.session.InventoryManager;
-
-import java.util.Arrays;
 
 public class RetroCapeCommand extends AbstractModeCommand {
   public static final String[] SUPERHEROS = {"vampire", "heck", "robot"};
@@ -25,7 +24,7 @@ public class RetroCapeCommand extends AbstractModeCommand {
   public boolean validate(final String command, final String parameters) {
     String[] parts = parameters.split(" ");
     return Arrays.asList(SUPERHEROS).contains(parts[0])
-            && Arrays.asList(WASHING_INSTRUCTIONS).contains(parts[1]);
+        && Arrays.asList(WASHING_INSTRUCTIONS).contains(parts[1]);
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/textui/command/SnowsuitCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/SnowsuitCommand.java
@@ -9,7 +9,9 @@ import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 
-public class SnowsuitCommand extends AbstractCommand {
+import java.util.Arrays;
+
+public class SnowsuitCommand extends AbstractModeCommand {
   public static final String[][] DECORATION = {
     {"eyebrows", "1"},
     {"smirk", "2"},
@@ -22,6 +24,15 @@ public class SnowsuitCommand extends AbstractCommand {
     this.usage = "[?] <decoration> - decorate Snowsuit (and equip it if unequipped)";
   }
 
+  private String getChoice(final String parameters) {
+    return Arrays.stream(DECORATION).filter(d -> d[0].equalsIgnoreCase(parameters)).map(d -> d[1]).findAny().orElse(null);
+  }
+
+  @Override
+  public boolean validate(final String command, final String parameters) {
+    return getChoice(parameters) != null;
+  }
+
   @Override
   public void run(final String cmd, String parameters) {
     String currentDecoration = Preferences.getString("snowsuit");
@@ -32,17 +43,9 @@ public class SnowsuitCommand extends AbstractCommand {
     }
 
     String decoration = parameters;
-    String choice = "0";
+    String choice = getChoice(decoration);
 
-    for (int i = 0; i < SnowsuitCommand.DECORATION.length; i++) {
-      if (decoration.equalsIgnoreCase(SnowsuitCommand.DECORATION[i][0])) {
-        choice = SnowsuitCommand.DECORATION[i][1];
-        decoration = SnowsuitCommand.DECORATION[i][0];
-        break;
-      }
-    }
-
-    if (choice.equals("0")) {
+    if (choice == null) {
       KoLmafia.updateDisplay(
           "Decoration "
               + decoration

--- a/src/net/sourceforge/kolmafia/textui/command/SnowsuitCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/SnowsuitCommand.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import java.util.Arrays;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestThread;
@@ -8,8 +9,6 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.EquipmentManager;
-
-import java.util.Arrays;
 
 public class SnowsuitCommand extends AbstractModeCommand {
   public static final String[][] DECORATION = {
@@ -25,7 +24,11 @@ public class SnowsuitCommand extends AbstractModeCommand {
   }
 
   private String getChoice(final String parameters) {
-    return Arrays.stream(DECORATION).filter(d -> d[0].equalsIgnoreCase(parameters)).map(d -> d[1]).findAny().orElse(null);
+    return Arrays.stream(DECORATION)
+        .filter(d -> d[0].equalsIgnoreCase(parameters))
+        .map(d -> d[1])
+        .findAny()
+        .orElse(null);
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/textui/command/UmbrellaCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/UmbrellaCommand.java
@@ -1,16 +1,14 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import java.util.Map;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.request.GenericRequest;
-import net.sourceforge.kolmafia.request.UmbrellaRequest;
 import net.sourceforge.kolmafia.request.UmbrellaRequest.Form;
 import net.sourceforge.kolmafia.session.InventoryManager;
-
-import java.util.Map;
 
 public class UmbrellaCommand extends AbstractModeCommand {
   public UmbrellaCommand() {
@@ -18,14 +16,14 @@ public class UmbrellaCommand extends AbstractModeCommand {
         "[ml | item | dr | weapon | spell | nc | broken | forward | bucket | pitchfork | twirling | cocoon] - fold your Umbrella";
   }
 
-  private static Map<String, String> SHORTHAND_MAP = Map.ofEntries(
+  private static Map<String, String> SHORTHAND_MAP =
+      Map.ofEntries(
           Map.entry("ml", "broken"),
           Map.entry("dr", "forward-facing"),
           Map.entry("item", "bucket style"),
           Map.entry("weapon", "pitchfork style"),
           Map.entry("spell", "constantly twirling"),
-          Map.entry("nc", "cocoon")
-  );
+          Map.entry("nc", "cocoon"));
 
   public Form getForm(final String parameter) {
     return Form.find(normalize(parameter));


### PR DESCRIPTION
There are a number of items that are configured via a preference. They all have identical implementation over several files and are generally problematic to implement (see: umbrella, implementation of which was non-obvious to anyone but seasoned contributors).

This is some code I worked on a few months ago to bring that into a new class type. I need to write tests for it but I present it here for feedback and thoughts on my implementation