### PR TITLE
Use non-autoflush PrintStream rather than LogStream for mall prices.

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/MallPriceDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/MallPriceDatabase.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.persistence;
 
+import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -19,6 +20,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import net.java.dev.spellcast.utilities.DataUtilities;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
@@ -27,7 +29,6 @@ import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.MallPriceManager;
 import net.sourceforge.kolmafia.utilities.FileUtilities;
 import net.sourceforge.kolmafia.utilities.HttpUtilities;
-import net.sourceforge.kolmafia.utilities.LogStream;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class MallPriceDatabase {
@@ -160,7 +161,9 @@ public class MallPriceDatabase {
       return;
     }
 
-    try (PrintStream writer = LogStream.openStream(PRICE_FILE, true)) {
+    try (PrintStream writer =
+        new PrintStream(
+            new BufferedOutputStream(DataUtilities.getOutputStream(PRICE_FILE)), false)) {
       writePrices(writer);
     }
   }


### PR DESCRIPTION
I meant to include this in #1382 - the price writing code should use a buffered output stream, instead of a LogStream which auto-flushes each byte array write.

This PR reduces time on the below benchmark from about 10 s to about 500 ms.

```java
  @Test
  void speed() {
    int N = 300;
    MallPriceDatabase.savePricesToFile = true;
    for (var entry : ItemDatabase.entrySet()) {
      MallPriceDatabase.recordPrice(entry.getKey(), entry.getKey(), true);
    }
    for (int i = 0; i < 2 * N / 5; i++) {
      MallPriceDatabase.writePrices();
    }
    long start =
        ManagementFactory.getThreadMXBean().getThreadCpuTime(Thread.currentThread().getId());
    for (int i = 0; i < N; i++) {
      MallPriceDatabase.writePrices();
    }
    long end = ManagementFactory.getThreadMXBean().getThreadCpuTime(Thread.currentThread().getId());
    System.out.println("Elapsed: " + (end - start) / 1_000_000);
    new File(KoLConstants.DATA_LOCATION, "mallprices.txt").delete();
  }
```