### PR TITLE
Allow Javascript to catch exceptions from ASH functions

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
@@ -224,16 +224,21 @@ public class JavascriptRuntime extends AbstractRuntime {
       returnValue = callback.get();
     } catch (WrappedException e) {
       Throwable unwrapped = e.getWrappedException();
-      if (stackOnAbort) {
-        StringBuilder message = new StringBuilder("Internal exception");
-        if (unwrapped.getMessage() != null) {
-          message.append(": ").append(e.getMessage());
-        }
-        message.append("\n").append(e.getScriptStackTrace());
-        String escapedMessage = escapeHtmlInMessage(message.toString());
+      if (unwrapped instanceof ScriptException) {
+        String escapedMessage = escapeHtmlInMessage("Script exception: " + unwrapped.getMessage());
         KoLmafia.updateDisplay(KoLConstants.MafiaState.ERROR, escapedMessage);
+      } else {
+        if (stackOnAbort) {
+          StringBuilder message = new StringBuilder("Internal exception");
+          if (unwrapped.getMessage() != null) {
+            message.append(": ").append(e.getMessage());
+          }
+          message.append("\n").append(e.getScriptStackTrace());
+          String escapedMessage = escapeHtmlInMessage(message.toString());
+          KoLmafia.updateDisplay(KoLConstants.MafiaState.ERROR, escapedMessage);
+        }
+        StaticEntity.printStackTrace(unwrapped);
       }
-      StaticEntity.printStackTrace(unwrapped);
     } catch (EvaluatorException e) {
       String escapedMessage =
           escapeHtmlInMessage(

--- a/src/net/sourceforge/kolmafia/textui/javascript/LibraryFunctionStub.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/LibraryFunctionStub.java
@@ -43,7 +43,12 @@ public class LibraryFunctionStub extends AshStub {
     ashArgsWithInterpreter.add(controller);
     ashArgsWithInterpreter.addAll(ashArgs);
 
-    return ashFunction.executeWithoutInterpreter(controller, ashArgsWithInterpreter.toArray());
+    try {
+      return ashFunction.executeWithoutInterpreter(controller, ashArgsWithInterpreter.toArray());
+    } catch (Throwable e) {
+      // ensure the exception can be caught in Javascript
+      throw Context.throwAsScriptRuntimeEx(e);
+    }
   }
 
   private int findFunctionReference(Object[] args) {

--- a/src/net/sourceforge/kolmafia/textui/javascript/UserDefinedFunctionStub.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/UserDefinedFunctionStub.java
@@ -8,6 +8,7 @@ import net.sourceforge.kolmafia.textui.parsetree.Function;
 import net.sourceforge.kolmafia.textui.parsetree.FunctionList;
 import net.sourceforge.kolmafia.textui.parsetree.UserDefinedFunction;
 import net.sourceforge.kolmafia.textui.parsetree.Value;
+import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 
 public class UserDefinedFunctionStub extends AshStub {
@@ -36,6 +37,11 @@ public class UserDefinedFunctionStub extends AshStub {
     ashArgsWithInterpreter.add(controller);
     ashArgsWithInterpreter.addAll(ashArgs);
 
-    return ashFunction.execute((AshRuntime) controller, ashArgsWithInterpreter.toArray());
+    try {
+      return ashFunction.execute((AshRuntime) controller, ashArgsWithInterpreter.toArray());
+    } catch (Throwable e) {
+      // ensure the exception can be caught in Javascript
+      throw Context.throwAsScriptRuntimeEx(e);
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/CustomScriptTest.java
+++ b/test/net/sourceforge/kolmafia/CustomScriptTest.java
@@ -67,7 +67,12 @@ public class CustomScriptTest {
       RequestLogger.closeCustom();
     }
 
-    String output = ostream.toString().trim();
+    String output =
+        ostream
+            .toString()
+            .trim()
+            // try to avoid environment-specific paths in stacktraces
+            .replaceAll("\\bfile:.*?([^\\\\/\\s]+#\\d+)\\b", "file:%%STACKTRACE_LOCATION%%/$1");
     assertEquals(expectedOutput, output, script + " output does not match: ");
   }
 

--- a/test/root/expected/exception_ash_library_exception_caught.js.out
+++ b/test/root/expected/exception_ash_library_exception_caught.js.out
@@ -1,0 +1,1 @@
+Script exception: Can't get session logs for a negative number of days (file:%%STACKTRACE_LOCATION%%/exception_ash_library_exception_caught.js#4)

--- a/test/root/expected/exception_ash_library_exception_caught.js.out
+++ b/test/root/expected/exception_ash_library_exception_caught.js.out
@@ -1,1 +1,1 @@
-Script exception: Can't get session logs for a negative number of days (file:%%STACKTRACE_LOCATION%%/exception_ash_library_exception_caught.js#4)
+Caught exception: net.sourceforge.kolmafia.textui.ScriptException: Can't get session logs for a negative number of days (file:%%STACKTRACE_LOCATION%%/exception_ash_library_exception_caught.js#4)

--- a/test/root/expected/exception_ash_library_exception_uncaught.js.out
+++ b/test/root/expected/exception_ash_library_exception_uncaught.js.out
@@ -1,0 +1,1 @@
+Script exception: Can't get session logs for a negative number of days (file:%%STACKTRACE_LOCATION%%/exception_ash_library_exception_uncaught.js#3)

--- a/test/root/expected/exception_ash_userfunction_exception_caught.js.out
+++ b/test/root/expected/exception_ash_userfunction_exception_caught.js.out
@@ -1,0 +1,2 @@
+11
+Script exception: Can't get session logs for a negative number of days (exception_ash_userfunction_helper.ash, line 10)

--- a/test/root/expected/exception_ash_userfunction_exception_caught.js.out
+++ b/test/root/expected/exception_ash_userfunction_exception_caught.js.out
@@ -1,2 +1,2 @@
 11
-Script exception: Can't get session logs for a negative number of days (exception_ash_userfunction_helper.ash, line 10)
+Caught exception: net.sourceforge.kolmafia.textui.ScriptException: Can't get session logs for a negative number of days (exception_ash_userfunction_helper.ash, line 10)

--- a/test/root/expected/exception_ash_userfunction_exception_uncaught.js.out
+++ b/test/root/expected/exception_ash_userfunction_exception_uncaught.js.out
@@ -1,0 +1,2 @@
+11
+Script exception: Can't get session logs for a negative number of days (exception_ash_userfunction_helper.ash, line 10)

--- a/test/root/expected/exception_javascript_syntax_caught.js.out
+++ b/test/root/expected/exception_javascript_syntax_caught.js.out
@@ -1,0 +1,1 @@
+Caught exception: missing ; before statement (file:%%STACKTRACE_LOCATION%%/exception_javascript_syntax_uncaught.js#1)

--- a/test/root/expected/exception_javascript_syntax_uncaught.js.out
+++ b/test/root/expected/exception_javascript_syntax_uncaught.js.out
@@ -1,0 +1,1 @@
+JavaScript evaluator exception: missing ; before statement (file:%%STACKTRACE_LOCATION%%/exception_javascript_syntax_uncaught.js#1)

--- a/test/root/expected/exception_proxy_expression_exception_caught.js.out
+++ b/test/root/expected/exception_proxy_expression_exception_caught.js.out
@@ -1,0 +1,1 @@
+Caught exception: net.sourceforge.kolmafia.textui.ScriptException: Bad effect value: this effect does not exist

--- a/test/root/expected/exception_proxy_expression_exception_uncaught.js.out
+++ b/test/root/expected/exception_proxy_expression_exception_uncaught.js.out
@@ -1,0 +1,1 @@
+Unexpected error, debug log printed.

--- a/test/root/expected/exception_proxy_expression_exception_uncaught.js.out
+++ b/test/root/expected/exception_proxy_expression_exception_uncaught.js.out
@@ -1,1 +1,1 @@
-Unexpected error, debug log printed.
+Script exception: Bad effect value: this effect does not exist

--- a/test/root/scripts/exception_ash_library_exception_caught.js
+++ b/test/root/scripts/exception_ash_library_exception_caught.js
@@ -1,0 +1,8 @@
+const { print, sessionLogs } = require("kolmafia");
+
+try {
+  sessionLogs(-1); // this will throw an exception
+  print("This code should not be reached.");
+} catch (e) {
+  print("Caught exception: " + e.message);
+}

--- a/test/root/scripts/exception_ash_library_exception_uncaught.js
+++ b/test/root/scripts/exception_ash_library_exception_uncaught.js
@@ -1,0 +1,4 @@
+const { print, sessionLogs } = require("kolmafia");
+
+sessionLogs(-1); // this will throw an exception
+print("This code should not be reached.");

--- a/test/root/scripts/exception_ash_userfunction_exception_caught.js
+++ b/test/root/scripts/exception_ash_userfunction_exception_caught.js
@@ -1,0 +1,10 @@
+const { print } = require("kolmafia");
+const helper = require("exception_ash_userfunction_helper.ash");
+
+try {
+  print(helper.returnsEleven());
+  helper.throwScriptException();
+  print("This code should not be reached.");
+} catch (e) {
+  print("Caught exception: " + e.message);
+}

--- a/test/root/scripts/exception_ash_userfunction_exception_uncaught.js
+++ b/test/root/scripts/exception_ash_userfunction_exception_uncaught.js
@@ -1,0 +1,6 @@
+const { print } = require("kolmafia");
+const helper = require("exception_ash_userfunction_helper.ash");
+
+print(helper.returnsEleven());
+helper.throwScriptException();
+print("This code should not be reached.");

--- a/test/root/scripts/exception_ash_userfunction_helper.ash
+++ b/test/root/scripts/exception_ash_userfunction_helper.ash
@@ -1,0 +1,12 @@
+// This is just a helper to be able to call an ash user function,
+// that throws an exception, from javascript
+
+int returns_eleven() {
+    return 11;
+}
+
+void throw_script_exception()
+{
+  session_logs(-1); // this will throw an exception
+  print("This code should not be reached.");
+}

--- a/test/root/scripts/exception_javascript_syntax_caught.js
+++ b/test/root/scripts/exception_javascript_syntax_caught.js
@@ -1,0 +1,7 @@
+const { print } = require("kolmafia");
+try {
+  require("exception_javascript_syntax_uncaught.js");
+  print("This code should not be reached.");
+} catch (e) {
+  print("Caught exception: " + e.message);
+}

--- a/test/root/scripts/exception_javascript_syntax_uncaught.js
+++ b/test/root/scripts/exception_javascript_syntax_uncaught.js
@@ -1,0 +1,1 @@
+invalid javascript

--- a/test/root/scripts/exception_proxy_expression_exception_caught.js
+++ b/test/root/scripts/exception_proxy_expression_exception_caught.js
@@ -1,0 +1,8 @@
+const { print } = require("kolmafia");
+
+try {
+  Effect.get("this effect does not exist"); // this will throw an exception
+  print("This code should not be reached.");
+} catch (e) {
+  print("Caught exception: " + e.message);
+}

--- a/test/root/scripts/exception_proxy_expression_exception_uncaught.js
+++ b/test/root/scripts/exception_proxy_expression_exception_uncaught.js
@@ -1,0 +1,4 @@
+const { print } = require("kolmafia");
+
+Effect.get("this effect does not exist"); // this will throw an exception
+print("This code should not be reached.");


### PR DESCRIPTION
Exceptions thrown by a ASH library function cannot  be caught in Javascript. 

This PR changes the two function stubs to wrap any exception in Rhino's WrappedException (there is a helper function for that, `Context.throwAsScriptRuntimeEx(e)`).
The code that already catches the WrappedException is modified to also look at the unwrapped exception and handle ScriptExceptions the usual way.

I've added a Test as first commit before the change, to showcase the old behaviour, and make the change documented in code.