### PR TITLE
Coal car stuff

### DIFF
--- a/src/data/adventures.txt
+++ b/src/data/adventures.txt
@@ -413,6 +413,7 @@ Tammy's Offshore Platform	adventure=538	DiffLevel: unknown Env: underwater Stat:
 Crimbo22	adventure=559	DiffLevel: mid Env: indoor Stat: 0 nowander	Crimbo Train (Caboose)
 Crimbo22	adventure=560	DiffLevel: mid Env: indoor Stat: 0 nowander	Crimbo Train (Passenger Car)
 Crimbo22	adventure=561	DiffLevel: mid Env: indoor Stat: 0 nowander	Crimbo Train (Dining Car)
+Crimbo22	adventure=562	DiffLevel: mid Env: indoor Stat: 0 nowander	Crimbo Train (Coal Car)
 
 Crimbo21	adventure=554	DiffLevel: unknown Env: indoor Stat: 0	Site Alpha Dormitory
 Crimbo21	adventure=555	DiffLevel: unknown Env: indoor Stat: 0	Site Alpha Greenhouse

--- a/src/data/combats.txt
+++ b/src/data/combats.txt
@@ -108,6 +108,7 @@ Crimbo Town Toy Factory (2012)	100	circuit-soldering animelf	plastic-extruding a
 Crimbo Train (Caboose)	100	Brake-Operating Trainbot	Ping-Pong-Playing Trainbot	Track-Switching Trainbot
 Crimbo Train (Passenger Car)	100	Drink-Delivery Trainbot	Luggage-Handling Trainbot	Ticket-Checking Trainbot
 Crimbo Train (Dining Car)	100	Table-Bussing Trainbot	Table-Waiting Trainbot	Wine-Pairing Trainbot
+Crimbo Train (Coal Car)	100	Coal-Shoveling Trainbot	Slag-Processing Trainbot	Steam-Routing Trainbot
 Crimbo's Beard	100	the Crimborg	penguin mafioso	angry viking warriors
 Crimbo's Boots	100	endless winter	bottle of cheap whiskey	the Crimborg
 Crimbo's Hat	100	simple hobo	bottle of cheap whiskey	angry viking warriors	The Krampus: 0

--- a/src/data/concoctions.txt
+++ b/src/data/concoctions.txt
@@ -3161,6 +3161,11 @@ tempura green and red bean bento box with mer-kin weaksauce	SUSHI	Mer-kin lunchb
 tempura green and red bean bento box with peanut sauce	SUSHI	Mer-kin lunchbox	beefy fish meat	glistening fish meat	slick fish meat	white rice	seaweed	peanut sauce	tempura green and red bean
 tempura green and red bean bento box with peppermint eel sauce	SUSHI	Mer-kin lunchbox	beefy fish meat	glistening fish meat	slick fish meat	white rice	seaweed	peppermint eel sauce	tempura green and red bean
 
+# Crimbo 2022
+
+Crimbosmopolitan	SUSE	crystal Crimbo goblet	dregs of a Crimbo cocktail	cinnamon machine oil	industrially-crushed ice
+Crimbo dinner	SUSE	crystal Crimbo platter	steamed oyster	Crimbo food scraps	honey-drenched ham slice
+
 # February 29
 
 # Only on February 29

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -3042,6 +3042,7 @@ user	choiceAdventure1475	0
 user	choiceAdventure1486	0
 user	choiceAdventure1487	1
 user	choiceAdventure1488	0
+user	choiceAdventure1489	0
 user	lockedItem4637	true
 user	lockedItem4638	true
 user	lockedItem4639	true

--- a/src/data/equipment.txt
+++ b/src/data/equipment.txt
@@ -177,6 +177,7 @@ hangman's hood	250	Mus: 200
 hardened slime hat	200	Mox: 200
 Hat O' Nine Tails	10	none
 hazmat helmet	200	Mox: 85
+head-mounted Trainbot	50	none
 headlamp	100	none
 heavy crown	110	Mox: 40
 Helm of the Scream Emperor	120	none
@@ -571,6 +572,7 @@ Krakrox's Loincloth	125	Mus: 30
 lava-proof pants	100	Mox: 35
 Leapin' Trousers	12	none
 leather chaps	160	Mox: 65
+leg-mounted Trainbots	50	none
 Lederhosen of the Night	125	Mox: 30
 leggings of the Spider Queen	200	Mox: 40
 lemon drop trousers	50	Mox: 10
@@ -2956,6 +2958,7 @@ shiny hood ornament	190	Mys: 80
 shiny ring	50	Mys: 10
 shiny tribal beads	80	Mys: 25
 shock belt	80	none
+shoulder-mounted Trainbot	50	none
 sicksilver ring	100	Mys: 10
 signal jammer	0	none
 silent nightlight	10	none
@@ -3134,6 +3137,7 @@ tiny plastic briefcase bat	10	none
 tiny plastic bugaboo	10	none
 tiny plastic Bugbear Captain	50	Mys: 10
 tiny plastic buzzerker	10	none
+tiny plastic caboose	10	none
 tiny plastic Caf&eacute; Elf	10	none
 tiny plastic Captain Kerkard	10	none
 tiny plastic cavebugbear	10	none
@@ -3243,6 +3247,7 @@ tiny plastic nog lab	10	none
 tiny plastic Norville Rogers	10	none
 tiny plastic Orcish Frat Boy	10	none
 tiny plastic orphan	10	none
+tiny plastic passenger car	10	none
 tiny plastic pastamancer	20	none
 tiny plastic peacannon	30	none
 tiny plastic Penny	10	none

--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -315,3 +315,4 @@
 286	Synthetic Rock	synthrock.gif	none	synthetic rock		0	0	0	0
 287	Grey Goose	greygoose.gif	item0	grey gosling	grey down vest	1	2	3	3
 288	Cookbookbat	bbat_fam.gif	drop	mummified entombed cookbookbat	cookbookbat book	0	0	0	0
+289	Mini-Trainbot	tbot_on.gif	combat0,hp1, mp1	deactivated mini-Trainbot	overloaded Yule battery	0	0	0	0

--- a/src/data/fullness.txt
+++ b/src/data/fullness.txt
@@ -237,6 +237,7 @@ CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	5	1	good	12-13	0	0	0	l
 CRIMBCO Reconstituted Gruel	3	1	decent	4-5	0	0	0	lose 10% boredom
 CRIMBCOIDS mints	1	1	good	3	10-20	10-20	10-20
 CRIMBCOLOAF	3	1	decent	4-5	15-20	15-20	15-20
+Crimbo dinner	3	11	EPIC	0	0	0	0	Unspaded
 Crimbo food scraps	4	1	decent	0	0	0	0	Unspaded
 Crimbo pie	3	7	awesome	8-14	25-45	0	0
 Crimbo salad	2	1	good	5-7	10-20	0	0	40 Salad Days (+50 HP, +2 muscle stats/fight), SALAD
@@ -872,6 +873,7 @@ stalk of asparagus	1	1	crappy	1	0	1-3	0
 standard-issue cupcake	1	1	good	3	2-4	2-4	2-4
 star key lime pie	4	6	awesome	14-16	20-24	20-24	20-24	2-4 lines, 2-4 stars
 star pop	1	1	awesome	0	0	0	0	Unspaded
+steamed oyster	1	1	good	0	0	0	0	Unspaded
 steel lasagna	5	5	quest	00	0	0	0	Stomach of Steel skill
 stinky hi mein	5	12	EPIC	24-27	30-35	70-75	15-20	5 Stinky Breath (combat skill), SAUCY
 stinky mushroom	3	2	decent	3-9	0	0	3-5	lose 3 HP

--- a/src/data/inebriety.txt
+++ b/src/data/inebriety.txt
@@ -179,6 +179,7 @@ CRIMBCO wine	3	1	decent	4-8	10-20	10-20	10-20	WINE
 Crimbo Saketini	3	1	decent	3-6	0	0	0
 Crimbojito	2	2	EPIC	10-13	10-20	25-50	10-20
 Crimboku Drop	4	1	decent	6-10	0	0	0
+Crimbosmopolitan	3	11	EPIC	0	0	0	0	Unspaded
 cruelty-free wine	1	10	good	2-4	0	10-15	0	5 Compensatory Cruelness (+5 weapon dmg), WINE
 crystal skeleton vodka	3	3	EPIC	15-17	15-35	15-35	15-35	20 Aykrophobia (+25% Item Drop, +20 spooky dmg, +15 ML)
 CSA cheerfulness ration	1	6	awesome	4	40-50	40-50	40-50	BEER, CANNED

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11064,8 +11064,8 @@
 11036	chocomotive	925688122	chocomotoive.gif	food	t,d	10
 11037	freightcake	930577194	freightcake.gif	food	t,d	10
 11038	cabooze	454104733	cabooze.gif	drink	t,d	10
-11039
-11040
+11039	tiny plastic caboose	945352490	c22_tp5.gif	accessory	t	0
+11040	tiny plastic passenger car	540277464	c22_tp4.gif	accessory	t	0
 11041
 11042
 11043
@@ -11087,9 +11087,9 @@
 11059	portable ping-pong table	454745356	pingpongtable.gif	none, reusable, curse	t	0
 11060	Crimbo train emergency brake	781085744	trainbrake.gif	none, combat	t,d	0
 11061	Trainbot autoassembly module	926072076	tbot0.gif	usable	t	0
-11062
-11063
-11064
+11062	head-mounted Trainbot	603555109	tbot1.gif	hat		0
+11063	leg-mounted Trainbots	797495750	tbot2.gif	pants		0
+11064	shoulder-mounted Trainbot	411957097	tbot3.gif	accessory		0
 11065	cinnamon machine oil	497085839	cinnamonoil.gif	none, combat	t	0	cans of cinnamon machine oil
 11066	Crimbo crystal shards	719160229	crystalshards.gif	none	t	0	piles of Crimbo crystal shards
 11067	dregs of a Crimbo cocktail	136802765	crimbodreg.gif	drink	t	0
@@ -11101,3 +11101,14 @@
 11073	white arm towel	878129314	waitertowel.gif	familiar	t	0
 11074	automatic wine thief	291533165	winethief.gif	accessory	t	0
 11075	silver table-scraper	551850812	tablescraper.gif	accessory	t	0
+11076	Trainbot slag	734616813	crimboslag.gif	none	t	0
+11077	industrially-crushed ice	728200658	trainice.gif	none, combat	t	0
+11078	steamed oyster	430732320	steamoyster.gif	food	t	0
+11079
+11080	deactivated mini-Trainbot	870545906	tbot_off.gif	grow	t	0
+11081	portable steam unit	945628546	steamunit.gif	usable	t	0
+11082	crystal Crimbo goblet	539925082	crimgoblet.gif	usable	t	0
+11083	crystal Crimbo platter	779956577	crimplatter.gif	usable	t	0
+11084	Crimbosmopolitan	965534353	crimbosmo.gif	drink	t	0
+11085	Crimbo dinner	343926636	crimbodinner.gif	food	t	0
+11086	overloaded Yule battery	858172004	battery.gif	familiar	t,d	75

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -276,6 +276,7 @@ Item	Hat O' Nine Tails	Moxie Percent: +9
 # hazmat helmet: 75% Chance of Preventing Negative Status Attacks
 # hazmat helmet: Changes Your Avatar
 Item	hazmat helmet	Damage Absorption: +50, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 40, HP Regen Max: 60
+Item	head-mounted Trainbot	Item Drop: +5, Maximum MP: +5, Moxie: +5
 Item	headlamp	Item Drop: +15, Lasts Until Rollover
 Item	heavy crown	Muscle: +5, Mysticality: +5, Moxie: +5, Familiar Damage: +5, Initiative: +15, Familiar Effect: "atk, 1xGhuol, cap 27"
 Item	Helm of the Scream Emperor	MP Regen Min: 1, MP Regen Max: 3, Experience: +2, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Familiar Effect: "spooky atk, 1xFairy, cap 30"
@@ -721,6 +722,7 @@ Item	lava-proof pants	Hot Resistance: +5, Muscle Percent: -50, Mysticality Perce
 Item	Leapin' Trousers	Adventures: +1, Muscle: +4, Mysticality: +4, Moxie: +4
 Item	leather chaps	Moxie: +8, Muscle: -4, Familiar Effect: "sleaze atk, 1xBarrr, cap 40"
 Item	Lederhosen of the Night	Moxie: +11, Initiative: +15, Class: "Accordion Thief", Familiar Effect: "atk, 2xGhuol, cap 31"
+Item	leg-mounted Trainbots	Maximum HP: +5, Damage Reduction: 5, Muscle: +5
 Item	leggings of the Spider Queen	Moxie: +15, Moxie Percent: +25, Maximum HP: +50, Maximum MP: +50
 Item	lemon drop trousers	Candy Drop: +50, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12"
 Item	leotarrrd	Initiative: +15, Familiar Effect: "2xVolley, 2xPotato, cap 22"
@@ -3501,6 +3503,7 @@ Item	shiny ring	Muscle: +3, Mysticality: +3, Moxie: +3
 Item	shiny tribal beads	Mysticality: +6
 # shock belt: Shocks enemies that hit you
 Item	shock belt	Single Equip
+Item	shoulder-mounted Trainbot	Meat Drop: +5, Monster Level: -5, Mysticality: +5, Single Equip
 Item	sicksilver ring	Stench Damage: +20, Stench Spell Damage: +40, Muscle: +10, Single Equip
 # signal jammer: Repels Skeleton Astronauts
 Item	signal jammer	Single Equip
@@ -3708,6 +3711,7 @@ Item	tiny plastic briefcase bat	Monster Level: +1
 Item	tiny plastic bugaboo	Monster Level: +1
 Item	tiny plastic Bugbear Captain	Maximum HP: +20, Maximum MP: +20, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4, Single Equip
 Item	tiny plastic buzzerker	Monster Level: +1
+Item	tiny plastic caboose	Damage Reduction: 3
 Item	tiny plastic Caf&eacute; Elf	Hot Resistance: +1
 Item	tiny plastic Captain Kerkard	Monster Level: +1
 Item	tiny plastic cavebugbear	Monster Level: +1
@@ -3817,6 +3821,7 @@ Item	tiny plastic nog lab	Booze Drop: +20, Single Equip
 Item	tiny plastic Norville Rogers	Monster Level: +1
 Item	tiny plastic Orcish Frat Boy	Monster Level: +1
 Item	tiny plastic orphan	Stench Resistance: +1
+Item	tiny plastic passenger car	Familiar Weight: +3
 Item	tiny plastic pastamancer	Mysticality: +2, Muscle: +1
 Item	tiny plastic peacannon	Ranged Damage: +5
 Item	tiny plastic Penny	Meat Drop: +10
@@ -4332,6 +4337,7 @@ Item	nosy nose ringy ring	Familiar Weight: +15
 # origami &quot;gentlemen's&quot; magazine: +10 lbs. of Ghuol Whelp
 Item	origami &quot;gentlemen's&quot; magazine	Softcore Only, Generic
 Item	overclocked avian microprocessor	Familiar Weight: +5
+Item	overloaded Yule battery	Familiar Weight: +25
 # oversized fish scaler: Allows familiar to scale fish
 Item	oversized fish scaler	Generic, Familiar Effect: "attack"
 Item	oversized sparkler	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, Item Drop: +20, Lasts Until Rollover
@@ -8426,6 +8432,7 @@ Outfit	Thousandth Birthday Suit	Spooky Damage: +15
 Outfit	Time Trappings	Adventures: +3
 Outfit	Topiaria	Hot Resistance: +2, Cold Resistance: +2, Stench Resistance: +2, Spooky Resistance: +2, Sleaze Resistance: +2
 Outfit	Toxic Togs	Stench Damage: +20, Stench Spell Damage: +20
+Outfit	Trainbot Trappings	Hot Resistance: +2, Cold Resistance: +2
 Outfit	Transparent Trappings	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20
 Outfit	Tropical Crimbo Duds	Muscle: +10, Mysticality: +10, Moxie: +10
 Outfit	Unblemished Uniform	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10
@@ -11642,6 +11649,7 @@ Item	Pop Art: a Guide	Skill: "Fifteen Minutes of Flame"
 # portable Mayo Clinic: Installs a mayonnaise-centered medical clinic in your workshed
 # portable photocopier: Makes a photocopy of an enemy
 # portable Spacegate: Provides one day's access to a random Spacegate planet
+# portable steam unit: Clears Your Sinuses (once per day)
 # portable table: You can hide behind it
 # possessed tomato: Deals 6-8 <font color=gray>Spooky Damage</font> per round for the rest of the fight
 # possessed top: Weakens enemies a little bit

--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -2269,6 +2269,9 @@ Ticket-Checking Trainbot	2259	trainbot_check.gif	Scale: 0 Cap: ? Init: -10000 P:
 Table-Waiting Trainbot	2260	trainbot_wait.gif	Scale: 0 Cap: ? Init: -10000 P: construct NOCOPY Article: a	Trainbot autoassembly module (0)	honey-drenched ham slice (0)	white arm towel (0)
 Wine-Pairing Trainbot	2261	trainbot_wine.gif	Scale: 0 Cap: ? Init: -10000 P: construct EA: sleaze NOCOPY Article: a	Trainbot autoassembly module (0)	mostly-empty bottle of cookie wine (0)	automatic wine thief (0)
 Table-Bussing Trainbot	2262	trainbot_bus.gif	Scale: 0 Cap: ? Init: -10000 P: construct NOCOPY Article: a	Trainbot autoassembly module (0)	Crimbo food scraps (0)	silver table-scraper (0)
+Coal-Shoveling Trainbot	2263	trainbot_coal.gif	Scale: 0 Cap: ? Init: -10000 P: construct NOCOPY Article: a	industrially-crushed ice (0)
+Slag-Processing Trainbot	2264	trainbot_steam.gif	Scale: 0 Cap: ? Init: -10000 P: construct NOCOPY Article: a	Trainbot slag (0)
+Steam-Routing Trainbot	2265	trainbot_steam.gif	Scale: 0 Cap: ? Init: -10000 P: construct NOCOPY Article: a	steamed oyster (0)	portable steam unit (0)
 
 # Old Events
 

--- a/src/data/outfits.txt
+++ b/src/data/outfits.txt
@@ -170,3 +170,4 @@
 # Treats: Random booze from specific subset
 159	Guzzlr Uniform	guzzlrtat.gif	Guzzlr hat, Guzzlr shoes, Guzzlr pants
 160	Lathed Livery	lathetat.gif	hemlock helm, balsam barrel, purpleheart &quot;pants&quot;, wormwood wedding ring	fistful of wood shavings
+161	Trainbot Trappings	tbottat.gif	head-mounted Trainbot, leg-mounted Trainbots, shoulder-mounted Trainbot

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3470,9 +3470,12 @@ public class ItemPool {
   public static final int PING_PONG_PADDLE = 11056;
   public static final int TRAINBOT_HARNESS = 11058;
   public static final int PING_PONG_TABLE = 11059;
+  public static final int TRAINBOT_AUTOASSEMBLY_MODULE = 11061;
+  public static final int CRIMBO_CRYSTAL_SHARDS = 11066;
   public static final int LOST_ELF_LUGGAGE = 11068;
   public static final int TRAINBOT_LUGGAGE_HOOK = 11069;
   public static final int WHITE_ARM_TOWEL = 11073;
+  public static final int TRAINBOT_SLAG = 11076;
 
   private ItemPool() {}
 

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -5960,6 +5960,14 @@ public class UseItemRequest extends GenericRequest {
           Preferences.increment("elfGratitude", count);
         }
         break;
+
+      case ItemPool.TRAINBOT_AUTOASSEMBLY_MODULE:
+        // The module scans you, whirrs for a moment, then reassembles your pile of Trainbot slag
+        // into a small robot you can wear.
+        if (responseText.contains("reassembles your pile of Trainbot slag")) {
+          ResultProcessor.removeItem(ItemPool.TRAINBOT_SLAG);
+        }
+        break;
     }
 
     if (CampgroundRequest.isWorkshedItem(itemId)) {

--- a/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
@@ -6221,6 +6221,15 @@ public abstract class ChoiceAdventures {
         "Crimbo Train (Dining Car)",
         new Option("acquire 3 lost elf trunks", 1),
         new Option("decrease Trainbot strength", 2));
+
+    // Slagging Off
+    new ChoiceAdventure(
+        1489,
+        "Crimbo22",
+        "Crimbo Train (Coal Car)",
+        new Option("acquire crystal Crimbo Goblet", 1),
+        new Option("acquire crystal Crimbo platter", 2),
+        new Option("(skip choice with no crystal shards)", 3));
   }
 
   // This array is used by the ChoiceOptionsPanel to provide all the GUI configurable choices.

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -6419,6 +6419,12 @@ public abstract class ChoiceControl {
       case 1487: // A Passenger Among Passengers
         Preferences.increment("elfGratitude", 5);
         break;
+
+      case 1489: // Slagging Off
+        switch (ChoiceManager.lastDecision) {
+          case 1, 2 -> ResultProcessor.removeItem(ItemPool.CRIMBO_CRYSTAL_SHARDS);
+        }
+        break;
     }
   }
 


### PR DESCRIPTION
More to come in other PRs, but I'd like to get this in quickly.

1) Coal-Shoveling Trainbot rare drop is the "really nice lump of goal" - a gift item which I have not seen yet
2) portable steam unit is once-per day
3) portable steam unit gives you an effect
4) If you have no crystal shards, Slagging Off offers only choice 3.
5) Maybe we'd like a way to alternate the options in Slagging Off? And automatically take choice 3 if you have no shards.
6) Arena parameters for Mini-Trainbot. That can certainly wait until we/I are done farming Crimbo stuff.