### PR TITLE
fix context menus always showing first element of list or table

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/listener/PopupListener.java
+++ b/src/net/sourceforge/kolmafia/swingui/listener/PopupListener.java
@@ -62,7 +62,7 @@ public class PopupListener extends MouseAdapter {
 
     if (!table.isRowSelected(row)) {
       table.clearSelection();
-      table.addRowSelectionInterval(row, row);
+      table.setRowSelectionInterval(row, row);
     }
   }
 }

--- a/src/net/sourceforge/kolmafia/swingui/widget/ShowDescriptionList.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/ShowDescriptionList.java
@@ -49,7 +49,6 @@ import net.sourceforge.kolmafia.utilities.WikiUtilities;
 import net.sourceforge.kolmafia.webui.RelayLoader;
 
 public class ShowDescriptionList<E> extends JList<E> {
-  public int lastSelectIndex;
   public JPopupMenu contextMenu;
   public ListElementFilter filter;
 
@@ -247,10 +246,7 @@ public class ShowDescriptionList<E> extends JList<E> {
 
     @Override
     protected void execute() {
-      this.index =
-          ShowDescriptionList.this.lastSelectIndex == -1
-              ? ShowDescriptionList.this.getSelectedIndex()
-              : ShowDescriptionList.this.lastSelectIndex;
+      this.index = ShowDescriptionList.this.getSelectedIndex();
 
       this.item = ShowDescriptionList.this.displayModel.getElementAt(this.index);
 

--- a/src/net/sourceforge/kolmafia/swingui/widget/ShowDescriptionTable.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/ShowDescriptionTable.java
@@ -79,7 +79,6 @@ and all the "List-specific" methods will be provided in adapter methods.
 */
 
 public class ShowDescriptionTable<E> extends JXTable {
-  public int lastSelectIndex;
   public JPopupMenu contextMenu;
   public ListElementFilter filter;
 
@@ -518,10 +517,7 @@ public class ShowDescriptionTable<E> extends JXTable {
 
     @Override
     protected void execute() {
-      this.index =
-          ShowDescriptionTable.this.lastSelectIndex == -1
-              ? ShowDescriptionTable.this.getSelectedRow()
-              : ShowDescriptionTable.this.lastSelectIndex;
+      this.index = ShowDescriptionTable.this.getSelectedRow();
 
       this.item =
           ShowDescriptionTable.this.displayModel.getElementAt(


### PR DESCRIPTION
ShowDesciptionList and showDescriptionTable each had a "lastSelectIndex" field which was set by the context menu popup. When an element in the context menu was selected, the action was invoked on the element at that index, unless the index was -1, in which case it would fetch the current selected index.

Those variables were not initialized. Hence, as ints, they defaulted to 0.

When PopupListener was refactored into an independent widget, it no longer had access to set "lastSelectedIndex".

Therefore, ShowDescriptionList/ShowDescriptionTable looked at the uninitialized index, got a zero, and always executed the action on element 0.

This PR removes lastSelectedIndex from both ShowDescriptionList and ShowDescriptionTable and instead gets the currently selected index - which PopupLIstener ensured was valid; if not, the popup was not displayed.