### PR TITLE
count ConcoctionDatabase refreshes

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
@@ -1252,6 +1252,7 @@ public class ConcoctionDatabase {
   }
 
   public static final synchronized void refreshConcoctionsNow() {
+    Preferences.increment("_concoctionDatabaseRefreshes");
     ConcoctionDatabase.refreshNeeded = false;
 
     List<AdventureResult> availableIngredients = ConcoctionDatabase.getAvailableIngredients();


### PR DESCRIPTION
ConcoctionDatabase.refreshConcoctions is a relatively expensive operation.

We've made an effort to eliminate unnecessary calls. Used to be, we'd call it for each item that came into inventory after a fight. Now we defer refreshing until we've processed all the items.

I recently noticed that it now takes many seconds (well, 5 or 10) after clicking on the Item Manager icon before the frame appears. This is new. I decided to see if this was the issue. So I added a simple metric - "_concoctionDatabaseRefreshes" - to get a feel for it.

Turns out, no.

We refresh concoctions 12 times while logging in.
Building the Item Manager Frame? 0 times.

I should learn how to profile to find out what the real slowdown is. ListCellRenderers? Who knows? Need data!

In any case, this metric is still interesting, so, here we are.