### PR TITLE
feat: autumnaton locations

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/AdventureDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/AdventureDatabase.java
@@ -102,6 +102,10 @@ public class AdventureDatabase {
       return this.name().toLowerCase();
     }
 
+    public String toTitle() {
+      return StringUtilities.capitalize(this.toString());
+    }
+
     public static Optional<Environment> fromString(String text) {
       if (text == null || text.isEmpty()) return Optional.empty();
       return Arrays.stream(values()).filter(e -> e.name().equalsIgnoreCase(text)).findAny();
@@ -122,6 +126,10 @@ public class AdventureDatabase {
     @Override
     public String toString() {
       return this.name().toLowerCase();
+    }
+
+    public String toTitle() {
+      return StringUtilities.capitalize(this.toString());
     }
 
     public static Optional<DifficultyLevel> fromString(String text) {

--- a/src/net/sourceforge/kolmafia/session/AutumnatonManager.java
+++ b/src/net/sourceforge/kolmafia/session/AutumnatonManager.java
@@ -1,15 +1,19 @@
 package net.sourceforge.kolmafia.session;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class AutumnatonManager {
@@ -113,5 +117,23 @@ public class AutumnatonManager {
       Preferences.setString("autumnatonQuestLocation", "");
       Preferences.setInteger("autumnatonQuestTurn", KoLCharacter.getTurnsPlayed());
     }
+  }
+
+  public static String useAutumnaton() {
+    GenericRequest request =
+        new GenericRequest("inv_use.php?which=3&whichitem=" + ItemPool.AUTUMNATON);
+    RequestThread.postRequest(request);
+    return request.responseText;
+  }
+
+  private static final Pattern VISITABLE_LOCATION = Pattern.compile("<option +value=\"(\\d+)\">");
+
+  public static Set<Integer> parseLocations(final String responseText) {
+    var locs = new HashSet<Integer>();
+    var m = VISITABLE_LOCATION.matcher(responseText);
+    while (m.find()) {
+      locs.add(Integer.parseInt(m.group(1)));
+    }
+    return locs;
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -2747,9 +2747,7 @@ public abstract class RuntimeLibrary {
     params = new Type[] {};
     functions.add(
         new LibraryFunction(
-            "get_autumnaton_locations",
-            new AggregateType(DataTypes.LOCATION_TYPE, 0),
-            params));
+            "get_autumnaton_locations", new AggregateType(DataTypes.LOCATION_TYPE, 0), params));
   }
 
   public static Method findMethod(final String name, final Class<?>[] args)

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -120,6 +120,7 @@ import net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.EveryCard;
 import net.sourceforge.kolmafia.request.FloristRequest.Florist;
 import net.sourceforge.kolmafia.scripts.git.GitManager;
 import net.sourceforge.kolmafia.scripts.svn.SVNManager;
+import net.sourceforge.kolmafia.session.AutumnatonManager;
 import net.sourceforge.kolmafia.session.BanishManager;
 import net.sourceforge.kolmafia.session.ChoiceManager;
 import net.sourceforge.kolmafia.session.ClanManager;
@@ -2742,6 +2743,13 @@ public abstract class RuntimeLibrary {
 
     params = new Type[] {DataTypes.ITEM_TYPE};
     functions.add(new LibraryFunction("zap", DataTypes.ITEM_TYPE, params));
+
+    params = new Type[] {};
+    functions.add(
+        new LibraryFunction(
+            "get_autumnaton_locations",
+            new AggregateType(DataTypes.LOCATION_TYPE, 0),
+            params));
   }
 
   public static Method findMethod(final String name, final Class<?>[] args)
@@ -9826,5 +9834,26 @@ public abstract class RuntimeLibrary {
     int itemId = acquired == null ? -1 : acquired.getItemId();
 
     return DataTypes.makeItemValue(itemId, true);
+  }
+
+  public static Value get_autumnaton_locations(ScriptRuntime controller) {
+    if (!InventoryManager.hasItem(ItemPool.AUTUMNATON)) {
+      return new ArrayValue(new AggregateType(DataTypes.LOCATION_TYPE, 0));
+    }
+
+    var response = AutumnatonManager.useAutumnaton();
+    var locs = AutumnatonManager.parseLocations(response);
+
+    var size = locs.size();
+    AggregateType type = new AggregateType(DataTypes.LOCATION_TYPE, size);
+    ArrayValue value = new ArrayValue(type);
+
+    int i = 0;
+    for (var id : locs) {
+      Value location = DataTypes.makeLocationValue(AdventureDatabase.getAdventure(id));
+      value.aset(DataTypes.makeIntValue(i++), location);
+    }
+
+    return value;
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/command/AutumnatonCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AutumnatonCommand.java
@@ -1,5 +1,11 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import static net.sourceforge.kolmafia.session.AutumnatonManager.useAutumnaton;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
@@ -9,13 +15,16 @@ import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
+import net.sourceforge.kolmafia.persistence.AdventureDatabase.DifficultyLevel;
+import net.sourceforge.kolmafia.persistence.AdventureDatabase.Environment;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.GenericRequest;
+import net.sourceforge.kolmafia.session.AutumnatonManager;
 import net.sourceforge.kolmafia.session.InventoryManager;
 
 public class AutumnatonCommand extends AbstractCommand {
   public AutumnatonCommand() {
-    this.usage = " <blank> | upgrade | send [location] - deal with your autumn-aton";
+    this.usage = " <blank> | upgrade | locations | send [location] - deal with your autumn-aton";
   }
 
   private static final Pattern UPGRADE_PATTERN = Pattern.compile("Attach the (.+) that you found.");
@@ -33,6 +42,7 @@ public class AutumnatonCommand extends AbstractCommand {
       case "" -> status();
       case "send" -> send(params);
       case "upgrade" -> upgrade();
+      case "locations" -> locations();
       default -> KoLmafia.updateDisplay(MafiaState.ERROR, "Usage: autumnaton" + this.usage);
     }
   }
@@ -103,6 +113,11 @@ public class AutumnatonCommand extends AbstractCommand {
   }
 
   public void upgrade() {
+    if (!InventoryManager.hasItem(ItemPool.AUTUMNATON)) {
+      KoLmafia.updateDisplay(MafiaState.ERROR, "Your autumn-aton is away.");
+      return;
+    }
+
     String response = useAutumnaton();
 
     var upgrades = UPGRADE_PATTERN.matcher(response);
@@ -117,13 +132,6 @@ public class AutumnatonCommand extends AbstractCommand {
     KoLmafia.updateDisplay("Added upgrades " + upgrades.group(1));
   }
 
-  private String useAutumnaton() {
-    GenericRequest request =
-        new GenericRequest("inv_use.php?which=3&whichitem=" + ItemPool.AUTUMNATON);
-    RequestThread.postRequest(request);
-    return request.responseText;
-  }
-
   private String turnsRemainingString() {
     var turns = Preferences.getInteger("autumnatonQuestTurn") - KoLCharacter.getTurnsPlayed();
     if (turns > 0) {
@@ -132,5 +140,85 @@ public class AutumnatonCommand extends AbstractCommand {
     } else {
       return "Your autumn-aton will return after your next combat.";
     }
+  }
+
+  public void locations() {
+    if (!InventoryManager.hasItem(ItemPool.AUTUMNATON)) {
+      KoLmafia.updateDisplay(MafiaState.ERROR, "Your autumn-aton is away.");
+      return;
+    }
+
+    String response = useAutumnaton();
+    var locs = AutumnatonManager.parseLocations(response);
+
+    Map<Environment, Map<DifficultyLevel, List<KoLAdventure>>> locMapping = new HashMap<>();
+
+    for (var id : locs) {
+      var adv = AdventureDatabase.getAdventure(id);
+      var env = locMapping.computeIfAbsent(adv.getEnvironment(), m -> new HashMap<>());
+      env.computeIfAbsent(adv.getDifficultyLevel(), m -> new ArrayList<>()).add(adv);
+    }
+
+    StringBuilder output = new StringBuilder();
+
+    output.append("You can send your autumn-aton to ").append(locs.size()).append(" locations.");
+
+    addEnvironmentLocations(output, locMapping, Environment.OUTDOOR);
+    addEnvironmentLocations(output, locMapping, Environment.INDOOR);
+    addEnvironmentLocations(output, locMapping, Environment.UNDERGROUND);
+
+    RequestLogger.printLine(output.toString());
+  }
+
+  private void addEnvironmentLocations(StringBuilder output, Map<Environment, Map<DifficultyLevel, List<KoLAdventure>>> locMapping, Environment env) {
+    var dl = locMapping.get(env);
+    if (dl != null) {
+      output.append("<b>").append(env.toTitle()).append("</b>");
+      addDiffLevelLocations(output, dl, env, DifficultyLevel.LOW);
+      addDiffLevelLocations(output, dl, env, DifficultyLevel.MID);
+      addDiffLevelLocations(output, dl, env, DifficultyLevel.HIGH);
+    }
+  }
+
+  private void addDiffLevelLocations(StringBuilder output, Map<DifficultyLevel, List<KoLAdventure>> dlMapping, Environment env, DifficultyLevel level) {
+    var advs = dlMapping.get(level);
+    if (advs != null) {
+      output.append(diffLevelDescription(env, level))
+          .append(" <ul>");
+
+      for (var item : advs) {
+        output.append("<li>")
+            .append(item.getAdventureName())
+            .append("</li>");
+      }
+
+      output.append("</ul>");
+    }
+  }
+
+  private String diffLevelDescription(Environment env, DifficultyLevel level) {
+    var title = level.toTitle();
+    var desc = switch (env) {
+      case OUTDOOR -> switch (level) {
+        case LOW -> "gives autumn leaf (potion, +25% item, +5% combat chance)";
+        case MID -> "gives autumn debris shield (shield, +10 DR, +30% init, +20 all hot)";
+        case HIGH -> "gives autumn leaf pendant (accessory, 5 fam weight, 10 fam damage, +1 fam exp)";
+        default -> "";
+      };
+      case INDOOR -> switch (level) {
+        case LOW -> "gives AutumnFest Ale (booze, 1 drunk, 4-6 advs)";
+        case MID -> "gives autumn-spice donut (food, 1 full, 4-6 advs)";
+        case HIGH -> "gives autumn breeze (spleen, 1 toxicity, +100% all stats)";
+        default -> "";
+      };
+      case UNDERGROUND -> switch (level) {
+        case LOW -> "gives autumn sweater-weather sweater (shirt, +3 cold res, +50 HP, +8-12 HP Regen)";
+        case MID -> "gives autumn dollar (potion, +50% meat)";
+        case HIGH -> "gives autumn years wisdom (potion, +20% spell dmg, +100 MP, +15-20 MP Regen)";
+        default -> "";
+      };
+      default -> "";
+    };
+    return title + ": " + desc;
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/command/AutumnatonCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AutumnatonCommand.java
@@ -170,7 +170,10 @@ public class AutumnatonCommand extends AbstractCommand {
     RequestLogger.printLine(output.toString());
   }
 
-  private void addEnvironmentLocations(StringBuilder output, Map<Environment, Map<DifficultyLevel, List<KoLAdventure>>> locMapping, Environment env) {
+  private void addEnvironmentLocations(
+      StringBuilder output,
+      Map<Environment, Map<DifficultyLevel, List<KoLAdventure>>> locMapping,
+      Environment env) {
     var dl = locMapping.get(env);
     if (dl != null) {
       output.append("<b>").append(env.toTitle()).append("</b>");
@@ -180,16 +183,17 @@ public class AutumnatonCommand extends AbstractCommand {
     }
   }
 
-  private void addDiffLevelLocations(StringBuilder output, Map<DifficultyLevel, List<KoLAdventure>> dlMapping, Environment env, DifficultyLevel level) {
+  private void addDiffLevelLocations(
+      StringBuilder output,
+      Map<DifficultyLevel, List<KoLAdventure>> dlMapping,
+      Environment env,
+      DifficultyLevel level) {
     var advs = dlMapping.get(level);
     if (advs != null) {
-      output.append(diffLevelDescription(env, level))
-          .append(" <ul>");
+      output.append(diffLevelDescription(env, level)).append(" <ul>");
 
       for (var item : advs) {
-        output.append("<li>")
-            .append(item.getAdventureName())
-            .append("</li>");
+        output.append("<li>").append(item.getAdventureName()).append("</li>");
       }
 
       output.append("</ul>");
@@ -198,27 +202,28 @@ public class AutumnatonCommand extends AbstractCommand {
 
   private String diffLevelDescription(Environment env, DifficultyLevel level) {
     var title = level.toTitle();
-    var desc = switch (env) {
-      case OUTDOOR -> switch (level) {
-        case LOW -> "gives autumn leaf (potion, +25% item, +5% combat chance)";
-        case MID -> "gives autumn debris shield (shield, +10 DR, +30% init, +20 all hot)";
-        case HIGH -> "gives autumn leaf pendant (accessory, 5 fam weight, 10 fam damage, +1 fam exp)";
-        default -> "";
-      };
-      case INDOOR -> switch (level) {
-        case LOW -> "gives AutumnFest Ale (booze, 1 drunk, 4-6 advs)";
-        case MID -> "gives autumn-spice donut (food, 1 full, 4-6 advs)";
-        case HIGH -> "gives autumn breeze (spleen, 1 toxicity, +100% all stats)";
-        default -> "";
-      };
-      case UNDERGROUND -> switch (level) {
-        case LOW -> "gives autumn sweater-weather sweater (shirt, +3 cold res, +50 HP, +8-12 HP Regen)";
-        case MID -> "gives autumn dollar (potion, +50% meat)";
-        case HIGH -> "gives autumn years wisdom (potion, +20% spell dmg, +100 MP, +15-20 MP Regen)";
-        default -> "";
-      };
-      default -> "";
-    };
+    var desc =
+        switch (env) {
+          case OUTDOOR -> switch (level) {
+            case LOW -> "gives autumn leaf (potion, +25% item, +5% combat chance)";
+            case MID -> "gives autumn debris shield (shield, +10 DR, +30% init, +20 all hot)";
+            case HIGH -> "gives autumn leaf pendant (accessory, 5 fam weight, 10 fam damage, +1 fam exp)";
+            default -> "";
+          };
+          case INDOOR -> switch (level) {
+            case LOW -> "gives AutumnFest Ale (booze, 1 drunk, 4-6 advs)";
+            case MID -> "gives autumn-spice donut (food, 1 full, 4-6 advs)";
+            case HIGH -> "gives autumn breeze (spleen, 1 toxicity, +100% all stats)";
+            default -> "";
+          };
+          case UNDERGROUND -> switch (level) {
+            case LOW -> "gives autumn sweater-weather sweater (shirt, +3 cold res, +50 HP, +8-12 HP Regen)";
+            case MID -> "gives autumn dollar (potion, +50% meat)";
+            case HIGH -> "gives autumn years wisdom (potion, +20% spell dmg, +100 MP, +15-20 MP Regen)";
+            default -> "";
+          };
+          default -> "";
+        };
     return title + ": " + desc;
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/command/AutumnatonCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AutumnatonCommand.java
@@ -161,7 +161,10 @@ public class AutumnatonCommand extends AbstractCommand {
 
     StringBuilder output = new StringBuilder();
 
-    output.append("You can send your autumn-aton to ").append(locs.size()).append(" locations.");
+    output
+        .append("You can send your autumn-aton to ")
+        .append(locs.size())
+        .append(" locations.\n\n");
 
     addEnvironmentLocations(output, locMapping, Environment.OUTDOOR);
     addEnvironmentLocations(output, locMapping, Environment.INDOOR);
@@ -176,10 +179,11 @@ public class AutumnatonCommand extends AbstractCommand {
       Environment env) {
     var dl = locMapping.get(env);
     if (dl != null) {
-      output.append("<b>").append(env.toTitle()).append("</b>");
+      output.append("<b>").append(env.toTitle()).append("</b><br>");
       addDiffLevelLocations(output, dl, env, DifficultyLevel.LOW);
       addDiffLevelLocations(output, dl, env, DifficultyLevel.MID);
       addDiffLevelLocations(output, dl, env, DifficultyLevel.HIGH);
+      addDiffLevelLocations(output, dl, env, DifficultyLevel.UNKNOWN);
     }
   }
 

--- a/src/net/sourceforge/kolmafia/textui/command/HeistCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/HeistCommand.java
@@ -44,22 +44,14 @@ public class HeistCommand extends AbstractCommand {
     var heistManager = heistManager();
     var heistData = heistManager.getHeistTargets();
 
-    output.append("You have ")
-    .append(heistData.heists)
-    .append(" heists.\n\n");
+    output.append("You have ").append(heistData.heists).append(" heists.\n\n");
 
     for (var heistable : heistData.heistables.entrySet()) {
       var key = heistable.getKey();
-      output.append("From ")
-      .append(key.pronoun)
-      .append(" ")
-      .append(key.name)
-      .append(": <ul>");
+      output.append("From ").append(key.pronoun).append(" ").append(key.name).append(": <ul>");
 
       for (var item : heistable.getValue()) {
-        output.append("<li>")
-        .append(item.name)
-        .append("</li>");
+        output.append("<li>").append(item.name).append("</li>");
       }
 
       output.append("</ul>");

--- a/src/net/sourceforge/kolmafia/textui/command/HeistCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/HeistCommand.java
@@ -44,22 +44,22 @@ public class HeistCommand extends AbstractCommand {
     var heistManager = heistManager();
     var heistData = heistManager.getHeistTargets();
 
-    output.append("You have ");
-    output.append(heistData.heists);
-    output.append(" heists.\n\n");
+    output.append("You have ")
+    .append(heistData.heists)
+    .append(" heists.\n\n");
 
     for (var heistable : heistData.heistables.entrySet()) {
       var key = heistable.getKey();
-      output.append("From ");
-      output.append(key.pronoun);
-      output.append(" ");
-      output.append(key.name);
-      output.append(": <ul>");
+      output.append("From ")
+      .append(key.pronoun)
+      .append(" ")
+      .append(key.name)
+      .append(": <ul>");
 
       for (var item : heistable.getValue()) {
-        output.append("<li>");
-        output.append(item.name);
-        output.append("</li>");
+        output.append("<li>")
+        .append(item.name)
+        .append("</li>");
       }
 
       output.append("</ul>");

--- a/test/net/sourceforge/kolmafia/session/AutumnatonManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/AutumnatonManagerTest.java
@@ -4,6 +4,9 @@ import static internal.helpers.Networking.html;
 import static internal.helpers.Player.*;
 import static internal.matchers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import internal.helpers.Cleanups;
@@ -12,6 +15,7 @@ import net.sourceforge.kolmafia.objectpool.AdventurePool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -85,5 +89,13 @@ class AutumnatonManagerTest {
       assertThat("autumnatonQuestLocation", isSetTo("The Haunted Kitchen"));
       assertThat("autumnatonQuestTurn", isSetTo(expected));
     }
+  }
+
+  @Test
+  public void canParseLocations() {
+    var locs = AutumnatonManager.parseLocations(html("request/test_choice_autumnaton_all_upgrades.html"));
+    assertThat(locs, hasItem(258));
+    assertThat(locs, hasItem(439));
+    assertThat(locs, not(hasItem(11)));
   }
 }

--- a/test/net/sourceforge/kolmafia/session/AutumnatonManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/AutumnatonManagerTest.java
@@ -4,7 +4,6 @@ import static internal.helpers.Networking.html;
 import static internal.helpers.Player.*;
 import static internal.matchers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -93,7 +92,8 @@ class AutumnatonManagerTest {
 
   @Test
   public void canParseLocations() {
-    var locs = AutumnatonManager.parseLocations(html("request/test_choice_autumnaton_all_upgrades.html"));
+    var locs =
+        AutumnatonManager.parseLocations(html("request/test_choice_autumnaton_all_upgrades.html"));
     assertThat(locs, hasItem(258));
     assertThat(locs, hasItem(439));
     assertThat(locs, not(hasItem(11)));

--- a/test/net/sourceforge/kolmafia/textui/command/AutumnatonCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AutumnatonCommandTest.java
@@ -297,5 +297,25 @@ public class AutumnatonCommandTest extends AbstractCommandTestBase {
         assertThat(output, containsString("Added upgrades " + upgrades));
       }
     }
+
+    @Test
+    public void showsLocations() {
+      var cleanups =
+          new Cleanups(
+              hasAutumnaton(),
+              withItem(ItemPool.AUTUMNATON),
+              withNextResponse(
+                  200,
+                  html("request/test_choice_autumnaton_all_upgrades.html")));
+
+      try (cleanups) {
+        String output = execute("locations");
+        assertContinueState();
+        // Daily Dungeon
+        assertThat(output, containsString("<b>Underground</b>"));
+        assertThat(output, containsString("Mid: gives autumn dollar (potion, +50% meat)"));
+        assertThat(output, containsString("<li>The Daily Dungeon</li>"));
+      }
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/command/AutumnatonCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AutumnatonCommandTest.java
@@ -304,9 +304,7 @@ public class AutumnatonCommandTest extends AbstractCommandTestBase {
           new Cleanups(
               hasAutumnaton(),
               withItem(ItemPool.AUTUMNATON),
-              withNextResponse(
-                  200,
-                  html("request/test_choice_autumnaton_all_upgrades.html")));
+              withNextResponse(200, html("request/test_choice_autumnaton_all_upgrades.html")));
 
       try (cleanups) {
         String output = execute("locations");


### PR DESCRIPTION
Add location list to autumnaton command. Also add ASH command for getting locations.

This is a useful increment, but there's more I want to do here:
* display upgrades, and what they do, if you don't have them
* cache the locations like `LocketManager` does

To update the cache, I need to know exactly what causes the location to appear (is a turn necessary, or is a combat enough?) and also where this should go in the codebase (somewhere in AdventureRequest?).

Checked "visited": initial copperhead NC is enough, as is free lianas. Didn't try canceling the copperhead NC. Next run.