### PR TITLE
chore: run npm install from .github/npm

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -30,8 +30,14 @@ jobs:
           ORG_GRADLE_PROJECT_commit: ${{ github.sha }}
         run: ./gradlew --no-daemon tsDefs
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: "https://registry.npmjs.org"
+
       - name: Checking generated TypeScript definitions
         run: |
+          cd .github/npm
           npm install
           npm run validate
 
@@ -40,11 +46,6 @@ jobs:
           PACKAGE_VERSION=$(head -n 1 index.d.ts | cut -c 5-)
           mv index.d.ts .github/npm/index.d.ts
           sed -i 's/{{version}}/'$PACKAGE_VERSION'/g' .github/npm/package.json
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "16.x"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Publishing TypeScript package to npm
         run: |


### PR DESCRIPTION
#1148 failed after the merge. Try to fix.

Move the setting up of npm before the first npm command (apparently unnecessary). Go to the right directory before running `npm install`.