### PR TITLE
Use HashMap over TreeMap in ConsumablesDatabase.

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/ConsumablesDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConsumablesDatabase.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.AdventureResult;
@@ -25,6 +24,7 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.UseSkillRequest;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import net.sourceforge.kolmafia.session.InventoryManager;
+import net.sourceforge.kolmafia.utilities.CaseInsensitiveHashMap;
 import net.sourceforge.kolmafia.utilities.FileUtilities;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
@@ -40,12 +40,9 @@ public class ConsumablesDatabase {
   public static final AdventureResult REFINED_PALATE = EffectPool.get(EffectPool.REFINED_PALATE);
 
   private static final Map<String, Integer> levelReqByName = new HashMap<String, Integer>();
-  public static final Map<String, Integer> fullnessByName =
-      new TreeMap<String, Integer>(KoLConstants.ignoreCaseComparator);
-  public static final Map<String, Integer> inebrietyByName =
-      new TreeMap<String, Integer>(KoLConstants.ignoreCaseComparator);
-  public static final Map<String, Integer> spleenHitByName =
-      new TreeMap<String, Integer>(KoLConstants.ignoreCaseComparator);
+  public static final Map<String, Integer> fullnessByName = new CaseInsensitiveHashMap<>();
+  public static final Map<String, Integer> inebrietyByName = new CaseInsensitiveHashMap<>();
+  public static final Map<String, Integer> spleenHitByName = new CaseInsensitiveHashMap<>();
   private static final Map<String, ConsumableQuality> qualityByName = new HashMap<>();
   private static final Map<String, String> notesByName = new HashMap<String, String>();
 

--- a/src/net/sourceforge/kolmafia/utilities/CaseInsensitiveHashMap.java
+++ b/src/net/sourceforge/kolmafia/utilities/CaseInsensitiveHashMap.java
@@ -1,0 +1,77 @@
+package net.sourceforge.kolmafia.utilities;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class CaseInsensitiveHashMap<V> extends HashMap<String, V> {
+  public CaseInsensitiveHashMap() {
+    super();
+  }
+
+  CaseInsensitiveHashMap(int initialCapacity) {
+    super(initialCapacity);
+  }
+
+  CaseInsensitiveHashMap(int initialCapacity, float loadFactor) {
+    super(initialCapacity, loadFactor);
+  }
+
+  CaseInsensitiveHashMap(Map<? extends String, ? extends V> m) {
+    super();
+    putAll(m);
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return super.containsKey(key instanceof String ? ((String) key).toLowerCase() : key);
+  }
+
+  @Override
+  public V get(Object key) {
+    return super.get(key instanceof String ? ((String) key).toLowerCase() : key);
+  }
+
+  @Override
+  public V put(String key, V value) {
+    return super.put(key.toLowerCase(), value);
+  }
+
+  @Override
+  public void putAll(Map<? extends String, ? extends V> m) {
+    super.putAll(
+        m.entrySet().stream()
+            .collect(Collectors.toMap(entry -> entry.getKey().toLowerCase(), Map.Entry::getValue)));
+  }
+
+  @Override
+  public V remove(Object key) {
+    return super.remove(key instanceof String ? ((String) key).toLowerCase() : key);
+  }
+
+  @Override
+  public V merge(
+      String key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+    return super.merge(key.toLowerCase(), value, remappingFunction);
+  }
+
+  @Override
+  public V compute(
+      String key, BiFunction<? super String, ? super V, ? extends V> remappingFunction) {
+    return super.compute(key.toLowerCase(), (k, v) -> remappingFunction.apply(k.toLowerCase(), v));
+  }
+
+  @Override
+  public V computeIfAbsent(String key, Function<? super String, ? extends V> mappingFunction) {
+    return super.computeIfAbsent(key.toLowerCase(), (k) -> mappingFunction.apply(k.toLowerCase()));
+  }
+
+  @Override
+  public V computeIfPresent(
+      String key, BiFunction<? super String, ? super V, ? extends V> remappingFunction) {
+    return super.computeIfPresent(
+        key.toLowerCase(), (k, v) -> remappingFunction.apply(k.toLowerCase(), v));
+  }
+}

--- a/test/net/sourceforge/kolmafia/utilities/CaseInsensitiveHashMapTest.java
+++ b/test/net/sourceforge/kolmafia/utilities/CaseInsensitiveHashMapTest.java
@@ -1,0 +1,133 @@
+package net.sourceforge.kolmafia.utilities;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class CaseInsensitiveHashMapTest {
+  @Test
+  public void construct() {
+    var map = new CaseInsensitiveHashMap<>(Map.of("A", 0, "b", 0));
+
+    assertThat(map.size(), equalTo(2));
+    assertThat(map.keySet(), contains("a", "b"));
+  }
+
+  @Test
+  public void containsKey() {
+    var map = new CaseInsensitiveHashMap<>(Map.of("A", 0, "b", 0));
+
+    assertThat(map.size(), equalTo(2));
+    assertThat(map.containsKey("A"), is(true));
+    assertThat(map.containsKey("a"), is(true));
+    assertThat(map.containsKey("B"), is(true));
+    assertThat(map.containsKey("b"), is(true));
+    assertThat(map.containsKey("c"), is(false));
+  }
+
+  @Test
+  public void get() {
+    var map = new CaseInsensitiveHashMap<>(Map.of("A", 0, "b", 1));
+
+    assertThat(map.size(), equalTo(2));
+    assertThat(map.get("A"), equalTo(0));
+    assertThat(map.get("a"), equalTo(0));
+    assertThat(map.get("B"), equalTo(1));
+    assertThat(map.get("b"), equalTo(1));
+    assertThat(map.get("c"), nullValue());
+  }
+
+  @Test
+  public void put() {
+    var map = new CaseInsensitiveHashMap<>(Map.of("A", 0));
+    map.put("a", 1);
+    map.put("B", 2);
+
+    assertThat(map.size(), equalTo(2));
+    assertThat(map.get("A"), equalTo(1));
+    assertThat(map.get("a"), equalTo(1));
+    assertThat(map.get("B"), equalTo(2));
+    assertThat(map.get("b"), equalTo(2));
+    assertThat(map.get("c"), nullValue());
+  }
+
+  @Test
+  public void putAll() {
+    var map = new CaseInsensitiveHashMap<>(Map.of("A", 0));
+    map.putAll(Map.of("a", 1, "B", 2));
+
+    assertThat(map.size(), equalTo(2));
+    assertThat(map.get("A"), equalTo(1));
+    assertThat(map.get("a"), equalTo(1));
+    assertThat(map.get("B"), equalTo(2));
+    assertThat(map.get("b"), equalTo(2));
+    assertThat(map.get("c"), nullValue());
+  }
+
+  @Test
+  public void remove() {
+    var map = new CaseInsensitiveHashMap<>(Map.of("A", 0, "b", 0));
+    map.remove("B");
+
+    assertThat(map.size(), equalTo(1));
+    assertThat(map.get("A"), equalTo(0));
+    assertThat(map.get("a"), equalTo(0));
+    assertThat(map.get("b"), nullValue());
+  }
+
+  @Test
+  public void merge() {
+    var map = new CaseInsensitiveHashMap<>(Map.of("A", 1));
+    map.merge("a", 1, (existingValue, newValue) -> existingValue + newValue);
+    map.merge("b", 1, (existingValue, newValue) -> existingValue + newValue);
+
+    assertThat(map.size(), equalTo(2));
+    assertThat(map.get("A"), equalTo(2));
+    assertThat(map.get("a"), equalTo(2));
+    assertThat(map.get("B"), equalTo(1));
+    assertThat(map.get("b"), equalTo(1));
+    assertThat(map.get("c"), nullValue());
+  }
+
+  @Test
+  public void compute() {
+    var map = new CaseInsensitiveHashMap<>(Map.of("A", 1));
+    map.compute("a", (key, existing) -> existing == null ? 0 : 1 + existing);
+    map.compute("b", (key, existing) -> existing == null ? 0 : 1 + existing);
+
+    assertThat(map.size(), equalTo(2));
+    assertThat(map.get("A"), equalTo(2));
+    assertThat(map.get("a"), equalTo(2));
+    assertThat(map.get("B"), equalTo(0));
+    assertThat(map.get("b"), equalTo(0));
+    assertThat(map.get("c"), nullValue());
+  }
+
+  @Test
+  public void computeIfAbsent() {
+    var map = new CaseInsensitiveHashMap<>(Map.of("A", 1));
+    map.computeIfAbsent("a", (key) -> 2);
+    map.computeIfAbsent("b", (key) -> 2);
+
+    assertThat(map.size(), equalTo(2));
+    assertThat(map.get("A"), equalTo(1));
+    assertThat(map.get("a"), equalTo(1));
+    assertThat(map.get("B"), equalTo(2));
+    assertThat(map.get("b"), equalTo(2));
+    assertThat(map.get("c"), nullValue());
+  }
+
+  @Test
+  public void computeIfPresent() {
+    var map = new CaseInsensitiveHashMap<>(Map.of("A", 1));
+    map.computeIfPresent("a", (key, existing) -> 1 + existing);
+    map.computeIfPresent("b", (key, existing) -> 1 + existing);
+
+    assertThat(map.size(), equalTo(1));
+    assertThat(map.get("A"), equalTo(2));
+    assertThat(map.get("a"), equalTo(2));
+    assertThat(map.get("b"), nullValue());
+  }
+}


### PR DESCRIPTION
This commit adds a CaseInsensitiveHashMap class and test, and then uses them to replace the TreeMaps in ConsumablesDatabase. These are performance-critical maps as they are read from a few thousand times during every concoction database refresh. They are modified rarely and don't grow in size essentially ever.

In the following speed test, this change caused a roughly 40% decrease in execution time for `getAdventureRange`, a function which takes up high single digits of execution time in my profiling tests.

```java
    for (int i = 0; i < 500; i++) {
      for (var entry : ItemDatabase.entrySet()) {
        ConsumablesDatabase.getAdventureRange(entry.getValue());
      }
    }
```