### PR TITLE
Elaborate when failing to acquire session lock.

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -204,6 +204,8 @@ public abstract class KoLmafia {
       KoLmafia.SESSION_HOLDER = KoLmafia.SESSION_CHANNEL.lock();
       return true;
     } catch (Exception e) {
+      KoLmafia.updateDisplay(
+          MafiaState.ABORT, "Could not acquire file lock for " + suffix + ": " + e);
       return false;
     }
   }

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -2,7 +2,6 @@ package net.sourceforge.kolmafia.session;
 
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
-import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.KoLmafiaCLI;
 import net.sourceforge.kolmafia.KoLmafiaGUI;
@@ -45,8 +44,7 @@ public class LoginManager {
   public static void login(String username) {
     try {
       if (!KoLmafia.acquireFileLock(Preferences.baseUserName(username))) {
-        KoLmafia.updateDisplay(
-            MafiaState.ABORT, "Could not acquire file lock for " + username + ".");
+        // acquireFileLock should call updateDisplay with a more detailed error message.
         return;
       }
       KoLmafia.forceContinue();


### PR DESCRIPTION
It would be good to know why we can't acquire the lock, whether it's because it's already held, or because we don't have write permissions to the directory, or something else.