### PR TITLE
Add the <main> tag inside <body>, help HtmlDocument recognize the root

### DIFF
--- a/lib/net/java/dev/spellcast/utilities/ChatBuffer.java
+++ b/lib/net/java/dev/spellcast/utilities/ChatBuffer.java
@@ -307,11 +307,11 @@ public class ChatBuffer
 
 		htmlContent.append( "<html><head><style>" );
 		htmlContent.append( this.getStyle() );
-		htmlContent.append( "</style></head><body>" );
+		htmlContent.append( "</style></head><body><main>" );
 
 		htmlContent.append( this.content.toString() );
 
-		htmlContent.append( "</body></html>" );
+		htmlContent.append( "</main></body></html>" );
 
 		return htmlContent.toString();
 	}


### PR DESCRIPTION
Java swingx render sometimes can't recognize the true root element, which we fetch here

https://github.com/libraryaddict/kolmafia/blob/82bc912ef32175281cec391678c5f05fe0ac9b8c/lib/net/java/dev/spellcast/utilities/ChatBuffer.java#L481

Adding debugging, it uses the "content" tag until the document is trimmed to size, then it seems to bug out and declares the <table> tag as the root.

The issue might not be fixed with this, however I can't replicate it anymore with this change with what I was previously doing to trigger the issue, namely "prefref" as tables are obvious when they break.

A better fix likely exists.