### PR TITLE
Fix serialization of Ed the Undying's forms.

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/parsetree/Value.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Value.java
@@ -233,7 +233,8 @@ public class Value implements TypedNode, Comparable<Value> {
     var type = this.getType();
 
     if (type == DataTypes.MONSTER_TYPE) {
-      return this.contentLong == 0;
+      // Ed the Undying has special handling in persistence/MonsterDatabase...
+      return this.contentLong == 0 || this.contentLong == 473;
     }
 
     return type.isStringLike();
@@ -272,7 +273,7 @@ public class Value implements TypedNode, Comparable<Value> {
     if (this.getType().equals(DataTypes.MONSTER_TYPE)
         && o.getType().equals(DataTypes.MONSTER_TYPE)) {
       int cmp = Long.compare(this.contentLong, o.contentLong);
-      if (cmp != 0 || this.contentLong != 0) {
+      if (cmp != 0 || !this.isStringLike()) {
         return cmp;
       }
     }
@@ -422,7 +423,7 @@ public class Value implements TypedNode, Comparable<Value> {
                     + this.contentLong
                     + "]"
                     + EffectDatabase.getEffectName((int) this.contentLong)
-                : type == DataTypes.TYPE_MONSTER && this.contentLong != 0
+                : type == DataTypes.TYPE_MONSTER && !this.isStringLike()
                     ? "["
                         + this.contentLong
                         + "]"

--- a/test/net/sourceforge/kolmafia/textui/parsetree/ValueTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/ValueTest.java
@@ -5,6 +5,8 @@ import static internal.matchers.SignMatcher.Sign.POSITIVE;
 import static internal.matchers.SignMatcher.Sign.ZERO;
 import static internal.matchers.SignMatcher.hasSign;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Objects;
@@ -263,6 +265,22 @@ class ValueTest {
           "$monster[ancient protector spirit] < $monster[spooky vampire]",
           aps.compareTo(vampire),
           hasSign(NEGATIVE));
+
+      var ed =
+          Objects.requireNonNull(
+              DataTypes.makeMonsterValue(MonsterDatabase.findMonster("Ed the Undying")));
+      var ed1 =
+          Objects.requireNonNull(
+              DataTypes.makeMonsterValue(MonsterDatabase.findMonster("Ed the Undying (1)")));
+      assertNotEquals(ed, ed1, "$monster[Ed the Undying] != $monster[Ed the Undying (1)]");
+    }
+
+    @Test
+    void edSerializesConsistently() {
+      var ed =
+          Objects.requireNonNull(
+              DataTypes.makeMonsterValue(MonsterDatabase.findMonster("Ed the Undying (1)")));
+      assertEquals(ed.dumpValue(), "Ed the Undying (1)");
     }
 
     @Test


### PR DESCRIPTION
MonsterDatabase has special handling for Ed's forms such that they all have the same nonzero id. This has two consequences in the current implementation:

1. Ed's forms are all == to each other. This has unexpected results when inserting multiple forms into the same map.

2. Attempting to write any of Ed's forms via map_to_file will look up the Monster with id=473, namely $monster[Ed the Undying].

This commit addresses both of those cases.