### PR TITLE
Wine Glass works in Shadow Rift locations

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -507,13 +507,22 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
           Map.entry("Drunken Stupor", ""));
 
   public boolean tooDrunkToAdventure() {
-    if (!KoLCharacter.isFallingDown()) return false;
+    if (!KoLCharacter.isFallingDown()) {
+      return false;
+    }
 
     // The wine glass allows you to adventure in snarfblat zones while falling down drunk
     // There may be some non-snarfblat zones coded to respect the wineglass, but I've not
     // been able to find any.
-    if (KoLCharacter.hasEquipped(ItemPool.get(ItemPool.DRUNKULA_WINEGLASS)) && hasSnarfblat())
-      return false;
+    if (KoLCharacter.hasEquipped(ItemPool.get(ItemPool.DRUNKULA_WINEGLASS))) {
+      if (this.hasSnarfblat()) {
+        return false;
+      }
+      // Shadow Rift locations are place.php redirecting to adventure.php?snarfblat=567
+      if (this.zone.equals("Shadow Rift")) {
+        return false;
+      }
+    }
 
     // There are some limit modes that allow adventuring even while falling down drunk
     switch (KoLCharacter.getLimitMode()) {

--- a/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
+++ b/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
@@ -93,6 +93,8 @@ public class KoLAdventureValidationTest {
   class Overdrunk {
     private static final KoLAdventure WARREN =
         AdventureDatabase.getAdventureByName("The Dire Warren");
+    private static final KoLAdventure SHADOW_RIFT =
+        AdventureDatabase.getAdventureByName("Shadow Rift (Desert Beach)");
 
     @Test
     void beingSoberPassesPreValidation() {
@@ -100,6 +102,7 @@ public class KoLAdventureValidationTest {
 
       try (cleanups) {
         assertThat(WARREN.preValidateAdventure(), is(true));
+        assertThat(SHADOW_RIFT.preValidateAdventure(), is(true));
       }
     }
 
@@ -109,6 +112,7 @@ public class KoLAdventureValidationTest {
 
       try (cleanups) {
         assertThat(WARREN.preValidateAdventure(), is(false));
+        assertThat(SHADOW_RIFT.preValidateAdventure(), is(false));
       }
     }
 
@@ -125,6 +129,7 @@ public class KoLAdventureValidationTest {
 
       try (cleanups) {
         assertThat(WARREN.preValidateAdventure(), is(true));
+        assertThat(SHADOW_RIFT.preValidateAdventure(), is(true));
       }
     }
 


### PR DESCRIPTION
Shadow Rift locations are place.php that redirects to adventure.php?snarfblat=567 (that further redirects to fight.php or choice.php).

Drunkula's wineglass works fine there.