### PR TITLE
Break Prism Warnings should return false if previously confirmed

### DIFF
--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -137,7 +137,7 @@ public class RelayRequest extends PasswordHashRequest {
   private static final String CONFIRM_STICKER = "confirm25";
   private static final String CONFIRM_DESERT_OFFHAND = "confirm26";
   public static final String CONFIRM_MACHETE = "confirm27";
-  private static final String CONFIRM_RALPH = "confirm28";
+  public static final String CONFIRM_RALPH = "confirm28";
   private static final String CONFIRM_RALPH1 = "confirm29";
   private static final String CONFIRM_RALPH2 = "confirm30";
   public static final String CONFIRM_DESERT_WEAPON = "confirm31";
@@ -795,7 +795,6 @@ public class RelayRequest extends PasswordHashRequest {
 
   public boolean sendBreakPrismWarning(final String urlString) {
     // place.php?whichplace=nstower&action=ns_11_prism
-
     if (!urlString.startsWith("place.php")
         || !urlString.contains("whichplace=nstower")
         || !urlString.contains("action=ns_11_prism")) {
@@ -809,6 +808,11 @@ public class RelayRequest extends PasswordHashRequest {
     // Isotopes
 
     if (KoLCharacter.isKingdomOfExploathing()) {
+      // If user has already confirmed he wants to break the prism, accept it
+      if (this.getFormField(CONFIRM_RALPH) != null) {
+        return false;
+      }
+
       if (InventoryManager.getCount(ItemPool.RARE_MEAT_ISOTOPE) <= 0) {
         return false;
       }
@@ -883,6 +887,11 @@ public class RelayRequest extends PasswordHashRequest {
     // You might want to spend Energy on Adventures or Stats.
 
     if (KoLCharacter.inRobocore()) {
+      // If user has already confirmed he wants to go there, accept it
+      if (this.getFormField(CONFIRM_RALPH) != null) {
+        return false;
+      }
+
       int energy = KoLCharacter.getYouRobotEnergy();
       int chronolithCost = Preferences.getInteger("_chronolithNextCost");
       int statbotCost = Preferences.getInteger("statbotUses") + 10;
@@ -925,6 +934,11 @@ public class RelayRequest extends PasswordHashRequest {
     // your dinodollars
 
     if (KoLCharacter.inDinocore()) {
+      // If user has already confirmed he wants to go there, accept it
+      if (this.getFormField(CONFIRM_RALPH) != null) {
+        return false;
+      }
+
       if (InventoryManager.getCount(ItemPool.DINODOLLAR) <= 0) {
         return false;
       }


### PR DESCRIPTION
I was irked when I got a warning that suggested I spend my DInodollars, clicked the icon to say I was fine with not doing this, and was immediately given the same warning.

The "hand" icon add a confirmation field to the URL.
The warning failed to check the confirmation.

This same issue was present in Kingdom of Explothing and Robocore.

1) I fixed all three paths.
2) I split the Robocore test into multiple single tests
I put them into a Nested test class
I made them use Cleanups
3) I added a test for Robocore
4) I added a test for Dinocore