### PR TITLE
Remove manual  java selection in jenkinsfile

### DIFF
--- a/jenkinsfile
+++ b/jenkinsfile
@@ -18,24 +18,20 @@ pipeline {
     stage('Building') {
       steps {
         script {
-          withEnv(["JAVA_HOME=/usr/lib/jvm/temurin-17-jdk-amd64"]) {
             sh 'ls'
             sh 'java --version'
             sh './gradlew -v'
             sh './gradlew --no-daemon clean shadowJar'
-          }
         }
       }
     }
     stage('Testing') {
       steps {
         script {
-          withEnv(["JAVA_HOME=/usr/lib/jvm/temurin-17-jdk-amd64"]) {
-            sh './gradlew --no-daemon --stacktrace jacocoTestReport'
+            sh './gradlew --no-daemon jacocoTestReport'
             jacoco buildOverBuild: true, changeBuildStatus: true, deltaBranchCoverage: '5', deltaClassCoverage: '5', deltaComplexityCoverage: '5', deltaInstructionCoverage: '5', deltaLineCoverage: '5', deltaMethodCoverage: '5', maximumBranchCoverage: '70', maximumClassCoverage: '70', maximumComplexityCoverage: '70', maximumInstructionCoverage: '70', maximumLineCoverage: '70', maximumMethodCoverage: '70', runAlways: true
             publishCoverage adapters: [jacocoAdapter(mergeToOneReport: true, path: 'build/reports/jacoco/test/jacocoTestReport.xml')], sourceFileResolver: sourceFiles('NEVER_STORE')
             publishHTML([allowMissing: true, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'build/reports/jacoco/test/html/', reportFiles: 'index.html', reportName: 'JaCoCo Test Report', reportTitles: ''])
-          }
         }
       }
     }


### PR DESCRIPTION
Jenkins no longer needs to run an older version of Java so we can now use the same version for both.