### PR TITLE
Never set campawayTentAvailable to false when viewing woods

### DIFF
--- a/src/net/sourceforge/kolmafia/moods/HPRestoreItemList.java
+++ b/src/net/sourceforge/kolmafia/moods/HPRestoreItemList.java
@@ -160,12 +160,9 @@ public abstract class HPRestoreItemList {
   public static void updateHealthRestored() {
     HPRestoreItemList.CAMPGROUND.healthPerUse = KoLCharacter.getRestingHP();
     HPRestoreItemList.FREEREST.healthPerUse =
-        ChateauRequest.chateauRestUsable()
+        (ChateauRequest.chateauRestUsable() || CampAwayRequest.campAwayTentRestUsable())
             ? 250
-            : (Preferences.getBoolean("restUsingCampAwayTent")
-                    && Preferences.getBoolean("getawayCampsiteUnlocked"))
-                ? 250
-                : KoLCharacter.getRestingHP();
+            : KoLCharacter.getRestingHP();
     HPRestoreItemList.SOFA.healthPerUse = KoLCharacter.getLevel() * 5 + 1;
     HPRestoreItemList.DISCONAP.healthPerUse =
         KoLCharacter.hasSkill(SkillPool.ADVENTURER_OF_LEISURE) ? 40 : 20;

--- a/src/net/sourceforge/kolmafia/moods/MPRestoreItemList.java
+++ b/src/net/sourceforge/kolmafia/moods/MPRestoreItemList.java
@@ -150,12 +150,9 @@ public abstract class MPRestoreItemList {
   public static void updateManaRestored() {
     MPRestoreItemList.CAMPGROUND.manaPerUse = KoLCharacter.getRestingMP();
     MPRestoreItemList.FREEREST.manaPerUse =
-        ChateauRequest.chateauRestUsable()
+        (ChateauRequest.chateauRestUsable() || CampAwayRequest.campAwayTentRestUsable())
             ? 125
-            : (Preferences.getBoolean("restUsingCampAwayTent")
-                    && Preferences.getBoolean("getawayCampsiteUnlocked"))
-                ? 125
-                : KoLCharacter.getRestingMP();
+            : KoLCharacter.getRestingMP();
     MPRestoreItemList.SOFA.manaPerUse = KoLCharacter.getLevel() * 5 + 1;
     MPRestoreItemList.MYSTERY_JUICE.manaPerUse = (int) (KoLCharacter.getLevel() * 1.5f) + 5;
     MPRestoreItemList.GENERIC_MANA.manaPerUse = (int) (KoLCharacter.getLevel() * 2.5f);

--- a/src/net/sourceforge/kolmafia/request/CampAwayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CampAwayRequest.java
@@ -270,11 +270,15 @@ public class CampAwayRequest extends PlaceRequest {
     return true;
   }
 
-  public static boolean campAwayTentRestUsable() {
-    return Preferences.getBoolean("restUsingCampAwayTent")
-        && Preferences.getBoolean("getawayCampsiteUnlocked")
+  public static boolean campAwayTentAvailable() {
+    return Preferences.getBoolean("getawayCampsiteUnlocked")
         && StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Distant Woods Getaway Brochure")
         && !KoLCharacter.getLimitMode().limitZone("Woods")
         && !KoLCharacter.inBadMoon();
+  }
+
+  public static boolean campAwayTentRestUsable() {
+    return Preferences.getBoolean("restUsingCampAwayTent")
+        && CampAwayRequest.campAwayTentAvailable();
   }
 }

--- a/src/net/sourceforge/kolmafia/request/PlaceRequest.java
+++ b/src/net/sourceforge/kolmafia/request/PlaceRequest.java
@@ -301,8 +301,10 @@ public class PlaceRequest extends GenericRequest {
         }
       }
       case "woods" -> {
-        if (!responseText.contains("You are not yet ready to be here."))
-          Preferences.setBoolean("getawayCampsiteUnlocked", responseText.contains("campaway"));
+        if (!responseText.contains("You are not yet ready to be here.")
+            && responseText.contains("campaway")) {
+          Preferences.setBoolean("getawayCampsiteUnlocked", true);
+        }
       }
       case "wildfire_camp" -> WildfireCampRequest.parseResponse(urlString, responseText);
       default -> {


### PR DESCRIPTION
Your Getaway Campsite is unlocked by using the IOTM.
There is no "day pass" to get access.
If we saw you use the item, we set getawayCampsiteAvailable to true
If we see it in the woods, we set getawayCampsiteAvailable to true.

If it restricted, you will not see it in the woods.

1) Do NOT set that property to false in that case; you still own the IOTM
2) Model usage of the tent for HP/MP recovery exactly on how we do it for the Chateau:
CampAwayRequest.campAwayTentAvailable is true if you have it and have access to it.
CampAwayRequest.campAwayTentRestUsable is true if "restUsingCampAwayTent" is true and it is available.
3) HPRestoreList and MPRestoreList using that latter function (a la how it uses the Chateau) rather than explicitly checking properties on its own. This means it correctly detects standard restrictions, etc.