### PR TITLE
fix: don't error on deleting shared folder for scripts

### DIFF
--- a/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
@@ -21,6 +21,7 @@ import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.scripts.ScriptManager;
+import net.sourceforge.kolmafia.utilities.FileUtilities;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.InvalidRemoteException;
@@ -314,6 +315,7 @@ public class GitManager extends ScriptManager {
     var root = getRoot(projectPath);
     KoLmafia.updateDisplay("Removing project " + folder);
     List<Path> toDelete;
+    // get the files under the project root folder in the git/ directory that should be deleted
     try {
       toDelete = getPermissibleFiles(root, true);
     } catch (IOException e) {
@@ -325,7 +327,13 @@ public class GitManager extends ScriptManager {
       var shortPath = root.relativize(absPath);
       var relPath = KoLConstants.ROOT_LOCATION.toPath().resolve(shortPath);
       try {
-        Files.deleteIfExists(relPath);
+        // delete both from the root permissible folder, and the relative file in the project in
+        // git/
+        if (!Files.isDirectory(relPath) || FileUtilities.isEmptyDirectory(relPath)) {
+          // if the folder is a non-empty directory, deletion will fail.
+          // Deletion is ordered such that all script-relevant files have already been deleted.
+          Files.deleteIfExists(relPath);
+        }
         Files.delete(absPath);
         KoLmafia.updateDisplay(shortPath + " => DELETED");
       } catch (IOException e) {

--- a/src/net/sourceforge/kolmafia/utilities/FileUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/FileUtilities.java
@@ -16,6 +16,8 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
@@ -564,5 +566,15 @@ public class FileUtilities {
     s = matchPathLists(homelist, filelist);
 
     return s;
+  }
+
+  public static boolean isEmptyDirectory(Path path) throws IOException {
+    if (!Files.isDirectory(path)) return false;
+
+    var listFiles = Files.list(path);
+
+    try (listFiles) {
+      return listFiles.findAny().isEmpty();
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
+++ b/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
@@ -126,12 +126,7 @@ public class GitManagerTest {
 
     @BeforeAll
     public static void cloneRepo() {
-      String output =
-          CliCaller.callCli(
-              "git",
-              "checkout https://github.com/midgleyc/mafia-script-install-test.git test-deps");
-      assertThat(output, containsString("Installing dependencies"));
-      assertThat(output, containsString("Cloned project " + id));
+      installGit(id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps", true);
     }
 
     @AfterAll
@@ -186,12 +181,7 @@ public class GitManagerTest {
 
     @BeforeAll
     public static void cloneRepo() {
-      String output =
-          CliCaller.callCli(
-              "svn",
-              "checkout https://github.com/midgleyc/mafia-script-install-test/branches/test-deps");
-      assertThat(output, containsString("Installing dependencies"));
-      assertThat(output, containsString("Successfully checked out working copy"));
+      installSvn("https://github.com/midgleyc/mafia-script-install-test/branches/test-deps");
     }
 
     @AfterAll
@@ -224,12 +214,8 @@ public class GitManagerTest {
 
     @BeforeAll
     public static void cloneRepo() {
-      String output =
-          CliCaller.callCli(
-              "git",
-              "checkout https://github.com/midgleyc/mafia-script-install-test.git test-manifest");
-      assertThat(output, containsString("Installing dependencies"));
-      assertThat(output, containsString("Cloned project " + id));
+      installGit(
+          id, "https://github.com/midgleyc/mafia-script-install-test.git test-manifest", true);
     }
 
     @AfterAll
@@ -248,6 +234,49 @@ public class GitManagerTest {
     public void didNotInstallFilesRelativeToRoot() {
       assertFalse(Files.exists(Paths.get("scripts", "1-root.ash")));
     }
+  }
+
+  @Nested
+  class DeletionSuccess {
+    @BeforeAll
+    public static void cloneRepo() {
+      installGit(
+          "midgleyc-mafia-script-install-test-shared-1",
+          "midgleyc/mafia-script-install-test shared-1",
+          false);
+      installGit(
+          "midgleyc-mafia-script-install-test-shared-2",
+          "midgleyc/mafia-script-install-test shared-2",
+          false);
+    }
+
+    @AfterAll
+    public static void removeRepo() {
+      removeGitIfExists("midgleyc-mafia-script-install-test-shared-1");
+      removeGitIfExists("midgleyc-mafia-script-install-test-shared-2");
+    }
+
+    @Test
+    public void noErrorIfSharedFolder() {
+      // these two repos contain distinct scripts both in scripts/shared
+      String remove = "midgleyc-mafia-script-install-test-shared-1";
+      String output = CliCaller.callCli("git", "delete " + remove);
+      assertThat(output, containsString("Project " + remove + " removed"));
+    }
+  }
+
+  private static void installGit(String id, String params, boolean hasDeps) {
+    String output = CliCaller.callCli("git", "checkout " + params);
+    if (hasDeps) {
+      assertThat(output, containsString("Installing dependencies"));
+    }
+    assertThat(output, containsString("Cloned project " + id));
+  }
+
+  private static void installSvn(String params) {
+    String output = CliCaller.callCli("svn", "checkout " + params);
+    assertThat(output, containsString("Installing dependencies"));
+    assertThat(output, containsString("Successfully checked out working copy"));
   }
 
   private static void removeGitIfExists(String remove) {

--- a/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
+++ b/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
@@ -262,6 +262,16 @@ public class GitManagerTest {
       String remove = "midgleyc-mafia-script-install-test-shared-1";
       String output = CliCaller.callCli("git", "delete " + remove);
       assertThat(output, containsString("Project " + remove + " removed"));
+      // first script does not exist
+      assertFalse(Files.exists(Paths.get("scripts", "shared", "1.ash")));
+      // second script still exists
+      assertTrue(Files.exists(Paths.get("scripts", "shared", "2.ash")));
+
+      remove = "midgleyc-mafia-script-install-test-shared-2";
+      output = CliCaller.callCli("git", "delete " + remove);
+      assertThat(output, containsString("Project " + remove + " removed"));
+
+      assertFalse(Files.exists(Paths.get("scripts", "shared")));
     }
   }
 

--- a/test/net/sourceforge/kolmafia/utilities/FileUtilitiesTest.java
+++ b/test/net/sourceforge/kolmafia/utilities/FileUtilitiesTest.java
@@ -1,14 +1,23 @@
 package net.sourceforge.kolmafia.utilities;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class FileUtilitiesTest {
 
@@ -103,5 +112,30 @@ class FileUtilitiesTest {
   public void itShouldNotDoAnythingWithANullInput() {
     assertNull(FileUtilities.readData(null));
     assertNull(FileUtilities.readLine(null));
+  }
+
+  @Nested
+  class EmptyDirectory {
+    @BeforeAll
+    public static void setupEmpty() throws IOException {
+      Files.createDirectory(KoLConstants.ROOT_LOCATION.toPath().resolve("empty"));
+    }
+
+    @AfterAll
+    public static void removeEmpty() throws IOException {
+      Files.deleteIfExists(KoLConstants.ROOT_LOCATION.toPath().resolve("empty"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      "ccs, false",
+      "README, false",
+      "empty, true",
+    })
+    public void shouldDetectEmptyDirectory(String directory, boolean isEmptyDirectory)
+        throws IOException {
+      var path = KoLConstants.ROOT_LOCATION.toPath().resolve(directory);
+      assertThat(FileUtilities.isEmptyDirectory(path), equalTo(isEmptyDirectory));
+    }
   }
 }


### PR DESCRIPTION
Probably the issue on https://github.com/Loathing-Associates-Scripting-Society/ChIT/issues/24.

Suppose we have two scripts, both of which store something in the folder `images/relayimages`. Then deleting one script would fail, because the folder will fail to be deleted (as it's non-empty).

Check for a non-empty folder, and don't delete the folder in that case.