### PR TITLE
fix: compute smithsness before things that depend on it

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -5058,6 +5058,16 @@ public abstract class KoLCharacter {
       }
     }
 
+    // We need to compute and store smithsness before equipment that use it
+
+    // Temporary custom modifier (e.g. Gel Noob absorbed equipment / skills)
+    if (custom != null) {
+      newModifiers.add(ModifierDatabase.parseModifiers(ModifierType.GENERATED, "custom", custom));
+    }
+
+    // Store some modifiers as statics
+    Modifiers.smithsness = KoLCharacter.getSmithsnessModifier(equipment, effects);
+
     // Look at items
     for (int slot = EquipmentManager.HAT; slot <= EquipmentManager.FAMILIAR + 1; ++slot) {
       AdventureResult item = equipment[slot];
@@ -5222,14 +5232,8 @@ public abstract class KoLCharacter {
     Modifiers fightMods = ModifierDatabase.getModifiers(ModifierType.GENERATED, "fightMods");
     newModifiers.add(fightMods);
 
-    // Temporary custom modifier
-    if (custom != null) {
-      newModifiers.add(ModifierDatabase.parseModifiers(ModifierType.GENERATED, "custom", custom));
-    }
-
     // Store some modifiers as statics
     Modifiers.hoboPower = newModifiers.getDouble(DoubleModifier.HOBO_POWER);
-    Modifiers.smithsness = KoLCharacter.getSmithsnessModifier(equipment, effects);
 
     if (Modifiers.currentLocation.equals("The Slime Tube")) {
       int hatred = (int) newModifiers.getDouble(DoubleModifier.SLIME_HATES_IT);

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerRegressionTest.java
@@ -232,4 +232,18 @@ public class MaximizerRegressionTest {
       assertEquals(7, modFor(DerivedModifier.BUFFED_MUS), 0.01);
     }
   }
+
+  // https://kolmafia.us/threads/maximizer-recommends-unequipping-weapon-with-smithsness-offhand.28600/
+  @Test
+  public void shouldntUnequipWeaponWithSmithsnessOffhand() {
+    var cleanups =
+        new Cleanups(
+            withEquipped(EquipmentManager.WEAPON, "seal-clubbing club"),
+            withEquippableItem("Half a Purse"));
+
+    try (cleanups) {
+      assertTrue(maximize("meat"));
+      recommendedSlotIsUnchanged(EquipmentManager.WEAPON);
+    }
+  }
 }

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -48,7 +48,6 @@ import net.sourceforge.kolmafia.persistence.AdventureDatabase.Environment;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -798,7 +797,6 @@ public class MaximizerTest {
       }
 
       @Test
-      @Disabled("fails to recommend to use the flask")
       public void usesFlaskfullOfHollow() {
         final var cleanups =
             new Cleanups(withItem("Flaskfull of Hollow"), withStats(100, 100, 100));


### PR DESCRIPTION
As in https://kolmafia.us/threads/maximizer-recommends-unequipping-weapon-with-smithsness-offhand.28600/#post-171232

Don't move hobo power: the stored value uses the current modifier value, so it needs to be computed first. I think ideally it would do that same as smithsness does: a separate method that goes through both equipment and effects, just to compute hobo power.

Technically, both methods should also check the custom modifier, as that can give smithsness / hobo power. Might do that for smithsness in a follow-up if I can figure out how to write the test.