### PR TITLE
Update chat to match KoL behaviour

### DIFF
--- a/src/net/sourceforge/kolmafia/chat/ChatPoller.java
+++ b/src/net/sourceforge/kolmafia/chat/ChatPoller.java
@@ -34,10 +34,10 @@ public class ChatPoller extends Thread {
   public static long localLastSent = 0;
 
   // Milliseconds between polls. Extracted from the Javascript source on
-  // Sept 30, 2014
-  private static final int LCHAT_DELAY_NORMAL = 5000;
-  private static final int LCHAT_DELAY_PAUSED = 30000;
-  private static final int MCHAT_DELAY_NORMAL = 5000;
+  // Oct 21, 2022
+  private static final int LCHAT_DELAY_NORMAL = 3000;
+  private static final int LCHAT_DELAY_PAUSED = 10000;
+  private static final int MCHAT_DELAY_NORMAL = 3000;
   private static final int MCHAT_DELAY_PAUSED = 10000;
 
   // lchat and mchat like to go into "away" mode after 15 minutes.  If

--- a/src/net/sourceforge/kolmafia/request/ChatRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ChatRequest.java
@@ -2,6 +2,7 @@ package net.sourceforge.kolmafia.request;
 
 import java.nio.charset.StandardCharsets;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.chat.ChatManager;
 
 public class ChatRequest extends GenericRequest {
@@ -21,7 +22,9 @@ public class ChatRequest extends GenericRequest {
     StringBuilder newURLString = new StringBuilder("newchatmessages.php?");
 
     if (tabbedChat) {
-      newURLString.append("j=1&");
+      newURLString.append("aa=");
+      newURLString.append(KoLConstants.RNG.nextDouble());
+      newURLString.append("&j=1&");
     }
 
     newURLString.append("lasttime=");

--- a/test/net/sourceforge/kolmafia/request/ChatRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/ChatRequestTest.java
@@ -2,6 +2,7 @@ package net.sourceforge.kolmafia.request;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import net.sourceforge.kolmafia.KoLConstants;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -16,15 +17,17 @@ public class ChatRequestTest {
 
   @Test
   public void itShouldBuildAModernChatRequestWithLastSeen() {
+    KoLConstants.RNG.setSeed(42);
+
     creq = new ChatRequest(0L, true, false);
     fullURL = creq.getFullURLString();
-    expect = "newchatmessages.php?j=1&lasttime=0";
+    expect = "newchatmessages.php?aa=0.7275636800328681&j=1&lasttime=0";
     assertEquals(fullURL, expect);
     assertEquals(creq.getGraf(), "");
     assertTrue(creq.retryOnTimeout());
     creq = new ChatRequest(8675309L, true, false);
     fullURL = creq.getFullURLString();
-    expect = "newchatmessages.php?j=1&lasttime=8675309";
+    expect = "newchatmessages.php?aa=0.6832234717598454&j=1&lasttime=8675309";
     assertEquals(fullURL, expect);
     assertEquals(creq.getGraf(), "");
     assertTrue(creq.retryOnTimeout());


### PR DESCRIPTION
This PR consists of two parts:

1. Both KoL mchat and lchat have switched to 3000/10000ms somewhen in the last 8 years. Adjust our values to do the same.

lchat:
![image](https://user-images.githubusercontent.com/1388972/197203091-1f4d8b9e-9c58-4878-91bc-dd734e33a43c.png)
mchat (away time comes from server, not from source code):
![image](https://user-images.githubusercontent.com/1388972/197203216-34f86587-3645-4b42-9b63-983ffd4ad14f.png)
![image](https://user-images.githubusercontent.com/1388972/197204034-9b8f06f6-413e-4246-8ebd-37b4eb5bcd86.png)

2. KoL mchat is adding a random aa=%RANDOMNUMBER% parameter to each newchatmessages.php request. Probably some kind of cache buster? I've added this to ChatRequest for the mchat relay requests.