### PR TITLE
Don't always progress the Nemesis quest after acquiring fizzing spore pods

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -2162,12 +2162,13 @@ public class ResultProcessor {
         QuestDatabase.setQuestProgress(Quest.NEMESIS, "step8");
         break;
 
-      case ItemPool.FIZZING_SPORE_POD:
-        if (InventoryManager.getCount(ItemPool.FIZZING_SPORE_POD) + count >= 6) {
-          QuestDatabase.setQuestIfBetter(Quest.NEMESIS, "step14");
-        }
-        break;
-
+        case ItemPool.FIZZING_SPORE_POD:
+          if (InventoryManager.getCount(ItemPool.FIZZING_SPORE_POD) + count >= 6
+              && QuestDatabase.isQuestLaterThan(Quest.NEMESIS, "step9")) {
+            QuestDatabase.setQuestIfBetter(Quest.NEMESIS, "step14");
+          }
+          break;
+  
       case ItemPool.SCALP_OF_GORGOLOK:
       case ItemPool.ELDER_TURTLE_SHELL:
       case ItemPool.COLANDER_OF_EMERIL:

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -2162,13 +2162,13 @@ public class ResultProcessor {
         QuestDatabase.setQuestProgress(Quest.NEMESIS, "step8");
         break;
 
-        case ItemPool.FIZZING_SPORE_POD:
-          if (InventoryManager.getCount(ItemPool.FIZZING_SPORE_POD) + count >= 6
-              && QuestDatabase.isQuestLaterThan(Quest.NEMESIS, "step9")) {
-            QuestDatabase.setQuestIfBetter(Quest.NEMESIS, "step14");
-          }
-          break;
-  
+      case ItemPool.FIZZING_SPORE_POD:
+        if (InventoryManager.getCount(ItemPool.FIZZING_SPORE_POD) + count >= 6
+            && QuestDatabase.isQuestLaterThan(Quest.NEMESIS, "step9")) {
+          QuestDatabase.setQuestIfBetter(Quest.NEMESIS, "step14");
+        }
+        break;
+
       case ItemPool.SCALP_OF_GORGOLOK:
       case ItemPool.ELDER_TURTLE_SHELL:
       case ItemPool.COLANDER_OF_EMERIL:


### PR DESCRIPTION
Currently, if you have NOT started the nemesis quest, and don't have fizzing spore pods in inventory:
```
> ash can_adventure($location[the "fun" house])

Returned: false
```
The above works as expected.
If you still have not started the nemesis quest, upon acquiring 6 fizzing spore pods:
```
Preference questG04Nemesis changed from unstarted to step14

> ash can_adventure($location[the "fun" house])

Returned: true
```
These are both incorrect. This proposed fix is to check that the quest state has progressed far enough.
Based on the comments from the GuildRequest describing the quest steps, step10 should be sufficiently far along, I think.
https://github.com/kolmafia/kolmafia/blob/4324e20a0e0f541486622c8e878196013046ba6c/src/net/sourceforge/kolmafia/request/GuildRequest.java#L380-L385