### PR TITLE
Combat data rates for The Battlefield

### DIFF
--- a/src/net/sourceforge/kolmafia/AreaCombatData.java
+++ b/src/net/sourceforge/kolmafia/AreaCombatData.java
@@ -1399,8 +1399,8 @@ public class AreaCombatData {
               ? 1
               : 0;
             // After specific number of hippies defeated
-          case "Mobile Armored Sweat Lodge" -> hippiesDefeated > 150 ? 1 : 0;
-          case "Green Ops Soldier" -> hippiesDefeated > 400 ? 1 : 0;
+          case "Mobile Armored Sweat Lodge" -> hippiesDefeated >= 151 ? 1 : 0;
+          case "Green Ops Soldier" -> hippiesDefeated >= 401 ? 1 : 0;
             // Hippy Heroes only appear in specific range. Very low encounter chance
           case "Slow Talkin' Elliot" -> hippiesDefeated >= 501 && hippiesDefeated <= 600 ? -1 : 0;
           case "Neil" -> hippiesDefeated >= 601 && hippiesDefeated <= 700 ? -1 : 0;
@@ -1430,8 +1430,8 @@ public class AreaCombatData {
               ? 1
               : 0;
             // After specific number of fratboys defeated
-          case "Sorority Operator" -> fratboysDefeated > 150 ? 1 : 0;
-          case "Panty Raider Frat Boy" -> fratboysDefeated > 400 ? 1 : 0;
+          case "Sorority Operator" -> fratboysDefeated >= 151 ? 1 : 0;
+          case "Panty Raider Frat Boy" -> fratboysDefeated >= 401 ? 1 : 0;
             // Fratboy Heroes only appear in specific range. Very low encounter chance
           case "Next-generation Frat Boy" -> fratboysDefeated >= 501 && fratboysDefeated <= 600
               ? -1

--- a/src/net/sourceforge/kolmafia/AreaCombatData.java
+++ b/src/net/sourceforge/kolmafia/AreaCombatData.java
@@ -1383,20 +1383,67 @@ public class AreaCombatData {
         };
       }
       case "The Battlefield (Frat Uniform)" -> {
+        int hippiesDefeated = Preferences.getInteger("hippiesDefeated");
+
+        // If the battlefield is cleared, only the boss can appear unless the quest is finished
+        if (hippiesDefeated == 1000) {
+          return switch (monster) {
+            case "The Big Wisniewski" -> !QuestDatabase.isQuestFinished(Quest.ISLAND_WAR) ? 1 : 0;
+            default -> 0;
+          };
+        }
         return switch (monster) {
+            // Junkyard quest completed as hippy
           case "Bailey's Beetle" -> Preferences.getString("sidequestJunkyardCompleted")
                   .equals("hippy")
               ? 1
               : 0;
+            // After specific number of hippies defeated
+          case "Mobile Armored Sweat Lodge" -> hippiesDefeated > 150 ? 1 : 0;
+          case "Green Ops Soldier" -> hippiesDefeated > 400 ? 1 : 0;
+            // Hippy Heroes only appear in specific range. Very low encounter chance
+          case "Slow Talkin' Elliot" -> hippiesDefeated >= 501 && hippiesDefeated <= 600 ? -1 : 0;
+          case "Neil" -> hippiesDefeated >= 601 && hippiesDefeated <= 700 ? -1 : 0;
+          case "Zim Merman" -> hippiesDefeated >= 701 && hippiesDefeated <= 800 ? -1 : 0;
+          case "C.A.R.N.I.V.O.R.E. Operative" -> hippiesDefeated >= 801 && hippiesDefeated <= 900
+              ? -1
+              : 0;
+          case "Glass of Orange Juice" -> hippiesDefeated >= 901 && hippiesDefeated <= 999 ? -1 : 0;
           default -> weighting;
         };
       }
       case "The Battlefield (Hippy Uniform)" -> {
+        int fratboysDefeated = Preferences.getInteger("fratboysDefeated");
+
+        // If the battlefield is cleared, only the boss can appear unless the quest is finished
+        if (fratboysDefeated == 1000) {
+          return switch (monster) {
+            case "The Man" -> !QuestDatabase.isQuestFinished(Quest.ISLAND_WAR) ? 1 : 0;
+            default -> 0;
+          };
+        }
+
         return switch (monster) {
+            // Junkyard quest completed as fratboy
           case "War Frat Mobile Grill Unit" -> Preferences.getString("sidequestJunkyardCompleted")
                   .equals("fratboy")
               ? 1
               : 0;
+            // After specific number of fratboys defeated
+          case "Sorority Operator" -> fratboysDefeated > 150 ? 1 : 0;
+          case "Panty Raider Frat Boy" -> fratboysDefeated > 400 ? 1 : 0;
+            // Fratboy Heroes only appear in specific range. Very low encounter chance
+          case "Next-generation Frat Boy" -> fratboysDefeated >= 501 && fratboysDefeated <= 600
+              ? -1
+              : 0;
+          case "Monty Basingstoke-Pratt, IV" -> fratboysDefeated >= 601 && fratboysDefeated <= 700
+              ? -1
+              : 0;
+          case "Brutus, the toga-clad lout" -> fratboysDefeated >= 701 && fratboysDefeated <= 800
+              ? -1
+              : 0;
+          case "Danglin' Chad" -> fratboysDefeated >= 801 && fratboysDefeated <= 900 ? -1 : 0;
+          case "War Frat Streaker" -> fratboysDefeated >= 901 && fratboysDefeated <= 999 ? -1 : 0;
           default -> weighting;
         };
       }

--- a/src/net/sourceforge/kolmafia/AreaCombatData.java
+++ b/src/net/sourceforge/kolmafia/AreaCombatData.java
@@ -1388,7 +1388,7 @@ public class AreaCombatData {
         // If the battlefield is cleared, only the boss can appear unless the quest is finished
         if (hippiesDefeated == 1000) {
           return switch (monster) {
-            case "The Big Wisniewski" -> !QuestDatabase.isQuestFinished(Quest.ISLAND_WAR) ? 1 : 0;
+            case "The Big Wisniewski" -> 1;
             default -> 0;
           };
         }
@@ -1418,7 +1418,7 @@ public class AreaCombatData {
         // If the battlefield is cleared, only the boss can appear unless the quest is finished
         if (fratboysDefeated == 1000) {
           return switch (monster) {
-            case "The Man" -> !QuestDatabase.isQuestFinished(Quest.ISLAND_WAR) ? 1 : 0;
+            case "The Man" -> 1;
             default -> 0;
           };
         }

--- a/src/net/sourceforge/kolmafia/AreaCombatData.java
+++ b/src/net/sourceforge/kolmafia/AreaCombatData.java
@@ -1385,12 +1385,9 @@ public class AreaCombatData {
       case "The Battlefield (Frat Uniform)" -> {
         int hippiesDefeated = Preferences.getInteger("hippiesDefeated");
 
-        // If the battlefield is cleared, only the boss can appear unless the quest is finished
+        // If the battlefield is cleared, only the boss can appear
         if (hippiesDefeated == 1000) {
-          return switch (monster) {
-            case "The Big Wisniewski" -> 1;
-            default -> 0;
-          };
+          return monster.equals("The Big Wisniewski") ? 1 : 0;
         }
         return switch (monster) {
             // Junkyard quest completed as hippy
@@ -1415,12 +1412,9 @@ public class AreaCombatData {
       case "The Battlefield (Hippy Uniform)" -> {
         int fratboysDefeated = Preferences.getInteger("fratboysDefeated");
 
-        // If the battlefield is cleared, only the boss can appear unless the quest is finished
+        // If the battlefield is cleared, only the boss can appear
         if (fratboysDefeated == 1000) {
-          return switch (monster) {
-            case "The Man" -> 1;
-            default -> 0;
-          };
+          return monster.equals("The Man") ? 1 : 0;
         }
 
         return switch (monster) {

--- a/src/net/sourceforge/kolmafia/AreaCombatData.java
+++ b/src/net/sourceforge/kolmafia/AreaCombatData.java
@@ -1396,8 +1396,26 @@ public class AreaCombatData {
               ? 1
               : 0;
             // After specific number of hippies defeated
-          case "Mobile Armored Sweat Lodge" -> hippiesDefeated >= 151 ? 1 : 0;
           case "Green Ops Soldier" -> hippiesDefeated >= 401 ? 1 : 0;
+          case "Mobile Armored Sweat Lodge" -> hippiesDefeated >= 151 ? 1 : 0;
+          case "War Hippy Airborne Commander" -> hippiesDefeated >= 351 ? 1 : 0;
+          case "War Hippy Baker" -> hippiesDefeated <= 600 ? 2 : 0;
+          case "War Hippy Dread Squad" -> hippiesDefeated <= 850 ? 1 : 0;
+          case "War Hippy Elder Shaman" -> hippiesDefeated >= 251 ? 1 : 0;
+          case "War Hippy Elite Fire Spinner" -> hippiesDefeated >= 501 ? 1 : 0;
+          case "War Hippy Elite Rigger" -> hippiesDefeated >= 301 ? 2 : 0;
+          case "War Hippy F.R.O.G." -> hippiesDefeated >= 51 && hippiesDefeated <= 500 ? 2 : 0;
+          case "War Hippy Fire Spinner" -> hippiesDefeated >= 301 && hippiesDefeated <= 650 ? 1 : 0;
+          case "War Hippy Green Gourmet" -> hippiesDefeated >= 201 && hippiesDefeated <= 750
+              ? 2
+              : 0;
+          case "War Hippy Homeopath" -> hippiesDefeated <= 900 ? 1 : 0;
+          case "War Hippy Infantryman" -> hippiesDefeated <= 400 ? 2 : 0;
+          case "War Hippy Naturopathic Homeopath" -> hippiesDefeated >= 451 ? 1 : 0;
+          case "War Hippy Rigger" -> hippiesDefeated <= 800 ? 2 : 0;
+          case "War Hippy Shaman" -> hippiesDefeated >= 26 && hippiesDefeated <= 700 ? 1 : 0;
+          case "War Hippy Sky Captain" -> hippiesDefeated >= 76 && hippiesDefeated <= 550 ? 1 : 0;
+          case "War Hippy Windtalker" -> hippiesDefeated > 0 ? 1 : 0;
             // Hippy Heroes only appear in specific range. Very low encounter chance
           case "Slow Talkin' Elliot" -> hippiesDefeated >= 501 && hippiesDefeated <= 600 ? -1 : 0;
           case "Neil" -> hippiesDefeated >= 601 && hippiesDefeated <= 700 ? -1 : 0;
@@ -1423,7 +1441,7 @@ public class AreaCombatData {
                   .equals("fratboy")
               ? 1
               : 0;
-            // After specific number of fratboys defeated
+            // After specific number of fratboys defeated (todo: has not been spaded)
           case "Sorority Operator" -> fratboysDefeated >= 151 ? 1 : 0;
           case "Panty Raider Frat Boy" -> fratboysDefeated >= 401 ? 1 : 0;
             // Fratboy Heroes only appear in specific range. Very low encounter chance

--- a/test/net/sourceforge/kolmafia/AreaCombatDataTest.java
+++ b/test/net/sourceforge/kolmafia/AreaCombatDataTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.core.Every.everyItem;
 
 import internal.helpers.Cleanups;
 import java.io.File;
-import java.util.HashMap;
 import java.util.Map;
 import net.sourceforge.kolmafia.equipment.Slot;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
@@ -64,29 +63,23 @@ public class AreaCombatDataTest {
       MonsterDatabase.findMonster("War Frat Mobile Grill Unit");
   static final MonsterData HIPPY_JUNKYARD = MonsterDatabase.findMonster("Bailey's Beetle");
   static final Map<MonsterData, Integer> HIPPY_DEFEATED =
-      new HashMap<>() {
-        {
-          put(MonsterDatabase.findMonster("Mobile Armored Sweat Lodge"), 151);
-          put(MonsterDatabase.findMonster("Green Ops Soldier"), 401);
-          put(MonsterDatabase.findMonster("Slow Talkin' Elliot"), 501);
-          put(MonsterDatabase.findMonster("Neil"), 601);
-          put(MonsterDatabase.findMonster("Zim Merman"), 701);
-          put(MonsterDatabase.findMonster("C.A.R.N.I.V.O.R.E. Operative"), 801);
-          put(MonsterDatabase.findMonster("Glass of Orange Juice"), 901);
-        }
-      };
+      Map.ofEntries(
+          Map.entry(MonsterDatabase.findMonster("Mobile Armored Sweat Lodge"), 151),
+          Map.entry(MonsterDatabase.findMonster("Green Ops Soldier"), 401),
+          Map.entry(MonsterDatabase.findMonster("Slow Talkin' Elliot"), 501),
+          Map.entry(MonsterDatabase.findMonster("Neil"), 601),
+          Map.entry(MonsterDatabase.findMonster("Zim Merman"), 701),
+          Map.entry(MonsterDatabase.findMonster("C.A.R.N.I.V.O.R.E. Operative"), 801),
+          Map.entry(MonsterDatabase.findMonster("Glass of Orange Juice"), 901));
   static final Map<MonsterData, Integer> FRATBOY_DEFEATED =
-      new HashMap<>() {
-        {
-          put(MonsterDatabase.findMonster("Sorority Operator"), 151);
-          put(MonsterDatabase.findMonster("Panty Raider Frat Boy"), 401);
-          put(MonsterDatabase.findMonster("Next-generation Frat Boy"), 501);
-          put(MonsterDatabase.findMonster("Monty Basingstoke-Pratt, IV"), 601);
-          put(MonsterDatabase.findMonster("Brutus, the toga-clad lout"), 701);
-          put(MonsterDatabase.findMonster("Danglin' Chad"), 801);
-          put(MonsterDatabase.findMonster("War Frat Streaker"), 901);
-        }
-      };
+      Map.ofEntries(
+          Map.entry(MonsterDatabase.findMonster("Sorority Operator"), 151),
+          Map.entry(MonsterDatabase.findMonster("Panty Raider Frat Boy"), 401),
+          Map.entry(MonsterDatabase.findMonster("Next-generation Frat Boy"), 501),
+          Map.entry(MonsterDatabase.findMonster("Monty Basingstoke-Pratt, IV"), 601),
+          Map.entry(MonsterDatabase.findMonster("Brutus, the toga-clad lout"), 701),
+          Map.entry(MonsterDatabase.findMonster("Danglin' Chad"), 801),
+          Map.entry(MonsterDatabase.findMonster("War Frat Streaker"), 901));
 
   @BeforeEach
   public void beforeEach() {

--- a/test/net/sourceforge/kolmafia/AreaCombatDataTest.java
+++ b/test/net/sourceforge/kolmafia/AreaCombatDataTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.core.Every.everyItem;
 
 import internal.helpers.Cleanups;
 import java.io.File;
+import java.util.HashMap;
 import java.util.Map;
 import net.sourceforge.kolmafia.equipment.Slot;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
@@ -49,13 +50,43 @@ public class AreaCombatDataTest {
   static final MonsterData PERVERT = MonsterDatabase.findMonster("smut orc pervert");
   static final MonsterData SNAKE = MonsterDatabase.findMonster("The Frattlesnake");
   static final MonsterData GHOST = MonsterDatabase.findMonster("The ghost of Richard Cockingham");
-  static final MonsterData HIPPY_YOSS = MonsterDatabase.findMonster("Bailey's Beetle");
-  static final MonsterData FRAT_YOSS = MonsterDatabase.findMonster("War Frat Mobile Grill Unit");
   static final MonsterData EVIL_CULTIST = MonsterDatabase.findMonster("evil cultist");
   static final MonsterData CYBORG_POLICEMAN = MonsterDatabase.findMonster("cyborg policeman");
   static final MonsterData OBESE_TOURIST = MonsterDatabase.findMonster("obese tourist");
   static final MonsterData TERRIFYING_ROBOT = MonsterDatabase.findMonster("terrifying robot");
   static final AdventureResult MULTI_PASS = ItemPool.get(ItemPool.MULTI_PASS);
+
+  static final String BATTLEFIELD_FRATUNIFORM = "The Battlefield (Frat Uniform)";
+  static final String BATTLEFIELD_HIPPYUNIFORM = "The Battlefield (Hippy Uniform)";
+  static final MonsterData FRATBOY_BOSS = MonsterDatabase.findMonster("The Man");
+  static final MonsterData HIPPY_BOSS = MonsterDatabase.findMonster("The Big Wisniewski");
+  static final MonsterData FRATBOY_JUNKYARD =
+      MonsterDatabase.findMonster("War Frat Mobile Grill Unit");
+  static final MonsterData HIPPY_JUNKYARD = MonsterDatabase.findMonster("Bailey's Beetle");
+  static final Map<MonsterData, Integer> HIPPY_DEFEATED =
+      new HashMap<>() {
+        {
+          put(MonsterDatabase.findMonster("Mobile Armored Sweat Lodge"), 151);
+          put(MonsterDatabase.findMonster("Green Ops Soldier"), 401);
+          put(MonsterDatabase.findMonster("Slow Talkin' Elliot"), 501);
+          put(MonsterDatabase.findMonster("Neil"), 601);
+          put(MonsterDatabase.findMonster("Zim Merman"), 701);
+          put(MonsterDatabase.findMonster("C.A.R.N.I.V.O.R.E. Operative"), 801);
+          put(MonsterDatabase.findMonster("Glass of Orange Juice"), 901);
+        }
+      };
+  static final Map<MonsterData, Integer> FRATBOY_DEFEATED =
+      new HashMap<>() {
+        {
+          put(MonsterDatabase.findMonster("Sorority Operator"), 151);
+          put(MonsterDatabase.findMonster("Panty Raider Frat Boy"), 401);
+          put(MonsterDatabase.findMonster("Next-generation Frat Boy"), 501);
+          put(MonsterDatabase.findMonster("Monty Basingstoke-Pratt, IV"), 601);
+          put(MonsterDatabase.findMonster("Brutus, the toga-clad lout"), 701);
+          put(MonsterDatabase.findMonster("Danglin' Chad"), 801);
+          put(MonsterDatabase.findMonster("War Frat Streaker"), 901);
+        }
+      };
 
   @BeforeEach
   public void beforeEach() {
@@ -196,32 +227,105 @@ public class AreaCombatDataTest {
   }
 
   @Test
-  public void battlefieldFratYoss() {
+  public void battlefieldHippyUniform() {
     AdventureQueueDatabase.resetQueue();
-    Preferences.setString("sidequestJunkyardCompleted", "fratboy");
-    Map<MonsterData, Double> appearanceRates =
-        AdventureDatabase.getAreaCombatData("The Battlefield (Hippy Uniform)").getMonsterData(true);
 
-    assertThat(appearanceRates.get(FRAT_YOSS), greaterThan(0.0));
+    // Defeated count
+    for (var entry : FRATBOY_DEFEATED.entrySet()) {
+      Preferences.setInteger("fratboysDefeated", 0);
+      assertThat(
+          AdventureDatabase.getAreaCombatData(BATTLEFIELD_HIPPYUNIFORM)
+              .getMonsterData(true)
+              .get(entry.getKey()),
+          equalTo(0.0));
+      Preferences.setInteger("fratboysDefeated", entry.getValue());
+      assertThat(
+          AdventureDatabase.getAreaCombatData(BATTLEFIELD_HIPPYUNIFORM)
+              .getMonsterData(true)
+              .get(entry.getKey()),
+          not(0.0));
+    }
+
+    // Boss
+    Preferences.setInteger("fratboysDefeated", 999);
+    assertThat(
+        AdventureDatabase.getAreaCombatData(BATTLEFIELD_HIPPYUNIFORM)
+            .getMonsterData(true)
+            .get(FRATBOY_BOSS),
+        equalTo(0.0));
+    Preferences.setInteger("fratboysDefeated", 1000);
+    assertThat(
+        AdventureDatabase.getAreaCombatData(BATTLEFIELD_HIPPYUNIFORM)
+            .getMonsterData(true)
+            .get(FRATBOY_BOSS),
+        equalTo(100.0));
+
+    // Junkyard sidequest state
+    Preferences.setInteger("fratboysDefeated", 0);
+    Preferences.setString("sidequestJunkyardCompleted", "fratboy");
+    assertThat(
+        AdventureDatabase.getAreaCombatData(BATTLEFIELD_HIPPYUNIFORM)
+            .getMonsterData(true)
+            .get(FRATBOY_JUNKYARD),
+        greaterThan(0.0));
 
     Preferences.setString("sidequestJunkyardCompleted", "hippy");
-    appearanceRates =
-        AdventureDatabase.getAreaCombatData("The Battlefield (Hippy Uniform)").getMonsterData(true);
-    assertThat(appearanceRates.get(FRAT_YOSS), equalTo(0.0));
+    assertThat(
+        AdventureDatabase.getAreaCombatData(BATTLEFIELD_HIPPYUNIFORM)
+            .getMonsterData(true)
+            .get(FRATBOY_JUNKYARD),
+        equalTo(0.0));
   }
 
   @Test
-  public void battlefieldHippyYoss() {
+  public void battlefieldFratUniform() {
     AdventureQueueDatabase.resetQueue();
+
+    // Defeated count
+    for (var entry : HIPPY_DEFEATED.entrySet()) {
+      Preferences.setInteger("hippiesDefeated", 0);
+      assertThat(
+          AdventureDatabase.getAreaCombatData(BATTLEFIELD_FRATUNIFORM)
+              .getMonsterData(true)
+              .get(entry.getKey()),
+          equalTo(0.0));
+      Preferences.setInteger("hippiesDefeated", entry.getValue());
+      assertThat(
+          AdventureDatabase.getAreaCombatData(BATTLEFIELD_FRATUNIFORM)
+              .getMonsterData(true)
+              .get(entry.getKey()),
+          not(0.0));
+    }
+
+    // Boss
+    Preferences.setInteger("hippiesDefeated", 999);
+    assertThat(
+        AdventureDatabase.getAreaCombatData(BATTLEFIELD_FRATUNIFORM)
+            .getMonsterData(true)
+            .get(HIPPY_BOSS),
+        equalTo(0.0));
+    Preferences.setInteger("hippiesDefeated", 1000);
+    assertThat(
+        AdventureDatabase.getAreaCombatData(BATTLEFIELD_FRATUNIFORM)
+            .getMonsterData(true)
+            .get(HIPPY_BOSS),
+        equalTo(100.0));
+
+    // Junkyard sidequest state
+    Preferences.setInteger("hippiesDefeated", 0);
     Preferences.setString("sidequestJunkyardCompleted", "hippy");
-    Map<MonsterData, Double> appearanceRates =
-        AdventureDatabase.getAreaCombatData("The Battlefield (Frat Uniform)").getMonsterData(true);
-    assertThat(appearanceRates.get(HIPPY_YOSS), greaterThan(0.0));
+    assertThat(
+        AdventureDatabase.getAreaCombatData(BATTLEFIELD_FRATUNIFORM)
+            .getMonsterData(true)
+            .get(HIPPY_JUNKYARD),
+        greaterThan(0.0));
 
     Preferences.setString("sidequestJunkyardCompleted", "fratboy");
-    appearanceRates =
-        AdventureDatabase.getAreaCombatData("The Battlefield (Frat Uniform)").getMonsterData(true);
-    assertThat(appearanceRates.get(HIPPY_YOSS), equalTo(0.0));
+    assertThat(
+        AdventureDatabase.getAreaCombatData(BATTLEFIELD_FRATUNIFORM)
+            .getMonsterData(true)
+            .get(HIPPY_JUNKYARD),
+        equalTo(0.0));
   }
 
   @Test


### PR DESCRIPTION
- Handle monsters that only appear after a fixed number of kills
- Handle heroes that appear in ranges, return -1 as the rate to denote that the hero is possible but otherwise doesn't affect normal encounter rates (superlikelies with a very low chance) 
- Return boss as the only encounter when battlefield is cleared