### PR TITLE
Don't add html to the toString() of PurchaseRequest

### DIFF
--- a/src/net/sourceforge/kolmafia/request/PurchaseRequest.java
+++ b/src/net/sourceforge/kolmafia/request/PurchaseRequest.java
@@ -120,14 +120,6 @@ public abstract class PurchaseRequest extends GenericRequest
   @Override
   public String toString() {
     StringBuilder buffer = new StringBuilder();
-    String color = this.color();
-
-    buffer.append("<html><nobr>");
-    if (color != null) {
-      buffer.append("<font color=\"");
-      buffer.append(color);
-      buffer.append("\">");
-    }
 
     buffer.append(this.item.getName());
     buffer.append(" (");
@@ -149,12 +141,6 @@ public abstract class PurchaseRequest extends GenericRequest
     buffer.append(this.getPriceString());
     buffer.append("): ");
     buffer.append(this.shopName);
-
-    if (color != null) {
-      buffer.append("</font>");
-    }
-
-    buffer.append("</nobr></html>");
 
     return buffer.toString();
   }


### PR DESCRIPTION
As far as I can tell, it's meaningless as ListCellRenderer handles the rendering.

Always found it a little irritating when copying a mall search result came up with `<html><nobr><font color="gray">Manual of Numberology (1 @ 85,000,000): Cheap Stuff Here --&gt;</font></nobr></html>`

Especially when other list cell renderers didn't have this behavior.

So I looked into it, and it appears quite meaningless.

https://github.com/kolmafia/kolmafia/blob/main/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java#L121