### PR TITLE
refactor: make surgeonosity a bitmap modifier

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -8626,7 +8626,6 @@ MutexE	Broken Heart/Fiery Heart/Cold Hearted/Sweet Heart/Withered Heart/Lustful 
 # Consider them to be Single Equip, insofar as the specified modifier is concerned.
 
 Unique	Clowniness	balloon helmet/clown wig/foolscap fool's cap/bloody clown pants/clownskin harness/balloon sword/clown whip/clownskin buckler/big red clown nose/clown shoes/clownskin belt/polka-dot bow tie
-Unique	Surgeonosity	bloodied surgical dungarees/surgical apron/half-size scalpel/head mirror/surgical mask
 
 # Maximization categories section of modifiers.txt
 # These pseudo-items list the indirect benefits of certain classes of

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -5589,7 +5589,6 @@ public abstract class KoLCharacter {
         for (var mod : DoubleModifier.DOUBLE_MODIFIERS) {
           switch (mod) {
             case SLIME_HATES_IT:
-            case SURGEONOSITY:
               continue;
           }
           iModCopy.setDouble(mod, 0.0);

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -363,7 +363,6 @@ public class Evaluator {
       if (keyword.equals("surgeonosity")) {
         // If no weight specified, assume 5
         this.surgeonosity = (m.end(2) == m.start(2)) ? 5 : (int) weight;
-        this.addUniqueItems("Surgeonosity");
         continue;
       }
 
@@ -874,7 +873,7 @@ public class Evaluator {
       if (osity < this.raveosity) this.failed = true;
     }
     if (this.surgeonosity > 0) {
-      int osity = (int) mods.getDouble(DoubleModifier.SURGEONOSITY);
+      int osity = mods.getBitmap(BitmapModifier.SURGEONOSITY);
       score += Math.min(osity, this.surgeonosity);
       if (osity < this.surgeonosity) this.failed = true;
     }
@@ -1483,7 +1482,7 @@ public class Evaluator {
             || (slimeHateUseful && mods.getDouble(DoubleModifier.SLIME_HATES_IT) > 0.0)
             || (this.clownosity > 0 && mods.getDouble(DoubleModifier.CLOWNINESS) != 0)
             || (this.raveosity > 0 && mods.getRawBitmap(BitmapModifier.RAVEOSITY) != 0)
-            || (this.surgeonosity > 0 && mods.getDouble(DoubleModifier.SURGEONOSITY) != 0)
+            || (this.surgeonosity > 0 && mods.getRawBitmap(BitmapModifier.SURGEONOSITY) != 0)
             || ((mods.getRawBitmap(BitmapModifier.SYNERGETIC) & usefulSynergies) != 0)) {
           item.automaticFlag = true;
           break gotItem;

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -279,10 +279,6 @@ public class Maximizer {
         // Only take numeric modifiers, and not Surgeonosity, from Items in Noobcore
         StringBuilder mods = new StringBuilder();
         for (var mod : DoubleModifier.DOUBLE_MODIFIERS) {
-          switch (mod) {
-            case SURGEONOSITY:
-              continue;
-          }
           if (itemMods.getDouble(mod) != 0.0) {
             if (mods.length() > 0) {
               mods.append(", ");

--- a/src/net/sourceforge/kolmafia/modifiers/BitmapModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/BitmapModifier.java
@@ -13,14 +13,27 @@ public enum BitmapModifier implements Modifier {
   BRIMSTONE("Brimstone", Pattern.compile("Brimstone")),
   CLOATHING("Cloathing", Pattern.compile("Cloathing")),
   SYNERGETIC("Synergetic", Pattern.compile("Synergetic")),
+  SURGEONOSITY(
+      "Surgeonosity",
+      new Pattern[] {
+        Pattern.compile("Makes you look like a doctor"),
+        Pattern.compile("Makes you look like a gross doctor"),
+      },
+      Pattern.compile("Surgeonosity: (\\+?\\d+)")),
   RAVEOSITY("Raveosity", Pattern.compile("Raveosity: (\\+?\\d+)")),
   MUTEX("Mutually Exclusive", null),
   MUTEX_VIOLATIONS("Mutex Violations", null);
   private final String name;
+  private final Pattern[] descPatterns;
   private final Pattern tagPattern;
 
   BitmapModifier(String name, Pattern tagPattern) {
+    this(name, null, tagPattern);
+  }
+
+  BitmapModifier(String name, Pattern[] descPatterns, Pattern tagPattern) {
     this.name = name;
+    this.descPatterns = descPatterns;
     this.tagPattern = tagPattern;
   }
 
@@ -31,7 +44,7 @@ public enum BitmapModifier implements Modifier {
 
   @Override
   public Pattern[] getDescPatterns() {
-    return null;
+    return descPatterns;
   }
 
   @Override
@@ -69,6 +82,41 @@ public enum BitmapModifier implements Modifier {
         return modifier;
       }
     }
+    return null;
+  }
+
+  // equivalent to `Modifiers.parseModifier`
+  public static String parseModifier(final String enchantment) {
+    for (var mod : BITMAP_MODIFIERS) {
+      Pattern[] patterns = mod.getDescPatterns();
+
+      if (patterns == null) {
+        continue;
+      }
+
+      for (Pattern pattern : patterns) {
+        Matcher matcher = pattern.matcher(enchantment);
+        if (!matcher.find()) {
+          continue;
+        }
+
+        if (matcher.groupCount() == 0) {
+          String tag = mod.getTag();
+          // Kludge for Surgeonosity, which always gives +1
+          if (mod == BitmapModifier.SURGEONOSITY) {
+            return tag + ": +1";
+          }
+          return tag;
+        }
+
+        String tag = mod.getTag();
+
+        String value = matcher.group(1);
+
+        return tag + ": " + value.trim();
+      }
+    }
+
     return null;
   }
 }

--- a/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
@@ -386,13 +386,6 @@ public enum DoubleModifier implements Modifier {
       "Pool Skill",
       Pattern.compile("([+-]\\d+) Pool Skill"),
       Pattern.compile("Pool Skill: " + EXPR)),
-  SURGEONOSITY(
-      "Surgeonosity",
-      new Pattern[] {
-        Pattern.compile("Makes you look like a doctor"),
-        Pattern.compile("Makes you look like a gross doctor"),
-      },
-      Pattern.compile("Surgeonosity: (\\+?\\d+)")),
   FAMILIAR_DAMAGE(
       "Familiar Damage",
       new Pattern[] {
@@ -624,12 +617,7 @@ public enum DoubleModifier implements Modifier {
         }
 
         if (matcher.groupCount() == 0) {
-          String tag = mod.getTag();
-          // Kludge for Surgeonosity, which always gives +1
-          if (mod == DoubleModifier.SURGEONOSITY) {
-            return tag + ": +1";
-          }
-          return tag;
+          return mod.getTag();
         }
 
         String tag = mod.getTag();

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -809,6 +809,13 @@ public class ModifierDatabase {
       return result;
     }
 
+    // Then the bitmap modifiers
+
+    result = BitmapModifier.parseModifier(enchantment);
+    if (result != null) {
+      return result;
+    }
+
     // Special handling needed
 
     Matcher matcher;

--- a/src/net/sourceforge/kolmafia/swingui/panel/CompactSidePane.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/CompactSidePane.java
@@ -981,7 +981,7 @@ public class CompactSidePane extends JPanel implements Runnable {
         this.bonusValueLabel[count].setText(KoLConstants.MODIFIER_FORMAT.format(smithsness));
         count++;
       }
-      int surgeon = (int) KoLCharacter.currentNumericModifier(DoubleModifier.SURGEONOSITY);
+      int surgeon = (int) KoLCharacter.currentNumericModifier(BitmapModifier.SURGEONOSITY);
       if (surgeon != 0 && count < this.BONUS_LABELS) {
         this.bonusLabel[count].setText("Surgeon: ");
         this.bonusValueLabel[count].setText(surgeon + " / 5");

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -324,7 +324,22 @@ public class MaximizerTest {
         recommends("surgical mask");
         recommends("half-size scalpel");
         recommendedSlotIs(Slot.SHIRT, "surgical apron");
-        assertEquals(5, modFor(DoubleModifier.SURGEONOSITY), 0.01);
+        assertEquals(5, modFor(BitmapModifier.SURGEONOSITY), 0.01);
+      }
+    }
+
+    @Test
+    public void surgeonosityItemsDontStack() {
+      var cleanups = withEquippableItem("surgical mask", 3);
+
+      try (cleanups) {
+        maximize("surgeonosity, -tie");
+        assertEquals(1, modFor(BitmapModifier.SURGEONOSITY), 0.01);
+        assertThat(
+            getBoosts().stream()
+                .filter(x -> x.isEquipment() && "surgical mask".equals(x.getItem().getName()))
+                .count(),
+            equalTo(1L));
       }
     }
   }
@@ -1302,8 +1317,7 @@ public class MaximizerTest {
                 .filter(x -> x.isEquipment() && "surgical mask".equals(x.getItem().getName()))
                 .count(),
             equalTo(3L));
-        // TODO: make duplicate surgeonosity not count in modifiers
-        // assertEquals(1, modFor(DoubleModifier.SURGEONOSITY), 0.01);
+        assertEquals(1, modFor(BitmapModifier.SURGEONOSITY), 0.01);
       }
     }
 


### PR DESCRIPTION
Bitmap modifiers are numeric, so externally everything should continue to work.

This fixes the problem where equipping duplicate surgical equipment increased the surgeonosity modifier when it shouldn't. The maximizer always correctly didn't recommend multiple items -- it was just the modifiers that displayed the incorrect value.

Planning to do the same for clownosity and remove the concept of "unique items" -- items that are unique only for one modifier.