### PR TITLE
fix: modifiers NPE

### DIFF
--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -1307,6 +1307,7 @@ public class Modifiers {
   }
 
   public Modifiers(Modifiers copy) {
+    this();
     this.set(copy);
   }
 
@@ -1557,7 +1558,7 @@ public class Modifiers {
 
     String[] copyStrings = mods.strings;
     for (int index = 0; index < this.strings.length; ++index) {
-      if (this.strings[index] == null || !this.strings[index].equals(copyStrings[index])) {
+      if (!this.strings[index].equals(copyStrings[index])) {
         this.strings[index] = copyStrings[index];
         changed = true;
       }

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -589,6 +589,7 @@ public class ItemPool {
   public static final int STUFFED_COCOABO = 1974;
   public static final int RUBBER_WWTNSD_BRACELET = 1994;
   public static final int SPADE_NECKLACE = 2017;
+  public static final int WICKER_SHIELD = 2034;
   public static final int PATCHOULI_OIL_BOMB = 2040;
   public static final int EXPLODING_HACKY_SACK = 2042;
   public static final int MACGUFFIN_DIARY = 2044;

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -1153,4 +1153,23 @@ public class MaximizerTest {
       }
     }
   }
+
+  @Nested
+  public class Familiars {
+    @Test
+    public void leftHandManEquipsItem() {
+      var cleanups =
+          new Cleanups(
+              withFamiliar(FamiliarPool.LEFT_HAND),
+              withEquippableItem(ItemPool.WICKER_SHIELD, 2),
+              withItem(ItemPool.STUFFED_CHEST) // equipment with no enchant to test modifiers crash
+              );
+
+      try (cleanups) {
+        assertTrue(maximize("moxie"));
+        recommendedSlotIs(EquipmentManager.OFFHAND, "wicker shield");
+        recommendedSlotIs(EquipmentManager.FAMILIAR, "wicker shield");
+      }
+    }
+  }
 }


### PR DESCRIPTION
Came in on #1394. A modifier can end up with particular string entries (e.g. `Modifiers.EQUALIZE`) being null.

Not yet sure what's causing it, but the only way I can see that happening is if the Modifiers constructor is called, and not all the string fields are set (for some reason), Not sure how this could happen, can't reproduce from scratch. `getModifiersInternal` can return null under some circumstances, and in that case `set` doesn't populate anything, so /maybe/ that's happening?