### PR TITLE
fix: use the default token for creating annotations

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -48,7 +48,6 @@ jobs:
         uses: mikepenz/action-junit-report@v3
         if: always()
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Report (${{ matrix.os }})"
           report_paths: "**/build/test-results/test/TEST-*.xml"
 


### PR DESCRIPTION
By https://github.com/mikepenz/action-junit-report/issues/23, this might allow annotations to be created from forks.