### PR TITLE
Reduce frequency of name-to-id-to-name conversions.

### DIFF
--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -1760,7 +1760,7 @@ public class Modifiers {
       return null;
     }
     String name = "[" + id + "]";
-    return Modifiers.getModifiers("Item", name);
+    return Modifiers.getModifiers("Item", id, name);
   }
 
   /**
@@ -1793,22 +1793,32 @@ public class Modifiers {
       }
     }
     String name = "[" + id + "]";
-    return Modifiers.getModifiers("Effect", name);
+    return Modifiers.getModifiers("Effect", id, name);
   }
 
-  public static final Modifiers getModifiers(String type, final String name) {
-    String changeType = null;
+  public static final Modifiers getModifiers(final String type, final int id, final String name) {
+    String lookup = Modifiers.getLookupName(type, id);
+    return Modifiers.getModifiersInternal(type, name, lookup);
+  }
+
+  public static final Modifiers getModifiers(final String type, final String name) {
     if (name == null || name.isEmpty()) {
       return null;
     }
 
+    String lookup = Modifiers.getLookupName(type, name);
+    return Modifiers.getModifiersInternal(type, name, lookup);
+  }
+
+  private static final Modifiers getModifiersInternal(
+      String type, final String name, final String lookup) {
+    Object modifier = Modifiers.modifiersByName.get(lookup);
+
+    String changeType = null;
     if (type.equals("Bjorn")) {
       changeType = type;
       type = "Throne";
     }
-
-    String lookup = Modifiers.getLookupName(type, name);
-    Object modifier = Modifiers.modifiersByName.get(lookup);
 
     if (modifier == null) {
       return null;
@@ -3333,6 +3343,10 @@ public class Modifiers {
 
   public static void setFamiliar(FamiliarData fam) {
     Modifiers.currentFamiliar = fam == null ? "" : fam.getRace();
+  }
+
+  public static String getLookupName(final String type, final int id) {
+    return type + ":[" + id + "]";
   }
 
   public static String getLookupName(final String type, final String name) {

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -1811,14 +1811,15 @@ public class Modifiers {
   }
 
   private static final Modifiers getModifiersInternal(
-      String type, final String name, final String lookup) {
-    Object modifier = Modifiers.modifiersByName.get(lookup);
-
+      String type, final String name, String lookup) {
     String changeType = null;
     if (type.equals("Bjorn")) {
       changeType = type;
       type = "Throne";
+      lookup = getLookupName(type, name);
     }
+
+    Object modifier = Modifiers.modifiersByName.get(lookup);
 
     if (modifier == null) {
       return null;


### PR DESCRIPTION
`getEffectModifiers` currently starts with an effect id, which then gets turned into a lookup string, which then gets parsed back into an id in `getLookupName`. Instead we should just use the id.