### PR TITLE
refactor: convert price level to enum

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/CheckedItem.java
+++ b/src/net/sourceforge/kolmafia/maximizer/CheckedItem.java
@@ -19,7 +19,7 @@ import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.session.MallPriceManager;
 
 public class CheckedItem extends AdventureResult {
-  public CheckedItem(int itemId, EquipScope equipScope, int maxPrice, int priceLevel) {
+  public CheckedItem(int itemId, EquipScope equipScope, int maxPrice, PriceLevel priceLevel) {
     super(itemId, 1, false);
 
     this.inventory = InventoryManager.getCount(itemId);
@@ -100,7 +100,7 @@ public class CheckedItem extends AdventureResult {
         // We include things with historical price up to twice as high as limit, as current price
         // may be lower
         long price = Math.min(maxPrice, KoLCharacter.getAvailableMeat());
-        if (priceLevel == 0 || MallPriceDatabase.getPrice(itemId) < price * 2) {
+        if (priceLevel == PriceLevel.DONT_CHECK || MallPriceDatabase.getPrice(itemId) < price * 2) {
           this.mallBuyable = 1;
           this.buyableFlag = true;
         }
@@ -116,7 +116,8 @@ public class CheckedItem extends AdventureResult {
           // We include things with historical price up to twice as high as limit, as current price
           // may be lower
           long price = Math.min(maxPrice, KoLCharacter.getStorageMeat());
-          if (priceLevel == 0 || MallPriceDatabase.getPrice(itemId) < price * 2) {
+          if (priceLevel == PriceLevel.DONT_CHECK
+              || MallPriceDatabase.getPrice(itemId) < price * 2) {
             this.pullBuyable = 1;
             this.buyableFlag = true;
           }
@@ -187,12 +188,12 @@ public class CheckedItem extends AdventureResult {
         + this.pullBuyable;
   }
 
-  public void validate(int maxPrice, int priceLevel) throws MaximizerInterruptedException {
+  public void validate(int maxPrice, PriceLevel priceLevel) throws MaximizerInterruptedException {
     if (!KoLmafia.permitsContinue()) {
       throw new MaximizerInterruptedException();
     }
 
-    if (priceLevel <= 0) {
+    if (priceLevel == PriceLevel.DONT_CHECK) {
       return;
     }
 

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -1008,7 +1008,7 @@ public class Evaluator {
     };
   }
 
-  void enumerateEquipment(EquipScope equipScope, int maxPrice, int priceLevel)
+  void enumerateEquipment(EquipScope equipScope, int maxPrice, PriceLevel priceLevel)
       throws MaximizerInterruptedException {
     // Items automatically considered regardless of their score -
     // synergies, hobo power, brimstone, etc.

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -88,7 +88,7 @@ public class Maximizer {
   private Maximizer() {}
 
   public static boolean maximize(
-      String maximizerString, int maxPrice, int priceLevel, boolean isSpeculationOnly) {
+      String maximizerString, int maxPrice, PriceLevel priceLevel, boolean isSpeculationOnly) {
     MaximizerFrame.expressionSelect.setSelectedItem(maximizerString);
     EquipScope equipScope =
         isSpeculationOnly ? EquipScope.SPECULATE_INVENTORY : EquipScope.EQUIP_NOW;
@@ -114,7 +114,7 @@ public class Maximizer {
   public static void maximize(
       EquipScope equipScope,
       int maxPrice,
-      int priceLevel,
+      PriceLevel priceLevel,
       boolean includeAll,
       Set<filterType> filter) {
     KoLmafia.forceContinue();
@@ -1312,7 +1312,7 @@ public class Maximizer {
               cmd = "pull \u00B6" + itemId + ";" + cmd;
             } else if (checkedItem.mallBuyable > 0) {
               text = "acquire & " + text;
-              if (priceLevel > 0) {
+              if (priceLevel != PriceLevel.DONT_CHECK) {
                 if (MallPriceDatabase.getPrice(itemId) > maxPrice * 2) {
                   continue;
                 }
@@ -1327,7 +1327,7 @@ public class Maximizer {
             } else if (checkedItem.pullBuyable > 0) {
               text = "buy & pull & " + text;
               cmd = "buy using storage 1 \u00B6" + itemId + ";pull \u00B6" + itemId + ";" + cmd;
-              if (priceLevel > 0) {
+              if (priceLevel != PriceLevel.DONT_CHECK) {
                 if (MallPriceDatabase.getPrice(itemId) > maxPrice * 2) {
                   continue;
                 }
@@ -1344,7 +1344,7 @@ public class Maximizer {
             }
 
             if (price > maxPrice || price == -1) continue;
-            if (priceLevel == 2
+            if (priceLevel == PriceLevel.ALL
                 && (checkedItem.initial > 0
                     || checkedItem.creatable > 0
                     || checkedItem.pullable > 0
@@ -1510,7 +1510,7 @@ public class Maximizer {
   }
 
   private static EquipScope emitSlot(
-      Slot slot, EquipScope equipScope, int maxPrice, int priceLevel, double current) {
+      Slot slot, EquipScope equipScope, int maxPrice, PriceLevel priceLevel, double current) {
     if (slot == Slot.FAMILIAR) { // Insert any familiar switch at this point
       FamiliarData fam = Maximizer.best.getFamiliar();
       if (!fam.equals(KoLCharacter.getFamiliar())) {
@@ -1720,12 +1720,12 @@ public class Maximizer {
       } else if (checkedItem.pullBuyable + checkedItem.initial > count) {
         text = "buy & pull & " + text;
         cmd = "buy using storage 1 \u00B6" + itemId + ";pull \u00B6" + itemId + ";" + cmd;
-        if (priceLevel > 0) {
+        if (priceLevel != PriceLevel.DONT_CHECK) {
           price = MallPriceManager.getMallPrice(itemId);
         }
       } else { // Mall buyable
         text = "acquire & " + text;
-        if (priceLevel > 0) {
+        if (priceLevel != PriceLevel.DONT_CHECK) {
           price = MallPriceManager.getMallPrice(itemId);
         }
       }
@@ -1774,7 +1774,7 @@ public class Maximizer {
   }
 
   private static Makeable getAbsorbable(
-      int itemId, EquipScope equipScope, int maxPrice, int priceLevel) {
+      int itemId, EquipScope equipScope, int maxPrice, PriceLevel priceLevel) {
     // Check if we have access to item
     CheckedItem checkedItem = new CheckedItem(itemId, equipScope, maxPrice, priceLevel);
     // We won't include unavailable items, as this just gets far too large
@@ -1811,13 +1811,13 @@ public class Maximizer {
       cmd = "pull \u00B6" + itemId + ";" + cmd;
     } else if (checkedItem.mallBuyable > 0) {
       text = "acquire & " + text;
-      if (priceLevel > 0) {
+      if (priceLevel != PriceLevel.DONT_CHECK) {
         price = MallPriceManager.getMallPrice(itemId);
       }
     } else if (checkedItem.pullBuyable > 0) {
       text = "buy & pull & " + text;
       cmd = "buy using storage 1 \u00B6" + itemId + ";pull \u00B6" + itemId + ";" + cmd;
-      if (priceLevel > 0) {
+      if (priceLevel != PriceLevel.DONT_CHECK) {
         price = MallPriceManager.getMallPrice(itemId);
       }
     } else {

--- a/src/net/sourceforge/kolmafia/maximizer/PriceLevel.java
+++ b/src/net/sourceforge/kolmafia/maximizer/PriceLevel.java
@@ -1,0 +1,16 @@
+package net.sourceforge.kolmafia.maximizer;
+
+public enum PriceLevel {
+  DONT_CHECK,
+  BUYABLE_ONLY,
+  ALL;
+
+  public static PriceLevel byIndex(int index) {
+    return switch (index) {
+      case 2 -> ALL;
+      case 1 -> BUYABLE_ONLY;
+        // backwards compat
+      default -> DONT_CHECK;
+    };
+  }
+}

--- a/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
@@ -34,6 +34,7 @@ import net.sourceforge.kolmafia.maximizer.Boost;
 import net.sourceforge.kolmafia.maximizer.EquipScope;
 import net.sourceforge.kolmafia.maximizer.Maximizer;
 import net.sourceforge.kolmafia.maximizer.MaximizerSpeculation;
+import net.sourceforge.kolmafia.maximizer.PriceLevel;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.swingui.panel.GenericPanel;
@@ -147,7 +148,7 @@ public class MaximizerFrame extends GenericFrame implements ListSelectionListene
     Maximizer.maximize(
         EquipScope.byIndex(this.equipmentSelect.getSelectedIndex()),
         InputFieldUtilities.getValue(this.maxPriceField),
-        this.mallSelect.getSelectedIndex(),
+        PriceLevel.byIndex(this.mallSelect.getSelectedIndex()),
         Preferences.getBoolean("maximizerIncludeAll"),
         this.activeFilters);
 

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -74,6 +74,7 @@ import net.sourceforge.kolmafia.equipment.Slot;
 import net.sourceforge.kolmafia.equipment.SlotSet;
 import net.sourceforge.kolmafia.maximizer.Boost;
 import net.sourceforge.kolmafia.maximizer.Maximizer;
+import net.sourceforge.kolmafia.maximizer.PriceLevel;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.Modifier;
 import net.sourceforge.kolmafia.modifiers.ModifierList.ModifierValue;
@@ -7593,7 +7594,9 @@ public abstract class RuntimeLibrary {
     int priceLevel = (int) priceLevelValue.intValue();
     boolean isSpeculateOnly = isSpeculateOnlyValue.intValue() != 0;
 
-    return new Value(Maximizer.maximize(maximizerString, maxPrice, priceLevel, isSpeculateOnly));
+    return new Value(
+        Maximizer.maximize(
+            maximizerString, maxPrice, PriceLevel.byIndex(priceLevel), isSpeculateOnly));
   }
 
   public static Value maximize(
@@ -7609,7 +7612,7 @@ public abstract class RuntimeLibrary {
     boolean isSpeculateOnly = isSpeculateOnlyValue.intValue() != 0;
     boolean showEquip = showEquipment.intValue() == 1;
 
-    Maximizer.maximize(maximizerString, maxPrice, priceLevel, isSpeculateOnly);
+    Maximizer.maximize(maximizerString, maxPrice, PriceLevel.byIndex(priceLevel), isSpeculateOnly);
 
     List<Boost> m = Maximizer.boosts;
 

--- a/src/net/sourceforge/kolmafia/textui/command/ModifierMaximizeCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ModifierMaximizeCommand.java
@@ -5,6 +5,7 @@ import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.KoLmafiaCLI;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.maximizer.Maximizer;
+import net.sourceforge.kolmafia.maximizer.PriceLevel;
 
 public class ModifierMaximizeCommand extends AbstractCommand {
   public ModifierMaximizeCommand() {
@@ -20,7 +21,8 @@ public class ModifierMaximizeCommand extends AbstractCommand {
       RequestLogger.updateSessionLog(command + " " + parameters);
     }
 
-    if (!Maximizer.maximize(parameters, 0, 0, isSpeculateOnly) && !isSpeculateOnly) {
+    if (!Maximizer.maximize(parameters, 0, PriceLevel.DONT_CHECK, isSpeculateOnly)
+        && !isSpeculateOnly) {
       KoLmafia.updateDisplay(
           MafiaState.ERROR, "Unable to meet all requirements via equipment changes.");
       RequestLogger.printLine("See the Modifier Maximizer for further suggestions.");

--- a/test/internal/helpers/Maximizer.java
+++ b/test/internal/helpers/Maximizer.java
@@ -13,6 +13,7 @@ import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.equipment.Slot;
 import net.sourceforge.kolmafia.maximizer.Boost;
 import net.sourceforge.kolmafia.maximizer.EquipScope;
+import net.sourceforge.kolmafia.maximizer.PriceLevel;
 import net.sourceforge.kolmafia.modifiers.Modifier;
 import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 import net.sourceforge.kolmafia.swingui.MaximizerFrame;
@@ -21,13 +22,18 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 public class Maximizer {
 
   public static boolean maximize(String maximizerString) {
-    return net.sourceforge.kolmafia.maximizer.Maximizer.maximize(maximizerString, 0, 0, true);
+    return net.sourceforge.kolmafia.maximizer.Maximizer.maximize(
+        maximizerString, 0, PriceLevel.DONT_CHECK, true);
   }
 
   public static void maximizeCreatable(String maximizerString) {
     MaximizerFrame.expressionSelect.setSelectedItem(maximizerString);
     net.sourceforge.kolmafia.maximizer.Maximizer.maximize(
-        EquipScope.SPECULATE_CREATABLE, 0, 0, false, EnumSet.allOf(filterType.class));
+        EquipScope.SPECULATE_CREATABLE,
+        0,
+        PriceLevel.DONT_CHECK,
+        false,
+        EnumSet.allOf(filterType.class));
   }
 
   public static double modFor(Modifier modifier) {


### PR DESCRIPTION
Valid values were 0, 1 and 2. -1 was also a consistent value, which was treated as 0 in practice (by functions checking > 0 or <= 0).

Names were taken from the UI: "don't check", "buyable only", "all consumables".