### PR TITLE
fix: match modifier strings exactly

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -4803,7 +4803,7 @@ Throne	Underworld Bonsai	Spell Damage Percent: +10
 Throne	Uniclops	Experience (Mysticality): +2
 Throne	Untamed Turtle	Initiative: +20, Drops Items
 Throne	Urchin Urchin	Weapon Damage: +10
-Throne	Vampire Vintner	HP: +10, HP Regen Min: 10, HP Regen Max: 12
+Throne	Vampire Vintner	Maximum HP: +10, HP Regen Min: 10, HP Regen Max: 12
 Throne	Warbear Drone	Maximum HP: +10, Maximum MP: +10, Drops Items
 Throne	Wereturtle	Muscle Percent: +15, Drops Meat
 Throne	Whirling Maple Leaf	Spell Damage Percent: +10
@@ -6595,7 +6595,7 @@ Effect	Mixed Nutrients	Muscle: +15, Mysticality: +15, Moxie: +15
 Effect	Mmmmmelon	Item Drop: +30
 Effect	Mo' Hobo	Hobo Power: +10
 # Molasses Flooded: Makes you a better diver
-Effect	Molasses Flooded	Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)],
+Effect	Molasses Flooded	Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)]
 Effect	Monkeymask	Avatar: "damned dirty ape"
 Effect	monsters.enq	Monster Level: +25
 Effect	Monstrosi Tea	Monster Level: -30
@@ -7014,7 +7014,7 @@ Effect	Salamanderenity	MP Regen Min: 3, MP Regen Max: 4
 Effect	Salsa Satanica	Item Drop: +50
 Effect	Salt Rockin'	Moxie: +30
 # Salt Rush: Makes you a better diver
-Effect	Salt Rush	Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)],
+Effect	Salt Rush	Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)]
 # Salty Dogs: Makes you a better diver
 Effect	Salty Dogs	Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)]
 # Salty Mouth: You really need a beer...
@@ -7331,7 +7331,7 @@ Effect	Stenchtastic	Muscle Percent: +20, Mysticality Percent: +30, Moxie Percent
 Effect	Steroid Boost	Muscle: +2
 Effect	Stevedave's Shanty of Superiority	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10
 Effect	Stick Emporium Membership	Weapon Drop: +100
-Effect	Stickler for Promptness	Familiar Action Bonus: +20,
+Effect	Stickler for Promptness	Familiar Action Bonus: +20
 # Sticks and Stones: +50% Damage vs. Skeletons
 Effect	Sticky Fingers	Meat Drop: +20
 # Sticky Hands: Reduced chance of fumbling
@@ -7617,8 +7617,8 @@ Effect	Touched by a Ghost	Muscle Percent: [-(30+T)], Mysticality Percent: [-(30+
 Effect	Towering Strength	Muscle Percent: [100+2*min(50,pref(chessboardsCleared))]
 Effect	Toxic Vengeance	Muscle: [-T], Mysticality: [-T], Moxie: [-T], Stench Damage: [3*T], Spell Damage Percent: [3*T]
 Effect	Traditional Eating	Meat Drop: +25
-Effect	Trainbot Circuitry	MP: [T], MP Regen Min: [T/5], MP Regen Max: [T/5]
-Effect	Trainbot Tubing	HP: [T], HP Regen Min: [T/5], HP Regen Max: [T/5]
+Effect	Trainbot Circuitry	Maximum MP: [T], MP Regen Min: [T/5], MP Regen Max: [T/5]
+Effect	Trainbot Tubing	Maximum HP: [T], HP Regen Min: [T/5], HP Regen Max: [T/5]
 Effect	Trainbot Plating	Damage Reduction: [3*T]
 Effect	Trainbot Optics	Spell Damage Percent: [3*T]
 Effect	Trainbot Servomotors	Weapon Damage: [3*T]
@@ -12430,8 +12430,8 @@ RetroCape	vampire kiss	Muscle Percent: 30, Maximum HP: +50
 RetroCape	vampire kill	Muscle Percent: 30, Maximum HP: +50
 RetroCape	heck hold	Mysticality Percent: 30, Maximum MP: +50
 RetroCape	heck thrill	Mysticality Percent: 30, Maximum MP: +50, Experience (Mysticality): 3
-RetroCape	heck kiss	Mysticality Percent: 30, Maximum MP: +50,
-RetroCape	heck kill	Mysticality Percent: 30, Maximum MP: +50,
+RetroCape	heck kiss	Mysticality Percent: 30, Maximum MP: +50
+RetroCape	heck kill	Mysticality Percent: 30, Maximum MP: +50
 RetroCape	robot hold	Moxie Percent: 30, Maximum HP: +25, Maximum MP: +25
 RetroCape	robot thrill	Moxie Percent: 30, Maximum HP: +25, Maximum MP: +25, Experience (Moxie): 3
 RetroCape	robot kiss	Moxie Percent: 30, Maximum HP: +25, Maximum MP: +25

--- a/src/net/sourceforge/kolmafia/modifiers/BitmapModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/BitmapModifier.java
@@ -88,7 +88,7 @@ public enum BitmapModifier implements Modifier {
       }
 
       Matcher matcher = pattern.matcher(tag);
-      if (matcher.find()) {
+      if (matcher.matches()) {
         return modifier;
       }
     }

--- a/src/net/sourceforge/kolmafia/modifiers/BooleanModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/BooleanModifier.java
@@ -124,7 +124,7 @@ public enum BooleanModifier implements Modifier {
       }
 
       Matcher matcher = pattern.matcher(tag);
-      if (matcher.find()) {
+      if (matcher.matches()) {
         return modifier;
       }
     }

--- a/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
@@ -129,7 +129,7 @@ public enum DoubleModifier implements Modifier {
       new Pattern[] {
         Pattern.compile("Spell Damage ([+-]\\d+)$"), Pattern.compile("([+-]\\d+) Spell Damage"),
       },
-      Pattern.compile("(?:^|, )Spell Damage: " + EXPR)),
+      Pattern.compile("Spell Damage: " + EXPR)),
   SPELL_DAMAGE_PCT(
       "Spell Damage Percent",
       new Pattern[] {
@@ -225,7 +225,7 @@ public enum DoubleModifier implements Modifier {
   VOLLEYBALL_WEIGHT("Volleyball", Pattern.compile("Volley(?:ball)?: " + EXPR)),
   SOMBRERO_WEIGHT("Sombrero", Pattern.compile("Somb(?:rero)?: " + EXPR)),
   LEPRECHAUN_WEIGHT("Leprechaun", Pattern.compile("Lep(?:rechaun)?: " + EXPR)),
-  FAIRY_WEIGHT("Fairy", Pattern.compile("(?:^|, )Fairy: " + EXPR)),
+  FAIRY_WEIGHT("Fairy", Pattern.compile("Fairy: " + EXPR)),
   MEATDROP_PENALTY("Meat Drop Penalty", Pattern.compile("Meat Drop Penalty: " + EXPR)),
   HIDDEN_FAMILIAR_WEIGHT(
       "Hidden Familiar Weight", Pattern.compile("Familiar Weight \\(hidden\\): " + EXPR)),
@@ -295,7 +295,7 @@ public enum DoubleModifier implements Modifier {
       Pattern.compile("([+-]\\d+) Moxie Stat.*Per Fight"),
       Pattern.compile("Experience \\(Moxie\\): " + EXPR),
       "Experience (Moxie)"),
-  EFFECT_DURATION("Effect Duration", Pattern.compile("(?:^|, )Effect Duration: " + EXPR)),
+  EFFECT_DURATION("Effect Duration", Pattern.compile("Effect Duration: " + EXPR)),
   CANDYDROP(
       "Candy Drop",
       Pattern.compile("([+-]\\d+)% Candy Drops? [Ff]rom Monsters$"),
@@ -502,7 +502,7 @@ public enum DoubleModifier implements Modifier {
         Pattern.compile("Sauce Spell Damage ([+-]\\d+)$"),
         Pattern.compile("([+-]\\d+) Sauce Spell Damage"),
       },
-      Pattern.compile("(?:^|, )Sauce Spell Damage: " + EXPR)),
+      Pattern.compile("Sauce Spell Damage: " + EXPR)),
   MONSTER_LEVEL_PERCENT(
       "Monster Level Percent",
       Pattern.compile("([+-]\\d+)% Monster Level"),
@@ -590,7 +590,7 @@ public enum DoubleModifier implements Modifier {
       }
 
       Matcher matcher = pattern.matcher(tag);
-      if (matcher.find()) {
+      if (matcher.matches()) {
         return modifier;
       }
     }

--- a/src/net/sourceforge/kolmafia/modifiers/StringModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/StringModifier.java
@@ -28,7 +28,7 @@ public enum StringModifier implements Modifier {
   MODIFIERS("Modifiers", Pattern.compile("^(none)$")),
   OUTFIT("Outfit", null),
   STAT_TUNING("Stat Tuning", Pattern.compile("Stat Tuning: \"(.*?)\"")),
-  EFFECT("Effect", Pattern.compile("(?:^|, )Effect: \"(.*?)\"")),
+  EFFECT("Effect", Pattern.compile("Effect: \"(.*?)\"")),
   EQUIPS_ON("Equips On", Pattern.compile("Equips On: \"(.*?)\"")),
   FAMILIAR_EFFECT("Familiar Effect", Pattern.compile("Familiar Effect: \"(.*?)\"")),
   JIGGLE("Jiggle", Pattern.compile("Jiggle: *(.*?)$"), Pattern.compile("Jiggle: \"(.*?)\"")),
@@ -120,7 +120,7 @@ public enum StringModifier implements Modifier {
       }
 
       Matcher matcher = pattern.matcher(tag);
-      if (matcher.find()) {
+      if (matcher.matches()) {
         return modifier;
       }
     }

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -680,9 +680,8 @@ public class ModifierDatabase {
         newMods.setString(mod, value);
         break;
       }
-
-      newMods.setString(StringModifier.MODIFIERS, string);
     }
+    newMods.setString(StringModifier.MODIFIERS, list.toString());
 
     return newMods;
   }

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -567,110 +567,122 @@ public class ModifierDatabase {
   }
 
   public static final Modifiers parseModifiers(final Lookup lookup, final String string) {
+    return parseModifiers(lookup, splitModifiers(string));
+  }
+
+  public static final Modifiers parseModifiers(final Lookup lookup, final ModifierList list) {
     Modifiers newMods = new Modifiers();
 
     newMods.setLookup(lookup);
 
-    for (var mod : DoubleModifier.DOUBLE_MODIFIERS) {
-      Pattern pattern = mod.getTagPattern();
-      if (pattern == null) {
-        continue;
-      }
+    for (var modValue : list) {
+      var string = modValue.toString();
 
-      Matcher matcher = pattern.matcher(string);
-      if (!matcher.find()) {
-        continue;
-      }
-
-      if (matcher.group(1) != null) {
-        newMods.setDouble(mod, Double.parseDouble(matcher.group(1)));
-      } else {
-        newMods.addExpression(
-            new Indexed<>(mod, ModifierExpression.getInstance(matcher.group(2), lookup)));
-      }
-    }
-
-    for (var mod : BitmapModifier.BITMAP_MODIFIERS) {
-      Pattern pattern = mod.getTagPattern();
-      if (pattern == null) {
-        continue;
-      }
-
-      Matcher matcher = pattern.matcher(string);
-      if (!matcher.find()) {
-        continue;
-      }
-      int bitcount = 1;
-      if (matcher.groupCount() > 0) {
-        bitcount = StringUtilities.parseInt(matcher.group(1));
-        if (mod == BitmapModifier.CLOWNINESS) {
-          bitcount = bitcount / 25;
-        }
-      }
-      // bitmapMasks stores the next mask we're going to use for modifier mod
-      int mask = bitmapMasks.get(mod);
-      switch (bitcount) {
-        case 1 -> bitmapMasks.put(mod, mask << 1);
-        case 2 -> {
-          bitmapMasks.put(mod, mask << 2);
-          mask |= mask << 1;
-        }
-        case 3 -> {
-          bitmapMasks.put(mod, mask << 3);
-          mask |= mask << 1;
-          mask |= mask << 1;
-        }
-        default -> {
-          KoLmafia.updateDisplay(
-              "ERROR: invalid count for bitmap modifier in " + lookup.toString());
+      for (var mod : DoubleModifier.DOUBLE_MODIFIERS) {
+        Pattern pattern = mod.getTagPattern();
+        if (pattern == null) {
           continue;
         }
-      }
-      if (bitmapMasks.get(mod) == 0) {
-        KoLmafia.updateDisplay(
-            "ERROR: too many sources for bitmap modifier "
-                + mod.getName()
-                + ", consider using longs.");
+
+        Matcher matcher = pattern.matcher(string);
+        if (!matcher.matches()) {
+          continue;
+        }
+
+        if (matcher.group(1) != null) {
+          newMods.setDouble(mod, Double.parseDouble(matcher.group(1)));
+        } else {
+          newMods.addExpression(
+              new Indexed<>(mod, ModifierExpression.getInstance(matcher.group(2), lookup)));
+        }
+        break;
       }
 
-      newMods.addBitmap(mod, mask);
+      for (var mod : BitmapModifier.BITMAP_MODIFIERS) {
+        Pattern pattern = mod.getTagPattern();
+        if (pattern == null) {
+          continue;
+        }
+
+        Matcher matcher = pattern.matcher(string);
+        if (!matcher.matches()) {
+          continue;
+        }
+        int bitcount = 1;
+        if (matcher.groupCount() > 0) {
+          bitcount = StringUtilities.parseInt(matcher.group(1));
+          if (mod == BitmapModifier.CLOWNINESS) {
+            bitcount = bitcount / 25;
+          }
+        }
+        // bitmapMasks stores the next mask we're going to use for modifier mod
+        int mask = bitmapMasks.get(mod);
+        switch (bitcount) {
+          case 1 -> bitmapMasks.put(mod, mask << 1);
+          case 2 -> {
+            bitmapMasks.put(mod, mask << 2);
+            mask |= mask << 1;
+          }
+          case 3 -> {
+            bitmapMasks.put(mod, mask << 3);
+            mask |= mask << 1;
+            mask |= mask << 1;
+          }
+          default -> {
+            KoLmafia.updateDisplay(
+                "ERROR: invalid count for bitmap modifier in " + lookup.toString());
+            continue;
+          }
+        }
+        if (bitmapMasks.get(mod) == 0) {
+          KoLmafia.updateDisplay(
+              "ERROR: too many sources for bitmap modifier "
+                  + mod.getName()
+                  + ", consider using longs.");
+        }
+
+        newMods.addBitmap(mod, mask);
+        break;
+      }
+
+      for (var mod : BooleanModifier.BOOLEAN_MODIFIERS) {
+        Pattern pattern = mod.getTagPattern();
+        if (pattern == null) {
+          continue;
+        }
+
+        Matcher matcher = pattern.matcher(string);
+        if (!matcher.matches()) {
+          continue;
+        }
+
+        newMods.setBoolean(mod, true);
+        break;
+      }
+
+      for (var mod : StringModifier.STRING_MODIFIERS) {
+        Pattern pattern = mod.getTagPattern();
+        if (pattern == null) {
+          continue;
+        }
+
+        Matcher matcher = pattern.matcher(string);
+        if (!matcher.matches()) {
+          continue;
+        }
+
+        String value = matcher.group(1);
+
+        if (mod == StringModifier.CLASS) {
+          value = StringModifier.depluralizeClassName(value);
+        }
+
+        newMods.setString(mod, value);
+        break;
+      }
+
+      newMods.setString(StringModifier.MODIFIERS, string);
     }
-
-    for (var mod : BooleanModifier.BOOLEAN_MODIFIERS) {
-      Pattern pattern = mod.getTagPattern();
-      if (pattern == null) {
-        continue;
-      }
-
-      Matcher matcher = pattern.matcher(string);
-      if (!matcher.find()) {
-        continue;
-      }
-
-      newMods.setBoolean(mod, true);
-    }
-
-    for (var mod : StringModifier.STRING_MODIFIERS) {
-      Pattern pattern = mod.getTagPattern();
-      if (pattern == null) {
-        continue;
-      }
-
-      Matcher matcher = pattern.matcher(string);
-      if (!matcher.find()) {
-        continue;
-      }
-
-      String value = matcher.group(1);
-
-      if (mod == StringModifier.CLASS) {
-        value = StringModifier.depluralizeClassName(value);
-      }
-
-      newMods.setString(mod, value);
-    }
-
-    newMods.setString(StringModifier.MODIFIERS, string);
 
     return newMods;
   }


### PR DESCRIPTION
Fix issue reported in https://kolmafia.us/threads/gelnoob-skills-are-counted-in-rollover-adventures.28682/

Fix logic to check each modifier individually instead of matching on the whole string.

Also run `checkmodifiers` and fix the reported issues.