### PR TITLE
feat: more difflevels

### DIFF
--- a/src/data/adventures.txt
+++ b/src/data/adventures.txt
@@ -89,8 +89,8 @@ Knob	cobbsknob=0	DiffLevel: none Env: none Stat: 0 Level: 6	Throne Room
 Lab	adventure=50	DiffLevel: mid Env: underground Stat: 30	Cobb's Knob Laboratory	1 Cobb's Knob Menagerie key|1 Subject 37 file|+1 bottle of Mystic Shell
 Lab	adventure=101	DiffLevel: mid Env: underground Stat: 30	The Knob Shaft
 Lab	mining=2	DiffLevel: none Env: none Stat: 0	The Knob Shaft (Mining)
-Menagerie	adventure=51	DiffLevel: unknown Env: underground Stat: 35	Cobb's Knob Menagerie, Level 1	1 GOTO
-Menagerie	adventure=52	DiffLevel: unknown Env: underground Stat: 40	Cobb's Knob Menagerie, Level 2	1 weremoose spit|+1 irradiated pet snacks
+Menagerie	adventure=51	DiffLevel: mid Env: underground Stat: 35	Cobb's Knob Menagerie, Level 1	1 GOTO
+Menagerie	adventure=52	DiffLevel: mid Env: underground Stat: 40	Cobb's Knob Menagerie, Level 2	1 weremoose spit|+1 irradiated pet snacks
 Menagerie	adventure=53	DiffLevel: mid Env: underground Stat: 45	Cobb's Knob Menagerie, Level 3	1 abominable blubber
 
 Rift	adventure=85	DiffLevel: unknown Env: outdoor Stat: 0	Battlefield (No Uniform)	Cloaca-Cola helmet, Cloaca-Cola fatigues, Cloaca-Cola shield|Dyspepsi-Cola helmet, Dyspepsi-Cola fatigues, Dyspepsi-Cola shield|six-pack of New Cloaca-Cola
@@ -167,9 +167,9 @@ McLarge	adventure=176	DiffLevel: high Env: underground Stat: 0	The Mine Foremens
 McLarge	dwarffactory=0	DiffLevel: none Env: none Stat: 0	Dwarven Factory Warehouse
 McLarge	mining=1	DiffLevel: none Env: none Stat: 0	Itznotyerzitz Mine (in Disguise)
 
-Highlands	adventure=296	DiffLevel: unknown Env: outdoor Stat: 75	A-Boo Peak	3 A-Boo clue
+Highlands	adventure=296	DiffLevel: mid Env: outdoor Stat: 75	A-Boo Peak	3 A-Boo clue
 Highlands	adventure=297	DiffLevel: mid Env: outdoor Stat: 90	Twin Peak	1 gold wedding ring
-Highlands	adventure=298	DiffLevel: unknown Env: outdoor Stat: 85	Oil Peak	1 jar of oil|oil cap, oil lamp, oil slacks|oil cap, oil lamp, oil slacks, oily boid, oil pan
+Highlands	adventure=298	DiffLevel: mid Env: outdoor Stat: 85	Oil Peak	1 jar of oil|oil cap, oil lamp, oil slacks|oil cap, oil lamp, oil slacks, oily boid, oil pan
 
 The Red Zeppelin's Mooring	adventure=384	DiffLevel: high Env: outdoor Stat: 125	A Mob of Zeppelin Protesters
 The Red Zeppelin's Mooring	adventure=385	DiffLevel: high Env: indoor Stat: 150	The Red Zeppelin	1 Copperhead Charm (rampant)
@@ -193,7 +193,7 @@ Friars	adventure=539	DiffLevel: mid Env: outdoor Stat: 45	The Dark Elbow of the 
 Friars	friars=0	DiffLevel: none Env: none Stat: 0	Friar Ceremony Location
 Friars	adventure=438	DiffLevel: unknown Env: outdoor	Pandamonium
 
-Pandamonium	adventure=248	DiffLevel: unknown Env: outdoor Stat: 45	Pandamonium Slums	1 ruby W|3 hot wing|1 Hey Deze map|+1 SPF 451 lip balm|+5 figurine of a charred seal|heavy-duty bendy straw
+Pandamonium	adventure=248	DiffLevel: mid Env: outdoor Stat: 45	Pandamonium Slums	1 ruby W|3 hot wing|1 Hey Deze map|+1 SPF 451 lip balm|+5 figurine of a charred seal|heavy-duty bendy straw
 Pandamonium	adventure=242	DiffLevel: mid Env: indoor Stat: 60	The Laugh Floor	5 imp air|1 observational glasses
 Pandamonium	adventure=243	DiffLevel: mid Env: indoor Stat: 55	Infernal Rackets Backstage	5 bus pass
 
@@ -508,7 +508,7 @@ PastEvents	adventure=508	DiffLevel: unknown Env: outdoor nowander	A Monorail Sta
 
 Portal	adventure=164	DiffLevel: unknown Env: underground Stat: 365	El Vibrato Island
 
-Tunnel of L.O.V.E.	place=townwrong_tunnel	DiffLevel: unknown Env: indoor overdrunk	The Tunnel of L.O.V.E.
+Tunnel of L.O.V.E.	place=townwrong_tunnel	DiffLevel: none Env: indoor overdrunk	The Tunnel of L.O.V.E.
 Deep Machine Tunnels	adventure=458	DiffLevel: mid Env: underground Stat: 0	The Deep Machine Tunnels
 LT&T	adventure=474	DiffLevel: mid Env: outdoor Stat: 0	Investigating a Plaintive Telegram
 Neverending Party	adventure=528	DiffLevel: mid Env: indoor Stat: 0	The Neverending Party
@@ -533,8 +533,8 @@ Wormwood	adventure=151	DiffLevel: low Env: indoor Stat: 0	The Stately Pleasure D
 Wormwood	adventure=152	DiffLevel: low Env: indoor Stat: 0	The Mouldering Mansion	1 choiceadv
 Wormwood	adventure=153	DiffLevel: low Env: indoor Stat: 0	The Rogue Windmill	1 choiceadv
 
-Memories	adventure=204	DiffLevel: unknown Env: outdoor Stat: 20	The Primordial Soup
-Memories	adventure=205	DiffLevel: unknown Env: outdoor Stat: 55	The Jungles of Ancient Loathing
+Memories	adventure=204	DiffLevel: mid Env: outdoor Stat: 20	The Primordial Soup
+Memories	adventure=205	DiffLevel: mid Env: outdoor Stat: 55	The Jungles of Ancient Loathing
 Memories	adventure=206	DiffLevel: mid Env: indoor Stat: 150	Seaside Megalopolis
 
 Spaaace	adventure=265	DiffLevel: unknown Env: indoor Stat: 0	Domed City of Ronaldus	2 Map to Safety Shelter Ronald Prime|1 E.M.U. Unit
@@ -680,28 +680,28 @@ FantasyRealm	adventure=525	DiffLevel: unknown Env: outdoor Stat: 0 nowander	The 
 FantasyRealm	adventure=526	DiffLevel: unknown Env: outdoor Stat: 0 nowander	The Ghoul King's Catacomb
 FantasyRealm	adventure=527	DiffLevel: unknown Env: outdoor Stat: 0 nowander	The Ogre Chieftain's Keep
 
-PirateRealm	adventure=530	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Sailing the PirateRealm Seas
-PirateRealm	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	PirateRealm Island
+PirateRealm	adventure=530	DiffLevel: mid Env: outdoor Stat: 0 nowander	Sailing the PirateRealm Seas
+PirateRealm	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	PirateRealm Island
 
 # Every PirateRealm Island has the same adventure #.
 
 # First Island
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Battle Island
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Crab Island
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Glass Island
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Dessert Island
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Key Key
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Skull Island
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Battle Island
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Crab Island
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Glass Island
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Dessert Island
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Key Key
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Skull Island
 # Second Island
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Isla Gublar
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Cemetery Island
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Jungle Island
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Trash Island
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Prison Island
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Isla Gublar
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Cemetery Island
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Jungle Island
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Trash Island
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Prison Island
 # Third Island
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Signal Island
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Tiki Island
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Storm Island
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Red Roger's Fortress
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	Jack's Hideout
-PirateRealm Island	adventure=531	DiffLevel: unknown Env: outdoor Stat: 0 nowander	The Temple
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Signal Island
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Tiki Island
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Storm Island
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Red Roger's Fortress
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	Jack's Hideout
+PirateRealm Island	adventure=531	DiffLevel: mid Env: outdoor Stat: 0 nowander	The Temple


### PR DESCRIPTION
The PirateRealm Island shows up in KoL as "PirateRealm Island" but in Mafia as "The Temple" -- presumably it reads the last name.