### PR TITLE
Don't cache fought monsters in Locket.

### DIFF
--- a/src/net/sourceforge/kolmafia/session/LocketManager.java
+++ b/src/net/sourceforge/kolmafia/session/LocketManager.java
@@ -26,7 +26,7 @@ public class LocketManager {
       Set.of("HP Regen Min", "HP Regen Max", "MP Regen Min", "MP Regen Max", "Single Equip");
 
   private static void addFoughtMonster(int monsterId) {
-    Set<Integer> foughtMonsters = getFoughtMonsters();
+    Set<Integer> foughtMonsters = new TreeSet<>(getFoughtMonsters());
     foughtMonsters.add(monsterId);
 
     // Add monster id to pref ensuring distinct

--- a/src/net/sourceforge/kolmafia/session/LocketManager.java
+++ b/src/net/sourceforge/kolmafia/session/LocketManager.java
@@ -21,14 +21,12 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class LocketManager {
   private static final Set<Integer> knownMonsters = new TreeSet<>();
-  private static final Set<Integer> foughtMonsters = new TreeSet<>();
   private static final Pattern REMINISCABLE_MONSTER = Pattern.compile("<option value=\"(\\d+)\"");
   private static final Set<String> CONSTANT_MODS =
       Set.of("HP Regen Min", "HP Regen Max", "MP Regen Min", "MP Regen Max", "Single Equip");
 
   private static void addFoughtMonster(int monsterId) {
-    parseFoughtMonsters();
-
+    Set<Integer> foughtMonsters = getFoughtMonsters();
     foughtMonsters.add(monsterId);
 
     // Add monster id to pref ensuring distinct
@@ -38,15 +36,6 @@ public class LocketManager {
   }
 
   private LocketManager() {}
-
-  public static void parseFoughtMonsters() {
-    foughtMonsters.clear();
-
-    Arrays.stream(Preferences.getString("_locketMonstersFought").split(","))
-        .filter(StringUtilities::isNumeric)
-        .map(Integer::parseInt)
-        .forEach(foughtMonsters::add);
-  }
 
   public static Set<Integer> getMonsters() {
     return Collections.unmodifiableSet(knownMonsters);
@@ -65,7 +54,7 @@ public class LocketManager {
   }
 
   public static boolean foughtMonster(int monsterId) {
-    return foughtMonsters.contains(monsterId);
+    return getFoughtMonsters().contains(monsterId);
   }
 
   public static boolean foughtMonster(MonsterData monster) {
@@ -73,7 +62,10 @@ public class LocketManager {
   }
 
   public static Set<Integer> getFoughtMonsters() {
-    return Collections.unmodifiableSet(foughtMonsters);
+    return Arrays.stream(Preferences.getString("_locketMonstersFought").split(","))
+        .filter(StringUtilities::isNumeric)
+        .map(Integer::parseInt)
+        .collect(Collectors.toUnmodifiableSet());
   }
 
   public static void parseMonsters(final String text) {
@@ -87,8 +79,7 @@ public class LocketManager {
     }
 
     // Add all the monsters you've fought today, which will not otherwise show on said page
-    parseFoughtMonsters();
-    knownMonsters.addAll(foughtMonsters);
+    knownMonsters.addAll(getFoughtMonsters());
   }
 
   public static void parseFight(final MonsterData monster, final String text) {
@@ -165,7 +156,6 @@ public class LocketManager {
 
   public static void clear() {
     knownMonsters.clear();
-    foughtMonsters.clear();
   }
 
   public static void reset() {

--- a/test/net/sourceforge/kolmafia/session/LocketManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/LocketManagerTest.java
@@ -8,10 +8,17 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class LocketManagerTest {
+  @BeforeAll
+  public static void beforeAll() {
+    Preferences.reset("ReminisceCommandTest");
+  }
+
   @BeforeEach
   public void beforeEach() {
     LocketManager.clear();

--- a/test/net/sourceforge/kolmafia/session/LocketManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/LocketManagerTest.java
@@ -1,21 +1,20 @@
 package net.sourceforge.kolmafia.session;
 
 import static internal.helpers.Networking.html;
+import static internal.helpers.Player.withProperty;
 import static internal.matchers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 
-import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
-import net.sourceforge.kolmafia.preferences.Preferences;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class LocketManagerTest {
   @BeforeEach
   public void beforeEach() {
-    KoLCharacter.reset("LocketManagerTest");
-    Preferences.reset("LocketManagerTest");
+    LocketManager.clear();
   }
 
   @Test
@@ -27,23 +26,33 @@ public class LocketManagerTest {
 
   @Test
   public void addsFightToMonsterList() {
-    Preferences.setString("_locketMonstersFought", "5");
+    try (var cleanups = withProperty("_locketMonstersFought", "5")) {
+      var monster = MonsterDatabase.findMonster("alielf");
+      var html = html("request/test_fight_start_locket_fight_with_horror.html");
+      LocketManager.parseFight(monster, html);
 
-    var monster = MonsterDatabase.findMonster("alielf");
-    var html = html("request/test_fight_start_locket_fight_with_horror.html");
-    LocketManager.parseFight(monster, html);
-
-    assertThat("_locketMonstersFought", isSetTo("5,1092"));
+      assertThat("_locketMonstersFought", isSetTo("5,1092"));
+    }
   }
 
   @Test
   public void addsFightToMonsterListWithoutDuplicating() {
-    Preferences.setString("_locketMonstersFought", "5,1092");
+    try (var cleanups = withProperty("_locketMonstersFought", "5,1092")) {
+      var monster = MonsterDatabase.findMonster("alielf");
+      var html = html("request/test_fight_start_locket_fight_with_horror.html");
+      LocketManager.parseFight(monster, html);
 
-    var monster = MonsterDatabase.findMonster("alielf");
-    var html = html("request/test_fight_start_locket_fight_with_horror.html");
-    LocketManager.parseFight(monster, html);
+      assertThat("_locketMonstersFought", isSetTo("5,1092"));
+    }
+  }
 
-    assertThat("_locketMonstersFought", isSetTo("5,1092"));
+  @Test
+  public void foughtMonstersResetsOnNewDay() {
+    try (var cleanups = withProperty("_locketMonstersFought", "5")) {
+      LocketManager.getFoughtMonsters();
+      try (var cleanups2 = withProperty("_locketMonstersFought", "")) {
+        assertThat(LocketManager.getFoughtMonsters(), empty());
+      }
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/session/LocketManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/LocketManagerTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 public class LocketManagerTest {
   @BeforeAll
   public static void beforeAll() {
-    Preferences.reset("ReminisceCommandTest");
+    Preferences.reset("LocketManagerTest");
   }
 
   @BeforeEach

--- a/test/net/sourceforge/kolmafia/textui/command/ReminisceCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ReminisceCommandTest.java
@@ -1,32 +1,25 @@
 package net.sourceforge.kolmafia.textui.command;
 
 import static internal.helpers.Player.withItem;
+import static internal.helpers.Player.withProperty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 
-import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.preferences.Preferences;
+import internal.helpers.Cleanups;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.LocketManager;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ReminisceCommandTest extends AbstractCommandTestBase {
   @BeforeEach
   public void initEach() {
-    KoLCharacter.reset("ReminisceCommandTest");
-    Preferences.reset("ReminisceCommandTest");
+    LocketManager.clear();
 
     // Stop requests from actually running
     GenericRequest.sessionId = null;
-  }
-
-  @AfterEach
-  public void afterEach() {
-    KoLCharacter.reset("");
   }
 
   public ReminisceCommandTest() {
@@ -43,9 +36,11 @@ public class ReminisceCommandTest extends AbstractCommandTestBase {
 
   @Test
   void cannotFightMoreThanThree() {
-    Preferences.setString("_locketMonstersFought", "1,3,5");
-    LocketManager.parseFoughtMonsters();
-    var cleanups = withItem("combat lover's locket");
+    LocketManager.rememberMonster(1204);
+
+    var cleanups =
+        new Cleanups(
+            withItem("combat lover's locket"), withProperty("_locketMonstersFought", "1,3,5"));
     try (cleanups) {
       String output = execute("Black Crayon Penguin");
       assertThat(output, containsString("You can only"));
@@ -66,7 +61,6 @@ public class ReminisceCommandTest extends AbstractCommandTestBase {
 
   @Test
   void mustReminisceAValidMonster() {
-    LocketManager.parseFoughtMonsters();
     var cleanups = withItem("combat lover's locket");
     try (cleanups) {
       String output = execute("monster that does not exist purple monkey dishwasher");
@@ -78,9 +72,10 @@ public class ReminisceCommandTest extends AbstractCommandTestBase {
 
   @Test
   void cannotFightSameMonsterTwice() {
-    Preferences.setString("_locketMonstersFought", "1");
-    LocketManager.parseFoughtMonsters();
-    var cleanups = withItem("combat lover's locket");
+    LocketManager.rememberMonster(1);
+
+    var cleanups =
+        new Cleanups(withItem("combat lover's locket"), withProperty("_locketMonstersFought", "1"));
     try (cleanups) {
       String output = execute("1");
 

--- a/test/net/sourceforge/kolmafia/textui/command/ReminisceCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ReminisceCommandTest.java
@@ -8,18 +8,25 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 
 import internal.helpers.Cleanups;
+import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.LocketManager;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ReminisceCommandTest extends AbstractCommandTestBase {
-  @BeforeEach
-  public void initEach() {
-    LocketManager.clear();
+  @BeforeAll
+  public static void beforeAll() {
+    Preferences.reset("ReminisceCommandTest");
 
     // Stop requests from actually running
     GenericRequest.sessionId = null;
+  }
+
+  @BeforeEach
+  public void beforeEach() {
+    LocketManager.clear();
   }
 
   public ReminisceCommandTest() {


### PR DESCRIPTION
In the current code, resetting when the day turns over doesn't reset LocketManager, meaning that you won't be able to make locket requests because the monsters fought property has been reset but the cached `foughtMonsters` variable hasn't. 

This PR makes it so `getFoughtMonsters` is no longer cached, meaning the value can't get out of sync with the pref (there is one source of truth). `getFoughtMonsters` gets called only infrequently, so this is not a performance issue. The PR also adds a test for this case and cleans up the tests a little.