### PR TITLE
breakfast lets ChoiceManager automate sea jelly

### DIFF
--- a/src/net/sourceforge/kolmafia/session/BreakfastManager.java
+++ b/src/net/sourceforge/kolmafia/session/BreakfastManager.java
@@ -801,8 +801,11 @@ public class BreakfastManager {
     FamiliarData currentFam = KoLCharacter.getFamiliar();
 
     FamiliarManager.changeFamiliar(jellyfish, false);
+    // Force automation to take option 1
+    Preferences.setInteger("choiceAdventure1219", 1);
+    // This will redirect to choice.php?forceoption=0 which will make
+    // ChoiceManager automate the choice through option 1
     RequestThread.postRequest(new PlaceRequest("thesea", "thesea_left2", false));
-    RequestThread.postRequest(new GenericRequest("choice.php?whichchoice=1219&option=1"));
     FamiliarManager.changeFamiliar(currentFam);
 
     KoLmafia.forceContinue();


### PR DESCRIPTION
Choice 1219/1 collects a sea jelly - or not, if you already have done that today.
In either case, KoL dumps you out of the choice.

whichchoice1219 defaults to 1 - and is not configurable in the GUI.

Breakfast now resets it to 1, will ye nill ye, simply not caring if ye have changed it.

Breakfast now lets ChoiceManager simply automate collecting sea jelly, rather than trying to do it manually, which simply can't work, unless you have manually changed that preference to 0 - "Show in Browser".

I am quite certain that nobody has ever done that.