### PR TITLE
Add session_log(int) : string

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -668,6 +668,12 @@ public abstract class RuntimeLibrary {
     params = new Type[] {};
     functions.add(new LibraryFunction("moon_light", DataTypes.INT_TYPE, params));
 
+    params = new Type[] {DataTypes.INT_TYPE};
+    functions.add(new LibraryFunction("session_log", DataTypes.STRING_TYPE, params));
+
+    params = new Type[] {DataTypes.STRING_TYPE, DataTypes.INT_TYPE};
+    functions.add(new LibraryFunction("session_log", DataTypes.STRING_TYPE, params));
+
     params = new Type[] {};
     functions.add(new LibraryFunction("stat_bonus_today", DataTypes.STAT_TYPE, params));
 
@@ -3784,6 +3790,31 @@ public abstract class RuntimeLibrary {
     }
 
     return DataTypes.STAT_INIT;
+  }
+
+  public static Value session_log(ScriptRuntime controller, final Value dayCount) {
+    return RuntimeLibrary.getSessionLog(
+        controller, KoLCharacter.getUserName(), (int) dayCount.intValue());
+  }
+
+  public static Value session_log(
+      ScriptRuntime controller, final Value player, final Value dayCount) {
+    return RuntimeLibrary.getSessionLog(controller, player.toString(), (int) dayCount.intValue());
+  }
+
+  private static Value getSessionLog(
+      ScriptRuntime controller, final String name, final int dayCount) {
+    if (dayCount < 0) {
+      throw controller.runtimeException("Can't get session log for a negative day count");
+    }
+
+    Calendar timestamp = Calendar.getInstance(KoLmafia.KOL_TIME_ZONE);
+    timestamp.add(Calendar.DATE, -dayCount);
+
+    String logContents =
+        getContentsOfSessionLog(name, KoLConstants.DAILY_FORMAT.format(timestamp.getTime()));
+
+    return new Value(logContents);
   }
 
   public static Value session_logs(ScriptRuntime controller, final Value dayCount) {


### PR DESCRIPTION
This introduces a new function `session_log(int)` and `session_log(name, int)` which differs from `session_logs()` in that it will retrieve a single session log.

Another way it differs is that it starts from 0, where `session_logs` starts from 1, meaning how many logs `session_logs` will return.

This could be changed, but my train of thought is that `session_logs` asks for the number of days / session logs to return.

`session_log` is asking how many days ago should it go to find the session log, where 0 is obviously today as 1 day ago is not today.

So the main use case of this PR is that you can retrieve a single session log from a specified day, without parsing every session log up to said day.

Such as a script that parses a run and compares it against another run, if you want to do a large number of sessions you're not forced to load every file into memory at once.

Of course, `session_logs` does support adding a calendar date to start from, but it is far simpler to just ask for the session log for a specified `day ago`.