### PR TITLE
feat: add alias for old name of love potion

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
@@ -88,6 +88,7 @@ public class ItemDatabase {
     new Alias(ItemPool.BUGGED_POTION, "bugged Knob Goblin love potion"),
     new Alias(ItemPool.BUGGED_KNICKERBOCKERS, "bugged old school Mafia knickerbockers"),
     new Alias(ItemPool.BUGGED_BAIO, "bugged Talisman of Baio"),
+    new Alias(ItemPool.LOVE_POTION_XYZ, "Love Potion #0"),
     new Alias(ItemPool.UNBREAKABLE_UMBRELLA, "unbreakable umbrella (broken)"),
     new Alias(ItemPool.UNBREAKABLE_UMBRELLA, "unbreakable umbrella (forward-facing)"),
     new Alias(ItemPool.UNBREAKABLE_UMBRELLA, "unbreakable umbrella (bucket style)"),


### PR DESCRIPTION
Follow-up to #1614: changing the name of the love potion made `$item[love potion #0]` no longer pick it up. Keep that working.