### PR TITLE
Use requested request method for redirected requests

### DIFF
--- a/src/net/sourceforge/kolmafia/request/AdventureRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AdventureRequest.java
@@ -1041,7 +1041,7 @@ public class AdventureRequest extends GenericRequest {
     return this.adventureName;
   }
 
-  public static final void handleServerRedirect(String redirectLocation) {
+  public static final void handleServerRedirect(String redirectLocation, boolean usePostMethod) {
     if (redirectLocation.contains("main.php")) {
       return;
     }
@@ -1051,7 +1051,7 @@ public class AdventureRequest extends GenericRequest {
       redirectLocation = "campground.php";
     }
 
-    AdventureRequest.ZONE_UNLOCK.constructURLString(redirectLocation);
+    AdventureRequest.ZONE_UNLOCK.constructURLString(redirectLocation, usePostMethod);
 
     if (redirectLocation.contains("palinshelves.php")) {
       AdventureRequest.ZONE_UNLOCK.run();

--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -1907,7 +1907,7 @@ public class GenericRequest implements Runnable {
             continue;
           }
           if (FightRequest.choiceFollowsFight) {
-            RequestThread.postRequest(new GenericRequest("choice.php"));
+            RequestThread.postRequest(new GenericRequest("choice.php", false));
             // Fall through
           }
           if (ChoiceManager.handlingChoice) {
@@ -2013,7 +2013,10 @@ public class GenericRequest implements Runnable {
       }
 
       this.redirectHandled = true;
-      ChoiceManager.processRedirectedChoiceAdventure(this.redirectLocation);
+      String redirectLocation = this.redirectLocation;
+      boolean usePostMethod = this.redirectMethod.equals("POST");
+      ChoiceManager.processRedirectedChoiceAdventure(redirectLocation, usePostMethod);
+      this.responseText = ChoiceManager.CHOICE_HANDLER.responseText;
       return true;
     }
 
@@ -2039,7 +2042,9 @@ public class GenericRequest implements Runnable {
     }
 
     if (this instanceof AdventureRequest || this.formURLString.startsWith("choice.php")) {
-      AdventureRequest.handleServerRedirect(this.redirectLocation);
+      String redirectLocation = this.redirectLocation;
+      boolean usePostMethod = this.redirectMethod.equals("POST");
+      AdventureRequest.handleServerRedirect(redirectLocation, usePostMethod);
       return true;
     }
 

--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -122,12 +122,15 @@ public abstract class ChoiceManager {
         }
       };
 
-  public static final void processRedirectedChoiceAdventure(final String redirectLocation) {
-    ChoiceManager.processChoiceAdventure(ChoiceManager.CHOICE_HANDLER, redirectLocation, null);
+  public static final void processRedirectedChoiceAdventure(
+      final String redirectLocation, final boolean usePostMethod) {
+    ChoiceManager.processChoiceAdventure(
+        ChoiceManager.CHOICE_HANDLER, redirectLocation, usePostMethod, null);
   }
 
   public static final void processChoiceAdventure(final String responseText) {
-    ChoiceManager.processChoiceAdventure(ChoiceManager.CHOICE_HANDLER, "choice.php", responseText);
+    ChoiceManager.processChoiceAdventure(
+        ChoiceManager.CHOICE_HANDLER, "choice.php", false, responseText);
   }
 
   public static final String processChoiceAdventure(
@@ -156,7 +159,7 @@ public abstract class ChoiceManager {
     request.run();
 
     if (tryToAutomate) {
-      ChoiceManager.processChoiceAdventure(request, "choice.php", request.responseText);
+      ChoiceManager.processChoiceAdventure(request, "choice.php", false, request.responseText);
       return "";
     }
 
@@ -186,13 +189,16 @@ public abstract class ChoiceManager {
   }
 
   public static final void processChoiceAdventure(
-      final GenericRequest request, final String initialURL, String responseText) {
+      final GenericRequest request,
+      final String initialURL,
+      boolean usePostMethod,
+      String responseText) {
     // You can no longer simply ignore a choice adventure.  One of
     // the options may have that effect, but we must at least run
     // choice.php to find out which choice it is.
 
     // Get rid of extra fields - like "action=auto"
-    request.constructURLString(initialURL);
+    request.constructURLString(initialURL, usePostMethod);
 
     if (responseText == null) {
       GoalManager.updateProgress(GoalManager.GOAL_CHOICE);
@@ -2081,7 +2087,7 @@ public abstract class ChoiceManager {
   public static final String gotoGoal() {
     String responseText = ChoiceManager.lastResponseText;
     GenericRequest request = ChoiceManager.CHOICE_HANDLER;
-    ChoiceManager.processChoiceAdventure(request, "choice.php", responseText);
+    ChoiceManager.processChoiceAdventure(request, "choice.php", false, responseText);
     RelayRequest.specialCommandResponse = ChoiceManager.lastDecoratedResponseText;
     RelayRequest.specialCommandIsAdventure = true;
     return request.responseText;

--- a/src/net/sourceforge/kolmafia/webui/RelayAgent.java
+++ b/src/net/sourceforge/kolmafia/webui/RelayAgent.java
@@ -447,7 +447,8 @@ public class RelayAgent extends Thread {
     // /choice.php?action=auto
     try {
       request.setAllowOverride(false);
-      ChoiceManager.processChoiceAdventure(request, "choice.php", ChoiceManager.lastResponseText);
+      ChoiceManager.processChoiceAdventure(
+          request, "choice.php", false, ChoiceManager.lastResponseText);
       if (StaticEntity.userAborted || KoLmafia.refusesContinue()) {
         // Resubmit the choice request to let the user see it again
         KoLmafia.forceContinue();

--- a/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
+++ b/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
@@ -2005,7 +2005,7 @@ public class KoLAdventureValidationTest {
       var requests = client.getRequests();
       assertThat(requests, hasSize(8));
       assertPostRequest(requests.get(0), "/place.php", "whichplace=forestvillage&action=fv_mystic");
-      assertPostRequest(requests.get(1), "/choice.php", "forceoption=0");
+      assertGetRequest(requests.get(1), "/choice.php", "forceoption=0");
       assertPostRequest(requests.get(2), "/choice.php", "whichchoice=664&option=1");
       assertPostRequest(requests.get(3), "/choice.php", "whichchoice=664&option=1");
       assertPostRequest(requests.get(4), "/choice.php", "whichchoice=664&option=1");

--- a/test/net/sourceforge/kolmafia/session/ElVibratoManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/ElVibratoManagerTest.java
@@ -332,7 +332,7 @@ public class ElVibratoManagerTest {
         var requests = builder.client.getRequests();
         assertThat(requests, hasSize(6));
         assertPostRequest(requests.get(0), "/adventure.php", "snarfblat=164");
-        assertPostRequest(requests.get(1), "/choice.php", "forceoption=0");
+        assertGetRequest(requests.get(1), "/choice.php", "forceoption=0");
         assertGetRequest(requests.get(2), "/elvmachine.php");
         assertPostRequest(requests.get(3), "/api.php", "what=status&for=KoLmafia");
         assertPostRequest(requests.get(4), "/elvmachine.php", "action=slot&whichcard=3151");

--- a/test/net/sourceforge/kolmafia/session/OceanManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/OceanManagerTest.java
@@ -325,7 +325,7 @@ public class OceanManagerTest {
         var requests = builder.client.getRequests();
         assertThat(requests, hasSize(3));
         assertPostRequest(requests.get(0), "/adventure.php", "snarfblat=159&pwd=choice");
-        assertPostRequest(requests.get(1), "/choice.php", "forceoption=0&pwd=choice");
+        assertGetRequest(requests.get(1), "/choice.php", "forceoption=0");
         assertPostRequest(requests.get(2), "/api.php", "what=status&for=KoLmafia");
       }
     }
@@ -375,7 +375,7 @@ public class OceanManagerTest {
         var requests = builder.client.getRequests();
         assertThat(requests, hasSize(6));
         assertPostRequest(requests.get(0), "/adventure.php", "snarfblat=159&pwd=choice");
-        assertPostRequest(requests.get(1), "/choice.php", "forceoption=0&pwd=choice");
+        assertGetRequest(requests.get(1), "/choice.php", "forceoption=0");
         assertPostRequest(requests.get(2), "/api.php", "what=status&for=KoLmafia");
         assertPostRequest(requests.get(3), "/choice.php", "whichchoice=189&option=1&pwd=choice");
         // With "sphere", we choose one of three random destinations:
@@ -431,7 +431,7 @@ public class OceanManagerTest {
         var requests = builder.client.getRequests();
         assertThat(requests, hasSize(6));
         assertPostRequest(requests.get(0), "/adventure.php", "snarfblat=159&pwd=choice");
-        assertPostRequest(requests.get(1), "/choice.php", "forceoption=0&pwd=choice");
+        assertGetRequest(requests.get(1), "/choice.php", "forceoption=0");
         assertPostRequest(requests.get(2), "/api.php", "what=status&for=KoLmafia");
         assertPostRequest(requests.get(3), "/choice.php", "whichchoice=189&option=1&pwd=choice");
         assertPostRequest(requests.get(4), "/ocean.php", "lon=86&lat=40&pwd=choice");

--- a/test/net/sourceforge/kolmafia/session/QuestManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/QuestManagerTest.java
@@ -850,7 +850,7 @@ public class QuestManagerTest {
 
         builder.client.addResponse(200, html("request/test_duck_choice_1.html"));
         var request = new RelayRequest(false);
-        request.constructURLString("choice.php?forceoption=0");
+        request.constructURLString("choice.php?forceoption=0", false);
         request.run();
         assertTrue(ChoiceManager.handlingChoice);
         assertEquals(147, ChoiceManager.lastChoice);
@@ -868,7 +868,7 @@ public class QuestManagerTest {
         assertThat(requests, hasSize(2));
         // assertPostRequest(requests.get(0), "/adventure.php", "snarfblat=" +
         // AdventurePool.THE_BARN);
-        assertPostRequest(requests.get(0), "/choice.php", "forceoption=0");
+        assertGetRequest(requests.get(0), "/choice.php", "forceoption=0");
         assertPostRequest(requests.get(1), "/choice.php", "pwd=&whichchoice=147&option=3");
       }
     }


### PR DESCRIPTION
This came about because I had a lot of trouble with my Chess Puzzle automation test:

When I submitted a RelayRequest to use a reflection of a map via inv_use.php, it redirects to choice.php.
When I coded my test to handle that, for some reason, the list of requests did not include the initial inv_use.php. The first was choice.php. Very strange, since debug logging showed it WAS submitted. So I coded my test to ignore that and it worked perfectly every time on my Mac.

But when I pushed it github, the test failed on Ubuntu, which DID have inv_use first.

I worked around it for now by not starting with the map, but with choice.php, in my other PR.
I want to fix that, so I opened this PR to try and debug the situation.

To my surprise, in my three test cases, I got inv_use.php as the first request every single time.

I did notice a number of things that needed fixing, though.

1) When a request redirects, there is always a method supplied - GET or POST. It is almost always GET, but we should comply. GenericRequest complies when it submits a redirect, but both AdventureRequest and ChoiceManager need to be supplied with the request method and use it. They do now.
2) I had written a number of tests that tested requests being submitted, and sometimes "choice.php&forceoption=0" incorrectly ended up being a POST. They are now GETs, as KoL intended, and I had to fix the tests.
3) If I submit a request which redirects, if KoLmafia follows the redirect, you get the responseText in your request.
For RelayRequests, which do not follow the redirect, no responseText, and the RelayRequest handles the redirection itself, when the Browser requests it.
But for classes which say "don't handle the redirect", if it was to choice.php, GenericRequest would still let ChoiceManager automate it - and the final response was sitting in CHOICE_HANDLER. Now we copy it back to the request that got the redirect.