### PR TITLE
use correct modifiers parsing method for voting

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -5123,9 +5123,7 @@ public abstract class KoLCharacter {
 
     // Mummery
     newModifiers.add(
-        new Modifiers(
-            "Mummery",
-            Modifiers.evaluateModifiers("Mummery", Preferences.getString("_mummeryMods"))));
+        Modifiers.evaluatedModifiers("Mummery", Preferences.getString("_mummeryMods")));
 
     // Add modifiers from inventory
     if (InventoryManager.hasItem(ItemPool.FISHING_POLE)) {

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -5144,7 +5144,7 @@ public abstract class KoLCharacter {
 
     // Voting Booth
     newModifiers.add(
-        Modifiers.parseModifiers("Local Vote:Local Vote", Preferences.getString("_voteModifier")));
+        Modifiers.evaluatedModifiers("Local Vote", Preferences.getString("_voteModifier")));
 
     // Miscellaneous
 

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -5146,10 +5146,7 @@ public abstract class KoLCharacter {
 
     // Voting Booth
     newModifiers.add(
-        new Modifiers(
-            "Local Vote:Local Vote",
-            Modifiers.evaluateModifiers(
-                "Local Vote:Local Vote", Preferences.getString("_voteModifier"))));
+        Modifiers.parseModifiers("Local Vote:Local Vote", Preferences.getString("_voteModifier")));
 
     // Miscellaneous
 

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -2234,6 +2234,10 @@ public class Modifiers {
     return list;
   }
 
+  public static final Modifiers evaluatedModifiers(final String lookup, final String modifiers) {
+    return new Modifiers(lookup, evaluateModifiers(lookup, modifiers));
+  }
+
   public static final ModifierList evaluateModifiers(final String lookup, final String modifiers) {
     ModifierList list = Modifiers.splitModifiers(modifiers);
     // Nothing to do if no expressions

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -2229,14 +2229,14 @@ public class Modifiers {
   }
 
   public static final ModifierList evaluateModifiers(final String lookup, final String modifiers) {
+    ModifierList list = Modifiers.splitModifiers(modifiers);
     // Nothing to do if no expressions
     if (!modifiers.contains("[")) {
-      return Modifiers.splitModifiers(modifiers);
+      return list;
     }
 
     // Otherwise, break apart the string and rebuild it with all
     // expressions evaluated.
-    ModifierList list = Modifiers.splitModifiers(modifiers);
     for (Modifier modifier : list) {
       // Evaluate the modifier expression
       modifier.eval(lookup);

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -747,7 +747,8 @@ public class Modifiers {
       DoubleModifier modifier = Modifiers.doubleModifiers[i];
       modifierIndicesByName.put(modifier.getName(), i);
       String tag = modifier.getTag();
-      Modifiers.numericModifiers.add(tag);
+      modifierIndicesByName.put(tag, i);
+      numericModifiers.add(tag);
     }
   }
 
@@ -781,7 +782,9 @@ public class Modifiers {
 
     for (int i = 0; i < BITMAP_MODIFIERS; ++i) {
       BitmapModifier modifier = Modifiers.bitmapModifiers[i];
-      modifierIndicesByName.put(modifier.getName(), DOUBLE_MODIFIERS + i);
+      int index = DOUBLE_MODIFIERS + i;
+      modifierIndicesByName.put(modifier.getName(), index);
+      modifierIndicesByName.put(modifier.getTag(), index);
     }
   }
 
@@ -885,7 +888,9 @@ public class Modifiers {
     }
     for (int i = 0; i < BOOLEAN_MODIFIERS; ++i) {
       BooleanModifier modifier = Modifiers.booleanModifiers[i];
-      modifierIndicesByName.put(modifier.getName(), DOUBLE_MODIFIERS + BITMAP_MODIFIERS + i);
+      int index = DOUBLE_MODIFIERS + BITMAP_MODIFIERS + i;
+      modifierIndicesByName.put(modifier.getName(), index);
+      modifierIndicesByName.put(modifier.getTag(), index);
     }
   }
 
@@ -964,8 +969,9 @@ public class Modifiers {
   static {
     for (int i = 0; i < STRING_MODIFIERS; ++i) {
       StringModifier modifier = Modifiers.stringModifiers[i];
-      modifierIndicesByName.put(
-          modifier.getName(), DOUBLE_MODIFIERS + BITMAP_MODIFIERS + BOOLEAN_MODIFIERS + i);
+      int index = DOUBLE_MODIFIERS + BITMAP_MODIFIERS + BOOLEAN_MODIFIERS + i;
+      modifierIndicesByName.put(modifier.getName(), index);
+      modifierIndicesByName.put(modifier.getTag(), index);
     }
   }
 

--- a/src/net/sourceforge/kolmafia/webui/RelayLoader.java
+++ b/src/net/sourceforge/kolmafia/webui/RelayLoader.java
@@ -5,6 +5,7 @@ import java.awt.Desktop.Action;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -84,10 +85,11 @@ public class RelayLoader extends Thread {
       return;
     }
 
-    URI uri = URI.create(location);
-
     try {
+      URI uri = new URI(location);
       Desktop.getDesktop().browse(uri);
+    } catch (URISyntaxException e) {
+      KoLmafia.updateDisplay("Exception: " + e.getMessage());
     } catch (IOException e) {
       KoLmafia.updateDisplay(
           "Exception: " + e.getMessage() + " for location " + location + " in browser.");

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -726,4 +726,38 @@ public class ModifiersTest {
       }
     }
   }
+
+  @Nested
+  class Voter {
+    @BeforeAll
+    private static void beforeAll() {
+      Preferences.saveSettingsToFile = false;
+      Preferences.reset("voter");
+    }
+
+    @AfterAll
+    private static void afterAll() {
+      Preferences.saveSettingsToFile = true;
+    }
+
+    @Test
+    void canEvaluateExperienceModifiers() {
+      String setting = "Meat Drop: +30, Experience (familiar): +2, Experience (Muscle): +4";
+      String lookup = "Local Vote:Local Vote";
+
+      Modifiers mods = Modifiers.parseModifiers(lookup, setting);
+      assertEquals(30, mods.get(Modifiers.MEATDROP));
+      assertEquals(2, mods.get(Modifiers.FAMILIAR_EXP));
+      assertEquals(4, mods.get(Modifiers.MUS_EXPERIENCE));
+
+      var cleanups = new Cleanups(setProperty("_voteModifier", setting));
+      try (cleanups) {
+        KoLCharacter.recalculateAdjustments();
+        Modifiers current = KoLCharacter.getCurrentModifiers();
+        assertEquals(30, current.get(Modifiers.MEATDROP));
+        assertEquals(2, current.get(Modifiers.FAMILIAR_EXP));
+        assertEquals(4, current.get(Modifiers.MUS_EXPERIENCE));
+      }
+    }
+  }
 }

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -743,7 +743,7 @@ public class ModifiersTest {
     @Test
     void canEvaluateExperienceModifiers() {
       String setting = "Meat Drop: +30, Experience (familiar): +2, Experience (Muscle): +4";
-      String lookup = "Local Vote:Local Vote";
+      String lookup = "Local Vote";
 
       Modifiers mods = Modifiers.parseModifiers(lookup, setting);
       assertEquals(30, mods.get(Modifiers.MEATDROP));

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -750,7 +750,7 @@ public class ModifiersTest {
       assertEquals(2, mods.get(Modifiers.FAMILIAR_EXP));
       assertEquals(4, mods.get(Modifiers.MUS_EXPERIENCE));
 
-      Modifiers evaluated = new Modifiers(lookup, Modifiers.evaluateModifiers(lookup, setting));
+      Modifiers evaluated = Modifiers.evaluatedModifiers(lookup, setting);
       assertEquals(30, evaluated.get(Modifiers.MEATDROP));
       assertEquals(2, evaluated.get(Modifiers.FAMILIAR_EXP));
       assertEquals(4, evaluated.get(Modifiers.MUS_EXPERIENCE));

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -750,6 +750,11 @@ public class ModifiersTest {
       assertEquals(2, mods.get(Modifiers.FAMILIAR_EXP));
       assertEquals(4, mods.get(Modifiers.MUS_EXPERIENCE));
 
+      Modifiers evaluated = new Modifiers(lookup, Modifiers.evaluateModifiers(lookup, setting));
+      assertEquals(30, evaluated.get(Modifiers.MEATDROP));
+      assertEquals(2, evaluated.get(Modifiers.FAMILIAR_EXP));
+      assertEquals(4, evaluated.get(Modifiers.MUS_EXPERIENCE));
+
       var cleanups = new Cleanups(setProperty("_voteModifier", setting));
       try (cleanups) {
         KoLCharacter.recalculateAdjustments();


### PR DESCRIPTION
Local Voting has Experience (familiar) and Experience (Muscle), at least, on occasion.
Since they are not variable, we can use Modifiers.parseModifiers, rather than Modifiers.evaluateModifiers.
This will look up modifiers by tag, rather than name.

Now that I think about it, why does Modifiers.evaluateModifiers not do that, too?
It splits a String into a ModifierList. The modifiers can be either names or tags.
But when we turn a ModifierList into a Modifiers object, we look up the modifier index by name.
It's easy enough to add the tag to the same nameToIndex hash table and be able to look up the index by whichever one.

I also added a catch for a bad URI string in RelayLoader. This is defensive; we supposedly always give a good input, but recent in-development code gave a bad input and an exception was thrown. In the Swing event thread. Oops.