### PR TITLE
snow snow suit shrinks, recalculate adjustments

### DIFF
--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -23,6 +23,7 @@ import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
+import net.sourceforge.kolmafia.request.LoginRequest;
 import net.sourceforge.kolmafia.request.StandardRequest;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import net.sourceforge.kolmafia.session.YouRobotManager;
@@ -453,6 +454,12 @@ public class FamiliarData implements Comparable<FamiliarData> {
 
     // Sanity check: don't adjust NO_FAMILIAR
     if (this.id == -1) {
+      return;
+    }
+
+    // If we are logging in, api.php is called very early. Before reading
+    // charsheet.php
+    if (LoginRequest.isInstanceRunning()) {
       return;
     }
 

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -3175,7 +3175,7 @@ public class FightRequest extends GenericRequest {
   // FightRequest.lastResponseText instead.
   // Note that this is not run if the combat is finished by
   // rollover-runaway, saber, or similar mechanic.
-  private static void updateFinalRoundData(final String responseText, final boolean won) {
+  public static void updateFinalRoundData(final String responseText, final boolean won) {
     MonsterData monster = MonsterStatusTracker.getLastMonster();
     String monsterName = monster != null ? monster.getName() : "";
     SpecialMonster special = FightRequest.specialMonsterCategory(monsterName);

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -4244,7 +4244,10 @@ public class FightRequest extends GenericRequest {
       }
 
       if (KoLCharacter.hasEquipped(ItemPool.SNOW_SUIT, EquipmentManager.FAMILIAR)) {
-        Preferences.increment("_snowSuitCount", 1, 75, false);
+        if (Preferences.getInteger("_snowSuitCount") < 75
+            && Preferences.increment("_snowSuitCount") % 5 == 0) {
+          KoLCharacter.recalculateAdjustments();
+        }
       }
 
       if (KoLCharacter.hasEquipped(ItemPool.get(ItemPool.XIBLAXIAN_HOLOWRIST_PUTER, 1))) {

--- a/test/net/sourceforge/kolmafia/request/FightRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FightRequestTest.java
@@ -5,6 +5,7 @@ import static internal.helpers.Player.addItem;
 import static internal.helpers.Player.equip;
 import static internal.helpers.Player.fightingMonster;
 import static internal.helpers.Player.inAnapest;
+import static internal.helpers.Player.setFamiliar;
 import static internal.helpers.Player.setProperty;
 import static internal.helpers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -688,6 +689,32 @@ public class FightRequestTest {
     try (cleanups) {
       parseCombatData(responseHtml);
       assertEquals(10 + sweatChange, Preferences.getInteger("sweat"));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 4, 75})
+  public void canUpdateSnowSuitUsage(int count) {
+    var cleanups =
+        new Cleanups(
+            setFamiliar(FamiliarPool.CORNBEEFADON),
+            equip(EquipmentManager.FAMILIAR, "Snow Suit"),
+            setProperty("_snowSuitCount", count));
+
+    try (cleanups) {
+      // Calculate initial Familiar Weight Modifier
+      KoLCharacter.recalculateAdjustments();
+      int property = count;
+      int expected = 20 - (property / 5);
+      int adjustment = KoLCharacter.getFamiliarWeightAdjustment();
+      assertEquals(expected, adjustment);
+      FightRequest.updateFinalRoundData("", true);
+      // We expect the property to increment, but cap at 75
+      property = Math.min(75, property + 1);
+      assertEquals(property, Preferences.getInteger("_snowSuitCount"));
+      expected = 20 - (property / 5);
+      adjustment = KoLCharacter.getFamiliarWeightAdjustment();
+      assertEquals(expected, adjustment);
     }
   }
 }


### PR DESCRIPTION
2 little fixes:

1) When you log in, KoLmafia refreshes your session. The very first thing it does is to fetch api.php to see if it redirects to valhalla. If it does not so-redirect, it parses the status and learns all sorts of stuff about equipment, effects, current familiar, and so on. Note that it has not looked at your char sheet or terrarium yet. Therefore, if you have Amphibian Sympathy, we don't know it, and cannot accurately calculate the modified weight of your familiar.

Therefore, don't check modified weight if you are currently logging in. Subsequent session refreshes work fine.

2) If a familiar is wearing a Snow Suit, it has Familiar Weight +20. Every five combats (up to 75), that decrements by 1, to a minimum of Familiar Weight +5. We track that in a property, and the modifier uses that property, but we weren't noticing it in the compact side pane because we were not recalculating adjustments.

Now we do so when incrementing that property would actually change the Familiar Weight modifier of the Snow Suit.