### PR TITLE
shadow rift fixes

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -8574,6 +8574,7 @@ Event	Mysticality Day	Experience Percent (Mysticality): +25
 # -100% is the most common penalty in The Sea; use it as the default
 
 Zone	The Sea	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
+Zone    Shadow Rift	Item Drop: [-0.8*mod(Item Drop))
 
 # Location-specific section of modifiers.txt
 
@@ -8596,8 +8597,6 @@ Loc	The Impenetrable Kelp-Holly Forest	Initiative Penalty: -100, Item Drop Penal
 Loc	The Sunken Party Yacht	Initiative Penalty: -50, Item Drop Penalty: -50, Meat Drop Penalty: -50
 
 Loc	The Ice Hole	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
-
-Loc	Shadow Rift	Item Drop: [-0.8*mod(Item Drop)]
 
 # Synergies section of modifiers.txt
 # Synergies are triggered when an arbitrary combination of two or more

--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -2117,12 +2117,12 @@ undercover prohibition agent	2253	olivers_prohie.gif	Atk: 60 Def: 60 HP: 70 Init
 Moleman	2267	moleman.gif	NOCOPY Scale: 15 Cap: ? Floor: ? Init: -10000 P: humanoid Article: a
 
 # closed-circuit pay phone (Mar 2023)
-shadow spire	2298	shadowspire.gif	Atk: [300+5*pref(_shadowRiftCombats)] Def: [300+5*pref(_shadowRiftCombats)] HP: [500+10*pref(_shadowRiftCombats)] Init: -10000 P: horror Phys: 100 Elem: [min(pref(_shadowRiftCombats),90)] Article: a	shadow brick (100)	shadow stick (100)
-shadow orrery	2299	shadoworrery.gif	Atk: [300+5*pref(_shadowRiftCombats)] Def: [300+5*pref(_shadowRiftCombats)] HP: [250+10*pref(_shadowRiftCombats)] Init: -10000 P: horror Phys: 100 Elem: [min(pref(_shadowRiftCombats),90)] Article: a	shadow glass (100)	shadow ice (100)
-shadow tongue	2300	shadowtongue.gif	Atk: [300+5*pref(_shadowRiftCombats)] Def: [300+5*pref(_shadowRiftCombats)] HP: [500+10*pref(_shadowRiftCombats)] Init: 200 P: horror Phys: 100 Elem: [min(pref(_shadowRiftCombats),90)] Article: a	shadow sinew (100)	shadow sausage (100)
-shadow scythe	2301	shadowscythe.gif	Atk: [300+5*pref(_shadowRiftCombats)] Def: [300+5*pref(_shadowRiftCombats)] HP: [50+10*pref(_shadowRiftCombats)] Init: 10000 P: horror Phys: 100 Elem: [min(pref(_shadowRiftCombats),90)] Article: a	shadow bread (100)	shadow venom (100)
-shadow cauldron	2302	shadowcauldron.gif	Atk: [300+5*pref(_shadowRiftCombats)] Def: [300+5*pref(_shadowRiftCombats)] HP: [1000+10*pref(_shadowRiftCombats)] Init: -10000 P: horror Phys: 100 Elem: [min(pref(_shadowRiftCombats),90)] Article: a	shadow fluid (100)	shadow nectar (100)
-shadow matrix	2303	shadowmatrix.gif	Atk: [300+5*pref(_shadowRiftCombats)] Def: [300+5*pref(_shadowRiftCombats)] HP: [500+10*pref(_shadowRiftCombats)] Init: 1000 P: horror Phys: 100 Elem: [min(pref(_shadowRiftCombats),90)] Article: a	shadow flame (100)	shadow skin (100)
+shadow spire	2298	shadowspire.gif	BOSS Atk: [300+5*pref(_shadowRiftCombats)] Def: [300+5*pref(_shadowRiftCombats)] HP: [500+10*pref(_shadowRiftCombats)] Init: -10000 P: horror Phys: 100 Elem: [min(pref(_shadowRiftCombats),90)] Article: a	shadow brick (100)	shadow stick (100)
+shadow orrery	2299	shadoworrery.gif	BOSS Atk: [300+5*pref(_shadowRiftCombats)] Def: [300+5*pref(_shadowRiftCombats)] HP: [250+10*pref(_shadowRiftCombats)] Init: -10000 P: horror Phys: 100 Elem: [min(pref(_shadowRiftCombats),90)] Article: a	shadow glass (100)	shadow ice (100)
+shadow tongue	2300	shadowtongue.gif	BOSS Atk: [300+5*pref(_shadowRiftCombats)] Def: [300+5*pref(_shadowRiftCombats)] HP: [500+10*pref(_shadowRiftCombats)] Init: 200 P: horror Phys: 100 Elem: [min(pref(_shadowRiftCombats),90)] Article: a	shadow sinew (100)	shadow sausage (100)
+shadow scythe	2301	shadowscythe.gif	BOSS Atk: [300+5*pref(_shadowRiftCombats)] Def: [300+5*pref(_shadowRiftCombats)] HP: [50+10*pref(_shadowRiftCombats)] Init: 10000 P: horror Phys: 100 Elem: [min(pref(_shadowRiftCombats),90)] Article: a	shadow bread (100)	shadow venom (100)
+shadow cauldron	2302	shadowcauldron.gif	BOSS Atk: [300+5*pref(_shadowRiftCombats)] Def: [300+5*pref(_shadowRiftCombats)] HP: [1000+10*pref(_shadowRiftCombats)] Init: -10000 P: horror Phys: 100 Elem: [min(pref(_shadowRiftCombats),90)] Article: a	shadow fluid (100)	shadow nectar (100)
+shadow matrix	2303	shadowmatrix.gif	BOSS Atk: [300+5*pref(_shadowRiftCombats)] Def: [300+5*pref(_shadowRiftCombats)] HP: [500+10*pref(_shadowRiftCombats)] Init: 1000 P: horror Phys: 100 Elem: [min(pref(_shadowRiftCombats),90)] Article: a	shadow flame (100)	shadow skin (100)
 
 # KoL Con
 

--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -859,6 +859,7 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
     if (this.zone.equals("Shadow Rift")) {
       // These are "place.php" visits.
       ShadowRift rift = ShadowRift.findAdventureName(this.adventureName);
+      String ingress = Preferences.getString("shadowRiftIngress");
       if (rift == null) {
         // Requesting generic Shadow Rift, which will go straight to
         // adventure.php as if through the most recent rift you entered.
@@ -866,7 +867,11 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
         // If we haven't yet gone through a Shadow Rift this ascension,
         // you'll find nothing but tumbleweeds, which is unlikely to be
         // what the user wants.
-        return !Preferences.getString("shadowRiftIngress").equals("");
+        return !ingress.equals("");
+      }
+      // If the desired rift is through the current ingress, cool.
+      if (rift.getPlace().equals(ingress)) {
+        return true;
       }
       // Otherwise, we want to adventure through a specific rift.
       // Ensure that we can reach it.
@@ -2510,6 +2515,12 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
     if (this.zone.equals("The 8-Bit Realm")
         || this.zone.equals("Vanya's Castle")
         || rift == ShadowRift.REALM) {
+      // You don't need a transfunctioner to go to the Shadow Rift in
+      // The 8-bit Realm if that is the current ingress.
+      if (rift == ShadowRift.REALM && Preferences.getString("shadowRiftIngress").equals("8bit")) {
+        return true;
+      }
+
       if (!InventoryManager.hasItem(TRANSFUNCTIONER)) {
         RequestThread.postRequest(new PlaceRequest("forestvillage", "fv_mystic"));
         // This redirects to choice.php&forceoption=0.

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -5541,11 +5541,14 @@ public abstract class KoLCharacter {
             EffectPool.STEELY_EYED_SQUINT);
       }
     }
-    if (Modifiers.currentLocation.equals("Shadow Rift")) {
+    if (Modifiers.currentZone.equals("Shadow Rift")) {
       newModifiers.addDouble(
           DoubleModifier.ITEMDROP,
+          // If does include current familiar:
+          // newModifiers.getDouble(DoubleModifier.ITEMDROP) * -0.8,
+          // If does not include current familiar:
           newModifiers.getAccumulator(DoubleModifier.ITEMDROP) * -0.8,
-          ModifierType.LOC,
+          ModifierType.ZONE,
           "Shadow Rift");
     }
 

--- a/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
+++ b/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
@@ -7162,7 +7162,7 @@ public class KoLAdventureValidationTest {
     }
 
     @Test
-    public void canVisitPixelRiftithTransfunctionerEquipped() {
+    public void canVisitPixelRiftWithTransfunctionerEquipped() {
       setupFakeClient();
 
       var cleanups =
@@ -7179,7 +7179,7 @@ public class KoLAdventureValidationTest {
     }
 
     @Test
-    public void canAdventureWithTransfunctionerInInventory() {
+    public void canVisitPixelRiftWithTransfunctionerInInventory() {
       setupFakeClient();
 
       var cleanups =
@@ -7196,6 +7196,24 @@ public class KoLAdventureValidationTest {
             requests.get(0),
             "/inv_equip.php",
             "which=2&ajax=1&slot=1&action=equip&whichitem=" + ItemPool.TRANSFUNCTIONER);
+      }
+    }
+
+    @Test
+    public void canVisitPixelRiftIfCurrentRift() {
+      setupFakeClient();
+
+      var cleanups =
+          new Cleanups(
+              withQuestProgress(Quest.LARVA, QuestDatabase.STARTED),
+              withProperty("shadowRiftIngress", "8bit"));
+      try (cleanups) {
+
+        assertTrue(PIXEL_REALM.canAdventure());
+        assertTrue(PIXEL_REALM.prepareForAdventure());
+
+        var requests = getRequests();
+        assertThat(requests, hasSize(0));
       }
     }
 


### PR DESCRIPTION
1) Shadow Rift bosses are marked BOSS
2) If your current Shadow Rift Ingress is from The 8-Bit Realm, you do not need to have the continuum transfunctioner equipped to adventure there.
3) Item Drop is reduced by 80% when adventuring in the Shadow Rift zone, not just the location of that name.

The existing code that did that for the Location reduced the Item Drop bonus EXCLUDING that from your familiar by 80%.
Is that correct? It is trivial to INCLUDE the familiar's contribution - and I have a commented out line that does it that way.

Which is correct? -80% not including familiar or including familiar?