### PR TITLE
decrement encountersUntilSRChoice at end of combat, not start

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -3375,6 +3375,10 @@ public class FightRequest extends GenericRequest {
       Preferences.decrement("encountersUntilNEPChoice", 1, 0);
     }
 
+    if (adventure == AdventurePool.SHADOW_RIFT) {
+      Preferences.decrement("encountersUntilSRChoice", 1, 0);
+    }
+
     if (monsterName.equals("unusual construct")) {
       ResultProcessor.removeItem(ItemPool.STRANGE_DISC_WHITE);
       ResultProcessor.removeItem(ItemPool.STRANGE_DISC_BLACK);

--- a/src/net/sourceforge/kolmafia/session/RufusManager.java
+++ b/src/net/sourceforge/kolmafia/session/RufusManager.java
@@ -525,7 +525,6 @@ public class RufusManager {
 
   public static void handleShadowRiftFight(MonsterData monster) {
     int currentTurns = Preferences.getInteger("shadowRiftTotalTurns");
-    int lastNC = Preferences.getInteger("shadowRiftLastNC");
     switch (monster.getName()) {
       case "shadow spire",
           "shadow orrery",
@@ -535,14 +534,12 @@ public class RufusManager {
           "shadow matrix" -> {
         // Bosses are NCs
         Preferences.setInteger("shadowRiftLastNC", currentTurns);
-        lastNC = currentTurns;
+        Preferences.resetToDefault("encountersUntilSRChoice");
       }
     }
 
     // All fights - including bosses - advance turns in zone
     currentTurns = Preferences.increment("shadowRiftTotalTurns", 1);
-    // Next NC comes if (turns in zone - last nc) >= 11
-    Preferences.setInteger("encountersUntilSRChoice", 11 - Math.max(currentTurns - lastNC, 0));
   }
 
   public static void handleShadowRiftNC(int choice, String responseText) {
@@ -553,13 +550,12 @@ public class RufusManager {
       case 1499 -> {
         // The Shadow Labyrinth
         Preferences.setInteger("shadowRiftLastNC", currentTurns);
-        lastNC = currentTurns;
+        Preferences.resetToDefault("encountersUntilSRChoice");
       }
       case 1500 -> {
         // Like a Loded Stone
         ResultProcessor.removeItem(ItemPool.RUFUS_SHADOW_LODESTONE);
       }
     }
-    Preferences.setInteger("encountersUntilSRChoice", 11 - Math.max(currentTurns - lastNC, 0));
   }
 }


### PR DESCRIPTION
This is failing tests right now. I need to get the two tests it's failing (and any potential other tests I add) to process the end of combat with all the monsters in question, but I don't immediately see a way to do that, so this is a draft for now.