### PR TITLE
Give Ed stages the same monsterId when creating a MonsterData

### DIFF
--- a/src/data/consequences.txt
+++ b/src/data/consequences.txt
@@ -124,9 +124,6 @@ DESC_EFFECT	Wine-Friendly	\+(\d+) .*? Damage	vintnerWineLevel=[$1/3]
 
 # Monster disambiguation:
 
-# Monster ID -94
-MONSTER	pooltergeist	poolter2\.gif	"pooltergeist (ultra-rare)"
-
 MONSTER	Ed the Undying	/ed(\d)\.gif	"Ed the Undying ($1)"
 MONSTER	Ed the Undying	.	"Ed the Undying (1)"
 

--- a/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
@@ -804,11 +804,22 @@ public class MonsterDatabase {
   }
 
   public static final MonsterData newMonster(
-      final String name, final int id, final String[] images, final String attributes) {
+      final String name, int id, final String[] images, final String attributes) {
     MonsterData monster = MonsterDatabase.findMonster(name);
     if (monster != null && monster.getId() == id) {
       // *** Is this an error?
       return monster;
+    }
+
+    // Ed the Undying has ID = 473. We have 7 different pseudo-monsters for his
+    // different stages, named Ed the Undying (1), and so on.  on.  We've given
+    // wach of those id = 0, so that looking up monster by id will find the
+    // base.  However, when we are in a fight, we want to match MONSTERID with
+    // the disambiguated version. Therefore, give each of them id = 473 here.
+    if (id == 0) {
+      if (name.startsWith("Ed the Undying")) {
+        id = 473;
+      }
     }
 
     return new MonsterData(name, id, images, attributes);


### PR DESCRIPTION
1) In monsters.txt, bas Ed the Undying is monsterId = 473, but Ed the Undying (1) - Ed the Undying (7) all have monsterId = 0. This is because we can't have a map keyed by monsterId with 8 different key = 473.

However, when processing a fight, when we look at MONSTERID of 473, but we've disambiguated the monster by image to one of the (1) - (7) versions with monsterId = 0, that doesn't mtch, so we look up the monster by ID using the aforementioned map.

When creating the MonsterData associated with the (1) - (7) names, we now set the id to 473. FIghtRequest is happy.

2) I noticed that consequences.txt tried to figure out the Ultrarare pooltergeist by image, rather than use monsterId = -94. Since we know the actual monsterId  - 425 - no need to do that any more.