### PR TITLE
feat: some data for El Vibrato

### DIFF
--- a/src/data/adventures.txt
+++ b/src/data/adventures.txt
@@ -524,7 +524,7 @@ PastEvents	adventure=508	DiffLevel: unknown Env: outdoor nowander	A Monorail Sta
 
 # Item-supplied adventuring zones
 
-Portal	adventure=164	DiffLevel: unknown Env: underground Stat: 365	El Vibrato Island
+Portal	adventure=164	DiffLevel: high Env: underground Stat: 365	El Vibrato Island
 
 Tunnel of L.O.V.E.	place=townwrong_tunnel	DiffLevel: none Env: indoor overdrunk	The Tunnel of L.O.V.E.
 Deep Machine Tunnels	adventure=458	DiffLevel: mid Env: underground Stat: 0	The Deep Machine Tunnels

--- a/src/data/inebriety.txt
+++ b/src/data/inebriety.txt
@@ -480,7 +480,7 @@ nega-mushroom wine	2	1	awesome	8-10	0	30-40	0	50 Double Negavision (+50% Item Dr
 Neuromancer	4	6	awesome	14-18	25-27	0	16-20
 New Zealand iced tea	2	4	awesome	6-8	20-30	0	0	20 New Zeal (+40 HP, +20 MP)
 Newark	1	3	awesome	4-6	10-20	10-20	10-20	40 Hobo Powering Up! (+10 Hobo Power)
-nice warm beer	1	1	awesome	0	0	0	0	Unspaded
+nice warm beer	1	1	awesome	0	0	0	0	Unspaded, BEER
 Nog-on-the-Cob	3	1	awesome	12	15-30	15-30	15-30	20 Sulfurous Sinuses (+3 Stench Resist, +20 Stench Dam, +40 Meat Drop)
 non-aged vinegar	2	4	awesome	6-7	5-10	5-10	5-10	40 Sour Grapes (+40% Item Drop)
 nothingtini	1	1	good	2-4	0	0	0	40 Nothing Happened (+20 Monster Level), MARTINI

--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -71,8 +71,8 @@ biclops	1579	biclops.gif	NOCOPY Atk: 38 Def: 33 HP: 30 Init: 25 Meat: 30 P: huma
 big creepy spider	156	spider1.gif	Atk: 1 Def: 0 HP: 1 Init: 40 Meat: 5 P: bug Article: a Poison: "Hardly Poisoned at All"	spider web (25)	spider web (25)
 big swarm of ghuol whelps	1073	whelps2.gif	Atk: 50 Def: 45 HP: 150 Init: 300 Group: 15 P: undead ED: spooky Article: a
 Big Wheelin' Twins	1241	twins_bigwheel.gif	Atk: 92 Def: 85 HP: 105 Init: 60 Meat: 70 Group: 2 P: dude Article: the	badge of authority (5)	vial of The Glistening (15)
-bizarre construct	665	vib2.gif	Atk: 300 Def: 270 HP: 300 Init: 30 P: construct Article: a	El Vibrato punchcard (97 holes) (1)	El Vibrato punchcard (216 holes) (1)
-bizarre construct (translated)	671	vib2.gif	Atk: 300 Def: 270 HP: 300 Init: 30 P: construct Article: a Manuel: "bizarre construct" Wiki: "bizarre construct"	El Vibrato punchcard (97 holes) (1)	El Vibrato punchcard (216 holes) (1)
+bizarre construct	665	vib2.gif	Atk: 300 Def: 270 HP: 300 Init: 30 P: construct Article: a	El Vibrato punchcard (97 holes) (15)	El Vibrato punchcard (216 holes) (15)
+bizarre construct (translated)	671	vib2.gif	Atk: 300 Def: 270 HP: 300 Init: 30 P: construct Article: a Manuel: "bizarre construct" Wiki: "bizarre construct"	El Vibrato punchcard (97 holes) (15)	El Vibrato punchcard (216 holes) (15)
 BL Imp	980	blimp.gif	Atk: 65 Def: 58 HP: 65 Init: 30 Meat: 40 P: demon ED: hot EA: stench Article: a	imp air (20)
 black adder	414	blackadder.gif	Atk: 129 Def: 114 HP: 124 Init: 50 Meat: 100 P: beast SNAKE Article: a Poison: "Really Quite Poisoned"	adder bladder (30)	black snake skin (15)	sunken eyes (c50)
 black friar	1577	blackfriar.gif	Atk: 130 Def: 111 HP: 122 Init: 75 P: dude Article: a	black label (15)	Mornington crescent roll (15)	black cloak (5)	black friar's tonsure (c15)
@@ -329,15 +329,15 @@ Hooded Warrior	183	hooded.gif	Atk: 165 Def: 148 HP: 150 Init: 70 P: constellatio
 huge barrel mimic	289	mimic4.gif	Atk: 35 Def: 31 HP: 45 Init: 90 P: weird Article: a
 huge ghuol	191	ghuol_huge.gif	NOCOPY Atk: 73 Def: 63 HP: 120 Exp: [53+ML/3] Init: 60 Meat: 300 P: undead E: spooky Article: a	ghuol ears (0)	ghuol egg (0)
 huge mosquito	1341	giantmosquito.gif	Atk: 16 Def: 14 HP: 18 Init: 20 Meat: 10 P: bug Article: a	delicious swamp muck (0)	huge mosquito proboscis (0)
-hulking construct	669	vib6.gif	Atk: 500 Def: 450 HP: 1000000 Init: -10000 P: construct Phys: 100 Elem: 100 Article: a	El Vibrato punchcard (104 holes) (1)
-hulking construct (translated)	675	vib6.gif	Atk: 500 Def: 450 HP: 1000000 Init: -10000 P: construct Phys: 100 Elem: 100 Article: a Manuel: "hulking construct" Wiki: "hulking construct"	El Vibrato punchcard (104 holes) (1)
+hulking construct	669	vib6.gif	Atk: 500 Def: 450 HP: 1000000 Init: -10000 P: construct Phys: 100 Elem: 100 Article: a	El Vibrato punchcard (115 holes) (c15)	El Vibrato punchcard (97 holes) (c15)	El Vibrato punchcard (129 holes) (c15)	El Vibrato punchcard (165 holes) (c15)	El Vibrato punchcard (142 holes) (c15)	El Vibrato punchcard (216 holes) (c15)	El Vibrato punchcard (88 holes) (c15)	El Vibrato punchcard (182 holes) (c15)	El Vibrato punchcard (176 holes) (c15)	El Vibrato punchcard (104 holes) (c15)
+hulking construct (translated)	675	vib6.gif	Atk: 500 Def: 450 HP: 1000000 Init: -10000 P: construct Phys: 100 Elem: 100 Article: a Manuel: "hulking construct" Wiki: "hulking construct"	El Vibrato punchcard (115 holes) (c15)	El Vibrato punchcard (97 holes) (c15)	El Vibrato punchcard (129 holes) (c15)	El Vibrato punchcard (165 holes) (c15)	El Vibrato punchcard (142 holes) (c15)	El Vibrato punchcard (216 holes) (c15)	El Vibrato punchcard (88 holes) (c15)	El Vibrato punchcard (182 holes) (c15)	El Vibrato punchcard (176 holes) (c15)	El Vibrato punchcard (104 holes) (c15)
 hung-over half-orc hobo	281	hobo.gif	Atk: 1 Def: 0 HP: 1 Init: 40 P: hobo E: stench Article: a	dirty hobo gloves (32)	Mad Train wine (60)	moxie weed (15)	Boozehounds Anonymous token (p10)
 hustled spectre	809	poolghost.gif	LUCKY Atk: 25 Def: 22 HP: 35 Init: 100 P: undead GHOST Article: a	cube of billiard chalk (100)
 Hypnotist of Hey Deze	232	hypnotist.gif	NOCOPY NOMANUEL ULTRARARE Atk: 85 Def: 115 HP: 85 Init: 10000 P: dude	hypnodisk (100)
 ice skate	731	iceskate.gif	Atk: 400 Def: 450 HP: 600 Init: 75 Meat: 100 P: fish Article: an	collapsible baton (0)	skate blade (0)	skate skin (0)	spangly unitard (0)
 Iiti Kitty	572	mummycat.gif	Atk: 165 Def: 148 HP: 150 Init: 75 P: undead EA: spooky	leathery cat skin (30)	unidentified jerky (10)	ancient Magi-Wipes (50)	ancient vinyl coin purse (20)	mummy wrapping (20)	Iiti Kitty phone charm (10)	crumbling rat skull (c0)	Iiti Kitty Gumdrop (c0)
-industrious construct	666	vib3.gif	Atk: 350 Def: 270 HP: 300 Init: 50 P: construct Article: an	El Vibrato punchcard (129 holes) (1)	El Vibrato punchcard (88 holes) (1)
-industrious construct (translated)	672	vib3.gif	Atk: 350 Def: 270 HP: 300 Init: 50 P: construct Article: an Manuel: "industrious construct" Wiki: "industrious construct"	El Vibrato punchcard (129 holes) (1)	El Vibrato punchcard (88 holes) (1)
+industrious construct	666	vib3.gif	Atk: 350 Def: 270 HP: 300 Init: 50 P: construct Article: an	El Vibrato punchcard (129 holes) (15)	El Vibrato punchcard (88 holes) (15)
+industrious construct (translated)	672	vib3.gif	Atk: 350 Def: 270 HP: 300 Init: 50 P: construct Article: an Manuel: "industrious construct" Wiki: "industrious construct"	El Vibrato punchcard (129 holes) (15)	El Vibrato punchcard (88 holes) (15)
 infernal seal larva	652	seal_larva.gif	NOCOPY Atk: 21 Def: 18 HP: 18 Init: 20 P: demon Article: an	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)
 infernal seal spawn	653	seal_baby.gif	NOCOPY Atk: 24 Def: 21 HP: 21 Init: 40 P: demon Article: an	a creased paper strip (30)	a crinkled paper strip (30)	a crumpled paper strip (30)	a folded paper strip (30)	a ragged paper strip (30)	a ripped paper strip (30)	a rumpled paper strip (30)	a torn paper strip (30)	seal eyeball (0)
 infinite meat bug	230	meatbug.gif	NOCOPY NOMANUEL ULTRARARE Atk: 45 Def: 40 HP: 30 Init: 10000 Meat: 10000 P: bug	incredibly dense meat gem (100)
@@ -389,8 +389,8 @@ Lesser Fruit Golem	284	lfruitgol.gif	Atk: 17 Def: 15 HP: 9 Init: 50 P: construct
 lihc	32	lich.gif	Atk: 20 Def: 18 HP: 11 Init: 60 Meat: 36 P: undead ED: spooky EA: sleaze EA: spooky Article: a	lihc eye (30)
 Little Man in the Canoe	540	canoeman.gif	Atk: 165 Def: 148 HP: 150 Init: 70 P: constellation ED: sleaze EA: hot EA: sleaze Article: The	line (30)	star (30)	star (30)
 lobsterfrogman	529	lobsterman.gif	Atk: 171 Def: 152 HP: 190 Init: 40 Meat: 60 P: beast Article: a	barrel of gunpowder (n100)
-lonely construct	668	vib5.gif	Atk: 300 Def: 315 HP: 350 Init: 80 P: construct Article: a	El Vibrato punchcard (213 holes) (1)	El Vibrato punchcard (182 holes) (1)
-lonely construct (translated)	674	vib5.gif	Atk: 300 Def: 315 HP: 350 Init: 80 P: construct Article: a Manuel: "lonely construct" Wiki: "lonely construct"	El Vibrato punchcard (213 holes) (1)	El Vibrato punchcard (182 holes) (1)
+lonely construct	668	vib5.gif	Atk: 300 Def: 315 HP: 350 Init: 80 P: construct Article: a	El Vibrato punchcard (213 holes) (15)	El Vibrato punchcard (182 holes) (15)
+lonely construct (translated)	674	vib5.gif	Atk: 300 Def: 315 HP: 350 Init: 80 P: construct Article: a Manuel: "lonely construct" Wiki: "lonely construct"	El Vibrato punchcard (213 holes) (15)	El Vibrato punchcard (182 holes) (15)
 Lord Spookyraven	464	lordspooky.gif	BOSS NOCOPY Atk: 165 Def: 148 HP: 200 Exp: [120+ML/3] Init: 10000 P: undead ED: spooky EA: cold EA: hot EA: sleaze EA: spooky EA: stench	Eye of Ed (n100)	Lord Spookyraven's ear trumpet (n100)
 Lot's Wife	1757	lotswife.gif	NOCOPY Atk: 3 Def: 3 HP: 10 Init: -10000 P: beast EA: stench Article: the	The Lot's engagement ring (n100)
 lounge lizardfish	770	lizardfish.gif	Atk: 400 Def: 630 HP: 550 Init: 100 Meat: 200 P: fish EA: stench Article: a	amber aviator shades (n5)	hair of the fish (c7)	rough fish scale (n4)	slug of shochu (21)
@@ -416,8 +416,8 @@ me4t begZ0r	144	beggar.gif	Atk: 87 Def: 78 HP: 77 Init: 50 P: dude EA: "bad spel
 medium-sized barrel mimic	288	mimic3.gif	Atk: 25 Def: 22 HP: 35 Init: 90 P: weird Article: a
 mean drunk duck	567	duckmeandrunk.gif	Atk: 180 Def: 157 HP: 190 Init: 50 Meat: 200 P: beast EA: sleaze Article: a	bottle of vodka (20)	bottle of tequila (20)	bottle of whiskey (20)	duct tape (5)
 mega frog	1342	megafrog.gif	Atk: 14 Def: 16 HP: 20 Init: 10 Meat: 15 P: beast EA: stench Article: a	delicious swamp muck (0)	swamp lolly (0)
-menacing construct	664	vib1.gif	Atk: 400 Def: 315 HP: 400 Init: 65 P: construct Article: a	El Vibrato punchcard (115 holes) (1)	El Vibrato punchcard (142 holes) (1)
-menacing construct (translated)	670	vib1.gif	Atk: 400 Def: 315 HP: 400 Init: 65 P: construct Article: a Manuel: "menacing construct" Wiki: "menacing construct"	El Vibrato punchcard (115 holes) (1)	El Vibrato punchcard (142 holes) (1)
+menacing construct	664	vib1.gif	Atk: 400 Def: 315 HP: 400 Init: 65 P: construct Article: a	El Vibrato punchcard (115 holes) (15)	El Vibrato punchcard (142 holes) (15)
+menacing construct (translated)	670	vib1.gif	Atk: 400 Def: 315 HP: 400 Init: 65 P: construct Article: a Manuel: "menacing construct" Wiki: "menacing construct"	El Vibrato punchcard (115 holes) (15)	El Vibrato punchcard (142 holes) (15)
 Mer-kin alphabetizer	850	merkinalphabet.gif	Atk: 750 Def: 800 HP: 900 Init: 100 Meat: 80 P: mer-kin Article: a	Mer-kin smartjuice (0)	Mer-kin worktea (0)
 Mer-kin balldodger	842	merkinballer.gif	NOCOPY Atk: [820+30*pref(lastColosseumRoundWon)] Def: [770+30*pref(lastColosseumRoundWon)] HP: [750+50*pref(lastColosseumRoundWon)] Init: -10000 Meat: 50 P: mer-kin Article: a
 Mer-kin bladeswitcher	844	merkinswitcher.gif	NOCOPY Atk: [820+30*pref(lastColosseumRoundWon)] Def: [770+30*pref(lastColosseumRoundWon)] HP: [750+50*pref(lastColosseumRoundWon)] Init: -10000 Meat: 50 P: mer-kin Article: a
@@ -653,7 +653,7 @@ swamp gator	595	swampgator.gif	Atk: 36 Def: 32 HP: 32 Init: 40 Meat: 30 P: beast
 swamp hag	1344	swamphag.gif	Atk: 35 Def: 28 HP: 40 Init: 30 Meat: 25 P: dude ED: stench EA: spooky Article: a	moonberry wine cooler (0)	witch wart (0)	vial of swamp vapors (c0)
 swamp owl	1350	swampowl.gif	Atk: 56 Def: 48 HP: 46 Init: 80 Meat: 20 P: beast EA: hot Article: a	moonberry wine cooler (0)	dilapidated wizard hat (0)
 swamp skunk	1353	swampskunk.gif	BOSS NOCOPY Atk: 68 Def: 66 HP: 65 Init: 50 Meat: 40 P: beast E: stench Article: a	bouquet of swamp roses (c100)	floral-print skirt (c100)	pogo stick (0)
-swarm of fire ants	461	ants.gif	Atk: 142 Def: 119 HP: 136 Init: 60 Meat: 50 Group: 20 P: bug ED: hot Article: a	ant agonist (20)	ant hoe (1)	ant pick (1)	ant pitchfork (1)	ant rake (1)	ant sickle (1)	handful of sand (20)
+swarm of fire ants	461	ants.gif	Atk: 142 Def: 119 HP: 136 Init: 60 Meat: 50 Group: 20 P: bug ED: hot Article: a	ant agonist (20)	ant hoe (c5)	ant pick (c5)	ant pitchfork (c5)	ant rake (c5)	ant sickle (c5)	handful of sand (20)
 swarm of ghuol whelps	1072	whelps1.gif	Atk: 50 Def: 45 HP: 100 Init: 300 Group: 15 P: undead ED: spooky Article: a
 swarm of killer bees	221	aswarm.gif	Atk: 59 Def: 53 HP: 75 Init: 90 Group: 6 P: bug Article: a Poison: "Somewhat Poisoned"	baby killer bee (5)	royal jelly (25)
 swarm of Knob lice	1059	kg_lice.gif	Atk: 25 Def: 22 HP: 30 Init: 50 Group: 100 P: bug Phys: 50 Elem: 50 Article: a
@@ -699,8 +699,8 @@ tomb rat king	997	tombratking.gif	BOSS NOCOPY Atk: [350] Def: [315] HP: [300] In
 tomb servant	468	tombguy.gif	Atk: 160 Def: 153 HP: 185 Init: 20 Meat: 50 P: undead ED: spooky Article: a	canopic jar (30)	ancient protein powder (15)	mummy wrapping (20)	unidentified jerky (12)	ancient ice cream scoop (5)	secret mummy herbs and spices (c10)
 toothy pirate	620	toothpirate.gif	Atk: 83 Def: 76 HP: 75 Init: 50 Meat: 45 P: pirate Article: a	bottle of rum (20)	cocktail napkin (10)	gold toothbrush (c0)
 toothy sklelton	186	toothskel.gif	Atk: 57 Def: 52 HP: 50 Init: 50 P: undead E: spooky Article: a	loose teeth (20)	loose teeth (20)	skeleton bone (20)	bone flute (10)	evil eye (20)	bone bandoneon (a0)
-towering construct	667	vib4.gif	Atk: 350 Def: 360 HP: 450 Init: 20 P: construct Article: a	El Vibrato punchcard (165 holes) (1)	El Vibrato punchcard (176 holes) (1)
-towering construct (translated)	673	vib4.gif	Atk: 350 Def: 360 HP: 450 Init: 20 P: construct Article: a Manuel: "towering construct" Wiki: "towering construct"	El Vibrato punchcard (165 holes) (1)	El Vibrato punchcard (176 holes) (1)
+towering construct	667	vib4.gif	Atk: 350 Def: 360 HP: 450 Init: 20 P: construct Article: a	El Vibrato punchcard (165 holes) (15)	El Vibrato punchcard (176 holes) (15)
+towering construct (translated)	673	vib4.gif	Atk: 350 Def: 360 HP: 450 Init: 20 P: construct Article: a Manuel: "towering construct" Wiki: "towering construct"	El Vibrato punchcard (165 holes) (15)	El Vibrato punchcard (176 holes) (15)
 triffid	342	triffid.gif	Atk: 5 Def: 4 HP: 6 Init: 70 P: plant Article: a	moxie weed (30)	spooky stick (30)
 Troll Twins	1244	twins_troll.gif	Atk: 94 Def: 82 HP: 98 Init: 40 Meat: 75 Group: 2 P: dude EA: spooky Article: the	incredible pizza (5)	troll britches (5)
 trophyfish	774	trophyfish.gif	NOCOPY Atk: 5000 Def: 4500 HP: 15000 Init: 200 P: fish Phys: 25 Elem: 25 Article: a


### PR DESCRIPTION
Construct drop rates are likely to be 15% each, by wiki data and autumn-aton drops.

All hulking construct drops are conditional: first, you only get drops if it is told to "ATTACK FLOOR" or "ATTACK WALL". Floor gives the command cards, wall gives the object cards. Second, you get 2-4 drops total. Third, item drop bonuses are ignored.

By wiki, nice warm beer is beer. Probably not canned though!

On the topic of conditional drops, fix swarm of fire ants: the familiar items are all 5%, not 1%, but they're conditional so at most one can drop.