### PR TITLE
fix: bird of the day doesn't show up in maximizer

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -5291,6 +5291,7 @@ Effect	Blessing of Serqet	Monster Level: +20
 Effect	Blessing of She-Who-Was	Mysticality: +5, Spooky Damage: +5
 # Blessing of Squirtlcthulli: Recover HP and MP after battle
 Effect	Blessing of Squirtlcthulli	HP Regen Min: 2, HP Regen Max: 10, MP Regen Min: 2, MP Regen Max: 10
+Effect	Blessing of the Bird	none
 Effect	Blessing of the Creepy Pasta	Spooky Spell Damage: +20, Sleaze Resistance: +2
 Effect	Blessing of the Frozen Tortellini	Cold Spell Damage: +20, Stench Resistance: +2
 Effect	Blessing of the Hot Linguine	Hot Spell Damage: +20, Cold Resistance: +2
@@ -5299,6 +5300,7 @@ Effect	Blessing of the Spaghetto	Spell Damage: +40, Hot Resistance: +2, Cold Res
 Effect	Blessing of the Stinking Alphredo&trade;	Stench Spell Damage: +20, Spooky Resistance: +2
 Effect	Blessing of the Storm Tortoise	Initiative: +5, Maximum MP: +10
 Effect	Blessing of the War Snapper	Muscle: +5, Weapon Damage: +5
+Effect	Blessing of your favorite Bird	none
 Effect	Blinking Belly	Combat Rate: +10
 Effect	Block-Rockin' Beet	Damage Reduction: 15
 # Blood Bond: Lose 8-10 HP per Adventure

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -19,6 +19,7 @@ import static internal.helpers.Player.withItem;
 import static internal.helpers.Player.withLocation;
 import static internal.helpers.Player.withMeat;
 import static internal.helpers.Player.withNotAllowedInStandard;
+import static internal.helpers.Player.withOverrideModifiers;
 import static internal.helpers.Player.withPath;
 import static internal.helpers.Player.withProperty;
 import static internal.helpers.Player.withRestricted;
@@ -35,6 +36,7 @@ import java.util.Optional;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.equipment.Slot;
@@ -1638,6 +1640,53 @@ public class MaximizerTest {
       try (cleanups) {
         assertTrue(maximize("Monster Level"));
         assertFalse(someBoostIs(x -> commandStartsWith(x, "drink 1 1950 Vampire Vintner wine")));
+      }
+    }
+  }
+
+  @Nested
+  class Skills {
+    @Test
+    public void suggestsSkillsIfRelevant() {
+      var cleanups = new Cleanups(withSkill(SkillPool.SCARYSAUCE));
+
+      try (cleanups) {
+        assertTrue(maximize("cold res"));
+        assertTrue(someBoostIs(x -> commandStartsWith(x, "cast 1 Scarysauce")));
+      }
+    }
+
+    @Nested
+    class BirdOfTheDay {
+      @Test
+      public void suggestsBirdIfRelevant() {
+        var cleanups =
+            new Cleanups(
+                withProperty("_canSeekBirds", true),
+                withProperty("_birdOfTheDay", "Filthy Smiling Pine Parrot"),
+                withProperty(
+                    "_birdOfTheDayMods",
+                    "Mysticality Percent: +75, Stench Resistance: +2, Experience: +2, MP Regen Min: 10, MP Regen Max: 20"),
+                withProperty("yourFavoriteBird", "Southern Clandestine Fig Chachalaca"),
+                withProperty(
+                    "yourFavoriteBirdMods",
+                    "Stench Resistance: +2, Combat Rate: -9, MP Regen Min: 10, MP Regen Max: 20"),
+                withSkill(SkillPool.SEEK_OUT_A_BIRD),
+                withSkill(SkillPool.VISIT_YOUR_FAVORITE_BIRD),
+                withOverrideModifiers(
+                    ModifierType.EFFECT,
+                    2551,
+                    "Mysticality Percent: +75, Stench Resistance: +2, Experience: +2, MP Regen Min: 10, MP Regen Max: 20"),
+                withOverrideModifiers(
+                    ModifierType.EFFECT,
+                    2552,
+                    "Stench Resistance: +2, Combat Rate: -9, MP Regen Min: 10, MP Regen Max: 20"));
+
+        try (cleanups) {
+          assertTrue(maximize("mp regen"));
+          assertTrue(someBoostIs(x -> commandStartsWith(x, "cast 1 Seek out a Bird")));
+          assertTrue(someBoostIs(x -> commandStartsWith(x, "cast 1 Visit your Favorite Bird")));
+        }
       }
     }
   }


### PR DESCRIPTION
Issue introduced in #1307.

The problem is that `getAllModifiers` checks `modifierStringsByName` for keys, but `overrideModifier` only modifies `modifiersByName`. So if we override a modifier that isn't in `modifiers.txt`, the maximizer won't see it.

I wrote the test in r26967 to confirm this was the issue, then fixed it.