### PR TITLE
refactor: convert gender to enum

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -7442,7 +7442,7 @@ Effect	The Fire Inside	Muscle Percent: [min(200,10*res(hot))], Mysticality Perce
 Effect	The Glistening	Initiative: +20, Damage Reduction: 5
 Effect	The Good Salmonella	Muscle Percent: [20*F], Mysticality Percent: [20*F], Moxie Percent: [20*F]
 Effect	The Grass...  Is Blue...	Meat Drop: +40, Item Drop: +20
-Effect	The Great Tit's Blessing	Monster Level: +20, Moxie Percent: +5
+Effect	The Great Tit's Blessing	Monster Level: +20, Moxie Percent: [2.5+2.5*X]
 Effect	The Great White Mope	Avatar: "confused goth music student"
 Effect	The Halls of Moxiousness	Experience (Moxie): +3
 Effect	The Halls of Muscularity	Experience (Muscle): +3

--- a/src/net/sourceforge/kolmafia/AreaCombatData.java
+++ b/src/net/sourceforge/kolmafia/AreaCombatData.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.KoLConstants.Stat;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
@@ -1244,9 +1245,9 @@ public class AreaCombatData {
       }
       case "The F'c'le" -> {
         if (monster.equals("clingy pirate (female)")) {
-          return KoLCharacter.getGender() == KoLCharacter.MALE ? 1 : 0;
+          return KoLCharacter.getGender() == Gender.MALE ? 1 : 0;
         } else if (monster.equals("clingy pirate (male)")) {
-          return KoLCharacter.getGender() == KoLCharacter.FEMALE ? 1 : 0;
+          return KoLCharacter.getGender() == Gender.FEMALE ? 1 : 0;
         }
       }
       case "Summoning Chamber" -> {

--- a/src/net/sourceforge/kolmafia/Expression.java
+++ b/src/net/sourceforge/kolmafia/Expression.java
@@ -404,7 +404,7 @@ public class Expression {
                 : Math.max(1, this.effect.getCount(KoLConstants.activeEffects));
         case 'U' -> v = KoLCharacter.getTelescopeUpgrades();
         case 'W' -> v = Modifiers.currentWeight;
-        case 'X' -> v = KoLCharacter.getGender();
+        case 'X' -> v = KoLCharacter.getGender().modifierValue;
         case 'Y' -> v = KoLCharacter.getFury();
         default -> {
           if (inst > '\u00FF') {

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -102,8 +102,17 @@ public abstract class KoLCharacter {
   public static final String STORM_BLESSING = "Storm";
   public static final String SHE_WHO_WAS_BLESSING = "She-who-was";
 
-  public static final int MALE = -1;
-  public static final int FEMALE = 1;
+  public enum Gender {
+    UNKNOWN(0),
+    MALE(-1),
+    FEMALE(1);
+
+    public final int modifierValue;
+
+    Gender(int modifierValue) {
+      this.modifierValue = modifierValue;
+    }
+  }
 
   // Create this early before subsequent initializers want to look at it.
   private static final Modifiers currentModifiers = new Modifiers();
@@ -130,7 +139,7 @@ public abstract class KoLCharacter {
 
   private static List<String> avatar = Collections.emptyList();
   private static AscensionClass ascensionClass = null;
-  private static int gender = 0;
+  private static Gender gender = Gender.UNKNOWN;
   public static int AWOLtattoo = 0;
 
   private static int currentLevel = 1;
@@ -302,7 +311,7 @@ public abstract class KoLCharacter {
   public static final void reset(boolean newCharacter) {
     KoLCharacter.ascensionClass = null;
 
-    KoLCharacter.gender = 0;
+    KoLCharacter.gender = Gender.UNKNOWN;
     KoLCharacter.currentLevel = 1;
     KoLCharacter.decrementPrime = 0L;
     KoLCharacter.incrementPrime = 25L;
@@ -857,7 +866,7 @@ public abstract class KoLCharacter {
     }
 
     if (female) {
-      KoLCharacter.setGender(KoLCharacter.FEMALE);
+      KoLCharacter.setGender(Gender.FEMALE);
     } else {
       // Unfortunately, lack of '_f' in the avatar doesn't
       // necessarily indicate a male character - it could be a custom
@@ -877,10 +886,10 @@ public abstract class KoLCharacter {
     return KoLCharacter.avatar;
   }
 
-  private static int setGender() {
+  private static Gender setGender() {
     // If we already know our gender, are in Valhalla (where gender
     // is meaningless), or are not logged in (ditto), nothing to do
-    if (KoLCharacter.gender != 0
+    if (KoLCharacter.gender != Gender.UNKNOWN
         || CharPaneRequest.inValhalla()
         || GenericRequest.passwordHash.isEmpty()) {
       return KoLCharacter.gender;
@@ -891,18 +900,17 @@ public abstract class KoLCharacter {
     GenericRequest req = new GenericRequest("desc_item.php?whichitem=" + descId);
     RequestThread.postRequest(req);
     if (req.responseText != null) {
-      KoLCharacter.gender =
-          req.responseText.contains("+15%") ? KoLCharacter.FEMALE : KoLCharacter.MALE;
+      KoLCharacter.gender = req.responseText.contains("+15%") ? Gender.FEMALE : Gender.MALE;
     }
 
     return KoLCharacter.gender;
   }
 
-  public static final void setGender(final int gender) {
+  public static final void setGender(final Gender gender) {
     KoLCharacter.gender = gender;
   }
 
-  public static final int getGender() {
+  public static final Gender getGender() {
     return KoLCharacter.setGender();
   }
 

--- a/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
@@ -21,6 +21,7 @@ import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.CoinmasterData;
 import net.sourceforge.kolmafia.CoinmasterRegistry;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLConstants.CraftingMisc;
@@ -1539,7 +1540,7 @@ public class ConcoctionDatabase {
     ConcoctionDatabase.EXCUSE.clear();
     int freeCrafts = ConcoctionDatabase.getFreeCraftingTurns();
 
-    if (KoLCharacter.getGender() == KoLCharacter.MALE) {
+    if (KoLCharacter.getGender() == Gender.MALE) {
       ConcoctionDatabase.REQUIREMENT_MET.add(CraftingRequirements.MALE);
     } else {
       ConcoctionDatabase.REQUIREMENT_MET.add(CraftingRequirements.FEMALE);

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -12,6 +12,7 @@ import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.EdServantData;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
@@ -4634,7 +4635,7 @@ public abstract class ChoiceControl {
           Preferences.increment("sexChanges", 1);
           Preferences.setBoolean("_sexChanged", true);
           KoLCharacter.setGender(
-              text.contains("in more ways than one") ? KoLCharacter.FEMALE : KoLCharacter.MALE);
+              text.contains("in more ways than one") ? Gender.FEMALE : Gender.MALE);
           ConcoctionDatabase.setRefreshNeeded(false);
         }
         break;

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -21,6 +21,7 @@ import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
@@ -977,10 +978,10 @@ public class Player {
    * @param gender Required gender
    * @return Resets gender to unknown
    */
-  public static Cleanups withGender(final int gender) {
+  public static Cleanups withGender(final Gender gender) {
     KoLCharacter.setGender(gender);
     KoLCharacter.recalculateAdjustments();
-    return new Cleanups(() -> KoLCharacter.setGender(0));
+    return new Cleanups(() -> KoLCharacter.setGender(Gender.UNKNOWN));
   }
 
   /**

--- a/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
+++ b/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import net.sourceforge.kolmafia.AscensionPath.Path;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.objectpool.AdventurePool;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
@@ -1403,7 +1404,7 @@ public class KoLAdventureValidationTest {
               withLimitMode(LimitMode.ASTRAL),
               withPasswordHash("astral"),
               // If you have a password hash, KoL looks at your vinyl boots
-              withGender(KoLCharacter.FEMALE));
+              withGender(Gender.FEMALE));
       try (cleanups) {
         client.addResponse(302, Map.of("location", List.of("choice.php?forceoption=0")), "");
         client.addResponse(200, html("request/test_visit_astral_travel_agent.html"));
@@ -1441,7 +1442,7 @@ public class KoLAdventureValidationTest {
               withLimitMode(LimitMode.NONE),
               withPasswordHash("astral"),
               // If you have a password hash, KoL looks at your vinyl boots
-              withGender(KoLCharacter.FEMALE));
+              withGender(Gender.FEMALE));
       try (cleanups) {
         client.addResponse(200, html("request/test_use_astral_mushroom.html"));
         client.addResponse(200, ""); // api.php
@@ -1522,7 +1523,7 @@ public class KoLAdventureValidationTest {
               withLimitMode(LimitMode.NONE),
               withPasswordHash("mole"),
               // If you have a password hash, KoL looks at your vinyl boots
-              withGender(KoLCharacter.FEMALE));
+              withGender(Gender.FEMALE));
       try (cleanups) {
         client.addResponse(302, Map.of("location", List.of("choice.php?forceoption=0")), "");
         client.addResponse(200, html("request/test_use_llama_lama_gong.html"));
@@ -3544,7 +3545,7 @@ public class KoLAdventureValidationTest {
               withHttpClientBuilder(builder),
               withPasswordHash("friars"),
               // If you have a password hash, KoL looks at your vinyl boots
-              withGender(KoLCharacter.FEMALE),
+              withGender(Gender.FEMALE),
               withQuestProgress(Quest.FRIAR, QuestDatabase.STARTED),
               withItem(ItemPool.DODECAGRAM),
               withItem(ItemPool.CANDLES),

--- a/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
+++ b/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import internal.helpers.Cleanups;
 import java.time.Month;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.persistence.HolidayDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
@@ -485,7 +486,7 @@ public class ModifierExpressionTest {
 
   @Test
   public void canDetectGender() {
-    KoLCharacter.setGender(KoLCharacter.MALE);
+    KoLCharacter.setGender(Gender.MALE);
     var exp = new ModifierExpression("X", "Gender");
     assertThat(exp.eval(), is(-1.0));
   }

--- a/test/net/sourceforge/kolmafia/session/CrystalBallManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/CrystalBallManagerTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.MonsterData;
 import net.sourceforge.kolmafia.combat.MonsterStatusTracker;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
@@ -397,7 +398,7 @@ public class CrystalBallManagerTest {
                         "request/test_adventure_crystal_ball_invalidates_properly_choice_result.html"))),
             withProperty(
                 "crystalBallPredictions", "291:The Hidden Office Building:pygmy headhunter"),
-            withGender(1),
+            withGender(Gender.FEMALE),
             withCurrentRun(0));
 
     try (cleanups) {
@@ -446,7 +447,7 @@ public class CrystalBallManagerTest {
                     html(
                         "request/test_adventure_crystal_ball_handles_noncombat_api_afteradventure.json"))),
             withProperty("crystalBallPredictions", "522:The Middle Chamber:tomb rat"),
-            withGender(1),
+            withGender(Gender.FEMALE),
             withCurrentRun(0));
 
     try (cleanups) {

--- a/test/net/sourceforge/kolmafia/session/GrimstoneManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/GrimstoneManagerTest.java
@@ -18,6 +18,7 @@ import internal.network.FakeHttpClientBuilder;
 import java.util.List;
 import java.util.Map;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.FightRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
@@ -64,7 +65,7 @@ public class GrimstoneManagerTest {
           new Cleanups(
               withHttpClientBuilder(builder),
               withPasswordHash("grimstone"),
-              withGender(KoLCharacter.FEMALE),
+              withGender(Gender.FEMALE),
               withFight(0),
               withProperty("wolfTurnsUsed", 27));
       try (cleanups) {
@@ -126,7 +127,7 @@ public class GrimstoneManagerTest {
           new Cleanups(
               withHttpClientBuilder(builder),
               withPasswordHash("grimstone"),
-              withGender(KoLCharacter.FEMALE),
+              withGender(Gender.FEMALE),
               withProperty("candyWitchCandyTotal", initial));
       try (cleanups) {
         client.addResponse(302, Map.of("location", List.of("choice.php?forceoption=0")), "");

--- a/test/net/sourceforge/kolmafia/session/JuneCleaverManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/JuneCleaverManagerTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import org.junit.jupiter.api.BeforeAll;
@@ -56,7 +57,7 @@ public class JuneCleaverManagerTest {
               // Needed when automating AdventureRequest -> CHOICE_HANDLER
               withPasswordHash("june"),
               // No need to look at vinyl boots
-              withGender(KoLCharacter.FEMALE));
+              withGender(Gender.FEMALE));
       try (cleanups) {
         builder.client.addResponse(
             302, Map.of("location", List.of("choice.php?forceoption=0")), "");

--- a/test/net/sourceforge/kolmafia/session/OceanManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/OceanManagerTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.RequestLogger;
@@ -289,7 +290,7 @@ public class OceanManagerTest {
               withProperty("oceanAction", "continue"),
               // Needed when automating AdventureRequest -> CHOICE_HANDLER
               withPasswordHash("choice"),
-              withGender(1));
+              withGender(Gender.FEMALE));
       try (cleanups) {
         // adventure.php?snarfblat=159
         builder.client.addResponse(
@@ -330,7 +331,7 @@ public class OceanManagerTest {
               withProperty("oceanAction", "continue"),
               // Needed when automating AdventureRequest -> CHOICE_HANDLER
               withPasswordHash("choice"),
-              withGender(1));
+              withGender(Gender.FEMALE));
       try (cleanups) {
         builder.client.addResponse(
             302, Map.of("location", List.of("choice.php?forceoption=0")), "");
@@ -386,7 +387,7 @@ public class OceanManagerTest {
               withProperty("oceanAction", "continue"),
               // Needed when automating AdventureRequest -> CHOICE_HANDLER
               withPasswordHash("choice"),
-              withGender(1));
+              withGender(Gender.FEMALE));
       try (cleanups) {
         builder.client.addResponse(
             302, Map.of("location", List.of("choice.php?forceoption=0")), "");

--- a/test/net/sourceforge/kolmafia/session/QuestManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/QuestManagerTest.java
@@ -44,6 +44,7 @@ import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.objectpool.AdventurePool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
@@ -1652,7 +1653,7 @@ public class QuestManagerTest {
                 withQuestProgress(Quest.SEA_OLD_GUY, QuestDatabase.UNSTARTED),
                 withProperty("dampOldBootPurchased", false),
                 withPasswordHash("SEAMONKEES"),
-                withGender(KoLCharacter.FEMALE));
+                withGender(Gender.FEMALE));
         try (cleanups) {
           builder.client.addResponse(200, html("request/test_buy_damp_old_boot.html"));
           builder.client.addResponse(200, ""); // api.php
@@ -1785,7 +1786,7 @@ public class QuestManagerTest {
                 withItem(WRIGGLING_FLYTRAP_PELLET),
                 withQuestProgress(Quest.SEA_MONKEES, QuestDatabase.UNSTARTED),
                 withPasswordHash("SEAMONKEES"),
-                withGender(KoLCharacter.FEMALE));
+                withGender(Gender.FEMALE));
         try (cleanups) {
           builder.client.addResponse(200, html("request/test_quest_sea_monkee_started_2.html"));
           builder.client.addResponse(200, ""); // api.php
@@ -1902,7 +1903,7 @@ public class QuestManagerTest {
                 withQuestProgress(Quest.SEA_MONKEES, QuestDatabase.UNSTARTED),
                 withProperty("bigBrotherRescued", false),
                 withPasswordHash("SEAMONKEES"),
-                withGender(KoLCharacter.FEMALE));
+                withGender(Gender.FEMALE));
         try (cleanups) {
           builder.client.addResponse(
               302, Map.of("location", List.of("choice.php?forceoption=0")), "");
@@ -2037,7 +2038,7 @@ public class QuestManagerTest {
                 withHttpClientBuilder(builder),
                 withQuestProgress(Quest.SEA_MONKEES, QuestDatabase.UNSTARTED),
                 withPasswordHash("SEAMONKEES"),
-                withGender(KoLCharacter.FEMALE));
+                withGender(Gender.FEMALE));
         try (cleanups) {
           builder.client.addResponse(
               302, Map.of("location", List.of("choice.php?forceoption=0")), "");
@@ -2333,7 +2334,7 @@ public class QuestManagerTest {
                 withItem(SAND_DOLLAR.getInstance(2887)),
                 withQuestProgress(Quest.SEA_MONKEES, QuestDatabase.UNSTARTED),
                 withPasswordHash("SEAMONKEES"),
-                withGender(KoLCharacter.FEMALE));
+                withGender(Gender.FEMALE));
         try (cleanups) {
           builder.client.addResponse(200, html("request/test_quest_sea_monkee_step_12.html"));
           builder.client.addResponse(200, ""); // api.php
@@ -2447,7 +2448,7 @@ public class QuestManagerTest {
                 withItem(MERKIN_TRAILMAP),
                 withProperty("intenseCurrents", false),
                 withPasswordHash("MERKIN"),
-                withGender(KoLCharacter.FEMALE));
+                withGender(Gender.FEMALE));
         try (cleanups) {
           builder.client.addResponse(200, html("request/test_quest_intense_currents_1.html"));
           builder.client.addResponse(200, ""); // api.php
@@ -3069,7 +3070,7 @@ public class QuestManagerTest {
           new Cleanups(
               withItem(ItemPool.FORGED_ID_DOCUMENTS),
               withItem(ItemPool.MACGUFFIN_DIARY),
-              withGender(KoLCharacter.FEMALE),
+              withGender(Gender.FEMALE),
               withQuestProgress(Quest.BLACK, "step2"),
               withProperty("autoQuest", true),
               withQuestProgress(Quest.MACGUFFIN, QuestDatabase.STARTED),

--- a/test/net/sourceforge/kolmafia/session/RabbitHoleManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/RabbitHoleManagerTest.java
@@ -17,6 +17,7 @@ import internal.network.FakeHttpClientBuilder;
 import java.util.List;
 import java.util.Map;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.RelayRequest;
@@ -106,7 +107,7 @@ public class RabbitHoleManagerTest {
               // Avoid health warning
               withHP(100, 100, 100),
               // Avoid looking at your vinyl boots
-              withGender(KoLCharacter.FEMALE));
+              withGender(Gender.FEMALE));
       try (cleanups) {
         client.addResponse(302, Map.of("location", List.of("choice.php?forceoption=0")), "");
         client.addResponse(200, html("request/test_rabbithole_reflection.html"));
@@ -166,7 +167,7 @@ public class RabbitHoleManagerTest {
               // Avoid health warning
               withHP(100, 100, 100),
               // Avoid looking at your vinyl boots
-              withGender(KoLCharacter.FEMALE),
+              withGender(Gender.FEMALE),
               withHandlingChoice(false));
       try (cleanups) {
         client.addResponse(302, Map.of("location", List.of("choice.php?forceoption=0")), "");

--- a/test/net/sourceforge/kolmafia/session/ResponseTextParserTest.java
+++ b/test/net/sourceforge/kolmafia/session/ResponseTextParserTest.java
@@ -16,6 +16,7 @@ import internal.helpers.Cleanups;
 import internal.network.FakeHttpClientBuilder;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -67,7 +68,7 @@ class ResponseTextParserTest {
               withHttpClientBuilder(builder),
               withPasswordHash("recipe"),
               // If you have a password hash, KoL looks at your vinyl boots
-              withGender(KoLCharacter.FEMALE),
+              withGender(Gender.FEMALE),
               withItem(recipe),
               withProperty("unknownRecipe10974", true),
               withProperty("_concoctionDatabaseRefreshes", 0));
@@ -104,7 +105,7 @@ class ResponseTextParserTest {
               withHttpClientBuilder(builder),
               withPasswordHash("recipe"),
               // If you have a password hash, KoL looks at your vinyl boots
-              withGender(KoLCharacter.FEMALE),
+              withGender(Gender.FEMALE),
               withItem(recipe),
               withProperty("unknownRecipe10974", true),
               withProperty("_concoctionDatabaseRefreshes", 0));

--- a/test/net/sourceforge/kolmafia/session/RumpleManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/RumpleManagerTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import internal.helpers.Cleanups;
 import internal.network.FakeHttpClientBuilder;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.GenericRequest;
@@ -65,7 +66,7 @@ public class RumpleManagerTest {
               withEmptyWorkshop(),
               withPasswordHash("gnome"),
               // If you have a password hash, KoL looks at your vinyl boots
-              withGender(KoLCharacter.FEMALE),
+              withGender(Gender.FEMALE),
               withHandlingChoice(845));
       try (cleanups) {
         var html = html("request/test_visit_workshop_1.html");
@@ -103,7 +104,7 @@ public class RumpleManagerTest {
               withEmptyWorkshop(),
               withPasswordHash("gnome"),
               // If you have a password hash, KoL looks at your vinyl boots
-              withGender(KoLCharacter.FEMALE),
+              withGender(Gender.FEMALE),
               withHandlingChoice(845));
       try (cleanups) {
         var html = html("request/test_visit_workshop_2.html");
@@ -145,7 +146,7 @@ public class RumpleManagerTest {
                 withItem(ItemPool.LEATHER, initialLeather),
                 withPasswordHash("gnome"),
                 // If you have a password hash, KoL looks at your vinyl boots
-                withGender(KoLCharacter.FEMALE),
+                withGender(Gender.FEMALE),
                 withHandlingChoice(849));
         try (cleanups) {
           var html = html("request/test_practice_crafting_" + triesLeft + ".html");

--- a/test/net/sourceforge/kolmafia/session/VolcanoMazeManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/VolcanoMazeManagerTest.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.RelayRequest;
@@ -297,7 +298,7 @@ public class VolcanoMazeManagerTest {
               // Avoid a "health warning" from RelayRequest
               withHP(500, 500, 500),
               // Avoid looking at your vinyl boots
-              withGender(KoLCharacter.FEMALE),
+              withGender(Gender.FEMALE),
               // Not strictly necessary in simulation, but KoL requires it.
               withClass(AscensionClass.ACCORDION_THIEF),
               withEquipped(EquipmentManager.WEAPON, ItemPool.SQUEEZEBOX_OF_THE_AGES));
@@ -402,7 +403,7 @@ public class VolcanoMazeManagerTest {
               // Avoid a "health warning" from RelayRequest
               withHP(500, 500, 500),
               // Avoid looking at your vinyl boots
-              withGender(KoLCharacter.FEMALE),
+              withGender(Gender.FEMALE),
               // Not strictly necessary in simulation, but KoL requires it.
               withClass(AscensionClass.ACCORDION_THIEF),
               withEquipped(EquipmentManager.WEAPON, ItemPool.SQUEEZEBOX_OF_THE_AGES));

--- a/test/net/sourceforge/kolmafia/textui/command/GongCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/GongCommandTest.java
@@ -24,6 +24,7 @@ import internal.network.FakeHttpClientBuilder;
 import java.util.List;
 import java.util.Map;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.objectpool.AdventurePool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
@@ -69,7 +70,7 @@ public class GongCommandTest extends AbstractCommandTestBase {
               withLimitMode(LimitMode.NONE),
               withPasswordHash("gong"),
               // If you have a password hash, KoL looks at your vinyl boots
-              withGender(KoLCharacter.FEMALE));
+              withGender(Gender.FEMALE));
       try (cleanups) {
         client.addResponse(302, Map.of("location", List.of("choice.php?forceoption=0")), "");
         client.addResponse(200, html("request/test_use_llama_lama_gong.html"));
@@ -138,7 +139,7 @@ public class GongCommandTest extends AbstractCommandTestBase {
               withProperty("welcomeBackAdv", snarfblat),
               withPasswordHash("gong"),
               // If you have a password hash, KoL looks at your vinyl boots
-              withGender(KoLCharacter.FEMALE));
+              withGender(Gender.FEMALE));
       try (cleanups) {
         client.addResponse(302, Map.of("location", List.of("choice.php")), "");
         client.addResponse(200, html("request/test_leave_reincarnation.html"));


### PR DESCRIPTION
Also fix The Great Tit's Blessing, which only gives the Moxie bonus for females.

Another one which uses the value, but only in modifiers. I think something like 0 for males and 1 for females would have lead to clearer expressions than the [A/2+A/2*X] thing we're using now, but no real need to change it.