### PR TITLE
More once per combat skills

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
@@ -746,8 +746,13 @@ public class SkillPool {
   public static final int HOT_FOOT = 28015;
   public static final int SECOND_WIND = 28016;
   public static final int STOP_HITTING_YOURSELF = 28017;
+  public static final int EMMENTAL_ELEMENTAL = 29017;
+  public static final int STILTON_SPLATTER = 29019;
   public static final int FONDELUGE = 29021;
+  public static final int KNIFE_IN_THE_DARKNESS = 30014;
+  public static final int VENOMOUS_RIFF = 30015;
   public static final int DRUM_ROLL = 30016;
+  public static final int MOTIF = 30021;
 
   private SkillPool() {}
 }

--- a/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
@@ -231,8 +231,8 @@ public class MonsterDatabase {
   }
 
   private static void addMapping(Map<MonsterData, MonsterData> map, String name1, String name2) {
-    MonsterData mon1 = MONSTER_DATA.get(name1);
-    MonsterData mon2 = name2 != null ? MONSTER_DATA.get(name2) : MonsterData.NO_MONSTER;
+    MonsterData mon1 = MONSTER_DATA.get(monsterKey(name1));
+    MonsterData mon2 = name2 != null ? MONSTER_DATA.get(monsterKey(name2)) : MonsterData.NO_MONSTER;
     MonsterDatabase.addMapping(map, mon1, mon2);
   }
 
@@ -543,8 +543,12 @@ public class MonsterDatabase {
     MONSTER_ALIASES.add(alias);
   }
 
+  private static String monsterKey(String name) {
+    return CombatActionManager.encounterKey(name, false);
+  }
+
   private static void saveMonster(final String name, final MonsterData monster) {
-    String keyName = CombatActionManager.encounterKey(name, false);
+    String keyName = monsterKey(name);
     StringUtilities.registerPrepositions(keyName);
     MonsterDatabase.ALL_MONSTER_DATA.add(monster);
     MonsterDatabase.MONSTER_DATA.put(keyName, monster);
@@ -560,7 +564,7 @@ public class MonsterDatabase {
   }
 
   private static void removeAlias(final String name) {
-    String keyName = CombatActionManager.encounterKey(name, false);
+    String keyName = monsterKey(name);
     MonsterDatabase.MONSTER_DATA.remove(keyName);
     MonsterDatabase.OLD_MONSTER_DATA.remove(keyName.toLowerCase());
     if (keyName.toLowerCase().startsWith("the ")) {
@@ -620,7 +624,7 @@ public class MonsterDatabase {
   public static final MonsterData findMonster(
       final String name, boolean trySubstrings, boolean matchCase) {
     // Look for case-sensitive exact match
-    String keyName = CombatActionManager.encounterKey(name, false);
+    String keyName = monsterKey(name);
     MonsterData match = MonsterDatabase.MONSTER_DATA.get(keyName);
 
     if (match != null) {
@@ -786,8 +790,9 @@ public class MonsterDatabase {
   public static final void registerMonster(final MonsterData monster) {
     int id = monster.getId();
     String name = monster.getName();
-    MonsterDatabase.MONSTER_DATA.put(name, monster);
-    MonsterDatabase.OLD_MONSTER_DATA.put(name.toLowerCase(), monster);
+    String keyName = monsterKey(name);
+    MonsterDatabase.MONSTER_DATA.put(keyName, monster);
+    MonsterDatabase.OLD_MONSTER_DATA.put(keyName.toLowerCase(), monster);
     MonsterDatabase.LEET_MONSTER_DATA.put(StringUtilities.leetify(name), monster);
     MonsterDatabase.registerMonsterId(id, name, monster);
     MonsterDatabase.saveCanonicalNames();
@@ -797,8 +802,9 @@ public class MonsterDatabase {
   public static final void unregisterMonster(final MonsterData monster) {
     int id = monster.getId();
     String name = monster.getName();
-    MonsterDatabase.MONSTER_DATA.remove(name);
-    MonsterDatabase.OLD_MONSTER_DATA.remove(name.toLowerCase());
+    String keyName = monsterKey(name);
+    MonsterDatabase.MONSTER_DATA.remove(keyName);
+    MonsterDatabase.OLD_MONSTER_DATA.remove(keyName.toLowerCase());
     MonsterDatabase.LEET_MONSTER_DATA.remove(StringUtilities.leetify(name));
     MonsterDatabase.MONSTER_IDS.remove(id);
     MonsterDatabase.saveCanonicalNames();

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -9066,6 +9066,11 @@ public class FightRequest extends GenericRequest {
       case SkillPool.HOT_FOOT:
       case SkillPool.SECOND_WIND:
       case SkillPool.STOP_HITTING_YOURSELF:
+      case SkillPool.EMMENTAL_ELEMENTAL:
+      case SkillPool.STILTON_SPLATTER:
+      case SkillPool.KNIFE_IN_THE_DARKNESS:
+      case SkillPool.VENOMOUS_RIFF:
+      case SkillPool.DRUM_ROLL:
         singleCastsThisFight.add(skillId);
         return;
 

--- a/src/net/sourceforge/kolmafia/webui/StationaryButtonDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/StationaryButtonDecorator.java
@@ -31,6 +31,8 @@ public class StationaryButtonDecorator {
 
   private static final AdventureResult EVERYTHING_LOOKS_YELLOW =
       EffectPool.get(EffectPool.EVERYTHING_LOOKS_YELLOW);
+  private static final AdventureResult EVERYTHING_LOOKS_BLUE =
+      EffectPool.get(EffectPool.EVERYTHING_LOOKS_BLUE);
 
   private StationaryButtonDecorator() {}
 
@@ -708,6 +710,8 @@ public class StationaryButtonDecorator {
               !Preferences.getBoolean("_gingerbreadMobHitUsed");
           case SkillPool.FONDELUGE -> isEnabled =
               !KoLConstants.activeEffects.contains(EVERYTHING_LOOKS_YELLOW);
+          case SkillPool.MOTIF -> isEnabled =
+              !KoLConstants.activeEffects.contains(EVERYTHING_LOOKS_BLUE);
         }
       }
     }


### PR DESCRIPTION
1) Emmental Elemental and Stilton Splatter are once per combat Cheese Wizard skills
2) Knife in the Darkness, Venomous Rift, and Drum Roll are once per combat Jazz Agent skills
3) Motif gives 25 turns of Everything Looks Blue and cannot be cast while that effect is active.
Disable the Stationary Button for that skill if so.

I wondered why Dark Noël was not showing up as a mapped monster.
Turns out, the "key" in MONSTER_DATA is CombatActionManager.encounterKey(name, false).
Which is to say, entityEncoded, not lowercased.

4) create MonsterDatabase.monsterKey(name).
Use this when putting/getting from MONSTER_DATA - including setting up path/class boss mappings.

Note that KoL may have Dark Noël with either a UTF-8 character or a character entity. For example, the angry pi&ntilde;ata, cr&ecirc;ep, and Wardr&ouml;b nightstand have a character entity.

(So does Elp&iacute;zo & Crosybdis - except the "&" between the two names is literally a "&" character.)

I'll see Dark Noël tomorrow and will see for myself and fix, if needed, in monsters.txt.
OK, I defeated both of her forms. It really is Noël with a UTF-8 character.

