### PR TITLE
feat: support installing git scripts from non-root folders

### DIFF
--- a/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
@@ -234,17 +234,18 @@ public class GitManager extends ScriptManager {
     }
     var folder = folderOpt.get();
     var projectPath = KoLConstants.GIT_LOCATION.toPath().resolve(folder);
+    var root = getRoot(projectPath);
     KoLmafia.updateDisplay("Removing project " + folder);
     List<Path> toDelete;
     try {
-      toDelete = getPermissibleFiles(projectPath, true);
+      toDelete = getPermissibleFiles(root, true);
     } catch (IOException e) {
       KoLmafia.updateDisplay(MafiaState.ERROR, "Failed to remove project " + folder + ": " + e);
       return;
     }
     var errored = false;
     for (var absPath : toDelete) {
-      var shortPath = projectPath.relativize(absPath);
+      var shortPath = root.relativize(absPath);
       var relPath = KoLConstants.ROOT_LOCATION.toPath().resolve(shortPath);
       try {
         Files.deleteIfExists(relPath);

--- a/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
@@ -551,6 +551,8 @@ public class GitManager extends ScriptManager {
     var manifest = json.get();
     var root = manifest.optString(MANIFEST_ROOTDIR, "");
     if (root.length() == 0) return projectPath;
+    // deny absolute paths or folder escapes
+    if (root.startsWith("/") || root.startsWith("\\") || root.contains("..")) return projectPath;
     return projectPath.resolve(root);
   }
 

--- a/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
@@ -154,16 +154,13 @@ public class GitManager extends ScriptManager {
       List<DiffEntry> diffs;
       try {
         var cmd =
-            git.diff()
-                .setOldTree(currTree)
-                .setNewTree(incomingTree)
-                .setShowNameAndStatusOnly(true);
+            git.diff().setOldTree(currTree).setNewTree(incomingTree).setShowNameAndStatusOnly(true);
         if (!projectPath.equals(newRoot)) {
           var relFilter = projectPath.relativize(newRoot);
           var filter = PathFilter.create(relFilter.toString().replace(File.separatorChar, '/'));
           cmd = cmd.setPathFilter(filter);
         }
-                diffs = cmd.call();
+        diffs = cmd.call();
       } catch (GitAPIException e) {
         KoLmafia.updateDisplay(
             MafiaState.ERROR, "Failed to diff incoming changes for project " + folder + ": " + e);
@@ -537,8 +534,7 @@ public class GitManager extends ScriptManager {
   }
 
   private static Optional<JSONObject> readManifest(Path manifest) {
-    if (!Files.exists(manifest))
-      return Optional.empty();
+    if (!Files.exists(manifest)) return Optional.empty();
 
     JSONObject json;
     try {

--- a/test/internal/helpers/CliCaller.java
+++ b/test/internal/helpers/CliCaller.java
@@ -1,0 +1,18 @@
+package internal.helpers;
+
+import net.sourceforge.kolmafia.KoLmafiaCLI;
+
+public class CliCaller {
+  public static String callCli(final String command, final String params) {
+    return callCli(command, params, false);
+  }
+
+  public static String callCli(final String command, final String params, final boolean check) {
+    RequestLoggerOutput.startStream();
+    var cli = new KoLmafiaCLI(System.in);
+    KoLmafiaCLI.isExecutingCheckOnlyCommand = check;
+    cli.executeCommand(command, params);
+    KoLmafiaCLI.isExecutingCheckOnlyCommand = false;
+    return RequestLoggerOutput.stopStream();
+  }
+}

--- a/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
+++ b/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
@@ -161,4 +161,41 @@ public class GitManagerTest {
       assertThat(output, containsString(dep));
     }
   }
+
+  @Nested
+  public class ManifestTests {
+
+    private static final String id = "midgleyc-mafia-script-install-test-test-manifest";
+
+    @BeforeAll
+    public static void cloneRepo() {
+      String output =
+          CliCaller.callCli(
+              "git",
+              "checkout https://github.com/midgleyc/mafia-script-install-test.git test-manifest");
+      assertThat(output, containsString("Installing dependencies"));
+      assertThat(output, containsString("Cloned project " + id));
+    }
+
+    @AfterAll
+    public static void removeRepo() {
+      String remove = id;
+      String output = CliCaller.callCli("git", "delete " + remove);
+      assertThat(output, containsString("Project " + remove + " removed"));
+      remove = "midgleyc-mafia-script-install-test-test-deps-git";
+      output = CliCaller.callCli("git", "delete " + remove);
+      assertThat(output, containsString("Project " + remove + " removed"));
+    }
+
+    @Test
+    public void installedFilesAndDepenciesRelativeToManifest() {
+      assertTrue(Files.exists(Paths.get("scripts", "1-manifest.ash")));
+      assertTrue(Files.exists(Paths.get("scripts", "1-git.ash")));
+    }
+
+    @Test
+    public void didNotInstallFilesRelativeToRoot() {
+      assertFalse(Files.exists(Paths.get("scripts", "1-root.ash")));
+    }
+  }
 }

--- a/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
+++ b/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
@@ -113,4 +113,52 @@ public class GitManagerTest {
           containsString("Returned: https://github.com/midgleyc/mafia-script-install-test.git"));
     }
   }
+
+  @Nested
+  public class DependencyTests {
+    private static final String id = "midgleyc-mafia-script-install-test-test-deps";
+
+    @BeforeAll
+    public static void cloneRepo() {
+      String output =
+          CliCaller.callCli(
+              "git",
+              "checkout https://github.com/midgleyc/mafia-script-install-test.git test-deps");
+      assertThat(output, containsString("Installing dependencies"));
+      assertThat(output, containsString("Cloned project " + id));
+    }
+
+    @AfterAll
+    public static void removeRepo() {
+      String remove = id;
+      String output = CliCaller.callCli("git", "delete " + remove);
+      assertThat(output, containsString("Project " + remove + " removed"));
+      remove = id + "-git";
+      output = CliCaller.callCli("git", "delete " + remove);
+      assertThat(output, containsString("Project " + remove + " removed"));
+      remove = "midgleyc-mafia-script-install-test-branches-test-deps-svn";
+      output = CliCaller.callCli("svn", "delete " + remove);
+      assertThat(output, containsString("Project uninstalled." + remove));
+    }
+
+    @Test
+    public void installedDependencies() {
+      assertTrue(Files.exists(Paths.get("scripts", "1-git.ash")));
+      assertTrue(Files.exists(Paths.get("scripts", "1-svn.ash")));
+    }
+
+    @Test
+    public void syncReinstallsDependencies() {
+      String dep = id + "-git";
+      // delete script files
+      CliCaller.callCli("git", "delete " + dep);
+
+      // sync
+      CliCaller.callCli("git", "sync");
+
+      // files should return
+      String output = CliCaller.callCli("git", "list");
+      assertThat(output, containsString(dep));
+    }
+  }
 }

--- a/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
+++ b/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
@@ -1,0 +1,116 @@
+package net.sourceforge.kolmafia.scripts.git;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import internal.helpers.CliCaller;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import net.sourceforge.kolmafia.KoLConstants.MafiaState;
+import net.sourceforge.kolmafia.StaticEntity;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class GitManagerTest {
+
+  /**
+   * Run tests using the public API accessible through the CLI command "git" and the ASH commands to
+   * avoid tying tests to current internal API
+   */
+  @Nested
+  public class BasicTests {
+    private static final String id = "midgleyc-mafia-script-install-test-test-basic";
+
+    @BeforeAll
+    public static void cloneRepo() {
+      String output =
+          CliCaller.callCli(
+              "git",
+              "checkout https://github.com/midgleyc/mafia-script-install-test.git test-basic");
+      assertThat(output, containsString("Cloned project " + id));
+      assertTrue(Files.exists(Paths.get("git", id)));
+    }
+
+    @AfterAll
+    public static void removeRepo() {
+      String output = CliCaller.callCli("git", "delete " + id);
+      assertThat(output, containsString("Project " + id + " removed"));
+      assertFalse(Files.exists(Paths.get("git", id)));
+      assertFalse(Files.exists(Paths.get("scripts", "1.ash")));
+    }
+
+    @Test
+    public void shouldCopyPermissibleFolders() {
+      assertTrue(Files.exists(Paths.get("scripts", "1.ash")));
+      assertTrue(Files.exists(Paths.get("relay", "1.ash")));
+      assertTrue(Files.exists(Paths.get("data", "1.txt")));
+    }
+
+    @Test
+    public void shouldNotCopyUnpermissibleFiles() {
+      assertFalse(Files.exists(Paths.get("uncopied.js")));
+      assertFalse(Files.exists(Paths.get("unpermissible", "1.txt")));
+    }
+
+    @Test
+    public void shouldUpdate() {
+      // there is nothing it can do, but check this doesn't error
+      CliCaller.callCli("git", "update");
+      CliCaller.callCli("git", "update " + id);
+      assertEquals(MafiaState.CONTINUE, StaticEntity.getContinuationState());
+    }
+
+    @Test
+    public void shouldList() {
+      String output = CliCaller.callCli("git", "list");
+      assertThat(output, containsString(id));
+    }
+
+    @Test
+    public void shouldSync() throws IOException {
+      // delete a script file
+      Path scriptFile = Path.of("scripts", "1.ash");
+      Files.delete(scriptFile);
+      // sync
+      CliCaller.callCli("git", "sync");
+      // file should exist
+      assertTrue(Files.exists(scriptFile));
+    }
+
+    @Test
+    public void shouldListAsh() {
+      String output = CliCaller.callCli("ash", "git_list()");
+      assertThat(output, containsString("0 => " + id));
+    }
+
+    @Test
+    public void shouldCheckUpdated() {
+      String output = CliCaller.callCli("ash", "git_at_head(\"" + id + "\")");
+      assertThat(output, containsString("Returned: true"));
+      assertEquals(MafiaState.CONTINUE, StaticEntity.getContinuationState());
+    }
+
+    @Test
+    public void shouldCheckExists() {
+      String output = CliCaller.callCli("ash", "git_exists(\"" + id + "\")");
+      assertThat(output, containsString("Returned: true"));
+      output = CliCaller.callCli("ash", "git_exists(\"absent-script\")");
+      assertThat(output, containsString("Returned: false"));
+    }
+
+    @Test
+    public void shouldCheckInfo() {
+      String output = CliCaller.callCli("ash", "git_info(\"" + id + "\").url");
+      assertThat(
+          output,
+          containsString("Returned: https://github.com/midgleyc/mafia-script-install-test.git"));
+    }
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTestBase.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AbstractCommandTestBase.java
@@ -2,9 +2,8 @@ package net.sourceforge.kolmafia.textui.command;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import internal.helpers.RequestLoggerOutput;
+import internal.helpers.CliCaller;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
-import net.sourceforge.kolmafia.KoLmafiaCLI;
 import net.sourceforge.kolmafia.StaticEntity;
 
 public abstract class AbstractCommandTestBase {
@@ -15,12 +14,7 @@ public abstract class AbstractCommandTestBase {
   }
 
   public String execute(final String params, final boolean check) {
-    RequestLoggerOutput.startStream();
-    var cli = new KoLmafiaCLI(System.in);
-    KoLmafiaCLI.isExecutingCheckOnlyCommand = check;
-    cli.executeCommand(this.command, params);
-    KoLmafiaCLI.isExecutingCheckOnlyCommand = false;
-    return RequestLoggerOutput.stopStream();
+    return CliCaller.callCli(this.command, params, check);
   }
 
   public static void assertState(final MafiaState state) {


### PR DESCRIPTION
Certain existing scripts, such as [ChIT](https://github.com/Loathing-Associates-Scripting-Society/ChIT) install from a folder one level lower than the base directory when using SVN. It is desirable to support this from git as well, to avoid breaking existing installations.

Introduce a file `manifest.json` with a key `root_directory` to specify the directory that contains the other files Mafia is interested in: those under the permissible folders (e.g. `scripts`), and the `dependencies.txt` file.

Removed comment about not supporting local changes because local changes are supported implicitly without me having to write any code, which is nice. It seems that `git update` will handle unstaged changes -- I thought asking people to commit changes was a good halfway house, but even this isn't necessary. Merge conflicts will probably error, though.

To install ChIT locally, a user could:
* run `git checkout https://github.com/Loathing-Associates-Scripting-Society/ChIT.git` to install ChIT, but not copy any files
* create a `manifest.json` file under `MAFIA_ROOT/git/Loathing-Associates-Scripting-Society-ChIT` containing
```
{
  "root_directory": "src"
}
```
* run `git sync`

This file could be added to the remote git repo, after this feature is released, to avoid the need for local changes.

I'm not certain I want the configuration to be json or to be named as it is -- arguments for / against welcomed.