### PR TITLE
Maximizer suggests vintner wine only if you have one with the correct effect

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -577,6 +577,21 @@ public class Maximizer {
               continue;
             }
 
+            if (itemId == ItemPool.VAMPIRE_VINTNER_WINE) {
+              // 1950 Vampire Vintner wine is a quest item.
+              // If you don't have it, you must adventure to get one.
+              if (!InventoryManager.hasItem(itemId)) {
+                continue;
+              }
+              // 1950 Vampire Vintner wine can provide any of seven
+              // effects.  Only consider using one if the wine you
+              // currently have provides this effect.
+              if (!Preferences.getString("vintnerWineEffect").equals(name)) {
+                continue;
+              }
+              duration = 12;
+            }
+
             // Resolve bang potions and slime vials
             if (itemId == -1) {
               item = item.resolveBangPotion();

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -1578,4 +1578,45 @@ public class MaximizerTest {
       }
     }
   }
+
+  @Nested
+  public class VampireVintnerWine {
+    @Test
+    public void doesNotSuggestVintnerWineIfUnavailable() {
+      var cleanups = new Cleanups(withItem(ItemPool.VAMPIRE_VINTNER_WINE, 0));
+
+      try (cleanups) {
+        assertTrue(maximize("Item Drop"));
+        assertFalse(someBoostIs(x -> commandStartsWith(x, "drink 1 1950 Vampire Vintner wine")));
+      }
+    }
+
+    @Test
+    public void doesSuggestVintnerWineIfAvailableWithCorrectEffect() {
+      var cleanups =
+          new Cleanups(
+              withItem(ItemPool.VAMPIRE_VINTNER_WINE, 1),
+              withProperty("vintnerWineEffect", "Wine-Hot"),
+              withProperty("vintnerWineLevel", 12));
+
+      try (cleanups) {
+        assertTrue(maximize("Item Drop"));
+        assertTrue(someBoostIs(x -> commandStartsWith(x, "drink 1 1950 Vampire Vintner wine")));
+      }
+    }
+
+    @Test
+    public void doesNotSuggestVintnerWineIfAvailableWithWrongEffect() {
+      var cleanups =
+          new Cleanups(
+              withItem(ItemPool.VAMPIRE_VINTNER_WINE, 1),
+              withProperty("vintnerWineEffect", "Wine-Hot"),
+              withProperty("vintnerWineLevel", 12));
+
+      try (cleanups) {
+        assertTrue(maximize("Monster Level"));
+        assertFalse(someBoostIs(x -> commandStartsWith(x, "drink 1 1950 Vampire Vintner wine")));
+      }
+    }
+  }
 }


### PR DESCRIPTION
My character was overdrunk when I coded this, so, although debug logging showed the right code paths being executed, I have not actually seen the end result in-game.

However, I wrote tests - and they all seem to indicate it will work, so I look forward to trying it live after rollover - using the Wine-Fortified wine I generated with Drunkula's wineglass while overdrunk. :)

I want to see the tests succeed here, so, I opened the PR.

Edit: it worked perfectly.

Maximize for init, it says to drink the wine for +80.
Maximize for other wine effects, they are not considered.