### PR TITLE
tests: use cleanups in early command tests

### DIFF
--- a/test/net/sourceforge/kolmafia/textui/command/UseSkillCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/UseSkillCommandTest.java
@@ -1,51 +1,52 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import static internal.helpers.Player.withItem;
+import static internal.helpers.Player.withMP;
+import static internal.helpers.Player.withSkill;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
-import net.sourceforge.kolmafia.AdventureResult;
-import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLConstants;
+import internal.helpers.Cleanups;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
-import net.sourceforge.kolmafia.request.GenericRequest;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class UseSkillCommandTest extends AbstractCommandTestBase {
-  @BeforeEach
-  public void initEach() {
-    // Stop requests from actually running
-    GenericRequest.sessionId = null;
-  }
-
   public UseSkillCommandTest() {
     this.command = "cast";
   }
 
   @Test
   void expandsKnownShorthand() {
-    KoLCharacter.addAvailableSkill(SkillPool.ODE_TO_BOOZE);
-    KoLCharacter.addAvailableSkill("CHEAT CODE: Invisible Avatar");
-    KoLCharacter.addAvailableSkill("CHEAT CODE: Triple Size");
-    AdventureResult.addResultToList(
-        KoLConstants.inventory, ItemPool.get(ItemPool.ANTIQUE_ACCORDION));
-    KoLCharacter.setMP(100, 100, 100);
+    var cleanups =
+        new Cleanups(
+            withSkill(SkillPool.ODE_TO_BOOZE),
+            withSkill("CHEAT CODE: Invisible Avatar"),
+            withSkill("CHEAT CODE: Triple Size"),
+            withItem(ItemPool.ANTIQUE_ACCORDION),
+            withMP(100, 100, 100));
 
-    String output = execute("ode");
+    try (cleanups) {
+      String output = execute("ode");
 
-    assertContinueState();
-    assertThat(output, containsString("Casting The Ode to Booze"));
+      assertContinueState();
+      assertThat(output, containsString("Casting The Ode to Booze"));
+    }
   }
 
   @Test
   void doesNotExpandUnknownShorthand() {
-    KoLCharacter.addAvailableSkill(SkillPool.ODE_TO_BOOZE);
-    KoLCharacter.addAvailableSkill("CHEAT CODE: Invisible Avatar");
-    KoLCharacter.addAvailableSkill("CHEAT CODE: Triple Size");
-    String output = execute("od");
+    var cleanups =
+        new Cleanups(
+            withSkill(SkillPool.ODE_TO_BOOZE),
+            withSkill("CHEAT CODE: Invisible Avatar"),
+            withSkill("CHEAT CODE: Triple Size"));
 
-    assertErrorState();
-    assertThat(output, containsString("Possible matches:"));
+    try (cleanups) {
+      String output = execute("od");
+
+      assertErrorState();
+      assertThat(output, containsString("Possible matches:"));
+    }
   }
 }


### PR DESCRIPTION
Make them use newer patterns so they're easier to copy from.

Stop testing sign in the spoon test: it doesn't change it, so there's no point.