### PR TITLE
refactor: change KoLConstant's consume types to an enum

### DIFF
--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -4,7 +4,7 @@
 #	PRIMARY_USE:
 #	none,
 #	food, drink, spleen,
-#	potion
+#	potion, avatar
 #	usable, multiple, reusable, message,
 #	grow, pokepill
 #	hat, weapon, sixgun, offhand, container, shirt, pants, accessory, familiar,

--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -13,6 +13,7 @@ import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.SwingConstants;
 import net.java.dev.spellcast.utilities.JComponentUtilities;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -1309,7 +1310,7 @@ public class FamiliarData implements Comparable<FamiliarData> {
       case FamiliarPool.HATRACK:
         // Hatrack can wear Hats as well as familiar items, but not Crown of Thrones
         if (itemId != ItemPool.HATSEAT
-            && ItemDatabase.getConsumptionType(itemId) == KoLConstants.EQUIP_HAT) {
+            && ItemDatabase.getConsumptionType(itemId) == ConsumptionType.EQUIP_HAT) {
           return true;
         }
         break;
@@ -1324,14 +1325,14 @@ public class FamiliarData implements Comparable<FamiliarData> {
 
       case FamiliarPool.LEFT_HAND:
         // Left-Hand Man can wear Offhand items as well as familiar items
-        if (ItemDatabase.getConsumptionType(itemId) == KoLConstants.EQUIP_OFFHAND) {
+        if (ItemDatabase.getConsumptionType(itemId) == ConsumptionType.EQUIP_OFFHAND) {
           return true;
         }
         break;
 
       case FamiliarPool.SCARECROW:
         // Scarecrow can wear Pants as well as familiar items
-        if (ItemDatabase.getConsumptionType(itemId) == KoLConstants.EQUIP_PANTS) {
+        if (ItemDatabase.getConsumptionType(itemId) == ConsumptionType.EQUIP_PANTS) {
           return true;
         }
         break;
@@ -1368,18 +1369,18 @@ public class FamiliarData implements Comparable<FamiliarData> {
     return false;
   }
 
-  public int specialEquipmentType() {
+  public ConsumptionType specialEquipmentType() {
     switch (this.id) {
       case FamiliarPool.HATRACK:
-        return KoLConstants.EQUIP_HAT;
+        return ConsumptionType.EQUIP_HAT;
       case FamiliarPool.HAND:
-        return KoLConstants.EQUIP_WEAPON;
+        return ConsumptionType.EQUIP_WEAPON;
       case FamiliarPool.LEFT_HAND:
-        return KoLConstants.EQUIP_OFFHAND;
+        return ConsumptionType.EQUIP_OFFHAND;
       case FamiliarPool.SCARECROW:
-        return KoLConstants.EQUIP_PANTS;
+        return ConsumptionType.EQUIP_PANTS;
       default:
-        return KoLConstants.NO_CONSUME;
+        return ConsumptionType.NO_CONSUME;
     }
   }
 

--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -1310,7 +1310,7 @@ public class FamiliarData implements Comparable<FamiliarData> {
       case FamiliarPool.HATRACK:
         // Hatrack can wear Hats as well as familiar items, but not Crown of Thrones
         if (itemId != ItemPool.HATSEAT
-            && ItemDatabase.getConsumptionType(itemId) == ConsumptionType.EQUIP_HAT) {
+            && ItemDatabase.getConsumptionType(itemId) == ConsumptionType.HAT) {
           return true;
         }
         break;
@@ -1325,14 +1325,14 @@ public class FamiliarData implements Comparable<FamiliarData> {
 
       case FamiliarPool.LEFT_HAND:
         // Left-Hand Man can wear Offhand items as well as familiar items
-        if (ItemDatabase.getConsumptionType(itemId) == ConsumptionType.EQUIP_OFFHAND) {
+        if (ItemDatabase.getConsumptionType(itemId) == ConsumptionType.OFFHAND) {
           return true;
         }
         break;
 
       case FamiliarPool.SCARECROW:
         // Scarecrow can wear Pants as well as familiar items
-        if (ItemDatabase.getConsumptionType(itemId) == ConsumptionType.EQUIP_PANTS) {
+        if (ItemDatabase.getConsumptionType(itemId) == ConsumptionType.PANTS) {
           return true;
         }
         break;
@@ -1372,15 +1372,15 @@ public class FamiliarData implements Comparable<FamiliarData> {
   public ConsumptionType specialEquipmentType() {
     switch (this.id) {
       case FamiliarPool.HATRACK:
-        return ConsumptionType.EQUIP_HAT;
+        return ConsumptionType.HAT;
       case FamiliarPool.HAND:
-        return ConsumptionType.EQUIP_WEAPON;
+        return ConsumptionType.WEAPON;
       case FamiliarPool.LEFT_HAND:
-        return ConsumptionType.EQUIP_OFFHAND;
+        return ConsumptionType.OFFHAND;
       case FamiliarPool.SCARECROW:
-        return ConsumptionType.EQUIP_PANTS;
+        return ConsumptionType.PANTS;
       default:
-        return ConsumptionType.NO_CONSUME;
+        return ConsumptionType.NONE;
     }
   }
 

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -4862,22 +4862,20 @@ public abstract class KoLCharacter {
 
   public static boolean hasEquipped(AdventureResult[] equipment, final AdventureResult item) {
     return switch (ItemDatabase.getConsumptionType(item.getItemId())) {
-      case EQUIP_WEAPON -> KoLCharacter.hasEquipped(
+      case WEAPON -> KoLCharacter.hasEquipped(
           equipment, item, new int[] {EquipmentManager.WEAPON, EquipmentManager.OFFHAND});
-      case EQUIP_OFFHAND -> KoLCharacter.hasEquipped(
+      case OFFHAND -> KoLCharacter.hasEquipped(
           equipment, item, new int[] {EquipmentManager.OFFHAND, EquipmentManager.FAMILIAR});
-      case EQUIP_HAT -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.HAT);
-      case EQUIP_SHIRT -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.SHIRT);
-      case EQUIP_PANTS -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.PANTS);
-      case EQUIP_CONTAINER -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.CONTAINER);
-      case EQUIP_ACCESSORY -> KoLCharacter.hasEquipped(
-          equipment, item, EquipmentManager.ACCESSORY_SLOTS);
-      case CONSUME_STICKER -> KoLCharacter.hasEquipped(
-          equipment, item, EquipmentManager.STICKER_SLOTS);
-      case CONSUME_CARD -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.CARDSLEEVE);
-      case CONSUME_FOLDER -> KoLCharacter.hasEquipped(
-          equipment, item, EquipmentManager.FOLDER_SLOTS);
-      case EQUIP_FAMILIAR -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.FAMILIAR);
+      case HAT -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.HAT);
+      case SHIRT -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.SHIRT);
+      case PANTS -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.PANTS);
+      case CONTAINER -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.CONTAINER);
+      case ACCESSORY -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.ACCESSORY_SLOTS);
+      case STICKER -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.STICKER_SLOTS);
+      case CARD -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.CARDSLEEVE);
+      case FOLDER -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.FOLDER_SLOTS);
+      case FAMILIAR_EQUIPMENT -> KoLCharacter.hasEquipped(
+          equipment, item, EquipmentManager.FAMILIAR);
       default -> false;
     };
   }
@@ -4895,19 +4893,19 @@ public abstract class KoLCharacter {
 
   public static final int equipmentSlot(final AdventureResult item) {
     return switch (ItemDatabase.getConsumptionType(item.getItemId())) {
-      case EQUIP_WEAPON -> equipmentSlotFromSubset(
+      case WEAPON -> equipmentSlotFromSubset(
           item, new int[] {EquipmentManager.WEAPON, EquipmentManager.OFFHAND});
-      case EQUIP_OFFHAND -> equipmentSlotFromSubset(
+      case OFFHAND -> equipmentSlotFromSubset(
           item, new int[] {EquipmentManager.OFFHAND, EquipmentManager.FAMILIAR});
-      case EQUIP_HAT -> equipmentSlotFromSubset(item, EquipmentManager.HAT);
-      case EQUIP_SHIRT -> equipmentSlotFromSubset(item, EquipmentManager.SHIRT);
-      case EQUIP_PANTS -> equipmentSlotFromSubset(item, EquipmentManager.PANTS);
-      case EQUIP_CONTAINER -> equipmentSlotFromSubset(item, EquipmentManager.CONTAINER);
-      case EQUIP_ACCESSORY -> equipmentSlotFromSubset(item, EquipmentManager.ACCESSORY_SLOTS);
-      case CONSUME_STICKER -> equipmentSlotFromSubset(item, EquipmentManager.STICKER_SLOTS);
-      case CONSUME_CARD -> equipmentSlotFromSubset(item, EquipmentManager.CARDSLEEVE);
-      case CONSUME_FOLDER -> equipmentSlotFromSubset(item, EquipmentManager.FOLDER_SLOTS);
-      case EQUIP_FAMILIAR -> equipmentSlotFromSubset(item, EquipmentManager.FAMILIAR);
+      case HAT -> equipmentSlotFromSubset(item, EquipmentManager.HAT);
+      case SHIRT -> equipmentSlotFromSubset(item, EquipmentManager.SHIRT);
+      case PANTS -> equipmentSlotFromSubset(item, EquipmentManager.PANTS);
+      case CONTAINER -> equipmentSlotFromSubset(item, EquipmentManager.CONTAINER);
+      case ACCESSORY -> equipmentSlotFromSubset(item, EquipmentManager.ACCESSORY_SLOTS);
+      case STICKER -> equipmentSlotFromSubset(item, EquipmentManager.STICKER_SLOTS);
+      case CARD -> equipmentSlotFromSubset(item, EquipmentManager.CARDSLEEVE);
+      case FOLDER -> equipmentSlotFromSubset(item, EquipmentManager.FOLDER_SLOTS);
+      case FAMILIAR_EQUIPMENT -> equipmentSlotFromSubset(item, EquipmentManager.FAMILIAR);
       default -> EquipmentManager.NONE;
     };
   }
@@ -5466,7 +5464,7 @@ public abstract class KoLCharacter {
     ConsumptionType consume = ItemDatabase.getConsumptionType(itemId);
 
     if (slot == EquipmentManager.FAMILIAR
-        && (consume == ConsumptionType.EQUIP_HAT || consume == ConsumptionType.EQUIP_PANTS)) {
+        && (consume == ConsumptionType.HAT || consume == ConsumptionType.PANTS)) {
       // Hatrack hats don't get their normal enchantments
       // Scarecrow pants don't get their normal enchantments
       return;
@@ -5475,10 +5473,10 @@ public abstract class KoLCharacter {
     Modifiers imod;
 
     if (slot == EquipmentManager.FAMILIAR
-        && (consume == ConsumptionType.EQUIP_WEAPON || consume == ConsumptionType.EQUIP_OFFHAND)) {
+        && (consume == ConsumptionType.WEAPON || consume == ConsumptionType.OFFHAND)) {
       imod = Modifiers.getItemModifiersInFamiliarSlot(itemId);
 
-      if (consume == ConsumptionType.EQUIP_WEAPON) {
+      if (consume == ConsumptionType.WEAPON) {
         newModifiers.add(
             Modifiers.WEAPON_DAMAGE,
             EquipmentDatabase.getPower(itemId) * 0.15f,
@@ -5595,7 +5593,7 @@ public abstract class KoLCharacter {
     // Add modifiers that depend on equipment power
     switch (slot) {
       case EquipmentManager.OFFHAND:
-        if (consume != ConsumptionType.EQUIP_WEAPON) {
+        if (consume != ConsumptionType.WEAPON) {
           break;
         }
         /*FALLTHRU*/

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -14,6 +14,7 @@ import java.util.stream.IntStream;
 import net.java.dev.spellcast.utilities.LockableListModel;
 import net.java.dev.spellcast.utilities.SortedListModel;
 import net.sourceforge.kolmafia.AscensionPath.Path;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.Stat;
 import net.sourceforge.kolmafia.KoLConstants.WeaponType;
 import net.sourceforge.kolmafia.KoLConstants.ZodiacType;
@@ -4861,27 +4862,27 @@ public abstract class KoLCharacter {
 
   public static boolean hasEquipped(AdventureResult[] equipment, final AdventureResult item) {
     return switch (ItemDatabase.getConsumptionType(item.getItemId())) {
-      case KoLConstants.EQUIP_WEAPON -> KoLCharacter.hasEquipped(
+      case EQUIP_WEAPON -> KoLCharacter.hasEquipped(
           equipment, item, new int[] {EquipmentManager.WEAPON, EquipmentManager.OFFHAND});
-      case KoLConstants.EQUIP_OFFHAND -> KoLCharacter.hasEquipped(
+      case EQUIP_OFFHAND -> KoLCharacter.hasEquipped(
           equipment, item, new int[] {EquipmentManager.OFFHAND, EquipmentManager.FAMILIAR});
-      case KoLConstants.EQUIP_HAT -> KoLCharacter.hasEquipped(
+      case EQUIP_HAT -> KoLCharacter.hasEquipped(
           equipment, item, EquipmentManager.HAT);
-      case KoLConstants.EQUIP_SHIRT -> KoLCharacter.hasEquipped(
+      case EQUIP_SHIRT -> KoLCharacter.hasEquipped(
           equipment, item, EquipmentManager.SHIRT);
-      case KoLConstants.EQUIP_PANTS -> KoLCharacter.hasEquipped(
+      case EQUIP_PANTS -> KoLCharacter.hasEquipped(
           equipment, item, EquipmentManager.PANTS);
-      case KoLConstants.EQUIP_CONTAINER -> KoLCharacter.hasEquipped(
+      case EQUIP_CONTAINER -> KoLCharacter.hasEquipped(
           equipment, item, EquipmentManager.CONTAINER);
-      case KoLConstants.EQUIP_ACCESSORY -> KoLCharacter.hasEquipped(
+      case EQUIP_ACCESSORY -> KoLCharacter.hasEquipped(
           equipment, item, EquipmentManager.ACCESSORY_SLOTS);
-      case KoLConstants.CONSUME_STICKER -> KoLCharacter.hasEquipped(
+      case CONSUME_STICKER -> KoLCharacter.hasEquipped(
           equipment, item, EquipmentManager.STICKER_SLOTS);
-      case KoLConstants.CONSUME_CARD -> KoLCharacter.hasEquipped(
+      case CONSUME_CARD -> KoLCharacter.hasEquipped(
           equipment, item, EquipmentManager.CARDSLEEVE);
-      case KoLConstants.CONSUME_FOLDER -> KoLCharacter.hasEquipped(
+      case CONSUME_FOLDER -> KoLCharacter.hasEquipped(
           equipment, item, EquipmentManager.FOLDER_SLOTS);
-      case KoLConstants.EQUIP_FAMILIAR -> KoLCharacter.hasEquipped(
+      case EQUIP_FAMILIAR -> KoLCharacter.hasEquipped(
           equipment, item, EquipmentManager.FAMILIAR);
       default -> false;
     };
@@ -4900,23 +4901,23 @@ public abstract class KoLCharacter {
 
   public static final int equipmentSlot(final AdventureResult item) {
     return switch (ItemDatabase.getConsumptionType(item.getItemId())) {
-      case KoLConstants.EQUIP_WEAPON -> equipmentSlotFromSubset(
+      case EQUIP_WEAPON -> equipmentSlotFromSubset(
           item, new int[] {EquipmentManager.WEAPON, EquipmentManager.OFFHAND});
-      case KoLConstants.EQUIP_OFFHAND -> equipmentSlotFromSubset(
+      case EQUIP_OFFHAND -> equipmentSlotFromSubset(
           item, new int[] {EquipmentManager.OFFHAND, EquipmentManager.FAMILIAR});
-      case KoLConstants.EQUIP_HAT -> equipmentSlotFromSubset(item, EquipmentManager.HAT);
-      case KoLConstants.EQUIP_SHIRT -> equipmentSlotFromSubset(item, EquipmentManager.SHIRT);
-      case KoLConstants.EQUIP_PANTS -> equipmentSlotFromSubset(item, EquipmentManager.PANTS);
-      case KoLConstants.EQUIP_CONTAINER -> equipmentSlotFromSubset(
+      case EQUIP_HAT -> equipmentSlotFromSubset(item, EquipmentManager.HAT);
+      case EQUIP_SHIRT -> equipmentSlotFromSubset(item, EquipmentManager.SHIRT);
+      case EQUIP_PANTS -> equipmentSlotFromSubset(item, EquipmentManager.PANTS);
+      case EQUIP_CONTAINER -> equipmentSlotFromSubset(
           item, EquipmentManager.CONTAINER);
-      case KoLConstants.EQUIP_ACCESSORY -> equipmentSlotFromSubset(
+      case EQUIP_ACCESSORY -> equipmentSlotFromSubset(
           item, EquipmentManager.ACCESSORY_SLOTS);
-      case KoLConstants.CONSUME_STICKER -> equipmentSlotFromSubset(
+      case CONSUME_STICKER -> equipmentSlotFromSubset(
           item, EquipmentManager.STICKER_SLOTS);
-      case KoLConstants.CONSUME_CARD -> equipmentSlotFromSubset(item, EquipmentManager.CARDSLEEVE);
-      case KoLConstants.CONSUME_FOLDER -> equipmentSlotFromSubset(
+      case CONSUME_CARD -> equipmentSlotFromSubset(item, EquipmentManager.CARDSLEEVE);
+      case CONSUME_FOLDER -> equipmentSlotFromSubset(
           item, EquipmentManager.FOLDER_SLOTS);
-      case KoLConstants.EQUIP_FAMILIAR -> equipmentSlotFromSubset(item, EquipmentManager.FAMILIAR);
+      case EQUIP_FAMILIAR -> equipmentSlotFromSubset(item, EquipmentManager.FAMILIAR);
       default -> EquipmentManager.NONE;
     };
   }
@@ -5472,10 +5473,10 @@ public abstract class KoLCharacter {
     }
 
     int itemId = item.getItemId();
-    int consume = ItemDatabase.getConsumptionType(itemId);
+    ConsumptionType consume = ItemDatabase.getConsumptionType(itemId);
 
     if (slot == EquipmentManager.FAMILIAR
-        && (consume == KoLConstants.EQUIP_HAT || consume == KoLConstants.EQUIP_PANTS)) {
+        && (consume == ConsumptionType.EQUIP_HAT || consume == ConsumptionType.EQUIP_PANTS)) {
       // Hatrack hats don't get their normal enchantments
       // Scarecrow pants don't get their normal enchantments
       return;
@@ -5484,10 +5485,10 @@ public abstract class KoLCharacter {
     Modifiers imod;
 
     if (slot == EquipmentManager.FAMILIAR
-        && (consume == KoLConstants.EQUIP_WEAPON || consume == KoLConstants.EQUIP_OFFHAND)) {
+        && (consume == ConsumptionType.EQUIP_WEAPON || consume == ConsumptionType.EQUIP_OFFHAND)) {
       imod = Modifiers.getItemModifiersInFamiliarSlot(itemId);
 
-      if (consume == KoLConstants.EQUIP_WEAPON) {
+      if (consume == ConsumptionType.EQUIP_WEAPON) {
         newModifiers.add(
             Modifiers.WEAPON_DAMAGE,
             EquipmentDatabase.getPower(itemId) * 0.15f,
@@ -5604,7 +5605,7 @@ public abstract class KoLCharacter {
     // Add modifiers that depend on equipment power
     switch (slot) {
       case EquipmentManager.OFFHAND:
-        if (consume != KoLConstants.EQUIP_WEAPON) {
+        if (consume != ConsumptionType.EQUIP_WEAPON) {
           break;
         }
         /*FALLTHRU*/

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -4866,24 +4866,18 @@ public abstract class KoLCharacter {
           equipment, item, new int[] {EquipmentManager.WEAPON, EquipmentManager.OFFHAND});
       case EQUIP_OFFHAND -> KoLCharacter.hasEquipped(
           equipment, item, new int[] {EquipmentManager.OFFHAND, EquipmentManager.FAMILIAR});
-      case EQUIP_HAT -> KoLCharacter.hasEquipped(
-          equipment, item, EquipmentManager.HAT);
-      case EQUIP_SHIRT -> KoLCharacter.hasEquipped(
-          equipment, item, EquipmentManager.SHIRT);
-      case EQUIP_PANTS -> KoLCharacter.hasEquipped(
-          equipment, item, EquipmentManager.PANTS);
-      case EQUIP_CONTAINER -> KoLCharacter.hasEquipped(
-          equipment, item, EquipmentManager.CONTAINER);
+      case EQUIP_HAT -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.HAT);
+      case EQUIP_SHIRT -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.SHIRT);
+      case EQUIP_PANTS -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.PANTS);
+      case EQUIP_CONTAINER -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.CONTAINER);
       case EQUIP_ACCESSORY -> KoLCharacter.hasEquipped(
           equipment, item, EquipmentManager.ACCESSORY_SLOTS);
       case CONSUME_STICKER -> KoLCharacter.hasEquipped(
           equipment, item, EquipmentManager.STICKER_SLOTS);
-      case CONSUME_CARD -> KoLCharacter.hasEquipped(
-          equipment, item, EquipmentManager.CARDSLEEVE);
+      case CONSUME_CARD -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.CARDSLEEVE);
       case CONSUME_FOLDER -> KoLCharacter.hasEquipped(
           equipment, item, EquipmentManager.FOLDER_SLOTS);
-      case EQUIP_FAMILIAR -> KoLCharacter.hasEquipped(
-          equipment, item, EquipmentManager.FAMILIAR);
+      case EQUIP_FAMILIAR -> KoLCharacter.hasEquipped(equipment, item, EquipmentManager.FAMILIAR);
       default -> false;
     };
   }
@@ -4908,15 +4902,11 @@ public abstract class KoLCharacter {
       case EQUIP_HAT -> equipmentSlotFromSubset(item, EquipmentManager.HAT);
       case EQUIP_SHIRT -> equipmentSlotFromSubset(item, EquipmentManager.SHIRT);
       case EQUIP_PANTS -> equipmentSlotFromSubset(item, EquipmentManager.PANTS);
-      case EQUIP_CONTAINER -> equipmentSlotFromSubset(
-          item, EquipmentManager.CONTAINER);
-      case EQUIP_ACCESSORY -> equipmentSlotFromSubset(
-          item, EquipmentManager.ACCESSORY_SLOTS);
-      case CONSUME_STICKER -> equipmentSlotFromSubset(
-          item, EquipmentManager.STICKER_SLOTS);
+      case EQUIP_CONTAINER -> equipmentSlotFromSubset(item, EquipmentManager.CONTAINER);
+      case EQUIP_ACCESSORY -> equipmentSlotFromSubset(item, EquipmentManager.ACCESSORY_SLOTS);
+      case CONSUME_STICKER -> equipmentSlotFromSubset(item, EquipmentManager.STICKER_SLOTS);
       case CONSUME_CARD -> equipmentSlotFromSubset(item, EquipmentManager.CARDSLEEVE);
-      case CONSUME_FOLDER -> equipmentSlotFromSubset(
-          item, EquipmentManager.FOLDER_SLOTS);
+      case CONSUME_FOLDER -> equipmentSlotFromSubset(item, EquipmentManager.FOLDER_SLOTS);
       case EQUIP_FAMILIAR -> equipmentSlotFromSubset(item, EquipmentManager.FAMILIAR);
       default -> EquipmentManager.NONE;
     };

--- a/src/net/sourceforge/kolmafia/KoLConstants.java
+++ b/src/net/sourceforge/kolmafia/KoLConstants.java
@@ -22,6 +22,8 @@ import net.sourceforge.kolmafia.swingui.menu.PartialMRUList;
 import net.sourceforge.kolmafia.swingui.menu.ScriptMRUList;
 import net.sourceforge.kolmafia.utilities.LockableListFactory;
 
+import static net.sourceforge.kolmafia.KoLConstants.ConsumptionType.EQUIP_FAMILIAR;
+
 public interface KoLConstants extends UtilityConstants {
   // General constants used for calculations and formatting of
   // strings, as well as for string parsing.
@@ -267,7 +269,7 @@ public interface KoLConstants extends UtilityConstants {
    * @param type Consumption type constant
    * @return True if the type relates to equipment
    */
-  static boolean isEquipmentType(final int type, final boolean includeFamiliarEquipment) {
+  static boolean isEquipmentType(final ConsumptionType type, final boolean includeFamiliarEquipment) {
     return switch (type) {
       case EQUIP_ACCESSORY,
           EQUIP_CONTAINER,
@@ -349,59 +351,62 @@ public interface KoLConstants extends UtilityConstants {
     OTHER
   }
 
-  // Cannot be "used" in any way by itself
-  int NO_CONSUME = 0;
+  enum ConsumptionType {
+    UNKNOWN,
+    // Cannot be "used" in any way by itself
+    NO_CONSUME,
 
-  // Consumables
-  int CONSUME_EAT = 1;
-  int CONSUME_DRINK = 2;
-  int CONSUME_SPLEEN = 3;
+    // Consumables
+    CONSUME_EAT,
+    CONSUME_DRINK,
+    CONSUME_SPLEEN,
 
-  // Usables
-  int CONSUME_USE = 4;
-  int CONSUME_MULTIPLE = 5;
-  int INFINITE_USES = 6;
-  int MESSAGE_DISPLAY = 7;
+    // Usables
+    CONSUME_USE,
+    CONSUME_MULTIPLE,
+    INFINITE_USES,
+    MESSAGE_DISPLAY,
 
-  // Familiar hatchlings
-  int GROW_FAMILIAR = 8;
+    // Familiar hatchlings
+    GROW_FAMILIAR,
 
-  // Equipment
-  int EQUIP_HAT = 9;
-  int EQUIP_WEAPON = 10;
-  int EQUIP_OFFHAND = 11;
-  int EQUIP_CONTAINER = 12;
-  int EQUIP_SHIRT = 13;
-  int EQUIP_PANTS = 14;
-  int EQUIP_ACCESSORY = 15;
-  int EQUIP_FAMILIAR = 16;
+    // Equipment
+    EQUIP_HAT,
+    EQUIP_WEAPON,
+    EQUIP_OFFHAND,
+    EQUIP_CONTAINER,
+    EQUIP_SHIRT,
+    EQUIP_PANTS,
+    EQUIP_ACCESSORY,
+    EQUIP_FAMILIAR,
 
-  // Customizable "equipment"
-  int CONSUME_STICKER = 17;
-  int CONSUME_CARD = 18;
-  int CONSUME_FOLDER = 19;
-  int CONSUME_BOOTSKIN = 20;
-  int CONSUME_BOOTSPUR = 21;
-  int CONSUME_SIXGUN = 22;
+    // Customizable "equipment"
+    CONSUME_STICKER,
+    CONSUME_CARD,
+    CONSUME_FOLDER,
+    CONSUME_BOOTSKIN,
+    CONSUME_BOOTSPUR,
+    CONSUME_SIXGUN,
 
-  // Special "uses"
-  int CONSUME_FOOD_HELPER = 30;
-  int CONSUME_DRINK_HELPER = 31;
-  int CONSUME_ZAP = 32;
-  int CONSUME_SPHERE = 33;
-  int CONSUME_GUARDIAN = 34;
-  int CONSUME_POKEPILL = 35;
+    // Special "uses"
+    CONSUME_FOOD_HELPER,
+    CONSUME_DRINK_HELPER,
+    CONSUME_ZAP,
+    CONSUME_SPHERE,
+    CONSUME_GUARDIAN,
+    CONSUME_POKEPILL,
 
-  // Potions
-  int CONSUME_POTION = 40;
-  int CONSUME_AVATAR = 41;
+    // Potions
+    CONSUME_POTION,
+    CONSUME_AVATAR,
 
-  // Familiar "uses"
-  int CONSUME_ROBO = 95;
-  int CONSUME_MIMIC = 96;
-  int CONSUME_SLIME = 97;
-  int CONSUME_HOBO = 98;
-  int CONSUME_GHOST = 99;
+    // Familiar "uses"
+    CONSUME_ROBO,
+    CONSUME_MIMIC,
+    CONSUME_SLIME,
+    CONSUME_HOBO,
+    CONSUME_GHOST
+  }
 
   enum CraftingType {
     SUBCLASS, // ???

--- a/src/net/sourceforge/kolmafia/KoLConstants.java
+++ b/src/net/sourceforge/kolmafia/KoLConstants.java
@@ -1,6 +1,6 @@
 package net.sourceforge.kolmafia;
 
-import static net.sourceforge.kolmafia.KoLConstants.ConsumptionType.EQUIP_FAMILIAR;
+import static net.sourceforge.kolmafia.KoLConstants.ConsumptionType.FAMILIAR_EQUIPMENT;
 
 import java.awt.Color;
 import java.io.File;
@@ -272,14 +272,8 @@ public interface KoLConstants extends UtilityConstants {
   static boolean isEquipmentType(
       final ConsumptionType type, final boolean includeFamiliarEquipment) {
     return switch (type) {
-      case EQUIP_ACCESSORY,
-          EQUIP_CONTAINER,
-          EQUIP_HAT,
-          EQUIP_SHIRT,
-          EQUIP_PANTS,
-          EQUIP_WEAPON,
-          EQUIP_OFFHAND -> true;
-      default -> includeFamiliarEquipment && type == EQUIP_FAMILIAR;
+      case ACCESSORY, CONTAINER, HAT, SHIRT, PANTS, WEAPON, OFFHAND -> true;
+      default -> includeFamiliarEquipment && type == FAMILIAR_EQUIPMENT;
     };
   }
 
@@ -355,58 +349,58 @@ public interface KoLConstants extends UtilityConstants {
   enum ConsumptionType {
     UNKNOWN,
     // Cannot be "used" in any way by itself
-    NO_CONSUME,
+    NONE,
 
     // Consumables
-    CONSUME_EAT,
-    CONSUME_DRINK,
-    CONSUME_SPLEEN,
+    EAT,
+    DRINK,
+    SPLEEN,
 
     // Usables
-    CONSUME_USE,
-    CONSUME_MULTIPLE,
-    INFINITE_USES,
-    MESSAGE_DISPLAY,
+    USE,
+    USE_MULTIPLE,
+    USE_INFINITE,
+    USE_MESSAGE_DISPLAY,
 
     // Familiar hatchlings
-    GROW_FAMILIAR,
+    FAMILIAR_HATCHLING,
 
     // Equipment
-    EQUIP_HAT,
-    EQUIP_WEAPON,
-    EQUIP_OFFHAND,
-    EQUIP_CONTAINER,
-    EQUIP_SHIRT,
-    EQUIP_PANTS,
-    EQUIP_ACCESSORY,
-    EQUIP_FAMILIAR,
+    HAT,
+    WEAPON,
+    OFFHAND,
+    CONTAINER,
+    SHIRT,
+    PANTS,
+    ACCESSORY,
+    FAMILIAR_EQUIPMENT,
 
     // Customizable "equipment"
-    CONSUME_STICKER,
-    CONSUME_CARD,
-    CONSUME_FOLDER,
-    CONSUME_BOOTSKIN,
-    CONSUME_BOOTSPUR,
-    CONSUME_SIXGUN,
+    STICKER,
+    CARD,
+    FOLDER,
+    BOOTSKIN,
+    BOOTSPUR,
+    SIXGUN,
 
     // Special "uses"
-    CONSUME_FOOD_HELPER,
-    CONSUME_DRINK_HELPER,
-    CONSUME_ZAP,
-    CONSUME_SPHERE,
-    CONSUME_GUARDIAN,
-    CONSUME_POKEPILL,
+    FOOD_HELPER,
+    DRINK_HELPER,
+    ZAP,
+    EL_VIBRATO_SPHERE,
+    PASTA_GUARDIAN,
+    POKEPILL,
 
     // Potions
-    CONSUME_POTION,
-    CONSUME_AVATAR,
+    POTION,
+    AVATAR_POTION,
 
     // Familiar "uses"
-    CONSUME_ROBO,
-    CONSUME_MIMIC,
-    CONSUME_SLIME,
-    CONSUME_HOBO,
-    CONSUME_GHOST
+    ROBORTENDER,
+    STOCKING_MIMIC,
+    SLIMELING,
+    SPIRIT_HOBO,
+    GLUTTONOUS_GHOST
   }
 
   enum CraftingType {

--- a/src/net/sourceforge/kolmafia/KoLConstants.java
+++ b/src/net/sourceforge/kolmafia/KoLConstants.java
@@ -1,5 +1,7 @@
 package net.sourceforge.kolmafia;
 
+import static net.sourceforge.kolmafia.KoLConstants.ConsumptionType.EQUIP_FAMILIAR;
+
 import java.awt.Color;
 import java.io.File;
 import java.text.DecimalFormat;
@@ -21,8 +23,6 @@ import net.sourceforge.kolmafia.session.EncounterManager.RegisteredEncounter;
 import net.sourceforge.kolmafia.swingui.menu.PartialMRUList;
 import net.sourceforge.kolmafia.swingui.menu.ScriptMRUList;
 import net.sourceforge.kolmafia.utilities.LockableListFactory;
-
-import static net.sourceforge.kolmafia.KoLConstants.ConsumptionType.EQUIP_FAMILIAR;
 
 public interface KoLConstants extends UtilityConstants {
   // General constants used for calculations and formatting of
@@ -269,7 +269,8 @@ public interface KoLConstants extends UtilityConstants {
    * @param type Consumption type constant
    * @return True if the type relates to equipment
    */
-  static boolean isEquipmentType(final ConsumptionType type, final boolean includeFamiliarEquipment) {
+  static boolean isEquipmentType(
+      final ConsumptionType type, final boolean includeFamiliarEquipment) {
     return switch (type) {
       case EQUIP_ACCESSORY,
           EQUIP_CONTAINER,

--- a/src/net/sourceforge/kolmafia/KoLConstants.java
+++ b/src/net/sourceforge/kolmafia/KoLConstants.java
@@ -346,6 +346,21 @@ public interface KoLConstants extends UtilityConstants {
     OTHER
   }
 
+  /**
+   * Ways to use items.
+   *
+   * A conflation of a few concepts. Most are "primary uses" as appear in items.txt
+   *
+   * Primary uses determine how you can interact with an item. Some items are "usable"
+   * in addition to their primary use (for example, the fortune cookie or glitch season 
+   * reward).
+   *
+   * ConsumptionType is also used for how the user /intends/ to interact with an item.
+   * This is what the "Familiar 'uses'" are used for: when the user uses a command specifically
+   * for feeding a familiar.
+   *
+   * Most of this is handled in UseItemRequest.
+   */
   enum ConsumptionType {
     UNKNOWN,
     // Cannot be "used" in any way by itself

--- a/src/net/sourceforge/kolmafia/KoLConstants.java
+++ b/src/net/sourceforge/kolmafia/KoLConstants.java
@@ -349,17 +349,16 @@ public interface KoLConstants extends UtilityConstants {
   /**
    * Ways to use items.
    *
-   * A conflation of a few concepts. Most are "primary uses" as appear in items.txt
+   * <p>A conflation of a few concepts. Most are "primary uses" as appear in items.txt
    *
-   * Primary uses determine how you can interact with an item. Some items are "usable"
-   * in addition to their primary use (for example, the fortune cookie or glitch season 
-   * reward).
+   * <p>Primary uses determine how you can interact with an item. Some items are "usable" in
+   * addition to their primary use (for example, the fortune cookie or glitch season reward).
    *
-   * ConsumptionType is also used for how the user /intends/ to interact with an item.
-   * This is what the "Familiar 'uses'" are used for: when the user uses a command specifically
-   * for feeding a familiar.
+   * <p>ConsumptionType is also used for how the user /intends/ to interact with an item. This is
+   * what the "Familiar 'uses'" are used for: when the user uses a command specifically for feeding
+   * a familiar.
    *
-   * Most of this is handled in UseItemRequest.
+   * <p>Most of this is handled in UseItemRequest.
    */
   enum ConsumptionType {
     UNKNOWN,

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -24,6 +24,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
 import net.sourceforge.kolmafia.maximizer.Maximizer;
 import net.sourceforge.kolmafia.modifiers.BitmapModifier;
@@ -2452,9 +2454,9 @@ public class Modifiers {
     // Mad Hatrack ... hats do not give their normal modifiers
     // Fancypants Scarecrow ... pants do not give their normal modifiers
     int itemId = item.getItemId();
-    int type = ItemDatabase.getConsumptionType(itemId);
-    if ((familiarId != FamiliarPool.HATRACK || type != KoLConstants.EQUIP_HAT)
-        && (familiarId != FamiliarPool.SCARECROW || type != KoLConstants.EQUIP_PANTS)) {
+    ConsumptionType type = ItemDatabase.getConsumptionType(itemId);
+    if ((familiarId != FamiliarPool.HATRACK || type != ConsumptionType.EQUIP_HAT)
+        && (familiarId != FamiliarPool.SCARECROW || type != ConsumptionType.EQUIP_PANTS)) {
       // Add in all the modifiers bestowed by this item
       tempMods.add(Modifiers.getItemModifiers(itemId));
 
@@ -3507,43 +3509,43 @@ public class Modifiers {
     for (Entry<Integer, String> entry : ItemDatabase.dataNameEntrySet()) {
       Integer key = entry.getKey();
       String name = entry.getValue();
-      int type = ItemDatabase.getConsumptionType(key);
+      ConsumptionType type = ItemDatabase.getConsumptionType(key);
 
       switch (type) {
-        case KoLConstants.EQUIP_HAT:
+        case EQUIP_HAT:
           hats.add(name);
           break;
-        case KoLConstants.EQUIP_PANTS:
+        case EQUIP_PANTS:
           pants.add(name);
           break;
-        case KoLConstants.EQUIP_SHIRT:
+        case EQUIP_SHIRT:
           shirts.add(name);
           break;
-        case KoLConstants.EQUIP_WEAPON:
+        case EQUIP_WEAPON:
           weapons.add(name);
           break;
-        case KoLConstants.EQUIP_OFFHAND:
+        case EQUIP_OFFHAND:
           offhands.add(name);
           break;
-        case KoLConstants.EQUIP_ACCESSORY:
+        case EQUIP_ACCESSORY:
           accessories.add(name);
           break;
-        case KoLConstants.EQUIP_CONTAINER:
+        case EQUIP_CONTAINER:
           containers.add(name);
           break;
-        case KoLConstants.EQUIP_FAMILIAR:
+        case EQUIP_FAMILIAR:
           famitems.add(name);
           break;
-        case KoLConstants.CONSUME_SIXGUN:
+        case CONSUME_SIXGUN:
           sixguns.add(name);
           break;
-        case KoLConstants.CONSUME_STICKER:
+        case CONSUME_STICKER:
           bedazzlements.add(name);
           break;
-        case KoLConstants.CONSUME_CARD:
+        case CONSUME_CARD:
           cards.add(name);
           break;
-        case KoLConstants.CONSUME_FOLDER:
+        case CONSUME_FOLDER:
           folders.add(name);
           break;
         default:
@@ -3792,7 +3794,7 @@ public class Modifiers {
     writer.println(Modifiers.modifierCommentString(type, name));
   }
 
-  public static final void registerItem(final String name, final String text, final int type) {
+  public static final void registerItem(final String name, final String text, final ConsumptionType type) {
     // Examine the item description and decide what it is.
     ArrayList<String> unknown = new ArrayList<>();
     String known = DebugDatabase.parseItemEnchantments(text, unknown, type);

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -24,7 +24,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
 import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
 import net.sourceforge.kolmafia.maximizer.Maximizer;
@@ -3794,7 +3793,8 @@ public class Modifiers {
     writer.println(Modifiers.modifierCommentString(type, name));
   }
 
-  public static final void registerItem(final String name, final String text, final ConsumptionType type) {
+  public static final void registerItem(
+      final String name, final String text, final ConsumptionType type) {
     // Examine the item description and decide what it is.
     ArrayList<String> unknown = new ArrayList<>();
     String known = DebugDatabase.parseItemEnchantments(text, unknown, type);

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -2454,8 +2454,8 @@ public class Modifiers {
     // Fancypants Scarecrow ... pants do not give their normal modifiers
     int itemId = item.getItemId();
     ConsumptionType type = ItemDatabase.getConsumptionType(itemId);
-    if ((familiarId != FamiliarPool.HATRACK || type != ConsumptionType.EQUIP_HAT)
-        && (familiarId != FamiliarPool.SCARECROW || type != ConsumptionType.EQUIP_PANTS)) {
+    if ((familiarId != FamiliarPool.HATRACK || type != ConsumptionType.HAT)
+        && (familiarId != FamiliarPool.SCARECROW || type != ConsumptionType.PANTS)) {
       // Add in all the modifiers bestowed by this item
       tempMods.add(Modifiers.getItemModifiers(itemId));
 
@@ -3511,40 +3511,40 @@ public class Modifiers {
       ConsumptionType type = ItemDatabase.getConsumptionType(key);
 
       switch (type) {
-        case EQUIP_HAT:
+        case HAT:
           hats.add(name);
           break;
-        case EQUIP_PANTS:
+        case PANTS:
           pants.add(name);
           break;
-        case EQUIP_SHIRT:
+        case SHIRT:
           shirts.add(name);
           break;
-        case EQUIP_WEAPON:
+        case WEAPON:
           weapons.add(name);
           break;
-        case EQUIP_OFFHAND:
+        case OFFHAND:
           offhands.add(name);
           break;
-        case EQUIP_ACCESSORY:
+        case ACCESSORY:
           accessories.add(name);
           break;
-        case EQUIP_CONTAINER:
+        case CONTAINER:
           containers.add(name);
           break;
-        case EQUIP_FAMILIAR:
+        case FAMILIAR_EQUIPMENT:
           famitems.add(name);
           break;
-        case CONSUME_SIXGUN:
+        case SIXGUN:
           sixguns.add(name);
           break;
-        case CONSUME_STICKER:
+        case STICKER:
           bedazzlements.add(name);
           break;
-        case CONSUME_CARD:
+        case CARD:
           cards.add(name);
           break;
-        case CONSUME_FOLDER:
+        case FOLDER:
           folders.add(name);
           break;
         default:

--- a/src/net/sourceforge/kolmafia/SpecialOutfit.java
+++ b/src/net/sourceforge/kolmafia/SpecialOutfit.java
@@ -8,7 +8,6 @@ import java.util.TreeMap;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -117,7 +116,8 @@ public class SpecialOutfit implements Comparable<SpecialOutfit> {
       }
     } else if (type == EquipmentManager.WEAPON
         || (type == EquipmentManager.OFFHAND
-            && ItemDatabase.getConsumptionType(piece.getItemId()) == ConsumptionType.EQUIP_WEAPON)) {
+            && ItemDatabase.getConsumptionType(piece.getItemId())
+                == ConsumptionType.EQUIP_WEAPON)) {
       int weaponCount =
           (KoLCharacter.hasEquipped(piece, EquipmentManager.WEAPON) ? 1 : 0)
               + (KoLCharacter.hasEquipped(piece, EquipmentManager.OFFHAND) ? 1 : 0);

--- a/src/net/sourceforge/kolmafia/SpecialOutfit.java
+++ b/src/net/sourceforge/kolmafia/SpecialOutfit.java
@@ -116,8 +116,7 @@ public class SpecialOutfit implements Comparable<SpecialOutfit> {
       }
     } else if (type == EquipmentManager.WEAPON
         || (type == EquipmentManager.OFFHAND
-            && ItemDatabase.getConsumptionType(piece.getItemId())
-                == ConsumptionType.EQUIP_WEAPON)) {
+            && ItemDatabase.getConsumptionType(piece.getItemId()) == ConsumptionType.WEAPON)) {
       int weaponCount =
           (KoLCharacter.hasEquipped(piece, EquipmentManager.WEAPON) ? 1 : 0)
               + (KoLCharacter.hasEquipped(piece, EquipmentManager.OFFHAND) ? 1 : 0);

--- a/src/net/sourceforge/kolmafia/SpecialOutfit.java
+++ b/src/net/sourceforge/kolmafia/SpecialOutfit.java
@@ -8,6 +8,8 @@ import java.util.TreeMap;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
@@ -115,7 +117,7 @@ public class SpecialOutfit implements Comparable<SpecialOutfit> {
       }
     } else if (type == EquipmentManager.WEAPON
         || (type == EquipmentManager.OFFHAND
-            && ItemDatabase.getConsumptionType(piece.getItemId()) == KoLConstants.EQUIP_WEAPON)) {
+            && ItemDatabase.getConsumptionType(piece.getItemId()) == ConsumptionType.EQUIP_WEAPON)) {
       int weaponCount =
           (KoLCharacter.hasEquipped(piece, EquipmentManager.WEAPON) ? 1 : 0)
               + (KoLCharacter.hasEquipped(piece, EquipmentManager.OFFHAND) ? 1 : 0);

--- a/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
@@ -493,7 +493,7 @@ public class ConcoctionDatabase {
     ConsumptionType consumpt = ItemDatabase.getConsumptionType(id);
 
     if (c.getFullness() > 0
-        || consumpt == ConsumptionType.CONSUME_FOOD_HELPER
+        || consumpt == ConsumptionType.FOOD_HELPER
         || ConcoctionDatabase.canQueueFood(id)) {
       queue = ConcoctionDatabase.queuedFood;
       queuedIngredients = ConcoctionDatabase.queuedFoodIngredients;
@@ -502,7 +502,7 @@ public class ConcoctionDatabase {
         ConcoctionDatabase.queuedInebriety++;
       }
     } else if (c.getInebriety() > 0
-        || consumpt == ConsumptionType.CONSUME_DRINK_HELPER
+        || consumpt == ConsumptionType.DRINK_HELPER
         || ConcoctionDatabase.canQueueBooze(id)) {
       queue = ConcoctionDatabase.queuedBooze;
       queuedIngredients = ConcoctionDatabase.queuedBoozeIngredients;
@@ -887,9 +887,9 @@ public class ConcoctionDatabase {
       Concoction c = currentItem.getConcoction();
       int quantity = currentItem.getCount();
 
-      if (consumptionType != ConsumptionType.CONSUME_EAT
-          && consumptionType != ConsumptionType.CONSUME_DRINK
-          && consumptionType != ConsumptionType.CONSUME_SPLEEN) {
+      if (consumptionType != ConsumptionType.EAT
+          && consumptionType != ConsumptionType.DRINK
+          && consumptionType != ConsumptionType.SPLEEN) {
         // Binge familiar or create only
 
         // If it's not an actual item, it's a purchase from a cafe.
@@ -902,18 +902,16 @@ public class ConcoctionDatabase {
 
         // Skip consumption helpers; we cannot binge a
         // familiar with them and we don't "create" them
-        if (consumpt == ConsumptionType.CONSUME_FOOD_HELPER
-            || consumpt == ConsumptionType.CONSUME_DRINK_HELPER) {
+        if (consumpt == ConsumptionType.FOOD_HELPER || consumpt == ConsumptionType.DRINK_HELPER) {
           continue;
         }
 
         // Certain items are virtual consumption
         // helpers, but are "used" first. Skip if
         // bingeing familiar.
-        if ((consumptionType == ConsumptionType.CONSUME_GHOST
-                && consumpt != ConsumptionType.CONSUME_EAT)
-            || (consumptionType == ConsumptionType.CONSUME_HOBO
-                && consumpt != ConsumptionType.CONSUME_DRINK)) {
+        if ((consumptionType == ConsumptionType.GLUTTONOUS_GHOST && consumpt != ConsumptionType.EAT)
+            || (consumptionType == ConsumptionType.SPIRIT_HOBO
+                && consumpt != ConsumptionType.DRINK)) {
           continue;
         }
 
@@ -921,14 +919,14 @@ public class ConcoctionDatabase {
         AdventureResult toConsume = c.getItem().getInstance(quantity);
         InventoryManager.retrieveItem(toConsume);
 
-        if (consumptionType == ConsumptionType.CONSUME_GHOST
-            | consumptionType == ConsumptionType.CONSUME_HOBO) {
+        if (consumptionType == ConsumptionType.GLUTTONOUS_GHOST
+            | consumptionType == ConsumptionType.SPIRIT_HOBO) {
           // Binge the familiar!
           RequestThread.postRequest(UseItemRequest.getInstance(consumptionType, toConsume));
           continue;
         }
 
-        if (consumptionType == ConsumptionType.NO_CONSUME) {
+        if (consumptionType == ConsumptionType.NONE) {
           // Create only
           continue;
         }
@@ -1001,7 +999,7 @@ public class ConcoctionDatabase {
     String minderSetting = Preferences.getString("mayoMinderSetting");
     AdventureResult workshedItem = CampgroundRequest.getCurrentWorkshedItem();
     if (item != null
-        && consumptionType == ConsumptionType.CONSUME_EAT
+        && consumptionType == ConsumptionType.EAT
         && !ConcoctionDatabase.isMayo(item.getItemId())
         && !minderSetting.equals("")
         && Preferences.getBoolean("autoFillMayoMinder")
@@ -1161,13 +1159,13 @@ public class ConcoctionDatabase {
 
   public static final void setRefreshNeeded(int itemId) {
     switch (ItemDatabase.getConsumptionType(itemId)) {
-      case CONSUME_EAT:
-      case CONSUME_DRINK:
-      case CONSUME_SPLEEN:
-      case CONSUME_USE:
-      case CONSUME_MULTIPLE:
-      case CONSUME_FOOD_HELPER:
-      case CONSUME_DRINK_HELPER:
+      case EAT:
+      case DRINK:
+      case SPLEEN:
+      case USE:
+      case USE_MULTIPLE:
+      case FOOD_HELPER:
+      case DRINK_HELPER:
         ConcoctionDatabase.setRefreshNeeded(false);
         return;
     }

--- a/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
@@ -18,6 +18,7 @@ import net.sourceforge.kolmafia.CoinmasterData;
 import net.sourceforge.kolmafia.CoinmasterRegistry;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.CraftingMisc;
 import net.sourceforge.kolmafia.KoLConstants.CraftingRequirements;
 import net.sourceforge.kolmafia.KoLConstants.CraftingType;
@@ -489,10 +490,10 @@ public class ConcoctionDatabase {
     LockableListModel<AdventureResult> queuedIngredients;
 
     int id = c.getItemId();
-    int consumpt = ItemDatabase.getConsumptionType(id);
+    ConsumptionType consumpt = ItemDatabase.getConsumptionType(id);
 
     if (c.getFullness() > 0
-        || consumpt == KoLConstants.CONSUME_FOOD_HELPER
+        || consumpt == ConsumptionType.CONSUME_FOOD_HELPER
         || ConcoctionDatabase.canQueueFood(id)) {
       queue = ConcoctionDatabase.queuedFood;
       queuedIngredients = ConcoctionDatabase.queuedFoodIngredients;
@@ -501,7 +502,7 @@ public class ConcoctionDatabase {
         ConcoctionDatabase.queuedInebriety++;
       }
     } else if (c.getInebriety() > 0
-        || consumpt == KoLConstants.CONSUME_DRINK_HELPER
+        || consumpt == ConsumptionType.CONSUME_DRINK_HELPER
         || ConcoctionDatabase.canQueueBooze(id)) {
       queue = ConcoctionDatabase.queuedBooze;
       queuedIngredients = ConcoctionDatabase.queuedBoozeIngredients;
@@ -838,18 +839,18 @@ public class ConcoctionDatabase {
             : type == ConcoctionType.BOOZE ? DrinkItemRequest.boozeConsumed : 0);
   }
 
-  public static final void handleQueue(ConcoctionType type, int consumptionType) {
+  public static final void handleQueue(ConcoctionType type, ConsumptionType consumptionType) {
     // consumptionType can be:
     //
-    // KoLConstants.NO_CONSUME - create or retrieve items
-    // KoLConstants.CONSUME_EAT - eat food items
-    // KoLConstants.CONSUME_DRINK - drink booze items
-    // KoLConstants.CONSUME_SPLEEN - use spleen items
-    // KoLConstants.CONSUME_GHOST - binge ghost with food
-    // KoLConstants.CONSUME_HOBO - binge hobo with booze
-    // KoLConstants.CONSUME_USE - use potions
-    // KoLConstants.CONSUME_MULTIPLE - use potions
-    // KoLConstants.CONSUME_AVATAR - use potions
+    // ConsumptionType.NO_CONSUME - create or retrieve items
+    // ConsumptionType.CONSUME_EAT - eat food items
+    // ConsumptionType.CONSUME_DRINK - drink booze items
+    // ConsumptionType.CONSUME_SPLEEN - use spleen items
+    // ConsumptionType.CONSUME_GHOST - binge ghost with food
+    // ConsumptionType.CONSUME_HOBO - binge hobo with booze
+    // ConsumptionType.CONSUME_USE - use potions
+    // ConsumptionType.CONSUME_MULTIPLE - use potions
+    // ConsumptionType.CONSUME_AVATAR - use potions
 
     QueuedConcoction currentItem;
     Stack<QueuedConcoction> toProcess = new Stack<QueuedConcoction>();
@@ -874,7 +875,7 @@ public class ConcoctionDatabase {
   }
 
   private static void handleQueue(
-      Stack<QueuedConcoction> toProcess, ConcoctionType type, int consumptionType) {
+      Stack<QueuedConcoction> toProcess, ConcoctionType type, ConsumptionType consumptionType) {
     // Keep track of current consumption helper. These can be
     // "queued" by simply "using" them. Account for that.
     AdventureResult helper = ConcoctionDatabase.currentConsumptionHelper(type);
@@ -886,9 +887,9 @@ public class ConcoctionDatabase {
       Concoction c = currentItem.getConcoction();
       int quantity = currentItem.getCount();
 
-      if (consumptionType != KoLConstants.CONSUME_EAT
-          && consumptionType != KoLConstants.CONSUME_DRINK
-          && consumptionType != KoLConstants.CONSUME_SPLEEN) {
+      if (consumptionType != ConsumptionType.CONSUME_EAT
+          && consumptionType != ConsumptionType.CONSUME_DRINK
+          && consumptionType != ConsumptionType.CONSUME_SPLEEN) {
         // Binge familiar or create only
 
         // If it's not an actual item, it's a purchase from a cafe.
@@ -897,21 +898,21 @@ public class ConcoctionDatabase {
           continue;
         }
 
-        int consumpt = ItemDatabase.getConsumptionType(c.getItemId());
+        ConsumptionType consumpt = ItemDatabase.getConsumptionType(c.getItemId());
 
         // Skip consumption helpers; we cannot binge a
         // familiar with them and we don't "create" them
-        if (consumpt == KoLConstants.CONSUME_FOOD_HELPER
-            || consumpt == KoLConstants.CONSUME_DRINK_HELPER) {
+        if (consumpt == ConsumptionType.CONSUME_FOOD_HELPER
+            || consumpt == ConsumptionType.CONSUME_DRINK_HELPER) {
           continue;
         }
 
         // Certain items are virtual consumption
         // helpers, but are "used" first. Skip if
         // bingeing familiar.
-        if ((consumptionType == KoLConstants.CONSUME_GHOST && consumpt != KoLConstants.CONSUME_EAT)
-            || (consumptionType == KoLConstants.CONSUME_HOBO
-                && consumpt != KoLConstants.CONSUME_DRINK)) {
+        if ((consumptionType == ConsumptionType.CONSUME_GHOST && consumpt != ConsumptionType.CONSUME_EAT)
+            || (consumptionType == ConsumptionType.CONSUME_HOBO
+                && consumpt != ConsumptionType.CONSUME_DRINK)) {
           continue;
         }
 
@@ -919,14 +920,14 @@ public class ConcoctionDatabase {
         AdventureResult toConsume = c.getItem().getInstance(quantity);
         InventoryManager.retrieveItem(toConsume);
 
-        if (consumptionType == KoLConstants.CONSUME_GHOST
-            | consumptionType == KoLConstants.CONSUME_HOBO) {
+        if (consumptionType == ConsumptionType.CONSUME_GHOST
+            | consumptionType == ConsumptionType.CONSUME_HOBO) {
           // Binge the familiar!
           RequestThread.postRequest(UseItemRequest.getInstance(consumptionType, toConsume));
           continue;
         }
 
-        if (consumptionType == KoLConstants.NO_CONSUME) {
+        if (consumptionType == ConsumptionType.NO_CONSUME) {
           // Create only
           continue;
         }
@@ -990,7 +991,7 @@ public class ConcoctionDatabase {
     }
   }
 
-  private static void consumeItem(Concoction c, int quantity, int consumptionType) {
+  private static void consumeItem(Concoction c, int quantity, ConsumptionType consumptionType) {
     AdventureResult item = c.getItem();
 
     // If it's food we're consuming, we have a MayoMinder set, and we are autostocking it, do so
@@ -999,7 +1000,7 @@ public class ConcoctionDatabase {
     String minderSetting = Preferences.getString("mayoMinderSetting");
     AdventureResult workshedItem = CampgroundRequest.getCurrentWorkshedItem();
     if (item != null
-        && consumptionType == KoLConstants.CONSUME_EAT
+        && consumptionType == ConsumptionType.CONSUME_EAT
         && !ConcoctionDatabase.isMayo(item.getItemId())
         && !minderSetting.equals("")
         && Preferences.getBoolean("autoFillMayoMinder")
@@ -1159,13 +1160,13 @@ public class ConcoctionDatabase {
 
   public static final void setRefreshNeeded(int itemId) {
     switch (ItemDatabase.getConsumptionType(itemId)) {
-      case KoLConstants.CONSUME_EAT:
-      case KoLConstants.CONSUME_DRINK:
-      case KoLConstants.CONSUME_SPLEEN:
-      case KoLConstants.CONSUME_USE:
-      case KoLConstants.CONSUME_MULTIPLE:
-      case KoLConstants.CONSUME_FOOD_HELPER:
-      case KoLConstants.CONSUME_DRINK_HELPER:
+      case CONSUME_EAT:
+      case CONSUME_DRINK:
+      case CONSUME_SPLEEN:
+      case CONSUME_USE:
+      case CONSUME_MULTIPLE:
+      case CONSUME_FOOD_HELPER:
+      case CONSUME_DRINK_HELPER:
         ConcoctionDatabase.setRefreshNeeded(false);
         return;
     }

--- a/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
@@ -842,15 +842,15 @@ public class ConcoctionDatabase {
   public static final void handleQueue(ConcoctionType type, ConsumptionType consumptionType) {
     // consumptionType can be:
     //
-    // ConsumptionType.NO_CONSUME - create or retrieve items
-    // ConsumptionType.CONSUME_EAT - eat food items
-    // ConsumptionType.CONSUME_DRINK - drink booze items
-    // ConsumptionType.CONSUME_SPLEEN - use spleen items
-    // ConsumptionType.CONSUME_GHOST - binge ghost with food
-    // ConsumptionType.CONSUME_HOBO - binge hobo with booze
-    // ConsumptionType.CONSUME_USE - use potions
-    // ConsumptionType.CONSUME_MULTIPLE - use potions
-    // ConsumptionType.CONSUME_AVATAR - use potions
+    // ConsumptionType.NONE - create or retrieve items
+    // ConsumptionType.EAT - eat food items
+    // ConsumptionType.DRINK - drink booze items
+    // ConsumptionType.SPLEEN - use spleen items
+    // ConsumptionType.GLUTTONOUS_GHOST - binge ghost with food
+    // ConsumptionType.SPIRIT_HOBO - binge hobo with booze
+    // ConsumptionType.USE - use potions
+    // ConsumptionType.USE_MULTIPLE - use potions
+    // ConsumptionType.AVATAR_POTION - use potions
 
     QueuedConcoction currentItem;
     Stack<QueuedConcoction> toProcess = new Stack<QueuedConcoction>();

--- a/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
@@ -910,7 +910,8 @@ public class ConcoctionDatabase {
         // Certain items are virtual consumption
         // helpers, but are "used" first. Skip if
         // bingeing familiar.
-        if ((consumptionType == ConsumptionType.CONSUME_GHOST && consumpt != ConsumptionType.CONSUME_EAT)
+        if ((consumptionType == ConsumptionType.CONSUME_GHOST
+                && consumpt != ConsumptionType.CONSUME_EAT)
             || (consumptionType == ConsumptionType.CONSUME_HOBO
                 && consumpt != ConsumptionType.CONSUME_DRINK)) {
           continue;

--- a/src/net/sourceforge/kolmafia/persistence/Consumable.java
+++ b/src/net/sourceforge/kolmafia/persistence/Consumable.java
@@ -79,10 +79,10 @@ public class Consumable {
 
   public ConsumptionType getConsumptionType() {
     return this.fullness != null
-        ? ConsumptionType.CONSUME_EAT
+        ? ConsumptionType.EAT
         : this.inebriety != null
-            ? ConsumptionType.CONSUME_DRINK
-            : this.spleenHit != null ? ConsumptionType.CONSUME_SPLEEN : ConsumptionType.CONSUME_USE;
+            ? ConsumptionType.DRINK
+            : this.spleenHit != null ? ConsumptionType.SPLEEN : ConsumptionType.USE;
   }
 
   public Integer getRawFullness() {

--- a/src/net/sourceforge/kolmafia/persistence/Consumable.java
+++ b/src/net/sourceforge/kolmafia/persistence/Consumable.java
@@ -2,7 +2,7 @@ package net.sourceforge.kolmafia.persistence;
 
 import java.util.Arrays;
 import java.util.Set;
-import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 
 // Consumable represents the static attributes of a consumable as pulled out of a line in the
 // relevant data file.
@@ -77,12 +77,12 @@ public class Consumable {
     };
   }
 
-  public int getConsumptionType() {
+  public ConsumptionType getConsumptionType() {
     return this.fullness != null
-        ? KoLConstants.CONSUME_EAT
+        ? ConsumptionType.CONSUME_EAT
         : this.inebriety != null
-            ? KoLConstants.CONSUME_DRINK
-            : this.spleenHit != null ? KoLConstants.CONSUME_SPLEEN : KoLConstants.CONSUME_USE;
+            ? ConsumptionType.CONSUME_DRINK
+            : this.spleenHit != null ? ConsumptionType.CONSUME_SPLEEN : ConsumptionType.CONSUME_USE;
   }
 
   public Integer getRawFullness() {

--- a/src/net/sourceforge/kolmafia/persistence/ConsumablesDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConsumablesDatabase.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.StaticEntity;
@@ -134,11 +135,11 @@ public class ConsumablesDatabase {
 
   public static void reset() {
     ConsumablesDatabase.readConsumptionData(
-        "fullness.txt", KoLConstants.FULLNESS_VERSION, KoLConstants.CONSUME_EAT);
+        "fullness.txt", KoLConstants.FULLNESS_VERSION, ConsumptionType.CONSUME_EAT);
     ConsumablesDatabase.readConsumptionData(
-        "inebriety.txt", KoLConstants.INEBRIETY_VERSION, KoLConstants.CONSUME_DRINK);
+        "inebriety.txt", KoLConstants.INEBRIETY_VERSION, ConsumptionType.CONSUME_DRINK);
     ConsumablesDatabase.readConsumptionData(
-        "spleenhit.txt", KoLConstants.SPLEENHIT_VERSION, KoLConstants.CONSUME_SPLEEN);
+        "spleenhit.txt", KoLConstants.SPLEENHIT_VERSION, ConsumptionType.CONSUME_SPLEEN);
     ConsumablesDatabase.readNonfillingData();
   }
 
@@ -153,7 +154,7 @@ public class ConsumablesDatabase {
     writer.println(consumable.toString());
   }
 
-  private static void readConsumptionData(String filename, int version, int usage) {
+  private static void readConsumptionData(String filename, int version, ConsumptionType usage) {
     try (BufferedReader reader = FileUtilities.getVersionedReader(filename, version)) {
       String[] data;
 
@@ -247,7 +248,7 @@ public class ConsumablesDatabase {
     }
   }
 
-  private static void saveConsumptionValues(String[] data, int usage) {
+  private static void saveConsumptionValues(String[] data, ConsumptionType usage) {
     if (data.length < 2) {
       return;
     }
@@ -290,9 +291,9 @@ public class ConsumablesDatabase {
     Consumable consumable =
         setConsumptionData(
             name,
-            usage == KoLConstants.CONSUME_EAT ? size : null,
-            usage == KoLConstants.CONSUME_DRINK ? size : null,
-            usage == KoLConstants.CONSUME_SPLEEN ? size : null,
+            usage == ConsumptionType.CONSUME_EAT ? size : null,
+            usage == ConsumptionType.CONSUME_DRINK ? size : null,
+            usage == ConsumptionType.CONSUME_SPLEEN ? size : null,
             level,
             quality,
             adventures,
@@ -349,7 +350,7 @@ public class ConsumablesDatabase {
     int advs = (c == null) ? 0 : c.getAdventuresNeeded(1, true);
 
     if (KoLCharacter.inNuclearAutumn()) {
-      if (consumable.getConsumptionType() == KoLConstants.CONSUME_EAT) {
+      if (consumable.getConsumptionType() == ConsumptionType.CONSUME_EAT) {
         int multiplier = 1;
         if (KoLCharacter.hasSkill("Extra Gall Bladder")) multiplier += 1;
         if (KoLConstants.activeEffects.contains(EffectPool.get(EffectPool.RECORD_HUNGER)))
@@ -358,7 +359,7 @@ public class ConsumablesDatabase {
         end *= multiplier;
       }
       // && KoLCharacter.hasSkill( "Extra Kidney" )
-      else if (consumable.getConsumptionType() == KoLConstants.CONSUME_DRINK) {
+      else if (consumable.getConsumptionType() == ConsumptionType.CONSUME_DRINK) {
         int multiplier = 1;
         if (KoLCharacter.hasSkill("Extra Kidney")) multiplier += 1;
         if (KoLConstants.activeEffects.contains(EffectPool.get(EffectPool.DRUNK_AVUNCULAR)))
@@ -400,7 +401,7 @@ public class ConsumablesDatabase {
     ConsumablesDatabase.addCurrentAdventures(name, size, true, true, false, false, gain2);
 
     // Only foods have effects 3-4
-    if (consumable.getConsumptionType() != KoLConstants.CONSUME_EAT) {
+    if (consumable.getConsumptionType() != ConsumptionType.CONSUME_EAT) {
       return;
     }
 
@@ -516,11 +517,11 @@ public class ConsumablesDatabase {
         (isNegative ? 1 : statFactor) * num / statUnit);
   }
 
-  public static void registerConsumable(final String itemName, final int usage, final String text) {
+  public static void registerConsumable(final String itemName, final ConsumptionType usage, final String text) {
     // Get information from description
-    if (usage != KoLConstants.CONSUME_EAT
-        && usage != KoLConstants.CONSUME_DRINK
-        && usage != KoLConstants.CONSUME_SPLEEN) {
+    if (usage != ConsumptionType.CONSUME_EAT
+        && usage != ConsumptionType.CONSUME_DRINK
+        && usage != ConsumptionType.CONSUME_SPLEEN) {
       return;
     }
 

--- a/src/net/sourceforge/kolmafia/persistence/ConsumablesDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConsumablesDatabase.java
@@ -135,11 +135,11 @@ public class ConsumablesDatabase {
 
   public static void reset() {
     ConsumablesDatabase.readConsumptionData(
-        "fullness.txt", KoLConstants.FULLNESS_VERSION, ConsumptionType.CONSUME_EAT);
+        "fullness.txt", KoLConstants.FULLNESS_VERSION, ConsumptionType.EAT);
     ConsumablesDatabase.readConsumptionData(
-        "inebriety.txt", KoLConstants.INEBRIETY_VERSION, ConsumptionType.CONSUME_DRINK);
+        "inebriety.txt", KoLConstants.INEBRIETY_VERSION, ConsumptionType.DRINK);
     ConsumablesDatabase.readConsumptionData(
-        "spleenhit.txt", KoLConstants.SPLEENHIT_VERSION, ConsumptionType.CONSUME_SPLEEN);
+        "spleenhit.txt", KoLConstants.SPLEENHIT_VERSION, ConsumptionType.SPLEEN);
     ConsumablesDatabase.readNonfillingData();
   }
 
@@ -291,9 +291,9 @@ public class ConsumablesDatabase {
     Consumable consumable =
         setConsumptionData(
             name,
-            usage == ConsumptionType.CONSUME_EAT ? size : null,
-            usage == ConsumptionType.CONSUME_DRINK ? size : null,
-            usage == ConsumptionType.CONSUME_SPLEEN ? size : null,
+            usage == ConsumptionType.EAT ? size : null,
+            usage == ConsumptionType.DRINK ? size : null,
+            usage == ConsumptionType.SPLEEN ? size : null,
             level,
             quality,
             adventures,
@@ -350,7 +350,7 @@ public class ConsumablesDatabase {
     int advs = (c == null) ? 0 : c.getAdventuresNeeded(1, true);
 
     if (KoLCharacter.inNuclearAutumn()) {
-      if (consumable.getConsumptionType() == ConsumptionType.CONSUME_EAT) {
+      if (consumable.getConsumptionType() == ConsumptionType.EAT) {
         int multiplier = 1;
         if (KoLCharacter.hasSkill("Extra Gall Bladder")) multiplier += 1;
         if (KoLConstants.activeEffects.contains(EffectPool.get(EffectPool.RECORD_HUNGER)))
@@ -359,7 +359,7 @@ public class ConsumablesDatabase {
         end *= multiplier;
       }
       // && KoLCharacter.hasSkill( "Extra Kidney" )
-      else if (consumable.getConsumptionType() == ConsumptionType.CONSUME_DRINK) {
+      else if (consumable.getConsumptionType() == ConsumptionType.DRINK) {
         int multiplier = 1;
         if (KoLCharacter.hasSkill("Extra Kidney")) multiplier += 1;
         if (KoLConstants.activeEffects.contains(EffectPool.get(EffectPool.DRUNK_AVUNCULAR)))
@@ -401,7 +401,7 @@ public class ConsumablesDatabase {
     ConsumablesDatabase.addCurrentAdventures(name, size, true, true, false, false, gain2);
 
     // Only foods have effects 3-4
-    if (consumable.getConsumptionType() != ConsumptionType.CONSUME_EAT) {
+    if (consumable.getConsumptionType() != ConsumptionType.EAT) {
       return;
     }
 
@@ -520,9 +520,9 @@ public class ConsumablesDatabase {
   public static void registerConsumable(
       final String itemName, final ConsumptionType usage, final String text) {
     // Get information from description
-    if (usage != ConsumptionType.CONSUME_EAT
-        && usage != ConsumptionType.CONSUME_DRINK
-        && usage != ConsumptionType.CONSUME_SPLEEN) {
+    if (usage != ConsumptionType.EAT
+        && usage != ConsumptionType.DRINK
+        && usage != ConsumptionType.SPLEEN) {
       return;
     }
 

--- a/src/net/sourceforge/kolmafia/persistence/ConsumablesDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConsumablesDatabase.java
@@ -517,7 +517,8 @@ public class ConsumablesDatabase {
         (isNegative ? 1 : statFactor) * num / statUnit);
   }
 
-  public static void registerConsumable(final String itemName, final ConsumptionType usage, final String text) {
+  public static void registerConsumable(
+      final String itemName, final ConsumptionType usage, final String text) {
     // Get information from description
     if (usage != ConsumptionType.CONSUME_EAT
         && usage != ConsumptionType.CONSUME_DRINK

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -22,6 +22,7 @@ import net.java.dev.spellcast.utilities.LockableListModel;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.ModifierExpression;
 import net.sourceforge.kolmafia.Modifiers;
@@ -149,10 +150,10 @@ public class DebugDatabase {
 
   private static class ItemMap {
     private final String tag;
-    private final int type;
+    private final ConsumptionType type;
     private final Map<String, String> map;
 
-    public ItemMap(final String tag, final int type) {
+    public ItemMap(final String tag, final ConsumptionType type) {
       this.tag = tag;
       this.type = type;
       this.map = new TreeMap<>(KoLConstants.ignoreCaseComparator);
@@ -162,7 +163,7 @@ public class DebugDatabase {
       return this.tag;
     }
 
-    public int getType() {
+    public ConsumptionType getType() {
       return this.type;
     }
 
@@ -185,31 +186,31 @@ public class DebugDatabase {
   }
 
   private static final ItemMap[] ITEM_MAPS = {
-    new ItemMap("Food", KoLConstants.CONSUME_EAT),
-    new ItemMap("Booze", KoLConstants.CONSUME_DRINK),
-    new ItemMap("Spleen Toxins", KoLConstants.CONSUME_SPLEEN),
-    new ItemMap("Hats", KoLConstants.EQUIP_HAT),
-    new ItemMap("Weapons", KoLConstants.EQUIP_WEAPON),
-    new ItemMap("Off-hand Items", KoLConstants.EQUIP_OFFHAND),
-    new ItemMap("Shirts", KoLConstants.EQUIP_SHIRT),
-    new ItemMap("Pants", KoLConstants.EQUIP_PANTS),
-    new ItemMap("Accessories", KoLConstants.EQUIP_ACCESSORY),
-    new ItemMap("Containers", KoLConstants.EQUIP_CONTAINER),
-    new ItemMap("Familiar Items", KoLConstants.EQUIP_FAMILIAR),
-    new ItemMap("Potions", KoLConstants.CONSUME_POTION),
-    new ItemMap("Avatar Potions", KoLConstants.CONSUME_AVATAR),
-    new ItemMap("Everything Else", -1),
+    new ItemMap("Food", ConsumptionType.CONSUME_EAT),
+    new ItemMap("Booze", ConsumptionType.CONSUME_DRINK),
+    new ItemMap("Spleen Toxins", ConsumptionType.CONSUME_SPLEEN),
+    new ItemMap("Hats", ConsumptionType.EQUIP_HAT),
+    new ItemMap("Weapons", ConsumptionType.EQUIP_WEAPON),
+    new ItemMap("Off-hand Items", ConsumptionType.EQUIP_OFFHAND),
+    new ItemMap("Shirts", ConsumptionType.EQUIP_SHIRT),
+    new ItemMap("Pants", ConsumptionType.EQUIP_PANTS),
+    new ItemMap("Accessories", ConsumptionType.EQUIP_ACCESSORY),
+    new ItemMap("Containers", ConsumptionType.EQUIP_CONTAINER),
+    new ItemMap("Familiar Items", ConsumptionType.EQUIP_FAMILIAR),
+    new ItemMap("Potions", ConsumptionType.CONSUME_POTION),
+    new ItemMap("Avatar Potions", ConsumptionType.CONSUME_AVATAR),
+    new ItemMap("Everything Else", ConsumptionType.UNKNOWN),
   };
 
-  private static ItemMap findItemMap(final int type) {
+  private static ItemMap findItemMap(final ConsumptionType type) {
     ItemMap other = null;
     for (int i = 0; i < DebugDatabase.ITEM_MAPS.length; ++i) {
       ItemMap map = DebugDatabase.ITEM_MAPS[i];
-      int mapType = map.getType();
+      ConsumptionType mapType = map.getType();
       if (mapType == type) {
         return map;
       }
-      if (mapType == -1) {
+      if (mapType == ConsumptionType.UNKNOWN) {
         other = map;
       }
     }
@@ -301,9 +302,9 @@ public class DebugDatabase {
       return;
     }
 
-    int type = ItemDatabase.getConsumptionType(itemId);
+    ConsumptionType type = ItemDatabase.getConsumptionType(itemId);
     String descType = DebugDatabase.parseType(text);
-    int descPrimary = DebugDatabase.typeToPrimary(descType, false);
+    ConsumptionType descPrimary = DebugDatabase.typeToPrimary(descType, false);
     if (!typesMatch(type, descPrimary)) {
       String primary = ItemDatabase.typeToPrimaryUsage(type);
       report.println(
@@ -347,12 +348,12 @@ public class DebugDatabase {
 
     // If description says it's a potion, make that the primary
     // type and move usability and multiusability into attributes
-    if (descPrimary == KoLConstants.CONSUME_POTION) {
-      if (type == KoLConstants.CONSUME_USE) {
-        type = KoLConstants.CONSUME_POTION;
+    if (descPrimary == ConsumptionType.CONSUME_POTION) {
+      if (type == ConsumptionType.CONSUME_USE) {
+        type = ConsumptionType.CONSUME_POTION;
         attrs |= ItemDatabase.ATTR_USABLE;
-      } else if (type == KoLConstants.CONSUME_MULTIPLE) {
-        type = KoLConstants.CONSUME_POTION;
+      } else if (type == ConsumptionType.CONSUME_MULTIPLE) {
+        type = ConsumptionType.CONSUME_POTION;
         attrs |= ItemDatabase.ATTR_MULTIPLE;
       }
     }
@@ -559,7 +560,7 @@ public class DebugDatabase {
     return type.equals("back item") ? "container" : type;
   }
 
-  public static final int typeToPrimary(final String type, final boolean multi) {
+  public static final ConsumptionType typeToPrimary(final String type, final boolean multi) {
     // Type: <b>food <font color=#999999>(crappy)</font></b>
     // Type: <b>food (decent)</b>
     // Type: <b>booze <font color=green>(good)</font></b>
@@ -567,62 +568,62 @@ public class DebugDatabase {
     // Type: <b>food <font color=blueviolet>(EPIC)</font></b>
 
     if (type.equals("") || type.equals("crafting item")) {
-      return KoLConstants.NO_CONSUME;
+      return ConsumptionType.NO_CONSUME;
     }
     if (type.startsWith("food") || type.startsWith("beverage")) {
-      return KoLConstants.CONSUME_EAT;
+      return ConsumptionType.CONSUME_EAT;
     }
     if (type.startsWith("booze")) {
-      return KoLConstants.CONSUME_DRINK;
+      return ConsumptionType.CONSUME_DRINK;
     }
     if (type.startsWith("spleen item")) {
-      return KoLConstants.CONSUME_SPLEEN;
+      return ConsumptionType.CONSUME_SPLEEN;
     }
     if (type.contains("self or others")) {
       // Curse items are special
-      return KoLConstants.NO_CONSUME;
+      return ConsumptionType.NO_CONSUME;
     }
     if (type.equals("potion")) {
-      return KoLConstants.CONSUME_POTION;
+      return ConsumptionType.CONSUME_POTION;
     }
     if (type.startsWith("usable") || type.contains(" usable") || type.equals("gift package")) {
       // We'll assume these are single-usable unless we are
       // explicitly told otherwise in a "rel" string
 
-      return multi ? KoLConstants.CONSUME_MULTIPLE : KoLConstants.CONSUME_USE;
+      return multi ? ConsumptionType.CONSUME_MULTIPLE : ConsumptionType.CONSUME_USE;
     }
     if (type.equals("familiar equipment")) {
-      return KoLConstants.EQUIP_FAMILIAR;
+      return ConsumptionType.EQUIP_FAMILIAR;
     }
     if (type.startsWith("familiar")) {
-      return KoLConstants.GROW_FAMILIAR;
+      return ConsumptionType.GROW_FAMILIAR;
     }
     if (type.startsWith("accessory")) {
-      return KoLConstants.EQUIP_ACCESSORY;
+      return ConsumptionType.EQUIP_ACCESSORY;
     }
     if (type.startsWith("container")) {
-      return KoLConstants.EQUIP_CONTAINER;
+      return ConsumptionType.EQUIP_CONTAINER;
     }
     if (type.startsWith("hat")) {
-      return KoLConstants.EQUIP_HAT;
+      return ConsumptionType.EQUIP_HAT;
     }
     if (type.startsWith("shirt")) {
-      return KoLConstants.EQUIP_SHIRT;
+      return ConsumptionType.EQUIP_SHIRT;
     }
     if (type.startsWith("pants")) {
-      return KoLConstants.EQUIP_PANTS;
+      return ConsumptionType.EQUIP_PANTS;
     }
     if (type.contains("weapon")) {
-      return KoLConstants.EQUIP_WEAPON;
+      return ConsumptionType.EQUIP_WEAPON;
     }
     if (type.startsWith("off-hand item")) {
-      return KoLConstants.EQUIP_OFFHAND;
+      return ConsumptionType.EQUIP_OFFHAND;
     }
-    return KoLConstants.NO_CONSUME;
+    return ConsumptionType.NO_CONSUME;
   }
 
   public static final int typeToSecondary(
-      final String type, final int primary, final String text, final boolean multi) {
+      final String type, final ConsumptionType primary, final String text, final boolean multi) {
     int attributes = 0;
     boolean usable =
         type.startsWith("usable")
@@ -637,10 +638,10 @@ public class DebugDatabase {
     } else if (type.contains("reusable")) {
       attributes |= ItemDatabase.ATTR_REUSABLE;
     }
-    if (multi && primary != KoLConstants.CONSUME_MULTIPLE && usable) {
+    if (multi && primary != ConsumptionType.CONSUME_MULTIPLE && usable) {
       attributes |= ItemDatabase.ATTR_MULTIPLE;
     }
-    if (!multi && primary != KoLConstants.CONSUME_USE && usable) {
+    if (!multi && primary != ConsumptionType.CONSUME_USE && usable) {
       attributes |= ItemDatabase.ATTR_USABLE;
     }
     if (type.contains("self or others")) {
@@ -664,47 +665,47 @@ public class DebugDatabase {
     return attributes;
   }
 
-  private static boolean typesMatch(final int type, final int descType) {
+  private static boolean typesMatch(final ConsumptionType type, final ConsumptionType descType) {
     switch (type) {
-      case KoLConstants.NO_CONSUME:
-      case KoLConstants.CONSUME_FOOD_HELPER:
-      case KoLConstants.CONSUME_DRINK_HELPER:
-      case KoLConstants.CONSUME_STICKER:
-      case KoLConstants.CONSUME_FOLDER:
-      case KoLConstants.CONSUME_POKEPILL:
+      case NO_CONSUME:
+      case CONSUME_FOOD_HELPER:
+      case CONSUME_DRINK_HELPER:
+      case CONSUME_STICKER:
+      case CONSUME_FOLDER:
+      case CONSUME_POKEPILL:
         // We intentionally disallow certain items from being
         // "used" through the GUI.
-        return descType == KoLConstants.NO_CONSUME || descType == KoLConstants.CONSUME_USE;
-      case KoLConstants.CONSUME_EAT:
-      case KoLConstants.CONSUME_DRINK:
-      case KoLConstants.CONSUME_SPLEEN:
-      case KoLConstants.GROW_FAMILIAR:
-      case KoLConstants.EQUIP_FAMILIAR:
-      case KoLConstants.EQUIP_ACCESSORY:
-      case KoLConstants.EQUIP_CONTAINER:
-      case KoLConstants.EQUIP_HAT:
-      case KoLConstants.EQUIP_PANTS:
-      case KoLConstants.EQUIP_SHIRT:
-      case KoLConstants.EQUIP_WEAPON:
-      case KoLConstants.EQUIP_OFFHAND:
+        return descType == ConsumptionType.NO_CONSUME || descType == ConsumptionType.CONSUME_USE;
+      case CONSUME_EAT:
+      case CONSUME_DRINK:
+      case CONSUME_SPLEEN:
+      case GROW_FAMILIAR:
+      case EQUIP_FAMILIAR:
+      case EQUIP_ACCESSORY:
+      case EQUIP_CONTAINER:
+      case EQUIP_HAT:
+      case EQUIP_PANTS:
+      case EQUIP_SHIRT:
+      case EQUIP_WEAPON:
+      case EQUIP_OFFHAND:
         return descType == type;
-      case KoLConstants.MESSAGE_DISPLAY:
-      case KoLConstants.CONSUME_USE:
-      case KoLConstants.CONSUME_MULTIPLE:
-      case KoLConstants.INFINITE_USES:
-        return descType == KoLConstants.CONSUME_USE
-            || descType == KoLConstants.CONSUME_MULTIPLE
-            || descType == KoLConstants.CONSUME_EAT
-            || descType == KoLConstants.CONSUME_DRINK
-            || descType == KoLConstants.CONSUME_AVATAR
-            || descType == KoLConstants.NO_CONSUME;
-      case KoLConstants.CONSUME_POTION:
-      case KoLConstants.CONSUME_AVATAR:
-        return descType == KoLConstants.CONSUME_POTION;
-      case KoLConstants.CONSUME_CARD:
-      case KoLConstants.CONSUME_SPHERE:
-      case KoLConstants.CONSUME_ZAP:
-        return descType == KoLConstants.NO_CONSUME;
+      case MESSAGE_DISPLAY:
+      case CONSUME_USE:
+      case CONSUME_MULTIPLE:
+      case INFINITE_USES:
+        return descType == ConsumptionType.CONSUME_USE
+            || descType == ConsumptionType.CONSUME_MULTIPLE
+            || descType == ConsumptionType.CONSUME_EAT
+            || descType == ConsumptionType.CONSUME_DRINK
+            || descType == ConsumptionType.CONSUME_AVATAR
+            || descType == ConsumptionType.NO_CONSUME;
+      case CONSUME_POTION:
+      case CONSUME_AVATAR:
+        return descType == ConsumptionType.CONSUME_POTION;
+      case CONSUME_CARD:
+      case CONSUME_SPHERE:
+      case CONSUME_ZAP:
+        return descType == ConsumptionType.NO_CONSUME;
     }
     return true;
   }
@@ -765,10 +766,10 @@ public class DebugDatabase {
   private static void checkConsumableItems(final PrintStream report) {
     RequestLogger.printLine("Checking level requirements...");
 
-    DebugDatabase.checkConsumableMap(report, DebugDatabase.findItemMap(KoLConstants.CONSUME_EAT));
-    DebugDatabase.checkConsumableMap(report, DebugDatabase.findItemMap(KoLConstants.CONSUME_DRINK));
+    DebugDatabase.checkConsumableMap(report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_EAT));
+    DebugDatabase.checkConsumableMap(report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_DRINK));
     DebugDatabase.checkConsumableMap(
-        report, DebugDatabase.findItemMap(KoLConstants.CONSUME_SPLEEN));
+        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_SPLEEN));
   }
 
   private static void checkConsumableMap(final PrintStream report, final ItemMap imap) {
@@ -778,11 +779,11 @@ public class DebugDatabase {
     }
 
     String tag = imap.getTag();
-    int type = imap.getType();
+    ConsumptionType type = imap.getType();
     String file =
-        type == KoLConstants.CONSUME_EAT
+        type == ConsumptionType.CONSUME_EAT
             ? "fullness"
-            : type == KoLConstants.CONSUME_DRINK ? "inebriety" : "spleenhit";
+            : type == ConsumptionType.CONSUME_DRINK ? "inebriety" : "spleenhit";
 
     RequestLogger.printLine("Checking " + tag + "...");
 
@@ -797,7 +798,7 @@ public class DebugDatabase {
   }
 
   private static void checkConsumableDatum(
-      final String name, final int type, final String text, final PrintStream report) {
+      final String name, final ConsumptionType type, final String text, final PrintStream report) {
     Integer requirement = ConsumablesDatabase.getLevelReqByName(name);
     int level = requirement == null ? 0 : requirement;
     int descLevel = DebugDatabase.parseLevel(text);
@@ -807,11 +808,11 @@ public class DebugDatabase {
     }
 
     int size =
-        (type == KoLConstants.CONSUME_EAT)
+        (type == ConsumptionType.CONSUME_EAT)
             ? ConsumablesDatabase.getFullness(name)
-            : (type == KoLConstants.CONSUME_DRINK)
+            : (type == ConsumptionType.CONSUME_DRINK)
                 ? ConsumablesDatabase.getInebriety(name)
-                : (type == KoLConstants.CONSUME_SPLEEN)
+                : (type == ConsumptionType.CONSUME_SPLEEN)
                     ? ConsumablesDatabase.getSpleenHit(name)
                     : 1;
 
@@ -860,15 +861,15 @@ public class DebugDatabase {
 
     RequestLogger.printLine("Checking equipment...");
 
-    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(KoLConstants.EQUIP_HAT));
-    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(KoLConstants.EQUIP_PANTS));
-    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(KoLConstants.EQUIP_SHIRT));
-    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(KoLConstants.EQUIP_WEAPON));
-    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(KoLConstants.EQUIP_OFFHAND));
+    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_HAT));
+    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_PANTS));
+    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_SHIRT));
+    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_WEAPON));
+    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_OFFHAND));
     DebugDatabase.checkEquipmentMap(
-        report, DebugDatabase.findItemMap(KoLConstants.EQUIP_ACCESSORY));
+        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_ACCESSORY));
     DebugDatabase.checkEquipmentMap(
-        report, DebugDatabase.findItemMap(KoLConstants.EQUIP_CONTAINER));
+        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_CONTAINER));
   }
 
   private static void checkEquipmentMap(final PrintStream report, ItemMap imap) {
@@ -1028,30 +1029,30 @@ public class DebugDatabase {
   private static void checkItemModifiers(final PrintStream report) {
     RequestLogger.printLine("Checking modifiers...");
 
-    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(KoLConstants.EQUIP_HAT));
-    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(KoLConstants.EQUIP_PANTS));
-    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(KoLConstants.EQUIP_SHIRT));
+    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_HAT));
+    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_PANTS));
+    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_SHIRT));
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(KoLConstants.EQUIP_WEAPON));
+        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_WEAPON));
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(KoLConstants.EQUIP_OFFHAND));
+        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_OFFHAND));
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(KoLConstants.EQUIP_ACCESSORY));
+        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_ACCESSORY));
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(KoLConstants.EQUIP_CONTAINER));
+        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_CONTAINER));
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(KoLConstants.EQUIP_FAMILIAR));
+        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_FAMILIAR));
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(KoLConstants.CONSUME_EAT), false);
+        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_EAT), false);
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(KoLConstants.CONSUME_DRINK), false);
+        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_DRINK), false);
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(KoLConstants.CONSUME_SPLEEN), false);
+        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_SPLEEN), false);
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(KoLConstants.CONSUME_POTION), false);
+        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_POTION), false);
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(KoLConstants.CONSUME_AVATAR), false);
-    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(-1), false);
+        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_AVATAR), false);
+    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(ConsumptionType.UNKNOWN), false);
   }
 
   private static void checkItemModifierMap(final PrintStream report, final ItemMap imap) {
@@ -1072,7 +1073,7 @@ public class DebugDatabase {
     report.println("# " + tag + " section of modifiers.txt");
     report.println();
 
-    int type = imap.getType();
+    ConsumptionType type = imap.getType();
     for (Entry<String, String> entry : map.entrySet()) {
       String name = entry.getKey();
       String text = entry.getValue();
@@ -1083,7 +1084,7 @@ public class DebugDatabase {
   private static void checkItemModifierDatum(
       final String name,
       final String text,
-      final int type,
+      final ConsumptionType type,
       final PrintStream report,
       final boolean showAll) {
     ModifierList known = new ModifierList();
@@ -1260,7 +1261,7 @@ public class DebugDatabase {
           Pattern.DOTALL);
 
   public static final void parseItemEnchantments(
-      String text, final ModifierList known, final ArrayList<String> unknown, final int type) {
+      String text, final ModifierList known, final ArrayList<String> unknown, final ConsumptionType type) {
     // KoL now includes the enchantments of the effect in the item
     // descriptions. Strip them out.
     int eindex = text.indexOf("Effect:");
@@ -1296,7 +1297,7 @@ public class DebugDatabase {
     DebugDatabase.appendModifier(known, Modifiers.parseSongDuration(text));
     DebugDatabase.appendModifier(known, Modifiers.parseDropsItems(text));
 
-    if (type == KoLConstants.EQUIP_FAMILIAR) {
+    if (type == ConsumptionType.EQUIP_FAMILIAR) {
       String familiar = DebugDatabase.parseFamiliar(text);
       if (familiar.equals("any")) {
         DebugDatabase.appendModifier(known, "Generic");
@@ -1365,13 +1366,13 @@ public class DebugDatabase {
   }
 
   public static final String parseItemEnchantments(
-      final String text, final ArrayList<String> unknown, final int type) {
+      final String text, final ArrayList<String> unknown, final ConsumptionType type) {
     ModifierList known = new ModifierList();
     DebugDatabase.parseItemEnchantments(text, known, unknown, type);
     return DebugDatabase.createModifierString(known);
   }
 
-  public static final String parseItemEnchantments(final String text, final int type) {
+  public static final String parseItemEnchantments(final String text, final ConsumptionType type) {
     ModifierList known = new ModifierList();
     ArrayList<String> unknown = new ArrayList<>();
     DebugDatabase.parseItemEnchantments(text, known, unknown, type);
@@ -1571,7 +1572,7 @@ public class DebugDatabase {
   private static final String OUTFIT_HTML = "outfithtml.txt";
   private static final String OUTFIT_DATA = "outfitdata.txt";
   private static final Map<Integer, String> rawOutfits = new HashMap<>();
-  private static final ItemMap outfits = new ItemMap("Outfits", 0);
+  private static final ItemMap outfits = new ItemMap("Outfits", ConsumptionType.NO_CONSUME);
 
   public static final void checkOutfits() {
     RequestLogger.printLine("Loading previous data...");
@@ -1748,7 +1749,7 @@ public class DebugDatabase {
   private static final String EFFECT_HTML = "effecthtml.txt";
   private static final String EFFECT_DATA = "effectdata.txt";
   private static final Map<Integer, String> rawEffects = new HashMap<>();
-  private static final ItemMap effects = new ItemMap("Status Effects", 0);
+  private static final ItemMap effects = new ItemMap("Status Effects", ConsumptionType.NO_CONSUME);
 
   public static final void checkEffects(final int effectId) {
     RequestLogger.printLine("Loading previous data...");
@@ -1990,7 +1991,7 @@ public class DebugDatabase {
   private static final String SKILL_HTML = "skillhtml.txt";
   private static final String SKILL_DATA = "skilldata.txt";
   private static final Map<Integer, String> rawSkills = new HashMap<>();
-  private static final ItemMap passiveSkills = new ItemMap("Passive Skills", 0);
+  private static final ItemMap passiveSkills = new ItemMap("Passive Skills", ConsumptionType.NO_CONSUME);
 
   public static final void checkSkills(final int skillId) {
     RequestLogger.printLine("Loading previous data...");
@@ -2437,10 +2438,10 @@ public class DebugDatabase {
 
   private static boolean powerFilter(AdventureResult item) {
     int itemId = item.getItemId();
-    int type = ItemDatabase.getConsumptionType(itemId);
-    return (type == KoLConstants.EQUIP_OFFHAND
-        || type == KoLConstants.EQUIP_ACCESSORY
-        || type == KoLConstants.EQUIP_CONTAINER);
+    ConsumptionType type = ItemDatabase.getConsumptionType(itemId);
+    return (type == ConsumptionType.EQUIP_OFFHAND
+        || type == ConsumptionType.EQUIP_ACCESSORY
+        || type == ConsumptionType.EQUIP_CONTAINER);
   }
 
   private static boolean unknownPower(AdventureResult item) {

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -186,19 +186,19 @@ public class DebugDatabase {
   }
 
   private static final ItemMap[] ITEM_MAPS = {
-    new ItemMap("Food", ConsumptionType.CONSUME_EAT),
-    new ItemMap("Booze", ConsumptionType.CONSUME_DRINK),
-    new ItemMap("Spleen Toxins", ConsumptionType.CONSUME_SPLEEN),
-    new ItemMap("Hats", ConsumptionType.EQUIP_HAT),
-    new ItemMap("Weapons", ConsumptionType.EQUIP_WEAPON),
-    new ItemMap("Off-hand Items", ConsumptionType.EQUIP_OFFHAND),
-    new ItemMap("Shirts", ConsumptionType.EQUIP_SHIRT),
-    new ItemMap("Pants", ConsumptionType.EQUIP_PANTS),
-    new ItemMap("Accessories", ConsumptionType.EQUIP_ACCESSORY),
-    new ItemMap("Containers", ConsumptionType.EQUIP_CONTAINER),
-    new ItemMap("Familiar Items", ConsumptionType.EQUIP_FAMILIAR),
-    new ItemMap("Potions", ConsumptionType.CONSUME_POTION),
-    new ItemMap("Avatar Potions", ConsumptionType.CONSUME_AVATAR),
+    new ItemMap("Food", ConsumptionType.EAT),
+    new ItemMap("Booze", ConsumptionType.DRINK),
+    new ItemMap("Spleen Toxins", ConsumptionType.SPLEEN),
+    new ItemMap("Hats", ConsumptionType.HAT),
+    new ItemMap("Weapons", ConsumptionType.WEAPON),
+    new ItemMap("Off-hand Items", ConsumptionType.OFFHAND),
+    new ItemMap("Shirts", ConsumptionType.SHIRT),
+    new ItemMap("Pants", ConsumptionType.PANTS),
+    new ItemMap("Accessories", ConsumptionType.ACCESSORY),
+    new ItemMap("Containers", ConsumptionType.CONTAINER),
+    new ItemMap("Familiar Items", ConsumptionType.FAMILIAR_EQUIPMENT),
+    new ItemMap("Potions", ConsumptionType.POTION),
+    new ItemMap("Avatar Potions", ConsumptionType.AVATAR_POTION),
     new ItemMap("Everything Else", ConsumptionType.UNKNOWN),
   };
 
@@ -348,12 +348,12 @@ public class DebugDatabase {
 
     // If description says it's a potion, make that the primary
     // type and move usability and multiusability into attributes
-    if (descPrimary == ConsumptionType.CONSUME_POTION) {
-      if (type == ConsumptionType.CONSUME_USE) {
-        type = ConsumptionType.CONSUME_POTION;
+    if (descPrimary == ConsumptionType.POTION) {
+      if (type == ConsumptionType.USE) {
+        type = ConsumptionType.POTION;
         attrs |= ItemDatabase.ATTR_USABLE;
-      } else if (type == ConsumptionType.CONSUME_MULTIPLE) {
-        type = ConsumptionType.CONSUME_POTION;
+      } else if (type == ConsumptionType.USE_MULTIPLE) {
+        type = ConsumptionType.POTION;
         attrs |= ItemDatabase.ATTR_MULTIPLE;
       }
     }
@@ -568,58 +568,58 @@ public class DebugDatabase {
     // Type: <b>food <font color=blueviolet>(EPIC)</font></b>
 
     if (type.equals("") || type.equals("crafting item")) {
-      return ConsumptionType.NO_CONSUME;
+      return ConsumptionType.NONE;
     }
     if (type.startsWith("food") || type.startsWith("beverage")) {
-      return ConsumptionType.CONSUME_EAT;
+      return ConsumptionType.EAT;
     }
     if (type.startsWith("booze")) {
-      return ConsumptionType.CONSUME_DRINK;
+      return ConsumptionType.DRINK;
     }
     if (type.startsWith("spleen item")) {
-      return ConsumptionType.CONSUME_SPLEEN;
+      return ConsumptionType.SPLEEN;
     }
     if (type.contains("self or others")) {
       // Curse items are special
-      return ConsumptionType.NO_CONSUME;
+      return ConsumptionType.NONE;
     }
     if (type.equals("potion")) {
-      return ConsumptionType.CONSUME_POTION;
+      return ConsumptionType.POTION;
     }
     if (type.startsWith("usable") || type.contains(" usable") || type.equals("gift package")) {
       // We'll assume these are single-usable unless we are
       // explicitly told otherwise in a "rel" string
 
-      return multi ? ConsumptionType.CONSUME_MULTIPLE : ConsumptionType.CONSUME_USE;
+      return multi ? ConsumptionType.USE_MULTIPLE : ConsumptionType.USE;
     }
     if (type.equals("familiar equipment")) {
-      return ConsumptionType.EQUIP_FAMILIAR;
+      return ConsumptionType.FAMILIAR_EQUIPMENT;
     }
     if (type.startsWith("familiar")) {
-      return ConsumptionType.GROW_FAMILIAR;
+      return ConsumptionType.FAMILIAR_HATCHLING;
     }
     if (type.startsWith("accessory")) {
-      return ConsumptionType.EQUIP_ACCESSORY;
+      return ConsumptionType.ACCESSORY;
     }
     if (type.startsWith("container")) {
-      return ConsumptionType.EQUIP_CONTAINER;
+      return ConsumptionType.CONTAINER;
     }
     if (type.startsWith("hat")) {
-      return ConsumptionType.EQUIP_HAT;
+      return ConsumptionType.HAT;
     }
     if (type.startsWith("shirt")) {
-      return ConsumptionType.EQUIP_SHIRT;
+      return ConsumptionType.SHIRT;
     }
     if (type.startsWith("pants")) {
-      return ConsumptionType.EQUIP_PANTS;
+      return ConsumptionType.PANTS;
     }
     if (type.contains("weapon")) {
-      return ConsumptionType.EQUIP_WEAPON;
+      return ConsumptionType.WEAPON;
     }
     if (type.startsWith("off-hand item")) {
-      return ConsumptionType.EQUIP_OFFHAND;
+      return ConsumptionType.OFFHAND;
     }
-    return ConsumptionType.NO_CONSUME;
+    return ConsumptionType.NONE;
   }
 
   public static final int typeToSecondary(
@@ -638,10 +638,10 @@ public class DebugDatabase {
     } else if (type.contains("reusable")) {
       attributes |= ItemDatabase.ATTR_REUSABLE;
     }
-    if (multi && primary != ConsumptionType.CONSUME_MULTIPLE && usable) {
+    if (multi && primary != ConsumptionType.USE_MULTIPLE && usable) {
       attributes |= ItemDatabase.ATTR_MULTIPLE;
     }
-    if (!multi && primary != ConsumptionType.CONSUME_USE && usable) {
+    if (!multi && primary != ConsumptionType.USE && usable) {
       attributes |= ItemDatabase.ATTR_USABLE;
     }
     if (type.contains("self or others")) {
@@ -667,45 +667,45 @@ public class DebugDatabase {
 
   private static boolean typesMatch(final ConsumptionType type, final ConsumptionType descType) {
     switch (type) {
-      case NO_CONSUME:
-      case CONSUME_FOOD_HELPER:
-      case CONSUME_DRINK_HELPER:
-      case CONSUME_STICKER:
-      case CONSUME_FOLDER:
-      case CONSUME_POKEPILL:
+      case NONE:
+      case FOOD_HELPER:
+      case DRINK_HELPER:
+      case STICKER:
+      case FOLDER:
+      case POKEPILL:
         // We intentionally disallow certain items from being
         // "used" through the GUI.
-        return descType == ConsumptionType.NO_CONSUME || descType == ConsumptionType.CONSUME_USE;
-      case CONSUME_EAT:
-      case CONSUME_DRINK:
-      case CONSUME_SPLEEN:
-      case GROW_FAMILIAR:
-      case EQUIP_FAMILIAR:
-      case EQUIP_ACCESSORY:
-      case EQUIP_CONTAINER:
-      case EQUIP_HAT:
-      case EQUIP_PANTS:
-      case EQUIP_SHIRT:
-      case EQUIP_WEAPON:
-      case EQUIP_OFFHAND:
+        return descType == ConsumptionType.NONE || descType == ConsumptionType.USE;
+      case EAT:
+      case DRINK:
+      case SPLEEN:
+      case FAMILIAR_HATCHLING:
+      case FAMILIAR_EQUIPMENT:
+      case ACCESSORY:
+      case CONTAINER:
+      case HAT:
+      case PANTS:
+      case SHIRT:
+      case WEAPON:
+      case OFFHAND:
         return descType == type;
-      case MESSAGE_DISPLAY:
-      case CONSUME_USE:
-      case CONSUME_MULTIPLE:
-      case INFINITE_USES:
-        return descType == ConsumptionType.CONSUME_USE
-            || descType == ConsumptionType.CONSUME_MULTIPLE
-            || descType == ConsumptionType.CONSUME_EAT
-            || descType == ConsumptionType.CONSUME_DRINK
-            || descType == ConsumptionType.CONSUME_AVATAR
-            || descType == ConsumptionType.NO_CONSUME;
-      case CONSUME_POTION:
-      case CONSUME_AVATAR:
-        return descType == ConsumptionType.CONSUME_POTION;
-      case CONSUME_CARD:
-      case CONSUME_SPHERE:
-      case CONSUME_ZAP:
-        return descType == ConsumptionType.NO_CONSUME;
+      case USE_MESSAGE_DISPLAY:
+      case USE:
+      case USE_MULTIPLE:
+      case USE_INFINITE:
+        return descType == ConsumptionType.USE
+            || descType == ConsumptionType.USE_MULTIPLE
+            || descType == ConsumptionType.EAT
+            || descType == ConsumptionType.DRINK
+            || descType == ConsumptionType.AVATAR_POTION
+            || descType == ConsumptionType.NONE;
+      case POTION:
+      case AVATAR_POTION:
+        return descType == ConsumptionType.POTION;
+      case CARD:
+      case EL_VIBRATO_SPHERE:
+      case ZAP:
+        return descType == ConsumptionType.NONE;
     }
     return true;
   }
@@ -766,12 +766,9 @@ public class DebugDatabase {
   private static void checkConsumableItems(final PrintStream report) {
     RequestLogger.printLine("Checking level requirements...");
 
-    DebugDatabase.checkConsumableMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_EAT));
-    DebugDatabase.checkConsumableMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_DRINK));
-    DebugDatabase.checkConsumableMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_SPLEEN));
+    DebugDatabase.checkConsumableMap(report, DebugDatabase.findItemMap(ConsumptionType.EAT));
+    DebugDatabase.checkConsumableMap(report, DebugDatabase.findItemMap(ConsumptionType.DRINK));
+    DebugDatabase.checkConsumableMap(report, DebugDatabase.findItemMap(ConsumptionType.SPLEEN));
   }
 
   private static void checkConsumableMap(final PrintStream report, final ItemMap imap) {
@@ -783,9 +780,9 @@ public class DebugDatabase {
     String tag = imap.getTag();
     ConsumptionType type = imap.getType();
     String file =
-        type == ConsumptionType.CONSUME_EAT
+        type == ConsumptionType.EAT
             ? "fullness"
-            : type == ConsumptionType.CONSUME_DRINK ? "inebriety" : "spleenhit";
+            : type == ConsumptionType.DRINK ? "inebriety" : "spleenhit";
 
     RequestLogger.printLine("Checking " + tag + "...");
 
@@ -810,13 +807,11 @@ public class DebugDatabase {
     }
 
     int size =
-        (type == ConsumptionType.CONSUME_EAT)
+        (type == ConsumptionType.EAT)
             ? ConsumablesDatabase.getFullness(name)
-            : (type == ConsumptionType.CONSUME_DRINK)
+            : (type == ConsumptionType.DRINK)
                 ? ConsumablesDatabase.getInebriety(name)
-                : (type == ConsumptionType.CONSUME_SPLEEN)
-                    ? ConsumablesDatabase.getSpleenHit(name)
-                    : 1;
+                : (type == ConsumptionType.SPLEEN) ? ConsumablesDatabase.getSpleenHit(name) : 1;
 
     int descSize = DebugDatabase.parseSize(text);
     if (size != descSize) {
@@ -863,17 +858,13 @@ public class DebugDatabase {
 
     RequestLogger.printLine("Checking equipment...");
 
-    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_HAT));
-    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_PANTS));
-    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_SHIRT));
-    DebugDatabase.checkEquipmentMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_WEAPON));
-    DebugDatabase.checkEquipmentMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_OFFHAND));
-    DebugDatabase.checkEquipmentMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_ACCESSORY));
-    DebugDatabase.checkEquipmentMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_CONTAINER));
+    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.HAT));
+    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.PANTS));
+    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.SHIRT));
+    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.WEAPON));
+    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.OFFHAND));
+    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.ACCESSORY));
+    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.CONTAINER));
   }
 
   private static void checkEquipmentMap(final PrintStream report, ItemMap imap) {
@@ -1033,32 +1024,27 @@ public class DebugDatabase {
   private static void checkItemModifiers(final PrintStream report) {
     RequestLogger.printLine("Checking modifiers...");
 
+    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(ConsumptionType.HAT));
+    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(ConsumptionType.PANTS));
+    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(ConsumptionType.SHIRT));
+    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(ConsumptionType.WEAPON));
+    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(ConsumptionType.OFFHAND));
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_HAT));
+        report, DebugDatabase.findItemMap(ConsumptionType.ACCESSORY));
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_PANTS));
+        report, DebugDatabase.findItemMap(ConsumptionType.CONTAINER));
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_SHIRT));
+        report, DebugDatabase.findItemMap(ConsumptionType.FAMILIAR_EQUIPMENT));
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_WEAPON));
+        report, DebugDatabase.findItemMap(ConsumptionType.EAT), false);
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_OFFHAND));
+        report, DebugDatabase.findItemMap(ConsumptionType.DRINK), false);
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_ACCESSORY));
+        report, DebugDatabase.findItemMap(ConsumptionType.SPLEEN), false);
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_CONTAINER));
+        report, DebugDatabase.findItemMap(ConsumptionType.POTION), false);
     DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_FAMILIAR));
-    DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_EAT), false);
-    DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_DRINK), false);
-    DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_SPLEEN), false);
-    DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_POTION), false);
-    DebugDatabase.checkItemModifierMap(
-        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_AVATAR), false);
+        report, DebugDatabase.findItemMap(ConsumptionType.AVATAR_POTION), false);
     DebugDatabase.checkItemModifierMap(
         report, DebugDatabase.findItemMap(ConsumptionType.UNKNOWN), false);
   }
@@ -1308,7 +1294,7 @@ public class DebugDatabase {
     DebugDatabase.appendModifier(known, Modifiers.parseSongDuration(text));
     DebugDatabase.appendModifier(known, Modifiers.parseDropsItems(text));
 
-    if (type == ConsumptionType.EQUIP_FAMILIAR) {
+    if (type == ConsumptionType.FAMILIAR_EQUIPMENT) {
       String familiar = DebugDatabase.parseFamiliar(text);
       if (familiar.equals("any")) {
         DebugDatabase.appendModifier(known, "Generic");
@@ -1583,7 +1569,7 @@ public class DebugDatabase {
   private static final String OUTFIT_HTML = "outfithtml.txt";
   private static final String OUTFIT_DATA = "outfitdata.txt";
   private static final Map<Integer, String> rawOutfits = new HashMap<>();
-  private static final ItemMap outfits = new ItemMap("Outfits", ConsumptionType.NO_CONSUME);
+  private static final ItemMap outfits = new ItemMap("Outfits", ConsumptionType.NONE);
 
   public static final void checkOutfits() {
     RequestLogger.printLine("Loading previous data...");
@@ -1760,7 +1746,7 @@ public class DebugDatabase {
   private static final String EFFECT_HTML = "effecthtml.txt";
   private static final String EFFECT_DATA = "effectdata.txt";
   private static final Map<Integer, String> rawEffects = new HashMap<>();
-  private static final ItemMap effects = new ItemMap("Status Effects", ConsumptionType.NO_CONSUME);
+  private static final ItemMap effects = new ItemMap("Status Effects", ConsumptionType.NONE);
 
   public static final void checkEffects(final int effectId) {
     RequestLogger.printLine("Loading previous data...");
@@ -2002,8 +1988,7 @@ public class DebugDatabase {
   private static final String SKILL_HTML = "skillhtml.txt";
   private static final String SKILL_DATA = "skilldata.txt";
   private static final Map<Integer, String> rawSkills = new HashMap<>();
-  private static final ItemMap passiveSkills =
-      new ItemMap("Passive Skills", ConsumptionType.NO_CONSUME);
+  private static final ItemMap passiveSkills = new ItemMap("Passive Skills", ConsumptionType.NONE);
 
   public static final void checkSkills(final int skillId) {
     RequestLogger.printLine("Loading previous data...");
@@ -2451,9 +2436,9 @@ public class DebugDatabase {
   private static boolean powerFilter(AdventureResult item) {
     int itemId = item.getItemId();
     ConsumptionType type = ItemDatabase.getConsumptionType(itemId);
-    return (type == ConsumptionType.EQUIP_OFFHAND
-        || type == ConsumptionType.EQUIP_ACCESSORY
-        || type == ConsumptionType.EQUIP_CONTAINER);
+    return (type == ConsumptionType.OFFHAND
+        || type == ConsumptionType.ACCESSORY
+        || type == ConsumptionType.CONTAINER);
   }
 
   private static boolean unknownPower(AdventureResult item) {

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -766,8 +766,10 @@ public class DebugDatabase {
   private static void checkConsumableItems(final PrintStream report) {
     RequestLogger.printLine("Checking level requirements...");
 
-    DebugDatabase.checkConsumableMap(report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_EAT));
-    DebugDatabase.checkConsumableMap(report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_DRINK));
+    DebugDatabase.checkConsumableMap(
+        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_EAT));
+    DebugDatabase.checkConsumableMap(
+        report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_DRINK));
     DebugDatabase.checkConsumableMap(
         report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_SPLEEN));
   }
@@ -864,8 +866,10 @@ public class DebugDatabase {
     DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_HAT));
     DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_PANTS));
     DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_SHIRT));
-    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_WEAPON));
-    DebugDatabase.checkEquipmentMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_OFFHAND));
+    DebugDatabase.checkEquipmentMap(
+        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_WEAPON));
+    DebugDatabase.checkEquipmentMap(
+        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_OFFHAND));
     DebugDatabase.checkEquipmentMap(
         report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_ACCESSORY));
     DebugDatabase.checkEquipmentMap(
@@ -1029,9 +1033,12 @@ public class DebugDatabase {
   private static void checkItemModifiers(final PrintStream report) {
     RequestLogger.printLine("Checking modifiers...");
 
-    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_HAT));
-    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_PANTS));
-    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_SHIRT));
+    DebugDatabase.checkItemModifierMap(
+        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_HAT));
+    DebugDatabase.checkItemModifierMap(
+        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_PANTS));
+    DebugDatabase.checkItemModifierMap(
+        report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_SHIRT));
     DebugDatabase.checkItemModifierMap(
         report, DebugDatabase.findItemMap(ConsumptionType.EQUIP_WEAPON));
     DebugDatabase.checkItemModifierMap(
@@ -1052,7 +1059,8 @@ public class DebugDatabase {
         report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_POTION), false);
     DebugDatabase.checkItemModifierMap(
         report, DebugDatabase.findItemMap(ConsumptionType.CONSUME_AVATAR), false);
-    DebugDatabase.checkItemModifierMap(report, DebugDatabase.findItemMap(ConsumptionType.UNKNOWN), false);
+    DebugDatabase.checkItemModifierMap(
+        report, DebugDatabase.findItemMap(ConsumptionType.UNKNOWN), false);
   }
 
   private static void checkItemModifierMap(final PrintStream report, final ItemMap imap) {
@@ -1261,7 +1269,10 @@ public class DebugDatabase {
           Pattern.DOTALL);
 
   public static final void parseItemEnchantments(
-      String text, final ModifierList known, final ArrayList<String> unknown, final ConsumptionType type) {
+      String text,
+      final ModifierList known,
+      final ArrayList<String> unknown,
+      final ConsumptionType type) {
     // KoL now includes the enchantments of the effect in the item
     // descriptions. Strip them out.
     int eindex = text.indexOf("Effect:");
@@ -1991,7 +2002,8 @@ public class DebugDatabase {
   private static final String SKILL_HTML = "skillhtml.txt";
   private static final String SKILL_DATA = "skilldata.txt";
   private static final Map<Integer, String> rawSkills = new HashMap<>();
-  private static final ItemMap passiveSkills = new ItemMap("Passive Skills", ConsumptionType.NO_CONSUME);
+  private static final ItemMap passiveSkills =
+      new ItemMap("Passive Skills", ConsumptionType.NO_CONSUME);
 
   public static final void checkSkills(final int skillId) {
     RequestLogger.printLine("Loading previous data...");

--- a/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
@@ -252,25 +252,25 @@ public class EquipmentDatabase {
       ConsumptionType type = ItemDatabase.getConsumptionType(key.intValue());
 
       switch (type) {
-        case EQUIP_HAT:
+        case HAT:
           hats.put(name, key);
           break;
-        case EQUIP_PANTS:
+        case PANTS:
           pants.put(name, key);
           break;
-        case EQUIP_SHIRT:
+        case SHIRT:
           shirts.put(name, key);
           break;
-        case EQUIP_WEAPON:
+        case WEAPON:
           weapons.put(name, key);
           break;
-        case EQUIP_OFFHAND:
+        case OFFHAND:
           offhands.put(name, key);
           break;
-        case EQUIP_ACCESSORY:
+        case ACCESSORY:
           accessories.put(name, key);
           break;
-        case EQUIP_CONTAINER:
+        case CONTAINER:
           containers.put(name, key);
           break;
       }
@@ -311,7 +311,7 @@ public class EquipmentDatabase {
       int power = EquipmentDatabase.getPower(itemId);
       String req = EquipmentDatabase.getEquipRequirement(itemId);
       ConsumptionType usage = ItemDatabase.getConsumptionType(itemId);
-      boolean isWeapon = usage == ConsumptionType.EQUIP_WEAPON;
+      boolean isWeapon = usage == ConsumptionType.WEAPON;
       String type = EquipmentDatabase.itemTypes.get(itemId);
       boolean isShield = type != null && type.equals("shield");
       String weaponType = "";
@@ -467,8 +467,8 @@ public class EquipmentDatabase {
     while (++prevId <= limit) {
       String req = EquipmentDatabase.statRequirements.get(prevId);
       if ((req != null && req.length() > 0)
-          || ItemDatabase.getConsumptionType(prevId) == ConsumptionType.EQUIP_FAMILIAR
-          || ItemDatabase.getConsumptionType(prevId) == ConsumptionType.CONSUME_SIXGUN) {
+          || ItemDatabase.getConsumptionType(prevId) == ConsumptionType.FAMILIAR_EQUIPMENT
+          || ItemDatabase.getConsumptionType(prevId) == ConsumptionType.SIXGUN) {
         return prevId;
       }
     }
@@ -530,59 +530,59 @@ public class EquipmentDatabase {
 
   public static final String getItemType(final int itemId) {
     switch (ItemDatabase.getConsumptionType(itemId)) {
-      case CONSUME_EAT:
+      case EAT:
         return "food";
-      case CONSUME_DRINK:
+      case DRINK:
         return "booze";
-      case CONSUME_SPLEEN:
+      case SPLEEN:
         return "spleen item";
-      case CONSUME_FOOD_HELPER:
+      case FOOD_HELPER:
         return "food helper";
-      case CONSUME_DRINK_HELPER:
+      case DRINK_HELPER:
         return "drink helper";
-      case CONSUME_STICKER:
+      case STICKER:
         return "sticker";
-      case CONSUME_CARD:
+      case CARD:
         return "card";
-      case CONSUME_FOLDER:
+      case FOLDER:
         return "folder";
-      case CONSUME_BOOTSKIN:
+      case BOOTSKIN:
         return "bootskin";
-      case CONSUME_BOOTSPUR:
+      case BOOTSPUR:
         return "bootspur";
-      case CONSUME_SIXGUN:
+      case SIXGUN:
         return "sixgun";
-      case CONSUME_POTION:
+      case POTION:
         return "potion";
-      case CONSUME_AVATAR:
+      case AVATAR_POTION:
         return "avatar potion";
-      case GROW_FAMILIAR:
+      case FAMILIAR_HATCHLING:
         return "familiar larva";
-      case CONSUME_ZAP:
+      case ZAP:
         return "zap wand";
-      case EQUIP_FAMILIAR:
+      case FAMILIAR_EQUIPMENT:
         return "familiar equipment";
-      case EQUIP_ACCESSORY:
+      case ACCESSORY:
         return "accessory";
-      case EQUIP_HAT:
+      case HAT:
         return "hat";
-      case EQUIP_PANTS:
+      case PANTS:
         return "pants";
-      case EQUIP_SHIRT:
+      case SHIRT:
         return "shirt";
-      case EQUIP_WEAPON:
+      case WEAPON:
         {
           String type = EquipmentDatabase.itemTypes.get(itemId);
           return type != null ? type : "weapon";
         }
-      case EQUIP_OFFHAND:
+      case OFFHAND:
         {
           String type = EquipmentDatabase.itemTypes.get(itemId);
           return type != null ? type : "offhand";
         }
-      case EQUIP_CONTAINER:
+      case CONTAINER:
         return "container";
-      case CONSUME_GUARDIAN:
+      case PASTA_GUARDIAN:
         return "pasta guardian";
       default:
         return "";
@@ -603,7 +603,7 @@ public class EquipmentDatabase {
   public static final Stat getWeaponStat(final int itemId) {
     ConsumptionType consumptionType = ItemDatabase.getConsumptionType(itemId);
 
-    if (consumptionType != ConsumptionType.EQUIP_WEAPON) {
+    if (consumptionType != ConsumptionType.WEAPON) {
       return Stat.NONE;
     }
 
@@ -693,11 +693,11 @@ public class EquipmentDatabase {
   }
 
   public static final boolean isShirt(final AdventureResult item) {
-    return ItemDatabase.getConsumptionType(item.getItemId()) == ConsumptionType.EQUIP_SHIRT;
+    return ItemDatabase.getConsumptionType(item.getItemId()) == ConsumptionType.SHIRT;
   }
 
   public static final boolean isContainer(final AdventureResult item) {
-    return ItemDatabase.getConsumptionType(item.getItemId()) == ConsumptionType.EQUIP_CONTAINER;
+    return ItemDatabase.getConsumptionType(item.getItemId()) == ConsumptionType.CONTAINER;
   }
 
   public static final boolean isMainhandOnly(final AdventureResult item) {
@@ -724,16 +724,16 @@ public class EquipmentDatabase {
     }
 
     switch (ItemDatabase.getConsumptionType(id)) {
-      case EQUIP_ACCESSORY:
-      case EQUIP_HAT:
-      case EQUIP_PANTS:
-      case EQUIP_SHIRT:
-      case EQUIP_WEAPON:
-      case EQUIP_OFFHAND:
-      case EQUIP_CONTAINER:
+      case ACCESSORY:
+      case HAT:
+      case PANTS:
+      case SHIRT:
+      case WEAPON:
+      case OFFHAND:
+      case CONTAINER:
         break;
 
-      case EQUIP_FAMILIAR:
+      case FAMILIAR_EQUIPMENT:
       default:
         return false;
     }

--- a/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.Stat;
 import net.sourceforge.kolmafia.KoLConstants.WeaponType;
 import net.sourceforge.kolmafia.Modifiers;
@@ -248,28 +249,28 @@ public class EquipmentDatabase {
       Entry<Integer, String> entry = it.next();
       Integer key = entry.getKey();
       String name = entry.getValue();
-      int type = ItemDatabase.getConsumptionType(key.intValue());
+      ConsumptionType type = ItemDatabase.getConsumptionType(key.intValue());
 
       switch (type) {
-        case KoLConstants.EQUIP_HAT:
+        case EQUIP_HAT:
           hats.put(name, key);
           break;
-        case KoLConstants.EQUIP_PANTS:
+        case EQUIP_PANTS:
           pants.put(name, key);
           break;
-        case KoLConstants.EQUIP_SHIRT:
+        case EQUIP_SHIRT:
           shirts.put(name, key);
           break;
-        case KoLConstants.EQUIP_WEAPON:
+        case EQUIP_WEAPON:
           weapons.put(name, key);
           break;
-        case KoLConstants.EQUIP_OFFHAND:
+        case EQUIP_OFFHAND:
           offhands.put(name, key);
           break;
-        case KoLConstants.EQUIP_ACCESSORY:
+        case EQUIP_ACCESSORY:
           accessories.put(name, key);
           break;
-        case KoLConstants.EQUIP_CONTAINER:
+        case EQUIP_CONTAINER:
           containers.put(name, key);
           break;
       }
@@ -309,8 +310,8 @@ public class EquipmentDatabase {
       int itemId = val.intValue();
       int power = EquipmentDatabase.getPower(itemId);
       String req = EquipmentDatabase.getEquipRequirement(itemId);
-      int usage = ItemDatabase.getConsumptionType(itemId);
-      boolean isWeapon = usage == KoLConstants.EQUIP_WEAPON;
+      ConsumptionType usage = ItemDatabase.getConsumptionType(itemId);
+      boolean isWeapon = usage == ConsumptionType.EQUIP_WEAPON;
       String type = EquipmentDatabase.itemTypes.get(itemId);
       boolean isShield = type != null && type.equals("shield");
       String weaponType = "";
@@ -466,8 +467,8 @@ public class EquipmentDatabase {
     while (++prevId <= limit) {
       String req = EquipmentDatabase.statRequirements.get(prevId);
       if ((req != null && req.length() > 0)
-          || ItemDatabase.getConsumptionType(prevId) == KoLConstants.EQUIP_FAMILIAR
-          || ItemDatabase.getConsumptionType(prevId) == KoLConstants.CONSUME_SIXGUN) {
+          || ItemDatabase.getConsumptionType(prevId) == ConsumptionType.EQUIP_FAMILIAR
+          || ItemDatabase.getConsumptionType(prevId) == ConsumptionType.CONSUME_SIXGUN) {
         return prevId;
       }
     }
@@ -529,59 +530,59 @@ public class EquipmentDatabase {
 
   public static final String getItemType(final int itemId) {
     switch (ItemDatabase.getConsumptionType(itemId)) {
-      case KoLConstants.CONSUME_EAT:
+      case CONSUME_EAT:
         return "food";
-      case KoLConstants.CONSUME_DRINK:
+      case CONSUME_DRINK:
         return "booze";
-      case KoLConstants.CONSUME_SPLEEN:
+      case CONSUME_SPLEEN:
         return "spleen item";
-      case KoLConstants.CONSUME_FOOD_HELPER:
+      case CONSUME_FOOD_HELPER:
         return "food helper";
-      case KoLConstants.CONSUME_DRINK_HELPER:
+      case CONSUME_DRINK_HELPER:
         return "drink helper";
-      case KoLConstants.CONSUME_STICKER:
+      case CONSUME_STICKER:
         return "sticker";
-      case KoLConstants.CONSUME_CARD:
+      case CONSUME_CARD:
         return "card";
-      case KoLConstants.CONSUME_FOLDER:
+      case CONSUME_FOLDER:
         return "folder";
-      case KoLConstants.CONSUME_BOOTSKIN:
+      case CONSUME_BOOTSKIN:
         return "bootskin";
-      case KoLConstants.CONSUME_BOOTSPUR:
+      case CONSUME_BOOTSPUR:
         return "bootspur";
-      case KoLConstants.CONSUME_SIXGUN:
+      case CONSUME_SIXGUN:
         return "sixgun";
-      case KoLConstants.CONSUME_POTION:
+      case CONSUME_POTION:
         return "potion";
-      case KoLConstants.CONSUME_AVATAR:
+      case CONSUME_AVATAR:
         return "avatar potion";
-      case KoLConstants.GROW_FAMILIAR:
+      case GROW_FAMILIAR:
         return "familiar larva";
-      case KoLConstants.CONSUME_ZAP:
+      case CONSUME_ZAP:
         return "zap wand";
-      case KoLConstants.EQUIP_FAMILIAR:
+      case EQUIP_FAMILIAR:
         return "familiar equipment";
-      case KoLConstants.EQUIP_ACCESSORY:
+      case EQUIP_ACCESSORY:
         return "accessory";
-      case KoLConstants.EQUIP_HAT:
+      case EQUIP_HAT:
         return "hat";
-      case KoLConstants.EQUIP_PANTS:
+      case EQUIP_PANTS:
         return "pants";
-      case KoLConstants.EQUIP_SHIRT:
+      case EQUIP_SHIRT:
         return "shirt";
-      case KoLConstants.EQUIP_WEAPON:
+      case EQUIP_WEAPON:
         {
           String type = EquipmentDatabase.itemTypes.get(itemId);
           return type != null ? type : "weapon";
         }
-      case KoLConstants.EQUIP_OFFHAND:
+      case EQUIP_OFFHAND:
         {
           String type = EquipmentDatabase.itemTypes.get(itemId);
           return type != null ? type : "offhand";
         }
-      case KoLConstants.EQUIP_CONTAINER:
+      case EQUIP_CONTAINER:
         return "container";
-      case KoLConstants.CONSUME_GUARDIAN:
+      case CONSUME_GUARDIAN:
         return "pasta guardian";
       default:
         return "";
@@ -600,9 +601,9 @@ public class EquipmentDatabase {
   }
 
   public static final Stat getWeaponStat(final int itemId) {
-    int consumptionType = ItemDatabase.getConsumptionType(itemId);
+    ConsumptionType consumptionType = ItemDatabase.getConsumptionType(itemId);
 
-    if (consumptionType != KoLConstants.EQUIP_WEAPON) {
+    if (consumptionType != ConsumptionType.EQUIP_WEAPON) {
       return Stat.NONE;
     }
 
@@ -692,11 +693,11 @@ public class EquipmentDatabase {
   }
 
   public static final boolean isShirt(final AdventureResult item) {
-    return ItemDatabase.getConsumptionType(item.getItemId()) == KoLConstants.EQUIP_SHIRT;
+    return ItemDatabase.getConsumptionType(item.getItemId()) == ConsumptionType.EQUIP_SHIRT;
   }
 
   public static final boolean isContainer(final AdventureResult item) {
-    return ItemDatabase.getConsumptionType(item.getItemId()) == KoLConstants.EQUIP_CONTAINER;
+    return ItemDatabase.getConsumptionType(item.getItemId()) == ConsumptionType.EQUIP_CONTAINER;
   }
 
   public static final boolean isMainhandOnly(final AdventureResult item) {
@@ -723,16 +724,16 @@ public class EquipmentDatabase {
     }
 
     switch (ItemDatabase.getConsumptionType(id)) {
-      case KoLConstants.EQUIP_ACCESSORY:
-      case KoLConstants.EQUIP_HAT:
-      case KoLConstants.EQUIP_PANTS:
-      case KoLConstants.EQUIP_SHIRT:
-      case KoLConstants.EQUIP_WEAPON:
-      case KoLConstants.EQUIP_OFFHAND:
-      case KoLConstants.EQUIP_CONTAINER:
+      case EQUIP_ACCESSORY:
+      case EQUIP_HAT:
+      case EQUIP_PANTS:
+      case EQUIP_SHIRT:
+      case EQUIP_WEAPON:
+      case EQUIP_OFFHAND:
+      case EQUIP_CONTAINER:
         break;
 
-      case KoLConstants.EQUIP_FAMILIAR:
+      case EQUIP_FAMILIAR:
       default:
         return false;
     }

--- a/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
@@ -172,8 +172,7 @@ public class ItemDatabase {
   public static final int ATTR_MIX = 0x00400000;
 
   private static final HashMap<String, ConsumptionType> PRIMARY_USE = new HashMap<>();
-  private static final HashMap<ConsumptionType, String> INVERSE_PRIMARY_USE =
-      new HashMap<>();
+  private static final HashMap<ConsumptionType, String> INVERSE_PRIMARY_USE = new HashMap<>();
   private static final HashMap<String, Integer> SECONDARY_USE = new HashMap<String, Integer>();
   private static final TreeMap<Integer, String> INVERSE_SECONDARY_USE =
       new TreeMap<Integer, String>();
@@ -899,7 +898,8 @@ public class ItemDatabase {
   }
 
   public static final void registerMultiUsability(final int itemId, final boolean multi) {
-    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType =
+        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     int attributes = ItemDatabase.getAttributes(itemId);
 
     if (multi) {
@@ -1857,7 +1857,8 @@ public class ItemDatabase {
   public static boolean isUsable(final int itemId) {
     // Anything that you can manipulate with inv_use.php
 
-    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType =
+        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     int attributes = ItemDatabase.getAttributes(itemId);
 
     return switch (useType) {
@@ -1889,64 +1890,76 @@ public class ItemDatabase {
   }
 
   public static final boolean isPotion(final int itemId) {
-    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType =
+        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     return (useType == ConsumptionType.CONSUME_POTION || useType == ConsumptionType.CONSUME_AVATAR);
   }
 
   public static final boolean isEquipment(final int itemId) {
-    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType =
+        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     return KoLConstants.isEquipmentType(useType, true);
   }
 
   public static final boolean isFood(final int itemId) {
-    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType =
+        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     return useType == ConsumptionType.CONSUME_EAT;
   }
 
   public static final boolean isBooze(final int itemId) {
-    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType =
+        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     return useType == ConsumptionType.CONSUME_DRINK;
   }
 
   public static final boolean isHat(final int itemId) {
-    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType =
+        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     return useType == ConsumptionType.EQUIP_HAT;
   }
 
   public static final boolean isWeapon(final int itemId) {
-    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType =
+        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     return useType == ConsumptionType.EQUIP_WEAPON;
   }
 
   public static final boolean isOffHand(final int itemId) {
-    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType =
+        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     return useType == ConsumptionType.EQUIP_OFFHAND;
   }
 
   public static final boolean isShirt(final int itemId) {
-    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType =
+        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     return useType == ConsumptionType.EQUIP_SHIRT;
   }
 
   public static final boolean isPants(final int itemId) {
-    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType =
+        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     return useType == ConsumptionType.EQUIP_PANTS;
   }
 
   public static final boolean isAccessory(final int itemId) {
-    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType =
+        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     return useType == ConsumptionType.EQUIP_ACCESSORY;
   }
 
   public static final boolean isFamiliarEquipment(final int itemId) {
-    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType =
+        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     return useType == ConsumptionType.EQUIP_FAMILIAR;
   }
 
   public static final boolean isMultiUsable(final int itemId) {
     // Anything that you can manipulate with multiuse.php
 
-    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType =
+        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     int attributes = ItemDatabase.getAttributes(itemId);
 
     switch (useType) {
@@ -1962,9 +1975,11 @@ public class ItemDatabase {
   }
 
   public static final boolean isReusable(final int itemId) {
-    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType =
+        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     int attributes = ItemDatabase.getAttributes(itemId);
-    return useType == ConsumptionType.INFINITE_USES || (attributes & ItemDatabase.ATTR_REUSABLE) != 0;
+    return useType == ConsumptionType.INFINITE_USES
+        || (attributes & ItemDatabase.ATTR_REUSABLE) != 0;
   }
 
   /**
@@ -2060,7 +2075,9 @@ public class ItemDatabase {
    * @return The consumption associated with the item
    */
   public static final ConsumptionType getConsumptionType(final int itemId) {
-    return itemId <= 0 ? ConsumptionType.NO_CONSUME : ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    return itemId <= 0
+        ? ConsumptionType.NO_CONSUME
+        : ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
   }
 
   public static final ConsumptionType getConsumptionType(final AdventureResult item) {

--- a/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
@@ -1015,11 +1015,12 @@ public class ItemDatabase {
     if (!effectName.equals("") && EffectDatabase.getEffectId(effectName, true) == -1) {
       String effectDescid = DebugDatabase.parseEffectDescid(rawText);
       String command =
-          usage == ConsumptionType.EAT
-              ? "eat 1 "
-              : usage == ConsumptionType.DRINK
-                  ? "drink 1 "
-                  : usage == ConsumptionType.SPLEEN ? "chew 1 " : "use 1 ";
+          switch (usage) {
+            case EAT -> "eat 1 ";
+            case DRINK -> "drink 1 ";
+            case SPLEEN -> "chew 1 ";
+            default -> "use 1 ";
+          };
       EffectDatabase.registerEffect(effectName, effectDescid, command + itemName);
     }
 

--- a/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
@@ -189,44 +189,44 @@ public class ItemDatabase {
   }
 
   static {
-    ItemDatabase.definePrimaryUse("none", ConsumptionType.NO_CONSUME);
+    ItemDatabase.definePrimaryUse("none", ConsumptionType.NONE);
 
-    ItemDatabase.definePrimaryUse("food", ConsumptionType.CONSUME_EAT);
-    ItemDatabase.definePrimaryUse("drink", ConsumptionType.CONSUME_DRINK);
-    ItemDatabase.definePrimaryUse("spleen", ConsumptionType.CONSUME_SPLEEN);
+    ItemDatabase.definePrimaryUse("food", ConsumptionType.EAT);
+    ItemDatabase.definePrimaryUse("drink", ConsumptionType.DRINK);
+    ItemDatabase.definePrimaryUse("spleen", ConsumptionType.SPLEEN);
 
-    ItemDatabase.definePrimaryUse("usable", ConsumptionType.CONSUME_USE);
-    ItemDatabase.definePrimaryUse("multiple", ConsumptionType.CONSUME_MULTIPLE);
-    ItemDatabase.definePrimaryUse("reusable", ConsumptionType.INFINITE_USES);
-    ItemDatabase.definePrimaryUse("message", ConsumptionType.MESSAGE_DISPLAY);
+    ItemDatabase.definePrimaryUse("usable", ConsumptionType.USE);
+    ItemDatabase.definePrimaryUse("multiple", ConsumptionType.USE_MULTIPLE);
+    ItemDatabase.definePrimaryUse("reusable", ConsumptionType.USE_INFINITE);
+    ItemDatabase.definePrimaryUse("message", ConsumptionType.USE_MESSAGE_DISPLAY);
 
-    ItemDatabase.definePrimaryUse("grow", ConsumptionType.GROW_FAMILIAR);
+    ItemDatabase.definePrimaryUse("grow", ConsumptionType.FAMILIAR_HATCHLING);
 
-    ItemDatabase.definePrimaryUse("hat", ConsumptionType.EQUIP_HAT);
-    ItemDatabase.definePrimaryUse("weapon", ConsumptionType.EQUIP_WEAPON);
-    ItemDatabase.definePrimaryUse("offhand", ConsumptionType.EQUIP_OFFHAND);
-    ItemDatabase.definePrimaryUse("container", ConsumptionType.EQUIP_CONTAINER);
-    ItemDatabase.definePrimaryUse("shirt", ConsumptionType.EQUIP_SHIRT);
-    ItemDatabase.definePrimaryUse("pants", ConsumptionType.EQUIP_PANTS);
-    ItemDatabase.definePrimaryUse("accessory", ConsumptionType.EQUIP_ACCESSORY);
-    ItemDatabase.definePrimaryUse("familiar", ConsumptionType.EQUIP_FAMILIAR);
+    ItemDatabase.definePrimaryUse("hat", ConsumptionType.HAT);
+    ItemDatabase.definePrimaryUse("weapon", ConsumptionType.WEAPON);
+    ItemDatabase.definePrimaryUse("offhand", ConsumptionType.OFFHAND);
+    ItemDatabase.definePrimaryUse("container", ConsumptionType.CONTAINER);
+    ItemDatabase.definePrimaryUse("shirt", ConsumptionType.SHIRT);
+    ItemDatabase.definePrimaryUse("pants", ConsumptionType.PANTS);
+    ItemDatabase.definePrimaryUse("accessory", ConsumptionType.ACCESSORY);
+    ItemDatabase.definePrimaryUse("familiar", ConsumptionType.FAMILIAR_EQUIPMENT);
 
-    ItemDatabase.definePrimaryUse("sticker", ConsumptionType.CONSUME_STICKER);
-    ItemDatabase.definePrimaryUse("card", ConsumptionType.CONSUME_CARD);
-    ItemDatabase.definePrimaryUse("folder", ConsumptionType.CONSUME_FOLDER);
-    ItemDatabase.definePrimaryUse("bootskin", ConsumptionType.CONSUME_BOOTSKIN);
-    ItemDatabase.definePrimaryUse("bootspur", ConsumptionType.CONSUME_BOOTSPUR);
-    ItemDatabase.definePrimaryUse("sixgun", ConsumptionType.CONSUME_SIXGUN);
+    ItemDatabase.definePrimaryUse("sticker", ConsumptionType.STICKER);
+    ItemDatabase.definePrimaryUse("card", ConsumptionType.CARD);
+    ItemDatabase.definePrimaryUse("folder", ConsumptionType.FOLDER);
+    ItemDatabase.definePrimaryUse("bootskin", ConsumptionType.BOOTSKIN);
+    ItemDatabase.definePrimaryUse("bootspur", ConsumptionType.BOOTSPUR);
+    ItemDatabase.definePrimaryUse("sixgun", ConsumptionType.SIXGUN);
 
-    ItemDatabase.definePrimaryUse("food helper", ConsumptionType.CONSUME_FOOD_HELPER);
-    ItemDatabase.definePrimaryUse("drink helper", ConsumptionType.CONSUME_DRINK_HELPER);
-    ItemDatabase.definePrimaryUse("zap", ConsumptionType.CONSUME_ZAP);
-    ItemDatabase.definePrimaryUse("sphere", ConsumptionType.CONSUME_SPHERE);
-    ItemDatabase.definePrimaryUse("guardian", ConsumptionType.CONSUME_GUARDIAN);
-    ItemDatabase.definePrimaryUse("pokepill", ConsumptionType.CONSUME_POKEPILL);
+    ItemDatabase.definePrimaryUse("food helper", ConsumptionType.FOOD_HELPER);
+    ItemDatabase.definePrimaryUse("drink helper", ConsumptionType.DRINK_HELPER);
+    ItemDatabase.definePrimaryUse("zap", ConsumptionType.ZAP);
+    ItemDatabase.definePrimaryUse("sphere", ConsumptionType.EL_VIBRATO_SPHERE);
+    ItemDatabase.definePrimaryUse("guardian", ConsumptionType.PASTA_GUARDIAN);
+    ItemDatabase.definePrimaryUse("pokepill", ConsumptionType.POKEPILL);
 
-    ItemDatabase.definePrimaryUse("potion", ConsumptionType.CONSUME_POTION);
-    ItemDatabase.definePrimaryUse("avatar", ConsumptionType.CONSUME_AVATAR);
+    ItemDatabase.definePrimaryUse("potion", ConsumptionType.POTION);
+    ItemDatabase.definePrimaryUse("avatar", ConsumptionType.AVATAR_POTION);
 
     ItemDatabase.defineSecondaryUse("usable", ItemDatabase.ATTR_USABLE);
     ItemDatabase.defineSecondaryUse("multiple", ItemDatabase.ATTR_MULTIPLE);
@@ -898,21 +898,20 @@ public class ItemDatabase {
   }
 
   public static final void registerMultiUsability(final int itemId, final boolean multi) {
-    ConsumptionType useType =
-        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
     int attributes = ItemDatabase.getAttributes(itemId);
 
     if (multi) {
       // We think the item is single usable but it really is multiusable
-      if (useType == ConsumptionType.CONSUME_USE) {
-        ItemDatabase.useTypeById.put(itemId, ConsumptionType.CONSUME_MULTIPLE);
+      if (useType == ConsumptionType.USE) {
+        ItemDatabase.useTypeById.put(itemId, ConsumptionType.USE_MULTIPLE);
       } else {
         ItemDatabase.attributesById.put(itemId, attributes | ItemDatabase.ATTR_MULTIPLE);
       }
     } else {
       // We think the item is multi usable but it really is single usable
-      if (useType == ConsumptionType.CONSUME_MULTIPLE) {
-        ItemDatabase.useTypeById.put(itemId, ConsumptionType.CONSUME_USE);
+      if (useType == ConsumptionType.USE_MULTIPLE) {
+        ItemDatabase.useTypeById.put(itemId, ConsumptionType.USE);
       } else {
         ItemDatabase.attributesById.put(itemId, attributes | ItemDatabase.ATTR_USABLE);
       }
@@ -927,7 +926,7 @@ public class ItemDatabase {
     String text = DebugDatabase.itemDescriptionText(rawText);
     if (text == null) {
       // Assume defaults
-      ItemDatabase.useTypeById.put(itemId, ConsumptionType.NO_CONSUME);
+      ItemDatabase.useTypeById.put(itemId, ConsumptionType.NONE);
       ItemDatabase.attributesById.put(itemId, 0);
       ItemDatabase.accessById.put(id, TRADE_FLAG + "," + DISCARD_FLAG);
       ItemDatabase.priceById.put(itemId, 0);
@@ -943,7 +942,7 @@ public class ItemDatabase {
     String type = DebugDatabase.parseType(text);
     ConsumptionType usage = DebugDatabase.typeToPrimary(type, multi);
     if (text.contains("blue\">Makes you look like")) {
-      usage = ConsumptionType.CONSUME_AVATAR;
+      usage = ConsumptionType.AVATAR_POTION;
     }
     ItemDatabase.useTypeById.put(itemId, usage);
 
@@ -955,7 +954,7 @@ public class ItemDatabase {
     attrs |= access.contains(GIFT_FLAG) ? ItemDatabase.ATTR_GIFT : 0;
     attrs |= access.contains(QUEST_FLAG) ? ItemDatabase.ATTR_QUEST : 0;
     attrs |= access.contains(DISCARD_FLAG) ? ItemDatabase.ATTR_DISCARDABLE : 0;
-    if (multi && usage != ConsumptionType.CONSUME_MULTIPLE) {
+    if (multi && usage != ConsumptionType.USE_MULTIPLE) {
       attrs |= ItemDatabase.ATTR_MULTIPLE;
     }
     ItemDatabase.attributesById.put(itemId, attrs);
@@ -987,9 +986,9 @@ public class ItemDatabase {
 
       // Let equipment database do what it wishes with this item
       EquipmentDatabase.registerItem(itemId, itemName, text, power);
-    } else if (usage == ConsumptionType.CONSUME_EAT
-        || usage == ConsumptionType.CONSUME_DRINK
-        || usage == ConsumptionType.CONSUME_SPLEEN) {
+    } else if (usage == ConsumptionType.EAT
+        || usage == ConsumptionType.DRINK
+        || usage == ConsumptionType.SPLEEN) {
       ConsumablesDatabase.registerConsumable(itemName, usage, text);
     }
 
@@ -1016,11 +1015,11 @@ public class ItemDatabase {
     if (!effectName.equals("") && EffectDatabase.getEffectId(effectName, true) == -1) {
       String effectDescid = DebugDatabase.parseEffectDescid(rawText);
       String command =
-          usage == ConsumptionType.CONSUME_EAT
+          usage == ConsumptionType.EAT
               ? "eat 1 "
-              : usage == ConsumptionType.CONSUME_DRINK
+              : usage == ConsumptionType.DRINK
                   ? "drink 1 "
-                  : usage == ConsumptionType.CONSUME_SPLEEN ? "chew 1 " : "use 1 ";
+                  : usage == ConsumptionType.SPLEEN ? "chew 1 " : "use 1 ";
       EffectDatabase.registerEffect(effectName, effectDescid, command + itemName);
     }
 
@@ -1857,23 +1856,22 @@ public class ItemDatabase {
   public static boolean isUsable(final int itemId) {
     // Anything that you can manipulate with inv_use.php
 
-    ConsumptionType useType =
-        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
     int attributes = ItemDatabase.getAttributes(itemId);
 
     return switch (useType) {
       case
           // Explicit "use"
-          CONSUME_USE,
-          MESSAGE_DISPLAY,
-          INFINITE_USES,
+          USE,
+          USE_MESSAGE_DISPLAY,
+          USE_INFINITE,
           // Multi-use
-          CONSUME_MULTIPLE,
+          USE_MULTIPLE,
           // Grow is a type of use
-          GROW_FAMILIAR,
+          FAMILIAR_HATCHLING,
           // Any potion
-          CONSUME_POTION,
-          CONSUME_AVATAR -> true;
+          POTION,
+          AVATAR_POTION -> true;
       default -> (attributes
               & (ItemDatabase.ATTR_USABLE
                   | ItemDatabase.ATTR_MULTIPLE
@@ -1890,84 +1888,72 @@ public class ItemDatabase {
   }
 
   public static final boolean isPotion(final int itemId) {
-    ConsumptionType useType =
-        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
-    return (useType == ConsumptionType.CONSUME_POTION || useType == ConsumptionType.CONSUME_AVATAR);
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
+    return (useType == ConsumptionType.POTION || useType == ConsumptionType.AVATAR_POTION);
   }
 
   public static final boolean isEquipment(final int itemId) {
-    ConsumptionType useType =
-        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
     return KoLConstants.isEquipmentType(useType, true);
   }
 
   public static final boolean isFood(final int itemId) {
-    ConsumptionType useType =
-        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
-    return useType == ConsumptionType.CONSUME_EAT;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
+    return useType == ConsumptionType.EAT;
   }
 
   public static final boolean isBooze(final int itemId) {
-    ConsumptionType useType =
-        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
-    return useType == ConsumptionType.CONSUME_DRINK;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
+    return useType == ConsumptionType.DRINK;
   }
 
   public static final boolean isHat(final int itemId) {
-    ConsumptionType useType =
-        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
-    return useType == ConsumptionType.EQUIP_HAT;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
+    return useType == ConsumptionType.HAT;
   }
 
   public static final boolean isWeapon(final int itemId) {
-    ConsumptionType useType =
-        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
-    return useType == ConsumptionType.EQUIP_WEAPON;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
+    return useType == ConsumptionType.WEAPON;
   }
 
   public static final boolean isOffHand(final int itemId) {
-    ConsumptionType useType =
-        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
-    return useType == ConsumptionType.EQUIP_OFFHAND;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
+    return useType == ConsumptionType.OFFHAND;
   }
 
   public static final boolean isShirt(final int itemId) {
-    ConsumptionType useType =
-        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
-    return useType == ConsumptionType.EQUIP_SHIRT;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
+    return useType == ConsumptionType.SHIRT;
   }
 
   public static final boolean isPants(final int itemId) {
-    ConsumptionType useType =
-        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
-    return useType == ConsumptionType.EQUIP_PANTS;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
+    return useType == ConsumptionType.PANTS;
   }
 
   public static final boolean isAccessory(final int itemId) {
-    ConsumptionType useType =
-        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
-    return useType == ConsumptionType.EQUIP_ACCESSORY;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
+    return useType == ConsumptionType.ACCESSORY;
   }
 
   public static final boolean isFamiliarEquipment(final int itemId) {
-    ConsumptionType useType =
-        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
-    return useType == ConsumptionType.EQUIP_FAMILIAR;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
+    return useType == ConsumptionType.FAMILIAR_EQUIPMENT;
   }
 
   public static final boolean isMultiUsable(final int itemId) {
     // Anything that you can manipulate with multiuse.php
 
-    ConsumptionType useType =
-        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
     int attributes = ItemDatabase.getAttributes(itemId);
 
     switch (useType) {
-      case CONSUME_MULTIPLE:
+      case USE_MULTIPLE:
         return true;
-      case CONSUME_POTION:
-      case CONSUME_AVATAR:
-      case CONSUME_SPLEEN:
+      case POTION:
+      case AVATAR_POTION:
+      case SPLEEN:
         return (attributes & ItemDatabase.ATTR_USABLE) == 0;
       default:
         return (attributes & ItemDatabase.ATTR_MULTIPLE) != 0;
@@ -1975,10 +1961,9 @@ public class ItemDatabase {
   }
 
   public static final boolean isReusable(final int itemId) {
-    ConsumptionType useType =
-        ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
     int attributes = ItemDatabase.getAttributes(itemId);
-    return useType == ConsumptionType.INFINITE_USES
+    return useType == ConsumptionType.USE_INFINITE
         || (attributes & ItemDatabase.ATTR_REUSABLE) != 0;
   }
 
@@ -2076,8 +2061,8 @@ public class ItemDatabase {
    */
   public static final ConsumptionType getConsumptionType(final int itemId) {
     return itemId <= 0
-        ? ConsumptionType.NO_CONSUME
-        : ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+        ? ConsumptionType.NONE
+        : ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NONE);
   }
 
   public static final ConsumptionType getConsumptionType(final AdventureResult item) {
@@ -2223,8 +2208,7 @@ public class ItemDatabase {
 
   public static void parseVampireVintnerWine(final String idesc) {
     String iEnchantments =
-        DebugDatabase.parseItemEnchantments(
-            idesc, new ArrayList<String>(), ConsumptionType.CONSUME_DRINK);
+        DebugDatabase.parseItemEnchantments(idesc, new ArrayList<String>(), ConsumptionType.DRINK);
     String iname = DebugDatabase.parseName(idesc);
     Modifiers imods = Modifiers.parseModifiers(iname, iEnchantments);
 

--- a/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
@@ -20,6 +20,7 @@ import net.java.dev.spellcast.utilities.JComponentUtilities;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.CraftingType;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.Modifiers;
@@ -53,7 +54,7 @@ public class ItemDatabase {
   private static int maxItemId = 0;
 
   private static String[] canonicalNames = new String[0];
-  private static final Map<Integer, Integer> useTypeById = new HashMap<>();
+  private static final Map<Integer, ConsumptionType> useTypeById = new HashMap<>();
   private static final Map<Integer, Integer> attributesById = new HashMap<>();
   private static final Map<Integer, Integer> priceById = new HashMap<>();
   private static final Map<Integer, Integer> nameLength = new HashMap<>();
@@ -170,17 +171,16 @@ public class ItemDatabase {
   public static final int ATTR_COOK = 0x00200000;
   public static final int ATTR_MIX = 0x00400000;
 
-  private static final HashMap<String, Integer> PRIMARY_USE = new HashMap<String, Integer>();
-  private static final HashMap<Integer, String> INVERSE_PRIMARY_USE =
-      new HashMap<Integer, String>();
+  private static final HashMap<String, ConsumptionType> PRIMARY_USE = new HashMap<>();
+  private static final HashMap<ConsumptionType, String> INVERSE_PRIMARY_USE =
+      new HashMap<>();
   private static final HashMap<String, Integer> SECONDARY_USE = new HashMap<String, Integer>();
   private static final TreeMap<Integer, String> INVERSE_SECONDARY_USE =
       new TreeMap<Integer, String>();
 
-  private static void definePrimaryUse(final String key, final int usage) {
-    Integer val = usage;
-    PRIMARY_USE.put(key, val);
-    INVERSE_PRIMARY_USE.put(val, key);
+  private static void definePrimaryUse(final String key, final ConsumptionType usage) {
+    PRIMARY_USE.put(key, usage);
+    INVERSE_PRIMARY_USE.put(usage, key);
   }
 
   private static void defineSecondaryUse(final String key, final int usage) {
@@ -190,44 +190,44 @@ public class ItemDatabase {
   }
 
   static {
-    ItemDatabase.definePrimaryUse("none", KoLConstants.NO_CONSUME);
+    ItemDatabase.definePrimaryUse("none", ConsumptionType.NO_CONSUME);
 
-    ItemDatabase.definePrimaryUse("food", KoLConstants.CONSUME_EAT);
-    ItemDatabase.definePrimaryUse("drink", KoLConstants.CONSUME_DRINK);
-    ItemDatabase.definePrimaryUse("spleen", KoLConstants.CONSUME_SPLEEN);
+    ItemDatabase.definePrimaryUse("food", ConsumptionType.CONSUME_EAT);
+    ItemDatabase.definePrimaryUse("drink", ConsumptionType.CONSUME_DRINK);
+    ItemDatabase.definePrimaryUse("spleen", ConsumptionType.CONSUME_SPLEEN);
 
-    ItemDatabase.definePrimaryUse("usable", KoLConstants.CONSUME_USE);
-    ItemDatabase.definePrimaryUse("multiple", KoLConstants.CONSUME_MULTIPLE);
-    ItemDatabase.definePrimaryUse("reusable", KoLConstants.INFINITE_USES);
-    ItemDatabase.definePrimaryUse("message", KoLConstants.MESSAGE_DISPLAY);
+    ItemDatabase.definePrimaryUse("usable", ConsumptionType.CONSUME_USE);
+    ItemDatabase.definePrimaryUse("multiple", ConsumptionType.CONSUME_MULTIPLE);
+    ItemDatabase.definePrimaryUse("reusable", ConsumptionType.INFINITE_USES);
+    ItemDatabase.definePrimaryUse("message", ConsumptionType.MESSAGE_DISPLAY);
 
-    ItemDatabase.definePrimaryUse("grow", KoLConstants.GROW_FAMILIAR);
+    ItemDatabase.definePrimaryUse("grow", ConsumptionType.GROW_FAMILIAR);
 
-    ItemDatabase.definePrimaryUse("hat", KoLConstants.EQUIP_HAT);
-    ItemDatabase.definePrimaryUse("weapon", KoLConstants.EQUIP_WEAPON);
-    ItemDatabase.definePrimaryUse("offhand", KoLConstants.EQUIP_OFFHAND);
-    ItemDatabase.definePrimaryUse("container", KoLConstants.EQUIP_CONTAINER);
-    ItemDatabase.definePrimaryUse("shirt", KoLConstants.EQUIP_SHIRT);
-    ItemDatabase.definePrimaryUse("pants", KoLConstants.EQUIP_PANTS);
-    ItemDatabase.definePrimaryUse("accessory", KoLConstants.EQUIP_ACCESSORY);
-    ItemDatabase.definePrimaryUse("familiar", KoLConstants.EQUIP_FAMILIAR);
+    ItemDatabase.definePrimaryUse("hat", ConsumptionType.EQUIP_HAT);
+    ItemDatabase.definePrimaryUse("weapon", ConsumptionType.EQUIP_WEAPON);
+    ItemDatabase.definePrimaryUse("offhand", ConsumptionType.EQUIP_OFFHAND);
+    ItemDatabase.definePrimaryUse("container", ConsumptionType.EQUIP_CONTAINER);
+    ItemDatabase.definePrimaryUse("shirt", ConsumptionType.EQUIP_SHIRT);
+    ItemDatabase.definePrimaryUse("pants", ConsumptionType.EQUIP_PANTS);
+    ItemDatabase.definePrimaryUse("accessory", ConsumptionType.EQUIP_ACCESSORY);
+    ItemDatabase.definePrimaryUse("familiar", ConsumptionType.EQUIP_FAMILIAR);
 
-    ItemDatabase.definePrimaryUse("sticker", KoLConstants.CONSUME_STICKER);
-    ItemDatabase.definePrimaryUse("card", KoLConstants.CONSUME_CARD);
-    ItemDatabase.definePrimaryUse("folder", KoLConstants.CONSUME_FOLDER);
-    ItemDatabase.definePrimaryUse("bootskin", KoLConstants.CONSUME_BOOTSKIN);
-    ItemDatabase.definePrimaryUse("bootspur", KoLConstants.CONSUME_BOOTSPUR);
-    ItemDatabase.definePrimaryUse("sixgun", KoLConstants.CONSUME_SIXGUN);
+    ItemDatabase.definePrimaryUse("sticker", ConsumptionType.CONSUME_STICKER);
+    ItemDatabase.definePrimaryUse("card", ConsumptionType.CONSUME_CARD);
+    ItemDatabase.definePrimaryUse("folder", ConsumptionType.CONSUME_FOLDER);
+    ItemDatabase.definePrimaryUse("bootskin", ConsumptionType.CONSUME_BOOTSKIN);
+    ItemDatabase.definePrimaryUse("bootspur", ConsumptionType.CONSUME_BOOTSPUR);
+    ItemDatabase.definePrimaryUse("sixgun", ConsumptionType.CONSUME_SIXGUN);
 
-    ItemDatabase.definePrimaryUse("food helper", KoLConstants.CONSUME_FOOD_HELPER);
-    ItemDatabase.definePrimaryUse("drink helper", KoLConstants.CONSUME_DRINK_HELPER);
-    ItemDatabase.definePrimaryUse("zap", KoLConstants.CONSUME_ZAP);
-    ItemDatabase.definePrimaryUse("sphere", KoLConstants.CONSUME_SPHERE);
-    ItemDatabase.definePrimaryUse("guardian", KoLConstants.CONSUME_GUARDIAN);
-    ItemDatabase.definePrimaryUse("pokepill", KoLConstants.CONSUME_POKEPILL);
+    ItemDatabase.definePrimaryUse("food helper", ConsumptionType.CONSUME_FOOD_HELPER);
+    ItemDatabase.definePrimaryUse("drink helper", ConsumptionType.CONSUME_DRINK_HELPER);
+    ItemDatabase.definePrimaryUse("zap", ConsumptionType.CONSUME_ZAP);
+    ItemDatabase.definePrimaryUse("sphere", ConsumptionType.CONSUME_SPHERE);
+    ItemDatabase.definePrimaryUse("guardian", ConsumptionType.CONSUME_GUARDIAN);
+    ItemDatabase.definePrimaryUse("pokepill", ConsumptionType.CONSUME_POKEPILL);
 
-    ItemDatabase.definePrimaryUse("potion", KoLConstants.CONSUME_POTION);
-    ItemDatabase.definePrimaryUse("avatar", KoLConstants.CONSUME_AVATAR);
+    ItemDatabase.definePrimaryUse("potion", ConsumptionType.CONSUME_POTION);
+    ItemDatabase.definePrimaryUse("avatar", ConsumptionType.CONSUME_AVATAR);
 
     ItemDatabase.defineSecondaryUse("usable", ItemDatabase.ATTR_USABLE);
     ItemDatabase.defineSecondaryUse("multiple", ItemDatabase.ATTR_MULTIPLE);
@@ -270,7 +270,6 @@ public class ItemDatabase {
       return;
     }
 
-    ItemDatabase.itemIdSetByName.clear();
     ItemDatabase.itemSourceByNoobSkillId.clear();
 
     ItemDatabase.readItems();
@@ -389,7 +388,7 @@ public class ItemDatabase {
         int price = StringUtilities.parseInt(data[6]);
 
         String usage = usages[0];
-        Integer useType = ItemDatabase.PRIMARY_USE.get(usage);
+        ConsumptionType useType = ItemDatabase.PRIMARY_USE.get(usage);
         if (useType == null) {
           RequestLogger.printLine("Unknown primary usage for " + name + ": " + usage);
         } else {
@@ -399,11 +398,11 @@ public class ItemDatabase {
         int attrs = 0;
         for (int i = 1; i < usages.length; ++i) {
           usage = usages[i];
-          useType = ItemDatabase.SECONDARY_USE.get(usage);
-          if (useType == null) {
+          Integer secUse = ItemDatabase.SECONDARY_USE.get(usage);
+          if (secUse == null) {
             RequestLogger.printLine("Unknown secondary usage for " + name + ": " + usage);
           } else {
-            attrs |= useType;
+            attrs |= secUse;
             CandyDatabase.registerCandy(id, usage);
           }
         }
@@ -500,7 +499,7 @@ public class ItemDatabase {
       String image = ItemDatabase.getImage(itemId);
       // Intentionally get a null if there is not an explicit plural in the database
       String plural = ItemDatabase.getPluralById(itemId);
-      int type = ItemDatabase.getConsumptionType(itemId);
+      ConsumptionType type = ItemDatabase.getConsumptionType(itemId);
       int attrs = ItemDatabase.getAttributes(itemId);
       String access = ItemDatabase.getAccessById(nextInteger);
       int price = ItemDatabase.getPriceById(itemId);
@@ -518,7 +517,7 @@ public class ItemDatabase {
       final String name,
       final String descId,
       final String image,
-      final int type,
+      final ConsumptionType type,
       final int attrs,
       final String access,
       final int autosell,
@@ -900,20 +899,20 @@ public class ItemDatabase {
   }
 
   public static final void registerMultiUsability(final int itemId, final boolean multi) {
-    int useType = ItemDatabase.useTypeById.getOrDefault(itemId, 0);
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     int attributes = ItemDatabase.getAttributes(itemId);
 
     if (multi) {
       // We think the item is single usable but it really is multiusable
-      if (useType == KoLConstants.CONSUME_USE) {
-        ItemDatabase.useTypeById.put(itemId, KoLConstants.CONSUME_MULTIPLE);
+      if (useType == ConsumptionType.CONSUME_USE) {
+        ItemDatabase.useTypeById.put(itemId, ConsumptionType.CONSUME_MULTIPLE);
       } else {
         ItemDatabase.attributesById.put(itemId, attributes | ItemDatabase.ATTR_MULTIPLE);
       }
     } else {
       // We think the item is multi usable but it really is single usable
-      if (useType == KoLConstants.CONSUME_MULTIPLE) {
-        ItemDatabase.useTypeById.put(itemId, KoLConstants.CONSUME_USE);
+      if (useType == ConsumptionType.CONSUME_MULTIPLE) {
+        ItemDatabase.useTypeById.put(itemId, ConsumptionType.CONSUME_USE);
       } else {
         ItemDatabase.attributesById.put(itemId, attributes | ItemDatabase.ATTR_USABLE);
       }
@@ -928,7 +927,7 @@ public class ItemDatabase {
     String text = DebugDatabase.itemDescriptionText(rawText);
     if (text == null) {
       // Assume defaults
-      ItemDatabase.useTypeById.put(itemId, KoLConstants.NO_CONSUME);
+      ItemDatabase.useTypeById.put(itemId, ConsumptionType.NO_CONSUME);
       ItemDatabase.attributesById.put(itemId, 0);
       ItemDatabase.accessById.put(id, TRADE_FLAG + "," + DISCARD_FLAG);
       ItemDatabase.priceById.put(itemId, 0);
@@ -942,9 +941,9 @@ public class ItemDatabase {
 
     // Parse use type, access, and price from description
     String type = DebugDatabase.parseType(text);
-    int usage = DebugDatabase.typeToPrimary(type, multi);
+    ConsumptionType usage = DebugDatabase.typeToPrimary(type, multi);
     if (text.contains("blue\">Makes you look like")) {
-      usage = KoLConstants.CONSUME_AVATAR;
+      usage = ConsumptionType.CONSUME_AVATAR;
     }
     ItemDatabase.useTypeById.put(itemId, usage);
 
@@ -956,7 +955,7 @@ public class ItemDatabase {
     attrs |= access.contains(GIFT_FLAG) ? ItemDatabase.ATTR_GIFT : 0;
     attrs |= access.contains(QUEST_FLAG) ? ItemDatabase.ATTR_QUEST : 0;
     attrs |= access.contains(DISCARD_FLAG) ? ItemDatabase.ATTR_DISCARDABLE : 0;
-    if (multi && usage != KoLConstants.CONSUME_MULTIPLE) {
+    if (multi && usage != ConsumptionType.CONSUME_MULTIPLE) {
       attrs |= ItemDatabase.ATTR_MULTIPLE;
     }
     ItemDatabase.attributesById.put(itemId, attrs);
@@ -988,9 +987,9 @@ public class ItemDatabase {
 
       // Let equipment database do what it wishes with this item
       EquipmentDatabase.registerItem(itemId, itemName, text, power);
-    } else if (usage == KoLConstants.CONSUME_EAT
-        || usage == KoLConstants.CONSUME_DRINK
-        || usage == KoLConstants.CONSUME_SPLEEN) {
+    } else if (usage == ConsumptionType.CONSUME_EAT
+        || usage == ConsumptionType.CONSUME_DRINK
+        || usage == ConsumptionType.CONSUME_SPLEEN) {
       ConsumablesDatabase.registerConsumable(itemName, usage, text);
     }
 
@@ -1017,11 +1016,11 @@ public class ItemDatabase {
     if (!effectName.equals("") && EffectDatabase.getEffectId(effectName, true) == -1) {
       String effectDescid = DebugDatabase.parseEffectDescid(rawText);
       String command =
-          usage == KoLConstants.CONSUME_EAT
+          usage == ConsumptionType.CONSUME_EAT
               ? "eat 1 "
-              : usage == KoLConstants.CONSUME_DRINK
+              : usage == ConsumptionType.CONSUME_DRINK
                   ? "drink 1 "
-                  : usage == KoLConstants.CONSUME_SPLEEN ? "chew 1 " : "use 1 ";
+                  : usage == ConsumptionType.CONSUME_SPLEEN ? "chew 1 " : "use 1 ";
       EffectDatabase.registerEffect(effectName, effectDescid, command + itemName);
     }
 
@@ -1858,22 +1857,22 @@ public class ItemDatabase {
   public static boolean isUsable(final int itemId) {
     // Anything that you can manipulate with inv_use.php
 
-    int useType = ItemDatabase.useTypeById.getOrDefault(itemId, 0);
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     int attributes = ItemDatabase.getAttributes(itemId);
 
     return switch (useType) {
       case
           // Explicit "use"
-          KoLConstants.CONSUME_USE,
-          KoLConstants.MESSAGE_DISPLAY,
-          KoLConstants.INFINITE_USES,
+          CONSUME_USE,
+          MESSAGE_DISPLAY,
+          INFINITE_USES,
           // Multi-use
-          KoLConstants.CONSUME_MULTIPLE,
+          CONSUME_MULTIPLE,
           // Grow is a type of use
-          KoLConstants.GROW_FAMILIAR,
+          GROW_FAMILIAR,
           // Any potion
-          KoLConstants.CONSUME_POTION,
-          KoLConstants.CONSUME_AVATAR -> true;
+          CONSUME_POTION,
+          CONSUME_AVATAR -> true;
       default -> (attributes
               & (ItemDatabase.ATTR_USABLE
                   | ItemDatabase.ATTR_MULTIPLE
@@ -1890,72 +1889,72 @@ public class ItemDatabase {
   }
 
   public static final boolean isPotion(final int itemId) {
-    int useType = ItemDatabase.useTypeById.getOrDefault(itemId, 0);
-    return (useType == KoLConstants.CONSUME_POTION || useType == KoLConstants.CONSUME_AVATAR);
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    return (useType == ConsumptionType.CONSUME_POTION || useType == ConsumptionType.CONSUME_AVATAR);
   }
 
   public static final boolean isEquipment(final int itemId) {
-    int useType = ItemDatabase.useTypeById.getOrDefault(itemId, 0);
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     return KoLConstants.isEquipmentType(useType, true);
   }
 
   public static final boolean isFood(final int itemId) {
-    int useType = ItemDatabase.useTypeById.getOrDefault(itemId, 0);
-    return useType == KoLConstants.CONSUME_EAT;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    return useType == ConsumptionType.CONSUME_EAT;
   }
 
   public static final boolean isBooze(final int itemId) {
-    int useType = ItemDatabase.useTypeById.getOrDefault(itemId, 0);
-    return useType == KoLConstants.CONSUME_DRINK;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    return useType == ConsumptionType.CONSUME_DRINK;
   }
 
   public static final boolean isHat(final int itemId) {
-    int useType = ItemDatabase.useTypeById.getOrDefault(itemId, 0);
-    return useType == KoLConstants.EQUIP_HAT;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    return useType == ConsumptionType.EQUIP_HAT;
   }
 
   public static final boolean isWeapon(final int itemId) {
-    int useType = ItemDatabase.useTypeById.getOrDefault(itemId, 0);
-    return useType == KoLConstants.EQUIP_WEAPON;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    return useType == ConsumptionType.EQUIP_WEAPON;
   }
 
   public static final boolean isOffHand(final int itemId) {
-    int useType = ItemDatabase.useTypeById.getOrDefault(itemId, 0);
-    return useType == KoLConstants.EQUIP_OFFHAND;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    return useType == ConsumptionType.EQUIP_OFFHAND;
   }
 
   public static final boolean isShirt(final int itemId) {
-    int useType = ItemDatabase.useTypeById.getOrDefault(itemId, 0);
-    return useType == KoLConstants.EQUIP_SHIRT;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    return useType == ConsumptionType.EQUIP_SHIRT;
   }
 
   public static final boolean isPants(final int itemId) {
-    int useType = ItemDatabase.useTypeById.getOrDefault(itemId, 0);
-    return useType == KoLConstants.EQUIP_PANTS;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    return useType == ConsumptionType.EQUIP_PANTS;
   }
 
   public static final boolean isAccessory(final int itemId) {
-    int useType = ItemDatabase.useTypeById.getOrDefault(itemId, 0);
-    return useType == KoLConstants.EQUIP_ACCESSORY;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    return useType == ConsumptionType.EQUIP_ACCESSORY;
   }
 
   public static final boolean isFamiliarEquipment(final int itemId) {
-    int useType = ItemDatabase.useTypeById.getOrDefault(itemId, 0);
-    return useType == KoLConstants.EQUIP_FAMILIAR;
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
+    return useType == ConsumptionType.EQUIP_FAMILIAR;
   }
 
   public static final boolean isMultiUsable(final int itemId) {
     // Anything that you can manipulate with multiuse.php
 
-    int useType = ItemDatabase.useTypeById.getOrDefault(itemId, 0);
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     int attributes = ItemDatabase.getAttributes(itemId);
 
     switch (useType) {
-      case KoLConstants.CONSUME_MULTIPLE:
+      case CONSUME_MULTIPLE:
         return true;
-      case KoLConstants.CONSUME_POTION:
-      case KoLConstants.CONSUME_AVATAR:
-      case KoLConstants.CONSUME_SPLEEN:
+      case CONSUME_POTION:
+      case CONSUME_AVATAR:
+      case CONSUME_SPLEEN:
         return (attributes & ItemDatabase.ATTR_USABLE) == 0;
       default:
         return (attributes & ItemDatabase.ATTR_MULTIPLE) != 0;
@@ -1963,9 +1962,9 @@ public class ItemDatabase {
   }
 
   public static final boolean isReusable(final int itemId) {
-    int useType = ItemDatabase.useTypeById.getOrDefault(itemId, 0);
+    ConsumptionType useType = ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
     int attributes = ItemDatabase.getAttributes(itemId);
-    return useType == KoLConstants.INFINITE_USES || (attributes & ItemDatabase.ATTR_REUSABLE) != 0;
+    return useType == ConsumptionType.INFINITE_USES || (attributes & ItemDatabase.ATTR_REUSABLE) != 0;
   }
 
   /**
@@ -2060,15 +2059,15 @@ public class ItemDatabase {
    *
    * @return The consumption associated with the item
    */
-  public static final int getConsumptionType(final int itemId) {
-    return itemId <= 0 ? KoLConstants.NO_CONSUME : ItemDatabase.useTypeById.getOrDefault(itemId, 0);
+  public static final ConsumptionType getConsumptionType(final int itemId) {
+    return itemId <= 0 ? ConsumptionType.NO_CONSUME : ItemDatabase.useTypeById.getOrDefault(itemId, ConsumptionType.NO_CONSUME);
   }
 
-  public static final int getConsumptionType(final AdventureResult item) {
+  public static final ConsumptionType getConsumptionType(final AdventureResult item) {
     return ItemDatabase.getConsumptionType(item.getItemId());
   }
 
-  public static final String typeToPrimaryUsage(final int type) {
+  public static final String typeToPrimaryUsage(final ConsumptionType type) {
     return ItemDatabase.INVERSE_PRIMARY_USE.get(type);
   }
 
@@ -2208,7 +2207,7 @@ public class ItemDatabase {
   public static void parseVampireVintnerWine(final String idesc) {
     String iEnchantments =
         DebugDatabase.parseItemEnchantments(
-            idesc, new ArrayList<String>(), KoLConstants.CONSUME_DRINK);
+            idesc, new ArrayList<String>(), ConsumptionType.CONSUME_DRINK);
     String iname = DebugDatabase.parseName(idesc);
     Modifiers imods = Modifiers.parseModifiers(iname, iEnchantments);
 

--- a/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
@@ -9,6 +9,7 @@ import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.AdventureResult.AdventureLongCountResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.CraftingType;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
@@ -179,39 +180,39 @@ public class ItemFinder {
         continue;
       }
 
-      int useType = ItemDatabase.getConsumptionType(itemId);
+      ConsumptionType useType = ItemDatabase.getConsumptionType(itemId);
 
       switch (filterType) {
         case FOOD:
           ItemFinder.conditionalRemove(
               nameIterator,
-              useType != KoLConstants.CONSUME_EAT && useType != KoLConstants.CONSUME_FOOD_HELPER);
+              useType != ConsumptionType.CONSUME_EAT && useType != ConsumptionType.CONSUME_FOOD_HELPER);
           break;
         case BOOZE:
           ItemFinder.conditionalRemove(
               nameIterator,
-              useType != KoLConstants.CONSUME_DRINK
-                  && useType != KoLConstants.CONSUME_DRINK_HELPER);
+              useType != ConsumptionType.CONSUME_DRINK
+                  && useType != ConsumptionType.CONSUME_DRINK_HELPER);
           break;
         case SPLEEN:
-          ItemFinder.conditionalRemove(nameIterator, useType != KoLConstants.CONSUME_SPLEEN);
+          ItemFinder.conditionalRemove(nameIterator, useType != ConsumptionType.CONSUME_SPLEEN);
           break;
         case EQUIP:
           switch (useType) {
-            case KoLConstants.EQUIP_FAMILIAR:
-            case KoLConstants.EQUIP_ACCESSORY:
-            case KoLConstants.EQUIP_HAT:
-            case KoLConstants.EQUIP_PANTS:
-            case KoLConstants.EQUIP_SHIRT:
-            case KoLConstants.EQUIP_WEAPON:
-            case KoLConstants.EQUIP_OFFHAND:
-            case KoLConstants.EQUIP_CONTAINER:
-            case KoLConstants.CONSUME_STICKER:
-            case KoLConstants.CONSUME_CARD:
-            case KoLConstants.CONSUME_FOLDER:
-            case KoLConstants.CONSUME_BOOTSKIN:
-            case KoLConstants.CONSUME_BOOTSPUR:
-            case KoLConstants.CONSUME_SIXGUN:
+            case EQUIP_FAMILIAR:
+            case EQUIP_ACCESSORY:
+            case EQUIP_HAT:
+            case EQUIP_PANTS:
+            case EQUIP_SHIRT:
+            case EQUIP_WEAPON:
+            case EQUIP_OFFHAND:
+            case EQUIP_CONTAINER:
+            case CONSUME_STICKER:
+            case CONSUME_CARD:
+            case CONSUME_FOLDER:
+            case CONSUME_BOOTSKIN:
+            case CONSUME_BOOTSPUR:
+            case CONSUME_SIXGUN:
               break;
 
             default:

--- a/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
@@ -186,34 +186,32 @@ public class ItemFinder {
         case FOOD:
           ItemFinder.conditionalRemove(
               nameIterator,
-              useType != ConsumptionType.CONSUME_EAT
-                  && useType != ConsumptionType.CONSUME_FOOD_HELPER);
+              useType != ConsumptionType.EAT && useType != ConsumptionType.FOOD_HELPER);
           break;
         case BOOZE:
           ItemFinder.conditionalRemove(
               nameIterator,
-              useType != ConsumptionType.CONSUME_DRINK
-                  && useType != ConsumptionType.CONSUME_DRINK_HELPER);
+              useType != ConsumptionType.DRINK && useType != ConsumptionType.DRINK_HELPER);
           break;
         case SPLEEN:
-          ItemFinder.conditionalRemove(nameIterator, useType != ConsumptionType.CONSUME_SPLEEN);
+          ItemFinder.conditionalRemove(nameIterator, useType != ConsumptionType.SPLEEN);
           break;
         case EQUIP:
           switch (useType) {
-            case EQUIP_FAMILIAR:
-            case EQUIP_ACCESSORY:
-            case EQUIP_HAT:
-            case EQUIP_PANTS:
-            case EQUIP_SHIRT:
-            case EQUIP_WEAPON:
-            case EQUIP_OFFHAND:
-            case EQUIP_CONTAINER:
-            case CONSUME_STICKER:
-            case CONSUME_CARD:
-            case CONSUME_FOLDER:
-            case CONSUME_BOOTSKIN:
-            case CONSUME_BOOTSPUR:
-            case CONSUME_SIXGUN:
+            case FAMILIAR_EQUIPMENT:
+            case ACCESSORY:
+            case HAT:
+            case PANTS:
+            case SHIRT:
+            case WEAPON:
+            case OFFHAND:
+            case CONTAINER:
+            case STICKER:
+            case CARD:
+            case FOLDER:
+            case BOOTSKIN:
+            case BOOTSPUR:
+            case SIXGUN:
               break;
 
             default:

--- a/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
@@ -186,7 +186,8 @@ public class ItemFinder {
         case FOOD:
           ItemFinder.conditionalRemove(
               nameIterator,
-              useType != ConsumptionType.CONSUME_EAT && useType != ConsumptionType.CONSUME_FOOD_HELPER);
+              useType != ConsumptionType.CONSUME_EAT
+                  && useType != ConsumptionType.CONSUME_FOOD_HELPER);
           break;
         case BOOZE:
           ItemFinder.conditionalRemove(

--- a/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
@@ -626,11 +626,12 @@ public class TCRSDatabase {
       return;
     }
     String verb =
-        (usage == ConsumptionType.EAT)
-            ? "eat "
-            : (usage == ConsumptionType.DRINK)
-                ? "drink "
-                : (usage == ConsumptionType.SPLEEN) ? "chew " : "use ";
+        switch (usage) {
+          case EAT -> "eat ";
+          case DRINK -> "drink ";
+          case SPLEEN -> "chew ";
+          default -> "use ";
+        };
     String actions = EffectDatabase.getActions(effectId);
     boolean added = false;
     StringBuilder buffer = new StringBuilder();

--- a/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
@@ -535,14 +535,14 @@ public class TCRSDatabase {
       Integer id = entry.getKey();
       TCRS tcrs = entry.getValue();
       String name = CafeDatabase.getCafeBoozeName(id.intValue());
-      applyConsumableModifiers(ConsumptionType.CONSUME_DRINK, name, tcrs);
+      applyConsumableModifiers(ConsumptionType.DRINK, name, tcrs);
     }
 
     for (Entry<Integer, TCRS> entry : TCRSFoodMap.entrySet()) {
       Integer id = entry.getKey();
       TCRS tcrs = entry.getValue();
       String name = CafeDatabase.getCafeFoodName(id.intValue());
-      applyConsumableModifiers(ConsumptionType.CONSUME_EAT, name, tcrs);
+      applyConsumableModifiers(ConsumptionType.EAT, name, tcrs);
     }
 
     // Fix all the consumables whose adv yield varies by level
@@ -594,9 +594,9 @@ public class TCRSDatabase {
 
     // *** Do this after modifiers are set so can log effect modifiers
     ConsumptionType usage = ItemDatabase.getConsumptionType(itemId);
-    if (usage == ConsumptionType.CONSUME_EAT
-        || usage == ConsumptionType.CONSUME_DRINK
-        || usage == ConsumptionType.CONSUME_SPLEEN) {
+    if (usage == ConsumptionType.EAT
+        || usage == ConsumptionType.DRINK
+        || usage == ConsumptionType.SPLEEN) {
       applyConsumableModifiers(usage, itemName, tcrs);
     }
 
@@ -626,11 +626,11 @@ public class TCRSDatabase {
       return;
     }
     String verb =
-        (usage == ConsumptionType.CONSUME_EAT)
+        (usage == ConsumptionType.EAT)
             ? "eat "
-            : (usage == ConsumptionType.CONSUME_DRINK)
+            : (usage == ConsumptionType.DRINK)
                 ? "drink "
-                : (usage == ConsumptionType.CONSUME_SPLEEN) ? "chew " : "use ";
+                : (usage == ConsumptionType.SPLEEN) ? "chew " : "use ";
     String actions = EffectDatabase.getActions(effectId);
     boolean added = false;
     StringBuilder buffer = new StringBuilder();
@@ -680,10 +680,7 @@ public class TCRSDatabase {
     Integer lint = ConsumablesDatabase.getLevelReq(consumable);
     int level = lint == null ? 0 : lint;
     // Guess
-    int adv =
-        (usage == ConsumptionType.CONSUME_SPLEEN)
-            ? 0
-            : (tcrs.size * qualityMultiplier(tcrs.quality));
+    int adv = (usage == ConsumptionType.SPLEEN) ? 0 : (tcrs.size * qualityMultiplier(tcrs.quality));
     int mus = 0;
     int mys = 0;
     int mox = 0;

--- a/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
@@ -681,7 +681,9 @@ public class TCRSDatabase {
     int level = lint == null ? 0 : lint;
     // Guess
     int adv =
-        (usage == ConsumptionType.CONSUME_SPLEEN) ? 0 : (tcrs.size * qualityMultiplier(tcrs.quality));
+        (usage == ConsumptionType.CONSUME_SPLEEN)
+            ? 0
+            : (tcrs.size * qualityMultiplier(tcrs.quality));
     int mus = 0;
     int mys = 0;
     int mox = 0;

--- a/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
@@ -19,6 +19,7 @@ import net.java.dev.spellcast.utilities.DataUtilities;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RequestLogger;
@@ -439,7 +440,7 @@ public class TCRSDatabase {
     int size = DebugDatabase.parseConsumableSize(text);
     var quality = DebugDatabase.parseQuality(text);
     ArrayList<String> unknown = new ArrayList<String>();
-    String modifiers = DebugDatabase.parseItemEnchantments(text, unknown, -1);
+    String modifiers = DebugDatabase.parseItemEnchantments(text, unknown, ConsumptionType.UNKNOWN);
 
     // Create and return the TCRS object
     return new TCRS(name, size, quality, modifiers);
@@ -534,14 +535,14 @@ public class TCRSDatabase {
       Integer id = entry.getKey();
       TCRS tcrs = entry.getValue();
       String name = CafeDatabase.getCafeBoozeName(id.intValue());
-      applyConsumableModifiers(KoLConstants.CONSUME_DRINK, name, tcrs);
+      applyConsumableModifiers(ConsumptionType.CONSUME_DRINK, name, tcrs);
     }
 
     for (Entry<Integer, TCRS> entry : TCRSFoodMap.entrySet()) {
       Integer id = entry.getKey();
       TCRS tcrs = entry.getValue();
       String name = CafeDatabase.getCafeFoodName(id.intValue());
-      applyConsumableModifiers(KoLConstants.CONSUME_EAT, name, tcrs);
+      applyConsumableModifiers(ConsumptionType.CONSUME_EAT, name, tcrs);
     }
 
     // Fix all the consumables whose adv yield varies by level
@@ -592,10 +593,10 @@ public class TCRSDatabase {
     Modifiers.updateItem(itemName, tcrs.modifiers);
 
     // *** Do this after modifiers are set so can log effect modifiers
-    int usage = ItemDatabase.getConsumptionType(itemId);
-    if (usage == KoLConstants.CONSUME_EAT
-        || usage == KoLConstants.CONSUME_DRINK
-        || usage == KoLConstants.CONSUME_SPLEEN) {
+    ConsumptionType usage = ItemDatabase.getConsumptionType(itemId);
+    if (usage == ConsumptionType.CONSUME_EAT
+        || usage == ConsumptionType.CONSUME_DRINK
+        || usage == ConsumptionType.CONSUME_SPLEEN) {
       applyConsumableModifiers(usage, itemName, tcrs);
     }
 
@@ -619,17 +620,17 @@ public class TCRSDatabase {
   }
 
   private static void addEffectSource(
-      final String itemName, final int usage, final String effectName) {
+      final String itemName, final ConsumptionType usage, final String effectName) {
     int effectId = EffectDatabase.getEffectId(effectName);
     if (effectId == -1) {
       return;
     }
     String verb =
-        (usage == KoLConstants.CONSUME_EAT)
+        (usage == ConsumptionType.CONSUME_EAT)
             ? "eat "
-            : (usage == KoLConstants.CONSUME_DRINK)
+            : (usage == ConsumptionType.CONSUME_DRINK)
                 ? "drink "
-                : (usage == KoLConstants.CONSUME_SPLEEN) ? "chew " : "use ";
+                : (usage == ConsumptionType.CONSUME_SPLEEN) ? "chew " : "use ";
     String actions = EffectDatabase.getActions(effectId);
     boolean added = false;
     StringBuilder buffer = new StringBuilder();
@@ -674,13 +675,13 @@ public class TCRSDatabase {
   }
 
   private static void applyConsumableModifiers(
-      final int usage, final String itemName, final TCRS tcrs) {
+      final ConsumptionType usage, final String itemName, final TCRS tcrs) {
     var consumable = ConsumablesDatabase.getConsumableByName(itemName);
     Integer lint = ConsumablesDatabase.getLevelReq(consumable);
     int level = lint == null ? 0 : lint;
     // Guess
     int adv =
-        (usage == KoLConstants.CONSUME_SPLEEN) ? 0 : (tcrs.size * qualityMultiplier(tcrs.quality));
+        (usage == ConsumptionType.CONSUME_SPLEEN) ? 0 : (tcrs.size * qualityMultiplier(tcrs.quality));
     int mus = 0;
     int mys = 0;
     int mox = 0;

--- a/src/net/sourceforge/kolmafia/request/DrinkItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/DrinkItemRequest.java
@@ -203,7 +203,7 @@ public class DrinkItemRequest extends UseItemRequest {
       return;
     }
 
-    if (this.consumptionType == ConsumptionType.CONSUME_DRINK_HELPER) {
+    if (this.consumptionType == ConsumptionType.DRINK_HELPER) {
       int count = this.itemUsed.getCount();
 
       if (!InventoryManager.retrieveItem(this.itemUsed)) {
@@ -744,7 +744,7 @@ public class DrinkItemRequest extends UseItemRequest {
     // In the event that the item is not used, then proceed to
     // undo the consumption.
 
-    if (consumptionType == ConsumptionType.CONSUME_DRINK_HELPER) {
+    if (consumptionType == ConsumptionType.DRINK_HELPER) {
       // Consumption helpers are removed above when you
       // successfully eat or drink.
       return;

--- a/src/net/sourceforge/kolmafia/request/DrinkItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/DrinkItemRequest.java
@@ -6,6 +6,7 @@ import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.CraftingType;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
@@ -202,7 +203,7 @@ public class DrinkItemRequest extends UseItemRequest {
       return;
     }
 
-    if (this.consumptionType == KoLConstants.CONSUME_DRINK_HELPER) {
+    if (this.consumptionType == ConsumptionType.CONSUME_DRINK_HELPER) {
       int count = this.itemUsed.getCount();
 
       if (!InventoryManager.retrieveItem(this.itemUsed)) {
@@ -737,13 +738,13 @@ public class DrinkItemRequest extends UseItemRequest {
       ResultProcessor.processResult(helper.getNegation());
     }
 
-    int consumptionType = UseItemRequest.getConsumptionType(item);
+    ConsumptionType consumptionType = UseItemRequest.getConsumptionType(item);
 
     // Assume initially that this causes the item to disappear.
     // In the event that the item is not used, then proceed to
     // undo the consumption.
 
-    if (consumptionType == KoLConstants.CONSUME_DRINK_HELPER) {
+    if (consumptionType == ConsumptionType.CONSUME_DRINK_HELPER) {
       // Consumption helpers are removed above when you
       // successfully eat or drink.
       return;

--- a/src/net/sourceforge/kolmafia/request/EatItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/EatItemRequest.java
@@ -196,7 +196,7 @@ public class EatItemRequest extends UseItemRequest {
     String name = this.itemUsed.getName();
     int itemId = this.itemUsed.getItemId();
 
-    if (this.consumptionType == ConsumptionType.CONSUME_FOOD_HELPER) {
+    if (this.consumptionType == ConsumptionType.FOOD_HELPER) {
       if (!InventoryManager.retrieveItem(this.itemUsed)) {
         KoLmafia.updateDisplay(MafiaState.ERROR, "Helper not available.");
         return;
@@ -252,7 +252,7 @@ public class EatItemRequest extends UseItemRequest {
     // Don't get Mayoflex if the food does not give adventures
     String minderSetting = Preferences.getString("mayoMinderSetting");
     AdventureResult workshedItem = CampgroundRequest.getCurrentWorkshedItem();
-    if (consumptionType == ConsumptionType.CONSUME_EAT
+    if (consumptionType == ConsumptionType.EAT
         && !ConcoctionDatabase.isMayo(itemId)
         && !minderSetting.equals("")
         && Preferences.getBoolean("autoFillMayoMinder")
@@ -315,7 +315,7 @@ public class EatItemRequest extends UseItemRequest {
       return;
     }
 
-    if (this.consumptionType == ConsumptionType.CONSUME_MULTIPLE && this.itemUsed.getCount() > 1) {
+    if (this.consumptionType == ConsumptionType.USE_MULTIPLE && this.itemUsed.getCount() > 1) {
       this.addFormField("action", "useitem");
     }
 
@@ -818,7 +818,7 @@ public class EatItemRequest extends UseItemRequest {
     }
 
     ConsumptionType consumptionType = UseItemRequest.getConsumptionType(item);
-    if (consumptionType == ConsumptionType.CONSUME_FOOD_HELPER) {
+    if (consumptionType == ConsumptionType.FOOD_HELPER) {
       // Consumption helpers are removed above when you
       // successfully eat or drink.
       return;

--- a/src/net/sourceforge/kolmafia/request/EatItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/EatItemRequest.java
@@ -6,6 +6,7 @@ import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.AdventureResult.AdventureLongCountResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.CraftingType;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
@@ -195,7 +196,7 @@ public class EatItemRequest extends UseItemRequest {
     String name = this.itemUsed.getName();
     int itemId = this.itemUsed.getItemId();
 
-    if (this.consumptionType == KoLConstants.CONSUME_FOOD_HELPER) {
+    if (this.consumptionType == ConsumptionType.CONSUME_FOOD_HELPER) {
       if (!InventoryManager.retrieveItem(this.itemUsed)) {
         KoLmafia.updateDisplay(MafiaState.ERROR, "Helper not available.");
         return;
@@ -251,7 +252,7 @@ public class EatItemRequest extends UseItemRequest {
     // Don't get Mayoflex if the food does not give adventures
     String minderSetting = Preferences.getString("mayoMinderSetting");
     AdventureResult workshedItem = CampgroundRequest.getCurrentWorkshedItem();
-    if (consumptionType == KoLConstants.CONSUME_EAT
+    if (consumptionType == ConsumptionType.CONSUME_EAT
         && !ConcoctionDatabase.isMayo(itemId)
         && !minderSetting.equals("")
         && Preferences.getBoolean("autoFillMayoMinder")
@@ -314,7 +315,7 @@ public class EatItemRequest extends UseItemRequest {
       return;
     }
 
-    if (this.consumptionType == KoLConstants.CONSUME_MULTIPLE && this.itemUsed.getCount() > 1) {
+    if (this.consumptionType == ConsumptionType.CONSUME_MULTIPLE && this.itemUsed.getCount() > 1) {
       this.addFormField("action", "useitem");
     }
 
@@ -816,8 +817,8 @@ public class EatItemRequest extends UseItemRequest {
       ResultProcessor.processResult(helper.getNegation());
     }
 
-    int consumptionType = UseItemRequest.getConsumptionType(item);
-    if (consumptionType == KoLConstants.CONSUME_FOOD_HELPER) {
+    ConsumptionType consumptionType = UseItemRequest.getConsumptionType(item);
+    if (consumptionType == ConsumptionType.CONSUME_FOOD_HELPER) {
       // Consumption helpers are removed above when you
       // successfully eat or drink.
       return;

--- a/src/net/sourceforge/kolmafia/request/EquipmentRequest.java
+++ b/src/net/sourceforge/kolmafia/request/EquipmentRequest.java
@@ -388,7 +388,7 @@ public class EquipmentRequest extends PasswordHashRequest {
     // Find out what kind of item it is
     this.equipmentType = ItemDatabase.getConsumptionType(this.itemId);
 
-    if (this.equipmentType != ConsumptionType.CONSUME_STICKER) {
+    if (this.equipmentType != ConsumptionType.STICKER) {
       this.error =
           "You can't equip a " + ItemDatabase.getItemName(this.itemId) + " in a sticker slot.";
       return;
@@ -422,7 +422,7 @@ public class EquipmentRequest extends PasswordHashRequest {
     // Find out what kind of item it is
     this.equipmentType = ItemDatabase.getConsumptionType(this.itemId);
 
-    if (this.equipmentType != ConsumptionType.CONSUME_CARD) {
+    if (this.equipmentType != ConsumptionType.CARD) {
       this.error =
           "You can't slide a " + ItemDatabase.getItemName(this.itemId) + " into a card sleeze.";
       return;
@@ -458,7 +458,7 @@ public class EquipmentRequest extends PasswordHashRequest {
     // Find out what kind of item it is
     this.equipmentType = ItemDatabase.getConsumptionType(this.itemId);
 
-    if (this.equipmentType != ConsumptionType.CONSUME_FOLDER) {
+    if (this.equipmentType != ConsumptionType.FOLDER) {
       this.error =
           "You can't equip a " + ItemDatabase.getItemName(this.itemId) + " in a folder slot.";
       return;
@@ -484,21 +484,21 @@ public class EquipmentRequest extends PasswordHashRequest {
     // Find out what kind of item it is
     this.equipmentType = ItemDatabase.getConsumptionType(this.itemId);
 
-    if (this.equipmentType != ConsumptionType.CONSUME_BOOTSKIN
-        && this.equipmentType != ConsumptionType.CONSUME_BOOTSPUR) {
+    if (this.equipmentType != ConsumptionType.BOOTSKIN
+        && this.equipmentType != ConsumptionType.BOOTSPUR) {
       this.error =
           "You can't equip a " + ItemDatabase.getItemName(this.itemId) + " on your cowboy boots.";
       return;
     }
 
     if (this.equipmentSlot == EquipmentManager.BOOTSKIN
-        && this.equipmentType == ConsumptionType.CONSUME_BOOTSPUR) {
+        && this.equipmentType == ConsumptionType.BOOTSPUR) {
       this.error = ItemDatabase.getItemName(this.itemId) + " is a spur, not a skin.";
       return;
     }
 
     if (this.equipmentSlot == EquipmentManager.BOOTSPUR
-        && this.equipmentType == ConsumptionType.CONSUME_BOOTSKIN) {
+        && this.equipmentType == ConsumptionType.BOOTSKIN) {
       this.error = ItemDatabase.getItemName(this.itemId) + " is a skin, not a spur.";
       return;
     }
@@ -529,7 +529,7 @@ public class EquipmentRequest extends PasswordHashRequest {
     // Find out what kind of item it is
     this.equipmentType = ItemDatabase.getConsumptionType(this.itemId);
 
-    if (this.equipmentType != ConsumptionType.CONSUME_SIXGUN) {
+    if (this.equipmentType != ConsumptionType.SIXGUN) {
       this.error = "You can't holster a " + ItemDatabase.getItemName(this.itemId);
       return;
     }
@@ -546,62 +546,62 @@ public class EquipmentRequest extends PasswordHashRequest {
   private String getAction(final boolean force) {
     switch (this.equipmentSlot) {
       case EquipmentManager.HAT:
-        if (this.equipmentType == ConsumptionType.EQUIP_HAT) {
+        if (this.equipmentType == ConsumptionType.HAT) {
           return "equip";
         }
         break;
 
       case EquipmentManager.WEAPON:
-        if (this.equipmentType == ConsumptionType.EQUIP_WEAPON) {
+        if (this.equipmentType == ConsumptionType.WEAPON) {
           return "equip";
         }
         break;
 
       case EquipmentManager.OFFHAND:
-        if (this.equipmentType == ConsumptionType.EQUIP_OFFHAND) {
+        if (this.equipmentType == ConsumptionType.OFFHAND) {
           return "equip";
         }
 
-        if (this.equipmentType == ConsumptionType.EQUIP_WEAPON
+        if (this.equipmentType == ConsumptionType.WEAPON
             && EquipmentDatabase.getHands(this.itemId) == 1) {
           return "dualwield";
         }
         break;
 
       case EquipmentManager.CONTAINER:
-        if (this.equipmentType == ConsumptionType.EQUIP_CONTAINER) {
+        if (this.equipmentType == ConsumptionType.CONTAINER) {
           return "equip";
         }
         break;
 
       case EquipmentManager.SHIRT:
-        if (this.equipmentType == ConsumptionType.EQUIP_SHIRT) {
+        if (this.equipmentType == ConsumptionType.SHIRT) {
           return "equip";
         }
         break;
 
       case EquipmentManager.PANTS:
-        if (this.equipmentType == ConsumptionType.EQUIP_PANTS) {
+        if (this.equipmentType == ConsumptionType.PANTS) {
           return "equip";
         }
         break;
 
       case EquipmentManager.ACCESSORY1:
-        if (this.equipmentType == ConsumptionType.EQUIP_ACCESSORY) {
+        if (this.equipmentType == ConsumptionType.ACCESSORY) {
           this.addFormField("slot", "1");
           return "equip";
         }
         break;
 
       case EquipmentManager.ACCESSORY2:
-        if (this.equipmentType == ConsumptionType.EQUIP_ACCESSORY) {
+        if (this.equipmentType == ConsumptionType.ACCESSORY) {
           this.addFormField("slot", "2");
           return "equip";
         }
         break;
 
       case EquipmentManager.ACCESSORY3:
-        if (this.equipmentType == ConsumptionType.EQUIP_ACCESSORY) {
+        if (this.equipmentType == ConsumptionType.ACCESSORY) {
           this.addFormField("slot", "3");
           return "equip";
         }
@@ -609,13 +609,13 @@ public class EquipmentRequest extends PasswordHashRequest {
 
       case EquipmentManager.FAMILIAR:
         switch (this.equipmentType) {
-          case EQUIP_FAMILIAR:
+          case FAMILIAR_EQUIPMENT:
             return "equip";
 
-          case EQUIP_HAT:
-          case EQUIP_WEAPON:
-          case EQUIP_OFFHAND:
-          case EQUIP_PANTS:
+          case HAT:
+          case WEAPON:
+          case OFFHAND:
+          case PANTS:
             return "hatrack";
         }
         break;
@@ -665,40 +665,40 @@ public class EquipmentRequest extends PasswordHashRequest {
 
     ConsumptionType equipmentType = ItemDatabase.getConsumptionType(itemId);
     switch (equipmentType) {
-      case EQUIP_HAT:
+      case HAT:
         return EquipmentManager.HAT;
 
-      case EQUIP_WEAPON:
+      case WEAPON:
         return EquipmentManager.WEAPON;
 
-      case EQUIP_OFFHAND:
+      case OFFHAND:
         return itemId == ItemPool.FAKE_HAND ? EquipmentManager.FAKEHAND : EquipmentManager.OFFHAND;
 
-      case EQUIP_CONTAINER:
+      case CONTAINER:
         return EquipmentManager.CONTAINER;
 
-      case EQUIP_SHIRT:
+      case SHIRT:
         return EquipmentManager.SHIRT;
 
-      case EQUIP_PANTS:
+      case PANTS:
         return EquipmentManager.PANTS;
 
-      case EQUIP_ACCESSORY:
+      case ACCESSORY:
         return EquipmentRequest.availableAccessory();
 
-      case EQUIP_FAMILIAR:
+      case FAMILIAR_EQUIPMENT:
         return EquipmentManager.FAMILIAR;
 
-      case CONSUME_STICKER:
+      case STICKER:
         return EquipmentRequest.availableSticker();
 
-      case CONSUME_CARD:
+      case CARD:
         return EquipmentManager.CARDSLEEVE;
 
-      case CONSUME_FOLDER:
+      case FOLDER:
         return EquipmentRequest.availableFolder();
 
-      case CONSUME_SIXGUN:
+      case SIXGUN:
         return EquipmentManager.HOLSTER;
 
       default:
@@ -855,7 +855,7 @@ public class EquipmentRequest extends PasswordHashRequest {
           && EquipmentDatabase.getHands(itemId) == 1) {
         int offhand = EquipmentManager.getEquipment(EquipmentManager.OFFHAND).getItemId();
 
-        if (ItemDatabase.getConsumptionType(offhand) == ConsumptionType.EQUIP_WEAPON
+        if (ItemDatabase.getConsumptionType(offhand) == ConsumptionType.WEAPON
             && EquipmentDatabase.getWeaponType(itemId)
                 != EquipmentDatabase.getWeaponType(offhand)) {
           (new EquipmentRequest(EquipmentRequest.UNEQUIP, EquipmentManager.OFFHAND)).run();
@@ -871,7 +871,7 @@ public class EquipmentRequest extends PasswordHashRequest {
         AdventureResult weapon = EquipmentManager.getEquipment(EquipmentManager.WEAPON);
         int weaponItemId = weapon.getItemId();
 
-        if (itemType == ConsumptionType.EQUIP_WEAPON && weaponItemId <= 0) {
+        if (itemType == ConsumptionType.WEAPON && weaponItemId <= 0) {
           KoLmafia.updateDisplay(
               MafiaState.ERROR, "You can't dual wield unless you already have a main weapon.");
           return;
@@ -879,7 +879,7 @@ public class EquipmentRequest extends PasswordHashRequest {
 
         if (EquipmentDatabase.getHands(weaponItemId) > 1) {
           String message =
-              itemType == ConsumptionType.EQUIP_WEAPON
+              itemType == ConsumptionType.WEAPON
                   ? ("You can't wield a "
                       + this.changeItem.getName()
                       + " in your off-hand while wielding a 2-handed weapon.")
@@ -890,7 +890,7 @@ public class EquipmentRequest extends PasswordHashRequest {
           return;
         }
 
-        if (itemType == ConsumptionType.EQUIP_WEAPON
+        if (itemType == ConsumptionType.WEAPON
             && EquipmentDatabase.getWeaponType(itemId)
                 != EquipmentDatabase.getWeaponType(weaponItemId)) {
           KoLmafia.updateDisplay(

--- a/src/net/sourceforge/kolmafia/request/EquipmentRequest.java
+++ b/src/net/sourceforge/kolmafia/request/EquipmentRequest.java
@@ -7,6 +7,7 @@ import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.KoLmafiaCLI;
@@ -178,7 +179,7 @@ public class EquipmentRequest extends PasswordHashRequest {
   private int equipmentSlot;
   private AdventureResult changeItem;
   private int itemId;
-  private int equipmentType;
+  private ConsumptionType equipmentType;
   private SpecialOutfit outfit;
   private String outfitName;
   private String error;
@@ -387,7 +388,7 @@ public class EquipmentRequest extends PasswordHashRequest {
     // Find out what kind of item it is
     this.equipmentType = ItemDatabase.getConsumptionType(this.itemId);
 
-    if (this.equipmentType != KoLConstants.CONSUME_STICKER) {
+    if (this.equipmentType != ConsumptionType.CONSUME_STICKER) {
       this.error =
           "You can't equip a " + ItemDatabase.getItemName(this.itemId) + " in a sticker slot.";
       return;
@@ -421,7 +422,7 @@ public class EquipmentRequest extends PasswordHashRequest {
     // Find out what kind of item it is
     this.equipmentType = ItemDatabase.getConsumptionType(this.itemId);
 
-    if (this.equipmentType != KoLConstants.CONSUME_CARD) {
+    if (this.equipmentType != ConsumptionType.CONSUME_CARD) {
       this.error =
           "You can't slide a " + ItemDatabase.getItemName(this.itemId) + " into a card sleeze.";
       return;
@@ -457,7 +458,7 @@ public class EquipmentRequest extends PasswordHashRequest {
     // Find out what kind of item it is
     this.equipmentType = ItemDatabase.getConsumptionType(this.itemId);
 
-    if (this.equipmentType != KoLConstants.CONSUME_FOLDER) {
+    if (this.equipmentType != ConsumptionType.CONSUME_FOLDER) {
       this.error =
           "You can't equip a " + ItemDatabase.getItemName(this.itemId) + " in a folder slot.";
       return;
@@ -483,21 +484,21 @@ public class EquipmentRequest extends PasswordHashRequest {
     // Find out what kind of item it is
     this.equipmentType = ItemDatabase.getConsumptionType(this.itemId);
 
-    if (this.equipmentType != KoLConstants.CONSUME_BOOTSKIN
-        && this.equipmentType != KoLConstants.CONSUME_BOOTSPUR) {
+    if (this.equipmentType != ConsumptionType.CONSUME_BOOTSKIN
+        && this.equipmentType != ConsumptionType.CONSUME_BOOTSPUR) {
       this.error =
           "You can't equip a " + ItemDatabase.getItemName(this.itemId) + " on your cowboy boots.";
       return;
     }
 
     if (this.equipmentSlot == EquipmentManager.BOOTSKIN
-        && this.equipmentType == KoLConstants.CONSUME_BOOTSPUR) {
+        && this.equipmentType == ConsumptionType.CONSUME_BOOTSPUR) {
       this.error = ItemDatabase.getItemName(this.itemId) + " is a spur, not a skin.";
       return;
     }
 
     if (this.equipmentSlot == EquipmentManager.BOOTSPUR
-        && this.equipmentType == KoLConstants.CONSUME_BOOTSKIN) {
+        && this.equipmentType == ConsumptionType.CONSUME_BOOTSKIN) {
       this.error = ItemDatabase.getItemName(this.itemId) + " is a skin, not a spur.";
       return;
     }
@@ -528,7 +529,7 @@ public class EquipmentRequest extends PasswordHashRequest {
     // Find out what kind of item it is
     this.equipmentType = ItemDatabase.getConsumptionType(this.itemId);
 
-    if (this.equipmentType != KoLConstants.CONSUME_SIXGUN) {
+    if (this.equipmentType != ConsumptionType.CONSUME_SIXGUN) {
       this.error = "You can't holster a " + ItemDatabase.getItemName(this.itemId);
       return;
     }
@@ -545,62 +546,62 @@ public class EquipmentRequest extends PasswordHashRequest {
   private String getAction(final boolean force) {
     switch (this.equipmentSlot) {
       case EquipmentManager.HAT:
-        if (this.equipmentType == KoLConstants.EQUIP_HAT) {
+        if (this.equipmentType == ConsumptionType.EQUIP_HAT) {
           return "equip";
         }
         break;
 
       case EquipmentManager.WEAPON:
-        if (this.equipmentType == KoLConstants.EQUIP_WEAPON) {
+        if (this.equipmentType == ConsumptionType.EQUIP_WEAPON) {
           return "equip";
         }
         break;
 
       case EquipmentManager.OFFHAND:
-        if (this.equipmentType == KoLConstants.EQUIP_OFFHAND) {
+        if (this.equipmentType == ConsumptionType.EQUIP_OFFHAND) {
           return "equip";
         }
 
-        if (this.equipmentType == KoLConstants.EQUIP_WEAPON
+        if (this.equipmentType == ConsumptionType.EQUIP_WEAPON
             && EquipmentDatabase.getHands(this.itemId) == 1) {
           return "dualwield";
         }
         break;
 
       case EquipmentManager.CONTAINER:
-        if (this.equipmentType == KoLConstants.EQUIP_CONTAINER) {
+        if (this.equipmentType == ConsumptionType.EQUIP_CONTAINER) {
           return "equip";
         }
         break;
 
       case EquipmentManager.SHIRT:
-        if (this.equipmentType == KoLConstants.EQUIP_SHIRT) {
+        if (this.equipmentType == ConsumptionType.EQUIP_SHIRT) {
           return "equip";
         }
         break;
 
       case EquipmentManager.PANTS:
-        if (this.equipmentType == KoLConstants.EQUIP_PANTS) {
+        if (this.equipmentType == ConsumptionType.EQUIP_PANTS) {
           return "equip";
         }
         break;
 
       case EquipmentManager.ACCESSORY1:
-        if (this.equipmentType == KoLConstants.EQUIP_ACCESSORY) {
+        if (this.equipmentType == ConsumptionType.EQUIP_ACCESSORY) {
           this.addFormField("slot", "1");
           return "equip";
         }
         break;
 
       case EquipmentManager.ACCESSORY2:
-        if (this.equipmentType == KoLConstants.EQUIP_ACCESSORY) {
+        if (this.equipmentType == ConsumptionType.EQUIP_ACCESSORY) {
           this.addFormField("slot", "2");
           return "equip";
         }
         break;
 
       case EquipmentManager.ACCESSORY3:
-        if (this.equipmentType == KoLConstants.EQUIP_ACCESSORY) {
+        if (this.equipmentType == ConsumptionType.EQUIP_ACCESSORY) {
           this.addFormField("slot", "3");
           return "equip";
         }
@@ -608,13 +609,13 @@ public class EquipmentRequest extends PasswordHashRequest {
 
       case EquipmentManager.FAMILIAR:
         switch (this.equipmentType) {
-          case KoLConstants.EQUIP_FAMILIAR:
+          case EQUIP_FAMILIAR:
             return "equip";
 
-          case KoLConstants.EQUIP_HAT:
-          case KoLConstants.EQUIP_WEAPON:
-          case KoLConstants.EQUIP_OFFHAND:
-          case KoLConstants.EQUIP_PANTS:
+          case EQUIP_HAT:
+          case EQUIP_WEAPON:
+          case EQUIP_OFFHAND:
+          case EQUIP_PANTS:
             return "hatrack";
         }
         break;
@@ -662,42 +663,42 @@ public class EquipmentRequest extends PasswordHashRequest {
         }
     }
 
-    int equipmentType = ItemDatabase.getConsumptionType(itemId);
+    ConsumptionType equipmentType = ItemDatabase.getConsumptionType(itemId);
     switch (equipmentType) {
-      case KoLConstants.EQUIP_HAT:
+      case EQUIP_HAT:
         return EquipmentManager.HAT;
 
-      case KoLConstants.EQUIP_WEAPON:
+      case EQUIP_WEAPON:
         return EquipmentManager.WEAPON;
 
-      case KoLConstants.EQUIP_OFFHAND:
+      case EQUIP_OFFHAND:
         return itemId == ItemPool.FAKE_HAND ? EquipmentManager.FAKEHAND : EquipmentManager.OFFHAND;
 
-      case KoLConstants.EQUIP_CONTAINER:
+      case EQUIP_CONTAINER:
         return EquipmentManager.CONTAINER;
 
-      case KoLConstants.EQUIP_SHIRT:
+      case EQUIP_SHIRT:
         return EquipmentManager.SHIRT;
 
-      case KoLConstants.EQUIP_PANTS:
+      case EQUIP_PANTS:
         return EquipmentManager.PANTS;
 
-      case KoLConstants.EQUIP_ACCESSORY:
+      case EQUIP_ACCESSORY:
         return EquipmentRequest.availableAccessory();
 
-      case KoLConstants.EQUIP_FAMILIAR:
+      case EQUIP_FAMILIAR:
         return EquipmentManager.FAMILIAR;
 
-      case KoLConstants.CONSUME_STICKER:
+      case CONSUME_STICKER:
         return EquipmentRequest.availableSticker();
 
-      case KoLConstants.CONSUME_CARD:
+      case CONSUME_CARD:
         return EquipmentManager.CARDSLEEVE;
 
-      case KoLConstants.CONSUME_FOLDER:
+      case CONSUME_FOLDER:
         return EquipmentRequest.availableFolder();
 
-      case KoLConstants.CONSUME_SIXGUN:
+      case CONSUME_SIXGUN:
         return EquipmentManager.HOLSTER;
 
       default:
@@ -854,7 +855,7 @@ public class EquipmentRequest extends PasswordHashRequest {
           && EquipmentDatabase.getHands(itemId) == 1) {
         int offhand = EquipmentManager.getEquipment(EquipmentManager.OFFHAND).getItemId();
 
-        if (ItemDatabase.getConsumptionType(offhand) == KoLConstants.EQUIP_WEAPON
+        if (ItemDatabase.getConsumptionType(offhand) == ConsumptionType.EQUIP_WEAPON
             && EquipmentDatabase.getWeaponType(itemId)
                 != EquipmentDatabase.getWeaponType(offhand)) {
           (new EquipmentRequest(EquipmentRequest.UNEQUIP, EquipmentManager.OFFHAND)).run();
@@ -866,11 +867,11 @@ public class EquipmentRequest extends PasswordHashRequest {
       // main weapon.
 
       if (this.equipmentSlot == EquipmentManager.OFFHAND) {
-        int itemType = ItemDatabase.getConsumptionType(itemId);
+        ConsumptionType itemType = ItemDatabase.getConsumptionType(itemId);
         AdventureResult weapon = EquipmentManager.getEquipment(EquipmentManager.WEAPON);
         int weaponItemId = weapon.getItemId();
 
-        if (itemType == KoLConstants.EQUIP_WEAPON && weaponItemId <= 0) {
+        if (itemType == ConsumptionType.EQUIP_WEAPON && weaponItemId <= 0) {
           KoLmafia.updateDisplay(
               MafiaState.ERROR, "You can't dual wield unless you already have a main weapon.");
           return;
@@ -878,7 +879,7 @@ public class EquipmentRequest extends PasswordHashRequest {
 
         if (EquipmentDatabase.getHands(weaponItemId) > 1) {
           String message =
-              itemType == KoLConstants.EQUIP_WEAPON
+              itemType == ConsumptionType.EQUIP_WEAPON
                   ? ("You can't wield a "
                       + this.changeItem.getName()
                       + " in your off-hand while wielding a 2-handed weapon.")
@@ -889,7 +890,7 @@ public class EquipmentRequest extends PasswordHashRequest {
           return;
         }
 
-        if (itemType == KoLConstants.EQUIP_WEAPON
+        if (itemType == ConsumptionType.EQUIP_WEAPON
             && EquipmentDatabase.getWeaponType(itemId)
                 != EquipmentDatabase.getWeaponType(weaponItemId)) {
           KoLmafia.updateDisplay(

--- a/src/net/sourceforge/kolmafia/request/ProfileRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ProfileRequest.java
@@ -8,7 +8,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.StaticEntity;
@@ -227,9 +226,9 @@ public class ProfileRequest extends GenericRequest implements Comparable<Profile
       while (st.hasMoreTokens()
           && EquipmentDatabase.contains(itemId = ItemDatabase.getItemId(token = st.nextToken()))) {
         switch (ItemDatabase.getConsumptionType(itemId)) {
-          case KoLConstants.EQUIP_HAT:
-          case KoLConstants.EQUIP_PANTS:
-          case KoLConstants.EQUIP_SHIRT:
+          case EQUIP_HAT:
+          case EQUIP_PANTS:
+          case EQUIP_SHIRT:
             this.equipmentPower += EquipmentDatabase.getPower(itemId);
             break;
         }

--- a/src/net/sourceforge/kolmafia/request/ProfileRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ProfileRequest.java
@@ -226,9 +226,9 @@ public class ProfileRequest extends GenericRequest implements Comparable<Profile
       while (st.hasMoreTokens()
           && EquipmentDatabase.contains(itemId = ItemDatabase.getItemId(token = st.nextToken()))) {
         switch (ItemDatabase.getConsumptionType(itemId)) {
-          case EQUIP_HAT:
-          case EQUIP_PANTS:
-          case EQUIP_SHIRT:
+          case HAT:
+          case PANTS:
+          case SHIRT:
             this.equipmentPower += EquipmentDatabase.getPower(itemId);
             break;
         }

--- a/src/net/sourceforge/kolmafia/request/PulverizeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/PulverizeRequest.java
@@ -97,13 +97,13 @@ public class PulverizeRequest extends GenericRequest {
     }
 
     switch (ItemDatabase.getConsumptionType(this.item.getItemId())) {
-      case KoLConstants.EQUIP_ACCESSORY:
-      case KoLConstants.EQUIP_HAT:
-      case KoLConstants.EQUIP_PANTS:
-      case KoLConstants.EQUIP_SHIRT:
-      case KoLConstants.EQUIP_WEAPON:
-      case KoLConstants.EQUIP_OFFHAND:
-      case KoLConstants.EQUIP_CONTAINER:
+      case EQUIP_ACCESSORY:
+      case EQUIP_HAT:
+      case EQUIP_PANTS:
+      case EQUIP_SHIRT:
+      case EQUIP_WEAPON:
+      case EQUIP_OFFHAND:
+      case EQUIP_CONTAINER:
         break;
 
       default:

--- a/src/net/sourceforge/kolmafia/request/PulverizeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/PulverizeRequest.java
@@ -97,13 +97,13 @@ public class PulverizeRequest extends GenericRequest {
     }
 
     switch (ItemDatabase.getConsumptionType(this.item.getItemId())) {
-      case EQUIP_ACCESSORY:
-      case EQUIP_HAT:
-      case EQUIP_PANTS:
-      case EQUIP_SHIRT:
-      case EQUIP_WEAPON:
-      case EQUIP_OFFHAND:
-      case EQUIP_CONTAINER:
+      case ACCESSORY:
+      case HAT:
+      case PANTS:
+      case SHIRT:
+      case WEAPON:
+      case OFFHAND:
+      case CONTAINER:
         break;
 
       default:

--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -2422,9 +2422,8 @@ public class RelayRequest extends PasswordHashRequest {
     list.removeModifier("Modifiers");
     list.removeModifier("Outfit");
     ConsumptionType type = ItemDatabase.getConsumptionType(itemId);
-    if (!(type == ConsumptionType.EQUIP_HAT
-            && KoLCharacter.usableFamiliar(FamiliarPool.HATRACK) != null)
-        && !(type == ConsumptionType.EQUIP_PANTS
+    if (!(type == ConsumptionType.HAT && KoLCharacter.usableFamiliar(FamiliarPool.HATRACK) != null)
+        && !(type == ConsumptionType.PANTS
             && KoLCharacter.usableFamiliar(FamiliarPool.SCARECROW) != null)) {
       list.removeModifier("Familiar Effect");
     }

--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -24,6 +24,7 @@ import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.KoLmafiaASH;
 import net.sourceforge.kolmafia.Modifiers;
@@ -2420,10 +2421,10 @@ public class RelayRequest extends PasswordHashRequest {
     list.removeModifier("Wiki Name");
     list.removeModifier("Modifiers");
     list.removeModifier("Outfit");
-    int type = ItemDatabase.getConsumptionType(itemId);
-    if (!(type == KoLConstants.EQUIP_HAT
+    ConsumptionType type = ItemDatabase.getConsumptionType(itemId);
+    if (!(type == ConsumptionType.EQUIP_HAT
             && KoLCharacter.usableFamiliar(FamiliarPool.HATRACK) != null)
-        && !(type == KoLConstants.EQUIP_PANTS
+        && !(type == ConsumptionType.EQUIP_PANTS
             && KoLCharacter.usableFamiliar(FamiliarPool.SCARECROW) != null)) {
       list.removeModifier("Familiar Effect");
     }

--- a/src/net/sourceforge/kolmafia/request/SingleUseRequest.java
+++ b/src/net/sourceforge/kolmafia/request/SingleUseRequest.java
@@ -4,6 +4,7 @@ import java.util.regex.Matcher;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestLogger;
@@ -30,18 +31,18 @@ public class SingleUseRequest extends CreateItemRequest {
     }
 
     int use = this.ingredients[0].getItemId();
-    int type = ItemDatabase.getConsumptionType(use);
+    ConsumptionType type = ItemDatabase.getConsumptionType(use);
     int count = this.getQuantityNeeded();
 
-    if (type == KoLConstants.CONSUME_USE
+    if (type == ConsumptionType.CONSUME_USE
         || ItemDatabase.getAttribute(use, ItemDatabase.ATTR_USABLE)
         || count == 1) {
       this.constructURLString("inv_use.php");
       this.addFormField("which", "3");
       this.addFormField("whichitem", String.valueOf(use));
       this.addFormField("ajax", "1");
-    } else if (type == KoLConstants.CONSUME_MULTIPLE
-        || type == KoLConstants.CONSUME_AVATAR
+    } else if (type == ConsumptionType.CONSUME_MULTIPLE
+        || type == ConsumptionType.CONSUME_AVATAR
         || ItemDatabase.getAttribute(use, ItemDatabase.ATTR_MULTIPLE)) {
       this.constructURLString("multiuse.php");
       this.addFormField("action", "useitem");
@@ -78,13 +79,13 @@ public class SingleUseRequest extends CreateItemRequest {
       return;
     }
 
-    int type = ItemDatabase.getConsumptionType(itemId);
+    ConsumptionType type = ItemDatabase.getConsumptionType(itemId);
     int quantity = this.getQuantityNeeded();
     int yield = this.getYield();
     int count = (quantity + yield - 1) / yield;
 
     if (count > 1
-        && (type == KoLConstants.CONSUME_USE
+        && (type == ConsumptionType.CONSUME_USE
             || ItemDatabase.getAttribute(itemId, ItemDatabase.ATTR_USABLE))) {
       // We have to create one at a time.
       for (int i = 1; i <= count; ++i) {

--- a/src/net/sourceforge/kolmafia/request/SingleUseRequest.java
+++ b/src/net/sourceforge/kolmafia/request/SingleUseRequest.java
@@ -34,15 +34,15 @@ public class SingleUseRequest extends CreateItemRequest {
     ConsumptionType type = ItemDatabase.getConsumptionType(use);
     int count = this.getQuantityNeeded();
 
-    if (type == ConsumptionType.CONSUME_USE
+    if (type == ConsumptionType.USE
         || ItemDatabase.getAttribute(use, ItemDatabase.ATTR_USABLE)
         || count == 1) {
       this.constructURLString("inv_use.php");
       this.addFormField("which", "3");
       this.addFormField("whichitem", String.valueOf(use));
       this.addFormField("ajax", "1");
-    } else if (type == ConsumptionType.CONSUME_MULTIPLE
-        || type == ConsumptionType.CONSUME_AVATAR
+    } else if (type == ConsumptionType.USE_MULTIPLE
+        || type == ConsumptionType.AVATAR_POTION
         || ItemDatabase.getAttribute(use, ItemDatabase.ATTR_MULTIPLE)) {
       this.constructURLString("multiuse.php");
       this.addFormField("action", "useitem");
@@ -85,7 +85,7 @@ public class SingleUseRequest extends CreateItemRequest {
     int count = (quantity + yield - 1) / yield;
 
     if (count > 1
-        && (type == ConsumptionType.CONSUME_USE
+        && (type == ConsumptionType.USE
             || ItemDatabase.getAttribute(itemId, ItemDatabase.ATTR_USABLE))) {
       // We have to create one at a time.
       for (int i = 1; i <= count; ++i) {

--- a/src/net/sourceforge/kolmafia/request/SpelunkyRequest.java
+++ b/src/net/sourceforge/kolmafia/request/SpelunkyRequest.java
@@ -223,13 +223,13 @@ public class SpelunkyRequest extends GenericRequest {
       int itemId = ItemDatabase.getItemIdFromDescription(descId);
       AdventureResult item = ItemPool.get(itemId, 1);
       switch (ItemDatabase.getConsumptionType(itemId)) {
-        case EQUIP_HAT:
+        case HAT:
           EquipmentManager.setEquipment(EquipmentManager.HAT, item);
           break;
-        case EQUIP_WEAPON:
+        case WEAPON:
           EquipmentManager.setEquipment(EquipmentManager.WEAPON, item);
           break;
-        case EQUIP_OFFHAND:
+        case OFFHAND:
           EquipmentManager.setEquipment(EquipmentManager.OFFHAND, item);
           switch (itemId) {
             case ItemPool.SPELUNKY_SKULL:
@@ -265,10 +265,10 @@ public class SpelunkyRequest extends GenericRequest {
               break;
           }
           break;
-        case EQUIP_CONTAINER:
+        case CONTAINER:
           EquipmentManager.setEquipment(EquipmentManager.CONTAINER, item);
           break;
-        case EQUIP_ACCESSORY:
+        case ACCESSORY:
           EquipmentManager.setEquipment(EquipmentManager.ACCESSORY1, item);
           break;
       }

--- a/src/net/sourceforge/kolmafia/request/SpelunkyRequest.java
+++ b/src/net/sourceforge/kolmafia/request/SpelunkyRequest.java
@@ -223,13 +223,13 @@ public class SpelunkyRequest extends GenericRequest {
       int itemId = ItemDatabase.getItemIdFromDescription(descId);
       AdventureResult item = ItemPool.get(itemId, 1);
       switch (ItemDatabase.getConsumptionType(itemId)) {
-        case KoLConstants.EQUIP_HAT:
+        case EQUIP_HAT:
           EquipmentManager.setEquipment(EquipmentManager.HAT, item);
           break;
-        case KoLConstants.EQUIP_WEAPON:
+        case EQUIP_WEAPON:
           EquipmentManager.setEquipment(EquipmentManager.WEAPON, item);
           break;
-        case KoLConstants.EQUIP_OFFHAND:
+        case EQUIP_OFFHAND:
           EquipmentManager.setEquipment(EquipmentManager.OFFHAND, item);
           switch (itemId) {
             case ItemPool.SPELUNKY_SKULL:
@@ -265,10 +265,10 @@ public class SpelunkyRequest extends GenericRequest {
               break;
           }
           break;
-        case KoLConstants.EQUIP_CONTAINER:
+        case EQUIP_CONTAINER:
           EquipmentManager.setEquipment(EquipmentManager.CONTAINER, item);
           break;
-        case KoLConstants.EQUIP_ACCESSORY:
+        case EQUIP_ACCESSORY:
           EquipmentManager.setEquipment(EquipmentManager.ACCESSORY1, item);
           break;
       }

--- a/src/net/sourceforge/kolmafia/request/SpleenItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/SpleenItemRequest.java
@@ -2,7 +2,7 @@ package net.sourceforge.kolmafia.request;
 
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestLogger;
@@ -141,7 +141,7 @@ public class SpleenItemRequest extends UseItemRequest {
   }
 
   private boolean singleConsume() {
-    return this.consumptionType == KoLConstants.CONSUME_USE;
+    return this.consumptionType == ConsumptionType.CONSUME_USE;
   }
 
   private boolean allowSpleenConsumption() {

--- a/src/net/sourceforge/kolmafia/request/SpleenItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/SpleenItemRequest.java
@@ -141,7 +141,7 @@ public class SpleenItemRequest extends UseItemRequest {
   }
 
   private boolean singleConsume() {
-    return this.consumptionType == ConsumptionType.CONSUME_USE;
+    return this.consumptionType == ConsumptionType.USE;
   }
 
   private boolean allowSpleenConsumption() {

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -11,6 +11,7 @@ import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.Modifiers;
@@ -121,7 +122,7 @@ public class UseItemRequest extends GenericRequest {
   private static AdventureResult lastUntinker = null;
 
   protected boolean shouldFollowRedirect = true;
-  protected final int consumptionType;
+  protected final ConsumptionType consumptionType;
   protected AdventureResult itemUsed;
 
   protected static AdventureResult lastItemUsed = null;
@@ -144,27 +145,27 @@ public class UseItemRequest extends GenericRequest {
   }
 
   public static final UseItemRequest getInstance(
-      final int consumptionType, final AdventureResult item) {
+          final ConsumptionType consumptionType, final AdventureResult item) {
     switch (consumptionType) {
-      case KoLConstants.CONSUME_DRINK:
-      case KoLConstants.CONSUME_DRINK_HELPER:
+      case CONSUME_DRINK:
+      case CONSUME_DRINK_HELPER:
         return new DrinkItemRequest(item);
-      case KoLConstants.CONSUME_EAT:
-      case KoLConstants.CONSUME_FOOD_HELPER:
+      case CONSUME_EAT:
+      case CONSUME_FOOD_HELPER:
         return new EatItemRequest(item);
-      case KoLConstants.CONSUME_SPLEEN:
+      case CONSUME_SPLEEN:
         return new SpleenItemRequest(item);
     }
 
     return new UseItemRequest(consumptionType, item);
   }
 
-  protected UseItemRequest(final int consumptionType, final AdventureResult item) {
+  protected UseItemRequest(final ConsumptionType consumptionType, final AdventureResult item) {
     this(UseItemRequest.getConsumptionLocation(consumptionType, item), consumptionType, item);
   }
 
   private UseItemRequest(
-      final String location, final int consumptionType, final AdventureResult item) {
+      final String location, final ConsumptionType consumptionType, final AdventureResult item) {
     super(location);
 
     this.consumptionType = consumptionType;
@@ -173,66 +174,66 @@ public class UseItemRequest extends GenericRequest {
     this.addFormField("whichitem", String.valueOf(item.getItemId()));
   }
 
-  public static final int getConsumptionType(final AdventureResult item) {
+  public static final ConsumptionType getConsumptionType(final AdventureResult item) {
     int itemId = item.getItemId();
 
     // We want to display the result of using certain items
     switch (itemId) {
       case ItemPool.HOBO_CODE_BINDER:
       case ItemPool.STUFFED_BARON:
-        return KoLConstants.MESSAGE_DISPLAY;
+        return ConsumptionType.MESSAGE_DISPLAY;
     }
 
-    int consumptionType = ItemDatabase.getConsumptionType(itemId);
+    ConsumptionType consumptionType = ItemDatabase.getConsumptionType(itemId);
 
     // Spleen items can be marked "usable", if you can only use one
     // at a time, but must use a SpleenItemRequest
-    if (consumptionType == KoLConstants.CONSUME_SPLEEN) {
-      return KoLConstants.CONSUME_SPLEEN;
+    if (consumptionType == ConsumptionType.CONSUME_SPLEEN) {
+      return ConsumptionType.CONSUME_SPLEEN;
     }
 
     int attrs = ItemDatabase.getAttributes(itemId);
     if ((attrs & ItemDatabase.ATTR_USABLE) != 0) {
-      return KoLConstants.CONSUME_USE;
+      return ConsumptionType.CONSUME_USE;
     }
     if ((attrs & ItemDatabase.ATTR_MULTIPLE) != 0) {
-      return KoLConstants.CONSUME_MULTIPLE;
+      return ConsumptionType.CONSUME_MULTIPLE;
     }
     if ((attrs & ItemDatabase.ATTR_REUSABLE) != 0) {
-      return KoLConstants.INFINITE_USES;
+      return ConsumptionType.INFINITE_USES;
     }
 
     return consumptionType;
   }
 
   private static String getConsumptionLocation(
-      final int consumptionType, final AdventureResult item) {
+      final ConsumptionType consumptionType, final AdventureResult item) {
     switch (consumptionType) {
-      case KoLConstants.CONSUME_EAT:
+      case CONSUME_EAT:
         return "inv_eat.php";
-      case KoLConstants.CONSUME_DRINK:
+      case CONSUME_DRINK:
         return "inv_booze.php";
-      case KoLConstants.CONSUME_SPLEEN:
+      case CONSUME_SPLEEN:
         return "inv_spleen.php";
-      case KoLConstants.GROW_FAMILIAR:
+      case GROW_FAMILIAR:
         return "inv_familiar.php";
-      case KoLConstants.CONSUME_HOBO:
-      case KoLConstants.CONSUME_GHOST:
-      case KoLConstants.CONSUME_SLIME:
+      case CONSUME_HOBO:
+      case CONSUME_GHOST:
+      case CONSUME_SLIME:
         return "familiarbinger.php";
-      case KoLConstants.CONSUME_ROBO:
+      case CONSUME_ROBO:
         return "inventory.php";
-      case KoLConstants.CONSUME_SPHERE:
+      case CONSUME_SPHERE:
         return "campground.php";
-      case KoLConstants.CONSUME_MULTIPLE:
+      case CONSUME_MULTIPLE:
         if (item.getCount() > 1) {
           return "multiuse.php";
         }
         return "inv_use.php";
-      case KoLConstants.INFINITE_USES:
+      case INFINITE_USES:
         {
-          int type = ItemDatabase.getConsumptionType(item.getItemId());
-          return type == KoLConstants.CONSUME_MULTIPLE ? "multiuse.php" : "inv_use.php";
+          ConsumptionType type = ItemDatabase.getConsumptionType(item.getItemId());
+          return type == ConsumptionType.CONSUME_MULTIPLE ? "multiuse.php" : "inv_use.php";
         }
       default:
         return "inv_use.php";
@@ -259,10 +260,10 @@ public class UseItemRequest extends GenericRequest {
 
   private boolean isBingeRequest() {
     switch (this.consumptionType) {
-      case KoLConstants.CONSUME_HOBO:
-      case KoLConstants.CONSUME_GHOST:
-      case KoLConstants.CONSUME_SLIME:
-      case KoLConstants.CONSUME_MIMIC:
+      case CONSUME_HOBO:
+      case CONSUME_GHOST:
+      case CONSUME_SLIME:
+      case CONSUME_MIMIC:
         return true;
     }
     return false;
@@ -331,7 +332,7 @@ public class UseItemRequest extends GenericRequest {
     return true;
   }
 
-  public int getConsumptionType() {
+  public ConsumptionType getConsumptionType() {
     return this.consumptionType;
   }
 
@@ -341,23 +342,23 @@ public class UseItemRequest extends GenericRequest {
 
   public static final int maximumUses(final int itemId) {
     String itemName = ItemDatabase.getItemName(itemId);
-    return UseItemRequest.maximumUses(itemId, itemName, KoLConstants.NO_CONSUME, true);
+    return UseItemRequest.maximumUses(itemId, itemName, ConsumptionType.NO_CONSUME, true);
   }
 
-  public static final int maximumUses(final int itemId, final int consumptionType) {
+  public static final int maximumUses(final int itemId, final ConsumptionType consumptionType) {
     String itemName = ItemDatabase.getItemName(itemId);
     return UseItemRequest.maximumUses(itemId, itemName, consumptionType, true);
   }
 
   public static final int maximumUses(final String itemName) {
     int itemId = ItemDatabase.getItemId(itemName);
-    return UseItemRequest.maximumUses(itemId, itemName, KoLConstants.NO_CONSUME, false);
+    return UseItemRequest.maximumUses(itemId, itemName, ConsumptionType.NO_CONSUME, false);
   }
 
   private static int maximumUses(
       final int itemId,
       final String itemName,
-      final int consumptionType,
+      final ConsumptionType consumptionType,
       final boolean allowOverDrink) {
     if (FightRequest.inMultiFight) {
       UseItemRequest.limiter = "multi-stage fight in progress";
@@ -424,13 +425,13 @@ public class UseItemRequest extends GenericRequest {
 
     // Check binge requests before checking fullness or inebriety
     switch (consumptionType) {
-      case KoLConstants.CONSUME_HOBO:
-      case KoLConstants.CONSUME_GHOST:
-      case KoLConstants.CONSUME_SLIME:
+      case CONSUME_HOBO:
+      case CONSUME_GHOST:
+      case CONSUME_SLIME:
         return Integer.MAX_VALUE;
-      case KoLConstants.CONSUME_ROBO:
+      case CONSUME_ROBO:
         return 1;
-      case KoLConstants.CONSUME_GUARDIAN:
+      case CONSUME_GUARDIAN:
         UseItemRequest.limiter = "character class";
         return KoLCharacter.isPastamancer() ? 1 : 0;
     }
@@ -835,7 +836,7 @@ public class UseItemRequest extends GenericRequest {
     }
 
     switch (consumptionType) {
-      case KoLConstants.GROW_FAMILIAR:
+      case GROW_FAMILIAR:
         if (KoLCharacter.inAxecore()) {
           UseItemRequest.limiter = "Boris's scorn for familiars";
           return 0;
@@ -843,19 +844,19 @@ public class UseItemRequest extends GenericRequest {
         UseItemRequest.limiter =
             "the fine print in your Familiar-Gro\u2122 Terrarium owner's manual";
         return 1;
-      case KoLConstants.EQUIP_WEAPON:
+      case EQUIP_WEAPON:
         // Even if you can dual-wield, if we attempt to "use" a
         // weapon, it will become an "equip", which always goes
         // in the main hand.
-      case KoLConstants.EQUIP_FAMILIAR:
-      case KoLConstants.EQUIP_HAT:
-      case KoLConstants.EQUIP_PANTS:
-      case KoLConstants.EQUIP_CONTAINER:
-      case KoLConstants.EQUIP_SHIRT:
-      case KoLConstants.EQUIP_OFFHAND:
+      case EQUIP_FAMILIAR:
+      case EQUIP_HAT:
+      case EQUIP_PANTS:
+      case EQUIP_CONTAINER:
+      case EQUIP_SHIRT:
+      case EQUIP_OFFHAND:
         UseItemRequest.limiter = "slot";
         return 1;
-      case KoLConstants.EQUIP_ACCESSORY:
+      case EQUIP_ACCESSORY:
         UseItemRequest.limiter = "slot";
         return 3;
     }
@@ -1077,28 +1078,28 @@ public class UseItemRequest extends GenericRequest {
     }
 
     switch (this.consumptionType) {
-      case KoLConstants.CONSUME_STICKER:
-      case KoLConstants.CONSUME_CARD:
-      case KoLConstants.CONSUME_FOLDER:
-      case KoLConstants.CONSUME_BOOTSKIN:
-      case KoLConstants.CONSUME_BOOTSPUR:
-      case KoLConstants.CONSUME_SIXGUN:
-      case KoLConstants.EQUIP_HAT:
-      case KoLConstants.EQUIP_WEAPON:
-      case KoLConstants.EQUIP_OFFHAND:
-      case KoLConstants.EQUIP_SHIRT:
-      case KoLConstants.EQUIP_PANTS:
-      case KoLConstants.EQUIP_CONTAINER:
-      case KoLConstants.EQUIP_ACCESSORY:
-      case KoLConstants.EQUIP_FAMILIAR:
+      case CONSUME_STICKER:
+      case CONSUME_CARD:
+      case CONSUME_FOLDER:
+      case CONSUME_BOOTSKIN:
+      case CONSUME_BOOTSPUR:
+      case CONSUME_SIXGUN:
+      case EQUIP_HAT:
+      case EQUIP_WEAPON:
+      case EQUIP_OFFHAND:
+      case EQUIP_SHIRT:
+      case EQUIP_PANTS:
+      case EQUIP_CONTAINER:
+      case EQUIP_ACCESSORY:
+      case EQUIP_FAMILIAR:
         RequestThread.postRequest(new EquipmentRequest(this.itemUsed));
         return;
 
-      case KoLConstants.CONSUME_SPHERE:
+      case CONSUME_SPHERE:
         RequestThread.postRequest(new PortalRequest(this.itemUsed));
         return;
 
-      case KoLConstants.NO_CONSUME:
+      case NO_CONSUME:
         // no primary use, but a secondary use may be applicable
         if (ItemDatabase.getAttribute(itemId, ItemDatabase.ATTR_CURSE)) {
           RequestThread.postRequest(new CurseRequest(this.itemUsed));
@@ -1189,7 +1190,7 @@ public class UseItemRequest extends GenericRequest {
         break;
     }
 
-    if (this.consumptionType != KoLConstants.INFINITE_USES
+    if (this.consumptionType != ConsumptionType.INFINITE_USES
         && !UseItemRequest.sequentialConsume(itemId)
         && !InventoryManager.retrieveItem(this.itemUsed)) {
       return;
@@ -1209,20 +1210,20 @@ public class UseItemRequest extends GenericRequest {
         this.itemUsed = this.itemUsed.getInstance((origCount + 10) % 11 + 1);
       } else
         switch (this.consumptionType) {
-          case KoLConstants.INFINITE_USES:
+          case INFINITE_USES:
             {
-              int type = ItemDatabase.getConsumptionType(this.itemUsed.getItemId());
-              if (type != KoLConstants.CONSUME_MULTIPLE) {
+              ConsumptionType type = ItemDatabase.getConsumptionType(this.itemUsed.getItemId());
+              if (type != ConsumptionType.CONSUME_MULTIPLE) {
                 iterations = origCount;
                 this.itemUsed = this.itemUsed.getInstance(1);
               }
               break;
             }
-          case KoLConstants.CONSUME_MULTIPLE:
-          case KoLConstants.CONSUME_HOBO:
-          case KoLConstants.CONSUME_GHOST:
-          case KoLConstants.CONSUME_SLIME:
-          case KoLConstants.CONSUME_ROBO:
+          case CONSUME_MULTIPLE:
+          case CONSUME_HOBO:
+          case CONSUME_GHOST:
+          case CONSUME_SLIME:
+          case CONSUME_ROBO:
             break;
           default:
             iterations = origCount;
@@ -1294,7 +1295,7 @@ public class UseItemRequest extends GenericRequest {
       final int currentIteration, final int totalIterations, String useTypeAsString) {
     UseItemRequest.lastUpdate = "";
 
-    if (this.consumptionType == KoLConstants.CONSUME_ZAP) {
+    if (this.consumptionType == ConsumptionType.CONSUME_ZAP) {
       ZapCommand.zap(this.getItemUsed().getName());
       return;
     }
@@ -1316,7 +1317,7 @@ public class UseItemRequest extends GenericRequest {
     }
 
     switch (this.consumptionType) {
-      case KoLConstants.CONSUME_HOBO:
+      case CONSUME_HOBO:
         if (KoLCharacter.getFamiliar().getId() != FamiliarPool.HOBO) {
           KoLmafia.updateDisplay(MafiaState.ERROR, "You don't have a Spirit Hobo equipped");
           return;
@@ -1327,7 +1328,7 @@ public class UseItemRequest extends GenericRequest {
         useTypeAsString = "Boozing hobo with";
         break;
 
-      case KoLConstants.CONSUME_GHOST:
+      case CONSUME_GHOST:
         if (KoLCharacter.getFamiliar().getId() != FamiliarPool.GHOST) {
           KoLmafia.updateDisplay(
               MafiaState.ERROR, "You don't have a Gluttonous Green Ghost equipped");
@@ -1339,7 +1340,7 @@ public class UseItemRequest extends GenericRequest {
         useTypeAsString = "Feeding ghost with";
         break;
 
-      case KoLConstants.CONSUME_SLIME:
+      case CONSUME_SLIME:
         if (KoLCharacter.getFamiliar().getId() != FamiliarPool.SLIMELING) {
           KoLmafia.updateDisplay(MafiaState.ERROR, "You don't have a Slimeling equipped");
           return;
@@ -1349,7 +1350,7 @@ public class UseItemRequest extends GenericRequest {
         useTypeAsString = "Feeding slimeling with";
         break;
 
-      case KoLConstants.CONSUME_MIMIC:
+      case CONSUME_MIMIC:
         if (KoLCharacter.getFamiliar().getId() != FamiliarPool.STOCKING_MIMIC) {
           KoLmafia.updateDisplay(MafiaState.ERROR, "You don't have a Stocking Mimic equipped");
           return;
@@ -1358,7 +1359,7 @@ public class UseItemRequest extends GenericRequest {
         useTypeAsString = "Feeding stocking mimic with";
         break;
 
-      case KoLConstants.CONSUME_ROBO:
+      case CONSUME_ROBO:
         if (KoLCharacter.getFamiliar().getId() != FamiliarPool.ROBORTENDER) {
           KoLmafia.updateDisplay(MafiaState.ERROR, "You don't have a Robortender equipped");
           return;
@@ -1368,7 +1369,7 @@ public class UseItemRequest extends GenericRequest {
         useTypeAsString = "Boozing Robortender with";
         break;
 
-      case KoLConstants.CONSUME_MULTIPLE:
+      case CONSUME_MULTIPLE:
         if (this.itemUsed.getCount() > 1) {
           this.addFormField("action", "useitem");
           this.addFormField("quantity", String.valueOf(this.itemUsed.getCount()));
@@ -1450,15 +1451,15 @@ public class UseItemRequest extends GenericRequest {
     }
 
     switch (this.consumptionType) {
-      case KoLConstants.CONSUME_GHOST:
-      case KoLConstants.CONSUME_HOBO:
-      case KoLConstants.CONSUME_SLIME:
-      case KoLConstants.CONSUME_MIMIC:
+      case CONSUME_GHOST:
+      case CONSUME_HOBO:
+      case CONSUME_SLIME:
+      case CONSUME_MIMIC:
         if (!UseItemRequest.parseBinge(this.getURLString(), this.responseText)) {
           KoLmafia.updateDisplay(MafiaState.ERROR, "Your current familiar can't use that.");
         }
         return;
-      case KoLConstants.CONSUME_ROBO:
+      case CONSUME_ROBO:
         if (!UseItemRequest.parseRobortenderBinge(this.getURLString(), this.responseText)) {
           KoLmafia.updateDisplay(MafiaState.ERROR, "Your Robortender can't drink that.");
         }
@@ -1719,20 +1720,20 @@ public class UseItemRequest extends GenericRequest {
       return;
     }
 
-    int consumptionType = UseItemRequest.getConsumptionType(item);
+    ConsumptionType consumptionType = UseItemRequest.getConsumptionType(item);
 
     switch (consumptionType) {
-      case KoLConstants.CONSUME_DRINK:
-      case KoLConstants.CONSUME_DRINK_HELPER:
+      case CONSUME_DRINK:
+      case CONSUME_DRINK_HELPER:
         DrinkItemRequest.parseConsumption(item, helper, responseText);
         return;
 
-      case KoLConstants.CONSUME_EAT:
-      case KoLConstants.CONSUME_FOOD_HELPER:
+      case CONSUME_EAT:
+      case CONSUME_FOOD_HELPER:
         EatItemRequest.parseConsumption(item, helper, responseText);
         return;
 
-      case KoLConstants.CONSUME_SPLEEN:
+      case CONSUME_SPLEEN:
         SpleenItemRequest.parseConsumption(item, helper, responseText);
         return;
     }
@@ -1820,7 +1821,7 @@ public class UseItemRequest extends GenericRequest {
     // Check for familiar growth - if a familiar is added,
     // make sure to update the StaticEntity.getClient().
 
-    if (consumptionType == KoLConstants.GROW_FAMILIAR) {
+    if (consumptionType == ConsumptionType.GROW_FAMILIAR) {
       if (responseText.contains("You've already got a familiar of that type.")) {
         UseItemRequest.lastUpdate = "You already have that familiar.";
         KoLmafia.updateDisplay(MafiaState.ERROR, UseItemRequest.lastUpdate);
@@ -1891,15 +1892,15 @@ public class UseItemRequest extends GenericRequest {
     }
 
     switch (consumptionType) {
-      case KoLConstants.CONSUME_FOOD_HELPER:
-      case KoLConstants.CONSUME_DRINK_HELPER:
+      case CONSUME_FOOD_HELPER:
+      case CONSUME_DRINK_HELPER:
         // Consumption helpers are removed above when you
         // successfully eat or drink.
 
-      case KoLConstants.NO_CONSUME:
+      case NO_CONSUME:
         return;
 
-      case KoLConstants.MESSAGE_DISPLAY:
+      case MESSAGE_DISPLAY:
         if (!Preferences.getBoolean("suppressNegativeStatusPopup")) {
           UseItemRequest.showItemUsage(showHTML, responseText);
         }
@@ -5942,15 +5943,15 @@ public class UseItemRequest extends GenericRequest {
     // Finally, remove the item from inventory if it was successfully used.
 
     switch (consumptionType) {
-      case KoLConstants.CONSUME_ZAP:
-      case KoLConstants.EQUIP_FAMILIAR:
-      case KoLConstants.EQUIP_ACCESSORY:
-      case KoLConstants.EQUIP_HAT:
-      case KoLConstants.EQUIP_PANTS:
-      case KoLConstants.EQUIP_WEAPON:
-      case KoLConstants.EQUIP_OFFHAND:
-      case KoLConstants.EQUIP_CONTAINER:
-      case KoLConstants.INFINITE_USES:
+      case CONSUME_ZAP:
+      case EQUIP_FAMILIAR:
+      case EQUIP_ACCESSORY:
+      case EQUIP_HAT:
+      case EQUIP_PANTS:
+      case EQUIP_WEAPON:
+      case EQUIP_OFFHAND:
+      case EQUIP_CONTAINER:
+      case INFINITE_USES:
         break;
 
       default:
@@ -6332,18 +6333,18 @@ public class UseItemRequest extends GenericRequest {
     }
 
     int count = item.getCount();
-    int consumptionType = ItemDatabase.getConsumptionType(itemId);
+    ConsumptionType consumptionType = ItemDatabase.getConsumptionType(itemId);
     String useString = null;
 
     switch (consumptionType) {
-      case KoLConstants.NO_CONSUME:
+      case NO_CONSUME:
         if (itemId != ItemPool.LOATHING_LEGION_JACKHAMMER) {
           return false;
         }
         break;
 
-      case KoLConstants.CONSUME_USE:
-      case KoLConstants.CONSUME_MULTIPLE:
+      case CONSUME_USE:
+      case CONSUME_MULTIPLE:
 
         // See if it is a concoction
         if (SingleUseRequest.registerRequest(urlString)
@@ -6352,11 +6353,11 @@ public class UseItemRequest extends GenericRequest {
         }
         break;
 
-      case KoLConstants.CONSUME_EAT:
+      case CONSUME_EAT:
 
         // Fortune cookies, for example
         if (urlString.startsWith("inv_use")) {
-          consumptionType = KoLConstants.CONSUME_USE;
+          consumptionType = ConsumptionType.CONSUME_USE;
           break;
         }
         break;

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -147,13 +147,13 @@ public class UseItemRequest extends GenericRequest {
   public static final UseItemRequest getInstance(
       final ConsumptionType consumptionType, final AdventureResult item) {
     switch (consumptionType) {
-      case CONSUME_DRINK:
-      case CONSUME_DRINK_HELPER:
+      case DRINK:
+      case DRINK_HELPER:
         return new DrinkItemRequest(item);
-      case CONSUME_EAT:
-      case CONSUME_FOOD_HELPER:
+      case EAT:
+      case FOOD_HELPER:
         return new EatItemRequest(item);
-      case CONSUME_SPLEEN:
+      case SPLEEN:
         return new SpleenItemRequest(item);
     }
 
@@ -181,26 +181,26 @@ public class UseItemRequest extends GenericRequest {
     switch (itemId) {
       case ItemPool.HOBO_CODE_BINDER:
       case ItemPool.STUFFED_BARON:
-        return ConsumptionType.MESSAGE_DISPLAY;
+        return ConsumptionType.USE_MESSAGE_DISPLAY;
     }
 
     ConsumptionType consumptionType = ItemDatabase.getConsumptionType(itemId);
 
     // Spleen items can be marked "usable", if you can only use one
     // at a time, but must use a SpleenItemRequest
-    if (consumptionType == ConsumptionType.CONSUME_SPLEEN) {
-      return ConsumptionType.CONSUME_SPLEEN;
+    if (consumptionType == ConsumptionType.SPLEEN) {
+      return ConsumptionType.SPLEEN;
     }
 
     int attrs = ItemDatabase.getAttributes(itemId);
     if ((attrs & ItemDatabase.ATTR_USABLE) != 0) {
-      return ConsumptionType.CONSUME_USE;
+      return ConsumptionType.USE;
     }
     if ((attrs & ItemDatabase.ATTR_MULTIPLE) != 0) {
-      return ConsumptionType.CONSUME_MULTIPLE;
+      return ConsumptionType.USE_MULTIPLE;
     }
     if ((attrs & ItemDatabase.ATTR_REUSABLE) != 0) {
-      return ConsumptionType.INFINITE_USES;
+      return ConsumptionType.USE_INFINITE;
     }
 
     return consumptionType;
@@ -209,31 +209,31 @@ public class UseItemRequest extends GenericRequest {
   private static String getConsumptionLocation(
       final ConsumptionType consumptionType, final AdventureResult item) {
     switch (consumptionType) {
-      case CONSUME_EAT:
+      case EAT:
         return "inv_eat.php";
-      case CONSUME_DRINK:
+      case DRINK:
         return "inv_booze.php";
-      case CONSUME_SPLEEN:
+      case SPLEEN:
         return "inv_spleen.php";
-      case GROW_FAMILIAR:
+      case FAMILIAR_HATCHLING:
         return "inv_familiar.php";
-      case CONSUME_HOBO:
-      case CONSUME_GHOST:
-      case CONSUME_SLIME:
+      case SPIRIT_HOBO:
+      case GLUTTONOUS_GHOST:
+      case SLIMELING:
         return "familiarbinger.php";
-      case CONSUME_ROBO:
+      case ROBORTENDER:
         return "inventory.php";
-      case CONSUME_SPHERE:
+      case EL_VIBRATO_SPHERE:
         return "campground.php";
-      case CONSUME_MULTIPLE:
+      case USE_MULTIPLE:
         if (item.getCount() > 1) {
           return "multiuse.php";
         }
         return "inv_use.php";
-      case INFINITE_USES:
+      case USE_INFINITE:
         {
           ConsumptionType type = ItemDatabase.getConsumptionType(item.getItemId());
-          return type == ConsumptionType.CONSUME_MULTIPLE ? "multiuse.php" : "inv_use.php";
+          return type == ConsumptionType.USE_MULTIPLE ? "multiuse.php" : "inv_use.php";
         }
       default:
         return "inv_use.php";
@@ -260,10 +260,10 @@ public class UseItemRequest extends GenericRequest {
 
   private boolean isBingeRequest() {
     switch (this.consumptionType) {
-      case CONSUME_HOBO:
-      case CONSUME_GHOST:
-      case CONSUME_SLIME:
-      case CONSUME_MIMIC:
+      case SPIRIT_HOBO:
+      case GLUTTONOUS_GHOST:
+      case SLIMELING:
+      case STOCKING_MIMIC:
         return true;
     }
     return false;
@@ -342,7 +342,7 @@ public class UseItemRequest extends GenericRequest {
 
   public static final int maximumUses(final int itemId) {
     String itemName = ItemDatabase.getItemName(itemId);
-    return UseItemRequest.maximumUses(itemId, itemName, ConsumptionType.NO_CONSUME, true);
+    return UseItemRequest.maximumUses(itemId, itemName, ConsumptionType.NONE, true);
   }
 
   public static final int maximumUses(final int itemId, final ConsumptionType consumptionType) {
@@ -352,7 +352,7 @@ public class UseItemRequest extends GenericRequest {
 
   public static final int maximumUses(final String itemName) {
     int itemId = ItemDatabase.getItemId(itemName);
-    return UseItemRequest.maximumUses(itemId, itemName, ConsumptionType.NO_CONSUME, false);
+    return UseItemRequest.maximumUses(itemId, itemName, ConsumptionType.NONE, false);
   }
 
   private static int maximumUses(
@@ -425,13 +425,13 @@ public class UseItemRequest extends GenericRequest {
 
     // Check binge requests before checking fullness or inebriety
     switch (consumptionType) {
-      case CONSUME_HOBO:
-      case CONSUME_GHOST:
-      case CONSUME_SLIME:
+      case SPIRIT_HOBO:
+      case GLUTTONOUS_GHOST:
+      case SLIMELING:
         return Integer.MAX_VALUE;
-      case CONSUME_ROBO:
+      case ROBORTENDER:
         return 1;
-      case CONSUME_GUARDIAN:
+      case PASTA_GUARDIAN:
         UseItemRequest.limiter = "character class";
         return KoLCharacter.isPastamancer() ? 1 : 0;
     }
@@ -836,7 +836,7 @@ public class UseItemRequest extends GenericRequest {
     }
 
     switch (consumptionType) {
-      case GROW_FAMILIAR:
+      case FAMILIAR_HATCHLING:
         if (KoLCharacter.inAxecore()) {
           UseItemRequest.limiter = "Boris's scorn for familiars";
           return 0;
@@ -844,19 +844,19 @@ public class UseItemRequest extends GenericRequest {
         UseItemRequest.limiter =
             "the fine print in your Familiar-Gro\u2122 Terrarium owner's manual";
         return 1;
-      case EQUIP_WEAPON:
+      case WEAPON:
         // Even if you can dual-wield, if we attempt to "use" a
         // weapon, it will become an "equip", which always goes
         // in the main hand.
-      case EQUIP_FAMILIAR:
-      case EQUIP_HAT:
-      case EQUIP_PANTS:
-      case EQUIP_CONTAINER:
-      case EQUIP_SHIRT:
-      case EQUIP_OFFHAND:
+      case FAMILIAR_EQUIPMENT:
+      case HAT:
+      case PANTS:
+      case CONTAINER:
+      case SHIRT:
+      case OFFHAND:
         UseItemRequest.limiter = "slot";
         return 1;
-      case EQUIP_ACCESSORY:
+      case ACCESSORY:
         UseItemRequest.limiter = "slot";
         return 3;
     }
@@ -1078,28 +1078,28 @@ public class UseItemRequest extends GenericRequest {
     }
 
     switch (this.consumptionType) {
-      case CONSUME_STICKER:
-      case CONSUME_CARD:
-      case CONSUME_FOLDER:
-      case CONSUME_BOOTSKIN:
-      case CONSUME_BOOTSPUR:
-      case CONSUME_SIXGUN:
-      case EQUIP_HAT:
-      case EQUIP_WEAPON:
-      case EQUIP_OFFHAND:
-      case EQUIP_SHIRT:
-      case EQUIP_PANTS:
-      case EQUIP_CONTAINER:
-      case EQUIP_ACCESSORY:
-      case EQUIP_FAMILIAR:
+      case STICKER:
+      case CARD:
+      case FOLDER:
+      case BOOTSKIN:
+      case BOOTSPUR:
+      case SIXGUN:
+      case HAT:
+      case WEAPON:
+      case OFFHAND:
+      case SHIRT:
+      case PANTS:
+      case CONTAINER:
+      case ACCESSORY:
+      case FAMILIAR_EQUIPMENT:
         RequestThread.postRequest(new EquipmentRequest(this.itemUsed));
         return;
 
-      case CONSUME_SPHERE:
+      case EL_VIBRATO_SPHERE:
         RequestThread.postRequest(new PortalRequest(this.itemUsed));
         return;
 
-      case NO_CONSUME:
+      case NONE:
         // no primary use, but a secondary use may be applicable
         if (ItemDatabase.getAttribute(itemId, ItemDatabase.ATTR_CURSE)) {
           RequestThread.postRequest(new CurseRequest(this.itemUsed));
@@ -1190,7 +1190,7 @@ public class UseItemRequest extends GenericRequest {
         break;
     }
 
-    if (this.consumptionType != ConsumptionType.INFINITE_USES
+    if (this.consumptionType != ConsumptionType.USE_INFINITE
         && !UseItemRequest.sequentialConsume(itemId)
         && !InventoryManager.retrieveItem(this.itemUsed)) {
       return;
@@ -1210,20 +1210,20 @@ public class UseItemRequest extends GenericRequest {
         this.itemUsed = this.itemUsed.getInstance((origCount + 10) % 11 + 1);
       } else
         switch (this.consumptionType) {
-          case INFINITE_USES:
+          case USE_INFINITE:
             {
               ConsumptionType type = ItemDatabase.getConsumptionType(this.itemUsed.getItemId());
-              if (type != ConsumptionType.CONSUME_MULTIPLE) {
+              if (type != ConsumptionType.USE_MULTIPLE) {
                 iterations = origCount;
                 this.itemUsed = this.itemUsed.getInstance(1);
               }
               break;
             }
-          case CONSUME_MULTIPLE:
-          case CONSUME_HOBO:
-          case CONSUME_GHOST:
-          case CONSUME_SLIME:
-          case CONSUME_ROBO:
+          case USE_MULTIPLE:
+          case SPIRIT_HOBO:
+          case GLUTTONOUS_GHOST:
+          case SLIMELING:
+          case ROBORTENDER:
             break;
           default:
             iterations = origCount;
@@ -1295,7 +1295,7 @@ public class UseItemRequest extends GenericRequest {
       final int currentIteration, final int totalIterations, String useTypeAsString) {
     UseItemRequest.lastUpdate = "";
 
-    if (this.consumptionType == ConsumptionType.CONSUME_ZAP) {
+    if (this.consumptionType == ConsumptionType.ZAP) {
       ZapCommand.zap(this.getItemUsed().getName());
       return;
     }
@@ -1317,7 +1317,7 @@ public class UseItemRequest extends GenericRequest {
     }
 
     switch (this.consumptionType) {
-      case CONSUME_HOBO:
+      case SPIRIT_HOBO:
         if (KoLCharacter.getFamiliar().getId() != FamiliarPool.HOBO) {
           KoLmafia.updateDisplay(MafiaState.ERROR, "You don't have a Spirit Hobo equipped");
           return;
@@ -1328,7 +1328,7 @@ public class UseItemRequest extends GenericRequest {
         useTypeAsString = "Boozing hobo with";
         break;
 
-      case CONSUME_GHOST:
+      case GLUTTONOUS_GHOST:
         if (KoLCharacter.getFamiliar().getId() != FamiliarPool.GHOST) {
           KoLmafia.updateDisplay(
               MafiaState.ERROR, "You don't have a Gluttonous Green Ghost equipped");
@@ -1340,7 +1340,7 @@ public class UseItemRequest extends GenericRequest {
         useTypeAsString = "Feeding ghost with";
         break;
 
-      case CONSUME_SLIME:
+      case SLIMELING:
         if (KoLCharacter.getFamiliar().getId() != FamiliarPool.SLIMELING) {
           KoLmafia.updateDisplay(MafiaState.ERROR, "You don't have a Slimeling equipped");
           return;
@@ -1350,7 +1350,7 @@ public class UseItemRequest extends GenericRequest {
         useTypeAsString = "Feeding slimeling with";
         break;
 
-      case CONSUME_MIMIC:
+      case STOCKING_MIMIC:
         if (KoLCharacter.getFamiliar().getId() != FamiliarPool.STOCKING_MIMIC) {
           KoLmafia.updateDisplay(MafiaState.ERROR, "You don't have a Stocking Mimic equipped");
           return;
@@ -1359,7 +1359,7 @@ public class UseItemRequest extends GenericRequest {
         useTypeAsString = "Feeding stocking mimic with";
         break;
 
-      case CONSUME_ROBO:
+      case ROBORTENDER:
         if (KoLCharacter.getFamiliar().getId() != FamiliarPool.ROBORTENDER) {
           KoLmafia.updateDisplay(MafiaState.ERROR, "You don't have a Robortender equipped");
           return;
@@ -1369,7 +1369,7 @@ public class UseItemRequest extends GenericRequest {
         useTypeAsString = "Boozing Robortender with";
         break;
 
-      case CONSUME_MULTIPLE:
+      case USE_MULTIPLE:
         if (this.itemUsed.getCount() > 1) {
           this.addFormField("action", "useitem");
           this.addFormField("quantity", String.valueOf(this.itemUsed.getCount()));
@@ -1451,15 +1451,15 @@ public class UseItemRequest extends GenericRequest {
     }
 
     switch (this.consumptionType) {
-      case CONSUME_GHOST:
-      case CONSUME_HOBO:
-      case CONSUME_SLIME:
-      case CONSUME_MIMIC:
+      case GLUTTONOUS_GHOST:
+      case SPIRIT_HOBO:
+      case SLIMELING:
+      case STOCKING_MIMIC:
         if (!UseItemRequest.parseBinge(this.getURLString(), this.responseText)) {
           KoLmafia.updateDisplay(MafiaState.ERROR, "Your current familiar can't use that.");
         }
         return;
-      case CONSUME_ROBO:
+      case ROBORTENDER:
         if (!UseItemRequest.parseRobortenderBinge(this.getURLString(), this.responseText)) {
           KoLmafia.updateDisplay(MafiaState.ERROR, "Your Robortender can't drink that.");
         }
@@ -1723,17 +1723,17 @@ public class UseItemRequest extends GenericRequest {
     ConsumptionType consumptionType = UseItemRequest.getConsumptionType(item);
 
     switch (consumptionType) {
-      case CONSUME_DRINK:
-      case CONSUME_DRINK_HELPER:
+      case DRINK:
+      case DRINK_HELPER:
         DrinkItemRequest.parseConsumption(item, helper, responseText);
         return;
 
-      case CONSUME_EAT:
-      case CONSUME_FOOD_HELPER:
+      case EAT:
+      case FOOD_HELPER:
         EatItemRequest.parseConsumption(item, helper, responseText);
         return;
 
-      case CONSUME_SPLEEN:
+      case SPLEEN:
         SpleenItemRequest.parseConsumption(item, helper, responseText);
         return;
     }
@@ -1821,7 +1821,7 @@ public class UseItemRequest extends GenericRequest {
     // Check for familiar growth - if a familiar is added,
     // make sure to update the StaticEntity.getClient().
 
-    if (consumptionType == ConsumptionType.GROW_FAMILIAR) {
+    if (consumptionType == ConsumptionType.FAMILIAR_HATCHLING) {
       if (responseText.contains("You've already got a familiar of that type.")) {
         UseItemRequest.lastUpdate = "You already have that familiar.";
         KoLmafia.updateDisplay(MafiaState.ERROR, UseItemRequest.lastUpdate);
@@ -1892,15 +1892,15 @@ public class UseItemRequest extends GenericRequest {
     }
 
     switch (consumptionType) {
-      case CONSUME_FOOD_HELPER:
-      case CONSUME_DRINK_HELPER:
+      case FOOD_HELPER:
+      case DRINK_HELPER:
         // Consumption helpers are removed above when you
         // successfully eat or drink.
 
-      case NO_CONSUME:
+      case NONE:
         return;
 
-      case MESSAGE_DISPLAY:
+      case USE_MESSAGE_DISPLAY:
         if (!Preferences.getBoolean("suppressNegativeStatusPopup")) {
           UseItemRequest.showItemUsage(showHTML, responseText);
         }
@@ -5943,15 +5943,15 @@ public class UseItemRequest extends GenericRequest {
     // Finally, remove the item from inventory if it was successfully used.
 
     switch (consumptionType) {
-      case CONSUME_ZAP:
-      case EQUIP_FAMILIAR:
-      case EQUIP_ACCESSORY:
-      case EQUIP_HAT:
-      case EQUIP_PANTS:
-      case EQUIP_WEAPON:
-      case EQUIP_OFFHAND:
-      case EQUIP_CONTAINER:
-      case INFINITE_USES:
+      case ZAP:
+      case FAMILIAR_EQUIPMENT:
+      case ACCESSORY:
+      case HAT:
+      case PANTS:
+      case WEAPON:
+      case OFFHAND:
+      case CONTAINER:
+      case USE_INFINITE:
         break;
 
       default:
@@ -6337,14 +6337,14 @@ public class UseItemRequest extends GenericRequest {
     String useString = null;
 
     switch (consumptionType) {
-      case NO_CONSUME:
+      case NONE:
         if (itemId != ItemPool.LOATHING_LEGION_JACKHAMMER) {
           return false;
         }
         break;
 
-      case CONSUME_USE:
-      case CONSUME_MULTIPLE:
+      case USE:
+      case USE_MULTIPLE:
 
         // See if it is a concoction
         if (SingleUseRequest.registerRequest(urlString)
@@ -6353,11 +6353,11 @@ public class UseItemRequest extends GenericRequest {
         }
         break;
 
-      case CONSUME_EAT:
+      case EAT:
 
         // Fortune cookies, for example
         if (urlString.startsWith("inv_use")) {
-          consumptionType = ConsumptionType.CONSUME_USE;
+          consumptionType = ConsumptionType.USE;
           break;
         }
         break;

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -145,7 +145,7 @@ public class UseItemRequest extends GenericRequest {
   }
 
   public static final UseItemRequest getInstance(
-          final ConsumptionType consumptionType, final AdventureResult item) {
+      final ConsumptionType consumptionType, final AdventureResult item) {
     switch (consumptionType) {
       case CONSUME_DRINK:
       case CONSUME_DRINK_HELPER:

--- a/src/net/sourceforge/kolmafia/session/ConsequenceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ConsequenceManager.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.ModifierExpression;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RequestLogger;
@@ -290,7 +291,7 @@ public abstract class ConsequenceManager {
       switch (type) {
         case "DESC_ITEM" -> {
           int itemId = ItemDatabase.getItemId(this.getSpec());
-          int equipType = ItemDatabase.getConsumptionType(itemId);
+          ConsumptionType equipType = ItemDatabase.getConsumptionType(itemId);
           mods =
               DebugDatabase.parseItemEnchantments(
                   match.replaceFirst(match.group(0)), new ArrayList<>(), equipType);

--- a/src/net/sourceforge/kolmafia/session/EquipmentManager.java
+++ b/src/net/sourceforge/kolmafia/session/EquipmentManager.java
@@ -1701,7 +1701,9 @@ public class EquipmentManager {
       // If we want off-hand items and we can dual wield,
       // allow one-handed weapons of same type
 
-      if (filterId == ConsumptionType.EQUIP_OFFHAND && type == ConsumptionType.EQUIP_WEAPON && dual) {
+      if (filterId == ConsumptionType.EQUIP_OFFHAND
+          && type == ConsumptionType.EQUIP_WEAPON
+          && dual) {
         if (EquipmentDatabase.isMainhandOnly(itemId)
             || EquipmentDatabase.getWeaponType(itemId) != weaponType) {
           continue;

--- a/src/net/sourceforge/kolmafia/session/EquipmentManager.java
+++ b/src/net/sourceforge/kolmafia/session/EquipmentManager.java
@@ -221,7 +221,7 @@ public class EquipmentManager {
     if (KoLCharacter.getFamiliar().canEquip(item)) {
       AdventureResult.addResultToList(
           EquipmentManager.equipmentLists.get(EquipmentManager.FAMILIAR), item);
-      if (ItemDatabase.getConsumptionType(itemId) == ConsumptionType.EQUIP_FAMILIAR) {
+      if (ItemDatabase.getConsumptionType(itemId) == ConsumptionType.FAMILIAR_EQUIPMENT) {
         return;
       }
       // Even though the familiar can use it, it's not a
@@ -234,9 +234,9 @@ public class EquipmentManager {
     }
 
     ConsumptionType consumeType = ItemDatabase.getConsumptionType(itemId);
-    if (consumeType == ConsumptionType.EQUIP_ACCESSORY) {
+    if (consumeType == ConsumptionType.ACCESSORY) {
       AdventureResult.addResultToList(EquipmentManager.accessories, item);
-    } else if (consumeType == ConsumptionType.CONSUME_STICKER) {
+    } else if (consumeType == ConsumptionType.STICKER) {
       // The stickers cannot be combined into a single list, as is done with
       // accessories, since stickers cannot be moved to a different slot.  If a
       // slot contains your last sticker of a particular type, then that type must
@@ -255,7 +255,7 @@ public class EquipmentManager {
           EquipmentManager.equipmentLists.get(slot).add(current);
         }
       }
-    } else if (consumeType == ConsumptionType.CONSUME_FOLDER) {
+    } else if (consumeType == ConsumptionType.FOLDER) {
       // Folders are similar to stickers
 
       for (int slot : EquipmentManager.FOLDER_SLOTS) {
@@ -421,15 +421,15 @@ public class EquipmentManager {
             AdventureResult offhand = EquipmentManager.getEquipment(OFFHAND);
             AdventureResult pants = EquipmentManager.getEquipment(PANTS);
             switch (consumption) {
-              case EQUIP_HAT:
+              case HAT:
                 removed = hat.getItemId() != old.getItemId();
                 break;
-              case EQUIP_WEAPON:
-              case EQUIP_OFFHAND:
+              case WEAPON:
+              case OFFHAND:
                 removed =
                     weapon.getItemId() != old.getItemId() && offhand.getItemId() != old.getItemId();
                 break;
-              case EQUIP_PANTS:
+              case PANTS:
                 removed = pants.getItemId() != old.getItemId();
                 break;
             }
@@ -1436,7 +1436,7 @@ public class EquipmentManager {
     AdventureResult offhand = EquipmentManager.equipment.get(EquipmentManager.OFFHAND);
 
     return !mainhand.equals(EquipmentRequest.UNEQUIP)
-        && ItemDatabase.getConsumptionType(offhand) == ConsumptionType.EQUIP_WEAPON;
+        && ItemDatabase.getConsumptionType(offhand) == ConsumptionType.WEAPON;
   }
 
   /**
@@ -1701,9 +1701,7 @@ public class EquipmentManager {
       // If we want off-hand items and we can dual wield,
       // allow one-handed weapons of same type
 
-      if (filterId == ConsumptionType.EQUIP_OFFHAND
-          && type == ConsumptionType.EQUIP_WEAPON
-          && dual) {
+      if (filterId == ConsumptionType.OFFHAND && type == ConsumptionType.WEAPON && dual) {
         if (EquipmentDatabase.isMainhandOnly(itemId)
             || EquipmentDatabase.getWeaponType(itemId) != weaponType) {
           continue;
@@ -1713,7 +1711,7 @@ public class EquipmentManager {
       // If we are equipping familiar items, make sure
       // current familiar can use this one
 
-      else if (filterId == ConsumptionType.EQUIP_FAMILIAR) {
+      else if (filterId == ConsumptionType.FAMILIAR_EQUIPMENT) {
         if (currentFamiliar.canEquip(currentItem)) {
           temporary.add(currentItem.getInstance(1));
         }
@@ -1725,7 +1723,7 @@ public class EquipmentManager {
 
       else if (filterId != type) {
         continue;
-      } else if (filterId == ConsumptionType.EQUIP_WEAPON && dual) {
+      } else if (filterId == ConsumptionType.WEAPON && dual) {
         if (EquipmentDatabase.getHands(itemId) == 1
             && EquipmentDatabase.getWeaponType(itemId) != weaponType) {
           continue;
@@ -1809,41 +1807,41 @@ public class EquipmentManager {
   public static final ConsumptionType equipmentTypeToConsumeFilter(final int equipmentType) {
     switch (equipmentType) {
       case EquipmentManager.HAT:
-        return ConsumptionType.EQUIP_HAT;
+        return ConsumptionType.HAT;
       case EquipmentManager.WEAPON:
-        return ConsumptionType.EQUIP_WEAPON;
+        return ConsumptionType.WEAPON;
       case EquipmentManager.OFFHAND:
-        return ConsumptionType.EQUIP_OFFHAND;
+        return ConsumptionType.OFFHAND;
       case EquipmentManager.SHIRT:
-        return ConsumptionType.EQUIP_SHIRT;
+        return ConsumptionType.SHIRT;
       case EquipmentManager.PANTS:
-        return ConsumptionType.EQUIP_PANTS;
+        return ConsumptionType.PANTS;
       case EquipmentManager.CONTAINER:
-        return ConsumptionType.EQUIP_CONTAINER;
+        return ConsumptionType.CONTAINER;
       case EquipmentManager.ACCESSORY1:
       case EquipmentManager.ACCESSORY2:
       case EquipmentManager.ACCESSORY3:
-        return ConsumptionType.EQUIP_ACCESSORY;
+        return ConsumptionType.ACCESSORY;
       case EquipmentManager.FAMILIAR:
-        return ConsumptionType.EQUIP_FAMILIAR;
+        return ConsumptionType.FAMILIAR_EQUIPMENT;
       case EquipmentManager.STICKER1:
       case EquipmentManager.STICKER2:
       case EquipmentManager.STICKER3:
-        return ConsumptionType.CONSUME_STICKER;
+        return ConsumptionType.STICKER;
       case EquipmentManager.CARDSLEEVE:
-        return ConsumptionType.CONSUME_CARD;
+        return ConsumptionType.CARD;
       case EquipmentManager.FOLDER1:
       case EquipmentManager.FOLDER2:
       case EquipmentManager.FOLDER3:
       case EquipmentManager.FOLDER4:
       case EquipmentManager.FOLDER5:
-        return ConsumptionType.CONSUME_FOLDER;
+        return ConsumptionType.FOLDER;
       case EquipmentManager.BOOTSKIN:
-        return ConsumptionType.CONSUME_BOOTSKIN;
+        return ConsumptionType.BOOTSKIN;
       case EquipmentManager.BOOTSPUR:
-        return ConsumptionType.CONSUME_BOOTSPUR;
+        return ConsumptionType.BOOTSPUR;
       case EquipmentManager.HOLSTER:
-        return ConsumptionType.CONSUME_SIXGUN;
+        return ConsumptionType.SIXGUN;
       default:
         return ConsumptionType.UNKNOWN;
     }
@@ -1851,20 +1849,20 @@ public class EquipmentManager {
 
   public static final int consumeFilterToEquipmentType(final ConsumptionType consumeFilter) {
     return switch (consumeFilter) {
-      case EQUIP_HAT -> EquipmentManager.HAT;
-      case EQUIP_WEAPON -> EquipmentManager.WEAPON;
-      case EQUIP_OFFHAND -> EquipmentManager.OFFHAND;
-      case EQUIP_SHIRT -> EquipmentManager.SHIRT;
-      case EQUIP_PANTS -> EquipmentManager.PANTS;
-      case EQUIP_CONTAINER -> EquipmentManager.CONTAINER;
-      case EQUIP_ACCESSORY -> EquipmentManager.ACCESSORY1;
-      case EQUIP_FAMILIAR -> EquipmentManager.FAMILIAR;
-      case CONSUME_STICKER -> EquipmentManager.STICKER1;
-      case CONSUME_CARD -> EquipmentManager.CARDSLEEVE;
-      case CONSUME_FOLDER -> EquipmentManager.FOLDER1;
-      case CONSUME_BOOTSKIN -> EquipmentManager.BOOTSKIN;
-      case CONSUME_BOOTSPUR -> EquipmentManager.BOOTSPUR;
-      case CONSUME_SIXGUN -> EquipmentManager.HOLSTER;
+      case HAT -> EquipmentManager.HAT;
+      case WEAPON -> EquipmentManager.WEAPON;
+      case OFFHAND -> EquipmentManager.OFFHAND;
+      case SHIRT -> EquipmentManager.SHIRT;
+      case PANTS -> EquipmentManager.PANTS;
+      case CONTAINER -> EquipmentManager.CONTAINER;
+      case ACCESSORY -> EquipmentManager.ACCESSORY1;
+      case FAMILIAR_EQUIPMENT -> EquipmentManager.FAMILIAR;
+      case STICKER -> EquipmentManager.STICKER1;
+      case CARD -> EquipmentManager.CARDSLEEVE;
+      case FOLDER -> EquipmentManager.FOLDER1;
+      case BOOTSKIN -> EquipmentManager.BOOTSKIN;
+      case BOOTSPUR -> EquipmentManager.BOOTSPUR;
+      case SIXGUN -> EquipmentManager.HOLSTER;
       default -> -1;
     };
   }
@@ -2211,15 +2209,15 @@ public class EquipmentManager {
 
     ConsumptionType type = ItemDatabase.getConsumptionType(itemId);
 
-    if (type == ConsumptionType.CONSUME_SIXGUN) {
+    if (type == ConsumptionType.SIXGUN) {
       return KoLCharacter.isAWoLClass();
     }
 
-    if (type == ConsumptionType.EQUIP_SHIRT && !KoLCharacter.isTorsoAware()) {
+    if (type == ConsumptionType.SHIRT && !KoLCharacter.isTorsoAware()) {
       return false;
     }
 
-    if (type == ConsumptionType.EQUIP_FAMILIAR) {
+    if (type == ConsumptionType.FAMILIAR_EQUIPMENT) {
       return KoLCharacter.getFamiliar().canEquip(ItemPool.get(itemId, 1));
     }
 
@@ -2228,12 +2226,12 @@ public class EquipmentManager {
     }
 
     if (KoLCharacter.inFistcore()
-        && (type == ConsumptionType.EQUIP_WEAPON || type == ConsumptionType.EQUIP_OFFHAND)) {
+        && (type == ConsumptionType.WEAPON || type == ConsumptionType.OFFHAND)) {
       return false;
     }
 
     if (KoLCharacter.inAxecore()
-        && (type == ConsumptionType.EQUIP_WEAPON || type == ConsumptionType.EQUIP_OFFHAND)) {
+        && (type == ConsumptionType.WEAPON || type == ConsumptionType.OFFHAND)) {
       return itemId == ItemPool.TRUSTY;
     }
 

--- a/src/net/sourceforge/kolmafia/session/EquipmentManager.java
+++ b/src/net/sourceforge/kolmafia/session/EquipmentManager.java
@@ -9,6 +9,7 @@ import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLConstants.Stat;
 import net.sourceforge.kolmafia.KoLConstants.WeaponType;
@@ -220,7 +221,7 @@ public class EquipmentManager {
     if (KoLCharacter.getFamiliar().canEquip(item)) {
       AdventureResult.addResultToList(
           EquipmentManager.equipmentLists.get(EquipmentManager.FAMILIAR), item);
-      if (ItemDatabase.getConsumptionType(itemId) == KoLConstants.EQUIP_FAMILIAR) {
+      if (ItemDatabase.getConsumptionType(itemId) == ConsumptionType.EQUIP_FAMILIAR) {
         return;
       }
       // Even though the familiar can use it, it's not a
@@ -232,10 +233,10 @@ public class EquipmentManager {
       return;
     }
 
-    int consumeType = ItemDatabase.getConsumptionType(itemId);
-    if (consumeType == KoLConstants.EQUIP_ACCESSORY) {
+    ConsumptionType consumeType = ItemDatabase.getConsumptionType(itemId);
+    if (consumeType == ConsumptionType.EQUIP_ACCESSORY) {
       AdventureResult.addResultToList(EquipmentManager.accessories, item);
-    } else if (consumeType == KoLConstants.CONSUME_STICKER) {
+    } else if (consumeType == ConsumptionType.CONSUME_STICKER) {
       // The stickers cannot be combined into a single list, as is done with
       // accessories, since stickers cannot be moved to a different slot.  If a
       // slot contains your last sticker of a particular type, then that type must
@@ -254,7 +255,7 @@ public class EquipmentManager {
           EquipmentManager.equipmentLists.get(slot).add(current);
         }
       }
-    } else if (consumeType == KoLConstants.CONSUME_FOLDER) {
+    } else if (consumeType == ConsumptionType.CONSUME_FOLDER) {
       // Folders are similar to stickers
 
       for (int slot : EquipmentManager.FOLDER_SLOTS) {
@@ -368,7 +369,7 @@ public class EquipmentManager {
 
     // Remove skill first if item being removed had one
     if (old.getItemId() != item.getItemId()) {
-      int consumption = ItemDatabase.getConsumptionType(old);
+      ConsumptionType consumption = ItemDatabase.getConsumptionType(old);
       boolean removed = true;
       // Some items could be in multiple slots
       switch (slot) {
@@ -420,15 +421,15 @@ public class EquipmentManager {
             AdventureResult offhand = EquipmentManager.getEquipment(OFFHAND);
             AdventureResult pants = EquipmentManager.getEquipment(PANTS);
             switch (consumption) {
-              case KoLConstants.EQUIP_HAT:
+              case EQUIP_HAT:
                 removed = hat.getItemId() != old.getItemId();
                 break;
-              case KoLConstants.EQUIP_WEAPON:
-              case KoLConstants.EQUIP_OFFHAND:
+              case EQUIP_WEAPON:
+              case EQUIP_OFFHAND:
                 removed =
                     weapon.getItemId() != old.getItemId() && offhand.getItemId() != old.getItemId();
                 break;
-              case KoLConstants.EQUIP_PANTS:
+              case EQUIP_PANTS:
                 removed = pants.getItemId() != old.getItemId();
                 break;
             }
@@ -1435,7 +1436,7 @@ public class EquipmentManager {
     AdventureResult offhand = EquipmentManager.equipment.get(EquipmentManager.OFFHAND);
 
     return !mainhand.equals(EquipmentRequest.UNEQUIP)
-        && ItemDatabase.getConsumptionType(offhand) == KoLConstants.EQUIP_WEAPON;
+        && ItemDatabase.getConsumptionType(offhand) == ConsumptionType.EQUIP_WEAPON;
   }
 
   /**
@@ -1612,8 +1613,8 @@ public class EquipmentManager {
   }
 
   public static final void updateEquipmentList(final int listIndex) {
-    int consumeFilter = EquipmentManager.equipmentTypeToConsumeFilter(listIndex);
-    if (consumeFilter == -1) {
+    ConsumptionType consumeFilter = EquipmentManager.equipmentTypeToConsumeFilter(listIndex);
+    if (consumeFilter == ConsumptionType.UNKNOWN) {
       return;
     }
 
@@ -1678,7 +1679,7 @@ public class EquipmentManager {
   }
 
   private static void updateEquipmentList(
-      final int filterId, final List<AdventureResult> currentList) {
+      final ConsumptionType filterId, final List<AdventureResult> currentList) {
     ArrayList<AdventureResult> temporary = new ArrayList<AdventureResult>();
     temporary.add(EquipmentRequest.UNEQUIP);
 
@@ -1695,12 +1696,12 @@ public class EquipmentManager {
       String currentItemName = currentItem.getName();
 
       int itemId = currentItem.getItemId();
-      int type = ItemDatabase.getConsumptionType(itemId);
+      ConsumptionType type = ItemDatabase.getConsumptionType(itemId);
 
       // If we want off-hand items and we can dual wield,
       // allow one-handed weapons of same type
 
-      if (filterId == KoLConstants.EQUIP_OFFHAND && type == KoLConstants.EQUIP_WEAPON && dual) {
+      if (filterId == ConsumptionType.EQUIP_OFFHAND && type == ConsumptionType.EQUIP_WEAPON && dual) {
         if (EquipmentDatabase.isMainhandOnly(itemId)
             || EquipmentDatabase.getWeaponType(itemId) != weaponType) {
           continue;
@@ -1710,7 +1711,7 @@ public class EquipmentManager {
       // If we are equipping familiar items, make sure
       // current familiar can use this one
 
-      else if (filterId == KoLConstants.EQUIP_FAMILIAR) {
+      else if (filterId == ConsumptionType.EQUIP_FAMILIAR) {
         if (currentFamiliar.canEquip(currentItem)) {
           temporary.add(currentItem.getInstance(1));
         }
@@ -1722,7 +1723,7 @@ public class EquipmentManager {
 
       else if (filterId != type) {
         continue;
-      } else if (filterId == KoLConstants.EQUIP_WEAPON && dual) {
+      } else if (filterId == ConsumptionType.EQUIP_WEAPON && dual) {
         if (EquipmentDatabase.getHands(itemId) == 1
             && EquipmentDatabase.getWeaponType(itemId) != weaponType) {
           continue;
@@ -1803,65 +1804,65 @@ public class EquipmentManager {
     EquipmentManager.updateNormalOutfits();
   }
 
-  public static final int equipmentTypeToConsumeFilter(final int equipmentType) {
+  public static final ConsumptionType equipmentTypeToConsumeFilter(final int equipmentType) {
     switch (equipmentType) {
       case EquipmentManager.HAT:
-        return KoLConstants.EQUIP_HAT;
+        return ConsumptionType.EQUIP_HAT;
       case EquipmentManager.WEAPON:
-        return KoLConstants.EQUIP_WEAPON;
+        return ConsumptionType.EQUIP_WEAPON;
       case EquipmentManager.OFFHAND:
-        return KoLConstants.EQUIP_OFFHAND;
+        return ConsumptionType.EQUIP_OFFHAND;
       case EquipmentManager.SHIRT:
-        return KoLConstants.EQUIP_SHIRT;
+        return ConsumptionType.EQUIP_SHIRT;
       case EquipmentManager.PANTS:
-        return KoLConstants.EQUIP_PANTS;
+        return ConsumptionType.EQUIP_PANTS;
       case EquipmentManager.CONTAINER:
-        return KoLConstants.EQUIP_CONTAINER;
+        return ConsumptionType.EQUIP_CONTAINER;
       case EquipmentManager.ACCESSORY1:
       case EquipmentManager.ACCESSORY2:
       case EquipmentManager.ACCESSORY3:
-        return KoLConstants.EQUIP_ACCESSORY;
+        return ConsumptionType.EQUIP_ACCESSORY;
       case EquipmentManager.FAMILIAR:
-        return KoLConstants.EQUIP_FAMILIAR;
+        return ConsumptionType.EQUIP_FAMILIAR;
       case EquipmentManager.STICKER1:
       case EquipmentManager.STICKER2:
       case EquipmentManager.STICKER3:
-        return KoLConstants.CONSUME_STICKER;
+        return ConsumptionType.CONSUME_STICKER;
       case EquipmentManager.CARDSLEEVE:
-        return KoLConstants.CONSUME_CARD;
+        return ConsumptionType.CONSUME_CARD;
       case EquipmentManager.FOLDER1:
       case EquipmentManager.FOLDER2:
       case EquipmentManager.FOLDER3:
       case EquipmentManager.FOLDER4:
       case EquipmentManager.FOLDER5:
-        return KoLConstants.CONSUME_FOLDER;
+        return ConsumptionType.CONSUME_FOLDER;
       case EquipmentManager.BOOTSKIN:
-        return KoLConstants.CONSUME_BOOTSKIN;
+        return ConsumptionType.CONSUME_BOOTSKIN;
       case EquipmentManager.BOOTSPUR:
-        return KoLConstants.CONSUME_BOOTSPUR;
+        return ConsumptionType.CONSUME_BOOTSPUR;
       case EquipmentManager.HOLSTER:
-        return KoLConstants.CONSUME_SIXGUN;
+        return ConsumptionType.CONSUME_SIXGUN;
       default:
-        return -1;
+        return ConsumptionType.UNKNOWN;
     }
   }
 
-  public static final int consumeFilterToEquipmentType(final int consumeFilter) {
+  public static final int consumeFilterToEquipmentType(final ConsumptionType consumeFilter) {
     return switch (consumeFilter) {
-      case KoLConstants.EQUIP_HAT -> EquipmentManager.HAT;
-      case KoLConstants.EQUIP_WEAPON -> EquipmentManager.WEAPON;
-      case KoLConstants.EQUIP_OFFHAND -> EquipmentManager.OFFHAND;
-      case KoLConstants.EQUIP_SHIRT -> EquipmentManager.SHIRT;
-      case KoLConstants.EQUIP_PANTS -> EquipmentManager.PANTS;
-      case KoLConstants.EQUIP_CONTAINER -> EquipmentManager.CONTAINER;
-      case KoLConstants.EQUIP_ACCESSORY -> EquipmentManager.ACCESSORY1;
-      case KoLConstants.EQUIP_FAMILIAR -> EquipmentManager.FAMILIAR;
-      case KoLConstants.CONSUME_STICKER -> EquipmentManager.STICKER1;
-      case KoLConstants.CONSUME_CARD -> EquipmentManager.CARDSLEEVE;
-      case KoLConstants.CONSUME_FOLDER -> EquipmentManager.FOLDER1;
-      case KoLConstants.CONSUME_BOOTSKIN -> EquipmentManager.BOOTSKIN;
-      case KoLConstants.CONSUME_BOOTSPUR -> EquipmentManager.BOOTSPUR;
-      case KoLConstants.CONSUME_SIXGUN -> EquipmentManager.HOLSTER;
+      case EQUIP_HAT -> EquipmentManager.HAT;
+      case EQUIP_WEAPON -> EquipmentManager.WEAPON;
+      case EQUIP_OFFHAND -> EquipmentManager.OFFHAND;
+      case EQUIP_SHIRT -> EquipmentManager.SHIRT;
+      case EQUIP_PANTS -> EquipmentManager.PANTS;
+      case EQUIP_CONTAINER -> EquipmentManager.CONTAINER;
+      case EQUIP_ACCESSORY -> EquipmentManager.ACCESSORY1;
+      case EQUIP_FAMILIAR -> EquipmentManager.FAMILIAR;
+      case CONSUME_STICKER -> EquipmentManager.STICKER1;
+      case CONSUME_CARD -> EquipmentManager.CARDSLEEVE;
+      case CONSUME_FOLDER -> EquipmentManager.FOLDER1;
+      case CONSUME_BOOTSKIN -> EquipmentManager.BOOTSKIN;
+      case CONSUME_BOOTSPUR -> EquipmentManager.BOOTSPUR;
+      case CONSUME_SIXGUN -> EquipmentManager.HOLSTER;
       default -> -1;
     };
   }
@@ -2206,17 +2207,17 @@ public class EquipmentManager {
       return false;
     }
 
-    int type = ItemDatabase.getConsumptionType(itemId);
+    ConsumptionType type = ItemDatabase.getConsumptionType(itemId);
 
-    if (type == KoLConstants.CONSUME_SIXGUN) {
+    if (type == ConsumptionType.CONSUME_SIXGUN) {
       return KoLCharacter.isAWoLClass();
     }
 
-    if (type == KoLConstants.EQUIP_SHIRT && !KoLCharacter.isTorsoAware()) {
+    if (type == ConsumptionType.EQUIP_SHIRT && !KoLCharacter.isTorsoAware()) {
       return false;
     }
 
-    if (type == KoLConstants.EQUIP_FAMILIAR) {
+    if (type == ConsumptionType.EQUIP_FAMILIAR) {
       return KoLCharacter.getFamiliar().canEquip(ItemPool.get(itemId, 1));
     }
 
@@ -2225,12 +2226,12 @@ public class EquipmentManager {
     }
 
     if (KoLCharacter.inFistcore()
-        && (type == KoLConstants.EQUIP_WEAPON || type == KoLConstants.EQUIP_OFFHAND)) {
+        && (type == ConsumptionType.EQUIP_WEAPON || type == ConsumptionType.EQUIP_OFFHAND)) {
       return false;
     }
 
     if (KoLCharacter.inAxecore()
-        && (type == KoLConstants.EQUIP_WEAPON || type == KoLConstants.EQUIP_OFFHAND)) {
+        && (type == ConsumptionType.EQUIP_WEAPON || type == ConsumptionType.EQUIP_OFFHAND)) {
       return itemId == ItemPool.TRUSTY;
     }
 

--- a/src/net/sourceforge/kolmafia/session/LocketManager.java
+++ b/src/net/sourceforge/kolmafia/session/LocketManager.java
@@ -9,7 +9,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.MonsterData;
 import net.sourceforge.kolmafia.RequestThread;
@@ -115,7 +115,7 @@ public class LocketManager {
 
     // The plan here is to parse the locket description...
     DebugDatabase.parseItemEnchantments(
-        responseText, mods, new ArrayList<>(), KoLConstants.EQUIP_ACCESSORY);
+        responseText, mods, new ArrayList<>(), ConsumptionType.EQUIP_ACCESSORY);
 
     // ...find the first modifier that can indicate the phylum...
     var indicativeMod =

--- a/src/net/sourceforge/kolmafia/session/LocketManager.java
+++ b/src/net/sourceforge/kolmafia/session/LocketManager.java
@@ -115,7 +115,7 @@ public class LocketManager {
 
     // The plan here is to parse the locket description...
     DebugDatabase.parseItemEnchantments(
-        responseText, mods, new ArrayList<>(), ConsumptionType.EQUIP_ACCESSORY);
+        responseText, mods, new ArrayList<>(), ConsumptionType.ACCESSORY);
 
     // ...find the first modifier that can indicate the phylum...
     var indicativeMod =

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -3210,8 +3210,7 @@ public class ResultProcessor {
           String rawText =
               DebugDatabase.rawItemDescriptionText(ItemDatabase.getDescriptionId(itemId), true);
           String mod =
-              DebugDatabase.parseItemEnchantments(
-                  rawText, new ArrayList<>(), ConsumptionType.EQUIP_HAT);
+              DebugDatabase.parseItemEnchantments(rawText, new ArrayList<>(), ConsumptionType.HAT);
           Modifiers.overrideModifier("Item:[" + itemId + "]", mod);
           Preferences.setString("_noHatModifier", mod);
         }

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -13,6 +13,7 @@ import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.MonsterData;
@@ -3210,7 +3211,7 @@ public class ResultProcessor {
               DebugDatabase.rawItemDescriptionText(ItemDatabase.getDescriptionId(itemId), true);
           String mod =
               DebugDatabase.parseItemEnchantments(
-                  rawText, new ArrayList<>(), KoLConstants.EQUIP_HAT);
+                  rawText, new ArrayList<>(), ConsumptionType.EQUIP_HAT);
           Modifiers.overrideModifier("Item:[" + itemId + "]", mod);
           Preferences.setString("_noHatModifier", mod);
         }

--- a/src/net/sourceforge/kolmafia/session/SpadingManager.java
+++ b/src/net/sourceforge/kolmafia/session/SpadingManager.java
@@ -33,19 +33,19 @@ public class SpadingManager {
 
     public static SpadingEvent fromKoLConstant(final ConsumptionType constant) {
       switch (constant) {
-        case CONSUME_EAT:
+        case EAT:
           return SpadingEvent.CONSUME_EAT;
-        case CONSUME_DRINK:
+        case DRINK:
           return SpadingEvent.CONSUME_DRINK;
-        case CONSUME_SPLEEN:
+        case SPLEEN:
           return SpadingEvent.CONSUME_SPLEEN;
-        case CONSUME_USE:
+        case USE:
           return SpadingEvent.CONSUME_USE;
-        case CONSUME_MULTIPLE:
+        case USE_MULTIPLE:
           return SpadingEvent.CONSUME_MULTIPLE;
-        case INFINITE_USES:
+        case USE_INFINITE:
           return SpadingEvent.CONSUME_REUSABLE;
-        case MESSAGE_DISPLAY:
+        case USE_MESSAGE_DISPLAY:
           return SpadingEvent.CONSUME_MESSAGE;
         default:
           return null;

--- a/src/net/sourceforge/kolmafia/session/SpadingManager.java
+++ b/src/net/sourceforge/kolmafia/session/SpadingManager.java
@@ -3,7 +3,7 @@ package net.sourceforge.kolmafia.session;
 import java.io.File;
 import java.util.List;
 import net.sourceforge.kolmafia.AdventureResult;
-import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.KoLmafiaASH;
 import net.sourceforge.kolmafia.KoLmafiaCLI;
@@ -31,21 +31,21 @@ public class SpadingManager {
     PLACE,
     ;
 
-    public static SpadingEvent fromKoLConstant(final int constant) {
+    public static SpadingEvent fromKoLConstant(final ConsumptionType constant) {
       switch (constant) {
-        case KoLConstants.CONSUME_EAT:
+        case CONSUME_EAT:
           return SpadingEvent.CONSUME_EAT;
-        case KoLConstants.CONSUME_DRINK:
+        case CONSUME_DRINK:
           return SpadingEvent.CONSUME_DRINK;
-        case KoLConstants.CONSUME_SPLEEN:
+        case CONSUME_SPLEEN:
           return SpadingEvent.CONSUME_SPLEEN;
-        case KoLConstants.CONSUME_USE:
+        case CONSUME_USE:
           return SpadingEvent.CONSUME_USE;
-        case KoLConstants.CONSUME_MULTIPLE:
+        case CONSUME_MULTIPLE:
           return SpadingEvent.CONSUME_MULTIPLE;
-        case KoLConstants.INFINITE_USES:
+        case INFINITE_USES:
           return SpadingEvent.CONSUME_REUSABLE;
-        case KoLConstants.MESSAGE_DISPLAY:
+        case MESSAGE_DISPLAY:
           return SpadingEvent.CONSUME_MESSAGE;
         default:
           return null;
@@ -84,7 +84,7 @@ public class SpadingManager {
   }
 
   public static boolean processConsume(
-      final int consumptionType, final String itemName, final String responseText) {
+      final ConsumptionType consumptionType, final String itemName, final String responseText) {
     SpadingEvent event = SpadingEvent.fromKoLConstant(consumptionType);
 
     if (event == null) {
@@ -99,7 +99,7 @@ public class SpadingManager {
       return false;
     }
 
-    int consumptionType = UseItemRequest.getConsumptionType(item);
+    ConsumptionType consumptionType = UseItemRequest.getConsumptionType(item);
 
     return SpadingManager.processConsume(
         consumptionType, item.getDisambiguatedName(), responseText);

--- a/src/net/sourceforge/kolmafia/session/YouRobotManager.java
+++ b/src/net/sourceforge/kolmafia/session/YouRobotManager.java
@@ -589,15 +589,15 @@ public abstract class YouRobotManager {
   // Used by EquipmentManager.canEquip
   public static boolean canEquip(final ConsumptionType type) {
     switch (type) {
-      case EQUIP_HAT:
+      case HAT:
         return hasEquipped(RobotUpgrade.MANNEQUIN_HEAD);
-      case EQUIP_WEAPON:
+      case WEAPON:
         return hasEquipped(RobotUpgrade.VICE_GRIPS);
-      case EQUIP_OFFHAND:
+      case OFFHAND:
         return hasEquipped(RobotUpgrade.OMNI_CLAW);
-      case EQUIP_SHIRT:
+      case SHIRT:
         return hasEquipped(RobotUpgrade.TOPOLOGY_GRID);
-      case EQUIP_PANTS:
+      case PANTS:
         return hasEquipped(RobotUpgrade.ROBO_LEGS);
     }
 

--- a/src/net/sourceforge/kolmafia/session/YouRobotManager.java
+++ b/src/net/sourceforge/kolmafia/session/YouRobotManager.java
@@ -11,7 +11,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.listener.NamedListenerRegistry;
@@ -587,17 +587,17 @@ public abstract class YouRobotManager {
   }
 
   // Used by EquipmentManager.canEquip
-  public static boolean canEquip(final int type) {
+  public static boolean canEquip(final ConsumptionType type) {
     switch (type) {
-      case KoLConstants.EQUIP_HAT:
+      case EQUIP_HAT:
         return hasEquipped(RobotUpgrade.MANNEQUIN_HEAD);
-      case KoLConstants.EQUIP_WEAPON:
+      case EQUIP_WEAPON:
         return hasEquipped(RobotUpgrade.VICE_GRIPS);
-      case KoLConstants.EQUIP_OFFHAND:
+      case EQUIP_OFFHAND:
         return hasEquipped(RobotUpgrade.OMNI_CLAW);
-      case KoLConstants.EQUIP_SHIRT:
+      case EQUIP_SHIRT:
         return hasEquipped(RobotUpgrade.TOPOLOGY_GRID);
-      case KoLConstants.EQUIP_PANTS:
+      case EQUIP_PANTS:
         return hasEquipped(RobotUpgrade.ROBO_LEGS);
     }
 

--- a/src/net/sourceforge/kolmafia/swingui/ItemManageFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/ItemManageFrame.java
@@ -480,7 +480,8 @@ public class ItemManageFrame extends GenericFrame {
         return super.getDesiredItemAmount(item, itemName, itemCount, message, quantityType);
       }
 
-      ConsumptionType consumptionType = ItemDatabase.getConsumptionType(((AdventureResult) item).getItemId());
+      ConsumptionType consumptionType =
+          ItemDatabase.getConsumptionType(((AdventureResult) item).getItemId());
       switch (consumptionType) {
         case EQUIP_HAT:
         case EQUIP_PANTS:

--- a/src/net/sourceforge/kolmafia/swingui/ItemManageFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/ItemManageFrame.java
@@ -483,12 +483,12 @@ public class ItemManageFrame extends GenericFrame {
       ConsumptionType consumptionType =
           ItemDatabase.getConsumptionType(((AdventureResult) item).getItemId());
       switch (consumptionType) {
-        case EQUIP_HAT:
-        case EQUIP_PANTS:
-        case EQUIP_SHIRT:
-        case EQUIP_CONTAINER:
-        case EQUIP_WEAPON:
-        case EQUIP_OFFHAND:
+        case HAT:
+        case PANTS:
+        case SHIRT:
+        case CONTAINER:
+        case WEAPON:
+        case OFFHAND:
           return 1;
 
         default:

--- a/src/net/sourceforge/kolmafia/swingui/ItemManageFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/ItemManageFrame.java
@@ -23,6 +23,7 @@ import net.java.dev.spellcast.utilities.SortedListModel;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.RestrictedItemType;
@@ -479,14 +480,14 @@ public class ItemManageFrame extends GenericFrame {
         return super.getDesiredItemAmount(item, itemName, itemCount, message, quantityType);
       }
 
-      int consumptionType = ItemDatabase.getConsumptionType(((AdventureResult) item).getItemId());
+      ConsumptionType consumptionType = ItemDatabase.getConsumptionType(((AdventureResult) item).getItemId());
       switch (consumptionType) {
-        case KoLConstants.EQUIP_HAT:
-        case KoLConstants.EQUIP_PANTS:
-        case KoLConstants.EQUIP_SHIRT:
-        case KoLConstants.EQUIP_CONTAINER:
-        case KoLConstants.EQUIP_WEAPON:
-        case KoLConstants.EQUIP_OFFHAND:
+        case EQUIP_HAT:
+        case EQUIP_PANTS:
+        case EQUIP_SHIRT:
+        case EQUIP_CONTAINER:
+        case EQUIP_WEAPON:
+        case EQUIP_OFFHAND:
           return 1;
 
         default:

--- a/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
@@ -29,6 +29,7 @@ import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.KoLmafiaGUI;
 import net.sourceforge.kolmafia.Modeable;
@@ -971,15 +972,15 @@ public class GearChangePanel extends JPanel {
 
     // Certain familiars can carry non-familiar-items
     FamiliarData myFamiliar = KoLCharacter.getFamiliar();
-    int specialFamiliarType = myFamiliar.specialEquipmentType();
-    boolean specialFamiliar = (specialFamiliarType != KoLConstants.NO_CONSUME);
+    ConsumptionType specialFamiliarType = myFamiliar.specialEquipmentType();
+    boolean specialFamiliar = (specialFamiliarType != ConsumptionType.NO_CONSUME);
 
     // Look at every item in inventory
     for (AdventureResult item : KoLConstants.inventory) {
-      int consumption = ItemDatabase.getConsumptionType(item.getItemId());
+      ConsumptionType consumption = ItemDatabase.getConsumptionType(item.getItemId());
       int slot = EquipmentManager.consumeFilterToEquipmentType(consumption);
       switch (consumption) {
-        case KoLConstants.EQUIP_WEAPON:
+        case EQUIP_WEAPON:
           if (this.shouldAddItem(item, consumption, EquipmentManager.WEAPON)) {
             lists.get(EquipmentManager.WEAPON).add(item);
           }
@@ -988,7 +989,7 @@ public class GearChangePanel extends JPanel {
           }
           break;
 
-        case KoLConstants.EQUIP_ACCESSORY:
+        case EQUIP_ACCESSORY:
           if (this.shouldAddItem(item, consumption, slot)) {
             lists.get(EquipmentManager.ACCESSORY1).add(item);
             lists.get(EquipmentManager.ACCESSORY2).add(item);
@@ -997,7 +998,7 @@ public class GearChangePanel extends JPanel {
           break;
 
           /*
-          case KoLConstants.CONSUME_STICKER:
+          case CONSUME_STICKER:
             if (this.shouldAddItem(item, consumption, slot)) {
               lists.get(EquipmentManager.STICKER1).add(item);
               lists.get(EquipmentManager.STICKER2).add(item);
@@ -1005,7 +1006,7 @@ public class GearChangePanel extends JPanel {
             }
             break;
 
-          case KoLConstants.CONSUME_FOLDER:
+          case CONSUME_FOLDER:
             if (this.shouldAddItem(item, consumption, slot)) {
               lists.get(EquipmentManager.FOLDER1).add(item);
               lists.get(EquipmentManager.FOLDER2).add(item);
@@ -1075,37 +1076,37 @@ public class GearChangePanel extends JPanel {
     return this.shouldAddItem(item, ItemDatabase.getConsumptionType(item.getItemId()), slot);
   }
 
-  private boolean shouldAddItem(AdventureResult item, int consumption, int slot) {
+  private boolean shouldAddItem(AdventureResult item, ConsumptionType consumption, int slot) {
     switch (consumption) {
         // The following lists are local to GearChanger
-      case KoLConstants.EQUIP_HAT:
-      case KoLConstants.EQUIP_SHIRT:
-      case KoLConstants.EQUIP_CONTAINER:
-      case KoLConstants.EQUIP_PANTS:
-      case KoLConstants.EQUIP_ACCESSORY:
-      case KoLConstants.CONSUME_BOOTSKIN:
-      case KoLConstants.CONSUME_BOOTSPUR:
-      case KoLConstants.CONSUME_SIXGUN:
+      case EQUIP_HAT:
+      case EQUIP_SHIRT:
+      case EQUIP_CONTAINER:
+      case EQUIP_PANTS:
+      case EQUIP_ACCESSORY:
+      case CONSUME_BOOTSKIN:
+      case CONSUME_BOOTSPUR:
+      case CONSUME_SIXGUN:
         break;
-      case KoLConstants.EQUIP_WEAPON:
+      case EQUIP_WEAPON:
         if (!this.filterWeapon(item, slot)) {
           return false;
         }
         break;
-      case KoLConstants.EQUIP_OFFHAND:
-        if (!this.filterOffhand(item, KoLConstants.EQUIP_OFFHAND)) {
+      case EQUIP_OFFHAND:
+        if (!this.filterOffhand(item, ConsumptionType.EQUIP_OFFHAND)) {
           return false;
         }
         break;
-      case KoLConstants.EQUIP_FAMILIAR:
+      case EQUIP_FAMILIAR:
         if (!KoLCharacter.getFamiliar().canEquip(item)) {
           return false;
         }
         break;
         // The following lists are in EquipmentManager
-      case KoLConstants.CONSUME_STICKER:
-      case KoLConstants.CONSUME_CARD:
-      case KoLConstants.CONSUME_FOLDER:
+      case CONSUME_STICKER:
+      case CONSUME_CARD:
+      case CONSUME_FOLDER:
         break;
       default:
         return false;
@@ -1120,7 +1121,7 @@ public class GearChangePanel extends JPanel {
     }
 
     if (slot == EquipmentManager.OFFHAND) {
-      return this.filterOffhand(weapon, KoLConstants.EQUIP_WEAPON);
+      return this.filterOffhand(weapon, ConsumptionType.EQUIP_WEAPON);
     }
 
     if (KoLCharacter.inAxecore()) {
@@ -1145,7 +1146,7 @@ public class GearChangePanel extends JPanel {
     }
   }
 
-  private boolean filterOffhand(final AdventureResult offhand, int consumption) {
+  private boolean filterOffhand(final AdventureResult offhand, ConsumptionType consumption) {
     // In Fistcore, you must have both hands free.
     // In Axecore, you can equip only Trusty, a two-handed axe
     if (KoLCharacter.inFistcore() || KoLCharacter.inAxecore()) {
@@ -1160,7 +1161,7 @@ public class GearChangePanel extends JPanel {
     }
 
     // Do not even consider weapons unless we can dual-wield
-    if (consumption == KoLConstants.EQUIP_WEAPON) {
+    if (consumption == ConsumptionType.EQUIP_WEAPON) {
       if (!KoLCharacter.hasSkill("Double-Fisted Skull Smashing")) {
         return false;
       }
@@ -1198,7 +1199,7 @@ public class GearChangePanel extends JPanel {
       return true;
     }
 
-    if (consumption == KoLConstants.EQUIP_WEAPON) {
+    if (consumption == ConsumptionType.EQUIP_WEAPON) {
       return this.offhandTypes[1].isSelected();
     }
 
@@ -1216,7 +1217,7 @@ public class GearChangePanel extends JPanel {
     return false;
   }
 
-  private boolean shouldAddItem(final AdventureResult item, final int type) {
+  private boolean shouldAddItem(final AdventureResult item, final ConsumptionType type) {
     // Only add items of specified type
     if (type != ItemDatabase.getConsumptionType(item.getItemId())) {
       return false;

--- a/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
@@ -973,14 +973,14 @@ public class GearChangePanel extends JPanel {
     // Certain familiars can carry non-familiar-items
     FamiliarData myFamiliar = KoLCharacter.getFamiliar();
     ConsumptionType specialFamiliarType = myFamiliar.specialEquipmentType();
-    boolean specialFamiliar = (specialFamiliarType != ConsumptionType.NO_CONSUME);
+    boolean specialFamiliar = (specialFamiliarType != ConsumptionType.NONE);
 
     // Look at every item in inventory
     for (AdventureResult item : KoLConstants.inventory) {
       ConsumptionType consumption = ItemDatabase.getConsumptionType(item.getItemId());
       int slot = EquipmentManager.consumeFilterToEquipmentType(consumption);
       switch (consumption) {
-        case EQUIP_WEAPON:
+        case WEAPON:
           if (this.shouldAddItem(item, consumption, EquipmentManager.WEAPON)) {
             lists.get(EquipmentManager.WEAPON).add(item);
           }
@@ -989,7 +989,7 @@ public class GearChangePanel extends JPanel {
           }
           break;
 
-        case EQUIP_ACCESSORY:
+        case ACCESSORY:
           if (this.shouldAddItem(item, consumption, slot)) {
             lists.get(EquipmentManager.ACCESSORY1).add(item);
             lists.get(EquipmentManager.ACCESSORY2).add(item);
@@ -1079,34 +1079,34 @@ public class GearChangePanel extends JPanel {
   private boolean shouldAddItem(AdventureResult item, ConsumptionType consumption, int slot) {
     switch (consumption) {
         // The following lists are local to GearChanger
-      case EQUIP_HAT:
-      case EQUIP_SHIRT:
-      case EQUIP_CONTAINER:
-      case EQUIP_PANTS:
-      case EQUIP_ACCESSORY:
-      case CONSUME_BOOTSKIN:
-      case CONSUME_BOOTSPUR:
-      case CONSUME_SIXGUN:
+      case HAT:
+      case SHIRT:
+      case CONTAINER:
+      case PANTS:
+      case ACCESSORY:
+      case BOOTSKIN:
+      case BOOTSPUR:
+      case SIXGUN:
         break;
-      case EQUIP_WEAPON:
+      case WEAPON:
         if (!this.filterWeapon(item, slot)) {
           return false;
         }
         break;
-      case EQUIP_OFFHAND:
-        if (!this.filterOffhand(item, ConsumptionType.EQUIP_OFFHAND)) {
+      case OFFHAND:
+        if (!this.filterOffhand(item, ConsumptionType.OFFHAND)) {
           return false;
         }
         break;
-      case EQUIP_FAMILIAR:
+      case FAMILIAR_EQUIPMENT:
         if (!KoLCharacter.getFamiliar().canEquip(item)) {
           return false;
         }
         break;
         // The following lists are in EquipmentManager
-      case CONSUME_STICKER:
-      case CONSUME_CARD:
-      case CONSUME_FOLDER:
+      case STICKER:
+      case CARD:
+      case FOLDER:
         break;
       default:
         return false;
@@ -1121,7 +1121,7 @@ public class GearChangePanel extends JPanel {
     }
 
     if (slot == EquipmentManager.OFFHAND) {
-      return this.filterOffhand(weapon, ConsumptionType.EQUIP_WEAPON);
+      return this.filterOffhand(weapon, ConsumptionType.WEAPON);
     }
 
     if (KoLCharacter.inAxecore()) {
@@ -1161,7 +1161,7 @@ public class GearChangePanel extends JPanel {
     }
 
     // Do not even consider weapons unless we can dual-wield
-    if (consumption == ConsumptionType.EQUIP_WEAPON) {
+    if (consumption == ConsumptionType.WEAPON) {
       if (!KoLCharacter.hasSkill("Double-Fisted Skull Smashing")) {
         return false;
       }
@@ -1199,7 +1199,7 @@ public class GearChangePanel extends JPanel {
       return true;
     }
 
-    if (consumption == ConsumptionType.EQUIP_WEAPON) {
+    if (consumption == ConsumptionType.WEAPON) {
       return this.offhandTypes[1].isSelected();
     }
 

--- a/src/net/sourceforge/kolmafia/swingui/panel/InventoryPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/InventoryPanel.java
@@ -11,6 +11,7 @@ import javax.swing.JRadioButton;
 import net.java.dev.spellcast.utilities.LockableListModel;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.request.CreateItemRequest;
@@ -142,35 +143,35 @@ public class InventoryPanel<E> extends ItemTableManagePanel<E> {
       }
 
       switch (ItemDatabase.getConsumptionType(itemId)) {
-        case KoLConstants.EQUIP_WEAPON:
+        case EQUIP_WEAPON:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(0).isSelected();
           break;
 
-        case KoLConstants.EQUIP_OFFHAND:
+        case EQUIP_OFFHAND:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(1).isSelected();
           break;
 
-        case KoLConstants.EQUIP_HAT:
+        case EQUIP_HAT:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(2).isSelected();
           break;
 
-        case KoLConstants.EQUIP_CONTAINER:
+        case EQUIP_CONTAINER:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(3).isSelected();
           break;
 
-        case KoLConstants.EQUIP_SHIRT:
+        case EQUIP_SHIRT:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(4).isSelected();
           break;
 
-        case KoLConstants.EQUIP_PANTS:
+        case EQUIP_PANTS:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(5).isSelected();
           break;
 
-        case KoLConstants.EQUIP_ACCESSORY:
+        case EQUIP_ACCESSORY:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(6).isSelected();
           break;
 
-        case KoLConstants.EQUIP_FAMILIAR:
+        case EQUIP_FAMILIAR:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(7).isSelected();
           break;
 
@@ -196,7 +197,7 @@ public class InventoryPanel<E> extends ItemTableManagePanel<E> {
       for (int i = 0; i < items.length; ++i) {
         AdventureResult item = items[i];
 
-        RequestThread.postRequest(UseItemRequest.getInstance(KoLConstants.CONSUME_SLIME, item));
+        RequestThread.postRequest(UseItemRequest.getInstance(ConsumptionType.CONSUME_SLIME, item));
       }
     }
 

--- a/src/net/sourceforge/kolmafia/swingui/panel/InventoryPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/InventoryPanel.java
@@ -143,35 +143,35 @@ public class InventoryPanel<E> extends ItemTableManagePanel<E> {
       }
 
       switch (ItemDatabase.getConsumptionType(itemId)) {
-        case EQUIP_WEAPON:
+        case WEAPON:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(0).isSelected();
           break;
 
-        case EQUIP_OFFHAND:
+        case OFFHAND:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(1).isSelected();
           break;
 
-        case EQUIP_HAT:
+        case HAT:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(2).isSelected();
           break;
 
-        case EQUIP_CONTAINER:
+        case CONTAINER:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(3).isSelected();
           break;
 
-        case EQUIP_SHIRT:
+        case SHIRT:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(4).isSelected();
           break;
 
-        case EQUIP_PANTS:
+        case PANTS:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(5).isSelected();
           break;
 
-        case EQUIP_ACCESSORY:
+        case ACCESSORY:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(6).isSelected();
           break;
 
-        case EQUIP_FAMILIAR:
+        case FAMILIAR_EQUIPMENT:
           isVisibleWithFilter = InventoryPanel.this.equipmentFilters.get(7).isSelected();
           break;
 
@@ -197,7 +197,7 @@ public class InventoryPanel<E> extends ItemTableManagePanel<E> {
       for (int i = 0; i < items.length; ++i) {
         AdventureResult item = items[i];
 
-        RequestThread.postRequest(UseItemRequest.getInstance(ConsumptionType.CONSUME_SLIME, item));
+        RequestThread.postRequest(UseItemRequest.getInstance(ConsumptionType.SLIMELING, item));
       }
     }
 

--- a/src/net/sourceforge/kolmafia/swingui/panel/ItemManagePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/ItemManagePanel.java
@@ -14,6 +14,7 @@ import net.java.dev.spellcast.utilities.LockableListModel;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.Modifiers;
@@ -467,9 +468,9 @@ public abstract class ItemManagePanel<E, S extends JComponent> extends Scrollabl
       id = ((AdventureResult) item).getItemId();
     }
     switch (ItemDatabase.getConsumptionType(id)) {
-      case KoLConstants.EQUIP_HAT:
+      case EQUIP_HAT:
         return Preferences.getInteger("usableHats");
-      case KoLConstants.EQUIP_WEAPON:
+      case EQUIP_WEAPON:
         switch (EquipmentDatabase.getHands(id)) {
           case 3:
             return Preferences.getInteger("usable3HWeapons");
@@ -478,13 +479,13 @@ public abstract class ItemManagePanel<E, S extends JComponent> extends Scrollabl
           default:
             return Preferences.getInteger("usable1HWeapons");
         }
-      case KoLConstants.EQUIP_OFFHAND:
+      case EQUIP_OFFHAND:
         return Preferences.getInteger("usableOffhands");
-      case KoLConstants.EQUIP_SHIRT:
+      case EQUIP_SHIRT:
         return Preferences.getInteger("usableShirts");
-      case KoLConstants.EQUIP_PANTS:
+      case EQUIP_PANTS:
         return Preferences.getInteger("usablePants");
-      case KoLConstants.EQUIP_ACCESSORY:
+      case EQUIP_ACCESSORY:
         Modifiers mods = Modifiers.getItemModifiers(id);
         if (mods != null && mods.getBoolean(Modifiers.SINGLE)) {
           return Preferences.getInteger("usable1xAccs");
@@ -571,17 +572,17 @@ public abstract class ItemManagePanel<E, S extends JComponent> extends Scrollabl
 
       for (int i = 0; i < items.length; ++i) {
         AdventureResult item = items[i];
-        int usageType = ItemDatabase.getConsumptionType(item.getItemId());
+        ConsumptionType usageType = ItemDatabase.getConsumptionType(item.getItemId());
 
         switch (usageType) {
-          case KoLConstants.EQUIP_FAMILIAR:
-          case KoLConstants.EQUIP_ACCESSORY:
-          case KoLConstants.EQUIP_HAT:
-          case KoLConstants.EQUIP_PANTS:
-          case KoLConstants.EQUIP_CONTAINER:
-          case KoLConstants.EQUIP_SHIRT:
-          case KoLConstants.EQUIP_WEAPON:
-          case KoLConstants.EQUIP_OFFHAND:
+          case EQUIP_FAMILIAR:
+          case EQUIP_ACCESSORY:
+          case EQUIP_HAT:
+          case EQUIP_PANTS:
+          case EQUIP_CONTAINER:
+          case EQUIP_SHIRT:
+          case EQUIP_WEAPON:
+          case EQUIP_OFFHAND:
             RequestThread.postRequest(
                 new EquipmentRequest(
                     item, EquipmentManager.consumeFilterToEquipmentType(usageType)));
@@ -818,22 +819,22 @@ public abstract class ItemManagePanel<E, S extends JComponent> extends Scrollabl
               : ItemDatabase.getItemId(name, 1, false);
 
       switch (ItemDatabase.getConsumptionType(itemId)) {
-        case KoLConstants.CONSUME_EAT:
+        case CONSUME_EAT:
           isVisibleWithFilter = FilterItemField.this.food;
           break;
 
-        case KoLConstants.CONSUME_DRINK:
+        case CONSUME_DRINK:
           isVisibleWithFilter = FilterItemField.this.booze;
           break;
 
-        case KoLConstants.EQUIP_HAT:
-        case KoLConstants.EQUIP_SHIRT:
-        case KoLConstants.EQUIP_WEAPON:
-        case KoLConstants.EQUIP_OFFHAND:
-        case KoLConstants.EQUIP_PANTS:
-        case KoLConstants.EQUIP_CONTAINER:
-        case KoLConstants.EQUIP_ACCESSORY:
-        case KoLConstants.EQUIP_FAMILIAR:
+        case EQUIP_HAT:
+        case EQUIP_SHIRT:
+        case EQUIP_WEAPON:
+        case EQUIP_OFFHAND:
+        case EQUIP_PANTS:
+        case EQUIP_CONTAINER:
+        case EQUIP_ACCESSORY:
+        case EQUIP_FAMILIAR:
           isVisibleWithFilter = FilterItemField.this.equip;
           break;
 

--- a/src/net/sourceforge/kolmafia/swingui/panel/ItemManagePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/ItemManagePanel.java
@@ -468,9 +468,9 @@ public abstract class ItemManagePanel<E, S extends JComponent> extends Scrollabl
       id = ((AdventureResult) item).getItemId();
     }
     switch (ItemDatabase.getConsumptionType(id)) {
-      case EQUIP_HAT:
+      case HAT:
         return Preferences.getInteger("usableHats");
-      case EQUIP_WEAPON:
+      case WEAPON:
         switch (EquipmentDatabase.getHands(id)) {
           case 3:
             return Preferences.getInteger("usable3HWeapons");
@@ -479,13 +479,13 @@ public abstract class ItemManagePanel<E, S extends JComponent> extends Scrollabl
           default:
             return Preferences.getInteger("usable1HWeapons");
         }
-      case EQUIP_OFFHAND:
+      case OFFHAND:
         return Preferences.getInteger("usableOffhands");
-      case EQUIP_SHIRT:
+      case SHIRT:
         return Preferences.getInteger("usableShirts");
-      case EQUIP_PANTS:
+      case PANTS:
         return Preferences.getInteger("usablePants");
-      case EQUIP_ACCESSORY:
+      case ACCESSORY:
         Modifiers mods = Modifiers.getItemModifiers(id);
         if (mods != null && mods.getBoolean(Modifiers.SINGLE)) {
           return Preferences.getInteger("usable1xAccs");
@@ -575,14 +575,14 @@ public abstract class ItemManagePanel<E, S extends JComponent> extends Scrollabl
         ConsumptionType usageType = ItemDatabase.getConsumptionType(item.getItemId());
 
         switch (usageType) {
-          case EQUIP_FAMILIAR:
-          case EQUIP_ACCESSORY:
-          case EQUIP_HAT:
-          case EQUIP_PANTS:
-          case EQUIP_CONTAINER:
-          case EQUIP_SHIRT:
-          case EQUIP_WEAPON:
-          case EQUIP_OFFHAND:
+          case FAMILIAR_EQUIPMENT:
+          case ACCESSORY:
+          case HAT:
+          case PANTS:
+          case CONTAINER:
+          case SHIRT:
+          case WEAPON:
+          case OFFHAND:
             RequestThread.postRequest(
                 new EquipmentRequest(
                     item, EquipmentManager.consumeFilterToEquipmentType(usageType)));
@@ -819,22 +819,22 @@ public abstract class ItemManagePanel<E, S extends JComponent> extends Scrollabl
               : ItemDatabase.getItemId(name, 1, false);
 
       switch (ItemDatabase.getConsumptionType(itemId)) {
-        case CONSUME_EAT:
+        case EAT:
           isVisibleWithFilter = FilterItemField.this.food;
           break;
 
-        case CONSUME_DRINK:
+        case DRINK:
           isVisibleWithFilter = FilterItemField.this.booze;
           break;
 
-        case EQUIP_HAT:
-        case EQUIP_SHIRT:
-        case EQUIP_WEAPON:
-        case EQUIP_OFFHAND:
-        case EQUIP_PANTS:
-        case EQUIP_CONTAINER:
-        case EQUIP_ACCESSORY:
-        case EQUIP_FAMILIAR:
+        case HAT:
+        case SHIRT:
+        case WEAPON:
+        case OFFHAND:
+        case PANTS:
+        case CONTAINER:
+        case ACCESSORY:
+        case FAMILIAR_EQUIPMENT:
           isVisibleWithFilter = FilterItemField.this.equip;
           break;
 

--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemDequeuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemDequeuePanel.java
@@ -9,7 +9,7 @@ import javax.swing.JTabbedPane;
 import javax.swing.ListSelectionModel;
 import net.java.dev.spellcast.utilities.LockableListModel;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLmafiaGUI;
 import net.sourceforge.kolmafia.listener.Listener;
 import net.sourceforge.kolmafia.listener.NamedListenerRegistry;
@@ -143,22 +143,22 @@ public class UseItemDequeuePanel extends ItemListManagePanel<QueuedConcoction> i
     protected void execute() {
       switch (UseItemDequeuePanel.this.type) {
         case FOOD:
-          ConcoctionDatabase.handleQueue(type, KoLConstants.CONSUME_EAT);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_EAT);
           UseItemDequeuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedFullness() + " Full Queued");
           break;
         case BOOZE:
-          ConcoctionDatabase.handleQueue(type, KoLConstants.CONSUME_DRINK);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_DRINK);
           UseItemDequeuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedInebriety() + " Drunk Queued");
           break;
         case SPLEEN:
-          ConcoctionDatabase.handleQueue(type, KoLConstants.CONSUME_SPLEEN);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_SPLEEN);
           UseItemDequeuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedSpleenHit() + " Spleen Queued");
           break;
         case POTION:
-          ConcoctionDatabase.handleQueue(type, KoLConstants.CONSUME_USE);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_USE);
           break;
       }
       ConcoctionDatabase.getUsables().sort();
@@ -175,17 +175,17 @@ public class UseItemDequeuePanel extends ItemListManagePanel<QueuedConcoction> i
     protected void execute() {
       switch (UseItemDequeuePanel.this.type) {
         case FOOD:
-          ConcoctionDatabase.handleQueue(type, KoLConstants.NO_CONSUME);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.NO_CONSUME);
           UseItemDequeuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedFullness() + " Full Queued");
           break;
         case BOOZE:
-          ConcoctionDatabase.handleQueue(type, KoLConstants.NO_CONSUME);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.NO_CONSUME);
           UseItemDequeuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedInebriety() + " Drunk Queued");
           break;
         case POTION:
-          ConcoctionDatabase.handleQueue(type, KoLConstants.NO_CONSUME);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.NO_CONSUME);
           break;
       }
       ConcoctionDatabase.getUsables().sort();

--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemDequeuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemDequeuePanel.java
@@ -143,22 +143,22 @@ public class UseItemDequeuePanel extends ItemListManagePanel<QueuedConcoction> i
     protected void execute() {
       switch (UseItemDequeuePanel.this.type) {
         case FOOD:
-          ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_EAT);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.EAT);
           UseItemDequeuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedFullness() + " Full Queued");
           break;
         case BOOZE:
-          ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_DRINK);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.DRINK);
           UseItemDequeuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedInebriety() + " Drunk Queued");
           break;
         case SPLEEN:
-          ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_SPLEEN);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.SPLEEN);
           UseItemDequeuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedSpleenHit() + " Spleen Queued");
           break;
         case POTION:
-          ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_USE);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.USE);
           break;
       }
       ConcoctionDatabase.getUsables().sort();
@@ -175,17 +175,17 @@ public class UseItemDequeuePanel extends ItemListManagePanel<QueuedConcoction> i
     protected void execute() {
       switch (UseItemDequeuePanel.this.type) {
         case FOOD:
-          ConcoctionDatabase.handleQueue(type, ConsumptionType.NO_CONSUME);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.NONE);
           UseItemDequeuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedFullness() + " Full Queued");
           break;
         case BOOZE:
-          ConcoctionDatabase.handleQueue(type, ConsumptionType.NO_CONSUME);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.NONE);
           UseItemDequeuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedInebriety() + " Drunk Queued");
           break;
         case POTION:
-          ConcoctionDatabase.handleQueue(type, ConsumptionType.NO_CONSUME);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.NONE);
           break;
       }
       ConcoctionDatabase.getUsables().sort();

--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
@@ -443,21 +443,21 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
 
       switch (type) {
         case FOOD -> {
-          ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_EAT);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.EAT);
           UseItemEnqueuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedFullness() + " Full Queued");
         }
         case BOOZE -> {
-          ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_DRINK);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.DRINK);
           UseItemEnqueuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedInebriety() + " Drunk Queued");
         }
         case SPLEEN -> {
-          ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_SPLEEN);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.SPLEEN);
           UseItemEnqueuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedSpleenHit() + " Spleen Queued");
         }
-        case POTION -> ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_USE);
+        case POTION -> ConcoctionDatabase.handleQueue(type, ConsumptionType.USE);
       }
       ConcoctionDatabase.getUsables().sort();
     }
@@ -476,7 +476,7 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
 
     @Override
     public void handleQueue() {
-      ConcoctionDatabase.handleQueue(ConcoctionType.FOOD, ConsumptionType.CONSUME_GHOST);
+      ConcoctionDatabase.handleQueue(ConcoctionType.FOOD, ConsumptionType.GLUTTONOUS_GHOST);
     }
 
     @Override
@@ -498,7 +498,7 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
 
     @Override
     public void handleQueue() {
-      ConcoctionDatabase.handleQueue(ConcoctionType.BOOZE, ConsumptionType.CONSUME_HOBO);
+      ConcoctionDatabase.handleQueue(ConcoctionType.BOOZE, ConsumptionType.SPIRIT_HOBO);
     }
 
     @Override
@@ -707,19 +707,19 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
         }
       } else
         switch (ItemDatabase.getConsumptionType(creation.getItemId())) {
-          case CONSUME_FOOD_HELPER:
+          case FOOD_HELPER:
             if (type != ConcoctionType.FOOD) {
               return false;
             }
             return super.isVisible(element);
 
-          case CONSUME_DRINK_HELPER:
+          case DRINK_HELPER:
             if (type != ConcoctionType.BOOZE) {
               return false;
             }
             return super.isVisible(element);
 
-          case CONSUME_USE:
+          case USE:
             if (type == ConcoctionType.BOOZE) {
               if (creation.getItemId() != ItemPool.ICE_STEIN) {
                 return false;
@@ -735,7 +735,7 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
             }
             return super.isVisible(element);
 
-          case CONSUME_MULTIPLE:
+          case USE_MULTIPLE:
             if ((type == ConcoctionType.BOOZE) || (type == ConcoctionType.SPLEEN)) {
               return false;
             }
@@ -748,8 +748,8 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
             }
             return super.isVisible(element);
 
-          case CONSUME_POTION:
-          case CONSUME_AVATAR:
+          case POTION:
+          case AVATAR_POTION:
             if (type != ConcoctionType.POTION) {
               return false;
             }

--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
@@ -19,6 +19,7 @@ import net.java.dev.spellcast.utilities.LockableListModel;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.CraftingType;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
@@ -442,21 +443,21 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
 
       switch (type) {
         case FOOD -> {
-          ConcoctionDatabase.handleQueue(type, KoLConstants.CONSUME_EAT);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_EAT);
           UseItemEnqueuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedFullness() + " Full Queued");
         }
         case BOOZE -> {
-          ConcoctionDatabase.handleQueue(type, KoLConstants.CONSUME_DRINK);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_DRINK);
           UseItemEnqueuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedInebriety() + " Drunk Queued");
         }
         case SPLEEN -> {
-          ConcoctionDatabase.handleQueue(type, KoLConstants.CONSUME_SPLEEN);
+          ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_SPLEEN);
           UseItemEnqueuePanel.this.queueTabs.setTitleAt(
               0, ConcoctionDatabase.getQueuedSpleenHit() + " Spleen Queued");
         }
-        case POTION -> ConcoctionDatabase.handleQueue(type, KoLConstants.CONSUME_USE);
+        case POTION -> ConcoctionDatabase.handleQueue(type, ConsumptionType.CONSUME_USE);
       }
       ConcoctionDatabase.getUsables().sort();
     }
@@ -475,7 +476,7 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
 
     @Override
     public void handleQueue() {
-      ConcoctionDatabase.handleQueue(ConcoctionType.FOOD, KoLConstants.CONSUME_GHOST);
+      ConcoctionDatabase.handleQueue(ConcoctionType.FOOD, ConsumptionType.CONSUME_GHOST);
     }
 
     @Override
@@ -497,7 +498,7 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
 
     @Override
     public void handleQueue() {
-      ConcoctionDatabase.handleQueue(ConcoctionType.BOOZE, KoLConstants.CONSUME_HOBO);
+      ConcoctionDatabase.handleQueue(ConcoctionType.BOOZE, ConsumptionType.CONSUME_HOBO);
     }
 
     @Override
@@ -706,19 +707,19 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
         }
       } else
         switch (ItemDatabase.getConsumptionType(creation.getItemId())) {
-          case KoLConstants.CONSUME_FOOD_HELPER:
+          case CONSUME_FOOD_HELPER:
             if (type != ConcoctionType.FOOD) {
               return false;
             }
             return super.isVisible(element);
 
-          case KoLConstants.CONSUME_DRINK_HELPER:
+          case CONSUME_DRINK_HELPER:
             if (type != ConcoctionType.BOOZE) {
               return false;
             }
             return super.isVisible(element);
 
-          case KoLConstants.CONSUME_USE:
+          case CONSUME_USE:
             if (type == ConcoctionType.BOOZE) {
               if (creation.getItemId() != ItemPool.ICE_STEIN) {
                 return false;
@@ -734,7 +735,7 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
             }
             return super.isVisible(element);
 
-          case KoLConstants.CONSUME_MULTIPLE:
+          case CONSUME_MULTIPLE:
             if ((type == ConcoctionType.BOOZE) || (type == ConcoctionType.SPLEEN)) {
               return false;
             }
@@ -747,8 +748,8 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
             }
             return super.isVisible(element);
 
-          case KoLConstants.CONSUME_POTION:
-          case KoLConstants.CONSUME_AVATAR:
+          case CONSUME_POTION:
+          case CONSUME_AVATAR:
             if (type != ConcoctionType.POTION) {
               return false;
             }

--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemPanel.java
@@ -57,33 +57,33 @@ public class UseItemPanel extends InventoryPanel<AdventureResult> {
       boolean filter = false;
 
       switch (ItemDatabase.getConsumptionType(itemId)) {
-        case CONSUME_EAT:
+        case EAT:
           filter = UsableItemFilterField.this.food;
           break;
 
-        case CONSUME_DRINK:
+        case DRINK:
           filter = UsableItemFilterField.this.booze;
           break;
 
-        case CONSUME_USE:
-        case CONSUME_SPLEEN:
-        case MESSAGE_DISPLAY:
-        case INFINITE_USES:
-        case CONSUME_MULTIPLE:
-        case CONSUME_AVATAR:
-        case GROW_FAMILIAR:
-        case CONSUME_ZAP:
+        case USE:
+        case SPLEEN:
+        case USE_MESSAGE_DISPLAY:
+        case USE_INFINITE:
+        case USE_MULTIPLE:
+        case AVATAR_POTION:
+        case FAMILIAR_HATCHLING:
+        case ZAP:
           filter = UsableItemFilterField.this.other;
           break;
 
-        case EQUIP_FAMILIAR:
-        case EQUIP_ACCESSORY:
-        case EQUIP_HAT:
-        case EQUIP_PANTS:
-        case EQUIP_CONTAINER:
-        case EQUIP_SHIRT:
-        case EQUIP_WEAPON:
-        case EQUIP_OFFHAND:
+        case FAMILIAR_EQUIPMENT:
+        case ACCESSORY:
+        case HAT:
+        case PANTS:
+        case CONTAINER:
+        case SHIRT:
+        case WEAPON:
+        case OFFHAND:
           filter = UsableItemFilterField.this.equip;
           break;
 

--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemPanel.java
@@ -57,33 +57,33 @@ public class UseItemPanel extends InventoryPanel<AdventureResult> {
       boolean filter = false;
 
       switch (ItemDatabase.getConsumptionType(itemId)) {
-        case KoLConstants.CONSUME_EAT:
+        case CONSUME_EAT:
           filter = UsableItemFilterField.this.food;
           break;
 
-        case KoLConstants.CONSUME_DRINK:
+        case CONSUME_DRINK:
           filter = UsableItemFilterField.this.booze;
           break;
 
-        case KoLConstants.CONSUME_USE:
-        case KoLConstants.CONSUME_SPLEEN:
-        case KoLConstants.MESSAGE_DISPLAY:
-        case KoLConstants.INFINITE_USES:
-        case KoLConstants.CONSUME_MULTIPLE:
-        case KoLConstants.CONSUME_AVATAR:
-        case KoLConstants.GROW_FAMILIAR:
-        case KoLConstants.CONSUME_ZAP:
+        case CONSUME_USE:
+        case CONSUME_SPLEEN:
+        case MESSAGE_DISPLAY:
+        case INFINITE_USES:
+        case CONSUME_MULTIPLE:
+        case CONSUME_AVATAR:
+        case GROW_FAMILIAR:
+        case CONSUME_ZAP:
           filter = UsableItemFilterField.this.other;
           break;
 
-        case KoLConstants.EQUIP_FAMILIAR:
-        case KoLConstants.EQUIP_ACCESSORY:
-        case KoLConstants.EQUIP_HAT:
-        case KoLConstants.EQUIP_PANTS:
-        case KoLConstants.EQUIP_CONTAINER:
-        case KoLConstants.EQUIP_SHIRT:
-        case KoLConstants.EQUIP_WEAPON:
-        case KoLConstants.EQUIP_OFFHAND:
+        case EQUIP_FAMILIAR:
+        case EQUIP_ACCESSORY:
+        case EQUIP_HAT:
+        case EQUIP_PANTS:
+        case EQUIP_CONTAINER:
+        case EQUIP_SHIRT:
+        case EQUIP_WEAPON:
+        case EQUIP_OFFHAND:
           filter = UsableItemFilterField.this.equip;
           break;
 

--- a/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
@@ -12,6 +12,7 @@ import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.CraftingType;
 import net.sourceforge.kolmafia.KoLGUIConstants;
 import net.sourceforge.kolmafia.Modifiers;
@@ -750,12 +751,12 @@ public class ListCellRendererFactory {
       }
 
       AdventureResult ar = (AdventureResult) value;
-      int equipmentType = ItemDatabase.getConsumptionType(ar.getItemId());
+      ConsumptionType equipmentType = ItemDatabase.getConsumptionType(ar.getItemId());
 
       int power = EquipmentDatabase.getPower(ar.getItemId());
       String stringForm;
 
-      if (equipmentType == KoLConstants.EQUIP_FAMILIAR) {
+      if (equipmentType == ConsumptionType.EQUIP_FAMILIAR) {
         stringForm = ar.getName();
 
         String effect = Modifiers.getFamiliarEffect(ar.getName());
@@ -769,7 +770,7 @@ public class ListCellRendererFactory {
       } else if (ar.equals(EquipmentRequest.UNEQUIP)) {
         stringForm = ar.getName();
       } else {
-        if (equipmentType == KoLConstants.EQUIP_ACCESSORY) {
+        if (equipmentType == ConsumptionType.EQUIP_ACCESSORY) {
           int count;
           Modifiers mods = Modifiers.getItemModifiers(ar.getItemId());
           if (mods != null && mods.getBoolean(Modifiers.SINGLE)) {

--- a/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
@@ -756,7 +756,7 @@ public class ListCellRendererFactory {
       int power = EquipmentDatabase.getPower(ar.getItemId());
       String stringForm;
 
-      if (equipmentType == ConsumptionType.EQUIP_FAMILIAR) {
+      if (equipmentType == ConsumptionType.FAMILIAR_EQUIPMENT) {
         stringForm = ar.getName();
 
         String effect = Modifiers.getFamiliarEffect(ar.getName());
@@ -770,7 +770,7 @@ public class ListCellRendererFactory {
       } else if (ar.equals(EquipmentRequest.UNEQUIP)) {
         stringForm = ar.getName();
       } else {
-        if (equipmentType == ConsumptionType.EQUIP_ACCESSORY) {
+        if (equipmentType == ConsumptionType.ACCESSORY) {
           int count;
           Modifiers mods = Modifiers.getItemModifiers(ar.getItemId());
           if (mods != null && mods.getBoolean(Modifiers.SINGLE)) {

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -3562,21 +3562,21 @@ public abstract class RuntimeLibrary {
       return DataTypes.parseSlotValue(item.toString(), true);
     }
     switch (ItemDatabase.getConsumptionType((int) item.intValue())) {
-      case KoLConstants.EQUIP_HAT:
+      case EQUIP_HAT:
         return DataTypes.parseSlotValue("hat", true);
-      case KoLConstants.EQUIP_WEAPON:
+      case EQUIP_WEAPON:
         return DataTypes.parseSlotValue("weapon", true);
-      case KoLConstants.EQUIP_OFFHAND:
+      case EQUIP_OFFHAND:
         return DataTypes.parseSlotValue("off-hand", true);
-      case KoLConstants.EQUIP_SHIRT:
+      case EQUIP_SHIRT:
         return DataTypes.parseSlotValue("shirt", true);
-      case KoLConstants.EQUIP_PANTS:
+      case EQUIP_PANTS:
         return DataTypes.parseSlotValue("pants", true);
-      case KoLConstants.EQUIP_CONTAINER:
+      case EQUIP_CONTAINER:
         return DataTypes.parseSlotValue("container", true);
-      case KoLConstants.EQUIP_FAMILIAR:
+      case EQUIP_FAMILIAR:
         return DataTypes.parseSlotValue("familiar", true);
-      case KoLConstants.EQUIP_ACCESSORY:
+      case EQUIP_ACCESSORY:
         return DataTypes.parseSlotValue("acc1", true);
       default:
         return DataTypes.parseSlotValue("none", true);
@@ -6602,14 +6602,14 @@ public abstract class RuntimeLibrary {
     if (itemOrFamiliar.getType().equals(DataTypes.ITEM_TYPE)) {
       int itemId = (int) itemOrFamiliar.intValue();
       switch (ItemDatabase.getConsumptionType(itemId)) {
-        case KoLConstants.EQUIP_HAT:
-        case KoLConstants.EQUIP_WEAPON:
-        case KoLConstants.EQUIP_OFFHAND:
-        case KoLConstants.EQUIP_SHIRT:
-        case KoLConstants.EQUIP_PANTS:
-        case KoLConstants.EQUIP_CONTAINER:
-        case KoLConstants.EQUIP_FAMILIAR:
-        case KoLConstants.EQUIP_ACCESSORY:
+        case EQUIP_HAT:
+        case EQUIP_WEAPON:
+        case EQUIP_OFFHAND:
+        case EQUIP_SHIRT:
+        case EQUIP_PANTS:
+        case EQUIP_CONTAINER:
+        case EQUIP_FAMILIAR:
+        case EQUIP_ACCESSORY:
           break;
         default:
           return DataTypes.FALSE_VALUE;

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -3562,21 +3562,21 @@ public abstract class RuntimeLibrary {
       return DataTypes.parseSlotValue(item.toString(), true);
     }
     switch (ItemDatabase.getConsumptionType((int) item.intValue())) {
-      case EQUIP_HAT:
+      case HAT:
         return DataTypes.parseSlotValue("hat", true);
-      case EQUIP_WEAPON:
+      case WEAPON:
         return DataTypes.parseSlotValue("weapon", true);
-      case EQUIP_OFFHAND:
+      case OFFHAND:
         return DataTypes.parseSlotValue("off-hand", true);
-      case EQUIP_SHIRT:
+      case SHIRT:
         return DataTypes.parseSlotValue("shirt", true);
-      case EQUIP_PANTS:
+      case PANTS:
         return DataTypes.parseSlotValue("pants", true);
-      case EQUIP_CONTAINER:
+      case CONTAINER:
         return DataTypes.parseSlotValue("container", true);
-      case EQUIP_FAMILIAR:
+      case FAMILIAR_EQUIPMENT:
         return DataTypes.parseSlotValue("familiar", true);
-      case EQUIP_ACCESSORY:
+      case ACCESSORY:
         return DataTypes.parseSlotValue("acc1", true);
       default:
         return DataTypes.parseSlotValue("none", true);
@@ -6602,14 +6602,14 @@ public abstract class RuntimeLibrary {
     if (itemOrFamiliar.getType().equals(DataTypes.ITEM_TYPE)) {
       int itemId = (int) itemOrFamiliar.intValue();
       switch (ItemDatabase.getConsumptionType(itemId)) {
-        case EQUIP_HAT:
-        case EQUIP_WEAPON:
-        case EQUIP_OFFHAND:
-        case EQUIP_SHIRT:
-        case EQUIP_PANTS:
-        case EQUIP_CONTAINER:
-        case EQUIP_FAMILIAR:
-        case EQUIP_ACCESSORY:
+        case HAT:
+        case WEAPON:
+        case OFFHAND:
+        case SHIRT:
+        case PANTS:
+        case CONTAINER:
+        case FAMILIAR_EQUIPMENT:
+        case ACCESSORY:
           break;
         default:
           return DataTypes.FALSE_VALUE;

--- a/src/net/sourceforge/kolmafia/textui/command/CleanupJunkRequest.java
+++ b/src/net/sourceforge/kolmafia/textui/command/CleanupJunkRequest.java
@@ -130,11 +130,11 @@ public class CleanupJunkRequest extends AbstractCommand {
 
         if (itemCount > 0 && !NPCStoreDatabase.contains(itemId, false)) {
           switch (ItemDatabase.getConsumptionType(itemId)) {
-            case EQUIP_HAT:
-            case EQUIP_PANTS:
-            case EQUIP_SHIRT:
-            case EQUIP_WEAPON:
-            case EQUIP_OFFHAND:
+            case HAT:
+            case PANTS:
+            case SHIRT:
+            case WEAPON:
+            case OFFHAND:
               if (InventoryManager.hasItem(ItemPool.TENDER_HAMMER) && itemPower >= 100
                   || hasMalusAccess && itemPower > 10) {
                 RequestThread.postRequest(new PulverizeRequest(currentItem.getInstance(itemCount)));
@@ -142,8 +142,8 @@ public class CleanupJunkRequest extends AbstractCommand {
 
               break;
 
-            case EQUIP_FAMILIAR:
-            case EQUIP_ACCESSORY:
+            case FAMILIAR_EQUIPMENT:
+            case ACCESSORY:
               if (InventoryManager.hasItem(ItemPool.TENDER_HAMMER)) {
                 RequestThread.postRequest(new PulverizeRequest(currentItem.getInstance(itemCount)));
               }

--- a/src/net/sourceforge/kolmafia/textui/command/CleanupJunkRequest.java
+++ b/src/net/sourceforge/kolmafia/textui/command/CleanupJunkRequest.java
@@ -130,11 +130,11 @@ public class CleanupJunkRequest extends AbstractCommand {
 
         if (itemCount > 0 && !NPCStoreDatabase.contains(itemId, false)) {
           switch (ItemDatabase.getConsumptionType(itemId)) {
-            case KoLConstants.EQUIP_HAT:
-            case KoLConstants.EQUIP_PANTS:
-            case KoLConstants.EQUIP_SHIRT:
-            case KoLConstants.EQUIP_WEAPON:
-            case KoLConstants.EQUIP_OFFHAND:
+            case EQUIP_HAT:
+            case EQUIP_PANTS:
+            case EQUIP_SHIRT:
+            case EQUIP_WEAPON:
+            case EQUIP_OFFHAND:
               if (InventoryManager.hasItem(ItemPool.TENDER_HAMMER) && itemPower >= 100
                   || hasMalusAccess && itemPower > 10) {
                 RequestThread.postRequest(new PulverizeRequest(currentItem.getInstance(itemCount)));
@@ -142,8 +142,8 @@ public class CleanupJunkRequest extends AbstractCommand {
 
               break;
 
-            case KoLConstants.EQUIP_FAMILIAR:
-            case KoLConstants.EQUIP_ACCESSORY:
+            case EQUIP_FAMILIAR:
+            case EQUIP_ACCESSORY:
               if (InventoryManager.hasItem(ItemPool.TENDER_HAMMER)) {
                 RequestThread.postRequest(new PulverizeRequest(currentItem.getInstance(itemCount)));
               }

--- a/src/net/sourceforge/kolmafia/textui/command/UseItemCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/UseItemCommand.java
@@ -3,6 +3,7 @@ package net.sourceforge.kolmafia.textui.command;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.KoLmafiaCLI;
@@ -87,29 +88,29 @@ public class UseItemCommand extends AbstractCommand {
 
     // Now, handle the instance where the first item is actually
     // the quantity desired, and the next is the amount to use
-    int consumptionType = KoLConstants.NO_CONSUME;
+    ConsumptionType consumptionType = ConsumptionType.NO_CONSUME;
     Match filter;
 
     if (command.equals("eat") || command.equals("eatsilent")) {
-      consumptionType = KoLConstants.CONSUME_EAT;
+      consumptionType = ConsumptionType.CONSUME_EAT;
       filter = Match.FOOD;
     } else if (command.equals("ghost")) {
-      consumptionType = KoLConstants.CONSUME_GHOST;
+      consumptionType = ConsumptionType.CONSUME_GHOST;
       filter = Match.FOOD;
     } else if (command.equals("drink") || command.equals("overdrink")) {
-      consumptionType = KoLConstants.CONSUME_DRINK;
+      consumptionType = ConsumptionType.CONSUME_DRINK;
       filter = Match.BOOZE;
     } else if (command.equals("hobo")) {
-      consumptionType = KoLConstants.CONSUME_HOBO;
+      consumptionType = ConsumptionType.CONSUME_HOBO;
       filter = Match.BOOZE;
     } else if (command.equals("chew")) {
-      consumptionType = KoLConstants.CONSUME_SPLEEN;
+      consumptionType = ConsumptionType.CONSUME_SPLEEN;
       filter = Match.SPLEEN;
     } else if (command.equals("slimeling")) {
-      consumptionType = KoLConstants.CONSUME_SLIME;
+      consumptionType = ConsumptionType.CONSUME_SLIME;
       filter = Match.EQUIP;
     } else if (command.equals("robo")) {
-      consumptionType = KoLConstants.CONSUME_ROBO;
+      consumptionType = ConsumptionType.CONSUME_ROBO;
       filter = Match.ROBO;
     } else {
       filter = Match.USE;
@@ -148,26 +149,26 @@ public class UseItemCommand extends AbstractCommand {
           continue;
         }
 
-        int consumpt = ItemDatabase.getConsumptionType(itemId);
+        ConsumptionType consumpt = ItemDatabase.getConsumptionType(itemId);
 
-        if (command.equals("eat") && consumpt == KoLConstants.CONSUME_FOOD_HELPER) { // allowed
+        if (command.equals("eat") && consumpt == ConsumptionType.CONSUME_FOOD_HELPER) { // allowed
         } else if (command.equals("eat") || command.equals("ghost")) {
-          if (consumpt != KoLConstants.CONSUME_EAT) {
+          if (consumpt != ConsumptionType.CONSUME_EAT) {
             KoLmafia.updateDisplay(
                 MafiaState.ERROR, currentMatch.getName() + " cannot be consumed.");
             return false;
           }
         }
 
-        if (command.equals("drink") && consumpt == KoLConstants.CONSUME_DRINK_HELPER) { // allowed
+        if (command.equals("drink") && consumpt == ConsumptionType.CONSUME_DRINK_HELPER) { // allowed
         } else if (command.equals("drink") || command.equals("hobo")) {
-          if (consumpt != KoLConstants.CONSUME_DRINK) {
+          if (consumpt != ConsumptionType.CONSUME_DRINK) {
             KoLmafia.updateDisplay(
                 MafiaState.ERROR, currentMatch.getName() + " is not an alcoholic beverage.");
             return false;
           }
         } else if (command.equals("chew")) {
-          if (consumpt != KoLConstants.CONSUME_SPLEEN) {
+          if (consumpt != ConsumptionType.CONSUME_SPLEEN) {
             KoLmafia.updateDisplay(
                 MafiaState.ERROR, currentMatch.getName() + " is not a spleen toxin.");
             return false;
@@ -177,9 +178,9 @@ public class UseItemCommand extends AbstractCommand {
         if (command.equals("use") && !ItemDatabase.isUsable(itemId)) {
           var correctedUsage =
               switch (consumpt) {
-                case KoLConstants.CONSUME_EAT, KoLConstants.CONSUME_FOOD_HELPER -> "eaten";
-                case KoLConstants.CONSUME_DRINK, KoLConstants.CONSUME_DRINK_HELPER -> "drunk";
-                case KoLConstants.CONSUME_SPLEEN -> "chewed";
+                case CONSUME_EAT, CONSUME_FOOD_HELPER -> "eaten";
+                case CONSUME_DRINK, CONSUME_DRINK_HELPER -> "drunk";
+                case CONSUME_SPLEEN -> "chewed";
                 default -> null;
               };
           if (correctedUsage != null) {
@@ -198,7 +199,7 @@ public class UseItemCommand extends AbstractCommand {
             RequestLogger.printLine(currentMatch.toString());
           } else {
             UseItemRequest request =
-                consumptionType != KoLConstants.NO_CONSUME
+                consumptionType != ConsumptionType.NO_CONSUME
                     ? UseItemRequest.getInstance(consumptionType, currentMatch)
                     : UseItemRequest.getInstance(currentMatch);
 

--- a/src/net/sourceforge/kolmafia/textui/command/UseItemCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/UseItemCommand.java
@@ -160,7 +160,8 @@ public class UseItemCommand extends AbstractCommand {
           }
         }
 
-        if (command.equals("drink") && consumpt == ConsumptionType.CONSUME_DRINK_HELPER) { // allowed
+        if (command.equals("drink")
+            && consumpt == ConsumptionType.CONSUME_DRINK_HELPER) { // allowed
         } else if (command.equals("drink") || command.equals("hobo")) {
           if (consumpt != ConsumptionType.CONSUME_DRINK) {
             KoLmafia.updateDisplay(

--- a/src/net/sourceforge/kolmafia/textui/command/UseItemCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/UseItemCommand.java
@@ -88,29 +88,29 @@ public class UseItemCommand extends AbstractCommand {
 
     // Now, handle the instance where the first item is actually
     // the quantity desired, and the next is the amount to use
-    ConsumptionType consumptionType = ConsumptionType.NO_CONSUME;
+    ConsumptionType consumptionType = ConsumptionType.NONE;
     Match filter;
 
     if (command.equals("eat") || command.equals("eatsilent")) {
-      consumptionType = ConsumptionType.CONSUME_EAT;
+      consumptionType = ConsumptionType.EAT;
       filter = Match.FOOD;
     } else if (command.equals("ghost")) {
-      consumptionType = ConsumptionType.CONSUME_GHOST;
+      consumptionType = ConsumptionType.GLUTTONOUS_GHOST;
       filter = Match.FOOD;
     } else if (command.equals("drink") || command.equals("overdrink")) {
-      consumptionType = ConsumptionType.CONSUME_DRINK;
+      consumptionType = ConsumptionType.DRINK;
       filter = Match.BOOZE;
     } else if (command.equals("hobo")) {
-      consumptionType = ConsumptionType.CONSUME_HOBO;
+      consumptionType = ConsumptionType.SPIRIT_HOBO;
       filter = Match.BOOZE;
     } else if (command.equals("chew")) {
-      consumptionType = ConsumptionType.CONSUME_SPLEEN;
+      consumptionType = ConsumptionType.SPLEEN;
       filter = Match.SPLEEN;
     } else if (command.equals("slimeling")) {
-      consumptionType = ConsumptionType.CONSUME_SLIME;
+      consumptionType = ConsumptionType.SLIMELING;
       filter = Match.EQUIP;
     } else if (command.equals("robo")) {
-      consumptionType = ConsumptionType.CONSUME_ROBO;
+      consumptionType = ConsumptionType.ROBORTENDER;
       filter = Match.ROBO;
     } else {
       filter = Match.USE;
@@ -151,25 +151,24 @@ public class UseItemCommand extends AbstractCommand {
 
         ConsumptionType consumpt = ItemDatabase.getConsumptionType(itemId);
 
-        if (command.equals("eat") && consumpt == ConsumptionType.CONSUME_FOOD_HELPER) { // allowed
+        if (command.equals("eat") && consumpt == ConsumptionType.FOOD_HELPER) { // allowed
         } else if (command.equals("eat") || command.equals("ghost")) {
-          if (consumpt != ConsumptionType.CONSUME_EAT) {
+          if (consumpt != ConsumptionType.EAT) {
             KoLmafia.updateDisplay(
                 MafiaState.ERROR, currentMatch.getName() + " cannot be consumed.");
             return false;
           }
         }
 
-        if (command.equals("drink")
-            && consumpt == ConsumptionType.CONSUME_DRINK_HELPER) { // allowed
+        if (command.equals("drink") && consumpt == ConsumptionType.DRINK_HELPER) { // allowed
         } else if (command.equals("drink") || command.equals("hobo")) {
-          if (consumpt != ConsumptionType.CONSUME_DRINK) {
+          if (consumpt != ConsumptionType.DRINK) {
             KoLmafia.updateDisplay(
                 MafiaState.ERROR, currentMatch.getName() + " is not an alcoholic beverage.");
             return false;
           }
         } else if (command.equals("chew")) {
-          if (consumpt != ConsumptionType.CONSUME_SPLEEN) {
+          if (consumpt != ConsumptionType.SPLEEN) {
             KoLmafia.updateDisplay(
                 MafiaState.ERROR, currentMatch.getName() + " is not a spleen toxin.");
             return false;
@@ -179,9 +178,9 @@ public class UseItemCommand extends AbstractCommand {
         if (command.equals("use") && !ItemDatabase.isUsable(itemId)) {
           var correctedUsage =
               switch (consumpt) {
-                case CONSUME_EAT, CONSUME_FOOD_HELPER -> "eaten";
-                case CONSUME_DRINK, CONSUME_DRINK_HELPER -> "drunk";
-                case CONSUME_SPLEEN -> "chewed";
+                case EAT, FOOD_HELPER -> "eaten";
+                case DRINK, DRINK_HELPER -> "drunk";
+                case SPLEEN -> "chewed";
                 default -> null;
               };
           if (correctedUsage != null) {
@@ -200,7 +199,7 @@ public class UseItemCommand extends AbstractCommand {
             RequestLogger.printLine(currentMatch.toString());
           } else {
             UseItemRequest request =
-                consumptionType != ConsumptionType.NO_CONSUME
+                consumptionType != ConsumptionType.NONE
                     ? UseItemRequest.getInstance(consumptionType, currentMatch)
                     : UseItemRequest.getInstance(currentMatch);
 

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -16,7 +16,7 @@ import net.sourceforge.kolmafia.EdServantData.Servant;
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.MonsterData;
 import net.sourceforge.kolmafia.PastaThrallData;
@@ -523,7 +523,7 @@ public class ProxyRecordValue extends RecordValue {
      */
     public boolean get_reusable() {
       int id = (int) this.contentLong;
-      return ItemDatabase.getConsumptionType(id) == KoLConstants.INFINITE_USES
+      return ItemDatabase.getConsumptionType(id) == ConsumptionType.INFINITE_USES
           || ItemDatabase.getAttribute(id, ItemDatabase.ATTR_REUSABLE);
     }
 

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -523,7 +523,7 @@ public class ProxyRecordValue extends RecordValue {
      */
     public boolean get_reusable() {
       int id = (int) this.contentLong;
-      return ItemDatabase.getConsumptionType(id) == ConsumptionType.INFINITE_USES
+      return ItemDatabase.getConsumptionType(id) == ConsumptionType.USE_INFINITE
           || ItemDatabase.getAttribute(id, ItemDatabase.ATTR_REUSABLE);
     }
 

--- a/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
@@ -368,7 +368,7 @@ public abstract class UseLinkDecorator {
 
     // Skip items which are multi-use.
     ConsumptionType consumeMethod = ItemDatabase.getConsumptionType(itemId);
-    if (consumeMethod == ConsumptionType.CONSUME_MULTIPLE) {
+    if (consumeMethod == ConsumptionType.USE_MULTIPLE) {
       return CraftingType.NOCREATE;
     }
 
@@ -562,7 +562,7 @@ public abstract class UseLinkDecorator {
       return getCreateLink(itemId, itemCount, mixingMethod);
     }
 
-    if (consumeMethod == ConsumptionType.NO_CONSUME) {
+    if (consumeMethod == ConsumptionType.NONE) {
       return getNavigationLink(itemId, location);
     }
 
@@ -611,7 +611,7 @@ public abstract class UseLinkDecorator {
     boolean combatResults = location.startsWith("fight.php");
 
     switch (consumeMethod) {
-      case GROW_FAMILIAR:
+      case FAMILIAR_HATCHLING:
         if (itemId == ItemPool.MOSQUITO_LARVA) {
           return getCouncilLink(itemId);
         }
@@ -630,7 +630,7 @@ public abstract class UseLinkDecorator {
 
         return new UseLink(itemId, "grow", "inv_familiar.php?whichitem=");
 
-      case CONSUME_EAT:
+      case EAT:
         switch (itemId) {
           case ItemPool.GOAT_CHEESE:
             return new UseLink(
@@ -725,7 +725,7 @@ public abstract class UseLinkDecorator {
 
         return new UseLink(itemId, itemCount, "eat", "inv_eat.php?which=1&whichitem=");
 
-      case CONSUME_DRINK:
+      case DRINK:
         if (!KoLCharacter.canDrink()) {
           return null;
         }
@@ -759,20 +759,20 @@ public abstract class UseLinkDecorator {
         }
         return new UseLink(itemId, itemCount, "drink", "inv_booze.php?which=1&whichitem=");
 
-      case CONSUME_FOOD_HELPER:
+      case FOOD_HELPER:
         if (!KoLCharacter.canEat()) {
           return null;
         }
         return new UseLink(itemId, 1, "eat with", "inv_use.php?which=1&whichitem=");
 
-      case CONSUME_DRINK_HELPER:
+      case DRINK_HELPER:
         if (!KoLCharacter.canDrink()) {
           return null;
         }
         return new UseLink(itemId, 1, "drink with", "inv_use.php?which=1&whichitem=");
 
-      case CONSUME_POTION:
-      case CONSUME_AVATAR:
+      case POTION:
+      case AVATAR_POTION:
         {
           int count = InventoryManager.getCount(itemId);
           int useCount = Math.min(UseItemRequest.maximumUses(itemId), count);
@@ -803,7 +803,7 @@ public abstract class UseLinkDecorator {
           return new UseLink(itemId, useCount, use, "multiuse.php?passitem=");
         }
 
-      case CONSUME_MULTIPLE:
+      case USE_MULTIPLE:
         {
           int count = InventoryManager.getCount(itemId);
           int useCount = Math.min(UseItemRequest.maximumUses(itemId), count);
@@ -840,7 +840,7 @@ public abstract class UseLinkDecorator {
           }
 
           if (useCount == 1) {
-            String page = (consumeMethod == ConsumptionType.CONSUME_MULTIPLE) ? "3" : "1";
+            String page = (consumeMethod == ConsumptionType.USE_MULTIPLE) ? "3" : "1";
             return new UseLink(
                 itemId,
                 useCount,
@@ -856,14 +856,14 @@ public abstract class UseLinkDecorator {
           return new UseLink(itemId, useCount, use, "multiuse.php?passitem=");
         }
 
-      case CONSUME_FOLDER:
+      case FOLDER:
 
         // Not inline, since the redirection to a choice
         // doesn't work ajaxified.
 
         return new UseLink(itemId, 1, "use", "inv_use.php?which=3&whichitem=", false);
 
-      case CONSUME_SPLEEN:
+      case SPLEEN:
         {
           int count = InventoryManager.getCount(itemId);
           int useCount = Math.min(UseItemRequest.maximumUses(itemId), count);
@@ -890,9 +890,9 @@ public abstract class UseLinkDecorator {
               itemId, useCount, getPotionSpeculation("chew", itemId), "inv_spleen.php?whichitem=");
         }
 
-      case CONSUME_USE:
-      case MESSAGE_DISPLAY:
-      case INFINITE_USES:
+      case USE:
+      case USE_MESSAGE_DISPLAY:
+      case USE_INFINITE:
         if (KoLCharacter.inBeecore() && ItemDatabase.unusableInBeecore(itemId)) {
           return null;
         }
@@ -1136,7 +1136,7 @@ public abstract class UseLinkDecorator {
                 "inv_use.php?which=3&whichitem=");
         }
 
-      case CONSUME_GUARDIAN:
+      case PASTA_GUARDIAN:
         if (KoLCharacter.inBeecore() && ItemDatabase.unusableInBeecore(itemId)) {
           return null;
         }
@@ -1146,15 +1146,15 @@ public abstract class UseLinkDecorator {
         }
         return new UseLink(itemId, 1, "use", "inv_use.php?which=3&whichitem=");
 
-      case EQUIP_HAT:
-      case EQUIP_WEAPON:
-      case CONSUME_SIXGUN:
-      case EQUIP_OFFHAND:
-      case EQUIP_SHIRT:
-      case EQUIP_PANTS:
-      case EQUIP_CONTAINER:
-      case EQUIP_ACCESSORY:
-      case EQUIP_FAMILIAR:
+      case HAT:
+      case WEAPON:
+      case SIXGUN:
+      case OFFHAND:
+      case SHIRT:
+      case PANTS:
+      case CONTAINER:
+      case ACCESSORY:
+      case FAMILIAR_EQUIPMENT:
         switch (itemId) {
           case ItemPool.BATSKIN_BELT:
           case ItemPool.BONERDAGON_SKULL:
@@ -1323,8 +1323,7 @@ public abstract class UseLinkDecorator {
 
         // Don't offer an "equip" link for weapons or offhands
         // in Fistcore or Axecore
-        if ((consumeMethod == ConsumptionType.EQUIP_WEAPON
-                || consumeMethod == ConsumptionType.EQUIP_OFFHAND)
+        if ((consumeMethod == ConsumptionType.WEAPON || consumeMethod == ConsumptionType.OFFHAND)
             && (KoLCharacter.inFistcore() || KoLCharacter.inAxecore())) {
           return null;
         }
@@ -1342,7 +1341,7 @@ public abstract class UseLinkDecorator {
                   "inv_equip.php?action=outfit&which=2&whichoutfit=" + outfit));
         }
 
-        if (consumeMethod == ConsumptionType.EQUIP_ACCESSORY
+        if (consumeMethod == ConsumptionType.ACCESSORY
             && !EquipmentManager.getEquipment(EquipmentManager.ACCESSORY1)
                 .equals(EquipmentRequest.UNEQUIP)
             && !EquipmentManager.getEquipment(EquipmentManager.ACCESSORY2)
@@ -1367,7 +1366,7 @@ public abstract class UseLinkDecorator {
                   itemCount,
                   getEquipmentSpeculation("acc3", itemId, EquipmentManager.ACCESSORY3),
                   "inv_equip.php?which=2&action=equip&slot=3&whichitem="));
-        } else if (consumeMethod == ConsumptionType.CONSUME_SIXGUN) {
+        } else if (consumeMethod == ConsumptionType.SIXGUN) {
           // Only as WOL class
           if (KoLCharacter.getAscensionClass() != AscensionClass.COWPUNCHER
               && KoLCharacter.getAscensionClass() != AscensionClass.BEANSLINGER
@@ -1397,13 +1396,13 @@ public abstract class UseLinkDecorator {
           // triumphantly and trying really hard not to think about how oddly
           // chilly it has suddenly become.
 
-          if (consumeMethod == ConsumptionType.EQUIP_PANTS
+          if (consumeMethod == ConsumptionType.PANTS
               && text.contains("steal the pants from your unsuspecting self")) {
             uses.add(new UseLink(itemId, "guild", "guild.php?place=challenge"));
           }
         }
 
-        if (consumeMethod == ConsumptionType.EQUIP_WEAPON
+        if (consumeMethod == ConsumptionType.WEAPON
             && EquipmentDatabase.getHands(itemId) == 1
             && EquipmentDatabase.getHands(
                     EquipmentManager.getEquipment(EquipmentManager.WEAPON).getItemId())
@@ -1417,7 +1416,7 @@ public abstract class UseLinkDecorator {
                   "inv_equip.php?which=2&action=dualwield&whichitem="));
         }
 
-        if (consumeMethod != ConsumptionType.EQUIP_FAMILIAR
+        if (consumeMethod != ConsumptionType.FAMILIAR_EQUIPMENT
             && KoLCharacter.getFamiliar().canEquip(ItemPool.get(itemId, 1))) {
           uses.add(
               new UseLink(
@@ -1477,7 +1476,7 @@ public abstract class UseLinkDecorator {
           return new UsesLink(uses.toArray(new UseLink[uses.size()]));
         }
 
-      case CONSUME_ZAP:
+      case ZAP:
         return new UseLink(itemId, itemCount, "zap", "wand.php?whichwand=");
     }
 

--- a/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
@@ -599,7 +599,11 @@ public abstract class UseLinkDecorator {
   }
 
   private static UseLink getUseLink(
-      int itemId, int itemCount, String location, ConsumptionType consumeMethod, final String text) {
+      int itemId,
+      int itemCount,
+      String location,
+      ConsumptionType consumeMethod,
+      final String text) {
     if (!ConsumablesDatabase.meetsLevelRequirement(ItemDatabase.getItemName(itemId))) {
       return null;
     }

--- a/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.CraftingRequirements;
 import net.sourceforge.kolmafia.KoLConstants.CraftingType;
 import net.sourceforge.kolmafia.Modifiers;
@@ -367,8 +367,8 @@ public abstract class UseLinkDecorator {
     }
 
     // Skip items which are multi-use.
-    int consumeMethod = ItemDatabase.getConsumptionType(itemId);
-    if (consumeMethod == KoLConstants.CONSUME_MULTIPLE) {
+    ConsumptionType consumeMethod = ItemDatabase.getConsumptionType(itemId);
+    if (consumeMethod == ConsumptionType.CONSUME_MULTIPLE) {
       return CraftingType.NOCREATE;
     }
 
@@ -555,14 +555,14 @@ public abstract class UseLinkDecorator {
       }
     }
 
-    int consumeMethod = ItemDatabase.getConsumptionType(itemId);
+    ConsumptionType consumeMethod = ItemDatabase.getConsumptionType(itemId);
     CraftingType mixingMethod = shouldAddCreateLink(itemId, location);
 
     if (mixingMethod != CraftingType.NOCREATE) {
       return getCreateLink(itemId, itemCount, mixingMethod);
     }
 
-    if (consumeMethod == KoLConstants.NO_CONSUME) {
+    if (consumeMethod == ConsumptionType.NO_CONSUME) {
       return getNavigationLink(itemId, location);
     }
 
@@ -599,7 +599,7 @@ public abstract class UseLinkDecorator {
   }
 
   private static UseLink getUseLink(
-      int itemId, int itemCount, String location, int consumeMethod, final String text) {
+      int itemId, int itemCount, String location, ConsumptionType consumeMethod, final String text) {
     if (!ConsumablesDatabase.meetsLevelRequirement(ItemDatabase.getItemName(itemId))) {
       return null;
     }
@@ -607,7 +607,7 @@ public abstract class UseLinkDecorator {
     boolean combatResults = location.startsWith("fight.php");
 
     switch (consumeMethod) {
-      case KoLConstants.GROW_FAMILIAR:
+      case GROW_FAMILIAR:
         if (itemId == ItemPool.MOSQUITO_LARVA) {
           return getCouncilLink(itemId);
         }
@@ -626,7 +626,7 @@ public abstract class UseLinkDecorator {
 
         return new UseLink(itemId, "grow", "inv_familiar.php?whichitem=");
 
-      case KoLConstants.CONSUME_EAT:
+      case CONSUME_EAT:
         switch (itemId) {
           case ItemPool.GOAT_CHEESE:
             return new UseLink(
@@ -721,7 +721,7 @@ public abstract class UseLinkDecorator {
 
         return new UseLink(itemId, itemCount, "eat", "inv_eat.php?which=1&whichitem=");
 
-      case KoLConstants.CONSUME_DRINK:
+      case CONSUME_DRINK:
         if (!KoLCharacter.canDrink()) {
           return null;
         }
@@ -755,20 +755,20 @@ public abstract class UseLinkDecorator {
         }
         return new UseLink(itemId, itemCount, "drink", "inv_booze.php?which=1&whichitem=");
 
-      case KoLConstants.CONSUME_FOOD_HELPER:
+      case CONSUME_FOOD_HELPER:
         if (!KoLCharacter.canEat()) {
           return null;
         }
         return new UseLink(itemId, 1, "eat with", "inv_use.php?which=1&whichitem=");
 
-      case KoLConstants.CONSUME_DRINK_HELPER:
+      case CONSUME_DRINK_HELPER:
         if (!KoLCharacter.canDrink()) {
           return null;
         }
         return new UseLink(itemId, 1, "drink with", "inv_use.php?which=1&whichitem=");
 
-      case KoLConstants.CONSUME_POTION:
-      case KoLConstants.CONSUME_AVATAR:
+      case CONSUME_POTION:
+      case CONSUME_AVATAR:
         {
           int count = InventoryManager.getCount(itemId);
           int useCount = Math.min(UseItemRequest.maximumUses(itemId), count);
@@ -799,7 +799,7 @@ public abstract class UseLinkDecorator {
           return new UseLink(itemId, useCount, use, "multiuse.php?passitem=");
         }
 
-      case KoLConstants.CONSUME_MULTIPLE:
+      case CONSUME_MULTIPLE:
         {
           int count = InventoryManager.getCount(itemId);
           int useCount = Math.min(UseItemRequest.maximumUses(itemId), count);
@@ -836,7 +836,7 @@ public abstract class UseLinkDecorator {
           }
 
           if (useCount == 1) {
-            String page = (consumeMethod == KoLConstants.CONSUME_MULTIPLE) ? "3" : "1";
+            String page = (consumeMethod == ConsumptionType.CONSUME_MULTIPLE) ? "3" : "1";
             return new UseLink(
                 itemId,
                 useCount,
@@ -852,14 +852,14 @@ public abstract class UseLinkDecorator {
           return new UseLink(itemId, useCount, use, "multiuse.php?passitem=");
         }
 
-      case KoLConstants.CONSUME_FOLDER:
+      case CONSUME_FOLDER:
 
         // Not inline, since the redirection to a choice
         // doesn't work ajaxified.
 
         return new UseLink(itemId, 1, "use", "inv_use.php?which=3&whichitem=", false);
 
-      case KoLConstants.CONSUME_SPLEEN:
+      case CONSUME_SPLEEN:
         {
           int count = InventoryManager.getCount(itemId);
           int useCount = Math.min(UseItemRequest.maximumUses(itemId), count);
@@ -886,9 +886,9 @@ public abstract class UseLinkDecorator {
               itemId, useCount, getPotionSpeculation("chew", itemId), "inv_spleen.php?whichitem=");
         }
 
-      case KoLConstants.CONSUME_USE:
-      case KoLConstants.MESSAGE_DISPLAY:
-      case KoLConstants.INFINITE_USES:
+      case CONSUME_USE:
+      case MESSAGE_DISPLAY:
+      case INFINITE_USES:
         if (KoLCharacter.inBeecore() && ItemDatabase.unusableInBeecore(itemId)) {
           return null;
         }
@@ -1132,7 +1132,7 @@ public abstract class UseLinkDecorator {
                 "inv_use.php?which=3&whichitem=");
         }
 
-      case KoLConstants.CONSUME_GUARDIAN:
+      case CONSUME_GUARDIAN:
         if (KoLCharacter.inBeecore() && ItemDatabase.unusableInBeecore(itemId)) {
           return null;
         }
@@ -1142,15 +1142,15 @@ public abstract class UseLinkDecorator {
         }
         return new UseLink(itemId, 1, "use", "inv_use.php?which=3&whichitem=");
 
-      case KoLConstants.EQUIP_HAT:
-      case KoLConstants.EQUIP_WEAPON:
-      case KoLConstants.CONSUME_SIXGUN:
-      case KoLConstants.EQUIP_OFFHAND:
-      case KoLConstants.EQUIP_SHIRT:
-      case KoLConstants.EQUIP_PANTS:
-      case KoLConstants.EQUIP_CONTAINER:
-      case KoLConstants.EQUIP_ACCESSORY:
-      case KoLConstants.EQUIP_FAMILIAR:
+      case EQUIP_HAT:
+      case EQUIP_WEAPON:
+      case CONSUME_SIXGUN:
+      case EQUIP_OFFHAND:
+      case EQUIP_SHIRT:
+      case EQUIP_PANTS:
+      case EQUIP_CONTAINER:
+      case EQUIP_ACCESSORY:
+      case EQUIP_FAMILIAR:
         switch (itemId) {
           case ItemPool.BATSKIN_BELT:
           case ItemPool.BONERDAGON_SKULL:
@@ -1319,8 +1319,8 @@ public abstract class UseLinkDecorator {
 
         // Don't offer an "equip" link for weapons or offhands
         // in Fistcore or Axecore
-        if ((consumeMethod == KoLConstants.EQUIP_WEAPON
-                || consumeMethod == KoLConstants.EQUIP_OFFHAND)
+        if ((consumeMethod == ConsumptionType.EQUIP_WEAPON
+                || consumeMethod == ConsumptionType.EQUIP_OFFHAND)
             && (KoLCharacter.inFistcore() || KoLCharacter.inAxecore())) {
           return null;
         }
@@ -1338,7 +1338,7 @@ public abstract class UseLinkDecorator {
                   "inv_equip.php?action=outfit&which=2&whichoutfit=" + outfit));
         }
 
-        if (consumeMethod == KoLConstants.EQUIP_ACCESSORY
+        if (consumeMethod == ConsumptionType.EQUIP_ACCESSORY
             && !EquipmentManager.getEquipment(EquipmentManager.ACCESSORY1)
                 .equals(EquipmentRequest.UNEQUIP)
             && !EquipmentManager.getEquipment(EquipmentManager.ACCESSORY2)
@@ -1363,7 +1363,7 @@ public abstract class UseLinkDecorator {
                   itemCount,
                   getEquipmentSpeculation("acc3", itemId, EquipmentManager.ACCESSORY3),
                   "inv_equip.php?which=2&action=equip&slot=3&whichitem="));
-        } else if (consumeMethod == KoLConstants.CONSUME_SIXGUN) {
+        } else if (consumeMethod == ConsumptionType.CONSUME_SIXGUN) {
           // Only as WOL class
           if (KoLCharacter.getAscensionClass() != AscensionClass.COWPUNCHER
               && KoLCharacter.getAscensionClass() != AscensionClass.BEANSLINGER
@@ -1393,13 +1393,13 @@ public abstract class UseLinkDecorator {
           // triumphantly and trying really hard not to think about how oddly
           // chilly it has suddenly become.
 
-          if (consumeMethod == KoLConstants.EQUIP_PANTS
+          if (consumeMethod == ConsumptionType.EQUIP_PANTS
               && text.contains("steal the pants from your unsuspecting self")) {
             uses.add(new UseLink(itemId, "guild", "guild.php?place=challenge"));
           }
         }
 
-        if (consumeMethod == KoLConstants.EQUIP_WEAPON
+        if (consumeMethod == ConsumptionType.EQUIP_WEAPON
             && EquipmentDatabase.getHands(itemId) == 1
             && EquipmentDatabase.getHands(
                     EquipmentManager.getEquipment(EquipmentManager.WEAPON).getItemId())
@@ -1413,7 +1413,7 @@ public abstract class UseLinkDecorator {
                   "inv_equip.php?which=2&action=dualwield&whichitem="));
         }
 
-        if (consumeMethod != KoLConstants.EQUIP_FAMILIAR
+        if (consumeMethod != ConsumptionType.EQUIP_FAMILIAR
             && KoLCharacter.getFamiliar().canEquip(ItemPool.get(itemId, 1))) {
           uses.add(
               new UseLink(
@@ -1473,7 +1473,7 @@ public abstract class UseLinkDecorator {
           return new UsesLink(uses.toArray(new UseLink[uses.size()]));
         }
 
-      case KoLConstants.CONSUME_ZAP:
+      case CONSUME_ZAP:
         return new UseLink(itemId, itemCount, "zap", "wand.php?whichwand=");
     }
 

--- a/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
 import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;

--- a/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
@@ -105,7 +105,7 @@ public class DataFileConsistencyTest {
     var hatchlings = datafileItems("familiars.txt", 4, 4);
     var items = allItems();
     for (var id : items) {
-      if (ItemDatabase.getConsumptionType(id) == ConsumptionType.GROW_FAMILIAR) {
+      if (ItemDatabase.getConsumptionType(id) == ConsumptionType.FAMILIAR_HATCHLING) {
         var name = ItemDatabase.getItemDataName(id);
         assertThat(
             String.format("%s is in items.txt but not in familiars.txt", name),

--- a/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
@@ -20,6 +20,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
@@ -104,7 +106,7 @@ public class DataFileConsistencyTest {
     var hatchlings = datafileItems("familiars.txt", 4, 4);
     var items = allItems();
     for (var id : items) {
-      if (ItemDatabase.getConsumptionType(id) == KoLConstants.GROW_FAMILIAR) {
+      if (ItemDatabase.getConsumptionType(id) == ConsumptionType.GROW_FAMILIAR) {
         var name = ItemDatabase.getItemDataName(id);
         assertThat(
             String.format("%s is in items.txt but not in familiars.txt", name),

--- a/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
@@ -26,15 +26,15 @@ public class EquipmentDatabaseTest {
 
   @Test
   public void itShouldKnowWhatIsEquipment() {
-    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_ACCESSORY, false));
-    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_CONTAINER, false));
-    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_HAT, false));
-    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_OFFHAND, false));
-    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_PANTS, false));
-    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_SHIRT, false));
-    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_WEAPON, false));
-    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_FAMILIAR, true));
-    assertFalse(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_FAMILIAR, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.ACCESSORY, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.CONTAINER, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.HAT, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.OFFHAND, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.PANTS, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.SHIRT, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.WEAPON, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.FAMILIAR_EQUIPMENT, true));
+    assertFalse(KoLConstants.isEquipmentType(ConsumptionType.FAMILIAR_EQUIPMENT, false));
     assertFalse(KoLConstants.isEquipmentType(ConsumptionType.UNKNOWN, false));
   }
 

--- a/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import org.junit.jupiter.api.Test;
 
 public class EquipmentDatabaseTest {
@@ -25,16 +26,16 @@ public class EquipmentDatabaseTest {
 
   @Test
   public void itShouldKnowWhatIsEquipment() {
-    assertTrue(KoLConstants.isEquipmentType(KoLConstants.EQUIP_ACCESSORY, false));
-    assertTrue(KoLConstants.isEquipmentType(KoLConstants.EQUIP_CONTAINER, false));
-    assertTrue(KoLConstants.isEquipmentType(KoLConstants.EQUIP_HAT, false));
-    assertTrue(KoLConstants.isEquipmentType(KoLConstants.EQUIP_OFFHAND, false));
-    assertTrue(KoLConstants.isEquipmentType(KoLConstants.EQUIP_PANTS, false));
-    assertTrue(KoLConstants.isEquipmentType(KoLConstants.EQUIP_SHIRT, false));
-    assertTrue(KoLConstants.isEquipmentType(KoLConstants.EQUIP_WEAPON, false));
-    assertTrue(KoLConstants.isEquipmentType(KoLConstants.EQUIP_FAMILIAR, true));
-    assertFalse(KoLConstants.isEquipmentType(KoLConstants.EQUIP_FAMILIAR, false));
-    assertFalse(KoLConstants.isEquipmentType(-1, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_ACCESSORY, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_CONTAINER, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_HAT, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_OFFHAND, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_PANTS, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_SHIRT, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_WEAPON, false));
+    assertTrue(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_FAMILIAR, true));
+    assertFalse(KoLConstants.isEquipmentType(ConsumptionType.EQUIP_FAMILIAR, false));
+    assertFalse(KoLConstants.isEquipmentType(ConsumptionType.UNKNOWN, false));
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/session/YouRobotManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/YouRobotManagerTest.java
@@ -18,7 +18,7 @@ import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.listener.Listener;
 import net.sourceforge.kolmafia.listener.NamedListenerRegistry;
@@ -104,17 +104,17 @@ public class YouRobotManagerTest {
 
     // We start with no upgrades, neither body parts nor CPU enhancements.
 
-    assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_HAT));
-    assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_WEAPON));
-    assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_OFFHAND));
-    assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_SHIRT));
-    assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_PANTS));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_HAT));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_WEAPON));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_OFFHAND));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_SHIRT));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_PANTS));
 
     // For historical reasons, "back items" are "containers"
-    assertTrue(YouRobotManager.canEquip(KoLConstants.EQUIP_CONTAINER));
-    assertTrue(YouRobotManager.canEquip(KoLConstants.EQUIP_ACCESSORY));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_CONTAINER));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_ACCESSORY));
     // Probably only if you have an active familiar, but that's not our call to enforce
-    assertTrue(YouRobotManager.canEquip(KoLConstants.EQUIP_FAMILIAR));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_FAMILIAR));
 
     // Install a Pea Shooter as your Top Attachment.
     assertFalse(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
@@ -128,30 +128,30 @@ public class YouRobotManagerTest {
     assertTrue(YouRobotManager.canUseFamiliars());
 
     // Install a Mannequin Head as your Top Attachment.
-    assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_HAT));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_HAT));
     YouRobotManager.testInstallUpgrade(RobotUpgrade.MANNEQUIN_HEAD);
-    assertTrue(YouRobotManager.canEquip(KoLConstants.EQUIP_HAT));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_HAT));
 
     // Install Vice Grips as your Left Hand
-    assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_WEAPON));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_WEAPON));
     YouRobotManager.testInstallUpgrade(RobotUpgrade.VICE_GRIPS);
-    assertTrue(YouRobotManager.canEquip(KoLConstants.EQUIP_WEAPON));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_WEAPON));
 
     // Install Omni Claw as your Right Hand
-    assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_OFFHAND));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_OFFHAND));
     YouRobotManager.testInstallUpgrade(RobotUpgrade.OMNI_CLAW);
-    assertTrue(YouRobotManager.canEquip(KoLConstants.EQUIP_OFFHAND));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_OFFHAND));
 
     // Install Robo-Legs as your Propulsion System
-    assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_PANTS));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_PANTS));
     YouRobotManager.testInstallUpgrade(RobotUpgrade.ROBO_LEGS);
-    assertTrue(YouRobotManager.canEquip(KoLConstants.EQUIP_PANTS));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_PANTS));
 
     // Install Topology Grid CPU Upgrade
-    assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_SHIRT));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_SHIRT));
     assertFalse(KoLCharacter.hasSkill(SkillPool.TORSO));
     YouRobotManager.testInstallUpgrade(RobotUpgrade.TOPOLOGY_GRID);
-    assertTrue(YouRobotManager.canEquip(KoLConstants.EQUIP_SHIRT));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_SHIRT));
     assertTrue(KoLCharacter.hasSkill(SkillPool.TORSO));
     KoLCharacter.removeAvailableSkill(SkillPool.TORSO);
 
@@ -287,11 +287,11 @@ public class YouRobotManagerTest {
       verifyAvatarFromProperties();
 
       // Verify that we can't equip any items
-      assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_HAT));
-      assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_WEAPON));
-      assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_OFFHAND));
-      assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_PANTS));
-      assertFalse(YouRobotManager.canEquip(KoLConstants.EQUIP_SHIRT));
+      assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_HAT));
+      assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_WEAPON));
+      assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_OFFHAND));
+      assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_PANTS));
+      assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_SHIRT));
 
       // Verify that our Pea Shooter is active.
       assertTrue(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));

--- a/test/net/sourceforge/kolmafia/session/YouRobotManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/YouRobotManagerTest.java
@@ -104,17 +104,17 @@ public class YouRobotManagerTest {
 
     // We start with no upgrades, neither body parts nor CPU enhancements.
 
-    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_HAT));
-    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_WEAPON));
-    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_OFFHAND));
-    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_SHIRT));
-    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_PANTS));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.HAT));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.WEAPON));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.OFFHAND));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.SHIRT));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.PANTS));
 
     // For historical reasons, "back items" are "containers"
-    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_CONTAINER));
-    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_ACCESSORY));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.CONTAINER));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.ACCESSORY));
     // Probably only if you have an active familiar, but that's not our call to enforce
-    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_FAMILIAR));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.FAMILIAR_EQUIPMENT));
 
     // Install a Pea Shooter as your Top Attachment.
     assertFalse(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));
@@ -128,30 +128,30 @@ public class YouRobotManagerTest {
     assertTrue(YouRobotManager.canUseFamiliars());
 
     // Install a Mannequin Head as your Top Attachment.
-    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_HAT));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.HAT));
     YouRobotManager.testInstallUpgrade(RobotUpgrade.MANNEQUIN_HEAD);
-    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_HAT));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.HAT));
 
     // Install Vice Grips as your Left Hand
-    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_WEAPON));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.WEAPON));
     YouRobotManager.testInstallUpgrade(RobotUpgrade.VICE_GRIPS);
-    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_WEAPON));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.WEAPON));
 
     // Install Omni Claw as your Right Hand
-    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_OFFHAND));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.OFFHAND));
     YouRobotManager.testInstallUpgrade(RobotUpgrade.OMNI_CLAW);
-    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_OFFHAND));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.OFFHAND));
 
     // Install Robo-Legs as your Propulsion System
-    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_PANTS));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.PANTS));
     YouRobotManager.testInstallUpgrade(RobotUpgrade.ROBO_LEGS);
-    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_PANTS));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.PANTS));
 
     // Install Topology Grid CPU Upgrade
-    assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_SHIRT));
+    assertFalse(YouRobotManager.canEquip(ConsumptionType.SHIRT));
     assertFalse(KoLCharacter.hasSkill(SkillPool.TORSO));
     YouRobotManager.testInstallUpgrade(RobotUpgrade.TOPOLOGY_GRID);
-    assertTrue(YouRobotManager.canEquip(ConsumptionType.EQUIP_SHIRT));
+    assertTrue(YouRobotManager.canEquip(ConsumptionType.SHIRT));
     assertTrue(KoLCharacter.hasSkill(SkillPool.TORSO));
     KoLCharacter.removeAvailableSkill(SkillPool.TORSO);
 
@@ -287,11 +287,11 @@ public class YouRobotManagerTest {
       verifyAvatarFromProperties();
 
       // Verify that we can't equip any items
-      assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_HAT));
-      assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_WEAPON));
-      assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_OFFHAND));
-      assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_PANTS));
-      assertFalse(YouRobotManager.canEquip(ConsumptionType.EQUIP_SHIRT));
+      assertFalse(YouRobotManager.canEquip(ConsumptionType.HAT));
+      assertFalse(YouRobotManager.canEquip(ConsumptionType.WEAPON));
+      assertFalse(YouRobotManager.canEquip(ConsumptionType.OFFHAND));
+      assertFalse(YouRobotManager.canEquip(ConsumptionType.PANTS));
+      assertFalse(YouRobotManager.canEquip(ConsumptionType.SHIRT));
 
       // Verify that our Pea Shooter is active.
       assertTrue(KoLCharacter.hasCombatSkill(SkillPool.SHOOT_PEA));


### PR DESCRIPTION
Change consumption types to an enum, and rename for clarity. Container stays container for now, but I am tempted to make it "BACK" as containers haven't been relevant for a long time!

Commit by commit, the first has the actual refactor, and the others were automated reformatting and renaming.

Add "Unknown" for the purpose that "-1" was serving previously. 