### PR TITLE
fix: always adventure in 'PirateRealm Island'

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -2141,8 +2141,14 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
 
     if (this.zone.startsWith("PirateRealm")) {
       // *** You have limited turns available per day.
-      return (Preferences.getBoolean("prAlways") || Preferences.getBoolean("_prToday"))
-          && Preferences.getString("_lastPirateRealmIsland").equals(this.adventureName);
+      if (!Preferences.getBoolean("prAlways") && !Preferences.getBoolean("_prToday")) {
+        return false;
+      }
+      if (this.adventureName.equals("PirateRealm Island")
+          || this.adventureName.equals("Sailing the PirateRealm Seas")) {
+        return true;
+      }
+      return Preferences.getString("_lastPirateRealmIsland").equals(this.adventureName);
     }
 
     if (this.zone.equals("Speakeasy")) {

--- a/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
+++ b/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
@@ -1367,6 +1367,10 @@ public class KoLAdventureValidationTest {
         AdventureDatabase.getAdventureByName("Red Roger's Fortress");
     private static final KoLAdventure BATTLE_ISLAND =
         AdventureDatabase.getAdventureByName("Battle Island");
+    private static final KoLAdventure PIRATEREALM_ISLAND =
+        AdventureDatabase.getAdventureByName("PirateRealm Island");
+    private static final KoLAdventure SAILING =
+        AdventureDatabase.getAdventureByName("Sailing the PirateRealm Seas");
 
     @Test
     public void properlyChecksLastIsland() {
@@ -1377,6 +1381,18 @@ public class KoLAdventureValidationTest {
       try (cleanups) {
         assertFalse(RED_ROGERS_FORTRESS.canAdventure());
         assertTrue(BATTLE_ISLAND.canAdventure());
+        assertTrue(PIRATEREALM_ISLAND.canAdventure());
+      }
+    }
+
+    @Test
+    public void canAlwaysSail() {
+      var cleanups =
+          new Cleanups(
+              withProperty("_lastPirateRealmIsland", "Glass Island"),
+              withProperty("prAlways", true));
+      try (cleanups) {
+        assertTrue(SAILING.canAdventure());
       }
     }
   }


### PR DESCRIPTION
A follow-up to #1652 to fix issue reported in https://kolmafia.us/threads/cant-adventure-in-piraterealm-island.28793

When adventuring in specifically "PirateRealm Island" or "Sailing the PirateRealm Seas", we can always adventure if we can access the zone.