### PR TITLE
No Relay Boss Warnings in Dinocore

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3403,6 +3403,7 @@ public class ItemPool {
   public static final int DESIGNER_SWEATPANTS = 10929;
   public static final int STILLSUIT = 10932;
   public static final int DINODOLLAR = 10944;
+  public static final int DINOSAUR_DROPPINGS = 10945;
   public static final int JURASSIC_PARKA = 10952;
 
   private ItemPool() {}

--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -2349,7 +2349,8 @@ public class RelayRequest extends PasswordHashRequest {
     if (KoLCharacter.inRaincore()
         || KoLCharacter.isVampyre()
         || KoLCharacter.isPlumber()
-        || KoLCharacter.inRobocore()) {
+        || KoLCharacter.inRobocore()
+        || KoLCharacter.inDinocore()) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
@@ -2145,6 +2145,11 @@ public abstract class UseLinkDecorator {
         useLocation = "shop.php?whichshop=lathe";
         break;
 
+      case ItemPool.DINOSAUR_DROPPINGS:
+        useType = "turn in";
+        useLocation = "place.php?whichplace=dinorf&action=dinorf_owner";
+        break;
+
       default:
     }
 


### PR DESCRIPTION
1) 'cause regular bosses are replaced with special monsters.
2) Add "turn in" link in relay browser to turn in dinosaur droppings to Dino World owner