### PR TITLE
Have ChatBuffer write to file with utf-8

### DIFF
--- a/lib/net/java/dev/spellcast/utilities/ChatBuffer.java
+++ b/lib/net/java/dev/spellcast/utilities/ChatBuffer.java
@@ -41,6 +41,7 @@ package net.java.dev.spellcast.utilities;
 import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -155,7 +156,7 @@ public class ChatBuffer
 		else
 		{
 			boolean shouldAppend = f.exists();
-			this.logWriter = new PrintWriter( DataUtilities.getOutputStream( f, shouldAppend ), true );
+			this.logWriter = new PrintWriter( DataUtilities.getOutputStream( f, shouldAppend ), true , StandardCharsets.UTF_8 );
 
 			ChatBuffer.ACTIVE_LOG_FILES.put( filename, this.logWriter );
 


### PR DESCRIPTION
Noticed it wasn't writing the files with the utf-8 charset when playing with the class, with symbols missing when trying to view the html file.

TCRSDatabase also doesn't write in UTF-8 as seen [here](https://github.com/kolmafia/kolmafia/blob/e0a9e8d358bde820c963b1339fb2ec0932ecda45/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java#L849). But there's no way to be sure if it should be written in UTF-8 or not as its not ensured to be [grabbed as UTF-8](https://github.com/kolmafia/kolmafia/blob/292b3d1524d4b87c5cd28c520b1be61ff00466c2/lib/net/java/dev/spellcast/utilities/DataUtilities.java#L181), so I've left that alone.