### PR TITLE
Each Shadow Rift ingress is an adventure area

### DIFF
--- a/src/data/adventures.txt
+++ b/src/data/adventures.txt
@@ -405,7 +405,20 @@ Twitch	adventure=454	DiffLevel: mid Env: indoor Stat: 0	Globe Theatre Backstage
 Twitch	adventure=475	DiffLevel: mid Env: indoor Stat: 0	12 West Main
 Twitch	adventure=476	DiffLevel: mid Env: outdoor Stat: 0	KoL Con Clan Party House
 
-Events	adventure=567	DiffLevel: mid Env: outdoor Stat: 0 nowander	Shadow Rift
+Shadow Rift	adventure=567	DiffLevel: mid Env: outdoor Stat: 0 nowander	Shadow Rift
+Shadow Rift	place=shadow_rift	DiffLevel: mid Env: outdoor Stat: 0 nowander	Shadow Rift (Desert Beach)
+Shadow Rift	place=shadow_rift	DiffLevel: mid Env: outdoor Stat: 0 nowander	Shadow Rift (Forest Village)
+Shadow Rift	place=shadow_rift	DiffLevel: mid Env: outdoor Stat: 0 nowander	Shadow Rift (Mt. McLargeHuge)
+Shadow Rift	place=shadow_rift	DiffLevel: mid Env: outdoor Stat: 0 nowander	Shadow Rift (Somewhere Over the Beanstalk)
+Shadow Rift	place=shadow_rift	DiffLevel: mid Env: outdoor Stat: 0 nowander	Shadow Rift (Spookyraven Manor Third Floor)
+Shadow Rift	place=shadow_rift	DiffLevel: mid Env: outdoor Stat: 0 nowander	Shadow Rift (The 8-Bit Realm)
+Shadow Rift	place=shadow_rift	DiffLevel: mid Env: outdoor Stat: 0 nowander	Shadow Rift (The Ancient Buried Pyramid)
+Shadow Rift	place=shadow_rift	DiffLevel: mid Env: outdoor Stat: 0 nowander	Shadow Rift (The Castle in the Clouds in the Sky)
+Shadow Rift	place=shadow_rift	DiffLevel: mid Env: outdoor Stat: 0 nowander	Shadow Rift (The Distant Woods)
+Shadow Rift	place=shadow_rift	DiffLevel: mid Env: outdoor Stat: 0 nowander	Shadow Rift (The Hidden City)
+Shadow Rift	place=shadow_rift	DiffLevel: mid Env: outdoor Stat: 0 nowander	Shadow Rift (The Misspelled Cemetary)
+Shadow Rift	place=shadow_rift	DiffLevel: mid Env: outdoor Stat: 0 nowander	Shadow Rift (The Nearby Plains)
+Shadow Rift	place=shadow_rift	DiffLevel: mid Env: outdoor Stat: 0 nowander	Shadow Rift (The Right Side of the Tracks)
 
 # Special one-time Events - including Crimbo content
 

--- a/src/data/combats.txt
+++ b/src/data/combats.txt
@@ -215,6 +215,19 @@ Regret Man's Level	-1	ancient ghost	contemplative ghost	lovesick ghost	Regret Ma
 Science Lab	100	bugbear scientist	spiderbugbear
 Seaside Megalopolis	-1	7-Foot Dwarf Replicant	Bangyomaman Warrior	cyborg policeman	"Handyman" Jay Android	liquid metal robot	obese tourist	Space Marine	terrifying robot
 Shadow Rift	100	shadow bat	shadow cow	shadow devil	shadow guy	shadow hexagon	shadow orb	shadow prism	shadow slab	shadow spider	shadow snake	shadow stalk	shadow tree
+Shadow Rift (Desert Beach)	100	shadow devil	shadow orb	shadow snake
+Shadow Rift (Forest Village)	100	shadow guy	shadow hexagon	shadow spider
+Shadow Rift (Mt. McLargeHuge)	100	shadow cow	shadow hexagon	shadow tree
+Shadow Rift (Somewhere Over the Beanstalk)	100	shadow orb	shadow prism	shadow stalk
+Shadow Rift (Spookyraven Manor Third Floor)	100	shadow bat	shadow devil	shadow spider
+Shadow Rift (The 8-Bit Realm)	100	shadow hexagon	shadow orb	shadow prism
+Shadow Rift (The Ancient Buried Pyramid)	100	shadow bat	shadow slab	shadow snake
+Shadow Rift (The Castle in the Clouds in the Sky)	100	shadow bat	shadow guy	shadow orb
+Shadow Rift (The Distant Woods)	100	shadow devil	shadow stalk	shadow tree
+Shadow Rift (The Hidden City)	100	shadow slab	shadow snake	shadow stalk
+Shadow Rift (The Misspelled Cemetary)	100	shadow guy	shadow slab	shadow tree
+Shadow Rift (The Nearby Plains)	100	shadow bat	shadow cow	shadow spider
+Shadow Rift (The Right Side of the Tracks)	100	shadow cow	shadow guy	shadow prism
 Shivering Timbers	100	deadwood tree	fur tree	hangman's tree	pumpkin tree	toilet-papered tree	Underworld Tree: 0
 Shop Class	100	out-of-control bandsaw	deadly vise	demonic jigsaw	screw golem	X-fingered Shop Teacher: 0
 Simple Tool-Making Cave	100	flint-scraping cave elf	hunter-gatherer cave elf	rock-banging cave elf	sinew-stretching cave elf

--- a/src/data/zonelist.txt
+++ b/src/data/zonelist.txt
@@ -173,6 +173,8 @@ Override	Unsorted	Discoveries
 # The following zones are only available at the whim of KoL
 
 Events	Events	Events
+Shadow Rift	Events	Shadow Rift
+
 Twitch	Town	Time-Twitching Tower
 
 # The following zones are all retired Events or Holidays

--- a/src/net/sourceforge/kolmafia/objectpool/AdventurePool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/AdventurePool.java
@@ -290,6 +290,7 @@ public class AdventurePool {
   public static final int SITE_ALPHA_DORMITORY = 554;
   public static final int SITE_ALPHA_GREENHOUSE = 555;
   public static final int OLIVERS_SPEAKEASY_BRAWL = 558;
+  public static final int SHADOW_RIFT = 567;
 
   private AdventurePool() {}
 }

--- a/src/net/sourceforge/kolmafia/persistence/AdventureDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/AdventureDatabase.java
@@ -32,6 +32,7 @@ import net.sourceforge.kolmafia.objectpool.AdventurePool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase.Element;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.AdventureRequest.ShadowRift;
 import net.sourceforge.kolmafia.request.ClanRumpusRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.request.RelayRequest;
@@ -598,10 +599,20 @@ public class AdventureDatabase {
     KoLAdventure location = AdventureDatabase.adventureByURL.get(adventureURL);
     if (location != null) {
       // *** Why exclude these?
-      return location.getRequest() instanceof ClanRumpusRequest
-              || location.getRequest() instanceof RichardRequest
-          ? null
-          : location;
+      if (location.getRequest() instanceof ClanRumpusRequest
+          || location.getRequest() instanceof RichardRequest) {
+        return null;
+      }
+      // If this is a Shadow Rift adventure, decide which one, based on
+      // which one we visited last
+      if (location.getAdventureNumber() == AdventurePool.SHADOW_RIFT) {
+        String place = Preferences.getString("shadowRiftIngress");
+        ShadowRift rift = ShadowRift.findPlace(place);
+        if (rift != null) {
+          return getAdventure(rift.getAdventureName());
+        }
+      }
+      return location;
     }
 
     if (isPirateRealmIsland(adventureURL)) {

--- a/src/net/sourceforge/kolmafia/request/AdventureRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AdventureRequest.java
@@ -1,6 +1,9 @@
 package net.sourceforge.kolmafia.request;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.KoLAdventure;
@@ -68,6 +71,72 @@ public class AdventureRequest extends GenericRequest {
 
   private int override = -1;
 
+  public enum ShadowRift {
+    BEACH("Desert Beach", "desertbeach", "db_shadowrift"),
+    VILLAGE("Forest Village", "forestvillage", "fv_shadowrift"),
+    MCLARGEHUGE("Mt. McLargeHuge", "mclargehuge", "mcl_shadowrift"),
+    BEANSTALK("Somewhere Over the Beanstalk", "beanstalk", "stalk_rift"),
+    MANOR("Spookyraven Manor Third Floor", "manor3", "manor3_shadowrift"),
+    REALM("The 8-Bit Realm", "8bit", "8rift"),
+    PYRAMID("The Ancient Buried Pyramid", "pyramid", "pyramid_shadowrift"),
+    CASTLE("The Castle in the Clouds in the Sky", "giantcastle", "castle_shadowrift"),
+    WOODS("The Distant Woods", "woods", "woods_shadowrift"),
+    CITY("The Hidden City", "hiddencity", "hc_shadowrift"),
+    CEMETARY("The Misspelled Cemetary", "cemetery", "cem_shadowrift"),
+    PLAINS("The Nearby Plains", "plains", "plains_shadowrift"),
+    TOWN("The Right Side of the Tracks", "town_right", "townright_shadowrift");
+
+    // Class fields
+    private final String container;
+    private final String place;
+    private final String action;
+
+    // Derived fields
+    private final String adventureName;
+
+    // Lookups for Shadow Rifts
+    private static final Map<String, ShadowRift> adventureNameToRift = new HashMap<>();
+
+    private ShadowRift(String container, String place, String action) {
+      this.container = container;
+      this.place = place;
+      this.action = action;
+
+      // Derived fields
+      this.adventureName = "Shadow Rift (" + container + ")";
+    }
+
+    public String getContainer() {
+      return this.container;
+    }
+
+    public String getPlace() {
+      return this.place;
+    }
+
+    public String getAction() {
+      return this.action;
+    }
+
+    public String getAdventureName() {
+      return this.adventureName;
+    }
+
+    public void populateMaps() {
+      ShadowRift.adventureNameToRift.put(this.adventureName, this);
+    }
+
+    public static ShadowRift findAdventureName(String adventureName) {
+      return ShadowRift.adventureNameToRift.get(adventureName);
+    }
+  }
+
+  static {
+    for (var rift : EnumSet.allOf(ShadowRift.class)) {
+      rift.populateMaps();
+    }
+  }
+
   /**
    * Constructs a new <code>AdventureRequest</code> which executes the adventure designated by the
    * given Id by posting to the provided form, notifying the givenof results (or errors).
@@ -90,57 +159,95 @@ public class AdventureRequest extends GenericRequest {
     // everything for you.
     // Those that change mid session should be added to run() also.
 
-    if (formSource.equals("adventure.php")) {
-      this.addFormField("snarfblat", adventureId);
-    } else if (formSource.equals("casino.php")) {
-      this.addFormField("action", "slot");
-      this.addFormField("whichslot", adventureId);
-    } else if (formSource.equals("crimbo10.php")) {
-      this.addFormField("place", adventureId);
-    } else if (formSource.equals("cobbsknob.php")) {
-      this.addFormField("action", "throneroom");
-    } else if (formSource.equals("friars.php")) {
-      this.addFormField("action", "ritual");
-    } else if (formSource.equals("invasion.php")) {
-      this.addFormField("action", adventureId);
-    } else if (formSource.equals("mining.php")) {
-      this.addFormField("mine", adventureId);
-    } else if (formSource.equals("place.php")) {
-      if (adventureId.equals("cloudypeak2")) {
-        this.addFormField("whichplace", "mclargehuge");
-        this.addFormField("action", adventureId);
-      } else if (adventureId.equals("crimbo22_engine")) {
-        this.addFormField("whichplace", "crimbo22");
-        this.addFormField("action", adventureId);
-      } else if (adventureId.equals("pyramid_state")) {
-        this.addFormField("whichplace", "pyramid");
-        StringBuilder action = new StringBuilder();
-        action.append(adventureId);
-        action.append(Preferences.getString("pyramidPosition"));
-        if (Preferences.getBoolean("pyramidBombUsed")) {
-          action.append("a");
-        }
-        this.addFormField("action", action.toString());
-      } else if (adventureId.equals("manor4_chamberboss")) {
-        this.addFormField("whichplace", "manor4");
-        this.addFormField("action", adventureId);
-      } else if (formSource.equals("sea_merkin.php")) {
-        this.addFormField("action", "temple");
-      } else if (adventureId.equals("townwrong_tunnel")) {
-        this.addFormField("whichplace", "town_wrong");
-        this.addFormField("action", "townwrong_tunnel");
-      } else if (adventureId.startsWith("ns_")) {
-        this.addFormField("whichplace", "nstower");
-        this.addFormField("action", adventureId);
-      } else if (adventureId.equals("town_eincursion") || adventureId.equals("town_eicfight2")) {
-        this.addFormField("whichplace", "town");
-        this.addFormField("action", adventureId);
-      } else if (adventureId.equals("ioty2014_wolf")) {
-        this.addFormField("whichplace", "ioty2014_wolf");
-        this.addFormField("action", "wolf_houserun");
+    switch (formSource) {
+      case "adventure.php" -> {
+        this.addFormField("snarfblat", adventureId);
       }
-    } else if (!formSource.equals("basement.php") && !formSource.equals("cellar.php")) {
-      this.addFormField("action", adventureId);
+      case "casino.php" -> {
+        this.addFormField("action", "slot");
+        this.addFormField("whichslot", adventureId);
+      }
+      case "crimbo10.php" -> {
+        this.addFormField("place", adventureId);
+      }
+      case "cobbsknob.php" -> {
+        this.addFormField("action", "throneroom");
+      }
+      case "friars.php" -> {
+        this.addFormField("action", "ritual");
+      }
+      case "invasion.php" -> {
+        this.addFormField("action", adventureId);
+      }
+      case "mining.php" -> {
+        this.addFormField("mine", adventureId);
+      }
+      case "place.php" -> {
+        switch (adventureId) {
+          case "cloudypeak2" -> {
+            this.addFormField("whichplace", "mclargehuge");
+            this.addFormField("action", adventureId);
+          }
+          case "crimbo22_engine" -> {
+            this.addFormField("whichplace", "crimbo22");
+            this.addFormField("action", adventureId);
+          }
+          case "ioty2014_wolf" -> {
+            this.addFormField("whichplace", "ioty2014_wolf");
+            this.addFormField("action", "wolf_houserun");
+          }
+          case "manor4_chamberboss" -> {
+            this.addFormField("whichplace", "manor4");
+            this.addFormField("action", adventureId);
+          }
+          case "ns_01_crowd1",
+              "ns_01_crowd2",
+              "ns_01_crowd3",
+              "ns_03_hedgemaze",
+              "ns_05_monster1",
+              "ns_06_monster2",
+              "ns_07_monster3",
+              "ns_08_monster4",
+              "ns_09_monster5",
+              "ns_10_sorcfight" -> {
+            this.addFormField("whichplace", "nstower");
+            this.addFormField("action", adventureId);
+          }
+          case "pyramid_state" -> {
+            this.addFormField("whichplace", "pyramid");
+            StringBuilder action = new StringBuilder();
+            action.append(adventureId);
+            action.append(Preferences.getString("pyramidPosition"));
+            if (Preferences.getBoolean("pyramidBombUsed")) {
+              action.append("a");
+            }
+            this.addFormField("action", action.toString());
+          }
+          case "shadow_rift" -> {
+            // This is a pseudo-place. Lookup adventureName to get place/action
+            ShadowRift rift = ShadowRift.findAdventureName(adventureName);
+            if (rift != null) {
+              this.addFormField("whichplace", rift.getPlace());
+              this.addFormField("action", rift.getAction());
+            }
+          }
+          case "town_eincursion", "town_eicfight2" -> {
+            this.addFormField("whichplace", "town");
+            this.addFormField("action", adventureId);
+          }
+          case "townwrong_tunnel" -> {
+            this.addFormField("whichplace", "town_wrong");
+            this.addFormField("action", "townwrong_tunnel");
+          }
+        }
+      }
+      case "sea_merkin.php" -> {
+        this.addFormField("action", "temple");
+      }
+      case "basement.php", "cellar.php" -> {}
+      default -> {
+        this.addFormField("action", adventureId);
+      }
     }
   }
 
@@ -157,51 +264,79 @@ public class AdventureRequest extends GenericRequest {
   public void run() {
     // Prevent the request from happening if they attempted
     // to cancel in the delay period.
+    // *** What does that mean?
 
     if (!KoLmafia.permitsContinue()) {
       return;
-    } else if (this.formSource.equals("adventure.php")) {
-      if (this.adventureNumber == AdventurePool.THE_SHORE) {
-        // The Shore
-        int adv = KoLCharacter.inFistcore() ? 5 : 3;
-        if (KoLCharacter.getAdventuresLeft() < adv) {
-          KoLmafia.updateDisplay(MafiaState.ERROR, "Ran out of adventures.");
-          return;
-        }
-      }
-    } else if (this.formSource.equals("cellar.php")) {
-      if (TavernManager.shouldAutoFaucet()) {
-        this.removeFormField("whichspot");
-        this.addFormField("action", "autofaucet");
-      } else {
-        int square = TavernManager.recommendSquare();
-        if (square == 0) {
-          KoLmafia.updateDisplay(
-              MafiaState.ERROR, "Don't know which square to visit in the Typical Tavern Cellar.");
-          return;
-        }
+    }
 
-        this.addFormField("whichspot", String.valueOf(square));
-        this.addFormField("action", "explore");
+    switch (this.formSource) {
+      case "adventure.php" -> {
+        if (this.adventureNumber == AdventurePool.THE_SHORE) {
+          // The Shore
+          int adv = KoLCharacter.inFistcore() ? 5 : 3;
+          if (KoLCharacter.getAdventuresLeft() < adv) {
+            KoLmafia.updateDisplay(MafiaState.ERROR, "Ran out of adventures.");
+            return;
+          }
+        }
       }
-    } else if (this.formSource.equals("mining.php")) {
-      KoLmafia.updateDisplay(MafiaState.ERROR, "Automated mining is not currently implemented.");
-      return;
-    } else if (this.formSource.equals("place.php") && this.adventureId.equals("pyramid_state")) {
-      this.addFormField("whichplace", "pyramid");
-      StringBuilder action = new StringBuilder();
-      action.append(adventureId);
-      action.append(Preferences.getString("pyramidPosition"));
-      if (Preferences.getBoolean("pyramidBombUsed")) {
-        action.append("a");
+      case "cellar.php" -> {
+        if (TavernManager.shouldAutoFaucet()) {
+          this.removeFormField("whichspot");
+          this.addFormField("action", "autofaucet");
+        } else {
+          int square = TavernManager.recommendSquare();
+          if (square == 0) {
+            KoLmafia.updateDisplay(
+                MafiaState.ERROR, "Don't know which square to visit in the Typical Tavern Cellar.");
+            return;
+          }
+
+          this.addFormField("whichspot", String.valueOf(square));
+          this.addFormField("action", "explore");
+        }
       }
-      this.addFormField("action", action.toString());
-    } else if (this.formSource.equals("place.php") && this.adventureId.equals("manor4_chamber")) {
-      this.addFormField("whichplace", "manor4");
-      if (!QuestDatabase.isQuestFinished(Quest.MANOR)) {
-        this.addFormField("action", "manor4_chamberboss");
-      } else {
-        this.addFormField("action", "manor4_chamber");
+      case "mining.php" -> {
+        KoLmafia.updateDisplay(MafiaState.ERROR, "Automated mining is not currently implemented.");
+        return;
+      }
+      case "place.php" -> {
+        switch (this.adventureId) {
+          case "manor4_chamber" -> {
+            this.addFormField("whichplace", "manor4");
+            if (!QuestDatabase.isQuestFinished(Quest.MANOR)) {
+              this.addFormField("action", "manor4_chamberboss");
+            } else {
+              this.addFormField("action", "manor4_chamber");
+            }
+          }
+          case "pyramid_state" -> {
+            this.addFormField("whichplace", "pyramid");
+            StringBuilder action = new StringBuilder();
+            action.append(adventureId);
+            action.append(Preferences.getString("pyramidPosition"));
+            if (Preferences.getBoolean("pyramidBombUsed")) {
+              action.append("a");
+            }
+            this.addFormField("action", action.toString());
+          }
+          case "shadow_rift" -> {
+            // If we are going to the "current" Shadow Rift Ingress, we can go
+            // straight to adventure.php and avoid an extra redirection.
+            ShadowRift rift = ShadowRift.findAdventureName(this.adventureName);
+            if (rift != null) {
+              String current = Preferences.getString("shadowRiftIngress");
+              String desired = rift.getPlace();
+              if (current.equals(desired)) {
+                this.constructURLString("adventure.php");
+                this.addFormField("snarfblat", String.valueOf(AdventurePool.SHADOW_RIFT));
+              } else {
+                Preferences.setString("shadowRiftIngress", desired);
+              }
+            }
+          }
+        }
       }
     }
 

--- a/src/net/sourceforge/kolmafia/request/AdventureRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AdventureRequest.java
@@ -96,6 +96,7 @@ public class AdventureRequest extends GenericRequest {
 
     // Lookups for Shadow Rifts
     private static final Map<String, ShadowRift> adventureNameToRift = new HashMap<>();
+    private static final Map<String, ShadowRift> placeToRift = new HashMap<>();
 
     private ShadowRift(String container, String place, String action) {
       this.container = container;
@@ -123,7 +124,12 @@ public class AdventureRequest extends GenericRequest {
     }
 
     public void populateMaps() {
+      ShadowRift.placeToRift.put(this.place, this);
       ShadowRift.adventureNameToRift.put(this.adventureName, this);
+    }
+
+    public static ShadowRift findPlace(String place) {
+      return ShadowRift.placeToRift.get(place);
     }
 
     public static ShadowRift findAdventureName(String adventureName) {

--- a/src/net/sourceforge/kolmafia/request/PlaceRequest.java
+++ b/src/net/sourceforge/kolmafia/request/PlaceRequest.java
@@ -373,7 +373,7 @@ public class PlaceRequest extends GenericRequest {
             message = "Visiting The Treasure House";
           }
           case "8rift" -> {
-            message = "Entering the Shadow Rift via the 8-Bit Realm";
+            message = "Entering the Shadow Rift via The 8-Bit Realm";
             Preferences.setString("shadowRiftIngress", "8bit");
           }
         }
@@ -420,7 +420,7 @@ public class PlaceRequest extends GenericRequest {
       }
       case "beanstalk" -> {
         if (action.equals("stalk_rift")) {
-          message = "Entering the Shadow Rift via The Beanstalk";
+          message = "Entering the Shadow Rift via Somewhere Over the Beanstalk";
           Preferences.setString("shadowRiftIngress", "beanstalk");
         }
       }
@@ -497,7 +497,7 @@ public class PlaceRequest extends GenericRequest {
             // message = "Visiting the Small Pyramid";
           }
           case "db_shadowrift" -> {
-            message = "Entering the Shadow Rift via the Desert Beach";
+            message = "Entering the Shadow Rift via Desert Beach";
             Preferences.setString("shadowRiftIngress", "desertbeach");
           }
         }
@@ -555,7 +555,7 @@ public class PlaceRequest extends GenericRequest {
             message = "Visiting a Science Tent";
             break;
           case "fv_shadowrift":
-            message = "Entering the Shadow Rift via the Forest Village";
+            message = "Entering the Shadow Rift via Forest Village";
             Preferences.setString("shadowRiftIngress", "forestvillage");
             break;
         }
@@ -630,7 +630,7 @@ public class PlaceRequest extends GenericRequest {
         switch (action) {
           case "manor3_ladys" -> message = "Talking to Lady Spookyraven";
           case "manor3_shadowrift" -> {
-            message = "Entering the Shadow Rift via Spookyraven Manor, Third Floor";
+            message = "Entering the Shadow Rift via Spookyraven Manor Third Floor";
             Preferences.setString("shadowRiftIngress", "manor3");
           }
         }
@@ -802,7 +802,7 @@ public class PlaceRequest extends GenericRequest {
           }
           case "townright_vote" -> message = "Visiting The Voting Booth";
           case "townright_shadowrift" -> {
-            message = "Entering the Shadow Rift via the Right Side of the Tracks";
+            message = "Entering the Shadow Rift via The Right Side of the Tracks";
             Preferences.setString("shadowRiftIngress", "town_right");
           }
         }

--- a/test/net/sourceforge/kolmafia/persistence/AdventureDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/AdventureDatabaseTest.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.persistence;
 
+import static internal.helpers.Player.withProperty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -7,12 +8,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import internal.helpers.Cleanups;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.objectpool.AdventurePool;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 public class AdventureDatabaseTest {
+
+  @BeforeAll
+  public static void beforeAll() {
+    KoLCharacter.reset("AdventureDatabase");
+  }
+
+  @BeforeEach
+  public void beforeEach() {
+    Preferences.reset("AdventureDatabase");
+  }
 
   @Nested
   class GetAdventure {
@@ -69,6 +86,32 @@ public class AdventureDatabaseTest {
     @Test
     public void validatesInvalidArea() {
       assertFalse(AdventureDatabase.validateAdventureArea("Honest John's Shop"));
+    }
+  }
+
+  @Nested
+  class ShadowRift {
+    private static final String SHADOW_RIFT_URL =
+        "adventure.php?snarfblat=" + AdventurePool.SHADOW_RIFT;
+
+    @Test
+    public void canFindGenericShadowRiftAdventure() {
+      var cleanups = new Cleanups(withProperty("shadowRiftIngress", ""));
+      try (cleanups) {
+        var adventure = AdventureDatabase.getAdventureByURL(SHADOW_RIFT_URL);
+        assertFalse(adventure == null);
+        assertThat(adventure.getAdventureName(), is("Shadow Rift"));
+      }
+    }
+
+    @Test
+    public void canFindShadowRiftAdventureFromProperty() {
+      var cleanups = new Cleanups(withProperty("shadowRiftIngress", "hiddencity"));
+      try (cleanups) {
+        var adventure = AdventureDatabase.getAdventureByURL(SHADOW_RIFT_URL);
+        assertFalse(adventure == null);
+        assertThat(adventure.getAdventureName(), is("Shadow Rift (The Hidden City)"));
+      }
     }
   }
 }

--- a/test/net/sourceforge/kolmafia/persistence/AdventureDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/AdventureDatabaseTest.java
@@ -104,13 +104,28 @@ public class AdventureDatabaseTest {
       }
     }
 
-    @Test
-    public void canFindShadowRiftAdventureFromProperty() {
-      var cleanups = new Cleanups(withProperty("shadowRiftIngress", "hiddencity"));
+    @ParameterizedTest
+    @CsvSource({
+      "desertbeach, Shadow Rift (Desert Beach)",
+      "forestvillage, Shadow Rift (Forest Village)",
+      "mclargehuge, Shadow Rift (Mt. McLargeHuge)",
+      "beanstalk, Shadow Rift (Somewhere Over the Beanstalk)",
+      "manor3, Shadow Rift (Spookyraven Manor Third Floor)",
+      "8bit, Shadow Rift (The 8-Bit Realm)",
+      "pyramid, Shadow Rift (The Ancient Buried Pyramid)",
+      "giantcastle, Shadow Rift (The Castle in the Clouds in the Sky)",
+      "woods, Shadow Rift (The Distant Woods)",
+      "hiddencity, Shadow Rift (The Hidden City)",
+      "cemetery, Shadow Rift (The Misspelled Cemetary)",
+      "plains, Shadow Rift (The Nearby Plains)",
+      "town_right, Shadow Rift (The Right Side of the Tracks)",
+    })
+    public void canFindShadowRiftAdventureFromProperty(String property, String adventureName) {
+      var cleanups = new Cleanups(withProperty("shadowRiftIngress", property));
       try (cleanups) {
         var adventure = AdventureDatabase.getAdventureByURL(SHADOW_RIFT_URL);
         assertFalse(adventure == null);
-        assertThat(adventure.getAdventureName(), is("Shadow Rift (The Hidden City)"));
+        assertThat(adventure.getAdventureName(), is(adventureName));
       }
     }
   }


### PR DESCRIPTION
This attempts to make each of the 13 places you can enter a Shadow Rift a distinct adventure area.
The first time you adventure there, it goes to place.php, which redirects to adventure.php, which redirects to fight.php.
Subsequent times through the same rift, it goes straight to adventure.php which redirects to fight.php.

Automate 1 Shadow Rift (Forest Village)
Automate 1 Shadow Rift (Somewhere Over the Beanstalk)
Automate 1 Shadow Rift (Somewhere Over the Beanstalk)
Automate 2 Shadow Rift (The Castle in the Clouds in the Sky)

```
[742] Shadow Rift (Forest Village)
Encounter: shadow spider
...
[743] Shadow Rift (Somewhere Over the Beanstalk)
Encounter: shadow stalk
...
[744] Shadow Rift (Somewhere Over the Beanstalk)
Encounter: shadow orb
...
[745] Shadow Rift (The Castle in the Clouds in the Sky)
Encounter: shadow guy
...
[746] Shadow Rift (The Castle in the Clouds in the Sky)
Encounter: shadow bat
```

This successfully sets "shadowRiftIngress" each time it goes to a new place, since PlaceRequest.registerRequest is not called to do that in this case, since was automation.

This will allow canAdventure() and prepareForAdventure() to do the right thing for the individual areas.

I'll do that later. I think this is ready for review now.

