### PR TITLE
feat: undo special LoL standard familiar handling

### DIFF
--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -300,11 +300,6 @@ public class FamiliarData implements Comparable<FamiliarData> {
       return false;
     }
 
-    // In Legacy of Loathing, standard restrictions don't apply to replica familiars
-    if (KoLCharacter.inLegacyOfLoathing()) {
-      return true;
-    }
-
     // Unallowed familiars cannot be equipped
     if (!StandardRequest.isAllowed(RestrictedItemType.FAMILIARS, this.race)) {
       return false;

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -4532,11 +4532,6 @@ public abstract class KoLCharacter {
   private static boolean isUsable(FamiliarData f) {
     if (f == FamiliarData.NO_FAMILIAR) return !KoLCharacter.inQuantum();
 
-    if (KoLCharacter.inLegacyOfLoathing()) {
-      // if a familiar makes it into your terrarium, you can use it
-      return true;
-    }
-
     return StandardRequest.isAllowed(f)
         && (!KoLCharacter.inZombiecore() || f.isUndead())
         && (!KoLCharacter.inBeecore() || !KoLCharacter.hasBeeosity(f.getRace()))

--- a/test/net/sourceforge/kolmafia/FamiliarDataTest.java
+++ b/test/net/sourceforge/kolmafia/FamiliarDataTest.java
@@ -261,7 +261,7 @@ public class FamiliarDataTest {
           new Cleanups(
               withPath(Path.LEGACY_OF_LOATHING),
               withRestricted(true),
-              withNotAllowedInStandard(RestrictedItemType.FAMILIARS, "Crimbo Elf"));
+              withNotAllowedInStandard(RestrictedItemType.ITEMS, "pygmy bugbear shaman"));
 
       try (cleanups) {
         FamiliarData.registerFamiliarData(html("request/test_terrarium_legacy_of_loathing.html"));


### PR DESCRIPTION
Now that standard.php no longer includes familiars, we don't need to special case this.

Probably worth waiting a little to confirm standard.php is stable before merging.