### PR TITLE
feat: un-unspade some spleen items

### DIFF
--- a/src/data/spleenhit.txt
+++ b/src/data/spleenhit.txt
@@ -4,8 +4,8 @@
 
 # Item	Spleenhit	Level Req	Quality	Adv	Musc	Myst	Moxie
 
-[experimental crimbo spleen]	2	1		0	0	0	0	Unspaded
-a bug's lymph	1	1	awesome	0	0	0	0	Unspaded 60 A Bug's Life (+100% HP, +8-10 HP Regen)
+[experimental crimbo spleen]	2	1		0	0	0	0	50 Festively Experimented-Upon (+200% HP/MP), one random effect
+a bug's lymph	1	1	awesome	0	0	0	0	60 A Bug's Life (+100% HP, +8-10 HP Regen)
 abstraction: action	1	1	decent	0	0	0	0	50 Action (+100% mus)
 abstraction: category	1	1	decent	0	0	0	0	50 Category (+25% mys experience)
 abstraction: certainty	1	1	good	0	0	0	0	50 Certainty (+100% item drop)
@@ -28,7 +28,7 @@ antimatter wad	2	3	awesome	5-7	-20-30	-20-30	-20-30
 antique bottle of cough syrup	1	6	awesome	0	0	18-20	0	10 The Q Is Talking To You (+10% mys)
 armored prawn	1	1	EPIC	0	30-50	30-50	30-50	50 Rushtacean' (+50 Init)
 [5140]astral energy drink	8	1	awesome	29-35	0	0	0
-[10882]astral energy drink	5	1		0	0	0	0	Unspaded
+[10882]astral energy drink	5	1		0	0	0	0	Lucky!
 astronaut ice-cream	1	7	EPIC	8-10	0	0	0
 bakelite bits	3	12	awesome	0	1000-2000	1000-2000	1000-2000
 beastly paste	4	4	good	5-10	18-22	18-22	18-22	10 Beastly Flavor (+3 fam weight)
@@ -47,7 +47,7 @@ bottle of extra-strength melodramamine	3	1	good	0	0	0	0	50 Emotion Sickness (+ M
 bottle of melodramamine	1	1	good	0	0	0	0	5 Emotion Sickness (+ Meat and Items underwater)
 bottle of ultravitamins	1	6	awesome	0	18-20	0	0	10 Vitamin-Maxed (+10% mus)
 Breathetastic&trade; Premium Canned Air	5	13	EPIC	20-25	60-70	60-70	60-70
-Breathitin&trade;	2	1	crappy	0	0	0	0	Unspaded
+Breathitin&trade;	2	1	crappy	0	0	0	0	Next 10 outdoor fights are free
 brilliant oyster egg	1	5	EPIC	0	0	50-60	0	20 Eggstraordinary Brilliance (+5 mys stats/fight)
 bug paste	4	4	good	5-10	18-22	18-22	18-22	10 Buggy Flavor (25% chance of poisoning opponent)
 can of Red Minotaur	3	1	crappy	0	0	0	0	+1 PvP fight, 5 Wings
@@ -60,7 +60,7 @@ cold jelly	1	1	crappy	0	0	50-60	0	50 Cold Jellied (+3 mys stats/fight, +5 cold d
 cold wad	1	6	good	0	50-60	30-40	10-20	20 Cold Blooded (+30% mus, +20% mys, +10% mox, cold dmg/res)
 concentrated magicalness pill	1	2	decent	0	0	5-7	0
 cosmic paste	4	4	good	5-10	18-22	18-22	18-22	10 Cosmic Flavor (+10% critical spell)
-Crimbeau de toilette	1	1	awesome	0	0	0	0	Unspaded, 50 Crimbeau'd (+10 familiar weight, +25 item drop, +50 meat drop)
+Crimbeau de toilette	1	1	awesome	0	20	20	20	Unspaded, 50 Crimbeau'd (+10 familiar weight, +25 item drop, +50 meat drop)
 Crimbo paste	4	4	good	5-10	18-22	18-22	18-22	10 Crimbo Flavor (+30 spell dmg)
 cuppa Activi tea	2	1	decent	3-5	8-10	8-10	8-10
 cuppa Cruel tea	4	1	crappy	0	0	0	0	+5 PvP fights
@@ -77,14 +77,14 @@ epic wad	1	15	EPIC	5	140-150	140-150	140-150
 excitement pill	1	5	decent	0	0	0	0	Get random effect
 expensive cigar	1	7	decent	0	40-50	0	0
 extra-strength strongness elixir	1	3	good	0	8-10	0	0
-Extrovermectin&trade;	2	1	crappy	0	0	0	0	Unspaded
+Extrovermectin&trade;	2	1	crappy	0	0	0	0	Gain skill that gives 3 copies of a monster
 fiberglass fibers	3	12	awesome	0	1000-2000	1000-2000	1000-2000
 fish sauce	1	1	good	0	0	0	0	30 Fishy
 fishy paste	4	4	good	5-10	18-22	18-22	18-22	10 Fishy
 Five Second Energy&trade;	3	1	crappy	0	0	0	0	+3 PvP fights
 flagstone flagments	3	12		0	0	0	0	Unspaded
-Fleshazole&trade;	2	1	crappy	0	0	0	0	Unspaded
-fried air	1	1		0	0	0	0	Unspaded
+Fleshazole&trade;	2	1	crappy	0	0	0	0	Gain around level * 1000 meat (max 11500)
+fried air	1	1		0	0	0	0	30 Well-Ventilated (+15 mus, +15 mys, +15 mox)
 furry pill	1	3	decent	0	0	0	0	Remove negative effect, Restores 40-50 HP
 gabardine smithereens	2	12	good	0	0	0	0	Unspaded
 gaseous gravy	1	1	EPIC	0	0	0	0	50 Gettin' the Goods (+100% Item drop)
@@ -110,12 +110,12 @@ Hatorade	5	1	crappy	0	0	0	0	+1 PvP fight
 haunted battery	1	1	EPIC	0	0	30-40	0
 hippy paste	4	4	good	5-10	18-22	18-22	18-22	10 Hippy Flavor (+15 mys)
 hobo paste	4	4	good	5-10	18-22	18-22	18-22	10 Hobo Flavor (stench dmg/res)
-Homebodyl&trade;	2	1	good	0	0	0	0	Unspaded
+Homebodyl&trade;	2	1	good	0	0	0	0	Gives 11 Free Crafts
 homeopathic mint tea	1	1	decent	1-2	0	0	0	50 Alpine Mintiness (+25 HP/MP, +25 Weapon Damage, +25 Spell Damage)
 hot jelly	1	1	crappy	0	50-60	0	0	50 Hot Jellied (+3 mus stats/fight, +5 hot damage, +30% mus), grants one-use 20 turn banishing skill
 hot wad	1	6	good	0	50-60	10-20	30-40	20 Hot Blooded (+30% mus, +20% mox, +10% mys, hot dmg/res)
 indescribably horrible paste	4	4	good	5-10	18-22	18-22	18-22	10 Indescribable Flavor (+30 spell dmg)
-industrial lubricant	1	1	awesome	0	0	0	0	Unspaded 30 Industrially Lubricated (+150 init)
+industrial lubricant	1	1	awesome	0	0	0	0	30 Industrially Lubricated (+150 init)
 Instant Karma	5	13	EPIC	20-25	60-70	60-70	60-70
 jug-o-magicalness	1	3	good	0	0	8-10	0
 kelp	1	1	good	0	10-20	10-20	10-20	50 Does a Body Good (+60 max hp, +30 max mp, +10 dr)
@@ -127,7 +127,7 @@ lavender paisley oyster egg	1	1	awesome	0	0	11-15	11-15
 lavender polka-dot oyster egg	1	1	awesome	0	0	0	22-30
 lavender striped oyster egg	1	1	awesome	0	11-15	0	11-15
 liquid shifting time weirdness	2	6	awesome	0	50-65	50-65	50-65	10 Liquid Luck (+10% critical, +10% spell critical)
-livid energy	1	1	awesome	0	0	0	0	Unspaded 60 Lividly Energized (+50% MP, +3-5 MP Regen)
+livid energy	1	1	awesome	0	0	0	0	60 Lividly Energized (+50% MP, +3-5 MP Regen)
 loofah lumps	2	12		0	0	0	0	Unspaded
 LOV Echinacea Bouquet	1	1	crappy	0	20-40	20-40	20-40	20-40 HP, 20-40 MP
 lucky-ish pill	1	7		0	0	0	0	Get Lucky!
@@ -142,7 +142,7 @@ mauve polka-dot oyster egg	1	1	awesome	0	0	11-15	11-15
 mauve striped oyster egg	1	1	awesome	0	11-15	11-15	0
 Medicinal Herb's medicinal herbs	1	3	good	0	0	0	0	full heal
 Mer-kin paste	4	4	good	5-10	18-22	18-22	18-22	10 Mer-kinny Flavor (breathe underwater)
-mime army superserum	1	15	good	0	0	0	0	Unspaded, 50 I'll Have the Soup (+300% HP, 20 DR, +100 DA)
+mime army superserum	1	15	good	0	0	0	0	50 I'll Have the Soup (+300% HP, 20 DR, +100 DA)
 molotov soda	3	2	good	8-10	0	0	0
 moomy dust	1	1	decent	0	15-20	15-20	15-20	30 Cowrruption (+200% weapon dmg, +200% spell dmg, muscle limited to 30, moxie limited to 30)
 moxie weed	1	1	crappy	0	0	0	1-3
@@ -153,14 +153,14 @@ mushroom tea	1	1	good	0	10-20	10-20	10-20	50 Mush-Maw (+20 ml, +10 combat rate)
 nasty snuff	1	4	decent	1-2	15-30	15-30	15-30
 Nightmare Fuel	1	1	crappy	0	0	0	0	Add Free Campground Rest
 not-a-pipe	4	4	good	4-12	20-30	20-30	20-30
-non-Euclidean angle	1	1	awesome	0	0	0	0	Unspaded 30 Different Way of Seeing Things (+50 mys experience)
+non-Euclidean angle	1	1	awesome	0	0	0	0	30 Different Way of Seeing Things (+50 mys experience)
 octolus oculus	1	4	decent	2	0	0	15-30
 off-white paisley oyster egg	1	1	awesome	0	0	11-15	0	20 Eggs-tra Sensory Perception (+10% item drop)
 off-white polka-dot oyster egg	1	1	awesome	0	0	0	11-15	20 Eggs-tra Sensory Perception (+10% item drop)
 off-white striped oyster egg	1	1	awesome	0	11-15	0	0	20 Eggs-tra Sensory Perception (+10% item drop)
 oily paste	4	4	good	5-10	18-22	18-22	18-22	10 Oily Flavor (+15 mus)
 orc paste	4	4	good	5-10	18-22	18-22	18-22	10 Fratty Flavor (+15 mox)
-oversized ice molecule	1	1	awesome	0	0	0	0	Unspaded
+oversized ice molecule	1	1	awesome	0	0	0	0	50 Icy Composition (+5 cold res, +25 cold dmg, +50 cold spell dmg)
 paraffin pieces	2	6	good	0	0	0	0	Unspaded
 party balloon	1	2	good	0	10-20	10-20	10-20	50 Lifted Spirits (+25 init, +5 stats/fight)
 Party-in-a-Can&trade;	1	4	crappy	0	1-50	1-50	1-50	50 Party on Your Skin (+50% HP, +50% MP, +5 familiar weight, +3 all res)
@@ -174,7 +174,7 @@ porcelain powder	3	1	awesome	0	100-120	100-120	100-120
 powdered gold	4	1	good	5-10	20-30	20-30	20-30
 powdered oxygen	3	4	good	0	0	0	0	10 Hyperoxygenated Blood (Breath Underwater)
 prismatic wad	3	7	good	5-7	50-60	50-60	50-60	10 Rainbow Bright (+30% all, prismatic dmg/res)
-prototype stimulant	1	1	good	0	0	0	0	Unspaded, 50 Proto-Stimulated (+20 all stats)
+prototype stimulant	1	1	good	0	0	0	0	50 Proto-Stimulated (+20 all stats)
 puce paisley oyster egg	1	1	awesome	0	11-15	11-15	0
 puce polka-dot oyster egg	1	1	awesome	0	11-15	0	11-15
 puce striped oyster egg	1	1	awesome	0	22-30	0	0
@@ -186,7 +186,7 @@ residual zeal	5	20	EPIC	0	25000-35000	25000-35000	25000-35000
 sachet of strange powder	1	4	good	0	30-50	30-50	30-50	40 Powder Power (+5 prismatic damage)
 scintillating oyster egg	1	5	EPIC	0	0	0	0	20 Eggscitingly Colorful (+3 all res)
 sea jelly	1	1	crappy	0	30-40	30-40	30-40	10 Fishy
-Shantix&trade;	1	1	awesome	0	0	0	0	Unspaded 30 Thou Shant Not Sing (+50% mox experience)
+Shantix&trade;	1	1	awesome	0	0	0	0	30 Thou Shant Not Sing (+50% mox experience)
 single atom	1	1	decent	1	0	0	0
 sleaze jelly	1	1	crappy	0	0	0	50-60	50 Sleazy Jellied (+3 mox stats/fight, +5 sleaze damage, +30% mox), 10% off next NPC purchase (not Gift shop)
 sleaze wad	1	6	good	0	20-30	20-30	50-60	20 Supafly (+30% mox, +15% mus, +15% mys, sleaze dmg/res)
@@ -217,7 +217,7 @@ twinkly wad	1	6	decent	0	15-20	15-20	15-20	20 Aspect of the Twinklefairy (+10% a
 ultimate wad	15	13	EPIC	0	0	0	0	+1 level
 Unconscious Collective Dream Jar	4	1	good	5-10	20-30	20-30	20-30
 velour veneer	2	12	EPIC	0	0	0	0	Unspaded
-vial of humanoid growth hormone	1	1	awesome	0	0	0	0	Unspaded 30 HGH-charged (+50% mus experience)
+vial of humanoid growth hormone	1	1	awesome	0	0	0	0	30 HGH-charged (+50% mus experience)
 vibrating mushroom	2	4	decent	0	0	0	0	30 Weird Vibrations (+25 init)
 vitamin G pill	1	6	good	0	0	0	0	5 Riboflavin' (Pickin' Pockets like a G)
 voodoo snuff	3	13	good	8-10	0	100-150	0


### PR DESCRIPTION
Consumables tend to stay `Unspaded`. Go through the spleen items and update the ones we know about.