### PR TITLE
chore: upgrade some stuff to hopefully make the tests less flakey

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,12 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup Java 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: "temurin"
           java-version: "17"
@@ -53,12 +53,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup Java 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: "temurin"
           java-version: "17"
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -120,7 +120,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: "temurin"
           java-version: ${{ matrix.java }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,12 +38,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup Java 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         if: matrix.language == 'java'
         with:
           distribution: "temurin"

--- a/build.gradle
+++ b/build.gradle
@@ -56,14 +56,14 @@ repositories {
 
 dependencies {
 	// Use JUnit Jupiter for running JUnit5 tests.
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.8.1'
-	testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.8.1'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.8.2'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.8.2'
 
 	testImplementation 'org.hamcrest:hamcrest:2.2'
 	testImplementation 'com.spotify:hamcrest-optional:1.2.0'
-	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.1'
-	testImplementation 'org.mockito:mockito-inline:4.0.0'
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
+	testImplementation 'org.mockito:mockito-inline:4.6.1'
 	testImplementation('org.eclipse.xtext:org.eclipse.xtext.xbase.lib:2.12.0') {
 		because 'assertion errors including Location/Range/Position need it'
 	}
@@ -82,12 +82,12 @@ dependencies {
 		builtBy 'compileLibJava'
 	}
 
-	implementation 'net.sourceforge.htmlcleaner:htmlcleaner:2.25'
+	implementation 'net.sourceforge.htmlcleaner:htmlcleaner:2.26'
 	implementation('org.eclipse.lsp4j:org.eclipse.lsp4j:0.12.0') {
 		exclude group: 'org.eclipse.xtend', module: 'org.eclipse.xtend.lib'
 	}
 	implementation 'org.fusesource.jansi:jansi:2.4.0'
-	implementation 'org.json:json:20210307'
+	implementation 'org.json:json:20220320'
 	implementation 'org.mozilla:rhino:1.7.14'
 	implementation 'org.swinglabs:swingx:1.0'
 	implementation 'org.tmatesoft.svnkit:svnkit:1.10.6'


### PR DESCRIPTION
In recent PRs, the ubuntu version of the tests lasts over an hour, apparently without making any progress. Guesses have included "something to do with `@AfterAll`" and "something to do with circular imports". In #870, it happened without any test changes being made at all.

Update some stuff (test dependences + github workflow versions) to hopefully improve the circumstances here. 