### PR TITLE
fix: add powerful glove skills to daily limits

### DIFF
--- a/src/data/dailylimits.txt
+++ b/src/data/dailylimits.txt
@@ -178,6 +178,8 @@ Cast	Pirate Bellow	_pirateBellowUsed
 Cast	Summon Holiday Fun!	_holidayFunUsed
 Cast	Summon Carrot	_summonCarrotUsed
 Cast	Summon Kokomo Resort Pass	_summonResortPassUsed
+Cast	CHEAT CODE: Invisible Avatar	_powerfulGloveBatteryPowerUsed	100
+Cast	CHEAT CODE: Triple Size	_powerfulGloveBatteryPowerUsed	100
 Cast	Bowl Full of Jelly	_bowlFullOfJellyUsed
 Cast	Eye and a Twist	_eyeAndATwistUsed
 Cast	Chubby and Plump	_chubbyAndPlumpUsed

--- a/test/net/sourceforge/kolmafia/persistence/DailyLimitDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/DailyLimitDatabaseTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
-class gDailyLimitDatabaseTest {
+class DailyLimitDatabaseTest {
   @Nested
   class DailyLimitTests {
     @BeforeEach


### PR DESCRIPTION
In #605, code dealing with the glove non-combat skills was added, but the skills themselves were not. Correct this.

Also fix a test class name.