### PR TITLE
June cleaver cannot miss.

### DIFF
--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -10793,7 +10793,7 @@
 10765	yellow rocket	562478024	fwrocket3.gif	none, combat	d	10
 10766	blue rocket	830484549	fwrocket2.gif	none, combat	d	10
 10767	red rocket	942080224	fwrocket1.gif	none, combat	d	10
-10768	fire crackers	615027243	firecrackers.gif	food, combat		0
+10768	fire crackers	615027243	firecrackers.gif	food, combat		0	handfuls of fire crackers
 10769	Arr, M80	555632254	m80.gif	none, combat		0
 10770	Catherine Wheel	660770799	catherinewheel.gif	container	q	0
 10771	rocket boots	438783522	rocketboot.gif	accessory	q	0

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -1506,7 +1506,8 @@ Item	iron pasta spoon	Spell Damage: +10
 Item	ironic battle spoon	Spell Damage: +10
 Item	jack flapper	Spell Damage: +5
 Item	Jacob's rung	Maximum MP: +15, Spell Damage: +15
-Item	June Cleaver	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, HP Regen Min: 6, HP Regen Max: 8, MP Regen Min: 6, MP Regen Max: 8, Adventures: +5, Hot Damage: [pref(_juneCleaverHot)], Spooky Damage: [pref(_juneCleaverSpooky)], Sleaze Damage: [pref(_juneCleaverSleaze)], Cold Damage: [pref(_juneCleaverCold)], Stench Damage: [pref(_juneCleaverStench)], Attacks Can't Miss
+# Item June cleaver: Grows stronger the more you use it
+Item	June cleaver	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, HP Regen Min: 6, HP Regen Max: 8, MP Regen Min: 6, MP Regen Max: 8, Adventures: +5, Hot Damage: [pref(_juneCleaverHot)], Spooky Damage: [pref(_juneCleaverSpooky)], Sleaze Damage: [pref(_juneCleaverSleaze)], Cold Damage: [pref(_juneCleaverCold)], Stench Damage: [pref(_juneCleaverStench)], Attacks Can't Miss
 Item	jungle drum	Spooky Damage: +10, Spooky Resistance: +2, Initiative: -20
 Item	keel-haulin' knife	Spell Damage: +17
 Item	kelp-holly gun	Moxie: +10, Ranged Damage Percent: +50, Pickpocket Chance: +25

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -1506,7 +1506,7 @@ Item	iron pasta spoon	Spell Damage: +10
 Item	ironic battle spoon	Spell Damage: +10
 Item	jack flapper	Spell Damage: +5
 Item	Jacob's rung	Maximum MP: +15, Spell Damage: +15
-Item	June Cleaver	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, HP Regen Min: 6, HP Regen Max: 8, MP Regen Min: 6, MP Regen Max: 8, Adventures: +5, Hot Damage: [pref(_juneCleaverHot)], Spooky Damage: [pref(_juneCleaverSpooky)], Sleaze Damage: [pref(_juneCleaverSleaze)], Cold Damage: [pref(_juneCleaverCold)], Stench Damage: [pref(_juneCleaverStench)]
+Item	June Cleaver	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, HP Regen Min: 6, HP Regen Max: 8, MP Regen Min: 6, MP Regen Max: 8, Adventures: +5, Hot Damage: [pref(_juneCleaverHot)], Spooky Damage: [pref(_juneCleaverSpooky)], Sleaze Damage: [pref(_juneCleaverSleaze)], Cold Damage: [pref(_juneCleaverCold)], Stench Damage: [pref(_juneCleaverStench)], Attacks Can't Miss
 Item	jungle drum	Spooky Damage: +10, Spooky Resistance: +2, Initiative: -20
 Item	keel-haulin' knife	Spell Damage: +17
 Item	kelp-holly gun	Moxie: +10, Ranged Damage Percent: +50, Pickpocket Chance: +25

--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -2612,6 +2612,7 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
       if (this.areaSummary != null
           && action.startsWith("attack")
           && !this.areaSummary.willHitSomething()
+          && !KoLCharacter.currentBooleanModifier(Modifiers.ATTACKS_CANT_MISS)
           && !KoLCharacter.getFamiliar().isCombatFamiliar()) {
         KoLmafia.updateDisplay(MafiaState.ERROR, "You can't hit anything there.");
         return;

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -871,7 +871,9 @@ public class Modifiers {
         Pattern.compile("Lasts Until Rollover")),
     new BooleanModifier(
         "Attacks Can't Miss",
-        Pattern.compile("Regular Attacks Can't Miss"),
+        new Pattern[] {
+          Pattern.compile("Regular Attacks Can't Miss"), Pattern.compile("Cannot miss")
+        },
         Pattern.compile("Attacks Can't Miss")),
     new BooleanModifier("Pirate", Pattern.compile("Look like a Pirate")),
     new BooleanModifier("Breakable", Pattern.compile("Breakable")),


### PR DESCRIPTION
 Attacks Can't Miss negates 'you can't hit anything here' warning.

How would one test the new clause in the conditional in the middle of KoLAdventure.run()?

I did test the extra pattern for parsing Attacks Can't Miss using my (heavily used today) June Cleaver:

```
> test newitem 330396747

Unknown item found: June cleaver (10920, 330396747)
--------------------
10920 June cleaver 330396747 junecleaver.gif weapon 0
June cleaver 100 Mus: 0 1-handed cleaver
# Item June cleaver: Grows stronger the more you use it
Item June cleaver Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, HP Regen Min: 6, HP Regen Max: 8, MP Regen Min: 6, MP Regen Max: 8, Adventures: +5, Hot Damage: +48, Cold Damage: +47, Sleaze Damage: +47, Stench Damage: +47, Spooky Damage: +47, Attacks Can't Miss
--------------------
```

