### PR TITLE
No NPE in can_adventure() in Standard for non-item zone

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -1499,7 +1499,7 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
       // If we got here, we have the plans and planks
       RequestThread.postRequest(UseItemRequest.getInstance(ItemPool.DINGHY_PLANS));
     }
-    return InventoryManager.hasItem(DINGY_DINGHY);
+    return KoLCharacter.mysteriousIslandAccessible();
   }
 
   // Validation part 2:

--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -1822,12 +1822,20 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
   public int getOutfitId() {
     switch (this.adventureNumber) {
       case AdventurePool.FRAT_HOUSE_DISGUISED:
+        // Can be either FRAT_OUTFIT or WAR_FRAT_OUTFIT
+        return EquipmentManager.hasOutfit(OutfitPool.WAR_FRAT_OUTFIT)
+            ? OutfitPool.WAR_FRAT_OUTFIT
+            : EquipmentManager.hasOutfit(OutfitPool.FRAT_OUTFIT) ? OutfitPool.FRAT_OUTFIT : 0;
       case AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED:
         // Can be either HIPPY_OUTFIT or WAR_HIPPY_OUTFIT
         return EquipmentManager.hasOutfit(OutfitPool.WAR_HIPPY_OUTFIT)
             ? OutfitPool.WAR_HIPPY_OUTFIT
             : EquipmentManager.hasOutfit(OutfitPool.HIPPY_OUTFIT) ? OutfitPool.HIPPY_OUTFIT : 0;
       case AdventurePool.HIPPY_CAMP_DISGUISED:
+        // Can be either HIPPY_OUTFIT or WAR_HIPPY_OUTFIT
+        return EquipmentManager.hasOutfit(OutfitPool.WAR_HIPPY_OUTFIT)
+            ? OutfitPool.WAR_HIPPY_OUTFIT
+            : EquipmentManager.hasOutfit(OutfitPool.HIPPY_OUTFIT) ? OutfitPool.HIPPY_OUTFIT : 0;
       case AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED:
         // Can be either FRAT_OUTFIT or WAR_FRAT_OUTFIT
         return EquipmentManager.hasOutfit(OutfitPool.WAR_FRAT_OUTFIT)

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -647,6 +647,9 @@ public abstract class RuntimeLibrary {
     functions.add(new LibraryFunction("can_adventure", DataTypes.BOOLEAN_TYPE, params));
 
     params = new Type[] {DataTypes.LOCATION_TYPE};
+    functions.add(new LibraryFunction("prepare_for_adventure", DataTypes.BOOLEAN_TYPE, params));
+
+    params = new Type[] {DataTypes.LOCATION_TYPE};
     functions.add(new LibraryFunction("set_location", DataTypes.VOID_TYPE, params));
 
     params = new Type[] {DataTypes.LOCATION_TYPE, DataTypes.INT_TYPE};
@@ -3793,7 +3796,12 @@ public abstract class RuntimeLibrary {
 
   public static Value can_adventure(ScriptRuntime controller, final Value arg) {
     KoLAdventure location = (KoLAdventure) arg.content;
-    return DataTypes.makeBooleanValue(location.isCurrentlyAccessible());
+    return DataTypes.makeBooleanValue(location.canAdventure());
+  }
+
+  public static Value prepare_for_adventure(ScriptRuntime controller, final Value arg) {
+    KoLAdventure location = (KoLAdventure) arg.content;
+    return DataTypes.makeBooleanValue(location.prepareForAdventure());
   }
 
   public static Value adventure(ScriptRuntime controller, final Value arg1, final Value arg2) {

--- a/src/net/sourceforge/kolmafia/textui/command/JourneyCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/JourneyCommand.java
@@ -126,7 +126,7 @@ public class JourneyCommand extends AbstractCommand {
 
       output.append("<tr>");
 
-      boolean accessible = !me || zone.isCurrentlyAccessible();
+      boolean accessible = !me || zone.canAdventure();
 
       output.append("<td rowspan=2>");
       if (!accessible) {
@@ -141,8 +141,12 @@ public class JourneyCommand extends AbstractCommand {
       String[] skills = JourneyManager.journeymanData.get(zone).get(aclass);
       for (int i = 0; i < 6; ++i) {
         String skillName = skills[i];
+        int skillId = SkillDatabase.getSkillId(skillName);
         boolean known = me && KoLCharacter.hasSkill(skillName);
         output.append("<td>");
+        // output.append("<a href=\"desc_skill.php?whichskill=");
+        // output.append(skillId);
+        // output.append("&self=true\">");
         if (known) {
           output.append("<s>");
         }
@@ -150,6 +154,7 @@ public class JourneyCommand extends AbstractCommand {
         if (known) {
           output.append("</s>");
         }
+        // output.append("</a>");
         output.append("</td>");
         if (i == 2) {
           output.append("</tr><tr>");
@@ -256,7 +261,7 @@ public class JourneyCommand extends AbstractCommand {
     if (me) {
       if (unreachableZone(zone)) {
         output.append(" (which is permanently inaccessible to you)");
-      } else if (!zone.isCurrentlyAccessible()) {
+      } else if (!zone.canAdventure()) {
         output.append(" (which is not currently accessible to you)");
       }
     }

--- a/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
+++ b/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
@@ -5,6 +5,7 @@ import static internal.helpers.Player.withItem;
 import static internal.helpers.Player.withPath;
 import static internal.helpers.Player.withProperty;
 import static internal.helpers.Player.withQuestProgress;
+import static internal.helpers.Player.withRestricted;
 import static internal.helpers.Player.withStats;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -48,13 +49,35 @@ public class KoLAdventureValidationTest {
   }
 
   @Nested
+  class Standard {
+    @Test
+    public void restrictedItemZonesNotAllowedUnderStandard() {
+      var cleanups = new Cleanups(withRestricted(true));
+      try (cleanups) {
+        // From the tiny bottle of absinthe - a very old item
+        KoLAdventure area = AdventureDatabase.getAdventureByName("The Stately Pleasure Dome");
+        assertFalse(area.canAdventure());
+      }
+    }
+
+    @Test
+    public void nonItemZonesAllowedUnderStandard() {
+      var cleanups = new Cleanups(withRestricted(true));
+      try (cleanups) {
+        KoLAdventure area = AdventureDatabase.getAdventureByName("The Outskirts of Cobb's Knob");
+        assertTrue(area.canAdventure());
+      }
+    }
+  }
+
+  @Nested
   class BugbearInvasion {
     @Test
     public void cannotVisitMothershipUnlessBugbearsAreInvading() {
       var cleanups = new Cleanups(withPath(Path.NONE));
       try (cleanups) {
         KoLAdventure area = AdventureDatabase.getAdventureByName("Medbay");
-        assertFalse(area.isCurrentlyAccessible());
+        assertFalse(area.canAdventure());
       }
     }
 
@@ -63,7 +86,7 @@ public class KoLAdventureValidationTest {
       var cleanups = new Cleanups(withPath(Path.BUGBEAR_INVASION));
       try (cleanups) {
         KoLAdventure area = AdventureDatabase.getAdventureByName("Medbay");
-        assertTrue(area.isCurrentlyAccessible());
+        assertTrue(area.canAdventure());
       }
     }
   }
@@ -139,7 +162,7 @@ public class KoLAdventureValidationTest {
 
     private void testElementalZoneNoAccess(Map<Integer, KoLAdventure> zones) {
       for (Integer key : zones.keySet()) {
-        assertFalse(zones.get(key).isCurrentlyAccessible());
+        assertFalse(zones.get(key).canAdventure());
       }
     }
 
@@ -147,7 +170,7 @@ public class KoLAdventureValidationTest {
       var cleanups = new Cleanups(withProperty(property, true));
       try (cleanups) {
         for (Integer key : zones.keySet()) {
-          assertTrue(zones.get(key).isCurrentlyAccessible());
+          assertTrue(zones.get(key).canAdventure());
         }
       }
     }
@@ -227,12 +250,12 @@ public class KoLAdventureValidationTest {
     public void canVisitCobbsKnobBeforeQuest() {
       var cleanups = new Cleanups(withQuestProgress(Quest.GOBLIN, QuestDatabase.UNSTARTED));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.OUTSKIRTS_OF_THE_KNOB).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.COBB_BARRACKS).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.COBB_KITCHEN).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.COBB_HAREM).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.COBB_TREASURY).isCurrentlyAccessible());
-        assertFalse(throneRoom.isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.OUTSKIRTS_OF_THE_KNOB).canAdventure());
+        assertFalse(zones.get(AdventurePool.COBB_BARRACKS).canAdventure());
+        assertFalse(zones.get(AdventurePool.COBB_KITCHEN).canAdventure());
+        assertFalse(zones.get(AdventurePool.COBB_HAREM).canAdventure());
+        assertFalse(zones.get(AdventurePool.COBB_TREASURY).canAdventure());
+        assertFalse(throneRoom.canAdventure());
       }
     }
 
@@ -240,12 +263,12 @@ public class KoLAdventureValidationTest {
     public void canVisitCobbsKnobBeforeDecrypting() {
       var cleanups = new Cleanups(withQuestProgress(Quest.GOBLIN, QuestDatabase.STARTED));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.OUTSKIRTS_OF_THE_KNOB).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.COBB_BARRACKS).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.COBB_KITCHEN).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.COBB_HAREM).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.COBB_TREASURY).isCurrentlyAccessible());
-        assertFalse(throneRoom.isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.OUTSKIRTS_OF_THE_KNOB).canAdventure());
+        assertFalse(zones.get(AdventurePool.COBB_BARRACKS).canAdventure());
+        assertFalse(zones.get(AdventurePool.COBB_KITCHEN).canAdventure());
+        assertFalse(zones.get(AdventurePool.COBB_HAREM).canAdventure());
+        assertFalse(zones.get(AdventurePool.COBB_TREASURY).canAdventure());
+        assertFalse(throneRoom.canAdventure());
       }
     }
 
@@ -253,12 +276,12 @@ public class KoLAdventureValidationTest {
     public void canVisitCobbsKnobAfterDecrypting() {
       var cleanups = new Cleanups(withQuestProgress(Quest.GOBLIN, "step1"));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.OUTSKIRTS_OF_THE_KNOB).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.COBB_BARRACKS).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.COBB_KITCHEN).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.COBB_HAREM).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.COBB_TREASURY).isCurrentlyAccessible());
-        assertTrue(throneRoom.isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.OUTSKIRTS_OF_THE_KNOB).canAdventure());
+        assertTrue(zones.get(AdventurePool.COBB_BARRACKS).canAdventure());
+        assertTrue(zones.get(AdventurePool.COBB_KITCHEN).canAdventure());
+        assertTrue(zones.get(AdventurePool.COBB_HAREM).canAdventure());
+        assertTrue(zones.get(AdventurePool.COBB_TREASURY).canAdventure());
+        assertTrue(throneRoom.canAdventure());
       }
     }
 
@@ -266,12 +289,12 @@ public class KoLAdventureValidationTest {
     public void canVisitCobbsKnobAfterDefeatingKing() {
       var cleanups = new Cleanups(withQuestProgress(Quest.GOBLIN, QuestDatabase.FINISHED));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.OUTSKIRTS_OF_THE_KNOB).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.COBB_BARRACKS).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.COBB_KITCHEN).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.COBB_HAREM).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.COBB_TREASURY).isCurrentlyAccessible());
-        assertFalse(throneRoom.isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.OUTSKIRTS_OF_THE_KNOB).canAdventure());
+        assertTrue(zones.get(AdventurePool.COBB_BARRACKS).canAdventure());
+        assertTrue(zones.get(AdventurePool.COBB_KITCHEN).canAdventure());
+        assertTrue(zones.get(AdventurePool.COBB_HAREM).canAdventure());
+        assertTrue(zones.get(AdventurePool.COBB_TREASURY).canAdventure());
+        assertFalse(throneRoom.canAdventure());
       }
     }
 
@@ -279,8 +302,8 @@ public class KoLAdventureValidationTest {
     public void cannotVisitCobbsKnobLaboratoryWithoutKey() {
       var cleanups = new Cleanups(withQuestProgress(Quest.GOBLIN, "step1"));
       try (cleanups) {
-        assertFalse(zones.get(AdventurePool.COBB_LABORATORY).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.KNOB_SHAFT).isCurrentlyAccessible());
+        assertFalse(zones.get(AdventurePool.COBB_LABORATORY).canAdventure());
+        assertFalse(zones.get(AdventurePool.KNOB_SHAFT).canAdventure());
       }
     }
 
@@ -289,8 +312,8 @@ public class KoLAdventureValidationTest {
       var cleanups =
           new Cleanups(withItem("Cobb's Knob lab key"), withQuestProgress(Quest.GOBLIN, "step1"));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.COBB_LABORATORY).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.KNOB_SHAFT).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.COBB_LABORATORY).canAdventure());
+        assertTrue(zones.get(AdventurePool.KNOB_SHAFT).canAdventure());
       }
     }
 
@@ -298,9 +321,9 @@ public class KoLAdventureValidationTest {
     public void cannotVisitCobbsKnobMenagerieWithoutKey() {
       var cleanups = new Cleanups(withQuestProgress(Quest.GOBLIN, "step1"));
       try (cleanups) {
-        assertFalse(zones.get(AdventurePool.MENAGERIE_LEVEL_1).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.MENAGERIE_LEVEL_2).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.MENAGERIE_LEVEL_3).isCurrentlyAccessible());
+        assertFalse(zones.get(AdventurePool.MENAGERIE_LEVEL_1).canAdventure());
+        assertFalse(zones.get(AdventurePool.MENAGERIE_LEVEL_2).canAdventure());
+        assertFalse(zones.get(AdventurePool.MENAGERIE_LEVEL_3).canAdventure());
       }
     }
 
@@ -310,9 +333,9 @@ public class KoLAdventureValidationTest {
           new Cleanups(
               withItem("Cobb's Knob Menagerie key"), withQuestProgress(Quest.GOBLIN, "step1"));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.MENAGERIE_LEVEL_1).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.MENAGERIE_LEVEL_2).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.MENAGERIE_LEVEL_3).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.MENAGERIE_LEVEL_1).canAdventure());
+        assertTrue(zones.get(AdventurePool.MENAGERIE_LEVEL_2).canAdventure());
+        assertTrue(zones.get(AdventurePool.MENAGERIE_LEVEL_3).canAdventure());
       }
     }
   }
@@ -346,11 +369,11 @@ public class KoLAdventureValidationTest {
     public void cannotVisitCyrptBeforeQuest() {
       var cleanups = new Cleanups(withQuestProgress(Quest.CYRPT, QuestDatabase.UNSTARTED));
       try (cleanups) {
-        assertFalse(zones.get(AdventurePool.DEFILED_ALCOVE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.DEFILED_CRANNY).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.DEFILED_NICHE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.DEFILED_NOOK).isCurrentlyAccessible());
-        assertFalse(haert.isCurrentlyAccessible());
+        assertFalse(zones.get(AdventurePool.DEFILED_ALCOVE).canAdventure());
+        assertFalse(zones.get(AdventurePool.DEFILED_CRANNY).canAdventure());
+        assertFalse(zones.get(AdventurePool.DEFILED_NICHE).canAdventure());
+        assertFalse(zones.get(AdventurePool.DEFILED_NOOK).canAdventure());
+        assertFalse(haert.canAdventure());
       }
     }
 
@@ -365,11 +388,11 @@ public class KoLAdventureValidationTest {
               withProperty("cyrptNookEvilness", 50),
               withProperty("cyrptTotalEvilness", 200));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.DEFILED_ALCOVE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.DEFILED_CRANNY).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.DEFILED_NICHE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.DEFILED_NOOK).isCurrentlyAccessible());
-        assertFalse(haert.isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.DEFILED_ALCOVE).canAdventure());
+        assertTrue(zones.get(AdventurePool.DEFILED_CRANNY).canAdventure());
+        assertTrue(zones.get(AdventurePool.DEFILED_NICHE).canAdventure());
+        assertTrue(zones.get(AdventurePool.DEFILED_NOOK).canAdventure());
+        assertFalse(haert.canAdventure());
       }
     }
 
@@ -384,11 +407,11 @@ public class KoLAdventureValidationTest {
               withProperty("cyrptNookEvilness", 50),
               withProperty("cyrptTotalEvilness", 150));
       try (cleanups) {
-        assertFalse(zones.get(AdventurePool.DEFILED_ALCOVE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.DEFILED_CRANNY).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.DEFILED_NICHE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.DEFILED_NOOK).isCurrentlyAccessible());
-        assertFalse(haert.isCurrentlyAccessible());
+        assertFalse(zones.get(AdventurePool.DEFILED_ALCOVE).canAdventure());
+        assertTrue(zones.get(AdventurePool.DEFILED_CRANNY).canAdventure());
+        assertTrue(zones.get(AdventurePool.DEFILED_NICHE).canAdventure());
+        assertTrue(zones.get(AdventurePool.DEFILED_NOOK).canAdventure());
+        assertFalse(haert.canAdventure());
       }
     }
 
@@ -403,11 +426,11 @@ public class KoLAdventureValidationTest {
               withProperty("cyrptNookEvilness", 50),
               withProperty("cyrptTotalEvilness", 150));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.DEFILED_ALCOVE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.DEFILED_CRANNY).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.DEFILED_NICHE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.DEFILED_NOOK).isCurrentlyAccessible());
-        assertFalse(haert.isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.DEFILED_ALCOVE).canAdventure());
+        assertFalse(zones.get(AdventurePool.DEFILED_CRANNY).canAdventure());
+        assertTrue(zones.get(AdventurePool.DEFILED_NICHE).canAdventure());
+        assertTrue(zones.get(AdventurePool.DEFILED_NOOK).canAdventure());
+        assertFalse(haert.canAdventure());
       }
     }
 
@@ -422,11 +445,11 @@ public class KoLAdventureValidationTest {
               withProperty("cyrptNookEvilness", 50),
               withProperty("cyrptTotalEvilness", 150));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.DEFILED_ALCOVE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.DEFILED_CRANNY).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.DEFILED_NICHE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.DEFILED_NOOK).isCurrentlyAccessible());
-        assertFalse(haert.isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.DEFILED_ALCOVE).canAdventure());
+        assertTrue(zones.get(AdventurePool.DEFILED_CRANNY).canAdventure());
+        assertFalse(zones.get(AdventurePool.DEFILED_NICHE).canAdventure());
+        assertTrue(zones.get(AdventurePool.DEFILED_NOOK).canAdventure());
+        assertFalse(haert.canAdventure());
       }
     }
 
@@ -441,11 +464,11 @@ public class KoLAdventureValidationTest {
               withProperty("cyrptNookEvilness", 0),
               withProperty("cyrptTotalEvilness", 150));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.DEFILED_ALCOVE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.DEFILED_CRANNY).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.DEFILED_NICHE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.DEFILED_NOOK).isCurrentlyAccessible());
-        assertFalse(haert.isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.DEFILED_ALCOVE).canAdventure());
+        assertTrue(zones.get(AdventurePool.DEFILED_CRANNY).canAdventure());
+        assertTrue(zones.get(AdventurePool.DEFILED_NICHE).canAdventure());
+        assertFalse(zones.get(AdventurePool.DEFILED_NOOK).canAdventure());
+        assertFalse(haert.canAdventure());
       }
     }
 
@@ -460,11 +483,11 @@ public class KoLAdventureValidationTest {
               withProperty("cyrptNookEvilness", 0),
               withProperty("cyrptTotalEvilness", 0));
       try (cleanups) {
-        assertFalse(zones.get(AdventurePool.DEFILED_ALCOVE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.DEFILED_CRANNY).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.DEFILED_NICHE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.DEFILED_NOOK).isCurrentlyAccessible());
-        assertTrue(haert.isCurrentlyAccessible());
+        assertFalse(zones.get(AdventurePool.DEFILED_ALCOVE).canAdventure());
+        assertFalse(zones.get(AdventurePool.DEFILED_CRANNY).canAdventure());
+        assertFalse(zones.get(AdventurePool.DEFILED_NICHE).canAdventure());
+        assertFalse(zones.get(AdventurePool.DEFILED_NOOK).canAdventure());
+        assertTrue(haert.canAdventure());
       }
     }
 
@@ -472,11 +495,11 @@ public class KoLAdventureValidationTest {
     public void cannotVisitCyrptWhenQuestFinished() {
       var cleanups = new Cleanups(withQuestProgress(Quest.CYRPT, QuestDatabase.FINISHED));
       try (cleanups) {
-        assertFalse(zones.get(AdventurePool.DEFILED_ALCOVE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.DEFILED_CRANNY).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.DEFILED_NICHE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.DEFILED_NOOK).isCurrentlyAccessible());
-        assertFalse(haert.isCurrentlyAccessible());
+        assertFalse(zones.get(AdventurePool.DEFILED_ALCOVE).canAdventure());
+        assertFalse(zones.get(AdventurePool.DEFILED_CRANNY).canAdventure());
+        assertFalse(zones.get(AdventurePool.DEFILED_NICHE).canAdventure());
+        assertFalse(zones.get(AdventurePool.DEFILED_NOOK).canAdventure());
+        assertFalse(haert.canAdventure());
       }
     }
   }
@@ -513,11 +536,11 @@ public class KoLAdventureValidationTest {
     public void cannotVisitPiratesWithoutIslandAccess() {
       var cleanups = new Cleanups(withQuestProgress(Quest.ISLAND_WAR, QuestDatabase.UNSTARTED));
       try (cleanups) {
-        assertFalse(zones.get(AdventurePool.PIRATE_COVE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BARRRNEYS_BARRR).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.FCLE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.POOP_DECK).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BELOWDECKS).isCurrentlyAccessible());
+        assertFalse(zones.get(AdventurePool.PIRATE_COVE).canAdventure());
+        assertFalse(zones.get(AdventurePool.BARRRNEYS_BARRR).canAdventure());
+        assertFalse(zones.get(AdventurePool.FCLE).canAdventure());
+        assertFalse(zones.get(AdventurePool.POOP_DECK).canAdventure());
+        assertFalse(zones.get(AdventurePool.BELOWDECKS).canAdventure());
       }
     }
 
@@ -528,11 +551,11 @@ public class KoLAdventureValidationTest {
               withItem("dingy dinghy"),
               withQuestProgress(Quest.ISLAND_WAR, QuestDatabase.UNSTARTED));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.PIRATE_COVE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BARRRNEYS_BARRR).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.FCLE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.POOP_DECK).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BELOWDECKS).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.PIRATE_COVE).canAdventure());
+        assertFalse(zones.get(AdventurePool.BARRRNEYS_BARRR).canAdventure());
+        assertFalse(zones.get(AdventurePool.FCLE).canAdventure());
+        assertFalse(zones.get(AdventurePool.POOP_DECK).canAdventure());
+        assertFalse(zones.get(AdventurePool.BELOWDECKS).canAdventure());
       }
     }
 
@@ -541,11 +564,11 @@ public class KoLAdventureValidationTest {
       var cleanups =
           new Cleanups(withItem("dingy dinghy"), withQuestProgress(Quest.ISLAND_WAR, "step1"));
       try (cleanups) {
-        assertFalse(zones.get(AdventurePool.PIRATE_COVE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BARRRNEYS_BARRR).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.FCLE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.POOP_DECK).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BELOWDECKS).isCurrentlyAccessible());
+        assertFalse(zones.get(AdventurePool.PIRATE_COVE).canAdventure());
+        assertFalse(zones.get(AdventurePool.BARRRNEYS_BARRR).canAdventure());
+        assertFalse(zones.get(AdventurePool.FCLE).canAdventure());
+        assertFalse(zones.get(AdventurePool.POOP_DECK).canAdventure());
+        assertFalse(zones.get(AdventurePool.BELOWDECKS).canAdventure());
       }
     }
 
@@ -563,10 +586,10 @@ public class KoLAdventureValidationTest {
       try (cleanups) {
         EquipmentManager.updateNormalOutfits();
         assertTrue(EquipmentManager.hasOutfit(OutfitPool.SWASHBUCKLING_GETUP));
-        assertTrue(zones.get(AdventurePool.BARRRNEYS_BARRR).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.FCLE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.POOP_DECK).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.BELOWDECKS).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.BARRRNEYS_BARRR).canAdventure());
+        assertTrue(zones.get(AdventurePool.FCLE).canAdventure());
+        assertTrue(zones.get(AdventurePool.POOP_DECK).canAdventure());
+        assertTrue(zones.get(AdventurePool.BELOWDECKS).canAdventure());
       }
     }
 
@@ -580,10 +603,10 @@ public class KoLAdventureValidationTest {
               withQuestProgress(Quest.ISLAND_WAR, QuestDatabase.UNSTARTED),
               withQuestProgress(Quest.PIRATE, QuestDatabase.FINISHED));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.BARRRNEYS_BARRR).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.FCLE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.POOP_DECK).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.BELOWDECKS).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.BARRRNEYS_BARRR).canAdventure());
+        assertTrue(zones.get(AdventurePool.FCLE).canAdventure());
+        assertTrue(zones.get(AdventurePool.POOP_DECK).canAdventure());
+        assertTrue(zones.get(AdventurePool.BELOWDECKS).canAdventure());
       }
     }
 
@@ -601,10 +624,10 @@ public class KoLAdventureValidationTest {
       try (cleanups) {
         EquipmentManager.updateNormalOutfits();
         assertTrue(EquipmentManager.hasOutfit(OutfitPool.SWASHBUCKLING_GETUP));
-        assertTrue(zones.get(AdventurePool.BARRRNEYS_BARRR).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.FCLE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.POOP_DECK).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BELOWDECKS).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.BARRRNEYS_BARRR).canAdventure());
+        assertFalse(zones.get(AdventurePool.FCLE).canAdventure());
+        assertFalse(zones.get(AdventurePool.POOP_DECK).canAdventure());
+        assertFalse(zones.get(AdventurePool.BELOWDECKS).canAdventure());
       }
     }
 
@@ -622,10 +645,10 @@ public class KoLAdventureValidationTest {
       try (cleanups) {
         EquipmentManager.updateNormalOutfits();
         assertTrue(EquipmentManager.hasOutfit(OutfitPool.SWASHBUCKLING_GETUP));
-        assertTrue(zones.get(AdventurePool.BARRRNEYS_BARRR).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.FCLE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.POOP_DECK).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BELOWDECKS).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.BARRRNEYS_BARRR).canAdventure());
+        assertTrue(zones.get(AdventurePool.FCLE).canAdventure());
+        assertFalse(zones.get(AdventurePool.POOP_DECK).canAdventure());
+        assertFalse(zones.get(AdventurePool.BELOWDECKS).canAdventure());
       }
     }
 
@@ -643,10 +666,10 @@ public class KoLAdventureValidationTest {
       try (cleanups) {
         EquipmentManager.updateNormalOutfits();
         assertTrue(EquipmentManager.hasOutfit(OutfitPool.SWASHBUCKLING_GETUP));
-        assertTrue(zones.get(AdventurePool.BARRRNEYS_BARRR).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.FCLE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.POOP_DECK).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BELOWDECKS).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.BARRRNEYS_BARRR).canAdventure());
+        assertTrue(zones.get(AdventurePool.FCLE).canAdventure());
+        assertTrue(zones.get(AdventurePool.POOP_DECK).canAdventure());
+        assertFalse(zones.get(AdventurePool.BELOWDECKS).canAdventure());
       }
     }
 
@@ -664,10 +687,10 @@ public class KoLAdventureValidationTest {
       try (cleanups) {
         EquipmentManager.updateNormalOutfits();
         assertTrue(EquipmentManager.hasOutfit(OutfitPool.SWASHBUCKLING_GETUP));
-        assertTrue(zones.get(AdventurePool.BARRRNEYS_BARRR).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.FCLE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.POOP_DECK).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.BELOWDECKS).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.BARRRNEYS_BARRR).canAdventure());
+        assertTrue(zones.get(AdventurePool.FCLE).canAdventure());
+        assertTrue(zones.get(AdventurePool.POOP_DECK).canAdventure());
+        assertTrue(zones.get(AdventurePool.BELOWDECKS).canAdventure());
       }
     }
   }
@@ -725,11 +748,11 @@ public class KoLAdventureValidationTest {
 
     @Test
     public void cannotVisitHippyCampWithoutIslandAccess() {
-      assertFalse(zones.get(AdventurePool.HIPPY_CAMP).isCurrentlyAccessible());
-      assertFalse(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-      assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).isCurrentlyAccessible());
-      assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-      assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).isCurrentlyAccessible());
+      assertFalse(zones.get(AdventurePool.HIPPY_CAMP).canAdventure());
+      assertFalse(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).canAdventure());
+      assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).canAdventure());
+      assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).canAdventure());
+      assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).canAdventure());
     }
 
     @Test
@@ -739,12 +762,12 @@ public class KoLAdventureValidationTest {
               withItem("dingy dinghy"),
               withQuestProgress(Quest.ISLAND_WAR, QuestDatabase.UNSTARTED));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.HIPPY_CAMP).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.HIPPY_CAMP).canAdventure());
         // We check only quest status, not available equipment
-        assertTrue(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).canAdventure());
       }
     }
 
@@ -757,12 +780,12 @@ public class KoLAdventureValidationTest {
               withEquipped(EquipmentManager.HAT, "filthy knitted dread sack"),
               withEquipped(EquipmentManager.PANTS, "filthy corduroys"));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.HIPPY_CAMP).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.HIPPY_CAMP).canAdventure());
         // We check only quest status, not available equipment
-        assertTrue(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).canAdventure());
       }
     }
 
@@ -773,12 +796,12 @@ public class KoLAdventureValidationTest {
               withItem("dingy dinghy"), withQuestProgress(Quest.ISLAND_WAR, QuestDatabase.STARTED));
       try (cleanups) {
         // KoL does not require going directly to verge-od-war zones
-        assertTrue(zones.get(AdventurePool.HIPPY_CAMP).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.HIPPY_CAMP).canAdventure());
+        assertTrue(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).canAdventure());
         // ... but it allows it.
-        assertTrue(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).canAdventure());
+        assertTrue(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).canAdventure());
       }
     }
 
@@ -793,12 +816,12 @@ public class KoLAdventureValidationTest {
               withEquipped(EquipmentManager.WEAPON, "Orcish frat-paddle"));
       try (cleanups) {
         // KoL does not require going directly to verge-od-war zones
-        assertTrue(zones.get(AdventurePool.HIPPY_CAMP).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.HIPPY_CAMP).canAdventure());
+        assertTrue(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).canAdventure());
         // ... but it allows it.
-        assertTrue(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).canAdventure());
+        assertTrue(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).canAdventure());
       }
     }
 
@@ -807,11 +830,11 @@ public class KoLAdventureValidationTest {
       var cleanups =
           new Cleanups(withItem("dingy dinghy"), withQuestProgress(Quest.ISLAND_WAR, "step1"));
       try (cleanups) {
-        assertFalse(zones.get(AdventurePool.HIPPY_CAMP).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).isCurrentlyAccessible());
+        assertFalse(zones.get(AdventurePool.HIPPY_CAMP).canAdventure());
+        assertFalse(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).canAdventure());
       }
     }
 
@@ -823,12 +846,12 @@ public class KoLAdventureValidationTest {
               withQuestProgress(Quest.ISLAND_WAR, QuestDatabase.FINISHED),
               withProperty("sideDefeated", "fratboys"));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.HIPPY_CAMP).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.HIPPY_CAMP).canAdventure());
         // We check only quest status, not available equipment
-        assertTrue(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).canAdventure());
       }
     }
 
@@ -842,12 +865,12 @@ public class KoLAdventureValidationTest {
               withEquipped(EquipmentManager.HAT, "filthy knitted dread sack"),
               withEquipped(EquipmentManager.PANTS, "filthy corduroys"));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.HIPPY_CAMP).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.HIPPY_CAMP).canAdventure());
         // We check only quest status, not available equipment
-        assertTrue(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).canAdventure());
       }
     }
 
@@ -859,11 +882,11 @@ public class KoLAdventureValidationTest {
               withQuestProgress(Quest.ISLAND_WAR, QuestDatabase.FINISHED),
               withProperty("sideDefeated", "hippies"));
       try (cleanups) {
-        assertFalse(zones.get(AdventurePool.HIPPY_CAMP).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).isCurrentlyAccessible());
+        assertFalse(zones.get(AdventurePool.HIPPY_CAMP).canAdventure());
+        assertFalse(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).canAdventure());
+        assertTrue(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).canAdventure());
       }
     }
 
@@ -875,11 +898,11 @@ public class KoLAdventureValidationTest {
               withQuestProgress(Quest.ISLAND_WAR, QuestDatabase.FINISHED),
               withProperty("sideDefeated", "both"));
       try (cleanups) {
-        assertFalse(zones.get(AdventurePool.HIPPY_CAMP).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).isCurrentlyAccessible());
+        assertFalse(zones.get(AdventurePool.HIPPY_CAMP).canAdventure());
+        assertFalse(zones.get(AdventurePool.HIPPY_CAMP_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED).canAdventure());
+        assertTrue(zones.get(AdventurePool.BOMBED_HIPPY_CAMP).canAdventure());
       }
     }
   }
@@ -938,11 +961,11 @@ public class KoLAdventureValidationTest {
 
     @Test
     public void cannotVisitFratHouseWithoutIslandAccess() {
-      assertFalse(zones.get(AdventurePool.FRAT_HOUSE).isCurrentlyAccessible());
-      assertFalse(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-      assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).isCurrentlyAccessible());
-      assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-      assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).isCurrentlyAccessible());
+      assertFalse(zones.get(AdventurePool.FRAT_HOUSE).canAdventure());
+      assertFalse(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).canAdventure());
+      assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).canAdventure());
+      assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).canAdventure());
+      assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).canAdventure());
     }
 
     @Test
@@ -952,12 +975,12 @@ public class KoLAdventureValidationTest {
               withItem("dingy dinghy"),
               withQuestProgress(Quest.ISLAND_WAR, QuestDatabase.UNSTARTED));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.FRAT_HOUSE).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.FRAT_HOUSE).canAdventure());
         // We check only quest status, not available equipment
-        assertTrue(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).canAdventure());
       }
     }
 
@@ -971,12 +994,12 @@ public class KoLAdventureValidationTest {
               withEquipped(EquipmentManager.PANTS, "Orcish cargo shorts"),
               withEquipped(EquipmentManager.WEAPON, "Orcish frat-paddle"));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.FRAT_HOUSE).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.FRAT_HOUSE).canAdventure());
         // We check only quest status, not available equipment
-        assertTrue(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).canAdventure());
       }
     }
 
@@ -987,12 +1010,12 @@ public class KoLAdventureValidationTest {
               withItem("dingy dinghy"), withQuestProgress(Quest.ISLAND_WAR, QuestDatabase.STARTED));
       try (cleanups) {
         // KoL does not require going directly to verge-od-war zones
-        assertTrue(zones.get(AdventurePool.FRAT_HOUSE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.FRAT_HOUSE).canAdventure());
+        assertTrue(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).canAdventure());
         // ... but it allows it.
-        assertTrue(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).canAdventure());
+        assertTrue(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).canAdventure());
       }
     }
 
@@ -1006,12 +1029,12 @@ public class KoLAdventureValidationTest {
               withEquipped(EquipmentManager.PANTS, "filthy corduroys"));
       try (cleanups) {
         // KoL does not require going directly to verge-od-war zones
-        assertTrue(zones.get(AdventurePool.FRAT_HOUSE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.FRAT_HOUSE).canAdventure());
+        assertTrue(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).canAdventure());
         // ... but it allows it.
-        assertTrue(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).canAdventure());
+        assertTrue(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).canAdventure());
       }
     }
 
@@ -1020,11 +1043,11 @@ public class KoLAdventureValidationTest {
       var cleanups =
           new Cleanups(withItem("dingy dinghy"), withQuestProgress(Quest.ISLAND_WAR, "step1"));
       try (cleanups) {
-        assertFalse(zones.get(AdventurePool.FRAT_HOUSE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).isCurrentlyAccessible());
+        assertFalse(zones.get(AdventurePool.FRAT_HOUSE).canAdventure());
+        assertFalse(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).canAdventure());
       }
     }
 
@@ -1036,12 +1059,12 @@ public class KoLAdventureValidationTest {
               withQuestProgress(Quest.ISLAND_WAR, QuestDatabase.FINISHED),
               withProperty("sideDefeated", "hippies"));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.FRAT_HOUSE).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.FRAT_HOUSE).canAdventure());
         // We check only quest status, not available equipment
-        assertTrue(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).canAdventure());
       }
     }
 
@@ -1056,12 +1079,12 @@ public class KoLAdventureValidationTest {
               withEquipped(EquipmentManager.PANTS, "Orcish cargo shorts"),
               withEquipped(EquipmentManager.WEAPON, "Orcish frat-paddle"));
       try (cleanups) {
-        assertTrue(zones.get(AdventurePool.FRAT_HOUSE).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.FRAT_HOUSE).canAdventure());
         // We check only quest status, not available equipment
-        assertTrue(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).isCurrentlyAccessible());
+        assertTrue(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).canAdventure());
       }
     }
 
@@ -1073,11 +1096,11 @@ public class KoLAdventureValidationTest {
               withQuestProgress(Quest.ISLAND_WAR, QuestDatabase.FINISHED),
               withProperty("sideDefeated", "fratboys"));
       try (cleanups) {
-        assertFalse(zones.get(AdventurePool.FRAT_HOUSE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).isCurrentlyAccessible());
+        assertFalse(zones.get(AdventurePool.FRAT_HOUSE).canAdventure());
+        assertFalse(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).canAdventure());
+        assertTrue(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).canAdventure());
       }
     }
 
@@ -1089,11 +1112,11 @@ public class KoLAdventureValidationTest {
               withQuestProgress(Quest.ISLAND_WAR, QuestDatabase.FINISHED),
               withProperty("sideDefeated", "both"));
       try (cleanups) {
-        assertFalse(zones.get(AdventurePool.FRAT_HOUSE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).isCurrentlyAccessible());
-        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).isCurrentlyAccessible());
-        assertTrue(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).isCurrentlyAccessible());
+        assertFalse(zones.get(AdventurePool.FRAT_HOUSE).canAdventure());
+        assertFalse(zones.get(AdventurePool.FRAT_HOUSE_DISGUISED).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE).canAdventure());
+        assertFalse(zones.get(AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED).canAdventure());
+        assertTrue(zones.get(AdventurePool.BOMBED_FRAT_HOUSE).canAdventure());
       }
     }
   }


### PR DESCRIPTION
Which is a bug I just noticed.

I wrote a test for it and fixed it.

Other things:

- Just as we have ASH ```can_adventure(location)```, which is validate1, now we have ASH ```prepare_for_adventure(location)``` which is validate2.
- validate2 will now build a dingy dinghy, if necessary, for Island, Pirate, and IsleWar zones
- Modernized a few more switch statements.

The following are (easy) things I am hoping to get in, but the bug is serious enough we shouldn't necessarily wait.
I can easily start yet another PR.

Throne Room:
- King not killed
- Have (and can equip) Harem Girl outfit and either effect or potion of Knob Goblin Perfume
- or have (and can equip) Guardsman outfit and birthday cake.
- (validate2 does all of that; validate1 should pre-check.)
- Tests!

PFA:
- validate2 will use the bean
- Tests!

Isle War:
- have (and can equip) appropriate outfit
- validate2 will equip
- Tests!

Pirate:
- have (and can equip) appropriate outfit
- validate2 will equip

Disguise zones:
- validate1 should check have (and can equip) appropriate outfit
- validate2 will equip
- Tests!

Bat Hole:
- (validate1 already check if have enough sonars for validate2)
- (validate2 uses sonars)
- Tests!

McLarge Huge (and Shrouded Peak):
- Tests!

Investigating a Plaintive Telegram:
- You can only go here if you have taken an LT&T quest
- Having access to an item which will let you select it is good enough for validate1
- (validate2 will detect if you have not selected a quest and will fail.)
- Tests!
