### PR TITLE
Don't refill the June Cleaver queue with data from previous ascension

### DIFF
--- a/src/net/sourceforge/kolmafia/session/JuneCleaverManager.java
+++ b/src/net/sourceforge/kolmafia/session/JuneCleaverManager.java
@@ -10,15 +10,11 @@ public class JuneCleaverManager {
 
   private JuneCleaverManager() {}
 
-  public static ArrayList<Integer> queue = new ArrayList<>();
-
-  public static void reset() {
-    queue.clear();
-  }
-
   private static void updateQueue(int id) {
+    ArrayList<Integer> queue = new ArrayList<>();
+
     String savedQueue = Preferences.getString("juneCleaverQueue");
-    if (queue.isEmpty() && savedQueue.length() > 0) {
+    if (savedQueue.length() > 0) {
       for (String x : savedQueue.split(",")) {
         queue.add(Integer.parseInt(x));
       }

--- a/test/net/sourceforge/kolmafia/request/AdventureRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AdventureRequestTest.java
@@ -13,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import internal.helpers.Cleanups;
-import java.util.ArrayList;
 import java.util.Set;
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.KoLCharacter;
@@ -129,7 +128,6 @@ public class AdventureRequestTest {
     assertEquals(Preferences.getInteger("_juneCleaverSkips"), 1);
 
     // Can load queue
-    JuneCleaverManager.queue = new ArrayList<>();
     Preferences.setString("juneCleaverQueue", "1467,1468,1469,1470,1471");
     JuneCleaverManager.parseChoice("choice.php?whichchoice=1472&option=3");
     assertEquals(Preferences.getString("juneCleaverQueue"), "1467,1468,1469,1470,1471,1472");

--- a/test/net/sourceforge/kolmafia/session/JuneCleaverManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/JuneCleaverManagerTest.java
@@ -36,7 +36,6 @@ public class JuneCleaverManagerTest {
   @BeforeEach
   public void beforeEach() {
     Preferences.reset("June Cleaver");
-    JuneCleaverManager.reset();
   }
 
   @Nested


### PR DESCRIPTION
If you have a KoLmafia session that has encountered at least one [June Cleaver](https://kol.coldfront.net/thekolwiki/index.php/June_cleaver) noncombat, ascend, then encounter another June cleaver noncombat, the `juneCleaverQueue` preference will do something like this:
```
Preference juneCleaverQueue changed from  to 1475,1473,1470,1467,1474,1467
```
Instead of:
```
Preference juneCleaverQueue changed from  to 1467
```

Currently, the backing queue data is not emptied because the `reset` function is not hooked up.

This change will remove the static data structure, instead use a new one each time the function is called, and populate it with data from the preference if there is any.