### PR TITLE
feat: include underwater passive damage with `env` modifier

### DIFF
--- a/src/data/maximizer-help.html
+++ b/src/data/maximizer-help.html
@@ -6,7 +6,7 @@ The full name of any numeric modifier (as shown by the <b>modref</b> CLI command
 <p>
 Shorter forms are allowed for many commonly used modifiers.  They can be abbreviated down to just the bold letters:
 <br><b>mus</b>, <b>mys</b>, <b>mox</b>, <b>main</b>stat, <b>HP</b>, <b>MP</b>, <b>ML</b>, <b>DA</b>, <b>DR</b>, <b>com</b>bat rate, <b>item</b> drop, <b>meat</b> drop, <b>exp</b>erience, <b>(spell) crit</b>ical, <b>adv</b>entures, <b>fites</b> for "pvp fights"
-<br>Also, resistance (of any type) can be abbreviated as <b>res</b>, and damage can be abbreviated as <b>dmg</b>.  <b>all res</b>istance is a shortcut for giving the same weight to all five basic elements.  Likewise, <b>elemental dmg</b> is a shortcut for the five elemental damage types.
+<br>Also, resistance (of any type) can be abbreviated as <b>res</b>, and damage can be abbreviated as <b>dmg</b>.  <b>all res</b>istance is a shortcut for giving the same weight to all five basic elements.  Likewise, <b>elemental dmg</b> is a shortcut for the five elemental damage types. <b>passive damage</b> will look for both <b>damage aura</b> (every round) and <b>thorns</b> (when hit).
 <p>
 Note that many modifiers come in pairs: a base value, plus a percentage boost (such as Moxie and Moxie Percent), or a penalty value.  In general, you only need to specify the base modifier, and any related modifiers will automatically be taken into account.
 <p>


### PR DESCRIPTION
Follow-up to #1624.

Add the note about "passive damage" to the in-client maximizer help, too.