### PR TITLE
fix: check permitted concoctions in standard

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/Concoction.java
+++ b/src/net/sourceforge/kolmafia/objectpool/Concoction.java
@@ -992,6 +992,15 @@ public class Concoction implements Comparable<Concoction> {
         }
 
         return alreadyHave + purchaseRequest.affordableCount();
+    }
+
+    if (!ConcoctionDatabase.isPermittedMethod(this.mixingMethod, this.mixingRequirements)
+        || Preferences.getBoolean(
+            "unknownRecipe" + this.getItemId())) { // Impossible to create any more of this item.
+      return alreadyHave;
+    }
+
+    switch (this.mixingMethod) {
       case FLOUNDRY:
         return alreadyHave + (ClanLoungeRequest.availableFloundryItem(this.name) ? 1 : 0);
       case BARREL:
@@ -1029,14 +1038,6 @@ public class Concoction implements Comparable<Concoction> {
             + (StringUtilities.isNumeric(Preferences.getString("_frHoursLeft")) ? 0 : 1);
       case STILLSUIT:
         return StillSuitRequest.canMake() ? 1 : 0;
-      default:
-        if (!ConcoctionDatabase.isPermittedMethod(this.mixingMethod, this.mixingRequirements)
-            || Preferences.getBoolean(
-                "unknownRecipe"
-                    + this.getItemId())) { // Impossible to create any more of this item.
-          return alreadyHave;
-        }
-        break;
     }
 
     if (needToMake <= 0) { // Have enough on hand already.

--- a/src/net/sourceforge/kolmafia/request/BarrelShrineRequest.java
+++ b/src/net/sourceforge/kolmafia/request/BarrelShrineRequest.java
@@ -4,7 +4,6 @@ import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestThread;
-import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.preferences.Preferences;
 
@@ -15,20 +14,14 @@ public class BarrelShrineRequest extends CreateItemRequest {
 
   public static boolean availableBarrelItem(final String itemName) {
     if (Preferences.getBoolean("barrelShrineUnlocked")
-        && StandardRequest.isAllowed(RestrictedItemType.ITEMS, "shrine to the Barrel god")) {
-      if (itemName.equals("barrel lid")
-          && !Preferences.getBoolean("_barrelPrayer")
-          && !Preferences.getBoolean("prayedForProtection")) {
+        && !Preferences.getBoolean("_barrelPrayer")) {
+      if (itemName.equals("barrel lid") && !Preferences.getBoolean("prayedForProtection")) {
         return true;
       }
-      if (itemName.equals("barrel hoop earring")
-          && !Preferences.getBoolean("_barrelPrayer")
-          && !Preferences.getBoolean("prayedForGlamour")) {
+      if (itemName.equals("barrel hoop earring") && !Preferences.getBoolean("prayedForGlamour")) {
         return true;
       }
-      if (itemName.equals("bankruptcy barrel")
-          && !Preferences.getBoolean("_barrelPrayer")
-          && !Preferences.getBoolean("prayedForVigor")) {
+      if (itemName.equals("bankruptcy barrel") && !Preferences.getBoolean("prayedForVigor")) {
         return true;
       }
     }

--- a/test/internal/helpers/Maximizer.java
+++ b/test/internal/helpers/Maximizer.java
@@ -39,7 +39,7 @@ public class Maximizer {
   public static void recommendedSlotIs(int slot, String item) {
     Optional<AdventureResult> equipment = getSlot(slot);
     assertTrue(equipment.isPresent(), "Expected " + item + " to be recommended, but it was not");
-    assertEquals(AdventureResult.parseResult(item), equipment.get());
+    assertEquals(AdventureResult.tallyItem(item), equipment.get());
   }
 
   public static void recommendedSlotIsUnchanged(int slot) {

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -40,6 +40,7 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.BasementRequest;
 import net.sourceforge.kolmafia.request.CampgroundRequest;
 import net.sourceforge.kolmafia.request.CharPaneRequest;
+import net.sourceforge.kolmafia.request.ClanLoungeRequest;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.FightRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
@@ -282,7 +283,7 @@ public class Player {
   }
 
   /**
-   * Puts an amount of the given item into the player's clan stask
+   * Puts an amount of the given item into the player's clan stash
    *
    * @param itemName Item to give
    * @param count Quantity to give
@@ -305,6 +306,17 @@ public class Player {
           if (old != 0) AdventureResult.addResultToList(list, item.getInstance(old));
           EquipmentManager.updateEquipmentLists();
         });
+  }
+
+  /**
+   * Puts the given item into the player's clan lounge
+   *
+   * @param itemId Item to give
+   * @return Removes the item from the lounge
+   */
+  public static Cleanups withClanLoungeItem(final int itemId) {
+    ClanLoungeRequest.setClanLoungeItem(itemId, 1);
+    return new Cleanups(() -> ClanLoungeRequest.setClanLoungeItem(itemId, 0));
   }
 
   /**

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -142,12 +142,15 @@ public class Player {
     EquipmentManager.setEquipment(slot, item.getItemId() == -1 ? EquipmentRequest.UNEQUIP : item);
     EquipmentManager.updateNormalOutfits();
     KoLCharacter.recalculateAdjustments();
+    // may have access to a new item = may have access to a new concoction
+    ConcoctionDatabase.refreshConcoctions();
     cleanups.add(
         new Cleanups(
             () -> {
               EquipmentManager.setEquipment(slot, old);
               EquipmentManager.updateNormalOutfits();
               KoLCharacter.recalculateAdjustments();
+              ConcoctionDatabase.refreshConcoctions();
             }));
     return cleanups;
   }
@@ -299,12 +302,15 @@ public class Player {
     var old = item.getCount(list);
     AdventureResult.addResultToList(list, item);
     EquipmentManager.updateEquipmentLists();
+    // may have access to a new item = may have access to a new concoction
+    ConcoctionDatabase.refreshConcoctions();
 
     return new Cleanups(
         () -> {
           AdventureResult.removeResultFromList(list, item);
           if (old != 0) AdventureResult.addResultToList(list, item.getInstance(old));
           EquipmentManager.updateEquipmentLists();
+          ConcoctionDatabase.refreshConcoctions();
         });
   }
 

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -826,7 +826,8 @@ public class MaximizerTest {
 
       try (cleanups) {
         assertTrue(maximize("Monster Level Percent"));
-        recommendedSlotIs(EquipmentManager.OFFHAND, "umbrella broken");
+        someBoostIs(b -> commandStartsWith(b, "umbrella broken"));
+        recommendedSlotIs(EquipmentManager.OFFHAND, "unbreakable umbrella");
       }
     }
 
@@ -841,7 +842,8 @@ public class MaximizerTest {
 
       try (cleanups) {
         assertTrue(maximize("exp"));
-        recommendedSlotIs(EquipmentManager.OFFHAND, "umbrella broken");
+        someBoostIs(b -> commandStartsWith(b, "umbrella broken"));
+        recommendedSlotIs(EquipmentManager.OFFHAND, "unbreakable umbrella");
       }
     }
 

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -546,7 +546,7 @@ public class MaximizerTest {
     final var cleanups =
         new Cleanups(
             withEquippableItem("Space Trip safety headphones"),
-            withEquippableItem("Krampus horn"),
+            withEquippableItem("Krampus Horn"),
             // get ourselves to -25 combat
             withEffect("Shelter of Shed"),
             withEffect("Smooth Movements"));
@@ -555,7 +555,7 @@ public class MaximizerTest {
       assertTrue(
           EquipmentManager.canEquip("Space Trip safety headphones"),
           "Cannot equip Space Trip safety headphones");
-      assertTrue(EquipmentManager.canEquip("Krampus horn"), "Cannot equip Krampus Horn");
+      assertTrue(EquipmentManager.canEquip("Krampus Horn"), "Cannot equip Krampus Horn");
       assertTrue(
           maximize(
               "cold res,-combat -hat -weapon -offhand -back -shirt -pants -familiar -acc1 -acc2 -acc3"));
@@ -567,7 +567,7 @@ public class MaximizerTest {
           0.01,
           "Maximizing one slot should reach 27");
 
-      recommendedSlotIs(EquipmentManager.ACCESSORY1, "Krampus horn");
+      recommendedSlotIs(EquipmentManager.ACCESSORY1, "Krampus Horn");
     }
   }
 

--- a/test/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactoryTest.java
+++ b/test/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactoryTest.java
@@ -25,7 +25,7 @@ class ListCellRendererFactoryTest {
       assertThat(
           component.getText(),
           is(
-              "<html><i><nobr><b><font color=#999999>fortune cookie (0 possible, 1 current)</font></b></nobr><br><nobr>&nbsp;1 full, +1.00 adv, semi-rare numbers</i></nobr></html>"));
+              "<html><nobr><b><font color=#999999>fortune cookie (1 possible, 1 current)</font></b></nobr><br><nobr>&nbsp;1 full, +1.00 adv, semi-rare numbers</nobr></html>"));
     }
   }
 
@@ -42,7 +42,7 @@ class ListCellRendererFactoryTest {
       assertThat(
           component.getText(),
           is(
-              "<html><i><nobr><b>plain pizza (0 possible, 1 current)</b></nobr><br><nobr>&nbsp;2 full, +3.00 adv, PIZZA</i></nobr></html>"));
+              "<html><nobr><b>plain pizza (1 possible, 1 current)</b></nobr><br><nobr>&nbsp;2 full, +3.00 adv, PIZZA</nobr></html>"));
     }
   }
 
@@ -59,7 +59,7 @@ class ListCellRendererFactoryTest {
       assertThat(
           component.getText(),
           is(
-              "<html><i><nobr><b><font color=green>blackberry (0 possible, 1 current)</font></b></nobr><br><nobr>&nbsp;1 full, +2.50 adv, +3.0 mus, +3.0 mys, +3.0 mox</i></nobr></html>"));
+              "<html><nobr><b><font color=green>blackberry (1 possible, 1 current)</font></b></nobr><br><nobr>&nbsp;1 full, +2.50 adv, +3.0 mus, +3.0 mys, +3.0 mox</nobr></html>"));
     }
   }
 
@@ -76,7 +76,7 @@ class ListCellRendererFactoryTest {
       assertThat(
           component.getText(),
           is(
-              "<html><i><nobr><b><font color=gray>blackberry (0 possible, 1 current)</font></b></nobr><br><nobr>&nbsp;1 full, +2.50 adv, +3.0 mus, +3.0 mys, +3.0 mox</i></nobr></html>"));
+              "<html><nobr><b><font color=gray>blackberry (1 possible, 1 current)</font></b></nobr><br><nobr>&nbsp;1 full, +2.50 adv, +3.0 mus, +3.0 mys, +3.0 mox</nobr></html>"));
     }
   }
 
@@ -93,7 +93,7 @@ class ListCellRendererFactoryTest {
       assertThat(
           component.getText(),
           is(
-              "<html><i><nobr><b><font color=#964B00>drippy plum(?) (0 possible, 1 current)</font></b></nobr><br><nobr>&nbsp;5 full, +5.00 adv, 5 µg of Drippy Juice</i></nobr></html>"));
+              "<html><nobr><b><font color=#964B00>drippy plum(?) (1 possible, 1 current)</font></b></nobr><br><nobr>&nbsp;5 full, +5.00 adv, 5 µg of Drippy Juice</nobr></html>"));
     }
   }
 
@@ -110,7 +110,7 @@ class ListCellRendererFactoryTest {
       assertThat(
           component.getText(),
           is(
-              "<html><i><nobr><b>astral hot dog (<font color=green>?</font><font color=red>?</font><font color=gray>?</font>, 0 possible, 1 current)</b></nobr><br><nobr>&nbsp;3 full, +16.00 adv, +144.0 mus, +144.0 mys, +144.0 mox</i></nobr></html>"));
+              "<html><nobr><b>astral hot dog (<font color=green>?</font><font color=red>?</font><font color=gray>?</font>, 1 possible, 1 current)</b></nobr><br><nobr>&nbsp;3 full, +16.00 adv, +144.0 mus, +144.0 mys, +144.0 mox</nobr></html>"));
     }
   }
 
@@ -127,7 +127,7 @@ class ListCellRendererFactoryTest {
       assertThat(
           component.getText(),
           is(
-              "<html><nobr><b><font color=blue>Taco Dan's Taco Fish Fish Taco (2 Beach Bucks, 0 possible, 1 current)</font></b></nobr><br><nobr>&nbsp;2 full, +8.00 adv, +50.0 mus, +50.0 mys, +50.0 mox</nobr></html>"));
+              "<html><nobr><b><font color=blue>Taco Dan's Taco Fish Fish Taco (2 Beach Bucks, 1 possible, 1 current)</font></b></nobr><br><nobr>&nbsp;2 full, +8.00 adv, +50.0 mus, +50.0 mys, +50.0 mox</nobr></html>"));
     }
   }
 
@@ -144,7 +144,7 @@ class ListCellRendererFactoryTest {
       assertThat(
           component.getText(),
           is(
-              "<html><i><nobr><b><font color=#8a2be2>Mr. Burnsger (0 possible, 1 current)</font></b></nobr><br><nobr>&nbsp;4 full, +28.00 adv, +30.0 mus, +30.0 mys, +30.0 mox, -2 Drunkenness</i></nobr></html>"));
+              "<html><nobr><b><font color=#8a2be2>Mr. Burnsger (1 possible, 1 current)</font></b></nobr><br><nobr>&nbsp;4 full, +28.00 adv, +30.0 mus, +30.0 mys, +30.0 mox, -2 Drunkenness</nobr></html>"));
     }
   }
 
@@ -161,7 +161,7 @@ class ListCellRendererFactoryTest {
       assertThat(
           component.getText(),
           is(
-              "<html><i><nobr><b>fortune cookie (0 possible, 1 current)</b></nobr><br><nobr>&nbsp;1 full, +1.00 adv, semi-rare numbers</i></nobr></html>"));
+              "<html><nobr><b>fortune cookie (1 possible, 1 current)</b></nobr><br><nobr>&nbsp;1 full, +1.00 adv, semi-rare numbers</nobr></html>"));
     }
   }
 }


### PR DESCRIPTION
Revert some of #1064.

This issue was introduced in 228c600a384f99c60028ce38f413e91969fe7108, where the `ConcoctionDatabase.isPermittedMethod` check was moved out of the middle of the function, and so wasn't checked for a variety of createables. This meant that things like the barrel shrine, floundry etc. were considered to be available in standard when they aren't.

Add tests for these things.