### PR TITLE
refactor: remove liminal maximizer method

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -1,7 +1,6 @@
 package net.sourceforge.kolmafia.maximizer;
 
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
@@ -98,7 +97,7 @@ public class Maximizer {
 
     KoLmafiaCLI.isExecutingCheckOnlyCommand = false;
 
-    Maximizer.maximize(equipScope, maxPrice, priceLevel, false, 0);
+    Maximizer.maximize(equipScope, maxPrice, priceLevel, false, EnumSet.allOf(filterType.class));
 
     if (!KoLmafia.permitsContinue()) {
       return false;
@@ -1505,34 +1504,6 @@ public class Maximizer {
     }
 
     Maximizer.boosts.sort();
-  }
-
-  // convert the old method to use the new method, in case it gets called from elsewhere...
-  public static void maximize(
-      EquipScope equipLevel, int maxPrice, int priceLevel, boolean includeAll, int filterLevel) {
-    if (!Preferences.getBoolean("maximizerUseScope")) {
-      Integer maximizerEquipmentLevel = Preferences.getInteger("maximizerEquipmentLevel");
-      if (maximizerEquipmentLevel == 0) {
-        // no longer supported...
-        maximizerEquipmentLevel = 1;
-      }
-      Preferences.setInteger("maximizerEquipmentScope", maximizerEquipmentLevel - 1);
-      Preferences.setBoolean("maximizerUseScope", true);
-    }
-
-    EnumSet<KoLConstants.filterType> filters;
-
-    KoLConstants.filterType filterName;
-
-    // known filter levels are 1-7
-    if (filterLevel >= 1 && filterLevel <= 7) {
-      filterName = KoLConstants.filterType.values()[filterLevel - 1];
-      filters = EnumSet.of(filterName);
-    } else {
-      // covers filterLevel 0 and catchall...
-      filters = EnumSet.allOf(filterType.class);
-    }
-    maximize(equipLevel, maxPrice, priceLevel, includeAll, filters);
   }
 
   private static EquipScope emitSlot(

--- a/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
@@ -12,8 +12,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.EnumSet;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;

--- a/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
@@ -11,6 +11,9 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
@@ -25,6 +28,7 @@ import net.java.dev.spellcast.utilities.DataUtilities;
 import net.java.dev.spellcast.utilities.JComponentUtilities;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.filterType;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.listener.Listener;
 import net.sourceforge.kolmafia.listener.NamedListenerRegistry;
@@ -56,7 +60,7 @@ public class MaximizerFrame extends GenericFrame implements ListSelectionListene
   private SmartButtonGroup equipmentSelect, mallSelect;
   private AutoHighlightTextField maxPriceField;
   private final ShowDescriptionList<Boost> boostList;
-  private final EnumMap<KoLConstants.filterType, Boolean> activeFilters;
+  private final EnumSet<filterType> activeFilters;
   private EnumMap<KoLConstants.filterType, JCheckBox> filterButtons;
   private JLabel listTitle = null;
 
@@ -77,7 +81,7 @@ public class MaximizerFrame extends GenericFrame implements ListSelectionListene
 
     this.boostList = new ShowDescriptionList<>(Maximizer.boosts, 12);
     this.boostList.addListSelectionListener(this);
-    this.activeFilters = new EnumMap<>(KoLConstants.filterType.class);
+    this.activeFilters = EnumSet.noneOf(KoLConstants.filterType.class);
 
     wrapperPanel.add(new BoostsPanel(this.boostList), BorderLayout.CENTER);
 
@@ -91,7 +95,9 @@ public class MaximizerFrame extends GenericFrame implements ListSelectionListene
       }
     }
     for (KoLConstants.filterType f : KoLConstants.filterType.values()) {
-      activeFilters.put(f, filterButtons.get(f).isSelected());
+      if (filterButtons.get(f).isSelected()) {
+        activeFilters.add(f);
+      }
     }
   }
 
@@ -279,10 +285,10 @@ public class MaximizerFrame extends GenericFrame implements ListSelectionListene
 
           filterButtons.get(fType).setSelected(singleSelect);
 
-          if (activeFilters.containsKey(thisFilter)) {
-            activeFilters.replace(fType, singleSelect);
+          if (singleSelect) {
+            activeFilters.add(fType);
           } else {
-            activeFilters.put(fType, singleSelect);
+            activeFilters.remove(fType);
           }
         }
         Preferences.setString("maximizerLastSingleFilter", changedBox.getText());
@@ -322,12 +328,12 @@ public class MaximizerFrame extends GenericFrame implements ListSelectionListene
     }
   }
 
-  protected void updateFilter(KoLConstants.filterType f, Boolean value) {
+  protected void updateFilter(KoLConstants.filterType f, boolean value) {
     try {
-      if (activeFilters.containsKey(f)) {
-        activeFilters.replace(f, value);
+      if (value) {
+        activeFilters.add(f);
       } else {
-        activeFilters.put(f, value);
+        activeFilters.remove(f);
       }
     } catch (Exception Ex) {
       // This should probably log the error...

--- a/test/internal/helpers/Maximizer.java
+++ b/test/internal/helpers/Maximizer.java
@@ -3,10 +3,12 @@ package internal.helpers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import net.sourceforge.kolmafia.AdventureResult;
+import net.sourceforge.kolmafia.KoLConstants.filterType;
 import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.maximizer.Boost;
 import net.sourceforge.kolmafia.maximizer.EquipScope;
@@ -24,7 +26,7 @@ public class Maximizer {
   public static void maximizeCreatable(String maximizerString) {
     MaximizerFrame.expressionSelect.setSelectedItem(maximizerString);
     net.sourceforge.kolmafia.maximizer.Maximizer.maximize(
-        EquipScope.SPECULATE_CREATABLE, 0, 0, false, 0);
+        EquipScope.SPECULATE_CREATABLE, 0, 0, false, EnumSet.allOf(filterType.class));
   }
 
   public static double modFor(Modifier modifier) {


### PR DESCRIPTION
A while back, when the filter levels were changed, an old version of the method taking an int was left around to give time to migrate the preferences.

I think it's been long enough now. Additionally convert the filters from a Map<filterType, boolean> to a Set<filterType> for simplicity. We only care about whether the values are true, not whether they're in the map.