### PR TITLE
Fixing "Refresh menu" menu item.

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/menu/ScriptMenu.java
+++ b/src/net/sourceforge/kolmafia/swingui/menu/ScriptMenu.java
@@ -30,6 +30,7 @@ public class ScriptMenu extends JMenu implements Listener {
 
   @Override
   public void update() {
+    GenericFrame.compileScripts();
     SwingUtilities.invokeLater(this::init);
   }
 
@@ -54,7 +55,7 @@ public class ScriptMenu extends JMenu implements Listener {
     }
 
     if (!useMRUList) {
-      add(new InvocationMenuItem("Refresh menu", GenericFrame.class, "compileScripts"));
+      add(new InvocationMenuItem("Refresh menu", this, "update"));
       headers++;
     }
     JMenuItem shiftToEditMenuItem = new JMenuItem("(Shift key to edit)");


### PR DESCRIPTION
The "Refresh menu" menu item under scripts doesn't do anything anymore.  It only refreshes the backing list, not the actual UI.  This change makes it refresh the UI as well.