### PR TITLE
fix: fix maximum uses for non-ASCII named items

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -684,6 +684,7 @@ public class ItemPool {
   public static final int REINFORCED_BEADED_HEADBAND = 2337;
   public static final int BLACK_PUDDING = 2338;
   public static final int BLACKFLY_CHARDONNAY = 2339;
+  public static final int BLACK_TAN = 2340;
   public static final int FILTHWORM_HATCHLING_GLAND = 2344;
   public static final int FILTHWORM_DRONE_GLAND = 2345;
   public static final int FILTHWORM_GUARD_GLAND = 2346;
@@ -725,6 +726,7 @@ public class ItemPool {
   public static final int BAR_WHIP = 2455;
   public static final int ODOR_EXTRACTOR = 2462;
   public static final int OLFACTION_BOOK = 2463;
+  public static final int OREILLE_DIVISEE_BRANDY = 2465;
   public static final int TUXEDO_SHIRT = 2489;
   public static final int SHIRT_KIT = 2491;
   public static final int TROPICAL_ORCHID = 2492;
@@ -1037,6 +1039,7 @@ public class ItemPool {
   public static final int COTTON_CANDY_PILLOW = 3454;
   public static final int COTTON_CANDY_BALE = 3455;
   public static final int STYX_SPRAY = 3458;
+  public static final int BASH_OS_CEREAL = 3465;
   public static final int HAIKU_KATANA = 3466;
   public static final int BATHYSPHERE = 3470;
   public static final int DAMP_OLD_BOOT = 3471;

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -343,17 +343,19 @@ public class UseItemRequest extends GenericRequest {
   }
 
   public static final int maximumUses(final int itemId) {
-    String itemName = ItemDatabase.getItemName(itemId);
-    return UseItemRequest.maximumUses(itemId, itemName, ConsumptionType.NONE, true);
+    return UseItemRequest.maximumUses(itemId, ConsumptionType.NONE);
   }
 
   public static final int maximumUses(final int itemId, final ConsumptionType consumptionType) {
-    String itemName = ItemDatabase.getItemName(itemId);
+    String itemName = ItemDatabase.getItemDataName(itemId);
     return UseItemRequest.maximumUses(itemId, itemName, consumptionType, true);
   }
 
-  public static final int maximumUses(final String itemName) {
+  public static final int maximumUses(String itemName) {
     int itemId = ItemDatabase.getItemId(itemName);
+    if (itemId > 0) {
+      itemName = ItemDatabase.getItemDataName(itemId);
+    }
     return UseItemRequest.maximumUses(itemId, itemName, ConsumptionType.NONE, false);
   }
 

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -952,6 +952,18 @@ public class Player {
   }
 
   /**
+   * Sets the player's spleen use
+   *
+   * @param spleenUse Desired spleen use
+   * @return Resets spleen use to previous value
+   */
+  public static Cleanups withSpleenUse(final int spleenUse) {
+    var old = KoLCharacter.getSpleenUse();
+    KoLCharacter.setSpleenUse(spleenUse);
+    return new Cleanups(() -> KoLCharacter.setSpleenUse(old));
+  }
+
+  /**
    * Sets the player's class
    *
    * @param ascensionClass Desired class

--- a/test/net/sourceforge/kolmafia/request/UseItemRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/UseItemRequestTest.java
@@ -236,7 +236,8 @@ class UseItemRequestTest {
       var cleanups = withFullness(fullness);
 
       try (cleanups) {
-        assertThat(UseItemRequest.maximumUses(ItemPool.BASH_OS_CEREAL, ConsumptionType.EAT), is(maxUses));
+        assertThat(
+            UseItemRequest.maximumUses(ItemPool.BASH_OS_CEREAL, ConsumptionType.EAT), is(maxUses));
       }
     }
 
@@ -256,7 +257,9 @@ class UseItemRequestTest {
       var cleanups = withInebriety(drunk);
 
       try (cleanups) {
-        assertThat(UseItemRequest.maximumUses(ItemPool.OREILLE_DIVISEE_BRANDY, ConsumptionType.DRINK), is(maxUses));
+        assertThat(
+            UseItemRequest.maximumUses(ItemPool.OREILLE_DIVISEE_BRANDY, ConsumptionType.DRINK),
+            is(maxUses));
       }
     }
 
@@ -276,7 +279,9 @@ class UseItemRequestTest {
       var cleanups = withSpleenUse(spleenUsed);
 
       try (cleanups) {
-        assertThat(UseItemRequest.maximumUses(ItemPool.EXTROVERMECTIN, ConsumptionType.SPLEEN), is(maxUses));
+        assertThat(
+            UseItemRequest.maximumUses(ItemPool.EXTROVERMECTIN, ConsumptionType.SPLEEN),
+            is(maxUses));
       }
     }
   }

--- a/test/net/sourceforge/kolmafia/request/UseItemRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/UseItemRequestTest.java
@@ -3,11 +3,14 @@ package net.sourceforge.kolmafia.request;
 import static internal.helpers.Networking.html;
 import static internal.helpers.Player.withClass;
 import static internal.helpers.Player.withFamiliar;
+import static internal.helpers.Player.withFullness;
 import static internal.helpers.Player.withHandlingChoice;
+import static internal.helpers.Player.withInebriety;
 import static internal.helpers.Player.withItem;
 import static internal.helpers.Player.withLimitMode;
 import static internal.helpers.Player.withNextResponse;
 import static internal.helpers.Player.withProperty;
+import static internal.helpers.Player.withSpleenUse;
 import static internal.matchers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -23,6 +26,7 @@ import internal.network.FakeHttpResponse;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
@@ -31,16 +35,17 @@ import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.session.LimitMode;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
 
 class UseItemRequestTest {
-  @BeforeEach
-  void beforeEach() {
+  @BeforeAll
+  static void beforeAll() {
     KoLCharacter.reset("UseItemRequestTest");
     Preferences.reset("UseItemRequestTest");
   }
@@ -209,6 +214,69 @@ class UseItemRequestTest {
 
         assertThat("homemadeRobotUpgrades", isSetTo(9));
         assertThat(fam.getWeight(), equalTo(100));
+      }
+    }
+  }
+
+  @Nested
+  class MaximumUses {
+    @ParameterizedTest
+    @CsvSource({"0, 5", "15, 0", "8, 2"})
+    void maxUsesWorksForHtmlFood(int fullness, int maxUses) {
+      var cleanups = withFullness(fullness);
+
+      try (cleanups) {
+        assertThat(UseItemRequest.maximumUses(ItemPool.BASH_OS_CEREAL), is(maxUses));
+      }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0, 5", "15, 0", "8, 2"})
+    void maxUsesWorksForHtmlFoodWithConsumptionType(int fullness, int maxUses) {
+      var cleanups = withFullness(fullness);
+
+      try (cleanups) {
+        assertThat(UseItemRequest.maximumUses(ItemPool.BASH_OS_CEREAL, ConsumptionType.EAT), is(maxUses));
+      }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0, 5", "15, 0", "8, 3"})
+    void maxUsesWorksForHtmlBooze(int drunk, int maxUses) {
+      var cleanups = withInebriety(drunk);
+
+      try (cleanups) {
+        assertThat(UseItemRequest.maximumUses(ItemPool.OREILLE_DIVISEE_BRANDY), is(maxUses));
+      }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0, 5", "15, 0", "8, 3"})
+    void maxUsesWorksForHtmlBoozeWithConsumptionType(int drunk, int maxUses) {
+      var cleanups = withInebriety(drunk);
+
+      try (cleanups) {
+        assertThat(UseItemRequest.maximumUses(ItemPool.OREILLE_DIVISEE_BRANDY, ConsumptionType.DRINK), is(maxUses));
+      }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0, 7", "15, 0", "8, 3"})
+    void maxUsesWorksForHtmlSpleenItems(int spleenUsed, int maxUses) {
+      var cleanups = withSpleenUse(spleenUsed);
+
+      try (cleanups) {
+        assertThat(UseItemRequest.maximumUses(ItemPool.EXTROVERMECTIN), is(maxUses));
+      }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0, 7", "15, 0", "8, 3"})
+    void maxUsesWorksForHtmlSpleenItemsWithConsumptionType(int spleenUsed, int maxUses) {
+      var cleanups = withSpleenUse(spleenUsed);
+
+      try (cleanups) {
+        assertThat(UseItemRequest.maximumUses(ItemPool.EXTROVERMECTIN, ConsumptionType.SPLEEN), is(maxUses));
       }
     }
   }


### PR DESCRIPTION
As reported in https://kolmafia.us/threads/divide-by-zero-error-when-consuming-spleen-item.28353/. Fix from Veracity, tests from me.