### PR TITLE
feat(relay): allow to specify the relay port

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1257,6 +1257,7 @@ user	recoveryScript
 user	redSnapperPhylum
 user	redSnapperProgress	0
 user	relayCounters
+user	relayPort	0
 user	relayShowSpoilers	false
 user	relayShowWarnings	true
 user	relocatePygmyJanitor	-1

--- a/src/net/sourceforge/kolmafia/webui/RelayServer.java
+++ b/src/net/sourceforge/kolmafia/webui/RelayServer.java
@@ -96,18 +96,34 @@ public class RelayServer implements Runnable {
   @Override
   public void run() {
     boolean startedSuccessfully = true;
-    Integer minPort = 60080;
-    Integer maxPort = minPort + 10;
-    RelayServer.port = minPort;
-    while (!this.openServerSocket()) {
-      if (RelayServer.port < maxPort) {
-        ++RelayServer.port;
-      } else {
+
+    int relayPort = Preferences.getInteger("relayPort");
+    if (relayPort != 0) {
+      RelayServer.port = relayPort;
+      if (!this.openServerSocket()) {
         KoLmafia.updateDisplay(
             KoLConstants.MafiaState.ERROR,
-            "Failed to find free port in range " + minPort + " to " + maxPort + ".");
+            "Port " + relayPort + " which is set as relayPort is already in use.");
         startedSuccessfully = false;
-        break;
+      }
+    } else {
+      int minPort = 60080;
+      int maxPort = minPort + 10;
+      RelayServer.port = minPort;
+      while (!this.openServerSocket()) {
+        if (RelayServer.port < maxPort) {
+          ++RelayServer.port;
+        } else {
+          KoLmafia.updateDisplay(
+              KoLConstants.MafiaState.ERROR,
+              "Failed to find free port in range "
+                  + minPort
+                  + " to "
+                  + maxPort
+                  + ". You can set 'relayPort' preference to choose a different port.");
+          startedSuccessfully = false;
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
Allow to specify a specific relay port for a user.

I want my characters to always be reachable under the same port, regardless of which order I start them in. Also for this reason, when a relayPort is explicitly specified in preferences, there will be no checking for other free ports, only the one will be tried.