### PR TITLE
Add sparse/dense optimization to DoubleModifierCollection.

### DIFF
--- a/src/net/sourceforge/kolmafia/modifiers/DoubleModifierCollection.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DoubleModifierCollection.java
@@ -2,13 +2,25 @@ package net.sourceforge.kolmafia.modifiers;
 
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.BiConsumer;
 
 public class DoubleModifierCollection {
-  private final Map<DoubleModifier, Double> doubles = new EnumMap<>(DoubleModifier.class);
+  public static final int SPARSE_DOUBLES_MAX_SIZE = 32;
+
+  // If only a few values are set in doubles, we instead store all modifiers in a sparse TreeMap.
+  // When that map gets bigger than SPARSE_DOUBLES_MAX_SIZE, we copy it over to the dense EnumMap.
+  private Map<DoubleModifier, Double> doubles = new TreeMap<>();
 
   public void reset() {
-    this.doubles.clear();
+    this.doubles = new TreeMap<>();
+  }
+
+  public void densify() {
+    if (this.doubles instanceof EnumMap) return;
+    Map<DoubleModifier, Double> newDoubles = new EnumMap<>(DoubleModifier.class);
+    newDoubles.putAll(this.doubles);
+    this.doubles = newDoubles;
   }
 
   public double get(final DoubleModifier mod) {
@@ -18,11 +30,17 @@ public class DoubleModifierCollection {
   public boolean set(final DoubleModifier mod, final double value) {
     Double oldValue = value == 0.0 ? this.doubles.remove(mod) : this.doubles.put(mod, value);
 
+    if (this.doubles.size() >= DoubleModifierCollection.SPARSE_DOUBLES_MAX_SIZE) {
+      this.densify();
+    }
+
     // TODO: does anything use this return value, or can we save ourselves a check?
     return oldValue == null || oldValue != value;
   }
 
   public double add(final DoubleModifier mod, final double value) {
+    // Anything being accumulated onto should be dense.
+    this.densify();
     return this.doubles.merge(mod, value, Double::sum);
   }
 


### PR DESCRIPTION
This gets back some of the performance gains from sparse modifier collections, but not all for some reason. Might just be the increased indirection from using an enum rather than an int.