### PR TITLE
Convert PluralValues to arrays in Javascript

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/TypescriptDefinition.java
+++ b/src/net/sourceforge/kolmafia/textui/TypescriptDefinition.java
@@ -52,7 +52,6 @@ public class TypescriptDefinition {
           Map.entry("Bounty.location", "Location"),
           Map.entry("Class.primestat", "Stat"),
           Map.entry("Coinmaster.item", "Item"),
-          Map.entry("Effect.all", "{ [source: string]: boolean }"),
           Map.entry("Item.buyer", "Coinmaster"),
           Map.entry("Item.seller", "Coinmaster"),
           Map.entry("Item.noob_skill", "Skill"),
@@ -66,10 +65,7 @@ public class TypescriptDefinition {
           Map.entry("Monster.attack_element", "Element"),
           Map.entry("Monster.defense_element", "Element"),
           Map.entry("Monster.phylum", "Phylum"),
-          Map.entry("Monster.poison", "Effect"),
-          Map.entry("Monster.images", "{ [image: string]: boolean }"),
-          Map.entry("Monster.random_modifiers", "{ [randomModifier: string]: boolean }"),
-          Map.entry("Monster.sub_types", "{ [subType: string]: boolean }"));
+          Map.entry("Monster.poison", "Effect"));
 
   private static final List<Type> typesWithNumbers =
       List.of(

--- a/src/net/sourceforge/kolmafia/textui/command/JsRefCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/JsRefCommand.java
@@ -26,8 +26,11 @@ public class JsRefCommand extends AbstractCommand {
       return "any";
     }
 
+    if (type instanceof PluralValueType) {
+      return "readonly " + toJavascriptTypeName(((PluralValueType) type).getIndexType()) + "[]";
+    }
+
     if (type instanceof AggregateType) {
-      // FIXME: PluralValues are mapped to arrays, but there is no good way to distinguish them here
       if (((AggregateType) type).getSize() < 0) {
         return "{ ["
             + toObjectKeyType(((AggregateType) type).getIndexType())

--- a/src/net/sourceforge/kolmafia/textui/command/JsRefCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/JsRefCommand.java
@@ -27,6 +27,7 @@ public class JsRefCommand extends AbstractCommand {
     }
 
     if (type instanceof AggregateType) {
+      // FIXME: PluralValues are mapped to arrays, but there is no good way to distinguish them here
       if (((AggregateType) type).getSize() < 0) {
         return "{ ["
             + toObjectKeyType(((AggregateType) type).getIndexType())

--- a/src/net/sourceforge/kolmafia/textui/javascript/ProxyRecordMethodWrapper.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/ProxyRecordMethodWrapper.java
@@ -29,6 +29,13 @@ public class ProxyRecordMethodWrapper extends BaseFunction {
     try {
       Object returnValue = method.invoke(((EnumeratedWrapper) thisObj).getWrapped().asProxy());
 
+      // if the method returns a non-proxy Ash value (like Effect.all or Monster.attackElements),
+      // we need to convert it to a java object first
+      if (returnValue instanceof Value) {
+        ValueConverter coercer = new ValueConverter(cx, scope);
+        returnValue = coercer.asJava((Value) returnValue);
+      }
+
       if (returnValue instanceof Value
           && ((Value) returnValue).asProxy() instanceof ProxyRecordValue) {
         returnValue = EnumeratedWrapper.wrap(scope, returnValue.getClass(), (Value) returnValue);

--- a/src/net/sourceforge/kolmafia/textui/javascript/ValueConverter.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/ValueConverter.java
@@ -12,6 +12,7 @@ import net.sourceforge.kolmafia.textui.ScriptException;
 import net.sourceforge.kolmafia.textui.parsetree.AggregateType;
 import net.sourceforge.kolmafia.textui.parsetree.ArrayValue;
 import net.sourceforge.kolmafia.textui.parsetree.MapValue;
+import net.sourceforge.kolmafia.textui.parsetree.PluralValue;
 import net.sourceforge.kolmafia.textui.parsetree.RecordValue;
 import net.sourceforge.kolmafia.textui.parsetree.Type;
 import net.sourceforge.kolmafia.textui.parsetree.Value;
@@ -69,6 +70,11 @@ public class ValueConverter {
         scope, Arrays.stream((Value[]) arrayValue.content).map(this::asJava).toArray());
   }
 
+  private Scriptable asNativeArray(PluralValue arrayValue) {
+    return cx.newArray(
+        scope, Arrays.stream((Value[]) arrayValue.content).map(this::asJava).toArray());
+  }
+
   public Object asJava(Value value) {
     if (value == null) return null;
     else if (value.getType().equals(DataTypes.VOID_TYPE)) {
@@ -95,6 +101,8 @@ public class ValueConverter {
       return EnumeratedWrapper.wrap(scope, value.asProxy().getClass(), value);
     } else if (value instanceof RecordValue) {
       return asObject((RecordValue) value);
+    } else if (value instanceof PluralValue) {
+      return asNativeArray((PluralValue) value);
     } else {
       // record type, ...?
       return value;

--- a/src/net/sourceforge/kolmafia/textui/parsetree/AggregateType.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/AggregateType.java
@@ -62,9 +62,15 @@ public class AggregateType extends CompositeType {
   }
 
   // VarArg
-  public AggregateType(
+  protected AggregateType(
       final String name, final Type dataType, final int size, final Location location) {
     this(name, dataType, DataTypes.INT_TYPE, size, false, location);
+  }
+
+  // PluralValue
+  protected AggregateType(
+      final String name, final Type dataType, final Type indexType, final Location location) {
+    this(name, dataType, indexType, -1, false, location);
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/textui/parsetree/PluralValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/PluralValue.java
@@ -12,7 +12,7 @@ public class PluralValue extends AggregateValue {
   private TreeSet<Value> lookup;
 
   public PluralValue(final Type type, List<Value> values) {
-    super(new AggregateType(DataTypes.BOOLEAN_TYPE, type));
+    super(new PluralValueType(type));
 
     this.content = values.toArray(new Value[0]);
   }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/PluralValueType.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/PluralValueType.java
@@ -1,0 +1,36 @@
+package net.sourceforge.kolmafia.textui.parsetree;
+
+import net.sourceforge.kolmafia.textui.DataTypes;
+import org.eclipse.lsp4j.Location;
+
+public class PluralValueType extends AggregateType {
+  public PluralValueType(final Type type) {
+    this(type, null);
+  }
+
+  public PluralValueType(final Type type, final Location location) {
+    super("pluralValue", DataTypes.BOOLEAN_TYPE, type, location);
+  }
+
+  @Override
+  public void setSize(int size) {
+    throw new RuntimeException("Cannot modify constant value");
+  }
+
+  @Override
+  public PluralValueType reference(final Location location) {
+    return new PluralValueTypeReference(this, location);
+  }
+
+  private class PluralValueTypeReference extends PluralValueType {
+    private PluralValueTypeReference(
+        final PluralValueType pluralValueType, final Location location) {
+      super(pluralValueType.indexType, location);
+    }
+
+    @Override
+    public Location getDefinitionLocation() {
+      return PluralValueType.this.getDefinitionLocation();
+    }
+  }
+}

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -1222,7 +1222,7 @@ public class ProxyRecordValue extends RecordValue {
             .add("name", DataTypes.STRING_TYPE)
             .add("default", DataTypes.STRING_TYPE)
             .add("note", DataTypes.STRING_TYPE)
-            .add("all", new AggregateType(DataTypes.BOOLEAN_TYPE, DataTypes.STRING_TYPE))
+            .add("all", new PluralValueType(DataTypes.STRING_TYPE))
             .add("image", DataTypes.STRING_TYPE)
             .add("descid", DataTypes.STRING_TYPE)
             .add("candy_tier", DataTypes.INT_TYPE)
@@ -1462,9 +1462,7 @@ public class ProxyRecordValue extends RecordValue {
             .add("base_initiative", DataTypes.INT_TYPE)
             .add("raw_initiative", DataTypes.INT_TYPE)
             .add("attack_element", DataTypes.ELEMENT_TYPE)
-            .add(
-                "attack_elements",
-                new AggregateType(DataTypes.BOOLEAN_TYPE, DataTypes.ELEMENT_TYPE))
+            .add("attack_elements", new PluralValueType(DataTypes.ELEMENT_TYPE))
             .add("defense_element", DataTypes.ELEMENT_TYPE)
             .add("physical_resistance", DataTypes.INT_TYPE)
             .add("elemental_resistance", DataTypes.INT_TYPE)
@@ -1479,11 +1477,9 @@ public class ProxyRecordValue extends RecordValue {
             .add("boss", DataTypes.BOOLEAN_TYPE)
             .add("copyable", DataTypes.BOOLEAN_TYPE)
             .add("image", DataTypes.STRING_TYPE)
-            .add("images", new AggregateType(DataTypes.BOOLEAN_TYPE, DataTypes.STRING_TYPE))
-            .add("sub_types", new AggregateType(DataTypes.BOOLEAN_TYPE, DataTypes.STRING_TYPE))
-            .add(
-                "random_modifiers",
-                new AggregateType(DataTypes.BOOLEAN_TYPE, DataTypes.STRING_TYPE))
+            .add("images", new PluralValueType(DataTypes.STRING_TYPE))
+            .add("sub_types", new PluralValueType(DataTypes.STRING_TYPE))
+            .add("random_modifiers", new PluralValueType(DataTypes.STRING_TYPE))
             .add("manuel_name", DataTypes.STRING_TYPE)
             .add("wiki_name", DataTypes.STRING_TYPE)
             .add("attributes", DataTypes.STRING_TYPE)

--- a/test/root/expected/plural_values_are_returned_as_arrays.js.out
+++ b/test/root/expected/plural_values_are_returned_as_arrays.js.out
@@ -1,0 +1,70 @@
+{
+  "name": "Ed the Undying",
+  "attackElement": "none",
+  "attackElements": [
+    "none"
+  ],
+  "images": [
+    "ed.gif",
+    "ed2.gif",
+    "ed3.gif",
+    "ed4.gif",
+    "ed5.gif",
+    "ed6.gif",
+    "ed7.gif"
+  ],
+  "randomModifiers": [],
+  "subTypes": []
+}
+{
+  "name": "warwelf",
+  "attackElement": "none",
+  "attackElements": [
+    "none"
+  ],
+  "images": [
+    "werewolf.gif"
+  ],
+  "randomModifiers": [],
+  "subTypes": []
+}
+{
+  "name": "lihc",
+  "attackElement": "spooky",
+  "attackElements": [
+    "sleaze",
+    "spooky"
+  ],
+  "images": [
+    "lich.gif"
+  ],
+  "randomModifiers": [],
+  "subTypes": []
+}
+{
+  "name": "ancient protector spirit",
+  "attackElement": "spooky",
+  "attackElements": [
+    "spooky"
+  ],
+  "images": [
+    "protspirit.gif"
+  ],
+  "randomModifiers": [],
+  "subTypes": [
+    "ghost"
+  ]
+}
+{
+  "name": "Beaten up",
+  "all": [
+    "# losing in combat"
+  ]
+}
+{
+  "name": "Tomato Power",
+  "all": [
+    "use 1 tomato juice of powerful power",
+    "use 1 evil tomato juice of powerful power"
+  ]
+}

--- a/test/root/scripts/plural_values_are_returned_as_arrays.js
+++ b/test/root/scripts/plural_values_are_returned_as_arrays.js
@@ -1,0 +1,31 @@
+const { printHtml } = require("kolmafia");
+
+[
+  'Ed the Undying',
+  'warwelf',
+  'lihc',
+  'ancient protector spirit'
+].forEach((name) => {
+  const monster = Monster.get(name);
+
+  printHtml(JSON.stringify({
+    name,
+    attackElement: (monster.attackElement || '').toString(),
+    attackElements: monster.attackElements.map((element) => element.toString()),
+    images: monster.images,
+    randomModifiers: monster.randomModifiers,
+    subTypes: monster.subTypes,
+  }, null, 2));
+});
+
+[
+  'Beaten up',
+  'Tomato Power'
+].forEach((name) => {
+  const effect = Effect.get(name);
+
+  printHtml(JSON.stringify({
+    name,
+    all: effect.all,
+  }, null, 2));
+});


### PR DESCRIPTION
The Effect.all value cannot be accessed in Javascript because it is a PluralValue, and that is not suppored by the ValueConverter:
```
> js Effect.get("Mallowed Out").all

Script    exception: ASH function returned native Java object.
```

Here is my try to map PluralValues to arrays in Javascript. It works as expected, however the Typescript definitions are now wrong. Since PluralValues use an AggregateType to specify their content, there is no good way to distinguish them from maps on a type level. 
Some advise here would be much appreciated.

I've started a discussion about this in summer: https://kolmafia.us/threads/pluralvalues-in-javascript-and-should-effect-all-be-one.27510/
@gausie seemed to support the idea of using Arrays in Javascript. I'm happy to try any other data model, if someone can think of something more appropriate (some frozen MultiValueSet or whatnot 😄).