### PR TITLE
Equip a club even if tiebreaker is used

### DIFF
--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -640,6 +640,17 @@ public class MaximizerTest {
     }
 
     @Test
+    public void clubModifierWorksWithTieBreaker() {
+      final var cleanups =
+          new Cleanups(withEquippableItem("lawn dart"));
+
+      try (cleanups) {
+        assertTrue(maximize("-tie, club"));
+        recommendedSlotIs(Slot.WEAPON, "lawn dart");
+      }
+    }
+
+    @Test
     public void swordModifierFavorsSword() {
       final var cleanups =
           new Cleanups(withEquippableItem("sweet ninja sword"), withEquippableItem("spiked femur"));


### PR DESCRIPTION
This test will fail until the maximiser is adjusted to use explicit equipment specified. This should still work even if a tiebreaker argument is added.

_Logging this in lieu of creating a bug report on the forums._