### PR TITLE
refactor: small readability improvements for maximizer constraints

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -923,16 +923,21 @@ public class Evaluator {
     return !this.noTiebreaker;
   }
 
-  int checkConstraints(Modifiers mods) {
-    // Return value:
-    //	-1: item violates a constraint, don't use it
-    //	0: item not relevant to any constraints
-    //	1: item meets a constraint, give it special handling
-    if (mods == null) return 0;
+  enum Constraint {
+    /** Item violates a constraint, don't use it */
+    VIOLATES,
+    /** Item not relevant to any constraints */
+    IRRELEVANT,
+    /** Item meets a constraint, give it special handling */
+    MEETS
+  }
+
+  Constraint checkConstraints(Modifiers mods) {
+    if (mods == null) return Constraint.IRRELEVANT;
     EnumSet<BooleanModifier> bools = mods.getBooleans(this.booleanMask);
-    if (!this.booleanValue.containsAll(bools)) return -1;
-    if (bools.size() != 0) return 1;
-    return 0;
+    if (!this.booleanValue.containsAll(bools)) return Constraint.VIOLATES;
+    if (bools.size() != 0) return Constraint.MEETS;
+    return Constraint.IRRELEVANT;
   }
 
   public static boolean cannotGainEffect(int effectId) {
@@ -1029,9 +1034,9 @@ public class Evaluator {
       if (mods == null) continue;
 
       switch (this.checkConstraints(mods)) {
-        case -1:
+        case VIOLATES:
           continue;
-        case 0:
+        case IRRELEVANT:
           // intentionally not including outfit.getPieces() because this is
           // only rating whether the outfit itself is useful, not its pieces
           double delta = this.getScore(mods) - nullScore;
@@ -1140,9 +1145,9 @@ public class Evaluator {
         item = new CheckedItem(id, equipScope, maxPrice, priceLevel);
 
         switch (this.checkConstraints(familiarMods)) {
-          case -1:
+          case VIOLATES:
             continue;
-          case 1:
+          case MEETS:
             item.automaticFlag = true;
         }
 
@@ -1176,9 +1181,9 @@ public class Evaluator {
         }
 
         switch (this.checkConstraints(familiarMods)) {
-          case -1:
+          case VIOLATES:
             continue;
-          case 1:
+          case MEETS:
             item.automaticFlag = true;
         }
 
@@ -1462,9 +1467,9 @@ public class Evaluator {
         }
 
         switch (this.checkConstraints(mods)) {
-          case -1:
+          case VIOLATES:
             continue;
-          case 1:
+          case MEETS:
             item.automaticFlag = true;
             break gotItem;
         }

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -935,7 +935,7 @@ public class Evaluator {
     return 0;
   }
 
-  public static boolean checkEffectConstraints(int effectId) {
+  public static boolean cannotGainEffect(int effectId) {
     // Return true if effect cannot be gained due to current other effects or class
     return switch (effectId) {
       case EffectPool.NEARLY_SILENT_HUNTING -> KoLCharacter.isSealClubber();

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -421,12 +421,12 @@ public class Maximizer {
           continue;
         }
         switch (Maximizer.eval.checkConstraints(ModifierDatabase.getEffectModifiers(effectId))) {
-          case -1:
+          case VIOLATES:
             continue;
-          case 0:
+          case IRRELEVANT:
             if (delta <= 0.0) continue;
             break;
-          case 1:
+          case MEETS:
             isSpecial = true;
         }
         if (Evaluator.cannotGainEffect(effectId)) {
@@ -442,12 +442,12 @@ public class Maximizer {
         spec.removeEffect(effect);
         delta = spec.getScore() - current;
         switch (Maximizer.eval.checkConstraints(ModifierDatabase.getEffectModifiers(effectId))) {
-          case 1:
+          case MEETS:
             continue;
-          case 0:
+          case IRRELEVANT:
             if (delta <= 0.0) continue;
             break;
-          case -1:
+          case VIOLATES:
             isSpecial = true;
         }
         String cmd = MoodManager.getDefaultAction("gain_effect", name);

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -429,7 +429,7 @@ public class Maximizer {
           case 1:
             isSpecial = true;
         }
-        if (Evaluator.checkEffectConstraints(effectId)) {
+        if (Evaluator.cannotGainEffect(effectId)) {
           continue;
         }
         sources = EffectDatabase.getAllActions(effectId);

--- a/src/net/sourceforge/kolmafia/moods/ManaBurnManager.java
+++ b/src/net/sourceforge/kolmafia/moods/ManaBurnManager.java
@@ -134,7 +134,7 @@ public class ManaBurnManager {
       }
 
       // Don't cast if you are restricted by your current class/skills
-      if (Evaluator.checkEffectConstraints(currentEffect.getEffectId())) {
+      if (Evaluator.cannotGainEffect(currentEffect.getEffectId())) {
         continue;
       }
 

--- a/src/net/sourceforge/kolmafia/moods/MoodTrigger.java
+++ b/src/net/sourceforge/kolmafia/moods/MoodTrigger.java
@@ -298,7 +298,7 @@ public class MoodTrigger implements Comparable<MoodTrigger> {
     }
 
     // Don't cast if you are restricted by your current class/skills
-    if (this.effect != null && Evaluator.checkEffectConstraints(this.effect.getEffectId())) {
+    if (this.effect != null && Evaluator.cannotGainEffect(this.effect.getEffectId())) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/webui/CharPaneDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/CharPaneDecorator.java
@@ -1020,7 +1020,7 @@ public class CharPaneDecorator {
         int effectId = currentEffect.getEffectId();
         String escapedEffectName = StringUtilities.getEntityEncode(effectName);
 
-        if (Evaluator.checkEffectConstraints(effectId)) {
+        if (Evaluator.cannotGainEffect(effectId)) {
           // Don't include effects that you cannot cast
           continue;
         }


### PR DESCRIPTION
1. Rename `checkEffectConstraints` to what it does
2. Make `checkConstraints` return an enum describing what each number means