### PR TITLE
Arena parameters for 3 new familiars

### DIFF
--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -317,6 +317,6 @@
 285	Arachnelf	arachnelf.gif	none	festive egg sac	Site Alpha ID badge	3	1	3	1
 286	Synthetic Rock	synthrock.gif	none	synthetic rock		0	0	0	0
 287	Grey Goose	greygoose.gif	item0	grey gosling	grey down vest	1	2	3	3
-288	Cookbookbat	bbat_fam.gif	item1,drop	mummified entombed cookbookbat	cookbookbat book	0	0	0	0
-289	Mini-Trainbot	tbot_on.gif	combat1,hp1,mp1	deactivated mini-Trainbot	overloaded Yule battery	0	0	0	0
-290	Hobo in Sheep's Clothing	hobosheep.gif	stat0,item0,drop	unoccupied sheep suit	half-height cigar	0	0	0	0
+288	Cookbookbat	bbat_fam.gif	item1,drop	mummified entombed cookbookbat	cookbookbat book	0	3	2	3
+289	Mini-Trainbot	tbot_on.gif	combat1,hp1,mp1	deactivated mini-Trainbot	overloaded Yule battery	3	2	3	1
+290	Hobo in Sheep's Clothing	hobosheep.gif	stat0,item0,drop	unoccupied sheep suit	half-height cigar	1	3	3	2

--- a/src/net/sourceforge/kolmafia/RequestEditorKit.java
+++ b/src/net/sourceforge/kolmafia/RequestEditorKit.java
@@ -2169,14 +2169,14 @@ public class RequestEditorKit extends HTMLEditorKit {
     int crannyEvil = Preferences.getInteger("cyrptCrannyEvilness");
     int alcoveEvil = Preferences.getInteger("cyrptAlcoveEvilness");
 
-    String nookColor = nookEvil > 25 ? "000000" : "FF0000";
-    String nookHint = nookEvil > 25 ? "Item Drop" : "<b>BOSS</b>";
-    String nicheColor = nicheEvil > 25 ? "000000" : "FF0000";
-    String nicheHint = nicheEvil > 25 ? "Sniff Dirty Lihc" : "<b>BOSS</b>";
-    String crannyColor = crannyEvil > 25 ? "000000" : "FF0000";
-    String crannyHint = crannyEvil > 25 ? "ML & Noncombat" : "<b>BOSS</b>";
-    String alcoveColor = alcoveEvil > 25 ? "000000" : "FF0000";
-    String alcoveHint = alcoveEvil > 25 ? "Initiative" : "<b>BOSS</b>";
+    String nookColor = nookEvil > 13 ? "000000" : "FF0000";
+    String nookHint = nookEvil > 13 ? "Item Drop" : "<b>BOSS</b>";
+    String nicheColor = nicheEvil > 13 ? "000000" : "FF0000";
+    String nicheHint = nicheEvil > 13 ? "Sniff Dirty Lihc" : "<b>BOSS</b>";
+    String crannyColor = crannyEvil > 13 ? "000000" : "FF0000";
+    String crannyHint = crannyEvil > 13 ? "ML & Noncombat" : "<b>BOSS</b>";
+    String alcoveColor = alcoveEvil > 13 ? "000000" : "FF0000";
+    String alcoveHint = alcoveEvil > 13 ? "Initiative" : "<b>BOSS</b>";
 
     StringBuilder evilometer = new StringBuilder();
 

--- a/src/net/sourceforge/kolmafia/swingui/FamiliarTrainingFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/FamiliarTrainingFrame.java
@@ -1018,6 +1018,7 @@ public class FamiliarTrainingFrame extends GenericFrame {
     if (!InventoryManager.hasItem(FamiliarData.PUMPKIN_BUCKET)
         && !InventoryManager.hasItem(FamiliarData.FLOWER_BOUQUET)
         && !InventoryManager.hasItem(FamiliarData.FIREWORKS)
+        && !InventoryManager.hasItem(FamiliarData.PET_SWEATER)
         && !InventoryManager.hasItem(FamiliarData.SUGAR_SHIELD)
         && status.familiarItemWeight != 0
         && !InventoryManager.hasItem(status.familiarItem)
@@ -1254,6 +1255,7 @@ public class FamiliarTrainingFrame extends GenericFrame {
     boolean pumpkinBucket;
     boolean flowerBouquet;
     boolean boxFireworks;
+    boolean petSweater;
     boolean sugarShield;
     boolean doppelganger;
 
@@ -1378,6 +1380,7 @@ public class FamiliarTrainingFrame extends GenericFrame {
       this.pumpkinBucket = false;
       this.flowerBouquet = false;
       this.boxFireworks = false;
+      this.petSweater = false;
       this.sugarShield = false;
       this.doppelganger = false;
 
@@ -1427,6 +1430,11 @@ public class FamiliarTrainingFrame extends GenericFrame {
         if (itemId == FamiliarData.FIREWORKS.getItemId()) {
           this.boxFireworks = true;
           this.item = FamiliarData.FIREWORKS;
+        }
+
+        if (itemId == FamiliarData.PET_SWEATER.getItemId()) {
+          this.petSweater = true;
+          this.item = FamiliarData.PET_SWEATER;
         }
 
         if (itemId == FamiliarData.SUGAR_SHIELD.getItemId()) {
@@ -1529,6 +1537,10 @@ public class FamiliarTrainingFrame extends GenericFrame {
         this.boxFireworks |= FamiliarData.FIREWORKS.getCount(inventory) > 0;
       }
 
+      // If current familiar is not wearing an astral pet sweater
+      // search inventory
+      this.petSweater |= FamiliarData.PET_SWEATER.getCount(inventory) > 0;
+
       // If current familiar is not wearing a sugar shield,
       // search inventory
       this.sugarShield |= FamiliarData.SUGAR_SHIELD.getCount(inventory) > 0;
@@ -1576,9 +1588,11 @@ public class FamiliarTrainingFrame extends GenericFrame {
       if (this.familiar.getId() == FamiliarPool.CHAMELEON
           || this.leadNecklace
               && this.ratHeadBalloon
+              && this.petSweater
               && this.pumpkinBucket
               && this.flowerBouquet
               && this.boxFireworks
+              && this.petSweater
               && this.sugarShield
               && this.bathysphere
               && this.dasBoot) {
@@ -1603,6 +1617,7 @@ public class FamiliarTrainingFrame extends GenericFrame {
         this.flowerBouquet |= item.getItemId() == FamiliarData.FLOWER_BOUQUET.getItemId();
         this.doppelganger |= item.getItemId() == FamiliarData.DOPPELGANGER.getItemId();
         this.boxFireworks |= item.getItemId() == FamiliarData.FIREWORKS.getItemId();
+        this.petSweater |= item.getItemId() == FamiliarData.PET_SWEATER.getItemId();
         this.sugarShield |= item.getItemId() == FamiliarData.SUGAR_SHIELD.getItemId();
       }
     }
@@ -1697,6 +1712,11 @@ public class FamiliarTrainingFrame extends GenericFrame {
       // If familiar specific item adds weight, calculate
       if (this.specWeight != 0) {
         this.getAccessoryWeights(weight + this.specWeight);
+      }
+
+      // If we have an astral pet sweater, use it
+      if (this.petSweater) {
+        this.getAccessoryWeights(weight + 10);
       }
 
       // If we have a sugar shield, use it
@@ -1940,6 +1960,9 @@ public class FamiliarTrainingFrame extends GenericFrame {
       if (this.boxFireworks) {
         this.getAccessoryGearSets(weight, FamiliarData.FIREWORKS, hat);
       }
+      if (this.petSweater) {
+        this.getAccessoryGearSets(weight, FamiliarData.PET_SWEATER, hat);
+      }
       if (this.sugarShield) {
         this.getAccessoryGearSets(weight, FamiliarData.SUGAR_SHIELD, hat);
       }
@@ -2106,6 +2129,8 @@ public class FamiliarTrainingFrame extends GenericFrame {
       if (item == FamiliarData.DOPPELGANGER) {
       } else if (item == this.specItem) {
         weight += this.specWeight;
+      } else if (item == FamiliarData.PET_SWEATER) {
+        weight += 10;
       } else if (item == FamiliarData.SUGAR_SHIELD) {
         weight += 10;
       } else if (item == FamiliarData.PUMPKIN_BUCKET) {
@@ -2313,6 +2338,8 @@ public class FamiliarTrainingFrame extends GenericFrame {
         weight += 5;
       } else if (this.boxFireworks) {
         weight += 5;
+      } else if (this.petSweater) {
+        weight += 10;
       } else if (this.sugarShield) {
         weight += 10;
       } else if (this.specWeight > 3) {
@@ -2441,6 +2468,8 @@ public class FamiliarTrainingFrame extends GenericFrame {
         text.append(" " + FamiliarData.FLOWER_BOUQUET.getName() + " (+5)");
       } else if (this.item == FamiliarData.FIREWORKS) {
         text.append(" " + FamiliarData.FIREWORKS.getName() + " (+5)");
+      } else if (this.item == FamiliarData.PET_SWEATER) {
+        text.append(" " + FamiliarData.PET_SWEATER.getName() + " (+10)");
       } else if (this.item == FamiliarData.SUGAR_SHIELD) {
         text.append(" " + FamiliarData.SUGAR_SHIELD.getName() + " (+10)");
       } else if (this.item == FamiliarData.LEAD_NECKLACE) {
@@ -2491,6 +2520,9 @@ public class FamiliarTrainingFrame extends GenericFrame {
         }
         if (this.specItem != null) {
           text.append(" " + this.specItem.getName() + " (+" + this.specWeight + ")");
+        }
+        if (this.petSweater) {
+          text.append(" astral pet sweater (+10)");
         }
         if (this.sugarShield) {
           text.append(" sugar shield (+10)");

--- a/src/net/sourceforge/kolmafia/swingui/FamiliarTrainingFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/FamiliarTrainingFrame.java
@@ -1588,7 +1588,6 @@ public class FamiliarTrainingFrame extends GenericFrame {
       if (this.familiar.getId() == FamiliarPool.CHAMELEON
           || this.leadNecklace
               && this.ratHeadBalloon
-              && this.petSweater
               && this.pumpkinBucket
               && this.flowerBouquet
               && this.boxFireworks


### PR DESCRIPTION
1) Our Relay Browser annotation of the Evilometer thinks the boss has 25 Evil. I fixed that.
2) Teach Familiar Trainer to use astral pet sweater
3) Arena parameters for Cookbootbat
```
Results for Cookbookbat after 10 trials using 91 turns:

Contest         XP[1]   XP[2]   XP[3]  Original Rank Derived Rank
Cage Match      0       0       0            0              0
Scavenger Hunt  24      31      50           0              3
Obstacle Course 43      50      43           0              2
Hide and Seek   23      38      50           0              3
```
4) Arena parameters for Mini-Trainbot
```
Results for Mini-Trainbot after 10 trials using 120 turns:

Contest         XP[1]   XP[2]   XP[3]  Original Rank Derived Rank
Cage Match      20      29      47           0              3
Scavenger Hunt  29      49      35           0              2
Obstacle Course 32      49      50           0              3
Hide and Seek   45      40      10           0              1
```
5) Arena parameters for Hobo in Sheep's Clothing
```
Results for Hobo in Sheep's Clothing after 10 trials using 120 turns:

Contest         XP[1]   XP[2]   XP[3]  Original Rank Derived Rank
Cage Match      48      45      10           0              1
Scavenger Hunt  20      31      48           0              3
Obstacle Course 22      30      48           0              3
Hide and Seek   35      47      40           0              2
```