### PR TITLE
feat: add ability to stop relay server

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/command/RelayBrowserCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/RelayBrowserCommand.java
@@ -1,16 +1,19 @@
 package net.sourceforge.kolmafia.textui.command;
 
 import net.sourceforge.kolmafia.webui.RelayLoader;
+import net.sourceforge.kolmafia.webui.RelayServer;
 
 public class RelayBrowserCommand extends AbstractCommand {
   public RelayBrowserCommand() {
-    this.usage = " [nobrowser] - start the relay server and/or open the relay browser.";
+    this.usage = " [nobrowser|stop] - start/stop the relay server and/or open the relay browser.";
   }
 
   @Override
   public void run(final String cmd, final String parameters) {
     if (parameters.equals("nobrowser")) {
       RelayLoader.startRelayServer();
+    } else if (parameters.equals("stop")) {
+      RelayServer.stop();
     } else RelayLoader.openRelayBrowser();
   }
 }


### PR DESCRIPTION
Occasionally the relay server slows to a crawl for me. Historically I've restarted Mafia. I thought it would be nice to have the option to stop the relay server (and perhaps restart it later) if that happens.