### PR TITLE
refactor: avoid string references for known modifiers

### DIFF
--- a/src/net/sourceforge/kolmafia/DebugModifiers.java
+++ b/src/net/sourceforge/kolmafia/DebugModifiers.java
@@ -89,7 +89,7 @@ public class DebugModifiers extends Modifiers {
         "<td>"
             + KoLConstants.ROUNDED_MODIFIER_FORMAT.format(mod)
             + "</td><td>=&nbsp;"
-            + KoLConstants.ROUNDED_MODIFIER_FORMAT.format(this.get(modifier))
+            + KoLConstants.ROUNDED_MODIFIER_FORMAT.format(this.getDouble(modifier))
             + "</td>");
   }
 
@@ -113,7 +113,7 @@ public class DebugModifiers extends Modifiers {
         if (mods == null) {
           continue;
         }
-        double value = mods.get(key);
+        double value = mods.getDouble(key);
         if (value != 0.0) {
           ModifierType type = lookup.type;
           String name = lookup.getName();

--- a/src/net/sourceforge/kolmafia/Expression.java
+++ b/src/net/sourceforge/kolmafia/Expression.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
@@ -354,7 +355,8 @@ public class Expression {
         case '\u0093' -> {
           Modifiers mods = KoLCharacter.getCurrentModifiers();
           String modName = (String) this.literals.get((int) s[--sp]);
-          v = mods.getDoublerAccumulator(modName);
+          DoubleModifier modifier = DoubleModifier.byCaselessName(modName);
+          v = mods.getDoublerAccumulator(modifier);
         }
           // Valid with ModifierExpression:
         case '\u0094' -> v = KoLCharacter.canInteract() ? 1 : 0;

--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -1329,7 +1329,8 @@ public class FamiliarData implements Comparable<FamiliarData> {
       case FamiliarPool.HAND:
         // Disembodied Hand can't equip Mainhand only items or Single Equip items
         if (!EquipmentDatabase.isMainhandOnly(itemId)
-            && !ModifierDatabase.getBooleanModifier(ModifierType.ITEM, name, "Single Equip")) {
+            && !ModifierDatabase.getBooleanModifier(
+                ModifierType.ITEM, name, BooleanModifier.SINGLE)) {
           return true;
         }
         break;

--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -321,9 +321,9 @@ public class FamiliarData implements Comparable<FamiliarData> {
 
     int itemId = getItem().getItemId();
     if (itemId == ItemPool.MAYFLOWER_BOUQUET) {
-      String modifierName = DoubleModifier.FAMILIAR_EXP.getName();
       double itemModifier =
-          ModifierDatabase.getNumericModifier(ModifierType.ITEM, itemId, modifierName);
+          ModifierDatabase.getNumericModifier(
+              ModifierType.ITEM, itemId, DoubleModifier.FAMILIAR_EXP);
 
       experienceModifier -= itemModifier;
 
@@ -830,9 +830,9 @@ public class FamiliarData implements Comparable<FamiliarData> {
     // Get current fixed and percent weight modifiers
     Modifiers current = KoLCharacter.getCurrentModifiers();
     boolean fixodene = KoLConstants.activeEffects.contains(FIDOXENE);
-    double fixed = current.get(DoubleModifier.FAMILIAR_WEIGHT);
-    double hidden = current.get(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT);
-    double percent = current.get(DoubleModifier.FAMILIAR_WEIGHT_PCT);
+    double fixed = current.getDouble(DoubleModifier.FAMILIAR_WEIGHT);
+    double hidden = current.getDouble(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT);
+    double percent = current.getDouble(DoubleModifier.FAMILIAR_WEIGHT_PCT);
 
     FamiliarData familiar = KoLCharacter.getFamiliar();
 
@@ -844,9 +844,9 @@ public class FamiliarData implements Comparable<FamiliarData> {
       if (item != EquipmentRequest.UNEQUIP) {
         Modifiers mods = ModifierDatabase.getItemModifiers(item.getItemId());
         if (mods != null) {
-          fixed -= mods.get(DoubleModifier.FAMILIAR_WEIGHT);
-          hidden -= mods.get(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT);
-          percent -= mods.get(DoubleModifier.FAMILIAR_WEIGHT_PCT);
+          fixed -= mods.getDouble(DoubleModifier.FAMILIAR_WEIGHT);
+          hidden -= mods.getDouble(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT);
+          percent -= mods.getDouble(DoubleModifier.FAMILIAR_WEIGHT_PCT);
         }
       }
     }
@@ -859,9 +859,9 @@ public class FamiliarData implements Comparable<FamiliarData> {
       if (item != EquipmentRequest.UNEQUIP) {
         Modifiers mods = ModifierDatabase.getItemModifiers(item.getItemId());
         if (mods != null) {
-          fixed += mods.get(DoubleModifier.FAMILIAR_WEIGHT);
-          hidden += mods.get(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT);
-          percent += mods.get(DoubleModifier.FAMILIAR_WEIGHT_PCT);
+          fixed += mods.getDouble(DoubleModifier.FAMILIAR_WEIGHT);
+          hidden += mods.getDouble(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT);
+          percent += mods.getDouble(DoubleModifier.FAMILIAR_WEIGHT_PCT);
         }
       }
     }
@@ -890,7 +890,7 @@ public class FamiliarData implements Comparable<FamiliarData> {
     }
 
     // check if the familiar has a weight cap
-    int cap = (int) current.get(DoubleModifier.FAMILIAR_WEIGHT_CAP);
+    int cap = (int) current.getDouble(DoubleModifier.FAMILIAR_WEIGHT_CAP);
     int cappedWeight = (cap == 0) ? weight : Math.min(weight, cap);
 
     return Math.max(1, cappedWeight);
@@ -898,7 +898,7 @@ public class FamiliarData implements Comparable<FamiliarData> {
 
   public static final int itemWeightModifier(final int itemId) {
     Modifiers mods = ModifierDatabase.getItemModifiers(itemId);
-    return mods == null ? 0 : (int) mods.get(DoubleModifier.FAMILIAR_WEIGHT);
+    return mods == null ? 0 : (int) mods.getDouble(DoubleModifier.FAMILIAR_WEIGHT);
   }
 
   public final int getUncappedWeight() {

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -27,6 +27,7 @@ import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
+import net.sourceforge.kolmafia.modifiers.Modifier;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.moods.HPRestoreItemList;
 import net.sourceforge.kolmafia.moods.MPRestoreItemList;
@@ -1615,7 +1616,7 @@ public abstract class KoLCharacter {
   }
 
   public static final int calculateMaximumPP() {
-    return 1 + (int) KoLCharacter.currentModifiers.get(DoubleModifier.PP);
+    return 1 + (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.PP);
   }
 
   public static final void resetCurrentPP() {
@@ -2202,13 +2203,12 @@ public abstract class KoLCharacter {
     return KoLCharacter.currentModifiers;
   }
 
-  // TODO: many calls to this (with String name) (and the others) could be calls to the mod directly
-  public static final double currentNumericModifier(final String name) {
-    return KoLCharacter.currentModifiers.get(name);
+  public static final double currentNumericModifier(final Modifier modifier) {
+    return KoLCharacter.currentModifiers.getNumeric(modifier);
   }
 
   public static final double currentNumericModifier(final DoubleModifier modifier) {
-    return KoLCharacter.currentModifiers.get(modifier);
+    return KoLCharacter.currentModifiers.getDouble(modifier);
   }
 
   public static final double currentDerivedModifier(final DerivedModifier modifier) {
@@ -2237,24 +2237,24 @@ public abstract class KoLCharacter {
       return 0;
     }
 
-    return (int) KoLCharacter.currentModifiers.get(DoubleModifier.MONSTER_LEVEL)
+    return (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.MONSTER_LEVEL)
         + KoLCharacter.getWaterLevel() * 10;
   }
 
   /** Accessor method to retrieve the total current count of random monster modifiers */
   public static final int getRandomMonsterModifiers() {
-    return (int) KoLCharacter.currentModifiers.get(DoubleModifier.RANDOM_MONSTER_MODIFIERS);
+    return (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.RANDOM_MONSTER_MODIFIERS);
   }
 
   /** Accessor method to retrieve the total current familiar weight adjustment */
   public static final int getFamiliarWeightAdjustment() {
     return (int)
-        (KoLCharacter.currentModifiers.get(DoubleModifier.FAMILIAR_WEIGHT)
-            + KoLCharacter.currentModifiers.get(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT));
+        (KoLCharacter.currentModifiers.getDouble(DoubleModifier.FAMILIAR_WEIGHT)
+            + KoLCharacter.currentModifiers.getDouble(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT));
   }
 
   public static final int getFamiliarWeightPercentAdjustment() {
-    return (int) KoLCharacter.currentModifiers.get(DoubleModifier.FAMILIAR_WEIGHT_PCT);
+    return (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.FAMILIAR_WEIGHT_PCT);
   }
 
   public static final int getManaCostAdjustment() {
@@ -2262,17 +2262,19 @@ public abstract class KoLCharacter {
   }
 
   public static final int getManaCostAdjustment(final boolean combat) {
-    return (int) KoLCharacter.currentModifiers.get(DoubleModifier.MANA_COST)
-        + (int) KoLCharacter.currentModifiers.get(DoubleModifier.STACKABLE_MANA_COST)
-        + (combat ? (int) KoLCharacter.currentModifiers.get(DoubleModifier.COMBAT_MANA_COST) : 0)
+    return (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.MANA_COST)
+        + (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.STACKABLE_MANA_COST)
+        + (combat
+            ? (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.COMBAT_MANA_COST)
+            : 0)
         - KoLCharacter.holidayManaCostReduction;
   }
 
   /** Accessor method to retrieve the total current combat percent adjustment */
   public static final double getCombatRateAdjustment() {
-    double rate = KoLCharacter.currentModifiers.get(DoubleModifier.COMBAT_RATE);
+    double rate = KoLCharacter.currentModifiers.getDouble(DoubleModifier.COMBAT_RATE);
     if (AdventureDatabase.getEnvironment(Modifiers.currentLocation).isUnderwater()) {
-      rate += KoLCharacter.currentModifiers.get(DoubleModifier.UNDERWATER_COMBAT_RATE);
+      rate += KoLCharacter.currentModifiers.getDouble(DoubleModifier.UNDERWATER_COMBAT_RATE);
     }
     return rate;
   }
@@ -2280,8 +2282,9 @@ public abstract class KoLCharacter {
   /** Accessor method to retrieve the total current initiative adjustment */
   public static final double getInitiativeAdjustment() {
     // Penalty is constrained to be non-positive
-    return KoLCharacter.currentModifiers.get(DoubleModifier.INITIATIVE)
-        + Math.min(KoLCharacter.currentModifiers.get(DoubleModifier.INITIATIVE_PENALTY), 0.0f);
+    return KoLCharacter.currentModifiers.getDouble(DoubleModifier.INITIATIVE)
+        + Math.min(
+            KoLCharacter.currentModifiers.getDouble(DoubleModifier.INITIATIVE_PENALTY), 0.0f);
   }
 
   /** Accessor method to retrieve the total current fixed experience adjustment */
@@ -2293,7 +2296,7 @@ public abstract class KoLCharacter {
           case 2 -> DoubleModifier.MOX_EXPERIENCE;
           default -> null;
         };
-    return mod == null ? 0.0 : KoLCharacter.currentModifiers.get(mod);
+    return mod == null ? 0.0 : KoLCharacter.currentModifiers.getDouble(mod);
   }
 
   /**
@@ -2303,8 +2306,8 @@ public abstract class KoLCharacter {
    */
   public static final double getMeatDropPercentAdjustment() {
     // Penalty is constrained to be non-positive
-    return KoLCharacter.currentModifiers.get(DoubleModifier.MEATDROP)
-        + Math.min(KoLCharacter.currentModifiers.get(DoubleModifier.MEATDROP_PENALTY), 0.0f);
+    return KoLCharacter.currentModifiers.getDouble(DoubleModifier.MEATDROP)
+        + Math.min(KoLCharacter.currentModifiers.getDouble(DoubleModifier.MEATDROP_PENALTY), 0.0f);
   }
 
   /**
@@ -2313,7 +2316,7 @@ public abstract class KoLCharacter {
    * @return Total Current Sprinkle Drop Percent Adjustment
    */
   public static final double getSprinkleDropPercentAdjustment() {
-    return KoLCharacter.currentModifiers.get(DoubleModifier.SPRINKLES);
+    return KoLCharacter.currentModifiers.getDouble(DoubleModifier.SPRINKLES);
   }
 
   /**
@@ -2322,8 +2325,8 @@ public abstract class KoLCharacter {
    * @return Total Current Item Drop Percent Adjustment
    */
   public static final double getItemDropPercentAdjustment() {
-    return KoLCharacter.currentModifiers.get(DoubleModifier.ITEMDROP)
-        + Math.min(KoLCharacter.currentModifiers.get(DoubleModifier.ITEMDROP_PENALTY), 0.0f);
+    return KoLCharacter.currentModifiers.getDouble(DoubleModifier.ITEMDROP)
+        + Math.min(KoLCharacter.currentModifiers.getDouble(DoubleModifier.ITEMDROP_PENALTY), 0.0f);
   }
 
   /**
@@ -2332,7 +2335,7 @@ public abstract class KoLCharacter {
    * @return Total Current Damage Absorption
    */
   public static final int getDamageAbsorption() {
-    return (int) KoLCharacter.currentModifiers.get(DoubleModifier.DAMAGE_ABSORPTION);
+    return (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.DAMAGE_ABSORPTION);
   }
 
   /**
@@ -2341,7 +2344,7 @@ public abstract class KoLCharacter {
    * @return Total Current Damage Reduction
    */
   public static final int getDamageReduction() {
-    return (int) KoLCharacter.currentModifiers.get(DoubleModifier.DAMAGE_REDUCTION);
+    return (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.DAMAGE_REDUCTION);
   }
 
   /**
@@ -2350,7 +2353,7 @@ public abstract class KoLCharacter {
    * @return Pool Skill
    */
   public static final int getPoolSkill() {
-    return (int) KoLCharacter.currentModifiers.get(DoubleModifier.POOL_SKILL);
+    return (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.POOL_SKILL);
   }
 
   public static int estimatedPoolSkill(boolean verbose) {
@@ -2397,7 +2400,7 @@ public abstract class KoLCharacter {
    * @return Total Hobo Power
    */
   public static final int getHoboPower() {
-    return (int) KoLCharacter.currentModifiers.get(DoubleModifier.HOBO_POWER);
+    return (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.HOBO_POWER);
   }
 
   /**
@@ -2406,7 +2409,7 @@ public abstract class KoLCharacter {
    * @return Total Smithsness
    */
   public static final int getSmithsness() {
-    return (int) KoLCharacter.currentModifiers.get(DoubleModifier.SMITHSNESS);
+    return (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.SMITHSNESS);
   }
 
   /**
@@ -2415,7 +2418,7 @@ public abstract class KoLCharacter {
    * @return Clownosity
    */
   public static final int getClownosity() {
-    return ((int) KoLCharacter.currentModifiers.get(DoubleModifier.CLOWNINESS)) / 25;
+    return ((int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.CLOWNINESS)) / 25;
   }
 
   /**
@@ -2461,21 +2464,21 @@ public abstract class KoLCharacter {
   }
 
   public static final int getRestingHP() {
-    int rv = (int) KoLCharacter.currentModifiers.get(DoubleModifier.BASE_RESTING_HP);
-    double factor = KoLCharacter.currentModifiers.get(DoubleModifier.RESTING_HP_PCT);
+    int rv = (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.BASE_RESTING_HP);
+    double factor = KoLCharacter.currentModifiers.getDouble(DoubleModifier.RESTING_HP_PCT);
     if (factor != 0) {
       rv = (int) (rv * (factor + 100.0f) / 100.0f);
     }
-    return rv + (int) KoLCharacter.currentModifiers.get(DoubleModifier.BONUS_RESTING_HP);
+    return rv + (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.BONUS_RESTING_HP);
   }
 
   public static final int getRestingMP() {
-    int rv = (int) KoLCharacter.currentModifiers.get(DoubleModifier.BASE_RESTING_MP);
-    double factor = KoLCharacter.currentModifiers.get(DoubleModifier.RESTING_MP_PCT);
+    int rv = (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.BASE_RESTING_MP);
+    double factor = KoLCharacter.currentModifiers.getDouble(DoubleModifier.RESTING_MP_PCT);
     if (factor != 0) {
       rv = (int) (rv * (factor + 100.0f) / 100.0f);
     }
-    return rv + (int) KoLCharacter.currentModifiers.get(DoubleModifier.BONUS_RESTING_MP);
+    return rv + (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.BONUS_RESTING_MP);
   }
 
   /**
@@ -2485,14 +2488,17 @@ public abstract class KoLCharacter {
    */
   public static final int getElementalResistanceLevels(final Element element) {
     return switch (element) {
-      case COLD -> (int) KoLCharacter.currentModifiers.get(DoubleModifier.COLD_RESISTANCE);
-      case HOT -> (int) KoLCharacter.currentModifiers.get(DoubleModifier.HOT_RESISTANCE);
-      case SLEAZE -> (int) KoLCharacter.currentModifiers.get(DoubleModifier.SLEAZE_RESISTANCE);
-      case SPOOKY -> (int) KoLCharacter.currentModifiers.get(DoubleModifier.SPOOKY_RESISTANCE);
-      case STENCH -> (int) KoLCharacter.currentModifiers.get(DoubleModifier.STENCH_RESISTANCE);
-      case SLIME -> (int) KoLCharacter.currentModifiers.get(DoubleModifier.SLIME_RESISTANCE);
+      case COLD -> (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.COLD_RESISTANCE);
+      case HOT -> (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.HOT_RESISTANCE);
+      case SLEAZE -> (int)
+          KoLCharacter.currentModifiers.getDouble(DoubleModifier.SLEAZE_RESISTANCE);
+      case SPOOKY -> (int)
+          KoLCharacter.currentModifiers.getDouble(DoubleModifier.SPOOKY_RESISTANCE);
+      case STENCH -> (int)
+          KoLCharacter.currentModifiers.getDouble(DoubleModifier.STENCH_RESISTANCE);
+      case SLIME -> (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.SLIME_RESISTANCE);
       case SUPERCOLD -> (int)
-          KoLCharacter.currentModifiers.get(DoubleModifier.SUPERCOLD_RESISTANCE);
+          KoLCharacter.currentModifiers.getDouble(DoubleModifier.SUPERCOLD_RESISTANCE);
       default -> 0;
     };
   }
@@ -2540,8 +2546,8 @@ public abstract class KoLCharacter {
    * @return Total Current Resistance to specified element
    */
   public static final int currentBonusDamage() {
-    int weaponDamage = (int) KoLCharacter.currentModifiers.get(DoubleModifier.WEAPON_DAMAGE);
-    int rangedDamage = (int) KoLCharacter.currentModifiers.get(DoubleModifier.RANGED_DAMAGE);
+    int weaponDamage = (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.WEAPON_DAMAGE);
+    int rangedDamage = (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.RANGED_DAMAGE);
     return weaponDamage
         + (EquipmentManager.getWeaponType() == WeaponType.RANGED ? rangedDamage : 0);
   }
@@ -2552,7 +2558,7 @@ public abstract class KoLCharacter {
    * @return Total Current Resistance to specified element
    */
   public static final int currentPrismaticDamage() {
-    return (int) KoLCharacter.currentModifiers.get(DoubleModifier.PRISMATIC_DAMAGE);
+    return (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.PRISMATIC_DAMAGE);
   }
 
   public static final int getWaterLevel() {
@@ -2569,7 +2575,7 @@ public abstract class KoLCharacter {
       }
     }
 
-    WL += (int) KoLCharacter.currentModifiers.get(DoubleModifier.WATER_LEVEL);
+    WL += (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.WATER_LEVEL);
 
     return WL < 1 ? 1 : Math.min(WL, 6);
   }
@@ -4257,7 +4263,7 @@ public abstract class KoLCharacter {
   }
 
   public static final int getMinstrelLevelAdjustment() {
-    return (int) KoLCharacter.currentModifiers.get(DoubleModifier.MINSTREL_LEVEL);
+    return (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.MINSTREL_LEVEL);
   }
 
   public static final void setClancy(
@@ -5221,11 +5227,11 @@ public abstract class KoLCharacter {
     }
 
     // Store some modifiers as statics
-    Modifiers.hoboPower = newModifiers.get(DoubleModifier.HOBO_POWER);
+    Modifiers.hoboPower = newModifiers.getDouble(DoubleModifier.HOBO_POWER);
     Modifiers.smithsness = KoLCharacter.getSmithsnessModifier(equipment, effects);
 
     if (Modifiers.currentLocation.equals("The Slime Tube")) {
-      int hatred = (int) newModifiers.get(DoubleModifier.SLIME_HATES_IT);
+      int hatred = (int) newModifiers.getDouble(DoubleModifier.SLIME_HATES_IT);
       if (hatred > 0) {
         newModifiers.addDouble(
             DoubleModifier.MONSTER_LEVEL,
@@ -5327,7 +5333,7 @@ public abstract class KoLCharacter {
         }
       }
       if (WL > 0) {
-        WL += (int) KoLCharacter.currentModifiers.get(DoubleModifier.WATER_LEVEL);
+        WL += (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.WATER_LEVEL);
         WL = WL < 1 ? 1 : Math.min(WL, 6);
         newModifiers.addDouble(
             DoubleModifier.EXPERIENCE,
@@ -5337,9 +5343,10 @@ public abstract class KoLCharacter {
       }
     }
 
-    double baseExp = KoLCharacter.estimatedBaseExp(newModifiers.get(DoubleModifier.MONSTER_LEVEL));
+    double baseExp =
+        KoLCharacter.estimatedBaseExp(newModifiers.getDouble(DoubleModifier.MONSTER_LEVEL));
 
-    double exp = newModifiers.get(DoubleModifier.EXPERIENCE);
+    double exp = newModifiers.getDouble(DoubleModifier.EXPERIENCE);
 
     if (KoLCharacter.inTheSource()) {
       // 1/3 base exp and exp when in The Source path
@@ -5373,7 +5380,7 @@ public abstract class KoLCharacter {
           };
       Function<DoubleModifier, Double> calc =
           (DoubleModifier statPct) ->
-              (finalBaseExp + finalExp) * (1 + newModifiers.get(statPct) / 100.0f);
+              (finalBaseExp + finalExp) * (1 + newModifiers.getDouble(statPct) / 100.0f);
 
       if (all) {
         var mod = mods.get(0);
@@ -5474,7 +5481,7 @@ public abstract class KoLCharacter {
       if (fightMods != null) {
         newModifiers.addDouble(
             DoubleModifier.ITEMDROP,
-            fightMods.get(DoubleModifier.ITEMDROP),
+            fightMods.getDouble(DoubleModifier.ITEMDROP),
             ModifierType.ITEM,
             EffectPool.STEELY_EYED_SQUINT);
       }
@@ -5676,7 +5683,7 @@ public abstract class KoLCharacter {
               || classType == ascensionClass
                   && (slot != EquipmentManager.FAMILIAR
                       || KoLCharacter.getFamiliar().getId() == FamiliarPool.HAND)) {
-            smithsness += imod.get(DoubleModifier.SMITHSNESS);
+            smithsness += imod.getDouble(DoubleModifier.SMITHSNESS);
           }
         }
       }
@@ -5691,7 +5698,7 @@ public abstract class KoLCharacter {
         continue;
       Modifiers emod = ModifierDatabase.getEffectModifiers(effect.getEffectId());
       if (emod != null) {
-        smithsness += emod.get(DoubleModifier.SMITHSNESS);
+        smithsness += emod.getDouble(DoubleModifier.SMITHSNESS);
       }
     }
     return smithsness;

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -2283,8 +2283,7 @@ public abstract class KoLCharacter {
   public static final double getInitiativeAdjustment() {
     // Penalty is constrained to be non-positive
     return KoLCharacter.currentModifiers.getDouble(DoubleModifier.INITIATIVE)
-        + Math.min(
-            KoLCharacter.currentModifiers.getDouble(DoubleModifier.INITIATIVE_PENALTY), 0.0f);
+        + Math.min(KoLCharacter.currentModifiers.getDouble(DoubleModifier.INITIATIVE_PENALTY), 0.0);
   }
 
   /** Accessor method to retrieve the total current fixed experience adjustment */
@@ -2307,7 +2306,7 @@ public abstract class KoLCharacter {
   public static final double getMeatDropPercentAdjustment() {
     // Penalty is constrained to be non-positive
     return KoLCharacter.currentModifiers.getDouble(DoubleModifier.MEATDROP)
-        + Math.min(KoLCharacter.currentModifiers.getDouble(DoubleModifier.MEATDROP_PENALTY), 0.0f);
+        + Math.min(KoLCharacter.currentModifiers.getDouble(DoubleModifier.MEATDROP_PENALTY), 0.0);
   }
 
   /**
@@ -2326,7 +2325,7 @@ public abstract class KoLCharacter {
    */
   public static final double getItemDropPercentAdjustment() {
     return KoLCharacter.currentModifiers.getDouble(DoubleModifier.ITEMDROP)
-        + Math.min(KoLCharacter.currentModifiers.getDouble(DoubleModifier.ITEMDROP_PENALTY), 0.0f);
+        + Math.min(KoLCharacter.currentModifiers.getDouble(DoubleModifier.ITEMDROP_PENALTY), 0.0);
   }
 
   /**
@@ -2467,7 +2466,7 @@ public abstract class KoLCharacter {
     int rv = (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.BASE_RESTING_HP);
     double factor = KoLCharacter.currentModifiers.getDouble(DoubleModifier.RESTING_HP_PCT);
     if (factor != 0) {
-      rv = (int) (rv * (factor + 100.0f) / 100.0f);
+      rv = (int) (rv * (factor + 100.0) / 100.0);
     }
     return rv + (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.BONUS_RESTING_HP);
   }
@@ -2476,7 +2475,7 @@ public abstract class KoLCharacter {
     int rv = (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.BASE_RESTING_MP);
     double factor = KoLCharacter.currentModifiers.getDouble(DoubleModifier.RESTING_MP_PCT);
     if (factor != 0) {
-      rv = (int) (rv * (factor + 100.0f) / 100.0f);
+      rv = (int) (rv * (factor + 100.0) / 100.0);
     }
     return rv + (int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.BONUS_RESTING_MP);
   }
@@ -2534,7 +2533,7 @@ public abstract class KoLCharacter {
    */
   public static final double getElementalResistance(final Element element) {
     if (element == Element.NONE) {
-      return 0.0f;
+      return 0.0;
     }
     int levels = KoLCharacter.getElementalResistanceLevels(element);
     return KoLCharacter.elementalResistanceByLevel(levels, element != Element.SLIME);
@@ -4929,8 +4928,8 @@ public abstract class KoLCharacter {
   public static final double estimatedBaseExp(double monsterLevel) {
     // 0.25 stats per monster ML + 0.33 stats per bonus ML, rounded to 2dp
 
-    double baseStats = (Modifiers.getCurrentML() / 4.0f);
-    double bonusStats = monsterLevel / ((monsterLevel > 0) ? 3.0f : 4.0f);
+    double baseStats = (Modifiers.getCurrentML() / 4.0);
+    double bonusStats = monsterLevel / ((monsterLevel > 0) ? 3.0 : 4.0);
     return Math.round((baseStats + bonusStats) * 100d) / 100d;
   }
 
@@ -5337,7 +5336,7 @@ public abstract class KoLCharacter {
         WL = WL < 1 ? 1 : Math.min(WL, 6);
         newModifiers.addDouble(
             DoubleModifier.EXPERIENCE,
-            (double) WL * 10 / 3.0f,
+            (double) WL * 10 / 3.0,
             ModifierType.PATH,
             "Water Level*10/3");
       }
@@ -5354,7 +5353,7 @@ public abstract class KoLCharacter {
       exp = exp / 3;
     }
 
-    if (exp != 0.0f) {
+    if (exp != 0.0) {
       String tuning = newModifiers.getString(StringModifier.STAT_TUNING);
       int prime = KoLCharacter.getPrimeIndex();
       if (tuning.startsWith("Muscle")) prime = 0;
@@ -5380,7 +5379,7 @@ public abstract class KoLCharacter {
           };
       Function<DoubleModifier, Double> calc =
           (DoubleModifier statPct) ->
-              (finalBaseExp + finalExp) * (1 + newModifiers.getDouble(statPct) / 100.0f);
+              (finalBaseExp + finalExp) * (1 + newModifiers.getDouble(statPct) / 100.0);
 
       if (all) {
         var mod = mods.get(0);
@@ -5389,12 +5388,11 @@ public abstract class KoLCharacter {
         // Adjust for prime stat
         // The base +1 Exp for mainstat IS tuned
         var mod = mods.get(0);
-        newModifiers.addDouble(
-            mod.exp, 1 + calc.apply(mod.pct) / 2.0f, ModifierType.CLASS, "EXP/2");
+        newModifiers.addDouble(mod.exp, 1 + calc.apply(mod.pct) / 2.0, ModifierType.CLASS, "EXP/2");
         mod = mods.get(1);
-        newModifiers.addDouble(mod.exp, calc.apply(mod.pct) / 4.0f, ModifierType.CLASS, "EXP/4");
+        newModifiers.addDouble(mod.exp, calc.apply(mod.pct) / 4.0, ModifierType.CLASS, "EXP/4");
         mod = mods.get(2);
-        newModifiers.addDouble(mod.exp, calc.apply(mod.pct) / 4.0f, ModifierType.CLASS, "EXP/4");
+        newModifiers.addDouble(mod.exp, calc.apply(mod.pct) / 4.0, ModifierType.CLASS, "EXP/4");
       }
     }
 
@@ -5529,7 +5527,7 @@ public abstract class KoLCharacter {
       if (consume == ConsumptionType.WEAPON) {
         newModifiers.addDouble(
             DoubleModifier.WEAPON_DAMAGE,
-            EquipmentDatabase.getPower(itemId) * 0.15f,
+            EquipmentDatabase.getPower(itemId) * 0.15,
             ModifierType.EQUIPMENT_POWER,
             "15% weapon power");
       }
@@ -5633,7 +5631,7 @@ public abstract class KoLCharacter {
       case EquipmentManager.WEAPON:
         newModifiers.addDouble(
             DoubleModifier.WEAPON_DAMAGE,
-            EquipmentDatabase.getPower(itemId) * 0.15f,
+            EquipmentDatabase.getPower(itemId) * 0.15,
             ModifierType.EQUIPMENT_POWER,
             "15% weapon power");
         break;

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -2227,10 +2227,6 @@ public abstract class KoLCharacter {
     return KoLCharacter.currentModifiers.getBoolean(mod);
   }
 
-  public static final String currentStringModifier(final String name) {
-    return KoLCharacter.currentModifiers.getString(name);
-  }
-
   public static final String currentStringModifier(final StringModifier mod) {
     return KoLCharacter.currentModifiers.getString(mod);
   }

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -390,30 +390,20 @@ public class Modifiers {
     return bools;
   }
 
-  public boolean getBoolean(final String name) {
-    BooleanModifier modifier = BooleanModifier.byCaselessName(name);
-    return getBoolean(modifier);
-  }
-
   public String getString(final StringModifier modifier) {
     if (modifier == null) {
       return "";
     }
 
-    return this.strings.get(modifier);
-  }
-
-  public String getString(final String name) {
     // Can't cache this as expressions can be dependent on things
     // that can change within a session, like character level.
-    if (name.equals("Evaluated Modifiers")) {
+    if (modifier == StringModifier.EVALUATED_MODIFIERS) {
       return ModifierDatabase.evaluateModifiers(
               this.originalLookup, this.strings.get(StringModifier.MODIFIERS))
           .toString();
     }
 
-    StringModifier modifier = StringModifier.byCaselessName(name);
-    return getString(modifier);
+    return this.strings.get(modifier);
   }
 
   public double getDoublerAccumulator(final DoubleModifier modifier) {
@@ -422,12 +412,6 @@ public class Modifiers {
       return -9999.0;
     }
     return this.doublerAccumulators.get(modifier);
-  }
-
-  public double getDoublerAccumulator(final String name) {
-    // doublerAccumulators uses the same keys as doubles, so the same lookup will work
-    DoubleModifier modifier = DoubleModifier.byCaselessName(name);
-    return getDoublerAccumulator(modifier);
   }
 
   public boolean setDouble(final DoubleModifier mod, final double value) {

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -20,6 +20,7 @@ import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifierCollection;
 import net.sourceforge.kolmafia.modifiers.Lookup;
+import net.sourceforge.kolmafia.modifiers.Modifier;
 import net.sourceforge.kolmafia.modifiers.ModifierList;
 import net.sourceforge.kolmafia.modifiers.ModifierList.ModifierValue;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
@@ -145,15 +146,15 @@ public class Modifiers {
       mox = mys;
     }
 
-    int mus_limit = (int) this.get(DoubleModifier.MUS_LIMIT);
+    int mus_limit = (int) this.getDouble(DoubleModifier.MUS_LIMIT);
     if (mus_limit > 0 && mus > mus_limit) {
       mus = mus_limit;
     }
-    int mys_limit = (int) this.get(DoubleModifier.MYS_LIMIT);
+    int mys_limit = (int) this.getDouble(DoubleModifier.MYS_LIMIT);
     if (mys_limit > 0 && mys > mys_limit) {
       mys = mys_limit;
     }
-    int mox_limit = (int) this.get(DoubleModifier.MOX_LIMIT);
+    int mox_limit = (int) this.getDouble(DoubleModifier.MOX_LIMIT);
     if (mox_limit > 0 && mox > mox_limit) {
       mox = mox_limit;
     }
@@ -161,18 +162,18 @@ public class Modifiers {
     rv.put(
         DerivedModifier.BUFFED_MUS,
         mus
-            + (int) this.get(DoubleModifier.MUS)
-            + (int) Math.ceil(this.get(DoubleModifier.MUS_PCT) * mus / 100.0));
+            + (int) this.getDouble(DoubleModifier.MUS)
+            + (int) Math.ceil(this.getDouble(DoubleModifier.MUS_PCT) * mus / 100.0));
     rv.put(
         DerivedModifier.BUFFED_MYS,
         mys
-            + (int) this.get(DoubleModifier.MYS)
-            + (int) Math.ceil(this.get(DoubleModifier.MYS_PCT) * mys / 100.0));
+            + (int) this.getDouble(DoubleModifier.MYS)
+            + (int) Math.ceil(this.getDouble(DoubleModifier.MYS_PCT) * mys / 100.0));
     rv.put(
         DerivedModifier.BUFFED_MOX,
         mox
-            + (int) this.get(DoubleModifier.MOX)
-            + (int) Math.ceil(this.get(DoubleModifier.MOX_PCT) * mox / 100.0));
+            + (int) this.getDouble(DoubleModifier.MOX)
+            + (int) Math.ceil(this.getDouble(DoubleModifier.MOX_PCT) * mox / 100.0));
 
     String mus_buffed_floor = this.getString(StringModifier.FLOOR_BUFFED_MUSCLE);
     if (mus_buffed_floor.startsWith("Mys")) {
@@ -216,23 +217,25 @@ public class Modifiers {
     int buffedHP;
     if (KoLCharacter.isVampyre()) {
       hpbase = KoLCharacter.getBaseMuscle();
-      hp = hpbase + (int) this.get(DoubleModifier.HP);
+      hp = hpbase + (int) this.getDouble(DoubleModifier.HP);
       buffedHP = Math.max(hp, mus);
     } else if (KoLCharacter.inRobocore()) {
       hpbase = 30;
-      hp = hpbase + (int) this.get(DoubleModifier.HP);
+      hp = hpbase + (int) this.getDouble(DoubleModifier.HP);
       buffedHP = hp;
     } else if (KoLCharacter.isGreyGoo()) {
       hpbase =
           (int) KoLCharacter.getBaseMaxHP()
               - (int) KoLCharacter.currentNumericModifier(DoubleModifier.HP);
-      hp = hpbase + (int) this.get(DoubleModifier.HP);
+      hp = hpbase + (int) this.getDouble(DoubleModifier.HP);
       buffedHP = hp;
     } else {
       hpbase = rv.get(DerivedModifier.BUFFED_MUS) + 3;
       double C = KoLCharacter.isMuscleClass() ? 1.5 : 1.0;
-      double hpPercent = this.get(DoubleModifier.HP_PCT);
-      hp = (int) Math.ceil(hpbase * (C + hpPercent / 100.0)) + (int) this.get(DoubleModifier.HP);
+      double hpPercent = this.getDouble(DoubleModifier.HP_PCT);
+      hp =
+          (int) Math.ceil(hpbase * (C + hpPercent / 100.0))
+              + (int) this.getDouble(DoubleModifier.HP);
       buffedHP = Math.max(hp, mus);
     }
     rv.put(DerivedModifier.BUFFED_HP, buffedHP);
@@ -244,7 +247,7 @@ public class Modifiers {
       mpbase =
           (int) KoLCharacter.getBaseMaxMP()
               - (int) KoLCharacter.currentNumericModifier(DoubleModifier.MP);
-      mp = mpbase + (int) this.get(DoubleModifier.MP);
+      mp = mpbase + (int) this.getDouble(DoubleModifier.MP);
       buffedMP = mp;
     } else {
       mpbase = rv.get(DerivedModifier.BUFFED_MYS);
@@ -254,8 +257,10 @@ public class Modifiers {
         mpbase = rv.get(DerivedModifier.BUFFED_MOX);
       }
       double C = KoLCharacter.isMysticalityClass() ? 1.5 : 1.0;
-      double mpPercent = this.get(DoubleModifier.MP_PCT);
-      mp = (int) Math.ceil(mpbase * (C + mpPercent / 100.0)) + (int) this.get(DoubleModifier.MP);
+      double mpPercent = this.getDouble(DoubleModifier.MP_PCT);
+      mp =
+          (int) Math.ceil(mpbase * (C + mpPercent / 100.0))
+              + (int) this.getDouble(DoubleModifier.MP);
       buffedMP = Math.max(mp, mys);
     }
     rv.put(DerivedModifier.BUFFED_MP, buffedMP);
@@ -277,6 +282,18 @@ public class Modifiers {
     this.booleans.reset();
     this.bitmaps.reset();
     this.expressions = null;
+  }
+
+  public double getNumeric(final Modifier modifier) {
+    if (modifier instanceof DoubleModifier db) {
+      return getDouble(db);
+    } else if (modifier instanceof DerivedModifier db) {
+      return getDerived(db);
+    } else if (modifier instanceof BitmapModifier bm) {
+      return getBitmap(bm);
+    } else {
+      return 0.0;
+    }
   }
 
   private double derivePrismaticDamage() {
@@ -304,7 +321,7 @@ public class Modifiers {
     return rate;
   }
 
-  public double get(final DoubleModifier modifier) {
+  public double getDouble(final DoubleModifier modifier) {
     if (modifier == DoubleModifier.PRISMATIC_DAMAGE) {
       return this.derivePrismaticDamage();
     }
@@ -314,26 +331,6 @@ public class Modifiers {
 
     if (modifier == null) {
       return 0.0;
-    }
-
-    return this.doubles.get(modifier);
-  }
-
-  public double get(final String name) {
-    if (name.equalsIgnoreCase("Prismatic Damage")) {
-      return this.derivePrismaticDamage();
-    }
-    if (name.equalsIgnoreCase("Combat Rate")) {
-      return this.cappedCombatRate();
-    }
-
-    DoubleModifier modifier = DoubleModifier.byCaselessName(name);
-    if (modifier == null) {
-      DerivedModifier derived = DerivedModifier.byCaselessName(name);
-      if (derived == null) {
-        return this.getBitmap(name);
-      }
-      return this.predict().get(derived);
     }
 
     return this.doubles.get(modifier);
@@ -361,10 +358,6 @@ public class Modifiers {
     n = ((n & 0xFF00FF00) >>> 8) + (n & 0x00FF00FF);
     n = ((n & 0xFFFF0000) >>> 16) + (n & 0x0000FFFF);
     return n;
-  }
-
-  public int getBitmap(final String name) {
-    return this.getBitmap(BitmapModifier.byCaselessName(name));
   }
 
   public double getDerived(final DerivedModifier modifier) {
@@ -550,7 +543,7 @@ public class Modifiers {
         this.doubles.add(mod, value);
         break;
       case FAMILIAR_ACTION_BONUS:
-        this.doubles.set(mod, Math.min(100, this.get(mod) + value));
+        this.doubles.set(mod, Math.min(100, this.getDouble(mod) + value));
         break;
       default:
         this.doubles.add(mod, value);
@@ -928,11 +921,11 @@ public class Modifiers {
       weight = Math.max(weight, 20);
     }
 
-    weight += (int) this.get(DoubleModifier.FAMILIAR_WEIGHT);
-    weight += (int) this.get(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT);
+    weight += (int) this.getDouble(DoubleModifier.FAMILIAR_WEIGHT);
+    weight += (int) this.getDouble(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT);
     weight += (familiar.getFeasted() ? 10 : 0);
 
-    double percent = this.get(DoubleModifier.FAMILIAR_WEIGHT_PCT) / 100.0;
+    double percent = this.getDouble(DoubleModifier.FAMILIAR_WEIGHT_PCT) / 100.0;
     if (percent != 0.0) {
       weight = (int) Math.floor(weight + weight * percent);
     }
@@ -964,20 +957,20 @@ public class Modifiers {
       this.add(ModifierDatabase.getModifiers(ModifierType.FAM_EQ, famItem.getName()));
     }
 
-    int cap = (int) this.get(DoubleModifier.FAMILIAR_WEIGHT_CAP);
+    int cap = (int) this.getDouble(DoubleModifier.FAMILIAR_WEIGHT_CAP);
     int cappedWeight = (cap == 0) ? weight : Math.min(weight, cap);
 
-    double effective = cappedWeight * this.get(DoubleModifier.VOLLEYBALL_WEIGHT);
+    double effective = cappedWeight * this.getDouble(DoubleModifier.VOLLEYBALL_WEIGHT);
     if (effective == 0.0 && FamiliarDatabase.isVolleyType(familiarId)) {
       effective = weight;
     }
     if (effective != 0.0) {
-      double factor = this.get(DoubleModifier.VOLLEYBALL_EFFECTIVENESS);
+      double factor = this.getDouble(DoubleModifier.VOLLEYBALL_EFFECTIVENESS);
       // The 0->1 factor for generic familiars conflicts with the JitB
       if (factor == 0.0 && familiarId != FamiliarPool.JACK_IN_THE_BOX) factor = 1.0;
       factor = factor * (2 + effective / 5);
       double tuning;
-      if ((tuning = this.get(DoubleModifier.FAMILIAR_TUNING_MUSCLE)) > 0) {
+      if ((tuning = this.getDouble(DoubleModifier.FAMILIAR_TUNING_MUSCLE)) > 0) {
         double mainstatFactor = tuning / 100;
         double offstatFactor = (1 - mainstatFactor) / 2;
         this.addDouble(
@@ -995,7 +988,7 @@ public class Modifiers {
             factor * offstatFactor,
             ModifierType.TUNED_VOLLEYBALL,
             race);
-      } else if ((tuning = this.get(DoubleModifier.FAMILIAR_TUNING_MYSTICALITY)) > 0) {
+      } else if ((tuning = this.getDouble(DoubleModifier.FAMILIAR_TUNING_MYSTICALITY)) > 0) {
         double mainstatFactor = tuning / 100;
         double offstatFactor = (1 - mainstatFactor) / 2;
         this.addDouble(
@@ -1013,7 +1006,7 @@ public class Modifiers {
             factor * offstatFactor,
             ModifierType.TUNED_VOLLEYBALL,
             race);
-      } else if ((tuning = this.get(DoubleModifier.FAMILIAR_TUNING_MOXIE)) > 0) {
+      } else if ((tuning = this.getDouble(DoubleModifier.FAMILIAR_TUNING_MOXIE)) > 0) {
         double mainstatFactor = tuning / 100;
         double offstatFactor = (1 - mainstatFactor) / 2;
         this.addDouble(
@@ -1036,13 +1029,13 @@ public class Modifiers {
       }
     }
 
-    effective = cappedWeight * this.get(DoubleModifier.SOMBRERO_WEIGHT);
+    effective = cappedWeight * this.getDouble(DoubleModifier.SOMBRERO_WEIGHT);
     if (effective == 0.0 && FamiliarDatabase.isSombreroType(familiarId)) {
       effective = weight;
     }
-    effective += this.get(DoubleModifier.SOMBRERO_BONUS);
+    effective += this.getDouble(DoubleModifier.SOMBRERO_BONUS);
     if (effective != 0.0) {
-      double factor = this.get(DoubleModifier.SOMBRERO_EFFECTIVENESS);
+      double factor = this.getDouble(DoubleModifier.SOMBRERO_EFFECTIVENESS);
       if (factor == 0.0) factor = 1.0;
       // currentML is always >= 4, so we don't need to check for negatives
       int maxStats = 230;
@@ -1055,12 +1048,12 @@ public class Modifiers {
           race);
     }
 
-    effective = cappedWeight * this.get(DoubleModifier.LEPRECHAUN_WEIGHT);
+    effective = cappedWeight * this.getDouble(DoubleModifier.LEPRECHAUN_WEIGHT);
     if (effective == 0.0 && FamiliarDatabase.isMeatDropType(familiarId)) {
       effective = weight;
     }
     if (effective != 0.0) {
-      double factor = this.get(DoubleModifier.LEPRECHAUN_EFFECTIVENESS);
+      double factor = this.getDouble(DoubleModifier.LEPRECHAUN_EFFECTIVENESS);
       if (factor == 0.0) factor = 1.0;
       this.addDouble(
           DoubleModifier.MEATDROP,
@@ -1127,7 +1120,7 @@ public class Modifiers {
       final DoubleModifier fairyModifier,
       final DoubleModifier effectivenessModifier,
       final DoubleModifier modifier) {
-    var effective = cappedWeight * this.get(fairyModifier);
+    var effective = cappedWeight * this.getDouble(fairyModifier);
 
     // If it has no explicit modifier but is the right familiar type, add effect regardless
     if (effective == 0.0 && FamiliarDatabase.isFairyType(familiar.getId(), fairyModifier)) {
@@ -1136,7 +1129,7 @@ public class Modifiers {
 
     if (effective == 0.0) return;
 
-    double factor = this.get(effectivenessModifier);
+    double factor = this.getDouble(effectivenessModifier);
     // The 0->1 factor for generic familiars conflicts with the JitB
     if (factor == 0.0 && familiar.getId() != FamiliarPool.JACK_IN_THE_BOX) factor = 1.0;
 
@@ -1152,22 +1145,26 @@ public class Modifiers {
     Lookup lookup = new Lookup(ModifierType.CLANCY, instrumentName);
     Modifiers imods = ModifierDatabase.getModifiers(lookup);
 
-    double effective = imods.get(DoubleModifier.VOLLEYBALL_WEIGHT);
+    double effective = imods.getDouble(DoubleModifier.VOLLEYBALL_WEIGHT);
     if (effective != 0.0) {
       double factor = 2 + effective / 5;
       this.addDouble(DoubleModifier.EXPERIENCE, factor, lookup);
     }
 
-    effective = imods.get(DoubleModifier.FAIRY_WEIGHT);
+    effective = imods.getDouble(DoubleModifier.FAIRY_WEIGHT);
     if (effective != 0.0) {
       double factor = Math.sqrt(55 * effective) + effective - 3;
       this.addDouble(DoubleModifier.ITEMDROP, factor, lookup);
     }
 
-    this.addDouble(DoubleModifier.HP_REGEN_MIN, imods.get(DoubleModifier.HP_REGEN_MIN), lookup);
-    this.addDouble(DoubleModifier.HP_REGEN_MAX, imods.get(DoubleModifier.HP_REGEN_MAX), lookup);
-    this.addDouble(DoubleModifier.MP_REGEN_MIN, imods.get(DoubleModifier.MP_REGEN_MIN), lookup);
-    this.addDouble(DoubleModifier.MP_REGEN_MAX, imods.get(DoubleModifier.MP_REGEN_MAX), lookup);
+    this.addDouble(
+        DoubleModifier.HP_REGEN_MIN, imods.getDouble(DoubleModifier.HP_REGEN_MIN), lookup);
+    this.addDouble(
+        DoubleModifier.HP_REGEN_MAX, imods.getDouble(DoubleModifier.HP_REGEN_MAX), lookup);
+    this.addDouble(
+        DoubleModifier.MP_REGEN_MIN, imods.getDouble(DoubleModifier.MP_REGEN_MIN), lookup);
+    this.addDouble(
+        DoubleModifier.MP_REGEN_MAX, imods.getDouble(DoubleModifier.MP_REGEN_MAX), lookup);
   }
 
   public void applyCompanionModifiers(Companion companion) {
@@ -1235,17 +1232,17 @@ public class Modifiers {
       if (ensorcelMods != null) {
         this.addDouble(
             DoubleModifier.MEATDROP,
-            ensorcelMods.get(DoubleModifier.MEATDROP) * 0.25,
+            ensorcelMods.getDouble(DoubleModifier.MEATDROP) * 0.25,
             ModifierType.ITEM,
             ItemPool.VAMPYRIC_CLOAKE);
         this.addDouble(
             DoubleModifier.ITEMDROP,
-            ensorcelMods.get(DoubleModifier.ITEMDROP) * 0.25,
+            ensorcelMods.getDouble(DoubleModifier.ITEMDROP) * 0.25,
             ModifierType.ITEM,
             ItemPool.VAMPYRIC_CLOAKE);
         this.addDouble(
             DoubleModifier.CANDYDROP,
-            ensorcelMods.get(DoubleModifier.CANDYDROP) * 0.25,
+            ensorcelMods.getDouble(DoubleModifier.CANDYDROP) * 0.25,
             ModifierType.ITEM,
             ItemPool.VAMPYRIC_CLOAKE);
       }

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -728,7 +728,7 @@ public class Evaluator {
       double weight = this.weight.get(mod);
       double min = this.min.get(mod);
       if (weight == 0.0 && min == Double.NEGATIVE_INFINITY) continue;
-      double val = mods.get(mod);
+      double val = mods.getDouble(mod);
       double max = this.max.get(mod);
       switch (mod) {
         case MUS:
@@ -741,29 +741,29 @@ public class Evaluator {
           val = predicted.get(DerivedModifier.BUFFED_MOX);
           break;
         case FAMILIAR_WEIGHT:
-          val += mods.get(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT);
-          if (mods.get(DoubleModifier.FAMILIAR_WEIGHT_PCT) < 0.0) {
+          val += mods.getDouble(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT);
+          if (mods.getDouble(DoubleModifier.FAMILIAR_WEIGHT_PCT) < 0.0) {
             val *= 0.5f;
           }
           break;
         case MANA_COST:
-          val += mods.get(DoubleModifier.STACKABLE_MANA_COST);
+          val += mods.getDouble(DoubleModifier.STACKABLE_MANA_COST);
           break;
         case INITIATIVE:
-          val += Math.min(0.0, mods.get(DoubleModifier.INITIATIVE_PENALTY));
+          val += Math.min(0.0, mods.getDouble(DoubleModifier.INITIATIVE_PENALTY));
           break;
         case MEATDROP:
           val +=
               100.0
-                  + Math.min(0.0, mods.get(DoubleModifier.MEATDROP_PENALTY))
-                  + mods.get(DoubleModifier.SPORADIC_MEATDROP)
-                  + mods.get(DoubleModifier.MEAT_BONUS) / 10000.0;
+                  + Math.min(0.0, mods.getDouble(DoubleModifier.MEATDROP_PENALTY))
+                  + mods.getDouble(DoubleModifier.SPORADIC_MEATDROP)
+                  + mods.getDouble(DoubleModifier.MEAT_BONUS) / 10000.0;
           break;
         case ITEMDROP:
           val +=
               100.0
-                  + Math.min(0.0, mods.get(DoubleModifier.ITEMDROP_PENALTY))
-                  + mods.get(DoubleModifier.SPORADIC_ITEMDROP);
+                  + Math.min(0.0, mods.getDouble(DoubleModifier.ITEMDROP_PENALTY))
+                  + mods.getDouble(DoubleModifier.SPORADIC_ITEMDROP);
           break;
         case HP:
           val = predicted.get(DerivedModifier.BUFFED_HP);
@@ -773,15 +773,15 @@ public class Evaluator {
           break;
         case WEAPON_DAMAGE:
           // Incorrect - needs to estimate base damage
-          val += mods.get(DoubleModifier.WEAPON_DAMAGE_PCT);
+          val += mods.getDouble(DoubleModifier.WEAPON_DAMAGE_PCT);
           break;
         case RANGED_DAMAGE:
           // Incorrect - needs to estimate base damage
-          val += mods.get(DoubleModifier.RANGED_DAMAGE_PCT);
+          val += mods.getDouble(DoubleModifier.RANGED_DAMAGE_PCT);
           break;
         case SPELL_DAMAGE:
           // Incorrect - base damage depends on spell used
-          val += mods.get(DoubleModifier.SPELL_DAMAGE_PCT);
+          val += mods.getDouble(DoubleModifier.SPELL_DAMAGE_PCT);
           break;
         case COLD_RESISTANCE:
           if (mods.getBoolean(BooleanModifier.COLD_IMMUNITY)) {
@@ -821,10 +821,10 @@ public class Evaluator {
         case EXPERIENCE:
           double baseExp =
               KoLCharacter.estimatedBaseExp(
-                  mods.get(DoubleModifier.MONSTER_LEVEL)
-                      * (1 + mods.get(DoubleModifier.MONSTER_LEVEL_PERCENT) / 100));
-          double expPct = mods.get(DoubleModifier.primeStatExpPercent()) / 100.0f;
-          double exp = mods.get(DoubleModifier.primeStatExp());
+                  mods.getDouble(DoubleModifier.MONSTER_LEVEL)
+                      * (1 + mods.getDouble(DoubleModifier.MONSTER_LEVEL_PERCENT) / 100));
+          double expPct = mods.getDouble(DoubleModifier.primeStatExpPercent()) / 100.0f;
+          double exp = mods.getDouble(DoubleModifier.primeStatExp());
 
           val = ((baseExp + exp) * (1 + expPct)) / 2.0f;
           break;
@@ -857,7 +857,7 @@ public class Evaluator {
     // Allow partials to contribute to the score (1:1 ratio) up to the desired value.
     // Similar to setting a max.
     if (this.clownosity > 0) {
-      int osity = ((int) mods.get(DoubleModifier.CLOWNINESS)) / 25;
+      int osity = ((int) mods.getDouble(DoubleModifier.CLOWNINESS)) / 25;
       score += Math.min(osity, this.clownosity);
       if (osity < this.clownosity) this.failed = true;
     }
@@ -867,7 +867,7 @@ public class Evaluator {
       if (osity < this.raveosity) this.failed = true;
     }
     if (this.surgeonosity > 0) {
-      int osity = (int) mods.get(DoubleModifier.SURGEONOSITY);
+      int osity = (int) mods.getDouble(DoubleModifier.SURGEONOSITY);
       score += Math.min(osity, this.surgeonosity);
       if (osity < this.surgeonosity) this.failed = true;
     }
@@ -1468,14 +1468,14 @@ public class Evaluator {
             break gotItem;
         }
 
-        if ((hoboPowerUseful && mods.get(DoubleModifier.HOBO_POWER) > 0.0)
-            || (smithsnessUseful && !wrongClass && mods.get(DoubleModifier.SMITHSNESS) > 0.0)
+        if ((hoboPowerUseful && mods.getDouble(DoubleModifier.HOBO_POWER) > 0.0)
+            || (smithsnessUseful && !wrongClass && mods.getDouble(DoubleModifier.SMITHSNESS) > 0.0)
             || (brimstoneUseful && mods.getRawBitmap(BitmapModifier.BRIMSTONE) != 0)
             || (cloathingUseful && mods.getRawBitmap(BitmapModifier.CLOATHING) != 0)
-            || (slimeHateUseful && mods.get(DoubleModifier.SLIME_HATES_IT) > 0.0)
-            || (this.clownosity > 0 && mods.get(DoubleModifier.CLOWNINESS) != 0)
+            || (slimeHateUseful && mods.getDouble(DoubleModifier.SLIME_HATES_IT) > 0.0)
+            || (this.clownosity > 0 && mods.getDouble(DoubleModifier.CLOWNINESS) != 0)
             || (this.raveosity > 0 && mods.getRawBitmap(BitmapModifier.RAVEOSITY) != 0)
-            || (this.surgeonosity > 0 && mods.get(DoubleModifier.SURGEONOSITY) != 0)
+            || (this.surgeonosity > 0 && mods.getDouble(DoubleModifier.SURGEONOSITY) != 0)
             || ((mods.getRawBitmap(BitmapModifier.SYNERGETIC) & usefulSynergies) != 0)) {
           item.automaticFlag = true;
           break gotItem;

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -278,11 +278,11 @@ public class Maximizer {
             case SURGEONOSITY:
               continue;
           }
-          if (itemMods.get(mod) != 0.0) {
+          if (itemMods.getDouble(mod) != 0.0) {
             if (mods.length() > 0) {
               mods.append(", ");
             }
-            mods.append(mod.getName() + ": " + itemMods.get(mod));
+            mods.append(mod.getName() + ": " + itemMods.getDouble(mod));
           }
         }
         if (mods.length() == 0) {
@@ -587,7 +587,7 @@ public class Maximizer {
 
             Modifiers effMod = ModifierDatabase.getItemModifiers(item.getItemId());
             if (effMod != null) {
-              duration = (int) effMod.get(DoubleModifier.EFFECT_DURATION);
+              duration = (int) effMod.getDouble(DoubleModifier.EFFECT_DURATION);
             }
           }
           // Hot Dogs don't have items
@@ -622,7 +622,7 @@ public class Maximizer {
             } else {
               Modifiers effMod = ModifierDatabase.getModifiers(ModifierType.ITEM, iName);
               if (effMod != null) {
-                duration = (int) effMod.get(DoubleModifier.EFFECT_DURATION);
+                duration = (int) effMod.getDouble(DoubleModifier.EFFECT_DURATION);
               }
               usesRemaining = 1;
             }

--- a/src/net/sourceforge/kolmafia/modifiers/StringModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/StringModifier.java
@@ -55,10 +55,15 @@ public enum StringModifier implements Modifier {
       "Floor Buffed Mysticality", Pattern.compile("Floor Buffed Mysticality: \"(.*?)\"")),
   FLOOR_BUFFED_MOXIE("Floor Buffed Moxie", Pattern.compile("Floor Buffed Moxie: \"(.*?)\"")),
   PLUMBER_STAT("Plumber Stat", Pattern.compile("Plumber Stat: \"(.*?)\"")),
-  RECIPE("Recipe", Pattern.compile("Recipe: \"(.*?)\""));
+  RECIPE("Recipe", Pattern.compile("Recipe: \"(.*?)\"")),
+  EVALUATED_MODIFIERS("Evaluated Modifiers");
   private final String name;
   private final Pattern[] descPatterns;
   private final Pattern tagPattern;
+
+  StringModifier(String name) {
+    this(name, null);
+  }
 
   StringModifier(String name, Pattern tagPattern) {
     this(name, (Pattern[]) null, tagPattern);

--- a/src/net/sourceforge/kolmafia/objectpool/Concoction.java
+++ b/src/net/sourceforge/kolmafia/objectpool/Concoction.java
@@ -13,6 +13,7 @@ import net.sourceforge.kolmafia.KoLConstants.CraftingRequirements;
 import net.sourceforge.kolmafia.KoLConstants.CraftingType;
 import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.RequestLogger;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.persistence.Consumable;
 import net.sourceforge.kolmafia.persistence.ConsumablesDatabase;
@@ -221,7 +222,8 @@ public class Concoction implements Comparable<Concoction> {
   }
 
   public void setEffectName() {
-    this.effectName = ModifierDatabase.getStringModifier(ModifierType.ITEM, this.name, "Effect");
+    this.effectName =
+        ModifierDatabase.getStringModifier(ModifierType.ITEM, this.name, StringModifier.EFFECT);
   }
 
   public void setStatGain() {

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -33,6 +33,7 @@ import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.modifiers.Lookup;
 import net.sourceforge.kolmafia.modifiers.ModifierList;
 import net.sourceforge.kolmafia.modifiers.ModifierList.ModifierValue;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
@@ -2672,7 +2673,8 @@ public class DebugDatabase {
 
       // Potions grant an effect. Check for a new effect.
       String itemName = ItemDatabase.getItemDataName(id);
-      String effectName = ModifierDatabase.getStringModifier(ModifierType.ITEM, itemId, "Effect");
+      String effectName =
+          ModifierDatabase.getStringModifier(ModifierType.ITEM, itemId, StringModifier.EFFECT);
       if (!effectName.equals("") && EffectDatabase.getEffectId(effectName, true) == -1) {
         String rawText = DebugDatabase.rawItemDescriptionText(itemId);
         String effectDescid = DebugDatabase.parseEffectDescid(rawText);

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -755,13 +755,14 @@ public class EffectDatabase {
 
     int level =
         switch (effectId) {
-          case EffectPool.WINE_FORTIFIED -> (int) emods.get(DoubleModifier.WEAPON_DAMAGE) / 3;
-          case EffectPool.WINE_HOT -> (int) emods.get(DoubleModifier.HOT_DAMAGE) / 3;
-          case EffectPool.WINE_COLD -> (int) emods.get(DoubleModifier.COLD_DAMAGE) / 3;
-          case EffectPool.WINE_DARK -> (int) emods.get(DoubleModifier.SPOOKY_DAMAGE) / 4;
-          case EffectPool.WINE_BEFOULED -> (int) emods.get(DoubleModifier.STENCH_DAMAGE) / 3;
-          case EffectPool.WINE_FRISKY -> (int) emods.get(DoubleModifier.SLEAZE_DAMAGE) / 3;
-          case EffectPool.WINE_FRIENDLY -> (int) emods.get(DoubleModifier.FAMILIAR_DAMAGE) / 3;
+          case EffectPool.WINE_FORTIFIED -> (int) emods.getDouble(DoubleModifier.WEAPON_DAMAGE) / 3;
+          case EffectPool.WINE_HOT -> (int) emods.getDouble(DoubleModifier.HOT_DAMAGE) / 3;
+          case EffectPool.WINE_COLD -> (int) emods.getDouble(DoubleModifier.COLD_DAMAGE) / 3;
+          case EffectPool.WINE_DARK -> (int) emods.getDouble(DoubleModifier.SPOOKY_DAMAGE) / 4;
+          case EffectPool.WINE_BEFOULED -> (int) emods.getDouble(DoubleModifier.STENCH_DAMAGE) / 3;
+          case EffectPool.WINE_FRISKY -> (int) emods.getDouble(DoubleModifier.SLEAZE_DAMAGE) / 3;
+          case EffectPool.WINE_FRIENDLY -> (int) emods.getDouble(DoubleModifier.FAMILIAR_DAMAGE)
+              / 3;
           default -> -1;
         };
 

--- a/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
@@ -765,7 +765,7 @@ public class EquipmentDatabase {
       pulver |= EquipmentDatabase.ELEM_TWINKLY;
     } else {
       for (var implication : IMPLICATIONS.entrySet()) {
-        if (mods.get(implication.getKey()) > 0.0f) {
+        if (mods.getDouble(implication.getKey()) > 0.0f) {
           pulver |= implication.getValue();
         }
       }

--- a/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
@@ -937,14 +937,16 @@ public class ItemDatabase {
     EquipmentDatabase.registerItemOutfit(itemId, text);
 
     // Skillbooks teach you a skill
-    String skillName = ModifierDatabase.getStringModifier(ModifierType.ITEM, itemId, "Skill");
+    String skillName =
+        ModifierDatabase.getStringModifier(ModifierType.ITEM, itemId, StringModifier.SKILL);
     if (!skillName.equals("") && SkillDatabase.getSkillId(skillName) == -1) {
       int skillId = DebugDatabase.parseSkillId(rawText);
       SkillDatabase.registerSkill(skillId, skillName);
     }
 
     // Potions grant an effect. Check for a new effect.
-    String effectName = ModifierDatabase.getStringModifier(ModifierType.ITEM, itemId, "Effect");
+    String effectName =
+        ModifierDatabase.getStringModifier(ModifierType.ITEM, itemId, StringModifier.EFFECT);
     if (!effectName.equals("") && EffectDatabase.getEffectId(effectName, true) == -1) {
       String effectDescid = DebugDatabase.parseEffectDescid(rawText);
       String command =
@@ -958,7 +960,9 @@ public class ItemDatabase {
     }
 
     // Equipment can have a Rollover Effect. Check for new effect.
-    effectName = ModifierDatabase.getStringModifier(ModifierType.ITEM, itemId, "Rollover Effect");
+    effectName =
+        ModifierDatabase.getStringModifier(
+            ModifierType.ITEM, itemId, StringModifier.ROLLOVER_EFFECT);
     if (!effectName.equals("") && EffectDatabase.getEffectId(effectName, true) == -1) {
       String effectDescid = DebugDatabase.parseEffectDescid(rawText);
       EffectDatabase.registerEffect(effectName, effectDescid, null);

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -418,16 +418,16 @@ public class ModifierDatabase {
   }
 
   public static final boolean getBooleanModifier(
-      final ModifierType type, final int id, final String mod) {
+      final ModifierType type, final int id, final BooleanModifier mod) {
     return getBooleanModifier(new Lookup(type, id), mod);
   }
 
   public static final boolean getBooleanModifier(
-      final ModifierType type, final String name, final String mod) {
+      final ModifierType type, final String name, final BooleanModifier mod) {
     return getBooleanModifier(new Lookup(type, name), mod);
   }
 
-  public static final boolean getBooleanModifier(final Lookup lookup, final String mod) {
+  public static final boolean getBooleanModifier(final Lookup lookup, final BooleanModifier mod) {
     Modifiers mods = getModifiers(lookup);
     if (mods == null) {
       return false;
@@ -436,16 +436,16 @@ public class ModifierDatabase {
   }
 
   public static final String getStringModifier(
-      final ModifierType type, final int id, final String mod) {
+      final ModifierType type, final int id, final StringModifier mod) {
     return getStringModifier(new Lookup(type, id), mod);
   }
 
   public static final String getStringModifier(
-      final ModifierType type, final String name, final String mod) {
+      final ModifierType type, final String name, final StringModifier mod) {
     return getStringModifier(new Lookup(type, name), mod);
   }
 
-  public static final String getStringModifier(final Lookup lookup, final String mod) {
+  public static final String getStringModifier(final Lookup lookup, final StringModifier mod) {
     Modifiers mods = getModifiers(lookup);
     if (mods == null) {
       return "";

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -36,6 +36,7 @@ import net.sourceforge.kolmafia.ZodiacSign;
 import net.sourceforge.kolmafia.maximizer.Maximizer;
 import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
+import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.Lookup;
 import net.sourceforge.kolmafia.modifiers.Modifier;
@@ -262,6 +263,19 @@ public class ModifierDatabase {
     return list.toString();
   }
 
+  /** Get a double, derived or boolean modifier by name, ignoring case */
+  public static Modifier numericByCaselessName(String name) {
+    DoubleModifier modifier = DoubleModifier.byCaselessName(name);
+    if (modifier != null) {
+      return modifier;
+    }
+    DerivedModifier derived = DerivedModifier.byCaselessName(name);
+    if (derived != null) {
+      return derived;
+    }
+    return BitmapModifier.byCaselessName(name);
+  }
+
   // region: get registered values
 
   public static final Modifiers getItemModifiers(final int id) {
@@ -355,30 +369,30 @@ public class ModifierDatabase {
   }
 
   public static final double getNumericModifier(
-      final ModifierType type, final int id, final String mod) {
+      final ModifierType type, final int id, final Modifier mod) {
     return getNumericModifier(new Lookup(type, id), mod);
   }
 
   public static final double getNumericModifier(
-      final ModifierType type, final String name, final String mod) {
+      final ModifierType type, final String name, final Modifier mod) {
     return getNumericModifier(new Lookup(type, name), mod);
   }
 
-  public static final double getNumericModifier(final Lookup lookup, final String mod) {
+  public static final double getNumericModifier(final Lookup lookup, final Modifier mod) {
     Modifiers mods = getModifiers(lookup);
     if (mods == null) {
       return 0.0;
     }
-    return mods.get(mod);
+    return mods.getNumeric(mod);
   }
 
-  public static final double getNumericModifier(final FamiliarData fam, final String mod) {
+  public static final double getNumericModifier(final FamiliarData fam, final Modifier mod) {
     return getNumericModifier(fam, mod, fam.getModifiedWeight(false), fam.getItem());
   }
 
   public static final double getNumericModifier(
       final FamiliarData fam,
-      final String mod,
+      final Modifier mod,
       final int passedWeight,
       final AdventureResult item) {
     int familiarId = fam != null ? fam.getId() : -1;
@@ -403,10 +417,10 @@ public class ModifierDatabase {
       tempMods.add(getItemModifiers(itemId));
 
       // Apply weight modifiers right now
-      weight += (int) tempMods.get(DoubleModifier.FAMILIAR_WEIGHT);
-      weight += (int) tempMods.get(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT);
+      weight += (int) tempMods.getDouble(DoubleModifier.FAMILIAR_WEIGHT);
+      weight += (int) tempMods.getDouble(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT);
       weight += (fam.getFeasted() ? 10 : 0);
-      double percent = tempMods.get(DoubleModifier.FAMILIAR_WEIGHT_PCT) / 100.0;
+      double percent = tempMods.getDouble(DoubleModifier.FAMILIAR_WEIGHT_PCT) / 100.0;
       if (percent != 0.0) {
         weight = (int) Math.floor(weight + weight * percent);
       }
@@ -414,7 +428,7 @@ public class ModifierDatabase {
 
     tempMods.lookupFamiliarModifiers(fam, weight, item);
 
-    return tempMods.get(mod);
+    return tempMods.getNumeric(mod);
   }
 
   public static final boolean getBooleanModifier(

--- a/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
@@ -26,6 +26,7 @@ import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.ZodiacSign;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.ConcoctionPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -601,7 +602,8 @@ public class TCRSDatabase {
     }
 
     // Add as effect source, if appropriate
-    String effectName = ModifierDatabase.getStringModifier(ModifierType.ITEM, itemName, "Effect");
+    String effectName =
+        ModifierDatabase.getStringModifier(ModifierType.ITEM, itemName, StringModifier.EFFECT);
     if (effectName != null && !effectName.equals("")) {
       addEffectSource(itemName, usage, effectName);
     }
@@ -691,12 +693,14 @@ public class TCRSDatabase {
     // Consumable attributes (like SAUCY, BEER, etc) are preserved
     ConsumablesDatabase.getAttributes(consumable).stream().map(Enum::name).forEach(comment::add);
 
-    String effectName = ModifierDatabase.getStringModifier(ModifierType.ITEM, itemName, "Effect");
+    String effectName =
+        ModifierDatabase.getStringModifier(ModifierType.ITEM, itemName, StringModifier.EFFECT);
     if (effectName != null && !effectName.isEmpty()) {
       int duration =
           (int) ModifierDatabase.getNumericModifier(ModifierType.ITEM, itemName, "Effect Duration");
       String effectModifiers =
-          ModifierDatabase.getStringModifier(ModifierType.EFFECT, effectName, "Modifiers");
+          ModifierDatabase.getStringModifier(
+              ModifierType.EFFECT, effectName, StringModifier.MODIFIERS);
       comment.add(duration + " " + effectName + " (" + effectModifiers + ")");
     }
 

--- a/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
@@ -26,6 +26,7 @@ import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.ZodiacSign;
+import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.ConcoctionPool;
@@ -697,7 +698,9 @@ public class TCRSDatabase {
         ModifierDatabase.getStringModifier(ModifierType.ITEM, itemName, StringModifier.EFFECT);
     if (effectName != null && !effectName.isEmpty()) {
       int duration =
-          (int) ModifierDatabase.getNumericModifier(ModifierType.ITEM, itemName, "Effect Duration");
+          (int)
+              ModifierDatabase.getNumericModifier(
+                  ModifierType.ITEM, itemName, DoubleModifier.EFFECT_DURATION);
       String effectModifiers =
           ModifierDatabase.getStringModifier(
               ModifierType.EFFECT, effectName, StringModifier.MODIFIERS);

--- a/src/net/sourceforge/kolmafia/request/BasementRequest.java
+++ b/src/net/sourceforge/kolmafia/request/BasementRequest.java
@@ -1223,7 +1223,7 @@ public class BasementRequest extends AdventureRequest {
       }
 
       Modifiers currentTest = ModifierDatabase.getEffectModifiers(effectId);
-      double value = currentTest.get(modifier);
+      double value = currentTest.getDouble(modifier);
 
       if (value == 0.0) {
         continue;

--- a/src/net/sourceforge/kolmafia/request/CharPaneRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CharPaneRequest.java
@@ -503,9 +503,9 @@ public class CharPaneRequest extends GenericRequest {
     boolean mus_equalize = mods.getString(StringModifier.EQUALIZE_MUSCLE).length() != 0;
     boolean mys_equalize = mods.getString(StringModifier.EQUALIZE_MYST).length() != 0;
     boolean mox_equalize = mods.getString(StringModifier.EQUALIZE_MOXIE).length() != 0;
-    boolean mus_limit = (int) mods.get(DoubleModifier.MUS_LIMIT) != 0;
-    boolean mys_limit = (int) mods.get(DoubleModifier.MYS_LIMIT) != 0;
-    boolean mox_limit = (int) mods.get(DoubleModifier.MOX_LIMIT) != 0;
+    boolean mus_limit = (int) mods.getDouble(DoubleModifier.MUS_LIMIT) != 0;
+    boolean mys_limit = (int) mods.getDouble(DoubleModifier.MYS_LIMIT) != 0;
+    boolean mox_limit = (int) mods.getDouble(DoubleModifier.MOX_LIMIT) != 0;
 
     boolean checkMus = !equalize && !mus_equalize && !mus_limit;
     boolean checkMys = !equalize && !mys_equalize && !mys_limit;

--- a/src/net/sourceforge/kolmafia/request/SpelunkyRequest.java
+++ b/src/net/sourceforge/kolmafia/request/SpelunkyRequest.java
@@ -959,12 +959,17 @@ public class SpelunkyRequest extends GenericRequest {
     // Spelunky weapons can have bonus damage
 
     int bonusWeaponDamage =
-        (int) ModifierDatabase.getNumericModifier(ModifierType.ITEM, weaponItemId, "Weapon Damage");
+        (int)
+            ModifierDatabase.getNumericModifier(
+                ModifierType.ITEM, weaponItemId, DoubleModifier.WEAPON_DAMAGE);
     int bonusOffhandDamage =
         (int)
-            ModifierDatabase.getNumericModifier(ModifierType.ITEM, offhandItemId, "Weapon Damage");
+            ModifierDatabase.getNumericModifier(
+                ModifierType.ITEM, offhandItemId, DoubleModifier.WEAPON_DAMAGE);
     int bonusRangedDamage =
-        (int) ModifierDatabase.getNumericModifier(ModifierType.ITEM, weaponItemId, "Ranged Damage");
+        (int)
+            ModifierDatabase.getNumericModifier(
+                ModifierType.ITEM, weaponItemId, DoubleModifier.RANGED_DAMAGE);
     int bonusDamage =
         bonusWeaponDamage + (stat == Stat.MOXIE ? bonusRangedDamage : 0) + bonusOffhandDamage;
 

--- a/src/net/sourceforge/kolmafia/request/StorageRequest.java
+++ b/src/net/sourceforge/kolmafia/request/StorageRequest.java
@@ -18,6 +18,7 @@ import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.listener.NamedListenerRegistry;
+import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
@@ -531,11 +532,13 @@ public class StorageRequest extends TransferItemRequest {
       return false;
     }
 
-    return ModifierDatabase.getBooleanModifier(ModifierType.ITEM, itemId, "Free Pull");
+    return ModifierDatabase.getBooleanModifier(
+        ModifierType.ITEM, itemId, BooleanModifier.FREE_PULL);
   }
 
   public static boolean isNoPull(final AdventureResult item) {
-    return ModifierDatabase.getBooleanModifier(ModifierType.ITEM, item.getItemId(), "No Pull");
+    return ModifierDatabase.getBooleanModifier(
+        ModifierType.ITEM, item.getItemId(), BooleanModifier.NOPULL);
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -20,6 +20,7 @@ import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.SpecialOutfit.Checkpoint;
 import net.sourceforge.kolmafia.ZodiacSign;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.moods.ManaBurnManager;
 import net.sourceforge.kolmafia.moods.RecoveryManager;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
@@ -6042,17 +6043,20 @@ public class UseItemRequest extends GenericRequest {
   }
 
   private static String itemToClass(final int itemId) {
-    String className = ModifierDatabase.getStringModifier(ModifierType.ITEM, itemId, "Class");
+    String className =
+        ModifierDatabase.getStringModifier(ModifierType.ITEM, itemId, StringModifier.CLASS);
     return className.equals("") ? null : className;
   }
 
   private static String itemToSkill(final int itemId) {
-    String skillName = ModifierDatabase.getStringModifier(ModifierType.ITEM, itemId, "Skill");
+    String skillName =
+        ModifierDatabase.getStringModifier(ModifierType.ITEM, itemId, StringModifier.SKILL);
     return skillName.equals("") ? null : skillName;
   }
 
   private static String itemToRecipe(final int itemId) {
-    String recipeName = ModifierDatabase.getStringModifier(ModifierType.ITEM, itemId, "Recipe");
+    String recipeName =
+        ModifierDatabase.getStringModifier(ModifierType.ITEM, itemId, StringModifier.RECIPE);
     return recipeName.equals("") ? null : recipeName;
   }
 

--- a/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
@@ -843,7 +843,7 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
     Modifiers mods = spec.getModifiers();
     int predictedSongLimit =
         3
-            + (int) mods.get(DoubleModifier.ADDITIONAL_SONG)
+            + (int) mods.getDouble(DoubleModifier.ADDITIONAL_SONG)
             + (mods.getBoolean(BooleanModifier.FOUR_SONGS) ? 1 : 0);
     int predictedSongsNeeded =
         UseSkillRequest.songsActive() + (UseSkillRequest.newSong(skillId) ? 1 : 0);
@@ -919,7 +919,7 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
         }
       } else if (item.getItemId() == ItemPool.KREMLIN_BRIEFCASE) {
         if (ModifierDatabase.getItemModifiers(ItemPool.KREMLIN_BRIEFCASE)
-                .get(DoubleModifier.MANA_COST)
+                .getDouble(DoubleModifier.MANA_COST)
             == 0) {
           continue;
         }

--- a/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
@@ -7486,8 +7486,12 @@ public abstract class ChoiceAdventures {
         double bonus = 0;
         // Check for familiars
         if (!KoLCharacter.getFamiliar().equals(FamiliarData.NO_FAMILIAR)) {
-          bonus = ModifierDatabase.getNumericModifier(KoLCharacter.getFamiliar(), "Item Drop");
-          bonus += ModifierDatabase.getNumericModifier(KoLCharacter.getFamiliar(), "Food Drop");
+          bonus =
+              ModifierDatabase.getNumericModifier(
+                  KoLCharacter.getFamiliar(), DoubleModifier.ITEMDROP);
+          bonus +=
+              ModifierDatabase.getNumericModifier(
+                  KoLCharacter.getFamiliar(), DoubleModifier.FOODDROP);
         }
         // Check for Clancy
         else if (KoLCharacter.getCurrentInstrument() != null
@@ -7514,14 +7518,14 @@ public abstract class ChoiceAdventures {
         if (!throned.equals(FamiliarData.NO_FAMILIAR)) {
           bonus +=
               ModifierDatabase.getNumericModifier(
-                  ModifierType.THRONE, throned.getRace(), "Item Drop");
+                  ModifierType.THRONE, throned.getRace(), DoubleModifier.ITEMDROP);
         }
         // Check for Bjorn
         FamiliarData bjorned = KoLCharacter.getBjorned();
         if (!bjorned.equals(FamiliarData.NO_FAMILIAR)) {
           bonus +=
               ModifierDatabase.getNumericModifier(
-                  ModifierType.THRONE, bjorned.getRace(), "Item Drop");
+                  ModifierType.THRONE, bjorned.getRace(), DoubleModifier.ITEMDROP);
         }
         // Check for Florist
         if (FloristRequest.haveFlorist()) {
@@ -7530,7 +7534,7 @@ public abstract class ChoiceAdventures {
             for (Florist plant : plants) {
               bonus +=
                   ModifierDatabase.getNumericModifier(
-                      ModifierType.FLORIST, plant.toString(), "Item Drop");
+                      ModifierType.FLORIST, plant.toString(), DoubleModifier.ITEMDROP);
             }
           }
         }

--- a/src/net/sourceforge/kolmafia/swingui/panel/CompactSidePane.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/CompactSidePane.java
@@ -408,7 +408,7 @@ public class CompactSidePane extends JPanel implements Runnable {
         // Stat Gain
         if (FamiliarDatabase.isVolleyType(id)
             || FamiliarDatabase.isSombreroType(id)
-            || (mods != null && mods.get(DoubleModifier.VOLLEYBALL_WEIGHT) != 0.0)) {
+            || (mods != null && mods.getDouble(DoubleModifier.VOLLEYBALL_WEIGHT) != 0.0)) {
           stat.add(new FamiliarMenuItem(fam));
           added = true;
         }

--- a/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/GearChangePanel.java
@@ -194,7 +194,7 @@ public class GearChangePanel extends JPanel {
     buff.append(">");
 
     for (var mod : DoubleModifier.DOUBLE_MODIFIERS) {
-      double val = mods.get(mod);
+      double val = mods.getDouble(mod);
       if (val == 0.0f) continue;
       name = mod.getName();
       name = StringUtilities.singleStringReplace(name, "Familiar", "Fam");

--- a/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
@@ -19,6 +19,7 @@ import net.sourceforge.kolmafia.KoLGUIConstants;
 import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -484,7 +485,8 @@ public class ListCellRendererFactory {
       }
 
       Modifiers mods = ModifierDatabase.getEffectModifiers(effectId);
-      String effectModifiers = (mods == null) ? null : mods.getString("Evaluated Modifiers");
+      String effectModifiers =
+          (mods == null) ? null : mods.getString(StringModifier.EVALUATED_MODIFIERS);
 
       if (effectModifiers != null) {
         stringForm.append(" (").append(effectModifiers).append(")");

--- a/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
@@ -19,6 +19,7 @@ import net.sourceforge.kolmafia.KoLGUIConstants;
 import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
+import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
@@ -476,7 +477,9 @@ public class ListCellRendererFactory {
       AdventureResult effect = EffectPool.get(effectId, 0);
 
       int effectDuration =
-          (int) ModifierDatabase.getNumericModifier(ModifierType.ITEM, name, "Effect Duration");
+          (int)
+              ModifierDatabase.getNumericModifier(
+                  ModifierType.ITEM, name, DoubleModifier.EFFECT_DURATION);
       stringForm.append(effectDuration).append(" ").append(effectName);
 
       int active = effect.getCount(KoLConstants.activeEffects);

--- a/src/net/sourceforge/kolmafia/swingui/widget/TableCellFactory.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/TableCellFactory.java
@@ -431,7 +431,7 @@ public class TableCellFactory {
     buff.append(">");
 
     for (var mod : DoubleModifier.DOUBLE_MODIFIERS) {
-      double val = mods.get(mod);
+      double val = mods.getDouble(mod);
       if (val == 0.0) continue;
       name = mod.getName();
       name = StringUtilities.singleStringReplace(name, "Familiar", "Fam");

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -74,6 +74,7 @@ import net.sourceforge.kolmafia.maximizer.Boost;
 import net.sourceforge.kolmafia.maximizer.Maximizer;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.ModifierList.ModifierValue;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.moods.Mood;
 import net.sourceforge.kolmafia.moods.MoodManager;
 import net.sourceforge.kolmafia.moods.MoodTrigger;
@@ -9108,12 +9109,14 @@ public abstract class RuntimeLibrary {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
     String mod = modifier.toString();
-    return DataTypes.makeBooleanValue(ModifierDatabase.getBooleanModifier(type, name, mod));
+    BooleanModifier boolMod = BooleanModifier.byCaselessName(mod);
+    return DataTypes.makeBooleanValue(ModifierDatabase.getBooleanModifier(type, name, boolMod));
   }
 
   public static Value string_modifier(ScriptRuntime controller, final Value modifier) {
     String mod = modifier.toString();
-    return new Value(KoLCharacter.currentStringModifier(mod));
+    StringModifier strMod = StringModifier.byCaselessName(mod);
+    return new Value(KoLCharacter.currentStringModifier(strMod));
   }
 
   public static Value string_modifier(
@@ -9121,7 +9124,8 @@ public abstract class RuntimeLibrary {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
     String mod = modifier.toString();
-    return new Value(ModifierDatabase.getStringModifier(type, name, mod));
+    StringModifier strMod = StringModifier.byCaselessName(mod);
+    return new Value(ModifierDatabase.getStringModifier(type, name, strMod));
   }
 
   public static Value effect_modifier(
@@ -9129,8 +9133,9 @@ public abstract class RuntimeLibrary {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
     String mod = modifier.toString();
+    StringModifier strMod = StringModifier.byCaselessName(mod);
     return new Value(
-        DataTypes.parseEffectValue(ModifierDatabase.getStringModifier(type, name, mod), true));
+        DataTypes.parseEffectValue(ModifierDatabase.getStringModifier(type, name, strMod), true));
   }
 
   public static Value class_modifier(
@@ -9138,8 +9143,9 @@ public abstract class RuntimeLibrary {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
     String mod = modifier.toString();
+    StringModifier strMod = StringModifier.byCaselessName(mod);
     return new Value(
-        DataTypes.parseClassValue(ModifierDatabase.getStringModifier(type, name, mod), true));
+        DataTypes.parseClassValue(ModifierDatabase.getStringModifier(type, name, strMod), true));
   }
 
   public static Value skill_modifier(
@@ -9147,8 +9153,9 @@ public abstract class RuntimeLibrary {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
     String mod = modifier.toString();
+    StringModifier strMod = StringModifier.byCaselessName(mod);
     return new Value(
-        DataTypes.parseSkillValue(ModifierDatabase.getStringModifier(type, name, mod), true));
+        DataTypes.parseSkillValue(ModifierDatabase.getStringModifier(type, name, strMod), true));
   }
 
   public static Value stat_modifier(
@@ -9156,8 +9163,9 @@ public abstract class RuntimeLibrary {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
     String mod = modifier.toString();
+    StringModifier strMod = StringModifier.byCaselessName(mod);
     return new Value(
-        DataTypes.parseStatValue(ModifierDatabase.getStringModifier(type, name, mod), true));
+        DataTypes.parseStatValue(ModifierDatabase.getStringModifier(type, name, strMod), true));
   }
 
   public static Value monster_modifier(
@@ -9165,8 +9173,9 @@ public abstract class RuntimeLibrary {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
     String mod = modifier.toString();
+    StringModifier strMod = StringModifier.byCaselessName(name);
     return new Value(
-        DataTypes.parseMonsterValue(ModifierDatabase.getStringModifier(type, name, mod), true));
+        DataTypes.parseMonsterValue(ModifierDatabase.getStringModifier(type, name, strMod), true));
   }
 
   public static Value white_citadel_available(ScriptRuntime controller) {

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -73,6 +73,7 @@ import net.sourceforge.kolmafia.combat.MonsterStatusTracker;
 import net.sourceforge.kolmafia.maximizer.Boost;
 import net.sourceforge.kolmafia.maximizer.Maximizer;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
+import net.sourceforge.kolmafia.modifiers.Modifier;
 import net.sourceforge.kolmafia.modifiers.ModifierList.ModifierValue;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.moods.Mood;
@@ -9073,7 +9074,8 @@ public abstract class RuntimeLibrary {
 
   public static Value numeric_modifier(ScriptRuntime controller, final Value modifier) {
     String mod = modifier.toString();
-    return new Value(KoLCharacter.currentNumericModifier(mod));
+    Modifier realMod = ModifierDatabase.numericByCaselessName(mod);
+    return new Value(KoLCharacter.currentNumericModifier(realMod));
   }
 
   public static Value numeric_modifier(
@@ -9081,7 +9083,8 @@ public abstract class RuntimeLibrary {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
     String mod = modifier.toString();
-    return new Value(ModifierDatabase.getNumericModifier(type, name, mod));
+    Modifier realMod = ModifierDatabase.numericByCaselessName(mod);
+    return new Value(ModifierDatabase.getNumericModifier(type, name, realMod));
   }
 
   public static Value numeric_modifier(
@@ -9092,10 +9095,11 @@ public abstract class RuntimeLibrary {
       final Value item) {
     FamiliarData fam = new FamiliarData((int) familiar.intValue());
     String mod = modifier.toString();
+    Modifier realMod = ModifierDatabase.numericByCaselessName(mod);
     int w = Math.max(1, (int) weight.intValue());
     AdventureResult it = ItemPool.get((int) item.intValue());
 
-    return new Value(ModifierDatabase.getNumericModifier(fam, mod, w, it));
+    return new Value(ModifierDatabase.getNumericModifier(fam, realMod, w, it));
   }
 
   public static Value boolean_modifier(ScriptRuntime controller, final Value modifier) {

--- a/src/net/sourceforge/kolmafia/textui/command/AccordionsCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AccordionsCommand.java
@@ -136,7 +136,7 @@ public class AccordionsCommand extends AbstractCommand {
 
       Modifiers mods = ModifierDatabase.getItemModifiers(itemId);
       if (mods != null) {
-        this.songDuration = (int) mods.get(DoubleModifier.SONG_DURATION);
+        this.songDuration = (int) mods.getDouble(DoubleModifier.SONG_DURATION);
         this.modsLookup = mods.getLookup();
 
         if (itemId == ItemPool.AUTOCALLIOPE) {

--- a/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
@@ -30,7 +30,7 @@ public class ModRefCommand extends AbstractCommand {
       buf.append(KoLCharacter.currentNumericModifier(mod));
       if (mods != null) {
         buf.append("</td><td>");
-        buf.append(mods.get(mod));
+        buf.append(mods.getDouble(mod));
       }
       buf.append("</td></tr>");
     }

--- a/src/net/sourceforge/kolmafia/textui/command/SpeculateCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/SpeculateCommand.java
@@ -99,7 +99,7 @@ public class SpeculateCommand extends AbstractCommand {
   private static void handleDouble(
       final DoubleModifier mod, final Modifiers mods, final StringBuilder buf) {
     double was = KoLCharacter.currentNumericModifier(mod);
-    double now = mods.get(mod);
+    double now = mods.getDouble(mod);
     if (now == was) {
       return;
     }

--- a/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
@@ -30,6 +30,7 @@ import net.sourceforge.kolmafia.chat.ChatParser;
 import net.sourceforge.kolmafia.chat.ChatPoller;
 import net.sourceforge.kolmafia.combat.CombatUtilities;
 import net.sourceforge.kolmafia.combat.MonsterStatusTracker;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.moods.RecoveryManager;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.ConcoctionPool;
@@ -799,7 +800,8 @@ public class TestCommand extends AbstractCommand {
         RequestLogger.printLine(name + " is a level " + level + " " + type + " wine.");
         RequestLogger.printLine("It grants 12 turns of the '" + effect + "' effect:");
         RequestLogger.printLine(
-            ModifierDatabase.getStringModifier(ModifierType.EFFECT, effect, "Evaluated Modifiers"));
+            ModifierDatabase.getStringModifier(
+                ModifierType.EFFECT, effect, StringModifier.EVALUATED_MODIFIERS));
       } else {
         RequestLogger.printLine("You currently have no access to a 1950 Vampire Vintner wine");
       }

--- a/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
@@ -30,6 +30,7 @@ import net.sourceforge.kolmafia.chat.ChatParser;
 import net.sourceforge.kolmafia.chat.ChatPoller;
 import net.sourceforge.kolmafia.combat.CombatUtilities;
 import net.sourceforge.kolmafia.combat.MonsterStatusTracker;
+import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.moods.RecoveryManager;
 import net.sourceforge.kolmafia.objectpool.Concoction;
@@ -331,7 +332,7 @@ public class TestCommand extends AbstractCommand {
       }
       double itemDrop =
           ModifierDatabase.getNumericModifier(
-              ModifierType.FAMILIAR, familiar.getRace(), "Item Drop");
+              ModifierType.FAMILIAR, familiar.getRace(), DoubleModifier.ITEMDROP);
       RequestLogger.printLine("Item Drop: " + itemDrop);
       return;
     }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -24,6 +24,7 @@ import net.sourceforge.kolmafia.PastaThrallData;
 import net.sourceforge.kolmafia.PastaThrallData.PastaThrallType;
 import net.sourceforge.kolmafia.PokefamData;
 import net.sourceforge.kolmafia.VYKEACompanionData;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.AdventureQueueDatabase;
 import net.sourceforge.kolmafia.persistence.AdventureSpentDatabase;
@@ -676,7 +677,8 @@ public class ProxyRecordValue extends RecordValue {
      */
     public Value get_skill() {
       String skillName =
-          ModifierDatabase.getStringModifier(ModifierType.ITEM, (int) this.contentLong, "Skill");
+          ModifierDatabase.getStringModifier(
+              ModifierType.ITEM, (int) this.contentLong, StringModifier.SKILL);
       return skillName.equals("")
           ? DataTypes.SKILL_INIT
           : DataTypes.makeSkillValue(SkillDatabase.getSkillId(skillName), true);
@@ -689,7 +691,8 @@ public class ProxyRecordValue extends RecordValue {
      */
     public Value get_recipe() {
       String recipeName =
-          ModifierDatabase.getStringModifier(ModifierType.ITEM, (int) this.contentLong, "Recipe");
+          ModifierDatabase.getStringModifier(
+              ModifierType.ITEM, (int) this.contentLong, StringModifier.RECIPE);
       return recipeName.equals("") ? DataTypes.ITEM_INIT : DataTypes.makeItemValue(recipeName);
     }
   }

--- a/src/net/sourceforge/kolmafia/webui/BasementDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/BasementDecorator.java
@@ -499,8 +499,8 @@ public class BasementDecorator {
 
       double base = StatBooster.getEqualizedStat(BasementRequest.getPrimaryBoost());
       double boost =
-          m.get(BasementRequest.getSecondaryBoost())
-              + m.get(BasementRequest.getPrimaryBoost()) * base / 100.0;
+          m.getDouble(BasementRequest.getSecondaryBoost())
+              + m.getDouble(BasementRequest.getPrimaryBoost()) * base / 100.0;
 
       return (int) Math.ceil(boost);
     }
@@ -538,9 +538,9 @@ public class BasementDecorator {
     }
 
     public static int boostMaxHP(final Modifiers m) {
-      double addedMuscleFixed = m.get(DoubleModifier.MUS);
-      double addedMusclePercent = m.get(DoubleModifier.MUS_PCT);
-      int addedHealthFixed = (int) m.get(DoubleModifier.HP);
+      double addedMuscleFixed = m.getDouble(DoubleModifier.MUS);
+      double addedMusclePercent = m.getDouble(DoubleModifier.MUS_PCT);
+      int addedHealthFixed = (int) m.getDouble(DoubleModifier.HP);
 
       if (addedMuscleFixed == 0.0 && addedMusclePercent == 0.0 && addedHealthFixed == 0) {
         return 0;
@@ -581,9 +581,9 @@ public class BasementDecorator {
         statPercentModifier = DoubleModifier.MYS_PCT;
       }
 
-      double addedStatFixed = m.get(statModifier);
-      double addedStatPercent = m.get(statPercentModifier);
-      int addedManaFixed = (int) m.get(DoubleModifier.MP);
+      double addedStatFixed = m.getDouble(statModifier);
+      double addedStatPercent = m.getDouble(statPercentModifier);
+      int addedManaFixed = (int) m.getDouble(DoubleModifier.MP);
 
       if (addedStatFixed == 0.0 && addedStatPercent == 0.0 && addedManaFixed == 0.0) {
         return 0;

--- a/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
@@ -1506,7 +1506,7 @@ public abstract class UseLinkDecorator {
     if (mods == null) return label;
     String effect = mods.getString(StringModifier.EFFECT);
     if (effect.equals("")) return label;
-    int duration = (int) mods.get(DoubleModifier.EFFECT_DURATION);
+    int duration = (int) mods.getDouble(DoubleModifier.EFFECT_DURATION);
     int effectId = EffectDatabase.getEffectId(effect);
     Speculation spec = new Speculation();
     spec.addEffect(EffectPool.get(effectId, Math.max(1, duration)));

--- a/test/internal/helpers/Maximizer.java
+++ b/test/internal/helpers/Maximizer.java
@@ -9,6 +9,7 @@ import java.util.function.Predicate;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.maximizer.Boost;
+import net.sourceforge.kolmafia.modifiers.Modifier;
 import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 import net.sourceforge.kolmafia.swingui.MaximizerFrame;
 
@@ -23,7 +24,7 @@ public class Maximizer {
     net.sourceforge.kolmafia.maximizer.Maximizer.maximize(1, 0, 0, false, 0);
   }
 
-  public static double modFor(String modifier) {
+  public static double modFor(Modifier modifier) {
     return ModifierDatabase.getNumericModifier(ModifierType.GENERATED, "_spec", modifier);
   }
 

--- a/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
+++ b/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
@@ -26,6 +26,7 @@ import internal.helpers.Cleanups;
 import java.time.Month;
 import net.sourceforge.kolmafia.KoLCharacter.Gender;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.persistence.HolidayDatabase;
 import net.sourceforge.kolmafia.persistence.ModifierDatabase;
@@ -267,7 +268,7 @@ public class ModifierExpressionTest {
     try (cleanups) {
       assertThat(
           ModifierDatabase.getStringModifier(
-              ModifierType.EFFECT, "Bow-Legged Swagger", "Modifiers"),
+              ModifierType.EFFECT, "Bow-Legged Swagger", StringModifier.MODIFIERS),
           containsString("mod("));
       KoLCharacter.recalculateAdjustments();
 

--- a/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
+++ b/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
@@ -272,7 +272,7 @@ public class ModifierExpressionTest {
           containsString("mod("));
       KoLCharacter.recalculateAdjustments();
 
-      assertThat(KoLCharacter.getCurrentModifiers().get(DoubleModifier.INITIATIVE), is(40.0));
+      assertThat(KoLCharacter.getCurrentModifiers().getDouble(DoubleModifier.INITIATIVE), is(40.0));
     }
   }
 

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -56,22 +56,22 @@ public class ModifiersTest {
       Modifiers mods = ModifierDatabase.getModifiers(ModifierType.ITEM, ItemPool.PATRIOT_SHIELD);
 
       // Always has
-      assertEquals(3, mods.get(DoubleModifier.EXPERIENCE));
+      assertEquals(3, mods.getDouble(DoubleModifier.EXPERIENCE));
 
       // Has because of class
-      assertEquals(5.0, mods.get(DoubleModifier.MP_REGEN_MIN));
-      assertEquals(6.0, mods.get(DoubleModifier.MP_REGEN_MAX));
-      assertEquals(20.0, mods.get(DoubleModifier.SPELL_DAMAGE));
+      assertEquals(5.0, mods.getDouble(DoubleModifier.MP_REGEN_MIN));
+      assertEquals(6.0, mods.getDouble(DoubleModifier.MP_REGEN_MAX));
+      assertEquals(20.0, mods.getDouble(DoubleModifier.SPELL_DAMAGE));
 
       // Does not have because of class
-      assertEquals(0, mods.get(DoubleModifier.HP_REGEN_MAX));
-      assertEquals(0, mods.get(DoubleModifier.HP_REGEN_MIN));
-      assertEquals(0, mods.get(DoubleModifier.WEAPON_DAMAGE));
-      assertEquals(0, mods.get(DoubleModifier.DAMAGE_REDUCTION));
-      assertEquals(0, mods.get(DoubleModifier.FAMILIAR_WEIGHT));
-      assertEquals(0, mods.get(DoubleModifier.RANGED_DAMAGE));
+      assertEquals(0, mods.getDouble(DoubleModifier.HP_REGEN_MAX));
+      assertEquals(0, mods.getDouble(DoubleModifier.HP_REGEN_MIN));
+      assertEquals(0, mods.getDouble(DoubleModifier.WEAPON_DAMAGE));
+      assertEquals(0, mods.getDouble(DoubleModifier.DAMAGE_REDUCTION));
+      assertEquals(0, mods.getDouble(DoubleModifier.FAMILIAR_WEIGHT));
+      assertEquals(0, mods.getDouble(DoubleModifier.RANGED_DAMAGE));
       assertFalse(mods.getBoolean(BooleanModifier.FOUR_SONGS));
-      assertEquals(0, mods.get(DoubleModifier.COMBAT_MANA_COST));
+      assertEquals(0, mods.getDouble(DoubleModifier.COMBAT_MANA_COST));
     }
   }
 
@@ -88,21 +88,28 @@ public class ModifiersTest {
     try (cleanup) {
       Modifiers mods = ModifierDatabase.getModifiers(ModifierType.ITEM, "Tuesday's Ruby");
 
-      assertThat(mods.get(DoubleModifier.MEATDROP), equalTo(dotw == DayOfWeek.SUNDAY ? 5.0 : 0.0));
-      assertThat(mods.get(DoubleModifier.MUS_PCT), equalTo(dotw == DayOfWeek.MONDAY ? 5.0 : 0.0));
       assertThat(
-          mods.get(DoubleModifier.MP_REGEN_MIN), equalTo(dotw == DayOfWeek.TUESDAY ? 3.0 : 0.0));
+          mods.getDouble(DoubleModifier.MEATDROP), equalTo(dotw == DayOfWeek.SUNDAY ? 5.0 : 0.0));
       assertThat(
-          mods.get(DoubleModifier.MP_REGEN_MAX), equalTo(dotw == DayOfWeek.TUESDAY ? 7.0 : 0.0));
+          mods.getDouble(DoubleModifier.MUS_PCT), equalTo(dotw == DayOfWeek.MONDAY ? 5.0 : 0.0));
       assertThat(
-          mods.get(DoubleModifier.MYS_PCT), equalTo(dotw == DayOfWeek.WEDNESDAY ? 5.0 : 0.0));
+          mods.getDouble(DoubleModifier.MP_REGEN_MIN),
+          equalTo(dotw == DayOfWeek.TUESDAY ? 3.0 : 0.0));
       assertThat(
-          mods.get(DoubleModifier.ITEMDROP), equalTo(dotw == DayOfWeek.THURSDAY ? 5.0 : 0.0));
-      assertThat(mods.get(DoubleModifier.MOX_PCT), equalTo(dotw == DayOfWeek.FRIDAY ? 5.0 : 0.0));
+          mods.getDouble(DoubleModifier.MP_REGEN_MAX),
+          equalTo(dotw == DayOfWeek.TUESDAY ? 7.0 : 0.0));
       assertThat(
-          mods.get(DoubleModifier.HP_REGEN_MIN), equalTo(dotw == DayOfWeek.SATURDAY ? 3.0 : 0.0));
+          mods.getDouble(DoubleModifier.MYS_PCT), equalTo(dotw == DayOfWeek.WEDNESDAY ? 5.0 : 0.0));
       assertThat(
-          mods.get(DoubleModifier.HP_REGEN_MAX), equalTo(dotw == DayOfWeek.SATURDAY ? 7.0 : 0.0));
+          mods.getDouble(DoubleModifier.ITEMDROP), equalTo(dotw == DayOfWeek.THURSDAY ? 5.0 : 0.0));
+      assertThat(
+          mods.getDouble(DoubleModifier.MOX_PCT), equalTo(dotw == DayOfWeek.FRIDAY ? 5.0 : 0.0));
+      assertThat(
+          mods.getDouble(DoubleModifier.HP_REGEN_MIN),
+          equalTo(dotw == DayOfWeek.SATURDAY ? 3.0 : 0.0));
+      assertThat(
+          mods.getDouble(DoubleModifier.HP_REGEN_MAX),
+          equalTo(dotw == DayOfWeek.SATURDAY ? 7.0 : 0.0));
     }
   }
 
@@ -113,7 +120,7 @@ public class ModifiersTest {
       int myst = (i == 1) ? 0 : (i - 1) * (i - 1) + 4;
       KoLCharacter.setStatPoints(0, 0, myst, (long) myst * myst, 0, 0);
       Modifiers mods = ModifierDatabase.getModifiers(ModifierType.SKILL, "Intrinsic Spiciness");
-      assertEquals(Math.min(i, 10), mods.get(DoubleModifier.SAUCE_SPELL_DAMAGE));
+      assertEquals(Math.min(i, 10), mods.getDouble(DoubleModifier.SAUCE_SPELL_DAMAGE));
     }
   }
 
@@ -122,20 +129,20 @@ public class ModifiersTest {
     Modifiers mod = new Modifiers();
     mod.addDouble(DoubleModifier.COMBAT_RATE, 25, ModifierType.NONE, "");
     mod.addDouble(DoubleModifier.COMBAT_RATE, 7, ModifierType.NONE, "");
-    assertEquals(26, mod.get(DoubleModifier.COMBAT_RATE));
+    assertEquals(26, mod.getDouble(DoubleModifier.COMBAT_RATE));
     mod.addDouble(DoubleModifier.COMBAT_RATE, 9, ModifierType.NONE, "");
-    assertEquals(28, mod.get(DoubleModifier.COMBAT_RATE));
+    assertEquals(28, mod.getDouble(DoubleModifier.COMBAT_RATE));
     mod.addDouble(DoubleModifier.COMBAT_RATE, 9, ModifierType.NONE, "");
-    assertEquals(30, mod.get(DoubleModifier.COMBAT_RATE));
+    assertEquals(30, mod.getDouble(DoubleModifier.COMBAT_RATE));
 
     mod = new Modifiers();
     mod.addDouble(DoubleModifier.COMBAT_RATE, -25, ModifierType.NONE, "");
     mod.addDouble(DoubleModifier.COMBAT_RATE, -7, ModifierType.NONE, "");
-    assertEquals(-26, mod.get(DoubleModifier.COMBAT_RATE));
+    assertEquals(-26, mod.getDouble(DoubleModifier.COMBAT_RATE));
     mod.addDouble(DoubleModifier.COMBAT_RATE, -9, ModifierType.NONE, "");
-    assertEquals(-28, mod.get(DoubleModifier.COMBAT_RATE));
+    assertEquals(-28, mod.getDouble(DoubleModifier.COMBAT_RATE));
     mod.addDouble(DoubleModifier.COMBAT_RATE, -9, ModifierType.NONE, "");
-    assertEquals(-30, mod.get(DoubleModifier.COMBAT_RATE));
+    assertEquals(-30, mod.getDouble(DoubleModifier.COMBAT_RATE));
   }
 
   public static Stream<Arguments> getsRightModifiersNakedHatrack() {
@@ -157,7 +164,7 @@ public class ModifiersTest {
       KoLCharacter.recalculateAdjustments();
 
       assertThat(fam.getModifiedWeight(), equalTo(1));
-      assertThat(familiarMods.get(mod), closeTo(50, 0.001));
+      assertThat(familiarMods.getDouble(mod), closeTo(50, 0.001));
     }
   }
 
@@ -173,7 +180,7 @@ public class ModifiersTest {
 
         familiarMods.applyFamiliarModifiers(familiar, null);
 
-        assertThat(familiarMods.get(DoubleModifier.ITEMDROP), closeTo(50.166, 0.001));
+        assertThat(familiarMods.getDouble(DoubleModifier.ITEMDROP), closeTo(50.166, 0.001));
       }
     }
 
@@ -187,7 +194,7 @@ public class ModifiersTest {
 
         familiarMods.applyFamiliarModifiers(familiar, null);
 
-        assertThat(familiarMods.get(DoubleModifier.ITEMDROP), closeTo(50.166, 0.001));
+        assertThat(familiarMods.getDouble(DoubleModifier.ITEMDROP), closeTo(50.166, 0.001));
       }
     }
   }
@@ -209,7 +216,7 @@ public class ModifiersTest {
       try (cleanups) {
         KoLCharacter.recalculateAdjustments();
         Modifiers mods = KoLCharacter.getCurrentModifiers();
-        assertThat(mods.get(DoubleModifier.ITEMDROP), equalTo(300.0));
+        assertThat(mods.getDouble(DoubleModifier.ITEMDROP), equalTo(300.0));
       }
     }
 
@@ -224,7 +231,7 @@ public class ModifiersTest {
       try (cleanups) {
         KoLCharacter.recalculateAdjustments();
         Modifiers mods = KoLCharacter.getCurrentModifiers();
-        assertThat(mods.get(DoubleModifier.ITEMDROP), equalTo(300.0));
+        assertThat(mods.getDouble(DoubleModifier.ITEMDROP), equalTo(300.0));
       }
     }
 
@@ -238,7 +245,7 @@ public class ModifiersTest {
       try (cleanups) {
         KoLCharacter.recalculateAdjustments();
         Modifiers mods = KoLCharacter.getCurrentModifiers();
-        assertThat(mods.get(DoubleModifier.ITEMDROP), equalTo(25.0));
+        assertThat(mods.getDouble(DoubleModifier.ITEMDROP), equalTo(25.0));
       }
     }
 
@@ -253,7 +260,7 @@ public class ModifiersTest {
       try (cleanups) {
         KoLCharacter.recalculateAdjustments();
         Modifiers mods = KoLCharacter.getCurrentModifiers();
-        var item = mods.get(DoubleModifier.ITEMDROP);
+        var item = mods.getDouble(DoubleModifier.ITEMDROP);
         assertThat(item, equalTo(50.0));
       }
     }
@@ -270,7 +277,7 @@ public class ModifiersTest {
       try (cleanups) {
         KoLCharacter.recalculateAdjustments();
         Modifiers mods = KoLCharacter.getCurrentModifiers();
-        assertThat(mods.get(DoubleModifier.ITEMDROP), equalTo(600.0));
+        assertThat(mods.getDouble(DoubleModifier.ITEMDROP), equalTo(600.0));
       }
     }
 
@@ -284,7 +291,7 @@ public class ModifiersTest {
       try (cleanups) {
         KoLCharacter.recalculateAdjustments();
         Modifiers mods = KoLCharacter.getCurrentModifiers();
-        assertThat(mods.get(DoubleModifier.ITEMDROP), equalTo(400.0));
+        assertThat(mods.getDouble(DoubleModifier.ITEMDROP), equalTo(400.0));
       }
     }
 
@@ -299,7 +306,7 @@ public class ModifiersTest {
       try (cleanups) {
         KoLCharacter.recalculateAdjustments();
         Modifiers mods = KoLCharacter.getCurrentModifiers();
-        assertThat(mods.get(DoubleModifier.ITEMDROP), equalTo(200.0));
+        assertThat(mods.getDouble(DoubleModifier.ITEMDROP), equalTo(200.0));
       }
     }
 
@@ -315,7 +322,7 @@ public class ModifiersTest {
       try (cleanups) {
         KoLCharacter.recalculateAdjustments();
         Modifiers mods = KoLCharacter.getCurrentModifiers();
-        assertThat(mods.get(DoubleModifier.ITEMDROP), equalTo(400.0));
+        assertThat(mods.getDouble(DoubleModifier.ITEMDROP), equalTo(400.0));
       }
     }
   }
@@ -336,8 +343,8 @@ public class ModifiersTest {
       try (cleanups) {
         KoLCharacter.recalculateAdjustments();
         Modifiers mods = KoLCharacter.getCurrentModifiers();
-        assertThat(mods.get(DoubleModifier.SLEAZE_DAMAGE), equalTo(100.0));
-        assertThat(mods.get(DoubleModifier.SLEAZE_SPELL_DAMAGE), equalTo(100.0));
+        assertThat(mods.getDouble(DoubleModifier.SLEAZE_DAMAGE), equalTo(100.0));
+        assertThat(mods.getDouble(DoubleModifier.SLEAZE_SPELL_DAMAGE), equalTo(100.0));
       }
     }
 
@@ -349,8 +356,8 @@ public class ModifiersTest {
       try (cleanups) {
         KoLCharacter.recalculateAdjustments();
         Modifiers mods = KoLCharacter.getCurrentModifiers();
-        assertThat(mods.get(DoubleModifier.SLEAZE_DAMAGE), equalTo(100.0));
-        assertThat(mods.get(DoubleModifier.SLEAZE_SPELL_DAMAGE), equalTo(100.0));
+        assertThat(mods.getDouble(DoubleModifier.SLEAZE_DAMAGE), equalTo(100.0));
+        assertThat(mods.getDouble(DoubleModifier.SLEAZE_SPELL_DAMAGE), equalTo(100.0));
       }
     }
 
@@ -365,8 +372,8 @@ public class ModifiersTest {
       try (cleanups) {
         KoLCharacter.recalculateAdjustments();
         Modifiers mods = KoLCharacter.getCurrentModifiers();
-        assertThat(mods.get(DoubleModifier.SLEAZE_DAMAGE), equalTo(200.0));
-        assertThat(mods.get(DoubleModifier.SLEAZE_SPELL_DAMAGE), equalTo(200.0));
+        assertThat(mods.getDouble(DoubleModifier.SLEAZE_DAMAGE), equalTo(200.0));
+        assertThat(mods.getDouble(DoubleModifier.SLEAZE_SPELL_DAMAGE), equalTo(200.0));
       }
     }
   }
@@ -390,7 +397,7 @@ public class ModifiersTest {
         KoLCharacter.recalculateAdjustments();
         Modifiers mods = KoLCharacter.getCurrentModifiers();
         // 3 from garbage shirt, 30 from Feeling Lost, *2 = 66
-        assertThat(mods.get(DoubleModifier.EXPERIENCE), equalTo(66.0));
+        assertThat(mods.getDouble(DoubleModifier.EXPERIENCE), equalTo(66.0));
       }
     }
   }
@@ -615,7 +622,7 @@ public class ModifiersTest {
 
         Modifiers current = KoLCharacter.getCurrentModifiers();
         KoLCharacter.recalculateAdjustments(false);
-        assertEquals(40, current.get(DoubleModifier.HP));
+        assertEquals(40, current.getDouble(DoubleModifier.HP));
 
         var currentStats = current.predict();
         assertEquals(100, currentStats.get(DerivedModifier.BUFFED_MUS));
@@ -623,7 +630,7 @@ public class ModifiersTest {
 
         // Make some modifiers to speculate with
         Modifiers speculate = new Modifiers(current);
-        assertEquals(40, speculate.get(DoubleModifier.HP));
+        assertEquals(40, speculate.getDouble(DoubleModifier.HP));
         // Suppose we want to replace the reinforced beaded headband (+40 HP)
         // with a nurse's hat (+300 HP)
         speculate.setDouble(DoubleModifier.HP, 300.0);
@@ -781,7 +788,7 @@ public class ModifiersTest {
 
         Modifiers current = KoLCharacter.getCurrentModifiers();
         KoLCharacter.recalculateAdjustments(false);
-        assertEquals(40, current.get(DoubleModifier.MP));
+        assertEquals(40, current.getDouble(DoubleModifier.MP));
 
         var currentStats = current.predict();
         assertEquals(100, currentStats.get(DerivedModifier.BUFFED_MYS));
@@ -789,7 +796,7 @@ public class ModifiersTest {
 
         // Make some modifiers to speculate with
         Modifiers speculate = new Modifiers(current);
-        assertEquals(40, speculate.get(DoubleModifier.MP));
+        assertEquals(40, speculate.getDouble(DoubleModifier.MP));
         // Suppose we want to replace the beer helmet (+40 HP)
         // with Covers-Your-Head (+100 MP)
         speculate.setDouble(DoubleModifier.MP, 100.0);
@@ -885,19 +892,19 @@ public class ModifiersTest {
         // Modifiers set "override" modifiers for the latte mug
         Modifiers latteModifiers =
             ModifierDatabase.getModifiers(ModifierType.ITEM, "[" + ItemPool.LATTE_MUG + "]");
-        assertEquals(5, latteModifiers.get(DoubleModifier.FAMILIAR_WEIGHT));
-        assertEquals(40, latteModifiers.get(DoubleModifier.MEATDROP));
-        assertEquals(1, latteModifiers.get(DoubleModifier.MOX_EXPERIENCE));
-        assertEquals(5, latteModifiers.get(DoubleModifier.MOX_PCT));
-        assertEquals(5, latteModifiers.get(DoubleModifier.PICKPOCKET_CHANCE));
+        assertEquals(5, latteModifiers.getDouble(DoubleModifier.FAMILIAR_WEIGHT));
+        assertEquals(40, latteModifiers.getDouble(DoubleModifier.MEATDROP));
+        assertEquals(1, latteModifiers.getDouble(DoubleModifier.MOX_EXPERIENCE));
+        assertEquals(5, latteModifiers.getDouble(DoubleModifier.MOX_PCT));
+        assertEquals(5, latteModifiers.getDouble(DoubleModifier.PICKPOCKET_CHANCE));
 
         // Verify that KoLCharacter applied the mods
         Modifiers currentModifiers = KoLCharacter.getCurrentModifiers();
-        assertEquals(5, currentModifiers.get(DoubleModifier.FAMILIAR_WEIGHT));
-        assertEquals(40, currentModifiers.get(DoubleModifier.MEATDROP));
-        assertEquals(1, currentModifiers.get(DoubleModifier.MOX_EXPERIENCE));
-        assertEquals(5, currentModifiers.get(DoubleModifier.MOX_PCT));
-        assertEquals(5, currentModifiers.get(DoubleModifier.PICKPOCKET_CHANCE));
+        assertEquals(5, currentModifiers.getDouble(DoubleModifier.FAMILIAR_WEIGHT));
+        assertEquals(40, currentModifiers.getDouble(DoubleModifier.MEATDROP));
+        assertEquals(1, currentModifiers.getDouble(DoubleModifier.MOX_EXPERIENCE));
+        assertEquals(5, currentModifiers.getDouble(DoubleModifier.MOX_PCT));
+        assertEquals(5, currentModifiers.getDouble(DoubleModifier.PICKPOCKET_CHANCE));
 
         // Verify the familiar is heavier
         assertEquals(25, familiar.getModifiedWeight());
@@ -918,22 +925,22 @@ public class ModifiersTest {
       Lookup lookup = new Lookup(ModifierType.LOCAL_VOTE, "");
 
       Modifiers mods = ModifierDatabase.parseModifiers(lookup, setting);
-      assertEquals(30, mods.get(DoubleModifier.MEATDROP));
-      assertEquals(2, mods.get(DoubleModifier.FAMILIAR_EXP));
-      assertEquals(4, mods.get(DoubleModifier.MUS_EXPERIENCE));
+      assertEquals(30, mods.getDouble(DoubleModifier.MEATDROP));
+      assertEquals(2, mods.getDouble(DoubleModifier.FAMILIAR_EXP));
+      assertEquals(4, mods.getDouble(DoubleModifier.MUS_EXPERIENCE));
 
       Modifiers evaluated = ModifierDatabase.evaluatedModifiers(lookup, setting);
-      assertEquals(30, evaluated.get(DoubleModifier.MEATDROP));
-      assertEquals(2, evaluated.get(DoubleModifier.FAMILIAR_EXP));
-      assertEquals(4, evaluated.get(DoubleModifier.MUS_EXPERIENCE));
+      assertEquals(30, evaluated.getDouble(DoubleModifier.MEATDROP));
+      assertEquals(2, evaluated.getDouble(DoubleModifier.FAMILIAR_EXP));
+      assertEquals(4, evaluated.getDouble(DoubleModifier.MUS_EXPERIENCE));
 
       var cleanups = new Cleanups(withProperty("_voteModifier", setting));
       try (cleanups) {
         KoLCharacter.recalculateAdjustments();
         Modifiers current = KoLCharacter.getCurrentModifiers();
-        assertEquals(30, current.get(DoubleModifier.MEATDROP));
-        assertEquals(2, current.get(DoubleModifier.FAMILIAR_EXP));
-        assertEquals(4, current.get(DoubleModifier.MUS_EXPERIENCE));
+        assertEquals(30, current.getDouble(DoubleModifier.MEATDROP));
+        assertEquals(2, current.getDouble(DoubleModifier.FAMILIAR_EXP));
+        assertEquals(4, current.getDouble(DoubleModifier.MUS_EXPERIENCE));
       }
     }
   }
@@ -950,13 +957,13 @@ public class ModifiersTest {
       KoLCharacter.recalculateAdjustments(false);
       Modifiers current = KoLCharacter.getCurrentModifiers();
 
-      assertThat(current.get(DoubleModifier.FAMILIAR_WEIGHT), equalTo(weightModifier));
+      assertThat(current.getDouble(DoubleModifier.FAMILIAR_WEIGHT), equalTo(weightModifier));
     }
 
     KoLCharacter.recalculateAdjustments(false);
     Modifiers current = KoLCharacter.getCurrentModifiers();
 
-    assertThat(current.get(DoubleModifier.FAMILIAR_WEIGHT), equalTo(0.0));
+    assertThat(current.getDouble(DoubleModifier.FAMILIAR_WEIGHT), equalTo(0.0));
   }
 
   @ParameterizedTest
@@ -969,6 +976,7 @@ public class ModifiersTest {
     "Overdeveloped Sense of Self Preservation, false",
   })
   public void identifiesVariableModifiers(String skillName, boolean variable) {
+    ModifierDatabase.ensureModifierDatabaseInitialised();
     assertThat(
         ModifierDatabase.getModifiers(ModifierType.SKILL, skillName).variable, equalTo(variable));
   }
@@ -1000,7 +1008,7 @@ public class ModifiersTest {
         var weight = 20;
         var familiarMods = getFamiliarMods(weight);
         assertThat(
-            familiarMods.get(DoubleModifier.ITEMDROP),
+            familiarMods.getDouble(DoubleModifier.ITEMDROP),
             closeTo(fairyFunction(weight * effectiveness), 0.001));
       }
     }
@@ -1024,9 +1032,10 @@ public class ModifiersTest {
         var weight = 20;
         var familiarMods = getFamiliarMods(weight);
         assertThat(
-            familiarMods.get(mod), closeTo(fairyFunction(weight) * otherFairyEffectiveness, 0.001));
+            familiarMods.getDouble(mod),
+            closeTo(fairyFunction(weight) * otherFairyEffectiveness, 0.001));
         assertThat(
-            familiarMods.get(DoubleModifier.ITEMDROP),
+            familiarMods.getDouble(DoubleModifier.ITEMDROP),
             closeTo(fairyFunction(weight) * itemFairyEffectiveness, 0.001));
       }
     }

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
@@ -15,6 +15,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import internal.helpers.Cleanups;
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.modifiers.DerivedModifier;
+import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,9 +45,10 @@ public class MaximizerRegressionTest {
       assertTrue(
           maximize(
               "-combat -hat -weapon -offhand -back -shirt -pants -familiar -acc1 -acc2 -acc3"));
-      assertEquals(5, -modFor("Combat Rate"), 0.01, "Base score is 5");
+      assertEquals(5, -modFor(DoubleModifier.COMBAT_RATE), 0.01, "Base score is 5");
       assertTrue(maximize("-combat"));
-      assertEquals(5, -modFor("Combat Rate"), 0.01, "Maximizing should not reduce score");
+      assertEquals(
+          5, -modFor(DoubleModifier.COMBAT_RATE), 0.01, "Maximizing should not reduce score");
     }
   }
 
@@ -56,7 +59,7 @@ public class MaximizerRegressionTest {
 
     try (cleanups) {
       assertTrue(maximize("familiar weight"));
-      assertEquals(5, modFor("Familiar Weight"), 0.01, "Base score is 5");
+      assertEquals(5, modFor(DoubleModifier.FAMILIAR_WEIGHT), 0.01, "Base score is 5");
       // monorail buff should always be available, but should not improve familiar weight.
       // so are friars, but I don't know why and that might be a bug
       assertEquals(1, Maximizer.boosts.size());
@@ -72,7 +75,7 @@ public class MaximizerRegressionTest {
 
     try (cleanups) {
       assertTrue(maximize("mys -tie"));
-      assertEquals(0, modFor("Buffed Muscle"), 0.01);
+      assertEquals(0, modFor(DerivedModifier.BUFFED_MUS), 0.01);
     }
   }
 
@@ -85,7 +88,7 @@ public class MaximizerRegressionTest {
     try (cleanups) {
       assertTrue(maximize("+25 bonus buddy bjorn -tie"));
       // Actually equipped the buddy bjorn with its current inhabitant.
-      assertEquals(25, modFor("Meat Drop"), 0.01);
+      assertEquals(25, modFor(DoubleModifier.MEATDROP), 0.01);
     }
   }
 
@@ -104,9 +107,9 @@ public class MaximizerRegressionTest {
     try (cleanups) {
       assertTrue(maximize("mus -buddy-bjorn +25 bonus buddy bjorn -tie"));
       // Unequipped the barskin cloak
-      assertEquals(0, modFor("Buffed Muscle"), 0.01);
+      assertEquals(0, modFor(DerivedModifier.BUFFED_MUS), 0.01);
       // Actually equipped the buddy bjorn
-      assertEquals(25, modFor("Meat Drop"), 0.01);
+      assertEquals(25, modFor(DoubleModifier.MEATDROP), 0.01);
     }
   }
 
@@ -127,9 +130,9 @@ public class MaximizerRegressionTest {
     try (cleanups) {
       assertTrue(maximize("mus -buddy-bjorn +25 bonus buddy bjorn -tie"));
       // Unequipped the barskin cloak, still have wreath of laurels equipped.
-      assertEquals(25, modFor("Buffed Muscle"), 0.01);
+      assertEquals(25, modFor(DerivedModifier.BUFFED_MUS), 0.01);
       // Actually equipped the buddy bjorn
-      assertEquals(25, modFor("Meat Drop"), 0.01);
+      assertEquals(25, modFor(DoubleModifier.MEATDROP), 0.01);
     }
   }
 
@@ -226,7 +229,7 @@ public class MaximizerRegressionTest {
       recommendedSlotIs(EquipmentManager.HAT, "basic meat fez");
       // No back change recommended.
       assertFalse(getSlot(EquipmentManager.CONTAINER).isPresent());
-      assertEquals(7, modFor("Buffed Muscle"), 0.01);
+      assertEquals(7, modFor(DerivedModifier.BUFFED_MUS), 0.01);
     }
   }
 }

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -37,6 +37,9 @@ import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RestrictedItemType;
+import net.sourceforge.kolmafia.modifiers.BitmapModifier;
+import net.sourceforge.kolmafia.modifiers.DerivedModifier;
+import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
@@ -62,7 +65,7 @@ public class MaximizerTest {
     final var cleanups = new Cleanups(withEquippableItem("helmet turtle"));
     try (cleanups) {
       assertTrue(maximize("mus"));
-      assertEquals(1, modFor("Buffed Muscle"), 0.01);
+      assertEquals(1, modFor(DerivedModifier.BUFFED_MUS), 0.01);
     }
   }
 
@@ -72,7 +75,7 @@ public class MaximizerTest {
         new Cleanups(withEquippableItem("helmet turtle"), withItem("wreath of laurels"));
     try (cleanups) {
       assertTrue(maximize("mus"));
-      assertEquals(1, modFor("Buffed Muscle"), 0.01);
+      assertEquals(1, modFor(DerivedModifier.BUFFED_MUS), 0.01);
       recommendedSlotIs(EquipmentManager.HAT, "helmet turtle");
     }
   }
@@ -82,7 +85,7 @@ public class MaximizerTest {
     final var cleanups = new Cleanups(withEquippableItem("helmet turtle"));
     try (cleanups) {
       assertTrue(maximize("-mus"));
-      assertEquals(0, modFor("Buffed Muscle"), 0.01);
+      assertEquals(0, modFor(DerivedModifier.BUFFED_MUS), 0.01);
     }
   }
 
@@ -96,7 +99,7 @@ public class MaximizerTest {
       assertTrue(maximize("Muscle Experience Percent, -tie"));
       recommendedSlotIsUnchanged(EquipmentManager.HAT);
       recommendedSlotIs(EquipmentManager.PANTS, "government-issued slacks");
-      assertEquals(10, modFor("Muscle Experience Percent"), 0.01);
+      assertEquals(10, modFor(DoubleModifier.MUS_EXPERIENCE_PCT), 0.01);
     }
   }
 
@@ -112,8 +115,8 @@ public class MaximizerTest {
       try (cleanups) {
         assertTrue(maximize("cold res 3 max, 0.1 item drop"));
 
-        assertEquals(3, modFor("Cold Resistance"), 0.01);
-        assertEquals(20, modFor("Item Drop"), 0.01);
+        assertEquals(3, modFor(DoubleModifier.COLD_RESISTANCE), 0.01);
+        assertEquals(20, modFor(DoubleModifier.ITEMDROP), 0.01);
 
         recommendedSlotIs(EquipmentManager.HAT, "bounty-hunting helmet");
       }
@@ -246,7 +249,7 @@ public class MaximizerTest {
         assertFalse(maximize("clownosity -tie"));
         // still provides equipment
         recommendedSlotIs(EquipmentManager.HAT, "clown wig");
-        assertEquals(50, modFor("Clowniness"), 0.01);
+        assertEquals(50, modFor(DoubleModifier.CLOWNINESS), 0.01);
       }
     }
 
@@ -258,7 +261,7 @@ public class MaximizerTest {
         assertTrue(maximize("clownosity -tie"));
         recommendedSlotIs(EquipmentManager.HAT, "clown wig");
         recommendedSlotIs(EquipmentManager.ACCESSORY1, "polka-dot bow tie");
-        assertEquals(125, modFor("Clowniness"), 0.01);
+        assertEquals(125, modFor(DoubleModifier.CLOWNINESS), 0.01);
       }
     }
   }
@@ -278,7 +281,7 @@ public class MaximizerTest {
         recommendedSlotIs(EquipmentManager.HAT, "rave visor");
         recommendedSlotIs(EquipmentManager.PANTS, "baggy rave pants");
         recommendedSlotIs(EquipmentManager.WEAPON, "rave whistle");
-        assertEquals(5, modFor("Raveosity"), 0.01);
+        assertEquals(5, modFor(BitmapModifier.RAVEOSITY), 0.01);
       }
     }
 
@@ -297,7 +300,7 @@ public class MaximizerTest {
         recommendedSlotIs(EquipmentManager.PANTS, "baggy rave pants");
         recommendedSlotIs(EquipmentManager.CONTAINER, "teddybear backpack");
         recommendedSlotIs(EquipmentManager.OFFHAND, "glowstick on a string");
-        assertEquals(7, modFor("Raveosity"), 0.01);
+        assertEquals(7, modFor(BitmapModifier.RAVEOSITY), 0.01);
       }
     }
   }
@@ -321,7 +324,7 @@ public class MaximizerTest {
         recommends("surgical mask");
         recommends("half-size scalpel");
         recommendedSlotIs(EquipmentManager.SHIRT, "surgical apron");
-        assertEquals(5, modFor("Surgeonosity"), 0.01);
+        assertEquals(5, modFor(DoubleModifier.SURGEONOSITY), 0.01);
       }
     }
   }
@@ -638,11 +641,15 @@ public class MaximizerTest {
       assertTrue(
           maximize(
               "cold res,-combat -hat -weapon -offhand -back -shirt -pants -familiar -acc1 -acc2 -acc3"));
-      assertEquals(25, modFor("Cold Resistance") - modFor("Combat Rate"), 0.01, "Base score is 25");
+      assertEquals(
+          25,
+          modFor(DoubleModifier.COLD_RESISTANCE) - modFor(DoubleModifier.COMBAT_RATE),
+          0.01,
+          "Base score is 25");
       assertTrue(maximize("cold res,-combat -acc2 -acc3"));
       assertEquals(
           27,
-          modFor("Cold Resistance") - modFor("Combat Rate"),
+          modFor(DoubleModifier.COLD_RESISTANCE) - modFor(DoubleModifier.COMBAT_RATE),
           0.01,
           "Maximizing one slot should reach 27");
 
@@ -659,7 +666,7 @@ public class MaximizerTest {
 
       try (cleanups) {
         assertTrue(maximize("-combat -tie"));
-        assertEquals(0, modFor("Combat Rate"), 0.01);
+        assertEquals(0, modFor(DoubleModifier.COMBAT_RATE), 0.01);
 
         recommendedSlotIsUnchanged(EquipmentManager.HAT);
       }
@@ -690,7 +697,7 @@ public class MaximizerTest {
       try (cleanups) {
         assertTrue(maximize("item -tie"));
 
-        assertEquals(50, modFor("Item Drop"), 0.01);
+        assertEquals(50, modFor(DoubleModifier.ITEMDROP), 0.01);
         recommendedSlotIs(EquipmentManager.HAT, "eldritch hat");
         recommendedSlotIs(EquipmentManager.PANTS, "eldritch pants");
       }
@@ -707,7 +714,7 @@ public class MaximizerTest {
       try (cleanups) {
         assertTrue(maximize("item -tie"));
 
-        assertEquals(100, modFor("Item Drop"), 0.01);
+        assertEquals(100, modFor(DoubleModifier.ITEMDROP), 0.01);
         recommendedSlotIs(EquipmentManager.HAT, "Team Avarice cap");
       }
     }
@@ -725,19 +732,19 @@ public class MaximizerTest {
       try (cleanups) {
         assertTrue(maximize("item -tie"));
 
-        assertEquals(70, modFor("Item Drop"), 0.01);
+        assertEquals(70, modFor(DoubleModifier.ITEMDROP), 0.01);
         recommendedSlotIs(EquipmentManager.HAT, "bounty-hunting helmet");
         recommendedSlotIs(EquipmentManager.WEAPON, "bounty-hunting rifle");
         recommendedSlotIs(EquipmentManager.PANTS, "bounty-hunting pants");
 
         assertTrue(maximize("item, +outfit Eldritch Equipage -tie"));
-        assertEquals(65, modFor("Item Drop"), 0.01);
+        assertEquals(65, modFor(DoubleModifier.ITEMDROP), 0.01);
         recommendedSlotIs(EquipmentManager.HAT, "eldritch hat");
         recommendedSlotIs(EquipmentManager.WEAPON, "bounty-hunting rifle");
         recommendedSlotIs(EquipmentManager.PANTS, "eldritch pants");
 
         assertTrue(maximize("item, -outfit Bounty-Hunting Rig -tie"));
-        assertEquals(65, modFor("Item Drop"), 0.01);
+        assertEquals(65, modFor(DoubleModifier.ITEMDROP), 0.01);
         recommendedSlotIs(EquipmentManager.HAT, "eldritch hat");
         recommendedSlotIs(EquipmentManager.WEAPON, "bounty-hunting rifle");
         recommendedSlotIs(EquipmentManager.PANTS, "eldritch pants");
@@ -755,7 +762,7 @@ public class MaximizerTest {
 
       try (cleanups) {
         assertTrue(maximize("ml -tie"));
-        assertEquals(4, modFor("Monster Level"), 0.01);
+        assertEquals(4, modFor(DoubleModifier.MONSTER_LEVEL), 0.01);
         recommendedSlotIs(EquipmentManager.HAT, "Brimstone Beret");
         recommendedSlotIs(EquipmentManager.PANTS, "Brimstone Boxers");
       }
@@ -811,7 +818,7 @@ public class MaximizerTest {
 
       try (cleanups) {
         assertTrue(maximize("item -tie"));
-        assertEquals(2, modFor("Item Drop"), 0.01);
+        assertEquals(2, modFor(DoubleModifier.ITEMDROP), 0.01);
         recommendedSlotIs(EquipmentManager.HAT, "Goggles of Loathing");
         recommendedSlotIs(EquipmentManager.PANTS, "Jeans of Loathing");
       }
@@ -886,7 +893,7 @@ public class MaximizerTest {
         try (cleanups) {
           assertTrue(maximize("meat -tie"));
 
-          assertEquals(30, modFor("Meat Drop"), 0.01);
+          assertEquals(30, modFor(DoubleModifier.MEATDROP), 0.01);
           recommendedSlotIs(EquipmentManager.OFFHAND, "silver cow creamer");
           recommendedSlotIsUnchanged(EquipmentManager.ACCESSORY1);
           recommendedSlotIsUnchanged(EquipmentManager.ACCESSORY2);
@@ -1205,7 +1212,7 @@ public class MaximizerTest {
 
       try (cleanups) {
         assertTrue(maximize("adv"));
-        assertEquals(14, modFor("Adventures"), 0.01);
+        assertEquals(14, modFor(DoubleModifier.ADVENTURES), 0.01);
         recommends("Counterclockwise Watch");
         recommends("plexiglass pocketwatch");
         recommends("gold wedding ring");
@@ -1222,7 +1229,7 @@ public class MaximizerTest {
 
       try (cleanups) {
         assertTrue(maximize("fites"));
-        assertEquals(5, modFor("PvP Fights"), 0.01);
+        assertEquals(5, modFor(DoubleModifier.PVP_FIGHTS), 0.01);
         recommends("Crimbolex watch");
         assertFalse(
             someBoostIs(x -> x.isEquipment() && ItemPool.SASQ_WATCH == x.getItem().getItemId()));
@@ -1235,14 +1242,14 @@ public class MaximizerTest {
 
       try (cleanups) {
         assertTrue(maximize("mp, -tie"));
-        assertEquals(120, modFor("Maximum MP"), 0.01);
+        assertEquals(120, modFor(DoubleModifier.MP), 0.01);
         assertThat(
             getBoosts().stream()
                 .filter(x -> x.isEquipment() && "surgical mask".equals(x.getItem().getName()))
                 .count(),
             equalTo(3L));
         // TODO: make duplicate surgeonosity not count in modifiers
-        // assertEquals(1, modFor("Surgeonosity"), 0.01);
+        // assertEquals(1, modFor(DoubleModifier.SURGEONOSITY), 0.01);
       }
     }
 
@@ -1252,14 +1259,14 @@ public class MaximizerTest {
 
       try (cleanups) {
         assertTrue(maximize("mp, -tie"));
-        assertEquals(45, modFor("Maximum MP"), 0.01);
+        assertEquals(45, modFor(DoubleModifier.MP), 0.01);
         assertThat(
             getBoosts().stream()
                 .filter(x -> x.isEquipment() && "clownskin belt".equals(x.getItem().getName()))
                 .count(),
             equalTo(3L));
         // TODO: make duplicate clowniness not count in modifiers
-        // assertEquals(50, modFor("Clowniness"), 0.01);
+        // assertEquals(50, modFor(DoubleModifier.CLOWNINESS), 0.01);
       }
     }
 
@@ -1269,13 +1276,13 @@ public class MaximizerTest {
 
       try (cleanups) {
         assertTrue(maximize("mp, -tie"));
-        assertEquals(15, modFor("Maximum MP"), 0.01);
+        assertEquals(15, modFor(DoubleModifier.MP), 0.01);
         assertThat(
             getBoosts().stream()
                 .filter(x -> x.isEquipment() && "blue glowstick".equals(x.getItem().getName()))
                 .count(),
             equalTo(3L));
-        assertEquals(1, modFor("Raveosity"), 0.01);
+        assertEquals(1, modFor(BitmapModifier.RAVEOSITY), 0.01);
       }
     }
 
@@ -1288,10 +1295,10 @@ public class MaximizerTest {
 
       try (cleanups) {
         assertTrue(maximize("muscle, -tie"));
-        assertEquals(100, modFor("Muscle Percent"), 0.01);
+        assertEquals(100, modFor(DoubleModifier.MUS_PCT), 0.01);
         recommendedSlotIs(EquipmentManager.WEAPON, "Brimstone Bludgeon");
         recommendedSlotIs(EquipmentManager.OFFHAND, "Brimstone Bludgeon");
-        assertEquals(1, modFor("Brimstone"), 0.01);
+        assertEquals(1, modFor(BitmapModifier.BRIMSTONE), 0.01);
       }
     }
 
@@ -1304,10 +1311,10 @@ public class MaximizerTest {
 
       try (cleanups) {
         assertTrue(maximize("spell dmg, -tie"));
-        assertEquals(400, modFor("Spell Damage Percent"), 0.01);
+        assertEquals(400, modFor(DoubleModifier.SPELL_DAMAGE_PCT), 0.01);
         recommendedSlotIs(EquipmentManager.WEAPON, "Stick-Knife of Loathing");
         recommendedSlotIs(EquipmentManager.OFFHAND, "Stick-Knife of Loathing");
-        assertEquals(1, modFor("Cloathing"), 0.01);
+        assertEquals(1, modFor(BitmapModifier.CLOATHING), 0.01);
       }
     }
   }

--- a/test/net/sourceforge/kolmafia/request/FightRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FightRequestTest.java
@@ -1315,7 +1315,7 @@ public class FightRequestTest {
         FightRequest.registerRequest(true, urlString);
         FightRequest.updateCombatData(null, null, html);
         var fightMods = ModifierDatabase.getModifiers(ModifierType.GENERATED, "fightMods");
-        assertThat(fightMods.get(DoubleModifier.ITEMDROP), equalTo(100.0));
+        assertThat(fightMods.getDouble(DoubleModifier.ITEMDROP), equalTo(100.0));
       }
     }
 
@@ -1329,7 +1329,7 @@ public class FightRequestTest {
         FightRequest.registerRequest(true, urlString);
         FightRequest.updateCombatData(null, null, html);
         var fightMods = ModifierDatabase.getModifiers(ModifierType.GENERATED, "fightMods");
-        assertThat(fightMods.get(DoubleModifier.MEATDROP), equalTo(100.0));
+        assertThat(fightMods.getDouble(DoubleModifier.MEATDROP), equalTo(100.0));
       }
     }
   }


### PR DESCRIPTION
1. Make "Evaluated Modifiers" a proper enum value instead of a special-cased string
2. Use functions taking Modifiers over functions taking Strings when looking up by enum.