### PR TITLE
refactor: convert snapshot filters to enums

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/AscensionSnapshot.java
+++ b/src/net/sourceforge/kolmafia/persistence/AscensionSnapshot.java
@@ -804,7 +804,10 @@ public class AscensionSnapshot {
           typeFilter == AscensionFilter.NORMAL
               ? "Normal "
               : typeFilter == AscensionFilter.HARDCORE ? "Hardcore " : "Casual ");
-      strbuf.append(pathFilter == null ? "" : pathFilter.getName());
+      strbuf.append(
+          pathFilter == null
+              ? ""
+              : (pathFilter == Path.NONE ? "No Path" : pathFilter.getName()) + " ");
 
       strbuf.append("Ascensions (Out of ");
       strbuf.append(resultsList.size());

--- a/src/net/sourceforge/kolmafia/persistence/AscensionSnapshot.java
+++ b/src/net/sourceforge/kolmafia/persistence/AscensionSnapshot.java
@@ -16,12 +16,13 @@ import net.sourceforge.kolmafia.session.ClanManager;
 import net.sourceforge.kolmafia.session.ContactManager;
 
 public class AscensionSnapshot {
-  public static final int NO_FILTER = 0;
-
-  public static final int UNKNOWN_TYPE = -1;
-  public static final int NORMAL = 1;
-  public static final int HARDCORE = 2;
-  public static final int CASUAL = 3;
+  public enum AscensionFilter {
+    UNKNOWN_TYPE,
+    NO_FILTER,
+    NORMAL,
+    HARDCORE,
+    CASUAL;
+  }
 
   private static final Map<String, String> ascensionMap = new TreeMap<>();
   private static final List<AscensionHistoryRequest> ascensionDataList = new ArrayList<>();
@@ -60,7 +61,7 @@ public class AscensionSnapshot {
   }
 
   public static final String getAscensionData(
-      final int typeFilter,
+      final AscensionFilter typeFilter,
       final int mostAscensionsBoardSize,
       final int mainBoardSize,
       final int classBoardSize,
@@ -76,9 +77,9 @@ public class AscensionSnapshot {
     strbuf.append("<title>");
 
     switch (typeFilter) {
-      case AscensionSnapshot.NORMAL -> strbuf.append("Normal");
-      case AscensionSnapshot.HARDCORE -> strbuf.append("Hardcore");
-      case AscensionSnapshot.CASUAL -> strbuf.append("Casual");
+      case NORMAL -> strbuf.append("Normal");
+      case HARDCORE -> strbuf.append("Hardcore");
+      case CASUAL -> strbuf.append("Casual");
     }
 
     String clanName = ClanManager.getClanName(true);
@@ -104,7 +105,7 @@ public class AscensionSnapshot {
 
     strbuf.append("<tr><td align=center><h3>Avg: ");
     strbuf.append(
-        ((typeFilter == AscensionSnapshot.NORMAL
+        ((typeFilter == AscensionFilter.NORMAL
                     ? (float) AscensionSnapshot.softcoreAscensionList.size()
                     : 0.0f)
                 + AscensionSnapshot.hardcoreAscensionList.size()
@@ -120,9 +121,9 @@ public class AscensionSnapshot {
     strbuf.append(KoLConstants.LINE_BREAK);
     strbuf.append("<tr><td style=\"color:white\" align=center bgcolor=blue><b>Most ");
     strbuf.append(
-        typeFilter == AscensionSnapshot.NORMAL
+        typeFilter == AscensionFilter.NORMAL
             ? "Normal "
-            : typeFilter == AscensionSnapshot.HARDCORE ? "Hardcore " : "Casual ");
+            : typeFilter == AscensionFilter.HARDCORE ? "Hardcore " : "Casual ");
     strbuf.append(
         "Ascensions</b></td></tr><tr><td style=\"padding: 5px; border: 1px solid blue;\"><center><table>");
     strbuf.append(KoLConstants.LINE_BREAK);
@@ -157,7 +158,7 @@ public class AscensionSnapshot {
     // Finally, the ascension leaderboards for fastest
     // ascension speed.  Do this for all paths individually.
 
-    if (typeFilter != AscensionSnapshot.CASUAL) {
+    if (typeFilter != AscensionFilter.CASUAL) {
       strbuf.append(KoLConstants.LINE_BREAK);
       strbuf.append(
           AscensionSnapshot.getPathedAscensionData(
@@ -535,7 +536,7 @@ public class AscensionSnapshot {
   }
 
   public static final String getPathedAscensionData(
-      final int typeFilter,
+      final AscensionFilter typeFilter,
       final Path pathFilter,
       final int mainBoardSize,
       final int classBoardSize,
@@ -728,7 +729,7 @@ public class AscensionSnapshot {
   }
 
   public static final String getAscensionData(
-      final int typeFilter,
+      final AscensionFilter typeFilter,
       final Path pathFilter,
       final AscensionClass classFilter,
       final int mainBoardSize,
@@ -741,15 +742,15 @@ public class AscensionSnapshot {
     AscensionDataField[] fields = null;
 
     switch (typeFilter) {
-      case AscensionSnapshot.NORMAL:
+      case NORMAL:
         fields = new AscensionDataField[AscensionSnapshot.softcoreAscensionList.size()];
         AscensionSnapshot.softcoreAscensionList.toArray(fields);
         break;
-      case AscensionSnapshot.HARDCORE:
+      case HARDCORE:
         fields = new AscensionDataField[AscensionSnapshot.hardcoreAscensionList.size()];
         AscensionSnapshot.hardcoreAscensionList.toArray(fields);
         break;
-      case AscensionSnapshot.CASUAL:
+      case CASUAL:
         fields = new AscensionDataField[AscensionSnapshot.casualAscensionList.size()];
         AscensionSnapshot.casualAscensionList.toArray(fields);
         break;
@@ -800,9 +801,9 @@ public class AscensionSnapshot {
       strbuf.append("Fastest ");
 
       strbuf.append(
-          typeFilter == AscensionSnapshot.NORMAL
+          typeFilter == AscensionFilter.NORMAL
               ? "Normal "
-              : typeFilter == AscensionSnapshot.HARDCORE ? "Hardcore " : "Casual ");
+              : typeFilter == AscensionFilter.HARDCORE ? "Hardcore " : "Casual ");
       strbuf.append(pathFilter == null ? "" : pathFilter.getName());
 
       strbuf.append("Ascensions (Out of ");
@@ -866,9 +867,9 @@ public class AscensionSnapshot {
       request.getAscensionData().toArray(fields);
 
       for (AscensionDataField field : fields) {
-        if (field.matchesFilter(AscensionSnapshot.NORMAL, null, null, 0)) {
+        if (field.matchesFilter(AscensionFilter.NORMAL, null, null, 0)) {
           AscensionSnapshot.softcoreAscensionList.add(field);
-        } else if (field.matchesFilter(AscensionSnapshot.HARDCORE, null, null, 0)) {
+        } else if (field.matchesFilter(AscensionFilter.HARDCORE, null, null, 0)) {
           AscensionSnapshot.hardcoreAscensionList.add(field);
         } else {
           AscensionSnapshot.casualAscensionList.add(field);

--- a/src/net/sourceforge/kolmafia/request/AscensionHistoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AscensionHistoryRequest.java
@@ -21,7 +21,7 @@ import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.StaticEntity;
-import net.sourceforge.kolmafia.persistence.AscensionSnapshot;
+import net.sourceforge.kolmafia.persistence.AscensionSnapshot.AscensionFilter;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.ClanManager;
 import net.sourceforge.kolmafia.session.ContactManager;
@@ -30,7 +30,7 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class AscensionHistoryRequest extends GenericRequest
     implements Comparable<AscensionHistoryRequest> {
-  private static int typeComparator = AscensionSnapshot.NORMAL;
+  private static AscensionFilter typeComparator = AscensionFilter.NORMAL;
 
   private static final SimpleDateFormat ASCEND_DATE_FORMAT =
       new SimpleDateFormat("MM/dd/yy", Locale.US);
@@ -56,7 +56,7 @@ public class AscensionHistoryRequest extends GenericRequest
     this.ascensionData = new ArrayList<>();
   }
 
-  public static final void setComparator(final int typeComparator) {
+  public static final void setComparator(final AscensionFilter typeComparator) {
     AscensionHistoryRequest.typeComparator = typeComparator;
   }
 
@@ -74,9 +74,9 @@ public class AscensionHistoryRequest extends GenericRequest
     stringForm.append("</b></a></td>");
     stringForm.append("<td align=right>");
     stringForm.append(
-        typeComparator == AscensionSnapshot.NORMAL
+        typeComparator == AscensionFilter.NORMAL
             ? this.softcoreCount
-            : typeComparator == AscensionSnapshot.HARDCORE ? this.hardcoreCount : casualCount);
+            : typeComparator == AscensionFilter.HARDCORE ? this.hardcoreCount : casualCount);
     stringForm.append("</td></tr>");
     return stringForm.toString();
   }
@@ -85,9 +85,9 @@ public class AscensionHistoryRequest extends GenericRequest
   public int compareTo(final AscensionHistoryRequest o) {
     return o == null
         ? -1
-        : typeComparator == AscensionSnapshot.NORMAL
+        : typeComparator == AscensionFilter.NORMAL
             ? o.softcoreCount - this.softcoreCount
-            : typeComparator == AscensionSnapshot.HARDCORE
+            : typeComparator == AscensionFilter.HARDCORE
                 ? o.hardcoreCount - this.hardcoreCount
                 : o.casualCount - this.casualCount;
   }
@@ -147,7 +147,7 @@ public class AscensionHistoryRequest extends GenericRequest
 
       lastField = new AscensionDataField(playerName, playerId, columns);
 
-      int pointsEarned = lastField.typeId == AscensionSnapshot.HARDCORE ? 2 : 1;
+      int pointsEarned = lastField.typeId == AscensionFilter.HARDCORE ? 2 : 1;
 
       if (lastField.path == Path.AVATAR_OF_WEST_OF_LOATHING) {
         challengeClassPoints.merge(lastField.ascensionClass, pointsEarned, Integer::sum);
@@ -326,9 +326,9 @@ public class AscensionHistoryRequest extends GenericRequest
           this.ascensionData.add(lastField);
 
           switch (lastField.typeId) {
-            case AscensionSnapshot.NORMAL -> ++this.softcoreCount;
-            case AscensionSnapshot.HARDCORE -> ++this.hardcoreCount;
-            case AscensionSnapshot.CASUAL -> ++this.casualCount;
+            case NORMAL -> ++this.softcoreCount;
+            case HARDCORE -> ++this.hardcoreCount;
+            case CASUAL -> ++this.casualCount;
           }
         } else if (columnsNew != null && columnsNew[0].equals(columnsOld[0])) {
           if (!fieldMatcher.find(lastFindIndex)) {
@@ -342,18 +342,18 @@ public class AscensionHistoryRequest extends GenericRequest
           this.ascensionData.add(lastField);
 
           switch (lastField.typeId) {
-            case AscensionSnapshot.NORMAL -> ++this.softcoreCount;
-            case AscensionSnapshot.HARDCORE -> ++this.hardcoreCount;
-            case AscensionSnapshot.CASUAL -> ++this.casualCount;
+            case NORMAL -> ++this.softcoreCount;
+            case HARDCORE -> ++this.hardcoreCount;
+            case CASUAL -> ++this.casualCount;
           }
         } else {
           lastField = new AscensionDataField(this.playerName, this.playerId, columnsOld);
           this.ascensionData.add(lastField);
 
           switch (lastField.typeId) {
-            case AscensionSnapshot.NORMAL -> ++this.softcoreCount;
-            case AscensionSnapshot.HARDCORE -> ++this.hardcoreCount;
-            case AscensionSnapshot.CASUAL -> ++this.casualCount;
+            case NORMAL -> ++this.softcoreCount;
+            case HARDCORE -> ++this.hardcoreCount;
+            case CASUAL -> ++this.casualCount;
           }
 
           try {
@@ -390,9 +390,9 @@ public class AscensionHistoryRequest extends GenericRequest
         this.ascensionData.add(lastField);
 
         switch (lastField.typeId) {
-          case AscensionSnapshot.NORMAL -> ++this.softcoreCount;
-          case AscensionSnapshot.HARDCORE -> ++this.hardcoreCount;
-          case AscensionSnapshot.CASUAL -> ++this.casualCount;
+          case NORMAL -> ++this.softcoreCount;
+          case HARDCORE -> ++this.hardcoreCount;
+          case CASUAL -> ++this.casualCount;
         }
 
         lastFindIndex = fieldMatcher.end() - 5;
@@ -412,9 +412,9 @@ public class AscensionHistoryRequest extends GenericRequest
       this.ascensionData.add(lastField);
 
       switch (lastField.typeId) {
-        case AscensionSnapshot.NORMAL -> ++this.softcoreCount;
-        case AscensionSnapshot.HARDCORE -> ++this.hardcoreCount;
-        case AscensionSnapshot.CASUAL -> ++this.casualCount;
+        case NORMAL -> ++this.softcoreCount;
+        case HARDCORE -> ++this.hardcoreCount;
+        case CASUAL -> ++this.casualCount;
       }
     }
   }
@@ -478,7 +478,8 @@ public class AscensionHistoryRequest extends GenericRequest
     private StringBuffer stringForm;
 
     private Date timestamp;
-    private int level, typeId;
+    private int level;
+    private AscensionFilter typeId = AscensionFilter.NO_FILTER;
     private int dayCount, turnCount;
     private Path path;
     private AscensionClass ascensionClass;
@@ -551,12 +552,12 @@ public class AscensionHistoryRequest extends GenericRequest
 
       this.typeId =
           path[0].equals("Normal")
-              ? AscensionSnapshot.NORMAL
+              ? AscensionFilter.NORMAL
               : path[0].equals("Hardcore")
-                  ? AscensionSnapshot.HARDCORE
+                  ? AscensionFilter.HARDCORE
                   : path[0].equals("Casual")
-                      ? AscensionSnapshot.CASUAL
-                      : AscensionSnapshot.UNKNOWN_TYPE;
+                      ? AscensionFilter.CASUAL
+                      : AscensionFilter.UNKNOWN_TYPE;
 
       String pathName = path[1];
       this.path = AscensionPath.nameToPath(pathName);
@@ -574,10 +575,8 @@ public class AscensionHistoryRequest extends GenericRequest
 
         this.typeId =
             columns[8].contains("hardcore")
-                ? AscensionSnapshot.HARDCORE
-                : columns[8].contains("beanbag")
-                    ? AscensionSnapshot.CASUAL
-                    : AscensionSnapshot.NORMAL;
+                ? AscensionFilter.HARDCORE
+                : columns[8].contains("beanbag") ? AscensionFilter.CASUAL : AscensionFilter.NORMAL;
 
         this.path =
             Arrays.stream(Path.values())
@@ -596,7 +595,7 @@ public class AscensionHistoryRequest extends GenericRequest
       return ProfileRequest.OUTPUT_FORMAT.format(this.timestamp);
     }
 
-    public int getTypeId() {
+    public AscensionFilter getTypeId() {
       return this.typeId;
     }
 
@@ -631,19 +630,19 @@ public class AscensionHistoryRequest extends GenericRequest
     }
 
     public boolean matchesFilter(
-        final int typeFilter,
+        final AscensionFilter typeFilter,
         final Path pathFilter,
         final AscensionClass classFilter,
         final int maxAge) {
-      return (typeFilter == AscensionSnapshot.NO_FILTER || typeFilter == this.typeId)
+      return (typeFilter == AscensionFilter.NO_FILTER || typeFilter == this.typeId)
           && (pathFilter == null || pathFilter == this.path)
           && (classFilter == null || classFilter == this.ascensionClass)
           && (maxAge == 0 || maxAge >= this.getAge());
     }
 
     public boolean matchesFilter(
-        final int typeFilter, final Path pathFilter, final AscensionClass classFilter) {
-      return (typeFilter == AscensionSnapshot.NO_FILTER || typeFilter == this.typeId)
+        final AscensionFilter typeFilter, final Path pathFilter, final AscensionClass classFilter) {
+      return (typeFilter == AscensionFilter.NO_FILTER || typeFilter == this.typeId)
           && (pathFilter == null || pathFilter == this.path)
           && (classFilter == null || classFilter == this.ascensionClass);
     }

--- a/src/net/sourceforge/kolmafia/session/ClanManager.java
+++ b/src/net/sourceforge/kolmafia/session/ClanManager.java
@@ -29,8 +29,10 @@ import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.ConcoctionPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.AscensionSnapshot;
+import net.sourceforge.kolmafia.persistence.AscensionSnapshot.AscensionFilter;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.persistence.ProfileSnapshot;
+import net.sourceforge.kolmafia.persistence.ProfileSnapshot.ProfileFilter;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.AscensionHistoryRequest;
 import net.sourceforge.kolmafia.request.ClanLogRequest;
@@ -606,7 +608,7 @@ public abstract class ClanManager {
       ostream = LogStream.openStream(softcoreFile, true);
       ostream.println(
           AscensionSnapshot.getAscensionData(
-              AscensionSnapshot.NORMAL,
+              AscensionFilter.NORMAL,
               mostAscensionsBoardSize,
               mainBoardSize,
               classBoardSize,
@@ -618,7 +620,7 @@ public abstract class ClanManager {
       ostream = LogStream.openStream(hardcoreFile, true);
       ostream.println(
           AscensionSnapshot.getAscensionData(
-              AscensionSnapshot.HARDCORE,
+              AscensionFilter.HARDCORE,
               mostAscensionsBoardSize,
               mainBoardSize,
               classBoardSize,
@@ -630,7 +632,7 @@ public abstract class ClanManager {
       ostream = LogStream.openStream(casualFile, true);
       ostream.println(
           AscensionSnapshot.getAscensionData(
-              AscensionSnapshot.CASUAL,
+              AscensionFilter.CASUAL,
               mostAscensionsBoardSize,
               mainBoardSize,
               classBoardSize,
@@ -686,7 +688,7 @@ public abstract class ClanManager {
   }
 
   public static final void applyFilter(
-      final int matchType, final int filterType, final String filter) {
+      final int matchType, final ProfileFilter filterType, final String filter) {
     ClanManager.retrieveClanData();
 
     // Certain filter types do not require the player profiles
@@ -694,9 +696,9 @@ public abstract class ClanManager {
     // without prompting the user for confirmation.
 
     switch (filterType) {
-      case ProfileSnapshot.NAME_FILTER:
-      case ProfileSnapshot.LEVEL_FILTER:
-      case ProfileSnapshot.KARMA_FILTER:
+      case NAME:
+      case LEVEL:
+      case KARMA:
         break;
 
       default:

--- a/src/net/sourceforge/kolmafia/swingui/ClanManageFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/ClanManageFrame.java
@@ -23,6 +23,7 @@ import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.persistence.ProfileSnapshot;
+import net.sourceforge.kolmafia.persistence.ProfileSnapshot.ProfileFilter;
 import net.sourceforge.kolmafia.request.ClanBuffRequest;
 import net.sourceforge.kolmafia.request.ClanMembersRequest;
 import net.sourceforge.kolmafia.request.ClanStashRequest;
@@ -407,8 +408,8 @@ public class ClanManageFrame extends GenericFrame {
       super("search clan", "apply changes", new Dimension(80, 20), new Dimension(240, 20));
 
       this.parameterSelect = new JComboBox<>();
-      for (int i = 0; i < ProfileSnapshot.FILTER_NAMES.length; ++i) {
-        this.parameterSelect.addItem(ProfileSnapshot.FILTER_NAMES[i]);
+      for (var filter : ProfileFilter.names()) {
+        this.parameterSelect.addItem(filter);
       }
 
       this.matchSelect = new JComboBox<>();
@@ -430,7 +431,7 @@ public class ClanManageFrame extends GenericFrame {
     public void actionConfirmed() {
       ClanManager.applyFilter(
           this.matchSelect.getSelectedIndex() - 1,
-          this.parameterSelect.getSelectedIndex(),
+          ProfileFilter.byOrdinal(this.parameterSelect.getSelectedIndex()),
           this.valueField.getText());
       KoLmafia.updateDisplay("Search results retrieved.");
     }

--- a/src/net/sourceforge/kolmafia/webui/RelayLoader.java
+++ b/src/net/sourceforge/kolmafia/webui/RelayLoader.java
@@ -111,9 +111,9 @@ public class RelayLoader extends Thread {
 
   public static void openSystemBrowser(final File file) {
     try {
-      String location = file.getCanonicalPath();
-      RelayLoader.openSystemBrowser("file://" + location, false);
-    } catch (IOException e) {
+      URI location = file.toURI();
+      RelayLoader.openSystemBrowser(location.toString(), false);
+    } catch (Error e) {
       KoLmafia.updateDisplay(
           "Exception: " + e.getMessage() + " for location " + file.getName() + " in browser.");
     }


### PR DESCRIPTION
Delving into fairly obscure parts of the codebase here. These classes make a snapshot (a series of web pages) and are accessed from the Clan Manager frame.

Also fix some bugs in the area. Yes, `file.toURI()` throws a RuntimeException if it fails... I don't know why.