### PR TITLE
Fix Class being unable to be fetched from its ID

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
@@ -213,8 +213,8 @@ public class Type extends Symbol {
       case DataTypes.TYPE_LOCATION -> DataTypes.parseLocationValue(id, returnDefault);
       case DataTypes.TYPE_SLOT -> DataTypes.makeSlotValue(id, returnDefault);
       case DataTypes.TYPE_PATH -> DataTypes.makePathValue(id, returnDefault);
+      case DataTypes.TYPE_CLASS -> DataTypes.makeClassValue(id, returnDefault);
         // The following don't have an integer -> object mapping
-      case DataTypes.TYPE_CLASS -> DataTypes.CLASS_INIT;
       case DataTypes.TYPE_STAT -> DataTypes.STAT_INIT;
       case DataTypes.TYPE_ELEMENT -> DataTypes.ELEMENT_INIT;
       case DataTypes.TYPE_COINMASTER -> DataTypes.COINMASTER_INIT;

--- a/test/net/sourceforge/kolmafia/textui/javascript/AshInteropTest.java
+++ b/test/net/sourceforge/kolmafia/textui/javascript/AshInteropTest.java
@@ -61,4 +61,14 @@ public class AshInteropTest {
     String retS = ret.toString();
     assertEquals("heeheehee", retS);
   }
+
+  @Test
+  void getClassFromId() {
+    var js = new JavascriptRuntime("Class.get(1)");
+    assertNotNull(js, "JavascriptRuntime returned as null.");
+    Value ret = js.execute(null, null, true);
+    assertNotNull(ret, "Javascript execute returns null instead of a result to be tested.");
+    String retS = ret.toString();
+    assertEquals("Seal Clubber", retS);
+  }
 }


### PR DESCRIPTION
Not sure if this is Javascript specific, but `to_class(1)` will work in ash. But `Class.get(1)` will fail in Javascript.