### PR TITLE
fix: avoid debug log on moons command

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/HolidayDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/HolidayDatabase.java
@@ -177,13 +177,13 @@ public class HolidayDatabase {
 
   public static void guessPhaseStep() {
     try {
-      int calendarDay = HolidayDatabase.getDayInKoLYear(ZonedDateTime.now(ROLLOVER));
+      int calendarDay = HolidayDatabase.getDayInKoLYear();
       int phaseStep = (calendarDay + 16) % 16;
 
       HolidayDatabase.RONALD_PHASE = phaseStep % 8;
       HolidayDatabase.GRIMACE_PHASE = phaseStep / 2;
       HolidayDatabase.HAMBURGLAR_POSITION =
-          HolidayDatabase.getHamburglarPosition(ZonedDateTime.now(ROLLOVER));
+          HolidayDatabase.getHamburglarPosition(getRolloverDateTime());
     } catch (Exception e) {
       // This should not happen. Therefore, print
       // a stack trace for debug purposes.

--- a/src/net/sourceforge/kolmafia/textui/command/ShowDataCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ShowDataCommand.java
@@ -2,6 +2,7 @@ package net.sourceforge.kolmafia.textui.command;
 
 import java.io.File;
 import java.io.PrintStream;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -98,7 +99,7 @@ public class ShowDataCommand extends AbstractCommand {
       var today = HolidayDatabase.getRolloverDateTime();
 
       desiredStream.println(
-          CalendarFrame.LONG_FORMAT.format(today)
+          today.format(DateTimeFormatter.ofPattern(CalendarFrame.LONG_FORMAT.toPattern()))
               + " - "
               + HolidayDatabase.getCalendarDayAsString(today));
       desiredStream.println();

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -942,6 +942,8 @@ public class Player {
             ZonedDateTime.of(
                 year, month.getValue(), day, hour, minute, 0, 0, HolidayDatabase.ROLLOVER));
 
+    HolidayDatabase.guessPhaseStep();
+
     return new Cleanups(mocked::close);
   }
 

--- a/test/net/sourceforge/kolmafia/textui/command/ShowDataCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ShowDataCommandTest.java
@@ -1,0 +1,26 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static internal.helpers.Player.withDay;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import java.time.Month;
+import org.junit.jupiter.api.Test;
+
+public class ShowDataCommandTest extends AbstractCommandTestBase {
+
+  @Test
+  public void canPrintDateInfo() {
+    this.command = "moons";
+
+    var cleanups = withDay(2022, Month.AUGUST, 21);;
+    try (cleanups) {
+      String output = execute("");
+      assertThat(output, containsString("August 21, 2022 - Martinus 6"));
+      assertThat(output, containsString("Ronald: waning gibbous"));
+      assertThat(output, containsString("Grimace: first quarter"));
+      assertThat(output, containsString("Arrrbor Day: 22 days"));
+      assertThat(output, containsString("3 days until Muscle."));
+    }
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/command/ShowDataCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ShowDataCommandTest.java
@@ -13,7 +13,7 @@ public class ShowDataCommandTest extends AbstractCommandTestBase {
   public void canPrintDateInfo() {
     this.command = "moons";
 
-    var cleanups = withDay(2022, Month.AUGUST, 21);;
+    var cleanups = withDay(2022, Month.AUGUST, 21);
     try (cleanups) {
       String output = execute("");
       assertThat(output, containsString("August 21, 2022 - Martinus 6"));


### PR DESCRIPTION
No test for the mini-moon because it looks like it's wrong. Looks like an off-by-one error was introduced in the refactor: it tells you the position the mini-moon was in yesterday.