### PR TITLE
fix: mistranslated method in r26667

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -5437,7 +5437,7 @@ public abstract class KoLCharacter {
         case ItemPool.FOLDER_HOLDER:
           // Apply folders
           Arrays.stream(EquipmentManager.FOLDER_SLOTS)
-              .mapToObj(EquipmentManager::getEquipment)
+              .mapToObj(i -> equipment[i])
               .filter(f -> f != null && f != EquipmentRequest.UNEQUIP)
               .map(AdventureResult::getItemId)
               .forEach((id) -> newModifiers.add(Modifiers.getItemModifiers(id)));


### PR DESCRIPTION
There are bug reports that something maximizer-related has started breaking on https://github.com/kolmafia/kolmafia/commit/f9a268c62529d240a27c701cd3f27740adc5506f, so I took a closer look.

All I could find that appeared to have changed is folder-related: this method checked the currently equipped item instead of the passed-in item, and ValhallaManager checks all folders instead of the first 3 (though the latter two should be null, so it should wash out).