### PR TITLE
Mark RecordType.get(names) param as readonly

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/TypescriptDefinition.java
+++ b/src/net/sourceforge/kolmafia/textui/TypescriptDefinition.java
@@ -151,7 +151,7 @@ public class TypescriptDefinition {
             "    static get%s(name: %s): %s;",
             isAbstract ? "<T extends MafiaClass>" : "", argType, isAbstract ? "T" : type),
         String.format(
-            "    static get%s(names: %s[]): %s[];",
+            "    static get%s(names: readonly %s[]): %s[];",
             isAbstract ? "<T extends MafiaClass>" : "", argType, isAbstract ? "T" : type),
         String.format(
             "    static all<T %s>(): T[];", isAbstract ? "extends MafiaClass" : "= " + type),


### PR DESCRIPTION
This lets the compiler know that the input array is not modified by the function. This is helpful when you have a const array of item names that you want to lookup:

```ts

const GIFT_PACKAGES = [
  'plain brown wrapper',
  'less-than-three-shaped box',
  'exactly-three-shaped box',
  'chocolate box',
  'miniature coffin',
  'solid asbestos box',
  'solid linoleum box',
  'solid chrome box',
  'cryptic puzzle box',
  'refrigerated biohazard container',
  'magnetic field',
  'black velvet box'
] as const;

const items = Item.get(GIFT_PACKAGES); // does not work without this change
```