### PR TITLE
feat: add modifier to strings by name if key not present

### DIFF
--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -1273,4 +1273,9 @@ public class Modifiers {
   public static void setFamiliar(FamiliarData fam) {
     Modifiers.currentFamiliar = fam == null ? "" : fam.getRace();
   }
+
+  @Override
+  public String toString() {
+    return this.getString(StringModifier.MODIFIERS);
+  }
 }

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -985,6 +985,11 @@ public class ModifierDatabase {
   }
 
   private static final void overrideModifierInternal(final Lookup lookup, final Modifiers value) {
+    if (!modifierStringsByName.containsKey(lookup.type, lookup.getKey())
+        && !(lookup.type == ModifierType.GENERATED)) {
+      RequestLogger.updateSessionLog("WARNING: updated modifier not in modifiers.txt");
+      modifierStringsByName.put(lookup.type, lookup.getKey(), value.toString());
+    }
     modifiersByName.put(lookup.type, lookup.getKey(), value);
   }
 


### PR DESCRIPTION
Follow-up to #1596.

I couldn't get the other data structure working, so I think warning + add current modifiers is the best we can do.

We shouldn't remove the modifier we overrode from strings if removing the override: strings is loaded once and never reset. Ideally we would remove it only if it wasn't present to begin with, but we have no way of knowing that.