### PR TITLE
update more aosol monsters

### DIFF
--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -1395,13 +1395,14 @@ goblin king's shadow	2284	aosol_gobking.gif	BOSS NOCOPY Atk: 60 Def: 60 HP: 60 I
 shadowboner shadowdagon	2285	aosol_dagon.gif	BOSS NOCOPY Atk: 100 Def: 100 HP: 150 Init: 100 P: horror Article: the	cursed dragon wishbone (100)
 W. Odah's Shadow	2286	aosol_drawkward.gif	BOSS NOCOPY Atk: 202 Def: 212 HP: 191 Init: 303 P: horror	cursed stats (100)
 shadow Lord Spookyraven	2287	aosol_lords.gif	BOSS NOCOPY Atk: 180 Def: 180 HP: 200 Init: 1000 P: horror Article: the	cursed arcane orb (100)
-# The following image is obviously incorrect
-corruptor shadow	2288	aosol_lords.gif	BOSS NOCOPY Atk: 200 Def: 200 HP: 100 Init: 300 P: horror Article: a	cursed machete (100)
+corruptor shadow	2288	aosol_spectre.gif	BOSS NOCOPY Atk: 200 Def: 200 HP: 100 Init: 300 P: horror Article: a	cursed machete (100)
 shadow of groar	2289	aosol_groar.gif	BOSS NOCOPY Atk: 200 Def: 200 HP: 200 Init: 200 P: horror Article: the	cursed blanket (100)
 shadow of the 1960s	2290	aosol_dude.gif	BOSS NOCOPY Atk: 250 Def: 250 HP: 1000 Init: -10000 P: horror Article: the	cursed medallion (100)
-# Replacement for The Man
-# Pig Skinner replacements for Naughty Sorceress
-# Cheese Wizard replacements for Naughty Sorceress replacements
+shadow of the 1980s	2291	aosol_man.gif	BOSS NOCOPY Atk: 250 Def: 250 HP: 1000 Init: -10000 P: horror Article: the	cursed medallion (100)
+General Bruise	2292	aosol_bruise.gif	BOSS NOCOPY Atk: 150 Def: 150 HP: 200 Init: 100 P: horror
+General Bruise (true form)	2293	aosol_gug.gif	BOSS NOCOPY Atk: 300 Def: 300 HP: 1000 Init: 100 P: horror	Instant Karma (c100)	Thwaitgold anti-moth statuette (n100)
+Dark Noël	2294	aosol_noel.gif	BOSS NOCOPY Atk: 150 Def: 150 HP: 200 Init: 100 P: horror
+Dark Noël (true form)	2295	aosol_darkyoung.gif	BOSS NOCOPY Atk: 300 Def: 300 HP: 1000 Init: 100 P: horror	Instant Karma (c100)	Thwaitgold anti-moth statuette (n100)
 Terrence Poindexter	2296	aosol_terrence.gif	BOSS NOCOPY Atk: 150 Def: 150 HP: 200 Init: 100 P: horror
 Terrence Poindexter (true form)	2297	aosol_horror.gif	BOSS NOCOPY Atk: 300 Def: 300 HP: 1000 Init: 100 P: horror	Instant Karma (c100)	Thwaitgold anti-moth statuette (n100)
 

--- a/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
@@ -360,9 +360,12 @@ public class MonsterDatabase {
     MonsterDatabase.addMapping(aosolMap, "Lord Spookyraven", "shadow Lord Spookyraven");
     MonsterDatabase.addMapping(aosolMap, "Protector Spectre", "corruptor shadow");
     MonsterDatabase.addMapping(aosolMap, "The Big Wisniewski", "shadow of the 1960s");
-    // MonsterDatabase.addMapping(aosolMap, "The Man", "shadow something");
-    // The following are for Jazz Agents.
+    MonsterDatabase.addMapping(aosolMap, "The Man", "shadow of the 1980s");
     // We don't have a mechanism for a class within a path, yet
+    // MonsterDatabase.addMapping(aosolMap, "Naughty Sorceress", "General Bruise");
+    // MonsterDatabase.addMapping(aosolMap, "Naughty Sorceress (2)", "General Bruise (true form)");
+    // MonsterDatabase.addMapping(aosolMap, "Naughty Sorceress", "Dark Noël");
+    // MonsterDatabase.addMapping(aosolMap, "Naughty Sorceress (2)", "Dark Noël (true form)");
     // MonsterDatabase.addMapping(aosolMap, "Naughty Sorceress", "Terrence Poindexter");
     // MonsterDatabase.addMapping(aosolMap, "Naughty Sorceress (2)", "Terrence Poindexter (true
     // form)");

--- a/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import net.sourceforge.kolmafia.AdventureResult;
+import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
@@ -37,6 +38,8 @@ public class MonsterDatabase {
   private static String[] MONSTER_STRINGS = null;
   private static final Map<String, MonsterData> MONSTER_IMAGES = new TreeMap<>();
   private static final Map<String, Map<MonsterData, MonsterData>> MONSTER_PATH_MAP =
+      new TreeMap<>();
+  private static final Map<String, Map<MonsterData, MonsterData>> MONSTER_CLASS_MAP =
       new TreeMap<>();
 
   // For handling duplicate monster and substring match of monster names
@@ -361,19 +364,32 @@ public class MonsterDatabase {
     MonsterDatabase.addMapping(aosolMap, "Protector Spectre", "corruptor shadow");
     MonsterDatabase.addMapping(aosolMap, "The Big Wisniewski", "shadow of the 1960s");
     MonsterDatabase.addMapping(aosolMap, "The Man", "shadow of the 1980s");
-    // We don't have a mechanism for a class within a path, yet
-    // MonsterDatabase.addMapping(aosolMap, "Naughty Sorceress", "General Bruise");
-    // MonsterDatabase.addMapping(aosolMap, "Naughty Sorceress (2)", "General Bruise (true form)");
-    // MonsterDatabase.addMapping(aosolMap, "Naughty Sorceress", "Dark Noël");
-    // MonsterDatabase.addMapping(aosolMap, "Naughty Sorceress (2)", "Dark Noël (true form)");
-    // MonsterDatabase.addMapping(aosolMap, "Naughty Sorceress", "Terrence Poindexter");
-    // MonsterDatabase.addMapping(aosolMap, "Naughty Sorceress (2)", "Terrence Poindexter (true
-    // form)");
     MonsterDatabase.MONSTER_PATH_MAP.put(Path.SHADOWS_OVER_LOATHING.getName(), aosolMap);
+
+    Map<MonsterData, MonsterData> pigSkinnerMap = new TreeMap<>();
+    MonsterDatabase.addMapping(pigSkinnerMap, "Naughty Sorceress", "General Bruise");
+    MonsterDatabase.addMapping(
+        pigSkinnerMap, "Naughty Sorceress (2)", "General Bruise (true form)");
+    MonsterDatabase.MONSTER_CLASS_MAP.put(AscensionClass.PIG_SKINNER.getName(), pigSkinnerMap);
+
+    Map<MonsterData, MonsterData> cheeseWizardMap = new TreeMap<>();
+    MonsterDatabase.addMapping(cheeseWizardMap, "Naughty Sorceress", "Dark Noël");
+    MonsterDatabase.addMapping(cheeseWizardMap, "Naughty Sorceress (2)", "Dark Noël (true form)");
+    MonsterDatabase.MONSTER_CLASS_MAP.put(AscensionClass.CHEESE_WIZARD.getName(), cheeseWizardMap);
+
+    Map<MonsterData, MonsterData> jazzAgentMap = new TreeMap<>();
+    MonsterDatabase.addMapping(jazzAgentMap, "Naughty Sorceress", "Terrence Poindexter");
+    MonsterDatabase.addMapping(
+        jazzAgentMap, "Naughty Sorceress (2)", "Terrence Poindexter (true form)");
+    MonsterDatabase.MONSTER_CLASS_MAP.put(AscensionClass.JAZZ_AGENT.getName(), jazzAgentMap);
   }
 
   public static Map<MonsterData, MonsterData> getMonsterPathMap(final String path) {
     return MonsterDatabase.MONSTER_PATH_MAP.get(path);
+  }
+
+  public static Map<MonsterData, MonsterData> getMonsterClassMap(final String clazz) {
+    return MonsterDatabase.MONSTER_CLASS_MAP.get(clazz);
   }
 
   public static final void refreshMonsterTable() {

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -8359,12 +8359,16 @@ public abstract class RuntimeLibrary {
     return DataTypes.makeMonsterValue(MonsterStatusTracker.getLastMonster());
   }
 
-  private static MonsterData mapMonster(MonsterData mon, Map<MonsterData, MonsterData> mapping) {
-    if (mapping == null) {
+  private static MonsterData mapMonster(
+      MonsterData mon,
+      Map<MonsterData, MonsterData> classMapping,
+      Map<MonsterData, MonsterData> pathMapping) {
+    if (classMapping == null && pathMapping == null) {
       return mon;
     }
-    MonsterData mapped = mapping.get(mon);
-    return mapped != null ? mapped : mon;
+    MonsterData classMapped = classMapping.get(mon);
+    MonsterData pathMapped = pathMapping.get(mon);
+    return classMapped != null ? classMapped : pathMapped != null ? pathMapped : mon;
   }
 
   public static Value get_monsters(ScriptRuntime controller, final Value location) {
@@ -8378,16 +8382,18 @@ public abstract class RuntimeLibrary {
         new AggregateType(DataTypes.MONSTER_TYPE, monsterCount + superlikelyMonsterCount);
     ArrayValue value = new ArrayValue(type);
 
-    Map<MonsterData, MonsterData> mapping =
+    Map<MonsterData, MonsterData> classMapping =
+        MonsterDatabase.getMonsterClassMap(KoLCharacter.getAscensionClass().getName());
+    Map<MonsterData, MonsterData> pathMapping =
         MonsterDatabase.getMonsterPathMap(KoLCharacter.getPath().getName());
 
     for (int i = 0; i < monsterCount; ++i) {
-      MonsterData mon = mapMonster(data.getMonster(i), mapping);
+      MonsterData mon = mapMonster(data.getMonster(i), classMapping, pathMapping);
       value.aset(new Value(i), DataTypes.makeMonsterValue(mon));
     }
 
     for (int i = 0; i < superlikelyMonsterCount; ++i) {
-      MonsterData mon = mapMonster(data.getSuperlikelyMonster(i), mapping);
+      MonsterData mon = mapMonster(data.getSuperlikelyMonster(i), classMapping, pathMapping);
       value.aset(new Value(i + monsterCount), DataTypes.makeMonsterValue(mon));
     }
 
@@ -8401,18 +8407,20 @@ public abstract class RuntimeLibrary {
     AggregateType type = new AggregateType(DataTypes.BOOLEAN_TYPE, DataTypes.MONSTER_TYPE);
     MapValue value = new MapValue(type);
 
-    Map<MonsterData, MonsterData> mapping =
+    Map<MonsterData, MonsterData> classMapping =
+        MonsterDatabase.getMonsterClassMap(KoLCharacter.getAscensionClass().getName());
+    Map<MonsterData, MonsterData> pathMapping =
         MonsterDatabase.getMonsterPathMap(KoLCharacter.getPath().getName());
 
     int monsterCount = data == null ? 0 : data.getMonsterCount();
     for (int i = 0; i < monsterCount; ++i) {
-      MonsterData mon = mapMonster(data.getMonster(i), mapping);
+      MonsterData mon = mapMonster(data.getMonster(i), classMapping, pathMapping);
       value.aset(DataTypes.makeMonsterValue(mon), DataTypes.TRUE_VALUE);
     }
 
     int superlikelyMonsterCount = data == null ? 0 : data.getSuperlikelyMonsterCount();
     for (int i = 0; i < superlikelyMonsterCount; ++i) {
-      MonsterData mon = mapMonster(data.getSuperlikelyMonster(i), mapping);
+      MonsterData mon = mapMonster(data.getSuperlikelyMonster(i), classMapping, pathMapping);
       value.aset(DataTypes.makeMonsterValue(mon), DataTypes.TRUE_VALUE);
     }
 

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -8361,14 +8361,21 @@ public abstract class RuntimeLibrary {
 
   private static MonsterData mapMonster(
       MonsterData mon,
-      Map<MonsterData, MonsterData> classMapping,
-      Map<MonsterData, MonsterData> pathMapping) {
-    if (classMapping == null && pathMapping == null) {
-      return mon;
+      Map<MonsterData, MonsterData> classMap,
+      Map<MonsterData, MonsterData> pathMap) {
+    if (pathMap != null) {
+      MonsterData mapped = pathMap.get(mon);
+      if (mapped != null) {
+        return mapped;
+      }
     }
-    MonsterData classMapped = classMapping.get(mon);
-    MonsterData pathMapped = pathMapping.get(mon);
-    return classMapped != null ? classMapped : pathMapped != null ? pathMapped : mon;
+    if (classMap != null) {
+      MonsterData mapped = classMap.get(mon);
+      if (mapped != null) {
+        return mapped;
+      }
+    }
+    return mon;
   }
 
   public static Value get_monsters(ScriptRuntime controller, final Value location) {
@@ -8382,18 +8389,18 @@ public abstract class RuntimeLibrary {
         new AggregateType(DataTypes.MONSTER_TYPE, monsterCount + superlikelyMonsterCount);
     ArrayValue value = new ArrayValue(type);
 
-    Map<MonsterData, MonsterData> classMapping =
+    Map<MonsterData, MonsterData> classMap =
         MonsterDatabase.getMonsterClassMap(KoLCharacter.getAscensionClass().getName());
-    Map<MonsterData, MonsterData> pathMapping =
+    Map<MonsterData, MonsterData> pathMap =
         MonsterDatabase.getMonsterPathMap(KoLCharacter.getPath().getName());
 
     for (int i = 0; i < monsterCount; ++i) {
-      MonsterData mon = mapMonster(data.getMonster(i), classMapping, pathMapping);
+      MonsterData mon = mapMonster(data.getMonster(i), classMap, pathMap);
       value.aset(new Value(i), DataTypes.makeMonsterValue(mon));
     }
 
     for (int i = 0; i < superlikelyMonsterCount; ++i) {
-      MonsterData mon = mapMonster(data.getSuperlikelyMonster(i), classMapping, pathMapping);
+      MonsterData mon = mapMonster(data.getSuperlikelyMonster(i), classMap, pathMap);
       value.aset(new Value(i + monsterCount), DataTypes.makeMonsterValue(mon));
     }
 
@@ -8407,20 +8414,20 @@ public abstract class RuntimeLibrary {
     AggregateType type = new AggregateType(DataTypes.BOOLEAN_TYPE, DataTypes.MONSTER_TYPE);
     MapValue value = new MapValue(type);
 
-    Map<MonsterData, MonsterData> classMapping =
+    Map<MonsterData, MonsterData> classMap =
         MonsterDatabase.getMonsterClassMap(KoLCharacter.getAscensionClass().getName());
-    Map<MonsterData, MonsterData> pathMapping =
+    Map<MonsterData, MonsterData> pathMap =
         MonsterDatabase.getMonsterPathMap(KoLCharacter.getPath().getName());
 
     int monsterCount = data == null ? 0 : data.getMonsterCount();
     for (int i = 0; i < monsterCount; ++i) {
-      MonsterData mon = mapMonster(data.getMonster(i), classMapping, pathMapping);
+      MonsterData mon = mapMonster(data.getMonster(i), classMap, pathMap);
       value.aset(DataTypes.makeMonsterValue(mon), DataTypes.TRUE_VALUE);
     }
 
     int superlikelyMonsterCount = data == null ? 0 : data.getSuperlikelyMonsterCount();
     for (int i = 0; i < superlikelyMonsterCount; ++i) {
-      MonsterData mon = mapMonster(data.getSuperlikelyMonster(i), classMapping, pathMapping);
+      MonsterData mon = mapMonster(data.getSuperlikelyMonster(i), classMap, pathMap);
       value.aset(DataTypes.makeMonsterValue(mon), DataTypes.TRUE_VALUE);
     }
 


### PR DESCRIPTION
Yendor gave us a bunch of Avatar of Shadows over Loathing monsters.
We are grateful. We took his data and integrated it.
Yendor then edited his post in-place to give us the rest.
I happened to notice it, and brought the new data in

I want confirmation that the name "Dark Noël" contains UTF-8 characters, as opposed to HTML character entities, but other than that, we're cool.

I think in addition to path monster maps, we need class monster maps.

I did that. Observations:

- The only place these are used is in ASH functions:
get_monsters(location) returns an array: index -> monster
get_location_monsters(location) returns a map: monster -> boolean
Both of these functions used to map monsters through the path map. Now they also run them through the class map.
- get_monster_mapping(string pathName) returns monster -> monster
That could be upgraded to take either a "path" object or a "class" object.
For now, I left it untouched.
- It'd be nice if the Area Combat Data as displayed in the GUI also took that into account, so you could look in Throne Room and see the actual version of the Goblin King that is there.
- The Naughty Sorceress' Chamber lists only Naughty Sorceress.
It omits Naughty Sorceress (2) and Naughty Sorceress (3).
Fair, I guess, since not every path has all of those. Unfortunately, AoSoL does have at least two. And even though I have class mappings for both, you don't get to see it.
- Speaking of which, do the "true form" versions replace (2) or (3)? Or what? Do you need a wand? I'lll see tomorrow.

Improving how we handle combat data when there are mapped monsters would be  a different project.

I also think we could have all three sorceress forms in combats.txt for the Sorceress's Chamber and map them to null (or something) if they are not present in a given path/class. All three with a 100% chance? Tricky.
AreaCombatData would map monsters and omit those that map to null.
That would also be a different project.