### PR TITLE
feat: add `git_` equivalents to `svn_` ASH functions

### DIFF
--- a/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
@@ -373,7 +373,8 @@ public class GitManager extends ScriptManager {
       var commit = rw.parseCommit(lastCommitId);
       var author = commit.getAuthorIdent();
       var datetime =
-          ZonedDateTime.ofInstant(Instant.ofEpochMilli(commit.getCommitTime()), author.getZoneId());
+          ZonedDateTime.ofInstant(
+              Instant.ofEpochSecond(commit.getCommitTime()), author.getZoneId());
 
       return Optional.of(
           new GitInfo(

--- a/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
@@ -7,6 +7,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -21,8 +23,11 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.InvalidRemoteException;
 import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.lib.BranchTrackingStatus;
+import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ProgressMonitor;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.treewalk.AbstractTreeIterator;
 import org.eclipse.jgit.treewalk.CanonicalTreeParser;
 import org.tmatesoft.svn.core.SVNException;
@@ -332,6 +337,88 @@ public class GitManager extends ScriptManager {
     var deps = projectPath.resolve(DEPENDENCIES);
     if (Files.exists(deps)) {
       installDependencies(deps);
+    }
+  }
+
+  public record GitInfo(
+      String url,
+      String branch,
+      String commit,
+      String lastChangedAuthor,
+      ZonedDateTime lastChangedDate) {}
+
+  /** Get info from specific project */
+  public static Optional<GitInfo> getInfo(String project) {
+    var folderOpt = getRequiredProject(project);
+    if (folderOpt.isEmpty()) {
+      return Optional.empty();
+    }
+    var folder = folderOpt.get();
+    Path projectPath = KoLConstants.GIT_LOCATION.toPath().resolve(folder);
+    Git git;
+    try {
+      git = Git.open(projectPath.toFile());
+    } catch (IOException e) {
+      return Optional.empty();
+    }
+
+    try (git) {
+      var repo = git.getRepository();
+      var config = repo.getConfig();
+      var url = config.getString("remote", "origin", "url");
+      var branch = repo.getBranch();
+
+      var lastCommitId = repo.resolve("HEAD");
+      var rw = new RevWalk(repo);
+      var commit = rw.parseCommit(lastCommitId);
+      var author = commit.getAuthorIdent();
+      var datetime =
+          ZonedDateTime.ofInstant(Instant.ofEpochMilli(commit.getCommitTime()), author.getZoneId());
+
+      return Optional.of(
+          new GitInfo(
+              url,
+              branch,
+              ObjectId.toString(lastCommitId),
+              author.getName() + " <" + author.getEmailAddress() + ">",
+              datetime));
+    } catch (IOException e) {
+      // all or nothing
+      return Optional.empty();
+    }
+  }
+
+  /** Return whether project is a valid git repo */
+  public static boolean isValidRepo(String project) {
+    var projectPath = KoLConstants.GIT_LOCATION.toPath().resolve(project);
+    if (!Files.isDirectory(projectPath)) return false;
+    try {
+      var git = Git.open(projectPath.toFile());
+      git.close();
+    } catch (IOException e) {
+      return false;
+    }
+    return true;
+  }
+
+  /** Return whether project is up-to-date with remote */
+  public static boolean isUpToDate(String project) {
+    var projectPath = KoLConstants.GIT_LOCATION.toPath().resolve(project);
+    Git git;
+    try {
+      git = Git.open(projectPath.toFile());
+    } catch (IOException e) {
+      return false;
+    }
+
+    try (git) {
+      var repo = git.getRepository();
+      var branch = repo.getBranch();
+      var bts = BranchTrackingStatus.of(repo, branch);
+      var behind = bts.getBehindCount();
+      return behind == 0;
+    } catch (IOException e) {
+      return false;
     }
   }
 

--- a/src/net/sourceforge/kolmafia/textui/DataTypes.java
+++ b/src/net/sourceforge/kolmafia/textui/DataTypes.java
@@ -28,6 +28,7 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.UseSkillRequest;
 import net.sourceforge.kolmafia.textui.parsetree.AggregateType;
+import net.sourceforge.kolmafia.textui.parsetree.ArrayValue;
 import net.sourceforge.kolmafia.textui.parsetree.Type;
 import net.sourceforge.kolmafia.textui.parsetree.TypeList;
 import net.sourceforge.kolmafia.textui.parsetree.Value;
@@ -918,6 +919,18 @@ public class DataTypes {
     }
 
     return new Value(DataTypes.MONSTER_TYPE, id, name, monster);
+  }
+
+  public static final Value makeStringArrayValue(final List<String> list) {
+    var length = list.size();
+    AggregateType type = new AggregateType(DataTypes.STRING_TYPE, length);
+    ArrayValue value = new ArrayValue(type);
+
+    for (int i = 0; i < length; ++i) {
+      value.aset(new Value(i), new Value(list.get(i)));
+    }
+
+    return value;
   }
 
   // Also supply:

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -8650,9 +8650,11 @@ public abstract class RuntimeLibrary {
   }
 
   public static Value svn_info(ScriptRuntime controller, final Value script) {
+    AshRuntime interpreter = controller instanceof AshRuntime ? (AshRuntime) controller : null;
+
     String[] projects = KoLConstants.SVN_LOCATION.list();
 
-    if (projects == null) return getRecInit();
+    if (projects == null) return getRecInit(interpreter);
 
     ArrayList<String> matches = new ArrayList<>();
     for (String s : projects) {
@@ -8662,15 +8664,15 @@ public abstract class RuntimeLibrary {
     }
 
     if (matches.size() != 1) {
-      return getRecInit();
+      return getRecInit(interpreter);
     }
     File projectFile = new File(KoLConstants.SVN_LOCATION, matches.get(0));
     try {
       if (!SVNWCUtil.isWorkingCopyRoot(projectFile)) {
-        return getRecInit();
+        return getRecInit(interpreter);
       }
     } catch (SVNException e1) {
-      return getRecInit();
+      return getRecInit(interpreter);
     }
     RecordType type = RuntimeLibrary.svnInfoRec;
     RecordValue rec = new RecordValue(type);
@@ -8682,75 +8684,77 @@ public abstract class RuntimeLibrary {
       info = SVNManager.doInfo(projectFile);
     } catch (SVNException e) {
       SVNManager.error(e, null);
-      return getRecInit();
+      return getRecInit(interpreter);
     }
 
     // URL
-    rec.aset(0, new Value(info.getURL().toString()), null);
+    rec.aset(0, new Value(info.getURL().toString()), interpreter);
     // revision
-    rec.aset(1, DataTypes.makeIntValue(info.getRevision().getNumber()), null);
+    rec.aset(1, DataTypes.makeIntValue(info.getRevision().getNumber()), interpreter);
     // lastChangedAuthor
-    rec.aset(2, new Value(info.getAuthor()), null);
+    rec.aset(2, new Value(info.getAuthor()), interpreter);
     // lastChangedRev
-    rec.aset(3, DataTypes.makeIntValue(info.getCommittedRevision().getNumber()), null);
+    rec.aset(3, DataTypes.makeIntValue(info.getCommittedRevision().getNumber()), interpreter);
     // lastChangedDate
     // use format that is similar to what 'svn info' gives, ex:
     // Last Changed Date: 2003-01-16 23:21:19 -0600 (Thu, 16 Jan 2003)
     SimpleDateFormat SVN_FORMAT =
         new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z (EEE, dd MMM yyyy)", Locale.US);
-    rec.aset(4, new Value(SVN_FORMAT.format(info.getCommittedDate())), null);
+    rec.aset(4, new Value(SVN_FORMAT.format(info.getCommittedDate())), interpreter);
 
     return rec;
   }
 
-  private static RecordValue getRecInit() {
+  private static RecordValue getRecInit(AshRuntime interpreter) {
     RecordType type = RuntimeLibrary.svnInfoRec;
     RecordValue rec = new RecordValue(type);
-    rec.aset(0, DataTypes.STRING_INIT, null);
+    rec.aset(0, DataTypes.STRING_INIT, interpreter);
     // revision
-    rec.aset(1, DataTypes.INT_INIT, null);
+    rec.aset(1, DataTypes.INT_INIT, interpreter);
     // lastChangedAuthor
-    rec.aset(2, DataTypes.STRING_INIT, null);
+    rec.aset(2, DataTypes.STRING_INIT, interpreter);
     // lastChangedRev
-    rec.aset(3, DataTypes.INT_INIT, null);
+    rec.aset(3, DataTypes.INT_INIT, interpreter);
     // lastChangedDate
-    rec.aset(4, DataTypes.STRING_INIT, null);
+    rec.aset(4, DataTypes.STRING_INIT, interpreter);
 
     return rec;
   }
 
   public static Value git_info(ScriptRuntime controller, final Value script) {
+    AshRuntime interpreter = controller instanceof AshRuntime ? (AshRuntime) controller : null;
+
     var infoOpt = GitManager.getInfo(script.toString());
-    if (infoOpt.isEmpty()) return getGitRecInit();
+    if (infoOpt.isEmpty()) return getGitRecInit(interpreter);
     var info = infoOpt.get();
 
-    RecordValue rec = new RecordValue(RuntimeLibrary.svnInfoRec);
+    RecordValue rec = new RecordValue(RuntimeLibrary.gitInfoRec);
 
     // URL
-    rec.aset(0, new Value(info.url()), null);
+    rec.aset(0, new Value(info.url()), interpreter);
     // branch
-    rec.aset(1, new Value(info.branch()), null);
+    rec.aset(1, new Value(info.branch()), interpreter);
     // revision
-    rec.aset(2, new Value(info.commit()), null);
+    rec.aset(2, new Value(info.commit()), interpreter);
     // lastChangedAuthor
-    rec.aset(3, new Value(info.lastChangedAuthor()), null);
+    rec.aset(3, new Value(info.lastChangedAuthor()), interpreter);
     // lastChangedDate
     // use format that is similar to what 'git show' gives, ex:
     // Date: Sat Jul 16 11:40:35 2022 +0100
     var fmt = DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss yyyy z");
     var date = fmt.format(info.lastChangedDate());
-    rec.aset(4, new Value(date), null);
+    rec.aset(4, new Value(date), interpreter);
 
     return rec;
   }
 
-  private static RecordValue getGitRecInit() {
+  private static RecordValue getGitRecInit(AshRuntime interpreter) {
     RecordValue rec = new RecordValue(RuntimeLibrary.gitInfoRec);
-    rec.aset(0, DataTypes.STRING_INIT, null);
-    rec.aset(1, DataTypes.STRING_INIT, null);
-    rec.aset(2, DataTypes.STRING_INIT, null);
-    rec.aset(3, DataTypes.STRING_INIT, null);
-    rec.aset(4, DataTypes.STRING_INIT, null);
+    rec.aset(0, DataTypes.STRING_INIT, interpreter);
+    rec.aset(1, DataTypes.STRING_INIT, interpreter);
+    rec.aset(2, DataTypes.STRING_INIT, interpreter);
+    rec.aset(3, DataTypes.STRING_INIT, interpreter);
+    rec.aset(4, DataTypes.STRING_INIT, interpreter);
 
     return rec;
   }

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -2498,7 +2498,7 @@ public abstract class RuntimeLibrary {
         new LibraryFunction("git_list", new AggregateType(DataTypes.STRING_TYPE, 0), params));
 
     params = new Type[] {DataTypes.STRING_TYPE};
-    functions.add(new LibraryFunction("git_info", svnInfoRec, params));
+    functions.add(new LibraryFunction("git_info", gitInfoRec, params));
 
     params = new Type[] {DataTypes.STRING_TYPE, DataTypes.STRING_TYPE};
     functions.add(


### PR DESCRIPTION
Follow-up to #849.

There are various `svn_` ASH functions, of which `svn_exists_at_head` is currently know to be used. Add `git_` equivalents doing similar things.

I thought about adding a `script_` equivalent that would look over both folders, but for most of these functions you need to know the exact project name, and it's likely to be different for svn or git installations, so this wouldn't be terribly useful.