### PR TITLE
fix: accept $skill[zero placeholder]

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/SkillDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/SkillDatabase.java
@@ -331,12 +331,9 @@ public class SkillDatabase {
       int index = skillName.indexOf("]");
       if (index > 0) {
         String idString = skillName.substring(1, index);
-        int skillId = -1;
-        try {
-          skillId = StringUtilities.parseInt(idString);
-        } catch (NumberFormatException e) {
+        if (StringUtilities.isNumeric(idString)) {
+          return StringUtilities.parseInt(idString);
         }
-        return skillId;
       }
     }
 
@@ -391,14 +388,12 @@ public class SkillDatabase {
       int index = skillName.indexOf("]");
       if (index > 0) {
         String idString = skillName.substring(1, index);
-        int skillId = -1;
-        try {
-          skillId = StringUtilities.parseInt(idString);
-        } catch (NumberFormatException e) {
+        if (StringUtilities.isNumeric(idString)) {
+          int skillId = StringUtilities.parseInt(idString);
+          int[] ids = new int[1];
+          ids[0] = skillId;
+          return ids;
         }
-        int[] ids = new int[1];
-        ids[0] = skillId;
-        return ids;
       }
     }
 
@@ -432,13 +427,10 @@ public class SkillDatabase {
       int index = substring.indexOf("]");
       if (index > 0) {
         String idString = substring.substring(1, index);
-        try {
-          int skillId = StringUtilities.parseInt(idString);
-          // It parsed to a number so is valid
+        if (StringUtilities.isNumeric(idString)) {
           List<String> list = new ArrayList<>();
           list.add(substring);
           return list;
-        } catch (NumberFormatException e) {
         }
       }
     }

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -643,4 +643,11 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
       assertThat(output, is("Returned: 7302\n"));
     }
   }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"16000", "zero placeholder", "[zero placeholder]", "[16000]"})
+  void canIdentifySkill(final String skillIdentifier) {
+    String output = execute("$skill[" + skillIdentifier + "].name");
+    assertThat(output, endsWith("Returned: [zero placeholder]\n"));
+  }
 }


### PR DESCRIPTION
`StringUtilities.parseInt` never throws a `NumberFormatException`. Check numeric first and continue if not.

As a side effect, `$skill[[anythingNonNumeric]whatever]` will no longer parse to `$skill[none]`. I hope nobody was relying on this degenerate behaviour.