### PR TITLE
we can only adventure in piraterealm islands that we can currently adventure in

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1962,7 +1962,7 @@ user	_kudzuSaladEaten	false
 user	_lastCombatStarted
 user	_lastCombatWon	true
 user	_lastDailyDungeonRoom	0
-user	_LastPirateRealmIsland
+user	_lastPirateRealmIsland
 user	_lastSausageMonsterTurn	0
 user	_lastZomboEye	0
 user	_latteBanishUsed	false

--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -2132,7 +2132,8 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
 
     if (this.zone.startsWith("PirateRealm")) {
       // *** You have limited turns available per day.
-      return Preferences.getBoolean("prAlways") || Preferences.getBoolean("_prToday");
+      return (Preferences.getBoolean("prAlways") || Preferences.getBoolean("_prToday"))
+          && Preferences.getString("_LastPirateRealmIsland").contains(this.adventureName);
     }
 
     if (this.zone.equals("Speakeasy")) {

--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -2133,7 +2133,7 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
     if (this.zone.startsWith("PirateRealm")) {
       // *** You have limited turns available per day.
       return (Preferences.getBoolean("prAlways") || Preferences.getBoolean("_prToday"))
-          && Preferences.getString("_LastPirateRealmIsland").contains(this.adventureName);
+          && Preferences.getString("_LastPirateRealmIsland").equals(this.adventureName);
     }
 
     if (this.zone.equals("Speakeasy")) {

--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -2133,7 +2133,7 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
     if (this.zone.startsWith("PirateRealm")) {
       // *** You have limited turns available per day.
       return (Preferences.getBoolean("prAlways") || Preferences.getBoolean("_prToday"))
-          && Preferences.getString("_LastPirateRealmIsland").equals(this.adventureName);
+          && Preferences.getString("_lastPirateRealmIsland").equals(this.adventureName);
     }
 
     if (this.zone.equals("Speakeasy")) {

--- a/src/net/sourceforge/kolmafia/persistence/AdventureDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/AdventureDatabase.java
@@ -380,7 +380,7 @@ public class AdventureDatabase {
   }
 
   public static final String pirateRealmIslandName() {
-    String island = Preferences.getString("_LastPirateRealmIsland");
+    String island = Preferences.getString("_lastPirateRealmIsland");
     return island.isEmpty() ? "PirateRealm Island" : island;
   }
 

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -9000,7 +9000,7 @@ public abstract class ChoiceControl {
             String desc = ChoiceManager.choiceDescription(choice, decision);
             RequestLogger.updateSessionLog("Took choice " + choice + "/" + decision + ": " + desc);
             if (desc != null && !desc.equals("Decide Later")) {
-              Preferences.setString("_LastPirateRealmIsland", desc);
+              Preferences.setString("_lastPirateRealmIsland", desc);
             }
             return true;
           }

--- a/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
+++ b/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
@@ -161,7 +161,7 @@ public class KoLAdventureValidationTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"Trick-or-Treating", "Drunken Stupor"})
-    void beignTooDrunkInSomeLocationsPassesPreValidation(final String adventureName) {
+    void beingTooDrunkInSomeLocationsPassesPreValidation(final String adventureName) {
       var cleanups = new Cleanups(withInebriety(30));
 
       try (cleanups) {
@@ -1352,6 +1352,26 @@ public class KoLAdventureValidationTest {
         assertThat(requests, hasSize(1));
         assertGetRequest(
             requests.get(0), "/inventory.php", "action=closetpull&ajax=1&whichitem=4130&qty=1");
+      }
+    }
+  }
+
+  @Nested
+  class PirateRealm {
+    private static final KoLAdventure RED_ROGERS_FORTRESS =
+        AdventureDatabase.getAdventureByName("Red Roger's Fortress");
+    private static final KoLAdventure BATTLE_ISLAND =
+        AdventureDatabase.getAdventureByName("Battle Island");
+
+    @Test
+    public void properlyChecksLastIsland() {
+      var cleanups =
+          new Cleanups(
+              withProperty("_LastPirateRealmIsland", "Battle Island"),
+              withProperty("prAlways", true));
+      try (cleanups) {
+        assertFalse(RED_ROGERS_FORTRESS.canAdventure());
+        assertTrue(BATTLE_ISLAND.canAdventure());
       }
     }
   }

--- a/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
+++ b/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
@@ -1367,7 +1367,7 @@ public class KoLAdventureValidationTest {
     public void properlyChecksLastIsland() {
       var cleanups =
           new Cleanups(
-              withProperty("_LastPirateRealmIsland", "Battle Island"),
+              withProperty("_lastPirateRealmIsland", "Battle Island"),
               withProperty("prAlways", true));
       try (cleanups) {
         assertFalse(RED_ROGERS_FORTRESS.canAdventure());


### PR DESCRIPTION
Right now, to check to see if we can adventure in a piraterealm location, we just naively check whether we have access to piraterealm today; this will also verify that we have unlocked the island.

Right now, this will continue to assert that you can access Red Roger's Fortress even if you've completed piraterealm. I don't see any tracking that lets us handle this the way things are currently set up