### PR TITLE
refactor: convert confirms to enum

### DIFF
--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -116,37 +116,37 @@ public class RelayRequest extends PasswordHashRequest {
   public static String redirectedCommandURL = "";
 
   public enum Confirm {
-    CONFIRM_COUNTER,
-    CONFIRM_MCD,
-    CONFIRM_FAMILIAR,
-    CONFIRM_RECOVERY,
-    CONFIRM_SORCERESS,
-    CONFIRM_WOSSNAME,
-    CONFIRM_TOKENS,
-    CONFIRM_SEAL,
-    CONFIRM_ARCADE,
-    CONFIRM_KUNGFU,
-    CONFIRM_POOL_SKILL,
-    CONFIRM_WINEGLASS,
-    CONFIRM_COLOSSEUM,
-    CONFIRM_GREMLINS,
-    CONFIRM_HARDCOREPVP,
-    CONFIRM_DESERT_UNHYDRATED,
-    CONFIRM_MOHAWK_WIG,
-    CONFIRM_CELLAR,
-    CONFIRM_BOILER,
-    CONFIRM_DIARY,
-    CONFIRM_BORING_DOORS,
-    CONFIRM_SPELUNKY,
-    CONFIRM_ZEPPELIN,
-    CONFIRM_OVERDRUNK_ADVENTURE,
-    CONFIRM_STICKER,
-    CONFIRM_DESERT_OFFHAND,
-    CONFIRM_MACHETE,
-    CONFIRM_RALPH,
-    CONFIRM_RALPH1,
-    CONFIRM_RALPH2,
-    CONFIRM_DESERT_WEAPON;
+    COUNTER,
+    MCD,
+    FAMILIAR,
+    RECOVERY,
+    SORCERESS,
+    WOSSNAME,
+    TOKENS,
+    SEAL,
+    ARCADE,
+    KUNGFU,
+    POOL_SKILL,
+    WINEGLASS,
+    COLOSSEUM,
+    GREMLINS,
+    HARDCOREPVP,
+    DESERT_UNHYDRATED,
+    MOHAWK_WIG,
+    CELLAR,
+    BOILER,
+    DIARY,
+    BORING_DOORS,
+    SPELUNKY,
+    ZEPPELIN,
+    OVERDRUNK_ADVENTURE,
+    STICKER,
+    DESERT_OFFHAND,
+    MACHETE,
+    RALPH,
+    RALPH1,
+    RALPH2,
+    DESERT_WEAPON;
 
     @Override
     public String toString() {
@@ -826,7 +826,7 @@ public class RelayRequest extends PasswordHashRequest {
 
     if (KoLCharacter.isKingdomOfExploathing()) {
       // If user has already confirmed he wants to break the prism, accept it
-      if (this.getFormField(Confirm.CONFIRM_RALPH) != null) {
+      if (this.getFormField(Confirm.RALPH) != null) {
         return false;
       }
 
@@ -841,7 +841,7 @@ public class RelayRequest extends PasswordHashRequest {
               + " If you are ready to break the prism, click on the icon on the left."
               + " If you wish to visit Cosmic Ray's Bazaar, click on icon on the right.";
       this.sendOptionalWarning(
-          Confirm.CONFIRM_RALPH,
+          Confirm.RALPH,
           warning,
           "hand.gif",
           "meatisotope.gif",
@@ -856,13 +856,13 @@ public class RelayRequest extends PasswordHashRequest {
       if (KoLCharacter.getFullness() < KoLCharacter.getFullnessLimit()
           && !RelayRequest.ignoreFullnessWarning) {
         // If it's already confirmed, then track that for the session
-        if (this.getFormField(Confirm.CONFIRM_RALPH1) == null) {
+        if (this.getFormField(Confirm.RALPH1) == null) {
           String warning =
               "When you stop being a plumber, you will lose five maximum fullness."
                   + " Since you are not yet full, perhaps you would like to eat more now?"
                   + " (It is not harmful to be over-full.)"
                   + " If you are sure you don't want to eat more at this time, click the icon. ";
-          this.sendGeneralWarning("knifefork.gif", warning, Confirm.CONFIRM_RALPH1);
+          this.sendGeneralWarning("knifefork.gif", warning, Confirm.RALPH1);
           return true;
         }
         RelayRequest.ignoreFullnessWarning = true;
@@ -905,7 +905,7 @@ public class RelayRequest extends PasswordHashRequest {
 
     if (KoLCharacter.inRobocore()) {
       // If user has already confirmed he wants to go there, accept it
-      if (this.getFormField(Confirm.CONFIRM_RALPH) != null) {
+      if (this.getFormField(Confirm.RALPH) != null) {
         return false;
       }
 
@@ -937,7 +937,7 @@ public class RelayRequest extends PasswordHashRequest {
       buf.append(" If you wish to visit the Scrapheap, click on icon on the right.");
 
       this.sendOptionalWarning(
-          Confirm.CONFIRM_RALPH,
+          Confirm.RALPH,
           buf.toString(),
           "hand.gif",
           "jigawatts.gif",
@@ -952,7 +952,7 @@ public class RelayRequest extends PasswordHashRequest {
 
     if (KoLCharacter.inDinocore()) {
       // If user has already confirmed he wants to go there, accept it
-      if (this.getFormField(Confirm.CONFIRM_RALPH) != null) {
+      if (this.getFormField(Confirm.RALPH) != null) {
         return false;
       }
 
@@ -967,7 +967,7 @@ public class RelayRequest extends PasswordHashRequest {
               + " If you are ready to break the prism, click on the icon on the left."
               + " If you wish to visit the Dino Staur, click on icon on the right.";
       this.sendOptionalWarning(
-          Confirm.CONFIRM_RALPH,
+          Confirm.RALPH,
           warning,
           "hand.gif",
           "dinobuck.gif",
@@ -1054,7 +1054,7 @@ public class RelayRequest extends PasswordHashRequest {
 
   private boolean sendCoinMasterWarning(final CoinmasterData camp) {
     // If user has already confirmed he wants to go there, accept it
-    if (this.getFormField(Confirm.CONFIRM_TOKENS) != null) {
+    if (this.getFormField(Confirm.TOKENS) != null) {
       return false;
     }
 
@@ -1071,7 +1071,7 @@ public class RelayRequest extends PasswordHashRequest {
         message
             + " Before you do so, you might want to redeem war loot for dimes and quarters and buy equipment. Click on the image to enter battle, once you are ready.";
 
-    this.sendGeneralWarning("lucre.gif", message, Confirm.CONFIRM_TOKENS);
+    this.sendGeneralWarning("lucre.gif", message, Confirm.TOKENS);
 
     return true;
   }
@@ -1088,7 +1088,7 @@ public class RelayRequest extends PasswordHashRequest {
       return false;
     }
 
-    if (this.getFormField(Confirm.CONFIRM_COLOSSEUM) != null) {
+    if (this.getFormField(Confirm.COLOSSEUM) != null) {
       return false;
     }
 
@@ -1146,7 +1146,7 @@ public class RelayRequest extends PasswordHashRequest {
             + weapon.getName()
             + ", click the icon on the right to closet it.";
     this.sendOptionalWarning(
-        Confirm.CONFIRM_COLOSSEUM,
+        Confirm.COLOSSEUM,
         warning,
         "hand.gif",
         image,
@@ -1167,7 +1167,7 @@ public class RelayRequest extends PasswordHashRequest {
 
   private boolean sendInfernalSealWarning(final String urlString) {
     // If user has already confirmed he wants to do it, accept it
-    if (this.getFormField(Confirm.CONFIRM_SEAL) != null) {
+    if (this.getFormField(Confirm.SEAL) != null) {
       return false;
     }
 
@@ -1196,7 +1196,7 @@ public class RelayRequest extends PasswordHashRequest {
     message =
         "You are trying to summon an infernal seal, but you are not wielding a club. You are either incredibly puissant or incredibly foolish. If you are sure you want to do this, click on the image and proceed to your doom.";
 
-    this.sendGeneralWarning("iblubbercandle.gif", message, Confirm.CONFIRM_SEAL, "checked=1");
+    this.sendGeneralWarning("iblubbercandle.gif", message, Confirm.SEAL, "checked=1");
 
     return true;
   }
@@ -1217,7 +1217,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If user has already confirmed he wants to do it, accept it
-    if (this.getFormField(Confirm.CONFIRM_GREMLINS) != null) {
+    if (this.getFormField(Confirm.GREMLINS) != null) {
       return false;
     }
 
@@ -1236,7 +1236,7 @@ public class RelayRequest extends PasswordHashRequest {
     message =
         "You are about to fight Gremlins, but do not have the Molybdenum Magnet. If you are sure you want to do this, click on the image to proceed.";
 
-    this.sendGeneralWarning("magnet2.gif", message, Confirm.CONFIRM_GREMLINS);
+    this.sendGeneralWarning("magnet2.gif", message, Confirm.GREMLINS);
 
     return true;
   }
@@ -1251,7 +1251,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // Don't remind a second time in a session if you decide not to do it.
-    if (urlString.contains(Confirm.CONFIRM_HARDCOREPVP.toString())) {
+    if (urlString.contains(Confirm.HARDCOREPVP.toString())) {
       return false;
     }
 
@@ -1285,7 +1285,7 @@ public class RelayRequest extends PasswordHashRequest {
     message =
         "You have fights remaining and are still in Hardcore. If you are sure you don't want to use the fights in hardcore, click on the image to proceed.";
 
-    this.sendGeneralWarning("swords.gif", message, Confirm.CONFIRM_HARDCOREPVP);
+    this.sendGeneralWarning("swords.gif", message, Confirm.HARDCOREPVP);
 
     return true;
   }
@@ -1297,7 +1297,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(Confirm.CONFIRM_DESERT_WEAPON) != null) {
+    if (this.getFormField(Confirm.DESERT_WEAPON) != null) {
       RelayRequest.ignoreDesertWeaponWarning = true;
       return false;
     }
@@ -1331,7 +1331,7 @@ public class RelayRequest extends PasswordHashRequest {
               + "If you are sure you wish to adventure without it, click the icon on the left to adventure. "
               + "If you want to equip the survival knife first, click the icon on the right. ";
       this.sendOptionalWarning(
-          Confirm.CONFIRM_DESERT_WEAPON,
+          Confirm.DESERT_WEAPON,
           warning,
           "hand.gif",
           "maydayknife.gif",
@@ -1357,7 +1357,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(Confirm.CONFIRM_DESERT_OFFHAND) != null) {
+    if (this.getFormField(Confirm.DESERT_OFFHAND) != null) {
       RelayRequest.ignoreDesertOffhandWarning = true;
       return false;
     }
@@ -1397,7 +1397,7 @@ public class RelayRequest extends PasswordHashRequest {
               + "If you are sure you wish to adventure without it, click the icon on the left to adventure. "
               + "If you want to equip the ornate dowsing rod first, click the icon on the right. ";
       this.sendOptionalWarning(
-          Confirm.CONFIRM_DESERT_OFFHAND,
+          Confirm.DESERT_OFFHAND,
           warning,
           "hand.gif",
           "dowsingrod.gif",
@@ -1421,7 +1421,7 @@ public class RelayRequest extends PasswordHashRequest {
               + "If you are sure you wish to adventure without it, click the icon on the left to adventure. "
               + "If you want to equip the UV-resistant compass first, click the icon on the right. ";
       this.sendOptionalWarning(
-          Confirm.CONFIRM_DESERT_OFFHAND,
+          Confirm.DESERT_OFFHAND,
           warning,
           "hand.gif",
           "uvcompass.gif",
@@ -1438,7 +1438,7 @@ public class RelayRequest extends PasswordHashRequest {
       String message =
           "You are about to adventure without a UV-resistant compass in the desert. If you are sure you want to do this, click on the image to proceed.";
 
-      this.sendGeneralWarning("uvcompass.gif", message, Confirm.CONFIRM_DESERT_OFFHAND);
+      this.sendGeneralWarning("uvcompass.gif", message, Confirm.DESERT_OFFHAND);
     }
 
     return true;
@@ -1451,7 +1451,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(Confirm.CONFIRM_DESERT_UNHYDRATED) != null) {
+    if (this.getFormField(Confirm.DESERT_UNHYDRATED) != null) {
       RelayRequest.ignoreDesertWarning = true;
       return false;
     }
@@ -1483,7 +1483,7 @@ public class RelayRequest extends PasswordHashRequest {
             + "If you are sure you wish to adventure unhydrated, click the icon on the left to adventure. "
             + "If you want to visit the Oasis to get ultrahydrated, click the icon on the right to adventure. ";
     this.sendOptionalWarning(
-        Confirm.CONFIRM_DESERT_UNHYDRATED,
+        Confirm.DESERT_UNHYDRATED,
         warning,
         "poison.gif",
         "raindrop.gif",
@@ -1517,7 +1517,7 @@ public class RelayRequest extends PasswordHashRequest {
       buf.append(" first, click the icon on the right.");
 
       this.sendOptionalWarning(
-          Confirm.CONFIRM_MACHETE,
+          Confirm.MACHETE,
           buf.toString(),
           "hand.gif",
           image,
@@ -1559,7 +1559,7 @@ public class RelayRequest extends PasswordHashRequest {
       buf.append(ok2);
       buf.append(" If you want to visit the Scrapheap, click the icon on the right.");
       this.sendOptionalWarning(
-          Confirm.CONFIRM_MACHETE,
+          Confirm.MACHETE,
           buf.toString(),
           "hand.gif",
           resource,
@@ -1571,7 +1571,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     buf.append(ok1);
-    this.sendGeneralWarning("hand.gif", buf.toString(), Confirm.CONFIRM_MACHETE);
+    this.sendGeneralWarning("hand.gif", buf.toString(), Confirm.MACHETE);
   }
 
   public boolean sendMacheteWarning() {
@@ -1581,7 +1581,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(Confirm.CONFIRM_MACHETE) != null) {
+    if (this.getFormField(Confirm.MACHETE) != null) {
       RelayRequest.ignoreMacheteWarning = true;
       return false;
     }
@@ -1656,7 +1656,7 @@ public class RelayRequest extends PasswordHashRequest {
     // Otherwise just ask if you want to adventure
     String message =
         "You are about to adventure without a machete to fight dense lianas. If you are sure you want to do this, click on the image to proceed.";
-    this.sendGeneralWarning("machetwo.gif", message, Confirm.CONFIRM_MACHETE);
+    this.sendGeneralWarning("machetwo.gif", message, Confirm.MACHETE);
 
     return true;
   }
@@ -1668,7 +1668,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(Confirm.CONFIRM_MOHAWK_WIG) != null) {
+    if (this.getFormField(Confirm.MOHAWK_WIG) != null) {
       RelayRequest.ignoreMohawkWigWarning = true;
       return false;
     }
@@ -1709,7 +1709,7 @@ public class RelayRequest extends PasswordHashRequest {
       buf.append(" If you want to put the hat on first, click the icon on the right.");
 
       this.sendOptionalWarning(
-          Confirm.CONFIRM_MOHAWK_WIG,
+          Confirm.MOHAWK_WIG,
           buf.toString(),
           "hand.gif",
           "mohawk.gif",
@@ -1749,7 +1749,7 @@ public class RelayRequest extends PasswordHashRequest {
       buf.append(" If you want to visit the Scrapheap, click the icon on the right.");
 
       this.sendOptionalWarning(
-          Confirm.CONFIRM_MOHAWK_WIG,
+          Confirm.MOHAWK_WIG,
           buf.toString(),
           "hand.gif",
           image,
@@ -1761,7 +1761,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     buf.append(ok1);
-    this.sendGeneralWarning("hand.gif", buf.toString(), Confirm.CONFIRM_MOHAWK_WIG);
+    this.sendGeneralWarning("hand.gif", buf.toString(), Confirm.MOHAWK_WIG);
 
     return true;
   }
@@ -1773,7 +1773,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(Confirm.CONFIRM_BORING_DOORS) != null) {
+    if (this.getFormField(Confirm.BORING_DOORS) != null) {
       RelayRequest.ignoreBoringDoorsWarning = true;
       return false;
     }
@@ -1807,7 +1807,7 @@ public class RelayRequest extends PasswordHashRequest {
             + "If you are sure you wish to adventure without it, click the icon on the left to adventure. "
             + "If you want to put the ring on first, click the icon on the right. ";
     this.sendOptionalWarning(
-        Confirm.CONFIRM_BORING_DOORS,
+        Confirm.BORING_DOORS,
         warning,
         "hand.gif",
         "weddingring.gif",
@@ -1829,7 +1829,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(Confirm.CONFIRM_POOL_SKILL) != null) {
+    if (this.getFormField(Confirm.POOL_SKILL) != null) {
       RelayRequest.ignorePoolSkillWarning = true;
       return false;
     }
@@ -1981,14 +1981,14 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     this.sendOptionalWarning(
-        Confirm.CONFIRM_POOL_SKILL, warning.toString(), "glove.gif", image2, action2, image3, action3);
+        Confirm.POOL_SKILL, warning.toString(), "glove.gif", image2, action2, image3, action3);
 
     return true;
   }
 
   private boolean sendCellarWarning() {
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(Confirm.CONFIRM_CELLAR) != null) {
+    if (this.getFormField(Confirm.CELLAR) != null) {
       return false;
     }
 
@@ -2025,14 +2025,14 @@ public class RelayRequest extends PasswordHashRequest {
         "You are about to adventure without reading the Mortar dissolving recipe with glasses equipped. "
             + " If you are sure you want to do this, click on the image to proceed.";
 
-    this.sendGeneralWarning("burgerrecipe.gif", message, Confirm.CONFIRM_CELLAR);
+    this.sendGeneralWarning("burgerrecipe.gif", message, Confirm.CELLAR);
 
     return true;
   }
 
   private boolean sendZeppelinWarning() {
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(Confirm.CONFIRM_ZEPPELIN) != null) {
+    if (this.getFormField(Confirm.ZEPPELIN) != null) {
       return false;
     }
 
@@ -2062,7 +2062,7 @@ public class RelayRequest extends PasswordHashRequest {
             + "If you are sure you wish to adventure without it, click the icon on the left to adventure. "
             + "If you want to visit the Black Market, click the icon on the right. ";
     this.sendOptionalWarning(
-        Confirm.CONFIRM_ZEPPELIN,
+        Confirm.ZEPPELIN,
         warning,
         "hand.gif",
         "zepticket.gif",
@@ -2075,7 +2075,7 @@ public class RelayRequest extends PasswordHashRequest {
 
   private boolean sendBoilerWarning() {
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(Confirm.CONFIRM_BOILER) != null) {
+    if (this.getFormField(Confirm.BOILER) != null) {
       return false;
     }
 
@@ -2115,14 +2115,14 @@ public class RelayRequest extends PasswordHashRequest {
     message =
         "You are about to adventure in the Haunted Boiler Room, but do not have Unstable Fulminate equipped. If you are sure you want to do this, click on the image to proceed.";
 
-    this.sendGeneralWarning("wine2.gif", message, Confirm.CONFIRM_BOILER);
+    this.sendGeneralWarning("wine2.gif", message, Confirm.BOILER);
 
     return true;
   }
 
   private boolean sendDiaryWarning() {
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(Confirm.CONFIRM_DIARY) != null) {
+    if (this.getFormField(Confirm.DIARY) != null) {
       return false;
     }
 
@@ -2160,13 +2160,13 @@ public class RelayRequest extends PasswordHashRequest {
     message =
         "You are about to adventure but have not obtained your father's MacGuffin diary. If you are sure you want to do this, click on the image to proceed.";
 
-    this.sendGeneralWarning("book2.gif", message, Confirm.CONFIRM_DIARY);
+    this.sendGeneralWarning("book2.gif", message, Confirm.DIARY);
 
     return true;
   }
 
   private boolean sendWossnameWarning(final CoinmasterData camp) {
-    if (this.getFormField(Confirm.CONFIRM_WOSSNAME) != null) {
+    if (this.getFormField(Confirm.WOSSNAME) != null) {
       return false;
     }
 
@@ -2179,13 +2179,13 @@ public class RelayRequest extends PasswordHashRequest {
             + " and open the way to their camp. However, you have not yet finished with the "
             + side2
             + ". If you are sure you don't want the Order of the Silver Wossname, click on the image and proceed.";
-    this.sendGeneralWarning("wossname.gif", message, Confirm.CONFIRM_WOSSNAME);
+    this.sendGeneralWarning("wossname.gif", message, Confirm.WOSSNAME);
 
     return true;
   }
 
   private boolean sendFamiliarWarning() {
-    if (this.getFormField(Confirm.CONFIRM_FAMILIAR) != null) {
+    if (this.getFormField(Confirm.FAMILIAR) != null) {
       return false;
     }
 
@@ -2228,7 +2228,7 @@ public class RelayRequest extends PasswordHashRequest {
         "<td align=center valign=center><div id=\"lucky\" style=\"padding: 4px 4px 4px 4px\"><a style=\"text-decoration: none\" href=\"");
     warning.append(url);
     warning.append(!url.contains("?") ? "?" : "&");
-    warning.append(Confirm.CONFIRM_FAMILIAR);
+    warning.append(Confirm.FAMILIAR);
     warning.append("=on\"><img src=\"/images/");
 
     if (familiar.getId() != FamiliarData.NO_FAMILIAR.getId()) {
@@ -2270,7 +2270,7 @@ public class RelayRequest extends PasswordHashRequest {
   }
 
   boolean sendKungFuWarning() {
-    if (this.getFormField(Confirm.CONFIRM_KUNGFU) != null) {
+    if (this.getFormField(Confirm.KUNGFU) != null) {
       return false;
     }
 
@@ -2306,7 +2306,7 @@ public class RelayRequest extends PasswordHashRequest {
         "<td align=center valign=center><div id=\"lucky\" style=\"padding: 4px 4px 4px 4px\"><a style=\"text-decoration: none\" href=\"");
     warning.append(url);
     warning.append(!url.contains("?") ? "?" : "&");
-    warning.append(Confirm.CONFIRM_KUNGFU);
+    warning.append(Confirm.KUNGFU);
     warning.append("=on\"><img src=\"/images/itemimages/kungfu.gif");
     warning.append("\" width=30 height=30 border=0>");
     warning.append("</a></div></td>");
@@ -2469,7 +2469,7 @@ public class RelayRequest extends PasswordHashRequest {
       return false;
     }
 
-    if (this.getFormField(Confirm.CONFIRM_MCD) != null) {
+    if (this.getFormField(Confirm.MCD) != null) {
       return false;
     }
 
@@ -2547,7 +2547,7 @@ public class RelayRequest extends PasswordHashRequest {
     warning.append("<tr align=center><td><a href=\"");
     warning.append(this.getURLString());
     warning.append("&");
-    warning.append(Confirm.CONFIRM_MCD);
+    warning.append(Confirm.MCD);
     warning.append("=on");
     warning.append("\"><img src=\"/images/adventureimages/");
     warning.append(image);
@@ -2613,7 +2613,7 @@ public class RelayRequest extends PasswordHashRequest {
       return false;
     }
 
-    if (urlString.contains(Confirm.CONFIRM_SORCERESS.toString())) {
+    if (urlString.contains(Confirm.SORCERESS.toString())) {
       return false;
     }
 
@@ -2664,7 +2664,7 @@ public class RelayRequest extends PasswordHashRequest {
       }
 
       warning.append(" <span title=\"Bedroom\">Antique hand mirror</span>");
-      this.sendGeneralWarning("handmirror.gif", warning.toString(), Confirm.CONFIRM_SORCERESS);
+      this.sendGeneralWarning("handmirror.gif", warning.toString(), Confirm.SORCERESS);
       return true;
     }
 
@@ -2703,13 +2703,13 @@ public class RelayRequest extends PasswordHashRequest {
       }
     }
 
-    this.sendGeneralWarning("wand.gif", warning.toString(), Confirm.CONFIRM_SORCERESS);
+    this.sendGeneralWarning("wand.gif", warning.toString(), Confirm.SORCERESS);
     return true;
   }
 
   private boolean sendArcadeWarning() {
 
-    if (this.getFormField(Confirm.CONFIRM_ARCADE) != null) {
+    if (this.getFormField(Confirm.ARCADE) != null) {
       return false;
     }
 
@@ -2731,7 +2731,7 @@ public class RelayRequest extends PasswordHashRequest {
       this.sendGeneralWarning(
           "ggtoken.gif",
           "You might not be properly equipped to play this game.<br>Click the token if you'd like to continue anyway.",
-          Confirm.CONFIRM_ARCADE);
+          Confirm.ARCADE);
       return true;
     }
 
@@ -2743,7 +2743,7 @@ public class RelayRequest extends PasswordHashRequest {
       return false;
     }
 
-    if (this.getFormField(Confirm.CONFIRM_WINEGLASS) != null) {
+    if (this.getFormField(Confirm.WINEGLASS) != null) {
       return false;
     }
 
@@ -2771,7 +2771,7 @@ public class RelayRequest extends PasswordHashRequest {
             + "If this was an accident, click the icon in the center to equip Drunkula's wineglass. "
             + "If you want to adventure in a Drunken Stupor and not be nagged, click the icon on the right to closet Drunkula's wineglass.";
     this.sendOptionalWarning(
-        Confirm.CONFIRM_WINEGLASS,
+        Confirm.WINEGLASS,
         warning,
         "hand.gif",
         "dr_wineglass.gif",
@@ -2796,8 +2796,8 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // Don't warn again if you've already said ok to Wineglass warning about overdrunk (or this one)
-    if (this.getFormField(Confirm.CONFIRM_OVERDRUNK_ADVENTURE) != null
-        || this.getFormField(Confirm.CONFIRM_WINEGLASS) != null) {
+    if (this.getFormField(Confirm.OVERDRUNK_ADVENTURE) != null
+        || this.getFormField(Confirm.WINEGLASS) != null) {
       return false;
     }
 
@@ -2820,7 +2820,7 @@ public class RelayRequest extends PasswordHashRequest {
     String warning =
         "KoLmafia has detected that you are about to adventure while overdrunk. "
             + "If you are sure you wish to adventure in a Drunken Stupor, click the icon to adventure. ";
-    this.sendGeneralWarning("martini.gif", warning, Confirm.CONFIRM_OVERDRUNK_ADVENTURE);
+    this.sendGeneralWarning("martini.gif", warning, Confirm.OVERDRUNK_ADVENTURE);
     return true;
   }
 
@@ -2841,16 +2841,16 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If the player has said he doesn't care about this warning, cool
-    if (this.getFormField(Confirm.CONFIRM_SPELUNKY) != null) {
+    if (this.getFormField(Confirm.SPELUNKY) != null) {
       return false;
     }
 
     // Depending on noncombat phase step and/or adventure location,
     // craft an appropriate warning
-    String message = SpelunkyRequest.spelunkyWarning(adventure, Confirm.CONFIRM_SPELUNKY);
+    String message = SpelunkyRequest.spelunkyWarning(adventure, Confirm.SPELUNKY);
     if (message != null) {
       String image = SpelunkyRequest.adventureImage(adventure);
-      this.sendGeneralWarning(image != null ? image : "spelwhip.gif", message, Confirm.CONFIRM_SPELUNKY);
+      this.sendGeneralWarning(image != null ? image : "spelwhip.gif", message, Confirm.SPELUNKY);
       return true;
     }
 
@@ -3630,7 +3630,7 @@ public class RelayRequest extends PasswordHashRequest {
 
     if (nextAdventure != null
         && RecoveryManager.isRecoveryPossible()
-        && this.getFormField(Confirm.CONFIRM_RECOVERY) == null) {
+        && this.getFormField(Confirm.RECOVERY) == null) {
       boolean isScript = !isNonCombatsOnly && Preferences.getBoolean("relayRunsBeforeBattleScript");
       boolean isMood = !isNonCombatsOnly && Preferences.getBoolean("relayMaintainsEffects");
       boolean isHealth = !isNonCombatsOnly && Preferences.getBoolean("relayMaintainsHealth");
@@ -3644,7 +3644,7 @@ public class RelayRequest extends PasswordHashRequest {
         this.sendGeneralWarning(
             "beatenup.gif",
             "Between battle actions failed. Click the image if you'd like to continue anyway.",
-            Confirm.CONFIRM_RECOVERY);
+            Confirm.RECOVERY);
         return true;
       }
     }
@@ -3818,7 +3818,7 @@ public class RelayRequest extends PasswordHashRequest {
             "You do not have the \"I voted\" sticker equipped, to continue without, click the icon on the left to adventure. ");
         msg.append("If you want the sticker equipped, click the icon on the right to adventure. ");
         this.sendOptionalWarning(
-            Confirm.CONFIRM_STICKER,
+            Confirm.STICKER,
             msg.toString(),
             image,
             "ivoted.gif",
@@ -3830,7 +3830,7 @@ public class RelayRequest extends PasswordHashRequest {
             null,
             null);
       } else {
-        this.sendGeneralWarning(image, msg.toString(), Confirm.CONFIRM_COUNTER, isSkill);
+        this.sendGeneralWarning(image, msg.toString(), Confirm.COUNTER, isSkill);
       }
       return true;
     }

--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -2862,7 +2862,10 @@ public class RelayRequest extends PasswordHashRequest {
   }
 
   public void sendGeneralWarning(
-      final String image, final String message, final Confirm confirm, final boolean usePostMethod) {
+      final String image,
+      final String message,
+      final Confirm confirm,
+      final boolean usePostMethod) {
     this.sendGeneralWarning(image, message, confirm.toString(), null, usePostMethod);
   }
 

--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -2858,7 +2858,7 @@ public class RelayRequest extends PasswordHashRequest {
   }
 
   public void sendGeneralWarning(final String image, final String message, final Confirm confirm) {
-    this.sendGeneralWarning(image, message, confirm.toString(), null, false);
+    this.sendGeneralWarning(image, message, confirm, null, false);
   }
 
   public void sendGeneralWarning(
@@ -2866,18 +2866,18 @@ public class RelayRequest extends PasswordHashRequest {
       final String message,
       final Confirm confirm,
       final boolean usePostMethod) {
-    this.sendGeneralWarning(image, message, confirm.toString(), null, usePostMethod);
+    this.sendGeneralWarning(image, message, confirm, null, usePostMethod);
   }
 
   public void sendGeneralWarning(
       final String image, final String message, final Confirm confirm, final String extra) {
-    this.sendGeneralWarning(image, message, confirm.toString(), extra, false);
+    this.sendGeneralWarning(image, message, confirm, extra, false);
   }
 
   public void sendGeneralWarning(
       final String image,
       final String message,
-      final String confirm,
+      final Confirm confirm,
       final String extra,
       final boolean usePostMethod) {
     // Save for testing

--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -115,37 +115,44 @@ public class RelayRequest extends PasswordHashRequest {
   public static String specialCommandStatus = "";
   public static String redirectedCommandURL = "";
 
-  private static final String CONFIRM_COUNTER = "confirm0";
-  private static final String CONFIRM_MCD = "confirm2";
-  private static final String CONFIRM_FAMILIAR = "confirm3";
-  private static final String CONFIRM_RECOVERY = "confirm4";
-  private static final String CONFIRM_SORCERESS = "confirm5";
-  private static final String CONFIRM_WOSSNAME = "confirm6";
-  private static final String CONFIRM_TOKENS = "confirm7";
-  private static final String CONFIRM_SEAL = "confirm8";
-  private static final String CONFIRM_ARCADE = "confirm9";
-  static final String CONFIRM_KUNGFU = "confirm10";
-  private static final String CONFIRM_POOL_SKILL = "confirm11";
-  public static final String CONFIRM_WINEGLASS = "confirm12";
-  private static final String CONFIRM_COLOSSEUM = "confirm13";
-  private static final String CONFIRM_GREMLINS = "confirm14";
-  private static final String CONFIRM_HARDCOREPVP = "confirm15";
-  public static final String CONFIRM_DESERT_UNHYDRATED = "confirm16";
-  public static final String CONFIRM_MOHAWK_WIG = "confirm17";
-  private static final String CONFIRM_CELLAR = "confirm18";
-  private static final String CONFIRM_BOILER = "confirm19";
-  private static final String CONFIRM_DIARY = "confirm20";
-  private static final String CONFIRM_BORING_DOORS = "confirm21";
-  private static final String CONFIRM_SPELUNKY = "confirm22";
-  private static final String CONFIRM_ZEPPELIN = "confirm23";
-  private static final String CONFIRM_OVERDRUNK_ADVENTURE = "confirm24";
-  private static final String CONFIRM_STICKER = "confirm25";
-  private static final String CONFIRM_DESERT_OFFHAND = "confirm26";
-  public static final String CONFIRM_MACHETE = "confirm27";
-  public static final String CONFIRM_RALPH = "confirm28";
-  private static final String CONFIRM_RALPH1 = "confirm29";
-  private static final String CONFIRM_RALPH2 = "confirm30";
-  public static final String CONFIRM_DESERT_WEAPON = "confirm31";
+  public enum Confirm {
+    CONFIRM_COUNTER,
+    CONFIRM_MCD,
+    CONFIRM_FAMILIAR,
+    CONFIRM_RECOVERY,
+    CONFIRM_SORCERESS,
+    CONFIRM_WOSSNAME,
+    CONFIRM_TOKENS,
+    CONFIRM_SEAL,
+    CONFIRM_ARCADE,
+    CONFIRM_KUNGFU,
+    CONFIRM_POOL_SKILL,
+    CONFIRM_WINEGLASS,
+    CONFIRM_COLOSSEUM,
+    CONFIRM_GREMLINS,
+    CONFIRM_HARDCOREPVP,
+    CONFIRM_DESERT_UNHYDRATED,
+    CONFIRM_MOHAWK_WIG,
+    CONFIRM_CELLAR,
+    CONFIRM_BOILER,
+    CONFIRM_DIARY,
+    CONFIRM_BORING_DOORS,
+    CONFIRM_SPELUNKY,
+    CONFIRM_ZEPPELIN,
+    CONFIRM_OVERDRUNK_ADVENTURE,
+    CONFIRM_STICKER,
+    CONFIRM_DESERT_OFFHAND,
+    CONFIRM_MACHETE,
+    CONFIRM_RALPH,
+    CONFIRM_RALPH1,
+    CONFIRM_RALPH2,
+    CONFIRM_DESERT_WEAPON;
+
+    @Override
+    public String toString() {
+      return "confirm" + ordinal();
+    }
+  }
 
   private static boolean ignoreBoringDoorsWarning = false;
   public static boolean ignoreDesertWarning = false;
@@ -819,7 +826,7 @@ public class RelayRequest extends PasswordHashRequest {
 
     if (KoLCharacter.isKingdomOfExploathing()) {
       // If user has already confirmed he wants to break the prism, accept it
-      if (this.getFormField(CONFIRM_RALPH) != null) {
+      if (this.getFormField(Confirm.CONFIRM_RALPH) != null) {
         return false;
       }
 
@@ -834,7 +841,7 @@ public class RelayRequest extends PasswordHashRequest {
               + " If you are ready to break the prism, click on the icon on the left."
               + " If you wish to visit Cosmic Ray's Bazaar, click on icon on the right.";
       this.sendOptionalWarning(
-          CONFIRM_RALPH,
+          Confirm.CONFIRM_RALPH,
           warning,
           "hand.gif",
           "meatisotope.gif",
@@ -849,13 +856,13 @@ public class RelayRequest extends PasswordHashRequest {
       if (KoLCharacter.getFullness() < KoLCharacter.getFullnessLimit()
           && !RelayRequest.ignoreFullnessWarning) {
         // If it's already confirmed, then track that for the session
-        if (this.getFormField(CONFIRM_RALPH1) == null) {
+        if (this.getFormField(Confirm.CONFIRM_RALPH1) == null) {
           String warning =
               "When you stop being a plumber, you will lose five maximum fullness."
                   + " Since you are not yet full, perhaps you would like to eat more now?"
                   + " (It is not harmful to be over-full.)"
                   + " If you are sure you don't want to eat more at this time, click the icon. ";
-          this.sendGeneralWarning("knifefork.gif", warning, CONFIRM_RALPH1);
+          this.sendGeneralWarning("knifefork.gif", warning, Confirm.CONFIRM_RALPH1);
           return true;
         }
         RelayRequest.ignoreFullnessWarning = true;
@@ -869,7 +876,7 @@ public class RelayRequest extends PasswordHashRequest {
       // If you don't have any coins, nothing to spend
       if ( InventoryManager.getCount( ItemPool.COIN ) > 0 )
       {
-        if ( this.getFormField( CONFIRM_RALPH2 ) == null )
+        if ( this.getFormField( Confirm.CONFIRM_RALPH2 ) == null )
         {
           StringBuilder warning = new StringBuilder();
           warning.append( "When you stop being a plumber, you will lose access to the Mushroom District." );
@@ -877,7 +884,7 @@ public class RelayRequest extends PasswordHashRequest {
           warning.append( " If you are sure you don't want to spend your coins, click the icon on the left. " );
           warning.append( " If you wish to visit the Mushroom District, click on icon on the right." );
           this.sendOptionalWarning(
-            CONFIRM_RALPH2,
+            Confirm.CONFIRM_RALPH2,
             warning.toString(),
             "mario_coin.gif",
             "mario_mushroom1.gif",
@@ -898,7 +905,7 @@ public class RelayRequest extends PasswordHashRequest {
 
     if (KoLCharacter.inRobocore()) {
       // If user has already confirmed he wants to go there, accept it
-      if (this.getFormField(CONFIRM_RALPH) != null) {
+      if (this.getFormField(Confirm.CONFIRM_RALPH) != null) {
         return false;
       }
 
@@ -930,7 +937,7 @@ public class RelayRequest extends PasswordHashRequest {
       buf.append(" If you wish to visit the Scrapheap, click on icon on the right.");
 
       this.sendOptionalWarning(
-          CONFIRM_RALPH,
+          Confirm.CONFIRM_RALPH,
           buf.toString(),
           "hand.gif",
           "jigawatts.gif",
@@ -945,7 +952,7 @@ public class RelayRequest extends PasswordHashRequest {
 
     if (KoLCharacter.inDinocore()) {
       // If user has already confirmed he wants to go there, accept it
-      if (this.getFormField(CONFIRM_RALPH) != null) {
+      if (this.getFormField(Confirm.CONFIRM_RALPH) != null) {
         return false;
       }
 
@@ -960,7 +967,7 @@ public class RelayRequest extends PasswordHashRequest {
               + " If you are ready to break the prism, click on the icon on the left."
               + " If you wish to visit the Dino Staur, click on icon on the right.";
       this.sendOptionalWarning(
-          CONFIRM_RALPH,
+          Confirm.CONFIRM_RALPH,
           warning,
           "hand.gif",
           "dinobuck.gif",
@@ -971,6 +978,10 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     return false;
+  }
+
+  private String getFormField(Confirm confirm) {
+    return super.getFormField(confirm.toString());
   }
 
   private boolean checkCampVisit(final String urlString) {
@@ -1043,7 +1054,7 @@ public class RelayRequest extends PasswordHashRequest {
 
   private boolean sendCoinMasterWarning(final CoinmasterData camp) {
     // If user has already confirmed he wants to go there, accept it
-    if (this.getFormField(CONFIRM_TOKENS) != null) {
+    if (this.getFormField(Confirm.CONFIRM_TOKENS) != null) {
       return false;
     }
 
@@ -1060,7 +1071,7 @@ public class RelayRequest extends PasswordHashRequest {
         message
             + " Before you do so, you might want to redeem war loot for dimes and quarters and buy equipment. Click on the image to enter battle, once you are ready.";
 
-    this.sendGeneralWarning("lucre.gif", message, CONFIRM_TOKENS);
+    this.sendGeneralWarning("lucre.gif", message, Confirm.CONFIRM_TOKENS);
 
     return true;
   }
@@ -1077,7 +1088,7 @@ public class RelayRequest extends PasswordHashRequest {
       return false;
     }
 
-    if (this.getFormField(CONFIRM_COLOSSEUM) != null) {
+    if (this.getFormField(Confirm.CONFIRM_COLOSSEUM) != null) {
       return false;
     }
 
@@ -1135,7 +1146,7 @@ public class RelayRequest extends PasswordHashRequest {
             + weapon.getName()
             + ", click the icon on the right to closet it.";
     this.sendOptionalWarning(
-        CONFIRM_COLOSSEUM,
+        Confirm.CONFIRM_COLOSSEUM,
         warning,
         "hand.gif",
         image,
@@ -1156,7 +1167,7 @@ public class RelayRequest extends PasswordHashRequest {
 
   private boolean sendInfernalSealWarning(final String urlString) {
     // If user has already confirmed he wants to do it, accept it
-    if (this.getFormField(CONFIRM_SEAL) != null) {
+    if (this.getFormField(Confirm.CONFIRM_SEAL) != null) {
       return false;
     }
 
@@ -1185,7 +1196,7 @@ public class RelayRequest extends PasswordHashRequest {
     message =
         "You are trying to summon an infernal seal, but you are not wielding a club. You are either incredibly puissant or incredibly foolish. If you are sure you want to do this, click on the image and proceed to your doom.";
 
-    this.sendGeneralWarning("iblubbercandle.gif", message, CONFIRM_SEAL, "checked=1");
+    this.sendGeneralWarning("iblubbercandle.gif", message, Confirm.CONFIRM_SEAL, "checked=1");
 
     return true;
   }
@@ -1206,7 +1217,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If user has already confirmed he wants to do it, accept it
-    if (this.getFormField(CONFIRM_GREMLINS) != null) {
+    if (this.getFormField(Confirm.CONFIRM_GREMLINS) != null) {
       return false;
     }
 
@@ -1225,7 +1236,7 @@ public class RelayRequest extends PasswordHashRequest {
     message =
         "You are about to fight Gremlins, but do not have the Molybdenum Magnet. If you are sure you want to do this, click on the image to proceed.";
 
-    this.sendGeneralWarning("magnet2.gif", message, CONFIRM_GREMLINS);
+    this.sendGeneralWarning("magnet2.gif", message, Confirm.CONFIRM_GREMLINS);
 
     return true;
   }
@@ -1240,7 +1251,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // Don't remind a second time in a session if you decide not to do it.
-    if (urlString.contains(CONFIRM_HARDCOREPVP)) {
+    if (urlString.contains(Confirm.CONFIRM_HARDCOREPVP.toString())) {
       return false;
     }
 
@@ -1274,7 +1285,7 @@ public class RelayRequest extends PasswordHashRequest {
     message =
         "You have fights remaining and are still in Hardcore. If you are sure you don't want to use the fights in hardcore, click on the image to proceed.";
 
-    this.sendGeneralWarning("swords.gif", message, CONFIRM_HARDCOREPVP);
+    this.sendGeneralWarning("swords.gif", message, Confirm.CONFIRM_HARDCOREPVP);
 
     return true;
   }
@@ -1286,7 +1297,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(CONFIRM_DESERT_WEAPON) != null) {
+    if (this.getFormField(Confirm.CONFIRM_DESERT_WEAPON) != null) {
       RelayRequest.ignoreDesertWeaponWarning = true;
       return false;
     }
@@ -1320,7 +1331,7 @@ public class RelayRequest extends PasswordHashRequest {
               + "If you are sure you wish to adventure without it, click the icon on the left to adventure. "
               + "If you want to equip the survival knife first, click the icon on the right. ";
       this.sendOptionalWarning(
-          CONFIRM_DESERT_WEAPON,
+          Confirm.CONFIRM_DESERT_WEAPON,
           warning,
           "hand.gif",
           "maydayknife.gif",
@@ -1346,7 +1357,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(CONFIRM_DESERT_OFFHAND) != null) {
+    if (this.getFormField(Confirm.CONFIRM_DESERT_OFFHAND) != null) {
       RelayRequest.ignoreDesertOffhandWarning = true;
       return false;
     }
@@ -1386,7 +1397,7 @@ public class RelayRequest extends PasswordHashRequest {
               + "If you are sure you wish to adventure without it, click the icon on the left to adventure. "
               + "If you want to equip the ornate dowsing rod first, click the icon on the right. ";
       this.sendOptionalWarning(
-          CONFIRM_DESERT_OFFHAND,
+          Confirm.CONFIRM_DESERT_OFFHAND,
           warning,
           "hand.gif",
           "dowsingrod.gif",
@@ -1410,7 +1421,7 @@ public class RelayRequest extends PasswordHashRequest {
               + "If you are sure you wish to adventure without it, click the icon on the left to adventure. "
               + "If you want to equip the UV-resistant compass first, click the icon on the right. ";
       this.sendOptionalWarning(
-          CONFIRM_DESERT_OFFHAND,
+          Confirm.CONFIRM_DESERT_OFFHAND,
           warning,
           "hand.gif",
           "uvcompass.gif",
@@ -1427,7 +1438,7 @@ public class RelayRequest extends PasswordHashRequest {
       String message =
           "You are about to adventure without a UV-resistant compass in the desert. If you are sure you want to do this, click on the image to proceed.";
 
-      this.sendGeneralWarning("uvcompass.gif", message, CONFIRM_DESERT_OFFHAND);
+      this.sendGeneralWarning("uvcompass.gif", message, Confirm.CONFIRM_DESERT_OFFHAND);
     }
 
     return true;
@@ -1440,7 +1451,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(CONFIRM_DESERT_UNHYDRATED) != null) {
+    if (this.getFormField(Confirm.CONFIRM_DESERT_UNHYDRATED) != null) {
       RelayRequest.ignoreDesertWarning = true;
       return false;
     }
@@ -1472,7 +1483,7 @@ public class RelayRequest extends PasswordHashRequest {
             + "If you are sure you wish to adventure unhydrated, click the icon on the left to adventure. "
             + "If you want to visit the Oasis to get ultrahydrated, click the icon on the right to adventure. ";
     this.sendOptionalWarning(
-        CONFIRM_DESERT_UNHYDRATED,
+        Confirm.CONFIRM_DESERT_UNHYDRATED,
         warning,
         "poison.gif",
         "raindrop.gif",
@@ -1506,7 +1517,7 @@ public class RelayRequest extends PasswordHashRequest {
       buf.append(" first, click the icon on the right.");
 
       this.sendOptionalWarning(
-          CONFIRM_MACHETE,
+          Confirm.CONFIRM_MACHETE,
           buf.toString(),
           "hand.gif",
           image,
@@ -1548,7 +1559,7 @@ public class RelayRequest extends PasswordHashRequest {
       buf.append(ok2);
       buf.append(" If you want to visit the Scrapheap, click the icon on the right.");
       this.sendOptionalWarning(
-          CONFIRM_MACHETE,
+          Confirm.CONFIRM_MACHETE,
           buf.toString(),
           "hand.gif",
           resource,
@@ -1560,7 +1571,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     buf.append(ok1);
-    this.sendGeneralWarning("hand.gif", buf.toString(), CONFIRM_MACHETE);
+    this.sendGeneralWarning("hand.gif", buf.toString(), Confirm.CONFIRM_MACHETE);
   }
 
   public boolean sendMacheteWarning() {
@@ -1570,7 +1581,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(CONFIRM_MACHETE) != null) {
+    if (this.getFormField(Confirm.CONFIRM_MACHETE) != null) {
       RelayRequest.ignoreMacheteWarning = true;
       return false;
     }
@@ -1645,7 +1656,7 @@ public class RelayRequest extends PasswordHashRequest {
     // Otherwise just ask if you want to adventure
     String message =
         "You are about to adventure without a machete to fight dense lianas. If you are sure you want to do this, click on the image to proceed.";
-    this.sendGeneralWarning("machetwo.gif", message, CONFIRM_MACHETE);
+    this.sendGeneralWarning("machetwo.gif", message, Confirm.CONFIRM_MACHETE);
 
     return true;
   }
@@ -1657,7 +1668,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(CONFIRM_MOHAWK_WIG) != null) {
+    if (this.getFormField(Confirm.CONFIRM_MOHAWK_WIG) != null) {
       RelayRequest.ignoreMohawkWigWarning = true;
       return false;
     }
@@ -1698,7 +1709,7 @@ public class RelayRequest extends PasswordHashRequest {
       buf.append(" If you want to put the hat on first, click the icon on the right.");
 
       this.sendOptionalWarning(
-          CONFIRM_MOHAWK_WIG,
+          Confirm.CONFIRM_MOHAWK_WIG,
           buf.toString(),
           "hand.gif",
           "mohawk.gif",
@@ -1738,7 +1749,7 @@ public class RelayRequest extends PasswordHashRequest {
       buf.append(" If you want to visit the Scrapheap, click the icon on the right.");
 
       this.sendOptionalWarning(
-          CONFIRM_MOHAWK_WIG,
+          Confirm.CONFIRM_MOHAWK_WIG,
           buf.toString(),
           "hand.gif",
           image,
@@ -1750,7 +1761,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     buf.append(ok1);
-    this.sendGeneralWarning("hand.gif", buf.toString(), CONFIRM_MOHAWK_WIG);
+    this.sendGeneralWarning("hand.gif", buf.toString(), Confirm.CONFIRM_MOHAWK_WIG);
 
     return true;
   }
@@ -1762,7 +1773,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(CONFIRM_BORING_DOORS) != null) {
+    if (this.getFormField(Confirm.CONFIRM_BORING_DOORS) != null) {
       RelayRequest.ignoreBoringDoorsWarning = true;
       return false;
     }
@@ -1796,7 +1807,7 @@ public class RelayRequest extends PasswordHashRequest {
             + "If you are sure you wish to adventure without it, click the icon on the left to adventure. "
             + "If you want to put the ring on first, click the icon on the right. ";
     this.sendOptionalWarning(
-        CONFIRM_BORING_DOORS,
+        Confirm.CONFIRM_BORING_DOORS,
         warning,
         "hand.gif",
         "weddingring.gif",
@@ -1818,7 +1829,7 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(CONFIRM_POOL_SKILL) != null) {
+    if (this.getFormField(Confirm.CONFIRM_POOL_SKILL) != null) {
       RelayRequest.ignorePoolSkillWarning = true;
       return false;
     }
@@ -1970,14 +1981,14 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     this.sendOptionalWarning(
-        CONFIRM_POOL_SKILL, warning.toString(), "glove.gif", image2, action2, image3, action3);
+        Confirm.CONFIRM_POOL_SKILL, warning.toString(), "glove.gif", image2, action2, image3, action3);
 
     return true;
   }
 
   private boolean sendCellarWarning() {
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(CONFIRM_CELLAR) != null) {
+    if (this.getFormField(Confirm.CONFIRM_CELLAR) != null) {
       return false;
     }
 
@@ -2014,14 +2025,14 @@ public class RelayRequest extends PasswordHashRequest {
         "You are about to adventure without reading the Mortar dissolving recipe with glasses equipped. "
             + " If you are sure you want to do this, click on the image to proceed.";
 
-    this.sendGeneralWarning("burgerrecipe.gif", message, CONFIRM_CELLAR);
+    this.sendGeneralWarning("burgerrecipe.gif", message, Confirm.CONFIRM_CELLAR);
 
     return true;
   }
 
   private boolean sendZeppelinWarning() {
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(CONFIRM_ZEPPELIN) != null) {
+    if (this.getFormField(Confirm.CONFIRM_ZEPPELIN) != null) {
       return false;
     }
 
@@ -2051,7 +2062,7 @@ public class RelayRequest extends PasswordHashRequest {
             + "If you are sure you wish to adventure without it, click the icon on the left to adventure. "
             + "If you want to visit the Black Market, click the icon on the right. ";
     this.sendOptionalWarning(
-        CONFIRM_ZEPPELIN,
+        Confirm.CONFIRM_ZEPPELIN,
         warning,
         "hand.gif",
         "zepticket.gif",
@@ -2064,7 +2075,7 @@ public class RelayRequest extends PasswordHashRequest {
 
   private boolean sendBoilerWarning() {
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(CONFIRM_BOILER) != null) {
+    if (this.getFormField(Confirm.CONFIRM_BOILER) != null) {
       return false;
     }
 
@@ -2104,14 +2115,14 @@ public class RelayRequest extends PasswordHashRequest {
     message =
         "You are about to adventure in the Haunted Boiler Room, but do not have Unstable Fulminate equipped. If you are sure you want to do this, click on the image to proceed.";
 
-    this.sendGeneralWarning("wine2.gif", message, CONFIRM_BOILER);
+    this.sendGeneralWarning("wine2.gif", message, Confirm.CONFIRM_BOILER);
 
     return true;
   }
 
   private boolean sendDiaryWarning() {
     // If it's already confirmed, then track that for the session
-    if (this.getFormField(CONFIRM_DIARY) != null) {
+    if (this.getFormField(Confirm.CONFIRM_DIARY) != null) {
       return false;
     }
 
@@ -2149,13 +2160,13 @@ public class RelayRequest extends PasswordHashRequest {
     message =
         "You are about to adventure but have not obtained your father's MacGuffin diary. If you are sure you want to do this, click on the image to proceed.";
 
-    this.sendGeneralWarning("book2.gif", message, CONFIRM_DIARY);
+    this.sendGeneralWarning("book2.gif", message, Confirm.CONFIRM_DIARY);
 
     return true;
   }
 
   private boolean sendWossnameWarning(final CoinmasterData camp) {
-    if (this.getFormField(CONFIRM_WOSSNAME) != null) {
+    if (this.getFormField(Confirm.CONFIRM_WOSSNAME) != null) {
       return false;
     }
 
@@ -2168,13 +2179,13 @@ public class RelayRequest extends PasswordHashRequest {
             + " and open the way to their camp. However, you have not yet finished with the "
             + side2
             + ". If you are sure you don't want the Order of the Silver Wossname, click on the image and proceed.";
-    this.sendGeneralWarning("wossname.gif", message, CONFIRM_WOSSNAME);
+    this.sendGeneralWarning("wossname.gif", message, Confirm.CONFIRM_WOSSNAME);
 
     return true;
   }
 
   private boolean sendFamiliarWarning() {
-    if (this.getFormField(CONFIRM_FAMILIAR) != null) {
+    if (this.getFormField(Confirm.CONFIRM_FAMILIAR) != null) {
       return false;
     }
 
@@ -2217,7 +2228,7 @@ public class RelayRequest extends PasswordHashRequest {
         "<td align=center valign=center><div id=\"lucky\" style=\"padding: 4px 4px 4px 4px\"><a style=\"text-decoration: none\" href=\"");
     warning.append(url);
     warning.append(!url.contains("?") ? "?" : "&");
-    warning.append(CONFIRM_FAMILIAR);
+    warning.append(Confirm.CONFIRM_FAMILIAR);
     warning.append("=on\"><img src=\"/images/");
 
     if (familiar.getId() != FamiliarData.NO_FAMILIAR.getId()) {
@@ -2259,7 +2270,7 @@ public class RelayRequest extends PasswordHashRequest {
   }
 
   boolean sendKungFuWarning() {
-    if (this.getFormField(CONFIRM_KUNGFU) != null) {
+    if (this.getFormField(Confirm.CONFIRM_KUNGFU) != null) {
       return false;
     }
 
@@ -2295,7 +2306,7 @@ public class RelayRequest extends PasswordHashRequest {
         "<td align=center valign=center><div id=\"lucky\" style=\"padding: 4px 4px 4px 4px\"><a style=\"text-decoration: none\" href=\"");
     warning.append(url);
     warning.append(!url.contains("?") ? "?" : "&");
-    warning.append(CONFIRM_KUNGFU);
+    warning.append(Confirm.CONFIRM_KUNGFU);
     warning.append("=on\"><img src=\"/images/itemimages/kungfu.gif");
     warning.append("\" width=30 height=30 border=0>");
     warning.append("</a></div></td>");
@@ -2458,7 +2469,7 @@ public class RelayRequest extends PasswordHashRequest {
       return false;
     }
 
-    if (this.getFormField(CONFIRM_MCD) != null) {
+    if (this.getFormField(Confirm.CONFIRM_MCD) != null) {
       return false;
     }
 
@@ -2536,7 +2547,7 @@ public class RelayRequest extends PasswordHashRequest {
     warning.append("<tr align=center><td><a href=\"");
     warning.append(this.getURLString());
     warning.append("&");
-    warning.append(CONFIRM_MCD);
+    warning.append(Confirm.CONFIRM_MCD);
     warning.append("=on");
     warning.append("\"><img src=\"/images/adventureimages/");
     warning.append(image);
@@ -2602,7 +2613,7 @@ public class RelayRequest extends PasswordHashRequest {
       return false;
     }
 
-    if (urlString.contains(CONFIRM_SORCERESS)) {
+    if (urlString.contains(Confirm.CONFIRM_SORCERESS.toString())) {
       return false;
     }
 
@@ -2653,7 +2664,7 @@ public class RelayRequest extends PasswordHashRequest {
       }
 
       warning.append(" <span title=\"Bedroom\">Antique hand mirror</span>");
-      this.sendGeneralWarning("handmirror.gif", warning.toString(), CONFIRM_SORCERESS);
+      this.sendGeneralWarning("handmirror.gif", warning.toString(), Confirm.CONFIRM_SORCERESS);
       return true;
     }
 
@@ -2692,13 +2703,13 @@ public class RelayRequest extends PasswordHashRequest {
       }
     }
 
-    this.sendGeneralWarning("wand.gif", warning.toString(), CONFIRM_SORCERESS);
+    this.sendGeneralWarning("wand.gif", warning.toString(), Confirm.CONFIRM_SORCERESS);
     return true;
   }
 
   private boolean sendArcadeWarning() {
 
-    if (this.getFormField(CONFIRM_ARCADE) != null) {
+    if (this.getFormField(Confirm.CONFIRM_ARCADE) != null) {
       return false;
     }
 
@@ -2720,7 +2731,7 @@ public class RelayRequest extends PasswordHashRequest {
       this.sendGeneralWarning(
           "ggtoken.gif",
           "You might not be properly equipped to play this game.<br>Click the token if you'd like to continue anyway.",
-          CONFIRM_ARCADE);
+          Confirm.CONFIRM_ARCADE);
       return true;
     }
 
@@ -2732,7 +2743,7 @@ public class RelayRequest extends PasswordHashRequest {
       return false;
     }
 
-    if (this.getFormField(CONFIRM_WINEGLASS) != null) {
+    if (this.getFormField(Confirm.CONFIRM_WINEGLASS) != null) {
       return false;
     }
 
@@ -2760,7 +2771,7 @@ public class RelayRequest extends PasswordHashRequest {
             + "If this was an accident, click the icon in the center to equip Drunkula's wineglass. "
             + "If you want to adventure in a Drunken Stupor and not be nagged, click the icon on the right to closet Drunkula's wineglass.";
     this.sendOptionalWarning(
-        CONFIRM_WINEGLASS,
+        Confirm.CONFIRM_WINEGLASS,
         warning,
         "hand.gif",
         "dr_wineglass.gif",
@@ -2785,8 +2796,8 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // Don't warn again if you've already said ok to Wineglass warning about overdrunk (or this one)
-    if (this.getFormField(CONFIRM_OVERDRUNK_ADVENTURE) != null
-        || this.getFormField(CONFIRM_WINEGLASS) != null) {
+    if (this.getFormField(Confirm.CONFIRM_OVERDRUNK_ADVENTURE) != null
+        || this.getFormField(Confirm.CONFIRM_WINEGLASS) != null) {
       return false;
     }
 
@@ -2809,7 +2820,7 @@ public class RelayRequest extends PasswordHashRequest {
     String warning =
         "KoLmafia has detected that you are about to adventure while overdrunk. "
             + "If you are sure you wish to adventure in a Drunken Stupor, click the icon to adventure. ";
-    this.sendGeneralWarning("martini.gif", warning, CONFIRM_OVERDRUNK_ADVENTURE);
+    this.sendGeneralWarning("martini.gif", warning, Confirm.CONFIRM_OVERDRUNK_ADVENTURE);
     return true;
   }
 
@@ -2830,34 +2841,34 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // If the player has said he doesn't care about this warning, cool
-    if (this.getFormField(CONFIRM_SPELUNKY) != null) {
+    if (this.getFormField(Confirm.CONFIRM_SPELUNKY) != null) {
       return false;
     }
 
     // Depending on noncombat phase step and/or adventure location,
     // craft an appropriate warning
-    String message = SpelunkyRequest.spelunkyWarning(adventure, CONFIRM_SPELUNKY);
+    String message = SpelunkyRequest.spelunkyWarning(adventure, Confirm.CONFIRM_SPELUNKY);
     if (message != null) {
       String image = SpelunkyRequest.adventureImage(adventure);
-      this.sendGeneralWarning(image != null ? image : "spelwhip.gif", message, CONFIRM_SPELUNKY);
+      this.sendGeneralWarning(image != null ? image : "spelwhip.gif", message, Confirm.CONFIRM_SPELUNKY);
       return true;
     }
 
     return false;
   }
 
-  public void sendGeneralWarning(final String image, final String message, final String confirm) {
-    this.sendGeneralWarning(image, message, confirm, null, false);
+  public void sendGeneralWarning(final String image, final String message, final Confirm confirm) {
+    this.sendGeneralWarning(image, message, confirm.toString(), null, false);
   }
 
   public void sendGeneralWarning(
-      final String image, final String message, final String confirm, final boolean usePostMethod) {
-    this.sendGeneralWarning(image, message, confirm, null, usePostMethod);
+      final String image, final String message, final Confirm confirm, final boolean usePostMethod) {
+    this.sendGeneralWarning(image, message, confirm.toString(), null, usePostMethod);
   }
 
   public void sendGeneralWarning(
-      final String image, final String message, final String confirm, final String extra) {
-    this.sendGeneralWarning(image, message, confirm, extra, false);
+      final String image, final String message, final Confirm confirm, final String extra) {
+    this.sendGeneralWarning(image, message, confirm.toString(), extra, false);
   }
 
   public void sendGeneralWarning(
@@ -2950,7 +2961,7 @@ public class RelayRequest extends PasswordHashRequest {
   }
 
   public void sendOptionalWarning(
-      final String confirm,
+      final Confirm confirm,
       final String message,
       final String image1,
       final String image2,
@@ -3619,7 +3630,7 @@ public class RelayRequest extends PasswordHashRequest {
 
     if (nextAdventure != null
         && RecoveryManager.isRecoveryPossible()
-        && this.getFormField(CONFIRM_RECOVERY) == null) {
+        && this.getFormField(Confirm.CONFIRM_RECOVERY) == null) {
       boolean isScript = !isNonCombatsOnly && Preferences.getBoolean("relayRunsBeforeBattleScript");
       boolean isMood = !isNonCombatsOnly && Preferences.getBoolean("relayMaintainsEffects");
       boolean isHealth = !isNonCombatsOnly && Preferences.getBoolean("relayMaintainsHealth");
@@ -3633,7 +3644,7 @@ public class RelayRequest extends PasswordHashRequest {
         this.sendGeneralWarning(
             "beatenup.gif",
             "Between battle actions failed. Click the image if you'd like to continue anyway.",
-            CONFIRM_RECOVERY);
+            Confirm.CONFIRM_RECOVERY);
         return true;
       }
     }
@@ -3807,7 +3818,7 @@ public class RelayRequest extends PasswordHashRequest {
             "You do not have the \"I voted\" sticker equipped, to continue without, click the icon on the left to adventure. ");
         msg.append("If you want the sticker equipped, click the icon on the right to adventure. ");
         this.sendOptionalWarning(
-            CONFIRM_STICKER,
+            Confirm.CONFIRM_STICKER,
             msg.toString(),
             image,
             "ivoted.gif",
@@ -3819,7 +3830,7 @@ public class RelayRequest extends PasswordHashRequest {
             null,
             null);
       } else {
-        this.sendGeneralWarning(image, msg.toString(), CONFIRM_COUNTER, isSkill);
+        this.sendGeneralWarning(image, msg.toString(), Confirm.CONFIRM_COUNTER, isSkill);
       }
       return true;
     }

--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -876,7 +876,7 @@ public class RelayRequest extends PasswordHashRequest {
       // If you don't have any coins, nothing to spend
       if ( InventoryManager.getCount( ItemPool.COIN ) > 0 )
       {
-        if ( this.getFormField( Confirm.CONFIRM_RALPH2 ) == null )
+        if ( this.getFormField( Confirm.RALPH2 ) == null )
         {
           StringBuilder warning = new StringBuilder();
           warning.append( "When you stop being a plumber, you will lose access to the Mushroom District." );
@@ -884,7 +884,7 @@ public class RelayRequest extends PasswordHashRequest {
           warning.append( " If you are sure you don't want to spend your coins, click the icon on the left. " );
           warning.append( " If you wish to visit the Mushroom District, click on icon on the right." );
           this.sendOptionalWarning(
-            Confirm.CONFIRM_RALPH2,
+            Confirm.RALPH2,
             warning.toString(),
             "mario_coin.gif",
             "mario_mushroom1.gif",

--- a/src/net/sourceforge/kolmafia/request/SpelunkyRequest.java
+++ b/src/net/sourceforge/kolmafia/request/SpelunkyRequest.java
@@ -23,6 +23,7 @@ import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.RelayRequest.Confirm;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.utilities.ChoiceUtilities;
@@ -1052,7 +1053,7 @@ public class SpelunkyRequest extends GenericRequest {
     return String.valueOf(damage);
   }
 
-  public static String spelunkyWarning(final KoLAdventure adventure, final String confirm) {
+  public static String spelunkyWarning(final KoLAdventure adventure, final Confirm confirm) {
     // If we have won fewer than 3 combats since the last
     // noncombat, no noncombat is due.
 
@@ -1394,7 +1395,7 @@ public class SpelunkyRequest extends GenericRequest {
     return item.getCount(KoLConstants.inventory) > 0 || InventoryManager.getEquippedCount(item) > 0;
   }
 
-  private static String spelunkyLocationLink(String name, final int id, final String confirm) {
+  private static String spelunkyLocationLink(String name, final int id, final Confirm confirm) {
     return "<a href=\"adventure.php?snarfblat="
         + id
         + "&"

--- a/test/net/sourceforge/kolmafia/request/RelayRequestWarningsTest.java
+++ b/test/net/sourceforge/kolmafia/request/RelayRequestWarningsTest.java
@@ -111,7 +111,7 @@ public class RelayRequestWarningsTest {
   class KungFuFighting {
     private static final KoLAdventure WARREN =
         AdventureDatabase.getAdventureByName("The Dire Warren");
-    private static final Confirm confirm = Confirm.CONFIRM_KUNGFU;
+    private static final Confirm confirm = Confirm.KUNGFU;
 
     @Test
     public void shouldNotWarnWithoutEffect() {
@@ -183,7 +183,7 @@ public class RelayRequestWarningsTest {
         AdventureDatabase.getAdventureByName("The Dire Warren");
     private static final KoLAdventure CELLAR =
         AdventureDatabase.getAdventureByName("The Typical Tavern Cellar");
-    private static final Confirm confirm = Confirm.CONFIRM_WINEGLASS;
+    private static final Confirm confirm = Confirm.WINEGLASS;
 
     @Test
     public void thatNoWarningNeededIfNotOverDrunk() {
@@ -297,7 +297,7 @@ public class RelayRequestWarningsTest {
         AdventureDatabase.getAdventureByName("A-Boo Peak");
     private static final KoLAdventure CASTLE_TOP_FLOOR =
         AdventureDatabase.getAdventureByName("The Castle in the Clouds in the Sky (Top Floor)");
-    private static final Confirm confirm = Confirm.CONFIRM_MOHAWK_WIG;
+    private static final Confirm confirm = Confirm.MOHAWK_WIG;
     private static final AdventureResult MOHAWK_WIG = ItemPool.get(ItemPool.MOHAWK_WIG);
 
     @BeforeEach
@@ -475,7 +475,7 @@ public class RelayRequestWarningsTest {
         AdventureDatabase.getAdventureByName("A-Boo Peak");
     private static final KoLAdventure ARID_DESERT =
         AdventureDatabase.getAdventureByName("The Arid, Extra-Dry Desert");
-    private static final Confirm confirm = Confirm.CONFIRM_DESERT_WEAPON;
+    private static final Confirm confirm = Confirm.DESERT_WEAPON;
     private static final AdventureResult SURVIVAL_KNIFE = ItemPool.get(ItemPool.SURVIVAL_KNIFE);
 
     @Test
@@ -542,7 +542,7 @@ public class RelayRequestWarningsTest {
         AdventureDatabase.getAdventureByName("An Overgrown Shrine (Southeast)");
     private static final KoLAdventure ZIGGURAT =
         AdventureDatabase.getAdventureByName("A Massive Ziggurat");
-    private static final Confirm confirm = Confirm.CONFIRM_MACHETE;
+    private static final Confirm confirm = Confirm.MACHETE;
 
     private void testMacheteItem(RelayRequest request, int itemId) {
       // No warning if we have the machete equipped
@@ -676,7 +676,7 @@ public class RelayRequestWarningsTest {
       assertFalse(request.sendMacheteWarning());
 
       // No warning needed if this a resubmission of the "go ahead" URL
-      request.constructURLString(adventureURL(NW_SHRINE, Confirm.CONFIRM_MACHETE), true);
+      request.constructURLString(adventureURL(NW_SHRINE, Confirm.MACHETE), true);
       assertFalse(request.sendMacheteWarning());
       assertTrue(RelayRequest.ignoreMacheteWarning);
 
@@ -764,7 +764,7 @@ public class RelayRequestWarningsTest {
       public void shouldNotWarnInExploathingIfAlreadyConfirmed() {
         var cleanups = withPath(Path.KINGDOM_OF_EXPLOATHING);
         try (cleanups) {
-          String URL = prismURL(Confirm.CONFIRM_RALPH);
+          String URL = prismURL(Confirm.RALPH);
           RelayRequest request = new RelayRequest(false);
           request.constructURLString(URL);
           assertFalse(request.sendBreakPrismWarning(URL));
@@ -798,7 +798,7 @@ public class RelayRequestWarningsTest {
         try (cleanups) {
           // No warning needed if already confirmed
           RelayRequest request = new RelayRequest(false);
-          String URL = prismURL(Confirm.CONFIRM_RALPH);
+          String URL = prismURL(Confirm.RALPH);
           request.constructURLString(URL, true);
           assertFalse(request.sendBreakPrismWarning(URL));
         }
@@ -937,7 +937,7 @@ public class RelayRequestWarningsTest {
       public void shouldNotWarnInDinocoreIfAlreadyConfirmed() {
         var cleanups = withPath(Path.DINOSAURS);
         try (cleanups) {
-          String URL = prismURL(Confirm.CONFIRM_RALPH);
+          String URL = prismURL(Confirm.RALPH);
           RelayRequest request = new RelayRequest(false);
           request.constructURLString(URL);
           assertFalse(request.sendBreakPrismWarning(URL));
@@ -952,7 +952,7 @@ public class RelayRequestWarningsTest {
         AdventureDatabase.getAdventureByName("A-Boo Peak");
     private static final KoLAdventure DESERT =
         AdventureDatabase.getAdventureByName("The Arid, Extra-Dry Desert");
-    private static final Confirm confirm = Confirm.CONFIRM_DESERT_UNHYDRATED;
+    private static final Confirm confirm = Confirm.DESERT_UNHYDRATED;
 
     @BeforeEach
     public void beforeEach() {

--- a/test/net/sourceforge/kolmafia/request/RelayRequestWarningsTest.java
+++ b/test/net/sourceforge/kolmafia/request/RelayRequestWarningsTest.java
@@ -31,6 +31,7 @@ import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
 import net.sourceforge.kolmafia.persistence.QuestDatabase;
 import net.sourceforge.kolmafia.persistence.QuestDatabase.Quest;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.RelayRequest.Confirm;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import net.sourceforge.kolmafia.session.EquipmentRequirement;
 import net.sourceforge.kolmafia.session.YouRobotManager;
@@ -94,7 +95,7 @@ public class RelayRequestWarningsTest {
     KoLCharacter.setPath(Path.NONE);
   }
 
-  private String adventureURL(KoLAdventure adventure, String confirmation) {
+  private String adventureURL(KoLAdventure adventure, Confirm confirmation) {
     var request = adventure.getRequest();
     StringBuilder buf = new StringBuilder();
     buf.append(request.getURLString());
@@ -110,7 +111,7 @@ public class RelayRequestWarningsTest {
   class KungFuFighting {
     private static final KoLAdventure WARREN =
         AdventureDatabase.getAdventureByName("The Dire Warren");
-    private static final String confirm = RelayRequest.CONFIRM_KUNGFU;
+    private static final Confirm confirm = Confirm.CONFIRM_KUNGFU;
 
     @Test
     public void shouldNotWarnWithoutEffect() {
@@ -182,7 +183,7 @@ public class RelayRequestWarningsTest {
         AdventureDatabase.getAdventureByName("The Dire Warren");
     private static final KoLAdventure CELLAR =
         AdventureDatabase.getAdventureByName("The Typical Tavern Cellar");
-    private static final String confirm = RelayRequest.CONFIRM_WINEGLASS;
+    private static final Confirm confirm = Confirm.CONFIRM_WINEGLASS;
 
     @Test
     public void thatNoWarningNeededIfNotOverDrunk() {
@@ -296,7 +297,7 @@ public class RelayRequestWarningsTest {
         AdventureDatabase.getAdventureByName("A-Boo Peak");
     private static final KoLAdventure CASTLE_TOP_FLOOR =
         AdventureDatabase.getAdventureByName("The Castle in the Clouds in the Sky (Top Floor)");
-    private static final String confirm = RelayRequest.CONFIRM_MOHAWK_WIG;
+    private static final Confirm confirm = Confirm.CONFIRM_MOHAWK_WIG;
     private static final AdventureResult MOHAWK_WIG = ItemPool.get(ItemPool.MOHAWK_WIG);
 
     @BeforeEach
@@ -474,7 +475,7 @@ public class RelayRequestWarningsTest {
         AdventureDatabase.getAdventureByName("A-Boo Peak");
     private static final KoLAdventure ARID_DESERT =
         AdventureDatabase.getAdventureByName("The Arid, Extra-Dry Desert");
-    private static final String confirm = RelayRequest.CONFIRM_DESERT_WEAPON;
+    private static final Confirm confirm = Confirm.CONFIRM_DESERT_WEAPON;
     private static final AdventureResult SURVIVAL_KNIFE = ItemPool.get(ItemPool.SURVIVAL_KNIFE);
 
     @Test
@@ -541,7 +542,7 @@ public class RelayRequestWarningsTest {
         AdventureDatabase.getAdventureByName("An Overgrown Shrine (Southeast)");
     private static final KoLAdventure ZIGGURAT =
         AdventureDatabase.getAdventureByName("A Massive Ziggurat");
-    private static final String confirm = RelayRequest.CONFIRM_MACHETE;
+    private static final Confirm confirm = Confirm.CONFIRM_MACHETE;
 
     private void testMacheteItem(RelayRequest request, int itemId) {
       // No warning if we have the machete equipped
@@ -675,7 +676,7 @@ public class RelayRequestWarningsTest {
       assertFalse(request.sendMacheteWarning());
 
       // No warning needed if this a resubmission of the "go ahead" URL
-      request.constructURLString(adventureURL(NW_SHRINE, RelayRequest.CONFIRM_MACHETE), true);
+      request.constructURLString(adventureURL(NW_SHRINE, Confirm.CONFIRM_MACHETE), true);
       assertFalse(request.sendMacheteWarning());
       assertTrue(RelayRequest.ignoreMacheteWarning);
 
@@ -715,7 +716,7 @@ public class RelayRequestWarningsTest {
 
   @Nested
   class Prism {
-    private String prismURL(String confirmation) {
+    private String prismURL(Confirm confirmation) {
       StringBuilder buf = new StringBuilder();
       buf.append("place.php?whichplace=nstower&action=ns_11_prism");
       if (confirmation != null) {
@@ -763,7 +764,7 @@ public class RelayRequestWarningsTest {
       public void shouldNotWarnInExploathingIfAlreadyConfirmed() {
         var cleanups = withPath(Path.KINGDOM_OF_EXPLOATHING);
         try (cleanups) {
-          String URL = prismURL(RelayRequest.CONFIRM_RALPH);
+          String URL = prismURL(Confirm.CONFIRM_RALPH);
           RelayRequest request = new RelayRequest(false);
           request.constructURLString(URL);
           assertFalse(request.sendBreakPrismWarning(URL));
@@ -797,7 +798,7 @@ public class RelayRequestWarningsTest {
         try (cleanups) {
           // No warning needed if already confirmed
           RelayRequest request = new RelayRequest(false);
-          String URL = prismURL(RelayRequest.CONFIRM_RALPH);
+          String URL = prismURL(Confirm.CONFIRM_RALPH);
           request.constructURLString(URL, true);
           assertFalse(request.sendBreakPrismWarning(URL));
         }
@@ -936,7 +937,7 @@ public class RelayRequestWarningsTest {
       public void shouldNotWarnInDinocoreIfAlreadyConfirmed() {
         var cleanups = withPath(Path.DINOSAURS);
         try (cleanups) {
-          String URL = prismURL(RelayRequest.CONFIRM_RALPH);
+          String URL = prismURL(Confirm.CONFIRM_RALPH);
           RelayRequest request = new RelayRequest(false);
           request.constructURLString(URL);
           assertFalse(request.sendBreakPrismWarning(URL));
@@ -951,7 +952,7 @@ public class RelayRequestWarningsTest {
         AdventureDatabase.getAdventureByName("A-Boo Peak");
     private static final KoLAdventure DESERT =
         AdventureDatabase.getAdventureByName("The Arid, Extra-Dry Desert");
-    private static final String confirm = RelayRequest.CONFIRM_DESERT_UNHYDRATED;
+    private static final Confirm confirm = Confirm.CONFIRM_DESERT_UNHYDRATED;
 
     @BeforeEach
     public void beforeEach() {


### PR DESCRIPTION
These are "enum-like", in that they're all alike, and the numbers don't matter, only that they're distinct.

Generate them automatically instead. Most numbers do change, but the specific values don't matter.

This should make adding new ones slightly easier (as now you don't have to care about the string value).