### PR TITLE
fix: don't suggest horsery if not allowed in standard

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -314,6 +314,10 @@ public class Maximizer {
 
       if (lookup.startsWith("Horsery:")
           && filter.getOrDefault(KoLConstants.filterType.OTHER, false)) {
+        // Must be available in your current path
+        if (!StandardRequest.isAllowed("Items", "Horsery contract")) {
+          continue;
+        }
         String cmd, text;
         int price = 0;
         String name = lookup.substring(8);

--- a/src/net/sourceforge/kolmafia/request/StandardRequest.java
+++ b/src/net/sourceforge/kolmafia/request/StandardRequest.java
@@ -176,7 +176,7 @@ public class StandardRequest extends GenericRequest {
       Pattern.compile("<span class=\"i\">(.*?)(, )?</span>");
 
   public static final void parseResponse(final String location, final String responseText) {
-    TrendyRequest.reset();
+    StandardRequest.reset();
 
     Matcher matcher = StandardRequest.STANDARD_PATTERN.matcher(responseText);
     while (matcher.find()) {
@@ -193,12 +193,6 @@ public class StandardRequest extends GenericRequest {
           set.add(object);
         }
       }
-    }
-
-    // Buggy items and skills that should be listed but aren't.
-    if (!itemSet.isEmpty()) {
-      itemSet.add("actual reality goggles");
-      skillSet.add("fifteen minutes of flame");
     }
 
     StandardRequest.initialized = true;

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -41,6 +41,7 @@ import net.sourceforge.kolmafia.request.CharPaneRequest;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.FightRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
+import net.sourceforge.kolmafia.request.StandardRequest;
 import net.sourceforge.kolmafia.session.ChoiceControl;
 import net.sourceforge.kolmafia.session.ChoiceManager;
 import net.sourceforge.kolmafia.session.ClanManager;
@@ -1388,6 +1389,24 @@ public class Player {
     var old = KoLCharacter.getRestricted();
     KoLCharacter.setRestricted(restricted);
     return new Cleanups(() -> KoLCharacter.setRestricted(old));
+  }
+
+  /**
+   * Sets whether a particular item / skill is allowed in Standard
+   *
+   * @param type The type of key
+   * @param key The restricted item / skill
+   * @param allowed Whether key is allowed
+   * @return Restores to previous value
+   */
+  public static Cleanups withAllowedInStandard(final String type, final String key, final boolean allowed) {
+    var mocked = mockStatic(StandardRequest.class, Mockito.CALLS_REAL_METHODS);
+
+    mocked
+        .when(() -> StandardRequest.isAllowedInStandard(type, key))
+        .thenReturn(allowed);
+
+    return new Cleanups(mocked::close);
   }
 
   /**

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -1399,12 +1399,11 @@ public class Player {
    * @param allowed Whether key is allowed
    * @return Restores to previous value
    */
-  public static Cleanups withAllowedInStandard(final String type, final String key, final boolean allowed) {
+  public static Cleanups withAllowedInStandard(
+      final String type, final String key, final boolean allowed) {
     var mocked = mockStatic(StandardRequest.class, Mockito.CALLS_REAL_METHODS);
 
-    mocked
-        .when(() -> StandardRequest.isAllowedInStandard(type, key))
-        .thenReturn(allowed);
+    mocked.when(() -> StandardRequest.isAllowedInStandard(type, key)).thenReturn(allowed);
 
     return new Cleanups(mocked::close);
   }

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -1068,7 +1068,11 @@ public class MaximizerTest {
 
     @Test
     public void doesNotSuggestHorseryIfUnaffordable() {
-      var cleanups = new Cleanups(withProperty("horseryAvailable", true), withProperty("_horsery", "normal horse"), withMeat(0));
+      var cleanups =
+          new Cleanups(
+              withProperty("horseryAvailable", true),
+              withProperty("_horsery", "normal horse"),
+              withMeat(0));
 
       try (cleanups) {
         assertTrue(maximize("-combat"));
@@ -1078,7 +1082,11 @@ public class MaximizerTest {
 
     @Test
     public void doesNotSuggestHorseryIfNotAllowedInStandard() {
-      var cleanups = new Cleanups(withProperty("horseryAvailable", true), withRestricted(true), withAllowedInStandard("Items", "Horsery contract", false));
+      var cleanups =
+          new Cleanups(
+              withProperty("horseryAvailable", true),
+              withRestricted(true),
+              withAllowedInStandard("Items", "Horsery contract", false));
 
       try (cleanups) {
         assertTrue(maximize("-combat"));

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -38,7 +38,6 @@ import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -47,11 +46,6 @@ public class MaximizerTest {
   @BeforeAll
   public static void beforeAll() {
     KoLCharacter.reset("MaximizerTest");
-    Preferences.reset("MaximizerTest");
-  }
-
-  @BeforeEach
-  public void allowPreferences() {
     Preferences.reset("MaximizerTest");
   }
   // basic


### PR DESCRIPTION
actual reality goggles and fifteen minutes of flame were listed, despite the comment that they weren't.

Mocking `isAllowedInStandard` makes that test take 11 seconds, which is not good. Might refactor the class to make it more easily configurable for tests.

It looks like `ClearSharedStateBefore` runs before all nested classes, which breaks setting properties. Will look into fixing outside this PR.