### PR TITLE
Failing Test - Location Mapping

### DIFF
--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -862,7 +862,7 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
             withQuestProgress(QuestDatabase.Quest.ISLAND_WAR, QuestDatabase.FINISHED));
 
     try (cleanups) {
-      String output = execute("to_location(\"Hippy Camp\");");
+      String output = execute("to_location(\"The Hippy Camp\");");
       assertContinueState();
       assertThat(
           output,
@@ -889,6 +889,24 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
                               water_level => 0
                               wanderers => true
                               """));
+    }
+  }
+
+  @Test
+  void mapAmbiguousLocationToAdventuringLocation() {
+    // The Hippy Camp is the KoL name for an area.  It can be one of several different locations
+    // based on character and game state.  For a character that has completed the war as a hippy
+    // The Hippy Camp should just be Hippy Camp and should be adventurable
+    var cleanups =
+        new Cleanups(
+            withProperty("lastIslandUnlock", KoLCharacter.getAscensions()),
+            withProperty("sideDefeated", "fratboys"),
+            withQuestProgress(QuestDatabase.Quest.ISLAND_WAR, QuestDatabase.FINISHED));
+
+    try (cleanups) {
+      String output = execute("can_adventure(to_location(\"The Hippy Camp\"));");
+      assertContinueState();
+      assertThat(output, containsString("Returned: true"));
     }
   }
 }


### PR DESCRIPTION
The Hippy Camp is a location name used by KoL.  It should resolve to an adventurable KoLmafia location.  It doesn't.

These failing tests demonstrate the problem.  At the moment I would like feedback on the two new tests although if anyone has a suggested fix, I'll be glad to use it.