### PR TITLE
feat: reserve extra types

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -342,6 +342,12 @@ public class Parser {
     reservedWords.add("monster");
     reservedWords.add("element");
     reservedWords.add("coinmaster");
+    reservedWords.add("phylum");
+    reservedWords.add("thrall");
+    reservedWords.add("bounty");
+    reservedWords.add("servant");
+    reservedWords.add("vykea");
+    reservedWords.add("path");
 
     reservedWords.add("record");
     reservedWords.add("typedef");

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -442,7 +442,7 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
       @ParameterizedTest
       @ValueSource(
           strings = {
-            "boolean test(string path) { return path == \"Trendy\"; } test($path[Trendy])",
+            "boolean test(string p) { return p == \"Trendy\"; } test($path[Trendy])",
             "string p = my_path(); (p == \"Trendy\")",
             "(my_path() == \"Trendy\")",
             "my_path().starts_with(\"Tre\")",

--- a/test/net/sourceforge/kolmafia/textui/parsetree/ReservedWordTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/ReservedWordTest.java
@@ -1,0 +1,33 @@
+package net.sourceforge.kolmafia.textui.parsetree;
+
+import static net.sourceforge.kolmafia.textui.ScriptData.invalid;
+
+import java.util.stream.Stream;
+import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.textui.ParserTest;
+import net.sourceforge.kolmafia.textui.ScriptData;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ReservedWordTest {
+  @BeforeAll
+  public static void setRevision() {
+    StaticEntity.overrideRevision(10000);
+  }
+
+  public static Stream<ScriptData> data() {
+    return Stream.of(
+        invalid(
+            "path",
+            "int[string] path;",
+            "Reserved word 'path' cannot be a variable name",
+            "char 13 to char 17"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testScriptValidity(ScriptData script) {
+    ParserTest.testScriptValidity(script);
+  }
+}


### PR DESCRIPTION
Follow-up to #1032.

By https://kolmafia.us/threads/witchess-puzzle-solver.19964/page-3#post-169591, ASH scripts that used "path" as an array variable broke anyway.

Reserve all the unreserved types to give a better error message.