### PR TITLE
More monkey characters

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/command/MonkeyPawCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/MonkeyPawCommand.java
@@ -14,7 +14,7 @@ public class MonkeyPawCommand extends AbstractCommand {
     this.usage = " effect [effectname] | item [itemname] | wish [wish]";
   }
 
-  private static final Pattern DISALLOWED_CHARACTER = Pattern.compile("[^a-z0-9A-Z ]");
+  private static final Pattern DISALLOWED_CHARACTER = Pattern.compile("[^a-z\\dA-Z \\-]");
 
   private static final Pattern RESPONSE = Pattern.compile("<span class='guts'>([^<]+)?</span>");
 

--- a/src/net/sourceforge/kolmafia/textui/command/MonkeyPawCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/MonkeyPawCommand.java
@@ -14,7 +14,7 @@ public class MonkeyPawCommand extends AbstractCommand {
     this.usage = " effect [effectname] | item [itemname] | wish [wish]";
   }
 
-  private static final Pattern DISALLOWED_CHARACTER = Pattern.compile("[^a-z\\dA-Z \\-]");
+  private static final Pattern DISALLOWED_CHARACTER = Pattern.compile("[^a-z\\d \\-]", Pattern.CASE_INSENSITIVE);
 
   private static final Pattern RESPONSE = Pattern.compile("<span class='guts'>([^<]+)?</span>");
 

--- a/src/net/sourceforge/kolmafia/textui/command/MonkeyPawCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/MonkeyPawCommand.java
@@ -14,8 +14,7 @@ public class MonkeyPawCommand extends AbstractCommand {
     this.usage = " effect [effectname] | item [itemname] | wish [wish]";
   }
 
-  private static final Pattern DISALLOWED_CHARACTER =
-      Pattern.compile("[^a-zA-Z\\d \\-]");
+  private static final Pattern DISALLOWED_CHARACTER = Pattern.compile("[^a-zA-Z\\d \\-]");
 
   private static final Pattern RESPONSE = Pattern.compile("<span class='guts'>([^<]+)?</span>");
 

--- a/src/net/sourceforge/kolmafia/textui/command/MonkeyPawCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/MonkeyPawCommand.java
@@ -14,7 +14,8 @@ public class MonkeyPawCommand extends AbstractCommand {
     this.usage = " effect [effectname] | item [itemname] | wish [wish]";
   }
 
-  private static final Pattern DISALLOWED_CHARACTER = Pattern.compile("[^a-z\\d \\-]", Pattern.CASE_INSENSITIVE);
+  private static final Pattern DISALLOWED_CHARACTER =
+      Pattern.compile("[^a-z\\d \\-]", Pattern.CASE_INSENSITIVE);
 
   private static final Pattern RESPONSE = Pattern.compile("<span class='guts'>([^<]+)?</span>");
 

--- a/src/net/sourceforge/kolmafia/textui/command/MonkeyPawCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/MonkeyPawCommand.java
@@ -15,7 +15,7 @@ public class MonkeyPawCommand extends AbstractCommand {
   }
 
   private static final Pattern DISALLOWED_CHARACTER =
-      Pattern.compile("[^a-z\\d \\-]", Pattern.CASE_INSENSITIVE);
+      Pattern.compile("[^a-zA-Z\\d \\-]");
 
   private static final Pattern RESPONSE = Pattern.compile("<span class='guts'>([^<]+)?</span>");
 

--- a/test/net/sourceforge/kolmafia/textui/command/MonkeyPawCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/MonkeyPawCommandTest.java
@@ -167,6 +167,18 @@ public class MonkeyPawCommandTest extends AbstractCommandTestBase {
     }
   }
 
+  @Test
+  public void dashesAreFineInItemAndEffectNames() {
+    var cleanups = withItem(ItemPool.CURSED_MONKEY_PAW);
+
+    try (cleanups) {
+      execute("item sonar-in-a-biscuit");
+
+      assertContinueState();
+      assertWish("sonar-in-a-biscuit");
+    }
+  }
+
   private void assertWish(String encodedWish) {
     var requests = getRequests();
     int i = 0;


### PR DESCRIPTION
When I wrote this branch name, I thought I would be adding a lot more than this. That being said, I can now confirm that the following are "illegal" characters: `.`, `,`, `'`, `"`, `(`, `)`, `!`, `?`.

But hey, we do get dashes! (tested using sonar-in-a-biscuit)

For future reference to any spaders, it looks like what happens is kol strips all "illegal" characters from the string and then compares it to item/effect names _including_ those characters. so `Let's Go Shopping!` gets stripped down to `Lets Go Shopping`, but that isn't a proper substring of `Let's Go Shopping!`. Which is to say if you're going to test whether a character can be used here, it needs to happen in the middle of the effect/item name, not as a bookend. Because `memento moiré`, for example, gets turned into `memento moir`, which matches `memento moiré` quite nicely.
I have been unsuccessful in finding a pattern that connects the valid characters and the invalid ones, but it is looking like "everything that isn't alphanumeric, whitespace, or a dash" is probably the rule.
