### PR TITLE
Improve handling of cellar elemental choices

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -613,6 +613,7 @@ public class ItemPool {
   public static final int ANTIQUE_HAND_MIRROR = 2092;
   public static final int TOWEL = 2095;
   public static final int GMOB_POLLEN = 2096;
+  public static final int SEVENTEEN_BALL = 2097;
   public static final int LUCRE = 2098;
   public static final int ASCII_SHIRT = 2121;
   public static final int TOY_MERCENARY = 2139;

--- a/src/net/sourceforge/kolmafia/request/YourCampfireRequest.java
+++ b/src/net/sourceforge/kolmafia/request/YourCampfireRequest.java
@@ -4,7 +4,6 @@ import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.CoinmasterData;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
-import net.sourceforge.kolmafia.preferences.Preferences;
 
 public class YourCampfireRequest extends CoinMasterRequest {
   public static final String master = "Your Campfire";
@@ -61,9 +60,7 @@ public class YourCampfireRequest extends CoinMasterRequest {
   }
 
   public static String accessible() {
-    return Preferences.getBoolean("getawayCampsiteUnlocked")
-        ? null
-        : "Need access to your Getaway Campsite";
+    return CampAwayRequest.campAwayTentAvailable() ? null : "Need access to your Getaway Campsite";
   }
 
   public static final boolean registerRequest(final String urlString) {

--- a/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
@@ -2709,8 +2709,14 @@ public abstract class ChoiceAdventures {
     // Choice 494 is unknown
     // Choice 495 is unknown
 
-    // Choice 496 is Crate Expectations
-    // -> can skip if have +20 hot damage
+    // Crate Expectations
+    new ChoiceAdventure(
+        496,
+        "Woods",
+        "Typical Tavern",
+        // Option...
+        new ChoiceOption("3 bottles of basic booze"),
+        new ChoiceOption("Get rid of crate without spending and adventure"));
 
     // Choice 497 is SHAFT!
     // Choice 498 is unknown
@@ -2797,12 +2803,32 @@ public abstract class ChoiceAdventures {
         new ChoiceOption("fight"),
         SKIP_ADVENTURE);
 
-    // Choice 513 is Staring Down the Barrel
-    // -> can skip if have +20 cold damage
-    // Choice 514 is 1984 Had Nothing on This Cellar
-    // -> can skip if have +20 stench damage
-    // Choice 515 is A Rat's Home...
-    // -> can skip if have +20 spooky damage
+    // Staring Down the Barrel
+    new ChoiceAdventure(
+        513,
+        "Woods",
+        "Typical Tavern",
+        // Option...
+        new ChoiceOption("3-5 ice-cold Willers"),
+        new ChoiceOption("Get rid of crate without spending and adventure"));
+
+    // 1984 Had Nothing on This Cellar
+    new ChoiceAdventure(
+        514,
+        "Woods",
+        "Typical Tavern",
+        // Option...
+        new ChoiceOption("3-5 rat whiskers and smiling rat (once)"),
+        new ChoiceOption("Get rid of crate without spending and adventure"));
+
+    // A Rat's Home...
+    new ChoiceAdventure(
+        515,
+        "Woods",
+        "Typical Tavern",
+        // Option...
+        new ChoiceOption("3 bottles of tequila"),
+        new ChoiceOption("Get rid of crate without spending and adventure"));
 
     // Choice 516 is unknown
     // Choice 517 is Mr. Alarm, I Presarm

--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -12,6 +12,7 @@ import net.sourceforge.kolmafia.KoLmafiaASH;
 import net.sourceforge.kolmafia.KoLmafiaCLI;
 import net.sourceforge.kolmafia.RequestEditorKit;
 import net.sourceforge.kolmafia.RequestLogger;
+import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.OutfitPool;
@@ -1156,6 +1157,54 @@ public abstract class ChoiceManager {
 
         if (decision.equals("1") && Preferences.getInteger("seaodesFound") == 3) {
           return "2";
+        }
+        return decision;
+
+        // These choices always have option 1, which takes a turn and
+        // gives you some items.
+        //
+        // If you have at least 20 of a particular kind of elemental
+        // damage, option 2 is available, which passes the choice
+        // without taking a turn.
+        //
+        // We could parse the page to make sure the option is actually
+        // available, but we'll be doing that later, anyway.
+        //
+        // Lets check the specific elemental weapon damage.
+
+        // Crate Expectations
+      case 496:
+        if (decision.equals("2")) {
+          if (KoLCharacter.currentNumericModifier(DoubleModifier.HOT_DAMAGE) < 20) {
+            return "1";
+          }
+        }
+        return decision;
+
+      case 513:
+        // Staring Down the Barrel
+        if (decision.equals("2")) {
+          if (KoLCharacter.currentNumericModifier(DoubleModifier.COLD_DAMAGE) < 20) {
+            return "1";
+          }
+        }
+        return decision;
+
+      case 514:
+        // 1984 Had Nothing on This Cellar
+        if (decision.equals("2")) {
+          if (KoLCharacter.currentNumericModifier(DoubleModifier.STENCH_DAMAGE) < 20) {
+            return "1";
+          }
+        }
+        return decision;
+
+      case 515:
+        // A Rat's Home...
+        if (decision.equals("2")) {
+          if (KoLCharacter.currentNumericModifier(DoubleModifier.SPOOKY_DAMAGE) < 20) {
+            return "1";
+          }
         }
         return decision;
 

--- a/test/net/sourceforge/kolmafia/session/ChoiceManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/ChoiceManagerTest.java
@@ -3,6 +3,7 @@ package net.sourceforge.kolmafia.session;
 import static internal.helpers.Networking.assertGetRequest;
 import static internal.helpers.Networking.assertPostRequest;
 import static internal.helpers.Networking.html;
+import static internal.helpers.Player.withAllEquipped;
 import static internal.helpers.Player.withContinuationState;
 import static internal.helpers.Player.withHP;
 import static internal.helpers.Player.withHandlingChoice;
@@ -451,6 +452,35 @@ public class ChoiceManagerTest {
         String ONE_SHARD = html("request/test_slagging_off_one_shard.html");
         int option = ChoiceManager.getDecision(SLAGGING_OFF, ONE_SHARD);
         // Always returns 1 so choice spoilers in the relay browser work.
+        assertEquals(1, option);
+      }
+    }
+  }
+
+  @Nested
+  class TavernChoices {
+    private static final int STARING_DOWN_THE_BARREL = 513;
+    private static final String property = "choiceAdventure513";
+
+    @Test
+    public void sufficientElementalDamageAllowsOption2() {
+      var cleanups =
+          new Cleanups(
+              withProperty(property, 2),
+              withAllEquipped(ItemPool.SEAL_CLUB, ItemPool.SEVENTEEN_BALL));
+      try (cleanups) {
+        String responseText = html("request/test_explore_cellar_choice.html");
+        int option = ChoiceManager.getDecision(STARING_DOWN_THE_BARREL, responseText);
+        assertEquals(2, option);
+      }
+    }
+
+    @Test
+    public void insufficientElementalDamageForcesOption1() {
+      var cleanups = new Cleanups(withProperty(property, 2), withAllEquipped(ItemPool.SEAL_CLUB));
+      try (cleanups) {
+        String responseText = html("request/test_explore_cellar_choice.html");
+        int option = ChoiceManager.getDecision(STARING_DOWN_THE_BARREL, responseText);
         assertEquals(1, option);
       }
     }

--- a/test/root/request/test_explore_cellar_choice.html
+++ b/test/root/request/test_explore_cellar_choice.html
@@ -1,0 +1,213 @@
+<html><head>
+<script language=Javascript>
+<!--
+if (parent.frames.length == 0) location.href="game.php";
+top.charpane.location.href="charpane.php";
+//-->
+</script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/jquery-1.5.1.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/keybinds.min.2.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/window.20111231.js"></script>
+<script language="javascript">function chatFocus(){if(top.chatpane.document.chatform.graf) top.chatpane.document.chatform.graf.focus();}
+if (typeof defaultBind != 'undefined') { defaultBind(47, 2, chatFocus); defaultBind(190, 2, chatFocus);defaultBind(191, 2, chatFocus); defaultBind(47, 8, chatFocus);defaultBind(190, 8, chatFocus); defaultBind(191, 8, chatFocus); }</script><script>
+function switchFocus()
+{
+	if (top.chatpane.document.chatform.graf.focus) 
+		top.chatpane.document.chatform.graf.focus(); 
+	return false;
+}
+function repeat()
+{
+	var linx = document.getElementsByTagName("A");
+	for (var i = 0; i < linx.length; i++)
+	{
+		if (typeof timersfunc != 'undefined') {
+			if (!timersfunc()) { 
+				return; 
+			}
+			timersfunc = null;
+		}
+		var link = linx[i];
+		if (link.innerHTML.match(/Adventure Again/) || link.innerHTML.match(/Do it again/))
+			location.href = link.href;
+	}
+}
+
+defaultBind(47, CTRL, switchFocus);
+defaultBind(191, CTRL, switchFocus);
+defaultBind(47, META, switchFocus);
+defaultBind(191, META, switchFocus);
+defaultBind(192, NONE, repeat);
+defaultBind(220, NONE, repeat);
+</script><script language="javascript">
+	function updateParseItem(iid, field, info) {
+		var tbl = $('#ic'+iid);
+		var data = parseItem(tbl);
+		if (!data) return;
+		data[field] = info;
+		var out = [];
+		for (i in data) {
+			if (!data.hasOwnProperty(i)) continue;
+			out.push(i+'='+data[i]);
+		}
+		tbl.attr('rel', out.join('&'));
+	}
+	function parseItem(tbl) {
+		tbl = $(tbl);
+		var rel = tbl.attr('rel');
+		var data = {};
+		if (!rel) return data;
+		var parts = rel.split('&');
+		for (i in parts) {
+			if (!parts.hasOwnProperty(i)) continue;
+			var kv = parts[i].split('=');
+			tbl.data(kv[0], kv[1]);
+			data[kv[0]] = kv[1];
+		}
+		return data;
+	}
+</script><script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/pop_query.20130705.js"></script>
+<script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/ircm.20161111.js"></script>
+<script type="text/javascript">
+var tp = top;
+function pop_ircm_contents(i, some) {
+	var contents = '',
+		shown = 0,
+		da = '&nbsp;<a href="#" rel="?" class="small dojaxy">[some]</a>&nbsp;<a href="#" rel="',
+		db = '" class="small dojaxy">[all]</a>',
+		dc = '<div style="width:100%; padding-bottom: 3px;" rel="',
+		dd = '<a href="#" rel="1" class="small dojaxy">[';
+	one = 'one'; ss=some;
+if (i.d==1 && i.s>0) { shown++; 
+contents += dc + 'sellstuff.php?action=sell&ajax=1&type=quant&whichitem%5B%5D=IID&howmany=NUM&pwd=ffe586e7b22887b5c3c0fd43a4ffe340" id="pircm_'+i.id+'"><b>Auto-Sell ('+i.s+' meat):</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'inventory.php?action=closetpush&ajax=1&whichitem=IID&qty=NUM&pwd=ffe586e7b22887b5c3c0fd43a4ffe340" id="pircm_'+i.id+'"><b>Closet:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0 && i.g==0 && i.t==1) { shown++; 
+contents += dc + 'managestore.php?action=additem&qty1=NUM&item1=IID&price1=&limit1=&ajax=1&pwd=ffe586e7b22887b5c3c0fd43a4ffe340" id="pircm_'+i.id+'"><b>Stock in Mall:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'managecollection.php?action=put&ajax=1&whichitem1=IID&howmany1=NUM&pwd=ffe586e7b22887b5c3c0fd43a4ffe340" id="pircm_'+i.id+'"><b>Add to Display Case:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0 && i.t==1) { shown++; 
+contents += dc + 'clan_stash.php?action=addgoodies&ajax=1&item1=IID&qty1=NUM&pwd=ffe586e7b22887b5c3c0fd43a4ffe340" id="pircm_'+i.id+'"><b>Contribute to Clan:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && !i.ac) { shown++; 
+contents += dc + 'inv_'+(i.u=="a"?"redir":(lab=(i.u=="u"?"use":(i.u=="e"?"eat":(i.u=="b"?"booze":(i.u=="s"?"spleen":"equip"))))))+'.php?ajax=1&whichitem=IID&itemquantity=NUM&quantity=NUM'+(i.u=="q"?"&action=equip":"")+'&pwd=ffe586e7b22887b5c3c0fd43a4ffe340" id="pircm_'+i.id+'"><b>'+ucfirst(unescape(i.ou ? i.ou.replace(/\+/g," ") : (lab=="booze"?"drink":lab)))+':</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=1&ajax=1&whichitem=IID&action=equip&pwd=ffe586e7b22887b5c3c0fd43a4ffe340" id="pircm_'+i.id+'"><b>Equip (slot 1):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=2&ajax=1&whichitem=IID&action=equip&pwd=ffe586e7b22887b5c3c0fd43a4ffe340" id="pircm_'+i.id+'"><b>Equip (slot 2):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=3&ajax=1&whichitem=IID&action=equip&pwd=ffe586e7b22887b5c3c0fd43a4ffe340" id="pircm_'+i.id+'"><b>Equip (slot 3):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+
+	return [contents, shown];
+}
+tp=top
+var todo = [];
+function nextAction() {
+	var next_todo = todo.shift();
+	if (next_todo) {
+		eval(next_todo);
+	}
+}
+function dojax(dourl, afterFunc, hoverCaller, failureFunc, method, params) {
+	$.ajax({
+		type: method || 'GET', url: dourl, cache: false,
+		data: params || null,
+		global: false,
+		success: function (out) {
+			nextAction();
+			if (out.match(/no\|/)) {
+				var parts = out.split(/\|/);
+				if (failureFunc) failureFunc(parts[1]);
+				else if (window.dojaxFailure) window.dojaxFailure(parts[1]);
+				else if (tp.chatpane.handleMessage) tp.chatpane.handleMessage({type: 'event', msg: 'Oops!  Sorry, Dave, you appear to be ' + parts[1]});
+				else  $('#ChatWindow').append('<font color="green">Oops!  Sorry, Dave, you appear to be ' + parts[1] + '.</font><br />' + "\n");
+				return;
+			}
+
+			if (hoverCaller)  {
+				float_results(hoverCaller, out);
+				if (afterFunc) { afterFunc(out); }
+				return;
+			}
+$(tp.mainpane.document).find("#effdiv").remove(); if(!window.dontscroll || (window.dontscroll && dontscroll==0)) { window.scroll(0,0);}
+			var $eff = $(tp.mainpane.document).find('#effdiv');
+			if ($eff.length == 0) {
+				var d = tp.mainpane.document.createElement('DIV');
+				d.id = 'effdiv';
+				var b = tp.mainpane.document.body;
+				if ($('#content_').length > 0) {
+					b = $('#content_ div:first')[0];
+				}
+				b.insertBefore(d, b.firstChild);
+				$eff = $(d);
+			}
+			$eff.find('a[name="effdivtop"]').remove().end()
+				.prepend('<a name="effdivtop"></a><center>' + out + '</center>').css('display','block');
+			if (!window.dontscroll || (window.dontscroll && dontscroll==0)) {
+				tp.mainpane.document.location = tp.mainpane.document.location + "#effdivtop";
+			}
+			if (afterFunc) { afterFunc(out); }
+		}
+	});
+}
+</script><script>
+
+var currentkey = 49;
+$(document).ready(function () {
+	$('form').each(function () {
+		var form = this;
+		defaultBind(currentkey++, NONE, function () { form.submit(); });
+		return currentkey < 58;
+	});
+});
+
+</script>	<link rel="stylesheet" type="text/css" href="https://d2uyhvukfffg5a.cloudfront.net/styles.20230117d.css">
+<style type='text/css'>
+.faded {
+	zoom: 1;
+	filter: alpha(opacity=35);
+	opacity: 0.35;
+	-khtml-opacity: 0.35; 
+    -moz-opacity: 0.35;
+}
+</style>
+
+</head>
+
+<body>
+<Center><centeR><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="color: white;" align=center bgcolor=blue><b>Staring Down the Barrel</b></td></tr><tr><td style="padding: 5px; border: 1px solid blue;"><center><table><tr><td><center><img src="https://d2uyhvukfffg5a.cloudfront.net/adventureimages/barrel.gif" width=100 height=100></center><p>Your progress through the darkened cellar is blocked by a massive barrel of beer.  You know what we do with barrels 'round these parts, don't you?<center><form style='margin: 0px 0px 0px 0px;' name=choiceform1 action=choice.php method=post><input type=hidden name=pwd value='ffe586e7b22887b5c3c0fd43a4ffe340'><input type=hidden name=whichchoice value=513><input type=hidden name=option value=1><input  class=button type=submit value="Smash the barrel"></form><p><form style='margin: 0px 0px 0px 0px;' name=choiceform2 action=choice.php method=post><input type=hidden name=pwd value='ffe586e7b22887b5c3c0fd43a4ffe340'><input type=hidden name=whichchoice value=513><input type=hidden name=option value=2><input  class=button type=submit value="Freeze the barrel"></form><p></center></td></tr></table></center></td></tr><tr><td height=4></td></tr></table></center><script>top.charpane.location.href="charpane.php";</script>
+</body></html>


### PR DESCRIPTION
There are four choice adventures in the Tavern Cellar which can be skipped, if your elemental weapon damage is high enough.
If not, you have a single option - 1 - to smash the barrel/crate.
If so, you can still take option 1 (spending a turn) and get some items.
However, you can also use option 2 to use your weapon's {hot, cold, stench, spooky} damage to pass the obstacle without spending a turn.

1) I made them configurable - which gives choice spoilers.
2) The existing defaults were 1. I left them at that, since changing them only affects new users.
I could change the default to 2, but current users will still have to change them to 2, if desired.
3) As always, with configurable choices, the Relay Browser points to the configured choice - and the "auto" button will take that option.
4) However, if your configured option is 2 and you don't have sufficient elemental damage, the chosen option will be 1 - the only available option.
That means automation will work, regardless of your elemental damage, even with option 2 as your default.
It also means that the displayed "default" in the Relay Browser will be the only visible option.

Also, a tiny tweak I noticed today when I wanted to maximize for Monster Level.

YourCampfireRequest is the coinmaster which allows you to trade sticks of firewood for items.
The maximizer suggested I get a whittled owl figurine for Monster Level +20.
I tried it and the creation failed, since I could not use my campfire.

If you have Campsite Away from your Campsite, you can find sticks of firewood while adventuring in various woods locations. You will find them even if said IOTM is out of Standard and you can not use it.

5) The Coinmaster which uses sticks of firewood is not available unless the Getaway Campsite is actually available, not simply unlocked because you own the IOTM.