### PR TITLE
refactor: store monster class map by class object, not string

### DIFF
--- a/src/net/sourceforge/kolmafia/AreaCombatData.java
+++ b/src/net/sourceforge/kolmafia/AreaCombatData.java
@@ -516,7 +516,7 @@ public class AreaCombatData {
     // Your Ascension Class is null in Valhalla
     AscensionClass clazz = KoLCharacter.getAscensionClass();
     if (clazz != null) {
-      Map<MonsterData, MonsterData> classMap = MonsterDatabase.getMonsterClassMap(clazz.getName());
+      Map<MonsterData, MonsterData> classMap = MonsterDatabase.getMonsterClassMap(clazz);
       if (classMap != null) {
         MonsterData mapped = classMap.get(mon);
         if (mapped != null) {

--- a/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/MonsterDatabase.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -39,8 +40,8 @@ public class MonsterDatabase {
   private static final Map<String, MonsterData> MONSTER_IMAGES = new TreeMap<>();
   private static final Map<String, Map<MonsterData, MonsterData>> MONSTER_PATH_MAP =
       new TreeMap<>();
-  private static final Map<String, Map<MonsterData, MonsterData>> MONSTER_CLASS_MAP =
-      new TreeMap<>();
+  private static final Map<AscensionClass, Map<MonsterData, MonsterData>> MONSTER_CLASS_MAP =
+      new EnumMap<>(AscensionClass.class);
 
   // For handling duplicate monster and substring match of monster names
   private static final Map<String, MonsterData[]> MONSTER_ID_SET = new HashMap<>();
@@ -387,27 +388,27 @@ public class MonsterDatabase {
     MonsterDatabase.addMapping(
         pigSkinnerMap, "Naughty Sorceress (2)", "General Bruise (true form)");
     MonsterDatabase.addMapping(pigSkinnerMap, "Naughty Sorceress (3)", null);
-    MonsterDatabase.MONSTER_CLASS_MAP.put(AscensionClass.PIG_SKINNER.getName(), pigSkinnerMap);
+    MonsterDatabase.MONSTER_CLASS_MAP.put(AscensionClass.PIG_SKINNER, pigSkinnerMap);
 
     Map<MonsterData, MonsterData> cheeseWizardMap = new TreeMap<>();
     MonsterDatabase.addMapping(cheeseWizardMap, "Naughty Sorceress", "Dark Noël");
     MonsterDatabase.addMapping(cheeseWizardMap, "Naughty Sorceress (2)", "Dark Noël (true form)");
     MonsterDatabase.addMapping(cheeseWizardMap, "Naughty Sorceress (3)", null);
-    MonsterDatabase.MONSTER_CLASS_MAP.put(AscensionClass.CHEESE_WIZARD.getName(), cheeseWizardMap);
+    MonsterDatabase.MONSTER_CLASS_MAP.put(AscensionClass.CHEESE_WIZARD, cheeseWizardMap);
 
     Map<MonsterData, MonsterData> jazzAgentMap = new TreeMap<>();
     MonsterDatabase.addMapping(jazzAgentMap, "Naughty Sorceress", "Terrence Poindexter");
     MonsterDatabase.addMapping(
         jazzAgentMap, "Naughty Sorceress (2)", "Terrence Poindexter (true form)");
     MonsterDatabase.addMapping(jazzAgentMap, "Naughty Sorceress (3)", null);
-    MonsterDatabase.MONSTER_CLASS_MAP.put(AscensionClass.JAZZ_AGENT.getName(), jazzAgentMap);
+    MonsterDatabase.MONSTER_CLASS_MAP.put(AscensionClass.JAZZ_AGENT, jazzAgentMap);
   }
 
   public static Map<MonsterData, MonsterData> getMonsterPathMap(final String path) {
     return MonsterDatabase.MONSTER_PATH_MAP.get(path);
   }
 
-  public static Map<MonsterData, MonsterData> getMonsterClassMap(final String clazz) {
+  public static Map<MonsterData, MonsterData> getMonsterClassMap(final AscensionClass clazz) {
     return MonsterDatabase.MONSTER_CLASS_MAP.get(clazz);
   }
 

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -8496,7 +8496,7 @@ public abstract class RuntimeLibrary {
     ArrayValue value = new ArrayValue(type);
 
     Map<MonsterData, MonsterData> classMap =
-        MonsterDatabase.getMonsterClassMap(KoLCharacter.getAscensionClass().getName());
+        MonsterDatabase.getMonsterClassMap(KoLCharacter.getAscensionClass());
     Map<MonsterData, MonsterData> pathMap =
         MonsterDatabase.getMonsterPathMap(KoLCharacter.getPath().getName());
 
@@ -8521,7 +8521,7 @@ public abstract class RuntimeLibrary {
     MapValue value = new MapValue(type);
 
     Map<MonsterData, MonsterData> classMap =
-        MonsterDatabase.getMonsterClassMap(KoLCharacter.getAscensionClass().getName());
+        MonsterDatabase.getMonsterClassMap(KoLCharacter.getAscensionClass());
     Map<MonsterData, MonsterData> pathMap =
         MonsterDatabase.getMonsterPathMap(KoLCharacter.getPath().getName());
 


### PR DESCRIPTION
The use-case is that I wanted to be able to run `get_location_monsters` without being logged in, but also I can't really see a reason for indexing this by class names instead of by classes.