### PR TITLE
latte lovers member's mug grants its enchantments in Noobcore

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -5471,6 +5471,15 @@ public abstract class KoLCharacter {
       }
     }
 
+    // Do appropriate things for specific items in Noobcore
+    if (KoLCharacter.inNoobcore()) {
+      switch (itemId) {
+        case ItemPool.LATTE_MUG:
+          newModifiers.add(Modifiers.getItemModifiers(itemId));
+          break;
+      }
+    }
+
     // Do appropriate things for specific items
     if (!KoLCharacter.inNoobcore()
         && (!KoLCharacter.inGLover() || KoLCharacter.hasGs(item.getName()))) {

--- a/src/net/sourceforge/kolmafia/request/LatteRequest.java
+++ b/src/net/sourceforge/kolmafia/request/LatteRequest.java
@@ -49,6 +49,10 @@ public class LatteRequest extends GenericRequest {
       this.modifier = modifier;
       this.discovery = discovery;
     }
+
+    public String getModifier() {
+      return this.modifier;
+    }
   }
 
   private static final Latte[] LATTE =
@@ -503,7 +507,8 @@ public class LatteRequest extends GenericRequest {
     super("choice.php");
   }
 
-  public static void refill(final String first, final String second, final String third) {
+  public static Latte[] parseIngredients(
+      final String first, final String second, final String third) {
     Latte[] ingredients = new Latte[3];
 
     for (Latte latte : LATTE) {
@@ -517,6 +522,11 @@ public class LatteRequest extends GenericRequest {
         ingredients[2] = latte;
       }
     }
+    return ingredients;
+  }
+
+  public static void refill(final String first, final String second, final String third) {
+    Latte[] ingredients = parseIngredients(first, second, third);
 
     for (int i = 0; i < 3; ++i) {
       if (ingredients[i] == null) {
@@ -674,24 +684,28 @@ public class LatteRequest extends GenericRequest {
       String message = "Filled your mug with " + first + " " + second + " Latte " + third + ".";
       RequestLogger.printLine(message);
       RequestLogger.updateSessionLog(message);
-
-      ModifierList modList = new ModifierList();
-      for (int i = 0; i < 3; ++i) {
-        ModifierList addModList = Modifiers.splitModifiers(mods[i]);
-        for (Modifier modifier : addModList) {
-          modList.addToModifier(modifier);
-        }
-      }
-
-      Preferences.setString("latteModifier", modList.toString());
-      Modifiers.overrideModifier("Item:[" + ItemPool.LATTE_MUG + "]", modList.toString());
-      KoLCharacter.recalculateAdjustments();
-      KoLCharacter.updateStatus();
+      setLatteEnchantments(mods);
       Preferences.increment("_latteRefillsUsed", 1, 3, false);
       Preferences.setBoolean("_latteBanishUsed", false);
       Preferences.setBoolean("_latteCopyUsed", false);
       Preferences.setBoolean("_latteDrinkUsed", false);
     }
+  }
+
+  public static void setLatteEnchantments(String[] mods) {
+    ModifierList modList = new ModifierList();
+    for (String mod : mods) {
+      ModifierList addModList = Modifiers.splitModifiers(mod);
+      for (Modifier modifier : addModList) {
+        modList.addToModifier(modifier);
+      }
+    }
+
+    String value = modList.toString();
+    Preferences.setString("latteModifier", value);
+    Modifiers.overrideModifier("Item:[" + ItemPool.LATTE_MUG + "]", value);
+    KoLCharacter.recalculateAdjustments();
+    KoLCharacter.updateStatus();
   }
 
   public static final void parseFight(final String location, final String responseText) {

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -48,6 +48,14 @@ public class Player {
     return cleanups;
   }
 
+  public static Cleanups equip(int slot, int itemId) {
+    var cleanups = new Cleanups();
+    EquipmentManager.setEquipment(
+        slot, itemId == -1 ? EquipmentRequest.UNEQUIP : ItemPool.get(itemId));
+    cleanups.add(() -> EquipmentManager.setEquipment(slot, EquipmentRequest.UNEQUIP));
+    return cleanups;
+  }
+
   public static Cleanups addItem(String name) {
     return addItem(name, 1);
   }


### PR DESCRIPTION
Lord President reported that KoLmafia was not picking up familiar weight enchantment from his latte lovers member's mug in Gelatinous Noob.

Wiki says this:

- Wearing equipment provides the attack/defense power, but gives no bonuses from regular enchantments.
   This includes familiar equipment, Valhalla rewards, rollover adventures.
   Unique and unusual enchantments with specially coded effects will generally still work. For example, items like the KoL Con 13 snowglobe that give post-combat drops will activate. Combat skills granted by equipment also remain available, as do outfit bonuses. Choice adventure and quest interactions involving equipment remain unaltered.

Well, OK. I guess the latte lovers member's mug is special.