### PR TITLE
Check for the olivers_nocost div instead of (1)

### DIFF
--- a/src/net/sourceforge/kolmafia/session/QuestManager.java
+++ b/src/net/sourceforge/kolmafia/session/QuestManager.java
@@ -504,7 +504,7 @@ public class QuestManager {
   }
 
   private static void handleSpeakeasyChange(final String text) {
-    if (text.contains("Unusually Quiet Barroom Brawl (1)")) {
+    if (!text.contains("olivers_nocost")) {
       Preferences.setInteger("_speakeasyFreeFights", 3);
     }
   }

--- a/test/net/sourceforge/kolmafia/session/QuestManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/QuestManagerTest.java
@@ -2080,10 +2080,18 @@ public class QuestManagerTest {
   }
 
   @Test
-  public void canParseSpeakeasyAdventures() {
+  public void canParseSpeakeasyBeingNotFree() {
     var request = new GenericRequest("place.php?whichplace=speakeasy");
     request.responseText = html("request/test_speakeasy_brawl_(1).html");
     QuestManager.handleQuestChange(request);
     assertEquals(Preferences.getInteger("_speakeasyFreeFights"), 3);
+  }
+
+  @Test
+  public void canParseSpeakeasyBeingFree() {
+    var request = new GenericRequest("place.php?whichplace=speakeasy");
+    request.responseText = html("request/test_speakeasy_brawl_(0).html");
+    QuestManager.handleQuestChange(request);
+    assertEquals(Preferences.getInteger("_speakeasyFreeFights"), 0);
   }
 }

--- a/test/root/request/test_speakeasy_brawl_(0).html
+++ b/test/root/request/test_speakeasy_brawl_(0).html
@@ -1,0 +1,53 @@
+<html><head>
+  <script language=Javascript>
+<!--
+if (parent.frames.length == -1) location.href="game.php";
+//-->
+</script>
+  <script language=Javascript src="/images/scripts/keybinds.min.2.js"></script>
+  <script language=Javascript src="/images/scripts/window.20111231.js"></script>
+  <script language="javascript">function chatFocus(){if(top.chatpane.document.chatform.graf) top.chatpane.document.chatform.graf.focus();}
+if (typeof defaultBind != 'undefined') { defaultBind(47, 2, chatFocus); defaultBind(190, 2, chatFocus);defaultBind(191, 2, chatFocus); defaultBind(47, 8, chatFocus);defaultBind(190, 8, chatFocus); defaultBind(191, 8, chatFocus); }</script><script language="javascript">
+	function updateParseItem(iid, field, info) {
+		var tbl = $('#ic'+iid);
+		var data = parseItem(tbl);
+		if (!data) return;
+		data[field] = info;
+		var out = [];
+		for (i in data) {
+			if (!data.hasOwnProperty(i)) continue;
+			out.push(i+'='+data[i]);
+		}
+		tbl.attr('rel', out.join('&'));
+	}
+	function parseItem(tbl) {
+		tbl = $(tbl);
+		var rel = tbl.attr('rel');
+		var data = {};
+		if (!rel) return data;
+		var parts = rel.split('&');
+		for (i in parts) {
+			if (!parts.hasOwnProperty(i)) continue;
+			var kv = parts[i].split('=');
+			tbl.data(kv[0], kv[1]);
+			data[kv[0]] = kv[1];
+		}
+		return data;
+	}
+</script><script language=Javascript src="/images/scripts/jquery-1.3.1.min.js"></script>
+  <script type="text/javascript" src="/images/scripts/pop_query.20130705.js"></script>
+  <script type="text/javascript"> function pop_ircm(clicked) { return false; } </script>	<link rel="stylesheet" type="text/css" href="/images/styles.20151006.css">
+  <style type='text/css'>
+.faded {
+	zoom: 1;
+	filter: alpha(opacity=35);
+	opacity: 0.35;
+	-khtml-opacity: 0.35;
+    -moz-opacity: 0.35;
+}
+</style>
+
+  <script language="Javascript" src="/basics.js"></script><link rel="stylesheet" href="/basics.1.css" /></head>
+
+<body>
+<centeR><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="color: white;" align=center bgcolor="#ffcccc"><b>Alice's Restaurant</b></td></tr><tr><td style="padding: 5px; border: 1px solid #ffcccc;"><center><table><tr><td><center><div id=background  style='position: relative; width:400px;height:350px'  ><img src="/images/otherimages/oliversplace.gif" width=400 height=350 border=0><div id=olivers_bartender style=' position: absolute; top: 28; left: 11; height: 120; width: 150;'><a  href=shop.php?whichshop=olivers><img src="/images/otherimages/1x1trans.gif" width=150 height=120 border=0 alt="Fancy Dan" title="Fancy Dan"></a></div><div id=olivers_bouncer style=' position: absolute; top: 202; left: 7; height: 60; width: 75;'><a  href=place.php?whichplace=speakeasy&action=olivers_bouncer><img src="/images/otherimages/1x1trans.gif" width=75 height=60 border=0 alt="The Bouncer" title="The Bouncer"></a></div><div id=olivers_brawl style=' position: absolute; top: 172; left: 231; height: 100; width: 150;'><a  href=adventure.php?snarfblat=558><img src="/images/otherimages/1x1trans.gif" width=150 height=100 border=0 alt="An Unusually Quiet Barroom Brawl (1)" title="An Unusually Quiet Barroom Brawl (1)"></a></div><div id=olivers_codetable style=' position: absolute; top: 163; left: 84; height: 60; width: 80;'><a  href=place.php?whichplace=speakeasy&action=olivers_codetable><img src="/images/otherimages/1x1trans.gif" width=80 height=60 border=0 alt="A Scratched-Up Table" title="A Scratched-Up Table"></a></div><div id=olivers_exit style=' position: absolute; top: 277; left: 6; height: 50; width: 50;'><a  href=place.php?whichplace=town_wrong><img src="/images/otherimages/1x1trans.gif" width=50 height=50 border=0 alt="Exit" title="Exit"></a></div><div id=olivers_nocost style=' position: absolute; top: 203; left: 342; height: 15; width: 20;'><img src="/images/otherimages/blank.gif" width=20 height=15 border=0 alt="" title=""></div><div id=olivers_piano style=' position: absolute; top: 21; left: 169; height: 70; width: 80;'><a  href=place.php?whichplace=speakeasy&action=olivers_piano><img src="/images/otherimages/1x1trans.gif" width=80 height=70 border=0 alt="Piano" title="Piano"></a></div><div id=olivers_pooltable style=' position: absolute; top: 96; left: 204; height: 75; width: 75;'><a  href=place.php?whichplace=speakeasy&action=olivers_pooltable><img src="/images/otherimages/1x1trans.gif" width=75 height=75 border=0 alt="Pool Table" title="Pool Table"></a></div><div id=olivers_sign style=' position: absolute; top: 19; left: 300; height: 50; width: 80;'><a  href=place.php?whichplace=speakeasy&action=olivers_sign><img src="/images/otherimages/1x1trans.gif" width=80 height=50 border=0 alt="A Conspicuous Plaque" title="A Conspicuous Plaque"></a></div><div id=olivers_sot style=' position: absolute; top: 94; left: 288; height: 80; width: 100;'><a  href=place.php?whichplace=speakeasy&action=olivers_sot><img src="/images/otherimages/1x1trans.gif" width=100 height=80 border=0 alt="Milky-Eyed Sot" title="Milky-Eyed Sot"></a></div></div><p></center></td></tr></table></center></td></tr><tr><td height=4></td></tr></table></center></body><script src="/onfocus.1.js"></script></html>


### PR DESCRIPTION
Unfortunately,the tooltip for the unusually quiet barroom brawl has (1) regardless of whether it currently costs a turn. It looks like they cover up the (1) in the image using a div, so we're now checking for the presence of that div. 