### PR TITLE
feat: hide PHPSESSID from cookie in debug logs

### DIFF
--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -33,6 +33,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLAdventure;
@@ -3035,10 +3036,25 @@ public class GenericRequest implements Runnable {
     RequestLogger.updateDebugLog(requestProperties.size() + " request properties");
 
     for (Entry<String, List<String>> entry : requestProperties.entrySet()) {
-      RequestLogger.updateDebugLog("Field: " + entry.getKey() + " = " + entry.getValue());
+      if ("Cookie".equalsIgnoreCase(entry.getKey())) {
+        RequestLogger.updateDebugLog(
+            "Field: " + entry.getKey() + " = " + filterCookieList(entry.getValue()));
+      } else {
+        RequestLogger.updateDebugLog("Field: " + entry.getKey() + " = " + entry.getValue());
+      }
     }
 
     RequestLogger.updateDebugLog();
+  }
+
+  private static List<String> filterCookieList(List<String> values) {
+    return values.stream()
+        .map(
+            s ->
+                Arrays.stream(s.split("\s*;\s*"))
+                    .map(t -> t.startsWith("PHPSESSID=") ? "PHPSESSID=OMITTED" : t)
+                    .collect(Collectors.joining("; ")))
+        .toList();
   }
 
   public void printHeaderFields() {

--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -3036,12 +3036,13 @@ public class GenericRequest implements Runnable {
     RequestLogger.updateDebugLog(requestProperties.size() + " request properties");
 
     for (Entry<String, List<String>> entry : requestProperties.entrySet()) {
+      List<String> value;
       if ("Cookie".equalsIgnoreCase(entry.getKey())) {
-        RequestLogger.updateDebugLog(
-            "Field: " + entry.getKey() + " = " + filterCookieList(entry.getValue()));
+        value = filterCookieList(entry.getValue());
       } else {
-        RequestLogger.updateDebugLog("Field: " + entry.getKey() + " = " + entry.getValue());
+        value = entry.getValue();
       }
+      RequestLogger.updateDebugLog("Field: " + entry.getKey() + " = " + value);
     }
 
     RequestLogger.updateDebugLog();


### PR DESCRIPTION
From https://kolmafia.us/threads/replace-pwd-hashes-in-debug-log-with-generic-string.28127/ the session id is a dangerous item to share in DEBUG logs, and removing it is easy enough.