### PR TITLE
In session log, note what clan we're switching to/are in

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ClanManager.java
+++ b/src/net/sourceforge/kolmafia/session/ClanManager.java
@@ -151,6 +151,7 @@ public abstract class ClanManager {
 
     // Visit lounge and rumpus room to see what is there
     if (clanName != null && !clanName.equals("")) {
+      RequestLogger.updateSessionLog("You are currently a member of " + clanName);
       RequestLogger.printLine("You are currently a member of " + clanName);
 
       if (!ClanManager.getClanRumpus().isEmpty()) {


### PR DESCRIPTION
Currently there's no way to see when someone switches clans in the session log, this aims to correct that.

A potential extra feature could be detecting when you are booted from a clan, or leave the clan. But that's hardly a concern.