### PR TITLE
feat: track drops from infinite drop familiars (including sheep)

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1799,6 +1799,7 @@ user	_fudgeSporkUsed	false
 user	_fudgeWaspFights	0
 user	_gallapagosMonster
 user	_gapBuffs	0
+user	_garbageFireDrops	0
 user	_garbageFireDropsCrown	0
 user	_garbageItemChanged	false
 user	_genieFightsUsed	0
@@ -1834,6 +1835,7 @@ user	_grimstoneMaskDrops	0
 user	_grimstoneMaskDropsCrown	0
 user	_grooseCharge	0
 user	_grooseDrops	0
+user	_grubbyWoolDrops	0
 user	_guildManualUsed	false
 user	_guzzlrDeliveries	0
 user	_guzzlrGoldDeliveries	0
@@ -2083,6 +2085,7 @@ user	_resolutionAdv	0
 user	_resolutionRareSummons	0
 user	_rhinestonesAcquired	false
 user	_riftletAdv	0
+user	_robinEggDrops	0
 user	_roboDrinks
 user	_roboDrops	0
 user	_rogueProgramCharge	0
@@ -2271,6 +2274,7 @@ user	_warbearBankUsed	false
 user	_warbearBreakfastMachineUsed	false
 user	_warbearGyrocopterUsed	false
 user	_warbearSodaMachineUsed	false
+user	_waxGlobDrops	0
 user	_whiteRiceDrops	0
 user	_wildfireBarrelHarvested	false
 user	_witchessBuff	false

--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -1147,7 +1147,31 @@ public class FamiliarData implements Comparable<FamiliarData> {
             1));
     DROP_FAMILIARS.add(
         new DropInfo(
+            FamiliarPool.ROCKIN_ROBIN,
+            ItemPool.ROBIN_EGG,
+            "robin's egg",
+            "_robinEggDrops",
+            Integer.MAX_VALUE));
+    DROP_FAMILIARS.add(
+        new DropInfo(
+            FamiliarPool.CANDLE,
+            ItemPool.WAX_GLOB,
+            "wax glob",
+            "_waxGlobDrops",
+            Integer.MAX_VALUE));
+    DROP_FAMILIARS.add(
+        new DropInfo(
+            FamiliarPool.GARBAGE_FIRE, -1, "burning item", "_garbageFireDrops", Integer.MAX_VALUE));
+    DROP_FAMILIARS.add(
+        new DropInfo(
             FamiliarPool.COOKBOOKBAT, -1, "cookbookbat recipe", "_cookbookbatRecipeDrops", 1));
+    DROP_FAMILIARS.add(
+        new DropInfo(
+            FamiliarPool.HOBO_IN_SHEEPS_CLOTHING,
+            ItemPool.GRUBBY_WOOL,
+            "grubby wool",
+            "_grubbyWoolDrops",
+            Integer.MAX_VALUE));
   }
 
   public static DropInfo getDropInfo(int id) {

--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -1147,21 +1147,11 @@ public class FamiliarData implements Comparable<FamiliarData> {
             1));
     DROP_FAMILIARS.add(
         new DropInfo(
-            FamiliarPool.ROCKIN_ROBIN,
-            ItemPool.ROBIN_EGG,
-            "robin's egg",
-            "_robinEggDrops",
-            Integer.MAX_VALUE));
+            FamiliarPool.ROCKIN_ROBIN, ItemPool.ROBIN_EGG, "robin's egg", "_robinEggDrops", -1));
     DROP_FAMILIARS.add(
-        new DropInfo(
-            FamiliarPool.CANDLE,
-            ItemPool.WAX_GLOB,
-            "wax glob",
-            "_waxGlobDrops",
-            Integer.MAX_VALUE));
+        new DropInfo(FamiliarPool.CANDLE, ItemPool.WAX_GLOB, "wax glob", "_waxGlobDrops", -1));
     DROP_FAMILIARS.add(
-        new DropInfo(
-            FamiliarPool.GARBAGE_FIRE, -1, "burning item", "_garbageFireDrops", Integer.MAX_VALUE));
+        new DropInfo(FamiliarPool.GARBAGE_FIRE, -1, "burning item", "_garbageFireDrops", -1));
     DROP_FAMILIARS.add(
         new DropInfo(
             FamiliarPool.COOKBOOKBAT, -1, "cookbookbat recipe", "_cookbookbatRecipeDrops", 1));
@@ -1171,7 +1161,7 @@ public class FamiliarData implements Comparable<FamiliarData> {
             ItemPool.GRUBBY_WOOL,
             "grubby wool",
             "_grubbyWoolDrops",
-            Integer.MAX_VALUE));
+            -1));
   }
 
   public static DropInfo getDropInfo(int id) {

--- a/src/net/sourceforge/kolmafia/objectpool/FamiliarPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/FamiliarPool.java
@@ -117,6 +117,7 @@ public class FamiliarPool {
   public static final int VAMPIRE_VINTNER = 284;
   public static final int GREY_GOOSE = 287;
   public static final int COOKBOOKBAT = 288;
+  public static final int HOBO_IN_SHEEPS_CLOTHING = 290;
 
   private FamiliarPool() {}
 }

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3481,6 +3481,7 @@ public class ItemPool {
   public static final int PORTABLE_STEAM_UNIT = 11081;
   public static final int CRYSTAL_CRIMBO_GOBLET = 11082;
   public static final int CRYSTAL_CRIMBO_PLATTER = 11083;
+  public static final int GRUBBY_WOOL = 11091;
   public static final int ROCK_SEEDS = 11100;
   public static final int GROVELING_GRAVEL = 11101;
   public static final int MILESTONE = 11104;

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -2692,6 +2692,7 @@ public class ResultProcessor {
               .equals(KoLCharacter.usableFamiliar(FamiliarPool.GARBAGE_FIRE))) {
             // This will be updated to 0 in FightRequest later
             Preferences.setInteger("garbageFireProgress", -1);
+            Preferences.increment("_garbageFireDrops", 1);
           }
         }
         break;
@@ -2702,6 +2703,7 @@ public class ResultProcessor {
               .equals(KoLCharacter.usableFamiliar(FamiliarPool.GARBAGE_FIRE))) {
             // This will be updated to 0 in FightRequest later
             Preferences.setInteger("garbageFireProgress", -1);
+            Preferences.increment("_garbageFireDrops", 1);
           } else if (KoLCharacter.currentBjorned.getId() == FamiliarPool.GARBAGE_FIRE
               || KoLCharacter.currentEnthroned.getId() == FamiliarPool.GARBAGE_FIRE) {
             Preferences.increment("_garbageFireDropsCrown");
@@ -3139,6 +3141,7 @@ public class ResultProcessor {
           if (KoLCharacter.currentFamiliar.getId() == FamiliarPool.ROCKIN_ROBIN) {
             // This will be updated to 0 in FightRequest later
             Preferences.setInteger("rockinRobinProgress", -1);
+            Preferences.increment("_robinEggDrops", 1);
           }
         }
         break;
@@ -3148,6 +3151,7 @@ public class ResultProcessor {
           if (KoLCharacter.currentFamiliar.getId() == FamiliarPool.CANDLE) {
             // This will be updated to 0 in FightRequest later
             Preferences.setInteger("optimisticCandleProgress", -1);
+            Preferences.increment("_waxGlobDrops", 1);
           } else if (KoLCharacter.currentBjorned.getId() == FamiliarPool.CANDLE
               || KoLCharacter.currentEnthroned.getId() == FamiliarPool.CANDLE) {
             Preferences.increment("_optimisticCandleDropsCrown");
@@ -3349,6 +3353,13 @@ public class ResultProcessor {
       case ItemPool.ROBY_PIZZA_OF_LEGEND:
         if (adventureResults) {
           Preferences.setBoolean("_cookbookbatRecipeDrops", true);
+        }
+        break;
+
+      case ItemPool.GRUBBY_WOOL:
+        if (adventureResults
+            && KoLCharacter.currentFamiliar.getId() == FamiliarPool.HOBO_IN_SHEEPS_CLOTHING) {
+          Preferences.increment("_grubbyWoolDrops", 1);
         }
         break;
     }

--- a/src/net/sourceforge/kolmafia/webui/CharPaneDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/CharPaneDecorator.java
@@ -436,8 +436,8 @@ public class CharPaneDecorator {
       if (familiar.fightDailyCap() != -1) {
         buffer.append("/");
         buffer.append(familiar.fightDailyCap());
-        buffer.append(" combats");
       }
+      buffer.append(" combats");
     }
 
     switch (familiar.getId()) {
@@ -731,9 +731,9 @@ public class CharPaneDecorator {
       if (familiar.dropDailyCap() != -1) {
         buffer.append("/");
         buffer.append(familiar.dropDailyCap());
-        buffer.append(" ");
-        buffer.append(familiar.dropName());
       }
+      buffer.append(" ");
+      buffer.append(familiar.dropName());
       return buffer;
     }
 

--- a/test/net/sourceforge/kolmafia/session/ResultProcessorTest.java
+++ b/test/net/sourceforge/kolmafia/session/ResultProcessorTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -260,7 +261,7 @@ public class ResultProcessorTest {
 
   @Nested
   class Cookbookbat {
-    private static Stream<AdventureResult> coobookbatRecipes() {
+    private static Stream<AdventureResult> cookbookbatRecipes() {
       return Stream.of(
           ItemPool.get(ItemPool.ROBY_BORIS_BEER),
           ItemPool.get(ItemPool.ROBY_HONEY_BUN_OF_BORIS),
@@ -280,7 +281,7 @@ public class ResultProcessorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("coobookbatRecipes")
+    @MethodSource("cookbookbatRecipes")
     public void cookbookbatPropertyGetsUpdated(AdventureResult recipe) {
       var cleanups =
           new Cleanups(
@@ -305,6 +306,44 @@ public class ResultProcessorTest {
         ResultProcessor.processResult(false, ItemPool.get(ItemPool.ROBY_BAKED_VEGGIE_RICOTTA));
 
         assertThat("_cookbookbatRecipeDrops", isSetTo(false));
+      }
+    }
+  }
+
+  @Nested
+  class InfiniteDropItems {
+    private static Stream<Arguments> infiniteDropFamiliars() {
+      return Stream.of(
+          Arguments.of(
+              FamiliarPool.ROCKIN_ROBIN, ItemPool.get(ItemPool.ROBIN_EGG), "_robinEggDrops"),
+          Arguments.of(FamiliarPool.CANDLE, ItemPool.get(ItemPool.WAX_GLOB), "_waxGlobDrops"),
+          Arguments.of(
+              FamiliarPool.GARBAGE_FIRE,
+              ItemPool.get(ItemPool.BURNING_NEWSPAPER),
+              "_garbageFireDrops"),
+          Arguments.of(
+              FamiliarPool.GARBAGE_FIRE,
+              ItemPool.get(ItemPool.TOASTED_HALF_SANDWICH),
+              "_garbageFireDrops"),
+          Arguments.of(
+              FamiliarPool.GARBAGE_FIRE,
+              ItemPool.get(ItemPool.MULLED_HOBO_WINE),
+              "_garbageFireDrops"),
+          Arguments.of(
+              FamiliarPool.HOBO_IN_SHEEPS_CLOTHING,
+              ItemPool.get(ItemPool.GRUBBY_WOOL),
+              "_grubbyWoolDrops"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("infiniteDropFamiliars")
+    public void propertyTracksDrops(int familiar, AdventureResult drop, String preference) {
+      var cleanups = new Cleanups(withFamiliar(familiar), withProperty(preference, 0));
+
+      try (cleanups) {
+        ResultProcessor.processResult(true, drop);
+
+        assertThat(preference, isSetTo(1));
       }
     }
   }


### PR DESCRIPTION
Track drops from optimistic candle, rockin' robin, garbage fire and hobo in sheep's clothing.

Only the Sheep needs the number dropped today to calculate the number of turns until the next one, but the others are also useful for scripting.

Implementation question for consideration: existing code in the sidebar looked for "-1" as a signifier for "no limit". I used this, but before that I had `Integer.MAX_VALUE`. Is -1 reasonable?