### PR TITLE
feat: new crimbo skills

### DIFF
--- a/src/data/classskills.txt
+++ b/src/data/classskills.txt
@@ -229,6 +229,17 @@
 204
 205	Dead Nostrils	stinknose.gif	0	0	0
 206	Ancient Crymbo Lore	crimbohat.gif	0	0	0
+207	Crimbo Training: First Aid Technician	trainskill1.gif	0	0	0
+208	Crimbo Training: Passenger Greeter	trainskill2.gif	0	0	0
+209	Crimbo Training: Concierge	trainskill3.gif	0	0	0
+210	Crimbo Training: Track Switcher	trainskill4.gif	0	0	0
+211	Crimbo Training: Bartender	trainskill5.gif	0	0	0
+212	Crimbo Training:  Waiter	trainskill6.gif	0	0	0
+213	Crimbo Training: Coal Taster	trainskill7.gif	0	0	0
+214	Crimbo Training: Dessert Steward	trainskill8.gif	0	0	0
+215	Crimbo Training: Night Watchman	trainskill9.gif	0	0	0
+216	Crimbo Training: Sanitation Consultant	trainskill10.gif	0	0	0
+217	Crimbo Training: Graffiti Censor	trainskill11.gif	0	0	0
 
 # Skills available to Clubbers
 

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11071,6 +11071,9 @@
 11043
 11044	packaged model train set	494254899	modeltrain_box.gif	usable	t	0
 11045	model train set	959599372	modeltrain.gif	usable		0
+11046	Crimbo training manual	990145553	trainmanual.gif	usable		0
+11047
+11048
 11049	pile of Trainbot parts	410098387	trainparts.gif	usable	t	0
 11050	Trainbot circuitry	729961257	traincircuit.gif	potion, multiple	t	0
 11051	Trainbot tubing	744569512	traintube.gif	potion, multiple	t	0

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11071,7 +11071,7 @@
 11043
 11044	packaged model train set	494254899	modeltrain_box.gif	usable	t	0
 11045	model train set	959599372	modeltrain.gif	usable		0
-11046	Crimbo training manual	990145553	trainmanual.gif	usable		0
+11046	Crimbo training manual	990145553	trainmanual.gif	reusable		0
 11047
 11048
 11049	pile of Trainbot parts	410098387	trainparts.gif	usable	t	0

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -7852,6 +7852,17 @@ Skill	Cool Heels	Cold Damage: +5
 Skill	Cooling Tubules	Cold Damage: +10
 Skill	Cosmic Ugnderstanding	Maximum MP Percent: +5
 # Crab Claw Technique: Makes your accordion attacks significantly more accurate
+Skill	Crimbo Training:  Waiter	Food Drop: +15
+Skill	Crimbo Training: Bartender	Booze Drop: +15
+Skill	Crimbo Training: Coal Taster	Hot Resistance: +1
+Skill	Crimbo Training: Concierge	Familiar Weight: +1
+Skill	Crimbo Training: Dessert Steward	Cold Resistance: +1
+Skill	Crimbo Training: First Aid Technician	Maximum HP: +10
+Skill	Crimbo Training: Graffiti Censor	Sleaze Resistance: +1
+Skill	Crimbo Training: Night Watchman	Spooky Resistance: +1
+Skill	Crimbo Training: Passenger Greeter	Experience: +1
+Skill	Crimbo Training: Sanitation Consultant	Stench Resistance: +1
+Skill	Crimbo Training: Track Switcher	Initiative: +10
 Skill	Crush	Maximum HP: -20
 Skill	Cryocurrency	Cold Damage: +5
 Skill	Curses Library	Spooky Damage: +5


### PR DESCRIPTION
Yes, "Waiter" has two spaces after the colon. Maybe that'll get fixed. Probably not.