### PR TITLE
feat: track whether last fight was won

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1881,6 +1881,7 @@ user	_kolhsSavedByTheBell	0
 user	_kolhsSchoolSpirited	false
 user	_kudzuSaladEaten	false
 user	_lastCombatStarted
+user	_lastCombatWon	true
 user	_lastDailyDungeonRoom	0
 user	_LastPirateRealmIsland
 user	_lastSausageMonsterTurn	0

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -3407,6 +3407,8 @@ public class FightRequest extends GenericRequest {
       trackEnvironment(location);
     }
 
+    Preferences.setBoolean("_lastCombatWon", won);
+
     if (!won) {
       QuestManager.updateQuestFightLost(responseText, monsterName);
     } else {

--- a/test/internal/matchers/Preference.java
+++ b/test/internal/matchers/Preference.java
@@ -34,11 +34,24 @@ public class Preference {
     };
   }
 
+  public static Matcher<String> hasBooleanValue(Matcher<? super Boolean> prefMatcher) {
+    return new FeatureMatcher<String, Boolean>(prefMatcher, "preference to be", "preference") {
+      @Override
+      protected Boolean featureValueOf(String pref) {
+        return Preferences.getBoolean(pref);
+      }
+    };
+  }
+
   public static Matcher<String> isSetTo(Object value) {
     return hasStringValue(equalTo(value.toString()));
   }
 
   public static Matcher<String> isSetTo(float value) {
     return hasFloatValue(equalTo(value));
+  }
+
+  public static Matcher<String> isSetTo(boolean value) {
+    return hasBooleanValue(equalTo(value));
   }
 }

--- a/test/net/sourceforge/kolmafia/request/FightRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FightRequestTest.java
@@ -16,6 +16,7 @@ import static internal.helpers.Player.withProperty;
 import static internal.helpers.Player.withSkill;
 import static internal.helpers.Player.withoutSkill;
 import static internal.matchers.Item.isInInventory;
+import static internal.matchers.Preference.hasBooleanValue;
 import static internal.matchers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -1539,4 +1540,15 @@ public class FightRequestTest {
       }
     }
   }
+
+    @ParameterizedTest
+    @CsvSource({"anapest_runaway, false", "goth_kid_pvp, true"})
+    void setsLastFightProperty(String html, boolean prop) {
+      var cleanups = withProperty("_lastCombatWon");
+
+      try (cleanups) {
+        parseCombatData("request/test_fight_" + html + ".html", "fight.php?action=attack");
+        assertThat("_lastCombatWon", isSetTo(prop));
+      }
+    }
 }

--- a/test/net/sourceforge/kolmafia/request/FightRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FightRequestTest.java
@@ -16,7 +16,6 @@ import static internal.helpers.Player.withProperty;
 import static internal.helpers.Player.withSkill;
 import static internal.helpers.Player.withoutSkill;
 import static internal.matchers.Item.isInInventory;
-import static internal.matchers.Preference.hasBooleanValue;
 import static internal.matchers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -1541,14 +1540,14 @@ public class FightRequestTest {
     }
   }
 
-    @ParameterizedTest
-    @CsvSource({"anapest_runaway, false", "goth_kid_pvp, true"})
-    void setsLastFightProperty(String html, boolean prop) {
-      var cleanups = withProperty("_lastCombatWon");
+  @ParameterizedTest
+  @CsvSource({"anapest_runaway, false", "goth_kid_pvp, true"})
+  void setsLastFightProperty(String html, boolean prop) {
+    var cleanups = withProperty("_lastCombatWon");
 
-      try (cleanups) {
-        parseCombatData("request/test_fight_" + html + ".html", "fight.php?action=attack");
-        assertThat("_lastCombatWon", isSetTo(prop));
-      }
+    try (cleanups) {
+      parseCombatData("request/test_fight_" + html + ".html", "fight.php?action=attack");
+      assertThat("_lastCombatWon", isSetTo(prop));
     }
+  }
 }


### PR DESCRIPTION
As requested in https://kolmafia.us/threads/track-combat-loss-when-adventuring.28096/, with a small change: the preference is `_lastCombatWon`, a boolean.

This counts fights won (i.e. we saw WINWINWIN) instead of lost because that's the thing we determine. This counts fights where we successfully ran away as not won.