### PR TITLE
Reading the macguffin diary doesn't finish the ballroom quest

### DIFF
--- a/src/net/sourceforge/kolmafia/request/QuestLogRequest.java
+++ b/src/net/sourceforge/kolmafia/request/QuestLogRequest.java
@@ -151,7 +151,7 @@ public class QuestLogRequest extends GenericRequest {
     if (QuestDatabase.isQuestStarted(Quest.SPOOKYRAVEN_BABIES)) {
       QuestDatabase.setQuestProgress(Quest.SPOOKYRAVEN_DANCE, QuestDatabase.FINISHED);
     }
-    if (QuestDatabase.isQuestStarted(Quest.MANOR)) {
+    if (QuestDatabase.isQuestLaterThan(Quest.MANOR, QuestDatabase.STARTED)) {
       QuestDatabase.setQuestProgress(Quest.SPOOKYRAVEN_DANCE, QuestDatabase.FINISHED);
     }
     if (QuestDatabase.isQuestLaterThan(Quest.MACGUFFIN, "step1")) {


### PR DESCRIPTION
questL11Manor is marked as `started` once you read the MacGuffin diary; it isn't until `step1` that the cellar is open.