### PR TITLE
feat: add more support for certain aosol skills

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1049,6 +1049,7 @@ user	miniAdvClass	0
 user	miniMartinisDrunk	0
 user	moleTunnelLevel	0
 user	moonTuned	false
+user	motifMonster	
 user	mothershipProgress	0
 user	mpAutoRecovery	-0.5
 user	mpAutoRecoveryItems	phonics down;knob goblin superseltzer;mountain stream soda;magical mystery juice;knob goblin seltzer;cherry cloaca cola;soda water

--- a/src/net/sourceforge/kolmafia/AreaCombatData.java
+++ b/src/net/sourceforge/kolmafia/AreaCombatData.java
@@ -160,6 +160,7 @@ public class AreaCombatData {
       if (Preferences.getString("longConMonster").equals(monsterName)) {
         currentWeighting += 3 * baseWeighting;
       }
+      // TODO: add motif copies after amount spaded
 
       if (BanishManager.isBanished(monsterName)) {
         // Banishing reduces number of copies

--- a/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
@@ -746,6 +746,8 @@ public class SkillPool {
   public static final int HOT_FOOT = 28015;
   public static final int SECOND_WIND = 28016;
   public static final int STOP_HITTING_YOURSELF = 28017;
+  public static final int FREE_FOR_ALL = 28019;
+  public static final int PUNT = 28021;
   public static final int EMMENTAL_ELEMENTAL = 29017;
   public static final int STILTON_SPLATTER = 29019;
   public static final int FONDELUGE = 29021;

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -9224,6 +9224,13 @@ public class FightRequest extends GenericRequest {
         }
         break;
 
+      case SkillPool.MOTIF:
+        if (responseText.contains("You whip out an instrument and play a quick motif")) {
+          Preferences.setString("motifMonster", monsterName);
+          skillSuccess = true;
+        }
+        break;
+
         // Banishing Shout has lots of success messages.  Check for the failure message instead
       case SkillPool.BANISHING_SHOUT:
         if (!responseText.contains("but this foe refuses")) {
@@ -9267,6 +9274,12 @@ public class FightRequest extends GenericRequest {
       case SkillPool.BATTER_UP:
         if (responseText.contains("knocked out of the park") || skillRunawaySuccess) {
           BanishManager.banishMonster(monster, Banisher.BATTER_UP);
+        }
+        break;
+
+      case SkillPool.PUNT:
+        if (responseText.contains("You punt your foe into next week") || skillRunawaySuccess) {
+          BanishManager.banishMonster(monster, Banisher.PUNT);
         }
         break;
 

--- a/src/net/sourceforge/kolmafia/session/BanishManager.java
+++ b/src/net/sourceforge/kolmafia/session/BanishManager.java
@@ -90,6 +90,7 @@ public class BanishManager {
     PANTSGIVING("pantsgiving", 30, 1, false, Reset.TURN_ROLLOVER_RESET),
     PEEL_OUT("peel out", -1, 1, true, Reset.AVATAR_RESET),
     PULLED_INDIGO_TAFFY("pulled indigo taffy", 40, 1, true, Reset.TURN_RESET),
+    PUNT("Punt", -1, 1, false, Reset.ROLLOVER_RESET),
     REFLEX_HAMMER("Reflex Hammer", 30, 1, true, Reset.TURN_ROLLOVER_RESET),
     SABER_FORCE("Saber Force", 30, 1, true, Reset.TURN_ROLLOVER_RESET),
     SHOW_YOUR_BORING_FAMILIAR_PICTURES(

--- a/src/net/sourceforge/kolmafia/webui/StationaryButtonDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/StationaryButtonDecorator.java
@@ -29,6 +29,8 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 public class StationaryButtonDecorator {
   private static final ArrayList<String> combatHotkeys = new ArrayList<>();
 
+  private static final AdventureResult EVERYTHING_LOOKS_RED =
+      EffectPool.get(EffectPool.EVERYTHING_LOOKS_RED);
   private static final AdventureResult EVERYTHING_LOOKS_YELLOW =
       EffectPool.get(EffectPool.EVERYTHING_LOOKS_YELLOW);
   private static final AdventureResult EVERYTHING_LOOKS_BLUE =
@@ -708,6 +710,8 @@ public class StationaryButtonDecorator {
           case SkillPool.LASH_OF_COBRA -> isEnabled = !Preferences.getBoolean("edUsedLash");
           case SkillPool.GINGERBREAD_MOB_HIT -> isEnabled =
               !Preferences.getBoolean("_gingerbreadMobHitUsed");
+          case SkillPool.FREE_FOR_ALL -> isEnabled =
+              !KoLConstants.activeEffects.contains(EVERYTHING_LOOKS_RED);
           case SkillPool.FONDELUGE -> isEnabled =
               !KoLConstants.activeEffects.contains(EVERYTHING_LOOKS_YELLOW);
           case SkillPool.MOTIF -> isEnabled =


### PR DESCRIPTION
Punt banishes, behaving the same as Batter Up!

Track the motif monster, but don't modify the area combat data yet as it's still unspaded what exactly it does. I think the current guess is +2 copies, adventure queue rejection still occurs.

By wiki messages, Free-For-All can be "used" with Everything Looks Red, but does nothing.