### PR TITLE
Add [optional] pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml
+  - repo: https://github.com/jguttman94/pre-commit-gradle
+    rev: v0.3.0
+    hooks:
+    - id: gradle-spotless
+      args: ['-w', --wrapper]


### PR DESCRIPTION
Add a config for [pre-commit](https://pre-commit.com/), which allows a user to locally opt-in to running some additional checks before committing. I've only enabled the additional check to run spotless as it completes very fast and it's something a few other devs have mentioned they forget to run before committing but would like to happen automatically.

To use pre-commit please see the [quick start instructions](https://pre-commit.com/#quick-start).

As an example if you were to try to commit a change that needs to be formatted by spotless, the first commit attempt fails because pre-commit modifies files then the second attempt succeeds:

```
> pre-commit install
pre-commit installed at .git/hooks/pre-commit

> git stage test/net/sourceforge/kolmafia/AreaCombatDataTest.java 

> git commit -m "test"                                           
check for merge conflicts................................................Passed
check yaml...........................................(no files to check)Skipped
gradle spotless..........................................................Failed
- hook id: gradle-spotless
- files were modified by this hook

Running 'gradle spotlessCheck spotlessApply' with wrapper enabled.

> git stage test/net/sourceforge/kolmafia/AreaCombatDataTest.java

> git commit -m "test"                                           
check for merge conflicts................................................Passed
check yaml...........................................(no files to check)Skipped
gradle spotless..........................................................Passed
[pre-commit-config 267954b930] test
 1 file changed, 1 insertion(+)
```

This is completely optional and this config will do nothing if you don't want to use pre-commit.