### PR TITLE
Fix adding speakeasy drinks using existing AdventureResults

### DIFF
--- a/src/net/sourceforge/kolmafia/request/ClanLoungeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ClanLoungeRequest.java
@@ -493,6 +493,7 @@ public class ClanLoungeRequest extends GenericRequest {
   }
 
   public static void addSpeakeasyDrink(final String itemName) {
+    // Called when parsing Speakeasy in lounge
     SpeakeasyDrink drink = SpeakeasyDrink.findName(itemName);
     if (drink != null && !availableSpeakeasyDrinks.contains(drink)) {
       availableSpeakeasyDrinks.add(drink);
@@ -509,6 +510,19 @@ public class ClanLoungeRequest extends GenericRequest {
     for (var drink : ALL_SPEAKEASY) {
       drink.getConcoction().resetCalculations();
     }
+  }
+
+  public static boolean maybeAddSpeakeasyDrink(final AdventureResult item) {
+    // Called when examining lounge items after switching clans.
+    // resetSpeakeasy has already been called.
+    SpeakeasyDrink drink = SpeakeasyDrink.findName(item.getName());
+    if (drink != null) {
+      availableSpeakeasyDrinks.add(drink);
+      drink.getConcoction().resetCalculations();
+      // But clan items are intact from previous visit.
+      return true;
+    }
+    return false;
   }
 
   public static final boolean isSpeakeasyDrink(String name) {

--- a/src/net/sourceforge/kolmafia/session/ClanManager.java
+++ b/src/net/sourceforge/kolmafia/session/ClanManager.java
@@ -164,10 +164,10 @@ public abstract class ClanManager {
         // All of this stuff has already been checked, but hot dogs and
         // such need to be re-added as concoctions for the returned-to clan
         for (AdventureResult item : ClanManager.getClanLounge()) {
-          String name = item.getName();
-          if (ClanLoungeRequest.isSpeakeasyDrink(name)) {
-            ClanLoungeRequest.addSpeakeasyDrink(name);
-          } else if (ClanLoungeRequest.isFloundryItem(item)) {
+          if (ClanLoungeRequest.maybeAddSpeakeasyDrink(item)) {
+            continue;
+          }
+          if (ClanLoungeRequest.isFloundryItem(item)) {
             Concoction c = ConcoctionPool.get(item);
             c.setMixingMethod(CraftingType.FLOUNDRY);
             ConcoctionDatabase.getUsables().add(c);


### PR DESCRIPTION
As reported by ... somebody.

When switching clans, speakeasy/hotdogs/floundry are rebuilt from saved clan lounge item lists.
Don't need to - can't - re-add the item to the item list.