### PR TITLE
Optimize mall price database.

### DIFF
--- a/src/net/sourceforge/kolmafia/request/MallSearchRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MallSearchRequest.java
@@ -230,13 +230,18 @@ public class MallSearchRequest extends GenericRequest {
       page++;
     }
 
+    this.maybeUpdateMallPrice();
+
+    KoLmafia.updateDisplay("Search complete.");
+  }
+
+  // Public for access from tests.
+  public void maybeUpdateMallPrice() {
     // If an exact match, we can think about updating mall_price().
     if (this.searchString.startsWith("\"") && this.results.size() > 0) {
       AdventureResult item = this.results.get(0).getItem();
       MallPriceManager.updateMallPrice(item, new ArrayList<>(this.results));
     }
-
-    KoLmafia.updateDisplay("Search complete.");
   }
 
   private boolean updateSearchString() {

--- a/src/net/sourceforge/kolmafia/session/MallPriceManager.java
+++ b/src/net/sourceforge/kolmafia/session/MallPriceManager.java
@@ -310,6 +310,11 @@ public abstract class MallPriceManager {
 
     if (KoLmafia.permitsContinue()) {
       MallPriceManager.mallSearches.put(id, results);
+      // searchMall will have saved the mall price if we got any results back (otherwise it
+      // doesn't know the item ID). If no results, we should save it ourselves (as -1) here.
+      if (results.size() == 0) {
+        MallPriceManager.updateMallPrice(itemId, results);
+      }
     }
 
     return results;
@@ -483,8 +488,7 @@ public abstract class MallPriceManager {
 
     if (price == 0) {
       AdventureResult search = ItemPool.get(itemId, NTH_CHEAPEST_COUNT);
-      List<PurchaseRequest> results = MallPriceManager.searchMall(search);
-      MallPriceManager.updateMallPrice(itemId, results);
+      MallPriceManager.searchMall(search);
       price = MallPriceManager.mallPrices.getOrDefault(itemId, 0);
     }
 

--- a/test/net/sourceforge/kolmafia/session/MallPriceManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/MallPriceManagerTest.java
@@ -121,6 +121,7 @@ public class MallPriceManagerTest {
               request.setSearchString(searchString);
               request.setCheapestCount(cheapestCount);
               request.setResults(results);
+              request.maybeUpdateMallPrice();
               return request;
             });
     mocked


### PR DESCRIPTION
This PR optimizes one of the remaining CPU bottlenecks in the code, the mall price database. Every write of the database serializes every recorded price again, which is slow—taking as much as 30% of execution CPU time while running mall-heavy segments of garbo.

Much like in Preferences, we can just cache the encoded values and only concatenate them when the database is written to disk. The PR also removes double-recording of mall prices when `mall_price` is called from the runtime library—in the current code `getMallPrice` saves the price and calls `searchMall`, which also saves the price.

MallPriceDatabase/MallPriceManager are sufficiently well-tested that I don't think any new tests are needed.

The PR increases speed of the following synthetic benchmark by a factor of roughly 2, and the real-world impact should be better due to removal of the double-recording behavior.

```java
  @Test
  void speed() {
    int N = 300;
    MallPriceDatabase.savePricesToFile = true;
    for (var entry : ItemDatabase.entrySet()) {
      MallPriceDatabase.recordPrice(entry.getKey(), entry.getKey(), true);
    }
    for (int i = 0; i < 2 * N / 5; i++) {
      MallPriceDatabase.writePrices();
    }
    long start =
        ManagementFactory.getThreadMXBean().getThreadCpuTime(Thread.currentThread().getId());
    for (int i = 0; i < N; i++) {
      MallPriceDatabase.writePrices();
    }
    long end = ManagementFactory.getThreadMXBean().getThreadCpuTime(Thread.currentThread().getId());
    System.out.println("Elapsed: " + (end - start) / 1_000_000);
    new File(KoLConstants.DATA_LOCATION, "mallprices.txt").delete();
  }
```