### PR TITLE
fix: can't create barrel lid in standard

### DIFF
--- a/src/net/sourceforge/kolmafia/request/BarrelShrineRequest.java
+++ b/src/net/sourceforge/kolmafia/request/BarrelShrineRequest.java
@@ -4,6 +4,7 @@ import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestThread;
+import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.preferences.Preferences;
 
@@ -13,7 +14,8 @@ public class BarrelShrineRequest extends CreateItemRequest {
   }
 
   public static boolean availableBarrelItem(final String itemName) {
-    if (Preferences.getBoolean("barrelShrineUnlocked")) {
+    if (Preferences.getBoolean("barrelShrineUnlocked")
+        && StandardRequest.isAllowed(RestrictedItemType.ITEMS, "shrine to the Barrel god")) {
       if (itemName.equals("barrel lid")
           && !Preferences.getBoolean("_barrelPrayer")
           && !Preferences.getBoolean("prayedForProtection")) {

--- a/src/net/sourceforge/kolmafia/textui/command/RefreshStatusCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/RefreshStatusCommand.java
@@ -4,6 +4,7 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestThread;
+import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.request.ApiRequest;
 import net.sourceforge.kolmafia.request.CampgroundRequest;
 import net.sourceforge.kolmafia.request.ClanStashRequest;
@@ -21,7 +22,7 @@ import net.sourceforge.kolmafia.session.Limitmode;
 public class RefreshStatusCommand extends AbstractCommand {
   public RefreshStatusCommand() {
     this.usage =
-        " all | [status | effects] | [gear | equip | outfit] | inv | camp | storage | stash | closet | [familiar | terarrium] | stickers | quests | shop - resynchronize with KoL.";
+        " all | [status | effects] | [gear | equip | outfit] | inv | camp | storage | stash | closet | [familiar | terarrium] | stickers | quests | shop | concoctions - resynchronize with KoL.";
   }
 
   @Override
@@ -66,6 +67,9 @@ public class RefreshStatusCommand extends AbstractCommand {
       return;
     } else if (parameters.equals("shop")) {
       RequestThread.postRequest(new ManageStoreRequest());
+      return;
+    } else if (parameters.equals("concoctions")) {
+      ConcoctionDatabase.refreshConcoctions(true);
       return;
     } else {
       KoLmafia.updateDisplay(MafiaState.ERROR, parameters + " cannot be refreshed.");

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerCreatableTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerCreatableTest.java
@@ -5,6 +5,7 @@ import static internal.helpers.Player.*;
 
 import internal.helpers.Cleanups;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -32,11 +33,57 @@ public class MaximizerCreatableTest {
   }
 
   @Nested
+  class BarrelShrine {
+    @Test
+    public void canCreateBarrelItems() {
+      var cleanups = withProperty("barrelShrineUnlocked", true);
+
+      try (cleanups) {
+        ConcoctionDatabase.refreshConcoctions();
+        maximizeCreatable("ml");
+        recommendedSlotIs(EquipmentManager.OFFHAND, "barrel lid");
+      }
+    }
+
+    @Test
+    public void cannotCreateBarrelItemsTwice() {
+      var cleanups =
+          new Cleanups(
+              withProperty("barrelShrineUnlocked", true),
+              withProperty("prayedForProtection", true));
+
+      try (cleanups) {
+        ConcoctionDatabase.refreshConcoctions();
+        maximizeCreatable("ml");
+        recommendedSlotIsUnchanged(EquipmentManager.OFFHAND);
+      }
+    }
+
+    @Test
+    public void cannotCreateBarrelItemsInStandard() {
+      var cleanups =
+          new Cleanups(
+              withProperty("barrelShrineUnlocked", true),
+              withRestricted(true),
+              withNotAllowedInStandard(RestrictedItemType.ITEMS, "shrine to the Barrel god"));
+
+      try (cleanups) {
+        ConcoctionDatabase.refreshConcoctions();
+        maximizeCreatable("ml");
+        recommendedSlotIsUnchanged(EquipmentManager.OFFHAND);
+      }
+    }
+  }
+
+  @Nested
   class NPCStore {
     @Test
     public void canBuyUtensil() {
-      var cleanups = new Cleanups(withProperty("autoSatisfyWithNPCs", true),
-          withProperty("autoBuyPriceLimit", 2_000), withMeat(2000));
+      var cleanups =
+          new Cleanups(
+              withProperty("autoSatisfyWithNPCs", true),
+              withProperty("autoBuyPriceLimit", 2_000),
+              withMeat(2000));
 
       try (cleanups) {
         maximizeCreatable("spell dmg");
@@ -46,8 +93,12 @@ public class MaximizerCreatableTest {
 
     @Test
     public void buyBestUtensil() {
-      var cleanups = new Cleanups(withProperty("autoSatisfyWithNPCs", true),
-          withProperty("autoBuyPriceLimit", 2_000), withMeat(2000), withStats(100, 100, 100));
+      var cleanups =
+          new Cleanups(
+              withProperty("autoSatisfyWithNPCs", true),
+              withProperty("autoBuyPriceLimit", 2_000),
+              withMeat(2000),
+              withStats(100, 100, 100));
 
       try (cleanups) {
         maximizeCreatable("spell dmg");
@@ -57,7 +108,11 @@ public class MaximizerCreatableTest {
 
     @Test
     public void canOnlyBuyOneSphygmayomanometer() {
-      var cleanups = new Cleanups(withProperty("autoSatisfyWithNPCs", true), withWorkshedItem(ItemPool.MAYO_CLINIC), withStats(100, 100, 100));
+      var cleanups =
+          new Cleanups(
+              withProperty("autoSatisfyWithNPCs", true),
+              withWorkshedItem(ItemPool.MAYO_CLINIC),
+              withStats(100, 100, 100));
 
       try (cleanups) {
         maximizeCreatable("muscle");
@@ -70,8 +125,10 @@ public class MaximizerCreatableTest {
     @Test
     public void canOnlyBuyOneOversizedSparkler() {
       var cleanups =
-          new Cleanups(withProperty("autoSatisfyWithNPCs", true),
-              withSkill("Double-Fisted Skull Smashing"), withProperty("_fireworksShop", true));
+          new Cleanups(
+              withProperty("autoSatisfyWithNPCs", true),
+              withSkill("Double-Fisted Skull Smashing"),
+              withProperty("_fireworksShop", true));
 
       try (cleanups) {
         ConcoctionDatabase.refreshConcoctions();
@@ -84,7 +141,8 @@ public class MaximizerCreatableTest {
     @Test
     public void cannotCreateFireworkHatIfAlreadyHave() {
       var cleanups =
-          new Cleanups(withProperty("autoSatisfyWithNPCs", true),
+          new Cleanups(
+              withProperty("autoSatisfyWithNPCs", true),
               withProperty("_fireworksShop", true),
               withProperty("_fireworksShopHatBought", true));
 


### PR DESCRIPTION
Still not sure why all these maximizer issues have come in recently.

Additionally add a "refresh concoctions" command for forcibly refreshing concoctions (i.e. fixing Mafia state), in case the session breaks in that way for some reason. Bit different to the other "refresh" commands because this deals with Mafia's internal stuff instead of interacting with KoL, but I think it's linked (as what can be created depends on KoL state).