### PR TITLE
Whetstone

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1535,6 +1535,7 @@ user	warehouseProgress	0
 user	watchedPreferences
 user	waxMonster
 user	welcomeBackAdv	0
+user	whetstonesUsed	0
 user	wildfireBarrelCaulked	false
 user	wildfireDusted	false
 user	wildfireFracked	false

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11133,6 +11133,6 @@
 11105	bolder boulder	697310877	rgboulder.gif	usable	t,d	25
 11106	molehill mountain	671315172	rgmountain.gif	reusable	t,d	250
 11107	whet stone	689119937	rgwhetstone.gif	multiple	t,d	5
-11108	hard rock	878413969	rghardrock.gif	usable	t,d	25
+11108	hard rock	878413969	rghardrock.gif	multiple	t,d	25
 11109	strange stalagmite	720163663	rgstalagmite.gif	reusable	t,d	250
 11110	chocolate covered ping-pong ball	997920598	ccppball.gif	usable	t,d	20

--- a/src/net/sourceforge/kolmafia/objectpool/Concoction.java
+++ b/src/net/sourceforge/kolmafia/objectpool/Concoction.java
@@ -88,6 +88,7 @@ public class Concoction implements Comparable<Concoction> {
       Set.of(
           ItemPool.QUANTUM_TACO,
           ItemPool.MUNCHIES_PILL,
+          ItemPool.WHETSTONE,
           ItemPool.MAGICAL_SAUSAGE,
           ItemPool.MAYONEX,
           ItemPool.MAYODIOL,
@@ -199,7 +200,7 @@ public class Concoction implements Comparable<Concoction> {
       return switch (ItemDatabase.getConsumptionType(itemId)) {
         case FOOD_HELPER -> ConcoctionType.FOOD;
         case DRINK_HELPER -> ConcoctionType.BOOZE;
-        case USE -> forceFood.contains(itemId)
+        case USE, USE_MULTIPLE -> forceFood.contains(itemId)
             ? ConcoctionType.FOOD
             : forceBooze.contains(itemId) ? ConcoctionType.BOOZE : ConcoctionType.NONE;
         case POTION, AVATAR_POTION -> ConcoctionType.POTION;

--- a/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
@@ -429,6 +429,7 @@ public class ConcoctionDatabase {
     switch (id) {
       case ItemPool.QUANTUM_TACO:
       case ItemPool.MUNCHIES_PILL:
+      case ItemPool.WHETSTONE:
       case ItemPool.MAGICAL_SAUSAGE:
         return true;
     }

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -472,6 +472,7 @@ public class Preferences {
         "vintnerWineType",
         "violetFogLayout",
         "waxMonster",
+        "whetstonesUsed",
         "wildfireBarrelCaulked",
         "wildfireDusted",
         "wildfireFracked",

--- a/src/net/sourceforge/kolmafia/request/EatItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/EatItemRequest.java
@@ -1049,6 +1049,17 @@ public class EatItemRequest extends UseItemRequest {
       ResultProcessor.processItem(ItemPool.SPECIAL_SEASONING, -itemsUsed);
     }
 
+    // With your sharpened appetite, that really hits the spot.
+    if (responseText.contains("With your sharpened appetite")) {
+      int itemsUsed = Math.min(count, InventoryManager.getCount(ItemPool.WHETSTONE));
+      if (itemsUsed > 1) {
+        EatItemRequest.logConsumption("You used " + itemsUsed + " whetstones with your food");
+      } else {
+        EatItemRequest.logConsumption("You used a whetstone with your food");
+      }
+      Preferences.decrement("whetstonesUsed", itemsUsed);
+    }
+
     // Satisfied, you let loose a nasty magnesium-flavored belch.
     if (responseText.contains("magnesium-flavored belch")) {
       EatItemRequest.logConsumption("Your milk of magnesium kicked in");

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -3631,23 +3631,6 @@ public class UseItemRequest extends GenericRequest {
 
         break;
 
-      case ItemPool.WHETSTONE:
-
-        // You run the when stone up and down your tongue several times.
-        // You feel your appetite sharpen. You swallow the whet stone
-        // for good measure.
-
-        if (!responseText.contains("feel your appetite sharpen")) {
-          return;
-        }
-
-        Preferences.increment("whetstonesUsed", count);
-        KoLCharacter.updateStatus();
-        ConcoctionDatabase.getUsables().sort();
-        ConcoctionDatabase.queuedFood.touch();
-
-        break;
-
       case ItemPool.NEWBIESPORT_TENT:
       case ItemPool.BARSKIN_TENT:
       case ItemPool.COTTAGE:
@@ -6454,6 +6437,10 @@ public class UseItemRequest extends GenericRequest {
 
       case ItemPool.MUNCHIES_PILL:
         Preferences.increment("munchiesPillsUsed", count);
+        break;
+
+      case ItemPool.WHETSTONE:
+        Preferences.increment("whetstonesUsed", count);
         break;
 
       case ItemPool.DRINK_ME_POTION:

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -3631,6 +3631,23 @@ public class UseItemRequest extends GenericRequest {
 
         break;
 
+      case ItemPool.WHETSTONE:
+
+        // You run the when stone up and down your tongue several times.
+        // You feel your appetite sharpen. You swallow the whet stone
+        // for good measure.
+
+        if (!responseText.contains("feel your appetite sharpen")) {
+          return;
+        }
+
+        Preferences.increment("whetstonesUsed", count);
+        KoLCharacter.updateStatus();
+        ConcoctionDatabase.getUsables().sort();
+        ConcoctionDatabase.queuedFood.touch();
+
+        break;
+
       case ItemPool.NEWBIESPORT_TENT:
       case ItemPool.BARSKIN_TENT:
       case ItemPool.COTTAGE:

--- a/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
@@ -379,6 +379,7 @@ public class ListCellRendererFactory {
 
       switch (item.getItemId()) {
         case ItemPool.MUNCHIES_PILL -> stringForm.append("+1-3 adv from next food");
+        case ItemPool.WHETSTONE -> stringForm.append("+1 adv from next food");
         case ItemPool.SUSHI_DOILY -> stringForm.append(
             "+3 adv from next sushi (automatically used from inventory)");
         case ItemPool.GRAINS_OF_SALT -> stringForm.append(


### PR DESCRIPTION
1) hard rock is multi usable
2) When ConcoctionDatabase.getUsables was split into multiple lists, "food helpers" were added to the FOOD list.
This includes items that are type USE - like Mayo - but forgot to include items that were USE_MULTIPLE - like munchies pills or whet stones. Now they are included again, and you can see and queue them in the Food panel of the Item Manager
3) Speaking of which, the whet stone adds +1 adventure to the next food eaten.
Handle it like we handle munchies pill