### PR TITLE
log if KoL's modified familiar weight differs from KoLmafia's

### DIFF
--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -458,6 +458,12 @@ public class FamiliarData implements Comparable<FamiliarData> {
     }
 
     this.feasted = feasted;
+
+    // Get modified weight excluding hidden weight modifiers
+    int modified = this.getModifiedWeight(false, true);
+    if (weight != modified) {
+      RequestLogger.printLine("Familiar weight: KoL = " + weight + " KoLmafia = " + modified);
+    }
   }
 
   public final void setName(final String name) {

--- a/test/internal/helpers/Networking.java
+++ b/test/internal/helpers/Networking.java
@@ -10,6 +10,8 @@ import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
 
 public class Networking {
@@ -18,6 +20,15 @@ public class Networking {
       return Files.readString(Paths.get(path)).trim();
     } catch (IOException e) {
       Assertions.fail("Failed to load HTML file: " + path);
+      throw new AssertionError(e);
+    }
+  }
+
+  public static JSONObject json(String str) {
+    try {
+      return new JSONObject(str);
+    } catch (JSONException e) {
+      Assertions.fail("Failed to parse JSON");
       throw new AssertionError(e);
     }
   }

--- a/test/net/sourceforge/kolmafia/FamiliarDataTest.java
+++ b/test/net/sourceforge/kolmafia/FamiliarDataTest.java
@@ -23,7 +23,6 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -170,16 +169,16 @@ public class FamiliarDataTest {
 
   @Nested
   class API {
-    @AfterEach
-    private void beforeEach() {
+    @BeforeAll
+    private static void beforeAll() {
       // Other tests add familiars to the character
       // Start clean.
       KoLCharacter.reset("");
       KoLCharacter.reset("familiar data test");
     }
 
-    @BeforeEach
-    private void afterAll() {
+    @AfterEach
+    private void afterEach() {
       // ApiRequest.parseStatus() sets all sorts of stuff
       // Reset the character to eliminate leaks to other tests
       KoLCharacter.reset("");

--- a/test/net/sourceforge/kolmafia/FamiliarDataTest.java
+++ b/test/net/sourceforge/kolmafia/FamiliarDataTest.java
@@ -1,17 +1,30 @@
 package net.sourceforge.kolmafia;
 
+import static internal.helpers.Networking.html;
+import static internal.helpers.Networking.json;
 import static internal.helpers.Player.addEffect;
+import static internal.helpers.Player.addSkill;
+import static internal.helpers.Player.equip;
+import static internal.helpers.Player.inPath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import internal.helpers.Cleanups;
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.ApiRequest;
+import net.sourceforge.kolmafia.session.EquipmentManager;
+import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class FamiliarDataTest {
@@ -153,5 +166,57 @@ public class FamiliarDataTest {
     assertFalse(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_PROTEIN));
     assertFalse(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_ENERGY));
     assertFalse(KoLCharacter.hasCombatSkill(SkillPool.CONVERT_MATTER_TO_POMADE));
+  }
+
+  @Nested
+  class API {
+    @AfterEach
+    private void beforeEach() {
+      // Other tests add familiars to the character
+      // Start clean.
+      KoLCharacter.reset("");
+      KoLCharacter.reset("familiar data test");
+    }
+
+    @BeforeEach
+    private void afterAll() {
+      // ApiRequest.parseStatus() sets all sorts of stuff
+      // Reset the character to eliminate leaks to other tests
+      KoLCharacter.reset("");
+      KoLCharacter.reset("familiar data test");
+    }
+
+    @Test
+    public void canSetFamiliarFromApi() {
+      String text = html("request/test_quantum_terrarium_api.json");
+      JSONObject JSON = json(text);
+
+      // Here are the attributes relevant to familiars
+      int famId = JSON.getInt("familiar");
+      int famExp = JSON.getInt("familiarexp");
+      String famPic = JSON.getString("familiarpic");
+      int famLevel = JSON.getInt("famlevel");
+      boolean feasted = JSON.getInt("familiar_wellfed") == 1;
+
+      Cleanups cleanups =
+          new Cleanups(
+              inPath(Path.QUANTUM),
+              addSkill("Amphibian Sympathy"),
+              equip(EquipmentManager.FAMILIAR, "astral pet sweater"));
+
+      try (cleanups) {
+        ApiRequest.parseStatus(JSON);
+        FamiliarData current = KoLCharacter.getFamiliar();
+        assertEquals(famId, current.getId());
+        assertEquals(famExp, current.getTotalExperience());
+        assertEquals(feasted, current.getFeasted());
+        // Image can change, so current image is in KoLCharacter
+        assertEquals(famPic + ".gif", KoLCharacter.getFamiliarImage());
+        // Base Weight
+        assertEquals(Math.min(20, Math.sqrt(famExp)), current.getWeight());
+        // Modified Weight
+        assertEquals(famLevel, current.getModifiedWeight());
+      }
+    }
   }
 }


### PR DESCRIPTION
When I worked on improving the compact sidepane for Quantum Terrarium, I noticed it initially showed the incorrect base weight of the familiar. This fixed itself with the next api request.

I discovered that ApiRequest (and CharpaneRequest) were calling a FamiliarData method to check - and "fix" - if KoL's idea of modified familiar weight disagreed with KoLmafia's. It "fixed" it by changing the familiar's base weight. That is incorrect. The base weight is based on experience - and we track that and adjust as necessary.

If we don't do that, that is a KoLmafia bug.

Similarly, if KoL displays a modified weight which disagrees with our calculation, that is a KoLmafia bug.

I removed the adjustment to the base familiar weight - and, sure enough, a user noticed that we did not support Fidoxene.

The code I removed had a commented out log message. The comment said "The following is informational, not an error, but it confuses people, so don't print it."

I would prefer to have an "infrmational" log message reporting a KoLmafia bug which "confuses" people and convinces them to report the bug than no message - and then they are "confused" when the compact side pane and the browser charpane disagree.

So I put back a log message - and still do not incorrectly adjust the base familiar weight.