### PR TITLE
refactor: reuse attributes instead of separate flags 

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -524,7 +524,7 @@ public class DebugDatabase {
     return StringUtilities.parseInt(matcher.group(1));
   }
 
-  private static StringBuilder appendAccessTypes(StringBuilder accessTypes, String accessType) {
+  private static StringBuilder appendAccessTypes(StringBuilder accessTypes, Attribute accessType) {
     if (accessTypes.length() > 0) {
       return accessTypes.append(",").append(accessType);
     }
@@ -537,23 +537,23 @@ public class DebugDatabase {
     if (text.contains("Quest Item")
         || text.contains("This item will disappear at the end of the day.")
         || text.contains("May not be moved out of inventory")) {
-      accessTypes = appendAccessTypes(accessTypes, ItemDatabase.QUEST_FLAG);
+      accessTypes = appendAccessTypes(accessTypes, Attribute.QUEST);
     }
 
     // Quest items cannot be gifted or traded
     else if (text.contains("Gift Item") && !text.contains("gift package")) {
-      accessTypes = appendAccessTypes(accessTypes, ItemDatabase.GIFT_FLAG);
+      accessTypes = appendAccessTypes(accessTypes, Attribute.GIFT);
     }
 
     // Gift items cannot be (normally) traded
     else if (!text.contains("Cannot be traded")) {
-      accessTypes = appendAccessTypes(accessTypes, ItemDatabase.TRADE_FLAG);
+      accessTypes = appendAccessTypes(accessTypes, Attribute.TRADEABLE);
     }
 
     // We shouldn't just check for "discarded", in case "discarded" appears somewhere else in the
     // description.
     if (!text.contains("Cannot be discarded") && !text.contains("Cannot be traded or discarded")) {
-      accessTypes = appendAccessTypes(accessTypes, ItemDatabase.DISCARD_FLAG);
+      accessTypes = appendAccessTypes(accessTypes, Attribute.DISCARDABLE);
     }
 
     return accessTypes.toString();
@@ -2338,7 +2338,7 @@ public class DebugDatabase {
     // Don't bother checking quest items
     String access = ItemDatabase.getAccessById(id);
     boolean logit = false;
-    if (access != null && !access.contains(ItemDatabase.QUEST_FLAG)) {
+    if (access != null && !access.contains(Attribute.QUEST.description)) {
       String otherPlural;
       boolean checkApi = InventoryManager.getCount(itemId) > 1;
       if (checkApi) {

--- a/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
@@ -138,7 +138,7 @@ public class ItemDatabase {
     String[] accessTypes = data.split("\\s*,\\s*");
     for (String accessType : accessTypes) {
       if (!ACCESS.contains(Attribute.byDescription(accessType))) {
-        return "";
+        throw new IllegalStateException("Data file contained unrecognised flag");
       }
     }
     return data;

--- a/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
@@ -80,12 +80,6 @@ public class ItemDatabase {
   private static final Map<Integer, int[]> itemSourceByNoobSkillId = new HashMap<>();
   private static final Map<Integer, Integer> noobSkillIdByItemSource = new HashMap<>();
 
-  public static final String QUEST_FLAG = "q";
-  public static final String GIFT_FLAG = "g";
-  public static final String TRADE_FLAG = "t";
-  public static final String DISCARD_FLAG = "d";
-  public static final String BOGUS_FLAG = "z";
-
   private record Alias(int id, String name) {}
 
   private static final Alias[] ALIASES = {
@@ -131,20 +125,20 @@ public class ItemDatabase {
     new Alias(-1, "vial of slime: moxiousness"),
   };
 
-  private static final List<String> ACCESS =
-      Arrays.asList(QUEST_FLAG, GIFT_FLAG, TRADE_FLAG, DISCARD_FLAG);
+  private static final EnumSet<Attribute> ACCESS =
+      EnumSet.of(Attribute.QUEST, Attribute.GIFT, Attribute.TRADEABLE, Attribute.DISCARDABLE);
 
   private ItemDatabase() {}
 
   private static String parseAccess(final String data) {
     if (data.equals("")) {
-      return data;
+      return "";
     }
 
     String[] accessTypes = data.split("\\s*,\\s*");
     for (String accessType : accessTypes) {
-      if (!ACCESS.contains(accessType)) {
-        return BOGUS_FLAG;
+      if (!ACCESS.contains(Attribute.byDescription(accessType))) {
+        return "";
       }
     }
     return data;
@@ -197,6 +191,11 @@ public class ItemDatabase {
               .findAny();
       search.ifPresent(x -> attributeByDescription.put(description, x));
       return search.orElse(null);
+    }
+
+    @Override
+    public String toString() {
+      return this.description;
     }
   }
 
@@ -356,10 +355,9 @@ public class ItemDatabase {
         ItemDatabase.nameById.put(id, displayName);
 
         ItemDatabase.accessById.put(id, access);
-        if (access.contains(TRADE_FLAG)) attrs.add(Attribute.TRADEABLE);
-        if (access.contains(GIFT_FLAG)) attrs.add(Attribute.GIFT);
-        if (access.contains(QUEST_FLAG)) attrs.add(Attribute.QUEST);
-        if (access.contains(DISCARD_FLAG)) attrs.add(Attribute.DISCARDABLE);
+        for (Attribute a : ACCESS) {
+          if (access.contains(a.description)) attrs.add(a);
+        }
 
         ItemDatabase.attributesById.put(itemId, attrs);
 
@@ -863,7 +861,7 @@ public class ItemDatabase {
       // Assume defaults
       ItemDatabase.useTypeById.put(itemId, ConsumptionType.NONE);
       ItemDatabase.attributesById.put(itemId, EnumSet.noneOf(Attribute.class));
-      ItemDatabase.accessById.put(id, TRADE_FLAG + "," + DISCARD_FLAG);
+      ItemDatabase.accessById.put(id, Attribute.TRADEABLE + "," + Attribute.DISCARDABLE);
       ItemDatabase.priceById.put(itemId, 0);
       return;
     }
@@ -885,10 +883,9 @@ public class ItemDatabase {
     ItemDatabase.accessById.put(id, access);
 
     EnumSet<Attribute> attrs = DebugDatabase.typeToSecondary(type, usage, text, multi);
-    if (access.contains(TRADE_FLAG)) attrs.add(Attribute.TRADEABLE);
-    if (access.contains(GIFT_FLAG)) attrs.add(Attribute.GIFT);
-    if (access.contains(QUEST_FLAG)) attrs.add(Attribute.QUEST);
-    if (access.contains(DISCARD_FLAG)) attrs.add(Attribute.DISCARDABLE);
+    for (Attribute a : ACCESS) {
+      if (access.contains(a.description)) attrs.add(a);
+    }
     if (multi && usage != ConsumptionType.USE_MULTIPLE) {
       attrs.add(Attribute.MULTIPLE);
     }


### PR DESCRIPTION
Instead of having separate flag variables which duplicate attribute flags, just use the attributes directly.

Also crash if we encounter an unknown flag instead of ignoring that line. It represents a data problem that should be fixed. 