### PR TITLE
refactor: convert string modifiers to enum

### DIFF
--- a/src/net/sourceforge/kolmafia/DebugModifiers.java
+++ b/src/net/sourceforge/kolmafia/DebugModifiers.java
@@ -21,7 +21,7 @@ public class DebugModifiers extends Modifiers {
     DebugModifiers.wanted = new EnumMap<>(DoubleModifier.class);
     DebugModifiers.adjustments = new EnumMap<>(DoubleModifier.class);
     for (var mod : Modifiers.DOUBLE_MODIFIERS) {
-      String name = Modifiers.getModifierName(mod);
+      String name = mod.getName();
       if (name.toLowerCase().contains(parameters)) {
         DebugModifiers.wanted.put(mod, "<td colspan=3>" + name + "</td>");
         DebugModifiers.adjustments.put(mod, "<td colspan=2>" + name + "</td>");

--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -319,7 +319,7 @@ public class FamiliarData implements Comparable<FamiliarData> {
 
     int itemId = getItem().getItemId();
     if (itemId == ItemPool.MAYFLOWER_BOUQUET) {
-      String modifierName = Modifiers.getModifierName(DoubleModifier.FAMILIAR_EXP);
+      String modifierName = DoubleModifier.FAMILIAR_EXP.getName();
       double itemModifier = Modifiers.getNumericModifier(ModifierType.ITEM, itemId, modifierName);
 
       experienceModifier -= itemModifier;

--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -15,6 +15,7 @@ import javax.swing.SwingConstants;
 import net.java.dev.spellcast.utilities.JComponentUtilities;
 import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -1362,8 +1363,8 @@ public class FamiliarData implements Comparable<FamiliarData> {
       return true;
     }
 
-    String others = mods.getString(Modifiers.EQUIPS_ON);
-    if (others == null || others.isEmpty()) {
+    String others = mods.getString(StringModifier.EQUIPS_ON);
+    if (others.isEmpty()) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -24,6 +24,7 @@ import net.sourceforge.kolmafia.listener.CharacterListenerRegistry;
 import net.sourceforge.kolmafia.listener.NamedListenerRegistry;
 import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.moods.HPRestoreItemList;
 import net.sourceforge.kolmafia.moods.MPRestoreItemList;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
@@ -2233,8 +2234,8 @@ public abstract class KoLCharacter {
     return KoLCharacter.currentModifiers.getString(name);
   }
 
-  public static final String currentStringModifier(final int index) {
-    return KoLCharacter.currentModifiers.getString(index);
+  public static final String currentStringModifier(final StringModifier mod) {
+    return KoLCharacter.currentModifiers.getString(mod);
   }
 
   /** Accessor method to retrieve the total current monster level adjustment */
@@ -4999,7 +5000,7 @@ public abstract class KoLCharacter {
     // from the outfit counts towards a Hodgman offhand.
     SpecialOutfit outfit = EquipmentManager.currentOutfit(equipment);
     if (outfit != null) {
-      newModifiers.setString(Modifiers.OUTFIT, outfit.getName());
+      newModifiers.setString(StringModifier.OUTFIT, outfit.getName());
       newModifiers.add(Modifiers.getModifiers(ModifierType.OUTFIT, outfit.getName()));
       // El Vibrato Relics may have additional benefits based on
       // punchcards inserted into the helmet:
@@ -5351,7 +5352,7 @@ public abstract class KoLCharacter {
     }
 
     if (exp != 0.0f) {
-      String tuning = newModifiers.getString(Modifiers.STAT_TUNING);
+      String tuning = newModifiers.getString(StringModifier.STAT_TUNING);
       int prime = KoLCharacter.getPrimeIndex();
       if (tuning.startsWith("Muscle")) prime = 0;
       else if (tuning.startsWith("Mysticality")) prime = 1;
@@ -5535,7 +5536,7 @@ public abstract class KoLCharacter {
 
     if (imod != null) {
       if (speculation) {
-        String intrinsic = imod.getString(Modifiers.INTRINSIC_EFFECT);
+        String intrinsic = imod.getString(StringModifier.INTRINSIC_EFFECT);
         if (intrinsic.length() > 0) {
           newModifiers.add(Modifiers.getModifiers(ModifierType.EFFECT, intrinsic));
         }
@@ -5674,7 +5675,7 @@ public abstract class KoLCharacter {
             || itemId > ItemPool.SHAKESPEARES_SISTERS_ACCORDION) continue;
         Modifiers imod = Modifiers.getItemModifiers(itemId);
         if (imod != null) {
-          AscensionClass classType = AscensionClass.find(imod.getString(Modifiers.CLASS));
+          AscensionClass classType = AscensionClass.find(imod.getString(StringModifier.CLASS));
           if (classType == null
               || classType == ascensionClass
                   && (slot != EquipmentManager.FAMILIAR

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -35,7 +35,6 @@ import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifierCollection;
-import net.sourceforge.kolmafia.modifiers.Modifier;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.modifiers.StringModifierCollection;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
@@ -148,9 +147,8 @@ public class Modifiers {
 
     for (int i = 0; i < BITMAP_MODIFIERS; ++i) {
       BitmapModifier modifier = Modifiers.bitmapModifiers[i];
-      int index = i;
-      modifierIndicesByName.put(modifier.getName(), index);
-      modifierIndicesByName.put(modifier.getTag(), index);
+      modifierIndicesByName.put(modifier.getName(), i);
+      modifierIndicesByName.put(modifier.getTag(), i);
     }
   }
 
@@ -493,20 +491,12 @@ public class Modifiers {
     Modifiers.modifiersByName.remove(lookup.type, lookup.getKey());
   }
 
-  public static final String getModifierName(final DoubleModifier modifier) {
-    return modifier.getName();
-  }
-
   public static final String getBitmapModifierName(final int index) {
     return Modifiers.bitmapModifiers[index].getName();
   }
 
   public static final String getBooleanModifierName(final int index) {
     return Modifiers.booleanModifiers[index].getName();
-  }
-
-  public static final String getStringModifierName(final StringModifier mod) {
-    return mod.getName();
   }
 
   public static final String getDerivedModifierName(final int index) {

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -790,7 +790,7 @@ public class Modifiers {
   }
 
   public double getDoublerAccumulator(final String name) {
-    // doublerAccumulators uses the same indexes as doubles, so the same lookup will work
+    // doublerAccumulators uses the same keys as doubles, so the same lookup will work
     DoubleModifier modifier = findName(name);
     return getDoublerAccumulator(modifier);
   }

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -35,7 +35,9 @@ import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifierCollection;
+import net.sourceforge.kolmafia.modifiers.Modifier;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
+import net.sourceforge.kolmafia.modifiers.StringModifierCollection;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -70,7 +72,7 @@ public class Modifiers {
   private static final TwoLevelEnumHashMap<ModifierType, IntOrString, Modifiers> modifiersByName =
       new TwoLevelEnumHashMap<>(ModifierType.class);
   private static final Map<String, String> familiarEffectByName = new HashMap<>();
-  private static final Map<String, DoubleModifier> modifierTypesByName = new HashMap<>();
+  private static final Map<String, net.sourceforge.kolmafia.modifiers.Modifier> modifierTypesByName = new HashMap<>();
   private static final Map<String, Integer> modifierIndicesByName = new HashMap<>();
   private static boolean availableSkillsChanged = false;
   private static final Map<Boolean, List<Modifiers>> availablePassiveSkillModifiersByVariable =
@@ -103,8 +105,8 @@ public class Modifiers {
 
   private static final HashSet<String> numericModifiers = new HashSet<>();
 
-  public static final EnumSet<DoubleModifier> DOUBLE_MODIFIERS =
-      EnumSet.allOf(DoubleModifier.class);
+  public static final Set<DoubleModifier> DOUBLE_MODIFIERS =
+    Collections.unmodifiableSet(EnumSet.allOf(DoubleModifier.class));
 
   static {
     for (var modifier : Modifiers.DOUBLE_MODIFIERS) {
@@ -259,86 +261,13 @@ public class Modifiers {
     }
   }
 
-  public static final int CLASS = 0;
-  public static final int INTRINSIC_EFFECT = 1;
-  public static final int EQUALIZE = 2;
-  public static final int WIKI_NAME = 3;
-  public static final int MODIFIERS = 4;
-  public static final int OUTFIT = 5;
-  public static final int STAT_TUNING = 6;
-  public static final int EFFECT = 7;
-  public static final int EQUIPS_ON = 8;
-  public static final int FAMILIAR_EFFECT = 9;
-  public static final int JIGGLE = 10;
-  public static final int EQUALIZE_MUSCLE = 11;
-  public static final int EQUALIZE_MYST = 12;
-  public static final int EQUALIZE_MOXIE = 13;
-  public static final int AVATAR = 14;
-  public static final int ROLLOVER_EFFECT = 15;
-  public static final int SKILL = 16;
-  public static final int FLOOR_BUFFED_MUSCLE = 17;
-  public static final int FLOOR_BUFFED_MYST = 18;
-  public static final int FLOOR_BUFFED_MOXIE = 19;
-  public static final int PLUMBER_STAT = 20;
-  public static final int RECIPE = 21;
-
-  private static final StringModifier[] stringModifiers = {
-    new StringModifier(
-        "Class",
-        new Pattern[] {
-          Pattern.compile("Only (.*?) may use this item"),
-          Pattern.compile("Bonus for (.*?) only"),
-          Pattern.compile("Bonus&nbsp;for&nbsp;(.*?)&nbsp;only"),
-        },
-        Pattern.compile("Class: \"(.*?)\"")),
-    new StringModifier(
-        "Intrinsic Effect",
-        Pattern.compile("Intrinsic Effect: <a.*?><font color=blue>(.*)</font></a>"),
-        Pattern.compile("Intrinsic Effect: \"(.*?)\"")),
-    new StringModifier("Equalize", Pattern.compile("Equalize: \"(.*?)\"")),
-    new StringModifier("Wiki Name", Pattern.compile("Wiki Name: \"(.*?)\"")),
-    new StringModifier("Modifiers", Pattern.compile("^(none)$")),
-    new StringModifier("Outfit", null),
-    new StringModifier("Stat Tuning", Pattern.compile("Stat Tuning: \"(.*?)\"")),
-    new StringModifier("Effect", Pattern.compile("(?:^|, )Effect: \"(.*?)\"")),
-    new StringModifier("Equips On", Pattern.compile("Equips On: \"(.*?)\"")),
-    new StringModifier("Familiar Effect", Pattern.compile("Familiar Effect: \"(.*?)\"")),
-    new StringModifier(
-        "Jiggle", Pattern.compile("Jiggle: *(.*?)$"), Pattern.compile("Jiggle: \"(.*?)\"")),
-    new StringModifier("Equalize Muscle", Pattern.compile("Equalize Muscle: \"(.*?)\"")),
-    new StringModifier("Equalize Mysticality", Pattern.compile("Equalize Mysticality: \"(.*?)\"")),
-    new StringModifier("Equalize Moxie", Pattern.compile("Equalize Moxie: \"(.*?)\"")),
-    new StringModifier(
-        "Avatar",
-        new Pattern[] {
-          Pattern.compile("Makes you look like (?:a |an |the )?(.++)(?<!doctor|gross doctor)"),
-          Pattern.compile("Te hace ver como un (.++)"),
-        },
-        Pattern.compile("Avatar: \"(.*?)\"")),
-    new StringModifier(
-        "Rollover Effect",
-        Pattern.compile("Adventures of <b><a.*?>(.*)</a></b> at Rollover"),
-        Pattern.compile("Rollover Effect: \"(.*?)\"")),
-    new StringModifier(
-        "Skill",
-        Pattern.compile("Grants Skill:.*?<b>(.*?)</b>"),
-        Pattern.compile("Skill: \"(.*?)\"")),
-    new StringModifier("Floor Buffed Muscle", Pattern.compile("Floor Buffed Muscle: \"(.*?)\"")),
-    new StringModifier(
-        "Floor Buffed Mysticality", Pattern.compile("Floor Buffed Mysticality: \"(.*?)\"")),
-    new StringModifier("Floor Buffed Moxie", Pattern.compile("Floor Buffed Moxie: \"(.*?)\"")),
-    new StringModifier("Plumber Stat", Pattern.compile("Plumber Stat: \"(.*?)\"")),
-    new StringModifier("Recipe", Pattern.compile("Recipe: \"(.*?)\"")),
-  };
-
-  public static final int STRING_MODIFIERS = Modifiers.stringModifiers.length;
+  public static final Set<StringModifier> STRING_MODIFIERS =
+    Collections.unmodifiableSet(EnumSet.allOf(StringModifier.class));
 
   static {
-    for (int i = 0; i < STRING_MODIFIERS; ++i) {
-      StringModifier modifier = Modifiers.stringModifiers[i];
-      int index = BITMAP_MODIFIERS + BOOLEAN_MODIFIERS + i;
-      modifierIndicesByName.put(modifier.getName(), index);
-      modifierIndicesByName.put(modifier.getTag(), index);
+    for (var modifier : Modifiers.STRING_MODIFIERS) {
+      modifierTypesByName.put(modifier.getName(), modifier);
+      modifierTypesByName.put(modifier.getTag(), modifier);
     }
   }
 
@@ -366,7 +295,7 @@ public class Modifiers {
     int mys = KoLCharacter.getBaseMysticality();
     int mox = KoLCharacter.getBaseMoxie();
 
-    String equalize = this.getString(Modifiers.EQUALIZE);
+    String equalize = this.getString(StringModifier.EQUALIZE);
     if (equalize.startsWith("Mus")) {
       mys = mox = mus;
     } else if (equalize.startsWith("Mys")) {
@@ -378,19 +307,19 @@ public class Modifiers {
       mus = mys = mox = high;
     }
 
-    String mus_equalize = this.getString(Modifiers.EQUALIZE_MUSCLE);
+    String mus_equalize = this.getString(StringModifier.EQUALIZE_MUSCLE);
     if (mus_equalize.startsWith("Mys")) {
       mus = mys;
     } else if (mus_equalize.startsWith("Mox")) {
       mus = mox;
     }
-    String mys_equalize = this.getString(Modifiers.EQUALIZE_MYST);
+    String mys_equalize = this.getString(StringModifier.EQUALIZE_MYST);
     if (mys_equalize.startsWith("Mus")) {
       mys = mus;
     } else if (mys_equalize.startsWith("Mox")) {
       mys = mox;
     }
-    String mox_equalize = this.getString(Modifiers.EQUALIZE_MOXIE);
+    String mox_equalize = this.getString(StringModifier.EQUALIZE_MOXIE);
     if (mox_equalize.startsWith("Mus")) {
       mox = mus;
     } else if (mox_equalize.startsWith("Mys")) {
@@ -423,7 +352,7 @@ public class Modifiers {
             + (int) this.get(DoubleModifier.MOX)
             + (int) Math.ceil(this.get(DoubleModifier.MOX_PCT) * mox / 100.0);
 
-    String mus_buffed_floor = this.getString(Modifiers.FLOOR_BUFFED_MUSCLE);
+    String mus_buffed_floor = this.getString(StringModifier.FLOOR_BUFFED_MUSCLE);
     if (mus_buffed_floor.startsWith("Mys")) {
       if (rv[Modifiers.BUFFED_MYS] > rv[Modifiers.BUFFED_MUS]) {
         rv[Modifiers.BUFFED_MUS] = rv[Modifiers.BUFFED_MYS];
@@ -433,7 +362,7 @@ public class Modifiers {
         rv[Modifiers.BUFFED_MUS] = rv[Modifiers.BUFFED_MOX];
       }
     }
-    String mys_buffed_floor = this.getString(Modifiers.FLOOR_BUFFED_MYST);
+    String mys_buffed_floor = this.getString(StringModifier.FLOOR_BUFFED_MYST);
     if (mys_buffed_floor.startsWith("Mus")) {
       if (rv[Modifiers.BUFFED_MUS] > rv[Modifiers.BUFFED_MYS]) {
         rv[Modifiers.BUFFED_MYS] = rv[Modifiers.BUFFED_MUS];
@@ -443,7 +372,7 @@ public class Modifiers {
         rv[Modifiers.BUFFED_MYS] = rv[Modifiers.BUFFED_MOX];
       }
     }
-    String mox_buffed_floor = this.getString(Modifiers.FLOOR_BUFFED_MOXIE);
+    String mox_buffed_floor = this.getString(StringModifier.FLOOR_BUFFED_MOXIE);
     if (mox_buffed_floor.startsWith("Mus")) {
       if (rv[Modifiers.BUFFED_MUS] > rv[Modifiers.BUFFED_MOX]) {
         rv[Modifiers.BUFFED_MOX] = rv[Modifiers.BUFFED_MUS];
@@ -575,8 +504,8 @@ public class Modifiers {
     return Modifiers.booleanModifiers[index].getName();
   }
 
-  public static final String getStringModifierName(final int index) {
-    return Modifiers.stringModifiers[index].getName();
+  public static final String getStringModifierName(final StringModifier mod) {
+    return mod.getName();
   }
 
   public static final String getDerivedModifierName(final int index) {
@@ -664,8 +593,7 @@ public class Modifiers {
   }
 
   public static final DoubleModifier findName(String name) {
-    // TODO: does this need to be caseless? Can it not use modifierTypesByName,
-    // which is case-sensitive and includes tags?
+    // this is caseless because it accepts anything typed into the maximizer, which is normally lowercase
     return DoubleModifier.byCaselessName(name);
   }
 
@@ -678,14 +606,13 @@ public class Modifiers {
   public boolean variable = true;
   private final DoubleModifierCollection doubles = new DoubleModifierCollection();
   private final int[] bitmaps = new int[Modifiers.BITMAP_MODIFIERS];
-  private final String[] strings = new String[Modifiers.STRING_MODIFIERS];
+  private final StringModifierCollection strings = new StringModifierCollection();
   private ArrayList<Indexed<ModifierExpression>> expressions = null;
   // These are used for Steely-Eyed Squint and so on
   private final DoubleModifierCollection doublerAccumulators = new DoubleModifierCollection();
 
   public Modifiers() {
-    Arrays.fill(this.strings, "");
-    // Everything else should be initialized above.
+    // Everything should be initialized above.
   }
 
   public Modifiers(Modifiers copy) {
@@ -709,8 +636,8 @@ public class Modifiers {
 
   public final void reset() {
     this.doubles.reset();
+    this.strings.reset();
     Arrays.fill(this.bitmaps, 0);
-    Arrays.fill(this.strings, "");
     this.expressions = null;
   }
 
@@ -827,32 +754,33 @@ public class Modifiers {
     return ((this.bitmaps[0] >>> index) & 1) != 0;
   }
 
-  public String getString(final int index) {
-    if (index < 0 || index >= this.strings.length) {
+  public String getString(final StringModifier modifier) {
+    if (modifier == null) {
       return "";
     }
 
-    return this.strings[index];
+    return this.strings.get(modifier);
   }
 
   public String getString(final String name) {
     // Can't cache this as expressions can be dependent on things
     // that can change within a session, like character level.
     if (name.equals("Evaluated Modifiers")) {
-      return Modifiers.evaluateModifiers(this.originalLookup, this.strings[Modifiers.MODIFIERS])
+      return Modifiers.evaluateModifiers(this.originalLookup, this.strings.get(StringModifier.MODIFIERS))
           .toString();
     }
 
-    int index = Modifiers.findName(Modifiers.stringModifiers, name);
-    if (index < 0 || index >= this.strings.length) {
+    StringModifier modifier = StringModifier.byCaselessName(name);
+    if (modifier == null) {
       return "";
     }
 
-    return this.strings[index];
+    return this.strings.get(modifier);
   }
 
   public double getDoublerAccumulator(final DoubleModifier modifier) {
     if (modifier == null) {
+      // For now, make it obvious that something went wrong
       return -9999.0;
     }
     return this.doublerAccumulators.get(modifier);
@@ -861,12 +789,7 @@ public class Modifiers {
   public double getDoublerAccumulator(final String name) {
     // doublerAccumulators uses the same indexes as doubles, so the same lookup will work
     DoubleModifier modifier = findName(name);
-    if (modifier == null) {
-      // For now, make it obvious that something went wrong
-      return -9999.0;
-    }
-
-    return this.doublerAccumulators.get(modifier);
+    return getDoublerAccumulator(modifier);
   }
 
   public boolean setDouble(final DoubleModifier mod, final double value) {
@@ -903,8 +826,8 @@ public class Modifiers {
     return false;
   }
 
-  public boolean setString(final int index, String mod) {
-    if (index < 0 || index >= this.strings.length) {
+  public boolean setString(final StringModifier modifier, String mod) {
+    if (modifier == null) {
       return false;
     }
 
@@ -912,11 +835,7 @@ public class Modifiers {
       mod = "";
     }
 
-    if (!mod.equals(this.strings[index])) {
-      this.strings[index] = mod;
-      return true;
-    }
-    return false;
+    return this.strings.set(modifier, mod);
   }
 
   public boolean set(final Modifiers mods) {
@@ -939,12 +858,8 @@ public class Modifiers {
       }
     }
 
-    String[] copyStrings = mods.strings;
-    for (int index = 0; index < this.strings.length; ++index) {
-      if (!this.strings[index].equals(copyStrings[index])) {
-        this.strings[index] = copyStrings[index];
-        changed = true;
-      }
+    for (var mod : Modifiers.STRING_MODIFIERS) {
+      changed |= this.setString(mod, mods.strings.get(mod));
     }
 
     return changed;
@@ -1052,7 +967,7 @@ public class Modifiers {
     }
 
     // Make sure the modifiers apply to current class
-    String className = mods.strings[Modifiers.CLASS];
+    String className = mods.strings.get(StringModifier.CLASS);
     if (className != null && !className.isEmpty()) {
       AscensionClass ascensionClass = AscensionClass.findByExactName(className);
       if (ascensionClass != null && ascensionClass != KoLCharacter.getAscensionClass()) {
@@ -1081,34 +996,34 @@ public class Modifiers {
     // Add in string modifiers as appropriate.
 
     String val;
-    val = mods.strings[Modifiers.EQUALIZE];
-    if (!val.isEmpty() && this.strings[Modifiers.EQUALIZE].isEmpty()) {
-      this.strings[Modifiers.EQUALIZE] = val;
+    val = mods.strings.get(StringModifier.EQUALIZE);
+    if (!val.isEmpty() && this.strings.get(StringModifier.EQUALIZE).isEmpty()) {
+      this.strings.set(StringModifier.EQUALIZE, val);
     }
-    val = mods.strings[Modifiers.INTRINSIC_EFFECT];
+    val = mods.strings.get(StringModifier.INTRINSIC_EFFECT);
     if (!val.isEmpty()) {
-      String prev = this.strings[INTRINSIC_EFFECT];
+      String prev = this.strings.get(StringModifier.INTRINSIC_EFFECT);
       if (prev.isEmpty()) {
-        this.strings[Modifiers.INTRINSIC_EFFECT] = val;
+        this.strings.set(StringModifier.INTRINSIC_EFFECT, val);
       } else {
-        this.strings[Modifiers.INTRINSIC_EFFECT] = prev + "\t" + val;
+        this.strings.set(StringModifier.INTRINSIC_EFFECT, prev + "\t" + val);
       }
     }
-    val = mods.strings[Modifiers.STAT_TUNING];
+    val = mods.strings.get(StringModifier.STAT_TUNING);
     if (!val.isEmpty()) {
-      this.strings[Modifiers.STAT_TUNING] = val;
+      this.strings.set(StringModifier.STAT_TUNING, val);
     }
-    val = mods.strings[Modifiers.EQUALIZE_MUSCLE];
+    val = mods.strings.get(StringModifier.EQUALIZE_MUSCLE);
     if (!val.isEmpty()) {
-      this.strings[Modifiers.EQUALIZE_MUSCLE] = val;
+      this.strings.set(StringModifier.EQUALIZE_MUSCLE, val);
     }
-    val = mods.strings[Modifiers.EQUALIZE_MYST];
+    val = mods.strings.get(StringModifier.EQUALIZE_MYST);
     if (!val.isEmpty()) {
-      this.strings[Modifiers.EQUALIZE_MYST] = val;
+      this.strings.set(StringModifier.EQUALIZE_MYST, val);
     }
-    val = mods.strings[Modifiers.EQUALIZE_MOXIE];
+    val = mods.strings.get(StringModifier.EQUALIZE_MOXIE);
     if (!val.isEmpty()) {
-      this.strings[Modifiers.EQUALIZE_MOXIE] = val;
+      this.strings.set(StringModifier.EQUALIZE_MOXIE, val);
     }
 
     // OR in the bitmap modifiers (including all the boolean modifiers)
@@ -1124,9 +1039,13 @@ public class Modifiers {
       return false;
     }
 
-    DoubleModifier modifier = modifierTypesByName.get(mod.getName());
+    var modifier = modifierTypesByName.get(mod.getName());
     if (modifier != null) {
-      return this.setDouble(modifier, Double.parseDouble(mod.getValue()));
+      if (modifier instanceof DoubleModifier d) {
+        return this.setDouble(d, Double.parseDouble(mod.getValue()));
+      } else if (modifier instanceof StringModifier s) {
+        return this.setString(s, mod.getValue());
+      }
     }
     Integer index = modifierIndicesByName.get(mod.getName());
     if (index == null) {
@@ -1138,12 +1057,7 @@ public class Modifiers {
     }
 
     index -= BITMAP_MODIFIERS;
-    if (index < BOOLEAN_MODIFIERS) {
-      return this.setBoolean(index, mod.getValue().equals("true"));
-    }
-
-    index -= BOOLEAN_MODIFIERS;
-    return this.setString(index, mod.getValue());
+    return this.setBoolean(index, mod.getValue().equals("true"));
   }
 
   public static final Modifiers getItemModifiers(final int id) {
@@ -1249,7 +1163,7 @@ public class Modifiers {
   public static final Modifiers parseModifiers(final Lookup lookup, final String string) {
     Modifiers newMods = new Modifiers();
     int[] newBitmaps = newMods.bitmaps;
-    String[] newStrings = newMods.strings;
+    StringModifierCollection newStrings = newMods.strings;
 
     newMods.originalLookup = lookup;
 
@@ -1326,8 +1240,8 @@ public class Modifiers {
       newBitmaps[0] |= 1 << i;
     }
 
-    for (int i = 0; i < newStrings.length; ++i) {
-      Pattern pattern = Modifiers.stringModifiers[i].getTagPattern();
+    for (var mod : Modifiers.STRING_MODIFIERS) {
+      Pattern pattern = mod.getTagPattern();
       if (pattern == null) {
         continue;
       }
@@ -1337,52 +1251,18 @@ public class Modifiers {
         continue;
       }
 
-      String modifierName = Modifiers.stringModifiers[i].getName();
       String value = matcher.group(1);
 
-      if (modifierName.equals("Class")) {
-        value = Modifiers.depluralizeClassName(value);
+      if (mod == StringModifier.CLASS) {
+        value = StringModifier.depluralizeClassName(value);
       }
 
-      newStrings[i] = value;
+      newStrings.set(mod, value);
     }
 
-    newStrings[Modifiers.MODIFIERS] = string;
+    newStrings.set(StringModifier.MODIFIERS, string);
 
     return newMods;
-  }
-
-  private static final String[][] classStrings = {
-    {
-      AscensionClass.SEAL_CLUBBER.getName(), "Seal Clubbers", "Seal&nbsp;Clubbers",
-    },
-    {
-      AscensionClass.TURTLE_TAMER.getName(), "Turtle Tamers", "Turtle&nbsp;Tamers",
-    },
-    {
-      AscensionClass.PASTAMANCER.getName(), "Pastamancers",
-    },
-    {
-      AscensionClass.SAUCEROR.getName(), "Saucerors",
-    },
-    {
-      AscensionClass.DISCO_BANDIT.getName(), "Disco Bandits", "Disco&nbsp;Bandits",
-    },
-    {
-      AscensionClass.ACCORDION_THIEF.getName(), "Accordion Thieves", "Accordion&nbsp;Thieves",
-    },
-  };
-
-  private static String depluralizeClassName(final String string) {
-    for (String[] results : Modifiers.classStrings) {
-      String result = results[0];
-      for (String candidate : results) {
-        if (candidate.equals(string)) {
-          return result;
-        }
-      }
-    }
-    return string;
   }
 
   public static class Modifier {
@@ -2345,7 +2225,7 @@ public class Modifiers {
   public static final String parseSkill(final String text) {
     Matcher matcher = Modifiers.SKILL_PATTERN.matcher(text);
     if (matcher.find()) {
-      return Modifiers.stringModifiers[Modifiers.SKILL].getTag() + ": \"" + matcher.group(1) + "\"";
+      return StringModifier.SKILL.getTag() + ": \"" + matcher.group(1) + "\"";
     }
 
     return null;
@@ -2446,7 +2326,7 @@ public class Modifiers {
           name = "[" + effectId + "]" + name;
         }
       }
-      return Modifiers.stringModifiers[Modifiers.EFFECT].getTag() + ": \"" + name + "\"";
+      return StringModifier.EFFECT.getTag() + ": \"" + name + "\"";
     }
 
     return null;
@@ -2520,7 +2400,7 @@ public class Modifiers {
 
     // Then the string modifiers
 
-    result = Modifiers.parseModifier(Modifiers.stringModifiers, enchantment, true);
+    result = StringModifier.parseModifier(enchantment);
     if (result != null) {
       return result;
     }
@@ -2562,7 +2442,7 @@ public class Modifiers {
 
       if (ascensionClass == null) return null;
 
-      return Modifiers.stringModifiers[Modifiers.CLASS].getTag()
+      return StringModifier.CLASS.getTag()
           + ": \""
           + ascensionClass.getName()
           + "\"";
@@ -2601,7 +2481,7 @@ public class Modifiers {
   }
 
   public static final String parseStringModifier(final String enchantment) {
-    return Modifiers.parseModifier(Modifiers.stringModifiers, enchantment, true);
+    return StringModifier.parseModifier(enchantment);
   }
 
   private static <T extends net.sourceforge.kolmafia.modifiers.Modifier> String parseModifier(
@@ -2628,10 +2508,6 @@ public class Modifiers {
         String tag = tableRow.getTag();
 
         String value = matcher.group(1);
-
-        if (tag.equals("Class")) {
-          value = Modifiers.depluralizeClassName(value);
-        }
 
         return tag + ": " + quote + value.trim() + quote;
       }
@@ -2754,7 +2630,7 @@ public class Modifiers {
 
         Modifiers modifiers = Modifiers.modifiersByName.get(type, key);
         if (modifiers != null) {
-          modifierString = modifiers.getString(Modifiers.MODIFIERS);
+          modifierString = modifiers.getString(StringModifier.MODIFIERS);
         }
 
         ModifierList list = Modifiers.splitModifiers(modifierString);
@@ -2771,7 +2647,7 @@ public class Modifiers {
           if (Modifiers.findModifier(Modifiers.booleanModifiers, mod)) {
             continue;
           }
-          if (Modifiers.findModifier(Modifiers.stringModifiers, mod)) {
+          if (StringModifier.byTagPattern(mod) != null) {
             continue;
           }
           if (type == ModifierType.FAM_EQ) {
@@ -3005,11 +2881,11 @@ public class Modifiers {
           if (mods == null) {
             break;
           }
-          if (!mods.getString(Modifiers.EFFECT).isEmpty()) {
+          if (!mods.getString(StringModifier.EFFECT).isEmpty()) {
             potions.add(name);
           } else if (mods.getBoolean(Modifiers.FREE_PULL)) {
             freepulls.add(name);
-          } else if (!mods.getString(Modifiers.WIKI_NAME).isEmpty()) {
+          } else if (!mods.getString(StringModifier.WIKI_NAME).isEmpty()) {
             wikiname.add(name);
           }
         }

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -72,7 +72,8 @@ public class Modifiers {
   private static final TwoLevelEnumHashMap<ModifierType, IntOrString, Modifiers> modifiersByName =
       new TwoLevelEnumHashMap<>(ModifierType.class);
   private static final Map<String, String> familiarEffectByName = new HashMap<>();
-  private static final Map<String, net.sourceforge.kolmafia.modifiers.Modifier> modifierTypesByName = new HashMap<>();
+  private static final Map<String, net.sourceforge.kolmafia.modifiers.Modifier>
+      modifierTypesByName = new HashMap<>();
   private static final Map<String, Integer> modifierIndicesByName = new HashMap<>();
   private static boolean availableSkillsChanged = false;
   private static final Map<Boolean, List<Modifiers>> availablePassiveSkillModifiersByVariable =
@@ -106,7 +107,7 @@ public class Modifiers {
   private static final HashSet<String> numericModifiers = new HashSet<>();
 
   public static final Set<DoubleModifier> DOUBLE_MODIFIERS =
-    Collections.unmodifiableSet(EnumSet.allOf(DoubleModifier.class));
+      Collections.unmodifiableSet(EnumSet.allOf(DoubleModifier.class));
 
   static {
     for (var modifier : Modifiers.DOUBLE_MODIFIERS) {
@@ -262,7 +263,7 @@ public class Modifiers {
   }
 
   public static final Set<StringModifier> STRING_MODIFIERS =
-    Collections.unmodifiableSet(EnumSet.allOf(StringModifier.class));
+      Collections.unmodifiableSet(EnumSet.allOf(StringModifier.class));
 
   static {
     for (var modifier : Modifiers.STRING_MODIFIERS) {
@@ -593,7 +594,8 @@ public class Modifiers {
   }
 
   public static final DoubleModifier findName(String name) {
-    // this is caseless because it accepts anything typed into the maximizer, which is normally lowercase
+    // this is caseless because it accepts anything typed into the maximizer, which is normally
+    // lowercase
     return DoubleModifier.byCaselessName(name);
   }
 
@@ -766,7 +768,8 @@ public class Modifiers {
     // Can't cache this as expressions can be dependent on things
     // that can change within a session, like character level.
     if (name.equals("Evaluated Modifiers")) {
-      return Modifiers.evaluateModifiers(this.originalLookup, this.strings.get(StringModifier.MODIFIERS))
+      return Modifiers.evaluateModifiers(
+              this.originalLookup, this.strings.get(StringModifier.MODIFIERS))
           .toString();
     }
 
@@ -2442,10 +2445,7 @@ public class Modifiers {
 
       if (ascensionClass == null) return null;
 
-      return StringModifier.CLASS.getTag()
-          + ": \""
-          + ascensionClass.getName()
-          + "\"";
+      return StringModifier.CLASS.getTag() + ": \"" + ascensionClass.getName() + "\"";
     }
 
     matcher = Modifiers.COMBAT_PATTERN.matcher(enchantment);

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -1445,7 +1445,7 @@ public class Modifiers {
       return new ModifierList();
     }
 
-    return Modifiers.splitModifiers(mods.getString("Modifiers"));
+    return Modifiers.splitModifiers(mods.getString(StringModifier.MODIFIERS));
   }
 
   public static final ModifierList splitModifiers(String modifiers) {

--- a/src/net/sourceforge/kolmafia/PastaThrallData.java
+++ b/src/net/sourceforge/kolmafia/PastaThrallData.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
@@ -340,7 +341,7 @@ public class PastaThrallData implements Comparable<PastaThrallData> {
     if (this.id != 0) {
       Modifiers mods = Modifiers.getModifiers(ModifierType.THRALL, this.type);
       if (mods != null) {
-        this.mods = mods.getString("Modifiers");
+        this.mods = mods.getString(StringModifier.MODIFIERS);
         this.modsLookup = mods.getLookup();
       }
     }

--- a/src/net/sourceforge/kolmafia/Speculation.java
+++ b/src/net/sourceforge/kolmafia/Speculation.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
@@ -40,7 +41,7 @@ public class Speculation {
       int itemId = this.equipment[i].getItemId();
       Modifiers mods = Modifiers.getItemModifiers(itemId);
       if (mods == null) continue;
-      String name = mods.getString(Modifiers.INTRINSIC_EFFECT);
+      String name = mods.getString(StringModifier.INTRINSIC_EFFECT);
       if (name.length() == 0) continue;
       int effectId = EffectDatabase.getEffectId(name);
       this.effects.remove(EffectPool.get(effectId));

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -29,6 +29,7 @@ import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.SpecialOutfit;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifierCollection;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -447,7 +448,7 @@ public class Evaluator {
       if (keyword.startsWith("outfit")) {
         keyword = keyword.substring(6).trim();
         if (keyword.equals("")) { // allow "+outfit" to mean "keep the current outfit on"
-          keyword = KoLCharacter.currentStringModifier(Modifiers.OUTFIT);
+          keyword = KoLCharacter.currentStringModifier(StringModifier.OUTFIT);
         }
         SpecialOutfit outfit = EquipmentManager.getMatchingOutfit(keyword);
         if (outfit == null || outfit.getOutfitId() <= 0) {
@@ -840,7 +841,7 @@ public class Evaluator {
       }
     }
     // Add fudge factor for Rollover Effect
-    if (mods.getString(Modifiers.ROLLOVER_EFFECT).length() > 0) {
+    if (mods.getString(StringModifier.ROLLOVER_EFFECT).length() > 0) {
       score += 0.01f;
     }
     if (score < this.totalMin) this.failed = true;
@@ -889,7 +890,7 @@ public class Evaluator {
       }
     }
     if (!this.failed) {
-      String outfit = mods.getString(Modifiers.OUTFIT);
+      String outfit = mods.getString(StringModifier.OUTFIT);
       if (this.negOutfits.contains(outfit)) {
         this.failed = true;
       } else {
@@ -1393,7 +1394,7 @@ public class Evaluator {
         }
 
         boolean wrongClass = false;
-        String classType = mods.getString(Modifiers.CLASS);
+        String classType = mods.getString(StringModifier.CLASS);
         if (classType != "" && !classType.equals(KoLCharacter.getAscensionClassName())) {
           wrongClass = true;
         }
@@ -1494,7 +1495,7 @@ public class Evaluator {
           break gotItem;
         }
 
-        String intrinsic = mods.getString(Modifiers.INTRINSIC_EFFECT);
+        String intrinsic = mods.getString(StringModifier.INTRINSIC_EFFECT);
         if (intrinsic.length() > 0) {
           Modifiers newMods = new Modifiers();
           newMods.add(mods);

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -614,7 +614,7 @@ public class Evaluator {
         // We found a match. If only the first instance
         // of particular equipped items provide this
         // modifier, add them to the "uniques" list.
-        String modifierName = Modifiers.getModifierName(index);
+        String modifierName = index.getName();
         this.addUniqueItems(modifierName);
         this.weight.set(index, weight);
         continue;

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -279,7 +279,7 @@ public class Maximizer {
             if (mods.length() > 0) {
               mods.append(", ");
             }
-            mods.append(Modifiers.getModifierName(mod) + ": " + itemMods.get(mod));
+            mods.append(mod.getName() + ": " + itemMods.get(mod));
           }
         }
         if (mods.length() == 0) {

--- a/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
+++ b/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
@@ -11,6 +11,7 @@ import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.Speculation;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
@@ -121,7 +122,7 @@ public class MaximizerSpeculation extends Speculation
       int itemId = this.equipment[i].getItemId();
       Modifiers mods = Modifiers.getItemModifiers(itemId);
       if (mods == null) continue;
-      String name = mods.getString(Modifiers.ROLLOVER_EFFECT);
+      String name = mods.getString(StringModifier.ROLLOVER_EFFECT);
       if (name.length() > 0) countThisEffects++;
       if (mods.getBoolean(Modifiers.BREAKABLE)) countThisBreakables++;
       if (mods.getBoolean(Modifiers.DROPS_ITEMS)) countThisDropsItems++;
@@ -132,7 +133,7 @@ public class MaximizerSpeculation extends Speculation
       int itemId = other.equipment[i].getItemId();
       Modifiers mods = Modifiers.getItemModifiers(itemId);
       if (mods == null) continue;
-      String name = mods.getString(Modifiers.ROLLOVER_EFFECT);
+      String name = mods.getString(StringModifier.ROLLOVER_EFFECT);
       if (name.length() > 0) countOtherEffects++;
       if (mods.getBoolean(Modifiers.BREAKABLE)) countOtherBreakables++;
       if (mods.getBoolean(Modifiers.DROPS_ITEMS)) countOtherDropsItems++;

--- a/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
@@ -9,7 +9,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.Modifiers;
 
 public enum DoubleModifier implements Modifier {
   FAMILIAR_WEIGHT(

--- a/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
@@ -9,6 +9,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.Modifiers;
 
 public enum DoubleModifier implements Modifier {
   FAMILIAR_WEIGHT(

--- a/src/net/sourceforge/kolmafia/modifiers/StringModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/StringModifier.java
@@ -7,55 +7,53 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.AscensionClass;
-import net.sourceforge.kolmafia.Modifiers;
 
 public enum StringModifier implements Modifier {
-    CLASS(
-        "Class",
-          new Pattern[] {
-    Pattern.compile("Only (.*?) may use this item"),
-      Pattern.compile("Bonus for (.*?) only"),
-      Pattern.compile("Bonus&nbsp;for&nbsp;(.*?)&nbsp;only"),
-  },
-    Pattern.compile("Class: \"(.*?)\"")),
-    INTRINSIC_EFFECT(
-        "Intrinsic Effect",
-    Pattern.compile("Intrinsic Effect: <a.*?><font color=blue>(.*)</font></a>"),
-        Pattern.compile("Intrinsic Effect: \"(.*?)\"")),
-          EQUALIZE("Equalize", Pattern.compile("Equalize: \"(.*?)\"")),
-    WIKI_NAME("Wiki Name", Pattern.compile("Wiki Name: \"(.*?)\"")),
-    MODIFIERS("Modifiers", Pattern.compile("^(none)$")),
-    OUTFIT("Outfit", null),
-    STAT_TUNING("Stat Tuning", Pattern.compile("Stat Tuning: \"(.*?)\"")),
-    EFFECT("Effect", Pattern.compile("(?:^|, )Effect: \"(.*?)\"")),
-    EQUIPS_ON("Equips On", Pattern.compile("Equips On: \"(.*?)\"")),
-    FAMILIAR_EFFECT("Familiar Effect", Pattern.compile("Familiar Effect: \"(.*?)\"")),
-    JIGGLE(
-        "Jiggle", Pattern.compile("Jiggle: *(.*?)$"), Pattern.compile("Jiggle: \"(.*?)\"")),
-    EQUALIZE_MUSCLE("Equalize Muscle", Pattern.compile("Equalize Muscle: \"(.*?)\"")),
-    EQUALIZE_MYST("Equalize Mysticality", Pattern.compile("Equalize Mysticality: \"(.*?)\"")),
-    EQUALIZE_MOXIE("Equalize Moxie", Pattern.compile("Equalize Moxie: \"(.*?)\"")),
-    AVATAR(
-        "Avatar",
-          new Pattern[] {
-    Pattern.compile("Makes you look like (?:a |an |the )?(.++)(?<!doctor|gross doctor)"),
-      Pattern.compile("Te hace ver como un (.++)"),
-  },
-    Pattern.compile("Avatar: \"(.*?)\"")),
-    ROLLOVER_EFFECT(
-        "Rollover Effect",
-    Pattern.compile("Adventures of <b><a.*?>(.*)</a></b> at Rollover"),
-        Pattern.compile("Rollover Effect: \"(.*?)\"")),
-          SKILL(
-        "Skill",
-    Pattern.compile("Grants Skill:.*?<b>(.*?)</b>"),
-        Pattern.compile("Skill: \"(.*?)\"")),
-          FLOOR_BUFFED_MUSCLE("Floor Buffed Muscle", Pattern.compile("Floor Buffed Muscle: \"(.*?)\"")),
-    FLOOR_BUFFED_MYST(
-        "Floor Buffed Mysticality", Pattern.compile("Floor Buffed Mysticality: \"(.*?)\"")),
-    FLOOR_BUFFED_MOXIE("Floor Buffed Moxie", Pattern.compile("Floor Buffed Moxie: \"(.*?)\"")),
-    PLUMBER_STAT("Plumber Stat", Pattern.compile("Plumber Stat: \"(.*?)\"")),
-    RECIPE("Recipe", Pattern.compile("Recipe: \"(.*?)\""));
+  CLASS(
+      "Class",
+      new Pattern[] {
+        Pattern.compile("Only (.*?) may use this item"),
+        Pattern.compile("Bonus for (.*?) only"),
+        Pattern.compile("Bonus&nbsp;for&nbsp;(.*?)&nbsp;only"),
+      },
+      Pattern.compile("Class: \"(.*?)\"")),
+  INTRINSIC_EFFECT(
+      "Intrinsic Effect",
+      Pattern.compile("Intrinsic Effect: <a.*?><font color=blue>(.*)</font></a>"),
+      Pattern.compile("Intrinsic Effect: \"(.*?)\"")),
+  EQUALIZE("Equalize", Pattern.compile("Equalize: \"(.*?)\"")),
+  WIKI_NAME("Wiki Name", Pattern.compile("Wiki Name: \"(.*?)\"")),
+  MODIFIERS("Modifiers", Pattern.compile("^(none)$")),
+  OUTFIT("Outfit", null),
+  STAT_TUNING("Stat Tuning", Pattern.compile("Stat Tuning: \"(.*?)\"")),
+  EFFECT("Effect", Pattern.compile("(?:^|, )Effect: \"(.*?)\"")),
+  EQUIPS_ON("Equips On", Pattern.compile("Equips On: \"(.*?)\"")),
+  FAMILIAR_EFFECT("Familiar Effect", Pattern.compile("Familiar Effect: \"(.*?)\"")),
+  JIGGLE("Jiggle", Pattern.compile("Jiggle: *(.*?)$"), Pattern.compile("Jiggle: \"(.*?)\"")),
+  EQUALIZE_MUSCLE("Equalize Muscle", Pattern.compile("Equalize Muscle: \"(.*?)\"")),
+  EQUALIZE_MYST("Equalize Mysticality", Pattern.compile("Equalize Mysticality: \"(.*?)\"")),
+  EQUALIZE_MOXIE("Equalize Moxie", Pattern.compile("Equalize Moxie: \"(.*?)\"")),
+  AVATAR(
+      "Avatar",
+      new Pattern[] {
+        Pattern.compile("Makes you look like (?:a |an |the )?(.++)(?<!doctor|gross doctor)"),
+        Pattern.compile("Te hace ver como un (.++)"),
+      },
+      Pattern.compile("Avatar: \"(.*?)\"")),
+  ROLLOVER_EFFECT(
+      "Rollover Effect",
+      Pattern.compile("Adventures of <b><a.*?>(.*)</a></b> at Rollover"),
+      Pattern.compile("Rollover Effect: \"(.*?)\"")),
+  SKILL(
+      "Skill",
+      Pattern.compile("Grants Skill:.*?<b>(.*?)</b>"),
+      Pattern.compile("Skill: \"(.*?)\"")),
+  FLOOR_BUFFED_MUSCLE("Floor Buffed Muscle", Pattern.compile("Floor Buffed Muscle: \"(.*?)\"")),
+  FLOOR_BUFFED_MYST(
+      "Floor Buffed Mysticality", Pattern.compile("Floor Buffed Mysticality: \"(.*?)\"")),
+  FLOOR_BUFFED_MOXIE("Floor Buffed Moxie", Pattern.compile("Floor Buffed Moxie: \"(.*?)\"")),
+  PLUMBER_STAT("Plumber Stat", Pattern.compile("Plumber Stat: \"(.*?)\"")),
+  RECIPE("Recipe", Pattern.compile("Recipe: \"(.*?)\""));
   private final String name;
   private final Pattern[] descPatterns;
   private final Pattern tagPattern;
@@ -95,8 +93,8 @@ public enum StringModifier implements Modifier {
   }
 
   private static final Map<String, StringModifier> caselessNameToModifier =
-    Arrays.stream(values())
-      .collect(Collectors.toMap(type -> type.name.toLowerCase(), Function.identity()));
+      Arrays.stream(values())
+          .collect(Collectors.toMap(type -> type.name.toLowerCase(), Function.identity()));
 
   // equivalent to `Modifiers.findName`
   public static StringModifier byCaselessName(String name) {

--- a/src/net/sourceforge/kolmafia/modifiers/StringModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/StringModifier.java
@@ -1,21 +1,74 @@
 package net.sourceforge.kolmafia.modifiers;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import net.sourceforge.kolmafia.AscensionClass;
+import net.sourceforge.kolmafia.Modifiers;
 
-public class StringModifier implements Modifier {
+public enum StringModifier implements Modifier {
+    CLASS(
+        "Class",
+          new Pattern[] {
+    Pattern.compile("Only (.*?) may use this item"),
+      Pattern.compile("Bonus for (.*?) only"),
+      Pattern.compile("Bonus&nbsp;for&nbsp;(.*?)&nbsp;only"),
+  },
+    Pattern.compile("Class: \"(.*?)\"")),
+    INTRINSIC_EFFECT(
+        "Intrinsic Effect",
+    Pattern.compile("Intrinsic Effect: <a.*?><font color=blue>(.*)</font></a>"),
+        Pattern.compile("Intrinsic Effect: \"(.*?)\"")),
+          EQUALIZE("Equalize", Pattern.compile("Equalize: \"(.*?)\"")),
+    WIKI_NAME("Wiki Name", Pattern.compile("Wiki Name: \"(.*?)\"")),
+    MODIFIERS("Modifiers", Pattern.compile("^(none)$")),
+    OUTFIT("Outfit", null),
+    STAT_TUNING("Stat Tuning", Pattern.compile("Stat Tuning: \"(.*?)\"")),
+    EFFECT("Effect", Pattern.compile("(?:^|, )Effect: \"(.*?)\"")),
+    EQUIPS_ON("Equips On", Pattern.compile("Equips On: \"(.*?)\"")),
+    FAMILIAR_EFFECT("Familiar Effect", Pattern.compile("Familiar Effect: \"(.*?)\"")),
+    JIGGLE(
+        "Jiggle", Pattern.compile("Jiggle: *(.*?)$"), Pattern.compile("Jiggle: \"(.*?)\"")),
+    EQUALIZE_MUSCLE("Equalize Muscle", Pattern.compile("Equalize Muscle: \"(.*?)\"")),
+    EQUALIZE_MYST("Equalize Mysticality", Pattern.compile("Equalize Mysticality: \"(.*?)\"")),
+    EQUALIZE_MOXIE("Equalize Moxie", Pattern.compile("Equalize Moxie: \"(.*?)\"")),
+    AVATAR(
+        "Avatar",
+          new Pattern[] {
+    Pattern.compile("Makes you look like (?:a |an |the )?(.++)(?<!doctor|gross doctor)"),
+      Pattern.compile("Te hace ver como un (.++)"),
+  },
+    Pattern.compile("Avatar: \"(.*?)\"")),
+    ROLLOVER_EFFECT(
+        "Rollover Effect",
+    Pattern.compile("Adventures of <b><a.*?>(.*)</a></b> at Rollover"),
+        Pattern.compile("Rollover Effect: \"(.*?)\"")),
+          SKILL(
+        "Skill",
+    Pattern.compile("Grants Skill:.*?<b>(.*?)</b>"),
+        Pattern.compile("Skill: \"(.*?)\"")),
+          FLOOR_BUFFED_MUSCLE("Floor Buffed Muscle", Pattern.compile("Floor Buffed Muscle: \"(.*?)\"")),
+    FLOOR_BUFFED_MYST(
+        "Floor Buffed Mysticality", Pattern.compile("Floor Buffed Mysticality: \"(.*?)\"")),
+    FLOOR_BUFFED_MOXIE("Floor Buffed Moxie", Pattern.compile("Floor Buffed Moxie: \"(.*?)\"")),
+    PLUMBER_STAT("Plumber Stat", Pattern.compile("Plumber Stat: \"(.*?)\"")),
+    RECIPE("Recipe", Pattern.compile("Recipe: \"(.*?)\""));
   private final String name;
   private final Pattern[] descPatterns;
   private final Pattern tagPattern;
 
-  public StringModifier(String name, Pattern tagPattern) {
+  StringModifier(String name, Pattern tagPattern) {
     this(name, (Pattern[]) null, tagPattern);
   }
 
-  public StringModifier(String name, Pattern descPattern, Pattern tagPattern) {
+  StringModifier(String name, Pattern descPattern, Pattern tagPattern) {
     this(name, new Pattern[] {descPattern}, tagPattern);
   }
 
-  public StringModifier(String name, Pattern[] descPatterns, Pattern tagPattern) {
+  StringModifier(String name, Pattern[] descPatterns, Pattern tagPattern) {
     this.name = name;
     this.descPatterns = descPatterns;
     this.tagPattern = tagPattern;
@@ -39,5 +92,99 @@ public class StringModifier implements Modifier {
   @Override
   public String getTag() {
     return name;
+  }
+
+  private static final Map<String, StringModifier> caselessNameToModifier =
+    Arrays.stream(values())
+      .collect(Collectors.toMap(type -> type.name.toLowerCase(), Function.identity()));
+
+  // equivalent to `Modifiers.findName`
+  public static StringModifier byCaselessName(String name) {
+    return caselessNameToModifier.get(name.toLowerCase());
+  }
+
+  // equivalent to `Modifiers.findModifier`
+  public static StringModifier byTagPattern(final String tag) {
+    for (var modifier : values()) {
+      Pattern pattern = modifier.getTagPattern();
+      if (pattern == null) {
+        continue;
+      }
+
+      Matcher matcher = pattern.matcher(tag);
+      if (matcher.find()) {
+        return modifier;
+      }
+    }
+    return null;
+  }
+
+  // equivalent to `Modifiers.parseModifier`
+  public static String parseModifier(final String enchantment) {
+    String quote = "\"";
+
+    for (var mod : values()) {
+      Pattern[] patterns = mod.getDescPatterns();
+
+      if (patterns == null) {
+        continue;
+      }
+
+      for (Pattern pattern : patterns) {
+        Matcher matcher = pattern.matcher(enchantment);
+        if (!matcher.find()) {
+          continue;
+        }
+
+        String tag = mod.getTag();
+
+        if (matcher.groupCount() == 0) {
+          return tag;
+        }
+
+        String value = matcher.group(1);
+
+        if (mod == StringModifier.CLASS) {
+          value = StringModifier.depluralizeClassName(value);
+        }
+
+        return tag + ": " + quote + value.trim() + quote;
+      }
+    }
+
+    return null;
+  }
+
+  private static final String[][] classStrings = {
+    {
+      AscensionClass.SEAL_CLUBBER.getName(), "Seal Clubbers", "Seal&nbsp;Clubbers",
+    },
+    {
+      AscensionClass.TURTLE_TAMER.getName(), "Turtle Tamers", "Turtle&nbsp;Tamers",
+    },
+    {
+      AscensionClass.PASTAMANCER.getName(), "Pastamancers",
+    },
+    {
+      AscensionClass.SAUCEROR.getName(), "Saucerors",
+    },
+    {
+      AscensionClass.DISCO_BANDIT.getName(), "Disco Bandits", "Disco&nbsp;Bandits",
+    },
+    {
+      AscensionClass.ACCORDION_THIEF.getName(), "Accordion Thieves", "Accordion&nbsp;Thieves",
+    },
+  };
+
+  public static String depluralizeClassName(final String string) {
+    for (String[] results : classStrings) {
+      String result = results[0];
+      for (String candidate : results) {
+        if (candidate.equals(string)) {
+          return result;
+        }
+      }
+    }
+    return string;
   }
 }

--- a/src/net/sourceforge/kolmafia/modifiers/StringModifierCollection.java
+++ b/src/net/sourceforge/kolmafia/modifiers/StringModifierCollection.java
@@ -15,7 +15,8 @@ public class StringModifierCollection {
   }
 
   public boolean set(StringModifier modifier, String value) {
-    String oldValue = value.isEmpty() ? this.strings.remove(modifier) : this.strings.put(modifier, value);
+    String oldValue =
+        value.isEmpty() ? this.strings.remove(modifier) : this.strings.put(modifier, value);
 
     // TODO: does anything use this return value, or can we save ourselves a check?
     return oldValue == null || !oldValue.equals(value);

--- a/src/net/sourceforge/kolmafia/modifiers/StringModifierCollection.java
+++ b/src/net/sourceforge/kolmafia/modifiers/StringModifierCollection.java
@@ -1,0 +1,23 @@
+package net.sourceforge.kolmafia.modifiers;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public class StringModifierCollection {
+  private final Map<StringModifier, String> strings = new EnumMap<>(StringModifier.class);
+
+  public void reset() {
+    this.strings.clear();
+  }
+
+  public String get(final StringModifier mod) {
+    return this.strings.getOrDefault(mod, "");
+  }
+
+  public boolean set(StringModifier modifier, String value) {
+    String oldValue = value.isEmpty() ? this.strings.remove(modifier) : this.strings.put(modifier, value);
+
+    // TODO: does anything use this return value, or can we save ourselves a check?
+    return oldValue == null || !oldValue.equals(value);
+  }
+}

--- a/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
@@ -31,6 +31,7 @@ import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.VYKEACompanionData;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.ConcoctionPool;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
@@ -2129,7 +2130,7 @@ public class ItemDatabase {
         Modifiers.parseModifiers(ModifierType.ITEM, ItemPool.VAMPIRE_VINTNER_WINE, iEnchantments);
 
     // Validate this by seeing what effect this wine grants.
-    String effectName = imods.getString("Effect");
+    String effectName = imods.getString(StringModifier.EFFECT);
     int effectId = EffectDatabase.getEffectId(effectName);
 
     // If it doesn't grant one, this is the generic 1950 Vampire Vintner wine

--- a/src/net/sourceforge/kolmafia/request/CharPaneRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CharPaneRequest.java
@@ -21,6 +21,7 @@ import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.VYKEACompanionData;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -497,10 +498,10 @@ public class CharPaneRequest extends GenericRequest {
     }
 
     Modifiers mods = KoLCharacter.getCurrentModifiers();
-    boolean equalize = mods.getString(Modifiers.EQUALIZE).length() != 0;
-    boolean mus_equalize = mods.getString(Modifiers.EQUALIZE_MUSCLE).length() != 0;
-    boolean mys_equalize = mods.getString(Modifiers.EQUALIZE_MYST).length() != 0;
-    boolean mox_equalize = mods.getString(Modifiers.EQUALIZE_MOXIE).length() != 0;
+    boolean equalize = mods.getString(StringModifier.EQUALIZE).length() != 0;
+    boolean mus_equalize = mods.getString(StringModifier.EQUALIZE_MUSCLE).length() != 0;
+    boolean mys_equalize = mods.getString(StringModifier.EQUALIZE_MYST).length() != 0;
+    boolean mox_equalize = mods.getString(StringModifier.EQUALIZE_MOXIE).length() != 0;
     boolean mus_limit = (int) mods.get(DoubleModifier.MUS_LIMIT) != 0;
     boolean mys_limit = (int) mods.get(DoubleModifier.MYS_LIMIT) != 0;
     boolean mox_limit = (int) mods.get(DoubleModifier.MOX_LIMIT) != 0;

--- a/src/net/sourceforge/kolmafia/session/GreyYouManager.java
+++ b/src/net/sourceforge/kolmafia/session/GreyYouManager.java
@@ -16,6 +16,7 @@ import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.MonsterData;
 import net.sourceforge.kolmafia.RequestLogger;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
@@ -520,7 +521,7 @@ public abstract class GreyYouManager {
       if (this.skillType == SkillType.PASSIVE) {
         mods = Modifiers.getModifiers(ModifierType.SKILL, this.name);
         if (mods != null) {
-          this.enchantments = mods.getString("Modifiers");
+          this.enchantments = mods.getString(StringModifier.MODIFIERS);
           this.modsLookup = mods.getLookup();
         } else {
           // This would be a KoLmafia bug.

--- a/src/net/sourceforge/kolmafia/session/LocketManager.java
+++ b/src/net/sourceforge/kolmafia/session/LocketManager.java
@@ -119,7 +119,8 @@ public class LocketManager {
 
     // ... grab the raw mod string for the locket from modifiers.txt...
     var locketModString =
-        Modifiers.getItemModifiers(ItemPool.COMBAT_LOVERS_LOCKET).getString(StringModifier.MODIFIERS);
+        Modifiers.getItemModifiers(ItemPool.COMBAT_LOVERS_LOCKET)
+            .getString(StringModifier.MODIFIERS);
 
     String phylum = "";
 

--- a/src/net/sourceforge/kolmafia/session/LocketManager.java
+++ b/src/net/sourceforge/kolmafia/session/LocketManager.java
@@ -13,6 +13,7 @@ import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.MonsterData;
 import net.sourceforge.kolmafia.RequestThread;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.DebugDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -118,7 +119,7 @@ public class LocketManager {
 
     // ... grab the raw mod string for the locket from modifiers.txt...
     var locketModString =
-        Modifiers.getItemModifiers(ItemPool.COMBAT_LOVERS_LOCKET).getString(Modifiers.MODIFIERS);
+        Modifiers.getItemModifiers(ItemPool.COMBAT_LOVERS_LOCKET).getString(StringModifier.MODIFIERS);
 
     String phylum = "";
 

--- a/src/net/sourceforge/kolmafia/session/TowerDoorManager.java
+++ b/src/net/sourceforge/kolmafia/session/TowerDoorManager.java
@@ -14,6 +14,7 @@ import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
@@ -114,7 +115,7 @@ public abstract class TowerDoorManager {
 
     public String keyEnchantments() {
       Modifiers mods = Modifiers.getItemModifiers(key.getItemId());
-      return mods == null ? "" : mods.getString("Modifiers");
+      return mods == null ? "" : mods.getString(StringModifier.MODIFIERS);
     }
   }
 

--- a/src/net/sourceforge/kolmafia/session/YouRobotManager.java
+++ b/src/net/sourceforge/kolmafia/session/YouRobotManager.java
@@ -16,6 +16,7 @@ import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.listener.NamedListenerRegistry;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
@@ -241,7 +242,7 @@ public abstract class YouRobotManager {
     RobotUpgrade(String name, Part part, int index, int cost) {
       this(name, part, Effect.PASSIVE, cost);
       this.index = index;
-      this.string = this.mods.getString("Modifiers");
+      this.string = this.mods.getString(StringModifier.MODIFIERS);
       addToIndexMaps();
     }
 
@@ -266,7 +267,7 @@ public abstract class YouRobotManager {
     RobotUpgrade(String name, String keyword, int cost) {
       this(name, Part.CPU, Effect.PASSIVE, cost);
       this.keyword = keyword;
-      this.string = this.mods.getString("Modifiers");
+      this.string = this.mods.getString(StringModifier.MODIFIERS);
       addToIndexMaps();
     }
 

--- a/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
@@ -192,7 +192,7 @@ public class GearChangePanel extends JPanel {
     for (var mod : Modifiers.DOUBLE_MODIFIERS) {
       double val = mods.get(mod);
       if (val == 0.0f) continue;
-      name = Modifiers.getModifierName(mod);
+      name = mod.getName();
       name = StringUtilities.singleStringReplace(name, "Familiar", "Fam");
       name = StringUtilities.singleStringReplace(name, "Experience", "Exp");
       name = StringUtilities.singleStringReplace(name, "Damage", "Dmg");
@@ -233,7 +233,7 @@ public class GearChangePanel extends JPanel {
 
       String strval = mods.getString(mod);
       if (strval.equals("")) continue;
-      name = Modifiers.getStringModifierName(mod);
+      name = mod.getName();
       name = StringUtilities.singleStringReplace(name, "Familiar", "Fam");
       if (anyBool) {
         buff.append(", ");

--- a/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
@@ -39,6 +39,7 @@ import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.SpecialOutfit;
 import net.sourceforge.kolmafia.listener.Listener;
 import net.sourceforge.kolmafia.listener.NamedListenerRegistry;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
@@ -176,7 +177,7 @@ public class GearChangePanel extends JPanel {
       return buff;
     }
 
-    String name = mods.getString(Modifiers.INTRINSIC_EFFECT);
+    String name = mods.getString(StringModifier.INTRINSIC_EFFECT);
     if (name.length() > 0) {
       Modifiers newMods = new Modifiers();
       newMods.add(mods);
@@ -222,17 +223,17 @@ public class GearChangePanel extends JPanel {
       buff.append(Modifiers.getBooleanModifierName(i));
     }
 
-    for (int i = 1; i < Modifiers.STRING_MODIFIERS; ++i) {
-      if (i == Modifiers.WIKI_NAME
-          || i == Modifiers.MODIFIERS
-          || i == Modifiers.OUTFIT
-          || i == Modifiers.FAMILIAR_EFFECT) {
+    for (var mod : Modifiers.STRING_MODIFIERS) {
+      if (mod == StringModifier.WIKI_NAME
+          || mod == StringModifier.MODIFIERS
+          || mod == StringModifier.OUTFIT
+          || mod == StringModifier.FAMILIAR_EFFECT) {
         continue;
       }
 
-      String strval = mods.getString(i);
+      String strval = mods.getString(mod);
       if (strval.equals("")) continue;
-      name = Modifiers.getStringModifierName(i);
+      name = Modifiers.getStringModifierName(mod);
       name = StringUtilities.singleStringReplace(name, "Familiar", "Fam");
       if (anyBool) {
         buff.append(", ");

--- a/src/net/sourceforge/kolmafia/swingui/widget/TableCellFactory.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/TableCellFactory.java
@@ -429,7 +429,7 @@ public class TableCellFactory {
     for (var mod : Modifiers.DOUBLE_MODIFIERS) {
       double val = mods.get(mod);
       if (val == 0.0) continue;
-      name = Modifiers.getModifierName(mod);
+      name = mod.getName();
       name = StringUtilities.singleStringReplace(name, "Familiar", "Fam");
       name = StringUtilities.singleStringReplace(name, "Experience", "Exp");
       name = StringUtilities.singleStringReplace(name, "Damage", "Dmg");

--- a/src/net/sourceforge/kolmafia/swingui/widget/TableCellFactory.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/TableCellFactory.java
@@ -7,6 +7,7 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.Modifiers;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.persistence.ConsumablesDatabase;
 import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
@@ -412,7 +413,7 @@ public class TableCellFactory {
     if (mods == null) {
       return null;
     }
-    String name = mods.getString(Modifiers.INTRINSIC_EFFECT);
+    String name = mods.getString(StringModifier.INTRINSIC_EFFECT);
     if (name.length() > 0) {
       Modifiers newMods = new Modifiers();
       newMods.add(mods);

--- a/src/net/sourceforge/kolmafia/textui/command/AccordionsCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AccordionsCommand.java
@@ -9,6 +9,7 @@ import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -140,7 +141,7 @@ public class AccordionsCommand extends AbstractCommand {
           // Special case to prevent stretching table way wide
           this.enchantments = "Prismatic Damage: [2*(1+skill(Accordion Appreciation))]";
         } else {
-          String enchantments = mods.getString("Modifiers");
+          String enchantments = mods.getString(StringModifier.MODIFIERS);
           enchantments = Modifiers.trimModifiers(enchantments, "Class");
           enchantments = Modifiers.trimModifiers(enchantments, "Song Duration");
           this.enchantments = enchantments;

--- a/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
@@ -18,7 +18,7 @@ public class ModRefCommand extends AbstractCommand {
         new StringBuilder(
             "<table border=2>" + "<tr><td colspan=" + colSpan + ">NUMERIC MODIFIERS</td></tr>");
     for (var mod : Modifiers.DOUBLE_MODIFIERS) {
-      String modName = Modifiers.getModifierName(mod);
+      String modName = mod.getName();
       buf.append("<tr><td>");
       buf.append(modName);
       buf.append("</td><td>");
@@ -63,7 +63,7 @@ public class ModRefCommand extends AbstractCommand {
     }
     buf.append("<tr><td colspan=").append(colSpan).append(">STRING MODIFIERS</td></tr>");
     for (var modifier : Modifiers.STRING_MODIFIERS) {
-      String mod = Modifiers.getStringModifierName(modifier);
+      String mod = modifier.getName();
       buf.append("<tr><td>");
       buf.append(mod);
       buf.append("</td><td>");

--- a/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
@@ -62,8 +62,8 @@ public class ModRefCommand extends AbstractCommand {
       buf.append("</td></tr>");
     }
     buf.append("<tr><td colspan=").append(colSpan).append(">STRING MODIFIERS</td></tr>");
-    for (int i = 0; i < Modifiers.STRING_MODIFIERS; i++) {
-      String mod = Modifiers.getStringModifierName(i);
+    for (var modifier : Modifiers.STRING_MODIFIERS) {
+      String mod = Modifiers.getStringModifierName(modifier);
       buf.append("<tr><td>");
       buf.append(mod);
       buf.append("</td><td>");

--- a/src/net/sourceforge/kolmafia/textui/command/SpeculateCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/SpeculateCommand.java
@@ -63,8 +63,8 @@ public class SpeculateCommand extends AbstractCommand {
       buf.append(now);
       buf.append("</td></tr>");
     }
-    for (int i = 0; i < Modifiers.STRING_MODIFIERS; i++) {
-      String mod = Modifiers.getStringModifierName(i);
+    for (var modifier : Modifiers.STRING_MODIFIERS) {
+      String mod = Modifiers.getStringModifierName(modifier);
       String was = KoLCharacter.currentStringModifier(mod);
       String now = mods.getString(mod);
       if (now.equals(was)) {

--- a/src/net/sourceforge/kolmafia/textui/command/SpeculateCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/SpeculateCommand.java
@@ -39,7 +39,7 @@ public class SpeculateCommand extends AbstractCommand {
     buf.append(">");
     int len = buf.length();
     for (var mod : Modifiers.DOUBLE_MODIFIERS) {
-      String modName = Modifiers.getModifierName(mod);
+      String modName = mod.getName();
       doNumeric(modName, mods, buf);
     }
     for (int i = 0; i < Modifiers.DERIVED_MODIFIERS; i++) {
@@ -64,7 +64,7 @@ public class SpeculateCommand extends AbstractCommand {
       buf.append("</td></tr>");
     }
     for (var modifier : Modifiers.STRING_MODIFIERS) {
-      String mod = Modifiers.getStringModifierName(modifier);
+      String mod = modifier.getName();
       String was = KoLCharacter.currentStringModifier(mod);
       String now = mods.getString(mod);
       if (now.equals(was)) {

--- a/src/net/sourceforge/kolmafia/utilities/WikiUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/WikiUtilities.java
@@ -6,6 +6,7 @@ import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.MonsterData;
 import net.sourceforge.kolmafia.maximizer.Boost;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase.QueuedConcoction;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
@@ -44,7 +45,7 @@ public class WikiUtilities {
 
       Modifiers mods = Modifiers.getModifiers(modType, name);
       if (mods != null) {
-        String wikiname = mods.getString("Wiki Name");
+        String wikiname = mods.getString(StringModifier.WIKI_NAME);
         if (wikiname != null && wikiname.length() > 0) {
           name = wikiname;
           checkOtherTables = false;

--- a/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
@@ -15,6 +15,7 @@ import net.sourceforge.kolmafia.KoLConstants.CraftingType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.Speculation;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
@@ -1502,14 +1503,14 @@ public abstract class UseLinkDecorator {
   private static String getPotionSpeculation(String label, int itemId) {
     Modifiers mods = Modifiers.getItemModifiers(itemId);
     if (mods == null) return label;
-    String effect = mods.getString(Modifiers.EFFECT);
+    String effect = mods.getString(StringModifier.EFFECT);
     if (effect.equals("")) return label;
     int duration = (int) mods.get(DoubleModifier.EFFECT_DURATION);
     int effectId = EffectDatabase.getEffectId(effect);
     Speculation spec = new Speculation();
     spec.addEffect(EffectPool.get(effectId, Math.max(1, duration)));
     mods = spec.calculate();
-    mods.setString(Modifiers.EFFECT, effect);
+    mods.setString(StringModifier.EFFECT, effect);
     if (duration > 0) {
       mods.setDouble(DoubleModifier.EFFECT_DURATION, (float) duration);
     }

--- a/src/net/sourceforge/kolmafia/webui/ValhallaDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/ValhallaDecorator.java
@@ -9,6 +9,7 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RestrictedItemType;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.DateTimeManager;
@@ -537,7 +538,7 @@ public class ValhallaDecorator {
         if (name.startsWith("folder (")) {
           Modifiers mods = Modifiers.getItemModifiers(folder.getItemId());
           name = name.substring(8, name.indexOf(")"));
-          enchantments = mods != null ? mods.getString("Modifiers") : "none";
+          enchantments = mods != null ? mods.getString(StringModifier.MODIFIERS) : "none";
         } else {
           name = "(empty)";
           enchantments = "none";

--- a/test/net/sourceforge/kolmafia/DebugModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/DebugModifiersTest.java
@@ -75,7 +75,7 @@ public class DebugModifiersTest {
   }
 
   private void evaluateDebugModifiers(DoubleModifier index) {
-    evaluateDebugModifiers(Modifiers.getModifierName(index));
+    evaluateDebugModifiers(index.getName());
   }
 
   @Test


### PR DESCRIPTION
Much easier than doubles. Might try some perf improvements, now that this is detracting:
* I think we can inline every function call that only calls a different function
* We can probably avoid doing the null checks most of the time, especially for constants
* stat-modifying intrinsic effects on equipment were removed in 2012, so code dealing with that (e.g. in the maximizer) can also be removed