### PR TITLE
Fix up some missing path points trackers and incorrect path images

### DIFF
--- a/src/data/consequences.txt
+++ b/src/data/consequences.txt
@@ -42,7 +42,7 @@ QUEST_LOG	demonName9	;&middot;([^<]*?), the Smith<br	demonName9=$1
 QUEST_LOG	demonName10	;&middot;([^<]*?), the Pain Enjoyer<br	demonName10=$1
 QUEST_LOG	demonName11	;&middot;([^<]*?), Friend of Gary<br	demonName11=$1
 
-DESC_ITEM	Adventurer bobblehead	Attributes \+(\d+)%	item9084=$1
+DESC_ITEM	Adventurer bobblehead	Attributes \+(\d+)%	nuclearAutumnPoints=$1
 DESC_ITEM	bishop cookie	\+(\d+)%	chessboardsCleared=[($1-100)/2]
 DESC_ITEM	bone abacus	defeated (\d+) opponent	boneAbacusVictories=$1
 DESC_ITEM	brainwave-controlled unicorn horn	(\d+)% inflated	unicornHornInflation=$1

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -739,7 +739,6 @@ user	iceSculptureMonster
 user	iceSwagger	0
 user	implementGlitchItem	false
 user	invalidBuffMessage	You sent an amount which does not correspond to a valid buff amount.
-user	item9084	0
 user	itemBoughtPerAscension637	false
 user	itemBoughtPerAscension8266	false
 user	itemBoughtPerAscension10790	false
@@ -1031,6 +1030,7 @@ user	nsContestants1	-1
 user	nsContestants2	-1
 user	nsContestants3	-1
 user	nsTowerDoorKeysUsed
+user	nuclearAutumnPoints	0
 user	numericSwagger	0
 user	nunsVisits	0
 user	oceanAction	savecontinue
@@ -1431,6 +1431,7 @@ user	trackVoteMonster	false
 user	turtleBlessingTurns	0
 user	trapperOre
 user	twinPeakProgress	0
+user	twoCRSPoints	0
 user	umbrellaState	broken
 user	umdLastObtained	
 user	uneffectWithHotTub	true

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -2036,7 +2036,7 @@ Item	A Light that Never Goes Out	Mysticality: +5, Hot Damage: +5, Smithsness: +5
 Item	Abracandalabra	Spell Damage Percent: +100, MP Regen Min: 5, MP Regen Max: 10, Maximum MP Percent: +100, Lasts Until Rollover
 Item	Abyssal ember	Hot Damage: +20, Weapon Drop: +25, Class: "Seal Clubber"
 Item	adhesive tape dolly	Moxie: +5
-Item	Adventurer bobblehead	Muscle Percent: [pref(item9084)], Mysticality Percent: [pref(item9084)], Moxie Percent: [pref(item9084)]
+Item	Adventurer bobblehead	Muscle Percent: [pref(nuclearAutumnPoints)], Mysticality Percent: [pref(nuclearAutumnPoints)], Moxie Percent: [pref(nuclearAutumnPoints)]
 # aerogel attache case: Produce random cocktailcrafting ingredients as you adventure
 Item	aerogel attache case	Pickpocket Chance: +10, Stench Damage: +10, Drops Items
 Item	ancient calendar	Adventures: +3, Damage Reduction: 4

--- a/src/net/sourceforge/kolmafia/AscensionPath.java
+++ b/src/net/sourceforge/kolmafia/AscensionPath.java
@@ -14,7 +14,7 @@ public class AscensionPath {
     TEETOTALER("Teetotaler", 2, false, "bowl", "a"),
     OXYGENARIAN("Oxygenarian", 3, false, "oxy", "an"),
     BEES_HATE_YOU("Bees Hate You", 4, false, "beeicon", "a"),
-    SURPRISING_FIST("Way of the Surprising Fist", 6, false, "wasp_fist", "a"),
+    SURPRISING_FIST("Way of the Surprising Fist", 6, false, "wosp_fist", "a"),
     TRENDY("Trendy", 7, false, "trendyicon", "a"),
     AVATAR_OF_BORIS("Avatar of Boris", 8, true, "trusty", "an", "borisPoints", 0, false),
     BUGBEAR_INVASION("Bugbear Invasion", 9, false, "familiar39", "a"),
@@ -37,7 +37,7 @@ public class AscensionPath {
     COMMUNITY_SERVICE("Community Service", 25, false, "csplaquesmall", "a"),
     AVATAR_OF_WEST_OF_LOATHING("Avatar of West of Loathing", 26, false, "badge", "an"),
     THE_SOURCE("The Source", 27, false, "ss_datasiphon", "a", "sourcePoints", 0, false),
-    NUCLEAR_AUTUMN("Nuclear Autumn", 28, false, "radiation", "a"),
+    NUCLEAR_AUTUMN("Nuclear Autumn", 28, false, "radiation", "a", "nuclearAutumnPoints", 23, false),
     GELATINOUS_NOOB("Gelatinous Noob", 29, true, "gcube", "a", "noobPoints", 20, true),
     LICENSE_TO_ADVENTURE(
         "License to Adventure", 30, false, "briefcase", "a", "bondPoints", 24, true),
@@ -46,7 +46,7 @@ public class AscensionPath {
     GLOVER("G-Lover", 33, false, "g-loveheart", "a", "gloverPoints", 10, false),
     DISGUISES_DELIMIT("Disguises Delimit", 34, false, "dd_icon", "a", "masksUnlocked", 25, false),
     DARK_GYFFTE("Dark Gyffte", 35, true, "darkgift", "a", "darkGyfftePoints", 23, true),
-    CRAZY_RANDOM_SUMMER_TWO("Two Crazy Random Summer", 36, false, "twocrazydice", "a"),
+    CRAZY_RANDOM_SUMMER_TWO("Two Crazy Random Summer", 36, false, "twocrazydice", "a", "twoCRSPoints", 37, false),
     KINGDOM_OF_EXPLOATHING("Kingdom of Exploathing", 37, false, "puff", "a"),
     PATH_OF_THE_PLUMBER(
         "Path of the Plumber", 38, true, "mario_mushroom1", "a", "plumberPoints", 22, false),
@@ -54,7 +54,7 @@ public class AscensionPath {
     GREY_GOO("Grey Goo", 40, false, "greygooball", "a"),
     YOU_ROBOT("You, Robot", 41, false, "robobattery", "a", "youRobotPoints", 37, false),
     QUANTUM("Quantum Terrarium", 42, false, "quantum", "a", "quantumPoints", 11, false),
-    WILDFIRE("Wildfire", 43, false, "brushfire", "a"),
+    WILDFIRE("Wildfire", 43, false, "fire", "a"),
     GREY_YOU("Grey You", 44, true, "greygooring", "a", "greyYouPoints", 11, false),
     JOURNEYMAN("Journeyman", 45, false, "map", "a"),
     // A "sign" rather than a "path" for some reason

--- a/src/net/sourceforge/kolmafia/AscensionPath.java
+++ b/src/net/sourceforge/kolmafia/AscensionPath.java
@@ -46,7 +46,8 @@ public class AscensionPath {
     GLOVER("G-Lover", 33, false, "g-loveheart", "a", "gloverPoints", 10, false),
     DISGUISES_DELIMIT("Disguises Delimit", 34, false, "dd_icon", "a", "masksUnlocked", 25, false),
     DARK_GYFFTE("Dark Gyffte", 35, true, "darkgift", "a", "darkGyfftePoints", 23, true),
-    CRAZY_RANDOM_SUMMER_TWO("Two Crazy Random Summer", 36, false, "twocrazydice", "a", "twoCRSPoints", 37, false),
+    CRAZY_RANDOM_SUMMER_TWO(
+        "Two Crazy Random Summer", 36, false, "twocrazydice", "a", "twoCRSPoints", 37, false),
     KINGDOM_OF_EXPLOATHING("Kingdom of Exploathing", 37, false, "puff", "a"),
     PATH_OF_THE_PLUMBER(
         "Path of the Plumber", 38, true, "mario_mushroom1", "a", "plumberPoints", 22, false),


### PR DESCRIPTION
- Nuclear autumn can be tracked like any other path, rather than just looking at the item
- 2CRS is worth tracking because you get that number of extra enchants on your ring
- Some path images were just wrong... including wosp!