### PR TITLE
Remove special handling for dodecapede sympathy

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -7749,7 +7749,7 @@ Skill	Alien Source Code	Maximum MP: +5
 Skill	Aluminum Nerves	MP Regen Min: 8, MP Regen Max: 10
 Skill	Always Never Not Guzzling	Booze Drop: +25
 # Ambidextrous Funkslinging: You can use two combat items per round
-Skill	Amphibian Sympathy	Familiar Weight: +5
+Skill	Amphibian Sympathy	Familiar Weight: [-10*(fam(Inflatable Dodecapede)-0.5)]
 # Ancient Crimbo Lore: +3 Stats Per Fight in December
 Skill	Animal Magnetism	Moxie Controls MP, MP Regen Min: 8, MP Regen Max: 10
 Skill	Ankle Joints	Initiative: +20

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -4135,11 +4135,15 @@ public abstract class KoLCharacter {
   }
 
   /** Utility methods which looks up whether or not the character has a particular skill. */
-  public static final boolean hasSkill(final int skillId) {
+  public static boolean hasSkill(final int skillId) {
     return KoLConstants.availableSkillsSet.contains(skillId);
   }
 
-  public static final boolean hasSkill(final String skillName) {
+  public static boolean hasSkill(final UseSkillRequest skill) {
+    return KoLConstants.availableSkillsSet.contains(skill.getSkillId());
+  }
+
+  public static boolean hasSkill(final String skillName) {
     // *** Skills can have ambiguous names. Best to use the methods that deal with skill id
     int skillId = SkillDatabase.getSkillId(skillName);
     return KoLCharacter.hasSkill(skillId);


### PR DESCRIPTION
This doesn't need special casing - we can express the interaction between dodecapedes and amphibian sympathy in modifier expressions.

Also refactor to java streams and add comments.