### PR TITLE
feat: add filter for modref

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
@@ -12,6 +12,7 @@ import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.Modifier;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.persistence.ModifierDatabase;
+import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class ModRefCommand extends AbstractCommand {
   public ModRefCommand() {
@@ -23,7 +24,7 @@ public class ModRefCommand extends AbstractCommand {
     String filter = null;
     Modifiers mods = null;
     String[] tokens = parameters.split("\\s+", 2);
-    if (tokens.length > 0) {
+    if (tokens.length > 0 && !tokens[0].equals("")) {
       mods = ModifierDatabase.getModifiers(ModifierType.ITEM, parameters);
       if (mods == null) {
         // assume first word is a filter
@@ -94,7 +95,7 @@ public class ModRefCommand extends AbstractCommand {
       Function<T, String> charModString,
       BiFunction<Modifiers, T, String> modString) {
     String mod = modifier.getName();
-    if (filter != null && !matchesFilter(mod.toLowerCase(), filter)) {
+    if (filter != null && !StringUtilities.matchesFilter(mod.toLowerCase(), filter)) {
       return;
     }
     buf.append("<tr><td>");
@@ -106,16 +107,5 @@ public class ModRefCommand extends AbstractCommand {
       buf.append(modString.apply(mods, modifier));
     }
     buf.append("</td></tr>");
-  }
-
-  /**
-   * Return whether a modifier matches a filter.
-   *
-   * @param name modifier name to match on
-   * @param filter filter. Filters can contain '*' which are interpreted as 'any nonempty string'.
-   * @return whether the name matches the filter
-   */
-  private boolean matchesFilter(String name, String filter) {
-    return name.contains(filter);
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
@@ -94,7 +94,7 @@ public class ModRefCommand extends AbstractCommand {
       Function<T, String> charModString,
       BiFunction<Modifiers, T, String> modString) {
     String mod = modifier.getName();
-    if (filter != null && !mod.toLowerCase().contains(filter)) {
+    if (filter != null && !matchesFilter(mod.toLowerCase(), filter)) {
       return;
     }
     buf.append("<tr><td>");
@@ -106,5 +106,16 @@ public class ModRefCommand extends AbstractCommand {
       buf.append(modString.apply(mods, modifier));
     }
     buf.append("</td></tr>");
+  }
+
+  /**
+   * Return whether a modifier matches a filter.
+   *
+   * @param name modifier name to match on
+   * @param filter filter. Filters can contain '*' which are interpreted as 'any nonempty string'.
+   * @return whether the name matches the filter
+   */
+  private boolean matchesFilter(String name, String filter) {
+    return name.contains(filter);
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
@@ -16,7 +16,7 @@ import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 public class ModRefCommand extends AbstractCommand {
   public ModRefCommand() {
     this.usage =
-        " [@<filter>] [<object>] - list all modifiers, show values for player [and object].";
+        " [*<filter>] [<object>] - list all modifiers, show values for player [and object].";
   }
 
   @Override
@@ -25,7 +25,7 @@ public class ModRefCommand extends AbstractCommand {
     Modifiers mods = null;
     String[] tokens = parameters.split("\\s+", 2);
     if (tokens.length > 0) {
-      if (tokens[0].startsWith("@")) {
+      if (tokens[0].startsWith("*")) {
         // it's a filter
         filter = tokens[0].substring(1).toLowerCase();
         if (tokens.length == 2) {

--- a/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
@@ -16,7 +16,8 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class ModRefCommand extends AbstractCommand {
   public ModRefCommand() {
-    this.usage = " [filter>] [<object>] - list all modifiers, show values for player [and object].";
+    this.usage =
+        " [<filter>] [<object>] - list all modifiers, show values for player [and object].";
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
@@ -15,8 +15,7 @@ import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 
 public class ModRefCommand extends AbstractCommand {
   public ModRefCommand() {
-    this.usage =
-        " [*<filter>] [<object>] - list all modifiers, show values for player [and object].";
+    this.usage = " [filter>] [<object>] - list all modifiers, show values for player [and object].";
   }
 
   @Override
@@ -25,14 +24,15 @@ public class ModRefCommand extends AbstractCommand {
     Modifiers mods = null;
     String[] tokens = parameters.split("\\s+", 2);
     if (tokens.length > 0) {
-      if (tokens[0].startsWith("*")) {
-        // it's a filter
-        filter = tokens[0].substring(1).toLowerCase();
+      mods = ModifierDatabase.getModifiers(ModifierType.ITEM, parameters);
+      if (mods == null) {
+        // assume first word is a filter
+        filter = tokens[0].toLowerCase();
         if (tokens.length == 2) {
           parameters = tokens[1];
         }
+        mods = ModifierDatabase.getModifiers(ModifierType.ITEM, parameters);
       }
-      mods = ModifierDatabase.getModifiers(ModifierType.ITEM, parameters);
     }
     String colSpan = mods == null ? "2" : "3";
     StringBuilder buf =

--- a/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/ModRefCommand.java
@@ -1,5 +1,7 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.Modifiers;
@@ -7,6 +9,7 @@ import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
+import net.sourceforge.kolmafia.modifiers.Modifier;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 
@@ -23,63 +26,64 @@ public class ModRefCommand extends AbstractCommand {
         new StringBuilder(
             "<table border=2>" + "<tr><td colspan=" + colSpan + ">NUMERIC MODIFIERS</td></tr>");
     for (var mod : DoubleModifier.DOUBLE_MODIFIERS) {
-      String modName = mod.getName();
-      buf.append("<tr><td>");
-      buf.append(modName);
-      buf.append("</td><td>");
-      buf.append(KoLCharacter.currentNumericModifier(mod));
-      if (mods != null) {
-        buf.append("</td><td>");
-        buf.append(mods.getDouble(mod));
-      }
-      buf.append("</td></tr>");
+      addModRow(
+          buf,
+          mod,
+          mods,
+          (m) -> String.valueOf(KoLCharacter.currentNumericModifier(m)),
+          (n, m) -> String.valueOf(n.getDouble(m)));
     }
     buf.append("<tr><td colspan=").append(colSpan).append(">BITMAP MODIFIERS</td></tr>");
     for (var mod : BitmapModifier.BITMAP_MODIFIERS) {
-      String modName = mod.getName();
-      buf.append("<tr><td>");
-      buf.append(modName);
-      buf.append("</td><td>0x");
-      buf.append(Integer.toHexString(KoLCharacter.currentRawBitmapModifier(mod)));
-      buf.append(" (");
-      buf.append(KoLCharacter.currentBitmapModifier(mod));
-      buf.append(")");
-      if (mods != null) {
-        buf.append("</td><td>0x");
-        buf.append(Integer.toHexString(mods.getRawBitmap(mod)));
-        buf.append(" (");
-        buf.append(mods.getBitmap(mod));
-        buf.append(")");
-      }
-      buf.append("</td></tr>");
+      addModRow(
+          buf,
+          mod,
+          mods,
+          (m) ->
+              "0x"
+                  + Integer.toHexString(KoLCharacter.currentRawBitmapModifier(m))
+                  + " ("
+                  + KoLCharacter.currentBitmapModifier(m)
+                  + ")",
+          (n, m) -> "0x" + Integer.toHexString(n.getRawBitmap(m)) + " (" + n.getBitmap(m) + ")");
     }
     buf.append("<tr><td colspan=").append(colSpan).append(">BOOLEAN MODIFIERS</td></tr>");
     for (var modifier : BooleanModifier.BOOLEAN_MODIFIERS) {
-      String mod = modifier.getName();
-      buf.append("<tr><td>");
-      buf.append(mod);
-      buf.append("</td><td>");
-      buf.append(KoLCharacter.currentBooleanModifier(modifier));
-      if (mods != null) {
-        buf.append("</td><td>");
-        buf.append(mods.getBoolean(modifier));
-      }
-      buf.append("</td></tr>");
+      addModRow(
+          buf,
+          modifier,
+          mods,
+          (m) -> String.valueOf(KoLCharacter.currentBooleanModifier(m)),
+          (n, m) -> String.valueOf(n.getBoolean(m)));
     }
     buf.append("<tr><td colspan=").append(colSpan).append(">STRING MODIFIERS</td></tr>");
     for (var modifier : StringModifier.STRING_MODIFIERS) {
-      String mod = modifier.getName();
-      buf.append("<tr><td>");
-      buf.append(mod);
-      buf.append("</td><td>");
-      buf.append(KoLCharacter.currentStringModifier(modifier).replaceAll("\t", "<br>"));
-      if (mods != null) {
-        buf.append("</td><td>");
-        buf.append(mods.getString(modifier));
-      }
-      buf.append("</td></tr>");
+      addModRow(
+          buf,
+          modifier,
+          mods,
+          (m) -> KoLCharacter.currentStringModifier(m).replaceAll("\t", "<br>"),
+          Modifiers::getString);
     }
     buf.append("</table><br>");
     RequestLogger.printLine(buf.toString());
+  }
+
+  private <T extends Modifier> void addModRow(
+      StringBuilder buf,
+      T modifier,
+      Modifiers mods,
+      Function<T, String> charModString,
+      BiFunction<Modifiers, T, String> modString) {
+    String mod = modifier.getName();
+    buf.append("<tr><td>");
+    buf.append(mod);
+    buf.append("</td><td>");
+    buf.append(charModString.apply(modifier));
+    if (mods != null) {
+      buf.append("</td><td>");
+      buf.append(modString.apply(mods, modifier));
+    }
+    buf.append("</td></tr>");
   }
 }

--- a/src/net/sourceforge/kolmafia/utilities/StringUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/StringUtilities.java
@@ -934,4 +934,40 @@ public class StringUtilities {
         .map(c -> capitalize(c.toLowerCase()))
         .collect(Collectors.joining(" "));
   }
+
+  /**
+   * Return whether a string matches a filter.
+   *
+   * @param str string to attempt match on
+   * @param filter filter. Filters can contain '*' which are interpreted as 'any string'.
+   * @return whether the string matches the filter
+   */
+  public static boolean matchesFilter(String str, String filter) {
+    if ("".equals(filter)) return "".equals(str);
+
+    if (!filter.contains("*")) return filter.equals(str);
+
+    // guarantee subFilters will have positive length
+    if (filter.equals("*")) return true;
+
+    String[] subFilters = filter.split("[*]");
+
+    if (!filter.startsWith("*")) {
+      var firstFilter = subFilters[0];
+      if (!str.startsWith(firstFilter)) return false;
+    }
+
+    if (!filter.endsWith("*")) {
+      var lastFilter = subFilters[subFilters.length - 1];
+      if (!str.endsWith(lastFilter)) return false;
+    }
+
+    int searchIndex = 0;
+    for (var s : subFilters) {
+      var index = str.indexOf(s, searchIndex);
+      if (index == -1) return false;
+      searchIndex = index + s.length();
+    }
+    return true;
+  }
 }

--- a/test/net/sourceforge/kolmafia/textui/command/ModRefCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ModRefCommandTest.java
@@ -2,6 +2,7 @@ package net.sourceforge.kolmafia.textui.command;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,10 +23,27 @@ public class ModRefCommandTest extends AbstractCommandTestBase {
   }
 
   @Test
+  public void showsFilteredModifiers() {
+    var mods = execute("@Drop");
+
+    // a selection
+    assertThat(mods, not(containsString("Monster Level Percent")));
+    assertThat(mods, containsString("Item Drop"));
+    assertThat(mods, containsString("Drops Meat"));
+  }
+
+  @Test
   public void showsModifiersForItem() {
     var mods = execute("Cargo Cultist Shorts");
 
-    // a selection
     assertThat(mods, containsString("Muscle: +6, Mysticality: +6, Moxie: +6"));
+  }
+
+  @Test
+  public void showsModifiersForFilteredItem() {
+    var mods = execute("@Initiative Cargo Cultist Shorts");
+
+    assertThat(mods, containsString(">66.0<"));
+    assertThat(mods, not(containsString(">6.0<")));
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/command/ModRefCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ModRefCommandTest.java
@@ -24,7 +24,7 @@ public class ModRefCommandTest extends AbstractCommandTestBase {
 
   @Test
   public void showsFilteredModifiers() {
-    var mods = execute("*Drop");
+    var mods = execute("Drop");
 
     // a selection
     assertThat(mods, not(containsString("Monster Level Percent")));
@@ -41,7 +41,7 @@ public class ModRefCommandTest extends AbstractCommandTestBase {
 
   @Test
   public void showsModifiersForFilteredItem() {
-    var mods = execute("*Initiative Cargo Cultist Shorts");
+    var mods = execute("Initiative Cargo Cultist Shorts");
 
     assertThat(mods, containsString(">66.0<"));
     assertThat(mods, not(containsString(">6.0<")));

--- a/test/net/sourceforge/kolmafia/textui/command/ModRefCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ModRefCommandTest.java
@@ -24,7 +24,7 @@ public class ModRefCommandTest extends AbstractCommandTestBase {
 
   @Test
   public void showsFilteredModifiers() {
-    var mods = execute("Drop");
+    var mods = execute("*Drop*");
 
     // a selection
     assertThat(mods, not(containsString("Monster Level Percent")));

--- a/test/net/sourceforge/kolmafia/textui/command/ModRefCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/ModRefCommandTest.java
@@ -24,7 +24,7 @@ public class ModRefCommandTest extends AbstractCommandTestBase {
 
   @Test
   public void showsFilteredModifiers() {
-    var mods = execute("@Drop");
+    var mods = execute("*Drop");
 
     // a selection
     assertThat(mods, not(containsString("Monster Level Percent")));
@@ -41,7 +41,7 @@ public class ModRefCommandTest extends AbstractCommandTestBase {
 
   @Test
   public void showsModifiersForFilteredItem() {
-    var mods = execute("@Initiative Cargo Cultist Shorts");
+    var mods = execute("*Initiative Cargo Cultist Shorts");
 
     assertThat(mods, containsString(">66.0<"));
     assertThat(mods, not(containsString(">6.0<")));

--- a/test/net/sourceforge/kolmafia/utilities/StringUtilitiesTest.java
+++ b/test/net/sourceforge/kolmafia/utilities/StringUtilitiesTest.java
@@ -12,6 +12,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -716,5 +717,48 @@ class StringUtilitiesTest {
   @Test
   void multipleValuelistToHumanString() {
     assertThat(StringUtilities.listToHumanString(List.of("a", "b", "c")), equalTo("a, b and c"));
+  }
+
+  @Nested
+  class Filter {
+    @ParameterizedTest
+    @CsvSource(
+        value = {
+          "'',''",
+          "'',*",
+          "a,a",
+          "ab,ab",
+          "a,*",
+          "b,*",
+          "ab,*",
+          "ab,a*",
+          "ab,*b",
+          "ab,*a*",
+          "ab,*b*",
+          "abc,a*c",
+          "abcd,a*d",
+          "abcde,a*b*c*e",
+        })
+    public void matches(String str, String filter) {
+      assertTrue(StringUtilities.matchesFilter(str, filter));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      "a,''",
+      "a,b",
+      "ab,a",
+      "ab,aa",
+      "a,*b",
+      "a,b*",
+      "ab,*a",
+      "ab,b*",
+      "ab,*b*a*",
+      "ab,*a*a*b*",
+      "abcd,*ab*bc*cd*",
+    })
+    public void nonMatches(String str, String filter) {
+      assertFalse(StringUtilities.matchesFilter(str, filter));
+    }
   }
 }


### PR DESCRIPTION
It can be hard to remember all the types of modifier KoL offers (e.g. for a hat drop, there is item drop, gear drop and hat drop).

Add a filter for modref so you can type `modref @Drop` to get all the drop modifiers (and some other stuff where the name contains "drop", but this is good enough for me).