### PR TITLE
Coinmaster Tokens

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -610,7 +610,7 @@ public class ItemPool {
   public static final int ANTIQUE_HAND_MIRROR = 2092;
   public static final int TOWEL = 2095;
   public static final int GMOB_POLLEN = 2096;
-  public static final int LUCRE = 2098;
+  public static final int FILTHY_LUCRE = 2098;
   public static final int ASCII_SHIRT = 2121;
   public static final int TOY_MERCENARY = 2139;
   public static final int EVIL_TEDDY_SEWING_KIT = 2147;

--- a/src/net/sourceforge/kolmafia/request/AWOLQuartermasterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AWOLQuartermasterRequest.java
@@ -20,7 +20,7 @@ public class AWOLQuartermasterRequest extends CoinMasterRequest {
 
   public static final CoinmasterData AWOL =
       new CoinmasterData(master, "awol", AWOLQuartermasterRequest.class)
-          .withToken("commendation")
+          .withToken("A. W. O. L. commendation")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COMMENDATION)
           .withBuyURL("inv_use.php?whichitem=5116&ajax=1")

--- a/src/net/sourceforge/kolmafia/request/BountyHunterHunterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/BountyHunterHunterRequest.java
@@ -22,11 +22,11 @@ public class BountyHunterHunterRequest extends CoinMasterRequest {
   private static final Pattern TOKEN_PATTERN =
       Pattern.compile("You have.*?<b>([\\d,]+)</b> filthy lucre");
 
-  public static final AdventureResult LUCRE = ItemPool.get(ItemPool.LUCRE, 1);
+  public static final AdventureResult LUCRE = ItemPool.get(ItemPool.FILTHY_LUCRE, 1);
 
   public static final CoinmasterData BHH =
       new CoinmasterData(master, "hunter", BountyHunterHunterRequest.class)
-          .withToken("lucre")
+          .withToken("filthy lucre")
           .withTokenTest("You don't have any filthy lucre")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(LUCRE)

--- a/src/net/sourceforge/kolmafia/request/DollHawkerRequest.java
+++ b/src/net/sourceforge/kolmafia/request/DollHawkerRequest.java
@@ -8,7 +8,7 @@ public class DollHawkerRequest extends CoinMasterRequest {
 
   public static final CoinmasterData DOLLHAWKER =
       new CoinmasterData(master, "dollhawker", DollHawkerRequest.class)
-          .withToken("isotope")
+          .withToken("lunar isotope")
           .withTokenTest("You have 0 lunar isotopes")
           .withTokenPattern(SpaaaceRequest.TOKEN_PATTERN)
           .withItem(SpaaaceRequest.ISOTOPE)

--- a/src/net/sourceforge/kolmafia/request/IsotopeSmitheryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/IsotopeSmitheryRequest.java
@@ -8,7 +8,7 @@ public class IsotopeSmitheryRequest extends CoinMasterRequest {
 
   public static final CoinmasterData ISOTOPE_SMITHERY =
       new CoinmasterData(master, "isotopesmithery", IsotopeSmitheryRequest.class)
-          .withToken("isotope")
+          .withToken("lunar isotope")
           .withTokenTest("You have 0 lunar isotopes")
           .withTokenPattern(SpaaaceRequest.TOKEN_PATTERN)
           .withItem(SpaaaceRequest.ISOTOPE)

--- a/src/net/sourceforge/kolmafia/request/LunarLunchRequest.java
+++ b/src/net/sourceforge/kolmafia/request/LunarLunchRequest.java
@@ -11,7 +11,7 @@ public class LunarLunchRequest extends CoinMasterRequest {
 
   public static final CoinmasterData LUNAR_LUNCH =
       new CoinmasterData(master, "lunarlunch", LunarLunchRequest.class)
-          .withToken("isotope")
+          .withToken("lunar isotope")
           .withTokenTest("You have 0 lunar isotopes")
           .withTokenPattern(SpaaaceRequest.TOKEN_PATTERN)
           .withItem(SpaaaceRequest.ISOTOPE)

--- a/src/net/sourceforge/kolmafia/request/MerchTableRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MerchTableRequest.java
@@ -29,7 +29,7 @@ public class MerchTableRequest extends CoinMasterRequest {
 
   public static final CoinmasterData MERCH_TABLE =
       new CoinmasterData(master, "conmerch", MerchTableRequest.class)
-          .withToken("Mr. A")
+          .withToken("Mr. Accessory")
           .withTokenTest("You have no Mr. Accessories to trade")
           .withTokenPattern(MR_A_PATTERN)
           .withItem(MR_A)

--- a/src/net/sourceforge/kolmafia/request/MrStoreRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MrStoreRequest.java
@@ -32,7 +32,7 @@ public class MrStoreRequest extends CoinMasterRequest {
 
   public static final CoinmasterData MR_STORE =
       new CoinmasterData(master, "mrstore", MrStoreRequest.class)
-          .withToken("Mr. A")
+          .withToken("Mr. Accessory")
           .withTokenTest("You have no Mr. Accessories to trade")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(MR_A)

--- a/src/net/sourceforge/kolmafia/request/PokemporiumRequest.java
+++ b/src/net/sourceforge/kolmafia/request/PokemporiumRequest.java
@@ -22,7 +22,7 @@ public class PokemporiumRequest extends CoinMasterRequest {
 
   public static final CoinmasterData POKEMPORIUM =
       new CoinmasterData(master, "pokefam", PokemporiumRequest.class)
-          .withToken("pok&eacute;dollar bills")
+          .withToken("1,960 pok&eacute;dollar bills")
           .withPluralToken("pok&eacute;dollar bills")
           .withTokenTest("no pok&eacute;dollar bills")
           .withTokenPattern(POKEDOLLAR_PATTERN)

--- a/src/net/sourceforge/kolmafia/request/PokemporiumRequest.java
+++ b/src/net/sourceforge/kolmafia/request/PokemporiumRequest.java
@@ -23,7 +23,7 @@ public class PokemporiumRequest extends CoinMasterRequest {
   public static final CoinmasterData POKEMPORIUM =
       new CoinmasterData(master, "pokefam", PokemporiumRequest.class)
           .withToken("1,960 pok&eacute;dollar bills")
-          .withPluralToken("pok&eacute;dollar bills")
+          .withPluralToken("1,960 pok&eacute;dollar bills")
           .withTokenTest("no pok&eacute;dollar bills")
           .withTokenPattern(POKEDOLLAR_PATTERN)
           .withItem(POKEDOLLAR)

--- a/src/net/sourceforge/kolmafia/request/TicketCounterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/TicketCounterRequest.java
@@ -20,7 +20,7 @@ public class TicketCounterRequest extends CoinMasterRequest {
 
   public static final CoinmasterData TICKET_COUNTER =
       new CoinmasterData(master, "arcade", TicketCounterRequest.class)
-          .withToken("ticket")
+          .withToken("Game Grid ticket")
           .withTokenTest("You currently have no Game Grid redemption tickets")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(TICKET)

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -1310,7 +1310,7 @@ public class ResultProcessor {
       case ItemPool.WORTHLESS_GEWGAW:
       case ItemPool.WORTHLESS_KNICK_KNACK:
       case ItemPool.YETI_FUR:
-      case ItemPool.LUCRE:
+      case ItemPool.FILTHY_LUCRE:
       case ItemPool.SAND_DOLLAR:
       case ItemPool.CRIMBUCK:
       case ItemPool.BONE_CHIPS:

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -1713,6 +1713,7 @@ public class ProxyRecordValue extends RecordValue {
             .add("buys", DataTypes.BOOLEAN_TYPE)
             .add("sells", DataTypes.BOOLEAN_TYPE)
             .add("nickname", DataTypes.STRING_TYPE)
+            .add("multiple_tokens", DataTypes.STRING_TYPE)
             .finish("coinmaster proxy");
 
     public CoinmasterProxy(Value obj) {
@@ -1721,6 +1722,35 @@ public class ProxyRecordValue extends RecordValue {
 
     public String get_token() {
       return this.content != null ? ((CoinmasterData) this.content).getToken() : "";
+    }
+
+    public String get_multiple_tokens() {
+      if (this.content == null) return "";
+      String cmName;
+      cmName = this.content.toString();
+      String retVal = "";
+      switch (cmName) {
+        case "Armory & Leggery":
+          retVal =
+              "wickerbits, bakelite bits, aerosolized aerogel, wrought-iron flakes, chalk chunks, marble molecules, paraffin pieces, terra cotta tidbits, velour veneer, stained glass shards, loofah lumps, flagstone flagments";
+          break;
+        case "Bat-Fabricator":
+          retVal = "high-grade metal, high-tensile-strength fibers, high-grade explosives";
+          break;
+        case "Cosmic Ray's Bazaar":
+          retVal = "rare Meat isotope, white pixel, fat loot token";
+          break;
+        case "Fancy Dan the Cocktail Man":
+          retVal = "milk cap, drink chit";
+          break;
+        case "Your SpinMaster&trade; lathe":
+          retVal =
+              "flimsy hardwood scraps, Dreadsylvanian hemlock, sweaty balsam, purpleheart logs, wormwood stick, ancient redwood, Dripwood slab ";
+          break;
+        default:
+          retVal = "";
+      }
+      return retVal;
     }
 
     public Value get_item() {

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -1777,14 +1777,13 @@ public class ProxyRecordValue extends RecordValue {
 
     public String get_image() {
       return switch ((Element) this.content) {
-        case NONE, SUPERCOLD -> "circle.gif";
+          // No image for Slime or Supercold in Manuel
+        case NONE, SLIME, SUPERCOLD -> "circle.gif";
         case COLD -> "snowflake.gif";
         case HOT -> "fire.gif";
         case SLEAZE -> "wink.gif";
         case SPOOKY -> "skull.gif";
         case STENCH -> "stench.gif";
-        // No image for Slime or Supercold in Manuel
-        case SLIME -> "circle.gif";
         default -> "";
       };
     }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -78,19 +78,19 @@ public class ProxyRecordValue extends RecordValue {
     }
 
     if (rv instanceof Integer) {
-      return DataTypes.makeIntValue(((Integer) rv).intValue());
+      return DataTypes.makeIntValue((Integer) rv);
     }
 
     if (rv instanceof Long) {
-      return DataTypes.makeIntValue(((Long) rv).longValue());
+      return DataTypes.makeIntValue((Long) rv);
     }
 
     if (rv instanceof Float) {
-      return DataTypes.makeFloatValue(((Float) rv).floatValue());
+      return DataTypes.makeFloatValue((Float) rv);
     }
 
     if (rv instanceof Double) {
-      return DataTypes.makeFloatValue(((Double) rv).doubleValue());
+      return DataTypes.makeFloatValue((Double) rv);
     }
 
     if (rv instanceof String) {
@@ -98,7 +98,7 @@ public class ProxyRecordValue extends RecordValue {
     }
 
     if (rv instanceof Boolean) {
-      return DataTypes.makeBooleanValue(((Boolean) rv).booleanValue());
+      return DataTypes.makeBooleanValue((Boolean) rv);
     }
 
     if (rv instanceof CoinmasterData) {
@@ -133,8 +133,8 @@ public class ProxyRecordValue extends RecordValue {
     private final ArrayList<Type> types;
 
     public RecordBuilder() {
-      names = new ArrayList<String>();
-      types = new ArrayList<Type>();
+      names = new ArrayList<>();
+      types = new ArrayList<>();
     }
 
     public RecordBuilder add(String name, Type type) {
@@ -151,7 +151,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class ClassProxy extends ProxyRecordValue {
-    public static RecordType _type =
+    public static final RecordType _type =
         new RecordBuilder()
             .add("primestat", DataTypes.STAT_TYPE)
             .add("path", DataTypes.PATH_TYPE)
@@ -186,7 +186,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class ItemProxy extends ProxyRecordValue {
-    public static RecordType _type =
+    public static final RecordType _type =
         new RecordBuilder()
             .add("name", DataTypes.STRING_TYPE)
             .add("plural", DataTypes.STRING_TYPE)
@@ -680,7 +680,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class FamiliarProxy extends ProxyRecordValue {
-    public static RecordType _type =
+    public static final RecordType _type =
         new RecordBuilder()
             .add("hatchling", DataTypes.ITEM_TYPE)
             .add("image", DataTypes.STRING_TYPE)
@@ -915,7 +915,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class BountyProxy extends ProxyRecordValue {
-    public static RecordType _type =
+    public static final RecordType _type =
         new RecordBuilder()
             .add("plural", DataTypes.STRING_TYPE)
             .add("type", DataTypes.STRING_TYPE)
@@ -950,8 +950,7 @@ public class ProxyRecordValue extends RecordValue {
     }
 
     public int get_number() {
-      int number = BountyDatabase.getNumber(this.contentString);
-      return number;
+      return BountyDatabase.getNumber(this.contentString);
     }
 
     public String get_image() {
@@ -971,7 +970,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class ThrallProxy extends ProxyRecordValue {
-    public static RecordType _type =
+    public static final RecordType _type =
         new RecordBuilder()
             .add("id", DataTypes.INT_TYPE)
             .add("name", DataTypes.STRING_TYPE)
@@ -1023,7 +1022,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class ServantProxy extends ProxyRecordValue {
-    public static RecordType _type =
+    public static final RecordType _type =
         new RecordBuilder()
             .add("id", DataTypes.INT_TYPE)
             .add("name", DataTypes.STRING_TYPE)
@@ -1087,7 +1086,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class VykeaProxy extends ProxyRecordValue {
-    public static RecordType _type =
+    public static final RecordType _type =
         new RecordBuilder()
             .add("id", DataTypes.INT_TYPE)
             .add("name", DataTypes.STRING_TYPE)
@@ -1148,7 +1147,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class SkillProxy extends ProxyRecordValue {
-    public static RecordType _type =
+    public static final RecordType _type =
         new RecordBuilder()
             .add("name", DataTypes.STRING_TYPE)
             .add("type", DataTypes.STRING_TYPE)
@@ -1244,7 +1243,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class EffectProxy extends ProxyRecordValue {
-    public static RecordType _type =
+    public static final RecordType _type =
         new RecordBuilder()
             .add("name", DataTypes.STRING_TYPE)
             .add("default", DataTypes.STRING_TYPE)
@@ -1284,7 +1283,7 @@ public class ProxyRecordValue extends RecordValue {
     }
 
     public Value get_all() {
-      ArrayList<Value> rv = new ArrayList<Value>();
+      ArrayList<Value> rv = new ArrayList<>();
       Iterator<String> i = EffectDatabase.getAllActions((int) this.contentLong);
       while (i.hasNext()) {
         rv.add(new Value(i.next()));
@@ -1310,7 +1309,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class LocationProxy extends ProxyRecordValue {
-    public static RecordType _type =
+    public static final RecordType _type =
         new RecordBuilder()
             .add("id", DataTypes.INT_TYPE)
             .add("nocombats", DataTypes.BOOLEAN_TYPE)
@@ -1342,7 +1341,7 @@ public class ProxyRecordValue extends RecordValue {
     }
 
     public boolean get_nocombats() {
-      return this.content != null ? ((KoLAdventure) this.content).isNonCombatsOnly() : false;
+      return this.content != null && ((KoLAdventure) this.content).isNonCombatsOnly();
     }
 
     public double get_combat_percent() {
@@ -1411,7 +1410,7 @@ public class ProxyRecordValue extends RecordValue {
 
         if (builder.length() > 0) builder.append("; ");
 
-        builder.append(ob.toString());
+        builder.append(ob);
       }
 
       return builder.toString();
@@ -1433,7 +1432,7 @@ public class ProxyRecordValue extends RecordValue {
 
         if (builder.length() > 0) builder.append("; ");
 
-        builder.append(ob.toString());
+        builder.append(ob);
       }
 
       return builder.toString();
@@ -1471,7 +1470,7 @@ public class ProxyRecordValue extends RecordValue {
     }
 
     public boolean get_wanderers() {
-      return this.content != null ? ((KoLAdventure) this.content).hasWanderers() : false;
+      return this.content != null && ((KoLAdventure) this.content).hasWanderers();
     }
 
     public int get_fire_level() {
@@ -1484,7 +1483,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class MonsterProxy extends ProxyRecordValue {
-    public static RecordType _type =
+    public static final RecordType _type =
         new RecordBuilder()
             .add("name", DataTypes.STRING_TYPE)
             .add("article", DataTypes.STRING_TYPE)
@@ -1578,7 +1577,7 @@ public class ProxyRecordValue extends RecordValue {
 
     public Value get_attack_elements() {
       if (this.content == null) {
-        return new PluralValue(DataTypes.ELEMENT_TYPE, new ArrayList<Value>());
+        return new PluralValue(DataTypes.ELEMENT_TYPE, new ArrayList<>());
       }
       MonsterData monster = (MonsterData) this.content;
       List<Value> elements =
@@ -1646,11 +1645,11 @@ public class ProxyRecordValue extends RecordValue {
     }
 
     public boolean get_boss() {
-      return this.content != null ? ((MonsterData) this.content).isBoss() : false;
+      return this.content != null && ((MonsterData) this.content).isBoss();
     }
 
     public boolean get_copyable() {
-      return this.content != null ? !(((MonsterData) this.content).isNoCopy()) : false;
+      return this.content != null && !(((MonsterData) this.content).isNoCopy());
     }
 
     public String get_image() {
@@ -1661,7 +1660,7 @@ public class ProxyRecordValue extends RecordValue {
       if (this.content == null) {
         return new PluralValue(DataTypes.STRING_TYPE, new ArrayList<>());
       }
-      ArrayList<Value> rv = new ArrayList<Value>();
+      ArrayList<Value> rv = new ArrayList<>();
       for (String image : ((MonsterData) this.content).getImages()) {
         rv.add(new Value(image));
       }
@@ -1672,7 +1671,7 @@ public class ProxyRecordValue extends RecordValue {
       if (this.content == null) {
         return new PluralValue(DataTypes.STRING_TYPE, new ArrayList<>());
       }
-      ArrayList<Value> rv = new ArrayList<Value>();
+      ArrayList<Value> rv = new ArrayList<>();
       for (String attribute : ((MonsterData) this.content).getRandomModifiers()) {
         rv.add(new Value(attribute));
       }
@@ -1683,7 +1682,7 @@ public class ProxyRecordValue extends RecordValue {
       if (this.content == null) {
         return new PluralValue(DataTypes.STRING_TYPE, new ArrayList<>());
       }
-      ArrayList<Value> rv = new ArrayList<Value>();
+      ArrayList<Value> rv = new ArrayList<>();
       for (String attribute : ((MonsterData) this.content).getSubTypes()) {
         rv.add(new Value(attribute));
       }
@@ -1704,7 +1703,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class CoinmasterProxy extends ProxyRecordValue {
-    public static RecordType _type =
+    public static final RecordType _type =
         new RecordBuilder()
             .add("token", DataTypes.STRING_TYPE)
             .add("item", DataTypes.ITEM_TYPE)
@@ -1728,29 +1727,14 @@ public class ProxyRecordValue extends RecordValue {
       if (this.content == null) return "";
       String cmName;
       cmName = this.content.toString();
-      String retVal = "";
-      switch (cmName) {
-        case "Armory & Leggery":
-          retVal =
-              "wickerbits, bakelite bits, aerosolized aerogel, wrought-iron flakes, chalk chunks, marble molecules, paraffin pieces, terra cotta tidbits, velour veneer, stained glass shards, loofah lumps, flagstone flagments";
-          break;
-        case "Bat-Fabricator":
-          retVal = "high-grade metal, high-tensile-strength fibers, high-grade explosives";
-          break;
-        case "Cosmic Ray's Bazaar":
-          retVal = "rare Meat isotope, white pixel, fat loot token";
-          break;
-        case "Fancy Dan the Cocktail Man":
-          retVal = "milk cap, drink chit";
-          break;
-        case "Your SpinMaster&trade; lathe":
-          retVal =
-              "flimsy hardwood scraps, Dreadsylvanian hemlock, sweaty balsam, purpleheart logs, wormwood stick, ancient redwood, Dripwood slab ";
-          break;
-        default:
-          retVal = "";
-      }
-      return retVal;
+      return switch (cmName) {
+        case "Armory & Leggery" -> "wickerbits, bakelite bits, aerosolized aerogel, wrought-iron flakes, chalk chunks, marble molecules, paraffin pieces, terra cotta tidbits, velour veneer, stained glass shards, loofah lumps, flagstone flagments";
+        case "Bat-Fabricator" -> "high-grade metal, high-tensile-strength fibers, high-grade explosives";
+        case "Cosmic Ray's Bazaar" -> "rare Meat isotope, white pixel, fat loot token";
+        case "Fancy Dan the Cocktail Man" -> "milk cap, drink chit";
+        case "Your SpinMaster&trade; lathe" -> "flimsy hardwood scraps, Dreadsylvanian hemlock, sweaty balsam, purpleheart logs, wormwood stick, ancient redwood, Dripwood slab ";
+        default -> "";
+      };
     }
 
     public Value get_item() {
@@ -1771,11 +1755,11 @@ public class ProxyRecordValue extends RecordValue {
     }
 
     public boolean get_buys() {
-      return this.content != null ? ((CoinmasterData) this.content).getSellAction() != null : false;
+      return this.content != null && ((CoinmasterData) this.content).getSellAction() != null;
     }
 
     public boolean get_sells() {
-      return this.content != null ? ((CoinmasterData) this.content).getBuyAction() != null : false;
+      return this.content != null && ((CoinmasterData) this.content).getBuyAction() != null;
     }
 
     public String get_nickname() {
@@ -1784,7 +1768,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class ElementProxy extends ProxyRecordValue {
-    public static RecordType _type =
+    public static final RecordType _type =
         new RecordBuilder().add("image", DataTypes.STRING_TYPE).finish("element proxy");
 
     public ElementProxy(Value obj) {
@@ -1792,31 +1776,22 @@ public class ProxyRecordValue extends RecordValue {
     }
 
     public String get_image() {
-      switch ((Element) this.content) {
-        case NONE:
-          return "circle.gif";
-        case COLD:
-          return "snowflake.gif";
-        case HOT:
-          return "fire.gif";
-        case SLEAZE:
-          return "wink.gif";
-        case SPOOKY:
-          return "skull.gif";
-        case STENCH:
-          return "stench.gif";
-          // No image for Slime or Supercold in Manuel
-        case SLIME:
-          return "circle.gif";
-        case SUPERCOLD:
-          return "circle.gif";
-      }
-      return "";
+      return switch ((Element) this.content) {
+        case NONE, SUPERCOLD -> "circle.gif";
+        case COLD -> "snowflake.gif";
+        case HOT -> "fire.gif";
+        case SLEAZE -> "wink.gif";
+        case SPOOKY -> "skull.gif";
+        case STENCH -> "stench.gif";
+        // No image for Slime or Supercold in Manuel
+        case SLIME -> "circle.gif";
+        default -> "";
+      };
     }
   }
 
   public static class PathProxy extends ProxyRecordValue {
-    public static RecordType _type =
+    public static final RecordType _type =
         new RecordBuilder()
             .add("id", DataTypes.INT_TYPE)
             .add("name", DataTypes.STRING_TYPE)
@@ -1860,7 +1835,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class PhylumProxy extends ProxyRecordValue {
-    public static RecordType _type =
+    public static final RecordType _type =
         new RecordBuilder().add("image", DataTypes.STRING_TYPE).finish("phylum proxy");
 
     public PhylumProxy(Value obj) {
@@ -1878,7 +1853,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class StatProxy extends ProxyRecordValue {
-    public static RecordType _type = new RecordBuilder().finish("stat proxy");
+    public static final RecordType _type = new RecordBuilder().finish("stat proxy");
 
     public StatProxy(Value obj) {
       super(_type, obj);
@@ -1886,7 +1861,7 @@ public class ProxyRecordValue extends RecordValue {
   }
 
   public static class SlotProxy extends ProxyRecordValue {
-    public static RecordType _type = new RecordBuilder().finish("slot proxy");
+    public static final RecordType _type = new RecordBuilder().finish("slot proxy");
 
     public SlotProxy(Value obj) {
       super(_type, obj);

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -1728,11 +1728,11 @@ public class ProxyRecordValue extends RecordValue {
       String cmName;
       cmName = this.content.toString();
       return switch (cmName) {
-        case "Armory & Leggery" -> "wickerbits, bakelite bits, aerosolized aerogel, wrought-iron flakes, chalk chunks, marble molecules, paraffin pieces, terra cotta tidbits, velour veneer, stained glass shards, loofah lumps, flagstone flagments";
-        case "Bat-Fabricator" -> "high-grade metal, high-tensile-strength fibers, high-grade explosives";
-        case "Cosmic Ray's Bazaar" -> "rare Meat isotope, white pixel, fat loot token";
-        case "Fancy Dan the Cocktail Man" -> "milk cap, drink chit";
-        case "Your SpinMaster&trade; lathe" -> "flimsy hardwood scraps, Dreadsylvanian hemlock, sweaty balsam, purpleheart logs, wormwood stick, ancient redwood, Dripwood slab ";
+        case "Armory & Leggery" -> "wickerbits,bakelite bits,aerosolized aerogel,wrought-iron flakes,chalk chunks,marble molecules,paraffin pieces,terra cotta tidbits,velour veneer,stained glass shards,loofah lumps,flagstone flagments";
+        case "Bat-Fabricator" -> "high-grade metal,high-tensile-strength fibers,high-grade explosives";
+        case "Cosmic Ray's Bazaar" -> "rare Meat isotope,white pixel,fat loot token";
+        case "Fancy Dan the Cocktail Man" -> "milk cap,drink chit";
+        case "Your SpinMaster&trade; lathe" -> "flimsy hardwood scraps,Dreadsylvanian hemlock,sweaty balsam,purpleheart logs,wormwood stick,ancient redwood,Dripwood slab";
         default -> "";
       };
     }

--- a/test/root/expected/FindTokensThatAreNotItems.ash.out
+++ b/test/root/expected/FindTokensThatAreNotItems.ash.out
@@ -1,0 +1,7 @@
+Crimbo 2011 uses Candy Credit which is not an item.
+Dimemaster uses dime which is not an item.
+PirateRealm Fun-a-Log uses FunPoint which is not an item.
+Game Shoppe uses store credit which is not an item.
+The Pokémporium uses pokédollar bills which is not an item.
+The Swagger Shop uses swagger which is not an item.
+Coinmaster checks all done.

--- a/test/root/expected/checkCoinmasterTokens.ash.out
+++ b/test/root/expected/checkCoinmasterTokens.ash.out
@@ -1,0 +1,1 @@
+All Done

--- a/test/root/scripts/FindTokensThatAreNotItems.ash
+++ b/test/root/scripts/FindTokensThatAreNotItems.ash
@@ -1,0 +1,21 @@
+void process(coinmaster cm, string token) {
+	if (token != "") {
+		string out = to_string(cm) + " uses " + token;
+		item tokenItem = to_item(token);
+		if (tokenItem == $item[none]) {
+			out = to_string(cm) + " uses " + token + " which is not an item.";
+			print(out);
+		}		
+	}
+}
+foreach cm in $coinmasters[]
+{
+	string token = cm.token;
+	process(cm, token);
+	string clist = cm.multiple_tokens;
+  	string[] tokens = split_string(clist, ",");
+	foreach it in tokens {
+		process(cm, tokens[it]);
+	}
+}
+print("Coinmaster checks all done.")

--- a/test/root/scripts/checkCoinmasterTokens.ash
+++ b/test/root/scripts/checkCoinmasterTokens.ash
@@ -1,0 +1,8 @@
+// Checks that every CoinMaster has a token, or a list of tokens but not both
+foreach cm in $coinmasters[] {
+	if (cm.token != "") continue;
+	string list = cm.multiple_tokens;
+	if (contains_text(list, ",")) continue;
+	print("Problem with " + cm);
+}
+print("All Done");


### PR DESCRIPTION
I am prepared to be told this is the wrong way to do this or that it is not a good idea at all.

There are a couple of Coinmasters that use multiple tokens and there is no way for a script to know what the possible tokens might be.  I did not want to break anything so I added a new Coinmaster proxy for multiple tokens.  A Coinmaster either has exactly one token in which the proxy token is used and the proxy multiple_tokens is "" OR it has multiple tokens and the proxy token is "" and the proxy multiple_tokens is a comma delimited list of tokens.

I then decided it would be nice if any token that was really an item would be recognized as such in a script.  So I changed some token values to match the corresponding item name.

I decided LUCRE needed to be FILTHY_LUCRE for no especially good reason.

I ran lint on ProxyrecordValue since I was already there.

I wrote two custom test scripts.  One checks that every Coinmaster has a proxy value for token or multiple_tokens but not both.  The other makes a list of Coinmasters that have non-item tokens.
