### PR TITLE
Unusable permed skills

### DIFF
--- a/src/net/sourceforge/kolmafia/request/CharSheetRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CharSheetRequest.java
@@ -388,6 +388,15 @@ public class CharSheetRequest extends GenericRequest {
     CharSheetRequest.parseAvatar(responseText);
   }
 
+  public static List<ParsedSkillInfo> parseSkills(final String responseText) {
+    try {
+      return parseSkills(domSerializer.createDOM(cleaner.clean(responseText)));
+    } catch (ParserConfigurationException e) {
+      e.printStackTrace();
+      return new ArrayList<ParsedSkillInfo>();
+    }
+  }
+
   private static final Pattern AVATAR_PATTERN =
       Pattern.compile(
           "<img src=[^>]*?(?:cloudfront.net|images.kingdomofloathing.com|/images)/([^>'\"\\s]+)");

--- a/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
@@ -911,7 +911,7 @@ public class TestCommand extends AbstractCommand {
     if (command.equals("charsheet-skills")) {
       var skills = CharSheetRequest.parseSkills(TestCommand.contents);
       for (var skill : skills) {
-	      RequestLogger.printLine(skill.toString());
+        RequestLogger.printLine(skill.toString());
       }
       TestCommand.contents = null;
       return;

--- a/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
@@ -48,6 +48,7 @@ import net.sourceforge.kolmafia.request.CampAwayRequest;
 import net.sourceforge.kolmafia.request.CampgroundRequest;
 import net.sourceforge.kolmafia.request.CargoCultistShortsRequest;
 import net.sourceforge.kolmafia.request.CharPaneRequest;
+import net.sourceforge.kolmafia.request.CharSheetRequest;
 import net.sourceforge.kolmafia.request.ClanLoungeRequest;
 import net.sourceforge.kolmafia.request.CreateItemRequest;
 import net.sourceforge.kolmafia.request.DeckOfEveryCardRequest;
@@ -903,6 +904,15 @@ public class TestCommand extends AbstractCommand {
 
     if (command.equals("charpane")) {
       CharPaneRequest.processResults(TestCommand.contents);
+      TestCommand.contents = null;
+      return;
+    }
+
+    if (command.equals("charsheet-skills")) {
+      var skills = CharSheetRequest.parseSkills(TestCommand.contents);
+      for (var skill : skills) {
+	      RequestLogger.printLine(skill.toString());
+      }
       TestCommand.contents = null;
       return;
     }

--- a/test/root/request/test_charsheet_unusable_permed_skills.html
+++ b/test/root/request/test_charsheet_unusable_permed_skills.html
@@ -1,0 +1,153 @@
+<html><head>
+<script language=Javascript>
+<!--
+if (parent.frames.length == 0) location.href="game.php";
+//-->
+</script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/keybinds.min.2.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/window.20111231.js"></script>
+<script language="javascript">function chatFocus(){if(top.chatpane.document.chatform.graf) top.chatpane.document.chatform.graf.focus();}
+if (typeof defaultBind != 'undefined') { defaultBind(47, 2, chatFocus); defaultBind(190, 2, chatFocus);defaultBind(191, 2, chatFocus); defaultBind(47, 8, chatFocus);defaultBind(190, 8, chatFocus); defaultBind(191, 8, chatFocus); }</script><script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/core.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/jquery-1.3.1.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://d2uyhvukfffg5a.cloudfront.net/styles.20151006.css">
+<style type='text/css'>
+.faded {
+zoom: 1;
+filter: alpha(opacity=35);
+opacity: 0.35;
+-khtml-opacity: 0.35;
+-moz-opacity: 0.35;
+}
+</style>
+
+</head>
+
+<body>
+<centeR><table width=95% cellspacing=0 cellpadding=0><tr><td style="color: white;" align=center bgcolor=blue><b>Svelte Velvet</b></td></tr><tr><td style="padding: 5px; border: 1px solid blue;"><center><table><tr><td><center><a href=account_avatar.php><div style='position: relative; width: 60px; height: 100px;'><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/peteavatar_f.gif" width=60 height=100 alt="An Adventurer is You!" title="An Adventurer is You!" border=0></div></a><center><b><a class=nounder href="showplayer.php?who=3561844">Svelte Velvet</a></b> (#3561844)<br>Level 16<br> Avatar of Sneaky Pete<p><b>Statistics:</b><br><table><tr><td colspan=2 height=1 bgcolor=black></td></tr><tr><td align=right>Current Hit Points:</td><td align=left><b>181</b></td></tr><tr><td align=right>Maximum Hit Points:</td><td align=left><b>330</b></td></tr><tr><td colspan=2 height=1 bgcolor=black></td></tr><tr><td align=right>Current Mojo Points:</td><td align=left><b>312</b></td></tr><tr><td align=right>Maximum Mojo Points:</td><td align=left><b>473</b></td></tr><tr><td colspan=2 height=1 bgcolor=black></td></tr><tr><td align=right>Muscle:</td><td><table><tr><td><b>268</b> (base: 183)</td><td valign=center><table cellpadding=0 cellspacing=0 style="border: 1px solid black"><tr><td height=10 width=12 bgcolor=black></td><td width=88 bgcolor=white></td></tr></table></td><td valign=center><font size=2>(<b>45</b>/<b>367</b>)</font></td></tr></table><tr><td align=right>Mysticality:</td><td><table><tr><td><b>275</b> (base: 207)</td><td valign=center><table cellpadding=0 cellspacing=0 style="border: 1px solid black"><tr><td height=10 width=38 bgcolor=black></td><td width=62 bgcolor=white></td></tr></table></td><td valign=center><font size=2>(<b>160</b>/<b>415</b>)</font></td></tr></table><tr><td align=right>Moxie:</td><td><table><tr><td><b>407</b> (base: 258)</td><td valign=center><table cellpadding=0 cellspacing=0 style="border: 1px solid black"><tr><td height=10 width=77 bgcolor=black></td><td width=23 bgcolor=white></td></tr></table></td><td valign=center><font size=2>(<b>403</b>/<b>517</b>)</font></td></tr></table><tr><td align=right>Hot Protection:</td><td><b>High (5)</b></td></tr><tr><td align=right>Cold Protection:</td><td><b>Low (2)</b></td></tr><tr><td align=right>Stench Protection:</td><td><b>Low (2)</b></td></tr><tr><td align=right>Fullness:</td><td><b>5</b></td></tr><tr><td align=right>Drunkenness:</td><td><b>39</b> (falling-down drunk)</td></tr><tr><td align=right>Adventures remaining:</td><td><b>53</b></td></tr><tr><td align=right>Meat:</td><td><b>39,427,708</b></td></tr><tr><td align=right><a class=nounder href="showconsumption.php">Favorite Food:</a></td><td><b>bar of freeze-dried water</b></td></tr><tr><td align=right><a class=nounder href="showconsumption.php#booze">Favorite Booze:</a></td><td><b>perfect negroni</b></td></tr><tr><td colspan=2 height=1 bgcolor=black></tr><tr><td align=right>Account Created:</td><td><b>May 27, 2022</b></td></tr><tr><td align=right><a class=nounder href="ascensionhistory.php?back=self&who=3561844">Ascensions:</a></td><td><b>10</b></td></tr><tr><td align=right>Turns Played (total):</td><td><b>53,576</b></td></tr><tr><td align=right>Days Played (total):</td><td><b>154</b></td></tr><tr><td align=right>Turns Played (this run):</td><td><b>41,639</b></td></tr><tr><td align=right>Days Played (this run):</td><td><b>96</b></td></tr><tr><td align=right>Sign:</td><td><b>The Vole</b></td></tr><tr><td align=right>Path:</td><td><b>Avatar of Sneaky Pete</b></td></tr><tr><td align=center colspan=2 class=small></td></tr><tr><td colspan=2 height=1 bgcolor=black></tr></table><p><b>Advancement:</b><br><table><tr><td height=1 bgcolor=black></td></tr><tr><td align=center>You must gain 2 Moxie to advance to level 17.</td></tr><tr><td height=1 bgcolor=black></td></tr></table><p><center><b>Equipment:</b></center><table><tr><td colspan=2 height=1 bgcolor=black></td></tr><tr><td width=30 height=30><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/gmushhat.gif" class=hand onClick='descitem(497619114)'></td><td valign=center><b>mushroom cap</b></td></tr><tr><td width=30 height=30><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/fpmcape.gif" class=hand onClick='descitem(876629337)'></td><td valign=center><b>burning cape</b></td></tr><tr><td width=30 height=30><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/shooshirt.gif" class=hand onClick='descitem(977886142)'></td><td valign=center><b>shoe ad T-shirt</b></td></tr><tr><td width=30 height=30><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/piratecutlass.gif" class=hand onClick='descitem(150533329)'></td><td valign=center><b>cursed pirate cutlass</b></td></tr><tr><td width=30 height=30><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/lavalamp.gif" class=hand onClick='descitem(699716715)'></td><td valign=center><b>green LavaCo Lamp&trade;</b></td></tr><tr><td width=30 height=30><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/atpants.gif" class=hand onClick='descitem(310929511)'></td><td valign=center><b>ratskin pajama pants</b></td></tr><tr><td width=30 height=30><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/fudgecycle.gif" class=hand onClick='descitem(836737182)'></td><td valign=center><b>fudgecycle</b></td></tr><tr><td width=30 height=30><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/gingerbeard.gif" class=hand onClick='descitem(484162042)'></td><td valign=center><b>gingerbeard</b></td></tr><tr><td width=30 height=30><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/weddingring.gif" class=hand onClick='descitem(485357896)'></td><td valign=center><b>ticksilver ring</b></td></tr><tr><td colspan=2 height=1 bgcolor=black></td></tr></table><centeR><p><table><tr><td height=1 bgcolor=black></td></tr><tr><td>You own a <b><A class=nounder href="managestore.php">Store</a></b> in the Mall of Loathing</td></tr><tr><td height=1 bgcolor=black></td></tr></table><center><p><b>Effects:</b><br></center><center><table><tr><td colspan=2 height=1 bgcolor=black></td></tr><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/odetobooze.gif" width=30 height=30 border=0 class=hand onClick='eff("626c8ef76cfc003c6ac2e65e9af5fd7a")'></td><td valign=center>Ode to Booze (20) <font size=1>[<A href="charsheet.php?pwd=####&action=unbuff&whichbuff=71">shrug off</a>]</font><br></td></tr><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/sleightshroom.gif" width=30 height=30 border=0 class=hand onClick='eff("fb4176165c054ea0a34ecfa6d6a03558")'></td><td valign=center>Truffle Tango (2579)<br></td></tr><tr><td colspan=2 height=1 bgcolor=black></td></tr></table><b><p>Skills:</b><br><font size=1>(click the skill name for a description)</font><br><table><tr><td height=1 bgcolor=black></td></tr><tr><td>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1&self=true","skill", 350, 300)'>Liver of Steel</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15&self=true","skill", 350, 300)'>CLEESH</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1003&self=true","skill", 350, 300)'>Thrust-Smack</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1005&self=true","skill", 350, 300)'>Lunging Thrust-Smack</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1007&self=true","skill", 350, 300)'>Blubber Up</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1008&self=true","skill", 350, 300)'>Fortitude of the Muskox</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1010&self=true","skill", 350, 300)'>Tongue of the Walrus</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1012&self=true","skill", 350, 300)'>Claws of the Walrus</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1016&self=true","skill", 350, 300)'>Pulverize</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1018&self=true","skill", 350, 300)'>Northern Exposure</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1027&self=true","skill", 350, 300)'>Hibernate</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1030&self=true","skill", 350, 300)'>Buoyancy of the Beluga</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1032&self=true","skill", 350, 300)'>Furious Wallop</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1033&self=true","skill", 350, 300)'>Club Foot</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1037&self=true","skill", 350, 300)'>Cavalcade of Fury</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1038&self=true","skill", 350, 300)'>Northern Explosion</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=1039&self=true","skill", 350, 300)'>Precision of the Penguin</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=2005&self=true","skill", 350, 300)'>Shieldbutt</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=2006&self=true","skill", 350, 300)'>Armorcraftiness</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=2007&self=true","skill", 350, 300)'>Ghostly Shell</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=2010&self=true","skill", 350, 300)'>Tenacity of the Snapper</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=2012&self=true","skill", 350, 300)'>Astral Shell</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=2014&self=true","skill", 350, 300)'>Amphibian Sympathy</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=2015&self=true","skill", 350, 300)'>Kneebutt</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=2020&self=true","skill", 350, 300)'>Hero of the Half-Shell</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=2027&self=true","skill", 350, 300)'>Spirit Vacation</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=2035&self=true","skill", 350, 300)'>Testudinal Teachings</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=2036&self=true","skill", 350, 300)'>Pizza Lover</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=2037&self=true","skill", 350, 300)'>Blessing of the Storm Tortoise</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=2038&self=true","skill", 350, 300)'>The Long View</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=2039&self=true","skill", 350, 300)'>Spirit Boon</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=2040&self=true","skill", 350, 300)'>Patient Smile</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3006&self=true","skill", 350, 300)'>Pastamastery</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3007&self=true","skill", 350, 300)'>Stuffed Mortar Shell</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3008&self=true","skill", 350, 300)'>Weapon of the Pastalord</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3009&self=true","skill", 350, 300)'>Lasagna Bandages</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3011&self=true","skill", 350, 300)'>Spirit of Rigatoni</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3012&self=true","skill", 350, 300)'>Cannelloni Cocoon</a> (P)<br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3015&self=true","skill", 350, 300)'>Springy Fusilli</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3016&self=true","skill", 350, 300)'>Tolerance of the Kitchen</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3025&self=true","skill", 350, 300)'>Utensil Twist</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3026&self=true","skill", 350, 300)'>Transcendent Al Dente</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3027&self=true","skill", 350, 300)'>Bind Vampieroghi</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3028&self=true","skill", 350, 300)'>Arched Eyebrow of the Archmage</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3029&self=true","skill", 350, 300)'>Bind Vermincelli</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3031&self=true","skill", 350, 300)'>Bind Angel Hair Wisp</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3032&self=true","skill", 350, 300)'>Shield of the Pastalord</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3033&self=true","skill", 350, 300)'>Bind Undead Elbow Macaroni</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3034&self=true","skill", 350, 300)'>Thrall Unit Tactics</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3037&self=true","skill", 350, 300)'>Bind Lasagmbie</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=3039&self=true","skill", 350, 300)'>Bind Spice Ghost</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=4003&self=true","skill", 350, 300)'>Stream of Sauce</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=4005&self=true","skill", 350, 300)'>Saucestorm</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=4009&self=true","skill", 350, 300)'>Wave of Sauce</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=4012&self=true","skill", 350, 300)'>Saucegeyser</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=4014&self=true","skill", 350, 300)'>Saucy Salve</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=4016&self=true","skill", 350, 300)'>Diminished Gag Reflex</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=4017&self=true","skill", 350, 300)'>Irrepressible Spunk</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=4024&self=true","skill", 350, 300)'>Curse of Vichyssoise</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=4027&self=true","skill", 350, 300)'>Soul Saucery</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=4032&self=true","skill", 350, 300)'>Saucecicle</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=4034&self=true","skill", 350, 300)'>Curse of Weaksauce</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=4039&self=true","skill", 350, 300)'>Saucemaven</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5003&self=true","skill", 350, 300)'>Disco Eye-Poke</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5004&self=true","skill", 350, 300)'>Nimble Fingers</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5005&self=true","skill", 350, 300)'>Disco Dance of Doom</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5006&self=true","skill", 350, 300)'>Mad Looting Skillz</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5007&self=true","skill", 350, 300)'>Disco Nap</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5009&self=true","skill", 350, 300)'>Disco Fever</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5010&self=true","skill", 350, 300)'>Overdeveloped Sense of Self Preservation</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5011&self=true","skill", 350, 300)'>Adventurer of Leisure</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5012&self=true","skill", 350, 300)'>Disco Face Stab</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5015&self=true","skill", 350, 300)'>Ambidextrous Funkslinging</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5017&self=true","skill", 350, 300)'>Smooth Movement</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5028&self=true","skill", 350, 300)'>That's Not a Knife</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5030&self=true","skill", 350, 300)'>Flashy Dancer</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5033&self=true","skill", 350, 300)'>Knife in the Dark</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5034&self=true","skill", 350, 300)'>Disco Bravado</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5035&self=true","skill", 350, 300)'>Disco Shank</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5036&self=true","skill", 350, 300)'>Disco Dance 3: Back in the Habit</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5037&self=true","skill", 350, 300)'>Disco Inferno</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5039&self=true","skill", 350, 300)'>Disco Leer</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=6004&self=true","skill", 350, 300)'>The Moxious Madrigal</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=6008&self=true","skill", 350, 300)'>The Power Ballad of the Arrowsmith</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=6009&self=true","skill", 350, 300)'>Brawnee's Anthem of Absorption</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=6015&self=true","skill", 350, 300)'>The Sonata of Sneakiness</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=6016&self=true","skill", 350, 300)'>Carlweather's Cantata of Confrontation</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=6032&self=true","skill", 350, 300)'>Accordion Bash</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=6035&self=true","skill", 350, 300)'>Five Finger Discount</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15001&self=true","skill", 350, 300)'>Catchphrase</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15002&self=true","skill", 350, 300)'>Mixologist</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15003&self=true","skill", 350, 300)'>Throw Party</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15004&self=true","skill", 350, 300)'>Fix Jukebox</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15005&self=true","skill", 350, 300)'>Snap Fingers</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15006&self=true","skill", 350, 300)'>Shake It Off</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15007&self=true","skill", 350, 300)'>Check Hair</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15008&self=true","skill", 350, 300)'>Cocktail Magic</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15009&self=true","skill", 350, 300)'>Make Friends</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15010&self=true","skill", 350, 300)'>Natural Dancer</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15011&self=true","skill", 350, 300)'>Rev Engine</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15012&self=true","skill", 350, 300)'>Born Showman</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15013&self=true","skill", 350, 300)'>Pop Wheelie</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15014&self=true","skill", 350, 300)'>Rowdy Drinker</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15015&self=true","skill", 350, 300)'>Peel Out</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15016&self=true","skill", 350, 300)'>Easy Riding</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15017&self=true","skill", 350, 300)'>Check Mirror</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15018&self=true","skill", 350, 300)'>Riding Tall</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15019&self=true","skill", 350, 300)'>Biker Swagger</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15020&self=true","skill", 350, 300)'>Flash Headlight</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15021&self=true","skill", 350, 300)'>Insult</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15022&self=true","skill", 350, 300)'>Best Dressed</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15023&self=true","skill", 350, 300)'>Live Fast</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15024&self=true","skill", 350, 300)'>Jump Shark</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15025&self=true","skill", 350, 300)'>Hard Drinker</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15026&self=true","skill", 350, 300)'>Smoke Break</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15027&self=true","skill", 350, 300)'>Animal Magnetism</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15028&self=true","skill", 350, 300)'>Brood</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15030&self=true","skill", 350, 300)'>Walk Away From Explosion</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15031&self=true","skill", 350, 300)'>Incite Riot</a><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=15032&self=true","skill", 350, 300)'>Unrepentant Thief</a><br></td></tr><tr><td height=1 bgcolor=black></td></tr><tr><td>
+<a id='permlink' class=tiny href='javascript:toggle("permskills");'>[show permanent skills you can't use right now]</a>
+<span id='permskills' style='display: none'><br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=12&self=true","skill", 350, 300)'>Torso Awareness</a> (P)<br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5014&self=true","skill", 350, 300)'>Advanced Cocktailcrafting</a> (P)<br>
+<a onClick='javascript:poop("desc_skill.php?whichskill=5018&self=true","skill", 350, 300)'>Superhuman Cocktailcrafting</a> (P)<br>
+</span>
+</td></tr><tr><td height=1 bgcolor=black></td></tr><tr><td>(P) = Permanent skill</td></tr><tr><td height=1 bgcolor=black></td></tr></table></center></td></tr></table></center></td></tr><tr><td height=4></td></tr></table></center></body></html>


### PR DESCRIPTION
From this bug report:

https://kolmafia.us/threads/getpermedskills-not-correctly-showing-all-skills-in-avatar-path.28216/

I munged his supplied charsheet to be usable
I created CharSheetRequest ```List<ParsedSkillInfo> parseSkills(final String responseText)```
I stuck his charsheet into my "data" directory and did
```
test load sscharsheet.html
test charsheet-skills
```
and reproduced his issue.

The CharSheet skill parsing is now done via xpath, which is new to me.

1) This PR contains the new CharSheetRequest method, "test charsheet-skills", and the test HTML file.

Presumably, next:

Write a test which uses the new method and the test fixture to demonstrate the failue.
Fix the skill parsing.