### PR TITLE
fix: allow autumnaton redirect to inventory

### DIFF
--- a/src/net/sourceforge/kolmafia/request/AdventureRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AdventureRequest.java
@@ -1106,6 +1106,12 @@ public class AdventureRequest extends GenericRequest {
       return;
     }
 
+    if (redirectLocation.startsWith("inventory.php")) {
+      // Autumnaton's "Back to Inventory"
+      AdventureRequest.ZONE_UNLOCK.run();
+      return;
+    }
+
     RequestSynchFrame.showRequest(AdventureRequest.ZONE_UNLOCK);
     RequestLogger.printLine("Unrecognized choice.php redirect: " + redirectLocation);
     RequestLogger.updateSessionLog("Unrecognized choice.php redirect: " + redirectLocation);


### PR DESCRIPTION
The autumn-aton choice adventure has an option that redirects you to your inventory. You can walk away from the choice, so you don't have to take it, but avoid crashing if you do.

Mafia prints "Unhandled redirect to inventory.php" which I think is fine.