### PR TITLE
fix: avoid NPE, and error explicitly, when using equip with crown or bjorn

### DIFF
--- a/src/net/sourceforge/kolmafia/request/EquipmentRequest.java
+++ b/src/net/sourceforge/kolmafia/request/EquipmentRequest.java
@@ -245,7 +245,11 @@ public class EquipmentRequest extends PasswordHashRequest {
 
     switch (equipmentSlot) {
       case EquipmentManager.CROWNOFTHRONES:
+        this.error = "Cannot change enthronement using equip command; use enthrone command instead";
+        break;
       case EquipmentManager.BUDDYBJORN:
+        this.error =
+            "Cannot change bjorned familiar using equip command; use bjornify command instead";
         break;
       case EquipmentManager.STICKER1:
       case EquipmentManager.STICKER2:


### PR DESCRIPTION
Declaring an `EquipmentRequest` with an explicit slot, where the slot was crown or bjorn, would lead to no `requestType` being set, and an NPE in `run`.

The NPE was presumably introduced in #1424: before that, `requestType` was initiliased to `0`, which matched `REFRESH`, so the command just silently did the wrong thing.