### PR TITLE
numeric_modifier(thrall, string) exists

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -2444,6 +2444,9 @@ public abstract class RuntimeLibrary {
         };
     functions.add(new LibraryFunction("numeric_modifier", DataTypes.FLOAT_TYPE, params));
 
+    params = new Type[] {DataTypes.THRALL_TYPE, DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("numeric_modifier", DataTypes.FLOAT_TYPE, params));
+
     params = new Type[] {DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("boolean_modifier", DataTypes.BOOLEAN_TYPE, params));
 


### PR DESCRIPTION
This function already exists in both js and ash; `RuntimeLibrary.getModifierType` handles thrall perfectly. This will make `ashref` and `jsref`, as well as the typescript definitions that get published alongside each mafia revision, reflect this reality.