### PR TITLE
refactor: use default github token for junit report

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -48,7 +48,6 @@ jobs:
         uses: mikepenz/action-junit-report@v3.3.0
         if: always()
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Report (${{ matrix.os }})"
           report_paths: "**/build/test-results/test/TEST-*.xml"
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,10 +45,11 @@ jobs:
         run: ./gradlew --no-daemon check jacocoTestReport
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3.2.0
+        uses: mikepenz/action-junit-report@v3
         if: always()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          job_summary: true
           check_name: "Test Report (${{ matrix.os }})"
           report_paths: "**/build/test-results/test/TEST-*.xml"
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,7 +45,7 @@ jobs:
         run: ./gradlew --no-daemon check jacocoTestReport
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3.3.0
+        uses: mikepenz/action-junit-report@v3.2.0
         if: always()
         with:
           check_name: "Test Report (${{ matrix.os }})"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,11 +45,10 @@ jobs:
         run: ./gradlew --no-daemon check jacocoTestReport
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
+        uses: mikepenz/action-junit-report@v3.3.0
         if: always()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          job_summary: true
           check_name: "Test Report (${{ matrix.os }})"
           report_paths: "**/build/test-results/test/TEST-*.xml"
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,7 +45,7 @@ jobs:
         run: ./gradlew --no-daemon check jacocoTestReport
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
+        uses: mikepenz/action-junit-report@v3.2.0
         if: always()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
JUnit report seems broken after the latest update. Going to try a few things that might fix it.