### PR TITLE
feat: allow specifying "github" dependencies

### DIFF
--- a/src/net/sourceforge/kolmafia/scripts/ScriptManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/ScriptManager.java
@@ -88,26 +88,30 @@ public class ScriptManager {
       if (potential.startsWith("#")) continue;
       String[] args = potential.split("\\s+");
       if (args.length == 0 || args[0].length() == 0) continue;
-      var url = args[0];
-      if (args.length > 1 || url.endsWith(".git")) {
-        // git
-        String branch = args.length == 1 ? null : args[1];
-        var id = GitManager.getRepoId(url, branch);
-        if (!Files.exists(KoLConstants.GIT_LOCATION.toPath().resolve(id))) {
-          GitManager.clone(url, branch);
-        }
-      } else {
-        SVNURL repo;
-        try {
-          repo = SVNURL.parseURIEncoded(potential);
-        } catch (SVNException e) {
-          RequestLogger.printLine("Cannot parse \"" + potential + "\" as SVN URL");
-          continue;
-        }
-        var id = SVNManager.getFolderUUID(repo);
-        if (!Files.exists(KoLConstants.SVN_LOCATION.toPath().resolve(id))) {
-          SVNManager.doCheckout(repo);
-        }
+      installDependency(args);
+    }
+  }
+
+  private static void installDependency(String[] args) {
+    var url = args[0];
+    if (args.length > 1 || url.endsWith(".git")) {
+      // git
+      String branch = args.length == 1 ? null : args[1];
+      var id = GitManager.getRepoId(url, branch);
+      if (!Files.exists(KoLConstants.GIT_LOCATION.toPath().resolve(id))) {
+        GitManager.clone(url, branch);
+      }
+    } else {
+      SVNURL repo;
+      try {
+        repo = SVNURL.parseURIEncoded(url);
+      } catch (SVNException e) {
+        RequestLogger.printLine("Cannot parse \"" + url + "\" as SVN URL");
+        return;
+      }
+      var id = SVNManager.getFolderUUID(repo);
+      if (!Files.exists(KoLConstants.SVN_LOCATION.toPath().resolve(id))) {
+        SVNManager.doCheckout(repo);
       }
     }
   }

--- a/src/net/sourceforge/kolmafia/scripts/ScriptManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/ScriptManager.java
@@ -94,25 +94,59 @@ public class ScriptManager {
 
   private static void installDependency(String[] args) {
     var url = args[0];
+    // check for special-case first arg
+    if (url.equals("github")) {
+      // github organisation/repo [branch]
+      if (args.length < 2) {
+        // invalid
+        RequestLogger.printLine("Cannot parse dependency " + Arrays.toString(args));
+        return;
+      }
+      String orgRepo = args[1];
+      String branch = args.length == 2 ? null : args[2];
+      // github-hosted projects can be installed using either git or svn, but prefer git
+      // is it installed using git?
+      String gitUrl = "https://github.com/" + orgRepo + ".git";
+      if (gitDepInstalled(gitUrl, branch)) return;
+      // is it installed using svn?
+      String path = "/" + orgRepo + (branch != null ? "/branches/" + branch : "/trunk");
+      String svnId = getProjectIdentifier("https://github.com", path);
+      if (Files.exists(KoLConstants.SVN_LOCATION.toPath().resolve(svnId))) return;
+      // it is not installed. Install using git
+      GitManager.clone(gitUrl, branch);
+      return;
+    }
     if (args.length > 1 || url.endsWith(".git")) {
       // git
       String branch = args.length == 1 ? null : args[1];
-      var id = GitManager.getRepoId(url, branch);
-      if (!Files.exists(KoLConstants.GIT_LOCATION.toPath().resolve(id))) {
-        GitManager.clone(url, branch);
-      }
+      installGitDependency(url, branch);
     } else {
-      SVNURL repo;
-      try {
-        repo = SVNURL.parseURIEncoded(url);
-      } catch (SVNException e) {
-        RequestLogger.printLine("Cannot parse \"" + url + "\" as SVN URL");
-        return;
-      }
-      var id = SVNManager.getFolderUUID(repo);
-      if (!Files.exists(KoLConstants.SVN_LOCATION.toPath().resolve(id))) {
-        SVNManager.doCheckout(repo);
-      }
+      installSvnDependency(url);
+    }
+  }
+
+  private static boolean gitDepInstalled(String url, String branch) {
+    var id = GitManager.getRepoId(url, branch);
+    return Files.exists(KoLConstants.GIT_LOCATION.toPath().resolve(id));
+  }
+
+  private static void installGitDependency(String url, String branch) {
+    if (!gitDepInstalled(url, branch)) {
+      GitManager.clone(url, branch);
+    }
+  }
+
+  private static void installSvnDependency(String url) {
+    SVNURL repo;
+    try {
+      repo = SVNURL.parseURIEncoded(url);
+    } catch (SVNException e) {
+      RequestLogger.printLine("Cannot parse \"" + url + "\" as SVN URL");
+      return;
+    }
+    var id = SVNManager.getFolderUUID(repo);
+    if (!Files.exists(KoLConstants.SVN_LOCATION.toPath().resolve(id))) {
+      SVNManager.doCheckout(repo);
     }
   }
 }

--- a/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
+++ b/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
@@ -222,34 +222,44 @@ public class GitManagerTest {
 
     @Test
     public void withSvnInstalledDoesNotInstall() {
-      installSvn("https://github.com/midgleyc/mafia-script-install-test/branches/test-deps-svn", false);
-      installGit(id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github", true);
+      installSvn(
+          "https://github.com/midgleyc/mafia-script-install-test/branches/test-deps-svn", false);
+      installGit(
+          id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github", true);
 
       assertFalse(
           Files.isDirectory(Paths.get("git", "midgleyc-mafia-script-install-test-test-deps-svn")));
       assertTrue(
-          Files.isDirectory(Paths.get("svn", "midgleyc-mafia-script-install-test-branches-test-deps-svn")));
+          Files.isDirectory(
+              Paths.get("svn", "midgleyc-mafia-script-install-test-branches-test-deps-svn")));
     }
 
     @Test
     public void withGitInstalledDoesNotInstall() {
-      installGit("midgleyc-mafia-script-install-test-test-deps-svn", "https://github.com/midgleyc/mafia-script-install-test.git test-deps-svn", false);
-      installGit(id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github", true);
+      installGit(
+          "midgleyc-mafia-script-install-test-test-deps-svn",
+          "https://github.com/midgleyc/mafia-script-install-test.git test-deps-svn",
+          false);
+      installGit(
+          id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github", true);
 
       assertTrue(
           Files.isDirectory(Paths.get("git", "midgleyc-mafia-script-install-test-test-deps-svn")));
       assertFalse(
-          Files.isDirectory(Paths.get("svn", "midgleyc-mafia-script-install-test-branches-test-deps-svn")));
+          Files.isDirectory(
+              Paths.get("svn", "midgleyc-mafia-script-install-test-branches-test-deps-svn")));
     }
 
     @Test
     public void withNothingInstalledInstallsToGit() {
-      installGit(id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github", true);
+      installGit(
+          id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github", true);
 
       assertTrue(
           Files.isDirectory(Paths.get("git", "midgleyc-mafia-script-install-test-test-deps-svn")));
       assertFalse(
-          Files.isDirectory(Paths.get("svn", "midgleyc-mafia-script-install-test-branches-test-deps-svn")));
+          Files.isDirectory(
+              Paths.get("svn", "midgleyc-mafia-script-install-test-branches-test-deps-svn")));
     }
   }
 
@@ -268,33 +278,39 @@ public class GitManagerTest {
     @Test
     public void withSvnInstalledDoesNotInstall() {
       installSvn("https://github.com/midgleyc/mafia-script-install-test/trunk", false);
-      installGit(id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github-trunk", true);
+      installGit(
+          id,
+          "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github-trunk",
+          true);
 
-      assertFalse(
-          Files.isDirectory(Paths.get("git", "midgleyc-mafia-script-install-test")));
-      assertTrue(
-          Files.isDirectory(Paths.get("svn", "midgleyc-mafia-script-install-test-trunk")));
+      assertFalse(Files.isDirectory(Paths.get("git", "midgleyc-mafia-script-install-test")));
+      assertTrue(Files.isDirectory(Paths.get("svn", "midgleyc-mafia-script-install-test-trunk")));
     }
 
     @Test
     public void withGitInstalledDoesNotInstall() {
-      installGit("midgleyc-mafia-script-install-test", "https://github.com/midgleyc/mafia-script-install-test.git", false);
-      installGit(id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github-trunk", true);
+      installGit(
+          "midgleyc-mafia-script-install-test",
+          "https://github.com/midgleyc/mafia-script-install-test.git",
+          false);
+      installGit(
+          id,
+          "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github-trunk",
+          true);
 
-      assertTrue(
-          Files.isDirectory(Paths.get("git", "midgleyc-mafia-script-install-test")));
-      assertFalse(
-          Files.isDirectory(Paths.get("svn", "midgleyc-mafia-script-install-test-trunk")));
+      assertTrue(Files.isDirectory(Paths.get("git", "midgleyc-mafia-script-install-test")));
+      assertFalse(Files.isDirectory(Paths.get("svn", "midgleyc-mafia-script-install-test-trunk")));
     }
 
     @Test
     public void withNothingInstalledInstallsToGit() {
-      installGit(id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github-trunk", true);
+      installGit(
+          id,
+          "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github-trunk",
+          true);
 
-      assertTrue(
-          Files.isDirectory(Paths.get("git", "midgleyc-mafia-script-install-test")));
-      assertFalse(
-          Files.isDirectory(Paths.get("svn", "midgleyc-mafia-script-install-test-trunk")));
+      assertTrue(Files.isDirectory(Paths.get("git", "midgleyc-mafia-script-install-test")));
+      assertFalse(Files.isDirectory(Paths.get("svn", "midgleyc-mafia-script-install-test-trunk")));
     }
   }
 

--- a/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
+++ b/test/net/sourceforge/kolmafia/scripts/git/GitManagerTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Paths;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.StaticEntity;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -181,7 +182,7 @@ public class GitManagerTest {
 
     @BeforeAll
     public static void cloneRepo() {
-      installSvn("https://github.com/midgleyc/mafia-script-install-test/branches/test-deps");
+      installSvn("https://github.com/midgleyc/mafia-script-install-test/branches/test-deps", true);
     }
 
     @AfterAll
@@ -204,6 +205,96 @@ public class GitManagerTest {
       assertTrue(
           Files.isDirectory(
               Paths.get("svn", "midgleyc-mafia-script-install-test-branches-test-deps-svn")));
+    }
+  }
+
+  @Nested
+  public class GitHubDependencyTests {
+
+    private static final String id = "midgleyc-mafia-script-install-test-test-deps-github";
+
+    @AfterEach
+    public void removeRepo() {
+      removeGitIfExists("midgleyc-mafia-script-install-test-test-deps-github");
+      removeSvnIfExists("midgleyc-mafia-script-install-test-branches-test-deps-svn");
+      removeGitIfExists("midgleyc-mafia-script-install-test-test-deps-svn");
+    }
+
+    @Test
+    public void withSvnInstalledDoesNotInstall() {
+      installSvn("https://github.com/midgleyc/mafia-script-install-test/branches/test-deps-svn", false);
+      installGit(id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github", true);
+
+      assertFalse(
+          Files.isDirectory(Paths.get("git", "midgleyc-mafia-script-install-test-test-deps-svn")));
+      assertTrue(
+          Files.isDirectory(Paths.get("svn", "midgleyc-mafia-script-install-test-branches-test-deps-svn")));
+    }
+
+    @Test
+    public void withGitInstalledDoesNotInstall() {
+      installGit("midgleyc-mafia-script-install-test-test-deps-svn", "https://github.com/midgleyc/mafia-script-install-test.git test-deps-svn", false);
+      installGit(id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github", true);
+
+      assertTrue(
+          Files.isDirectory(Paths.get("git", "midgleyc-mafia-script-install-test-test-deps-svn")));
+      assertFalse(
+          Files.isDirectory(Paths.get("svn", "midgleyc-mafia-script-install-test-branches-test-deps-svn")));
+    }
+
+    @Test
+    public void withNothingInstalledInstallsToGit() {
+      installGit(id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github", true);
+
+      assertTrue(
+          Files.isDirectory(Paths.get("git", "midgleyc-mafia-script-install-test-test-deps-svn")));
+      assertFalse(
+          Files.isDirectory(Paths.get("svn", "midgleyc-mafia-script-install-test-branches-test-deps-svn")));
+    }
+  }
+
+  @Nested
+  public class GitHubTrunkDependencyTests {
+
+    private static final String id = "midgleyc-mafia-script-install-test-test-deps-github-trunk";
+
+    @AfterEach
+    public void removeRepo() {
+      removeGitIfExists("midgleyc-mafia-script-install-test-test-deps-github-trunk");
+      removeSvnIfExists("midgleyc-mafia-script-install-test-trunk");
+      removeGitIfExists("midgleyc-mafia-script-install-test");
+    }
+
+    @Test
+    public void withSvnInstalledDoesNotInstall() {
+      installSvn("https://github.com/midgleyc/mafia-script-install-test/trunk", false);
+      installGit(id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github-trunk", true);
+
+      assertFalse(
+          Files.isDirectory(Paths.get("git", "midgleyc-mafia-script-install-test")));
+      assertTrue(
+          Files.isDirectory(Paths.get("svn", "midgleyc-mafia-script-install-test-trunk")));
+    }
+
+    @Test
+    public void withGitInstalledDoesNotInstall() {
+      installGit("midgleyc-mafia-script-install-test", "https://github.com/midgleyc/mafia-script-install-test.git", false);
+      installGit(id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github-trunk", true);
+
+      assertTrue(
+          Files.isDirectory(Paths.get("git", "midgleyc-mafia-script-install-test")));
+      assertFalse(
+          Files.isDirectory(Paths.get("svn", "midgleyc-mafia-script-install-test-trunk")));
+    }
+
+    @Test
+    public void withNothingInstalledInstallsToGit() {
+      installGit(id, "https://github.com/midgleyc/mafia-script-install-test.git test-deps-github-trunk", true);
+
+      assertTrue(
+          Files.isDirectory(Paths.get("git", "midgleyc-mafia-script-install-test")));
+      assertFalse(
+          Files.isDirectory(Paths.get("svn", "midgleyc-mafia-script-install-test-trunk")));
     }
   }
 
@@ -283,9 +374,11 @@ public class GitManagerTest {
     assertThat(output, containsString("Cloned project " + id));
   }
 
-  private static void installSvn(String params) {
+  private static void installSvn(String params, boolean hasDeps) {
     String output = CliCaller.callCli("svn", "checkout " + params);
-    assertThat(output, containsString("Installing dependencies"));
+    if (hasDeps) {
+      assertThat(output, containsString("Installing dependencies"));
+    }
     assertThat(output, containsString("Successfully checked out working copy"));
   }
 


### PR DESCRIPTION
`dependencies.txt` files can be used by scripts to specify necessary dependencies. At the moment, these dependencies are specified implicitly including the tool necessary to install them:
```
https://github.com/Loathing-Associates-Scripting-Society/combo/branches/release/ (SVN)
https://github.com/Loathing-Associates-Scripting-Society/combo.git release (git)
```

This PR introduces some new syntax
```
github Loathing-Associates-Scripting-Society/combo release
```

Dependencies specified with the new syntax will check the user's local install to see if the dependency is installed using either SVN or git and not install it if so (and otherwise install it using git). This means that it doesn't matter how the user initially installed the script, or what other scripts are using in their dependencies files.

The aim of this is to reduce the number of duplicate copies of scripts the user may install.

Scripts that use the folder install method are not supported. I figure that either:
* there is not a manifest file, so git install won't work, and SVN install should be used explicitly
* there is a manifest file, so the author intends the dep to be installed using git, and git install should be used explicitly

The main target of this PR is scripts that are on github, but still use the SVN install. There are competing philosophies for install:
* some users prefer to use git wherever possible
* some users prefer to use whatever the author recommends in the README

I hope that the new syntax will satisfy both.