### PR TITLE
Crimbo 21 no longer accessible

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/NPCStoreDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/NPCStoreDatabase.java
@@ -227,6 +227,8 @@ public class NPCStoreDatabase {
       return false;
     } else if (storeId.startsWith("crimbo20")) {
       return false;
+    } else if (storeId.startsWith("crimbo21")) {
+      return false;
     } else if (storeId.equals("guildstore1")) {
       // Shadowy Store
       return KoLCharacter.isMoxieClass() && KoLCharacter.getGuildStoreOpen();


### PR DESCRIPTION
On my IOTM-less testing alt, autoscend was attempting to drink and eat items from the Crimbo '21 shop and failing. No longer attempts to shop there after this change.