### PR TITLE
refactor: move VykeaCompanionType to enum

### DIFF
--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
+import net.sourceforge.kolmafia.VYKEACompanionData.VYKEACompanionType;
 import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
 import net.sourceforge.kolmafia.maximizer.Maximizer;
 import net.sourceforge.kolmafia.modifiers.BitmapModifier;
@@ -2949,13 +2950,11 @@ public class Modifiers {
   }
 
   public void applyCompanionModifiers(VYKEACompanionData companion) {
-    int type = companion.getType();
+    VYKEACompanionType type = companion.getType();
     int level = companion.getLevel();
     switch (type) {
-      case VYKEACompanionData.LAMP -> this.addDouble(
-          Modifiers.ITEMDROP, level * 10, ModifierType.VYKEA, "Lamp");
-      case VYKEACompanionData.COUCH -> this.addDouble(
-          Modifiers.MEATDROP, level * 10, ModifierType.VYKEA, "Couch");
+      case LAMP -> this.addDouble(Modifiers.ITEMDROP, level * 10, ModifierType.VYKEA, "Lamp");
+      case COUCH -> this.addDouble(Modifiers.MEATDROP, level * 10, ModifierType.VYKEA, "Couch");
     }
   }
 

--- a/src/net/sourceforge/kolmafia/VYKEACompanionData.java
+++ b/src/net/sourceforge/kolmafia/VYKEACompanionData.java
@@ -422,11 +422,11 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
     if (choice == 1120) {
       switch (decision) {
         case 1 ->
-          // Start with 5 planks -> bookshelf, ceiling fan, dresser
-          ResultProcessor.processItem(ItemPool.VYKEA_PLANK, -5);
+        // Start with 5 planks -> bookshelf, ceiling fan, dresser
+        ResultProcessor.processItem(ItemPool.VYKEA_PLANK, -5);
         case 2 ->
-          // Start with 5 rails -> couch, dishrack, lamp
-          ResultProcessor.processItem(ItemPool.VYKEA_RAIL, -5);
+        // Start with 5 rails -> couch, dishrack, lamp
+        ResultProcessor.processItem(ItemPool.VYKEA_RAIL, -5);
         default -> {
           // Do nothing or invalid decision (presumably from URL manipulation).
           return;
@@ -531,14 +531,14 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
     if (choice == 1123) {
       switch (decision) {
         case 1 ->
-          // Add 5 planks -> bookshelf, couch
-          ResultProcessor.processItem(ItemPool.VYKEA_PLANK, -5);
+        // Add 5 planks -> bookshelf, couch
+        ResultProcessor.processItem(ItemPool.VYKEA_PLANK, -5);
         case 2 ->
-          // Add 5 rails -> dresser, lamp
-          ResultProcessor.processItem(ItemPool.VYKEA_RAIL, -5);
+        // Add 5 rails -> dresser, lamp
+        ResultProcessor.processItem(ItemPool.VYKEA_RAIL, -5);
         case 3 ->
-          // Add 5 brackets -> ceiling fan, dishrack
-          ResultProcessor.processItem(ItemPool.VYKEA_BRACKET, -5);
+        // Add 5 brackets -> ceiling fan, dishrack
+        ResultProcessor.processItem(ItemPool.VYKEA_BRACKET, -5);
         default -> {
           // Invalid decision, presumably from URL manipulation.
           return;

--- a/src/net/sourceforge/kolmafia/VYKEACompanionData.java
+++ b/src/net/sourceforge/kolmafia/VYKEACompanionData.java
@@ -132,14 +132,16 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
     "level 5 lightning lamp",
   };
 
-  public static final int NONE = 0;
+  public enum VYKEACompanionType {
+    NONE,
 
-  public static final int BOOKSHELF = 1;
-  public static final int DRESSER = 2;
-  public static final int CEILING_FAN = 3;
-  public static final int COUCH = 4;
-  public static final int LAMP = 5;
-  public static final int DISHRACK = 6;
+    BOOKSHELF,
+    DRESSER,
+    CEILING_FAN,
+    COUCH,
+    LAMP,
+    DISHRACK
+  }
 
   public static final AdventureResult NO_RUNE = ItemPool.get("(none)", 1);
   public static final AdventureResult FRENZY_RUNE = ItemPool.get(ItemPool.VYKEA_FRENZY_RUNE, 1);
@@ -147,7 +149,7 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
   public static final AdventureResult LIGHTNING_RUNE =
       ItemPool.get(ItemPool.VYKEA_LIGHTNING_RUNE, 1);
 
-  private final int type;
+  private final VYKEACompanionType type;
   private final int level;
   private final AdventureResult rune;
   private final String name;
@@ -185,18 +187,27 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
   }
 
   public VYKEACompanionData() {
-    this(NONE, 0, NO_RUNE, "");
+    this(VYKEACompanionType.NONE, 0, NO_RUNE, "");
   }
 
   public VYKEACompanionData(
-      final int type, final int level, final AdventureResult rune, final String name) {
+      final VYKEACompanionType type,
+      final int level,
+      final AdventureResult rune,
+      final String name) {
     this.type = type;
     this.level = level;
     this.rune = rune;
     this.name = name == null ? "" : name;
 
     // Derived fields
-    this.image = (type < 1 || type > 6) ? "" : ("vykfurn" + type + ".gif");
+    this.image =
+        switch (type) {
+          case NONE -> "";
+          case BOOKSHELF, DRESSER, CEILING_FAN, COUCH, LAMP, DISHRACK -> "vykfurn"
+              + type.ordinal()
+              + ".gif";
+        };
     switch (this.type) {
       case BOOKSHELF -> {
         this.attackElement = Element.SPOOKY;
@@ -232,7 +243,7 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
     this.stringForm = null;
   }
 
-  public int getType() {
+  public VYKEACompanionType getType() {
     return this.type;
   }
 
@@ -260,7 +271,7 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
     return this.attackElement;
   }
 
-  public static String typeToString(final int type) {
+  public static String typeToString(final VYKEACompanionType type) {
     return switch (type) {
       case BOOKSHELF -> "bookshelf";
       case CEILING_FAN -> "ceiling fan";
@@ -276,16 +287,16 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
     return VYKEACompanionData.typeToString(this.type);
   }
 
-  public static int stringToType(final String type) {
-    if (type == null) return NONE;
+  public static VYKEACompanionType stringToType(final String type) {
+    if (type == null) return VYKEACompanionType.NONE;
     return switch (type) {
-      case "bookshelf" -> BOOKSHELF;
-      case "ceiling fan" -> CEILING_FAN;
-      case "couch" -> COUCH;
-      case "dishrack" -> DISHRACK;
-      case "dresser" -> DRESSER;
-      case "lamp" -> LAMP;
-      default -> NONE;
+      case "bookshelf" -> VYKEACompanionType.BOOKSHELF;
+      case "ceiling fan" -> VYKEACompanionType.CEILING_FAN;
+      case "couch" -> VYKEACompanionType.COUCH;
+      case "dishrack" -> VYKEACompanionType.DISHRACK;
+      case "dresser" -> VYKEACompanionType.DRESSER;
+      case "lamp" -> VYKEACompanionType.LAMP;
+      default -> VYKEACompanionType.NONE;
     };
   }
 
@@ -329,7 +340,7 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
       String name = matcher.group(1);
       int level = StringUtilities.parseInt(matcher.group(2));
       String typeString = matcher.group(3);
-      int type = VYKEACompanionData.stringToType(typeString);
+      VYKEACompanionType type = VYKEACompanionData.stringToType(typeString);
       // Use last saved rune
       AdventureResult rune =
           VYKEACompanionData.stringToRune(Preferences.getString("_VYKEACompanionRune"));
@@ -342,12 +353,15 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
   public static void settingsToVYKEACompanion() {
     String name = Preferences.getString("_VYKEACompanionName");
     int level = Preferences.getInteger("_VYKEACompanionLevel");
-    int type = VYKEACompanionData.stringToType(Preferences.getString("_VYKEACompanionType"));
+    VYKEACompanionType type =
+        VYKEACompanionData.stringToType(Preferences.getString("_VYKEACompanionType"));
     AdventureResult rune =
         VYKEACompanionData.stringToRune(Preferences.getString("_VYKEACompanionRune"));
 
     VYKEACompanionData companion =
-        type == NONE ? NO_COMPANION : new VYKEACompanionData(type, level, rune, name);
+        type == VYKEACompanionType.NONE
+            ? NO_COMPANION
+            : new VYKEACompanionData(type, level, rune, name);
     VYKEACompanionData.setVYKEACompanion(companion, false);
   }
 
@@ -385,7 +399,7 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
       String runeString = matcher.group(3);
       AdventureResult rune = VYKEACompanionData.stringToRune(runeString);
       String typeString = matcher.group(4);
-      int type = VYKEACompanionData.stringToType(typeString);
+      VYKEACompanionType type = VYKEACompanionData.stringToType(typeString);
 
       return new VYKEACompanionData(type, level, rune, name);
     }
@@ -546,7 +560,7 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
 
       String name = matcher.group(2);
       String typeString = matcher.group(1);
-      int type = VYKEACompanionData.stringToType(typeString);
+      VYKEACompanionType type = VYKEACompanionData.stringToType(typeString);
 
       // Set them into preferences
       Preferences.setString("_VYKEACompanionName", name);
@@ -577,7 +591,7 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
     }
 
     if (this.type != o.type) {
-      return this.type - o.type;
+      return this.type.compareTo(o.type);
     }
 
     if (this.rune != o.rune) {

--- a/src/net/sourceforge/kolmafia/VYKEACompanionData.java
+++ b/src/net/sourceforge/kolmafia/VYKEACompanionData.java
@@ -182,7 +182,7 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
     }
   }
 
-  public static final VYKEACompanionData currentCompanion() {
+  public static VYKEACompanionData currentCompanion() {
     return VYKEACompanionData.currentCompanion;
   }
 
@@ -421,20 +421,16 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
     // 6 - don't build anything
     if (choice == 1120) {
       switch (decision) {
-        case 1:
+        case 1 ->
           // Start with 5 planks -> bookshelf, ceiling fan, dresser
           ResultProcessor.processItem(ItemPool.VYKEA_PLANK, -5);
-          break;
-        case 2:
+        case 2 ->
           // Start with 5 rails -> couch, dishrack, lamp
           ResultProcessor.processItem(ItemPool.VYKEA_RAIL, -5);
-          break;
-        case 6:
-          // Do nothing
+        default -> {
+          // Do nothing or invalid decision (presumably from URL manipulation).
           return;
-        default:
-          // Invalid decision, presumably from URL manipulation.
-          return;
+        }
       }
 
       // You've started construction and cannot abort from
@@ -534,21 +530,19 @@ public class VYKEACompanionData implements Comparable<VYKEACompanionData> {
     // 3 - Add 5 brackets
     if (choice == 1123) {
       switch (decision) {
-        case 1:
+        case 1 ->
           // Add 5 planks -> bookshelf, couch
           ResultProcessor.processItem(ItemPool.VYKEA_PLANK, -5);
-          break;
-        case 2:
+        case 2 ->
           // Add 5 rails -> dresser, lamp
           ResultProcessor.processItem(ItemPool.VYKEA_RAIL, -5);
-          break;
-        case 3:
+        case 3 ->
           // Add 5 brackets -> ceiling fan, dishrack
           ResultProcessor.processItem(ItemPool.VYKEA_BRACKET, -5);
-          break;
-        default:
+        default -> {
           // Invalid decision, presumably from URL manipulation.
           return;
+        }
       }
 
       // Parse companion name and type from the result text

--- a/src/net/sourceforge/kolmafia/textui/DataTypes.java
+++ b/src/net/sourceforge/kolmafia/textui/DataTypes.java
@@ -653,7 +653,7 @@ public class DataTypes {
       return returnDefault ? DataTypes.VYKEA_INIT : null;
     }
 
-    return new Value(DataTypes.VYKEA_TYPE, companion.getType(), name, companion);
+    return new Value(DataTypes.VYKEA_TYPE, companion.getType().ordinal(), name, companion);
   }
 
   public static Value parsePathValue(final int id, final boolean returnDefault) {
@@ -946,7 +946,8 @@ public class DataTypes {
     if (companion == null || companion == VYKEACompanionData.NO_COMPANION) {
       return returnDefault ? DataTypes.VYKEA_INIT : null;
     }
-    return new Value(DataTypes.VYKEA_TYPE, companion.getType(), companion.toString(), companion);
+    return new Value(
+        DataTypes.VYKEA_TYPE, companion.getType().ordinal(), companion.toString(), companion);
   }
 
   public static final Value makePathValue(final Path path) {

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -31,6 +31,7 @@ import net.sourceforge.kolmafia.PastaThrallData;
 import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.VYKEACompanionData;
+import net.sourceforge.kolmafia.VYKEACompanionData.VYKEACompanionType;
 import net.sourceforge.kolmafia.ZodiacSign;
 import net.sourceforge.kolmafia.combat.MonsterStatusTracker;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
@@ -710,7 +711,7 @@ public class Player {
    * @param level Level of companion
    * @return Reset to previous companion or no companion
    */
-  public static Cleanups withVykea(int companionTypeId, int level) {
+  public static Cleanups withVykea(VYKEACompanionType companionTypeId, int level) {
     var propertyCleanups =
         new Cleanups(
             withProperty("_VYKEACompanionName", "DÕZEQÍRHRU"),

--- a/test/net/sourceforge/kolmafia/DebugModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/DebugModifiersTest.java
@@ -9,6 +9,7 @@ import internal.helpers.Cleanups;
 import java.io.ByteArrayOutputStream;
 import java.time.Month;
 import java.util.regex.Pattern;
+import net.sourceforge.kolmafia.VYKEACompanionData.VYKEACompanionType;
 import net.sourceforge.kolmafia.objectpool.AdventurePool;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
@@ -534,7 +535,7 @@ public class DebugModifiersTest {
 
   @Test
   void listsVykea() {
-    try (var cleanups = withVykea(VYKEACompanionData.COUCH, 5)) {
+    try (var cleanups = withVykea(VYKEACompanionType.COUCH, 5)) {
       evaluateDebugModifiers(Modifiers.MEATDROP);
       assertThat(output(), containsDebugRow("Vykea", "Couch", 50.0, 50.0));
     }

--- a/test/root/expected/test_vykea.ash.out
+++ b/test/root/expected/test_vykea.ash.out
@@ -1,1 +1,2 @@
 none
+vykfurn6.gif

--- a/test/root/scripts/test_vykea.ash
+++ b/test/root/scripts/test_vykea.ash
@@ -1,2 +1,4 @@
 string none = $vykea[none].to_string();
 print(none);
+vykea dishrack = $vykea[level 1 dishrack];
+print(dishrack.image);


### PR DESCRIPTION
There are several spaces in the codebase where we use `public static final int`s where enums would be better (and prevent passing ints outside the range, or from the wrong source, to functions). This is one of them.

This one uses the ordinal, both in the exposed ASH type and the image. Perhaps it should be explicitly in the enum, but equally I can't see it changing. I added a test for the image, so we'll know by failing test if the ordinal of the last entry changes.