### PR TITLE
log lovebug actions again

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -7694,6 +7694,10 @@ public class FightRequest extends GenericRequest {
     if (!status.lovebugs || !image.startsWith("lb_")) {
       return false;
     }
+
+    // Log what happened
+    FightRequest.logText(text, status);
+
     switch (image) {
       case "lb_ant.gif":
         // A love carpenter ant scurries up to you and coos as it drops off some additional building


### PR DESCRIPTION
It was reasonable to not bother looking for additional actions if we just processed lovebugs, but the code farther down in the caller which would log it was short circuited. Fix.