### PR TITLE
Fix typo when setting shadowRiftIngress at beanstalk

### DIFF
--- a/src/net/sourceforge/kolmafia/request/PlaceRequest.java
+++ b/src/net/sourceforge/kolmafia/request/PlaceRequest.java
@@ -419,7 +419,7 @@ public class PlaceRequest extends GenericRequest {
             };
       }
       case "beanstalk" -> {
-        if (action.equals("stalk-rift")) {
+        if (action.equals("stalk_rift")) {
           message = "Entering the Shadow Rift via The Beanstalk";
           Preferences.setString("shadowRiftIngress", "beanstalk");
         }


### PR DESCRIPTION
Link uses an underscore instead of a dash.