### PR TITLE
add pingpong command. soup up crimbotrain command. Add tests for both commands.

### DIFF
--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11112,5 +11112,5 @@
 11084	Crimbosmopolitan	965534353	crimbosmo.gif	drink	t	0
 11085	Crimbo dinner	343926636	crimbodinner.gif	food	t	0
 11086	overloaded Yule battery	858172004	battery.gif	familiar	t,d	75
-11087
+11087	train whistle	561292467	trainwhistle.gif	none, combat reusable		0
 11088	The Superconductor's CPU	952525089	cpu.gif	accessory		0

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -12066,6 +12066,7 @@ Item	toothbrush	Effect: "Very Clean Teeth", Effect Duration: 10
 # toy sixgun: Bang!
 # toy soldier: Deals 30-35 Damage (Requires Tequila)
 # toy soldier: (Not consumed when used)
+# train whistle: Blow it to weaken your foes
 # Trainbot autoassembly module: Gives you a piece of the Trainbot outfit
 Item	training scroll:  Shattering Punch	Skill: "Shattering Punch"
 Item	training scroll:  Shivering Monkey Technique	Skill: "Shivering Monkey Technique"

--- a/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
+++ b/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
@@ -716,6 +716,7 @@ public class KoLmafiaCLI {
     new PandaCommand().register("panda");
     new PastaThrallCommand().register("thralls");
     new PillKeeperCommand().register("pillkeeper");
+    new PingPongCommand().register("pingpong");
     new PirateInsultsCommand().register("insults");
     new PlayerSnapshotCommand().register("log");
     new PlayCommand().register("play").register("cheat");

--- a/src/net/sourceforge/kolmafia/textui/command/PingPongCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/PingPongCommand.java
@@ -7,19 +7,19 @@ import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.request.CurseRequest;
 
-public class CrimboTrainCommand extends AbstractCommand {
-  public CrimboTrainCommand() {
-    this.usage = "<player> - Offer Crimbo Training to someone else";
+public class PingPongCommand extends AbstractCommand {
+  public PingPongCommand() {
+    this.usage = "<player> - Play ping-pong with somebody.";
   }
 
   @Override
   public void run(String command, String parameters) {
     if (parameters.equals("")) {
-      KoLmafia.updateDisplay(MafiaState.ERROR, "Train whom?");
+      KoLmafia.updateDisplay(MafiaState.ERROR, "Play ping-pong with whom?");
       return;
     }
 
-    AdventureResult item = ItemPool.get(ItemPool.CRIMBO_TRAINING_MANUAL);
+    AdventureResult item = ItemPool.get(ItemPool.PING_PONG_TABLE);
     String target = parameters.trim();
     RequestThread.postRequest(new CurseRequest(item, target, ""));
   }

--- a/test/net/sourceforge/kolmafia/textui/command/CrimboTrainCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/CrimboTrainCommandTest.java
@@ -1,0 +1,112 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static internal.helpers.HttpClientWrapper.getRequests;
+import static internal.helpers.Networking.assertPostRequest;
+import static internal.helpers.Networking.html;
+import static internal.helpers.Player.withContinuationState;
+import static internal.helpers.Player.withHttpClientBuilder;
+import static internal.helpers.Player.withItem;
+import static internal.helpers.Player.withProperty;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import internal.helpers.Cleanups;
+import internal.helpers.HttpClientWrapper;
+import internal.network.FakeHttpClientBuilder;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CrimboTrainCommandTest extends AbstractCommandTestBase {
+
+  public CrimboTrainCommandTest() {
+    this.command = "crimbotrain";
+  }
+
+  @BeforeAll
+  public static void beforeAll() {
+    KoLCharacter.reset("CrimboTrainCommandTest");
+  }
+
+  @BeforeEach
+  public void beforeEach() {
+    Preferences.reset("CrimboTrainCommandTest");
+  }
+
+  @Test
+  public void noTargetIsError() {
+    HttpClientWrapper.setupFakeClient();
+    var cleanups =
+        new Cleanups(
+            withProperty("_crimboTraining", false),
+            withItem(ItemPool.CRIMBO_TRAINING_MANUAL),
+            withContinuationState());
+
+    try (cleanups) {
+      String output = execute("");
+      assertThat(output, containsString("Train whom?"));
+      assertErrorState();
+
+      var requests = getRequests();
+      assertThat(requests.size(), equalTo(0));
+    }
+  }
+
+  @Test
+  public void noCrimboTrainingManualIsError() {
+    HttpClientWrapper.setupFakeClient();
+    var cleanups = new Cleanups(withProperty("_crimboTraining", false));
+
+    try (cleanups) {
+      String output = execute("Hairy");
+      assertThat(output, containsString("You need 1 more Crimbo training manual to continue."));
+      assertErrorState();
+
+      var requests = getRequests();
+      assertThat(requests.size(), equalTo(0));
+    }
+  }
+
+  @Test
+  public void alreadyTrainedTodayIsError() {
+    HttpClientWrapper.setupFakeClient();
+    var cleanups =
+        new Cleanups(
+            withProperty("_crimboTraining", true), withItem(ItemPool.CRIMBO_TRAINING_MANUAL));
+
+    try (cleanups) {
+      String output = execute("Hairy");
+      assertThat(output, containsString("You've already trained somebody today."));
+      assertErrorState();
+
+      var requests = getRequests();
+      assertThat(requests.size(), equalTo(0));
+    }
+  }
+
+  @Test
+  public void canDetectTargetAlreadyKnowsSkill() {
+    var builder = new FakeHttpClientBuilder();
+    var client = builder.client;
+    var cleanups =
+        new Cleanups(
+            withHttpClientBuilder(builder),
+            withProperty("_crimboTraining", false),
+            withItem(ItemPool.CRIMBO_TRAINING_MANUAL));
+    try (cleanups) {
+      client.addResponse(200, html("request/test_use_crimbo_training_3c.html"));
+      String output = execute("121572");
+      assertThat(output, containsString("They already know that skill."));
+      assertErrorState();
+
+      var requests = client.getRequests();
+      assertThat(requests.size(), equalTo(1));
+      assertPostRequest(
+          requests.get(0), "/curse.php", "action=use&whichitem=11046&targetplayer=121572");
+    }
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/command/PingPongCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/PingPongCommandTest.java
@@ -1,0 +1,156 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static internal.helpers.HttpClientWrapper.getRequests;
+import static internal.helpers.Networking.assertPostRequest;
+import static internal.helpers.Networking.html;
+import static internal.helpers.Player.withContinuationState;
+import static internal.helpers.Player.withHttpClientBuilder;
+import static internal.helpers.Player.withItem;
+import static internal.helpers.Player.withProperty;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+
+import internal.helpers.Cleanups;
+import internal.helpers.HttpClientWrapper;
+import internal.network.FakeHttpClientBuilder;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PingPongCommandTest extends AbstractCommandTestBase {
+
+  public PingPongCommandTest() {
+    this.command = "pingpong";
+  }
+
+  @BeforeAll
+  public static void beforeAll() {
+    KoLCharacter.reset("PingPongCommandTest");
+  }
+
+  @BeforeEach
+  public void beforeEach() {
+    Preferences.reset("PingPongCommandTest");
+  }
+
+  @Test
+  public void noTargetIsError() {
+    HttpClientWrapper.setupFakeClient();
+    var cleanups =
+        new Cleanups(
+            withProperty("_pingPongGame", false),
+            withItem(ItemPool.PING_PONG_TABLE),
+            withContinuationState());
+
+    try (cleanups) {
+      String output = execute("");
+      assertThat(output, containsString("Play ping-pong with whom?"));
+      assertErrorState();
+
+      var requests = getRequests();
+      assertThat(requests, hasSize(0));
+    }
+  }
+
+  @Test
+  public void noPingPongingTableIsError() {
+    HttpClientWrapper.setupFakeClient();
+    var cleanups = new Cleanups(withProperty("_pingPongGame", false));
+
+    try (cleanups) {
+      String output = execute("Veracity");
+      assertThat(output, containsString("You need 1 more portable ping-pong table to continue."));
+      assertErrorState();
+      var requests = getRequests();
+      assertThat(requests, hasSize(0));
+    }
+  }
+
+  @Test
+  public void alreadyPlayedTodayIsError() {
+    HttpClientWrapper.setupFakeClient();
+    var cleanups =
+        new Cleanups(withProperty("_pingPongGame", true), withItem(ItemPool.PING_PONG_TABLE));
+
+    try (cleanups) {
+      String output = execute("Veracity");
+      assertThat(output, containsString("You've already played ping-pong today."));
+      assertErrorState();
+
+      var requests = getRequests();
+      assertThat(requests, hasSize(0));
+    }
+  }
+
+  @Test
+  public void canDetectTargetInHardcoreOrRonin() {
+    var builder = new FakeHttpClientBuilder();
+    var client = builder.client;
+    var cleanups =
+        new Cleanups(
+            withHttpClientBuilder(builder),
+            withProperty("_pingPongGame", false),
+            withItem(ItemPool.PING_PONG_TABLE));
+    try (cleanups) {
+      client.addResponse(200, html("request/test_use_ping_pong_table_ronin.html"));
+      String output = execute("Hairy");
+      assertThat(output, containsString("Can't use the item on that player at the moment."));
+      assertErrorState();
+
+      var requests = client.getRequests();
+      assertThat(requests, hasSize(1));
+      assertPostRequest(
+          requests.get(0), "/curse.php", "action=use&whichitem=11059&targetplayer=Hairy");
+    }
+  }
+
+  @Test
+  public void canDetectWinningGame() {
+    var builder = new FakeHttpClientBuilder();
+    var client = builder.client;
+    var cleanups =
+        new Cleanups(
+            withHttpClientBuilder(builder),
+            withProperty("_pingPongGame", false),
+            withItem(ItemPool.PING_PONG_TABLE));
+    try (cleanups) {
+      client.addResponse(200, html("request/test_use_ping_pong_table_prowess.html"));
+      String output = execute("Blippy Bloppy");
+      assertThat(output, containsString("You won the ping-pong game."));
+      assertContinueState();
+
+      var requests = client.getRequests();
+      assertThat(requests, hasSize(2));
+      assertPostRequest(
+          requests.get(0), "/curse.php", "action=use&whichitem=11059&targetplayer=Blippy Bloppy");
+      assertPostRequest(requests.get(1), "/api.php", "what=status&for=KoLmafia");
+    }
+  }
+
+  @Test
+  public void canDetectLosingGame() {
+    var builder = new FakeHttpClientBuilder();
+    var client = builder.client;
+    var cleanups =
+        new Cleanups(
+            withHttpClientBuilder(builder),
+            withProperty("_pingPongGame", false),
+            withItem(ItemPool.PING_PONG_TABLE));
+    try (cleanups) {
+      client.addResponse(200, html("request/test_use_ping_pong_table_persistence.html"));
+      String output = execute("Veracity");
+      assertThat(output, containsString("You lost the ping-pong game."));
+      assertContinueState();
+
+      var requests = client.getRequests();
+      assertThat(requests, hasSize(2));
+      assertPostRequest(
+          requests.get(0), "/curse.php", "action=use&whichitem=11059&targetplayer=Veracity");
+      assertPostRequest(requests.get(1), "/api.php", "what=status&for=KoLmafia");
+    }
+  }
+}


### PR DESCRIPTION
1) pingpong TARGET - play a ping-pong game
2) crimbotrain TARGET - train a Crimbo skill
3) Fix grammar: "who" is a subject, "whom" is an object.

Both of those are once per day.
CurseRequest now checks for that.

4) train whistle is now implemented.
This is the last Crimbo 2022 content I am aware of that we had not previously supported.
Well, Arena parameters for the Mini-Trainbot. But that is for completeness; does anybody automate training in the Cake Arena anymore? I just use Familiar Jacks to get the familiar item - but when I derive the parameters, I get a slew of them to put into the mall.
Perhaps I should train, sooner, rather than later, while the price is hot. ;)

Comment: I would like to have a "Combat Items" section in modifiers.txt, preceding the "Everything Else" section.
It may all be comments, for now, but if we ever decide to soup up combat item support (somehow), it will be helpful.
And it will be helpful for human-reading, immediately.