### PR TITLE
feat: dino parka

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/command/JurassicParkaCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/JurassicParkaCommand.java
@@ -20,8 +20,8 @@ public class JurassicParkaCommand extends AbstractCommand implements ModeCommand
       Map.ofEntries(
           Map.entry("kachungasaur", 1),
           Map.entry("dilophosaur", 2),
-          Map.entry("ghostasaurus", 3),
-          Map.entry("spikolodon", 4),
+          Map.entry("spikolodon", 3),
+          Map.entry("ghostasaurus", 4),
           Map.entry("pterodactyl", 5));
 
   public static final Map<String, String> ALIASES =

--- a/src/net/sourceforge/kolmafia/textui/command/JurassicParkaCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/JurassicParkaCommand.java
@@ -13,7 +13,7 @@ import net.sourceforge.kolmafia.session.InventoryManager;
 public class JurassicParkaCommand extends AbstractCommand implements ModeCommand {
   public JurassicParkaCommand() {
     this.usage =
-        " [kachungasaur | cold | dilophosaur | stench | ghostasaurus | spooky | spikolodon | sleaze | pterodactyl | hot] - pull a dino tab on your Jurassic Parka";
+        " [kachungasaur | cold | hp | meat | dilophosaur | stench | acid | ghostasaurus | spooky | mp | dr | spikolodon | sleaze | ml | spikes | pterodactyl | hot | init] - pull a dino tab on your Jurassic Parka";
   }
 
   public static final Map<String, Integer> MODES =
@@ -27,10 +27,18 @@ public class JurassicParkaCommand extends AbstractCommand implements ModeCommand
   public static final Map<String, String> ALIASES =
       Map.ofEntries(
           Map.entry("spooky", "ghostasaurus"),
+          Map.entry("mp", "ghostasaurus"),
+          Map.entry("dr", "ghostasaurus"),
           Map.entry("stench", "dilophosaur"),
+          Map.entry("acid", "dilophosaur"),
           Map.entry("hot", "pterodactyl"),
+          Map.entry("init", "pterodactyl"),
           Map.entry("cold", "kachungasaur"),
-          Map.entry("sleaze", "spokolodon"));
+          Map.entry("hp", "kachungasaur"),
+          Map.entry("meat", "kachungasaur"),
+          Map.entry("sleaze", "spikolodon"),
+          Map.entry("ml", "spikolodon"),
+          Map.entry("spikes", "spikolodon"));
 
   @Override
   public boolean validate(final String command, final String parameters) {


### PR DESCRIPTION
Correct spelling, fix ordering for two dinos.

Add more aliases: e.g., "parka spikes" is easier to type than "parka kachungasaur".

Aliases were not added for "sleaze" (damage or res?) and "nc" (pterodactyl base enchant or spikolodon combat skill?)