### PR TITLE
Fix Concoction.compareTo

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/Concoction.java
+++ b/src/net/sourceforge/kolmafia/objectpool/Concoction.java
@@ -432,8 +432,10 @@ public class Concoction implements Comparable<Concoction> {
 
     // Sort steel organs to the top.
     if (this.steelOrgan) {
-      // No need to see if they are both steel organs as they have different sort orders
-      // and are thus differentiated above.
+      if (o.steelOrgan) {
+        // both are steel organs so return name compare
+        return this.nameCheckCompare(o);
+      }
       return -1;
     } else if (o.steelOrgan) {
       return 1;


### PR DESCRIPTION
https://kolmafia.us/threads/r26661-attempt-to-permanently-meet-otherwise-stochastic-coverage-changes-by-g.27892/

This fixes the violation of the compareTo contract discovered by running checkconcoctions (from the gCLI).  checkconcoctions was moved from test code to debug code because of the resources it required as a test and that decision was not revisited.