### PR TITLE
The gong command finishes your journey of reincarnation

### DIFF
--- a/src/net/sourceforge/kolmafia/session/LimitMode.java
+++ b/src/net/sourceforge/kolmafia/session/LimitMode.java
@@ -69,6 +69,16 @@ public enum LimitMode {
     }
   }
 
+  public String effectName() {
+    return switch (this) {
+      case BIRD -> "Form of...Bird!";
+      case MOLE -> "Shape of...Mole!";
+      case ROACH -> "Form of...Cockroach!";
+      case ASTRAL -> "Half-Astral!";
+      default -> null;
+    };
+  }
+
   public boolean requiresCharPane() {
     return switch (this) {
       case SPELUNKY, BATMAN -> true;

--- a/test/internal/extensions/ClearSharedStateBefore.java
+++ b/test/internal/extensions/ClearSharedStateBefore.java
@@ -13,6 +13,7 @@ import java.util.List;
 import net.sourceforge.kolmafia.*;
 import net.sourceforge.kolmafia.persistence.AdventureSpentDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.FightRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.request.RelayRequest;
 import net.sourceforge.kolmafia.request.StandardRequest;
@@ -58,6 +59,8 @@ public class ClearSharedStateBefore implements BeforeAllCallback {
     StandardRequest.reset();
     KoLConstants.activeEffects.clear();
     KoLCharacter.setLimitMode(LimitMode.NONE);
+    FightRequest.currentRound = 0;
+    ChoiceManager.handlingChoice = false;
     ChoiceManager.reset();
   }
 

--- a/test/net/sourceforge/kolmafia/textui/command/GongCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/GongCommandTest.java
@@ -1,0 +1,163 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static internal.helpers.Networking.assertGetRequest;
+import static internal.helpers.Networking.assertPostRequest;
+import static internal.helpers.Networking.html;
+import static internal.helpers.Player.withEffect;
+import static internal.helpers.Player.withGender;
+import static internal.helpers.Player.withHttpClientBuilder;
+import static internal.helpers.Player.withItem;
+import static internal.helpers.Player.withLimitMode;
+import static internal.helpers.Player.withNoEffects;
+import static internal.helpers.Player.withPasswordHash;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+
+import internal.helpers.Cleanups;
+import internal.network.FakeHttpClientBuilder;
+import java.util.List;
+import java.util.Map;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLConstants.MafiaState;
+import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.objectpool.AdventurePool;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.session.ChoiceManager;
+import net.sourceforge.kolmafia.session.LimitMode;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class GongCommandTest extends AbstractCommandTestBase {
+
+  public GongCommandTest() {
+    this.command = "gong";
+  }
+
+  @BeforeAll
+  public static void beforeAll() {
+    KoLCharacter.reset("gong");
+  }
+
+  @BeforeEach
+  public void beforeEach() {
+    Preferences.reset("gong");
+  }
+
+  @BeforeEach
+  public void initEach() {
+    StaticEntity.setContinuationState(MafiaState.CONTINUE);
+    ChoiceManager.handlingChoice = false;
+  }
+
+  @Nested
+  class Bird {
+    @Test
+    public void birdModeNotOnJourney() {
+      var builder = new FakeHttpClientBuilder();
+      var client = builder.client;
+      var cleanups =
+          new Cleanups(
+              withHttpClientBuilder(builder),
+              withItem(ItemPool.GONG),
+              withLimitMode(LimitMode.NONE),
+              withPasswordHash("gong"),
+              // If you have a password hash, KoL looks at your vinyl boots
+              withGender(KoLCharacter.FEMALE));
+      try (cleanups) {
+        client.addResponse(302, Map.of("location", List.of("choice.php?forceoption=0")), "");
+        client.addResponse(200, html("request/test_use_llama_lama_gong.html"));
+        client.addResponse(200, html("request/test_choose_bird_form.html"));
+        client.addResponse(200, ""); // api.php
+
+        String output = execute("bird");
+        assertThat(output, containsString("Gong path: bird"));
+        assertThat(output, containsString("Using 1 llama lama gong"));
+        assertThat(output, containsString("Encounter: The Gong Has Been Bung"));
+        assertThat(output, containsString("You acquire an effect: Form of...Bird! (15)"));
+
+        var requests = client.getRequests();
+        assertThat(requests, hasSize(4));
+
+        assertPostRequest(
+            requests.get(0), "/inv_use.php", "whichitem=" + ItemPool.GONG + "&ajax=1&pwd=gong");
+        assertGetRequest(requests.get(1), "/choice.php", "forceoption=0");
+        assertPostRequest(requests.get(2), "/choice.php", "whichchoice=276&option=3&pwd=gong");
+        assertPostRequest(requests.get(3), "/api.php", "what=status&for=KoLmafia");
+      }
+    }
+
+    @Test
+    public void birdModeOnJourney() {
+      var builder = new FakeHttpClientBuilder();
+      var client = builder.client;
+      var cleanups =
+          new Cleanups(
+              withHttpClientBuilder(builder),
+              withItem(ItemPool.GONG),
+              withLimitMode(LimitMode.BIRD),
+              withNoEffects(),
+              withEffect("Form of...Bird!", 1));
+      try (cleanups) {
+        String output = execute("bird");
+        assertThat(output, containsString("You can't use a gong right now."));
+
+        var requests = client.getRequests();
+        assertThat(requests, hasSize(0));
+      }
+    }
+
+    @Test
+    public void birdModeAtEndOfJourney() {
+      var builder = new FakeHttpClientBuilder();
+      var client = builder.client;
+      var cleanups =
+          new Cleanups(
+              withHttpClientBuilder(builder),
+              withItem(ItemPool.GONG),
+              withLimitMode(LimitMode.BIRD),
+              withNoEffects(),
+              withPasswordHash("gong"),
+              // If you have a password hash, KoL looks at your vinyl boots
+              withGender(KoLCharacter.FEMALE));
+      try (cleanups) {
+        client.addResponse(302, Map.of("location", List.of("choice.php")), "");
+        client.addResponse(200, html("request/test_leave_reincarnation.html"));
+        client.addResponse(200, html("request/test_get_bird_reward.html"));
+        client.addResponse(200, ""); // api.php
+        client.addResponse(302, Map.of("location", List.of("choice.php?forceoption=0")), "");
+        client.addResponse(200, html("request/test_use_llama_lama_gong.html"));
+        client.addResponse(200, html("request/test_choose_bird_form.html"));
+        client.addResponse(200, ""); // api.php
+
+        String output = execute("bird");
+        assertThat(output, containsString("Gong path: bird"));
+        assertThat(output, containsString("Noob Cave"));
+        assertThat(output, containsString("Welcome Back!"));
+        assertThat(output, containsString("You acquire an item: glimmering roc feather"));
+        assertThat(output, containsString("Using 1 llama lama gong"));
+        assertThat(output, containsString("Encounter: The Gong Has Been Bung"));
+        assertThat(output, containsString("You acquire an effect: Form of...Bird! (15)"));
+
+        var requests = client.getRequests();
+        assertThat(requests, hasSize(8));
+
+        assertPostRequest(
+            requests.get(0),
+            "/adventure.php",
+            "snarfblat=" + AdventurePool.NOOB_CAVE + "&pwd=gong");
+        assertGetRequest(requests.get(1), "/choice.php", null);
+        assertPostRequest(requests.get(2), "/choice.php", "whichchoice=277&option=1&pwd=gong");
+        assertPostRequest(requests.get(3), "/api.php", "what=status&for=KoLmafia");
+        assertPostRequest(
+            requests.get(4), "/inv_use.php", "whichitem=" + ItemPool.GONG + "&ajax=1&pwd=gong");
+        assertGetRequest(requests.get(5), "/choice.php", "forceoption=0");
+        assertPostRequest(requests.get(6), "/choice.php", "whichchoice=276&option=3&pwd=gong");
+        assertPostRequest(requests.get(7), "/api.php", "what=status&for=KoLmafia");
+      }
+    }
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/command/GongCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/GongCommandTest.java
@@ -10,9 +10,12 @@ import static internal.helpers.Player.withItem;
 import static internal.helpers.Player.withLimitMode;
 import static internal.helpers.Player.withNoEffects;
 import static internal.helpers.Player.withPasswordHash;
+import static internal.helpers.Player.withProperty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import internal.helpers.Cleanups;
 import internal.network.FakeHttpClientBuilder;
@@ -23,6 +26,7 @@ import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.objectpool.AdventurePool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.ChoiceManager;
 import net.sourceforge.kolmafia.session.LimitMode;
@@ -30,6 +34,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class GongCommandTest extends AbstractCommandTestBase {
 
@@ -79,6 +85,9 @@ public class GongCommandTest extends AbstractCommandTestBase {
         assertThat(output, containsString("Encounter: The Gong Has Been Bung"));
         assertThat(output, containsString("You acquire an effect: Form of...Bird! (15)"));
 
+        assertEquals(LimitMode.BIRD, KoLCharacter.getLimitMode());
+        assertFalse(ChoiceManager.handlingChoice);
+
         var requests = client.getRequests();
         assertThat(requests, hasSize(4));
 
@@ -110,8 +119,9 @@ public class GongCommandTest extends AbstractCommandTestBase {
       }
     }
 
-    @Test
-    public void birdModeAtEndOfJourney() {
+    @ParameterizedTest
+    @ValueSource(ints = {0, AdventurePool.HAUNTED_KITCHEN})
+    public void birdModeAtEndOfJourney(int snarfblat) {
       var builder = new FakeHttpClientBuilder();
       var client = builder.client;
       var cleanups =
@@ -120,6 +130,7 @@ public class GongCommandTest extends AbstractCommandTestBase {
               withItem(ItemPool.GONG),
               withLimitMode(LimitMode.BIRD),
               withNoEffects(),
+              withProperty("welcomeBackAdv", snarfblat),
               withPasswordHash("gong"),
               // If you have a password hash, KoL looks at your vinyl boots
               withGender(KoLCharacter.FEMALE));
@@ -133,22 +144,26 @@ public class GongCommandTest extends AbstractCommandTestBase {
         client.addResponse(200, html("request/test_choose_bird_form.html"));
         client.addResponse(200, ""); // api.php
 
+        if (snarfblat == 0) snarfblat = AdventurePool.NOOB_CAVE;
+        String locationName = AdventureDatabase.getAdventure(snarfblat).getAdventureName();
+
         String output = execute("bird");
         assertThat(output, containsString("Gong path: bird"));
-        assertThat(output, containsString("Noob Cave"));
+        assertThat(output, containsString(locationName));
         assertThat(output, containsString("Welcome Back!"));
         assertThat(output, containsString("You acquire an item: glimmering roc feather"));
         assertThat(output, containsString("Using 1 llama lama gong"));
         assertThat(output, containsString("Encounter: The Gong Has Been Bung"));
         assertThat(output, containsString("You acquire an effect: Form of...Bird! (15)"));
 
+        assertEquals(LimitMode.BIRD, KoLCharacter.getLimitMode());
+        assertFalse(ChoiceManager.handlingChoice);
+
         var requests = client.getRequests();
         assertThat(requests, hasSize(8));
 
         assertPostRequest(
-            requests.get(0),
-            "/adventure.php",
-            "snarfblat=" + AdventurePool.NOOB_CAVE + "&pwd=gong");
+            requests.get(0), "/adventure.php", "snarfblat=" + snarfblat + "&pwd=gong");
         assertGetRequest(requests.get(1), "/choice.php", null);
         assertPostRequest(requests.get(2), "/choice.php", "whichchoice=277&option=1&pwd=gong");
         assertPostRequest(requests.get(3), "/api.php", "what=status&for=KoLmafia");

--- a/test/net/sourceforge/kolmafia/textui/command/GongCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/GongCommandTest.java
@@ -5,6 +5,7 @@ import static internal.helpers.Networking.assertPostRequest;
 import static internal.helpers.Networking.html;
 import static internal.helpers.Player.withEffect;
 import static internal.helpers.Player.withGender;
+import static internal.helpers.Player.withHandlingChoice;
 import static internal.helpers.Player.withHttpClientBuilder;
 import static internal.helpers.Player.withItem;
 import static internal.helpers.Player.withLimitMode;
@@ -56,7 +57,6 @@ public class GongCommandTest extends AbstractCommandTestBase {
   @BeforeEach
   public void initEach() {
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
-    ChoiceManager.handlingChoice = false;
   }
 
   @Nested
@@ -70,6 +70,7 @@ public class GongCommandTest extends AbstractCommandTestBase {
               withHttpClientBuilder(builder),
               withItem(ItemPool.GONG),
               withLimitMode(LimitMode.NONE),
+              withHandlingChoice(false),
               withPasswordHash("gong"),
               // If you have a password hash, KoL looks at your vinyl boots
               withGender(KoLCharacter.FEMALE));
@@ -108,6 +109,7 @@ public class GongCommandTest extends AbstractCommandTestBase {
               withHttpClientBuilder(builder),
               withItem(ItemPool.GONG),
               withLimitMode(LimitMode.BIRD),
+              withHandlingChoice(false),
               withNoEffects(),
               withEffect("Form of...Bird!", 1));
       try (cleanups) {
@@ -129,6 +131,7 @@ public class GongCommandTest extends AbstractCommandTestBase {
               withHttpClientBuilder(builder),
               withItem(ItemPool.GONG),
               withLimitMode(LimitMode.BIRD),
+              withHandlingChoice(false),
               withNoEffects(),
               withProperty("welcomeBackAdv", snarfblat),
               withPasswordHash("gong"),

--- a/test/net/sourceforge/kolmafia/textui/command/GongCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/GongCommandTest.java
@@ -3,6 +3,7 @@ package net.sourceforge.kolmafia.textui.command;
 import static internal.helpers.Networking.assertGetRequest;
 import static internal.helpers.Networking.assertPostRequest;
 import static internal.helpers.Networking.html;
+import static internal.helpers.Player.withContinuationState;
 import static internal.helpers.Player.withEffect;
 import static internal.helpers.Player.withGender;
 import static internal.helpers.Player.withHandlingChoice;
@@ -23,8 +24,6 @@ import internal.network.FakeHttpClientBuilder;
 import java.util.List;
 import java.util.Map;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLConstants.MafiaState;
-import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.objectpool.AdventurePool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
@@ -54,11 +53,6 @@ public class GongCommandTest extends AbstractCommandTestBase {
     Preferences.reset("gong");
   }
 
-  @BeforeEach
-  public void initEach() {
-    StaticEntity.setContinuationState(MafiaState.CONTINUE);
-  }
-
   @Nested
   class Bird {
     @Test
@@ -69,8 +63,9 @@ public class GongCommandTest extends AbstractCommandTestBase {
           new Cleanups(
               withHttpClientBuilder(builder),
               withItem(ItemPool.GONG),
-              withLimitMode(LimitMode.NONE),
               withHandlingChoice(false),
+              withContinuationState(),
+              withLimitMode(LimitMode.NONE),
               withPasswordHash("gong"),
               // If you have a password hash, KoL looks at your vinyl boots
               withGender(KoLCharacter.FEMALE));
@@ -108,13 +103,15 @@ public class GongCommandTest extends AbstractCommandTestBase {
           new Cleanups(
               withHttpClientBuilder(builder),
               withItem(ItemPool.GONG),
-              withLimitMode(LimitMode.BIRD),
               withHandlingChoice(false),
+              withContinuationState(),
+              withLimitMode(LimitMode.BIRD),
               withNoEffects(),
               withEffect("Form of...Bird!", 1));
       try (cleanups) {
         String output = execute("bird");
         assertThat(output, containsString("You can't use a gong right now."));
+        assertErrorState();
 
         var requests = client.getRequests();
         assertThat(requests, hasSize(0));
@@ -130,8 +127,9 @@ public class GongCommandTest extends AbstractCommandTestBase {
           new Cleanups(
               withHttpClientBuilder(builder),
               withItem(ItemPool.GONG),
-              withLimitMode(LimitMode.BIRD),
               withHandlingChoice(false),
+              withContinuationState(),
+              withLimitMode(LimitMode.BIRD),
               withNoEffects(),
               withProperty("welcomeBackAdv", snarfblat),
               withPasswordHash("gong"),

--- a/test/net/sourceforge/kolmafia/textui/command/GongCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/GongCommandTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class GongCommandTest extends AbstractCommandTestBase {
@@ -95,8 +96,11 @@ public class GongCommandTest extends AbstractCommandTestBase {
       }
     }
 
-    @Test
-    public void birdModeOnJourney() {
+    @ParameterizedTest
+    @EnumSource(
+        value = LimitMode.class,
+        names = {"BIRD", "ROACH", "MOLE", "ASTRAL"})
+    public void birdModeOnJourney(LimitMode lm) {
       var builder = new FakeHttpClientBuilder();
       var client = builder.client;
       var cleanups =
@@ -105,9 +109,9 @@ public class GongCommandTest extends AbstractCommandTestBase {
               withItem(ItemPool.GONG),
               withHandlingChoice(false),
               withContinuationState(),
-              withLimitMode(LimitMode.BIRD),
+              withLimitMode(lm),
               withNoEffects(),
-              withEffect("Form of...Bird!", 1));
+              withEffect(lm.effectName(), 1));
       try (cleanups) {
         String output = execute("bird");
         assertThat(output, containsString("You can't use a gong right now."));


### PR DESCRIPTION
We had this funky code in the responsetext parsing of UseItemRequest to detect that you hadn't finished you journey of reincarnation when you attempted to use a llama lama gong. If your effect had run out, it would visit the Noob Cave and accept your reward and then retry using the item.

Turns out this was to allow the "gong" command to immediately use a gong even if the user hadn't seen the Welcome Back adventure.

1) I moved the equivalent to the gong command itself: before it tries to use a gong, it sees if it needs to visit the Welcome Back NC, and if so, does it by visiting the Noob Cave.

2) I also learned that UseItemRequest now tells GenericRequest to follow redirects, which will leave it in a choice when the initial choice was so-followed; it did not automate the choice. Which is to say, this command has been broken ever since we made UseItemRequest automatically follow redirects.

   I added a fluid method to UseItemRequest to allow this instance to direct GenericRequest to NOT follow the redirect, but to automate the choice chain.

Rant:

It is really irritating when I make tests that work very hard to not leak state, but when incorporated into the whole set of tests, completely unrelated tests start failing. In this case, when I stuck a debug print into the failing tests, they stopped failing on my system when running the whole suite.

I managed to get one to print something useful: "You are currently in a fight or a choice" - which is why retrieving the stash failed.

The was not me. I called choices, but verified with assertions that I was not leaking ChoiceManager.handlingChoice.

But, due to having an extra file of tests, apparently a test which DID leak moved in front of other tests and broke them.

I added more stuff to ClearSharedStateBefore and the tests no longer fail.

Global static variables are making me more and more irritated.