### PR TITLE
Don't show Legendary foods in Food panel if you've already eaten one

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
@@ -628,6 +628,26 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
       ConcoctionType type = UseItemEnqueuePanel.this.type;
       String name = creation.getName();
 
+      if (item != null) {
+        switch (type) {
+          case FOOD -> {
+            // Some foods cannot be eaten (regardless of fullness) even
+            // if they can be created. Displaying them on a consumption
+            // panel is distracting; you can see them on a create panel.
+            String property =
+                switch (item.getItemId()) {
+                  case ItemPool.PIZZA_OF_LEGEND -> "pizzaOfLegendEaten";
+                  case ItemPool.DEEP_DISH_OF_LEGEND -> "deepDishOfLegendEaten";
+                  case ItemPool.CALZONE_OF_LEGEND -> "calzoneOfLegendEaten";
+                  default -> null;
+                };
+            if (property != null && Preferences.getBoolean(property)) {
+              return false;
+            }
+          }
+        }
+      }
+
       if (ConsumablesDatabase.getRawFullness(name) == null
           && ConsumablesDatabase.getRawInebriety(name) == null
           && ConsumablesDatabase.getRawSpleenHit(name) == null) {


### PR DESCRIPTION
It's distracting.

You can still create them - for a casual run or to be pulled - in a Create panel.