### PR TITLE
Correctly report last location if you multifight from an itemMonster

### DIFF
--- a/src/net/sourceforge/kolmafia/RequestLogger.java
+++ b/src/net/sourceforge/kolmafia/RequestLogger.java
@@ -1594,7 +1594,14 @@ public class RequestLogger extends NullStream {
     RequestLogger.updateSessionLog(message);
   }
 
-  public static final void registerLastLocation() {
-    RequestLogger.registerLocation(KoLAdventure.lastLocationName);
+  public static void registerLastLocation() {
+    String location = KoLAdventure.lastLocationName;
+
+    if (location == null) {
+      location =
+          (GenericRequest.itemMonster != null) ? GenericRequest.itemMonster : "Unknown Location";
+    }
+
+    RequestLogger.registerLocation(location);
   }
 }

--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -2814,6 +2814,7 @@ public class GenericRequest implements Runnable {
         return;
     }
 
+    GenericRequest.itemMonster = name;
     KoLAdventure.lastVisitedLocation = null;
     KoLAdventure.lastLocationName = null;
     KoLAdventure.lastLocationURL = location;

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -9,6 +9,7 @@ import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.FamiliarData;
+import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.Modifiers;
@@ -343,5 +344,32 @@ public class Player {
 
   public static Cleanups withPostChoice2(int choice, int decision) {
     return withPostChoice2(choice, decision, "");
+  }
+
+  public static Cleanups withLastLocationName(final String lastLocationName) {
+    var old = KoLAdventure.lastLocationName;
+    KoLAdventure.lastLocationName = lastLocationName;
+    return new Cleanups(
+        () -> {
+          KoLAdventure.lastLocationName = old;
+        });
+  }
+
+  public static Cleanups withMultiFight() {
+    var old = FightRequest.inMultiFight;
+    FightRequest.inMultiFight = true;
+    return new Cleanups(
+        () -> {
+          FightRequest.inMultiFight = old;
+        });
+  }
+
+  public static Cleanups withItemMonster(final String itemMonster) {
+    var old = GenericRequest.itemMonster;
+    GenericRequest.itemMonster = itemMonster;
+    return new Cleanups(
+        () -> {
+          GenericRequest.itemMonster = old;
+        });
   }
 }

--- a/test/net/sourceforge/kolmafia/RequestLoggerTest.java
+++ b/test/net/sourceforge/kolmafia/RequestLoggerTest.java
@@ -1,0 +1,71 @@
+package net.sourceforge.kolmafia;
+
+import static internal.helpers.Player.withItemMonster;
+import static internal.helpers.Player.withLastLocationName;
+import static internal.helpers.Player.withMultiFight;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.*;
+
+import internal.helpers.Cleanups;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class RequestLoggerTest {
+  private String withCapturedLogs(Runnable action) {
+    ByteArrayOutputStream ostream = new ByteArrayOutputStream();
+
+    try (PrintStream out = new PrintStream(ostream, true)) {
+      // Inject custom output stream.
+      RequestLogger.openCustom(out);
+      action.run();
+      RequestLogger.closeCustom();
+    }
+
+    return ostream.toString().trim();
+  }
+
+  @Nested
+  class RegisterLastLocation {
+    @Test
+    public void canReportPreviousLocationInMutliFightInLocation() {
+      var cleanups =
+          new Cleanups(withLastLocationName("The Outskirts of Cobb's Knob"), withMultiFight());
+
+      try (cleanups) {
+        var output = withCapturedLogs(RequestLogger::registerLastLocation);
+
+        assertThat(output, equalTo("[1] The Outskirts of Cobb's Knob"));
+      }
+    }
+
+    @Test
+    public void canReportPreviousLocationInMutliFightWithItemMonster() {
+      var cleanups =
+          new Cleanups(
+              withLastLocationName(null),
+              withMultiFight(),
+              withItemMonster("Combat Lover's Locket"));
+
+      try (cleanups) {
+        var output = withCapturedLogs(RequestLogger::registerLastLocation);
+
+        assertThat(output, equalTo("[1] Combat Lover's Locket"));
+      }
+    }
+
+    @Test
+    public void canReportUnknownLocationInMutliFight() {
+      var cleanups =
+          new Cleanups(withLastLocationName(null), withMultiFight(), withItemMonster(null));
+
+      try (cleanups) {
+        var output = withCapturedLogs(RequestLogger::registerLastLocation);
+
+        assertThat(output, equalTo("[1] Unknown Location"));
+      }
+    }
+  }
+}


### PR DESCRIPTION
I was tired of seeing `[1234] null` when I run a relativity fight from a Combat Lover's Locket fight - i.e. a fight without a location.

We have an existing infrastructure for these fights that are triggered without visiting a location. `itemMonster` might not be the best name for it really its there for handling locationless fights, so let's make sure we use it for some of the newer sources of those.