### PR TITLE
chore: don't time tests any more

### DIFF
--- a/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,4 +1,3 @@
 internal.extensions.ForbidNetworkAccess
 internal.extensions.ClearSharedStateBefore
 internal.extensions.ClearSharedStateAfter
-internal.extensions.TimeTests


### PR DESCRIPTION
The problem seems to have gone away, so don't time tests by default.

Leave the class in in case somebody (e.g. me) wants to time a test locally.