### PR TITLE
update repo and installed scripts from ScriptManageFrame, not ScriptManager

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/ScriptManager.java
+++ b/src/net/sourceforge/kolmafia/persistence/ScriptManager.java
@@ -87,11 +87,6 @@ public class ScriptManager {
       // this will change
       "https://raw.githubusercontent.com/kolmafia/kolmafia/main/data/SVN/svnrepo.json";
 
-  static {
-    ScriptManager.updateRepoScripts(false);
-    ScriptManager.updateInstalledScripts();
-  }
-
   public static void updateRepoScripts(boolean force) {
     File repoFile = KoLConstants.SVN_REPO_FILE;
     if (force || !repoFile.exists() || !Preferences.getBoolean("_svnRepoFileFetched")) {

--- a/src/net/sourceforge/kolmafia/swingui/ScriptManageFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/ScriptManageFrame.java
@@ -30,6 +30,12 @@ import org.jdesktop.swingx.JXTable;
 import org.jdesktop.swingx.decorator.HighlighterFactory;
 
 public class ScriptManageFrame extends GenericPanelFrame {
+
+  static {
+    ScriptManager.updateRepoScripts(false);
+    ScriptManager.updateInstalledScripts();
+  }
+
   private class ScriptManageTable extends ShowDescriptionTable<Script> {
     public ScriptManageTable() {
       super(ScriptManager.getInstalledScripts(), 4, 4);


### PR DESCRIPTION
A GUI element can have ScriptManager.getRepoScripts() or ScriptManager.getInstalledScripts() as its model.
As it turns out, the only frame that has such elements is ScriptManageFrame.

GUI tables have column headings and the names depend on the data type in the table.
If your table wraps one of the above models, TableCellFactory gets the column names from ScriptManager.

However, other GUI elements - in particular CreateSpecialPanel in the Inventory Manager - have a "not yet implemented" model, so TableCellFactory runs through all the globally known models before figuring that out.

The issue is that the above named Script models are initialized just fine via new LockableListModel<Script>(), but ScriptManager wants to load them up as part of class initialization.

Literally the only Frame that uses those models is ScriptManageFrame.

Therefore, I moved the model initialization out of ScriptManager and into ScriptManageFrame.

InventoryMangeFrame opens up immediately now.
ScriptManageFrame takes a long time. Which is OK, since you are opening the only frame which needs those models.