### PR TITLE
Add set_ccs ASH function.

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
@@ -2165,6 +2166,9 @@ public abstract class RuntimeLibrary {
 
     params = new Type[] {DataTypes.BUFFER_TYPE, DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("buffer_to_file", DataTypes.BOOLEAN_TYPE, params));
+
+    params = new Type[] {DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("set_ccs", DataTypes.BOOLEAN_TYPE, params));
 
     params = new Type[] {DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("read_ccs", DataTypes.BUFFER_TYPE, params));
@@ -8287,6 +8291,20 @@ public abstract class RuntimeLibrary {
     byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
     String location = var2.toString();
     return DataFileCache.printBytes(location, bytes);
+  }
+
+  public static Value set_ccs(ScriptRuntime controller, final Value name) {
+    String ccsName = name.toString();
+    Optional<String> strategy =
+        CombatActionManager.getAvailableLookups().stream()
+            .filter(script -> script.equalsIgnoreCase(ccsName))
+            .findFirst();
+    if (strategy.isPresent()) {
+      CombatActionManager.loadStrategyLookup(strategy.get());
+      return DataTypes.TRUE_VALUE;
+    } else {
+      return DataTypes.FALSE_VALUE;
+    }
   }
 
   public static Value read_ccs(ScriptRuntime controller, final Value name) {

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -578,6 +578,14 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
       }
     }
 
+    @Test
+    public void setCcs() {
+      String output = execute("set_ccs(\"default\");");
+      assertThat(output, endsWith("Returned: true\n"));
+      output = execute("set_ccs(\"fhghqwgads\");");
+      assertThat(output, endsWith("Returned: false\n"));
+    }
+
     private static void addNpcResults(int itemId) {
       List<PurchaseRequest> results =
           List.of(Objects.requireNonNull(NPCStoreDatabase.getPurchaseRequest(itemId)));


### PR DESCRIPTION
I got annoyed with the standard scripting path of calling `cliExecute("ccs xxx")` that prints an extra line of "CCS set to xxx" every adventure, so this function doesn't print anything and just returns true on success. I'll note in the docs on the wiki that script authors have to know that `battleAction` needs to be set as well or it won't work. This goes along with `read_ccs` and `write_ccs` which were recently added.