### PR TITLE
feat: add `equipped_amount(item, boolean)`.

### DIFF
--- a/src/net/sourceforge/kolmafia/session/InventoryManager.java
+++ b/src/net/sourceforge/kolmafia/session/InventoryManager.java
@@ -221,15 +221,7 @@ public abstract class InventoryManager {
       count += item.getCount(ClanManager.getStash());
     }
 
-    count += InventoryManager.getEquippedCount(item);
-
-    for (FamiliarData current : KoLCharacter.ownedFamiliars()) {
-      if (!current.equals(KoLCharacter.getFamiliar())
-          && current.getItem() != null
-          && current.getItem().equals(item)) {
-        ++count;
-      }
-    }
+    count += InventoryManager.getEquippedCount(item, true);
 
     return count;
   }
@@ -239,11 +231,25 @@ public abstract class InventoryManager {
   }
 
   public static final int getEquippedCount(final AdventureResult item) {
+    return getEquippedCount(item, false);
+  }
+
+  public static final int getEquippedCount(
+      final AdventureResult item, boolean includeAllFamiliars) {
     int count = 0;
     for (var slot : SlotSet.SLOTS) {
       AdventureResult equipment = EquipmentManager.getEquipment(slot);
       if (equipment != null && equipment.getItemId() == item.getItemId()) {
         ++count;
+      }
+    }
+    if (includeAllFamiliars) {
+      for (FamiliarData current : KoLCharacter.ownedFamiliars()) {
+        if (!current.equals(KoLCharacter.getFamiliar())
+            && current.getItem() != null
+            && current.getItem().equals(item)) {
+          ++count;
+        }
       }
     }
     return count;

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -71,7 +71,6 @@ import net.sourceforge.kolmafia.combat.CombatActionManager;
 import net.sourceforge.kolmafia.combat.Macrofier;
 import net.sourceforge.kolmafia.combat.MonsterStatusTracker;
 import net.sourceforge.kolmafia.equipment.Slot;
-import net.sourceforge.kolmafia.equipment.SlotSet;
 import net.sourceforge.kolmafia.maximizer.Boost;
 import net.sourceforge.kolmafia.maximizer.Maximizer;
 import net.sourceforge.kolmafia.maximizer.PriceLevel;
@@ -1174,6 +1173,9 @@ public abstract class RuntimeLibrary {
     functions.add(new LibraryFunction("closet_amount", DataTypes.INT_TYPE, params));
 
     params = new Type[] {DataTypes.ITEM_TYPE};
+    functions.add(new LibraryFunction("equipped_amount", DataTypes.INT_TYPE, params));
+
+    params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.BOOLEAN_TYPE};
     functions.add(new LibraryFunction("equipped_amount", DataTypes.INT_TYPE, params));
 
     params = new Type[] {DataTypes.ITEM_TYPE};
@@ -5518,15 +5520,18 @@ public abstract class RuntimeLibrary {
 
   public static Value equipped_amount(ScriptRuntime controller, final Value arg) {
     AdventureResult item = ItemPool.get((int) arg.intValue(), 0);
-    int runningTotal = 0;
+    int amount = InventoryManager.getEquippedCount(item);
 
-    for (var slot : SlotSet.SLOTS) {
-      if (EquipmentManager.getEquipment(slot).equals(item)) {
-        ++runningTotal;
-      }
-    }
+    return new Value(amount);
+  }
 
-    return new Value(runningTotal);
+  public static Value equipped_amount(
+      ScriptRuntime controller, final Value arg0, final Value arg1) {
+    AdventureResult item = ItemPool.get((int) arg0.intValue(), 0);
+    boolean includeAllFamiliars = arg1.intValue() == 1;
+    int amount = InventoryManager.getEquippedCount(item, includeAllFamiliars);
+
+    return new Value(amount);
   }
 
   public static Value creatable_amount(ScriptRuntime controller, final Value arg) {

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -592,6 +592,20 @@ public class Player {
   }
 
   /**
+   * Adds familiar to player's terrarium, but does not take it out
+   *
+   * @param familiarId Familiar to add
+   * @param itemId Item for familiar to equip
+   * @return Removes familiar from the terrarium
+   */
+  public static Cleanups withFamiliarInTerrariumWithItem(final int familiarId, final int itemId) {
+    var familiar = FamiliarData.registerFamiliar(familiarId, 0);
+    familiar.setItem(ItemPool.get(itemId, 1));
+    KoLCharacter.addFamiliar(familiar);
+    return new Cleanups(() -> KoLCharacter.removeFamiliar(familiar));
+  }
+
+  /**
    * Takes familiar as player's current familiar
    *
    * @param familiarId Familiar to take


### PR DESCRIPTION
Takes a boolean parameter on whether to check all familiars (including those not currently out).

Works like `available_amount`, but just the equipped bit.