### PR TITLE
refactor: download volcano maze images on program startup

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -102,6 +102,7 @@ import net.sourceforge.kolmafia.session.MallPriceManager;
 import net.sourceforge.kolmafia.session.ResultProcessor;
 import net.sourceforge.kolmafia.session.TurnCounter;
 import net.sourceforge.kolmafia.session.ValhallaManager;
+import net.sourceforge.kolmafia.session.VolcanoMazeManager;
 import net.sourceforge.kolmafia.session.VoteMonsterManager;
 import net.sourceforge.kolmafia.session.YouRobotManager;
 import net.sourceforge.kolmafia.swingui.AdventureFrame;
@@ -301,6 +302,7 @@ public abstract class KoLmafia {
     }
 
     FlaggedItems.initializeLists();
+    VolcanoMazeManager.downloadImages();
 
     // Now run the main routines for each, so that
     // you have an interface.

--- a/src/net/sourceforge/kolmafia/session/VolcanoMazeManager.java
+++ b/src/net/sourceforge/kolmafia/session/VolcanoMazeManager.java
@@ -75,10 +75,10 @@ public abstract class VolcanoMazeManager {
         "lava12.gif",
       };
 
-  static {
+  public static void downloadImages() {
     String base = KoLmafia.imageServerPath() + "itemimages/";
-    for (int i = 0; i < VolcanoMazeManager.IMAGES.length; ++i) {
-      FileUtilities.downloadImage(base + VolcanoMazeManager.IMAGES[i]);
+    for (var img : IMAGES) {
+      FileUtilities.downloadImage(base + img);
     }
   }
 


### PR DESCRIPTION
`VolcanoMazeManager` downloads the volcano maze images in a static initializer. This runs when running tests, and means that 15 files are "downloaded" at the start of every test. This makes debugging network requests more annoying.

These files need to be downloaded once, ever, so run this on program start -- we don't need to worry about login / logout needing to run it again.