### PR TITLE
chore: upgrade gradle to 7.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 	id 'jacoco'
 	id 'java'
 
-	id 'com.diffplug.spotless' version '6.11.0'
+	id 'com.diffplug.spotless' version '6.12.0'
 	id 'com.github.johnrengelman.shadow' version '7.1.2'
 	id 'net.nemerosa.versioning' version '3.0.0'
 	id 'org.ajoberstar.grgit' version '5.0.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
May as well go up a version.

I was waiting a while expecting a speedy 7.6.1, but it never arrived.