### PR TITLE
DiffLevels for Cola Wars zones

### DIFF
--- a/src/data/adventures.txt
+++ b/src/data/adventures.txt
@@ -93,9 +93,9 @@ Menagerie	adventure=51	DiffLevel: mid Env: underground Stat: 35	Cobb's Knob Mena
 Menagerie	adventure=52	DiffLevel: mid Env: underground Stat: 40	Cobb's Knob Menagerie, Level 2	1 weremoose spit|+1 irradiated pet snacks
 Menagerie	adventure=53	DiffLevel: mid Env: underground Stat: 45	Cobb's Knob Menagerie, Level 3	1 abominable blubber
 
-Rift	adventure=85	DiffLevel: unknown Env: outdoor Stat: 0	Battlefield (No Uniform)	Cloaca-Cola helmet, Cloaca-Cola fatigues, Cloaca-Cola shield|Dyspepsi-Cola helmet, Dyspepsi-Cola fatigues, Dyspepsi-Cola shield|six-pack of New Cloaca-Cola
-Rift	adventure=86	DiffLevel: unknown Env: outdoor Stat: 30	Battlefield (Cloaca Uniform)
-Rift	adventure=87	DiffLevel: unknown Env: outdoor Stat: 30	Battlefield (Dyspepsi Uniform)
+Rift	adventure=85	DiffLevel: mid Env: outdoor Stat: 0	Battlefield (No Uniform)	Cloaca-Cola helmet, Cloaca-Cola fatigues, Cloaca-Cola shield|Dyspepsi-Cola helmet, Dyspepsi-Cola fatigues, Dyspepsi-Cola shield|six-pack of New Cloaca-Cola
+Rift	adventure=86	DiffLevel: mid Env: outdoor Stat: 30	Battlefield (Cloaca Uniform)
+Rift	adventure=87	DiffLevel: mid Env: outdoor Stat: 30	Battlefield (Dyspepsi Uniform)
 
 Fernswarthy's Tower	adventure=22	DiffLevel: low Env: outdoor Stat: 11	Tower Ruins	1 disembodied brain
 Fernswarthy's Tower	basement=0	DiffLevel: none Env: none Stat: 0	Fernswarthy's Basement


### PR DESCRIPTION
This was tricky. The Rift is only open for levels 4 and 5, and you have to have completed the first part of the Wizard of Ego quest to even get it. I timed my first two Autumn-aton tasks to pick up the two upgrades that grant an additional 11-turn mission, so that when I eventually did open the rift, I could get two 11-turn and one 22-turn mission while the Rift was still open.

I did the "No Uniform" zone first and got an Autumn Debris Shield - the mid-outdoor reward.
The Cloaca Uniform mission yielded an autumn leaf - the low-outdoor reward.
The Dyspepsi Uniform missionn gave a autumn years wisdom - the high-underground reward.

I believe both of those had to also be mid-outdoor zones, but since the equipment had already been granted, it was replaced with a consumable item.