### PR TITLE
Fix You, Robot tests. Looking at CPU upgrades counts as a visit.

### DIFF
--- a/src/net/sourceforge/kolmafia/session/YouRobotManager.java
+++ b/src/net/sourceforge/kolmafia/session/YouRobotManager.java
@@ -647,6 +647,7 @@ public abstract class YouRobotManager {
       boolean changed = false;
 
       if (upgrade == null) {
+        visitChoice(request);
         return;
       }
 

--- a/test/net/sourceforge/kolmafia/request/ScrapheapRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/ScrapheapRequestTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class ScrapheapRequestTest {
 
@@ -68,30 +70,20 @@ public class ScrapheapRequestTest {
     assertEquals(cost + 10, Preferences.getInteger("_chronolithNextCost"));
   }
 
-  @Test
-  public void parseCPUUpgrades() {
-    String html = html("request/test_scrapheap_cpu_upgrades.html");
+  @ParameterizedTest
+  @CsvSource({
+    "request/test_scrapheap_cpu_upgrades.html, robot_muscle:robot_mysticality:robot_moxie:robot_meat:robot_hp1:robot_regen:robot_resist:robot_items:robot_shirt:robot_energy:robot_potions:robot_hp2"
+  })
+  public void parseCPUUpgrades(String path, String upgrades) {
+    String html = html(path);
 
-    var req = new GenericRequest("choice.php?whichchoice=1445&show=cpus");
-    req.responseText = html;
-    ChoiceManager.visitChoice(req);
+    var request = new GenericRequest("choice.php?whichchoice=1445&show=cpus");
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+    request.processResponse();
 
-    var expected =
-        new String[] {
-          "robot_muscle",
-          "robot_mysticality",
-          "robot_moxie",
-          "robot_meat",
-          "robot_hp1",
-          "robot_regen",
-          "robot_resist",
-          "robot_items",
-          "robot_shirt",
-          "robot_energy",
-          "robot_potions",
-          "robot_hp2"
-        };
-
+    var expected = upgrades.split(":");
     var actual = Preferences.getString("youRobotCPUUpgrades").split(",");
 
     assertThat(actual, arrayContainingInAnyOrder(expected));

--- a/test/net/sourceforge/kolmafia/session/YouRobotManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/YouRobotManagerTest.java
@@ -292,36 +292,42 @@ public class YouRobotManagerTest {
   @Test
   public void canDiscoverStatbotCostOnVisit() {
     String urlString = "choice.php?forceoption=0";
-    String responseText = html("request/test_scrapheap_visit_statbot.html");
+    String html = html("request/test_scrapheap_visit_statbot.html");
     GenericRequest request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1447;
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+
     assertEquals(0, Preferences.getInteger("statbotUses"));
-    YouRobotManager.visitChoice(request);
+    request.processResponse();
     assertEquals(10, Preferences.getInteger("statbotUses"));
   }
 
   @Test
   public void canDiscoverStatbotCostOnActivation() {
     String urlString = "choice.php?pwd&whichchoice=1447&option=3";
-    String responseText = html("request/test_scrapheap_activate_statbot.html");
+    String html = html("request/test_scrapheap_activate_statbot.html");
     GenericRequest request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1447;
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+
     assertEquals(0, Preferences.getInteger("statbotUses"));
-    YouRobotManager.postChoice1(responseText, request);
+    request.processResponse();
     assertEquals(11, Preferences.getInteger("statbotUses"));
   }
 
   @Test
   public void canDiscoverStatbotCostOnFailedActivation() {
     String urlString = "choice.php?pwd&whichchoice=1447&option=3";
-    String responseText = html("request/test_scrapheap_activate_statbot_fails.html");
+    String html = html("request/test_scrapheap_activate_statbot_fails.html");
     GenericRequest request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1447;
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+
     assertEquals(0, Preferences.getInteger("statbotUses"));
-    YouRobotManager.postChoice1(responseText, request);
+    request.processResponse();
     assertEquals(24, Preferences.getInteger("statbotUses"));
   }
 
@@ -391,19 +397,21 @@ public class YouRobotManagerTest {
 
     // Install Tesla Blaster, lose Shoot Pea, gain Tesla Blast
     String urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=7";
-    String responseText = html("request/test_scrapheap_add_skill.html");
+    String html = html("request/test_scrapheap_add_skill.html");
     GenericRequest request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1445;
-    YouRobotManager.postChoice1(urlString, request);
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+    request.processResponse();
     assertEquals(70, KoLCharacter.getYouRobotScraps());
 
     urlString = "choice.php?pwd&whichchoice=1445&part=cpus&show=cpus&option=2&p=robot_resist";
-    responseText = html("request/test_scrapheap_cpu_upgrade.html");
+    html = html("request/test_scrapheap_cpu_upgrade.html");
     request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1445;
-    YouRobotManager.postChoice1(urlString, request);
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+    request.processResponse();
     assertEquals(60, KoLCharacter.getYouRobotEnergy());
   }
 
@@ -417,41 +425,45 @@ public class YouRobotManagerTest {
 
     // Look at Top Attachments
     String urlString = "choice.php?whichchoice=1445&show=top";
-    String responseText = html("request/test_scrapheap_show_top.html");
+    String html = html("request/test_scrapheap_show_top.html");
     GenericRequest request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1445;
-    YouRobotManager.visitChoice(request);
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+    request.processResponse();
     assertEquals(4, Preferences.getInteger("youRobotTop"));
 
     // Install Pea Shooter, learn Shoot Pea
     urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=1";
-    responseText = html("request/test_scrapheap_add_skill.html");
+    html = html("request/test_scrapheap_add_skill.html");
     request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1445;
-    YouRobotManager.postChoice1(urlString, request);
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+    request.processResponse();
     assertEquals(1, Preferences.getInteger("youRobotTop"));
     assertTrue(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
 
     // Install Tesla Blaster, lose Shoot Pea, gain Tesla Blast
     urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=7";
-    responseText = html("request/test_scrapheap_add_skill_lose_skill.html");
+    html = html("request/test_scrapheap_add_skill_lose_skill.html");
     request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1445;
-    YouRobotManager.postChoice1(urlString, request);
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+    request.processResponse();
     assertEquals(7, Preferences.getInteger("youRobotTop"));
     assertFalse(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
     assertTrue(KoLCharacter.hasCombatSkill(SkillPool.TESLA_BLAST));
 
     // Install Solar Panel, lost Tesla Blast
     urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=3";
-    responseText = html("request/test_scrapheap_lose_skill.html");
+    html = html("request/test_scrapheap_lose_skill.html");
     request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1445;
-    YouRobotManager.postChoice1(urlString, request);
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+    request.processResponse();
     assertEquals(3, Preferences.getInteger("youRobotTop"));
     assertFalse(KoLCharacter.hasCombatSkill(SkillPool.TESLA_BLAST));
   }
@@ -460,11 +472,12 @@ public class YouRobotManagerTest {
   public void willUnequipWhenSwapOutEquipPart() {
     // Look at Top Attachments
     String urlString = "choice.php?whichchoice=1445&show=top";
-    String responseText = html("request/test_scrapheap_show_top.html");
+    String html = html("request/test_scrapheap_show_top.html");
     GenericRequest request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1445;
-    YouRobotManager.visitChoice(request);
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+    request.processResponse();
     assertEquals(4, Preferences.getInteger("youRobotTop"));
 
     // That is a Mannequin Head, which allows you to equip hats.
@@ -477,11 +490,12 @@ public class YouRobotManagerTest {
 
     // Install Pea Shooter
     urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=1";
-    responseText = html("request/test_scrapheap_add_skill.html");
+    html = html("request/test_scrapheap_add_skill.html");
     request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1445;
-    YouRobotManager.postChoice1(urlString, request);
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+    request.processResponse();
 
     // Verify that we are no longer wearing a hat
     assertEquals(EquipmentRequest.UNEQUIP, EquipmentManager.getEquipment(EquipmentManager.HAT));
@@ -491,11 +505,12 @@ public class YouRobotManagerTest {
   public void willUnsetFamiliarWhenUnequipBirdCage() {
     // Look at Top Attachments
     String urlString = "choice.php?whichchoice=1445&show=top";
-    String responseText = html("request/test_scrapheap_show_top_bird_cage.html");
+    String html = html("request/test_scrapheap_show_top_bird_cage.html");
     GenericRequest request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1445;
-    YouRobotManager.visitChoice(request);
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+    request.processResponse();
     assertEquals(2, Preferences.getInteger("youRobotTop"));
 
     // That is a Bird Cage, which allows you to equip familiars.
@@ -508,11 +523,12 @@ public class YouRobotManagerTest {
 
     // Install Mannequin Head
     urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=4";
-    responseText = html("request/test_scrapheap_unequip_bird_cage.html");
+    html = html("request/test_scrapheap_unequip_bird_cage.html");
     request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1445;
-    YouRobotManager.postChoice1(urlString, request);
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+    request.processResponse();
     assertEquals(4, Preferences.getInteger("youRobotTop"));
 
     // Verify that we no longer have our familiar
@@ -523,11 +539,12 @@ public class YouRobotManagerTest {
   public void willAddCPUUpgrades() {
     // Look at CPU Upgrades
     String urlString = "choice.php?whichchoice=1445&show=cpus";
-    String responseText = html("request/test_scrapheap_show_cpus.html");
+    String html = html("request/test_scrapheap_show_cpus.html");
     GenericRequest request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1445;
-    YouRobotManager.visitChoice(request);
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+    request.processResponse();
 
     String[] keywords = Preferences.getString("youRobotCPUUpgrades").split(",");
     Set<String> cpus = new HashSet<>(Arrays.asList(keywords));
@@ -542,11 +559,12 @@ public class YouRobotManagerTest {
 
     // Buy a CPU Upgrade
     urlString = "choice.php?pwd&whichchoice=1445&part=cpus&show=cpus&option=2&p=robot_resist";
-    responseText = html("request/test_scrapheap_cpu_upgrade.html");
+    html = html("request/test_scrapheap_cpu_upgrade.html");
     request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1445;
-    YouRobotManager.postChoice1(urlString, request);
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+    request.processResponse();
 
     keywords = Preferences.getString("youRobotCPUUpgrades").split(",");
     cpus = new HashSet<>(Arrays.asList(keywords));
@@ -586,11 +604,12 @@ public class YouRobotManagerTest {
 
     // Look at CPU Upgrades
     String urlString = "choice.php?whichchoice=1445&show=cpus";
-    String responseText = html("request/test_scrapheap_show_cpus.html");
+    String html = html("request/test_scrapheap_show_cpus.html");
     GenericRequest request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1445;
-    YouRobotManager.visitChoice(request);
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+    request.processResponse();
 
     // Verify that our listener fired
     assertEquals(1, potionListener.getCalls());
@@ -661,20 +680,23 @@ public class YouRobotManagerTest {
     KoLCharacter.setYouRobotEnergy(100);
 
     String urlString = "choice.php?forceoption=0";
-    String responseText = html("request/test_scrapheap_visit_statbot.html");
+    String html = html("request/test_scrapheap_visit_statbot.html");
     GenericRequest request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1447;
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+
     assertEquals(0, Preferences.getInteger("statbotUses"));
-    YouRobotManager.visitChoice(request);
+    request.processResponse();
     assertEquals(10, Preferences.getInteger("statbotUses"));
 
     urlString = "choice.php?pwd&whichchoice=1447&option=1";
-    responseText = html("request/test_scrapheap_activate_statbot.html");
+    html = html("request/test_scrapheap_activate_statbot.html");
     request = new GenericRequest(urlString);
-    request.responseText = responseText;
-    ChoiceManager.lastChoice = 1447;
-    YouRobotManager.postChoice1(responseText, request);
+    request.setHasResult(true);
+    request.responseText = html;
+    ChoiceManager.preChoice(request);
+    request.processResponse();
     assertEquals(11, Preferences.getInteger("statbotUses"));
     assertEquals(100 - 20, KoLCharacter.getYouRobotEnergy());
   }

--- a/test/net/sourceforge/kolmafia/session/YouRobotManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/YouRobotManagerTest.java
@@ -1,10 +1,12 @@
 package net.sourceforge.kolmafia.session;
 
 import static internal.helpers.Networking.html;
+import static internal.helpers.Player.withPath;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import internal.helpers.Cleanups;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -34,8 +36,8 @@ import net.sourceforge.kolmafia.swingui.panel.ItemManagePanel;
 import net.sourceforge.kolmafia.swingui.panel.UseItemDequeuePanel;
 import net.sourceforge.kolmafia.swingui.panel.UseItemEnqueuePanel;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class YouRobotManagerTest {
@@ -70,7 +72,6 @@ public class YouRobotManagerTest {
     GenericRequest.passwordHash = "";
     KoLCharacter.reset("");
     KoLCharacter.reset("you robot manager user");
-    KoLCharacter.setPath(Path.YOU_ROBOT);
     Preferences.saveSettingsToFile = false;
   }
 
@@ -79,8 +80,8 @@ public class YouRobotManagerTest {
     Preferences.saveSettingsToFile = true;
   }
 
-  @BeforeEach
-  private void beforeEach() {
+  @AfterEach
+  private void afterEach() {
     Preferences.setInteger("statbotUses", 0);
     Preferences.setInteger("youRobotTop", 0);
     Preferences.setInteger("youRobotLeft", 0);
@@ -92,6 +93,7 @@ public class YouRobotManagerTest {
     KoLCharacter.resetSkills();
     KoLCharacter.setYouRobotEnergy(0);
     KoLCharacter.setYouRobotScraps(0);
+    ChoiceManager.handlingChoice = false;
     ChoiceManager.lastChoice = 0;
     ChoiceManager.lastDecision = 0;
   }
@@ -216,367 +218,408 @@ public class YouRobotManagerTest {
 
   @Test
   public void canFindAvatarOnCharSheet() {
-    String responseText = html("request/test_scrapheap_charsheet.html");
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      String responseText = html("request/test_scrapheap_charsheet.html");
 
-    // Verify that the properties and avatar are not set
-    verifyNoAvatarOrProperties();
+      // Verify that the properties and avatar are not set
+      verifyNoAvatarOrProperties();
 
-    CharSheetRequest.parseStatus(responseText);
+      CharSheetRequest.parseStatus(responseText);
 
-    // Verify that the properties and avatar are now set
-    verifyAvatarFromProperties();
+      // Verify that the properties and avatar are now set
+      verifyAvatarFromProperties();
+    }
   }
 
   @Test
   public void canFindAvatarOnCharPane() {
-    String responseText = html("request/test_scrapheap_charpane.html");
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      String responseText = html("request/test_scrapheap_charpane.html");
 
-    // Verify that the properties and avatar are not set
-    verifyNoAvatarOrProperties();
+      // Verify that the properties and avatar are not set
+      verifyNoAvatarOrProperties();
 
-    CharPaneRequest.compactCharacterPane = false;
-    CharPaneRequest.checkYouRobot(responseText);
+      CharPaneRequest.compactCharacterPane = false;
+      CharPaneRequest.checkYouRobot(responseText);
 
-    // Verify that the properties and avatar are now set
-    verifyAvatarFromProperties();
+      // Verify that the properties and avatar are now set
+      verifyAvatarFromProperties();
+    }
   }
 
   @Test
   public void canFindAvatarOnReassemblyStationVisit() {
-    String responseText = html("request/test_scrapheap_reassembly_station.html");
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      // Verify that the properties and avatar are not set
+      verifyNoAvatarOrProperties();
 
-    // Verify that the properties and avatar are not set
-    verifyNoAvatarOrProperties();
+      String urlString = "choice.php?forceoption=0";
+      String html = html("request/test_scrapheap_reassembly_station.html");
+      GenericRequest request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
 
-    ChoiceManager.lastChoice = 1445;
-    GenericRequest request = new GenericRequest("choice.php?forceoption=0");
-    request.responseText = responseText;
-    YouRobotManager.visitChoice(request);
-
-    // Verify that the properties and avatar are now set
-    verifyAvatarFromProperties();
+      // Verify that the properties and avatar are now set
+      verifyAvatarFromProperties();
+    }
   }
 
   @Test
   public void canHandleThreePartAvatar() {
-    // This is a newly ascended Accordion Thief
-    String responseText = html("request/test_scrapheap_three_part_avatar.html");
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      // Verify that the properties and avatar are not set
+      verifyNoAvatarOrProperties();
 
-    // Verify that the properties and avatar are not set
-    verifyNoAvatarOrProperties();
+      String urlString = "choice.php?forceoption=0";
+      // This is a newly ascended Accordion Thief
+      String html = html("request/test_scrapheap_three_part_avatar.html");
+      GenericRequest request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
 
-    ChoiceManager.lastChoice = 1445;
-    GenericRequest request = new GenericRequest("choice.php?forceoption=0");
-    request.responseText = responseText;
-    YouRobotManager.visitChoice(request);
+      // Verify that the properties and avatar are now set
+      assertEquals(1, Preferences.getInteger("youRobotTop"));
+      assertEquals(0, Preferences.getInteger("youRobotLeft"));
+      assertEquals(3, Preferences.getInteger("youRobotRight"));
+      assertEquals(3, Preferences.getInteger("youRobotBottom"));
+      assertEquals(6, Preferences.getInteger("youRobotBody"));
+      verifyAvatarFromProperties();
 
-    // Verify that the properties and avatar are now set
-    assertEquals(1, Preferences.getInteger("youRobotTop"));
-    assertEquals(0, Preferences.getInteger("youRobotLeft"));
-    assertEquals(3, Preferences.getInteger("youRobotRight"));
-    assertEquals(3, Preferences.getInteger("youRobotBottom"));
-    assertEquals(6, Preferences.getInteger("youRobotBody"));
-    verifyAvatarFromProperties();
+      // Verify that we can't equip any items
+      assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_HAT));
+      assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_WEAPON));
+      assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_OFFHAND));
+      assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_PANTS));
+      assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_SHIRT));
 
-    // Verify that we can't equip any items
-    assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_HAT));
-    assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_WEAPON));
-    assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_OFFHAND));
-    assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_PANTS));
-    assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_SHIRT));
-
-    // Verify that our Pea Shooter is active.
-    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
+      // Verify that our Pea Shooter is active.
+      assertTrue(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
+    }
   }
 
   @Test
   public void canDiscoverStatbotCostOnVisit() {
-    String urlString = "choice.php?forceoption=0";
-    String html = html("request/test_scrapheap_visit_statbot.html");
-    GenericRequest request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      String urlString = "choice.php?forceoption=0";
+      String html = html("request/test_scrapheap_visit_statbot.html");
+      GenericRequest request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
 
-    assertEquals(0, Preferences.getInteger("statbotUses"));
-    request.processResponse();
-    assertEquals(10, Preferences.getInteger("statbotUses"));
+      assertEquals(0, Preferences.getInteger("statbotUses"));
+      request.processResponse();
+      assertEquals(10, Preferences.getInteger("statbotUses"));
+    }
   }
 
   @Test
   public void canDiscoverStatbotCostOnActivation() {
-    String urlString = "choice.php?pwd&whichchoice=1447&option=3";
-    String html = html("request/test_scrapheap_activate_statbot.html");
-    GenericRequest request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      String urlString = "choice.php?pwd&whichchoice=1447&option=3";
+      String html = html("request/test_scrapheap_activate_statbot.html");
+      GenericRequest request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
 
-    assertEquals(0, Preferences.getInteger("statbotUses"));
-    request.processResponse();
-    assertEquals(11, Preferences.getInteger("statbotUses"));
+      assertEquals(0, Preferences.getInteger("statbotUses"));
+      request.processResponse();
+      assertEquals(11, Preferences.getInteger("statbotUses"));
+    }
   }
 
   @Test
   public void canDiscoverStatbotCostOnFailedActivation() {
-    String urlString = "choice.php?pwd&whichchoice=1447&option=3";
-    String html = html("request/test_scrapheap_activate_statbot_fails.html");
-    GenericRequest request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      String urlString = "choice.php?pwd&whichchoice=1447&option=3";
+      String html = html("request/test_scrapheap_activate_statbot_fails.html");
+      GenericRequest request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
 
-    assertEquals(0, Preferences.getInteger("statbotUses"));
-    request.processResponse();
-    assertEquals(24, Preferences.getInteger("statbotUses"));
+      assertEquals(0, Preferences.getInteger("statbotUses"));
+      request.processResponse();
+      assertEquals(24, Preferences.getInteger("statbotUses"));
+    }
   }
 
   @Test
   public void canRegisterRequests() {
-    String urlString = "choice.php?whichchoice=1445&show=cpus";
-    String expected = "Inspecting CPU Upgrade options at the Reassembly Station.";
-    assertTrue(YouRobotManager.registerRequest(urlString));
-    assertEquals(expected, RequestLogger.previousUpdateString);
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      String urlString = "choice.php?whichchoice=1445&show=cpus";
+      String expected = "Inspecting CPU Upgrade options at the Reassembly Station.";
+      assertTrue(YouRobotManager.registerRequest(urlString));
+      assertEquals(expected, RequestLogger.previousUpdateString);
 
-    urlString = "choice.php?pwd&whichchoice=1445&part=cpus&show=cpus&option=2&p=robot_resist";
-    expected = "Upgrading your CPU with Weather Control Algorithms for 40 energy.";
-    assertTrue(YouRobotManager.registerRequest(urlString));
-    assertEquals(expected, RequestLogger.previousUpdateString);
+      urlString = "choice.php?pwd&whichchoice=1445&part=cpus&show=cpus&option=2&p=robot_resist";
+      expected = "Upgrading your CPU with Weather Control Algorithms for 40 energy.";
+      assertTrue(YouRobotManager.registerRequest(urlString));
+      assertEquals(expected, RequestLogger.previousUpdateString);
 
-    urlString = "choice.php?whichchoice=1445&show=top";
-    expected = "Inspecting Top Attachment options at the Reassembly Station.";
-    assertTrue(YouRobotManager.registerRequest(urlString));
-    assertEquals(expected, RequestLogger.previousUpdateString);
+      urlString = "choice.php?whichchoice=1445&show=top";
+      expected = "Inspecting Top Attachment options at the Reassembly Station.";
+      assertTrue(YouRobotManager.registerRequest(urlString));
+      assertEquals(expected, RequestLogger.previousUpdateString);
 
-    urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=1";
-    expected = "Installing Pea Shooter as your Top Attachment for 5 scrap.";
-    assertTrue(YouRobotManager.registerRequest(urlString));
-    assertEquals(expected, RequestLogger.previousUpdateString);
+      urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=1";
+      expected = "Installing Pea Shooter as your Top Attachment for 5 scrap.";
+      assertTrue(YouRobotManager.registerRequest(urlString));
+      assertEquals(expected, RequestLogger.previousUpdateString);
 
-    urlString = "choice.php?whichchoice=1445&show=left";
-    expected = "Inspecting Left Arm options at the Reassembly Station.";
-    assertTrue(YouRobotManager.registerRequest(urlString));
-    assertEquals(expected, RequestLogger.previousUpdateString);
+      urlString = "choice.php?whichchoice=1445&show=left";
+      expected = "Inspecting Left Arm options at the Reassembly Station.";
+      assertTrue(YouRobotManager.registerRequest(urlString));
+      assertEquals(expected, RequestLogger.previousUpdateString);
 
-    urlString = "choice.php?pwd&whichchoice=1445&part=left&show=left&option=1&p=4";
-    expected = "Installing Vice Grips as your Left Arm for 15 scrap.";
-    assertTrue(YouRobotManager.registerRequest(urlString));
-    assertEquals(expected, RequestLogger.previousUpdateString);
+      urlString = "choice.php?pwd&whichchoice=1445&part=left&show=left&option=1&p=4";
+      expected = "Installing Vice Grips as your Left Arm for 15 scrap.";
+      assertTrue(YouRobotManager.registerRequest(urlString));
+      assertEquals(expected, RequestLogger.previousUpdateString);
 
-    urlString = "choice.php?whichchoice=1445&show=right";
-    expected = "Inspecting Right Arm options at the Reassembly Station.";
-    assertTrue(YouRobotManager.registerRequest(urlString));
-    assertEquals(expected, RequestLogger.previousUpdateString);
+      urlString = "choice.php?whichchoice=1445&show=right";
+      expected = "Inspecting Right Arm options at the Reassembly Station.";
+      assertTrue(YouRobotManager.registerRequest(urlString));
+      assertEquals(expected, RequestLogger.previousUpdateString);
 
-    urlString = "choice.php?pwd&whichchoice=1445&part=right&show=right&option=1&p=8";
-    expected = "Installing Surplus Flamethrower as your Right Arm for 40 scrap.";
-    assertTrue(YouRobotManager.registerRequest(urlString));
-    assertEquals(expected, RequestLogger.previousUpdateString);
+      urlString = "choice.php?pwd&whichchoice=1445&part=right&show=right&option=1&p=8";
+      expected = "Installing Surplus Flamethrower as your Right Arm for 40 scrap.";
+      assertTrue(YouRobotManager.registerRequest(urlString));
+      assertEquals(expected, RequestLogger.previousUpdateString);
 
-    urlString = "choice.php?whichchoice=1445&show=bottom";
-    expected = "Inspecting Propulsion System options at the Reassembly Station.";
-    assertTrue(YouRobotManager.registerRequest(urlString));
-    assertEquals(expected, RequestLogger.previousUpdateString);
+      urlString = "choice.php?whichchoice=1445&show=bottom";
+      expected = "Inspecting Propulsion System options at the Reassembly Station.";
+      assertTrue(YouRobotManager.registerRequest(urlString));
+      assertEquals(expected, RequestLogger.previousUpdateString);
 
-    urlString = "choice.php?pwd&whichchoice=1445&part=bottom&show=bottom&option=1&p=7";
-    expected = "Installing Snowplow as your Propulsion System for 30 scrap.";
-    assertTrue(YouRobotManager.registerRequest(urlString));
-    assertEquals(expected, RequestLogger.previousUpdateString);
+      urlString = "choice.php?pwd&whichchoice=1445&part=bottom&show=bottom&option=1&p=7";
+      expected = "Installing Snowplow as your Propulsion System for 30 scrap.";
+      assertTrue(YouRobotManager.registerRequest(urlString));
+      assertEquals(expected, RequestLogger.previousUpdateString);
 
-    urlString = "choice.php?pwd&whichchoice=1447&option=3";
-    expected = "Spending 20 energy to upgrade Moxie by 5 points.";
-    Preferences.setInteger("statbotUses", 10);
-    assertTrue(YouRobotManager.registerRequest(urlString));
-    assertEquals(expected, RequestLogger.previousUpdateString);
+      urlString = "choice.php?pwd&whichchoice=1447&option=3";
+      expected = "Spending 20 energy to upgrade Moxie by 5 points.";
+      Preferences.setInteger("statbotUses", 10);
+      assertTrue(YouRobotManager.registerRequest(urlString));
+      assertEquals(expected, RequestLogger.previousUpdateString);
+    }
   }
 
   @Test
   public void canPayUpgradeCosts() {
-    KoLCharacter.setYouRobotEnergy(100);
-    KoLCharacter.setYouRobotScraps(100);
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      KoLCharacter.setYouRobotEnergy(100);
+      KoLCharacter.setYouRobotScraps(100);
 
-    // Install Tesla Blaster, lose Shoot Pea, gain Tesla Blast
-    String urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=7";
-    String html = html("request/test_scrapheap_add_skill.html");
-    GenericRequest request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
-    request.processResponse();
-    assertEquals(70, KoLCharacter.getYouRobotScraps());
+      // Install Tesla Blaster, lose Shoot Pea, gain Tesla Blast
+      String urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=7";
+      String html = html("request/test_scrapheap_add_skill.html");
+      GenericRequest request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
+      assertEquals(70, KoLCharacter.getYouRobotScraps());
 
-    urlString = "choice.php?pwd&whichchoice=1445&part=cpus&show=cpus&option=2&p=robot_resist";
-    html = html("request/test_scrapheap_cpu_upgrade.html");
-    request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
-    request.processResponse();
-    assertEquals(60, KoLCharacter.getYouRobotEnergy());
+      urlString = "choice.php?pwd&whichchoice=1445&part=cpus&show=cpus&option=2&p=robot_resist";
+      html = html("request/test_scrapheap_cpu_upgrade.html");
+      request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
+      assertEquals(60, KoLCharacter.getYouRobotEnergy());
+    }
   }
 
   @Test
   public void canTrackChangesInCombatSkills() {
-    // Start with no known combat skills.
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      // Start with no known combat skills.
 
-    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
-    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.TESLA_BLAST));
-    assertEquals(0, Preferences.getInteger("youRobotTop"));
+      assertFalse(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
+      assertFalse(KoLCharacter.hasCombatSkill(SkillPool.TESLA_BLAST));
+      assertEquals(0, Preferences.getInteger("youRobotTop"));
 
-    // Look at Top Attachments
-    String urlString = "choice.php?whichchoice=1445&show=top";
-    String html = html("request/test_scrapheap_show_top.html");
-    GenericRequest request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
-    request.processResponse();
-    assertEquals(4, Preferences.getInteger("youRobotTop"));
+      // Look at Top Attachments
+      String urlString = "choice.php?whichchoice=1445&show=top";
+      String html = html("request/test_scrapheap_show_top.html");
+      GenericRequest request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
+      assertEquals(4, Preferences.getInteger("youRobotTop"));
 
-    // Install Pea Shooter, learn Shoot Pea
-    urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=1";
-    html = html("request/test_scrapheap_add_skill.html");
-    request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
-    request.processResponse();
-    assertEquals(1, Preferences.getInteger("youRobotTop"));
-    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
+      // Install Pea Shooter, learn Shoot Pea
+      urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=1";
+      html = html("request/test_scrapheap_add_skill.html");
+      request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
+      assertEquals(1, Preferences.getInteger("youRobotTop"));
+      assertTrue(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
 
-    // Install Tesla Blaster, lose Shoot Pea, gain Tesla Blast
-    urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=7";
-    html = html("request/test_scrapheap_add_skill_lose_skill.html");
-    request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
-    request.processResponse();
-    assertEquals(7, Preferences.getInteger("youRobotTop"));
-    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
-    assertTrue(KoLCharacter.hasCombatSkill(SkillPool.TESLA_BLAST));
+      // Install Tesla Blaster, lose Shoot Pea, gain Tesla Blast
+      urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=7";
+      html = html("request/test_scrapheap_add_skill_lose_skill.html");
+      request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
+      assertEquals(7, Preferences.getInteger("youRobotTop"));
+      assertFalse(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
+      assertTrue(KoLCharacter.hasCombatSkill(SkillPool.TESLA_BLAST));
 
-    // Install Solar Panel, lost Tesla Blast
-    urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=3";
-    html = html("request/test_scrapheap_lose_skill.html");
-    request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
-    request.processResponse();
-    assertEquals(3, Preferences.getInteger("youRobotTop"));
-    assertFalse(KoLCharacter.hasCombatSkill(SkillPool.TESLA_BLAST));
+      // Install Solar Panel, lost Tesla Blast
+      urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=3";
+      html = html("request/test_scrapheap_lose_skill.html");
+      request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
+      assertEquals(3, Preferences.getInteger("youRobotTop"));
+      assertFalse(KoLCharacter.hasCombatSkill(SkillPool.TESLA_BLAST));
+    }
   }
 
   @Test
   public void willUnequipWhenSwapOutEquipPart() {
-    // Look at Top Attachments
-    String urlString = "choice.php?whichchoice=1445&show=top";
-    String html = html("request/test_scrapheap_show_top.html");
-    GenericRequest request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
-    request.processResponse();
-    assertEquals(4, Preferences.getInteger("youRobotTop"));
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      // Look at Top Attachments
+      String urlString = "choice.php?whichchoice=1445&show=top";
+      String html = html("request/test_scrapheap_show_top.html");
+      GenericRequest request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
+      assertEquals(4, Preferences.getInteger("youRobotTop"));
 
-    // That is a Mannequin Head, which allows you to equip hats.
-    assertTrue(EquipmentManager.canEquip(ItemPool.HELMET_TURTLE));
+      // That is a Mannequin Head, which allows you to equip hats.
+      assertTrue(EquipmentManager.canEquip(ItemPool.HELMET_TURTLE));
 
-    // Put one on
-    AdventureResult hat = ItemPool.get(ItemPool.HELMET_TURTLE, 1);
-    EquipmentManager.setEquipment(EquipmentManager.HAT, hat);
-    assertTrue(hat.equals(EquipmentManager.getEquipment(EquipmentManager.HAT)));
+      // Put one on
+      AdventureResult hat = ItemPool.get(ItemPool.HELMET_TURTLE, 1);
+      EquipmentManager.setEquipment(EquipmentManager.HAT, hat);
+      assertTrue(hat.equals(EquipmentManager.getEquipment(EquipmentManager.HAT)));
 
-    // Install Pea Shooter
-    urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=1";
-    html = html("request/test_scrapheap_add_skill.html");
-    request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
-    request.processResponse();
+      // Install Pea Shooter
+      urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=1";
+      html = html("request/test_scrapheap_add_skill.html");
+      request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
 
-    // Verify that we are no longer wearing a hat
-    assertEquals(EquipmentRequest.UNEQUIP, EquipmentManager.getEquipment(EquipmentManager.HAT));
+      // Verify that we are no longer wearing a hat
+      assertEquals(EquipmentRequest.UNEQUIP, EquipmentManager.getEquipment(EquipmentManager.HAT));
+    }
   }
 
   @Test
   public void willUnsetFamiliarWhenUnequipBirdCage() {
-    // Look at Top Attachments
-    String urlString = "choice.php?whichchoice=1445&show=top";
-    String html = html("request/test_scrapheap_show_top_bird_cage.html");
-    GenericRequest request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
-    request.processResponse();
-    assertEquals(2, Preferences.getInteger("youRobotTop"));
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      // Look at Top Attachments
+      String urlString = "choice.php?whichchoice=1445&show=top";
+      String html = html("request/test_scrapheap_show_top_bird_cage.html");
+      GenericRequest request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
+      assertEquals(2, Preferences.getInteger("youRobotTop"));
 
-    // That is a Bird Cage, which allows you to equip familiars.
-    FamiliarData familiar = new FamiliarData(FamiliarPool.EMO_SQUID);
-    assertTrue(familiar.canEquip());
+      // That is a Bird Cage, which allows you to equip familiars.
+      FamiliarData familiar = new FamiliarData(FamiliarPool.EMO_SQUID);
+      assertTrue(familiar.canEquip());
 
-    // Take it with you!
-    KoLCharacter.setFamiliar(familiar);
-    assertEquals(familiar, KoLCharacter.getFamiliar());
+      // Take it with you!
+      KoLCharacter.setFamiliar(familiar);
+      assertEquals(familiar, KoLCharacter.getFamiliar());
 
-    // Install Mannequin Head
-    urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=4";
-    html = html("request/test_scrapheap_unequip_bird_cage.html");
-    request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
-    request.processResponse();
-    assertEquals(4, Preferences.getInteger("youRobotTop"));
+      // Install Mannequin Head
+      urlString = "choice.php?pwd&whichchoice=1445&part=top&show=top&option=1&p=4";
+      html = html("request/test_scrapheap_unequip_bird_cage.html");
+      request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
+      assertEquals(4, Preferences.getInteger("youRobotTop"));
 
-    // Verify that we no longer have our familiar
-    assertEquals(FamiliarData.NO_FAMILIAR, KoLCharacter.getFamiliar());
+      // Verify that we no longer have our familiar
+      assertEquals(FamiliarData.NO_FAMILIAR, KoLCharacter.getFamiliar());
+    }
   }
 
   @Test
   public void willAddCPUUpgrades() {
-    // Look at CPU Upgrades
-    String urlString = "choice.php?whichchoice=1445&show=cpus";
-    String html = html("request/test_scrapheap_show_cpus.html");
-    GenericRequest request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
-    request.processResponse();
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      // Look at CPU Upgrades
+      String urlString = "choice.php?whichchoice=1445&show=cpus";
+      String html = html("request/test_scrapheap_show_cpus.html");
+      GenericRequest request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
 
-    String[] keywords = Preferences.getString("youRobotCPUUpgrades").split(",");
-    Set<String> cpus = new HashSet<>(Arrays.asList(keywords));
-    assertEquals(7, cpus.size());
-    assertTrue(cpus.contains("robot_energy"));
-    assertTrue(cpus.contains("robot_potions"));
-    assertTrue(cpus.contains("robot_meat"));
-    assertTrue(cpus.contains("robot_items"));
-    assertTrue(cpus.contains("robot_shirt"));
-    assertTrue(cpus.contains("robot_hp1"));
-    assertTrue(cpus.contains("robot_hp2"));
+      String[] keywords = Preferences.getString("youRobotCPUUpgrades").split(",");
+      Set<String> cpus = new HashSet<>(Arrays.asList(keywords));
+      assertEquals(7, cpus.size());
+      assertTrue(cpus.contains("robot_energy"));
+      assertTrue(cpus.contains("robot_potions"));
+      assertTrue(cpus.contains("robot_meat"));
+      assertTrue(cpus.contains("robot_items"));
+      assertTrue(cpus.contains("robot_shirt"));
+      assertTrue(cpus.contains("robot_hp1"));
+      assertTrue(cpus.contains("robot_hp2"));
 
-    // Buy a CPU Upgrade
-    urlString = "choice.php?pwd&whichchoice=1445&part=cpus&show=cpus&option=2&p=robot_resist";
-    html = html("request/test_scrapheap_cpu_upgrade.html");
-    request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
-    request.processResponse();
+      // Buy a CPU Upgrade
+      urlString = "choice.php?pwd&whichchoice=1445&part=cpus&show=cpus&option=2&p=robot_resist";
+      html = html("request/test_scrapheap_cpu_upgrade.html");
+      request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
 
-    keywords = Preferences.getString("youRobotCPUUpgrades").split(",");
-    cpus = new HashSet<>(Arrays.asList(keywords));
-    assertEquals(8, cpus.size());
-    assertTrue(cpus.contains("robot_energy"));
-    assertTrue(cpus.contains("robot_potions"));
-    assertTrue(cpus.contains("robot_meat"));
-    assertTrue(cpus.contains("robot_items"));
-    assertTrue(cpus.contains("robot_shirt"));
-    assertTrue(cpus.contains("robot_hp1"));
-    assertTrue(cpus.contains("robot_hp2"));
-    assertTrue(cpus.contains("robot_resist"));
+      keywords = Preferences.getString("youRobotCPUUpgrades").split(",");
+      cpus = new HashSet<>(Arrays.asList(keywords));
+      assertEquals(8, cpus.size());
+      assertTrue(cpus.contains("robot_energy"));
+      assertTrue(cpus.contains("robot_potions"));
+      assertTrue(cpus.contains("robot_meat"));
+      assertTrue(cpus.contains("robot_items"));
+      assertTrue(cpus.contains("robot_shirt"));
+      assertTrue(cpus.contains("robot_hp1"));
+      assertTrue(cpus.contains("robot_hp2"));
+      assertTrue(cpus.contains("robot_resist"));
+    }
   }
 
   private JButton findItemManagePanelButton(ItemManagePanel panel, String name) {
@@ -590,114 +633,129 @@ public class YouRobotManagerTest {
   public void willAllowPotionUsage() {
     TestListener potionListener = new TestListener("(potions)");
 
-    // Start with no CPU upgrades. We cannot use potions.
-    assertFalse(YouRobotManager.canUsePotions());
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      // Start with no CPU upgrades. We cannot use potions.
+      assertFalse(YouRobotManager.canUsePotions());
 
-    // Make ItemManager potion panels
-    UseItemEnqueuePanel enqueue = new UseItemEnqueuePanel(ConcoctionType.POTION, null);
-    JButton enqueueButton = findItemManagePanelButton(enqueue, "consume");
-    assertFalse(enqueueButton.isEnabled());
+      // Make ItemManager potion panels
+      UseItemEnqueuePanel enqueue = new UseItemEnqueuePanel(ConcoctionType.POTION, null);
+      JButton enqueueButton = findItemManagePanelButton(enqueue, "consume");
+      assertFalse(enqueueButton.isEnabled());
 
-    UseItemDequeuePanel dequeue = new UseItemDequeuePanel(ConcoctionType.POTION);
-    JButton dequeueButton = findItemManagePanelButton(dequeue, "consume");
-    assertFalse(dequeueButton.isEnabled());
+      UseItemDequeuePanel dequeue = new UseItemDequeuePanel(ConcoctionType.POTION);
+      JButton dequeueButton = findItemManagePanelButton(dequeue, "consume");
+      assertFalse(dequeueButton.isEnabled());
 
-    // Look at CPU Upgrades
-    String urlString = "choice.php?whichchoice=1445&show=cpus";
-    String html = html("request/test_scrapheap_show_cpus.html");
-    GenericRequest request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
-    request.processResponse();
+      // Look at CPU Upgrades
+      String urlString = "choice.php?whichchoice=1445&show=cpus";
+      String html = html("request/test_scrapheap_show_cpus.html");
+      GenericRequest request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
 
-    // Verify that our listener fired
-    assertEquals(1, potionListener.getCalls());
+      // Verify that our listener fired
+      assertEquals(1, potionListener.getCalls());
 
-    // Now we can use potions
-    assertTrue(YouRobotManager.canUsePotions());
+      // Now we can use potions
+      assertTrue(YouRobotManager.canUsePotions());
 
-    // And the ItemManager GUI knows it.
-    assertTrue(enqueueButton.isEnabled());
-    assertTrue(dequeueButton.isEnabled());
+      // And the ItemManager GUI knows it.
+      assertTrue(enqueueButton.isEnabled());
+      assertTrue(dequeueButton.isEnabled());
 
-    // Parse the same CPU Upgrade page
-    YouRobotManager.visitChoice(request);
+      // Parse the same CPU Upgrade page
+      ChoiceManager.preChoice(request);
+      request.processResponse();
 
-    // Verify that our listener did not fire
-    assertEquals(1, potionListener.getCalls());
+      // Verify that our listener did not fire
+      assertEquals(1, potionListener.getCalls());
+    }
   }
 
   @Test
   public void canSetAvatarAndGetSignal() {
     TestListener avatarListener = new TestListener("(avatar)");
 
-    // We started out with an avatar = ""
-    // Verify that if we set the same avatar, our listener doesn't fire.
-    KoLCharacter.setAvatar("");
-    assertEquals(0, avatarListener.getCalls());
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      // We started out with an avatar = ""
+      // Verify that if we set the same avatar, our listener doesn't fire.
+      KoLCharacter.setAvatar("");
+      assertEquals(0, avatarListener.getCalls());
 
-    // Female Accordion Thief
-    KoLCharacter.setAvatar("otherimages/classav6b_f.gif");
-    assertEquals(1, avatarListener.getCalls());
+      // Female Accordion Thief
+      KoLCharacter.setAvatar("otherimages/classav6b_f.gif");
+      assertEquals(1, avatarListener.getCalls());
 
-    // Load a 3-part robot
-    String responseText = html("request/test_scrapheap_three_part_avatar.html");
+      // Load a 3-part robot
+      String urlString = "choice.php?forceoption=0";
+      String html = html("request/test_scrapheap_three_part_avatar.html");
+      GenericRequest request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
 
-    ChoiceManager.lastChoice = 1445;
-    GenericRequest request = new GenericRequest("choice.php?forceoption=0");
-    request.responseText = responseText;
-    YouRobotManager.visitChoice(request);
+      // Our Listener fired
+      assertEquals(2, avatarListener.getCalls());
 
-    // Our Listener fired
-    assertEquals(2, avatarListener.getCalls());
+      // Do it again with the same image
+      ChoiceManager.preChoice(request);
+      request.processResponse();
+      assertEquals(2, avatarListener.getCalls());
 
-    // Do it again with the same image
-    YouRobotManager.visitChoice(request);
-    assertEquals(2, avatarListener.getCalls());
+      // Load a 4-part robot
+      urlString = "choice.php?forceoption=0";
+      html = html("request/test_scrapheap_reassembly_station.html");
+      request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
 
-    // Load a 4-part robot
-    responseText = html("request/test_scrapheap_reassembly_station.html");
-    ChoiceManager.lastChoice = 1445;
-    request = new GenericRequest("choice.php?forceoption=0");
-    request.responseText = responseText;
-    YouRobotManager.visitChoice(request);
+      // Our Listener fired
+      assertEquals(3, avatarListener.getCalls());
 
-    // Our Listener fired
-    assertEquals(3, avatarListener.getCalls());
+      // Do it again with the same image
+      ChoiceManager.preChoice(request);
+      request.processResponse();
+      assertEquals(3, avatarListener.getCalls());
 
-    // Do it again with the same image
-    YouRobotManager.visitChoice(request);
-    assertEquals(3, avatarListener.getCalls());
-
-    // Call setAvatar directly with the current images
-    KoLCharacter.setAvatar(KoLCharacter.getAvatar());
-    assertEquals(3, avatarListener.getCalls());
+      // Call setAvatar directly with the current images
+      KoLCharacter.setAvatar(KoLCharacter.getAvatar());
+      assertEquals(3, avatarListener.getCalls());
+    }
   }
 
   @Test
   public void canTrackStatbotEnergyCost() {
-    KoLCharacter.setYouRobotEnergy(100);
+    var cleanups = new Cleanups(withPath(Path.YOU_ROBOT));
+    try (cleanups) {
+      KoLCharacter.setYouRobotEnergy(100);
 
-    String urlString = "choice.php?forceoption=0";
-    String html = html("request/test_scrapheap_visit_statbot.html");
-    GenericRequest request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
+      String urlString = "choice.php?forceoption=0";
+      String html = html("request/test_scrapheap_visit_statbot.html");
+      GenericRequest request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
 
-    assertEquals(0, Preferences.getInteger("statbotUses"));
-    request.processResponse();
-    assertEquals(10, Preferences.getInteger("statbotUses"));
+      assertEquals(0, Preferences.getInteger("statbotUses"));
+      request.processResponse();
+      assertEquals(10, Preferences.getInteger("statbotUses"));
 
-    urlString = "choice.php?pwd&whichchoice=1447&option=1";
-    html = html("request/test_scrapheap_activate_statbot.html");
-    request = new GenericRequest(urlString);
-    request.setHasResult(true);
-    request.responseText = html;
-    ChoiceManager.preChoice(request);
-    request.processResponse();
-    assertEquals(11, Preferences.getInteger("statbotUses"));
-    assertEquals(100 - 20, KoLCharacter.getYouRobotEnergy());
+      urlString = "choice.php?pwd&whichchoice=1447&option=1";
+      html = html("request/test_scrapheap_activate_statbot.html");
+      request = new GenericRequest(urlString);
+      request.setHasResult(true);
+      request.responseText = html;
+      ChoiceManager.preChoice(request);
+      request.processResponse();
+      assertEquals(11, Preferences.getInteger("statbotUses"));
+      assertEquals(100 - 20, KoLCharacter.getYouRobotEnergy());
+    }
   }
 }


### PR DESCRIPTION
Bug Report says that looking at CPU Upgrades in Reassembly Station in a You, Robot run does not learn which ones you have installed.

I could have sworn that worked for me - and I even had a working unit test that showed it.

Well, yes. If YouRobotManager.visitChoice is called with a responseText for choice 1445, it will parse the upgrades.
Unfortunately, the normal choice processing path never called visitChoice in that way for CPU upgrades. It just called postChoice1 with a URL that indicated no change was being made.

The tests for YouRobotManager all called the specific method they thought was needed - visitChoice or postChoice1.

I changed them all to call the processResponse method of the request, which does all the steps of choice processing - and that showed the error I mentioned about visitChoice not being called.

I added one line to YouRobotManager to call visitChoice from postChoice1, if appropriate.

The test now passes.  One hopes the Bug Report will be fixed.