### PR TITLE
More test clean up of residue in data/

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/AdventureQueueDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/AdventureQueueDatabase.java
@@ -8,6 +8,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -32,12 +33,10 @@ import net.sourceforge.kolmafia.utilities.RollingLinkedList;
  */
 
 public class AdventureQueueDatabase implements Serializable {
-  private static final long serialVersionUID = -180241952508113931L;
+  @Serial private static final long serialVersionUID = -180241952508113931L;
 
-  private static TreeMap<String, RollingLinkedList<String>> COMBAT_QUEUE =
-      new TreeMap<String, RollingLinkedList<String>>();
-  private static TreeMap<String, RollingLinkedList<String>> NONCOMBAT_QUEUE =
-      new TreeMap<String, RollingLinkedList<String>>();
+  private static TreeMap<String, RollingLinkedList<String>> COMBAT_QUEUE = new TreeMap<>();
+  private static TreeMap<String, RollingLinkedList<String>> NONCOMBAT_QUEUE = new TreeMap<>();
 
   // for testing only, otherwise leave at true;
   public static boolean allowSerializationWrite = true;
@@ -85,16 +84,15 @@ public class AdventureQueueDatabase implements Serializable {
   }
 
   private static void resetQueue(boolean serializeAfterwards) {
-    AdventureQueueDatabase.COMBAT_QUEUE = new TreeMap<String, RollingLinkedList<String>>();
-    AdventureQueueDatabase.NONCOMBAT_QUEUE = new TreeMap<String, RollingLinkedList<String>>();
+    AdventureQueueDatabase.COMBAT_QUEUE = new TreeMap<>();
+    AdventureQueueDatabase.NONCOMBAT_QUEUE = new TreeMap<>();
 
     List<KoLAdventure> list = AdventureDatabase.getAsLockableListModel();
 
     for (KoLAdventure adv : list) {
-      AdventureQueueDatabase.COMBAT_QUEUE.put(
-          adv.getAdventureName(), new RollingLinkedList<String>(5));
+      AdventureQueueDatabase.COMBAT_QUEUE.put(adv.getAdventureName(), new RollingLinkedList<>(5));
       AdventureQueueDatabase.NONCOMBAT_QUEUE.put(
-          adv.getAdventureName(), new RollingLinkedList<String>(5));
+          adv.getAdventureName(), new RollingLinkedList<>(5));
     }
 
     if (serializeAfterwards) {
@@ -199,8 +197,7 @@ public class AdventureQueueDatabase implements Serializable {
         ObjectOutputStream out = new ObjectOutputStream(fileOut);
 
         // make a collection with combat queue first
-        List<TreeMap<String, RollingLinkedList<String>>> queues =
-            new ArrayList<TreeMap<String, RollingLinkedList<String>>>();
+        List<TreeMap<String, RollingLinkedList<String>>> queues = new ArrayList<>();
         queues.add(COMBAT_QUEUE);
         queues.add(NONCOMBAT_QUEUE);
         out.writeObject(queues);
@@ -241,24 +238,14 @@ public class AdventureQueueDatabase implements Serializable {
       AdventureQueueDatabase.checkZones();
     } catch (FileNotFoundException e) {
       AdventureQueueDatabase.resetQueue(false);
-      return;
-    } catch (ClassNotFoundException e) {
+    } catch (ClassNotFoundException | EOFException | ClassCastException e) {
       // Found the file, but the contents did not contain a properly-serialized treemap.
       // Wipe the bogus file.
       file.delete();
       AdventureQueueDatabase.resetQueue();
-      return;
-    } catch (ClassCastException e) {
-      // Old version of the combat queue handling.  Sorry, have to delete your queue.
-      file.delete();
-      AdventureQueueDatabase.resetQueue();
-      return;
-    } catch (EOFException e) {
-      // Malformed data. Wipe the bogus file.
-      file.delete();
-      AdventureQueueDatabase.resetQueue();
-      return;
-    } catch (IOException e) {
+    } // Old version of the combat queue handling.  Sorry, have to delete your queue.
+    // Malformed data. Wipe the bogus file.
+    catch (IOException e) {
       e.printStackTrace();
     }
   }
@@ -288,7 +275,7 @@ public class AdventureQueueDatabase implements Serializable {
     // a = weight of monsters in the zone
     // b = weight of monsters in the queue
 
-    HashSet<String> zoneSet = new HashSet<String>(zoneQueue); // just care about unique elements
+    HashSet<String> zoneSet = new HashSet<>(zoneQueue); // just care about unique elements
 
     // Ignore monsters in the queue that aren't actually part of the zone's normal monster list
     // This includes monsters that have special conditions to find and wandering monsters

--- a/src/net/sourceforge/kolmafia/persistence/AdventureQueueDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/AdventureQueueDatabase.java
@@ -188,23 +188,22 @@ public class AdventureQueueDatabase implements Serializable {
   }
 
   public static void serialize() {
-    if (allowSerializationWrite) {
-      File file =
-          new File(KoLConstants.DATA_LOCATION, KoLCharacter.baseUserName() + "_" + "queue.ser");
+    if (!allowSerializationWrite) return;
+    File file =
+        new File(KoLConstants.DATA_LOCATION, KoLCharacter.baseUserName() + "_" + "queue.ser");
 
-      try {
-        FileOutputStream fileOut = new FileOutputStream(file);
-        ObjectOutputStream out = new ObjectOutputStream(fileOut);
+    try {
+      FileOutputStream fileOut = new FileOutputStream(file);
+      ObjectOutputStream out = new ObjectOutputStream(fileOut);
 
-        // make a collection with combat queue first
-        List<TreeMap<String, RollingLinkedList<String>>> queues = new ArrayList<>();
-        queues.add(COMBAT_QUEUE);
-        queues.add(NONCOMBAT_QUEUE);
-        out.writeObject(queues);
-        out.close();
-      } catch (IOException e) {
-        e.printStackTrace();
-      }
+      // make a collection with combat queue first
+      List<TreeMap<String, RollingLinkedList<String>>> queues = new ArrayList<>();
+      queues.add(COMBAT_QUEUE);
+      queues.add(NONCOMBAT_QUEUE);
+      out.writeObject(queues);
+      out.close();
+    } catch (IOException e) {
+      e.printStackTrace();
     }
   }
 
@@ -239,13 +238,12 @@ public class AdventureQueueDatabase implements Serializable {
     } catch (FileNotFoundException e) {
       AdventureQueueDatabase.resetQueue(false);
     } catch (ClassNotFoundException | EOFException | ClassCastException e) {
-      // Found the file, but the contents did not contain a properly-serialized treemap.
+      // Found the file, but the contents did not contain a properly-serialized treemap or
+      // old version of the combat queue handling or some other kind of malformed data.
       // Wipe the bogus file.
       file.delete();
       AdventureQueueDatabase.resetQueue();
-    } // Old version of the combat queue handling.  Sorry, have to delete your queue.
-    // Malformed data. Wipe the bogus file.
-    catch (IOException e) {
+    } catch (IOException e) {
       e.printStackTrace();
     }
   }

--- a/src/net/sourceforge/kolmafia/persistence/AdventureQueueDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/AdventureQueueDatabase.java
@@ -39,6 +39,9 @@ public class AdventureQueueDatabase implements Serializable {
   private static TreeMap<String, RollingLinkedList<String>> NONCOMBAT_QUEUE =
       new TreeMap<String, RollingLinkedList<String>>();
 
+  // for testing only, otherwise leave at true;
+  public static boolean allowSerializationWrite = true;
+
   // debugging tool
   public static void showQueue() {
     Set<String> keys = COMBAT_QUEUE.keySet();
@@ -187,22 +190,24 @@ public class AdventureQueueDatabase implements Serializable {
   }
 
   public static void serialize() {
-    File file =
-        new File(KoLConstants.DATA_LOCATION, KoLCharacter.baseUserName() + "_" + "queue.ser");
+    if (allowSerializationWrite) {
+      File file =
+          new File(KoLConstants.DATA_LOCATION, KoLCharacter.baseUserName() + "_" + "queue.ser");
 
-    try {
-      FileOutputStream fileOut = new FileOutputStream(file);
-      ObjectOutputStream out = new ObjectOutputStream(fileOut);
+      try {
+        FileOutputStream fileOut = new FileOutputStream(file);
+        ObjectOutputStream out = new ObjectOutputStream(fileOut);
 
-      // make a collection with combat queue first
-      List<TreeMap<String, RollingLinkedList<String>>> queues =
-          new ArrayList<TreeMap<String, RollingLinkedList<String>>>();
-      queues.add(COMBAT_QUEUE);
-      queues.add(NONCOMBAT_QUEUE);
-      out.writeObject(queues);
-      out.close();
-    } catch (IOException e) {
-      e.printStackTrace();
+        // make a collection with combat queue first
+        List<TreeMap<String, RollingLinkedList<String>>> queues =
+            new ArrayList<TreeMap<String, RollingLinkedList<String>>>();
+        queues.add(COMBAT_QUEUE);
+        queues.add(NONCOMBAT_QUEUE);
+        out.writeObject(queues);
+        out.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
     }
   }
 

--- a/src/net/sourceforge/kolmafia/persistence/AdventureSpentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/AdventureSpentDatabase.java
@@ -136,19 +136,18 @@ public class AdventureSpentDatabase implements Serializable {
   }
 
   public static void serialize() {
-    if (allowSerializationWrite) {
-      File file =
-          new File(KoLConstants.DATA_LOCATION, KoLCharacter.baseUserName() + "_" + "turns.ser");
+    if (!allowSerializationWrite) return;
+    File file =
+        new File(KoLConstants.DATA_LOCATION, KoLCharacter.baseUserName() + "_" + "turns.ser");
 
-      try {
-        FileOutputStream fileOut = new FileOutputStream(file);
-        ObjectOutputStream out = new ObjectOutputStream(fileOut);
+    try {
+      FileOutputStream fileOut = new FileOutputStream(file);
+      ObjectOutputStream out = new ObjectOutputStream(fileOut);
 
-        out.writeObject(AdventureSpentDatabase.TURNS);
-        out.close();
-      } catch (IOException e) {
-        e.printStackTrace();
-      }
+      out.writeObject(AdventureSpentDatabase.TURNS);
+      out.close();
+    } catch (IOException e) {
+      e.printStackTrace();
     }
   }
 
@@ -177,12 +176,12 @@ public class AdventureSpentDatabase implements Serializable {
     } catch (FileNotFoundException e) {
       AdventureSpentDatabase.resetTurns(false);
     } catch (ClassNotFoundException | ClassCastException e) {
-      // Found the file, but the contents did not contain a properly-serialized treemap.
+      // Found the file, but the contents did not contain a properly-serialized treemap or
+      // old version of the combat queue handling.
       // Wipe the bogus file.
       file.delete();
       AdventureSpentDatabase.resetTurns();
-    } // Old version of the combat queue handling.  Sorry, have to delete your queue.
-    catch (IOException e) {
+    } catch (IOException e) {
       e.printStackTrace();
     }
   }

--- a/src/net/sourceforge/kolmafia/persistence/AdventureSpentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/AdventureSpentDatabase.java
@@ -1,13 +1,14 @@
 package net.sourceforge.kolmafia.persistence;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.io.Serial;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileNotFoundException;
+import java.io.ObjectOutputStream;
+import java.io.IOException;
+import java.io.FileInputStream;
+import java.io.ObjectInputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -25,8 +26,9 @@ import net.sourceforge.kolmafia.request.FightRequest;
  */
 
 public class AdventureSpentDatabase implements Serializable {
+  @Serial
   private static final long serialVersionUID = -180241952508113933L;
-  private static Map<String, Integer> TURNS = new TreeMap<String, Integer>();
+  private static Map<String, Integer> TURNS = new TreeMap<>();
 
   private static int lastTurnUpdated = -1;
 
@@ -50,7 +52,7 @@ public class AdventureSpentDatabase implements Serializable {
   }
 
   public static void resetTurns(boolean serializeAfterwards) {
-    AdventureSpentDatabase.TURNS = new TreeMap<String, Integer>();
+    AdventureSpentDatabase.TURNS = new TreeMap<>();
 
     List<KoLAdventure> list = AdventureDatabase.getAsLockableListModel();
 
@@ -175,36 +177,30 @@ public class AdventureSpentDatabase implements Serializable {
       AdventureSpentDatabase.checkZones();
     } catch (FileNotFoundException e) {
       AdventureSpentDatabase.resetTurns(false);
-      return;
-    } catch (ClassNotFoundException e) {
+    } catch (ClassNotFoundException | ClassCastException e) {
       // Found the file, but the contents did not contain a properly-serialized treemap.
       // Wipe the bogus file.
       file.delete();
       AdventureSpentDatabase.resetTurns();
-      return;
-    } catch (ClassCastException e) {
-      // Old version of the combat queue handling.  Sorry, have to delete your queue.
-      file.delete();
-      AdventureSpentDatabase.resetTurns();
-      return;
-    } catch (IOException e) {
+    } // Old version of the combat queue handling.  Sorry, have to delete your queue.
+    catch (IOException e) {
       e.printStackTrace();
     }
   }
 
-  public static final int getLastTurnUpdated() {
+  public static int getLastTurnUpdated() {
     return AdventureSpentDatabase.lastTurnUpdated;
   }
 
-  public static final void setLastTurnUpdated(final int turnUpdated) {
+  public static void setLastTurnUpdated(final int turnUpdated) {
     AdventureSpentDatabase.lastTurnUpdated = turnUpdated;
   }
 
-  public static final boolean getNoncombatEncountered() {
+  public static boolean getNoncombatEncountered() {
     return AdventureSpentDatabase.noncombatEncountered;
   }
 
-  public static final void setNoncombatEncountered(final boolean encountered) {
+  public static void setNoncombatEncountered(final boolean encountered) {
     if (encountered && FightRequest.edFightInProgress()) {
       return;
     }

--- a/src/net/sourceforge/kolmafia/persistence/AdventureSpentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/AdventureSpentDatabase.java
@@ -32,6 +32,9 @@ public class AdventureSpentDatabase implements Serializable {
 
   private static boolean noncombatEncountered = false;
 
+  // for testing only, otherwise leave at true;
+  public static boolean allowSerializationWrite = true;
+
   // debugging tool
   public static void showTurns() {
     Set<String> keys = TURNS.keySet();
@@ -132,17 +135,19 @@ public class AdventureSpentDatabase implements Serializable {
   }
 
   public static void serialize() {
-    File file =
-        new File(KoLConstants.DATA_LOCATION, KoLCharacter.baseUserName() + "_" + "turns.ser");
+    if (allowSerializationWrite) {
+      File file =
+          new File(KoLConstants.DATA_LOCATION, KoLCharacter.baseUserName() + "_" + "turns.ser");
 
-    try {
-      FileOutputStream fileOut = new FileOutputStream(file);
-      ObjectOutputStream out = new ObjectOutputStream(fileOut);
+      try {
+        FileOutputStream fileOut = new FileOutputStream(file);
+        ObjectOutputStream out = new ObjectOutputStream(fileOut);
 
-      out.writeObject(AdventureSpentDatabase.TURNS);
-      out.close();
-    } catch (IOException e) {
-      e.printStackTrace();
+        out.writeObject(AdventureSpentDatabase.TURNS);
+        out.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
     }
   }
 

--- a/src/net/sourceforge/kolmafia/persistence/AdventureSpentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/AdventureSpentDatabase.java
@@ -1,14 +1,14 @@
 package net.sourceforge.kolmafia.persistence;
 
-import java.io.Serializable;
-import java.io.Serial;
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileNotFoundException;
-import java.io.ObjectOutputStream;
-import java.io.IOException;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,8 +26,7 @@ import net.sourceforge.kolmafia.request.FightRequest;
  */
 
 public class AdventureSpentDatabase implements Serializable {
-  @Serial
-  private static final long serialVersionUID = -180241952508113933L;
+  @Serial private static final long serialVersionUID = -180241952508113933L;
   private static Map<String, Integer> TURNS = new TreeMap<>();
 
   private static int lastTurnUpdated = -1;

--- a/test/net/sourceforge/kolmafia/preferences/ForbiddenStoresTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/ForbiddenStoresTest.java
@@ -17,7 +17,7 @@ class ForbiddenStoresTest {
   // in this class.
   @BeforeEach
   public void initializeCharPrefs() {
-    KoLCharacter.reset("fakePrefUser");
+    KoLCharacter.reset("ForbiddenStoresPrefUser");
     KoLCharacter.reset(true);
   }
 
@@ -166,7 +166,7 @@ class ForbiddenStoresTest {
 
     assertEquals("5", Preferences.getString("forbiddenStores"));
 
-    KoLCharacter.reset("fakePrefUserToo");
+    KoLCharacter.reset("ForbiddenStoresPrefUserToo");
 
     assertEquals("", Preferences.getString("forbiddenStores"));
 

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -19,7 +19,7 @@ class PreferencesTest {
   // in this class.
   @BeforeEach
   public void initializeCharPrefs() {
-    KoLCharacter.reset("fakePrefUser");
+    KoLCharacter.reset("PreferencesTestFakeUser");
     KoLCharacter.reset(true);
   }
 
@@ -35,7 +35,7 @@ class PreferencesTest {
     String propName = "aTestProp";
     Preferences.setBoolean(propName, true);
     assertTrue(Preferences.getBoolean(propName), "Property Set but does not exist.");
-    Preferences.reset("fakePrefUser"); // reload from disk
+    Preferences.reset("PreferencesTestFakeUser"); // reload from disk
     assertFalse(Preferences.getBoolean(propName), "Property not restored from disk by reset.");
   }
 
@@ -516,7 +516,7 @@ class PreferencesTest {
     assertFalse(Preferences.isPerUserGlobalProperty("xyzzy"));
     assertFalse(Preferences.isPerUserGlobalProperty("xy..z.zy"));
     // property
-    assertTrue(Preferences.isPerUserGlobalProperty("getBreakfast.fakePrefUser"));
+    assertTrue(Preferences.isPerUserGlobalProperty("getBreakfast.PreferencesTestFakeUser"));
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/request/AdventureRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AdventureRequestTest.java
@@ -1,7 +1,11 @@
 package net.sourceforge.kolmafia.request;
 
 import static internal.helpers.Networking.html;
-import static internal.helpers.Player.*;
+import static internal.helpers.Player.withEffect;
+import static internal.helpers.Player.withLastLocation;
+import static internal.helpers.Player.withNextMonster;
+import static internal.helpers.Player.withPath;
+import static internal.helpers.Player.withProperty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -63,7 +67,7 @@ public class AdventureRequestTest {
   }
 
   @Test
-  public void regocgnizesSpookyWheelbarrow() {
+  public void recognizesSpookyWheelbarrow() {
     var cleanups =
         new Cleanups(withProperty("lastEncounter"), withLastLocation("The Spooky Gravy Burrow"));
 
@@ -124,7 +128,7 @@ public class AdventureRequestTest {
     assertEquals(Preferences.getInteger("_juneCleaverSkips"), 1);
 
     // Can load queue
-    JuneCleaverManager.queue = new ArrayList();
+    JuneCleaverManager.queue = new ArrayList<>();
     Preferences.setString("juneCleaverQueue", "1467,1468,1469,1470,1471");
     JuneCleaverManager.parseChoice("choice.php?whichchoice=1472&option=3");
     assertEquals(Preferences.getString("juneCleaverQueue"), "1467,1468,1469,1470,1471,1472");
@@ -170,20 +174,11 @@ public class AdventureRequestTest {
         // <modifier> <dinosaur> " consumed " <prey>
         // <modifier> <dinosaur> " swallowed the soul of " <prey>
         for (String gluttony : AdventureRequest.dinoGluttony) {
-          StringBuilder encounter = new StringBuilder();
-          encounter.append("a ");
-          encounter.append(modifier);
-          encounter.append(" ");
-          encounter.append(dinosaur);
-          encounter.append(" ");
-          encounter.append(gluttony);
-          encounter.append(" ");
-          encounter.append(prey);
+          String encounter = "a " + modifier + " " + dinosaur + " " + gluttony + " " + prey;
           MonsterData swallowed = MonsterDatabase.findMonster(prey);
           int monsterId = swallowed.getId();
           String responseText = "<!-- MONSTERID: " + monsterId + " -->";
-          MonsterData extracted =
-              AdventureRequest.extractMonster(encounter.toString(), responseText);
+          MonsterData extracted = AdventureRequest.extractMonster(encounter, responseText);
           MonsterStatusTracker.setNextMonster(extracted);
 
           MonsterData monster = MonsterStatusTracker.getLastMonster();

--- a/test/net/sourceforge/kolmafia/request/AdventureRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AdventureRequestTest.java
@@ -19,6 +19,7 @@ import net.sourceforge.kolmafia.persistence.AdventureQueueDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.JuneCleaverManager;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,12 @@ public class AdventureRequestTest {
   public void init() {
     KoLCharacter.reset("AdventureRequestTest");
     Preferences.reset("AdventureRequestTest");
+    AdventureQueueDatabase.allowSerializationWrite = false;
+  }
+
+  @AfterEach
+  public void restore() {
+    AdventureQueueDatabase.allowSerializationWrite = true;
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/request/AdventureRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AdventureRequestTest.java
@@ -23,7 +23,7 @@ import net.sourceforge.kolmafia.persistence.AdventureQueueDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.JuneCleaverManager;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -38,8 +38,8 @@ public class AdventureRequestTest {
     AdventureQueueDatabase.allowSerializationWrite = false;
   }
 
-  @AfterEach
-  public void restore() {
+  @AfterAll
+  static void restore() {
     AdventureQueueDatabase.allowSerializationWrite = true;
   }
 

--- a/test/net/sourceforge/kolmafia/request/AscensionRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AscensionRequestTest.java
@@ -18,16 +18,27 @@ import java.util.List;
 import java.util.Map;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.RequestLogger;
+import net.sourceforge.kolmafia.persistence.AdventureQueueDatabase;
+import net.sourceforge.kolmafia.persistence.AdventureSpentDatabase;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class AscensionRequestTest {
   @BeforeAll
   public static void initializeCharPrefs() {
-    KoLCharacter.reset("fakePrefUser");
+    KoLCharacter.reset("AscensionRequestFakeUser");
     KoLCharacter.reset(true);
     // Fix another test not cleaning up
     FightRequest.currentRound = 0;
+    AdventureQueueDatabase.allowSerializationWrite = false;
+    AdventureSpentDatabase.allowSerializationWrite = false;
+  }
+
+  @AfterAll
+  public static void restoreWritePermissions() {
+    AdventureQueueDatabase.allowSerializationWrite = true;
+    AdventureSpentDatabase.allowSerializationWrite = true;
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/request/PlaceRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/PlaceRequestTest.java
@@ -22,7 +22,7 @@ class PlaceRequestTest {
   // in this class.
   @BeforeEach
   public void initializeCharPrefs() {
-    KoLCharacter.reset("fakePrefUser");
+    KoLCharacter.reset("PlaceRequestTestFakePrefUser");
     KoLCharacter.reset(true);
   }
 


### PR DESCRIPTION
Added an option not to write the adventure queue and turns files and then disabled the write in tests that created them but were not cleaning them up.

Changed the username for several tests to make it easier to find which test was leaving files based on the username behind.

Lint and spotless.

Since the tests that got changed were not using the Cleanups framework I elected not to change them to do so.  baby steps.