### PR TITLE
Crimbo22 is over

### DIFF
--- a/src/data/fullness.txt
+++ b/src/data/fullness.txt
@@ -468,7 +468,7 @@ high-calorie sugar substitute	1	4	awesome	3-4	0	20-25	0
 hippy herbal tea	1	1	decent	2	0	4-7	0	5 Sleepy (-30% mus)
 holiday cheese log	3	1	good	8-10	10-20	10-20	10-20	Stands Alone (+10 Stench dmg)
 honey-dew	2	2	good	4-7	13-15	0	0	10 Mmmmmelon (+30% item drop)
-honey-drenched ham slice	1	1	EPIC	5-6	30-40	30-40	30-40
+honey-drenched ham slice	1	1	decent	0	0	0	0	Unspaded
 honey bun of Boris	1	1	EPIC	5-7	0	0	0	Unspaded, 30 Motherly Loved (+5 Muscle, +50% Muscle, +5 Cold Res)
 hot buttered roll	1	1	crappy	1	0	0	0
 hot date	2	7	good	4-5	0	0	20-30

--- a/src/data/fullness.txt
+++ b/src/data/fullness.txt
@@ -468,7 +468,7 @@ high-calorie sugar substitute	1	4	awesome	3-4	0	20-25	0
 hippy herbal tea	1	1	decent	2	0	4-7	0	5 Sleepy (-30% mus)
 holiday cheese log	3	1	good	8-10	10-20	10-20	10-20	Stands Alone (+10 Stench dmg)
 honey-dew	2	2	good	4-7	13-15	0	0	10 Mmmmmelon (+30% item drop)
-honey-drenched ham slice	1	1	decent	0	0	0	0	Unspaded
+honey-drenched ham slice	1	1	decent	1-2	1-5	1-5	1-5
 honey bun of Boris	1	1	EPIC	5-7	0	0	0	Unspaded, 30 Motherly Loved (+5 Muscle, +50% Muscle, +5 Cold Res)
 hot buttered roll	1	1	crappy	1	0	0	0
 hot date	2	7	good	4-5	0	0	20-30

--- a/src/data/inebriety.txt
+++ b/src/data/inebriety.txt
@@ -458,7 +458,7 @@ moreltini	1	3	awesome	3-5	0	0	10-20	40 Truffle Tango (+50 Item Drop), MARTINI
 Morlock's Mark Bourbon	4	4	awesome	10-15	10-28	10-28	10-28
 morning dew	1	1	awesome	4	4-6	0	0	40 Granolarrrgh (+20 Stench Damage & Stench Spell Damage)
 Morto Moreto	1	5	EPIC	4-6	0	0	0	100 Majorly Poisoned, WINE
-mostly-empty bottle of cookie wine	1	1	decent	0	0	0	0	Unspaded WINE
+mostly-empty bottle of cookie wine	1	1	decent	1-2	1-5	1-5	1-5	WINE
 mourning wine	2	1	good	5-7	30-50	30-50	30-50
 Mt. Noob Pale Ale	2	1	good	3-6	0	0	0	BEER
 mulled berry wine	5	7	awesome	18-22	0	30-50	0	30 Sweet Nostalgia (+20 Candy Drop), WINE

--- a/src/data/inebriety.txt
+++ b/src/data/inebriety.txt
@@ -458,7 +458,7 @@ moreltini	1	3	awesome	3-5	0	0	10-20	40 Truffle Tango (+50 Item Drop), MARTINI
 Morlock's Mark Bourbon	4	4	awesome	10-15	10-28	10-28	10-28
 morning dew	1	1	awesome	4	4-6	0	0	40 Granolarrrgh (+20 Stench Damage & Stench Spell Damage)
 Morto Moreto	1	5	EPIC	4-6	0	0	0	100 Majorly Poisoned, WINE
-mostly-empty bottle of cookie wine	1	1	EPIC	5-6	30-40	30-40	30-40	WINE
+mostly-empty bottle of cookie wine	1	1	decent	0	0	0	0	Unspaded WINE
 mourning wine	2	1	good	5-7	30-50	30-50	30-50
 Mt. Noob Pale Ale	2	1	good	3-6	0	0	0	BEER
 mulled berry wine	5	7	awesome	18-22	0	30-50	0	30 Sweet Nostalgia (+20 Candy Drop), WINE

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -10368,12 +10368,12 @@ Item	tobiko marble soda	Effect: "Pisces in the Skyces", Effect Duration: 15
 Item	tomato juice of powerful power	Effect: "Tomato Power", Effect Duration: [R]
 Item	tonic o' Banderas	Effect: "Bandersnatched", Effect Duration: 20
 Item	too legit potion	Effect: "Hammertime", Effect Duration: 30
-Item	Trainbot circuitry	Effect: "Trainbot Circuitry", Effect Duration: 10
-Item	Trainbot linkages	Effect: "Trainbot Linkages", Effect Duration: 10
-Item	Trainbot optics	Effect: "Trainbot Optics", Effect Duration: 10
-Item	Trainbot plating	Effect: "Trainbot Plating", Effect Duration: 10
-Item	Trainbot servomotors	Effect: "Trainbot Servomotors", Effect Duration: 10
-Item	Trainbot tubing	Effect: "Trainbot Tubing", Effect Duration: 10
+Item	Trainbot circuitry	Effect: "Trainbot Circuitry", Effect Duration: 1
+Item	Trainbot linkages	Effect: "Trainbot Linkages", Effect Duration: 1
+Item	Trainbot optics	Effect: "Trainbot Optics", Effect Duration: 1
+Item	Trainbot plating	Effect: "Trainbot Plating", Effect Duration: 1
+Item	Trainbot servomotors	Effect: "Trainbot Servomotors", Effect Duration: 1
+Item	Trainbot tubing	Effect: "Trainbot Tubing", Effect Duration: 1
 Item	trampled ticket stub	Effect: "Feeling Sneaky", Effect Duration: 30
 Item	transporter transponder	Effect: "Transpondent", Effect Duration: 30
 Item	Tremella Tarantella mushroom	Effect: "Tremella Tremens", Effect Duration: 10

--- a/src/data/zonelist.txt
+++ b/src/data/zonelist.txt
@@ -173,7 +173,6 @@ Override	Unsorted	Discoveries
 
 Events	Events	Events
 Twitch	Town	Time-Twitching Tower
-Crimbo22	Holiday	Christmas 2022
 
 # The following zones are all retired Events or Holidays
 
@@ -199,5 +198,6 @@ Crimbo18	Removed	Christmas 2018
 Crimbo19	Removed	Christmas 2019
 Tammy's Offshore Platform	Crimbo19	Crimbo 19 Underwater
 Crimbo21	Removed	Christmas 2021
+Crimbo22	Removed	Christmas 2022
 
 Obsolete	Removed	Retired zones


### PR DESCRIPTION
1) The Train adventure zones are Removed
2) The EPIC foods are now decent. I removed the consumption data and set them to Unspaded
3) The Trainbot effects are untouched, but the potions give 1 turn, not 10