### PR TITLE
Allow 'garden pick plot1' for the Rock Garden

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/command/GardenCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/GardenCommand.java
@@ -134,7 +134,7 @@ public class GardenCommand extends AbstractCommand {
             plots.remove(plot);
           }
           for (var plot : plots) {
-            RequestLogger.printLine("There is nothing to pick in " + plot);
+            RequestLogger.printLine("There is nothing to pick in " + plot + ".");
           }
         }
 

--- a/src/net/sourceforge/kolmafia/textui/command/GardenCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/GardenCommand.java
@@ -1,12 +1,17 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.CampgroundRequest;
+import net.sourceforge.kolmafia.request.CampgroundRequest.CropPlot;
 import net.sourceforge.kolmafia.request.CampgroundRequest.CropType;
 
 public class GardenCommand extends AbstractCommand {
@@ -51,9 +56,12 @@ public class GardenCommand extends AbstractCommand {
       return;
     }
 
+    String[] split = parameters.split(" +");
+    String command = split[0];
+
     CropType cropType = CampgroundRequest.getCropType(crops.get(0));
 
-    if (parameters.equals("")) {
+    if (command.equals("")) {
       String gardenType = cropType.toString();
       StringBuilder display = new StringBuilder();
       display.append("Your ").append(gardenType).append(" garden has ");
@@ -84,7 +92,7 @@ public class GardenCommand extends AbstractCommand {
       return;
     }
 
-    if (parameters.equals("fertilize")) {
+    if (command.equals("fertilize")) {
       // Mushroom garden only
       if (checkMushroomGarden(cropType)) {
         CampgroundRequest.harvestMushrooms(false);
@@ -92,10 +100,44 @@ public class GardenCommand extends AbstractCommand {
       return;
     }
 
-    if (parameters.equals("pick")) {
+    if (command.equals("pick")) {
       // Mushroom garden only
-      if (cropType == CropType.MUSHROOM && checkMushroomGarden(cropType)) {
-        CampgroundRequest.harvestMushrooms(true);
+      if (cropType == CropType.MUSHROOM) {
+        if (checkMushroomGarden(cropType)) {
+          CampgroundRequest.harvestMushrooms(true);
+        }
+        return;
+      }
+
+      // Rock garden only
+      if (cropType == CropType.ROCK && split.length > 1) {
+        Set<CropPlot> plots =
+            Arrays.stream(split, 1, split.length)
+                .map(CropPlot::nameToPlot)
+                .filter(x -> x != null)
+                .collect(Collectors.toSet());
+        if (plots.size() > 0) {
+          for (var crop : crops) {
+            if (crop.getCount() == 0) {
+              continue;
+            }
+            CropPlot plot = CampgroundRequest.cropToPlot(crop);
+            if (plot == null) {
+              // Not expected
+              continue;
+            }
+            if (!plots.contains(plot)) {
+              continue;
+            }
+            RequestLogger.printLine("Harvesting " + plot + ": " + crop);
+            CampgroundRequest.harvestCrop(plot);
+            plots.remove(plot);
+          }
+          for (var plot : plots) {
+            RequestLogger.printLine("There is nothing to pick in " + plot);
+          }
+        }
+
         return;
       }
 

--- a/test/net/sourceforge/kolmafia/textui/command/GardenCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/GardenCommandTest.java
@@ -121,4 +121,38 @@ public class GardenCommandTest extends AbstractCommandTestBase {
       assertPostRequest(requests.get(2), "/campground.php", "action=rgarden3");
     }
   }
+
+  @Test
+  public void skipsEmptySlotsInPartialRockGarden() {
+    var cleanups = withCampgroundItem(ItemPool.GROVELING_GRAVEL, 1);
+
+    try (cleanups) {
+      var output = execute("pick plot2 plot3");
+      assertThat(output, containsString("There is nothing to pick in plot2."));
+      assertThat(output, containsString("There is nothing to pick in plot3."));
+
+      var requests = getRequests();
+      assertThat(requests, hasSize(0));
+    }
+  }
+
+  @Test
+  public void picksSelectPlotsInFullRockGarden() {
+    var cleanups =
+        new Cleanups(
+            withCampgroundItem(ItemPool.FRUITY_PEBBLE, 2),
+            withCampgroundItem(ItemPool.BOLDER_BOULDER, 2),
+            withCampgroundItem(ItemPool.HARD_ROCK, 2));
+
+    try (cleanups) {
+      var output = execute("pick plot1 plot3");
+      assertThat(output, containsString("Harvesting plot1: fruity pebble (2)"));
+      assertThat(output, containsString("Harvesting plot3: hard rock (2)"));
+
+      var requests = getRequests();
+      assertThat(requests, hasSize(2));
+      assertPostRequest(requests.get(0), "/campground.php", "action=rgarden1");
+      assertPostRequest(requests.get(1), "/campground.php", "action=rgarden3");
+    }
+  }
 }


### PR DESCRIPTION
If you have a Rock Garden, "garden pick" will pick all three plots.

This PR allows:

garden pick plot1
garden pick plot1 plot3

etc., if you only want to pick a subset of the plots.

CampgroundRequest registers crop->plot for Rock Garden crops only.
If another garden with multiple plots is released in the future, changes will be required, obviously, but I don't want to try to predict what they will be. :)