### PR TITLE
refactor: convert turtle blessing level to enum

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -113,6 +113,31 @@ public abstract class KoLCharacter {
     SHE_WHO_WAS,
   }
 
+  public enum TurtleBlessingLevel {
+    PARIAH,
+    NONE,
+    BLESSING,
+    GRAND_BLESSING,
+    GLORIOUS_BLESSING,
+    AVATAR;
+
+    public boolean isBlessing() {
+      return switch (this) {
+        case BLESSING, GRAND_BLESSING, GLORIOUS_BLESSING -> true;
+        default -> false;
+      };
+    }
+
+    public int boonDuration() {
+      return switch (this) {
+        case BLESSING -> 5;
+        case GRAND_BLESSING -> 10;
+        case GLORIOUS_BLESSING -> 15;
+        default -> 0;
+      };
+    }
+  }
+
   public enum Gender {
     UNKNOWN(0),
     MALE(-1),
@@ -1029,12 +1054,12 @@ public abstract class KoLCharacter {
     return null;
   }
 
-  public static final int getBlessingLevel() {
+  public static final TurtleBlessingLevel getBlessingLevel() {
     if (KoLConstants.activeEffects.contains(EffectPool.get(EffectPool.BLESSING_OF_THE_WAR_SNAPPER))
         || KoLConstants.activeEffects.contains(EffectPool.get(EffectPool.BLESSING_OF_SHE_WHO_WAS))
         || KoLConstants.activeEffects.contains(
             EffectPool.get(EffectPool.BLESSING_OF_THE_STORM_TORTOISE))) {
-      return 1;
+      return TurtleBlessingLevel.BLESSING;
     }
     if (KoLConstants.activeEffects.contains(
             EffectPool.get(EffectPool.GRAND_BLESSING_OF_THE_WAR_SNAPPER))
@@ -1042,7 +1067,7 @@ public abstract class KoLCharacter {
             EffectPool.get(EffectPool.GRAND_BLESSING_OF_SHE_WHO_WAS))
         || KoLConstants.activeEffects.contains(
             EffectPool.get(EffectPool.GRAND_BLESSING_OF_THE_STORM_TORTOISE))) {
-      return 2;
+      return TurtleBlessingLevel.GRAND_BLESSING;
     }
     if (KoLConstants.activeEffects.contains(
             EffectPool.get(EffectPool.GLORIOUS_BLESSING_OF_THE_WAR_SNAPPER))
@@ -1050,18 +1075,18 @@ public abstract class KoLCharacter {
             EffectPool.get(EffectPool.GLORIOUS_BLESSING_OF_SHE_WHO_WAS))
         || KoLConstants.activeEffects.contains(
             EffectPool.get(EffectPool.GLORIOUS_BLESSING_OF_THE_STORM_TORTOISE))) {
-      return 3;
+      return TurtleBlessingLevel.GLORIOUS_BLESSING;
     }
     if (KoLConstants.activeEffects.contains(EffectPool.get(EffectPool.AVATAR_OF_THE_WAR_SNAPPER))
         || KoLConstants.activeEffects.contains(EffectPool.get(EffectPool.AVATAR_OF_SHE_WHO_WAS))
         || KoLConstants.activeEffects.contains(
             EffectPool.get(EffectPool.AVATAR_OF_THE_STORM_TORTOISE))) {
-      return 4;
+      return TurtleBlessingLevel.AVATAR;
     }
     if (KoLConstants.activeEffects.contains(EffectPool.get(EffectPool.SPIRIT_PARIAH))) {
-      return -1;
+      return TurtleBlessingLevel.PARIAH;
     }
-    return 0;
+    return TurtleBlessingLevel.NONE;
   }
 
   public static final int getSoulsauce() {

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -20,6 +20,7 @@ import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLCharacter.TurtleBlessing;
+import net.sourceforge.kolmafia.KoLCharacter.TurtleBlessingLevel;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLConstants.WeaponType;
 import net.sourceforge.kolmafia.KoLmafia;
@@ -952,34 +953,34 @@ public class Evaluator {
       case EffectPool.SILENT_HUNTING, EffectPool.BARREL_CHESTED -> !KoLCharacter.isSealClubber();
       case EffectPool.BOON_OF_SHE_WHO_WAS -> KoLCharacter.getBlessingType()
               != TurtleBlessing.SHE_WHO_WAS
-          || KoLCharacter.getBlessingLevel() == 4;
+          || KoLCharacter.getBlessingLevel() == TurtleBlessingLevel.AVATAR;
       case EffectPool.BOON_OF_THE_STORM_TORTOISE -> KoLCharacter.getBlessingType()
               != TurtleBlessing.STORM
-          || KoLCharacter.getBlessingLevel() == 4;
+          || KoLCharacter.getBlessingLevel() == TurtleBlessingLevel.AVATAR;
       case EffectPool.BOON_OF_THE_WAR_SNAPPER -> KoLCharacter.getBlessingType()
               != TurtleBlessing.WAR
-          || KoLCharacter.getBlessingLevel() == 4;
+          || KoLCharacter.getBlessingLevel() == TurtleBlessingLevel.AVATAR;
       case EffectPool.AVATAR_OF_SHE_WHO_WAS -> KoLCharacter.getBlessingType()
               != TurtleBlessing.SHE_WHO_WAS
-          || KoLCharacter.getBlessingLevel() != 3;
+          || KoLCharacter.getBlessingLevel() != TurtleBlessingLevel.GLORIOUS_BLESSING;
       case EffectPool.AVATAR_OF_THE_STORM_TORTOISE -> KoLCharacter.getBlessingType()
               != TurtleBlessing.STORM
-          || KoLCharacter.getBlessingLevel() != 3;
+          || KoLCharacter.getBlessingLevel() != TurtleBlessingLevel.GLORIOUS_BLESSING;
       case EffectPool.AVATAR_OF_THE_WAR_SNAPPER -> KoLCharacter.getBlessingType()
               != TurtleBlessing.WAR
-          || KoLCharacter.getBlessingLevel() != 3;
+          || KoLCharacter.getBlessingLevel() != TurtleBlessingLevel.GLORIOUS_BLESSING;
       case EffectPool.BLESSING_OF_SHE_WHO_WAS -> !KoLCharacter.isTurtleTamer()
           || KoLCharacter.getBlessingType() == TurtleBlessing.SHE_WHO_WAS
-          || KoLCharacter.getBlessingLevel() == -1
-          || KoLCharacter.getBlessingLevel() == 4;
+          || KoLCharacter.getBlessingLevel() == TurtleBlessingLevel.PARIAH
+          || KoLCharacter.getBlessingLevel() == TurtleBlessingLevel.AVATAR;
       case EffectPool.BLESSING_OF_THE_STORM_TORTOISE -> !KoLCharacter.isTurtleTamer()
           || KoLCharacter.getBlessingType() == TurtleBlessing.STORM
-          || KoLCharacter.getBlessingLevel() == -1
-          || KoLCharacter.getBlessingLevel() == 4;
+          || KoLCharacter.getBlessingLevel() == TurtleBlessingLevel.PARIAH
+          || KoLCharacter.getBlessingLevel() == TurtleBlessingLevel.AVATAR;
       case EffectPool.BLESSING_OF_THE_WAR_SNAPPER -> !KoLCharacter.isTurtleTamer()
           || KoLCharacter.getBlessingType() == TurtleBlessing.WAR
-          || KoLCharacter.getBlessingLevel() == -1
-          || KoLCharacter.getBlessingLevel() == 4;
+          || KoLCharacter.getBlessingLevel() == TurtleBlessingLevel.PARIAH
+          || KoLCharacter.getBlessingLevel() == TurtleBlessingLevel.AVATAR;
       case EffectPool.DISDAIN_OF_SHE_WHO_WAS,
           EffectPool.DISDAIN_OF_THE_STORM_TORTOISE,
           EffectPool.DISDAIN_OF_THE_WAR_SNAPPER -> KoLCharacter.isTurtleTamer();

--- a/src/net/sourceforge/kolmafia/persistence/SkillDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/SkillDatabase.java
@@ -849,7 +849,7 @@ public class SkillDatabase {
     if (type != SkillType.BUFF) {
       switch (skillId) {
         case SkillPool.SPIRIT_BOON:
-          return KoLCharacter.getBlessingLevel() * 5;
+          return KoLCharacter.getBlessingLevel().boonDuration();
 
         case SkillPool.WAR_BLESSING:
         case SkillPool.SHE_WHO_WAS_BLESSING:

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -23,6 +23,7 @@ import net.sourceforge.kolmafia.EdServantData;
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLAdventure;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLCharacter.TurtleBlessingLevel;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLConstants.Stat;
@@ -2241,8 +2242,8 @@ public class FightRequest extends GenericRequest {
       }
 
       // Increment Turtle Blessing counter
-      int blessingLevel = KoLCharacter.getBlessingLevel();
-      if (blessingLevel > 0 && blessingLevel < 4) {
+      TurtleBlessingLevel blessingLevel = KoLCharacter.getBlessingLevel();
+      if (blessingLevel.isBlessing()) {
         Preferences.increment("turtleBlessingTurns", 1);
       } else {
         Preferences.setInteger("turtleBlessingTurns", 0);

--- a/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
@@ -8,7 +8,7 @@ import net.sourceforge.kolmafia.AdventureResult.AdventureLongCountResult;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.BuffBotHome;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLCharacter.TurtleBlessing;
+import net.sourceforge.kolmafia.KoLCharacter.TurtleBlessingLevel;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
@@ -495,29 +495,17 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
       case SkillPool.DEEP_VISIONS:
         return KoLCharacter.getMaximumHP() >= 500 ? 1 : 0;
 
-      case SkillPool.WAR_BLESSING:
-        return (KoLCharacter.getBlessingLevel() != -1
-                || KoLCharacter.getBlessingType() == TurtleBlessing.WAR)
-            ? 1
-            : 0;
-
-      case SkillPool.SHE_WHO_WAS_BLESSING:
-        return (KoLCharacter.getBlessingLevel() != -1
-                || KoLCharacter.getBlessingType() == TurtleBlessing.SHE_WHO_WAS)
-            ? 1
-            : 0;
-
-      case SkillPool.STORM_BLESSING:
-        return (KoLCharacter.getBlessingLevel() != -1
-                || KoLCharacter.getBlessingType() == TurtleBlessing.STORM)
-            ? 1
-            : 0;
+      case SkillPool.WAR_BLESSING, SkillPool.SHE_WHO_WAS_BLESSING, SkillPool.STORM_BLESSING:
+        return KoLConstants.activeEffects.contains(EffectPool.get(EffectPool.SPIRIT_PARIAH))
+            ? 0
+            : 1;
 
       case SkillPool.SPIRIT_BOON:
-        return KoLCharacter.getBlessingLevel() != 0 ? Integer.MAX_VALUE : 0;
+        return KoLCharacter.getBlessingLevel().isBlessing() ? Integer.MAX_VALUE : 0;
 
       case SkillPool.TURTLE_POWER:
-        return KoLCharacter.getBlessingLevel() == 3 && !Preferences.getBoolean("_turtlePowerCast")
+        return KoLCharacter.getBlessingLevel() == TurtleBlessingLevel.GLORIOUS_BLESSING
+                && !Preferences.getBoolean("_turtlePowerCast")
             ? 1
             : 0;
 


### PR DESCRIPTION
Also fix logic around blessing level.

* Spirit boon gives turns only for normal blessings -- it doesn't give anything for avatars.
* Spirit Pariah prevents casting blessings, even if you have the avatar effect (or so says the wiki, I haven't been TT for a while).