### PR TITLE
feat: expose ids for kol objects through a .id field

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -167,6 +167,7 @@ public class ProxyRecordValue extends RecordValue {
   public static class ClassProxy extends ProxyRecordValue {
     public static final RecordType _type =
         new RecordBuilder()
+            .add("id", DataTypes.INT_TYPE)
             .add("primestat", DataTypes.STAT_TYPE)
             .add("path", DataTypes.PATH_TYPE)
             .finish("class proxy");
@@ -177,6 +178,10 @@ public class ProxyRecordValue extends RecordValue {
 
     private AscensionClass getAscensionClass() {
       return (AscensionClass) this.content;
+    }
+
+    public int get_id() {
+      return (int) this.contentLong;
     }
 
     public Value get_primestat() {
@@ -202,6 +207,7 @@ public class ProxyRecordValue extends RecordValue {
   public static class ItemProxy extends ProxyRecordValue {
     public static final RecordType _type =
         new RecordBuilder()
+            .add("id", DataTypes.INT_TYPE)
             .add("name", DataTypes.STRING_TYPE)
             .add("plural", DataTypes.STRING_TYPE)
             .add("descid", DataTypes.STRING_TYPE)
@@ -251,6 +257,10 @@ public class ProxyRecordValue extends RecordValue {
 
     public ItemProxy(Value obj) {
       super(_type, obj);
+    }
+
+    public int get_id() {
+      return (int) this.contentLong;
     }
 
     /**
@@ -700,6 +710,7 @@ public class ProxyRecordValue extends RecordValue {
   public static class FamiliarProxy extends ProxyRecordValue {
     public static final RecordType _type =
         new RecordBuilder()
+            .add("id", DataTypes.INT_TYPE)
             .add("hatchling", DataTypes.ITEM_TYPE)
             .add("image", DataTypes.STRING_TYPE)
             .add("name", DataTypes.STRING_TYPE)
@@ -744,6 +755,10 @@ public class ProxyRecordValue extends RecordValue {
 
     public FamiliarProxy(Value obj) {
       super(_type, obj);
+    }
+
+    public int get_id() {
+      return (int) this.contentLong;
     }
 
     public Value get_hatchling() {
@@ -1173,6 +1188,7 @@ public class ProxyRecordValue extends RecordValue {
   public static class SkillProxy extends ProxyRecordValue {
     public static final RecordType _type =
         new RecordBuilder()
+            .add("id", DataTypes.INT_TYPE)
             .add("name", DataTypes.STRING_TYPE)
             .add("type", DataTypes.STRING_TYPE)
             .add("level", DataTypes.INT_TYPE)
@@ -1194,6 +1210,10 @@ public class ProxyRecordValue extends RecordValue {
 
     public SkillProxy(Value obj) {
       super(_type, obj);
+    }
+
+    public int get_id() {
+      return (int) this.contentLong;
     }
 
     public String get_name() {
@@ -1269,6 +1289,7 @@ public class ProxyRecordValue extends RecordValue {
   public static class EffectProxy extends ProxyRecordValue {
     public static final RecordType _type =
         new RecordBuilder()
+            .add("id", DataTypes.INT_TYPE)
             .add("name", DataTypes.STRING_TYPE)
             .add("default", DataTypes.STRING_TYPE)
             .add("note", DataTypes.STRING_TYPE)
@@ -1283,6 +1304,10 @@ public class ProxyRecordValue extends RecordValue {
 
     public EffectProxy(Value obj) {
       super(_type, obj);
+    }
+
+    public int get_id() {
+      return (int) this.contentLong;
     }
 
     public String get_name() {

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -828,4 +828,23 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
     String output = execute("numeric_modifier($skill[Crimbo Training: Bartender], \"booze drop\")");
     assertThat(output, containsString("15.0"));
   }
+
+  @Nested
+  class Ids {
+    @ParameterizedTest
+    @CsvSource({
+      "$item[pirate radio ring].id, 10210",
+      "$skill[Unleash Terra Cotta Army].id, 7321",
+      "$effect[Wings].id, 6",
+      "$familiar[Cat Burglar].id, 267",
+      "$monster[Knob Goblin Embezzler].id, 530",
+      "$location[The Dire Warren].id, 92",
+      "$path[Trendy].id, 7",
+      "$class[Pig Skinner].id, 28"
+    })
+    void exposesIds(String exec, String value) {
+      String output = execute(exec);
+      assertThat(output, containsString("Returned: " + value));
+    }
+  }
 }


### PR DESCRIPTION
Currently, proxy-record-wise:

* we expose .id fields for monster, location, path, slot, thrall and servant
* .to_int() works for everything with an id except slot, but is hard to remember

Add .id fields for KoL things we know about.

Slot, thrall and servant relay our internal ids, which probably shouldn't be exposed, but too late now ;)