### PR TITLE
Strings with html removed, should be trimmed

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
@@ -198,6 +198,6 @@ public class RequestPane extends JEditorPane {
     selectedText = RequestPane.LINE_BREAK.matcher(selectedText).replaceAll("\n").trim();
     selectedText = KoLConstants.ANYTAG_PATTERN.matcher(selectedText).replaceAll("");
 
-    return StringUtilities.getEntityDecode(selectedText, false);
+    return StringUtilities.getEntityDecode(selectedText, false).trim();
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/RequestPaneTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RequestPaneTest.java
@@ -1,0 +1,90 @@
+package net.sourceforge.kolmafia.textui;
+
+import static internal.helpers.Player.withProperty;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import net.sourceforge.kolmafia.swingui.widget.RequestPane;
+import org.junit.jupiter.api.Test;
+
+public class RequestPaneTest {
+  @Test
+  public void testCopyAsHtml() {
+    var cleanups = withProperty("copyAsHTML", true);
+
+    try (cleanups) {
+      var pane = new RequestPane();
+      var html =
+          """
+                <table border="2" cols="4">
+                      <tr>
+                        <td>
+                          <p>
+                            roninStoragePulls
+                          </p>
+                        </td>
+                      </tr>
+                    </table>""";
+      pane.setText(html);
+
+      pane.select(0, pane.getText().length());
+
+      assertThat(pane.getSelectedText(), containsString(html));
+    }
+  }
+
+  @Test
+  public void testCopyWithoutHtml() {
+    var cleanups = withProperty("copyAsHTML", false);
+
+    try (cleanups) {
+      var pane = new RequestPane();
+      var html =
+          """
+                <table border="2" cols="4">
+                      <tr>
+                        <td>
+                          <p>
+                            roninStoragePulls
+                          </p>
+                        </td>
+                      </tr>
+                    </table>""";
+      var withoutHtml = "roninStoragePulls";
+      pane.setText(html);
+
+      pane.select(0, pane.getText().length());
+
+      assertThat(pane.getSelectedText(), not(containsString("<")));
+      assertThat(pane.getSelectedText(), containsString(withoutHtml));
+    }
+  }
+
+  @Test
+  public void testCopyWithoutHtmlTrimmed() {
+    var cleanups = withProperty("copyAsHTML", false);
+
+    try (cleanups) {
+      var pane = new RequestPane();
+      var html =
+          """
+                <table border="2" cols="4">
+                      <tr>
+                        <td>
+                          <p>
+                            roninStoragePulls
+                          </p>
+                        </td>
+                      </tr>
+                    </table>""";
+      var withoutHtml = "roninStoragePulls";
+      pane.setText(html);
+
+      pane.select(0, pane.getText().length());
+
+      assertThat(pane.getSelectedText(), equalTo(withoutHtml));
+    }
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/RequestPaneTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RequestPaneTest.java
@@ -31,7 +31,7 @@ public class RequestPaneTest {
 
       pane.select(0, pane.getText().length());
 
-      assertThat(pane.getSelectedText(), containsString(html));
+      assertThat(pane.getSelectedText(), equalTo(html));
     }
   }
 


### PR DESCRIPTION
When a string such as

```
<table border="2" cols="4">
      <tr>
        <td>
          <p>
            roninStoragePulls
          </p>
        </td>
      </tr>
    </table>
```

has the html removed, you're left with a bunch of spaces surrounding the string itself.
You will get this, note the spaces around the string.

```
                                    copyAsHTML                            
```

This could also be seen as another problem where the html shouldn't be formatted, but that's outside the scope of this small change.