### PR TITLE
Fix outfit swapping with empty accessory slots.

### DIFF
--- a/src/net/sourceforge/kolmafia/request/EquipmentRequest.java
+++ b/src/net/sourceforge/kolmafia/request/EquipmentRequest.java
@@ -1826,10 +1826,11 @@ public class EquipmentRequest extends PasswordHashRequest {
     // Calculate accessory fill order
     int accessoryIndex = 0;
 
+    int[] accessories = EquipmentManager.ACCESSORY_SLOTS.clone();
     // Consume unfilled slots from 1 to 3
     for (int slot : EquipmentManager.ACCESSORY_SLOTS) {
       if (oldEquipment[slot] == EquipmentRequest.UNEQUIP) {
-        EquipmentManager.ACCESSORY_SLOTS[accessoryIndex++] = slot;
+        accessories[accessoryIndex++] = slot;
       }
     }
     // Consume filled slots from 3 to 1
@@ -1838,7 +1839,7 @@ public class EquipmentRequest extends PasswordHashRequest {
         slot--) {
       if (oldEquipment[slot] != EquipmentRequest.UNEQUIP
           && newEquipment[slot] == EquipmentRequest.UNEQUIP) {
-        EquipmentManager.ACCESSORY_SLOTS[accessoryIndex++] = slot;
+        accessories[accessoryIndex++] = slot;
       }
     }
 
@@ -1879,7 +1880,7 @@ public class EquipmentRequest extends PasswordHashRequest {
             // KoL error: four accessories
             continue;
           }
-          slot = EquipmentManager.ACCESSORY_SLOTS[accessoryIndex++];
+          slot = accessories[accessoryIndex++];
           break;
 
         case EquipmentManager.WEAPON:


### PR DESCRIPTION
The trigger seems to be having an accessory in acc1 and an empty slot
in some higher value, then donning an outfit that fills that empty
slot.

Note: not ready for commit as-is, as I haven't written any tests
yet. I've only confirmed that the fix works :)