### PR TITLE
Let user configure Violet Fog under all three Astral zones.

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/panel/ChoiceOptionsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/ChoiceOptionsPanel.java
@@ -7,6 +7,7 @@ import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -721,16 +722,23 @@ public class ChoiceOptionsPanel extends JTabbedPane implements Listener {
       if (location == null) {
         return;
       }
+
       String zone = location.getZone();
+
+      // Spelunky Area and Batfellow Area are sub-zones of "Item-Driven".
+      // There are no adventuring areas that are directly under Item-Driven.
       if (zone.equals("Item-Driven")) {
         ChoiceOptionsPanel.this.setSelectedIndex(1);
         ChoiceOptionsPanel.this.choiceCards.show(ChoiceOptionsPanel.this.choicePanel, "");
-      } else {
-        ChoiceOptionsPanel.this.setSelectedIndex(0);
-        ChoiceOptionsPanel.this.choiceCards.show(
-            ChoiceOptionsPanel.this.choicePanel,
-            ChoiceOptionsPanel.this.choiceMap.containsKey(zone) ? zone : "");
+        return;
       }
+
+      Map map = ChoiceOptionsPanel.this.choiceMap;
+      String parent = location.getParentZone();
+      String key = map.containsKey(zone) ? zone : map.containsKey(parent) ? parent : "";
+
+      ChoiceOptionsPanel.this.setSelectedIndex(0);
+      ChoiceOptionsPanel.this.choiceCards.show(ChoiceOptionsPanel.this.choicePanel, key);
       KoLCharacter.updateSelectedLocation(location);
     }
   }


### PR DESCRIPTION
ChoiceAdventures defines configurable choices specifying the "zone" where the configuration gets sorted.
Even though a given choice only appears in a single adventure.php area (with two exceptions), we've chosen to collect all the choices from areas in a zone into the same panel.

That makes sense, I guess, for all the areas under "Woods" - Spooky Forest, Hidden Temple, Whitey's Grove.
Or HiddenCity. Or Island (Hippies, Fratboys, Pirates). Or McLarge (mine, extreme slope).

But it's trickier if you want to collect choices from areas that are not in the same Zone but are in different subzones.

Consider Spookyraven Manor. Manor0 - Manor3 are Basement, 1st, 2nd, and 3rd floors. Each contains three or four adventure.php areas. And several in Manor1 and several in Manor2 contain chioce adventures. We put those choices in zone "Manor1" and zone "Manor2". But what about "Light's Out"? That is a rare choice which appears in adventure.php locations on all four floors. We have chosen to put it in Manor1. We COULD put it in "Manor" - and all the other choices in the Manor there - but there is no mechanism for a parent zone like that to hold choice adventure configuration.

As we saw with the other case: Violet Fog appears in the {Bad, Mediocre, Great} Trip adventure.php areas - each of which is its own zone (since it was easier to support adventure validation). All are subzones of Astral.

One cannot share the same JComponent in multiple Swing containers. So, I need a single configuration panel for all three Astral subzones - and the ChoiceOptionPanel needs to associate it with each KoLAdventure's whose parentZone - not zone - is Astral.

That's what I did here.

If we wanted to combine the Manor1 and Manor2 choices into Manor, we could do the same thing and Lights Out would appear for every KoLAdventure in Spookyraven.

I did not do that.

I confess to being unpleased with ChoiceOptionsPanel. You change one dropdown? EVERY choiceAdventure setting is updated. Update a single preference? EVERY dropdown is updated. We have PreferenceCheckboxes elsewhere. Seems like each GUI element could have a single PreferenceListener associated.

That would be a big change.

I'm also not sure how to test almost anything in this package.