### PR TITLE
feat: during git sync, don't stop at first error

### DIFF
--- a/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
@@ -435,14 +435,21 @@ public class GitManager extends ScriptManager {
       KoLmafia.updateDisplay(MafiaState.ERROR, "Failed to sync project " + folder + ": " + e);
       return false;
     }
+    IOException lastError = null;
     for (var absPath : toAdd) {
       try {
         var toRel = root.relativize(absPath);
         copyPath(absPath, toRel);
       } catch (IOException e) {
-        KoLmafia.updateDisplay(MafiaState.ERROR, "Failed to sync project " + folder + ": " + e);
-        return false;
+        // other files might succeed, so keep going
+        lastError = e;
+        continue;
       }
+    }
+    if (lastError != null) {
+      KoLmafia.updateDisplay(
+          MafiaState.ERROR, "Failed to sync project " + folder + ": " + lastError);
+      return false;
     }
     var deps = root.resolve(DEPENDENCIES);
     if (Files.exists(deps)) {


### PR DESCRIPTION
Couldn't test this because I couldn't reproduce the initial error I had, but I think it should do what I want.