### PR TITLE
fix: don't error when unequipping nothing

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/command/UnequipCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/UnequipCommand.java
@@ -25,6 +25,11 @@ public class UnequipCommand extends AbstractCommand {
 
     parameters = parameters.toLowerCase();
 
+    if (parameters.equals("none")) {
+      // unequip nothing = do nothing
+      return;
+    }
+
     // Allow player to remove all of his fake hands
     if (parameters.equals("fake hand")) {
       if (EquipmentManager.getFakeHands() == 0) {


### PR DESCRIPTION
A side-effect of #1457.

Some folk have scripts that end up running code like `equip($item[none], $slot[none])`, which gets translated into `unequip none`, which observes that "none" matches the slot "none" but can't distinguish that from being unable to find a slot, and so looks for an item with name "none", finds that the crown or bjorn has nothing in it and tries to unequip that, and then errors.

Be kinder to those folk by doing nothing in that case.