### PR TITLE
fix: lowercase for environment + difficulty level on proxy record

### DIFF
--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -3322,7 +3322,7 @@ public class Modifiers {
 
     Modifiers.currentLocation = location.getAdventureName();
     Modifiers.currentZone = location.getZone();
-    Modifiers.currentEnvironment = location.getEnvironment().name();
+    Modifiers.currentEnvironment = location.getEnvironment().toString();
     AreaCombatData data = location.getAreaSummary();
     Modifiers.currentML = Math.max(4.0, data == null ? 0.0 : data.getAverageML());
   }

--- a/src/net/sourceforge/kolmafia/persistence/AdventureDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/AdventureDatabase.java
@@ -90,27 +90,21 @@ public class AdventureDatabase {
   private AdventureDatabase() {}
 
   public enum Environment {
-    UNKNOWN("unknown"),
-    NONE("none"),
-    INDOOR("indoor"),
-    OUTDOOR("outdoor"),
-    UNDERGROUND("underground"),
-    UNDERWATER("underwater");
-
-    private final String name;
-
-    Environment(String name) {
-      this.name = name;
-    }
+    UNKNOWN,
+    NONE,
+    INDOOR,
+    OUTDOOR,
+    UNDERGROUND,
+    UNDERWATER;
 
     @Override
     public String toString() {
-      return this.name;
+      return this.name().toLowerCase();
     }
 
     public static Optional<Environment> fromString(String text) {
       if (text == null || text.isEmpty()) return Optional.empty();
-      return Arrays.stream(values()).filter(e -> e.name.equalsIgnoreCase(text)).findAny();
+      return Arrays.stream(values()).filter(e -> e.name().equalsIgnoreCase(text)).findAny();
     }
 
     public boolean isUnderwater() {
@@ -119,26 +113,20 @@ public class AdventureDatabase {
   }
 
   public enum DifficultyLevel {
-    UNKNOWN("unknown"),
-    NONE("none"),
-    LOW("low"),
-    MID("mid"),
-    HIGH("high");
-
-    private final String name;
-
-    DifficultyLevel(String name) {
-      this.name = name;
-    }
+    UNKNOWN,
+    NONE,
+    LOW,
+    MID,
+    HIGH;
 
     @Override
     public String toString() {
-      return this.name;
+      return this.name().toLowerCase();
     }
 
     public static Optional<DifficultyLevel> fromString(String text) {
       if (text == null || text.isEmpty()) return Optional.empty();
-      return Arrays.stream(values()).filter(e -> e.name.equalsIgnoreCase(text)).findAny();
+      return Arrays.stream(values()).filter(e -> e.name().equalsIgnoreCase(text)).findAny();
     }
   }
 

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -1349,11 +1349,11 @@ public class ProxyRecordValue extends RecordValue {
     }
 
     public String get_difficulty_level() {
-      return this.content != null ? ((KoLAdventure) this.content).getDifficultyLevel().name() : "";
+      return this.content != null ? ((KoLAdventure) this.content).getDifficultyLevel().toString() : "";
     }
 
     public String get_environment() {
-      return this.content != null ? ((KoLAdventure) this.content).getEnvironment().name() : "";
+      return this.content != null ? ((KoLAdventure) this.content).getEnvironment().toString() : "";
     }
 
     public Value get_bounty() {

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -1349,7 +1349,9 @@ public class ProxyRecordValue extends RecordValue {
     }
 
     public String get_difficulty_level() {
-      return this.content != null ? ((KoLAdventure) this.content).getDifficultyLevel().toString() : "";
+      return this.content != null
+          ? ((KoLAdventure) this.content).getDifficultyLevel().toString()
+          : "";
     }
 
     public String get_environment() {

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -494,5 +494,17 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
         getInstance().command = "ash";
       }
     }
+
+    @Test
+    void environmentIsLowercase() {
+      String output = execute("($location[Noob Cave].environment == 'underground')");
+      assertThat(output, endsWith("Returned: true\n"));
+    }
+
+    @Test
+    void diffLevelIsLowercase() {
+      String output = execute("($location[Noob Cave].difficulty_level == 'low')");
+      assertThat(output, endsWith("Returned: true\n"));
+    }
   }
 }


### PR DESCRIPTION
I mixed up `name` and `name()`, and assumed coverage meant something was tested instead of just that we had some test that ran that bit of code.