### PR TITLE
Tests and fixes for PHP Random functions

### DIFF
--- a/src/net/sourceforge/kolmafia/utilities/PHPMTRandom.java
+++ b/src/net/sourceforge/kolmafia/utilities/PHPMTRandom.java
@@ -4,12 +4,12 @@ import java.util.ArrayList;
 import java.util.Random;
 
 /**
- * Constructed referencing the pseudocode available at
- * https://en.wikipedia.org/wiki/Mersenne_Twister#Pseudocode This is mostly derived from PHP's
- * source code by Gausie.
+ * Constructed referencing the pseudocode available at <a
+ * href="https://en.wikipedia.org/wiki/Mersenne_Twister#Pseudocode">...</a> This is mostly derived
+ * from PHP's source code by Gausie.
  */
 public class PHPMTRandom extends Random {
-  public static final long serialVersionUID = 0l;
+  public static final long serialVersionUID = 0L;
 
   static int STATE_LENGTH = 624;
   static int PERIOD = 397;
@@ -17,30 +17,30 @@ public class PHPMTRandom extends Random {
   static long MAX_UNSIGNED = 0xFFFFFFFFL;
 
   // Mask all but highest bit of u
-  static final long hiBit(long u) {
+  static long hiBit(long u) {
     return u & 0x80000000L;
   }
 
   // Mask all bit lowest bit of u
-  static final long loBit(long u) {
+  static long loBit(long u) {
     return u & 0x00000001L;
   }
 
   // Mask the highest bit of u
-  static final long loBits(long u) {
+  static long loBits(long u) {
     return u & 0x7FFFFFFFL;
   }
 
   // Move hi bit of u to hi bit of v
-  static final long mixBits(long u, long v) {
+  static long mixBits(long u, long v) {
     return hiBit(u) | loBits(v);
   }
 
-  static final long twist(long m, long u, long v) {
+  static long twist(long m, long u, long v) {
     return (m ^ (mixBits(u, v) >> 1) ^ ((MAX_UNSIGNED * (loBit(u))) & MAGIC_CONSTANT));
   }
 
-  static final long temper(long value) {
+  static long temper(long value) {
     value ^= (value >> 11);
     value ^= (value << 7) & 2_636_928_640L;
     value ^= (value << 15) & 4_022_730_752L;
@@ -73,13 +73,12 @@ public class PHPMTRandom extends Random {
   @SuppressWarnings("PMD.MissingOverride")
   public int nextInt(final int min, final int max) {
     double clamped = (max - min + 1.0) * nextDouble();
-    int val = min + (int) clamped;
-    return val;
+    return min + (int) clamped;
   }
 
   void initialize(final long seed) {
     state.clear();
-    state.add(seed & Integer.MAX_VALUE);
+    state.add(seed & Long.MAX_VALUE);
 
     for (int i = 1; i < STATE_LENGTH; i++) {
       long prev = state.get(i - 1);
@@ -100,7 +99,12 @@ public class PHPMTRandom extends Random {
   @Override
   public synchronized void setSeed(long seed) {
     if (state == null) {
-      state = new ArrayList<Long>();
+      state = new ArrayList<>();
+    }
+
+    // In PHP source code the signed int is converted to an unsigned int
+    if (seed < 0) {
+      seed += 0x100000000L;
     }
 
     initialize(seed);

--- a/src/net/sourceforge/kolmafia/utilities/PHPRandom.java
+++ b/src/net/sourceforge/kolmafia/utilities/PHPRandom.java
@@ -4,12 +4,12 @@ import java.util.ArrayList;
 import java.util.Random;
 
 /**
- * PHP < 7.1.0 uses glibc's rand function which is explained very clearly at
- * https://www.mscs.dal.ca/~selinger/random/. This is mostly derived directly from PHP's source code
- * by Gausie.
+ * PHP < 7.1.0 uses glibc's rand function which is explained very clearly at <a
+ * href="https://www.mscs.dal.ca/~selinger/random/">...</a>. This is mostly derived directly from
+ * PHP's source code by Gausie.
  */
 public class PHPRandom extends Random {
-  public static final long serialVersionUID = 0l;
+  public static final long serialVersionUID = 0L;
   public ArrayList<Integer> state;
 
   @Override
@@ -33,21 +33,20 @@ public class PHPRandom extends Random {
   @SuppressWarnings("PMD.MissingOverride")
   public int nextInt(final int min, final int max) {
     double clamped = (max - min + 1.0) * nextDouble();
-    int val = min + (int) clamped;
-    return val;
+    return min + (int) clamped;
   }
 
   @Override
   public synchronized void setSeed(long seed) {
     if (state == null) {
-      state = new ArrayList<Integer>();
+      state = new ArrayList<>();
     }
 
     state.clear();
     state.add((int) seed);
 
     for (int i = 1; i < 31; i++) {
-      int value = (int) ((16_807l * state.get(i - 1)) % Integer.MAX_VALUE);
+      int value = (int) ((16_807L * state.get(i - 1)) % Integer.MAX_VALUE);
       if (value < 0) {
         value += Integer.MAX_VALUE;
       }

--- a/test/net/sourceforge/kolmafia/utilities/PHPMTRandomTest.java
+++ b/test/net/sourceforge/kolmafia/utilities/PHPMTRandomTest.java
@@ -3,23 +3,23 @@ package net.sourceforge.kolmafia.utilities;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-class PHPRandomTest {
+class PHPMTRandomTest {
   // Just some data sourced from PHP 5.3 code to confirm we're right
 
   @ParameterizedTest
   @CsvSource({
-    "1, 1804289383, 846930886, 1681692777, 1714636915",
-    "2147483647, 1065668062, 2142264300, 1066566375, 1064012770",
-    "-8008135, 791676115, 1781863512, 1105079286, 549142576"
+    "1, 1244335972, 15217923, 1546885062, 2002651684",
+    "2147483647, 844801015, 1915574197, 726043576, 780612688"
   })
   void nextInt(
       final int seed, final int first, final int second, final int third, final int fourth) {
-    var rng = new PHPRandom(seed);
+    var rng = new PHPMTRandom(seed);
     assertThat(rng.nextInt(), equalTo(first));
     assertThat(rng.nextInt(), equalTo(second));
     assertThat(rng.nextInt(), equalTo(third));
@@ -27,19 +27,19 @@ class PHPRandomTest {
   }
 
   @Test
-  void nextIntRange() {
-    var rng = new PHPRandom(69420);
-    assertThat(rng.nextInt(5), is(1));
-    assertThat(rng.nextInt(10, 20), is(12));
-    assertThat(rng.nextInt(-5, 100), is(79));
+  void negativeSeed() {
+    var rng = new PHPMTRandom(-8008135);
+    assertThat(rng.nextInt(), equalTo(595078597));
+    assertThat(rng.nextInt(), equalTo(690674654));
+    assertThat(rng.nextInt(), equalTo(1259522838));
+    assertThat(rng.nextInt(), equalTo(277454392));
   }
 
   @Test
-  void array() {
-    var rng = new PHPRandom(6969);
-    var pick = rng.array(5, 3);
-    assertThat(pick[0], is(0));
-    assertThat(pick[1], is(2));
-    assertThat(pick[2], is(3));
+  void nextIntRange() {
+    var rng = new PHPMTRandom(69420);
+    assertThat(rng.nextInt(5), is(2));
+    assertThat(rng.nextInt(10, 20), is(11));
+    assertThat(rng.nextInt(-5, 100), is(32));
   }
 }

--- a/test/net/sourceforge/kolmafia/utilities/PHPRandomTest.java
+++ b/test/net/sourceforge/kolmafia/utilities/PHPRandomTest.java
@@ -1,0 +1,44 @@
+package net.sourceforge.kolmafia.utilities;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class PHPRandomTest {
+  // Just some data sourced from PHP 5.3 code to confirm we're right
+
+  @ParameterizedTest
+  @CsvSource({
+    "1, 1804289383, 846930886, 1681692777, 1714636915",
+    "2147483647, 1065668062, 2142264300, 1066566375, 1064012770"
+  })
+  void nextInt(
+      final int seed, final int first, final int second, final int third, final int fourth) {
+    var rng = new PHPRandom(seed);
+    assertThat(rng.nextInt(), equalTo(first));
+    assertThat(rng.nextInt(), equalTo(second));
+    assertThat(rng.nextInt(), equalTo(third));
+    assertThat(rng.nextInt(), equalTo(fourth));
+  }
+
+  @Test
+  void nextIntRange() {
+    var rng = new PHPRandom(69420);
+    assertThat(rng.nextInt(5), is(1));
+    assertThat(rng.nextInt(10, 20), is(12));
+    assertThat(rng.nextInt(-5, 100), is(79));
+  }
+
+  @Test
+  void array() {
+    var rng = new PHPRandom(6969);
+    var pick = rng.array(5, 3);
+    assertThat(pick[0], is(0));
+    assertThat(pick[1], is(2));
+    assertThat(pick[2], is(3));
+  }
+}


### PR DESCRIPTION
@phulin and I are working on reverse-engineering the code for TCRS item modification. On gausie/kolmafia we're close to correctly generating the mods (including the precise item name change) for every item in every seed. Expect a PR on that soon, negating the need for the TCRS datafiles!

But in doing so, it seemed pertinent to test my implementations of PHP's rand functions. @phulin found that PHPMTRandom didn't deal well with negative seeds (not used in any of the instances we've handled so far so we didn't notice) so I have fixed that issue too.

- Add tests for PHPRandom
- Add tests for PHPMTRandom
- Add tests for negative seeds
- Fix bugs with negative seeds in PHPMTRandom
