### PR TITLE
Simplify new equipment list.

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
@@ -1236,8 +1236,7 @@ public class GearChangePanel extends JPanel {
       final LockableListModel<AdventureResult> currentItems,
       final List<AdventureResult> newItems,
       final AdventureResult equippedItem) {
-    currentItems.retainAll(newItems);
-    newItems.removeAll(currentItems);
+    currentItems.clear();
     currentItems.addAll(newItems);
     currentItems.setSelectedItem(equippedItem);
   }


### PR DESCRIPTION
This code is a bottleneck. It's possible there is a reason the current code is the way it is, but I can't see one - unless there is some object-identity issues that are being worked around. newItems is mutated in this method but then the new value is never referenced afterwards.