### PR TITLE
feat: remove validate gradle wrapper action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,6 @@ jobs:
           java-version: "17"
           cache: "gradle"
 
-      - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1
-
       - name: Build
         env:
           ORG_GRADLE_PROJECT_commit: ${{ github.sha }}
@@ -63,9 +60,6 @@ jobs:
           distribution: "temurin"
           java-version: "17"
           cache: "gradle"
-
-      - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1
 
       - name: Build
         env:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,9 +40,6 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: "gradle"
 
-      - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1
-
       - name: Prepare Workspace
         run: mkdir -p ./build
 

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -22,9 +22,6 @@ jobs:
           java-version: "17"
           cache: "gradle"
 
-      - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1
-
       - name: Generating TypeScript definitions
         env:
           ORG_GRADLE_PROJECT_commit: ${{ github.sha }}


### PR DESCRIPTION
This action is failing far too often (as a false positive: failing to access some website) to be worth doing.

The aim is to avoid being vulnerable to a social engineering attack where an outsider upgrades gradle; to avoid that we can just always ensure that we only update gradle ourselves.