### PR TITLE
feat: write_ccs and read_ccs functions

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/CcsFileManager.java
+++ b/src/net/sourceforge/kolmafia/textui/CcsFileManager.java
@@ -1,0 +1,58 @@
+package net.sourceforge.kolmafia.textui;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import net.sourceforge.kolmafia.KoLConstants;
+
+public class CcsFileManager {
+
+  private CcsFileManager() {}
+
+  public static byte[] getBytes(String name) {
+    Path path = getPath(name);
+
+    if (path == null) {
+      return new byte[0];
+    }
+
+    if (!Files.exists(path)) {
+      return new byte[0];
+    }
+
+    try {
+      return Files.readAllBytes(path);
+    } catch (IOException e) {
+      return new byte[0];
+    }
+  }
+
+  public static boolean printBytes(String name, byte[] bytes) {
+    Path path = getPath(name);
+
+    if (path == null) {
+      return false;
+    }
+
+    if (!KoLConstants.CCS_LOCATION.exists() && !KoLConstants.CCS_LOCATION.mkdir()) {
+      return false;
+    }
+
+    try {
+      Files.write(path, bytes);
+    } catch (IOException e) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private static Path getPath(String name) {
+    if (name.contains("..") || name.contains("/") || name.contains("\\")) {
+      // forbid both .. and folders
+      return null;
+    }
+
+    return KoLConstants.CCS_LOCATION.toPath().resolve(name + ".ccs");
+  }
+}

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -2088,6 +2088,12 @@ public abstract class RuntimeLibrary {
     params = new Type[] {DataTypes.BUFFER_TYPE, DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("buffer_to_file", DataTypes.BOOLEAN_TYPE, params));
 
+    params = new Type[] {DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("read_ccs", DataTypes.BUFFER_TYPE, params));
+
+    params = new Type[] {DataTypes.BUFFER_TYPE, DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("write_ccs", DataTypes.BOOLEAN_TYPE, params));
+
     // Custom combat helper functions.
 
     params = new Type[] {};
@@ -8069,6 +8075,22 @@ public abstract class RuntimeLibrary {
     byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
     String location = var2.toString();
     return DataFileCache.printBytes(location, bytes);
+  }
+
+  public static Value read_ccs(ScriptRuntime controller, final Value name) {
+    String ccsName = name.toString();
+    byte[] bytes = CcsFileManager.getBytes(ccsName);
+    String string = new String(bytes, StandardCharsets.UTF_8);
+    StringBuffer buffer = new StringBuffer(string);
+    return new Value(DataTypes.BUFFER_TYPE, "", buffer);
+  }
+
+  public static Value write_ccs(ScriptRuntime controller, final Value data, final Value name) {
+    StringBuffer buffer = (StringBuffer) data.rawValue();
+    String string = buffer.toString();
+    byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
+    String ccsName = name.toString();
+    return DataTypes.makeBooleanValue(CcsFileManager.printBytes(ccsName, bytes));
   }
 
   // Custom combat helper functions.

--- a/src/net/sourceforge/kolmafia/textui/javascript/LibraryFunctionStub.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/LibraryFunctionStub.java
@@ -18,6 +18,8 @@ import org.mozilla.javascript.Scriptable;
 public class LibraryFunctionStub extends AshStub {
   private static final long serialVersionUID = 1L;
 
+  private final List<String> bufferFunctions = List.of("buffer_to_file", "write_ccs");
+
   public LibraryFunctionStub(
       Scriptable scope, Scriptable prototype, ScriptRuntime controller, String ashFunctionName) {
     super(scope, prototype, controller, ashFunctionName);
@@ -69,11 +71,12 @@ public class LibraryFunctionStub extends AshStub {
       return "[runtime library]";
     }
 
-    if (ashFunctionName.equals("buffer_to_file") && args.length > 0 && args[0] instanceof String) {
+    if (bufferFunctions.stream().anyMatch(ashFunctionName::equals)
+        && args.length > 0
+        && args[0] instanceof String str) {
       // Manually convert string to buffer, since AshStub.call() cannot match a string argument to a
       // buffer parameter.
       args = args.clone();
-      String str = (String) args[0];
       args[0] = new Value(DataTypes.BUFFER_TYPE, str, new StringBuffer(str));
     }
 


### PR DESCRIPTION
Introduce two new functions:
```
buffer read_ccs(string name)
boolean write_ccs(buffer data, string name)
```

Like `buffer_to_file` and `file_to_buffer` can be used to write to the `data` directory, these can be used to write to the `ccs` directory.

The intended users are script writers who want more control over combats. The main ways of controlling combat at the moment are:

1. ship a CCS file with your script, acknowledging that users can change or delete it, and have it handle all combats (or ship many such scripts)
2. use consult scripts
3. use combat filter functions

The first is unpopular because script writers want to do something very dynamic -- different things depending on which IoTMs, skills, and items the user has available. The second is comprehensive, but can be slow -- each combat, the consult script is checked, and the consult script has to handle all potential monsters -- even if the calling script knows exactly which monster is being fought, which items are available, and what it wants to do (e.g. something more complicated than winning the fight, like polar vortex farming smoke patches).

The third is nice, but sometimes unwieldly. Some functions like `adventure` or `adv1` are convenient and take it as a parameter directly, but others like `reminisce` do not. As such, library authors write code using `visit_url`, `run_choice` and `run_combat`, avoiding the convenience methods to gain full control over the combat.

`write_ccs` is intended as a friendlier way of managing this last option: script authors can set a CCS that runs their macro, call the `reminisce` command, then set everything back (or not, as desired).

As an aside: the [wiki article on buffer_to_file](https://wiki.kolmafia.us/index.php/Buffer_to_file) states that strings should be automatically converted to buffers, but this doesn't seem to happen, and scripts using it assume it can't: for example [excavator](https://github.com/gausie/excavator/blob/1d9e96fb7c34b99dc8d61ea30e3708a1cf2b5b0c/RELEASE/scripts/excavator/x_utils.ash#L268) calls `page.replace_string( "", "" )` to get a buffer from a string.