### PR TITLE
feat: default sharePriceData to true

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -136,7 +136,7 @@ global	saveState
 global	saveStateActive
 global	scriptButtonPosition	0
 global	scriptList	restore hp | restore mp
-global	sharePriceData	false
+global	sharePriceData	true
 global	showAllRequests	false
 global	showExceptionalRequests	false
 global	statusDropdown	0

--- a/src/net/sourceforge/kolmafia/persistence/MallPriceDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/MallPriceDatabase.java
@@ -38,6 +38,8 @@ public class MallPriceDatabase {
   private static final HashSet<String> submitted = new HashSet<>();
   private static int modCount = 0;
 
+  public static final File PRICE_FILE = new File(KoLConstants.DATA_LOCATION, "mallprices.txt");
+
   private static final int CONNECT_TIMEOUT = 15 * 1000;
 
   static {
@@ -159,8 +161,7 @@ public class MallPriceDatabase {
       return;
     }
 
-    File output = new File(KoLConstants.DATA_LOCATION, "mallprices.txt");
-    try (PrintStream writer = LogStream.openStream(output, true)) {
+    try (PrintStream writer = LogStream.openStream(PRICE_FILE, true)) {
       writePrices(writer);
     }
   }

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -123,7 +123,7 @@ public class LoginManager {
       Preferences.setInteger("lastBreakfast", today);
     }
 
-    if (Preferences.getBoolean("sharePriceData")) {
+    if (Preferences.getBoolean("sharePriceData") || !MallPriceDatabase.PRICE_FILE.exists()) {
       MallPriceDatabase.updatePricesInParallel(
           "https://kolmafia.us/scripts/updateprices.php?action=getmap");
     }


### PR DESCRIPTION
Inspired by https://kolmafia.us/threads/autoscend-ash-demands-ancient-magi-wipes-cant-find-file-divides-by-zero.28158

I think this is a potential problem caused by #687, which removed the bundled mallprices.txt file: if the user is not sharing mall prices, then they won't get any price data, which can cause scripts to crash.

One other option would be to download the file if it doesn't exist (but not keep it up to date), which would ensure the user always has some price data.