### PR TITLE
refactor: make clowniness a bitmap modifier and remove 'unique'

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -8625,8 +8625,6 @@ MutexE	Broken Heart/Fiery Heart/Cold Hearted/Sweet Heart/Withered Heart/Lustful 
 # These are items that all contribute to a modifier, but only once per unique item.
 # Consider them to be Single Equip, insofar as the specified modifier is concerned.
 
-Unique	Clowniness	balloon helmet/clown wig/foolscap fool's cap/bloody clown pants/clownskin harness/balloon sword/clown whip/clownskin buckler/big red clown nose/clown shoes/clownskin belt/polka-dot bow tie
-
 # Maximization categories section of modifiers.txt
 # These pseudo-items list the indirect benefits of certain classes of
 # equipment.  If the Modifier Maximizer finds that any of these classes

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -8621,10 +8621,6 @@ MutexE	Broken Heart/Fiery Heart/Cold Hearted/Sweet Heart/Withered Heart/Lustful 
 # MutexE	Song of Accompaniment/Song of Cockiness/Song of Fortune	none
 # MutexE	Spirit of Bacon Grease/Spirit of Cayenne/Spirit of Garlic/Spirit of Peppermint/Spirit of Wormwood	none
 
-# Unique items section of modifiers.txt.
-# These are items that all contribute to a modifier, but only once per unique item.
-# Consider them to be Single Equip, insofar as the specified modifier is concerned.
-
 # Maximization categories section of modifiers.txt
 # These pseudo-items list the indirect benefits of certain classes of
 # equipment.  If the Modifier Maximizer finds that any of these classes

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -2447,7 +2447,7 @@ public abstract class KoLCharacter {
    * @return Clownosity
    */
   public static final int getClownosity() {
-    return ((int) KoLCharacter.currentModifiers.getDouble(DoubleModifier.CLOWNINESS)) / 25;
+    return KoLCharacter.currentModifiers.getBitmap(BitmapModifier.CLOWNINESS);
   }
 
   /**

--- a/src/net/sourceforge/kolmafia/ModifierType.java
+++ b/src/net/sourceforge/kolmafia/ModifierType.java
@@ -66,7 +66,6 @@ public enum ModifierType {
   MUTEX_GENERIC,
   MUTEX_I,
   MUTEX_E,
-  UNIQUE,
   GENERATED,
   NONE;
 

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -357,7 +357,8 @@ public class Modifiers {
     n = ((n & 0xF0F0F0F0) >>> 4) + (n & 0x0F0F0F0F);
     n = ((n & 0xFF00FF00) >>> 8) + (n & 0x00FF00FF);
     n = ((n & 0xFFFF0000) >>> 16) + (n & 0x0000FFFF);
-    return n;
+
+    return modifier == BitmapModifier.CLOWNINESS ? 25 * n : n;
   }
 
   public double getDerived(final DerivedModifier modifier) {

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -105,7 +105,6 @@ public class Evaluator {
   private final Set<String> negOutfits = new HashSet<>();
   private final Set<AdventureResult> posEquip = new HashSet<>();
   private final Set<AdventureResult> negEquip = new HashSet<>();
-  private final Set<AdventureResult> uniques = new HashSet<>();
   private final Map<AdventureResult, Double> bonuses = new HashMap<>();
   private final List<BonusFunction> bonusFunc = new ArrayList<>();
 
@@ -209,15 +208,6 @@ public class Evaluator {
     this.min = new EnumMap<>(tiebreaker.min);
     this.max = new EnumMap<>(tiebreaker.max);
     this.parse(expr);
-  }
-
-  private void addUniqueItems(String name) {
-    Set<String> itemNames = ModifierDatabase.getUniques(name);
-    if (itemNames != null) {
-      for (String itemName : itemNames) {
-        this.uniques.add(ItemPool.get(itemName, 1));
-      }
-    }
   }
 
   private void parse(String expr) {
@@ -347,10 +337,6 @@ public class Evaluator {
       if (keyword.equals("clownosity")) {
         // If no weight specified, assume 100%
         this.clownosity = (m.end(2) == m.start(2)) ? 100 : (int) weight * 25;
-
-        // Clownosity is built on Clowniness and has
-        // same unique items requirement.
-        this.addUniqueItems("Clowniness");
         continue;
       }
 
@@ -623,11 +609,8 @@ public class Evaluator {
       }
 
       if (index != null) {
-        // We found a match. If only the first instance
-        // of particular equipped items provide this
-        // modifier, add them to the "uniques" list.
+        // We found a match.
         String modifierName = index.getName();
-        this.addUniqueItems(modifierName);
         this.weight.set(index, weight);
         continue;
       }
@@ -1412,13 +1395,6 @@ public class Evaluator {
         }
 
         if (mods.getBoolean(BooleanModifier.SINGLE)) {
-          item.singleFlag = true;
-        }
-
-        // If we are maximizing for a modifier that
-        // only counts one of a particular item,
-        // pretend that item is single equip
-        if (this.uniques.contains(preItem)) {
           item.singleFlag = true;
         }
 

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -345,8 +345,8 @@ public class Evaluator {
       }
 
       if (keyword.equals("clownosity")) {
-        // If no weight specified, assume 4
-        this.clownosity = (m.end(2) == m.start(2)) ? 4 : (int) weight;
+        // If no weight specified, assume 100%
+        this.clownosity = (m.end(2) == m.start(2)) ? 100 : (int) weight * 25;
 
         // Clownosity is built on Clowniness and has
         // same unique items requirement.
@@ -863,7 +863,7 @@ public class Evaluator {
     // Allow partials to contribute to the score (1:1 ratio) up to the desired value.
     // Similar to setting a max.
     if (this.clownosity > 0) {
-      int osity = ((int) mods.getDouble(DoubleModifier.CLOWNINESS)) / 25;
+      int osity = mods.getBitmap(BitmapModifier.CLOWNINESS);
       score += Math.min(osity, this.clownosity);
       if (osity < this.clownosity) this.failed = true;
     }
@@ -1480,7 +1480,7 @@ public class Evaluator {
             || (brimstoneUseful && mods.getRawBitmap(BitmapModifier.BRIMSTONE) != 0)
             || (cloathingUseful && mods.getRawBitmap(BitmapModifier.CLOATHING) != 0)
             || (slimeHateUseful && mods.getDouble(DoubleModifier.SLIME_HATES_IT) > 0.0)
-            || (this.clownosity > 0 && mods.getDouble(DoubleModifier.CLOWNINESS) != 0)
+            || (this.clownosity > 0 && mods.getRawBitmap(BitmapModifier.CLOWNINESS) != 0)
             || (this.raveosity > 0 && mods.getRawBitmap(BitmapModifier.RAVEOSITY) != 0)
             || (this.surgeonosity > 0 && mods.getRawBitmap(BitmapModifier.SURGEONOSITY) != 0)
             || ((mods.getRawBitmap(BitmapModifier.SYNERGETIC) & usefulSynergies) != 0)) {

--- a/src/net/sourceforge/kolmafia/modifiers/BitmapModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/BitmapModifier.java
@@ -23,9 +23,9 @@ public enum BitmapModifier implements Modifier {
       },
       Pattern.compile("Surgeonosity: (\\+?\\d+)")),
   CLOWNINESS(
-    "Clowniness",
-    Pattern.compile("Makes you look (\\d+)% clowny"),
-    Pattern.compile("Clowniness: " + EXPR)),
+      "Clowniness",
+      Pattern.compile("Makes you look (\\d+)% clowny"),
+      Pattern.compile("Clowniness: " + EXPR)),
   RAVEOSITY("Raveosity", Pattern.compile("Raveosity: (\\+?\\d+)")),
   MUTEX("Mutually Exclusive", null),
   MUTEX_VIOLATIONS("Mutex Violations", null);
@@ -34,7 +34,7 @@ public enum BitmapModifier implements Modifier {
   private final Pattern tagPattern;
 
   BitmapModifier(String name, Pattern tagPattern) {
-    this(name, (Pattern[])null, tagPattern);
+    this(name, (Pattern[]) null, tagPattern);
   }
 
   BitmapModifier(String name, Pattern descPattern, Pattern tagPattern) {

--- a/src/net/sourceforge/kolmafia/modifiers/BitmapModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/BitmapModifier.java
@@ -1,5 +1,7 @@
 package net.sourceforge.kolmafia.modifiers;
 
+import static net.sourceforge.kolmafia.persistence.ModifierDatabase.EXPR;
+
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Map;
@@ -20,6 +22,10 @@ public enum BitmapModifier implements Modifier {
         Pattern.compile("Makes you look like a gross doctor"),
       },
       Pattern.compile("Surgeonosity: (\\+?\\d+)")),
+  CLOWNINESS(
+    "Clowniness",
+    Pattern.compile("Makes you look (\\d+)% clowny"),
+    Pattern.compile("Clowniness: " + EXPR)),
   RAVEOSITY("Raveosity", Pattern.compile("Raveosity: (\\+?\\d+)")),
   MUTEX("Mutually Exclusive", null),
   MUTEX_VIOLATIONS("Mutex Violations", null);
@@ -28,7 +34,11 @@ public enum BitmapModifier implements Modifier {
   private final Pattern tagPattern;
 
   BitmapModifier(String name, Pattern tagPattern) {
-    this(name, null, tagPattern);
+    this(name, (Pattern[])null, tagPattern);
+  }
+
+  BitmapModifier(String name, Pattern descPattern, Pattern tagPattern) {
+    this(name, new Pattern[] {descPattern}, tagPattern);
   }
 
   BitmapModifier(String name, Pattern[] descPatterns, Pattern tagPattern) {

--- a/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
@@ -468,10 +468,6 @@ public enum DoubleModifier implements Modifier {
       "WarBear Armor Penetration",
       Pattern.compile("([+-]\\d+) WarBear Armor Penetration"),
       Pattern.compile("WarBear Armor Penetration: " + EXPR)),
-  CLOWNINESS(
-      "Clowniness",
-      Pattern.compile("Makes you look (\\d+)% clowny"),
-      Pattern.compile("Clowniness: " + EXPR)),
   PP(
       "Maximum PP",
       Pattern.compile("([+-]\\d+) Max(imum)? Power Point"),

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -67,9 +67,6 @@ public class ModifierDatabase {
   private static final Map<String, Integer> synergies = new HashMap<>();
   /** List of slash-separated members of a mutex */
   private static final List<String> mutexes = new ArrayList<>();
-  /** Map of unique item type (e.g. Clowniness) to names of items in set */
-  private static final Map<String, Set<String>> uniques = new HashMap<>();
-
   private static final HashSet<String> numericModifiers = new HashSet<>();
 
   private static final Map<BitmapModifier, Integer> bitmapMasks =
@@ -231,10 +228,6 @@ public class ModifierDatabase {
 
   public static final String getFamiliarEffect(final String itemName) {
     return familiarEffectByName.get(itemName);
-  }
-
-  public static Set<String> getUniques(String name) {
-    return uniques.get(name);
   }
 
   // Returned set yields bitmaps keyed by names
@@ -1517,22 +1510,6 @@ public class ModifierDatabase {
     }
   }
 
-  private static void computeUniques() {
-    uniques.clear();
-    for (Entry<IntOrString, String> entry :
-        modifierStringsByName.getAll(ModifierType.UNIQUE).entrySet()) {
-      IntOrString key = entry.getKey();
-      String modifiers = entry.getValue();
-      if (!key.isString()) continue;
-      String name = key.getStringValue();
-      if (uniques.containsKey(name)) {
-        KoLmafia.updateDisplay("Unique items for " + name + " already declared.");
-        continue;
-      }
-      uniques.put(name, new HashSet<>(Arrays.asList(modifiers.split("/"))));
-    }
-  }
-
   public static void resetModifiers() {
     // Don't reset any variables that are set up by loadAllModifiers, as subsequent calls to
     // resetModifiers then won't set them back up due to the if() guarding loadAllModifiers.
@@ -1548,6 +1525,5 @@ public class ModifierDatabase {
 
     computeSynergies();
     computeMutexes();
-    computeUniques();
   }
 }

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -609,6 +609,9 @@ public class ModifierDatabase {
       int bitcount = 1;
       if (matcher.groupCount() > 0) {
         bitcount = StringUtilities.parseInt(matcher.group(1));
+        if (mod == BitmapModifier.CLOWNINESS) {
+          bitcount = bitcount / 25;
+        }
       }
       // bitmapMasks stores the next mask we're going to use for modifier mod
       int mask = bitmapMasks.get(mod);
@@ -616,6 +619,11 @@ public class ModifierDatabase {
         case 1 -> bitmapMasks.put(mod, mask << 1);
         case 2 -> {
           bitmapMasks.put(mod, mask << 2);
+          mask |= mask << 1;
+        }
+        case 3 -> {
+          bitmapMasks.put(mod, mask << 3);
+          mask |= mask << 1;
           mask |= mask << 1;
         }
         default -> {

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -67,6 +67,7 @@ public class ModifierDatabase {
   private static final Map<String, Integer> synergies = new HashMap<>();
   /** List of slash-separated members of a mutex */
   private static final List<String> mutexes = new ArrayList<>();
+
   private static final HashSet<String> numericModifiers = new HashSet<>();
 
   private static final Map<BitmapModifier, Integer> bitmapMasks =

--- a/src/net/sourceforge/kolmafia/swingui/panel/CompactSidePane.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/CompactSidePane.java
@@ -996,7 +996,7 @@ public class CompactSidePane extends JPanel implements Runnable {
       int clown = KoLCharacter.getClownosity();
       if (clown != 0 && count < this.BONUS_LABELS) {
         this.bonusLabel[count].setText("Clown: ");
-        this.bonusValueLabel[count].setText(clown + " / 4");
+        this.bonusValueLabel[count].setText(clown + "%");
         count++;
       }
     } else {

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -273,10 +273,10 @@ public class MaximizerTest {
         maximize("clownosity, -tie");
         assertEquals(50, modFor(BitmapModifier.CLOWNINESS), 0.01);
         assertThat(
-          getBoosts().stream()
-            .filter(x -> x.isEquipment() && "clownskin belt".equals(x.getItem().getName()))
-            .count(),
-          equalTo(1L));
+            getBoosts().stream()
+                .filter(x -> x.isEquipment() && "clownskin belt".equals(x.getItem().getName()))
+                .count(),
+            equalTo(1L));
       }
     }
   }

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -249,7 +249,7 @@ public class MaximizerTest {
         assertFalse(maximize("clownosity -tie"));
         // still provides equipment
         recommendedSlotIs(Slot.HAT, "clown wig");
-        assertEquals(50, modFor(DoubleModifier.CLOWNINESS), 0.01);
+        assertEquals(50, modFor(BitmapModifier.CLOWNINESS), 0.01);
       }
     }
 
@@ -261,7 +261,22 @@ public class MaximizerTest {
         assertTrue(maximize("clownosity -tie"));
         recommendedSlotIs(Slot.HAT, "clown wig");
         recommendedSlotIs(Slot.ACCESSORY1, "polka-dot bow tie");
-        assertEquals(125, modFor(DoubleModifier.CLOWNINESS), 0.01);
+        assertEquals(125, modFor(BitmapModifier.CLOWNINESS), 0.01);
+      }
+    }
+
+    @Test
+    public void clownosityItemsDontStack() {
+      var cleanups = withEquippableItem("clownskin belt", 3);
+
+      try (cleanups) {
+        maximize("clownosity, -tie");
+        assertEquals(50, modFor(BitmapModifier.CLOWNINESS), 0.01);
+        assertThat(
+          getBoosts().stream()
+            .filter(x -> x.isEquipment() && "clownskin belt".equals(x.getItem().getName()))
+            .count(),
+          equalTo(1L));
       }
     }
   }
@@ -1333,8 +1348,7 @@ public class MaximizerTest {
                 .filter(x -> x.isEquipment() && "clownskin belt".equals(x.getItem().getName()))
                 .count(),
             equalTo(3L));
-        // TODO: make duplicate clowniness not count in modifiers
-        // assertEquals(50, modFor(DoubleModifier.CLOWNINESS), 0.01);
+        assertEquals(50, modFor(BitmapModifier.CLOWNINESS), 0.01);
       }
     }
 


### PR DESCRIPTION
Additionally, use the percentage (as seen in-game), instead of treating it as a value out of 4, in the side pane. The modifier already shows the percentage, so keep that the same.

Maximizer used to count the "score" of maximizing clownosity as 1 per 25 points of clowniness. Now, just use clowniness as clownosity for simplicity. This might change behaviour in fringe cases where clownosity + something else were being maximized, but I think that potential break is worthwhile for the simplification.