### PR TITLE
fix: autumnaton quest turn start with two 11s

### DIFF
--- a/src/net/sourceforge/kolmafia/session/AutumnatonManager.java
+++ b/src/net/sourceforge/kolmafia/session/AutumnatonManager.java
@@ -57,7 +57,7 @@ public class AutumnatonManager {
   }
 
   private static int calculateQuestTurns(final int questNumber) {
-    var effectiveQuest = questNumber;
+    var effectiveQuest = questNumber - 1;
     var upgrades = Preferences.getString("autumnatonUpgrades");
     if (upgrades.contains("leftleg1")) effectiveQuest--;
     if (upgrades.contains("rightleg1")) effectiveQuest--;

--- a/test/net/sourceforge/kolmafia/session/AutumnatonManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/AutumnatonManagerTest.java
@@ -60,11 +60,13 @@ class AutumnatonManagerTest {
   @ParameterizedTest
   @CsvSource({
     "0, '', 11",
+    "1, '', 11",
+    "4, '', 44",
+    "2, 'leftleg1', 11",
+    "4, 'rightleg1', 33",
     "0, 'leftleg1,rightleg1', 11",
-    "2, 'leftleg1', 22",
     "2, 'leftleg1,rightleg1', 11",
-    "4, '', 55",
-    "4, 'rightleg1', 44",
+    "4, 'leftleg1,rightleg1', 22",
   })
   public void canDetectQuest(final int questsToday, final String upgrades, final int expected) {
     var cleanups =


### PR DESCRIPTION
Autumnaton was consistently off by 11 just before the first longer quest.

I think it was missing the extra 11 at the start. This makes the numbers align with what I see.