### PR TITLE
Prevent ConcurrentModificationException in preference update when re-logging.

### DIFF
--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -704,11 +704,13 @@ public class Preferences {
 
   private static void reinitializeEncodedValuesOn(
       Map<String, Object> valuesMap, Map<String, byte[]> encodedMap) {
-    for (Entry<String, Object> entry : valuesMap.entrySet()) {
-      encodedMap.put(
-          entry.getKey(),
-          encodeProperty(entry.getKey(), entry.getValue().toString())
-              .getBytes(StandardCharsets.UTF_8));
+    synchronized (valuesMap) {
+      for (Entry<String, Object> entry : valuesMap.entrySet()) {
+        encodedMap.put(
+            entry.getKey(),
+            encodeProperty(entry.getKey(), entry.getValue().toString())
+                .getBytes(StandardCharsets.UTF_8));
+      }
     }
   }
 
@@ -1214,8 +1216,10 @@ public class Preferences {
       OutputStream fstream = new BufferedOutputStream(DataUtilities.getOutputStream(file));
 
       try {
-        for (Entry<String, byte[]> current : encodedData.entrySet()) {
-          fstream.write(current.getValue());
+        synchronized (encodedData) {
+          for (Entry<String, byte[]> current : encodedData.entrySet()) {
+            fstream.write(current.getValue());
+          }
         }
       } catch (IOException e) {
         System.out.println(e.getMessage() + " trying to write preferences as byte array.");


### PR DESCRIPTION
Java's `synchronizedSortedMap` needs to be synchronized any time we are iterating over it. Failure to do this seems to have been causing ConcurrentModificationExceptions in certain situations, especially when e.g. my laptop comes back from sleep that occurred during execution of a script. This was causing loss of preferences in some situations, as the re-login would reset the cached encoded prefs and then not successfully reinitialize them.

Not sure how to write a test for this.