### PR TITLE
Getaway unlocked

### DIFF
--- a/src/net/sourceforge/kolmafia/session/QuestManager.java
+++ b/src/net/sourceforge/kolmafia/session/QuestManager.java
@@ -1095,11 +1095,6 @@ public class QuestManager {
     if (responseText.contains("action=emptybm")) {
       Preferences.setInteger("lastWuTangDefeated", KoLCharacter.getAscensions());
     }
-
-    if (!responseText.contains("You are not yet ready to be here.")
-        && responseText.contains("campaway")) {
-      Preferences.setBoolean("getawayCampsiteUnlocked", true);
-    }
   }
 
   private static void handleBatholeChange(final String responseText) {

--- a/src/net/sourceforge/kolmafia/session/QuestManager.java
+++ b/src/net/sourceforge/kolmafia/session/QuestManager.java
@@ -1095,9 +1095,10 @@ public class QuestManager {
     if (responseText.contains("action=emptybm")) {
       Preferences.setInteger("lastWuTangDefeated", KoLCharacter.getAscensions());
     }
-    if (!responseText.contains("You are not yet ready to be here.")) {
-      // Detect if the Getaway Campsite is available
-      Preferences.setBoolean("getawayCampsiteUnlocked", responseText.contains("campaway"));
+
+    if (!responseText.contains("You are not yet ready to be here.")
+        && responseText.contains("campaway")) {
+      Preferences.setBoolean("getawayCampsiteUnlocked", true);
     }
   }
 


### PR DESCRIPTION
I previously fixed this by updating PlaceRequest to only set access to the Getaway Campsite if you actually see it; do not remove access if you don't see it.

Turns out QuestManager had code that undid that.

It's not a quest. PlaceRequest by itself suffices.
