### PR TITLE
refactor: make derived modifiers an enum

### DIFF
--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -270,25 +271,11 @@ public class Modifiers {
     }
   }
 
-  // Indexes for array returned by predict():
-  public static final int BUFFED_MUS = 0;
-  public static final int BUFFED_MYS = 1;
-  public static final int BUFFED_MOX = 2;
-  public static final int BUFFED_HP = 3;
-  public static final int BUFFED_MP = 4;
+  public static final Set<DerivedModifier> DERIVED_MODIFIERS =
+      Collections.unmodifiableSet(EnumSet.allOf(DerivedModifier.class));
 
-  private static final DerivedModifier[] derivedModifiers = {
-    new DerivedModifier("Buffed Muscle"),
-    new DerivedModifier("Buffed Mysticality"),
-    new DerivedModifier("Buffed Moxie"),
-    new DerivedModifier("Buffed HP Maximum"),
-    new DerivedModifier("Buffed MP Maximum"),
-  };
-
-  public static final int DERIVED_MODIFIERS = Modifiers.derivedModifiers.length;
-
-  public int[] predict() {
-    int[] rv = new int[Modifiers.DERIVED_MODIFIERS];
+  public Map<DerivedModifier, Integer> predict() {
+    Map<DerivedModifier, Integer> rv = new EnumMap<>(DerivedModifier.class);
 
     int mus = KoLCharacter.getBaseMuscle();
     int mys = KoLCharacter.getBaseMysticality();
@@ -338,47 +325,56 @@ public class Modifiers {
       mox = mox_limit;
     }
 
-    rv[Modifiers.BUFFED_MUS] =
+    rv.put(
+        DerivedModifier.BUFFED_MUS,
         mus
             + (int) this.get(DoubleModifier.MUS)
-            + (int) Math.ceil(this.get(DoubleModifier.MUS_PCT) * mus / 100.0);
-    rv[Modifiers.BUFFED_MYS] =
+            + (int) Math.ceil(this.get(DoubleModifier.MUS_PCT) * mus / 100.0));
+    rv.put(
+        DerivedModifier.BUFFED_MYS,
         mys
             + (int) this.get(DoubleModifier.MYS)
-            + (int) Math.ceil(this.get(DoubleModifier.MYS_PCT) * mys / 100.0);
-    rv[Modifiers.BUFFED_MOX] =
+            + (int) Math.ceil(this.get(DoubleModifier.MYS_PCT) * mys / 100.0));
+    rv.put(
+        DerivedModifier.BUFFED_MOX,
         mox
             + (int) this.get(DoubleModifier.MOX)
-            + (int) Math.ceil(this.get(DoubleModifier.MOX_PCT) * mox / 100.0);
+            + (int) Math.ceil(this.get(DoubleModifier.MOX_PCT) * mox / 100.0));
 
     String mus_buffed_floor = this.getString(StringModifier.FLOOR_BUFFED_MUSCLE);
     if (mus_buffed_floor.startsWith("Mys")) {
-      if (rv[Modifiers.BUFFED_MYS] > rv[Modifiers.BUFFED_MUS]) {
-        rv[Modifiers.BUFFED_MUS] = rv[Modifiers.BUFFED_MYS];
+      var mod = rv.get(DerivedModifier.BUFFED_MYS);
+      if (mod > rv.get(DerivedModifier.BUFFED_MUS)) {
+        rv.put(DerivedModifier.BUFFED_MUS, mod);
       }
     } else if (mus_buffed_floor.startsWith("Mox")) {
-      if (rv[Modifiers.BUFFED_MOX] > rv[Modifiers.BUFFED_MUS]) {
-        rv[Modifiers.BUFFED_MUS] = rv[Modifiers.BUFFED_MOX];
+      var mod = rv.get(DerivedModifier.BUFFED_MOX);
+      if (mod > rv.get(DerivedModifier.BUFFED_MUS)) {
+        rv.put(DerivedModifier.BUFFED_MUS, mod);
       }
     }
     String mys_buffed_floor = this.getString(StringModifier.FLOOR_BUFFED_MYST);
     if (mys_buffed_floor.startsWith("Mus")) {
-      if (rv[Modifiers.BUFFED_MUS] > rv[Modifiers.BUFFED_MYS]) {
-        rv[Modifiers.BUFFED_MYS] = rv[Modifiers.BUFFED_MUS];
+      var mod = rv.get(DerivedModifier.BUFFED_MUS);
+      if (mod > rv.get(DerivedModifier.BUFFED_MYS)) {
+        rv.put(DerivedModifier.BUFFED_MYS, mod);
       }
     } else if (mys_buffed_floor.startsWith("Mox")) {
-      if (rv[Modifiers.BUFFED_MOX] > rv[Modifiers.BUFFED_MYS]) {
-        rv[Modifiers.BUFFED_MYS] = rv[Modifiers.BUFFED_MOX];
+      var mod = rv.get(DerivedModifier.BUFFED_MOX);
+      if (mod > rv.get(DerivedModifier.BUFFED_MYS)) {
+        rv.put(DerivedModifier.BUFFED_MYS, mod);
       }
     }
     String mox_buffed_floor = this.getString(StringModifier.FLOOR_BUFFED_MOXIE);
     if (mox_buffed_floor.startsWith("Mus")) {
-      if (rv[Modifiers.BUFFED_MUS] > rv[Modifiers.BUFFED_MOX]) {
-        rv[Modifiers.BUFFED_MOX] = rv[Modifiers.BUFFED_MUS];
+      var mod = rv.get(DerivedModifier.BUFFED_MUS);
+      if (mod > rv.get(DerivedModifier.BUFFED_MOX)) {
+        rv.put(DerivedModifier.BUFFED_MOX, mod);
       }
     } else if (mox_buffed_floor.startsWith("Mys")) {
-      if (rv[Modifiers.BUFFED_MYS] > rv[Modifiers.BUFFED_MOX]) {
-        rv[Modifiers.BUFFED_MOX] = rv[Modifiers.BUFFED_MYS];
+      var mod = rv.get(DerivedModifier.BUFFED_MYS);
+      if (mod > rv.get(DerivedModifier.BUFFED_MOX)) {
+        rv.put(DerivedModifier.BUFFED_MOX, mod);
       }
     }
 
@@ -400,13 +396,13 @@ public class Modifiers {
       hp = hpbase + (int) this.get(DoubleModifier.HP);
       buffedHP = hp;
     } else {
-      hpbase = rv[Modifiers.BUFFED_MUS] + 3;
+      hpbase = rv.get(DerivedModifier.BUFFED_MUS) + 3;
       double C = KoLCharacter.isMuscleClass() ? 1.5 : 1.0;
       double hpPercent = this.get(DoubleModifier.HP_PCT);
       hp = (int) Math.ceil(hpbase * (C + hpPercent / 100.0)) + (int) this.get(DoubleModifier.HP);
       buffedHP = Math.max(hp, mus);
     }
-    rv[Modifiers.BUFFED_HP] = buffedHP;
+    rv.put(DerivedModifier.BUFFED_HP, buffedHP);
 
     int mpbase;
     int mp;
@@ -418,18 +414,18 @@ public class Modifiers {
       mp = mpbase + (int) this.get(DoubleModifier.MP);
       buffedMP = mp;
     } else {
-      mpbase = rv[Modifiers.BUFFED_MYS];
+      mpbase = rv.get(DerivedModifier.BUFFED_MYS);
       if (this.getBoolean(Modifiers.MOXIE_CONTROLS_MP)
           || (this.getBoolean(Modifiers.MOXIE_MAY_CONTROL_MP)
-              && rv[Modifiers.BUFFED_MOX] > mpbase)) {
-        mpbase = rv[Modifiers.BUFFED_MOX];
+              && rv.get(DerivedModifier.BUFFED_MOX) > mpbase)) {
+        mpbase = rv.get(DerivedModifier.BUFFED_MOX);
       }
       double C = KoLCharacter.isMysticalityClass() ? 1.5 : 1.0;
       double mpPercent = this.get(DoubleModifier.MP_PCT);
       mp = (int) Math.ceil(mpbase * (C + mpPercent / 100.0)) + (int) this.get(DoubleModifier.MP);
       buffedMP = Math.max(mp, mys);
     }
-    rv[Modifiers.BUFFED_MP] = buffedMP;
+    rv.put(DerivedModifier.BUFFED_MP, buffedMP);
 
     return rv;
   }
@@ -497,10 +493,6 @@ public class Modifiers {
 
   public static final String getBooleanModifierName(final int index) {
     return Modifiers.booleanModifiers[index].getName();
-  }
-
-  public static final String getDerivedModifierName(final int index) {
-    return Modifiers.derivedModifiers[index].getName();
   }
 
   private static final String COLD = DoubleModifier.COLD_RESISTANCE.getTag() + ": ";
@@ -682,11 +674,11 @@ public class Modifiers {
 
     DoubleModifier modifier = Modifiers.findName(name);
     if (modifier == null) {
-      int index = Modifiers.findName(Modifiers.derivedModifiers, name);
-      if (index < 0 || index >= Modifiers.DERIVED_MODIFIERS) {
+      DerivedModifier derived = DerivedModifier.byCaselessName(name);
+      if (derived == null) {
         return this.getBitmap(name);
       }
-      return this.predict()[index];
+      return this.predict().get(derived);
     }
 
     return this.doubles.get(modifier);

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -27,6 +27,7 @@ import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.SpecialOutfit;
+import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifierCollection;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
@@ -715,7 +716,7 @@ public class Evaluator {
   public double getScore(Modifiers mods, AdventureResult[] equipment) {
     this.failed = false;
     this.exceeded = false;
-    int[] predicted = mods.predict();
+    var predicted = mods.predict();
 
     double score = 0.0;
     for (var mod : Modifiers.DOUBLE_MODIFIERS) {
@@ -726,13 +727,13 @@ public class Evaluator {
       double max = this.max.get(mod);
       switch (mod) {
         case MUS:
-          val = predicted[Modifiers.BUFFED_MUS];
+          val = predicted.get(DerivedModifier.BUFFED_MUS);
           break;
         case MYS:
-          val = predicted[Modifiers.BUFFED_MYS];
+          val = predicted.get(DerivedModifier.BUFFED_MYS);
           break;
         case MOX:
-          val = predicted[Modifiers.BUFFED_MOX];
+          val = predicted.get(DerivedModifier.BUFFED_MOX);
           break;
         case FAMILIAR_WEIGHT:
           val += mods.get(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT);
@@ -760,10 +761,10 @@ public class Evaluator {
                   + mods.get(DoubleModifier.SPORADIC_ITEMDROP);
           break;
         case HP:
-          val = predicted[Modifiers.BUFFED_HP];
+          val = predicted.get(DerivedModifier.BUFFED_HP);
           break;
         case MP:
-          val = predicted[Modifiers.BUFFED_MP];
+          val = predicted.get(DerivedModifier.BUFFED_MP);
           break;
         case WEAPON_DAMAGE:
           // Incorrect - needs to estimate base damage

--- a/src/net/sourceforge/kolmafia/modifiers/DerivedModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DerivedModifier.java
@@ -1,11 +1,21 @@
 package net.sourceforge.kolmafia.modifiers;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
-public class DerivedModifier implements Modifier {
+public enum DerivedModifier implements Modifier {
+  BUFFED_MUS("Buffed Muscle"),
+  BUFFED_MYS("Buffed Mysticality"),
+  BUFFED_MOX("Buffed Moxie"),
+  BUFFED_HP("Buffed HP Maximum"),
+  BUFFED_MP("Buffed MP Maximum");
+
   private final String name;
 
-  public DerivedModifier(String name) {
+  DerivedModifier(String name) {
     this.name = name;
   }
 
@@ -27,5 +37,14 @@ public class DerivedModifier implements Modifier {
   @Override
   public String getTag() {
     return null;
+  }
+
+  private static final Map<String, DerivedModifier> caselessNameToModifier =
+      Arrays.stream(values())
+          .collect(Collectors.toMap(type -> type.name.toLowerCase(), Function.identity()));
+
+  // equivalent to `Modifiers.findName`
+  public static DerivedModifier byCaselessName(String name) {
+    return caselessNameToModifier.get(name.toLowerCase());
   }
 }

--- a/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
@@ -17,6 +17,7 @@ import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.SpecialOutfit.Checkpoint;
 import net.sourceforge.kolmafia.Speculation;
+import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.moods.HPRestoreItemList;
 import net.sourceforge.kolmafia.moods.MoodManager;
@@ -814,20 +815,22 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
     }
 
     Speculation spec_old = new Speculation();
-    int[] predictions_old = spec_old.calculate().predict();
+    var predictions_old = spec_old.calculate().predict();
 
     Speculation spec = new Speculation();
     spec.equip(slotId, newItem);
-    int[] predictions = spec.calculate().predict();
+    var predictions = spec.calculate().predict();
 
     double MPgap = KoLCharacter.getMaximumMP() - KoLCharacter.getCurrentMP();
-    double deltaMP = predictions[Modifiers.BUFFED_MP] - predictions_old[Modifiers.BUFFED_MP];
+    double deltaMP =
+        predictions.get(DerivedModifier.BUFFED_MP) - predictions_old.get(DerivedModifier.BUFFED_MP);
     // Make sure we do not lose mp in the switch
     if (MPgap + deltaMP < 0) {
       return false;
     }
     // Make sure we do not reduce max hp in the switch, to avoid loops when casting a heal
-    if (predictions_old[Modifiers.BUFFED_HP] > predictions[Modifiers.BUFFED_HP]) {
+    if (predictions_old.get(DerivedModifier.BUFFED_HP)
+        > predictions.get(DerivedModifier.BUFFED_HP)) {
       return false;
     }
     // Don't allow if we'd lose a song in the switch

--- a/src/net/sourceforge/kolmafia/swingui/panel/CompactSidePane.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/CompactSidePane.java
@@ -36,6 +36,7 @@ import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.MonsterData;
 import net.sourceforge.kolmafia.listener.Listener;
 import net.sourceforge.kolmafia.listener.NamedListenerRegistry;
+import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -1295,10 +1296,10 @@ public class CompactSidePane extends JPanel implements Runnable {
 
   private static String modifierPopupText() {
     StringBuffer buf = new StringBuffer("<html><body><table border=1>");
-    int[] predicted = KoLCharacter.getCurrentModifiers().predict();
-    int mus = Math.max(1, predicted[Modifiers.BUFFED_MUS]);
-    int mys = Math.max(1, predicted[Modifiers.BUFFED_MYS]);
-    int mox = Math.max(1, predicted[Modifiers.BUFFED_MOX]);
+    var predicted = KoLCharacter.getCurrentModifiers().predict();
+    int mus = Math.max(1, predicted.get(DerivedModifier.BUFFED_MUS));
+    int mys = Math.max(1, predicted.get(DerivedModifier.BUFFED_MYS));
+    int mox = Math.max(1, predicted.get(DerivedModifier.BUFFED_MOX));
     int dmus = KoLCharacter.getAdjustedMuscle() - mus;
     int dmys = KoLCharacter.getAdjustedMysticality() - mys;
     int dmox = KoLCharacter.getAdjustedMoxie() - mox;
@@ -1317,8 +1318,8 @@ public class CompactSidePane extends JPanel implements Runnable {
       buf.append(KoLConstants.MODIFIER_FORMAT.format(dmox));
       buf.append(")</td></tr>");
     }
-    long hp = Math.max(1, predicted[Modifiers.BUFFED_HP]);
-    long mp = Math.max(1, predicted[Modifiers.BUFFED_MP]);
+    long hp = Math.max(1, predicted.get(DerivedModifier.BUFFED_HP));
+    long mp = Math.max(1, predicted.get(DerivedModifier.BUFFED_MP));
     long dhp = KoLCharacter.getMaximumHP() - hp;
     long dmp = KoLCharacter.getMaximumMP() - mp;
     if (dhp != 0 || dmp != 0) {

--- a/src/net/sourceforge/kolmafia/textui/command/SpeculateCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/SpeculateCommand.java
@@ -42,9 +42,9 @@ public class SpeculateCommand extends AbstractCommand {
       String modName = mod.getName();
       doNumeric(modName, mods, buf);
     }
-    for (int i = 0; i < Modifiers.DERIVED_MODIFIERS; i++) {
-      String mod = Modifiers.getDerivedModifierName(i);
-      doNumeric(mod, mods, buf);
+    for (var mod : Modifiers.DERIVED_MODIFIERS) {
+      String modName = mod.getName();
+      doNumeric(modName, mods, buf);
     }
     for (int i = 1; i < Modifiers.BITMAP_MODIFIERS; i++) {
       String mod = Modifiers.getBitmapModifierName(i);

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.java.dev.spellcast.utilities.DataUtilities;
 import net.sourceforge.kolmafia.AscensionPath.Path;
+import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
@@ -462,32 +463,32 @@ public class ModifiersTest {
 
         Modifiers mods = KoLCharacter.getCurrentModifiers();
         KoLCharacter.recalculateAdjustments(false);
-        int[] stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(155, stats[Modifiers.BUFFED_HP]);
+        var stats = mods.predict();
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(155, stats.get(DerivedModifier.BUFFED_HP));
 
         // viking helmet: (+1 muscle)
         EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(101, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(156, stats[Modifiers.BUFFED_HP]);
+        assertEquals(101, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(156, stats.get(DerivedModifier.BUFFED_HP));
 
         // reinforced beaded headband (+40 HP)
         EquipmentManager.setEquipment(
             EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(195, stats[Modifiers.BUFFED_HP]);
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(195, stats.get(DerivedModifier.BUFFED_HP));
 
         // extra-wide head candle (+100% HP)
         EquipmentManager.setEquipment(
             EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(258, stats[Modifiers.BUFFED_HP]);
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(258, stats.get(DerivedModifier.BUFFED_HP));
       }
     }
 
@@ -502,32 +503,32 @@ public class ModifiersTest {
 
         Modifiers mods = KoLCharacter.getCurrentModifiers();
         KoLCharacter.recalculateAdjustments(false);
-        int[] stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(103, stats[Modifiers.BUFFED_HP]);
+        var stats = mods.predict();
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(103, stats.get(DerivedModifier.BUFFED_HP));
 
         // viking helmet: (+1 muscle)
         EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(101, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(104, stats[Modifiers.BUFFED_HP]);
+        assertEquals(101, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(104, stats.get(DerivedModifier.BUFFED_HP));
 
         // reinforced beaded headband (+40 HP)
         EquipmentManager.setEquipment(
             EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(143, stats[Modifiers.BUFFED_HP]);
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(143, stats.get(DerivedModifier.BUFFED_HP));
 
         // extra-wide head candle (+100% HP)
         EquipmentManager.setEquipment(
             EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(206, stats[Modifiers.BUFFED_HP]);
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(206, stats.get(DerivedModifier.BUFFED_HP));
       }
     }
 
@@ -540,32 +541,32 @@ public class ModifiersTest {
 
         Modifiers mods = KoLCharacter.getCurrentModifiers();
         KoLCharacter.recalculateAdjustments(false);
-        int[] stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(100, stats[Modifiers.BUFFED_HP]);
+        var stats = mods.predict();
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_HP));
 
         // viking helmet: (+1 muscle)
         EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(101, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(100, stats[Modifiers.BUFFED_HP]);
+        assertEquals(101, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_HP));
 
         // reinforced beaded headband (+40 HP)
         EquipmentManager.setEquipment(
             EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(140, stats[Modifiers.BUFFED_HP]);
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(140, stats.get(DerivedModifier.BUFFED_HP));
 
         // extra-wide head candle (+100% HP)
         EquipmentManager.setEquipment(
             EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(100, stats[Modifiers.BUFFED_HP]);
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_HP));
       }
     }
 
@@ -578,32 +579,32 @@ public class ModifiersTest {
 
         Modifiers mods = KoLCharacter.getCurrentModifiers();
         KoLCharacter.recalculateAdjustments(false);
-        int[] stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(30, stats[Modifiers.BUFFED_HP]);
+        var stats = mods.predict();
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(30, stats.get(DerivedModifier.BUFFED_HP));
 
         // viking helmet: (+1 muscle)
         EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(101, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(30, stats[Modifiers.BUFFED_HP]);
+        assertEquals(101, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(30, stats.get(DerivedModifier.BUFFED_HP));
 
         // reinforced beaded headband (+40 HP)
         EquipmentManager.setEquipment(
             EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(70, stats[Modifiers.BUFFED_HP]);
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(70, stats.get(DerivedModifier.BUFFED_HP));
 
         // extra-wide head candle (+100% HP)
         EquipmentManager.setEquipment(
             EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(30, stats[Modifiers.BUFFED_HP]);
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(30, stats.get(DerivedModifier.BUFFED_HP));
       }
     }
 
@@ -618,32 +619,32 @@ public class ModifiersTest {
 
         Modifiers mods = KoLCharacter.getCurrentModifiers();
         KoLCharacter.recalculateAdjustments(false);
-        int[] stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(176, stats[Modifiers.BUFFED_HP]);
+        var stats = mods.predict();
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(176, stats.get(DerivedModifier.BUFFED_HP));
 
         // viking helmet: (+1 muscle)
         EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.VIKING_HELMET));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(101, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(176, stats[Modifiers.BUFFED_HP]);
+        assertEquals(101, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(176, stats.get(DerivedModifier.BUFFED_HP));
 
         // reinforced beaded headband (+40 HP)
         EquipmentManager.setEquipment(
             EquipmentManager.HAT, ItemPool.get(ItemPool.REINFORCED_BEADED_HEADBAND));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(176, stats[Modifiers.BUFFED_HP]);
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(176, stats.get(DerivedModifier.BUFFED_HP));
 
         // extra-wide head candle (+100% HP)
         EquipmentManager.setEquipment(
             EquipmentManager.HAT, ItemPool.get(ItemPool.EXTRA_WIDE_HEAD_CANDLE));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MUS]);
-        assertEquals(176, stats[Modifiers.BUFFED_HP]);
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(176, stats.get(DerivedModifier.BUFFED_HP));
       }
     }
 
@@ -666,9 +667,9 @@ public class ModifiersTest {
         KoLCharacter.recalculateAdjustments(false);
         assertEquals(40, current.get(DoubleModifier.HP));
 
-        int[] currentStats = current.predict();
-        assertEquals(100, currentStats[Modifiers.BUFFED_MUS]);
-        assertEquals(216, currentStats[Modifiers.BUFFED_HP]);
+        var currentStats = current.predict();
+        assertEquals(100, currentStats.get(DerivedModifier.BUFFED_MUS));
+        assertEquals(216, currentStats.get(DerivedModifier.BUFFED_HP));
 
         // Make some modifiers to speculate with
         Modifiers speculate = new Modifiers(current);
@@ -677,8 +678,8 @@ public class ModifiersTest {
         // with a nurse's hat (+300 HP)
         speculate.setDouble(DoubleModifier.HP, 300.0);
 
-        int[] speculateStats = speculate.predict();
-        assertEquals(476, speculateStats[Modifiers.BUFFED_HP]);
+        var speculateStats = speculate.predict();
+        assertEquals(476, speculateStats.get(DerivedModifier.BUFFED_HP));
       }
     }
   }
@@ -701,23 +702,23 @@ public class ModifiersTest {
 
         Modifiers mods = KoLCharacter.getCurrentModifiers();
         KoLCharacter.recalculateAdjustments(false);
-        int[] stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MYS]);
-        assertEquals(150, stats[Modifiers.BUFFED_MP]);
+        var stats = mods.predict();
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MYS));
+        assertEquals(150, stats.get(DerivedModifier.BUFFED_MP));
 
         // fuzzy earmuffs: (+11 myst)
         EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.FUZZY_EARMUFFS));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(111, stats[Modifiers.BUFFED_MYS]);
-        assertEquals(167, stats[Modifiers.BUFFED_MP]);
+        assertEquals(111, stats.get(DerivedModifier.BUFFED_MYS));
+        assertEquals(167, stats.get(DerivedModifier.BUFFED_MP));
 
         // beer helmet (+40 MP)
         EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MYS]);
-        assertEquals(190, stats[Modifiers.BUFFED_MP]);
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MYS));
+        assertEquals(190, stats.get(DerivedModifier.BUFFED_MP));
 
         EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
 
@@ -726,8 +727,8 @@ public class ModifiersTest {
             EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(106, stats[Modifiers.BUFFED_MYS]);
-        assertEquals(229, stats[Modifiers.BUFFED_MP]);
+        assertEquals(106, stats.get(DerivedModifier.BUFFED_MYS));
+        assertEquals(229, stats.get(DerivedModifier.BUFFED_MP));
       }
     }
 
@@ -742,23 +743,23 @@ public class ModifiersTest {
 
         Modifiers mods = KoLCharacter.getCurrentModifiers();
         KoLCharacter.recalculateAdjustments(false);
-        int[] stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MYS]);
-        assertEquals(100, stats[Modifiers.BUFFED_MP]);
+        var stats = mods.predict();
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MYS));
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MP));
 
         // fuzzy earmuffs: (+11 myst)
         EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.FUZZY_EARMUFFS));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(111, stats[Modifiers.BUFFED_MYS]);
-        assertEquals(111, stats[Modifiers.BUFFED_MP]);
+        assertEquals(111, stats.get(DerivedModifier.BUFFED_MYS));
+        assertEquals(111, stats.get(DerivedModifier.BUFFED_MP));
 
         // beer helmet (+40 MP)
         EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MYS]);
-        assertEquals(140, stats[Modifiers.BUFFED_MP]);
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MYS));
+        assertEquals(140, stats.get(DerivedModifier.BUFFED_MP));
 
         EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
 
@@ -767,8 +768,8 @@ public class ModifiersTest {
             EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(106, stats[Modifiers.BUFFED_MYS]);
-        assertEquals(176, stats[Modifiers.BUFFED_MP]);
+        assertEquals(106, stats.get(DerivedModifier.BUFFED_MYS));
+        assertEquals(176, stats.get(DerivedModifier.BUFFED_MP));
       }
     }
 
@@ -783,23 +784,23 @@ public class ModifiersTest {
 
         Modifiers mods = KoLCharacter.getCurrentModifiers();
         KoLCharacter.recalculateAdjustments(false);
-        int[] stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MYS]);
-        assertEquals(126, stats[Modifiers.BUFFED_MP]);
+        var stats = mods.predict();
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MYS));
+        assertEquals(126, stats.get(DerivedModifier.BUFFED_MP));
 
         // fuzzy earmuffs: (+11 myst)
         EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.FUZZY_EARMUFFS));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(111, stats[Modifiers.BUFFED_MYS]);
-        assertEquals(126, stats[Modifiers.BUFFED_MP]);
+        assertEquals(111, stats.get(DerivedModifier.BUFFED_MYS));
+        assertEquals(126, stats.get(DerivedModifier.BUFFED_MP));
 
         // beer helmet (+40 MP)
         EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(100, stats[Modifiers.BUFFED_MYS]);
-        assertEquals(126, stats[Modifiers.BUFFED_MP]);
+        assertEquals(100, stats.get(DerivedModifier.BUFFED_MYS));
+        assertEquals(126, stats.get(DerivedModifier.BUFFED_MP));
 
         EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
 
@@ -808,8 +809,8 @@ public class ModifiersTest {
             EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(106, stats[Modifiers.BUFFED_MYS]);
-        assertEquals(126, stats[Modifiers.BUFFED_MP]);
+        assertEquals(106, stats.get(DerivedModifier.BUFFED_MYS));
+        assertEquals(126, stats.get(DerivedModifier.BUFFED_MP));
       }
     }
 
@@ -832,9 +833,9 @@ public class ModifiersTest {
         KoLCharacter.recalculateAdjustments(false);
         assertEquals(40, current.get(DoubleModifier.MP));
 
-        int[] currentStats = current.predict();
-        assertEquals(100, currentStats[Modifiers.BUFFED_MYS]);
-        assertEquals(126, currentStats[Modifiers.BUFFED_MP]);
+        var currentStats = current.predict();
+        assertEquals(100, currentStats.get(DerivedModifier.BUFFED_MYS));
+        assertEquals(126, currentStats.get(DerivedModifier.BUFFED_MP));
 
         // Make some modifiers to speculate with
         Modifiers speculate = new Modifiers(current);
@@ -843,8 +844,8 @@ public class ModifiersTest {
         // with Covers-Your-Head (+100 MP)
         speculate.setDouble(DoubleModifier.MP, 100.0);
 
-        int[] speculateStats = speculate.predict();
-        assertEquals(186, speculateStats[Modifiers.BUFFED_MP]);
+        var speculateStats = speculate.predict();
+        assertEquals(186, speculateStats.get(DerivedModifier.BUFFED_MP));
       }
     }
 
@@ -864,30 +865,30 @@ public class ModifiersTest {
 
         Modifiers mods = KoLCharacter.getCurrentModifiers();
         KoLCharacter.recalculateAdjustments(false);
-        int[] stats = mods.predict();
-        assertEquals(150, stats[Modifiers.BUFFED_MOX]);
-        assertEquals(150, stats[Modifiers.BUFFED_MP]);
+        var stats = mods.predict();
+        assertEquals(150, stats.get(DerivedModifier.BUFFED_MOX));
+        assertEquals(150, stats.get(DerivedModifier.BUFFED_MP));
 
         // Disco 'Fro Pick (+11 mox)
         EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.DISCO_FRO_PICK));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(161, stats[Modifiers.BUFFED_MOX]);
-        assertEquals(161, stats[Modifiers.BUFFED_MP]);
+        assertEquals(161, stats.get(DerivedModifier.BUFFED_MOX));
+        assertEquals(161, stats.get(DerivedModifier.BUFFED_MP));
 
         // beer helmet (+40 MP)
         EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.BEER_HELMET));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(150, stats[Modifiers.BUFFED_MOX]);
-        assertEquals(190, stats[Modifiers.BUFFED_MP]);
+        assertEquals(150, stats.get(DerivedModifier.BUFFED_MOX));
+        assertEquals(190, stats.get(DerivedModifier.BUFFED_MP));
 
         // training helmet: (+25% mox)
         EquipmentManager.setEquipment(EquipmentManager.HAT, ItemPool.get(ItemPool.TRAINING_HELMET));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(188, stats[Modifiers.BUFFED_MOX]);
-        assertEquals(188, stats[Modifiers.BUFFED_MP]);
+        assertEquals(188, stats.get(DerivedModifier.BUFFED_MOX));
+        assertEquals(188, stats.get(DerivedModifier.BUFFED_MP));
 
         EquipmentManager.setEquipment(EquipmentManager.HAT, EquipmentRequest.UNEQUIP);
 
@@ -896,8 +897,8 @@ public class ModifiersTest {
             EquipmentManager.PANTS, ItemPool.get(ItemPool.CARGO_CULTIST_SHORTS));
         KoLCharacter.recalculateAdjustments(false);
         stats = mods.predict();
-        assertEquals(156, stats[Modifiers.BUFFED_MOX]);
-        assertEquals(259, stats[Modifiers.BUFFED_MP]);
+        assertEquals(156, stats.get(DerivedModifier.BUFFED_MOX));
+        assertEquals(259, stats.get(DerivedModifier.BUFFED_MP));
       }
     }
   }


### PR DESCRIPTION
Convert "derived" modifiers to enum.

I think derived modifiers are doubles which have to be computed after all the other doubles are computed. But then, prismatic damage is in a similar boat, but that's a double.

Looking at the function `Modifiers.get`, line 681, we compute all the derived modifiers, then throw most of them away and only take the one we're interested in. Ha! But then, all the buffed stats require each other if anything is equalised, and HP and MP require muscle and mysticality respectively, so perhaps most of it washes out.

`SpeculateCommand.doNumeric` is a good example of something we can update once `bitmaps` is moved to an enum: we're starting with a modifier, converting to a string, passing through to a method that doesn't know what the type of modifier is any more, but wants to do different things in different cases...

Curious how `isNumericModifier` is true only for doubles, despite `doNumeric` receiving doubles, derived and bitmaps.