### PR TITLE
Cincho tracking fixes

### DIFF
--- a/src/data/consequences.txt
+++ b/src/data/consequences.txt
@@ -145,7 +145,7 @@ COMBAT_SKILL	Otoscope	Otoscope \((\d+) charges left\)	_otoscopeUsed=[3-$1]
 COMBAT_SKILL	Reflex Hammer	Reflex Hammer \((\d+) charges left\)	_reflexHammerUsed=[3-$1]
 COMBAT_SKILL	Chest X-Ray	Chest X-Ray \((\d+) charges left\)	_chestXRayUsed=[3-$1]
 COMBAT_SKILL	Back-Up to your Last Enemy	Back-Up to your Last Enemy \((\d+) uses? today\)	_backUpUses=[(11+path(You, Robot)*5)-$1]
-COMBAT_SKILL	Cincho: Confetti Extravaganza	Cincho: Confetti Extravaganza \(5 cinch, (\d+)% remaining\)	_cinchUsed=[100-$1]
+COMBAT_SKILL	Cincho: Party Foul	Cincho: Party Foul \(5 cinch, (\d+)% remaining\)	_cinchUsed=[100-$1]
 
 # Monster disambiguation:
 

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -10173,21 +10173,21 @@ public class FightRequest extends GenericRequest {
       case SkillPool.CINCHO_PROJECTILE_PINATA:
         if (responseText.contains(
             "You press the Projectile Pi&ntilde;ata button on your Cincho.")) {
-          Preferences.increment("_cinchUsed", 5, 100, false);
           skillSuccess = true;
+          increment = 5;
         }
         break;
       case SkillPool.CINCHO_CONFETTI_EXTRAVAGANZA:
         if (responseText.contains("You activate your Cincho's Confetti Extravaganza function.")) {
-          Preferences.increment("_cinchUsed", 5, 100, false);
           skillSuccess = true;
+          increment = 5;
         }
         break;
       case SkillPool.CINCHO_PARTY_FOUL:
         if (responseText.contains(
             "You press the button on your Cincho that unleashes a torrent of ghastly obscenities.")) {
-          Preferences.increment("_cinchUsed", 5, 100, false);
           skillSuccess = true;
+          increment = 5;
         }
         break;
     }

--- a/test/net/sourceforge/kolmafia/request/FightRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FightRequestTest.java
@@ -1775,11 +1775,11 @@ public class FightRequestTest {
   @ParameterizedTest
   @ValueSource(strings = {"projectile", "confetti", "party"})
   void cinchoCastRecorded(String fileName) {
-    var cleanups = new Cleanups(withProperty("_cinchUsed", 95));
+    var cleanups = new Cleanups(withProperty("_cinchUsed", 90));
 
     try (cleanups) {
       parseCombatData("request/test_fight_parse_casting_cinch_" + fileName + ".html");
-      assertThat("_cinchUsed", isSetTo(100));
+      assertThat("_cinchUsed", isSetTo(95));
     }
   }
 


### PR DESCRIPTION
 - Confetti extravaganza is once per fight and so it's not an optimal candidate for consequences.txt
 - Testing that cinch went from 95 to 100 wasn't reliable because it didn't account for overshooting our cinch counts
 - setting `skillSuccess` to true meant we incremented cinch as part of our dailylimit handling as well as the manual preference tracking previously included; this has been rectified.