### PR TITLE
tests: disable git manager test on Windows

### DIFF
--- a/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
+++ b/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-@DisabledOnOs({OS.WINDOWS})
+@DisabledOnOs(value = {OS.WINDOWS}, disabledReason = "deleting script can fail")
 public class GitManagerTest {
 
   /**

--- a/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
+++ b/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
@@ -17,7 +17,10 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
+@DisabledOnOs({OS.WINDOWS})
 public class GitManagerTest {
 
   /**

--- a/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
+++ b/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
@@ -20,7 +20,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-@DisabledOnOs(value = {OS.WINDOWS}, disabledReason = "deleting script can fail")
+@DisabledOnOs(
+    value = {OS.WINDOWS},
+    disabledReason = "deleting script can fail")
 public class GitManagerTest {
 
   /**


### PR DESCRIPTION
Deletion of an installed git script can fail under certain circumstances. I suspect the following:
* if a script is installed and deleted fairly quickly, [deleting the items in .git/objects/pack can fail](https://stackoverflow.com/questions/19191727/pack-file-from-git-repo-cant-be-deleted-using-file-delete-method) (the solutions in the attached SO post don't work).
* GitManager catches that error and tries moving it to the temporary directory instead, which should work for most users...
* ...but can fail if the temporary directory and the current directory are on different network drives, as I suspect they are in the GitHub actions runner.

Disable the git manager test on Windows to stop it failing the builds.