### PR TITLE
feat: allow setting a property to not abort on choice

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1,4 +1,5 @@
 1
+global	abortOnChoiceWhenNotInChoice	true
 global	addChatCommandLine	false
 global	addCreationQueue	true
 global	addStatusBarToFrames	false

--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -2154,9 +2154,12 @@ public abstract class ChoiceManager {
       // Allow a script to simply attempt to visit choice.php.
       if (!urlString.equals("choice.php")) {
         if (Preferences.getBoolean("abortOnChoiceWhenNotInChoice")) {
-          KoLmafia.updateDisplay(MafiaState.ABORT, "Whoops! You're not actually in a choice adventure");
+          KoLmafia.updateDisplay(
+              MafiaState.ABORT, "Whoops! You're not actually in a choice adventure");
         } else {
-          KoLmafia.updateDisplay(MafiaState.ERROR, "Script submitted " + urlString + " when KoL was not in a choice adventure");
+          KoLmafia.updateDisplay(
+              MafiaState.ERROR,
+              "Script submitted " + urlString + " when KoL was not in a choice adventure");
         }
       }
       ChoiceManager.handlingChoice = false;

--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -2153,8 +2153,11 @@ public abstract class ChoiceManager {
     if (request.responseText.contains("Whoops!  You're not actually in a choice adventure.")) {
       // Allow a script to simply attempt to visit choice.php.
       if (!urlString.equals("choice.php")) {
-        KoLmafia.updateDisplay(
-            MafiaState.ABORT, "Whoops! You're not actually in a choice adventure");
+        if (Preferences.getBoolean("abortOnChoiceWhenNotInChoice")) {
+          KoLmafia.updateDisplay(MafiaState.ABORT, "Whoops! You're not actually in a choice adventure");
+        } else {
+          KoLmafia.updateDisplay(MafiaState.ERROR, "Script submitted " + urlString + " when KoL was not in a choice adventure");
+        }
       }
       ChoiceManager.handlingChoice = false;
       return true;

--- a/test/net/sourceforge/kolmafia/session/ChoiceManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/ChoiceManagerTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import internal.helpers.Cleanups;
-import internal.helpers.Player;
 import java.util.Map;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.KoLCharacter;
@@ -152,7 +151,11 @@ public class ChoiceManagerTest {
 
     @Test
     public void returnsTrueWithoutAbortStateIfPreferenceFalse() {
-      var cleanup = new Cleanups(withHandlingChoice(), withContinuationState(), withProperty("abortOnChoiceWhenNotInChoice", false));
+      var cleanup =
+          new Cleanups(
+              withHandlingChoice(),
+              withContinuationState(),
+              withProperty("abortOnChoiceWhenNotInChoice", false));
 
       try (cleanup) {
         String urlString = "choice.php?whichchoice=1234&pwd&option=1";

--- a/test/net/sourceforge/kolmafia/session/ChoiceManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/ChoiceManagerTest.java
@@ -3,12 +3,14 @@ package net.sourceforge.kolmafia.session;
 import static internal.helpers.Networking.html;
 import static internal.helpers.Player.withContinuationState;
 import static internal.helpers.Player.withHandlingChoice;
+import static internal.helpers.Player.withProperty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import internal.helpers.Cleanups;
+import internal.helpers.Player;
 import java.util.Map;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.KoLCharacter;
@@ -145,6 +147,20 @@ public class ChoiceManagerTest {
 
         assertThat(ChoiceManager.bogusChoice(urlString, request), is(true));
         assertThat(StaticEntity.getContinuationState(), equalTo(MafiaState.ABORT));
+      }
+    }
+
+    @Test
+    public void returnsTrueWithoutAbortStateIfPreferenceFalse() {
+      var cleanup = new Cleanups(withHandlingChoice(), withContinuationState(), withProperty("abortOnChoiceWhenNotInChoice", false));
+
+      try (cleanup) {
+        String urlString = "choice.php?whichchoice=1234&pwd&option=1";
+        var request = new GenericRequest(urlString);
+        request.responseText = "Whoops!  You're not actually in a choice adventure.";
+
+        assertThat(ChoiceManager.bogusChoice(urlString, request), is(true));
+        assertThat(StaticEntity.getContinuationState(), equalTo(MafiaState.ERROR));
       }
     }
 


### PR DESCRIPTION
As suggested in https://kolmafia.us/threads/recent-problems-with-batfellow-ash.27847/#post-169118

There exist old scripts that have worked up to now and probably won't receive updates. Allow an out for users of those scripts to keep them going.

I considered whether the preference should be global or user. I figured global, as you're using this because you're using some script that needs it, and the script is shared across characters.

Abort by default, because we consider choice access when not in a choice as a bug that should be fixed.