### PR TITLE
fix: no visible delay in call script

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/menu/ScriptMRUList.java
+++ b/src/net/sourceforge/kolmafia/swingui/menu/ScriptMRUList.java
@@ -7,6 +7,7 @@ import java.util.LinkedList;
 import java.util.List;
 import javax.swing.JComboBox;
 import net.sourceforge.kolmafia.KoLmafiaCLI;
+import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.listener.Listener;
 import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -60,6 +61,24 @@ public class ScriptMRUList implements Listener {
 
   public void addItem(File file) {
     this.addItem(LoadScriptMenuItem.getRelativePath(file));
+  }
+
+  public void addItemInParallel(File file) {
+    RequestThread.runInParallel(new AddItemRunnable(this, file), true);
+  }
+
+  private class AddItemRunnable implements Runnable {
+    private final ScriptMRUList list;
+    private final File file;
+
+    public AddItemRunnable(ScriptMRUList list, File file) {
+      this.list = list;
+      this.file = file;
+    }
+    @Override
+    public void run() {
+      list.addItem(file);
+    }
   }
 
   public void addItem(String script) {

--- a/src/net/sourceforge/kolmafia/swingui/menu/ScriptMRUList.java
+++ b/src/net/sourceforge/kolmafia/swingui/menu/ScriptMRUList.java
@@ -75,6 +75,7 @@ public class ScriptMRUList implements Listener {
       this.list = list;
       this.file = file;
     }
+
     @Override
     public void run() {
       list.addItem(file);

--- a/src/net/sourceforge/kolmafia/textui/command/CallScriptCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/CallScriptCommand.java
@@ -125,7 +125,7 @@ public class CallScriptCommand extends AbstractCommand {
 
       // Got here so have valid script file name and not a directory.
 
-      KoLConstants.scriptMRUList.addItem(scriptFile);
+      KoLConstants.scriptMRUList.addItemInParallel(scriptFile);
 
       // Allow the ".ash" or ".js" to appear anywhere in the filename
       // in a case-insensitive manner.


### PR DESCRIPTION
Add items to the MRU List in parallel to avoid a pause before updating the GCLI after calling a script.

The `synchronized` keywords in this file can cause delays elsewhere, but this seemed the most obvious.