### PR TITLE
feat: support rock garden in garden command

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/command/GardenCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/GardenCommand.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import java.util.List;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLmafia;
@@ -41,20 +42,43 @@ public class GardenCommand extends AbstractCommand {
       return;
     }
 
-    AdventureResult crop = CampgroundRequest.getCrop();
-    CropType cropType = CampgroundRequest.getCropType(crop);
+    List<AdventureResult> crops = CampgroundRequest.getCrops();
 
-    if (crop == null) {
+    if (crops.isEmpty()) {
       KoLmafia.updateDisplay("You don't have a garden.");
       return;
     }
 
+    CropType cropType = CampgroundRequest.getCropType(crops.get(0));
+
     if (parameters.equals("")) {
-      int count = crop.getPluralCount();
-      String name = crop.getPluralName();
       String gardenType = cropType.toString();
-      KoLmafia.updateDisplay(
-          "Your " + gardenType + " garden has " + count + " " + name + " in it.");
+      StringBuilder display = new StringBuilder();
+      display.append("Your ").append(gardenType).append(" garden has ");
+      if (cropType == CropType.ROCK) {
+        boolean first = true;
+        for (var crop : crops) {
+          if (crop.getCount() > 0) {
+            if (!first) {
+              display.append(", and ");
+            }
+            int count = crop.getPluralCount();
+            String name = crop.getPluralName();
+            display.append(count).append(" ").append(name);
+            first = false;
+          }
+        }
+        if (first) {
+          display.append("nothing");
+        }
+      } else {
+        var onlyCrop = crops.get(0);
+        int count = onlyCrop.getPluralCount();
+        String name = onlyCrop.getPluralName();
+        display.append(count).append(" ").append(name);
+      }
+      display.append(" in it.");
+      KoLmafia.updateDisplay(display.toString());
       return;
     }
 
@@ -73,7 +97,7 @@ public class GardenCommand extends AbstractCommand {
         return;
       }
 
-      int count = crop.getCount();
+      int count = crops.stream().mapToInt(AdventureResult::getCount).sum();
       if (count == 0) {
         KoLmafia.updateDisplay("There is nothing ready to pick in your garden.");
         return;

--- a/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
@@ -2,7 +2,9 @@ package net.sourceforge.kolmafia.request;
 
 import static internal.helpers.Networking.html;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.sourceforge.kolmafia.KoLCharacter;
@@ -41,6 +43,14 @@ public class CampgroundRequestTest {
     @AfterEach
     public void afterEach() {
       CampgroundRequest.reset();
+    }
+
+    @Test
+    void canDetectNoGarden() {
+      String html = html("request/test_campground_no_garden.html");
+      CampgroundRequest.parseResponse("campground.php", html);
+      assertThat(CampgroundRequest.getCrop(), nullValue());
+      assertThat(CampgroundRequest.getCrops(), empty());
     }
 
     @Test

--- a/test/net/sourceforge/kolmafia/textui/command/AsdonMartinCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AsdonMartinCommandTest.java
@@ -4,6 +4,7 @@ import static internal.helpers.HttpClientWrapper.getRequests;
 import static internal.helpers.Networking.assertPostRequest;
 import static internal.helpers.Networking.html;
 import static internal.helpers.Player.withEffect;
+import static internal.helpers.Player.withEmptyCampground;
 import static internal.helpers.Player.withHttpClientBuilder;
 import static internal.helpers.Player.withItem;
 import static internal.helpers.Player.withWorkshedItem;
@@ -221,6 +222,7 @@ public class AsdonMartinCommandTest extends AbstractCommandTestBase {
 
     var cleanups =
         new Cleanups(
+            withEmptyCampground(),
             withHttpClientBuilder(builder),
             withWorkshedItem(ItemPool.ASDON_MARTIN),
             withFuel(136),

--- a/test/net/sourceforge/kolmafia/textui/command/GardenCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/GardenCommandTest.java
@@ -1,0 +1,124 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static internal.helpers.HttpClientWrapper.getRequests;
+import static internal.helpers.Networking.assertPostRequest;
+import static internal.helpers.Player.withCampgroundItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+
+import internal.helpers.Cleanups;
+import internal.helpers.HttpClientWrapper;
+import net.sourceforge.kolmafia.KoLConstants.MafiaState;
+import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class GardenCommandTest extends AbstractCommandTestBase {
+
+  public GardenCommandTest() {
+    this.command = "garden";
+  }
+
+  @BeforeEach
+  public void initializeState() {
+    HttpClientWrapper.setupFakeClient();
+    StaticEntity.setContinuationState(MafiaState.CONTINUE);
+  }
+
+  @Test
+  public void noGardenErrors() {
+    String output = execute("");
+    assertThat(output, containsString("You don't have a garden"));
+  }
+
+  @Test
+  public void inspectsThanksgarden() {
+    var cleanups = withCampgroundItem(ItemPool.CORNUCOPIA, 1);
+
+    try (cleanups) {
+      String output = execute("");
+      assertThat(output, containsString("Your thanksgarden garden has 1 cornucopia in it."));
+    }
+  }
+
+  @Test
+  public void inspectsThanksgardenPlural() {
+    var cleanups = withCampgroundItem(ItemPool.CORNUCOPIA, 2);
+
+    try (cleanups) {
+      String output = execute("");
+      assertThat(output, containsString("Your thanksgarden garden has 2 cornucopias in it."));
+    }
+  }
+
+  @Test
+  public void inspectsEmptyRockGarden() {
+    var cleanups = withCampgroundItem(ItemPool.GROVELING_GRAVEL, 0);
+
+    try (cleanups) {
+      String output = execute("");
+      assertThat(output, containsString("Your rock garden has nothing in it."));
+    }
+  }
+
+  @Test
+  public void inspectsPartialRockGarden() {
+    var cleanups = withCampgroundItem(ItemPool.GROVELING_GRAVEL, 1);
+
+    try (cleanups) {
+      String output = execute("");
+      assertThat(output, containsString("Your rock garden has 1 groveling gravel in it."));
+    }
+  }
+
+  @Test
+  public void inspectsFullRockGarden() {
+    var cleanups =
+        new Cleanups(
+            withCampgroundItem(ItemPool.FRUITY_PEBBLE, 2),
+            withCampgroundItem(ItemPool.BOLDER_BOULDER, 2),
+            withCampgroundItem(ItemPool.HARD_ROCK, 2));
+
+    try (cleanups) {
+      String output = execute("");
+      assertThat(
+          output,
+          containsString(
+              "Your rock garden has 2 fruity pebbles, and 2 bolder boulders, and 2 hard rocks in it."));
+    }
+  }
+
+  @Test
+  public void picksPartialRockGarden() {
+    var cleanups = withCampgroundItem(ItemPool.GROVELING_GRAVEL, 1);
+
+    try (cleanups) {
+      execute("pick");
+
+      var requests = getRequests();
+      assertThat(requests, hasSize(1));
+      assertPostRequest(requests.get(0), "/campground.php", "action=rgarden1");
+    }
+  }
+
+  @Test
+  public void picksFullRockGarden() {
+    var cleanups =
+        new Cleanups(
+            withCampgroundItem(ItemPool.FRUITY_PEBBLE, 2),
+            withCampgroundItem(ItemPool.BOLDER_BOULDER, 2),
+            withCampgroundItem(ItemPool.HARD_ROCK, 2));
+
+    try (cleanups) {
+      execute("pick");
+
+      var requests = getRequests();
+      assertThat(requests, hasSize(3));
+      assertPostRequest(requests.get(0), "/campground.php", "action=rgarden1");
+      assertPostRequest(requests.get(1), "/campground.php", "action=rgarden2");
+      assertPostRequest(requests.get(2), "/campground.php", "action=rgarden3");
+    }
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/command/GardenCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/GardenCommandTest.java
@@ -12,6 +12,8 @@ import internal.helpers.HttpClientWrapper;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.request.CampgroundRequest;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +27,12 @@ public class GardenCommandTest extends AbstractCommandTestBase {
   public void initializeState() {
     HttpClientWrapper.setupFakeClient();
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
+  }
+
+  @BeforeAll
+  public static void beforeAll() {
+    // there is a leak somewhere that makes every test return "you have 0 peppermint sprouts"
+    CampgroundRequest.reset();
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/textui/command/GardenCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/GardenCommandTest.java
@@ -12,8 +12,6 @@ import internal.helpers.HttpClientWrapper;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
-import net.sourceforge.kolmafia.request.CampgroundRequest;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -27,12 +25,6 @@ public class GardenCommandTest extends AbstractCommandTestBase {
   public void initializeState() {
     HttpClientWrapper.setupFakeClient();
     StaticEntity.setContinuationState(MafiaState.CONTINUE);
-  }
-
-  @BeforeAll
-  public static void beforeAll() {
-    // there is a leak somewhere that makes every test return "you have 0 peppermint sprouts"
-    CampgroundRequest.reset();
   }
 
   @Test

--- a/test/root/request/test_campground_no_garden.html
+++ b/test/root/request/test_campground_no_garden.html
@@ -1,0 +1,141 @@
+<html><head>
+  <script language=Javascript>
+<!--
+if (parent.frames.length == 0) location.href="game.php";
+top.charpane.location.href="charpane.php";
+//-->
+</script>
+  <script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/keybinds.min.2.js"></script>
+  <script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/window.20111231.js"></script>
+  <script language="javascript">function chatFocus(){if(top.chatpane.document.chatform.graf) top.chatpane.document.chatform.graf.focus();}
+if (typeof defaultBind != 'undefined') { defaultBind(47, 2, chatFocus); defaultBind(190, 2, chatFocus);defaultBind(191, 2, chatFocus); defaultBind(47, 8, chatFocus);defaultBind(190, 8, chatFocus); defaultBind(191, 8, chatFocus); }</script><script language="javascript">
+	function updateParseItem(iid, field, info) {
+		var tbl = $('#ic'+iid);
+		var data = parseItem(tbl);
+		if (!data) return;
+		data[field] = info;
+		var out = [];
+		for (i in data) {
+			if (!data.hasOwnProperty(i)) continue;
+			out.push(i+'='+data[i]);
+		}
+		tbl.attr('rel', out.join('&'));
+	}
+	function parseItem(tbl) {
+		tbl = $(tbl);
+		var rel = tbl.attr('rel');
+		var data = {};
+		if (!rel) return data;
+		var parts = rel.split('&');
+		for (i in parts) {
+			if (!parts.hasOwnProperty(i)) continue;
+			var kv = parts[i].split('=');
+			tbl.data(kv[0], kv[1]);
+			data[kv[0]] = kv[1];
+		}
+		return data;
+	}
+</script><script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/jquery-1.3.1.min.js"></script>
+  <script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/pop_query.20130705.js"></script>
+  <script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/ircm.20161111.js"></script>
+  <script type="text/javascript">
+var tp = top;
+function pop_ircm_contents(i, some) {
+	var contents = '',
+		shown = 0,
+		da = '&nbsp;<a href="#" rel="?" class="small dojaxy">[some]</a>&nbsp;<a href="#" rel="',
+		db = '" class="small dojaxy">[all]</a>',
+		dc = '<div style="width:100%; padding-bottom: 3px;" rel="',
+		dd = '<a href="#" rel="1" class="small dojaxy">[';
+	one = 'one'; ss=some;
+if (i.u && i.u != "." && !i.ac) { shown++;
+contents += dc + 'inv_'+(i.u=="a"?"redir":(lab=(i.u=="u"?"use":(i.u=="e"?"eat":(i.u=="b"?"booze":(i.u=="s"?"spleen":"equip"))))))+'.php?ajax=1&whichitem=IID&itemquantity=NUM&quantity=NUM'+(i.u=="q"?"&action=equip":"")+'&pwd=0ee672d5b8fceb233af42a80a47b5309" id="pircm_'+i.id+'"><b>'+ucfirst(unescape(i.ou ? i.ou.replace(/\+/g," ") : (lab=="booze"?"drink":lab)))+':</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++;
+contents += dc + 'inv_equip.php?slot=1&ajax=1&whichitem=IID&action=equip&pwd=0ee672d5b8fceb233af42a80a47b5309" id="pircm_'+i.id+'"><b>Equip (slot 1):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++;
+contents += dc + 'inv_equip.php?slot=2&ajax=1&whichitem=IID&action=equip&pwd=0ee672d5b8fceb233af42a80a47b5309" id="pircm_'+i.id+'"><b>Equip (slot 2):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++;
+contents += dc + 'inv_equip.php?slot=3&ajax=1&whichitem=IID&action=equip&pwd=0ee672d5b8fceb233af42a80a47b5309" id="pircm_'+i.id+'"><b>Equip (slot 3):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+
+	return [contents, shown];
+}
+tp=top
+var todo = [];
+function nextAction() {
+	var next_todo = todo.shift();
+	if (next_todo) {
+		eval(next_todo);
+	}
+}
+function dojax(dourl, afterFunc, hoverCaller, failureFunc, method, params) {
+	$.ajax({
+		type: method || 'GET', url: dourl, cache: false,
+		data: params || null,
+		global: false,
+		success: function (out) {
+			nextAction();
+			if (out.match(/no\|/)) {
+				var parts = out.split(/\|/);
+				if (failureFunc) failureFunc(parts[1]);
+				else if (window.dojaxFailure) window.dojaxFailure(parts[1]);
+				else if (tp.chatpane.handleMessage) tp.chatpane.handleMessage({type: 'event', msg: 'Oops!  Sorry, Dave, you appear to be ' + parts[1]});
+				else  $('#ChatWindow').append('<font color="green">Oops!  Sorry, Dave, you appear to be ' + parts[1] + '.</font><br />' + "\n");
+				return;
+			}
+
+			if (hoverCaller)  {
+				float_results(hoverCaller, out);
+				if (afterFunc) { afterFunc(out); }
+				return;
+			}
+$(tp.mainpane.document).find("#effdiv").remove(); if(!window.dontscroll || (window.dontscroll && dontscroll==0)) { window.scroll(0,0);}
+			var $eff = $(tp.mainpane.document).find('#effdiv');
+			if ($eff.length == 0) {
+				var d = tp.mainpane.document.createElement('DIV');
+				d.id = 'effdiv';
+				var b = tp.mainpane.document.body;
+				if ($('#content_').length > 0) {
+					b = $('#content_ div:first')[0];
+				}
+				b.insertBefore(d, b.firstChild);
+				$eff = $(d);
+			}
+			$eff.find('a[name="effdivtop"]').remove().end()
+				.prepend('<a name="effdivtop"></a><center>' + out + '</center>').css('display','block');
+			if (!window.dontscroll || (window.dontscroll && dontscroll==0)) {
+				tp.mainpane.document.location = tp.mainpane.document.location + "#effdivtop";
+			}
+			if (afterFunc) { afterFunc(out); }
+		}
+	});
+}
+</script>	<link rel="stylesheet" type="text/css" href="https://d2uyhvukfffg5a.cloudfront.net/styles.20151006.css">
+  <style type='text/css'>
+.faded {
+	zoom: 1;
+	filter: alpha(opacity=35);
+	opacity: 0.35;
+	-khtml-opacity: 0.35;
+    -moz-opacity: 0.35;
+}
+</style>
+
+</head>
+
+<body>
+<centeR><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="color: white;" align=center bgcolor=blue><b>Your Campsite</b></td></tr><tr><td style="padding: 5px; border: 1px solid blue;"><center><table><tr><td><center><table cellspacing=0 cellpadding=0><tr><td height=15 align=center><a href="campground.php?action=inspectdwelling"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/tinyglass.gif" width=15 height=15 border=0></a></td><td></td><td></td><td></td><td></td></tr><tr><td width=100 height=100><a href="campground.php?action=rest"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/rest1_free.gif" width=100 height=100 border=0 alt="Rest in Your Dwelling" title="Rest in Your Dwelling"></a></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains3.gif" width=100 height=100></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains1.gif" width=100 height=100></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains2.gif" width=100 height=100></td><td width=100 height=100><a href="closet.php"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/closet.gif" width=100 height=100 border=0 alt="Your Colossal Closet" title="Your Colossal Closet"></a></td></tr><tr><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains3.gif" width=100 height=100></td><td width=100 height=50><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/smallblank1.gif" width=100 height=50></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains2.gif" width=100 height=100></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains4.gif" width=100 height=100></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains5.gif" width=100 height=100></td></tr><tr><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains6.gif" width=100 height=100></td><td width=100 height=100><a href=campground.php?action=inspectkitchen><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/kitchen.gif" width=100 height=100 border=0 alt="Your Kitchen" title="Your Kitchen"></a></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains1.gif" width=100 height=100></td><td width=100 height=100><a href="familiar.php"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/bigterrarium.gif" width=100 height=100 border=0 alt="Familiar-Gro Terrarium" title="Familiar-Gro Terrarium"></a></td><td width=100 height=100><a href="questlog.php"><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/questlog2.gif" width=100 height=100 border=0 alt="Your Quest Log" title="Your Quest Log"></a></td></tr><tr><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains8.gif" width=100 height=100></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains1.gif" width=100 height=100></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains7.gif" width=100 height=100></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains9.gif" width=100 height=100></td><td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains3.gif" width=100 height=100></td></tr></table></center><center><p><a href="main.php">Back to the Main Map</a></center></td></tr></table></center></td></tr><tr><td height=4></td></tr></table></center></body></html>


### PR DESCRIPTION
Support harvesting rock garden. The normal `action=garden` destroys your garden but doesn't give you anything.

Tested with an actual rock garden.

Don't support harvesting individual slots, as that would be more complex and I think most of the time you want to harvest all the slots anyway. A user can easily do this by just calling the URL.

Fix a likely bug with harvesting grass / non-grass: the comment says that anything none-grass should have 1 request, but then sets grass (or anything with count 8) to count 1.