### PR TITLE
Allow aborting breakfast with escape.

### DIFF
--- a/src/net/sourceforge/kolmafia/session/BreakfastManager.java
+++ b/src/net/sourceforge/kolmafia/session/BreakfastManager.java
@@ -331,8 +331,6 @@ public class BreakfastManager {
       if (count > 0) {
         KoLmafiaCLI.DEFAULT_SHELL.executeLine("hermit " + count + " 11-leaf clover");
       }
-
-      BreakfastManager.ignoreErrors();
     }
   }
 

--- a/src/net/sourceforge/kolmafia/session/BreakfastManager.java
+++ b/src/net/sourceforge/kolmafia/session/BreakfastManager.java
@@ -770,6 +770,7 @@ public class BreakfastManager {
     IslandRequest request = IslandRequest.getPyroRequest();
     if (request != null) {
       RequestThread.postRequest(request);
+      BreakfastManager.ignoreErrors();
     }
   }
 

--- a/src/net/sourceforge/kolmafia/session/BreakfastManager.java
+++ b/src/net/sourceforge/kolmafia/session/BreakfastManager.java
@@ -133,7 +133,6 @@ public class BreakfastManager {
             KoLmafia.updateDisplay(MafiaState.ABORT, "Breakfast aborted by user.");
             return;
           }
-          ;
           BreakfastManager.ignoreErrors();
         }
       }

--- a/src/net/sourceforge/kolmafia/session/BreakfastManager.java
+++ b/src/net/sourceforge/kolmafia/session/BreakfastManager.java
@@ -14,6 +14,7 @@ import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.SpecialOutfit;
 import net.sourceforge.kolmafia.SpecialOutfit.Checkpoint;
+import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.OutfitPool;
@@ -85,6 +86,26 @@ public class BreakfastManager {
 
   private BreakfastManager() {}
 
+  private static List<Runnable> ACTIONS =
+      List.of(
+          BreakfastManager::checkRumpusRoom,
+          BreakfastManager::checkVIPLounge,
+          BreakfastManager::readGuildManual,
+          BreakfastManager::getHermitClovers,
+          BreakfastManager::harvestGarden,
+          BreakfastManager::collectHardwood,
+          BreakfastManager::useSpinningWheel,
+          BreakfastManager::visitBigIsland,
+          BreakfastManager::visitVolcanoIsland,
+          BreakfastManager::checkJackass,
+          BreakfastManager::makePocketWishes,
+          BreakfastManager::haveBoxingDaydream,
+          BreakfastManager::useToys,
+          BreakfastManager::collectAnticheese,
+          BreakfastManager::collectSeaJelly,
+          BreakfastManager::harvestBatteries,
+          BreakfastManager::useBookOfEverySkill);
+
   public static void getBreakfast(final boolean runComplete) {
     var limitmode = KoLCharacter.getLimitMode();
     if (limitmode != LimitMode.NONE) {
@@ -101,30 +122,20 @@ public class BreakfastManager {
 
     try (Checkpoint checkpoint = new Checkpoint()) {
       if (runComplete) {
-        checkRumpusRoom();
-        checkVIPLounge();
-        readGuildManual();
-        getHermitClovers();
-        harvestGarden();
-        if (GenericRequest.abortIfInFightOrChoice()) {
-          KoLmafia.updateDisplay(MafiaState.ABORT, "Breakfast aborted.");
-          return;
+        for (Runnable action : BreakfastManager.ACTIONS) {
+          action.run();
+          if (GenericRequest.abortIfInFightOrChoice()) {
+            KoLmafia.updateDisplay(
+                MafiaState.ABORT, "Breakfast aborted; stuck in fight or choice.");
+            return;
+          }
+          if (StaticEntity.userAborted) {
+            KoLmafia.updateDisplay(MafiaState.ABORT, "Breakfast aborted by user.");
+            return;
+          }
+          ;
+          BreakfastManager.ignoreErrors();
         }
-        collectHardwood();
-        useSpinningWheel();
-        visitBigIsland();
-        visitVolcanoIsland();
-        checkJackass();
-        makePocketWishes();
-        haveBoxingDaydream();
-        if (Preferences.getBoolean(
-            "useCrimboToys" + (KoLCharacter.canInteract() ? "Softcore" : "Hardcore"))) {
-          useToys();
-        }
-        collectAnticheese();
-        collectSeaJelly();
-        harvestBatteries();
-        useBookOfEverySkill();
       }
 
       boolean recoverMana =
@@ -138,7 +149,11 @@ public class BreakfastManager {
 
       Preferences.setBoolean("breakfastCompleted", done);
     }
-    KoLmafia.forceContinue();
+    BreakfastManager.ignoreErrors();
+  }
+
+  private static void ignoreErrors() {
+    StaticEntity.setContinuationState(MafiaState.CONTINUE);
   }
 
   public static void checkRumpusRoom() {
@@ -146,7 +161,6 @@ public class BreakfastManager {
         && Preferences.getBoolean(
             "visitRumpus" + (KoLCharacter.canInteract() ? "Softcore" : "Hardcore"))) {
       ClanRumpusRequest.getBreakfast();
-      KoLmafia.forceContinue();
     }
   }
 
@@ -156,7 +170,6 @@ public class BreakfastManager {
         && Preferences.getBoolean(
             "visitLounge" + (KoLCharacter.canInteract() ? "Softcore" : "Hardcore"))) {
       ClanLoungeRequest.getBreakfast();
-      KoLmafia.forceContinue();
     }
   }
 
@@ -189,11 +202,15 @@ public class BreakfastManager {
 
     if (InventoryManager.hasItem(manual)) {
       RequestThread.postRequest(UseItemRequest.getInstance(manual));
-      KoLmafia.forceContinue();
     }
   }
 
   private static void useToys() {
+    if (!Preferences.getBoolean(
+        "useCrimboToys" + (KoLCharacter.canInteract() ? "Softcore" : "Hardcore"))) {
+      return;
+    }
+
     boolean useCloset = true;
     boolean useStorage = KoLCharacter.canInteract();
 
@@ -289,13 +306,13 @@ public class BreakfastManager {
       int slot = KoLCharacter.equipmentSlot(toy);
 
       RequestThread.postRequest(request);
-      KoLmafia.forceContinue();
+      BreakfastManager.ignoreErrors();
 
       // If the toy is equipment, we had it equipped, and
       // "using" it unequipped it, re-equip it
       if (slot != EquipmentManager.NONE && !KoLCharacter.hasEquipped(toy, slot)) {
         RequestThread.postRequest(new EquipmentRequest(toy, slot));
-        KoLmafia.forceContinue();
+        BreakfastManager.ignoreErrors();
       }
     }
   }
@@ -315,7 +332,7 @@ public class BreakfastManager {
         KoLmafiaCLI.DEFAULT_SHELL.executeLine("hermit " + count + " 11-leaf clover");
       }
 
-      KoLmafia.forceContinue();
+      BreakfastManager.ignoreErrors();
     }
   }
 
@@ -597,7 +614,6 @@ public class BreakfastManager {
     if (Preferences.getBoolean(
         "checkJackass" + (KoLCharacter.canInteract() ? "Softcore" : "Hardcore"))) {
       ArcadeRequest.checkJackassPlumber();
-      KoLmafia.forceContinue();
     }
   }
 
@@ -616,7 +632,6 @@ public class BreakfastManager {
       int num = 3 - Preferences.getInteger("_genieWishesUsed");
       for (int i = 0; i < num; i++) {
         RequestThread.postRequest(new GenieRequest("for more wishes"));
-        KoLmafia.forceContinue();
       }
     }
   }
@@ -740,14 +755,14 @@ public class BreakfastManager {
     }
     KoLmafia.updateDisplay("Collecting cut of hippy profits...");
     RequestThread.postRequest(new GenericRequest("shop.php?whichshop=hippy"));
-    KoLmafia.forceContinue();
+    BreakfastManager.ignoreErrors();
   }
 
   private static void visitFarmer() {
     IslandRequest request = IslandRequest.getFarmerRequest();
     if (request != null) {
       RequestThread.postRequest(request);
-      KoLmafia.forceContinue();
+      BreakfastManager.ignoreErrors();
     }
   }
 
@@ -755,7 +770,6 @@ public class BreakfastManager {
     IslandRequest request = IslandRequest.getPyroRequest();
     if (request != null) {
       RequestThread.postRequest(request);
-      KoLmafia.forceContinue();
     }
   }
 
@@ -818,8 +832,6 @@ public class BreakfastManager {
     // ChoiceManager automate the choice through option 1
     RequestThread.postRequest(new PlaceRequest("thesea", "thesea_left2", false));
     FamiliarManager.changeFamiliar(currentFam);
-
-    KoLmafia.forceContinue();
   }
 
   private static void harvestBatteries() {
@@ -850,8 +862,6 @@ public class BreakfastManager {
               new GenericRequest("choice.php?pwd&whichchoice=1448&option=1&pp=" + (pp + 1)));
         }
       }
-
-      KoLmafia.forceContinue();
     }
   }
 
@@ -873,8 +883,6 @@ public class BreakfastManager {
       KoLmafia.updateDisplay("Reading for a guild skill...");
 
       RequestThread.postRequest(UseItemRequest.getInstance(book));
-
-      KoLmafia.forceContinue();
     }
   }
 }

--- a/src/net/sourceforge/kolmafia/session/BreakfastManager.java
+++ b/src/net/sourceforge/kolmafia/session/BreakfastManager.java
@@ -84,8 +84,6 @@ public class BreakfastManager {
 
   private static final AdventureResult VIP_LOUNGE_KEY = ItemPool.get(ItemPool.VIP_LOUNGE_KEY, 1);
 
-  private BreakfastManager() {}
-
   private static List<Runnable> ACTIONS =
       List.of(
           BreakfastManager::checkRumpusRoom,
@@ -105,6 +103,8 @@ public class BreakfastManager {
           BreakfastManager::collectSeaJelly,
           BreakfastManager::harvestBatteries,
           BreakfastManager::useBookOfEverySkill);
+
+  private BreakfastManager() {}
 
   public static void getBreakfast(final boolean runComplete) {
     var limitmode = KoLCharacter.getLimitMode();


### PR DESCRIPTION
As described. In BreakfastManager, the forceContinue calls were causing userAborted to be ignored. Instead we should just set the continuation state to ignore errors incurred during the breakfast actions.

Not sure how a test could be written for this PR.