### PR TITLE
refactor: convert bitmap modifiers to enum

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -25,6 +25,7 @@ import net.sourceforge.kolmafia.listener.NamedListenerRegistry;
 import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
 import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
+import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.moods.HPRestoreItemList;
@@ -2209,24 +2210,16 @@ public abstract class KoLCharacter {
     return KoLCharacter.currentModifiers.get(modifier);
   }
 
-  public static final int currentRawBitmapModifier(final String name) {
-    return KoLCharacter.currentModifiers.getRawBitmap(name);
+  public static final double currentDerivedModifier(final DerivedModifier modifier) {
+    return KoLCharacter.currentModifiers.getDerived(modifier);
   }
 
   public static final int currentRawBitmapModifier(final BitmapModifier modifier) {
     return KoLCharacter.currentModifiers.getRawBitmap(modifier);
   }
 
-  public static final int currentBitmapModifier(final String name) {
-    return KoLCharacter.currentModifiers.getBitmap(name);
-  }
-
   public static final int currentBitmapModifier(final BitmapModifier modifier) {
     return KoLCharacter.currentModifiers.getBitmap(modifier);
-  }
-
-  public static final boolean currentBooleanModifier(final String name) {
-    return KoLCharacter.currentModifiers.getBoolean(name);
   }
 
   public static final boolean currentBooleanModifier(final BooleanModifier mod) {

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -23,6 +23,7 @@ import net.sourceforge.kolmafia.chat.ChatManager;
 import net.sourceforge.kolmafia.listener.CharacterListenerRegistry;
 import net.sourceforge.kolmafia.listener.NamedListenerRegistry;
 import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
+import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
@@ -2212,16 +2213,16 @@ public abstract class KoLCharacter {
     return KoLCharacter.currentModifiers.getRawBitmap(name);
   }
 
-  public static final int currentRawBitmapModifier(final int index) {
-    return KoLCharacter.currentModifiers.getRawBitmap(index);
+  public static final int currentRawBitmapModifier(final BitmapModifier modifier) {
+    return KoLCharacter.currentModifiers.getRawBitmap(modifier);
   }
 
   public static final int currentBitmapModifier(final String name) {
     return KoLCharacter.currentModifiers.getBitmap(name);
   }
 
-  public static final int currentBitmapModifier(final int index) {
-    return KoLCharacter.currentModifiers.getBitmap(index);
+  public static final int currentBitmapModifier(final BitmapModifier modifier) {
+    return KoLCharacter.currentModifiers.getBitmap(modifier);
   }
 
   public static final boolean currentBooleanModifier(final String name) {
@@ -5087,7 +5088,7 @@ public abstract class KoLCharacter {
           "fake hand (" + fakeHands + ")");
     }
 
-    int brimstoneMonsterLevel = 1 << newModifiers.getBitmap(Modifiers.BRIMSTONE);
+    int brimstoneMonsterLevel = 1 << newModifiers.getBitmap(BitmapModifier.BRIMSTONE);
     // Brimstone was believed to affect monster level only if more than
     // one is worn, but this is confirmed to not be true now.
     // Also affects item/meat drop, but only one is needed
@@ -5100,7 +5101,7 @@ public abstract class KoLCharacter {
           DoubleModifier.ITEMDROP, brimstoneMonsterLevel, ModifierType.OUTFIT, "Brimstone");
     }
 
-    int cloathingLevel = 1 << newModifiers.getBitmap(Modifiers.CLOATHING);
+    int cloathingLevel = 1 << newModifiers.getBitmap(BitmapModifier.CLOATHING);
     // Cloathing gives item/meat drop and all stats.
     if (cloathingLevel > 1) {
       newModifiers.addDouble(

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -543,11 +543,6 @@ public class Modifiers {
     return this.bitmaps.get(modifier);
   }
 
-  public int getRawBitmap(final String name) {
-    var modifier = BitmapModifier.byCaselessName(name);
-    return getRawBitmap(modifier);
-  }
-
   public int getBitmap(final BitmapModifier modifier) {
     if (modifier == null) {
       return 0;
@@ -566,6 +561,10 @@ public class Modifiers {
 
   public int getBitmap(final String name) {
     return this.getBitmap(BitmapModifier.byCaselessName(name));
+  }
+
+  public double getDerived(final DerivedModifier modifier) {
+    return this.predict().get(modifier);
   }
 
   public boolean getBoolean(final BooleanModifier modifier) {

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -28,6 +28,7 @@ import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.SpecialOutfit;
+import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
@@ -860,7 +861,7 @@ public class Evaluator {
       if (osity < this.clownosity) this.failed = true;
     }
     if (this.raveosity > 0) {
-      int osity = mods.getBitmap(Modifiers.RAVEOSITY);
+      int osity = mods.getBitmap(BitmapModifier.RAVEOSITY);
       score += Math.min(osity, this.raveosity);
       if (osity < this.raveosity) this.failed = true;
     }
@@ -1468,13 +1469,13 @@ public class Evaluator {
 
         if ((hoboPowerUseful && mods.get(DoubleModifier.HOBO_POWER) > 0.0)
             || (smithsnessUseful && !wrongClass && mods.get(DoubleModifier.SMITHSNESS) > 0.0)
-            || (brimstoneUseful && mods.getRawBitmap(Modifiers.BRIMSTONE) != 0)
-            || (cloathingUseful && mods.getRawBitmap(Modifiers.CLOATHING) != 0)
+            || (brimstoneUseful && mods.getRawBitmap(BitmapModifier.BRIMSTONE) != 0)
+            || (cloathingUseful && mods.getRawBitmap(BitmapModifier.CLOATHING) != 0)
             || (slimeHateUseful && mods.get(DoubleModifier.SLIME_HATES_IT) > 0.0)
             || (this.clownosity > 0 && mods.get(DoubleModifier.CLOWNINESS) != 0)
-            || (this.raveosity > 0 && mods.getRawBitmap(Modifiers.RAVEOSITY) != 0)
+            || (this.raveosity > 0 && mods.getRawBitmap(BitmapModifier.RAVEOSITY) != 0)
             || (this.surgeonosity > 0 && mods.get(DoubleModifier.SURGEONOSITY) != 0)
-            || ((mods.getRawBitmap(Modifiers.SYNERGETIC) & usefulSynergies) != 0)) {
+            || ((mods.getRawBitmap(BitmapModifier.SYNERGETIC) & usefulSynergies) != 0)) {
           item.automaticFlag = true;
           break gotItem;
         }
@@ -1515,7 +1516,7 @@ public class Evaluator {
         }
 
         if (mods.getBoolean(BooleanModifier.UNARMED)
-            || mods.getRawBitmap(Modifiers.MUTEX)
+            || mods.getRawBitmap(BitmapModifier.MUTEX)
                 != 0) { // This item may turn out to be unequippable, so don't
           // count it towards the shortlist length.
           item.conditionalFlag = true;

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -19,6 +19,7 @@ import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RestrictedItemType;
+import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.moods.MoodManager;
 import net.sourceforge.kolmafia.objectpool.ConcoctionPool;
@@ -410,8 +411,8 @@ public class Maximizer {
       if (!hasEffect) {
         spec.addEffect(effect);
         delta = spec.getScore() - current;
-        if ((spec.getModifiers().getRawBitmap(Modifiers.MUTEX_VIOLATIONS)
-                & ~KoLCharacter.currentRawBitmapModifier(Modifiers.MUTEX_VIOLATIONS))
+        if ((spec.getModifiers().getRawBitmap(BitmapModifier.MUTEX_VIOLATIONS)
+                & ~KoLCharacter.currentRawBitmapModifier(BitmapModifier.MUTEX_VIOLATIONS))
             != 0) { // This effect creates a mutex problem that the player
           // didn't already have.  In the future, perhaps suggest
           // uneffecting the conflicting effect, but for now just skip.

--- a/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
+++ b/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
@@ -11,6 +11,7 @@ import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.Speculation;
+import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -68,8 +69,8 @@ public class MaximizerSpeculation extends Speculation
     }
     Maximizer.eval.checkEquipment(this.mods, this.equipment, this.beeosity);
     this.failed = Maximizer.eval.failed;
-    if ((this.mods.getRawBitmap(Modifiers.MUTEX_VIOLATIONS)
-            & ~KoLCharacter.currentRawBitmapModifier(Modifiers.MUTEX_VIOLATIONS))
+    if ((this.mods.getRawBitmap(BitmapModifier.MUTEX_VIOLATIONS)
+            & ~KoLCharacter.currentRawBitmapModifier(BitmapModifier.MUTEX_VIOLATIONS))
         != 0) { // We're speculating about something that would create a
       // mutex problem that the player didn't already have.
       this.failed = true;
@@ -817,7 +818,7 @@ public class MaximizerSpeculation extends Speculation
     if (mods == null) {
       return 0;
     }
-    return mods.getRawBitmap(Modifiers.MUTEX);
+    return mods.getRawBitmap(BitmapModifier.MUTEX);
   }
 
   private void trySwap(int slot1, int slot2) {

--- a/src/net/sourceforge/kolmafia/modifiers/BitmapModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/BitmapModifier.java
@@ -1,12 +1,25 @@
 package net.sourceforge.kolmafia.modifiers;
 
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
-public class BitmapModifier implements Modifier {
+public enum BitmapModifier implements Modifier {
+  BRIMSTONE("Brimstone", Pattern.compile("Brimstone")),
+  CLOATHING("Cloathing", Pattern.compile("Cloathing")),
+  SYNERGETIC("Synergetic", Pattern.compile("Synergetic")),
+  RAVEOSITY("Raveosity", Pattern.compile("Raveosity: (\\+?\\d+)")),
+  MUTEX("Mutually Exclusive", null),
+  MUTEX_VIOLATIONS("Mutex Violations", null);
   private final String name;
   private final Pattern tagPattern;
 
-  public BitmapModifier(String name, Pattern tagPattern) {
+  BitmapModifier(String name, Pattern tagPattern) {
     this.name = name;
     this.tagPattern = tagPattern;
   }
@@ -29,5 +42,33 @@ public class BitmapModifier implements Modifier {
   @Override
   public String getTag() {
     return name;
+  }
+
+  public static final Set<BitmapModifier> BITMAP_MODIFIERS =
+      Collections.unmodifiableSet(EnumSet.allOf(BitmapModifier.class));
+
+  private static final Map<String, BitmapModifier> caselessNameToModifier =
+      BITMAP_MODIFIERS.stream()
+          .collect(Collectors.toMap(type -> type.name.toLowerCase(), Function.identity()));
+
+  // equivalent to `Modifiers.findName`
+  public static BitmapModifier byCaselessName(String name) {
+    return caselessNameToModifier.get(name.toLowerCase());
+  }
+
+  // equivalent to `Modifiers.findModifier`
+  public static BitmapModifier byTagPattern(final String tag) {
+    for (var modifier : BITMAP_MODIFIERS) {
+      Pattern pattern = modifier.getTagPattern();
+      if (pattern == null) {
+        continue;
+      }
+
+      Matcher matcher = pattern.matcher(tag);
+      if (matcher.find()) {
+        return modifier;
+      }
+    }
+    return null;
   }
 }

--- a/src/net/sourceforge/kolmafia/modifiers/BitmapModifierCollection.java
+++ b/src/net/sourceforge/kolmafia/modifiers/BitmapModifierCollection.java
@@ -1,0 +1,28 @@
+package net.sourceforge.kolmafia.modifiers;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public class BitmapModifierCollection {
+  private final Map<BitmapModifier, Integer> bitmaps = new EnumMap<>(BitmapModifier.class);
+
+  public void reset() {
+    this.bitmaps.clear();
+  }
+
+  public Integer get(final BitmapModifier mod) {
+    return this.bitmaps.getOrDefault(mod, 0);
+  }
+
+  public boolean set(BitmapModifier modifier, Integer value) {
+    Integer oldValue =
+        value == 0 ? this.bitmaps.remove(modifier) : this.bitmaps.put(modifier, value);
+
+    // TODO: does anything use this return value, or can we save ourselves a check?
+    return oldValue == null || !oldValue.equals(value);
+  }
+
+  public double add(final BitmapModifier mod, final Integer value) {
+    return this.bitmaps.merge(mod, value, (v1, v2) -> v1 | v2);
+  }
+}

--- a/src/net/sourceforge/kolmafia/swingui/panel/CompactSidePane.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/CompactSidePane.java
@@ -36,6 +36,7 @@ import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.MonsterData;
 import net.sourceforge.kolmafia.listener.Listener;
 import net.sourceforge.kolmafia.listener.NamedListenerRegistry;
+import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
@@ -985,7 +986,7 @@ public class CompactSidePane extends JPanel implements Runnable {
         this.bonusValueLabel[count].setText(surgeon + " / 5");
         count++;
       }
-      int rave = KoLCharacter.currentBitmapModifier(Modifiers.RAVEOSITY);
+      int rave = KoLCharacter.currentBitmapModifier(BitmapModifier.RAVEOSITY);
       if (rave != 0 && count < this.BONUS_LABELS) {
         this.bonusLabel[count].setText("Rave: ");
         this.bonusValueLabel[count].setText(rave + " / 7");

--- a/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
@@ -39,6 +39,7 @@ import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.SpecialOutfit;
 import net.sourceforge.kolmafia.listener.Listener;
 import net.sourceforge.kolmafia.listener.NamedListenerRegistry;
+import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
@@ -207,13 +208,13 @@ public class GearChangePanel extends JPanel {
     }
 
     boolean anyBool = false;
-    for (int i = 1; i < Modifiers.BITMAP_MODIFIERS; ++i) {
-      if (mods.getRawBitmap(i) == 0) continue;
+    for (var mod : BitmapModifier.BITMAP_MODIFIERS) {
+      if (mods.getRawBitmap(mod) == 0) continue;
       if (anyBool) {
         buff.append(", ");
       }
       anyBool = true;
-      buff.append(Modifiers.getBitmapModifierName(i));
+      buff.append(mod.getName());
     }
 
     for (var mod : BooleanModifier.BOOLEAN_MODIFIERS) {

--- a/src/net/sourceforge/kolmafia/swingui/widget/TableCellFactory.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/TableCellFactory.java
@@ -7,6 +7,7 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.Modifiers;
+import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
@@ -444,13 +445,13 @@ public class TableCellFactory {
     }
 
     boolean anyBool = false;
-    for (int i = 1; i < Modifiers.BITMAP_MODIFIERS; ++i) {
-      if (mods.getRawBitmap(i) == 0) continue;
+    for (var mod : BitmapModifier.BITMAP_MODIFIERS) {
+      if (mods.getRawBitmap(mod) == 0) continue;
       if (anyBool) {
         buff.append(", ");
       }
       anyBool = true;
-      buff.append(Modifiers.getBitmapModifierName(i));
+      buff.append(mod.getName());
     }
 
     for (var mod : BooleanModifier.BOOLEAN_MODIFIERS) {

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -75,6 +75,7 @@ import net.sourceforge.kolmafia.combat.Macrofier;
 import net.sourceforge.kolmafia.combat.MonsterStatusTracker;
 import net.sourceforge.kolmafia.maximizer.Boost;
 import net.sourceforge.kolmafia.maximizer.Maximizer;
+import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.moods.Mood;
 import net.sourceforge.kolmafia.moods.MoodManager;
 import net.sourceforge.kolmafia.moods.MoodTrigger;
@@ -9098,7 +9099,8 @@ public abstract class RuntimeLibrary {
   }
 
   public static Value boolean_modifier(ScriptRuntime controller, final Value modifier) {
-    String mod = modifier.toString();
+    String modName = modifier.toString();
+    BooleanModifier mod = BooleanModifier.byCaselessName(modName);
     return DataTypes.makeBooleanValue(KoLCharacter.currentBooleanModifier(mod));
   }
 

--- a/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
@@ -4,6 +4,7 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RequestLogger;
+import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
@@ -33,10 +34,10 @@ public class ModRefCommand extends AbstractCommand {
       buf.append("</td></tr>");
     }
     buf.append("<tr><td colspan=").append(colSpan).append(">BITMAP MODIFIERS</td></tr>");
-    for (int i = 1; i < Modifiers.BITMAP_MODIFIERS; i++) {
-      String mod = Modifiers.getBitmapModifierName(i);
+    for (var mod : BitmapModifier.BITMAP_MODIFIERS) {
+      String modName = mod.getName();
       buf.append("<tr><td>");
-      buf.append(mod);
+      buf.append(modName);
       buf.append("</td><td>0x");
       buf.append(Integer.toHexString(KoLCharacter.currentRawBitmapModifier(mod)));
       buf.append(" (");

--- a/src/net/sourceforge/kolmafia/textui/command/SpeculateCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/SpeculateCommand.java
@@ -95,7 +95,8 @@ public class SpeculateCommand extends AbstractCommand {
     return null;
   }
 
-  private static void handleDouble(final DoubleModifier mod, final Modifiers mods, final StringBuilder buf) {
+  private static void handleDouble(
+      final DoubleModifier mod, final Modifiers mods, final StringBuilder buf) {
     double was = KoLCharacter.currentNumericModifier(mod);
     double now = mods.get(mod);
     if (now == was) {
@@ -104,7 +105,8 @@ public class SpeculateCommand extends AbstractCommand {
     doNumeric(mod.getName(), was, now, buf);
   }
 
-  private static void handleDerived(final DerivedModifier mod, final Modifiers mods, final StringBuilder buf) {
+  private static void handleDerived(
+      final DerivedModifier mod, final Modifiers mods, final StringBuilder buf) {
     double was = KoLCharacter.currentDerivedModifier(mod);
     double now = mods.getDerived(mod);
     if (now == was) {
@@ -113,7 +115,8 @@ public class SpeculateCommand extends AbstractCommand {
     doNumeric(mod.getName(), was, now, buf);
   }
 
-  private static void handleBitmap(final BitmapModifier mod, final Modifiers mods, final StringBuilder buf) {
+  private static void handleBitmap(
+      final BitmapModifier mod, final Modifiers mods, final StringBuilder buf) {
     double was = KoLCharacter.currentBitmapModifier(mod);
     double now = mods.getBitmap(mod);
     if (now == was) {
@@ -122,7 +125,8 @@ public class SpeculateCommand extends AbstractCommand {
     doNumeric(mod.getName(), was, now, buf);
   }
 
-  private static void doNumeric(final String mod, final double was, final double now, final StringBuilder buf) {
+  private static void doNumeric(
+      final String mod, final double was, final double now, final StringBuilder buf) {
     buf.append("<tr><td>");
     buf.append(mod);
     buf.append("</td><td>");

--- a/src/net/sourceforge/kolmafia/textui/command/SpeculateCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/SpeculateCommand.java
@@ -44,16 +44,13 @@ public class SpeculateCommand extends AbstractCommand {
     buf.append(">");
     int len = buf.length();
     for (var mod : DoubleModifier.DOUBLE_MODIFIERS) {
-      String modName = mod.getName();
-      doNumeric(modName, mods, buf);
+      handleDouble(mod, mods, buf);
     }
     for (var mod : DerivedModifier.DERIVED_MODIFIERS) {
-      String modName = mod.getName();
-      doNumeric(modName, mods, buf);
+      handleDerived(mod, mods, buf);
     }
     for (var mod : BitmapModifier.BITMAP_MODIFIERS) {
-      String modName = mod.getName();
-      doNumeric(modName, mods, buf);
+      handleBitmap(mod, mods, buf);
     }
     for (var mod : BooleanModifier.BOOLEAN_MODIFIERS) {
       String modName = mod.getName();
@@ -98,12 +95,34 @@ public class SpeculateCommand extends AbstractCommand {
     return null;
   }
 
-  private static void doNumeric(final String mod, final Modifiers mods, final StringBuilder buf) {
+  private static void handleDouble(final DoubleModifier mod, final Modifiers mods, final StringBuilder buf) {
     double was = KoLCharacter.currentNumericModifier(mod);
     double now = mods.get(mod);
     if (now == was) {
       return;
     }
+    doNumeric(mod.getName(), was, now, buf);
+  }
+
+  private static void handleDerived(final DerivedModifier mod, final Modifiers mods, final StringBuilder buf) {
+    double was = KoLCharacter.currentDerivedModifier(mod);
+    double now = mods.getDerived(mod);
+    if (now == was) {
+      return;
+    }
+    doNumeric(mod.getName(), was, now, buf);
+  }
+
+  private static void handleBitmap(final BitmapModifier mod, final Modifiers mods, final StringBuilder buf) {
+    double was = KoLCharacter.currentBitmapModifier(mod);
+    double now = mods.getBitmap(mod);
+    if (now == was) {
+      return;
+    }
+    doNumeric(mod.getName(), was, now, buf);
+  }
+
+  private static void doNumeric(final String mod, final double was, final double now, final StringBuilder buf) {
     buf.append("<tr><td>");
     buf.append(mod);
     buf.append("</td><td>");

--- a/src/net/sourceforge/kolmafia/textui/command/SpeculateCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/SpeculateCommand.java
@@ -7,6 +7,7 @@ import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.Speculation;
+import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
@@ -50,9 +51,9 @@ public class SpeculateCommand extends AbstractCommand {
       String modName = mod.getName();
       doNumeric(modName, mods, buf);
     }
-    for (int i = 1; i < Modifiers.BITMAP_MODIFIERS; i++) {
-      String mod = Modifiers.getBitmapModifierName(i);
-      doNumeric(mod, mods, buf);
+    for (var mod : BitmapModifier.BITMAP_MODIFIERS) {
+      String modName = mod.getName();
+      doNumeric(modName, mods, buf);
     }
     for (var mod : BooleanModifier.BOOLEAN_MODIFIERS) {
       String modName = mod.getName();

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.java.dev.spellcast.utilities.DataUtilities;
 import net.sourceforge.kolmafia.AscensionPath.Path;
+import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
@@ -127,7 +128,7 @@ public class ModifiersTest {
       int manualMask = 0;
       for (String piece : name.split("/")) {
         Modifiers mods = Modifiers.getModifiers(ModifierType.ITEM, piece);
-        manualMask |= mods.getRawBitmap(Modifiers.SYNERGETIC);
+        manualMask |= mods.getRawBitmap(BitmapModifier.SYNERGETIC);
       }
 
       assertEquals(manualMask, mask, name);


### PR DESCRIPTION
Keep doing the bit operations for now. I'm still not sure what the point of them is. It seems to be treating every int as equivalent to a list of booleans, but sometimes it counts the bits. I don't know what the "mask" is for, either. Number of relevant slots? But I don't see where this is stored.

It has bitmaps and "raw" bitmaps. Bitmaps are a count of the bits. "Raw" bitmaps are using for masking?