### PR TITLE
Revert "Simplify new equipment list. (#1264)"

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
@@ -1236,7 +1236,8 @@ public class GearChangePanel extends JPanel {
       final LockableListModel<AdventureResult> currentItems,
       final List<AdventureResult> newItems,
       final AdventureResult equippedItem) {
-    currentItems.clear();
+    currentItems.retainAll(newItems);
+    newItems.removeAll(currentItems);
     currentItems.addAll(newItems);
     currentItems.setSelectedItem(equippedItem);
   }


### PR DESCRIPTION
I misread the profiling results. After running mafia this morning, I noticed it seems to have made things much worse. After looking more closely, I realized I had missed impact on the AWT event queue thread.

I need to spend some more time with this code to see if there's an actually working way to improve performance. For now, I suggest reverting my change from yesterday.

This reverts commit 6e1b0cf592c3d4bf0b2c8e8bed8642618bb78ba8.