### PR TITLE
Fix maximizer failing to understand what absorbable equipment is in GNoob

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -24,7 +24,6 @@ import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.CandyDatabase;
 import net.sourceforge.kolmafia.persistence.ConsumablesDatabase;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
-import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.ItemFinder;
 import net.sourceforge.kolmafia.persistence.ItemFinder.Match;
@@ -255,8 +254,8 @@ public class Maximizer {
         if (!ItemDatabase.isTradeable(itemId) && !ItemDatabase.isGiftItem(itemId)) {
           continue;
         }
-        // Can only get it from Equipment
-        if (!EquipmentDatabase.isEquipment(itemId)) {
+        // Can only get it from Equipment (not including familiar equipment)
+        if (!ItemDatabase.isEquipment(itemId) || ItemDatabase.isFamiliarEquipment(itemId)) {
           continue;
         }
         MaximizerSpeculation spec = new MaximizerSpeculation();

--- a/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
@@ -237,7 +237,13 @@ public class EquipmentDatabase {
     }
   }
 
-  public static boolean isEquipment(final int type) {
+  /**
+   * Returns true if a given consumption type relates to equipment
+   *
+   * @param type Consumption type constant
+   * @return True if the type relates to equipment
+   */
+  public static boolean isEquipmentType(final int type) {
     switch (type) {
       case KoLConstants.EQUIP_ACCESSORY:
       case KoLConstants.EQUIP_CONTAINER:
@@ -246,6 +252,7 @@ public class EquipmentDatabase {
       case KoLConstants.EQUIP_PANTS:
       case KoLConstants.EQUIP_WEAPON:
       case KoLConstants.EQUIP_OFFHAND:
+      case KoLConstants.EQUIP_FAMILIAR:
         return true;
     }
 

--- a/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
@@ -1015,7 +1015,7 @@ public class ItemDatabase {
     RequestLogger.printLine(printMe);
     RequestLogger.updateSessionLog(printMe);
 
-    if (EquipmentDatabase.isEquipment(usage)) {
+    if (EquipmentDatabase.isEquipmentType(usage)) {
       EquipmentDatabase.newEquipment = true;
 
       // Get power from description, if otherwise unknown
@@ -1918,18 +1918,7 @@ public class ItemDatabase {
 
   public static final boolean isEquipment(final int itemId) {
     int useType = ItemDatabase.useTypeById.get(itemId);
-    switch (useType) {
-      case KoLConstants.EQUIP_ACCESSORY:
-      case KoLConstants.EQUIP_CONTAINER:
-      case KoLConstants.EQUIP_HAT:
-      case KoLConstants.EQUIP_SHIRT:
-      case KoLConstants.EQUIP_PANTS:
-      case KoLConstants.EQUIP_WEAPON:
-      case KoLConstants.EQUIP_OFFHAND:
-      case KoLConstants.EQUIP_FAMILIAR:
-        return true;
-    }
-    return false;
+    return EquipmentDatabase.isEquipmentType(useType);
   }
 
   public static final boolean isFood(final int itemId) {

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -406,8 +406,6 @@ public class MaximizerTest {
     }
 
     @Test
-    @Disabled(
-        "Doesn't try to absorb the turtle, even though this should use the same code as the mask case above")
     public void canAbsorbHelmetTurtleForEnchants() {
       final var cleanups = new Cleanups(inPath(Path.GELATINOUS_NOOB), addItem("helmet turtle"));
 

--- a/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
@@ -25,15 +25,15 @@ public class EquipmentDatabaseTest {
 
   @Test
   public void itShouldKnowWhatIsEquipment() {
-    assertTrue(EquipmentDatabase.isEquipment(KoLConstants.EQUIP_ACCESSORY));
-    assertTrue(EquipmentDatabase.isEquipment(KoLConstants.EQUIP_CONTAINER));
-    assertTrue(EquipmentDatabase.isEquipment(KoLConstants.EQUIP_HAT));
-    assertTrue(EquipmentDatabase.isEquipment(KoLConstants.EQUIP_OFFHAND));
-    assertTrue(EquipmentDatabase.isEquipment(KoLConstants.EQUIP_PANTS));
-    assertTrue(EquipmentDatabase.isEquipment(KoLConstants.EQUIP_SHIRT));
-    assertTrue(EquipmentDatabase.isEquipment(KoLConstants.EQUIP_WEAPON));
-    assertFalse(EquipmentDatabase.isEquipment(KoLConstants.EQUIP_FAMILIAR));
-    assertFalse(EquipmentDatabase.isEquipment(-1));
+    assertTrue(EquipmentDatabase.isEquipmentType(KoLConstants.EQUIP_ACCESSORY));
+    assertTrue(EquipmentDatabase.isEquipmentType(KoLConstants.EQUIP_CONTAINER));
+    assertTrue(EquipmentDatabase.isEquipmentType(KoLConstants.EQUIP_HAT));
+    assertTrue(EquipmentDatabase.isEquipmentType(KoLConstants.EQUIP_OFFHAND));
+    assertTrue(EquipmentDatabase.isEquipmentType(KoLConstants.EQUIP_PANTS));
+    assertTrue(EquipmentDatabase.isEquipmentType(KoLConstants.EQUIP_SHIRT));
+    assertTrue(EquipmentDatabase.isEquipmentType(KoLConstants.EQUIP_WEAPON));
+    assertFalse(EquipmentDatabase.isEquipmentType(KoLConstants.EQUIP_FAMILIAR));
+    assertFalse(EquipmentDatabase.isEquipmentType(-1));
   }
 
   @Test


### PR DESCRIPTION
We really need to turn all these static integers into enums, we would totally avoid issues like this.