### PR TITLE
tests: add tests for sticker command

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -1062,6 +1062,12 @@ public class ItemPool {
   public static final int LARP_MEMBERSHIP_CARD = 3506;
   public static final int STICKER_BOOK = 3507;
   public static final int STICKER_SWORD = 3508;
+  public static final int UNICORN_STICKER = 3509;
+  public static final int APPLE_STICKER = 3510;
+  public static final int UPC_STICKER = 3511;
+  public static final int WRESTLER_STICKER = 3512;
+  public static final int DRAGON_STICKER = 3513;
+  public static final int ROCK_BAND_STICKER = 3514;
   public static final int STICKER_CROSSBOW = 3526;
   public static final int PLANS_FOR_GRIMACITE_HAMMER = 3535;
   public static final int PLANS_FOR_GRIMACITE_GRAVY_BOAT = 3536;

--- a/test/net/sourceforge/kolmafia/textui/command/StickersCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/StickersCommandTest.java
@@ -1,0 +1,94 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static internal.helpers.HttpClientWrapper.getRequests;
+import static internal.helpers.Networking.assertPostRequest;
+import static internal.helpers.Player.withEquippableItem;
+import static internal.helpers.Player.withEquipped;
+import static internal.helpers.Player.withItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+
+import internal.helpers.Cleanups;
+import internal.helpers.HttpClientWrapper;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.session.EquipmentManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class StickersCommandTest extends AbstractCommandTestBase {
+  public StickersCommandTest() {
+    this.command = "stickers";
+  }
+
+  @BeforeAll
+  public static void beforeAll() {
+    KoLCharacter.reset("StickersCommandTest");
+  }
+
+  @Test
+  public void abortsWithoutStickers() {
+    String output = this.execute("wrestler");
+
+    assertErrorState();
+    assertThat(
+        output, containsString("You need 1 more scratch 'n' sniff wrestler sticker to continue"));
+  }
+
+  @Test
+  public void equipsSubset() {
+    HttpClientWrapper.setupFakeClient();
+    var cleanups =
+        new Cleanups(withItem(ItemPool.UNICORN_STICKER), withItem(ItemPool.APPLE_STICKER));
+
+    try (cleanups) {
+      String output = this.execute("unicorn, apple sticker");
+      assertThat(output, containsString("Putting on scratch 'n' sniff unicorn sticker..."));
+      assertThat(output, containsString("Putting on scratch 'n' sniff apple sticker..."));
+
+      var requests = getRequests();
+      assertThat(requests, hasSize(2));
+      assertPostRequest(requests.get(0), "/bedazzle.php", "sticker=3509&action=juststick");
+      // this one should be "stick", but because we're faking the requests Mafia doesn't know we'll
+      // have a sticker sword now
+      assertPostRequest(requests.get(1), "/bedazzle.php", "sticker=3510&action=juststick");
+    }
+  }
+
+  @Test
+  public void equipsAllToUnequipped() {
+    HttpClientWrapper.setupFakeClient();
+    var cleanups =
+        new Cleanups(withItem(ItemPool.UPC_STICKER, 3), withEquippableItem(ItemPool.STICKER_SWORD));
+
+    try (cleanups) {
+      this.execute("UPC, UPC, UPC");
+
+      var requests = getRequests();
+      assertThat(requests, hasSize(3));
+      assertPostRequest(requests.get(0), "/bedazzle.php", "slot=1&sticker=3511&action=stick");
+      assertPostRequest(requests.get(1), "/bedazzle.php", "slot=2&sticker=3511&action=stick");
+      assertPostRequest(requests.get(2), "/bedazzle.php", "slot=3&sticker=3511&action=stick");
+    }
+  }
+
+  @Test
+  public void equipsWithExistingStickers() {
+    HttpClientWrapper.setupFakeClient();
+    var cleanups =
+        new Cleanups(
+            withItem(ItemPool.ROCK_BAND_STICKER, 3),
+            withEquippableItem(ItemPool.STICKER_SWORD),
+            withEquipped(EquipmentManager.STICKER1, ItemPool.DRAGON_STICKER),
+            withEquipped(EquipmentManager.STICKER3, ItemPool.WRESTLER_STICKER));
+
+    try (cleanups) {
+      this.execute("rock band, rock band, rock band");
+
+      var requests = getRequests();
+      assertThat(requests, hasSize(1));
+      assertPostRequest(requests.get(0), "/bedazzle.php", "slot=2&sticker=3514&action=stick");
+    }
+  }
+}


### PR DESCRIPTION
I'm looking at using enums in EquipmentManager, and as part of that I'd like a few areas of the codebase to have more unit tests.

Add tests for sticker command, checking:
* StickerCommand itself
* In EquipmentRequest, equipping a sticker