### PR TITLE
shadow boss counts as a turn. shadow lodestone does not

### DIFF
--- a/src/net/sourceforge/kolmafia/session/RufusManager.java
+++ b/src/net/sourceforge/kolmafia/session/RufusManager.java
@@ -496,8 +496,7 @@ public class RufusManager {
   // Like a Loded Stone is a superlikely, per cannonfire
 
   public static void handleShadowRiftFight(MonsterData monster) {
-    // All fights - including bosses - advance turns in zone
-    int currentTurns = Preferences.increment("shadowRiftTotalTurns", 1);
+    int currentTurns = Preferences.getInteger("shadowRiftTotalTurns");
     int lastNC = Preferences.getInteger("shadowRiftLastNC");
     switch (monster.getName()) {
       case "shadow spire",
@@ -511,6 +510,9 @@ public class RufusManager {
         lastNC = currentTurns;
       }
     }
+
+    // All fights - including bosses - advance turns in zone
+    currentTurns = Preferences.increment("shadowRiftTotalTurns", 1);
     // Next NC comes if (turns in zone - last nc) >= 11
     Preferences.setInteger("encountersUntilSRChoice", 11 - Math.max(currentTurns - lastNC, 0));
   }
@@ -528,7 +530,6 @@ public class RufusManager {
       case 1500 -> {
         // Like a Loded Stone
         ResultProcessor.removeItem(ItemPool.RUFUS_SHADOW_LODESTONE);
-        currentTurns = Preferences.increment("shadowRiftTotalTurns", 1);
       }
     }
     Preferences.setInteger("encountersUntilSRChoice", 11 - Math.max(currentTurns - lastNC, 0));

--- a/test/net/sourceforge/kolmafia/session/RufusManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/RufusManagerTest.java
@@ -955,6 +955,8 @@ public class RufusManagerTest {
       var cleanups =
           new Cleanups(
               withHttpClientBuilder(builder),
+              // Parsing the fight page will add available combat items to inventory
+              withNoItems(),
               withProperty("shadowRiftTotalTurns", 11),
               withProperty("shadowRiftLastNC", 11),
               withProperty("encountersUntilSRChoice", 11));
@@ -995,8 +997,8 @@ public class RufusManagerTest {
         request.run();
 
         assertThat("shadowRiftTotalTurns", isSetTo(12));
-        assertThat("shadowRiftLastNC", isSetTo(12));
-        assertThat("encountersUntilSRChoice", isSetTo(11));
+        assertThat("shadowRiftLastNC", isSetTo(11));
+        assertThat("encountersUntilSRChoice", isSetTo(10));
       }
     }
 
@@ -1023,7 +1025,7 @@ public class RufusManagerTest {
     }
 
     @Test
-    void followingLodestoneCountsAsTurn() {
+    void followingLodestoneDoesNotCountsAsTurn() {
       var builder = new FakeHttpClientBuilder();
       var client = builder.client;
       var cleanups =
@@ -1043,9 +1045,9 @@ public class RufusManagerTest {
         var riftRequest = new GenericRequest(riftURL);
         riftRequest.run();
 
-        assertThat("shadowRiftTotalTurns", isSetTo(12));
+        assertThat("shadowRiftTotalTurns", isSetTo(11));
         assertThat("shadowRiftLastNC", isSetTo(11));
-        assertThat("encountersUntilSRChoice", isSetTo(10));
+        assertThat("encountersUntilSRChoice", isSetTo(11));
       }
     }
   }


### PR DESCRIPTION
After studying my logs again, I conclude I had a misunderstanding.

1) Shadow boss increments turns in zone - AFTER setting last NC turn
2) Shadow lodestone does not increment turns in zone.

Accept artifact quest
11 combats in Shadow Rift
Shadow Labyrinth (get artifact)
Turn in artifact
Follow Lodestone

Accept entity quest
11 combats in Shadow RIft
Fight & defeat boss
Talk to Rufus
Follow lodestone

Accept artifact quest
10 combats in Shadow Rift
Shadow Labyrinth (get artifact)
Talk to Rufus
Follow lodestone

Accept entity quest
11 combats in Shadow Rift
Fight and lose to boss
10 combats in Shadow Rift
Fight and defeat boss
Talk to Rufus
Follow lodestone

Accept entity quest
10 combats in Shadow Rift
Fight and defeat boss
Talk to Rufus
Follow lodestone

