### PR TITLE
chore: add buzzed on distillate effect to data

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -5313,6 +5313,7 @@ Effect	Buttery, Boy	Sleaze Resistance: +3, Sleaze Damage: +30, Moxie Percent: +1
 Effect	Buttons Rouged, Louisiana	Avatar: "man with the red buttons"
 Effect	Buy!  Sell!  Buy!  Sell!	Meat Drop: [max(0,202-2*T)]
 Effect	Buzzard Breath	Stench Damage: +30, Spooky Damage: +30
+# Buzzed on Distillate: Variable
 Effect	Cafeter&iacute;a Brujer&iacute;a	MP Regen Min: 3, MP Regen Max: 4
 Effect	Cake Caked	Mysticality Percent: +50
 Effect	Can Has Cyborger	Moxie Percent: +10

--- a/src/data/statuseffects.txt
+++ b/src/data/statuseffects.txt
@@ -2717,3 +2717,4 @@
 2717	Kinda Damp	blooddrops.gif	1e39ab0a1afcc1c70d5302304f7b93b2	good	none
 2718	Wholesomely Resolved	happy.gif	2b47f4772381abb5ac24e620be92da96	good	none
 2719	Slippery and Speedy	sweaty.gif	defb8cda55243471997f272f928a09f8	neutral	none	cast 1 Drench Yourself in Sweat
+2720	Buzzed on Distillate	chinsweat.gif	d64eab33f648e1a77da23ae516353fb2	neutral	none


### PR DESCRIPTION
Avoid the "unrecognised effect" text, but don't try to parse the effect or anything.