### PR TITLE
refactor: prefer java library functions

### DIFF
--- a/src/net/sourceforge/kolmafia/utilities/ByteBufferUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/ByteBufferUtilities.java
@@ -1,29 +1,19 @@
 package net.sourceforge.kolmafia.utilities;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
+import java.nio.file.Files;
 
 public class ByteBufferUtilities {
   private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
-
-  private static final ArrayList<byte[]> BYTEARRAYS = new ArrayList<>();
-  private static final ArrayList<Boolean> BYTEARRAYS_STATUS = new ArrayList<>();
-
-  private static final ArrayList<ByteArrayOutputStream> BYTESTREAMS = new ArrayList<>();
-  private static final ArrayList<Boolean> BYTESTREAMS_STATUS = new ArrayList<>();
 
   private ByteBufferUtilities() {}
 
   public static byte[] read(File file) {
     try {
-      FileInputStream istream = new FileInputStream(file);
-
-      return ByteBufferUtilities.read(istream);
+      return Files.readAllBytes(file.toPath());
     } catch (IOException e) {
       return EMPTY_BYTE_ARRAY;
     }
@@ -34,91 +24,21 @@ public class ByteBufferUtilities {
       return EMPTY_BYTE_ARRAY;
     }
 
-    ByteArrayOutputStream ostream = ByteBufferUtilities.getOutputStream();
-    ByteBufferUtilities.read(istream, ostream);
-    byte[] data = ostream.toByteArray();
-    ByteBufferUtilities.returnOutputStream(ostream);
-
-    return data;
+    try {
+      return istream.readAllBytes();
+    } catch (IOException e) {
+      return EMPTY_BYTE_ARRAY;
+    }
   }
 
   public static void read(InputStream istream, OutputStream ostream) {
     if (istream == null) {
       return;
     }
-
-    byte[] buffer = ByteBufferUtilities.getBuffer();
-    int availableBytes = 0;
-
     try {
-      while ((availableBytes = istream.read(buffer)) != -1) {
-        ostream.write(buffer, 0, availableBytes);
-      }
+      istream.transferTo(ostream);
     } catch (IOException e) {
-    }
-
-    ByteBufferUtilities.returnBuffer(buffer);
-
-    try {
-      ostream.flush();
-    } catch (IOException e) {
-    }
-
-    try {
-      istream.close();
-    } catch (IOException e) {
-    }
-  }
-
-  private static synchronized byte[] getBuffer() {
-    for (int i = 0; i < ByteBufferUtilities.BYTEARRAYS_STATUS.size(); ++i) {
-      if (ByteBufferUtilities.BYTEARRAYS_STATUS.get(i) == Boolean.FALSE) {
-        ByteBufferUtilities.BYTEARRAYS_STATUS.set(i, Boolean.TRUE);
-        return ByteBufferUtilities.BYTEARRAYS.get(i);
-      }
-    }
-
-    byte[] buffer = new byte[8192];
-
-    ByteBufferUtilities.BYTEARRAYS.add(buffer);
-    ByteBufferUtilities.BYTEARRAYS_STATUS.add(Boolean.TRUE);
-
-    return buffer;
-  }
-
-  private static void returnBuffer(byte[] buffer) {
-    for (int i = 0; i < ByteBufferUtilities.BYTEARRAYS_STATUS.size(); ++i) {
-      if (ByteBufferUtilities.BYTEARRAYS.get(i) == buffer) {
-        ByteBufferUtilities.BYTEARRAYS_STATUS.set(i, Boolean.FALSE);
-        return;
-      }
-    }
-  }
-
-  private static synchronized ByteArrayOutputStream getOutputStream() {
-    for (int i = 0; i < ByteBufferUtilities.BYTESTREAMS_STATUS.size(); ++i) {
-      if (ByteBufferUtilities.BYTESTREAMS_STATUS.get(i) == Boolean.FALSE) {
-        ByteBufferUtilities.BYTESTREAMS_STATUS.set(i, Boolean.TRUE);
-        return ByteBufferUtilities.BYTESTREAMS.get(i);
-      }
-    }
-
-    ByteArrayOutputStream ostream = new ByteArrayOutputStream();
-
-    ByteBufferUtilities.BYTESTREAMS.add(ostream);
-    ByteBufferUtilities.BYTESTREAMS_STATUS.add(Boolean.TRUE);
-
-    return ostream;
-  }
-
-  private static void returnOutputStream(ByteArrayOutputStream outputStream) {
-    outputStream.reset();
-
-    for (int i = 0; i < ByteBufferUtilities.BYTEARRAYS_STATUS.size(); ++i) {
-      if (ByteBufferUtilities.BYTESTREAMS.get(i) == outputStream) {
-        ByteBufferUtilities.BYTESTREAMS_STATUS.set(i, Boolean.FALSE);
-        return;
-      }
+      // do nothing
     }
   }
 }

--- a/src/net/sourceforge/kolmafia/utilities/ByteBufferUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/ByteBufferUtilities.java
@@ -24,7 +24,7 @@ public class ByteBufferUtilities {
       return EMPTY_BYTE_ARRAY;
     }
 
-    try {
+    try (istream) {
       return istream.readAllBytes();
     } catch (IOException e) {
       return EMPTY_BYTE_ARRAY;
@@ -35,7 +35,7 @@ public class ByteBufferUtilities {
     if (istream == null) {
       return;
     }
-    try {
+    try (istream) {
       istream.transferTo(ostream);
     } catch (IOException e) {
       // do nothing


### PR DESCRIPTION
post Java 7 & 9, most of this is inbuilt. Prefer those functions.

Also stop storing byte arrays in object. I think the aim was to avoid the overhead of creating many byte arrays, but it also stops them from being garbage collected.

Keep the previous behaviour of closing the input stream after reading it. I'm not sure this is a good idea, but easier to keep the behaviour.