### PR TITLE
Fixing asdon banish

### DIFF
--- a/src/net/sourceforge/kolmafia/session/BanishManager.java
+++ b/src/net/sourceforge/kolmafia/session/BanishManager.java
@@ -407,16 +407,11 @@ public class BanishManager {
     resetIf(m -> m.getBanisher().equals(banisher));
   }
 
-  public static final void removeBanishByMonster(final String monster) {
-    resetIf(m -> m.getMonsterName().equals(monster));
-  }
-
   private static final void removeOldestBanish(final Banisher banisher) {
     banishedMonsters.stream()
         .filter(b -> b.getBanisher().equals(banisher))
         .min(Comparator.comparingInt(BanishedMonster::getTurnBanished))
-        .map(BanishedMonster::getMonsterName)
-        .ifPresent(BanishManager::removeBanishByMonster);
+        .ifPresent(b -> resetIf(m -> m == b));
   }
 
   public static final boolean isBanished(final String monster) {

--- a/test/net/sourceforge/kolmafia/session/BanishManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/BanishManagerTest.java
@@ -207,6 +207,40 @@ class BanishManagerTest {
   }
 
   @Test
+  void oneExpiringBanishLeavesTheOther() {
+    KoLCharacter.setCurrentRun(100);
+    BanishManager.banishMonster(SPOOKY_MUMMY, Banisher.SPRING_LOADED_FRONT_BUMPER);
+    KoLCharacter.setCurrentRun(105);
+    BanishManager.banishMonster(SPOOKY_MUMMY, Banisher.STINKY_CHEESE_EYE);
+    KoLCharacter.setCurrentRun(120);
+    var data = BanishManager.getBanishData();
+    assertThat(data, arrayWithSize(1));
+    assertThat(
+        data,
+        arrayContaining(
+            arrayContaining(
+                "spooky mummy", "Spring-Loaded Front Bumper", "100", "10 or Until Rollover")));
+  }
+
+  @Test
+  void oneOverwritingBanishLeavesTheOther() {
+    KoLCharacter.setCurrentRun(100);
+    BanishManager.banishMonster(SPOOKY_MUMMY, Banisher.SPRING_LOADED_FRONT_BUMPER);
+    KoLCharacter.setCurrentRun(105);
+    BanishManager.banishMonster(SPOOKY_MUMMY, Banisher.STINKY_CHEESE_EYE);
+    KoLCharacter.setCurrentRun(106);
+    BanishManager.banishMonster(SPOOKY_MUMMY, Banisher.STINKY_CHEESE_EYE);
+    var data = BanishManager.getBanishData();
+    assertThat(data, arrayWithSize(2));
+    assertThat(
+        data,
+        arrayContaining(
+            arrayContaining(
+                "spooky mummy", "Spring-Loaded Front Bumper", "100", "24 or Until Rollover"),
+            arrayContaining("spooky mummy", "stinky cheese eye", "106", "10")));
+  }
+
+  @Test
   void banishMonsterDoesNotWorkOnNonExistant() {
     KoLCharacter.setCurrentRun(123);
 

--- a/test/net/sourceforge/kolmafia/session/BanishManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/BanishManagerTest.java
@@ -291,6 +291,22 @@ class BanishManagerTest {
   }
 
   @Test
+  void poppingFromQueueDoesNotResetUnrelatedBanish() {
+    KoLCharacter.setCurrentRun(14);
+    Preferences.setString(
+        "banishedMonsters",
+        "crate:banishing shout:5:zmobie:banishing shout:10:sabre-toothed lime:banishing shout:12:crate:snokebomb:9");
+    BanishManager.loadBanishedMonsters();
+
+    BanishManager.banishMonster(SCARY_PIRATE, Banisher.BANISHING_SHOUT);
+
+    assertTrue(BanishManager.isBanished("scary pirate"));
+    assertTrue(BanishManager.isBanished("sabre-toothed lime"));
+    assertTrue(BanishManager.isBanished("zmobie"));
+    assertTrue(BanishManager.isBanished("crate"));
+  }
+
+  @Test
   void removeBanishByBanisher() {
     KoLCharacter.setCurrentRun(128);
     Preferences.setString(
@@ -304,22 +320,6 @@ class BanishManagerTest {
         "banishedMonsters",
         isSetTo(
             "spooky vampire:ice house:20:smut orc nailer:banishing shout:115:unhinged survivor:Feel Hatred:119:grizzled survivor:Reflex Hammer:119:cat-alien:mafia middle finger ring:119:alielf:v for vivala mask:119:whiny survivor:stinky cheese eye:119:crate:louder than bomb:119:fluffy bunny:Be a Mind Master:119:paper towelgeist:divine champagne popper:128"));
-  }
-
-  @Test
-  void removeBanishByMonster() {
-    KoLCharacter.setCurrentRun(128);
-    Preferences.setString(
-        "banishedMonsters",
-        "spooky vampire:ice house:20:smut orc nailer:banishing shout:115:gingerbread lawyer:snokebomb:118:unhinged survivor:Feel Hatred:119:grizzled survivor:Reflex Hammer:119:cat-alien:mafia middle finger ring:119:alielf:v for vivala mask:119:whiny survivor:stinky cheese eye:119:crate:louder than bomb:119:fluffy bunny:Be a Mind Master:119:paper towelgeist:divine champagne popper:128");
-    BanishManager.loadBanishedMonsters();
-
-    BanishManager.removeBanishByMonster("crate");
-
-    assertThat(
-        "banishedMonsters",
-        isSetTo(
-            "spooky vampire:ice house:20:smut orc nailer:banishing shout:115:gingerbread lawyer:snokebomb:118:unhinged survivor:Feel Hatred:119:grizzled survivor:Reflex Hammer:119:cat-alien:mafia middle finger ring:119:alielf:v for vivala mask:119:whiny survivor:stinky cheese eye:119:fluffy bunny:Be a Mind Master:119:paper towelgeist:divine champagne popper:128"));
   }
 
   @Test


### PR DESCRIPTION
Fixed this issue that people have been complaining about for a while. Ultimately we never want to reset a banish *per monster*, that's not how KoL works on the backend.

Added tests to cover the specific failure that I was fixing, as well as asserting some other things that we want to be true about BanishManager