### PR TITLE
feat: allow accessing exactly choice.php

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -2146,6 +2146,7 @@ public abstract class ChoiceManager {
   public static boolean bogusChoice(final GenericRequest request) {
     if (!ChoiceManager.handlingChoice
         || !request.getURLString().startsWith("choice.php")
+        || "choice.php".equals(request.getURLString())
         || request.responseText == null) {
       return false;
     }

--- a/test/net/sourceforge/kolmafia/session/ChoiceManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/ChoiceManagerTest.java
@@ -127,5 +127,17 @@ public class ChoiceManagerTest {
         assertThat(ChoiceManager.bogusChoice(request), is(false));
       }
     }
+
+    @Test
+    public void returnsFalseGoingToExactlyChoicePhp() {
+      var cleanup = new Cleanups(withHandlingChoice());
+
+      try (cleanup) {
+        var request = new GenericRequest("choice.php");
+        request.responseText = "Whoops!  You're not actually in a choice adventure.";
+
+        assertThat(ChoiceManager.bogusChoice(request), is(false));
+      }
+    }
   }
 }


### PR DESCRIPTION
Related to #936.

https://github.com/Ezandora/Far-Future/blob/Release/scripts/FarFuture.ash#L1794 contains the code:
```
//Are we in a game?
string page_text = visit_url("choice.php");
if (!page_text.contains_text("Starship ") && !page_text.contains_text("blue><b>The Far Future")) //hack
{
```

Keep the code working by allowing accessing exactly "choice.php" (with no arguments).