### PR TITLE
Fix set_location($location[none])

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -8469,7 +8469,13 @@ public abstract class RuntimeLibrary {
 
   public static Value set_location(ScriptRuntime controller, final Value location) {
     KoLAdventure adventure = (KoLAdventure) location.rawValue();
-    KoLAdventure.setNextAdventure(adventure);
+    if (adventure == null) {
+      Preferences.setString("nextAdventure", "None");
+      KoLCharacter.updateSelectedLocation(null);
+    } else {
+      Preferences.setString("nextAdventure", adventure.getAdventureName());
+      KoLCharacter.updateSelectedLocation(adventure);
+    }
     return DataTypes.VOID_VALUE;
   }
 

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -810,4 +810,16 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
                     """));
     }
   }
+
+  @Test
+  void setLocation() {
+    String output = execute("set_location($location[Barf Mountain])");
+    assertThat(output, containsString("Returned: void"));
+    output = execute("my_location()");
+    assertThat(output, containsString("Returned: Barf Mountain"));
+    output = execute("set_location($location[none])");
+    assertThat(output, containsString("Returned: void"));
+    output = execute("my_location()");
+    assertThat(output, containsString("Returned: none"));
+  }
 }


### PR DESCRIPTION
Per [This report](https://kolmafia.us/threads/allow-set_location-location-none-to-set-your-location-to-none.28807/), ASH set_location(location[none]) does not set KoL's idea of the current location.

I can't think of any reason a script would depend on that behavior, so I changed it to actually do (more or less) what KoL itself will do with KoLAdventure.setNextAdventure("None") - which KoL itself calls when it determines that using an item will lead to a fight; the fight is (usually) not deemed to occur in a particular location.