### PR TITLE
Extra-greasy sliders give 29-34 adventures.

### DIFF
--- a/src/data/fullness.txt
+++ b/src/data/fullness.txt
@@ -327,7 +327,7 @@ exotic jungle fruit	1	6	good	2-3	20-30	20-30	20-30	25 Full of Fruit, Yourself (-
 expired can of franks 'n' beans	3	1	awesome	7-10	20-40	20-40	20-40	30 Crimbo Nostalgia (+5 exp)
 expired MRE	2	1	awesome	8-10	0	0	0	gain 10 turns of 3 random positive effects
 extra-flat panini	2	11	awesome	7-8	0	0	50-80
-extra-greasy slider	5	13	EPIC	31-34	80-100	80-100	80-100	-5 spleen
+extra-greasy slider	5	13	EPIC	29-34	80-100	80-100	80-100	-5 spleen
 extra-toasted half sandwich	1	1	awesome	4-5	5-15	5-15	5-15	20 Stop the Presses! (Unimplemented)
 fancy beef jerky	4	9	EPIC	19-22	0	48-58	0
 fancy canap&eacute;s	2	5	awesome	7-10	25-40	25-40	25-40	French slippers (1 time)


### PR DESCRIPTION
After consulting years of my logs, I believe that the adventure range is wrong - I have seen examples of both 29 and 30 adventures in my logs, after accounting for consumption modifiers. Note that 29-34 is also the listed range for pickle juice, which I believe is correct.