### PR TITLE
refactor: move simple request ints to enum

### DIFF
--- a/src/net/sourceforge/kolmafia/moods/MPRestoreItemList.java
+++ b/src/net/sourceforge/kolmafia/moods/MPRestoreItemList.java
@@ -19,6 +19,7 @@ import net.sourceforge.kolmafia.request.ChateauRequest;
 import net.sourceforge.kolmafia.request.ClanRumpusRequest;
 import net.sourceforge.kolmafia.request.ClanRumpusRequest.RequestType;
 import net.sourceforge.kolmafia.request.ClanStashRequest;
+import net.sourceforge.kolmafia.request.ClanStashRequest.ClanStashRequestType;
 import net.sourceforge.kolmafia.request.FalloutShelterRequest;
 import net.sourceforge.kolmafia.request.UseItemRequest;
 import net.sourceforge.kolmafia.session.InventoryManager;
@@ -300,11 +301,11 @@ public abstract class MPRestoreItemList {
 
         RequestThread.postRequest(
             new ClanStashRequest(
-                new AdventureResult[] {EXPRESS_CARD}, ClanStashRequest.STASH_TO_ITEMS));
+                new AdventureResult[] {EXPRESS_CARD}, ClanStashRequestType.STASH_TO_ITEMS));
         RequestThread.postRequest(UseItemRequest.getInstance(EXPRESS_CARD));
         RequestThread.postRequest(
             new ClanStashRequest(
-                new AdventureResult[] {EXPRESS_CARD}, ClanStashRequest.ITEMS_TO_STASH));
+                new AdventureResult[] {EXPRESS_CARD}, ClanStashRequestType.ITEMS_TO_STASH));
         return;
       }
 

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -41,11 +41,13 @@ import net.sourceforge.kolmafia.persistence.ItemDatabase.Attribute;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase.Element;
 import net.sourceforge.kolmafia.request.ApiRequest;
 import net.sourceforge.kolmafia.request.ClosetRequest;
+import net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType;
 import net.sourceforge.kolmafia.request.DisplayCaseRequest;
 import net.sourceforge.kolmafia.request.FamiliarRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.request.MonsterManuelRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.request.ZapRequest;
 import net.sourceforge.kolmafia.session.DisplayCaseManager;
 import net.sourceforge.kolmafia.session.EquipmentManager;
@@ -2451,8 +2453,9 @@ public class DebugDatabase {
         // Move a single one to inventory and then to the closet
         AdventureResult toTransfer = item.getInstance(1);
         RequestThread.postRequest(
-            new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, toTransfer));
-        RequestThread.postRequest(new ClosetRequest(ClosetRequest.INVENTORY_TO_CLOSET, toTransfer));
+            new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, toTransfer));
+        RequestThread.postRequest(
+            new ClosetRequest(ClosetRequestType.INVENTORY_TO_CLOSET, toTransfer));
       }
       items.add(item);
     }

--- a/src/net/sourceforge/kolmafia/request/CafeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CafeRequest.java
@@ -15,6 +15,7 @@ import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.persistence.ConsumablesDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.utilities.LockableListFactory;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
@@ -29,7 +30,7 @@ public class CafeRequest extends GenericRequest {
   private static final AdventureResult LARP = ItemPool.get(ItemPool.LARP_MEMBERSHIP_CARD, 1);
   private static final GenericRequest LARP_REQUEST =
       new StorageRequest(
-          StorageRequest.STORAGE_TO_INVENTORY, new AdventureResult[] {CafeRequest.LARP});
+          StorageRequestType.STORAGE_TO_INVENTORY, new AdventureResult[] {CafeRequest.LARP});
 
   protected String name = "";
   protected String itemName = null;

--- a/src/net/sourceforge/kolmafia/request/ClanStashRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ClanStashRequest.java
@@ -25,16 +25,18 @@ public class ClanStashRequest extends TransferItemRequest {
       Pattern.compile(
           "<option value=([\\d]+) descid=([\\d]+)>(.*?)( \\(([\\d,]+)\\))?( \\(-[\\d,]*\\))?</option>");
 
-  private final int moveType;
+  private final ClanStashRequestType moveType;
 
-  public static final int REFRESH_ONLY = 0;
-  public static final int ITEMS_TO_STASH = 1;
-  public static final int MEAT_TO_STASH = 2;
-  public static final int STASH_TO_ITEMS = 3;
+  public enum ClanStashRequestType {
+    REFRESH_ONLY,
+    ITEMS_TO_STASH,
+    MEAT_TO_STASH,
+    STASH_TO_ITEMS
+  }
 
   public ClanStashRequest() {
     super("clan_stash.php");
-    this.moveType = ClanStashRequest.REFRESH_ONLY;
+    this.moveType = ClanStashRequestType.REFRESH_ONLY;
     this.destination = new ArrayList<>();
   }
 
@@ -47,11 +49,11 @@ public class ClanStashRequest extends TransferItemRequest {
     super("clan_stash.php", new AdventureLongCountResult(AdventureResult.MEAT, amount));
     this.addFormField("action", "contribute");
 
-    this.moveType = ClanStashRequest.MEAT_TO_STASH;
+    this.moveType = ClanStashRequestType.MEAT_TO_STASH;
     this.destination = new ArrayList<>();
   }
 
-  public ClanStashRequest(AdventureResult attachment, final int moveType) {
+  public ClanStashRequest(AdventureResult attachment, final ClanStashRequestType moveType) {
     this(new AdventureResult[] {attachment}, moveType);
   }
 
@@ -60,11 +62,12 @@ public class ClanStashRequest extends TransferItemRequest {
    *
    * @param attachments The list of attachments involved in the request
    */
-  public ClanStashRequest(final AdventureResult[] attachments, final int moveType) {
+  public ClanStashRequest(
+      final AdventureResult[] attachments, final ClanStashRequestType moveType) {
     super("clan_stash.php", attachments);
     this.moveType = moveType;
 
-    if (moveType == ClanStashRequest.ITEMS_TO_STASH) {
+    if (moveType == ClanStashRequestType.ITEMS_TO_STASH) {
       this.addFormField("action", "addgoodies");
       this.source = KoLConstants.inventory;
       this.destination = ClanManager.getStash();
@@ -78,22 +81,22 @@ public class ClanStashRequest extends TransferItemRequest {
 
   @Override
   protected boolean retryOnTimeout() {
-    return this.moveType == ClanStashRequest.REFRESH_ONLY;
+    return this.moveType == ClanStashRequestType.REFRESH_ONLY;
   }
 
   @Override
   public boolean sendEmpty() {
-    return this.moveType == ClanStashRequest.REFRESH_ONLY;
+    return this.moveType == ClanStashRequestType.REFRESH_ONLY;
   }
 
   @Override
   public String getItemField() {
-    return this.moveType == ClanStashRequest.ITEMS_TO_STASH ? "item" : "whichitem";
+    return this.moveType == ClanStashRequestType.ITEMS_TO_STASH ? "item" : "whichitem";
   }
 
   @Override
   public String getQuantityField() {
-    return this.moveType == ClanStashRequest.ITEMS_TO_STASH ? "qty" : "quantity";
+    return this.moveType == ClanStashRequestType.ITEMS_TO_STASH ? "qty" : "quantity";
   }
 
   @Override
@@ -101,7 +104,7 @@ public class ClanStashRequest extends TransferItemRequest {
     return "howmuch";
   }
 
-  public int getMoveType() {
+  public ClanStashRequestType getMoveType() {
     return this.moveType;
   }
 
@@ -119,7 +122,7 @@ public class ClanStashRequest extends TransferItemRequest {
 
   @Override
   public int getCapacity() {
-    return this.moveType == ClanStashRequest.STASH_TO_ITEMS ? 1 : 11;
+    return this.moveType == ClanStashRequestType.STASH_TO_ITEMS ? 1 : 11;
   }
 
   @Override
@@ -309,9 +312,9 @@ public class ClanStashRequest extends TransferItemRequest {
   @Override
   public String getStatusMessage() {
     return switch (this.moveType) {
-      case ClanStashRequest.ITEMS_TO_STASH -> "Dropping items into stash";
-      case ClanStashRequest.STASH_TO_ITEMS -> "Pulling items from stash";
-      case ClanStashRequest.MEAT_TO_STASH -> "Donating meat to stash";
+      case ITEMS_TO_STASH -> "Dropping items into stash";
+      case STASH_TO_ITEMS -> "Pulling items from stash";
+      case MEAT_TO_STASH -> "Donating meat to stash";
       default -> "Refreshing stash contents";
     };
   }

--- a/src/net/sourceforge/kolmafia/request/ClosetRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ClosetRequest.java
@@ -1,5 +1,9 @@
 package net.sourceforge.kolmafia.request;
 
+import static net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType.CLOSET_TO_INVENTORY;
+import static net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType.INVENTORY_TO_CLOSET;
+import static net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType.REFRESH;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -21,14 +25,16 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class ClosetRequest extends TransferItemRequest {
-  private int moveType;
+  private ClosetRequestType moveType;
 
-  public static final int REFRESH = 0;
-  public static final int INVENTORY_TO_CLOSET = 1;
-  public static final int CLOSET_TO_INVENTORY = 2;
-  public static final int MEAT_TO_CLOSET = 3;
-  public static final int MEAT_TO_INVENTORY = 4;
-  public static final int EMPTY_CLOSET = 5;
+  public enum ClosetRequestType {
+    REFRESH,
+    INVENTORY_TO_CLOSET,
+    CLOSET_TO_INVENTORY,
+    MEAT_TO_CLOSET,
+    MEAT_TO_INVENTORY,
+    EMPTY_CLOSET
+  }
 
   public static void refresh() {
     // To refresh closet, we get Meat from any page
@@ -79,20 +85,20 @@ public class ClosetRequest extends TransferItemRequest {
     this.moveType = REFRESH;
   }
 
-  public ClosetRequest(final int moveType) {
+  public ClosetRequest(final ClosetRequestType moveType) {
     this(moveType, new AdventureResult[0]);
     this.moveType = moveType;
   }
 
-  public ClosetRequest(final int moveType, final long amount) {
+  public ClosetRequest(final ClosetRequestType moveType, final long amount) {
     this(moveType, new AdventureLongCountResult(AdventureResult.MEAT, amount));
   }
 
-  public ClosetRequest(final int moveType, final AdventureResult attachment) {
+  public ClosetRequest(final ClosetRequestType moveType, final AdventureResult attachment) {
     this(moveType, new AdventureResult[] {attachment});
   }
 
-  public ClosetRequest(final int moveType, final AdventureResult[] attachments) {
+  public ClosetRequest(final ClosetRequestType moveType, final AdventureResult[] attachments) {
     super(ClosetRequest.pickURL(moveType), attachments);
     this.moveType = moveType;
 
@@ -138,7 +144,7 @@ public class ClosetRequest extends TransferItemRequest {
     }
   }
 
-  private static String pickURL(final int moveType) {
+  private static String pickURL(final ClosetRequestType moveType) {
     return switch (moveType) {
       case INVENTORY_TO_CLOSET, CLOSET_TO_INVENTORY -> "inventory.php";
       default -> "closet.php";
@@ -150,7 +156,7 @@ public class ClosetRequest extends TransferItemRequest {
     return true;
   }
 
-  public int getMoveType() {
+  public ClosetRequestType getMoveType() {
     return this.moveType;
   }
 
@@ -210,7 +216,7 @@ public class ClosetRequest extends TransferItemRequest {
   @Override
   public void processResults() {
     switch (this.moveType) {
-      case ClosetRequest.REFRESH -> {
+      case REFRESH -> {
         ClosetRequest.parseCloset(this.getURLString(), this.responseText);
         return;
       }

--- a/src/net/sourceforge/kolmafia/request/ClosetRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ClosetRequest.java
@@ -1,9 +1,5 @@
 package net.sourceforge.kolmafia.request;
 
-import static net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType.CLOSET_TO_INVENTORY;
-import static net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType.INVENTORY_TO_CLOSET;
-import static net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType.REFRESH;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -40,7 +36,7 @@ public class ClosetRequest extends TransferItemRequest {
     // To refresh closet, we get Meat from any page
     // and items from api.php
 
-    RequestThread.postRequest(new ClosetRequest(REFRESH));
+    RequestThread.postRequest(new ClosetRequest(ClosetRequestType.REFRESH));
     ApiRequest.updateCloset();
   }
 
@@ -82,7 +78,7 @@ public class ClosetRequest extends TransferItemRequest {
 
   public ClosetRequest() {
     super("closet.php");
-    this.moveType = REFRESH;
+    this.moveType = ClosetRequestType.REFRESH;
   }
 
   public ClosetRequest(final ClosetRequestType moveType) {
@@ -194,7 +190,8 @@ public class ClosetRequest extends TransferItemRequest {
 
   @Override
   public boolean forceGETMethod() {
-    return this.moveType == INVENTORY_TO_CLOSET || this.moveType == CLOSET_TO_INVENTORY;
+    return this.moveType == ClosetRequestType.INVENTORY_TO_CLOSET
+        || this.moveType == ClosetRequestType.CLOSET_TO_INVENTORY;
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/request/SewerRequest.java
+++ b/src/net/sourceforge/kolmafia/request/SewerRequest.java
@@ -15,6 +15,8 @@ import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.persistence.NPCStoreDatabase;
+import net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
@@ -293,10 +295,10 @@ public class SewerRequest extends CreateItemRequest {
       final List<AdventureResult> destination) {
     TransferItemRequest request =
         (destination == KoLConstants.closet)
-            ? new ClosetRequest(ClosetRequest.INVENTORY_TO_CLOSET, transfers)
+            ? new ClosetRequest(ClosetRequestType.INVENTORY_TO_CLOSET, transfers)
             : (source == KoLConstants.storage)
-                ? new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, transfers)
-                : new ClosetRequest(ClosetRequest.CLOSET_TO_INVENTORY, transfers);
+                ? new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, transfers)
+                : new ClosetRequest(ClosetRequestType.CLOSET_TO_INVENTORY, transfers);
 
     RequestThread.postRequest(request);
   }

--- a/src/net/sourceforge/kolmafia/request/StorageRequest.java
+++ b/src/net/sourceforge/kolmafia/request/StorageRequest.java
@@ -1,9 +1,5 @@
 package net.sourceforge.kolmafia.request;
 
-import static net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType.EMPTY_STORAGE;
-import static net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType.REFRESH;
-import static net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType.STORAGE_TO_INVENTORY;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -115,13 +111,13 @@ public class StorageRequest extends TransferItemRequest {
     // To refresh storage, we get Meat and pulls from the main page
     // and items from api.php
 
-    RequestThread.postRequest(new StorageRequest(REFRESH));
+    RequestThread.postRequest(new StorageRequest(StorageRequestType.REFRESH));
     ApiRequest.updateStorage();
     StorageRequest.updateSettings();
   }
 
   public static void emptyStorage() {
-    RequestThread.postRequest(new StorageRequest(EMPTY_STORAGE));
+    RequestThread.postRequest(new StorageRequest(StorageRequestType.EMPTY_STORAGE));
   }
 
   public static final void parseStorage(final JSONObject JSON) {
@@ -274,7 +270,7 @@ public class StorageRequest extends TransferItemRequest {
 
   @Override
   public boolean forceGETMethod() {
-    return this.moveType == STORAGE_TO_INVENTORY;
+    return this.moveType == StorageRequestType.STORAGE_TO_INVENTORY;
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/request/StorageRequest.java
+++ b/src/net/sourceforge/kolmafia/request/StorageRequest.java
@@ -1,5 +1,9 @@
 package net.sourceforge.kolmafia.request;
 
+import static net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType.EMPTY_STORAGE;
+import static net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType.REFRESH;
+import static net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType.STORAGE_TO_INVENTORY;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -31,7 +35,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class StorageRequest extends TransferItemRequest {
-  private int moveType;
+  private StorageRequestType moveType;
   private boolean bulkTransfer;
 
   public static final Set<Integer> roninStoragePulls = new HashSet<>();
@@ -100,10 +104,12 @@ public class StorageRequest extends TransferItemRequest {
     return set.contains(itemId);
   }
 
-  public static final int REFRESH = 0;
-  public static final int EMPTY_STORAGE = 1;
-  public static final int STORAGE_TO_INVENTORY = 2;
-  public static final int PULL_MEAT_FROM_STORAGE = 3;
+  public enum StorageRequestType {
+    REFRESH,
+    EMPTY_STORAGE,
+    STORAGE_TO_INVENTORY,
+    PULL_MEAT_FROM_STORAGE
+  }
 
   public static void refresh() {
     // To refresh storage, we get Meat and pulls from the main page
@@ -174,28 +180,30 @@ public class StorageRequest extends TransferItemRequest {
 
   public StorageRequest() {
     super("storage.php");
-    this.moveType = StorageRequest.REFRESH;
+    this.moveType = StorageRequestType.REFRESH;
   }
 
-  public StorageRequest(final int moveType) {
+  public StorageRequest(final StorageRequestType moveType) {
     this(moveType, new AdventureResult[0]);
     this.moveType = moveType;
   }
 
-  public StorageRequest(final int moveType, final long amount) {
+  public StorageRequest(final StorageRequestType moveType, final long amount) {
     this(moveType, new AdventureLongCountResult(AdventureResult.MEAT, amount));
   }
 
-  public StorageRequest(final int moveType, final AdventureResult attachment) {
+  public StorageRequest(final StorageRequestType moveType, final AdventureResult attachment) {
     this(moveType, new AdventureResult[] {attachment});
   }
 
-  public StorageRequest(final int moveType, final AdventureResult[] attachments) {
+  public StorageRequest(final StorageRequestType moveType, final AdventureResult[] attachments) {
     this(moveType, attachments, false);
   }
 
   public StorageRequest(
-      final int moveType, final AdventureResult[] attachments, final boolean bulkTransfer) {
+      final StorageRequestType moveType,
+      final AdventureResult[] attachments,
+      final boolean bulkTransfer) {
     super("storage.php", attachments);
     this.moveType = moveType;
     this.bulkTransfer = bulkTransfer;
@@ -223,10 +231,10 @@ public class StorageRequest extends TransferItemRequest {
 
   @Override
   protected boolean retryOnTimeout() {
-    return this.moveType == StorageRequest.REFRESH;
+    return this.moveType == StorageRequestType.REFRESH;
   }
 
-  public int getMoveType() {
+  public StorageRequestType getMoveType() {
     return this.moveType;
   }
 
@@ -449,7 +457,7 @@ public class StorageRequest extends TransferItemRequest {
   @Override
   public void processResults() {
     switch (this.moveType) {
-      case StorageRequest.REFRESH -> {
+      case REFRESH -> {
         StorageRequest.parseStorage(this.getURLString(), this.responseText);
         return;
       }

--- a/src/net/sourceforge/kolmafia/session/BreakfastManager.java
+++ b/src/net/sourceforge/kolmafia/session/BreakfastManager.java
@@ -29,6 +29,7 @@ import net.sourceforge.kolmafia.request.CampgroundRequest.CropType;
 import net.sourceforge.kolmafia.request.ClanLoungeRequest;
 import net.sourceforge.kolmafia.request.ClanRumpusRequest;
 import net.sourceforge.kolmafia.request.ClosetRequest;
+import net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType;
 import net.sourceforge.kolmafia.request.CoinMasterRequest;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
@@ -39,6 +40,7 @@ import net.sourceforge.kolmafia.request.PlaceRequest;
 import net.sourceforge.kolmafia.request.SpinMasterLatheRequest;
 import net.sourceforge.kolmafia.request.StandardRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.request.UseItemRequest;
 import net.sourceforge.kolmafia.request.UseSkillRequest;
 import net.sourceforge.kolmafia.request.VolcanoIslandRequest;
@@ -287,7 +289,7 @@ public class BreakfastManager {
     if (useStorage && storageItems.size() > 0) {
       RequestThread.postRequest(
           new StorageRequest(
-              StorageRequest.STORAGE_TO_INVENTORY,
+              StorageRequestType.STORAGE_TO_INVENTORY,
               storageItems.toArray(new AdventureResult[0]),
               false));
     }
@@ -296,7 +298,7 @@ public class BreakfastManager {
     if (useCloset && closetItems.size() > 0) {
       RequestThread.postRequest(
           new ClosetRequest(
-              ClosetRequest.CLOSET_TO_INVENTORY, closetItems.toArray(new AdventureResult[0])));
+              ClosetRequestType.CLOSET_TO_INVENTORY, closetItems.toArray(new AdventureResult[0])));
     }
 
     // Use the toys!

--- a/src/net/sourceforge/kolmafia/session/FamiliarManager.java
+++ b/src/net/sourceforge/kolmafia/session/FamiliarManager.java
@@ -12,10 +12,12 @@ import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.FamiliarDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.ClosetRequest;
+import net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.FamiliarRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 
 public abstract class FamiliarManager {
   public static void changeFamiliar(int famId) {
@@ -94,7 +96,7 @@ public abstract class FamiliarManager {
     if (storageItems.size() > 0) {
       RequestThread.postRequest(
           new StorageRequest(
-              StorageRequest.STORAGE_TO_INVENTORY,
+              StorageRequestType.STORAGE_TO_INVENTORY,
               storageItems.toArray(new AdventureResult[0]),
               true));
     }
@@ -118,7 +120,7 @@ public abstract class FamiliarManager {
       // *** items to the session tally
       RequestThread.postRequest(
           new ClosetRequest(
-              ClosetRequest.CLOSET_TO_INVENTORY, closetItems.toArray(new AdventureResult[0])));
+              ClosetRequestType.CLOSET_TO_INVENTORY, closetItems.toArray(new AdventureResult[0])));
     }
 
     // Equip all familiars with equipment from inventory

--- a/src/net/sourceforge/kolmafia/session/InventoryManager.java
+++ b/src/net/sourceforge/kolmafia/session/InventoryManager.java
@@ -40,7 +40,9 @@ import net.sourceforge.kolmafia.persistence.RestoresDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.ApiRequest;
 import net.sourceforge.kolmafia.request.ClanStashRequest;
+import net.sourceforge.kolmafia.request.ClanStashRequest.ClanStashRequestType;
 import net.sourceforge.kolmafia.request.ClosetRequest;
+import net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType;
 import net.sourceforge.kolmafia.request.CombineMeatRequest;
 import net.sourceforge.kolmafia.request.CreateItemRequest;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
@@ -51,6 +53,7 @@ import net.sourceforge.kolmafia.request.PurchaseRequest;
 import net.sourceforge.kolmafia.request.SewerRequest;
 import net.sourceforge.kolmafia.request.StandardRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.request.UntinkerRequest;
 import net.sourceforge.kolmafia.request.UseSkillRequest;
 import net.sourceforge.kolmafia.swingui.GenericFrame;
@@ -636,7 +639,8 @@ public abstract class InventoryManager {
 
         int retrieveCount = Math.min(itemCount, missingCount);
         RequestThread.postRequest(
-            new ClosetRequest(ClosetRequest.CLOSET_TO_INVENTORY, item.getInstance(retrieveCount)));
+            new ClosetRequest(
+                ClosetRequestType.CLOSET_TO_INVENTORY, item.getInstance(retrieveCount)));
         missingCount = item.getCount() - item.getCount(KoLConstants.inventory);
 
         if (missingCount <= 0) {
@@ -657,7 +661,7 @@ public abstract class InventoryManager {
         int retrieveCount = Math.min(itemCount, missingCount);
         RequestThread.postRequest(
             new StorageRequest(
-                StorageRequest.STORAGE_TO_INVENTORY, item.getInstance(retrieveCount)));
+                StorageRequestType.STORAGE_TO_INVENTORY, item.getInstance(retrieveCount)));
         missingCount = item.getCount() - item.getCount(KoLConstants.inventory);
 
         if (missingCount <= 0) {
@@ -680,7 +684,7 @@ public abstract class InventoryManager {
         int retrieveCount = Math.min(itemCount, missingCount);
         RequestThread.postRequest(
             new StorageRequest(
-                StorageRequest.STORAGE_TO_INVENTORY, item.getInstance(retrieveCount)));
+                StorageRequestType.STORAGE_TO_INVENTORY, item.getInstance(retrieveCount)));
         missingCount = item.getCount() - item.getCount(KoLConstants.inventory);
 
         if (missingCount <= 0) {
@@ -703,7 +707,8 @@ public abstract class InventoryManager {
         int retrieveCount =
             Math.min(itemCount, InventoryManager.getPurchaseCount(itemId, missingCount));
         RequestThread.postRequest(
-            new ClanStashRequest(item.getInstance(retrieveCount), ClanStashRequest.STASH_TO_ITEMS));
+            new ClanStashRequest(
+                item.getInstance(retrieveCount), ClanStashRequestType.STASH_TO_ITEMS));
         missingCount = item.getCount() - item.getCount(KoLConstants.inventory);
 
         if (missingCount <= 0) {
@@ -892,7 +897,8 @@ public abstract class InventoryManager {
         int newbudget = ConcoctionDatabase.getPullsBudgeted() - pullCount;
 
         RequestThread.postRequest(
-            new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, item.getInstance(pullCount)));
+            new StorageRequest(
+                StorageRequestType.STORAGE_TO_INVENTORY, item.getInstance(pullCount)));
         ConcoctionDatabase.setPullsBudgeted(newbudget);
         missingCount = item.getCount() - item.getCount(KoLConstants.inventory);
 

--- a/src/net/sourceforge/kolmafia/session/ValhallaManager.java
+++ b/src/net/sourceforge/kolmafia/session/ValhallaManager.java
@@ -34,6 +34,7 @@ import net.sourceforge.kolmafia.request.HermitRequest;
 import net.sourceforge.kolmafia.request.MicroBreweryRequest;
 import net.sourceforge.kolmafia.request.PlaceRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.request.UntinkerRequest;
 import net.sourceforge.kolmafia.request.UseItemRequest;
 
@@ -279,7 +280,8 @@ public class ValhallaManager {
       }
 
       if (item.getCount(KoLConstants.freepulls) > 0) {
-        RequestThread.postRequest(new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, item));
+        RequestThread.postRequest(
+            new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, item));
       }
     }
   }

--- a/src/net/sourceforge/kolmafia/swingui/ClanManageFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/ClanManageFrame.java
@@ -26,6 +26,7 @@ import net.sourceforge.kolmafia.persistence.ProfileSnapshot;
 import net.sourceforge.kolmafia.request.ClanBuffRequest;
 import net.sourceforge.kolmafia.request.ClanMembersRequest;
 import net.sourceforge.kolmafia.request.ClanStashRequest;
+import net.sourceforge.kolmafia.request.ClanStashRequest.ClanStashRequestType;
 import net.sourceforge.kolmafia.request.ClanWarRequest;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.EquipmentRequest.EquipmentRequestType;
@@ -315,7 +316,7 @@ public class ClanManageFrame extends GenericFrame {
           return;
         }
 
-        RequestThread.postRequest(new ClanStashRequest(items, ClanStashRequest.ITEMS_TO_STASH));
+        RequestThread.postRequest(new ClanStashRequest(items, ClanStashRequestType.ITEMS_TO_STASH));
       }
 
       @Override
@@ -387,7 +388,7 @@ public class ClanManageFrame extends GenericFrame {
           return;
         }
 
-        RequestThread.postRequest(new ClanStashRequest(items, ClanStashRequest.STASH_TO_ITEMS));
+        RequestThread.postRequest(new ClanStashRequest(items, ClanStashRequestType.STASH_TO_ITEMS));
       }
 
       @Override

--- a/src/net/sourceforge/kolmafia/swingui/CoinmastersFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/CoinmastersFrame.java
@@ -31,6 +31,7 @@ import net.sourceforge.kolmafia.persistence.CoinmastersDatabase;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.*;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.swingui.button.InvocationButton;
 import net.sourceforge.kolmafia.swingui.listener.ThreadedListener;
@@ -580,10 +581,11 @@ public class CoinmastersFrame extends GenericFrame implements ChangeListener {
   public class MrStorePanel extends CoinmasterPanel {
     private static final StorageRequest PULL_MR_A_REQUEST =
         new StorageRequest(
-            StorageRequest.STORAGE_TO_INVENTORY, new AdventureResult[] {MrStoreRequest.MR_A});
+            StorageRequestType.STORAGE_TO_INVENTORY, new AdventureResult[] {MrStoreRequest.MR_A});
     private static final StorageRequest PULL_UNCLE_B_REQUEST =
         new StorageRequest(
-            StorageRequest.STORAGE_TO_INVENTORY, new AdventureResult[] {MrStoreRequest.UNCLE_B});
+            StorageRequestType.STORAGE_TO_INVENTORY,
+            new AdventureResult[] {MrStoreRequest.UNCLE_B});
 
     private final JButton pullA = new InvocationButton("pull Mr. A", this, "pullA");
     private final JButton pullB = new InvocationButton("pull Uncle B", this, "pullB");

--- a/src/net/sourceforge/kolmafia/swingui/ItemManageFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/ItemManageFrame.java
@@ -35,9 +35,11 @@ import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.ClosetRequest;
+import net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.StandardRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.session.StoreManager;
 import net.sourceforge.kolmafia.swingui.button.InvocationButton;
 import net.sourceforge.kolmafia.swingui.panel.CardLayoutSelectorPanel;
@@ -296,7 +298,7 @@ public class ItemManageFrame extends GenericFrame {
         items[i] = current.getInstance(Math.min(icount, Math.max(0, 1 - ccount)));
       }
 
-      RequestThread.postRequest(new ClosetRequest(ClosetRequest.INVENTORY_TO_CLOSET, items));
+      RequestThread.postRequest(new ClosetRequest(ClosetRequestType.INVENTORY_TO_CLOSET, items));
     }
 
     @Override
@@ -320,7 +322,7 @@ public class ItemManageFrame extends GenericFrame {
         items[i] = current.getInstance(current.getCount(KoLConstants.inventory));
       }
 
-      RequestThread.postRequest(new ClosetRequest(ClosetRequest.INVENTORY_TO_CLOSET, items));
+      RequestThread.postRequest(new ClosetRequest(ClosetRequestType.INVENTORY_TO_CLOSET, items));
     }
 
     @Override
@@ -509,9 +511,10 @@ public class ItemManageFrame extends GenericFrame {
       }
 
       if (items.length == KoLConstants.storage.size()) {
-        RequestThread.postRequest(new StorageRequest(StorageRequest.EMPTY_STORAGE));
+        RequestThread.postRequest(new StorageRequest(StorageRequestType.EMPTY_STORAGE));
       } else {
-        RequestThread.postRequest(new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, items));
+        RequestThread.postRequest(
+            new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, items));
       }
 
       return items;
@@ -536,7 +539,7 @@ public class ItemManageFrame extends GenericFrame {
           }
         }
       } else {
-        RequestThread.postRequest(new ClosetRequest(ClosetRequest.INVENTORY_TO_CLOSET, items));
+        RequestThread.postRequest(new ClosetRequest(ClosetRequestType.INVENTORY_TO_CLOSET, items));
       }
     }
   }
@@ -565,7 +568,7 @@ public class ItemManageFrame extends GenericFrame {
         return null;
       }
 
-      RequestThread.postRequest(new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, items));
+      RequestThread.postRequest(new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, items));
       return items;
     }
 
@@ -581,7 +584,7 @@ public class ItemManageFrame extends GenericFrame {
         return;
       }
 
-      RequestThread.postRequest(new ClosetRequest(ClosetRequest.INVENTORY_TO_CLOSET, items));
+      RequestThread.postRequest(new ClosetRequest(ClosetRequestType.INVENTORY_TO_CLOSET, items));
     }
   }
 

--- a/src/net/sourceforge/kolmafia/swingui/panel/CreateItemPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/CreateItemPanel.java
@@ -10,6 +10,7 @@ import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.request.CreateItemRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.request.UseItemRequest;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.swingui.widget.CreationSettingCheckBox;
@@ -97,7 +98,7 @@ public class CreateItemPanel extends InventoryPanel<CreateItemRequest> {
         int newbudget = ConcoctionDatabase.getPullsBudgeted() - pulled;
         RequestThread.postRequest(
             new StorageRequest(
-                StorageRequest.STORAGE_TO_INVENTORY,
+                StorageRequestType.STORAGE_TO_INVENTORY,
                 new AdventureResult[] {ItemPool.get(selection.getItemId(), pulled)}));
         ConcoctionDatabase.setPullsBudgeted(newbudget);
       }
@@ -133,7 +134,7 @@ public class CreateItemPanel extends InventoryPanel<CreateItemRequest> {
         int newbudget = ConcoctionDatabase.getPullsBudgeted() - pulled;
         RequestThread.postRequest(
             new StorageRequest(
-                StorageRequest.STORAGE_TO_INVENTORY,
+                StorageRequestType.STORAGE_TO_INVENTORY,
                 new AdventureResult[] {ItemPool.get(selection.getItemId(), pulled)}));
         ConcoctionDatabase.setPullsBudgeted(newbudget);
       }

--- a/src/net/sourceforge/kolmafia/swingui/panel/CreateSpecialPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/CreateSpecialPanel.java
@@ -22,6 +22,7 @@ import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.CreateItemRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.request.UseItemRequest;
 import net.sourceforge.kolmafia.swingui.widget.AutoHighlightSpinner;
 import net.sourceforge.kolmafia.swingui.widget.CreationSettingCheckBox;
@@ -111,7 +112,7 @@ public class CreateSpecialPanel extends InventoryPanel<CreateItemRequest> {
         int newbudget = ConcoctionDatabase.getPullsBudgeted() - pulled;
         RequestThread.postRequest(
             new StorageRequest(
-                StorageRequest.STORAGE_TO_INVENTORY,
+                StorageRequestType.STORAGE_TO_INVENTORY,
                 new AdventureResult[] {ItemPool.get(selection.getItemId(), pulled)}));
         ConcoctionDatabase.setPullsBudgeted(newbudget);
       }
@@ -150,7 +151,7 @@ public class CreateSpecialPanel extends InventoryPanel<CreateItemRequest> {
         int newbudget = ConcoctionDatabase.getPullsBudgeted() - pulled;
         RequestThread.postRequest(
             new StorageRequest(
-                StorageRequest.STORAGE_TO_INVENTORY,
+                StorageRequestType.STORAGE_TO_INVENTORY,
                 new AdventureResult[] {ItemPool.get(selection.getItemId(), pulled)}));
         ConcoctionDatabase.setPullsBudgeted(newbudget);
       }

--- a/src/net/sourceforge/kolmafia/swingui/panel/ItemManagePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/ItemManagePanel.java
@@ -29,7 +29,9 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.AutoMallRequest;
 import net.sourceforge.kolmafia.request.AutoSellRequest;
 import net.sourceforge.kolmafia.request.ClanStashRequest;
+import net.sourceforge.kolmafia.request.ClanStashRequest.ClanStashRequestType;
 import net.sourceforge.kolmafia.request.ClosetRequest;
+import net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType;
 import net.sourceforge.kolmafia.request.CreateItemRequest;
 import net.sourceforge.kolmafia.request.DisplayCaseRequest;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
@@ -502,7 +504,7 @@ public abstract class ItemManagePanel<E, S extends JComponent> extends Scrollabl
       }
 
       if (this.retrieveFromClosetFirst) {
-        RequestThread.postRequest(new ClosetRequest(ClosetRequest.CLOSET_TO_INVENTORY, items));
+        RequestThread.postRequest(new ClosetRequest(ClosetRequestType.CLOSET_TO_INVENTORY, items));
       }
 
       return items;
@@ -586,7 +588,7 @@ public abstract class ItemManagePanel<E, S extends JComponent> extends Scrollabl
       }
 
       if (!this.retrieveFromClosetFirst) {
-        RequestThread.postRequest(new ClosetRequest(ClosetRequest.INVENTORY_TO_CLOSET, items));
+        RequestThread.postRequest(new ClosetRequest(ClosetRequestType.INVENTORY_TO_CLOSET, items));
       }
     }
 
@@ -684,7 +686,7 @@ public abstract class ItemManagePanel<E, S extends JComponent> extends Scrollabl
         return;
       }
 
-      RequestThread.postRequest(new ClanStashRequest(items, ClanStashRequest.ITEMS_TO_STASH));
+      RequestThread.postRequest(new ClanStashRequest(items, ClanStashRequestType.ITEMS_TO_STASH));
     }
 
     @Override

--- a/src/net/sourceforge/kolmafia/swingui/panel/MeatTransferPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/MeatTransferPanel.java
@@ -8,8 +8,10 @@ import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.listener.CharacterListener;
 import net.sourceforge.kolmafia.listener.CharacterListenerRegistry;
 import net.sourceforge.kolmafia.request.ClosetRequest;
+import net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.swingui.widget.AutoHighlightTextField;
 import net.sourceforge.kolmafia.utilities.InputFieldUtilities;
 
@@ -57,11 +59,11 @@ public class MeatTransferPanel extends LabeledPanel {
   private GenericRequest getRequest(final long amount) {
     return switch (transferType) {
       case MeatTransferPanel.MEAT_TO_CLOSET -> new ClosetRequest(
-          ClosetRequest.MEAT_TO_CLOSET, amount);
+          ClosetRequestType.MEAT_TO_CLOSET, amount);
       case MeatTransferPanel.MEAT_TO_INVENTORY -> new ClosetRequest(
-          ClosetRequest.MEAT_TO_INVENTORY, amount);
+          ClosetRequestType.MEAT_TO_INVENTORY, amount);
       case MeatTransferPanel.PULL_MEAT_FROM_STORAGE -> new StorageRequest(
-          StorageRequest.PULL_MEAT_FROM_STORAGE, amount);
+          StorageRequestType.PULL_MEAT_FROM_STORAGE, amount);
       default -> null;
     };
   }

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -120,8 +120,11 @@ import net.sourceforge.kolmafia.persistence.SkillDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.*;
 import net.sourceforge.kolmafia.request.CampgroundRequest.CropType;
+import net.sourceforge.kolmafia.request.ClanStashRequest.ClanStashRequestType;
+import net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType;
 import net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.EveryCard;
 import net.sourceforge.kolmafia.request.FloristRequest.Florist;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.scripts.git.GitManager;
 import net.sourceforge.kolmafia.scripts.svn.SVNManager;
 import net.sourceforge.kolmafia.session.AutumnatonManager;
@@ -4367,7 +4370,7 @@ public abstract class RuntimeLibrary {
     if (controller.getBatched() != null) {
       RuntimeLibrary.batchCommand(controller, "closet", null, "empty");
     } else {
-      ClosetRequest request = new ClosetRequest(ClosetRequest.EMPTY_CLOSET);
+      ClosetRequest request = new ClosetRequest(ClosetRequestType.EMPTY_CLOSET);
       RequestThread.postRequest(request);
     }
     return RuntimeLibrary.continueValue();
@@ -4394,7 +4397,7 @@ public abstract class RuntimeLibrary {
       RuntimeLibrary.batchCommand(controller, cmd, prefix, params);
     } else {
       ClosetRequest request =
-          new ClosetRequest(ClosetRequest.INVENTORY_TO_CLOSET, ItemPool.get(itemId, count));
+          new ClosetRequest(ClosetRequestType.INVENTORY_TO_CLOSET, ItemPool.get(itemId, count));
       RequestThread.postRequest(request);
     }
     return RuntimeLibrary.continueValue();
@@ -4416,7 +4419,7 @@ public abstract class RuntimeLibrary {
       String params = meat + " meat";
       RuntimeLibrary.batchCommand(controller, cmd, prefix, params);
     } else {
-      ClosetRequest request = new ClosetRequest(ClosetRequest.MEAT_TO_CLOSET, (int) meat);
+      ClosetRequest request = new ClosetRequest(ClosetRequestType.MEAT_TO_CLOSET, (int) meat);
       RequestThread.postRequest(request);
     }
     return RuntimeLibrary.continueValue();
@@ -4550,7 +4553,7 @@ public abstract class RuntimeLibrary {
     } else {
       AdventureResult[] items = new AdventureResult[1];
       items[0] = ItemPool.get(itemId, count);
-      ClanStashRequest request = new ClanStashRequest(items, ClanStashRequest.ITEMS_TO_STASH);
+      ClanStashRequest request = new ClanStashRequest(items, ClanStashRequestType.ITEMS_TO_STASH);
       RequestThread.postRequest(request);
     }
 
@@ -4606,7 +4609,7 @@ public abstract class RuntimeLibrary {
       RuntimeLibrary.batchCommand(controller, cmd, prefix, params);
     } else {
       ClosetRequest request =
-          new ClosetRequest(ClosetRequest.CLOSET_TO_INVENTORY, ItemPool.get(itemId, count));
+          new ClosetRequest(ClosetRequestType.CLOSET_TO_INVENTORY, ItemPool.get(itemId, count));
       RequestThread.postRequest(request);
     }
 
@@ -4629,7 +4632,7 @@ public abstract class RuntimeLibrary {
       String params = meat + " meat";
       RuntimeLibrary.batchCommand(controller, cmd, prefix, params);
     } else {
-      ClosetRequest request = new ClosetRequest(ClosetRequest.MEAT_TO_INVENTORY, (int) meat);
+      ClosetRequest request = new ClosetRequest(ClosetRequestType.MEAT_TO_INVENTORY, (int) meat);
       RequestThread.postRequest(request);
     }
 
@@ -4710,7 +4713,7 @@ public abstract class RuntimeLibrary {
       RuntimeLibrary.batchCommand(controller, cmd, null, params);
     } else {
       StorageRequest request =
-          new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, ItemPool.get(itemId, count));
+          new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, ItemPool.get(itemId, count));
       RequestThread.postRequest(request);
     }
 
@@ -4768,7 +4771,7 @@ public abstract class RuntimeLibrary {
     } else {
       AdventureResult[] items = new AdventureResult[1];
       items[0] = ItemPool.get(itemId, count);
-      ClanStashRequest request = new ClanStashRequest(items, ClanStashRequest.STASH_TO_ITEMS);
+      ClanStashRequest request = new ClanStashRequest(items, ClanStashRequestType.STASH_TO_ITEMS);
       RequestThread.postRequest(request);
     }
 

--- a/src/net/sourceforge/kolmafia/textui/command/ClanStashCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ClanStashCommand.java
@@ -6,6 +6,7 @@ import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.persistence.ItemFinder;
 import net.sourceforge.kolmafia.request.ClanStashRequest;
+import net.sourceforge.kolmafia.request.ClanStashRequest.ClanStashRequestType;
 import net.sourceforge.kolmafia.session.ClanManager;
 
 public class ClanStashCommand extends AbstractCommand {
@@ -16,13 +17,13 @@ public class ClanStashCommand extends AbstractCommand {
   @Override
   public void run(final String cmd, String parameters) {
     List<AdventureResult> list = null;
-    int direction = ClanStashRequest.ITEMS_TO_STASH;
+    ClanStashRequestType direction = ClanStashRequestType.ITEMS_TO_STASH;
 
     int space = parameters.indexOf(" ");
     if (space != -1) {
       String command = parameters.substring(0, space);
       if (command.equals("take")) {
-        direction = ClanStashRequest.STASH_TO_ITEMS;
+        direction = ClanStashRequestType.STASH_TO_ITEMS;
         parameters = parameters.substring(4).trim();
         list = ClanManager.getStash();
       } else if (command.equals("put")) {

--- a/src/net/sourceforge/kolmafia/textui/command/CleanupJunkRequest.java
+++ b/src/net/sourceforge/kolmafia/textui/command/CleanupJunkRequest.java
@@ -15,6 +15,7 @@ import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.NPCStoreDatabase;
 import net.sourceforge.kolmafia.request.AutoSellRequest;
 import net.sourceforge.kolmafia.request.ClosetRequest;
+import net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType;
 import net.sourceforge.kolmafia.request.PulverizeRequest;
 import net.sourceforge.kolmafia.request.UntinkerRequest;
 import net.sourceforge.kolmafia.request.UseItemRequest;
@@ -61,7 +62,7 @@ public class CleanupJunkRequest extends AbstractCommand {
     if (closetList.size() > 0) {
       RequestThread.postRequest(
           new ClosetRequest(
-              ClosetRequest.INVENTORY_TO_CLOSET, closetList.toArray(new AdventureResult[0])));
+              ClosetRequestType.INVENTORY_TO_CLOSET, closetList.toArray(new AdventureResult[0])));
     }
 
     do {

--- a/src/net/sourceforge/kolmafia/textui/command/ClosetCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ClosetCommand.java
@@ -13,6 +13,7 @@ import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
 import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
 import net.sourceforge.kolmafia.persistence.ItemFinder;
 import net.sourceforge.kolmafia.request.ClosetRequest;
+import net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType;
 
 public class ClosetCommand extends AbstractCommand {
   public ClosetCommand() {
@@ -36,7 +37,7 @@ public class ClosetCommand extends AbstractCommand {
     }
 
     if (parameters.equals("empty")) {
-      RequestThread.postRequest(new ClosetRequest(ClosetRequest.EMPTY_CLOSET));
+      RequestThread.postRequest(new ClosetRequest(ClosetRequestType.EMPTY_CLOSET));
       return;
     }
 
@@ -67,7 +68,8 @@ public class ClosetCommand extends AbstractCommand {
       long meatCount =
           meat.stream().map(AdventureResult::getLongCount).mapToLong(Long::longValue).sum();
       if (meatCount > 0) {
-        int moveType = isTake ? ClosetRequest.MEAT_TO_INVENTORY : ClosetRequest.MEAT_TO_CLOSET;
+        ClosetRequestType moveType =
+            isTake ? ClosetRequestType.MEAT_TO_INVENTORY : ClosetRequestType.MEAT_TO_CLOSET;
         RequestThread.postRequest(new ClosetRequest(moveType, meatCount));
       }
     }
@@ -76,7 +78,8 @@ public class ClosetCommand extends AbstractCommand {
       return;
     }
 
-    int moveType = isTake ? ClosetRequest.CLOSET_TO_INVENTORY : ClosetRequest.INVENTORY_TO_CLOSET;
+    ClosetRequestType moveType =
+        isTake ? ClosetRequestType.CLOSET_TO_INVENTORY : ClosetRequestType.INVENTORY_TO_CLOSET;
     RequestThread.postRequest(new ClosetRequest(moveType, itemList));
 
     // update "Hatter" daily deed

--- a/src/net/sourceforge/kolmafia/textui/command/StorageCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/StorageCommand.java
@@ -14,6 +14,7 @@ import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.persistence.ItemFinder;
 import net.sourceforge.kolmafia.request.StandardRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import net.sourceforge.kolmafia.session.InventoryManager;
 
@@ -35,7 +36,7 @@ public class StorageCommand extends AbstractCommand {
         KoLmafia.updateDisplay(
             MafiaState.ERROR, "You cannot pull everything while your pulls are limited.");
       } else {
-        RequestThread.postRequest(new StorageRequest(StorageRequest.EMPTY_STORAGE));
+        RequestThread.postRequest(new StorageRequest(StorageRequestType.EMPTY_STORAGE));
       }
       return;
     }
@@ -137,7 +138,7 @@ public class StorageCommand extends AbstractCommand {
       if (item.getName().equals(AdventureResult.MEAT)) {
         if (!inHardcore) {
           RequestThread.postRequest(
-              new StorageRequest(StorageRequest.PULL_MEAT_FROM_STORAGE, item.getCount()));
+              new StorageRequest(StorageRequestType.PULL_MEAT_FROM_STORAGE, item.getCount()));
         }
 
         items[i] = null;
@@ -186,7 +187,8 @@ public class StorageCommand extends AbstractCommand {
     // Submit a StorageRequest if there is at least one item to pull.
     for (AdventureResult attachment : items) {
       if (attachment != null) {
-        RequestThread.postRequest(new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, items));
+        RequestThread.postRequest(
+            new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, items));
         break;
       }
     }

--- a/test/net/sourceforge/kolmafia/request/StorageRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/StorageRequestTest.java
@@ -30,6 +30,7 @@ import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -296,7 +297,8 @@ public class StorageRequestTest {
     KoLCharacter.setRonin(false);
 
     // Make a StorageRequest
-    StorageRequest request = new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, attachments);
+    StorageRequest request =
+        new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, attachments);
 
     // Generate subinstances.
     ArrayList<TransferItemRequest> subinstances = request.generateSubInstances();
@@ -357,7 +359,8 @@ public class StorageRequestTest {
     KoLCharacter.setRonin(false);
 
     // Make a StorageRequest
-    StorageRequest request = new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, attachments);
+    StorageRequest request =
+        new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, attachments);
 
     // Generate subinstances.
     ArrayList<TransferItemRequest> subinstances = request.generateSubInstances();
@@ -444,7 +447,8 @@ public class StorageRequestTest {
     KoLCharacter.setRonin(true);
 
     // Make a StorageRequest
-    StorageRequest request = new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, attachments);
+    StorageRequest request =
+        new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, attachments);
 
     // Generate subinstances.
     ArrayList<TransferItemRequest> subinstances = request.generateSubInstances();
@@ -495,7 +499,8 @@ public class StorageRequestTest {
     KoLCharacter.setRonin(false);
 
     // Make a StorageRequest
-    StorageRequest request = new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, attachments);
+    StorageRequest request =
+        new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, attachments);
 
     // Generate subinstances.
     ArrayList<TransferItemRequest> subinstances = request.generateSubInstances();
@@ -546,7 +551,8 @@ public class StorageRequestTest {
     KoLCharacter.setRonin(true);
 
     // Make a StorageRequest
-    StorageRequest request = new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, attachments);
+    StorageRequest request =
+        new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, attachments);
 
     // Generate subinstances.
     ArrayList<TransferItemRequest> subinstances = request.generateSubInstances();
@@ -668,7 +674,8 @@ public class StorageRequestTest {
     assertTrue(StorageRequest.itemPulledInRonin(ItemPool.HOT_WAD));
 
     // Make a StorageRequest
-    StorageRequest request = new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, attachments);
+    StorageRequest request =
+        new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, attachments);
 
     // Generate subinstances.
     ArrayList<TransferItemRequest> subinstances = request.generateSubInstances();
@@ -710,7 +717,8 @@ public class StorageRequestTest {
     AdventureResult[] attachments = items.toArray(new AdventureResult[items.size()]);
 
     // Make a StorageRequest
-    StorageRequest request = new StorageRequest(StorageRequest.PULL_MEAT_FROM_STORAGE, attachments);
+    StorageRequest request =
+        new StorageRequest(StorageRequestType.PULL_MEAT_FROM_STORAGE, attachments);
 
     // Generate subinstances.
     ArrayList<TransferItemRequest> subinstances = request.generateSubInstances();
@@ -764,7 +772,7 @@ public class StorageRequestTest {
     private StorageRequest makeZeroItemRequest() {
       // Make a StorageRequest
       StorageRequest request =
-          new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, new AdventureResult[0]);
+          new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, new AdventureResult[0]);
 
       // Return a subinstance
       return makeSubinstance(request);
@@ -775,7 +783,8 @@ public class StorageRequestTest {
       var attachments = List.of(ItemPool.get(itemId, 1)).toArray(new AdventureResult[0]);
 
       // Make a StorageRequest
-      StorageRequest request = new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, attachments);
+      StorageRequest request =
+          new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, attachments);
 
       // Return a subinstance
       return makeSubinstance(request);
@@ -789,7 +798,7 @@ public class StorageRequestTest {
 
       // Make a StorageRequest
       StorageRequest request =
-          new StorageRequest(StorageRequest.PULL_MEAT_FROM_STORAGE, attachments);
+          new StorageRequest(StorageRequestType.PULL_MEAT_FROM_STORAGE, attachments);
 
       // Return a subinstance
       return makeSubinstance(request);
@@ -801,7 +810,7 @@ public class StorageRequestTest {
 
       try (cleanups) {
         // Make an request to empty storage
-        StorageRequest request = new StorageRequest(StorageRequest.EMPTY_STORAGE);
+        StorageRequest request = new StorageRequest(StorageRequestType.EMPTY_STORAGE);
 
         // Run it and verify failure
         request.run();
@@ -843,7 +852,7 @@ public class StorageRequestTest {
 
       try (cleanups) {
         // Make an request to empty storage
-        StorageRequest request = new StorageRequest(StorageRequest.EMPTY_STORAGE);
+        StorageRequest request = new StorageRequest(StorageRequestType.EMPTY_STORAGE);
 
         // Run it and verify failure
         request.run();
@@ -931,7 +940,8 @@ public class StorageRequestTest {
     AdventureResult[] attachments = items.toArray(new AdventureResult[items.size()]);
 
     // Make a StorageRequest
-    StorageRequest request = new StorageRequest(StorageRequest.STORAGE_TO_INVENTORY, attachments);
+    StorageRequest request =
+        new StorageRequest(StorageRequestType.STORAGE_TO_INVENTORY, attachments);
 
     // Return a subinstance
     StorageRequest subinstance = makeSubinstance(request);


### PR DESCRIPTION
There are several spaces in the codebase where we use `public static final int`s where enums would be better (and prevent passing ints outside the range, or from the wrong source, to functions). This is one of them.

Convert the simple requests (closet, storage, stash) at once. They're all very similar.