### PR TITLE
Fix appearance_rates for jungles of ancient loathing & seaside megapolis

### DIFF
--- a/src/net/sourceforge/kolmafia/AreaCombatData.java
+++ b/src/net/sourceforge/kolmafia/AreaCombatData.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 import net.sourceforge.kolmafia.KoLConstants.Stat;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase.Environment;
 import net.sourceforge.kolmafia.persistence.AdventureQueueDatabase;
@@ -27,6 +28,7 @@ import net.sourceforge.kolmafia.session.CrystalBallManager;
 import net.sourceforge.kolmafia.session.EncounterManager;
 import net.sourceforge.kolmafia.session.EncounterManager.EncounterType;
 import net.sourceforge.kolmafia.session.EquipmentManager;
+import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.session.TurnCounter;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
@@ -1717,6 +1719,22 @@ public class AreaCombatData {
           return (monster.equals(Preferences.getString("glacierOfJerksBoss"))) ? 1 : 0;
         }
         break;
+      case "The Jungles of Ancient Loathing":
+        if (monster.equals("evil cultist")) {
+          return QuestDatabase.isQuestFinished(Quest.PRIMORDIAL) ? 1 : 0;
+        }
+        break;
+      case "Seaside Megalopolis":
+        switch (monster) {
+          case "cyborg policeman":
+            return (InventoryManager.hasItem(ItemPool.MULTI_PASS)
+                    && !QuestDatabase.isQuestFinished(Quest.FUTURE))
+                ? 1
+                : 0;
+          case "obese tourist":
+          case "terrifying robot":
+            return QuestDatabase.isQuestLaterThan(Quest.FUTURE, "step1") ? 1 : 0;
+        }
     }
     return weighting;
   }

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -1235,6 +1235,7 @@ public class ItemPool {
   public static final int ESSENCE_OF_FRIGHT = 4071;
   public static final int ESSENCE_OF_CUTE = 4072;
   public static final int SUPREME_BEING_GLOSSARY = 4073;
+  public static final int MULTI_PASS = 4074;
   public static final int GRISLY_SHIELD = 4080;
   public static final int CYBER_MATTOCK = 4086;
   public static final int GREEN_PEAWEE_MARBLE = 4095;

--- a/src/net/sourceforge/kolmafia/persistence/QuestDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/QuestDatabase.java
@@ -75,6 +75,7 @@ public class QuestDatabase {
     DOC("questM24Doc"),
     ARMORER("questM25Armorer"),
     PRIMORDIAL("questF01Primordial"),
+    FUTURE("questF03Future"),
     GENERATOR("questF04Elves"),
     CLANCY("questF05Clancy"),
     SEA_OLD_GUY("questS01OldGuy"),

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -721,6 +721,27 @@ public abstract class ChoiceControl {
 
         if (text.contains("Homina-homina")) {
           ResultProcessor.processResult(ItemPool.get(ItemPool.SUPREME_BEING_GLOSSARY, -1));
+          QuestDatabase.setQuestProgress(Quest.FUTURE, "step1");
+        }
+        break;
+
+      case 390:
+        // Choice 390 is A Winning Pass
+
+        // "Um, okay," you say, and stomp off to kill some more time.
+
+        if (text.contains("to kill some more time")) {
+          QuestDatabase.setQuestProgress(Quest.FUTURE, "step2");
+        }
+        break;
+
+      case 391:
+        // Choice 391 is OMG KAWAIII
+
+        // "Damn it!" you say, and chase after her.
+
+        if (text.contains("and chase after her")) {
+          QuestDatabase.setQuestProgress(Quest.FUTURE, "step3");
         }
         break;
 
@@ -741,6 +762,7 @@ public abstract class ChoiceControl {
           ResultProcessor.processResult(ItemPool.get(ItemPool.ESSENCE_OF_FRIGHT, -1));
           ResultProcessor.processResult(ItemPool.get(ItemPool.ESSENCE_OF_CUTE, -1));
           ResultProcessor.processResult(ItemPool.get(ItemPool.SECRET_FROM_THE_FUTURE, 1));
+          QuestDatabase.setQuestProgress(Quest.FUTURE, QuestDatabase.FINISHED);
         }
         break;
 


### PR DESCRIPTION
I don't have the page html to write tests for the quest progress but I wrote tests for the encounter rates.