### PR TITLE
Check the ownsSpeakeasy property in canAdventure

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -2069,6 +2069,10 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
       return Preferences.getBoolean("prAlways") || Preferences.getBoolean("_prToday");
     }
 
+    if (this.zone.equals("Speakeasy")) {
+      return (Preferences.getBoolean("ownsSpeakeasy"));
+    }
+
     // Assume that any areas we did not call out above are available
     return true;
   }


### PR DESCRIPTION
Currently this seems to always be the case in the GCLI even on a new account:
```
ash can_adventure( $location[An Unusually Quiet Barroom Brawl] )

Returned: true
```
Visiting the wrong side of the tracks and toggling the `ownsSpeakeasy` property do not have any effect.
This change will make the `canAdventure` function check the `ownsSpeakeasy` for determining if you can adventure and should be consistent with other content-unlocker behavior.