### PR TITLE
chore: update junit, svnkit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,13 +56,13 @@ repositories {
 
 dependencies {
 	// Use JUnit Jupiter for running JUnit5 tests.
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.8.2'
-	testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.8.2'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.0'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.9.0'
 
 	testImplementation 'org.hamcrest:hamcrest:2.2'
 	testImplementation 'com.spotify:hamcrest-optional:1.2.0'
-	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.0'
 	testImplementation 'org.mockito:mockito-inline:4.6.1'
 	testImplementation('org.eclipse.xtext:org.eclipse.xtext.xbase.lib:2.12.0') {
 		because 'assertion errors including Location/Range/Position need it'
@@ -90,7 +90,7 @@ dependencies {
 	implementation 'org.json:json:20220320'
 	implementation 'org.mozilla:rhino:1.7.14'
 	implementation 'org.swinglabs:swingx:1.0'
-	implementation 'org.tmatesoft.svnkit:svnkit:1.10.6'
+	implementation 'org.tmatesoft.svnkit:svnkit:1.10.7'
 	implementation 'com.jgoodies:jgoodies-binding:2.13.0'
 	implementation 'org.eclipse.jgit:org.eclipse.jgit:6.2.0.202206071550-r'
 }

--- a/test/net/sourceforge/kolmafia/FamiliarDataTest.java
+++ b/test/net/sourceforge/kolmafia/FamiliarDataTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 public class FamiliarDataTest {
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     // Simulate logging out and back in again.
     KoLCharacter.reset("");
     KoLCharacter.reset("familiar data test");
@@ -43,7 +43,7 @@ public class FamiliarDataTest {
   }
 
   @AfterAll
-  private static void afterAll() {
+  public static void afterAll() {
     Preferences.saveSettingsToFile = true;
   }
 
@@ -189,7 +189,7 @@ public class FamiliarDataTest {
   @Nested
   class API {
     @BeforeAll
-    private static void beforeAll() {
+    public static void beforeAll() {
       // Other tests add familiars to the character
       // Start clean.
       KoLCharacter.reset("");
@@ -197,7 +197,7 @@ public class FamiliarDataTest {
     }
 
     @AfterEach
-    private void afterEach() {
+    public void afterEach() {
       // ApiRequest.parseStatus() sets all sorts of stuff
       // Reset the character to eliminate leaks to other tests
       KoLCharacter.reset("");

--- a/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
+++ b/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 public class KoLAdventureValidationTest {
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     // Simulate logging out and back in again.
     Preferences.saveSettingsToFile = false;
   }
@@ -44,7 +44,7 @@ public class KoLAdventureValidationTest {
   }
 
   @AfterAll
-  private static void afterAll() {
+  public static void afterAll() {
     Preferences.saveSettingsToFile = true;
   }
 
@@ -102,7 +102,7 @@ public class KoLAdventureValidationTest {
     private static Map<Integer, KoLAdventure> coldZones = new HashMap<>();
 
     @BeforeAll
-    private static void beforeAll() {
+    public static void beforeAll() {
       sleazeZones.put(
           AdventurePool.FUN_GUY_MANSION,
           AdventureDatabase.getAdventureByName("The Fun-Guy Mansion"));
@@ -152,7 +152,7 @@ public class KoLAdventureValidationTest {
     }
 
     @AfterAll
-    private static void afterAll() {
+    public static void afterAll() {
       sleazeZones.clear();
       spookyZones.clear();
       stenchZones.clear();
@@ -211,7 +211,7 @@ public class KoLAdventureValidationTest {
     private static KoLAdventure throneRoom = AdventureDatabase.getAdventureByName("Throne Room");
 
     @BeforeAll
-    private static void beforeAll() {
+    public static void beforeAll() {
       zones.put(
           AdventurePool.OUTSKIRTS_OF_THE_KNOB,
           AdventureDatabase.getAdventureByName("The Outskirts of Cobb's Knob"));
@@ -241,7 +241,7 @@ public class KoLAdventureValidationTest {
     }
 
     @AfterAll
-    private static void afterAll() {
+    public static void afterAll() {
       zones.clear();
       throneRoom = null;
     }
@@ -348,7 +348,7 @@ public class KoLAdventureValidationTest {
     private static KoLAdventure haert = AdventureDatabase.getAdventureByName("Haert of the Cyrpt");
 
     @BeforeAll
-    private static void beforeAll() {
+    public static void beforeAll() {
       zones.put(
           AdventurePool.DEFILED_ALCOVE, AdventureDatabase.getAdventureByName("The Defiled Alcove"));
       zones.put(
@@ -360,7 +360,7 @@ public class KoLAdventureValidationTest {
     }
 
     @AfterAll
-    private static void afterAll() {
+    public static void afterAll() {
       zones.clear();
       haert = null;
     }
@@ -511,7 +511,7 @@ public class KoLAdventureValidationTest {
     private static Map<Integer, KoLAdventure> zones = new HashMap<>();
 
     @BeforeAll
-    private static void beforeAll() {
+    public static void beforeAll() {
       zones.put(
           AdventurePool.PIRATE_COVE,
           AdventureDatabase.getAdventureByName("The Obligatory Pirate's Cove"));
@@ -523,12 +523,12 @@ public class KoLAdventureValidationTest {
     }
 
     @AfterAll
-    private static void afterAll() {
+    public static void afterAll() {
       zones.clear();
     }
 
     @AfterEach
-    private void afterEach() {
+    public void afterEach() {
       EquipmentManager.updateNormalOutfits();
     }
 
@@ -725,7 +725,7 @@ public class KoLAdventureValidationTest {
     private static Map<Integer, KoLAdventure> zones = new HashMap<>();
 
     @BeforeAll
-    private static void beforeAll() {
+    public static void beforeAll() {
       zones.put(AdventurePool.HIPPY_CAMP, AdventureDatabase.getAdventureByName("Hippy Camp"));
       zones.put(
           AdventurePool.HIPPY_CAMP_DISGUISED,
@@ -742,7 +742,7 @@ public class KoLAdventureValidationTest {
     }
 
     @AfterAll
-    private static void afterAll() {
+    public static void afterAll() {
       zones.clear();
     }
 
@@ -937,7 +937,7 @@ public class KoLAdventureValidationTest {
     private static Map<Integer, KoLAdventure> zones = new HashMap<>();
 
     @BeforeAll
-    private static void beforeAll() {
+    public static void beforeAll() {
       zones.put(AdventurePool.FRAT_HOUSE, AdventureDatabase.getAdventureByName("Frat House"));
       zones.put(
           AdventurePool.FRAT_HOUSE_DISGUISED,
@@ -955,7 +955,7 @@ public class KoLAdventureValidationTest {
     }
 
     @AfterAll
-    private static void afterAll() {
+    public static void afterAll() {
       zones.clear();
     }
 

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -239,7 +239,7 @@ public class ModifiersTest {
   @Nested
   class BuffedHP {
     @AfterEach
-    private void afterEach() {
+    public void afterEach() {
       EquipmentManager.resetEquipment();
     }
 
@@ -478,7 +478,7 @@ public class ModifiersTest {
   @Nested
   class BuffedMP {
     @AfterEach
-    private void afterEach() {
+    public void afterEach() {
       EquipmentManager.resetEquipment();
     }
 
@@ -697,13 +697,13 @@ public class ModifiersTest {
   @Nested
   class Noobcore {
     @BeforeAll
-    private static void beforeAll() {
+    public static void beforeAll() {
       Preferences.saveSettingsToFile = false;
       Preferences.reset("noob");
     }
 
     @AfterAll
-    private static void afterAll() {
+    public static void afterAll() {
       Preferences.saveSettingsToFile = true;
     }
 
@@ -754,13 +754,13 @@ public class ModifiersTest {
   @Nested
   class Voter {
     @BeforeAll
-    private static void beforeAll() {
+    public static void beforeAll() {
       Preferences.saveSettingsToFile = false;
       Preferences.reset("voter");
     }
 
     @AfterAll
-    private static void afterAll() {
+    public static void afterAll() {
       Preferences.saveSettingsToFile = true;
     }
 

--- a/test/net/sourceforge/kolmafia/persistence/AdventureSpentDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/AdventureSpentDatabaseTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 public class AdventureSpentDatabaseTest {
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     // Simulate logging out and back in again.
     KoLCharacter.reset("");
     KoLCharacter.reset("adventure spent database user");
@@ -33,7 +33,7 @@ public class AdventureSpentDatabaseTest {
   }
 
   @BeforeEach
-  private void beforeEach() {
+  public void beforeEach() {
     CharPaneRequest.reset();
     AdventureSpentDatabase.resetTurns(false);
     // Some of the response texts have a CAB, some do not.

--- a/test/net/sourceforge/kolmafia/persistence/DailyLimitDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/DailyLimitDatabaseTest.java
@@ -38,7 +38,7 @@ class DailyLimitDatabaseTest {
   @Nested
   class DailyLimitTests {
     @BeforeEach
-    private void beforeEach() {
+    public void beforeEach() {
       KoLCharacter.reset("DailyLimitDatabaseTest");
       Preferences.reset("DailyLimitDatabaseTest");
     }

--- a/test/net/sourceforge/kolmafia/persistence/ItemFinderTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/ItemFinderTest.java
@@ -21,14 +21,14 @@ import org.junit.jupiter.api.Test;
 public class ItemFinderTest {
 
   @BeforeAll
-  private static void itemFinderClassSetup() {
+  public static void itemFinderClassSetup() {
     // Simulate logging out and back in again.
     KoLCharacter.reset("");
     KoLCharacter.reset("item finder user");
   }
 
   @BeforeEach
-  private void itemFinderSetup() {
+  public void itemFinderSetup() {
     // Reset exactly the preferences used by this package to defaults
     Preferences.setString("_roboDrinks", "");
     Preferences.setBoolean("autoSatisfyWithNPCs", false);

--- a/test/net/sourceforge/kolmafia/persistence/MallPriceDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/MallPriceDatabaseTest.java
@@ -16,12 +16,12 @@ import org.junit.jupiter.api.Test;
 public class MallPriceDatabaseTest {
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     MallPriceDatabase.savePricesToFile = false;
   }
 
   @AfterAll
-  private static void afterAll() {
+  public static void afterAll() {
     MallPriceDatabase.savePricesToFile = true;
   }
 

--- a/test/net/sourceforge/kolmafia/request/EatItemRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/EatItemRequestTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 
 class EatItemRequestTest {
   @BeforeEach
-  private void beforeEach() {
+  public void beforeEach() {
     // Simulate logging out and back in again.
     KoLCharacter.reset("EatItemRequest");
     Preferences.reset("EatItemRequest");
@@ -26,13 +26,13 @@ class EatItemRequestTest {
     private Cleanups cleanups = new Cleanups();
 
     @BeforeEach
-    private void beforeEach() {
+    public void beforeEach() {
       cleanups.add(withItem(ItemPool.MILK_OF_MAGNESIUM));
       cleanups.add(withItem(ItemPool.TOMATO));
     }
 
     @AfterEach
-    private void afterEach() {
+    public void afterEach() {
       cleanups.close();
     }
 

--- a/test/net/sourceforge/kolmafia/request/FightRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FightRequestTest.java
@@ -893,17 +893,17 @@ public class FightRequestTest {
   @Nested
   class LoveBugsPreferenceButtonGroupTest {
     @BeforeAll
-    private static void beforeAll() {
+    public static void beforeAll() {
       Preferences.saveSettingsToFile = false;
     }
 
     @AfterAll
-    private static void afterAll() {
+    public static void afterAll() {
       Preferences.saveSettingsToFile = true;
     }
 
     @BeforeEach
-    private void beforeEach() {
+    public void beforeEach() {
       KoLCharacter.reset("lovebugs");
     }
 

--- a/test/net/sourceforge/kolmafia/request/GuildRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/GuildRequestTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 public class GuildRequestTest {
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     KoLCharacter.reset("GuildRequestTest");
     Preferences.reset("GuildRequestTest");
     Preferences.saveSettingsToFile = false;
@@ -42,7 +42,7 @@ public class GuildRequestTest {
   }
 
   @AfterAll
-  private static void afterAll() {
+  public static void afterAll() {
     Preferences.saveSettingsToFile = true;
   }
 

--- a/test/net/sourceforge/kolmafia/request/QuantumTerrariumRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/QuantumTerrariumRequestTest.java
@@ -26,7 +26,7 @@ import org.mockito.Mockito;
 public class QuantumTerrariumRequestTest {
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     // Simulate logging out and back in again.
     KoLCharacter.reset("");
     KoLCharacter.reset("quantum terrarium user");
@@ -34,7 +34,7 @@ public class QuantumTerrariumRequestTest {
   }
 
   @AfterAll
-  private static void afterAll() {
+  public static void afterAll() {
     Preferences.saveSettingsToFile = true;
   }
 

--- a/test/net/sourceforge/kolmafia/request/RelayRequestWarningsTest.java
+++ b/test/net/sourceforge/kolmafia/request/RelayRequestWarningsTest.java
@@ -42,7 +42,7 @@ public class RelayRequestWarningsTest {
   // warnings. Once you have confirmed once, it holds for rest of the session.
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     // Simulate logging out and back in again.
     GenericRequest.passwordHash = "";
     KoLCharacter.reset("");
@@ -51,7 +51,7 @@ public class RelayRequestWarningsTest {
   }
 
   @BeforeEach
-  private void beforeEach() {
+  public void beforeEach() {
     KoLConstants.inventory.clear();
     RelayRequest.reset();
     EquipmentManager.resetEquipment();
@@ -59,7 +59,7 @@ public class RelayRequestWarningsTest {
   }
 
   @AfterAll
-  private static void afterAll() {
+  public static void afterAll() {
     Preferences.saveSettingsToFile = true;
     KoLConstants.inventory.clear();
     RelayRequest.reset();

--- a/test/net/sourceforge/kolmafia/request/ScrapheapRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/ScrapheapRequestTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 public class ScrapheapRequestTest {
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     Preferences.saveSettingsToFile = false;
   }
 
@@ -31,7 +31,7 @@ public class ScrapheapRequestTest {
   }
 
   @AfterAll
-  private static void afterAll() {
+  public static void afterAll() {
     ChoiceManager.handlingChoice = false;
     Preferences.saveSettingsToFile = true;
   }

--- a/test/net/sourceforge/kolmafia/session/BanishManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/BanishManagerTest.java
@@ -29,14 +29,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class BanishManagerTest {
   @BeforeEach
-  private void beforeEach() {
+  public void beforeEach() {
     KoLCharacter.reset("BanishManagerTest");
     Preferences.reset("BanishManagerTest");
     BanishManager.clearCache();
   }
 
   @AfterAll
-  private static void cleanup() {
+  public static void cleanup() {
     BanishManager.clearCache();
   }
 

--- a/test/net/sourceforge/kolmafia/session/BastilleBattalionManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/BastilleBattalionManagerTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 public class BastilleBattalionManagerTest {
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     // Simulate logging out and back in again.
     GenericRequest.passwordHash = "";
     KoLCharacter.reset("");
@@ -32,12 +32,12 @@ public class BastilleBattalionManagerTest {
   }
 
   @AfterAll
-  private static void afterAll() {
+  public static void afterAll() {
     Preferences.saveSettingsToFile = true;
   }
 
   @BeforeEach
-  private void beforeEach() {
+  public void beforeEach() {
     BastilleBattalionManager.reset();
     Preferences.setBoolean("logBastilleBattalionBattles", false);
     KoLConstants.activeEffects.clear();

--- a/test/net/sourceforge/kolmafia/session/ChoiceManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/ChoiceManagerTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 public class ChoiceManagerTest {
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     // Simulate logging out and back in again.
     GenericRequest.passwordHash = "";
     KoLCharacter.reset("");
@@ -35,12 +35,12 @@ public class ChoiceManagerTest {
   }
 
   @AfterAll
-  private static void afterAll() {
+  public static void afterAll() {
     Preferences.saveSettingsToFile = true;
   }
 
   @BeforeEach
-  private void beforeEach() {
+  public void beforeEach() {
     ChoiceManager.lastChoice = 0;
     ChoiceManager.lastDecision = 0;
   }

--- a/test/net/sourceforge/kolmafia/session/EncounterManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/EncounterManagerTest.java
@@ -407,7 +407,7 @@ class EncounterManagerTest {
 
     boolean actual = EncounterManager.isRelativityMonster();
 
-    assertThat(relativityMonster, equalTo(relativityMonster));
+    assertThat(actual, equalTo(relativityMonster));
     assertThat("_relativityMonster", isSetTo(false));
   }
 

--- a/test/net/sourceforge/kolmafia/session/EncounterManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/EncounterManagerTest.java
@@ -44,7 +44,7 @@ import org.mockito.Mockito;
 
 class EncounterManagerTest {
   @BeforeEach
-  private void beforeEach() {
+  public void beforeEach() {
     KoLCharacter.reset("EncounterManagerTest");
     Preferences.reset("EncounterManagerTest");
     KoLmafia.resetSession();
@@ -53,7 +53,7 @@ class EncounterManagerTest {
   }
 
   @AfterAll
-  private static void cleanup() {
+  public static void cleanup() {
     TurnCounter.clearCounters();
   }
 

--- a/test/net/sourceforge/kolmafia/session/EquipmentManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/EquipmentManagerTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class EquipmentManagerTest {
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     // Simulate logging out and back in again.
     GenericRequest.passwordHash = "";
     KoLCharacter.reset("");
@@ -33,7 +33,7 @@ public class EquipmentManagerTest {
   }
 
   @AfterAll
-  private static void afterAll() {
+  public static void afterAll() {
     Preferences.saveSettingsToFile = true;
   }
 

--- a/test/net/sourceforge/kolmafia/session/GreyYouManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/GreyYouManagerTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 public class GreyYouManagerTest {
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     // Simulate logging out and back in again.
     KoLCharacter.reset("");
     KoLCharacter.reset("grey you manager user");
@@ -25,7 +25,7 @@ public class GreyYouManagerTest {
   }
 
   @BeforeEach
-  private void beforeEach() {
+  public void beforeEach() {
     GreyYouManager.resetAbsorptions();
   }
 

--- a/test/net/sourceforge/kolmafia/session/LocketManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/LocketManagerTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 public class LocketManagerTest {
   @BeforeEach
-  private void beforeEach() {
+  public void beforeEach() {
     KoLCharacter.reset("LocketManagerTest");
     Preferences.reset("LocketManagerTest");
   }

--- a/test/net/sourceforge/kolmafia/session/MallPriceManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/MallPriceManagerTest.java
@@ -139,7 +139,7 @@ public class MallPriceManagerTest {
   }
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     // Simulate logging out and back in again.
     KoLCharacter.reset("");
     KoLCharacter.reset("mall price manager user");
@@ -149,13 +149,13 @@ public class MallPriceManagerTest {
   }
 
   @AfterAll
-  private static void afterAll() {
+  public static void afterAll() {
     MallPriceDatabase.savePricesToFile = true;
     Preferences.saveSettingsToFile = true;
   }
 
   @BeforeEach
-  private void beforeEach() {
+  public void beforeEach() {
     // Stop requests from actually running
     GenericRequest.sessionId = null;
     KoLCharacter.setAvailableMeat(1_000_000);

--- a/test/net/sourceforge/kolmafia/session/MonsterManuelManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/MonsterManuelManagerTest.java
@@ -17,12 +17,12 @@ import org.junit.jupiter.api.Test;
 public class MonsterManuelManagerTest {
 
   @AfterAll
-  private static void afterAll() {
+  public static void afterAll() {
     MonsterManuelManager.flushCache();
   }
 
   @BeforeEach
-  private void beforeEach() {
+  public void beforeEach() {
     MonsterManuelManager.flushCache();
   }
 

--- a/test/net/sourceforge/kolmafia/session/PriceToAcquireTest.java
+++ b/test/net/sourceforge/kolmafia/session/PriceToAcquireTest.java
@@ -99,7 +99,7 @@ public class PriceToAcquireTest {
   }
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     // Simulate logging out and back in again.
     KoLCharacter.reset("");
     KoLCharacter.reset("price to acquire user");
@@ -109,19 +109,19 @@ public class PriceToAcquireTest {
   }
 
   @AfterAll
-  private static void afterAll() {
+  public static void afterAll() {
     MallPriceDatabase.savePricesToFile = true;
     Preferences.saveSettingsToFile = true;
   }
 
   @BeforeEach
-  private void beforeEach() {
+  public void beforeEach() {
     CharPaneRequest.setCanInteract(true);
     Preferences.reset("price to acquire user");
   }
 
   @AfterEach
-  private void afterEach() {
+  public void afterEach() {
     // Prevent leakage; reset to initial state
 
     Preferences.setFloat("valueOfInventory", 1.8f);

--- a/test/net/sourceforge/kolmafia/session/YouRobotManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/YouRobotManagerTest.java
@@ -67,7 +67,7 @@ public class YouRobotManagerTest {
   }
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     // Simulate logging out and back in again.
     GenericRequest.passwordHash = "";
     KoLCharacter.reset("");
@@ -76,12 +76,12 @@ public class YouRobotManagerTest {
   }
 
   @AfterAll
-  private static void afterAll() {
+  public static void afterAll() {
     Preferences.saveSettingsToFile = true;
   }
 
   @AfterEach
-  private void afterEach() {
+  public void afterEach() {
     Preferences.setInteger("statbotUses", 0);
     Preferences.setInteger("youRobotTop", 0);
     Preferences.setInteger("youRobotLeft", 0);

--- a/test/net/sourceforge/kolmafia/swingui/OptionsFrameTest.java
+++ b/test/net/sourceforge/kolmafia/swingui/OptionsFrameTest.java
@@ -33,24 +33,24 @@ import org.junit.jupiter.api.Test;
 public class OptionsFrameTest {
 
   @BeforeAll
-  private static void beforeAll() {
+  public static void beforeAll() {
     Preferences.saveSettingsToFile = false;
   }
 
   @AfterAll
-  private static void afterAll() {
+  public static void afterAll() {
     Preferences.saveSettingsToFile = true;
   }
 
   @Nested
   class PreferenceCheckBoxTest {
     @BeforeEach
-    private void beforeEach() {
+    public void beforeEach() {
       KoLCharacter.reset("checkbox");
     }
 
     @AfterEach
-    private void afterEach() {
+    public void afterEach() {
       PreferenceListenerRegistry.reset();
     }
 
@@ -119,12 +119,12 @@ public class OptionsFrameTest {
   @Nested
   class PreferenceIntegerTextFieldTest {
     @BeforeEach
-    private void beforeEach() {
+    public void beforeEach() {
       KoLCharacter.reset("textfield");
     }
 
     @AfterEach
-    private void afterEach() {
+    public void afterEach() {
       PreferenceListenerRegistry.reset();
     }
 
@@ -198,12 +198,12 @@ public class OptionsFrameTest {
   @Nested
   class PreferenceButtonGroupTest {
     @BeforeEach
-    private void beforeEach() {
+    public void beforeEach() {
       KoLCharacter.reset("buttongroup");
     }
 
     @AfterEach
-    private void afterEach() {
+    public void afterEach() {
       PreferenceListenerRegistry.reset();
     }
 

--- a/test/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanelTest.java
+++ b/test/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanelTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 public class UseItemEnqueuePanelTest {
 
   @BeforeEach
-  private void beforeEach() {
+  public void beforeEach() {
     KoLCharacter.reset(true);
     KoLCharacter.reset("fakeUserName");
 

--- a/test/net/sourceforge/kolmafia/textui/langserver/AshLanguageServerTest.java
+++ b/test/net/sourceforge/kolmafia/textui/langserver/AshLanguageServerTest.java
@@ -33,7 +33,7 @@ public class AshLanguageServerTest {
   static Set<Logger> disabledLoggers = new HashSet<>();
 
   @BeforeAll
-  private static void disableLoggers() {
+  protected static void disableLoggers() {
     Set.of(StreamMessageProducer.class, RemoteEndpoint.class)
         .forEach(
             c -> {
@@ -44,7 +44,7 @@ public class AshLanguageServerTest {
   }
 
   @AfterAll
-  private static void disposeDisabledLoggers() {
+  protected static void disposeDisabledLoggers() {
     disabledLoggers.clear();
   }
 


### PR DESCRIPTION
JUnit has [changed](https://junit.org/junit5/docs/5.9.0/release-notes/) behaviour to be consistent with their docs and not accept private lifecycle methods. This leads to a lot of churn.

SVNKit has some [bug fixes](https://svn.svnkit.com/repos/svnkit/trunk/CHANGES.txt) that look worth having.