### PR TITLE
Log toy train action in session log

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -5574,10 +5574,8 @@ public class FightRequest extends GenericRequest {
       this.lovebugProperty = null;
 
       // If you have a toy train in your workshed
-      this.toyTrain =
-          (currentRound == 1)
-              && (CampgroundRequest.getCurrentWorkshedItem().getItemId()
-                  == ItemPool.MODEL_TRAIN_SET);
+      AdventureResult workshed = CampgroundRequest.getCurrentWorkshedItem();
+      this.toyTrain = workshed != null && workshed.getItemId() == ItemPool.MODEL_TRAIN_SET;
 
       this.ghost = null;
 

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -5491,6 +5491,7 @@ public class FightRequest extends GenericRequest {
     public boolean carnivorous;
     public boolean lovebugs;
     public String lovebugProperty;
+    public boolean toyTrain;
 
     public TagStatus() {
       FamiliarData current = KoLCharacter.getFamiliar();
@@ -5571,6 +5572,12 @@ public class FightRequest extends GenericRequest {
       // If you have lovebugs
       this.lovebugs = Preferences.getBoolean("lovebugsUnlocked");
       this.lovebugProperty = null;
+
+      // If you have a toy train in your workshed
+      this.toyTrain =
+          (currentRound == 1)
+              && (CampgroundRequest.getCurrentWorkshedItem().getItemId()
+                  == ItemPool.MODEL_TRAIN_SET);
 
       this.ghost = null;
 
@@ -6719,6 +6726,10 @@ public class FightRequest extends GenericRequest {
       return false;
     }
 
+    if (status.toyTrain) {
+      FightRequest.handleToyTrain(src, str, status);
+    }
+
     // Attempt to identify combat items
     String itemName = inode.getAttributeByName("title");
     int itemId = ItemDatabase.getItemId(itemName);
@@ -7000,6 +7011,14 @@ public class FightRequest extends GenericRequest {
     FightRequest.logText(text, status);
     status.grimstone = false;
     return true;
+  }
+
+  private static void handleToyTrain(String image, String str, TagStatus status) {
+    if (image == null || !image.contains("modeltrain")) {
+      return;
+    }
+    FightRequest.logText(str, status);
+    status.toyTrain = false;
   }
 
   private static boolean handleEldritchHorror(TagNode node, TagStatus status) {


### PR DESCRIPTION
I reported a bunch of typos to KoL.
Fortunately, we don't depend on the messages.

```
Round 1: Your toy train moves ahead to the Brawn Silo. You train picks up some fresh brawn!
Round 1: You gain 540 Strongness
Round 1: Your toy train moves ahead to the Brain Silo. You train picks up some fresh brain!
Round 1: You gain 555 Enchantedness
Round 1: Your toy train moves ahead to the Groin Silo. You train picks up some fresh groin!
Round 1: You gain 912 Chutzpah

Round 1: Your toy train moves ahead to the Viewing Platform. As your train passes the viewing platform, the crowd shouts and cheers inspiring you!
Round 1: You gain 225 Strongness
Round 1: You gain 225 Enchantedness
Round 1: You gain 288 Sarcasm

Round 1: Your toy train moves ahead to the Logging Mill. The lumber mill appears to be empty, but looking at it is an interesting experience.
Round 1: You gain 480 Sarcasm

Round 1: Your toy train moves ahead to the Coal Hopper. Your train takes on coal to power the next stop.

Round 1: Your toy train moves ahead to the Meat Mine Sluice. It's twice as effective because your train just visited the coal hopper. The sluice opens and pours out some meat!
You gain 1,604 Meat.
Round 1: Your toy train moves ahead to the Grain Silo. You spot some fermented grains (or grapes, or whatever) sitting on the loading dock and grab them.
You acquire an item: bottle of whiskey (2)
Round 1: Your toy train moves ahead to the Candy Factory. As your train passes the candy factory, you pick up some random candy
You acquire an item: lavender candy heart
Round 1: Your toy train moves ahead to the Ore Hopper Feeder. Some ore pours of the feeder into the hopper of your train.
You acquire an item: chrome ore
Round 1: Your toy train moves ahead to the Trackside Diner.  Somebody dropped some food by the tracks, you pick it up!
You acquire an item: toast

Round 1: Your toy train moves ahead to the Water Tower, Fizzy. Carbonated water bubbles and fizzes as it fills your tanker car!
You acquire an effect: Carbonated (8)
Round 1: Your toy train moves ahead to the Prawn Silo. The prawn silo is empty, but the smell makes you crave prawns or anything to eat!
You acquire an effect: Craving Prawns (8)
Round 1: Your toy train moves ahead to the Bridge over Flaming Oil. The flaming oil splahes over you as the train passes.
You acquire an effect: Burningly Oiled (8)
Round 1: Your toy train moves ahead to the Bridge over Troubled Water. As your train crosses the troubled waters, some of the trouble washes off onto you
You acquire an effect: Troubled Waters (8)
Round 1: Your toy train moves ahead to the Ectoplasmic Oil Refinery. Slimy, spooky sprays into the air from the stacks of the refinery, coating your body.
You acquire an effect: Spookily Greasy (8)
Round 1: Your toy train moves ahead to the Spooky Graveyard. Your train passes through a spooky graveyard, sending shivers down your spine.
You acquire an effect: Shivering Spine (8)
Round 1: Your toy train moves ahead to the Water Tower, Sewage. Hot, soupy, grabage water pours out of the water tower and freezes you to the bones.
You acquire an effect: Hot Soupy Garbage (8)
Round 1: Your toy train moves ahead to the Water Tower, Frozen. Frigid, just unfrozen water pours out of the water tower and freezes you to the bones.
You acquire an effect: Frozen (8)
```