### PR TITLE
feat: more new zone crimbo stuff

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -3035,6 +3035,7 @@ user	choiceAdventure1473	0
 user	choiceAdventure1474	0
 user	choiceAdventure1475	0
 user	choiceAdventure1486	0
+user	choiceAdventure1487	1
 user	lockedItem4637	true
 user	lockedItem4638	true
 user	lockedItem4639	true

--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -2263,9 +2263,9 @@ massive goo construct	2226		Atk: 100 Def: 100 HP: 100 Init: -10000 P: construct 
 Brake-Operating Trainbot	2254	trainbot_brake.gif	Scale: 0 Cap: ? Init: -10000 P: construct NOCOPY Article: a	pile of Trainbot parts (0)	Crimbo train emergency brake (0)	Trainbot harness (0)
 Track-Switching Trainbot	2255	trainbot_switch.gif	Scale: 0 Cap: ? Init: -10000 P: construct NOCOPY Article: a	pile of Trainbot parts (0)	pile of Trainbot parts (0)
 Ping-Pong-Playing Trainbot	2256	trainbot_ping.gif	Scale: 0 Cap: ? Init: -10000 P: construct NOCOPY Article: a	pile of Trainbot parts (0)	ping-pong ball (0)	portable ping-pong table (0)
-Drink-Delivery Trainbot	2257	trainbot_drinks.gif	Scale: 0 Cap: ? Init: -10000 P: construct NOCOPY Article: a	dregs of a Crimbo cocktail (0)	Crimbo crystal shards (0)
-Luggage-Handling Trainbot	2258	trainbot_bags.gif	Scale: 0 Cap: ? Init: -10000 P: construct NOCOPY Article: a	lost elf luggage (0)	Trainbot luggage hook (0)
-Ticket-Checking Trainbot	2259	trainbot_check.gif	Scale: 0 Cap: ? Init: -10000 P: construct NOCOPY Article: a	cinnamon machine oil (0)	Trainbot radar monocle (0)
+Drink-Delivery Trainbot	2257	trainbot_drinks.gif	Scale: 0 Cap: ? Init: -10000 P: construct EA: hot EA: cold NOCOPY Article: a	cinnamon machine oil (0)	dregs of a Crimbo cocktail (0)	Crimbo crystal shards (0)
+Luggage-Handling Trainbot	2258	trainbot_bags.gif	Scale: 0 Cap: ? Init: -10000 P: construct EA: hot NOCOPY Article: a	cinnamon machine oil (0)	lost elf luggage (0)	Trainbot luggage hook (0)
+Ticket-Checking Trainbot	2259	trainbot_check.gif	Scale: 0 Cap: ? Init: -10000 P: construct EA: hot NOCOPY Article: a	cinnamon machine oil (0)	Trainbot radar monocle (0)
 
 # Old Events
 

--- a/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
@@ -6209,6 +6209,10 @@ public abstract class ChoiceAdventures {
         new Option("acquire 6 Trainbot potions", 1),
         new Option("+3 Elf Gratitude", 2),
         new Option("acquire a ping-pong paddle then acquire 3-5 ping-pong balls", 3));
+
+    // A Passenger Among Passengers
+    new ChoiceAdventure(
+        1487, "Crimbo22", "Crimbo Train (Passenger Car)", new Option("+5 Elf Gratitude", 1));
   }
 
   // This array is used by the ChoiceOptionsPanel to provide all the GUI configurable choices.


### PR DESCRIPTION
From the wiki, all monsters drop a cinnamon machine oil.

Add the choice. Default to 1, because there's only one option so that's what you're likely to want to do.