### PR TITLE
Drunkula wineglass on familiar negates need for overdrunk warning

### DIFF
--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -2776,7 +2776,8 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If you are equipped with Drunkula's wineglass, nothing to warn about
-    if (KoLCharacter.hasEquipped(ItemPool.DRUNKULA_WINEGLASS, EquipmentManager.OFFHAND)) {
+    if (KoLCharacter.hasEquipped(ItemPool.DRUNKULA_WINEGLASS, EquipmentManager.OFFHAND)
+        || KoLCharacter.hasEquipped(ItemPool.DRUNKULA_WINEGLASS, EquipmentManager.FAMILIAR)) {
       return false;
     }
 


### PR DESCRIPTION
I could add a suite of tests in RelayRequestWarningTest for this, but I tested this one-line change in the Relay Browser and won't have time for development for the next two weeks.