### PR TITLE
Hover text over next platform in Volcano Maze is now 'Next Platform'

### DIFF
--- a/src/data/adventures.txt
+++ b/src/data/adventures.txt
@@ -309,7 +309,7 @@ The Mer-Kin Deepcity	sea_merkin=temple	DiffLevel: unknown Env: underwater overdr
 
 Nemesis Cave	adventure=452	DiffLevel: mid Env: underground Stat: 0	The Fungal Nethers	6 fizzing spore pod
 Volcano	adventure=214	DiffLevel: mid Env: outdoor Stat: 140	The Broodling Grounds	6 hellseal brain, 6 hellseal hide, 6 hellseal sinew|sealhide hood, sealhide leggings, sealhide buckler|sealhide hood, sealhide leggings, sealhide cloak, sealhide buckler, sealhide whip, sealhide moccasins, sealhide gloves, sealhide belt
-Volcano	adventure=215	DiffLevel: unknown Env: outdoor Stat: 140	The Outer Compound
+Volcano	adventure=215	DiffLevel: mid Env: outdoor Stat: 140	The Outer Compound
 Volcano	adventure=217	DiffLevel: unknown Env: outdoor Stat: 140	The Temple Portico	5 cult memo
 Volcano	adventure=218	DiffLevel: unknown Env: indoor Stat: 140	Convention Hall Lobby	6 vial of blue slime, 6 vial of red slime, 6 vial of yellow slime|9 vial of blue slime, 9 vial of red slime, 9 vial of yellow slime|91 vial of blue slime, 91 vial of red slime, 91 vial of yellow slime
 Volcano	adventure=219	DiffLevel: mid Env: outdoor Stat: 140	Outside the Club	1 rave visor, 1 glowstick on a string, 1 candy necklace, 1 pacifier necklace, 1 teddybear backpack

--- a/src/net/sourceforge/kolmafia/KoLConstants.java
+++ b/src/net/sourceforge/kolmafia/KoLConstants.java
@@ -245,7 +245,7 @@ public interface KoLConstants extends UtilityConstants {
   String SORTTABLE_JS = "sorttable.2.js";
   String STATIONARYBUTTONS_CSS = "stationarybuttons.2.css";
   String STATIONARYBUTTONS_JS = "stationarybuttons.2.js";
-  String VOLCANOMAZE_JS = "volcanomaze.1.js";
+  String VOLCANOMAZE_JS = "volcanomaze.2.js";
 
   String[] RELAY_FILES = {
     AFTERLIFE_ASH,

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -9187,6 +9187,7 @@ public abstract class ChoiceControl {
       case 1483: // Direct Autumn-Aton
       case 1484: // Conspicuous Plaque
       case 1485: // Play with your train
+      case 1493: // Treasure House
         return true;
 
       default:

--- a/src/relay/volcanomaze.2.js
+++ b/src/relay/volcanomaze.2.js
@@ -28,7 +28,7 @@ function adjustPlatforms(res) {
 				t.removeClass('no').addClass('you');
 				setTitle(t, 'You');
 			}
-		        t.removeClass('next');
+			t.removeClass('next');
 			if (t.attr('rel') == res.next) {
 				t.removeClass('no').addClass('yes').addClass('next');
 				setTitle(t, 'Next Platform');
@@ -40,10 +40,10 @@ function adjustPlatforms(res) {
 			if (sq.hasClass('goal')) continue;
 			if (sq.hasClass('you')) continue;
 			var image = 'platformup'+Math.floor((Math.random() * 4) +1);
-		        var url ='url("https://d2uyhvukfffg5a.cloudfront.net/itemimages/'+image+'.gif?foo='+1+'")';
-		        if (!sq.hasClass('next')) {
-			    sq.removeClass('no').addClass('yes');
-			    setTitle(sq, 'Platform');
+			var url ='url("https://d2uyhvukfffg5a.cloudfront.net/itemimages/'+image+'.gif?foo='+1+'")';
+			if (!sq.hasClass('next')) {
+				sq.removeClass('no').addClass('yes');
+				setTitle(sq, 'Platform');
 			}
 			sq.find('a').css('background', url);
 		}

--- a/src/relay/volcanomaze.2.js
+++ b/src/relay/volcanomaze.2.js
@@ -28,16 +28,24 @@ function adjustPlatforms(res) {
 				t.removeClass('no').addClass('you');
 				setTitle(t, 'You');
 			}
+		        t.removeClass('next');
+			if (t.attr('rel') == res.next) {
+				t.removeClass('no').addClass('yes').addClass('next');
+				setTitle(t, 'Next Platform');
+			}
 		});
 		for (i in res.show) {
 			if (!res.show.hasOwnProperty(i)) continue;
 			var sq = $('#sq'+res.show[i]);
 			if (sq.hasClass('goal')) continue;
-			sq.removeClass('no')
-			if (!sq.hasClass('you')) {	
-				sq.addClass('yes').find('a').css('background','url("https://d2uyhvukfffg5a.cloudfront.net/itemimages/platformup'+Math.floor((Math.random() * 4) +1)+'.gif?foo='+1+'")');
-				setTitle(sq, 'Platform');
+			if (sq.hasClass('you')) continue;
+			var image = 'platformup'+Math.floor((Math.random() * 4) +1);
+		        var url ='url("https://d2uyhvukfffg5a.cloudfront.net/itemimages/'+image+'.gif?foo='+1+'")';
+		        if (!sq.hasClass('next')) {
+			    sq.removeClass('no').addClass('yes');
+			    setTitle(sq, 'Platform');
 			}
+			sq.find('a').css('background', url);
 		}
 	}
 	else {

--- a/test/net/sourceforge/kolmafia/session/VolcanoMazeManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/VolcanoMazeManagerTest.java
@@ -443,7 +443,7 @@ public class VolcanoMazeManagerTest {
           // RelayAgent intercepts that and calls VolcanoMazeManager.autoStep,
           // which submits the appropriate request to KoL, leaving the response
           // in the responseText
-          url = "volcanomaze,php?autostep";
+          url = "volcanomaze.php?autostep";
           request = new RelayRequest(false);
           request.constructURLString(url);
           VolcanoMazeManager.autoStep(request);


### PR DESCRIPTION
1) DiffLevel of the Outer Compund is mid
2) You can walk away from the Treasure House choice
3) In the Volcano Maze, once we have seen all the maps and can calculate a solution (always the case, if using cached maps - the default), the hover text over the "correct" next platform (where we will go if you click the Step button) now says "Next Platform".

I considered actually changing the image to have an "X" on it or something, but I don't seem to have access to a gif editor that lets me change the pixels.