### PR TITLE
spading data for t4 cookbookbat foods

### DIFF
--- a/src/data/fullness.txt
+++ b/src/data/fullness.txt
@@ -129,7 +129,7 @@ bucket of honey	1	4	good	3	0	0	0	50 Sugar Rush
 bunch of square grapes	2	7	awesome	6-7	1-5	5-20	1-5
 C.H.U.M. chum	3	1	crappy	1	0	0	0	20 Majorly Poisoned
 cactus fruit	2	7	awesome	6-7	6-20	1-5	1-5	lose 8-10 HP
-Calzone of Legend	2	5	EPIC	0	0	0	0	Unspaded, 100 In the 'zone zone! (+50 Spell Damage, +25 Mys, +300% Mys, +100% Max HP/MP), PIZZA
+Calzone of Legend	2	5	EPIC	19-22	0	0	0	Unspaded, 100 In the 'zone zone! (+50 Spell Damage, +25 Mys, +300% Mys, +100% Max HP/MP), PIZZA
 campfire baked potato	1	1	awesome	4-5	15-30	0	0	60 Trial by Campfire (Damage Reduction: 10)
 campfire beans	1	1	awesome	3-4	0	10-20	0	40 The More You Eat (Stench Damage +15, Stench Spell Damage +15)
 campfire coffee	1	1	awesome	3-4	0	0	10-20	40 Coffee Achiever (+25 Init)
@@ -249,7 +249,7 @@ D roll	2	4	awesome	6-8	0	20-30	0	20 On a Roll (+25 Food Drop)
 dead lights pie	2	2	awesome	7-9	5-10	20-40	5-10
 dead meat bun	3	4	decent	5	10	0	0
 decent brain	1	1	decent	2	3-5	3-5	3-5	Zombie Slayer
-Deep Dish of Legend	2	1	EPIC	0	0	0	0	Unspaded, 100 In the Depths (+15 Familiar Weight, +25 Mus, +300% Mus, +100% Max HP/MP), PIZZA
+Deep Dish of Legend	2	1	EPIC	19-22	0	0	0	Unspaded, 100 In the Depths (+15 Familiar Weight, +25 Mus, +300% Mus, +100% Max HP/MP), PIZZA
 dehydrated caviar	1	2	decent	2	0	0	15
 delicious noodles	3	3	good	6-9	0	0	9-25
 delicious salad	3	1	decent	3-5	0	0	0	25% chance of tattoo, SALAD
@@ -684,7 +684,7 @@ piping organ pie	2	2	awesome	7-9	20-40	5-10	5-10
 pirate fork	4	1	???	0	0	0	0	Consume one random 4-fullness food
 pixel banana	2	4	awesome	9-11	0	0	0	40 Going Ape (+30% Item drops)
 pixel lemon	2	1	awesome	9-11	0	0	0
-Pizza of Legend	2	5	EPIC	0	0	0	0	Unspaded, 100 Endless Drool (+25 Moxie, +300% Moxie, +100% HP/MP, +50% pickpocket), PIZZA
+Pizza of Legend	2	5	EPIC	19-22	0	0	0	Unspaded, 100 Endless Drool (+25 Moxie, +300% Moxie, +100% HP/MP, +50% pickpocket), PIZZA
 plain bagel	3	1	decent	5-7	0	0	0
 plain calzone	2	1	EPIC	0	0	0	0	Unspaded, 50 Angering Pizza Purists (+15 Moxie, +200% Muscle, +50 ML), PIZZA
 plain candy cane	1	1	crappy	1	0	0	0


### PR DESCRIPTION
They've been found giving pizza lovers 21-24 adventures, which amounts to a base adventure gain of 19-22