### PR TITLE
Improve browser links when using workshed items

### DIFF
--- a/src/net/sourceforge/kolmafia/webui/UseItemDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/UseItemDecorator.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.webui;
 
 import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.request.CampgroundRequest;
 import net.sourceforge.kolmafia.request.UseItemRequest;
 
 public class UseItemDecorator {
@@ -14,6 +15,19 @@ public class UseItemDecorator {
     // Saved when we executed inv_use.php, whether or not it
     // redirected to inventory.php
     int itemId = UseItemRequest.currentItemId();
+
+    if (CampgroundRequest.isWorkshedItem(itemId)) {
+      // When you use a workshed item, the previous item is removed from
+      // the workshed.  UseLinkDecorator will not give you a "use" link,
+      // since you can only change your workshed item once per day.
+      //
+      // Instead, provide a "workshed" link so that you can go inspect
+      // and manipulate your newly installed item, whether or not you
+      // replaced a previous workshed item.
+
+      UseItemDecorator.decorateWorkshedItem(buffer);
+      return;
+    }
 
     switch (itemId) {
       case ItemPool.BOO_CLUE, ItemPool.GLUED_BOO_CLUE -> UseItemDecorator.decorateBooClue(buffer);
@@ -36,6 +50,20 @@ public class UseItemDecorator {
 
     String link = "<tr align=center><td>" + insert + "</td></tr>";
     buffer.insert(index, link);
+  }
+
+  private static void decorateWorkshedItem(final StringBuffer buffer) {
+    if (buffer.indexOf("in your workshed") == -1) {
+      return;
+    }
+
+    // Add the link to visit your workshed
+    StringBuilder link = new StringBuilder();
+    link.append("<a href=\"campground.php?action=workshed\">");
+    link.append("[Visit your workshed]");
+    link.append("</a>");
+
+    UseItemDecorator.decorateItem(buffer, link);
   }
 
   // <table  width=95%  cellspacing=0 cellpadding=0><tr><td style="color: white;" align=center

--- a/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
@@ -29,6 +29,7 @@ import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 import net.sourceforge.kolmafia.persistence.QuestDatabase;
 import net.sourceforge.kolmafia.persistence.QuestDatabase.Quest;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.CampgroundRequest;
 import net.sourceforge.kolmafia.request.CreateItemRequest;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.FightRequest;
@@ -538,6 +539,14 @@ public abstract class UseLinkDecorator {
 
   protected static UseLink generateUseLink(
       int itemId, int itemCount, String location, String text) {
+
+    // If this is a workshed item, and you've already replaced your
+    // workshed item today, it is pointless to provide a "use" link,
+    // since you can do that once per day.
+    if (CampgroundRequest.isWorkshedItem(itemId) && Preferences.getBoolean("_workshedItemUsed")) {
+      return null;
+    }
+
     // This might be a target of the Party Fair quest - if so we overwrite normal use link to
     // prevent accidents and show progress
     if (QuestDatabase.isQuestStep(Quest.PARTY_FAIR, "step1")


### PR DESCRIPTION
You can only replace the item in your workshed once per day.
When you do so:

```
You remove the spinning wheel from your workshed.
You acquire an item: spinning wheel
You place the model train set in your workshed.
```
1) Do not add a "use" link to the item you removed.
(Note that if you "acquire" a workshed item by purchasing it, say, we will give you a "use" link if you have not yet replaced an item in your workshed today.)
2) Add a "[Visit your workshed]" link any time you successfully "use" a workshed item.