### PR TITLE
Show mapped monsters in Location Details

### DIFF
--- a/src/data/combats.txt
+++ b/src/data/combats.txt
@@ -406,7 +406,7 @@ The Middle Chamber	100	tomb asp	tomb rat	tomb servant
 The Mines	-1	bat	cobra	snake	spider
 The Mouldering Mansion	70	bellhop	black cat	Ourang-Outang	raven	usher
 The Mystic Wood	100	fantasy forest faerie
-The Naughty Sorceress' Chamber	100	Naughty Sorceress
+The Naughty Sorceress' Chamber	100	Naughty Sorceress: 0	Naughty Sorceress (2): 0	Naughty Sorceress (3): 0
 The Nemesis' Lair	100	hellseal guardian	Gorgolok, the Infernal Seal (Inner Sanctum): 0	warehouse worker	Stella, the Turtle Poacher (Inner Sanctum): 0	evil spaghetti cult zealot	Spaghetti Elemental (Inner Sanctum): 0	security slime	Lumpy, the Sinister Sauceblob (Inner Sanctum): 0	daft punk	Spirit of New Wave (Inner Sanctum): 0	mariachi bruiser	Somerset Lopez, Dread Mariachi (Inner Sanctum): 0
 The Neverending Party	-1	biker	burnout	jock	party girl	"plain" girl
 The Nightmare Meatrealm	100	bacon snake	cold cutter	groast	pork butterfly	salaminder	The Beefhemoth: 0

--- a/src/net/sourceforge/kolmafia/AreaCombatData.java
+++ b/src/net/sourceforge/kolmafia/AreaCombatData.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import net.sourceforge.kolmafia.KoLCharacter.Gender;
@@ -473,6 +474,10 @@ public class AreaCombatData {
   }
 
   public String toString(final boolean fullString) {
+    return this.toString(fullString, false);
+  }
+
+  public String toString(final boolean fullString, boolean mapped) {
     StringBuffer buffer = new StringBuffer();
 
     buffer.append("<html><head>");
@@ -486,15 +491,38 @@ public class AreaCombatData {
 
     buffer.append("</head><body>");
 
-    this.getSummary(buffer, fullString);
+    this.getSummary(buffer, fullString, mapped);
     this.getEncounterData(buffer);
-    this.appendMonsterData(buffer, fullString);
+    this.appendMonsterData(buffer, fullString, mapped);
 
     buffer.append("</body></html>");
     return buffer.toString();
   }
 
-  public void getSummary(final StringBuffer buffer, final boolean fullString) {
+  private MonsterData mapMonster(MonsterData mon) {
+    Map<MonsterData, MonsterData> pathMap =
+        MonsterDatabase.getMonsterPathMap(KoLCharacter.getPath().getName());
+    if (pathMap != null) {
+      MonsterData mapped = pathMap.get(mon);
+      if (mapped != null) {
+        return mapped;
+      }
+    }
+
+    Map<MonsterData, MonsterData> classMap =
+        MonsterDatabase.getMonsterClassMap(KoLCharacter.getAscensionClass().getName());
+    if (classMap != null) {
+      MonsterData mapped = classMap.get(mon);
+      if (mapped != null) {
+        return mapped;
+      }
+    }
+
+    return mon;
+  }
+
+  public void getSummary(
+      final StringBuffer buffer, final boolean fullString, final boolean mapped) {
     // Get up-to-date monster stats in area summary
     this.recalculate();
 
@@ -524,15 +552,20 @@ public class AreaCombatData {
 
     for (MonsterData monster : monsters) {
       int weighting = this.getWeighting(monster);
+      int rejection = this.getRejection(monster);
+      if (mapped) {
+        monster = mapMonster(monster);
+      }
+      if (monster == MonsterData.NO_MONSTER) {
+        continue;
+      }
 
       // Omit impossible (-2), ultra-rare (-1) and special/banished (0) monsters
       if (weighting < 1) {
         continue;
       }
 
-      double weight =
-          dividedByTotalWeighting(
-              (double) weighting * (1 - (double) this.getRejection(monster) / 100));
+      double weight = dividedByTotalWeighting((double) weighting * (1 - (double) rejection / 100));
       int ml = monster.ML();
       averageExperience +=
           weight * (monster.getExperience() + experienceAdjustment - ml / (ml > 0 ? 6.0 : 8.0));
@@ -541,6 +574,12 @@ public class AreaCombatData {
     double averageSuperlikelyExperience = 0.0;
     double superlikelyChance = 0.0;
     for (MonsterData monster : this.superlikelyMonsters) {
+      if (mapped) {
+        monster = mapMonster(monster);
+      }
+      if (monster == MonsterData.NO_MONSTER) {
+        continue;
+      }
       String monsterName = monster.getName();
       double chance = AreaCombatData.superlikelyChance(monsterName);
       if (chance > 0) {
@@ -586,7 +625,11 @@ public class AreaCombatData {
   }
 
   public Map<MonsterData, Double> getMonsterData(boolean stateful) {
-    Map<MonsterData, Double> monsterData = new HashMap<>();
+    return getMonsterData(stateful, false);
+  }
+
+  public Map<MonsterData, Double> getMonsterData(boolean stateful, boolean mapped) {
+    Map<MonsterData, Double> monsterData = new TreeMap<>();
 
     if (stateful) {
       recalculate();
@@ -595,6 +638,12 @@ public class AreaCombatData {
     double totalSuperlikelyChance = 0.0;
 
     for (MonsterData monster : superlikelyMonsters) {
+      if (mapped) {
+        monster = mapMonster(monster);
+      }
+      if (monster == MonsterData.NO_MONSTER) {
+        continue;
+      }
       double chance = superlikelyChance(monster);
       monsterData.put(monster, chance);
       totalSuperlikelyChance += chance;
@@ -604,6 +653,12 @@ public class AreaCombatData {
 
     for (MonsterData monster : monsters) {
       int weighting = getWeighting(monster);
+      if (mapped) {
+        monster = mapMonster(monster);
+      }
+      if (monster == MonsterData.NO_MONSTER) {
+        continue;
+      }
 
       if (weighting == -2) {
         continue;
@@ -634,18 +689,24 @@ public class AreaCombatData {
     return monsterData;
   }
 
-  public void appendMonsterData(final StringBuffer buffer, final boolean fullString) {
+  public void appendMonsterData(
+      final StringBuffer buffer, final boolean fullString, final boolean mapped) {
     int moxie = KoLCharacter.getAdjustedMoxie();
     int hitstat = EquipmentManager.getAdjustedHitStat();
 
     for (Map.Entry<MonsterData, Double> entry : getMonsterData(true).entrySet()) {
       MonsterData monster = entry.getKey();
+      int weighting = getWeighting(monster);
+      if (mapped) {
+        monster = mapMonster(monster);
+      }
+      if (monster == MonsterData.NO_MONSTER) {
+        continue;
+      }
       double chance = entry.getValue();
       buffer
           .append("<br><br>")
-          .append(
-              this.getMonsterString(
-                  monster, moxie, hitstat, getWeighting(monster), chance, fullString));
+          .append(this.getMonsterString(monster, moxie, hitstat, weighting, chance, fullString));
     }
   }
 

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -3435,6 +3435,10 @@ public abstract class KoLCharacter {
     return KoLCharacter.ascensionPath == Path.DINOSAURS;
   }
 
+  public static final boolean inShadowsOverLoathing() {
+    return KoLCharacter.ascensionPath == Path.SHADOWS_OVER_LOATHING;
+  }
+
   public static final boolean isUnarmed() {
     AdventureResult weapon = EquipmentManager.getEquipment(Slot.WEAPON);
     AdventureResult offhand = EquipmentManager.getEquipment(Slot.OFFHAND);

--- a/src/net/sourceforge/kolmafia/MonsterData.java
+++ b/src/net/sourceforge/kolmafia/MonsterData.java
@@ -624,6 +624,8 @@ public class MonsterData extends AdventureResult {
   // The following apply to a specific (cloned) instance of a monster
   private String[] randomModifiers;
 
+  public static final MonsterData NO_MONSTER = new MonsterData("none", 0, new String[0], "");
+
   public MonsterData(String name, int id, String[] images, String attributeString) {
     super(Priority.MONSTER, name);
 

--- a/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
@@ -232,13 +232,13 @@ public class MonsterDatabase {
 
   private static void addMapping(Map<MonsterData, MonsterData> map, String name1, String name2) {
     MonsterData mon1 = MONSTER_DATA.get(name1);
-    MonsterData mon2 = MONSTER_DATA.get(name2);
+    MonsterData mon2 = name2 != null ? MONSTER_DATA.get(name2) : MonsterData.NO_MONSTER;
     MonsterDatabase.addMapping(map, mon1, mon2);
   }
 
   private static void addMapping(Map<MonsterData, MonsterData> map, String name1, int id2) {
     MonsterData mon1 = MONSTER_DATA.get(name1);
-    MonsterData mon2 = MONSTER_IDS.get(id2);
+    MonsterData mon2 = id2 != 0 ? MONSTER_IDS.get(id2) : MonsterData.NO_MONSTER;
     MonsterDatabase.addMapping(map, mon1, mon2);
   }
 
@@ -263,6 +263,8 @@ public class MonsterDatabase {
     MonsterDatabase.addMapping(youRobotMap, "The Big Wisniewski", "The Artificial Wisniewski");
     MonsterDatabase.addMapping(youRobotMap, "The Man", "The Android");
     MonsterDatabase.addMapping(youRobotMap, "Naughty Sorceress", "Nautomatic Sorceress");
+    MonsterDatabase.addMapping(youRobotMap, "Naughty Sorceress (2)", null);
+    MonsterDatabase.addMapping(youRobotMap, "Naughty Sorceress (3)", null);
     MonsterDatabase.MONSTER_PATH_MAP.put(Path.YOU_ROBOT.getName(), youRobotMap);
 
     Map<MonsterData, MonsterData> plumberMap = new TreeMap<>();
@@ -276,6 +278,8 @@ public class MonsterDatabase {
     MonsterDatabase.addMapping(plumberMap, "The Big Wisniewski", 2172);
     MonsterDatabase.addMapping(plumberMap, "The Man", 2173);
     MonsterDatabase.addMapping(plumberMap, "Naughty Sorceress", "Wa%playername/lowercase%");
+    MonsterDatabase.addMapping(plumberMap, "Naughty Sorceress (2)", null);
+    MonsterDatabase.addMapping(plumberMap, "Naughty Sorceress (3)", null);
     MonsterDatabase.MONSTER_PATH_MAP.put(Path.PATH_OF_THE_PLUMBER.getName(), plumberMap);
 
     Map<MonsterData, MonsterData> darkGyffteMap = new TreeMap<>();
@@ -290,6 +294,8 @@ public class MonsterDatabase {
     MonsterDatabase.addMapping(darkGyffteMap, "The Man", "Chad Alacarte");
     MonsterDatabase.addMapping(darkGyffteMap, "Your Shadow", "Your Lack of Reflection");
     MonsterDatabase.addMapping(darkGyffteMap, "Naughty Sorceress", "%alucard%");
+    MonsterDatabase.addMapping(darkGyffteMap, "Naughty Sorceress (2)", null);
+    MonsterDatabase.addMapping(darkGyffteMap, "Naughty Sorceress (3)", null);
     MonsterDatabase.MONSTER_PATH_MAP.put(Path.DARK_GYFFTE.getName(), darkGyffteMap);
 
     Map<MonsterData, MonsterData> pocketFamiliarsMap = new TreeMap<>();
@@ -304,6 +310,8 @@ public class MonsterDatabase {
     MonsterDatabase.addMapping(pocketFamiliarsMap, "The Big Wisniewski", 2057);
     MonsterDatabase.addMapping(pocketFamiliarsMap, "The Man", 2058);
     MonsterDatabase.addMapping(pocketFamiliarsMap, "Naughty Sorceress", 2059);
+    MonsterDatabase.addMapping(pocketFamiliarsMap, "Naughty Sorceress (2)", null);
+    MonsterDatabase.addMapping(pocketFamiliarsMap, "Naughty Sorceress (3)", null);
     MonsterDatabase.MONSTER_PATH_MAP.put(Path.POKEFAM.getName(), pocketFamiliarsMap);
 
     Map<MonsterData, MonsterData> heavyRainsMap = new TreeMap<>();
@@ -317,6 +325,8 @@ public class MonsterDatabase {
     MonsterDatabase.addMapping(heavyRainsMap, "The Big Wisniewski", "Big Wisnaqua");
     MonsterDatabase.addMapping(heavyRainsMap, "The Man", "The Aquaman");
     MonsterDatabase.addMapping(heavyRainsMap, "Naughty Sorceress", "The Rain King");
+    MonsterDatabase.addMapping(heavyRainsMap, "Naughty Sorceress (2)", null);
+    MonsterDatabase.addMapping(heavyRainsMap, "Naughty Sorceress (3)", null);
     MonsterDatabase.MONSTER_PATH_MAP.put(Path.HEAVY_RAINS.getName(), heavyRainsMap);
 
     Map<MonsterData, MonsterData> actuallyEdMap = new TreeMap<>();
@@ -325,6 +335,8 @@ public class MonsterDatabase {
     MonsterDatabase.addMapping(actuallyEdMap, "Bonerdagon", "Donerbagon");
     MonsterDatabase.addMapping(actuallyEdMap, "Groar", "Your winged yeti");
     MonsterDatabase.addMapping(actuallyEdMap, "Naughty Sorceress", "You the Adventurer");
+    MonsterDatabase.addMapping(actuallyEdMap, "Naughty Sorceress (2)", null);
+    MonsterDatabase.addMapping(actuallyEdMap, "Naughty Sorceress (3)", null);
     MonsterDatabase.MONSTER_PATH_MAP.put(Path.ACTUALLY_ED_THE_UNDYING.getName(), actuallyEdMap);
 
     Map<MonsterData, MonsterData> wildfireMap = new TreeMap<>();
@@ -338,6 +350,8 @@ public class MonsterDatabase {
     MonsterDatabase.addMapping(wildfireMap, "The Big Wisniewski", "The Big Ignatowicz");
     MonsterDatabase.addMapping(wildfireMap, "The Man", "The Man on Fire");
     MonsterDatabase.addMapping(wildfireMap, "Naughty Sorceress", "The Naughty Scorcheress");
+    MonsterDatabase.addMapping(wildfireMap, "Naughty Sorceress (2)", null);
+    MonsterDatabase.addMapping(wildfireMap, "Naughty Sorceress (3)", null);
     MonsterDatabase.MONSTER_PATH_MAP.put(Path.WILDFIRE.getName(), wildfireMap);
 
     Map<MonsterData, MonsterData> dinoMap = new TreeMap<>();
@@ -352,6 +366,8 @@ public class MonsterDatabase {
     MonsterDatabase.addMapping(dinoMap, "The Big Wisniewski", "Slackiosaurus");
     MonsterDatabase.addMapping(dinoMap, "The Man", "Oligarcheopteryx");
     MonsterDatabase.addMapping(dinoMap, "Naughty Sorceress", "Naughty Saursaurus");
+    MonsterDatabase.addMapping(dinoMap, "Naughty Sorceress (2)", null);
+    MonsterDatabase.addMapping(dinoMap, "Naughty Sorceress (3)", null);
     MonsterDatabase.MONSTER_PATH_MAP.put(Path.DINOSAURS.getName(), dinoMap);
 
     Map<MonsterData, MonsterData> aosolMap = new TreeMap<>();
@@ -370,17 +386,20 @@ public class MonsterDatabase {
     MonsterDatabase.addMapping(pigSkinnerMap, "Naughty Sorceress", "General Bruise");
     MonsterDatabase.addMapping(
         pigSkinnerMap, "Naughty Sorceress (2)", "General Bruise (true form)");
+    MonsterDatabase.addMapping(pigSkinnerMap, "Naughty Sorceress (3)", null);
     MonsterDatabase.MONSTER_CLASS_MAP.put(AscensionClass.PIG_SKINNER.getName(), pigSkinnerMap);
 
     Map<MonsterData, MonsterData> cheeseWizardMap = new TreeMap<>();
     MonsterDatabase.addMapping(cheeseWizardMap, "Naughty Sorceress", "Dark Noël");
     MonsterDatabase.addMapping(cheeseWizardMap, "Naughty Sorceress (2)", "Dark Noël (true form)");
+    MonsterDatabase.addMapping(cheeseWizardMap, "Naughty Sorceress (3)", null);
     MonsterDatabase.MONSTER_CLASS_MAP.put(AscensionClass.CHEESE_WIZARD.getName(), cheeseWizardMap);
 
     Map<MonsterData, MonsterData> jazzAgentMap = new TreeMap<>();
     MonsterDatabase.addMapping(jazzAgentMap, "Naughty Sorceress", "Terrence Poindexter");
     MonsterDatabase.addMapping(
         jazzAgentMap, "Naughty Sorceress (2)", "Terrence Poindexter (true form)");
+    MonsterDatabase.addMapping(jazzAgentMap, "Naughty Sorceress (3)", null);
     MonsterDatabase.MONSTER_CLASS_MAP.put(AscensionClass.JAZZ_AGENT.getName(), jazzAgentMap);
   }
 

--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -2619,7 +2619,8 @@ public class RelayRequest extends PasswordHashRequest {
         || KoLCharacter.isPlumber()
         || KoLCharacter.inRobocore()
         || KoLCharacter.inFirecore()
-        || KoLCharacter.inDinocore()) {
+        || KoLCharacter.inDinocore()
+        || KoLCharacter.inShadowsOverLoathing()) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/swingui/panel/AdventureSelectPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/AdventureSelectPanel.java
@@ -609,7 +609,7 @@ public class AdventureSelectPanel extends JPanel {
       }
 
       AreaCombatData combat = request.getAreaSummary();
-      String text = combat == null ? " " : combat.toString(true);
+      String text = combat == null ? " " : combat.toString(true, true);
 
       // Avoid rendering and screen flicker if no change.
       // Compare with our own copy of what we set, since

--- a/src/net/sourceforge/kolmafia/textui/command/AreaSummaryCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AreaSummaryCommand.java
@@ -25,7 +25,7 @@ public class AreaSummaryCommand extends AbstractCommand {
     StringBuffer buffer = new StringBuffer();
 
     buffer.append("<html>");
-    data.getSummary(buffer, false);
+    data.getSummary(buffer, false, true);
     buffer.append("</html>");
 
     KoLmafiaCLI.showHTML(buffer.toString());

--- a/src/net/sourceforge/kolmafia/textui/command/MonsterDataCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/MonsterDataCommand.java
@@ -25,7 +25,7 @@ public class MonsterDataCommand extends AbstractCommand {
     StringBuffer buffer = new StringBuffer();
 
     buffer.append("<html>");
-    data.appendMonsterData(buffer, false);
+    data.appendMonsterData(buffer, false, true);
     buffer.append("</html>");
 
     KoLmafiaCLI.showHTML(buffer.toString());


### PR DESCRIPTION
1) The Naughty Sorceress' Chamber has all three forms in it.
2) The Location Details pane in the Adventure Frame now shows the actual path-specific bosses
3) You don't need a wand in Shadows over Loathing