### PR TITLE
feat: detect rock garden levels

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3484,8 +3484,14 @@ public class ItemPool {
   public static final int GRUBBY_WOOL = 11091;
   public static final int ROCK_SEEDS = 11100;
   public static final int GROVELING_GRAVEL = 11101;
+  public static final int FRUITY_PEBBLE = 11102;
+  public static final int LODESTONE = 11103;
   public static final int MILESTONE = 11104;
+  public static final int BOLDER_BOULDER = 11105;
+  public static final int MOLEHILL_MOUNTAIN = 11106;
   public static final int WHETSTONE = 11107;
+  public static final int HARD_ROCK = 11108;
+  public static final int STRANGE_STALAGMITE = 11109;
 
   private ItemPool() {}
 

--- a/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
@@ -1293,6 +1293,8 @@ public class CampgroundRequest extends GenericRequest {
       return false;
     }
 
+    var hasSomething = false;
+
     if (findImage(responseText, "rockgarden/a1.gif", ItemPool.GROVELING_GRAVEL, 1)
         || findImage(responseText, "rockgarden/a2.gif", ItemPool.GROVELING_GRAVEL, 2)
         || findImage(responseText, "rockgarden/a3.gif", ItemPool.GROVELING_GRAVEL, 3)
@@ -1300,10 +1302,9 @@ public class CampgroundRequest extends GenericRequest {
         || findImage(responseText, "rockgarden/a5.gif", ItemPool.FRUITY_PEBBLE, 2)
         || findImage(responseText, "rockgarden/a6.gif", ItemPool.FRUITY_PEBBLE, 3)
         || findImage(responseText, "rockgarden/a7.gif", ItemPool.LODESTONE, 1)) {
-      CampgroundRequest.setCampgroundItem(ItemPool.ROCK_SEEDS, 1);
+      hasSomething = true;
     } else {
-      findImage(
-          responseText, "rockgarden/a0.gif", ItemPool.GROVELING_GRAVEL, 0, ItemPool.ROCK_SEEDS, 0);
+      findImage(responseText, "rockgarden/a0.gif", ItemPool.GROVELING_GRAVEL, 0);
     }
 
     if (findImage(responseText, "rockgarden/b1.gif", ItemPool.MILESTONE, 1)
@@ -1313,9 +1314,9 @@ public class CampgroundRequest extends GenericRequest {
         || findImage(responseText, "rockgarden/b5.gif", ItemPool.BOLDER_BOULDER, 2)
         || findImage(responseText, "rockgarden/b6.gif", ItemPool.BOLDER_BOULDER, 3)
         || findImage(responseText, "rockgarden/b7.gif", ItemPool.MOLEHILL_MOUNTAIN, 1)) {
-      CampgroundRequest.setCampgroundItem(ItemPool.ROCK_SEEDS, 1);
+      hasSomething = true;
     } else {
-      findImage(responseText, "rockgarden/b0.gif", ItemPool.MILESTONE, 0, ItemPool.ROCK_SEEDS, 0);
+      findImage(responseText, "rockgarden/b0.gif", ItemPool.MILESTONE, 0);
     }
 
     if (findImage(responseText, "rockgarden/c1.gif", ItemPool.WHETSTONE, 1)
@@ -1325,9 +1326,15 @@ public class CampgroundRequest extends GenericRequest {
         || findImage(responseText, "rockgarden/c5.gif", ItemPool.HARD_ROCK, 2)
         || findImage(responseText, "rockgarden/c6.gif", ItemPool.HARD_ROCK, 3)
         || findImage(responseText, "rockgarden/c7.gif", ItemPool.STRANGE_STALAGMITE, 1)) {
+      hasSomething = true;
+    } else {
+      findImage(responseText, "rockgarden/c0.gif", ItemPool.WHETSTONE, 0);
+    }
+
+    if (hasSomething) {
       CampgroundRequest.setCampgroundItem(ItemPool.ROCK_SEEDS, 1);
     } else {
-      findImage(responseText, "rockgarden/c0.gif", ItemPool.WHETSTONE, 0, ItemPool.ROCK_SEEDS, 0);
+      CampgroundRequest.setCampgroundItem(ItemPool.ROCK_SEEDS, 0);
     }
 
     return true;

--- a/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
@@ -284,8 +284,16 @@ public class CampgroundRequest extends GenericRequest {
   public static final AdventureResult IMMENSE_FREE_RANGE_MUSHROOM = new Mushroom(5);
   public static final AdventureResult COLOSSAL_FREE_RANGE_MUSHROOM = new Mushroom(11);
   public static final AdventureResult GROVELING_GRAVEL = ItemPool.get(ItemPool.GROVELING_GRAVEL, 1);
+  public static final AdventureResult FRUITY_PEBBLE = ItemPool.get(ItemPool.FRUITY_PEBBLE, 1);
+  public static final AdventureResult LODESTONE = ItemPool.get(ItemPool.LODESTONE, 1);
   public static final AdventureResult MILESTONE = ItemPool.get(ItemPool.MILESTONE, 1);
+  public static final AdventureResult BOLDER_BOULDER = ItemPool.get(ItemPool.BOLDER_BOULDER, 1);
+  public static final AdventureResult MOLEHILL_MOUNTAIN =
+      ItemPool.get(ItemPool.MOLEHILL_MOUNTAIN, 1);
   public static final AdventureResult WHETSTONE = ItemPool.get(ItemPool.WHETSTONE, 1);
+  public static final AdventureResult HARD_ROCK = ItemPool.get(ItemPool.HARD_ROCK, 1);
+  public static final AdventureResult STRANGE_STALAGMITE =
+      ItemPool.get(ItemPool.STRANGE_STALAGMITE, 1);
 
   // Crop seeds
   public static final AdventureResult PUMPKIN_SEEDS = ItemPool.get(ItemPool.PUMPKIN_SEEDS, 1);
@@ -341,8 +349,14 @@ public class CampgroundRequest extends GenericRequest {
     CROPMAP.put(IMMENSE_FREE_RANGE_MUSHROOM, CropType.MUSHROOM);
     CROPMAP.put(COLOSSAL_FREE_RANGE_MUSHROOM, CropType.MUSHROOM);
     CROPMAP.put(GROVELING_GRAVEL, CropType.ROCK);
+    CROPMAP.put(FRUITY_PEBBLE, CropType.ROCK);
+    CROPMAP.put(LODESTONE, CropType.ROCK);
     CROPMAP.put(MILESTONE, CropType.ROCK);
+    CROPMAP.put(BOLDER_BOULDER, CropType.ROCK);
+    CROPMAP.put(MOLEHILL_MOUNTAIN, CropType.ROCK);
     CROPMAP.put(WHETSTONE, CropType.ROCK);
+    CROPMAP.put(HARD_ROCK, CropType.ROCK);
+    CROPMAP.put(STRANGE_STALAGMITE, CropType.ROCK);
   }
 
   public static final List<Integer> workshedItems =
@@ -397,8 +411,14 @@ public class CampgroundRequest extends GenericRequest {
     CampgroundRequest.IMMENSE_FREE_RANGE_MUSHROOM,
     CampgroundRequest.COLOSSAL_FREE_RANGE_MUSHROOM,
     CampgroundRequest.GROVELING_GRAVEL,
+    CampgroundRequest.FRUITY_PEBBLE,
+    CampgroundRequest.LODESTONE,
     CampgroundRequest.MILESTONE,
+    CampgroundRequest.BOLDER_BOULDER,
+    CampgroundRequest.MOLEHILL_MOUNTAIN,
     CampgroundRequest.WHETSTONE,
+    CampgroundRequest.HARD_ROCK,
+    CampgroundRequest.STRANGE_STALAGMITE,
   };
 
   public static final AdventureResult[] CROP_SEEDS = {
@@ -1265,18 +1285,52 @@ public class CampgroundRequest extends GenericRequest {
             responseText,
             "mushgarden.gif",
             new Mushroom(Preferences.getInteger("mushroomGardenCropLevel")))
-        || findImage(
-            responseText, "rockgarden/a0.gif", ItemPool.GROVELING_GRAVEL, 0, ItemPool.ROCK_SEEDS, 0)
-        || findImage(
-            responseText, "rockgarden/b0.gif", ItemPool.MILESTONE, 0, ItemPool.ROCK_SEEDS, 0)
-        || findImage(
-            responseText, "rockgarden/c0.gif", ItemPool.WHETSTONE, 0, ItemPool.ROCK_SEEDS, 0)
-        || findImage(
-            responseText, "rockgarden/a1.gif", ItemPool.GROVELING_GRAVEL, 1, ItemPool.ROCK_SEEDS, 1)
-        || findImage(
-            responseText, "rockgarden/b1.gif", ItemPool.MILESTONE, 1, ItemPool.ROCK_SEEDS, 1)
-        || findImage(
-            responseText, "rockgarden/c1.gif", ItemPool.WHETSTONE, 1, ItemPool.ROCK_SEEDS, 1);
+        || findRockGarden(responseText);
+  }
+
+  private static boolean findRockGarden(final String responseText) {
+    if (!responseText.contains("/rockgarden/")) {
+      return false;
+    }
+
+    if (findImage(responseText, "rockgarden/a1.gif", ItemPool.GROVELING_GRAVEL, 1)
+        || findImage(responseText, "rockgarden/a2.gif", ItemPool.GROVELING_GRAVEL, 2)
+        || findImage(responseText, "rockgarden/a3.gif", ItemPool.GROVELING_GRAVEL, 3)
+        || findImage(responseText, "rockgarden/a4.gif", ItemPool.FRUITY_PEBBLE, 1)
+        || findImage(responseText, "rockgarden/a5.gif", ItemPool.FRUITY_PEBBLE, 2)
+        || findImage(responseText, "rockgarden/a6.gif", ItemPool.FRUITY_PEBBLE, 3)
+        || findImage(responseText, "rockgarden/a7.gif", ItemPool.LODESTONE, 1)) {
+      CampgroundRequest.setCampgroundItem(ItemPool.ROCK_SEEDS, 1);
+    } else {
+      findImage(
+          responseText, "rockgarden/a0.gif", ItemPool.GROVELING_GRAVEL, 0, ItemPool.ROCK_SEEDS, 0);
+    }
+
+    if (findImage(responseText, "rockgarden/b1.gif", ItemPool.MILESTONE, 1)
+        || findImage(responseText, "rockgarden/b2.gif", ItemPool.MILESTONE, 2)
+        || findImage(responseText, "rockgarden/b3.gif", ItemPool.MILESTONE, 3)
+        || findImage(responseText, "rockgarden/b4.gif", ItemPool.BOLDER_BOULDER, 1)
+        || findImage(responseText, "rockgarden/b5.gif", ItemPool.BOLDER_BOULDER, 2)
+        || findImage(responseText, "rockgarden/b6.gif", ItemPool.BOLDER_BOULDER, 3)
+        || findImage(responseText, "rockgarden/b7.gif", ItemPool.MOLEHILL_MOUNTAIN, 1)) {
+      CampgroundRequest.setCampgroundItem(ItemPool.ROCK_SEEDS, 1);
+    } else {
+      findImage(responseText, "rockgarden/b0.gif", ItemPool.MILESTONE, 0, ItemPool.ROCK_SEEDS, 0);
+    }
+
+    if (findImage(responseText, "rockgarden/c1.gif", ItemPool.WHETSTONE, 1)
+        || findImage(responseText, "rockgarden/c2.gif", ItemPool.WHETSTONE, 2)
+        || findImage(responseText, "rockgarden/c3.gif", ItemPool.WHETSTONE, 3)
+        || findImage(responseText, "rockgarden/c4.gif", ItemPool.HARD_ROCK, 1)
+        || findImage(responseText, "rockgarden/c5.gif", ItemPool.HARD_ROCK, 2)
+        || findImage(responseText, "rockgarden/c6.gif", ItemPool.HARD_ROCK, 3)
+        || findImage(responseText, "rockgarden/c7.gif", ItemPool.STRANGE_STALAGMITE, 1)) {
+      CampgroundRequest.setCampgroundItem(ItemPool.ROCK_SEEDS, 1);
+    } else {
+      findImage(responseText, "rockgarden/c0.gif", ItemPool.WHETSTONE, 0, ItemPool.ROCK_SEEDS, 0);
+    }
+
+    return true;
   }
 
   private static void parseDwelling(final String responseText) {

--- a/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
@@ -31,12 +31,23 @@ public class CampgroundRequestTest {
   void canDetectMeatMaid() {
     String html = html("request/test_campground_inspect_dwelling.html");
     CampgroundRequest.parseResponse("campground.php?action=inspectdwelling", html);
-    var maidOpt =
-        KoLConstants.campground.stream()
-            .filter(x -> x.getItemId() == ItemPool.CLOCKWORK_MAID)
-            .findAny();
-    assertThat(maidOpt.isPresent(), equalTo(true));
-    var maid = maidOpt.get();
-    assertThat(maid.getCount(), equalTo(1));
+    assertCampgroundItemCount(ItemPool.CLOCKWORK_MAID, 1);
+  }
+
+  @Test
+  void canDetectRockGarden() {
+    String html = html("request/test_campground_rock_garden_5.html");
+    CampgroundRequest.parseResponse("campground.php", html);
+    assertCampgroundItemCount(ItemPool.FRUITY_PEBBLE, 2);
+    assertCampgroundItemCount(ItemPool.BOLDER_BOULDER, 2);
+    assertCampgroundItemCount(ItemPool.HARD_ROCK, 2);
+    assertCampgroundItemCount(ItemPool.ROCK_SEEDS, 1);
+  }
+
+  private void assertCampgroundItemCount(int itemId, int count) {
+    var resOpt = KoLConstants.campground.stream().filter(x -> x.getItemId() == itemId).findAny();
+    assertThat(resOpt.isPresent(), equalTo(true));
+    var res = resOpt.get();
+    assertThat(res.getCount(), equalTo(count));
   }
 }

--- a/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
@@ -9,7 +9,9 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class CampgroundRequestTest {
@@ -34,14 +36,42 @@ public class CampgroundRequestTest {
     assertCampgroundItemCount(ItemPool.CLOCKWORK_MAID, 1);
   }
 
-  @Test
-  void canDetectRockGarden() {
-    String html = html("request/test_campground_rock_garden_5.html");
-    CampgroundRequest.parseResponse("campground.php", html);
-    assertCampgroundItemCount(ItemPool.FRUITY_PEBBLE, 2);
-    assertCampgroundItemCount(ItemPool.BOLDER_BOULDER, 2);
-    assertCampgroundItemCount(ItemPool.HARD_ROCK, 2);
-    assertCampgroundItemCount(ItemPool.ROCK_SEEDS, 1);
+  @Nested
+  class RockGarden {
+    @AfterEach
+    public void afterEach() {
+      CampgroundRequest.reset();
+    }
+
+    @Test
+    void canDetectNoRockGarden() {
+      String html = html("request/test_campground_rock_garden_0.html");
+      CampgroundRequest.parseResponse("campground.php", html);
+      assertCampgroundItemCount(ItemPool.GROVELING_GRAVEL, 0);
+      assertCampgroundItemCount(ItemPool.MILESTONE, 0);
+      assertCampgroundItemCount(ItemPool.WHETSTONE, 0);
+      assertCampgroundItemCount(ItemPool.ROCK_SEEDS, 0);
+    }
+
+    @Test
+    void canDetectPartialRockGarden() {
+      String html = html("request/test_campground_rock_garden_0_1.html");
+      CampgroundRequest.parseResponse("campground.php", html);
+      assertCampgroundItemCount(ItemPool.GROVELING_GRAVEL, 1);
+      assertCampgroundItemCount(ItemPool.MILESTONE, 0);
+      assertCampgroundItemCount(ItemPool.WHETSTONE, 0);
+      assertCampgroundItemCount(ItemPool.ROCK_SEEDS, 1);
+    }
+
+    @Test
+    void canDetectRockGarden() {
+      String html = html("request/test_campground_rock_garden_5.html");
+      CampgroundRequest.parseResponse("campground.php", html);
+      assertCampgroundItemCount(ItemPool.FRUITY_PEBBLE, 2);
+      assertCampgroundItemCount(ItemPool.BOLDER_BOULDER, 2);
+      assertCampgroundItemCount(ItemPool.HARD_ROCK, 2);
+      assertCampgroundItemCount(ItemPool.ROCK_SEEDS, 1);
+    }
   }
 
   private void assertCampgroundItemCount(int itemId, int count) {

--- a/test/root/request/test_campground_rock_garden_0.html
+++ b/test/root/request/test_campground_rock_garden_0.html
@@ -1,0 +1,165 @@
+<html><head>
+<script language=Javascript>
+<!--
+if (parent.frames.length == 0) location.href="game.php";
+top.charpane.location.href="charpane.php";
+//-->
+</script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/keybinds.min.2.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/window.20111231.js"></script>
+<script language="javascript">function chatFocus(){if(top.chatpane.document.chatform.graf) top.chatpane.document.chatform.graf.focus();}
+if (typeof defaultBind != 'undefined') { defaultBind(47, 2, chatFocus); defaultBind(190, 2, chatFocus);defaultBind(191, 2, chatFocus); defaultBind(47, 8, chatFocus);defaultBind(190, 8, chatFocus); defaultBind(191, 8, chatFocus); }</script><script language="javascript">
+	function updateParseItem(iid, field, info) {
+		var tbl = $('#ic'+iid);
+		var data = parseItem(tbl);
+		if (!data) return;
+		data[field] = info;
+		var out = [];
+		for (i in data) {
+			if (!data.hasOwnProperty(i)) continue;
+			out.push(i+'='+data[i]);
+		}
+		tbl.attr('rel', out.join('&'));
+	}
+	function parseItem(tbl) {
+		tbl = $(tbl);
+		var rel = tbl.attr('rel');
+		var data = {};
+		if (!rel) return data;
+		var parts = rel.split('&');
+		for (i in parts) {
+			if (!parts.hasOwnProperty(i)) continue;
+			var kv = parts[i].split('=');
+			tbl.data(kv[0], kv[1]);
+			data[kv[0]] = kv[1];
+		}
+		return data;
+	}
+</script><script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/jquery-1.3.1.min.js"></script>
+<script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/pop_query.20130705.js"></script>
+<script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/ircm.20161111.js"></script>
+<script type="text/javascript">
+var tp = top;
+function pop_ircm_contents(i, some) {
+	var contents = '',
+		shown = 0,
+		da = '&nbsp;<a href="#" rel="?" class="small dojaxy">[some]</a>&nbsp;<a href="#" rel="',
+		db = '" class="small dojaxy">[all]</a>',
+		dc = '<div style="width:100%; padding-bottom: 3px;" rel="',
+		dd = '<a href="#" rel="1" class="small dojaxy">[';
+	one = 'one'; ss=some;
+if (i.d==1 && i.s>0) { shown++; 
+contents += dc + 'sellstuff.php?action=sell&ajax=1&type=quant&whichitem%5B%5D=IID&howmany=NUM&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>Auto-Sell ('+i.s+' meat):</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'inventory.php?action=closetpush&ajax=1&whichitem=IID&qty=NUM&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>Closet:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0 && i.g==0 && i.t==1) { shown++; 
+contents += dc + 'managestore.php?action=additem&qty1=NUM&item1=IID&price1=&limit1=&ajax=1&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>Stock in Mall:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'managecollection.php?action=put&ajax=1&whichitem1=IID&howmany1=NUM&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>Add to Display Case:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && !i.ac) { shown++; 
+contents += dc + 'inv_'+(i.u=="a"?"redir":(lab=(i.u=="u"?"use":(i.u=="e"?"eat":(i.u=="b"?"booze":(i.u=="s"?"spleen":"equip"))))))+'.php?ajax=1&whichitem=IID&itemquantity=NUM&quantity=NUM'+(i.u=="q"?"&action=equip":"")+'&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>'+ucfirst(unescape(i.ou ? i.ou.replace(/\+/g," ") : (lab=="booze"?"drink":lab)))+':</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=1&ajax=1&whichitem=IID&action=equip&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>Equip (slot 1):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=2&ajax=1&whichitem=IID&action=equip&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>Equip (slot 2):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=3&ajax=1&whichitem=IID&action=equip&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>Equip (slot 3):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+
+	return [contents, shown];
+}
+tp=top
+var todo = [];
+function nextAction() {
+	var next_todo = todo.shift();
+	if (next_todo) {
+		eval(next_todo);
+	}
+}
+function dojax(dourl, afterFunc, hoverCaller, failureFunc, method, params) {
+	$.ajax({
+		type: method || 'GET', url: dourl, cache: false,
+		data: params || null,
+		global: false,
+		success: function (out) {
+			nextAction();
+			if (out.match(/no\|/)) {
+				var parts = out.split(/\|/);
+				if (failureFunc) failureFunc(parts[1]);
+				else if (window.dojaxFailure) window.dojaxFailure(parts[1]);
+				else if (tp.chatpane.handleMessage) tp.chatpane.handleMessage({type: 'event', msg: 'Oops!  Sorry, Dave, you appear to be ' + parts[1]});
+				else  $('#ChatWindow').append('<font color="green">Oops!  Sorry, Dave, you appear to be ' + parts[1] + '.</font><br />' + "\n");
+				return;
+			}
+
+			if (hoverCaller)  {
+				float_results(hoverCaller, out);
+				if (afterFunc) { afterFunc(out); }
+				return;
+			}
+$(tp.mainpane.document).find("#effdiv").remove(); if(!window.dontscroll || (window.dontscroll && dontscroll==0)) { window.scroll(0,0);}
+			var $eff = $(tp.mainpane.document).find('#effdiv');
+			if ($eff.length == 0) {
+				var d = tp.mainpane.document.createElement('DIV');
+				d.id = 'effdiv';
+				var b = tp.mainpane.document.body;
+				if ($('#content_').length > 0) {
+					b = $('#content_ div:first')[0];
+				}
+				b.insertBefore(d, b.firstChild);
+				$eff = $(d);
+			}
+			$eff.find('a[name="effdivtop"]').remove().end()
+				.prepend('<a name="effdivtop"></a><center>' + out + '</center>').css('display','block');
+			if (!window.dontscroll || (window.dontscroll && dontscroll==0)) {
+				tp.mainpane.document.location = tp.mainpane.document.location + "#effdivtop";
+			}
+			if (afterFunc) { afterFunc(out); }
+		}
+	});
+}
+</script>	<link rel="stylesheet" type="text/css" href="https://d2uyhvukfffg5a.cloudfront.net/styles.20151006.css">
+<style type='text/css'>
+.faded {
+	zoom: 1;
+	filter: alpha(opacity=35);
+	opacity: 0.35;
+	-khtml-opacity: 0.35; 
+    -moz-opacity: 0.35;
+}
+</style>
+
+</head>
+
+<body>
+<centeR><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="color: white;" align=center bgcolor=blue><b>Your Campsite</b></td></tr><tr><td style="padding: 5px; border: 1px solid blue;"><center><table><tr><td><center><Table><tr><td><a href="campground.php?action=advent"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/advent.gif" width=100 height=100 border=0 alt="Advent Calendar" title="Advent Calendar"></a></td><td valign=center><b>Merry Crimbo!</b><br>(Click the Advent Calendar for goodies!)</td></tr></table><P><table cellspacing=0 cellpadding=0><tr><td height=15 align=center><a href="campground.php?action=inspectdwelling"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/tinyglass.gif" width=15 height=15 border=0></a></td><td></td><td></td><td></td><td></td></tr><tr><td width=100 height=100><a href="campground.php?action=rest"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/rest4_free.gif" width=100 height=100 border=0 alt="Rest in Your Dwelling" title="Rest in Your Dwelling"></a></td><td width=100 height=100><a href=campground.php?action=workshed><img src=https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/workshed.gif width=100 height=100 border=0 alt="Your Workshed" title="Your Workshed"></a></td><td width=100 height=100><a href=campground.php?action=doghouse><img src=https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/doghouse.gif width=100 height=100 border=0 alt="Your Haunted Doghouse" title="Your Haunted Doghouse"></a></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/teatree_used.gif" width=100 height=100 alt="Tea Tree (Harvested)" title="Tea Tree (Harvested"></td><td width=100 height=100><a href="closet.php"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/closet.gif" width=100 height=100 border=0 alt="Your Colossal Closet" title="Your Colossal Closet"></a></td></tr><tr><td width=100 height=100><a href="campground.php?action=telescope"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/telescope.gif" width=100 height=100 border=0 alt="A Telescope" title="A Telescope"></a></td><td width=100 height=50><a href="campground.php?action=elvibratoportal"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/portal1.gif" width=100 height=100 border=0 alt="A Shimmering Portal" title="A Shimmering Portal"></a></td><td width=100 height=100><a href="campground.php?action=terminal"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/campterminal.gif" /></a><p></td><td width=100 height=100><a href="trophies.php"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/trophycase.gif" width=100 height=100 border=0 alt="Trophy Case" title="Trophy Case"></a></td><td width=100 height=100><a href="campground.php?action=bookshelf"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/bookshelf.gif" width=100 height=100 border=0 alt="Your Mystical Bookshelf" title="Your Mystical Bookshelf"></a></td></tr><tr><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/rockgarden/a0.gif" height="60" width="30" alt="an empty spot" title="an empty spot"> <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/rockgarden/b0.gif" height="60" width="30"  alt="an empty spot" title="an empty spot"> <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/rockgarden/c0.gif" height="60" width="30"  alt="an empty spot" title="an empty spot"> <img src='https://d2uyhvukfffg5a.cloudfront.net/otherimages/rockgarden/label.gif' height=40 width=100</td><td width=100 height=100><a href=campground.php?action=inspectkitchen><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/kitchen.gif" width=100 height=100 border=0 alt="Your Kitchen" title="Your Kitchen"></a></td><td width=100 height=100><a href="campground.php?action=pagoda"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/pagoda.gif" width=100 height=100 border=0 alt="Pagoda" title="Pagoda"></a></td><td width=100 height=100><a href="familiar.php"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/bigterrarium.gif" width=100 height=100 border=0 alt="Familiar-Gro Terrarium" title="Familiar-Gro Terrarium"></a></td><td width=100 height=100><a href="questlog.php"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/questlog2.gif" width=100 height=100 border=0 alt="Your Quest Log" title="Your Quest Log"></a></td></tr><tr><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains8.gif" width=100 height=100></td><td width=100 height=100><a href="campground.php?action=witchess"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/chesstable.gif" width=100 height=100 border=0 alt="Witchess Set" title="Witchess Set"></a></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains7.gif" width=100 height=100></td><td width=100 height=100><a href="campground.php?action=golem"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/golem.gif" width=100 height=100 border=0 alt="Meat Golem" title="Meat Golem"></a></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains3.gif" width=100 height=100></td></tr></table></center><center><p><a href="main.php">Back to the Main Map</a></center></td></tr></table></center></td></tr><tr><td height=4></td></tr></table></center></body></html>

--- a/test/root/request/test_campground_rock_garden_0_1.html
+++ b/test/root/request/test_campground_rock_garden_0_1.html
@@ -1,0 +1,165 @@
+<html><head>
+<script language=Javascript>
+<!--
+if (parent.frames.length == 0) location.href="game.php";
+top.charpane.location.href="charpane.php";
+//-->
+</script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/keybinds.min.2.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/window.20111231.js"></script>
+<script language="javascript">function chatFocus(){if(top.chatpane.document.chatform.graf) top.chatpane.document.chatform.graf.focus();}
+if (typeof defaultBind != 'undefined') { defaultBind(47, 2, chatFocus); defaultBind(190, 2, chatFocus);defaultBind(191, 2, chatFocus); defaultBind(47, 8, chatFocus);defaultBind(190, 8, chatFocus); defaultBind(191, 8, chatFocus); }</script><script language="javascript">
+	function updateParseItem(iid, field, info) {
+		var tbl = $('#ic'+iid);
+		var data = parseItem(tbl);
+		if (!data) return;
+		data[field] = info;
+		var out = [];
+		for (i in data) {
+			if (!data.hasOwnProperty(i)) continue;
+			out.push(i+'='+data[i]);
+		}
+		tbl.attr('rel', out.join('&'));
+	}
+	function parseItem(tbl) {
+		tbl = $(tbl);
+		var rel = tbl.attr('rel');
+		var data = {};
+		if (!rel) return data;
+		var parts = rel.split('&');
+		for (i in parts) {
+			if (!parts.hasOwnProperty(i)) continue;
+			var kv = parts[i].split('=');
+			tbl.data(kv[0], kv[1]);
+			data[kv[0]] = kv[1];
+		}
+		return data;
+	}
+</script><script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/jquery-1.3.1.min.js"></script>
+<script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/pop_query.20130705.js"></script>
+<script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/ircm.20161111.js"></script>
+<script type="text/javascript">
+var tp = top;
+function pop_ircm_contents(i, some) {
+	var contents = '',
+		shown = 0,
+		da = '&nbsp;<a href="#" rel="?" class="small dojaxy">[some]</a>&nbsp;<a href="#" rel="',
+		db = '" class="small dojaxy">[all]</a>',
+		dc = '<div style="width:100%; padding-bottom: 3px;" rel="',
+		dd = '<a href="#" rel="1" class="small dojaxy">[';
+	one = 'one'; ss=some;
+if (i.d==1 && i.s>0) { shown++; 
+contents += dc + 'sellstuff.php?action=sell&ajax=1&type=quant&whichitem%5B%5D=IID&howmany=NUM&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>Auto-Sell ('+i.s+' meat):</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'inventory.php?action=closetpush&ajax=1&whichitem=IID&qty=NUM&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>Closet:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0 && i.g==0 && i.t==1) { shown++; 
+contents += dc + 'managestore.php?action=additem&qty1=NUM&item1=IID&price1=&limit1=&ajax=1&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>Stock in Mall:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'managecollection.php?action=put&ajax=1&whichitem1=IID&howmany1=NUM&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>Add to Display Case:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && !i.ac) { shown++; 
+contents += dc + 'inv_'+(i.u=="a"?"redir":(lab=(i.u=="u"?"use":(i.u=="e"?"eat":(i.u=="b"?"booze":(i.u=="s"?"spleen":"equip"))))))+'.php?ajax=1&whichitem=IID&itemquantity=NUM&quantity=NUM'+(i.u=="q"?"&action=equip":"")+'&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>'+ucfirst(unescape(i.ou ? i.ou.replace(/\+/g," ") : (lab=="booze"?"drink":lab)))+':</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=1&ajax=1&whichitem=IID&action=equip&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>Equip (slot 1):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=2&ajax=1&whichitem=IID&action=equip&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>Equip (slot 2):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=3&ajax=1&whichitem=IID&action=equip&pwd=5052307cf13aba2a7b4225d42e4e577d" id="pircm_'+i.id+'"><b>Equip (slot 3):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+
+	return [contents, shown];
+}
+tp=top
+var todo = [];
+function nextAction() {
+	var next_todo = todo.shift();
+	if (next_todo) {
+		eval(next_todo);
+	}
+}
+function dojax(dourl, afterFunc, hoverCaller, failureFunc, method, params) {
+	$.ajax({
+		type: method || 'GET', url: dourl, cache: false,
+		data: params || null,
+		global: false,
+		success: function (out) {
+			nextAction();
+			if (out.match(/no\|/)) {
+				var parts = out.split(/\|/);
+				if (failureFunc) failureFunc(parts[1]);
+				else if (window.dojaxFailure) window.dojaxFailure(parts[1]);
+				else if (tp.chatpane.handleMessage) tp.chatpane.handleMessage({type: 'event', msg: 'Oops!  Sorry, Dave, you appear to be ' + parts[1]});
+				else  $('#ChatWindow').append('<font color="green">Oops!  Sorry, Dave, you appear to be ' + parts[1] + '.</font><br />' + "\n");
+				return;
+			}
+
+			if (hoverCaller)  {
+				float_results(hoverCaller, out);
+				if (afterFunc) { afterFunc(out); }
+				return;
+			}
+$(tp.mainpane.document).find("#effdiv").remove(); if(!window.dontscroll || (window.dontscroll && dontscroll==0)) { window.scroll(0,0);}
+			var $eff = $(tp.mainpane.document).find('#effdiv');
+			if ($eff.length == 0) {
+				var d = tp.mainpane.document.createElement('DIV');
+				d.id = 'effdiv';
+				var b = tp.mainpane.document.body;
+				if ($('#content_').length > 0) {
+					b = $('#content_ div:first')[0];
+				}
+				b.insertBefore(d, b.firstChild);
+				$eff = $(d);
+			}
+			$eff.find('a[name="effdivtop"]').remove().end()
+				.prepend('<a name="effdivtop"></a><center>' + out + '</center>').css('display','block');
+			if (!window.dontscroll || (window.dontscroll && dontscroll==0)) {
+				tp.mainpane.document.location = tp.mainpane.document.location + "#effdivtop";
+			}
+			if (afterFunc) { afterFunc(out); }
+		}
+	});
+}
+</script>	<link rel="stylesheet" type="text/css" href="https://d2uyhvukfffg5a.cloudfront.net/styles.20151006.css">
+<style type='text/css'>
+.faded {
+	zoom: 1;
+	filter: alpha(opacity=35);
+	opacity: 0.35;
+	-khtml-opacity: 0.35; 
+    -moz-opacity: 0.35;
+}
+</style>
+
+</head>
+
+<body>
+<centeR><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="color: white;" align=center bgcolor=blue><b>Your Campsite</b></td></tr><tr><td style="padding: 5px; border: 1px solid blue;"><center><table><tr><td><center><Table><tr><td><a href="campground.php?action=advent"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/advent.gif" width=100 height=100 border=0 alt="Advent Calendar" title="Advent Calendar"></a></td><td valign=center><b>Merry Crimbo!</b><br>(Click the Advent Calendar for goodies!)</td></tr></table><P><table cellspacing=0 cellpadding=0><tr><td height=15 align=center><a href="campground.php?action=inspectdwelling"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/tinyglass.gif" width=15 height=15 border=0></a></td><td></td><td></td><td></td><td></td></tr><tr><td width=100 height=100><a href="campground.php?action=rest"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/rest4_free.gif" width=100 height=100 border=0 alt="Rest in Your Dwelling" title="Rest in Your Dwelling"></a></td><td width=100 height=100><a href=campground.php?action=workshed><img src=https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/workshed.gif width=100 height=100 border=0 alt="Your Workshed" title="Your Workshed"></a></td><td width=100 height=100><a href=campground.php?action=doghouse><img src=https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/doghouse.gif width=100 height=100 border=0 alt="Your Haunted Doghouse" title="Your Haunted Doghouse"></a></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/teatree_used.gif" width=100 height=100 alt="Tea Tree (Harvested)" title="Tea Tree (Harvested"></td><td width=100 height=100><a href="closet.php"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/closet.gif" width=100 height=100 border=0 alt="Your Colossal Closet" title="Your Colossal Closet"></a></td></tr><tr><td width=100 height=100><a href="campground.php?action=telescope"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/telescope.gif" width=100 height=100 border=0 alt="A Telescope" title="A Telescope"></a></td><td width=100 height=50><a href="campground.php?action=elvibratoportal"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/portal1.gif" width=100 height=100 border=0 alt="A Shimmering Portal" title="A Shimmering Portal"></a></td><td width=100 height=100><a href="campground.php?action=terminal"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/campterminal.gif" /></a><p></td><td width=100 height=100><a href="trophies.php"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/trophycase.gif" width=100 height=100 border=0 alt="Trophy Case" title="Trophy Case"></a></td><td width=100 height=100><a href="campground.php?action=bookshelf"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/bookshelf.gif" width=100 height=100 border=0 alt="Your Mystical Bookshelf" title="Your Mystical Bookshelf"></a></td></tr><tr><td width=100 height=100><a href=campground.php?action=rgarden1&pwd=5052307cf13aba2a7b4225d42e4e577d style='text-decoration: none'><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/rockgarden/a1.gif" height="60" width="30" alt="groveling gravel(1)" title="groveling gravel(1)"> </a><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/rockgarden/b0.gif" height="60" width="30"  alt="an empty spot" title="an empty spot"> <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/rockgarden/c0.gif" height="60" width="30"  alt="an empty spot" title="an empty spot"> <img src='https://d2uyhvukfffg5a.cloudfront.net/otherimages/rockgarden/label.gif' height=40 width=100</td><td width=100 height=100><a href=campground.php?action=inspectkitchen><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/kitchen.gif" width=100 height=100 border=0 alt="Your Kitchen" title="Your Kitchen"></a></td><td width=100 height=100><a href="campground.php?action=pagoda"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/pagoda.gif" width=100 height=100 border=0 alt="Pagoda" title="Pagoda"></a></td><td width=100 height=100><a href="familiar.php"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/bigterrarium.gif" width=100 height=100 border=0 alt="Familiar-Gro Terrarium" title="Familiar-Gro Terrarium"></a></td><td width=100 height=100><a href="questlog.php"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/questlog2.gif" width=100 height=100 border=0 alt="Your Quest Log" title="Your Quest Log"></a></td></tr><tr><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains8.gif" width=100 height=100></td><td width=100 height=100><a href="campground.php?action=witchess"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/chesstable.gif" width=100 height=100 border=0 alt="Witchess Set" title="Witchess Set"></a></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains7.gif" width=100 height=100></td><td width=100 height=100><a href="campground.php?action=golem"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/golem.gif" width=100 height=100 border=0 alt="Meat Golem" title="Meat Golem"></a></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains3.gif" width=100 height=100></td></tr></table></center><center><p><a href="main.php">Back to the Main Map</a></center></td></tr></table></center></td></tr><tr><td height=4></td></tr></table></center></body></html>

--- a/test/root/request/test_campground_rock_garden_5.html
+++ b/test/root/request/test_campground_rock_garden_5.html
@@ -1,0 +1,146 @@
+<html><head>
+<script language=Javascript>
+<!--
+if (parent.frames.length == -1) location.href="game.php";
+//-->
+</script>
+<script language=Javascript src="/images/scripts/keybinds.min.2.js"></script>
+<script language=Javascript src="/images/scripts/window.20111231.js"></script>
+<script language="javascript">function chatFocus(){if(top.chatpane.document.chatform.graf) top.chatpane.document.chatform.graf.focus();}
+if (typeof defaultBind != 'undefined') { defaultBind(47, 2, chatFocus); defaultBind(190, 2, chatFocus);defaultBind(191, 2, chatFocus); defaultBind(47, 8, chatFocus);defaultBind(190, 8, chatFocus); defaultBind(191, 8, chatFocus); }</script><script language="javascript">
+	function updateParseItem(iid, field, info) {
+		var tbl = $('#ic'+iid);
+		var data = parseItem(tbl);
+		if (!data) return;
+		data[field] = info;
+		var out = [];
+		for (i in data) {
+			if (!data.hasOwnProperty(i)) continue;
+			out.push(i+'='+data[i]);
+		}
+		tbl.attr('rel', out.join('&'));
+	}
+	function parseItem(tbl) {
+		tbl = $(tbl);
+		var rel = tbl.attr('rel');
+		var data = {};
+		if (!rel) return data;
+		var parts = rel.split('&');
+		for (i in parts) {
+			if (!parts.hasOwnProperty(i)) continue;
+			var kv = parts[i].split('=');
+			tbl.data(kv[0], kv[1]);
+			data[kv[0]] = kv[1];
+		}
+		return data;
+	}
+</script><script language=Javascript src="/images/scripts/jquery-1.3.1.min.js"></script>
+<script type="text/javascript" src="/images/scripts/pop_query.20130705.js"></script>
+<script type="text/javascript" src="/images/scripts/ircm.20161111.js"></script>
+<script type="text/javascript">
+var tp = top;
+function pop_ircm_contents(i, some) {
+	var contents = '',
+		shown = 0,
+		da = '&nbsp;<a href="#" rel="?" class="small dojaxy">[some]</a>&nbsp;<a href="#" rel="',
+		db = '" class="small dojaxy">[all]</a>',
+		dc = '<div style="width:100%; padding-bottom: 3px;" rel="',
+		dd = '<a href="#" rel="1" class="small dojaxy">[';
+	one = 'one'; ss=some;
+if (i.d==1 && i.s>0) { shown++; 
+contents += dc + 'sellstuff.php?action=sell&ajax=1&type=quant&whichitem%5B%5D=IID&howmany=NUM&pwd=bf6d201d97dc4c529c1ab6df456abb9e" id="pircm_'+i.id+'"><b>Auto-Sell ('+i.s+' meat):</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && !i.ac) { shown++; 
+contents += dc + 'inv_'+(i.u=="a"?"redir":(lab=(i.u=="u"?"use":(i.u=="e"?"eat":(i.u=="b"?"booze":(i.u=="s"?"spleen":"equip"))))))+'.php?ajax=1&whichitem=IID&itemquantity=NUM&quantity=NUM'+(i.u=="q"?"&action=equip":"")+'&pwd=bf6d201d97dc4c529c1ab6df456abb9e" id="pircm_'+i.id+'"><b>'+ucfirst(unescape(i.ou ? i.ou.replace(/\+/g," ") : (lab=="booze"?"drink":lab)))+':</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=1&ajax=1&whichitem=IID&action=equip&pwd=bf6d201d97dc4c529c1ab6df456abb9e" id="pircm_'+i.id+'"><b>Equip (slot 1):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=2&ajax=1&whichitem=IID&action=equip&pwd=bf6d201d97dc4c529c1ab6df456abb9e" id="pircm_'+i.id+'"><b>Equip (slot 2):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=3&ajax=1&whichitem=IID&action=equip&pwd=bf6d201d97dc4c529c1ab6df456abb9e" id="pircm_'+i.id+'"><b>Equip (slot 3):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+
+	return [contents, shown];
+}
+tp=top
+var todo = [];
+function nextAction() {
+	var next_todo = todo.shift();
+	if (next_todo) {
+		eval(next_todo);
+	}
+}
+function dojax(dourl, afterFunc, hoverCaller, failureFunc, method, params) {
+	$.ajax({
+		type: method || 'GET', url: dourl, cache: false,
+		data: params || null,
+		global: false,
+		success: function (out) {
+			nextAction();
+			if (out.match(/no\|/)) {
+				var parts = out.split(/\|/);
+				if (failureFunc) failureFunc(parts[1]);
+				else if (window.dojaxFailure) window.dojaxFailure(parts[1]);
+				else if (tp.chatpane.handleMessage) tp.chatpane.handleMessage({type: 'event', msg: 'Oops!  Sorry, Dave, you appear to be ' + parts[1]});
+				else  $('#ChatWindow').append('<font color="green">Oops!  Sorry, Dave, you appear to be ' + parts[1] + '.</font><br />' + "\n");
+				return;
+			}
+
+			if (hoverCaller)  {
+				float_results(hoverCaller, out);
+				if (afterFunc) { afterFunc(out); }
+				return;
+			}
+$(tp.mainpane.document).find("#effdiv").remove(); if(!window.dontscroll || (window.dontscroll && dontscroll==0)) { window.scroll(0,0);}
+			var $eff = $(tp.mainpane.document).find('#effdiv');
+			if ($eff.length == 0) {
+				var d = tp.mainpane.document.createElement('DIV');
+				d.id = 'effdiv';
+				var b = tp.mainpane.document.body;
+				if ($('#content_').length > 0) {
+					b = $('#content_ div:first')[0];
+				}
+				b.insertBefore(d, b.firstChild);
+				$eff = $(d);
+			}
+			$eff.find('a[name="effdivtop"]').remove().end()
+				.prepend('<a name="effdivtop"></a><center>' + out + '</center>').css('display','block');
+			if (!window.dontscroll || (window.dontscroll && dontscroll==0)) {
+				tp.mainpane.document.location = tp.mainpane.document.location + "#effdivtop";
+			}
+			if (afterFunc) { afterFunc(out); }
+		}
+	});
+}
+</script>	<link rel="stylesheet" type="text/css" href="/images/styles.20151006.css">
+<style type='text/css'>
+.faded {
+	zoom: 1;
+	filter: alpha(opacity=35);
+	opacity: 0.35;
+	-khtml-opacity: 0.35; 
+    -moz-opacity: 0.35;
+}
+</style>
+
+<script language="Javascript" src="/basics.js"></script><link rel="stylesheet" href="/basics.1.css" /></head>
+
+<body>
+<centeR><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="color: white;" align=center bgcolor=blue><b>Your Campsite</b></td></tr><tr><td style="padding: 5px; border: 1px solid blue;"><center><table><tr><td><center><Table><tr><td><a href="campground.php?action=advent"><img src="/images/otherimages/campground/advent.gif" width=100 height=100 border=0 alt="Advent Calendar" title="Advent Calendar"></a></td><td valign=center><b>Merry Crimbo!</b><br>(Click the Advent Calendar for goodies!)</td></tr></table><P><table cellspacing=0 cellpadding=0><tr><td height=15 align=center><a href="campground.php?action=inspectdwelling"><img src="/images/otherimages/tinyglass.gif" width=15 height=15 border=0></a></td><td></td><td></td><td></td><td></td></tr><tr><td width=100 height=100><a href="campground.php?action=rest"><img src="/images/otherimages/campground/rest4_free.gif" width=100 height=100 border=0 alt="Rest in Your Dwelling" title="Rest in Your Dwelling"></a></td><td width=100 height=100><a href=campground.php?action=workshed><img src=/images/otherimages/campground/workshed.gif width=100 height=100 border=0 alt="Your Workshed" title="Your Workshed"></a></td><td width=100 height=100><img src="/images/otherimages/plains/plains1.gif" width=100 height=100></td><td width=100 height=100><img src="/images/otherimages/plains/plains2.gif" width=100 height=100></td><td width=100 height=100><a href="closet.php"><img src="/images/otherimages/campground/closet.gif" width=100 height=100 border=0 alt="Your Colossal Closet" title="Your Colossal Closet"></a></td></tr><tr><td width=100 height=100><a href="campground.php?action=telescope"><img src="/images/otherimages/campground/telescope.gif" width=100 height=100 border=0 alt="A Telescope" title="A Telescope"></a></td><td width=100 height=50><img src="/images/otherimages/campground/smallblank1.gif" width=100 height=50></td><td width=100 height=100><img src="/images/otherimages/plains/plains2.gif" width=100 height=100></td><td width=100 height=100><a href="trophies.php"><img src="/images/otherimages/campground/trophycase.gif" width=100 height=100 border=0 alt="Trophy Case" title="Trophy Case"></a></td><td width=100 height=100><img src="/images/otherimages/plains/plains5.gif" width=100 height=100></td></tr><tr><td width=100 height=100><a href=campground.php?action=rgarden1&pwd=bf6d201d97dc4c529c1ab6df456abb9e style='text-decoration: none'><img src="/images/otherimages/rockgarden/a5.gif" height="60" width="30" alt="fruity pebble(2)" title="fruity pebble(2)"> </a><a href=campground.php?action=rgarden2&pwd=bf6d201d97dc4c529c1ab6df456abb9e style='text-decoration: none'><img src="/images/otherimages/rockgarden/b5.gif" height="60" width="30"  alt="bolder boulder(2)" title="bolder boulder(2)"> </a><a href=campground.php?action=rgarden3&pwd=bf6d201d97dc4c529c1ab6df456abb9e style='text-decoration: none'><img src="/images/otherimages/rockgarden/c5.gif" height="60" width="30"  alt="hard rock(2)" title="hard rock(2)"> </a><img src='/images/otherimages/rockgarden/label.gif' height=40 width=100</td><td width=100 height=100><a href=campground.php?action=inspectkitchen><img src="/images/otherimages/campground/kitchen.gif" width=100 height=100 border=0 alt="Your Kitchen" title="Your Kitchen"></a></td><td width=100 height=100><a href="campground.php?action=pagoda"><img src="/images/otherimages/campground/pagoda.gif" width=100 height=100 border=0 alt="Pagoda" title="Pagoda"></a></td><td width=100 height=100><a href="familiar.php"><img src="/images/otherimages/campground/bigterrarium.gif" width=100 height=100 border=0 alt="Familiar-Gro Terrarium" title="Familiar-Gro Terrarium"></a></td><td width=100 height=100><a href="questlog.php"><img src="/images/otherimages/campground/questlog2.gif" width=100 height=100 border=0 alt="Your Quest Log" title="Your Quest Log"></a></td></tr><tr><td width=100 height=100><img src="/images/otherimages/plains/plains8.gif" width=100 height=100></td><td width=100 height=100><img src="/images/otherimages/plains/plains1.gif" width=100 height=100></td><td width=100 height=100><img src="/images/otherimages/plains/plains7.gif" width=100 height=100></td><td width=100 height=100><a href="campground.php?action=golem"><img src="/images/otherimages/campground/golem.gif" width=100 height=100 border=0 alt="Meat Golem" title="Meat Golem"></a></td><td width=100 height=100><img src="/images/otherimages/plains/plains3.gif" width=100 height=100></td></tr></table></center><center><p><a href="main.php">Back to the Main Map</a></center></td></tr></table></center></td></tr><tr><td height=4></td></tr></table></center></body><script src="/ircm_extend.3.js"></script><script src="/onfocus.1.js"></script></html>


### PR DESCRIPTION
Detect rock garden levels. 

Picking is slightly unusual, haven't yet decided what the best design would be. Might want to interpret this as three "garden"s as they're all individually pickable: `campground.php?action=rgarden1`, `rgarden2`, `rgarden3`. No idea how to configure this in the harvest preference. Don't really know how the garden command should work either; maybe it should take a number or otherwise do all? I think it's most likely folk will either harvest anything or all on day 7, though.