### PR TITLE
feat: standardise fam tag names to those ingame

### DIFF
--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -30,130 +30,130 @@
 #
 # no.	name	image	type	larva	item	CM	SH	OC	H&S	attributes (optional)
 
-1	Mosquito	familiar1.gif	combat0,hp0	mosquito larva	hypodermic needle	2	1	3	0	animal,bug,eyes,wings,quick,biting,flying
-2	Leprechaun	familiar2.gif	meat0	leprechaun hatchling	Meat detector	1	3	0	2	hands,clothes,eyes
-3	Levitating Potato	familiar3.gif	block	potato sprout	many-eyed glasses	0	1	2	3	eyes
-4	Angry Goat	familiar4.gif	combat0,combat1	goat	prosthetic forehead	3	0	2	1	animal,eyes,quick,biting
-5	Sabre-Toothed Lime	familiar5.gif	combat0	sabre-toothed lime cub	tiny shaker of salt	3	0	2	1	biting
+1	Mosquito	familiar1.gif	combat0,hp0	mosquito larva	hypodermic needle	2	1	3	0	animal,insect,haseyes,haswings,fast,bite,flies
+2	Leprechaun	familiar2.gif	meat0	leprechaun hatchling	Meat detector	1	3	0	2	hashands,wearsclothes,haseyes
+3	Levitating Potato	familiar3.gif	block	potato sprout	many-eyed glasses	0	1	2	3	haseyes
+4	Angry Goat	familiar4.gif	combat0,combat1	goat	prosthetic forehead	3	0	2	1	animal,haseyes,fast,bite
+5	Sabre-Toothed Lime	familiar5.gif	combat0	sabre-toothed lime cub	tiny shaker of salt	3	0	2	1	bite
 6	Fuzzy Dice	familiar6.gif	combat0,delevel,meat1,mp0,hp0	fuzzy dice	meatcar model	2	2	2	2
-7	Spooky Pirate Skeleton	familiar7.gif	combat1,delevel	spooky pirate skeleton	blundarrrbus	2	3	1	0	hands,eyes,undead,slayer
+7	Spooky Pirate Skeleton	familiar7.gif	combat1,delevel	spooky pirate skeleton	blundarrrbus	2	3	1	0	hashands,haseyes,undead
 8	Barrrnacle	familiar8.gif	delevel,underwater	barrrnacle	sucky decal	0	2	1	3	animal
 9	Howling Balloon Monkey	familiar9.gif	combat0,mp0	balloon monkey	tiny balloon knife	1	3	2	0	animal
-10	Stab Bat	familiar10.gif	combat0	rewinged stab bat	shock collar	3	2	1	0	animal,eyes,wings,evil,quick,flying
-11	Grue	familiar11.gif	combat1	grue egg	moonglasses	2	0	1	3	animal,eyes,evil,biting,flying
-12	Blood-Faced Volleyball	familiar12.gif	stat0	blood-faced volleyball	palm-frond toupee	0	1	3	2	eyes
+10	Stab Bat	familiar10.gif	combat0	rewinged stab bat	shock collar	3	2	1	0	animal,haseyes,haswings,evil,fast,flies
+11	Grue	familiar11.gif	combat1	grue egg	moonglasses	2	0	1	3	animal,haseyes,evil,bite,flies
+12	Blood-Faced Volleyball	familiar12.gif	stat0	blood-faced volleyball	palm-frond toupee	0	1	3	2	haseyes
 13
-14	Ghuol Whelp	familiar14.gif	hp1,mp1	fertilized ghuol egg	tiny knife and fork	1	2	0	3	hands,eyes,undead,slayer,evil,biting
-15	Baby Gravy Fairy	familiar15.gif	item0	pregnant mushroom	eye-pod	0	3	1	2	eyes,wings
-16	Cocoabo	familiar16.gif	combat0,delevel,hp0,mp0,meat1	cocoa egg	chocolate spurs	2	3	0	1	animal,eyes,wings
-17	Star Starfish	familiar17.gif	combat0,mp0	star starfish	magnifying glass	2	1	3	0	animal,sleazy,flying
-18	Hovering Sombrero	hat2.gif	stat1	hovering sombrero	tiny maracas	0	3	2	1	undead,slayer
-19	Ghost Pickle on a Stick	familiar19.gif	combat0,delevel	ghost pickle on a stick	skewer-mounted razor blade	3	1	0	2	undead,slayer
-20	Killer Bee	familiar20.gif	combat0,stat2	baby killer bee	brass stinger	3	1	2	0	wings,animal,evil,flying
+14	Ghuol Whelp	familiar14.gif	hp1,mp1	fertilized ghuol egg	tiny knife and fork	1	2	0	3	hashands,haseyes,undead,evil,bite
+15	Baby Gravy Fairy	familiar15.gif	item0	pregnant mushroom	eye-pod	0	3	1	2	haseyes,haswings
+16	Cocoabo	familiar16.gif	combat0,delevel,hp0,mp0,meat1	cocoa egg	chocolate spurs	2	3	0	1	animal,haseyes,haswings
+17	Star Starfish	familiar17.gif	combat0,mp0	star starfish	magnifying glass	2	1	3	0	animal,sleaze,flies
+18	Hovering Sombrero	hat2.gif	stat1	hovering sombrero	tiny maracas	0	3	2	1	undead
+19	Ghost Pickle on a Stick	familiar19.gif	combat0,delevel	ghost pickle on a stick	skewer-mounted razor blade	3	1	0	2	undead
+20	Killer Bee	familiar20.gif	combat0,stat2	baby killer bee	brass stinger	3	1	2	0	haswings,animal,evil,flies
 21	Whirling Maple Leaf	familiar21.gif	combat0,mp1	maple leaf	tiny Mountie hat	3	1	2	0
-22	Coffee Pixie	familiar22.gif	item0,meat0	coffee sprite	miniature espresso maker	1	1	3	2	hands,eyes,wings,quick,flying
-23	Cheshire Bat	familiar23.gif	stat0,meat0	Cheshire Bitten	smile-sharpening stone	1	2	3	1	animal,eyes,wings,quick,flying
-24	Jill-O-Lantern	familiar24.gif	combat0,combat1,stat0	Dark Jill-O-Lantern	100-Watt bulb	3	1	2	1	eyes,slayer,hot,biting
-25	Hand Turkey	familiar25.gif	combat0,meat0	hand turkey outline	candied yam pinky ring	3	2	1	1	wings,animal,eyes
-26	Crimbo Elf	familiar26.gif	combat0,item0	crimbo elfling	dental pliers	1	2	1	3	hands,clothes,eyes
+22	Coffee Pixie	familiar22.gif	item0,meat0	coffee sprite	miniature espresso maker	1	1	3	2	hashands,haseyes,haswings,fast,flies
+23	Cheshire Bat	familiar23.gif	stat0,meat0	Cheshire Bitten	smile-sharpening stone	1	2	3	1	animal,haseyes,haswings,fast,flies
+24	Jill-O-Lantern	familiar24.gif	combat0,combat1,stat0	Dark Jill-O-Lantern	100-Watt bulb	3	1	2	1	haseyes,hot,bite
+25	Hand Turkey	familiar25.gif	combat0,meat0	hand turkey outline	candied yam pinky ring	3	2	1	1	haswings,animal,haseyes
+26	Crimbo Elf	familiar26.gif	combat0,item0	crimbo elfling	dental pliers	1	2	1	3	hashands,wearsclothes,haseyes
 27	Hanukkimbo Dreidl	familiar27.gif	combat0,block,mp0,meat1	Hanukkimbo dreidl	menorette	2	1	3	1
-28	Baby Yeti	familiar28.gif	combat1,mp0	orphan baby yeti	penguin-smacking club	3	1	1	2	hands,clothes,animal,eyes,biting
-29	Feather Boa Constrictor	familiar29.gif	combat1,block,meat1	silk garter snake	velvet choker	2	3	1	1	animal,eyes,sleazy
-30	Emo Squid	familiar30.gif	block,delevel,underwater	emo roe	gazing shoes	1	3	1	2	animal,eyes
+28	Baby Yeti	familiar28.gif	combat1,mp0	orphan baby yeti	penguin-smacking club	3	1	1	2	hashands,wearsclothes,animal,haseyes,bite
+29	Feather Boa Constrictor	familiar29.gif	combat1,block,meat1	silk garter snake	velvet choker	2	3	1	1	animal,haseyes,sleaze
+30	Emo Squid	familiar30.gif	block,delevel,underwater	emo roe	gazing shoes	1	3	1	2	animal,haseyes
 31	Personal Raincloud	familiar31.gif	combat0,delevel,hp0,mp0,hp1,mp1,stat3	personal raindrop	rainbow tie	2	1	3	1
-32	Clockwork Grapefruit	familiar32.gif	combat0	unwound clockwork grapefruit	false eyelashes	3	2	0	1	mechanical,robot
-33	MagiMechTech MicroMechaMech	familiar33.gif	combat0,combat1	deactivated MicroMechaMech	targeting chip	3	0	1	2	mechanical,robot
-34	Flaming Gravy Fairy	familiar34.gif	combat1,item0	pregnant flaming mushroom	flaming glowsticks	2	3	1	2	eyes,wings,hot
-35	Frozen Gravy Fairy	familiar35.gif	combat1,item0	pregnant frozen mushroom	iced-out bling	2	3	1	2	eyes,wings,flying
-36	Stinky Gravy Fairy	familiar36.gif	combat1,item0	pregnant stinky mushroom	limburger biker boots	2	3	1	2	eyes,wings,flying
-37	Spooky Gravy Fairy	sgfairy.gif	combat1,item0	pregnant gloomy black mushroom	miniature carton of clove cigarettes	3	3	1	2	eyes,wings
+32	Clockwork Grapefruit	familiar32.gif	combat0	unwound clockwork grapefruit	false eyelashes	3	2	0	1	technological,robot
+33	MagiMechTech MicroMechaMech	familiar33.gif	combat0,combat1	deactivated MicroMechaMech	targeting chip	3	0	1	2	technological,robot
+34	Flaming Gravy Fairy	familiar34.gif	combat1,item0	pregnant flaming mushroom	flaming glowsticks	2	3	1	2	haseyes,haswings,hot
+35	Frozen Gravy Fairy	familiar35.gif	combat1,item0	pregnant frozen mushroom	iced-out bling	2	3	1	2	haseyes,haswings,flies
+36	Stinky Gravy Fairy	familiar36.gif	combat1,item0	pregnant stinky mushroom	limburger biker boots	2	3	1	2	haseyes,haswings,flies
+37	Spooky Gravy Fairy	sgfairy.gif	combat1,item0	pregnant gloomy black mushroom	miniature carton of clove cigarettes	3	3	1	2	haseyes,haswings
 38	Inflatable Dodecapede	familiar38.gif	combat0	deflated inflatable dodecapede	toy six-seater hovercraft	3	2	2	1
-39	Pygmy Bugbear Shaman	familiar39.gif	stat0,item0	pygmy bugbear shaman	tiny nose-bone fetish	1	3	1	2	hands,eyes,biting
-40	Doppelshifter	familiar40.gif	variable	doppelshifter egg	tiny makeup kit	3	3	3	3	eyes
-41	Attention-Deficit Demon	familiar41.gif	item0,meat0	calm attention-deficit demon	attention spanner	1	1	3	2	hands,eyes,wings,quick,evil,hot,flying
-42	Cymbal-Playing Monkey	familiar42.gif	stat0,meat0	unwound cymbal-playing monkey	funky brass fez	1	2	3	1	hands,clothes,mechanical,animal,eyes,robot
+39	Pygmy Bugbear Shaman	familiar39.gif	stat0,item0	pygmy bugbear shaman	tiny nose-bone fetish	1	3	1	2	hashands,haseyes,bite
+40	Doppelshifter	familiar40.gif	variable	doppelshifter egg	tiny makeup kit	3	3	3	3	haseyes
+41	Attention-Deficit Demon	familiar41.gif	item0,meat0	calm attention-deficit demon	attention spanner	1	1	3	2	hashands,haseyes,haswings,fast,evil,hot,flies
+42	Cymbal-Playing Monkey	familiar42.gif	stat0,meat0	unwound cymbal-playing monkey	funky brass fez	1	2	3	1	hashands,wearsclothes,technological,animal,haseyes,robot
 43	Temporal Riftlet	familiar43.gif	block,delevel,other1	miniscule temporal rip	1.21 jigawatts	1	3	1	2
-44	Sweet Nutcracker	familiar44.gif	combat0,other0	sweet nutcracker	metal mandible	2	3	0	2	clothes,eyes,robot
-45	Pet Rock	familiar45.gif	none	pet rock	pet rock &quot;Snooty&quot; disguise	0	0	0	0	eyes
-46	Snowy Owl	familiar46.gif	combat0	sleeping snowy owl	Pretty Predator Clawicure Kit	3	3	3	3	animal,eyes,wings,biting
-47	Teddy Bear	familiar47.gif	other0	teddy bear	teddy bear sewing kit	3	2	0	1	animal,eyes
-48	Ninja Pirate Zombie Robot	npzr.gif	combat0,block,delevel,hp0,mp0,meat1,other0	ninja pirate zombie robot	rhesus monkey	3	3	3	3	mechanical,clothes,eyes,robot,undead,slayer,evil,quick
-49	Sleazy Gravy Fairy	slgfairy.gif	combat1,item0	pregnant oily golden mushroom	hot pink lipstick	3	3	2	1	sleazy,eyes,wings,flying
-50	Wild Hare	hare.gif	item0,meat0,stat0,hp1,mp1,other1	March hat	miniature dormouse	1	3	2	0	animal,eyes,quick
-51	Wind-up Chattering Teeth	chatteeth.gif	combat0	wind-up chattering teeth	diamond-studded fronts	3	0	2	1	robot,biting
-52	Spirit Hobo	ghobo.gif	combat0,mp0,stat0	homeless hobo spirit	weegee sqouija	2	1	3	0	hands,eyes,undead,slayer
-53	Astral Badger	badger.gif	combat0,drop	astral badger	badger badge	3	0	2	3	animal,hands,eyes
-54	Comma Chameleon	commacha.gif	variable	Comma Chameleon egg		0	0	0	2	hands,animal,eyes
-55	Misshapen Animal Skeleton	animskel.gif	combat0,combat1,delevel	misshapen animal skeleton	bone collar	3	2	1	2	hands,eyes,undead,slayer,evil,biting
-56	Scary Death Orb	orb.gif	combat1	scary death orb	tuning fork	3	2	1	0	mechanical,robot,slayer,quick,evil
-57	Jitterbug	jitterbug.gif	item0,meat0	jitterbug larva	bottle of perfume	1	3	2	2	animal,eyes,quick
-58	Nervous Tick	tick.gif	stat0,meat0	nervous tick egg	spoon!	0	3	2	2	animal,eyes,quick,biting
-59	Reassembled Blackbird	blackbird2.gif	other1	reassembled blackbird	tiny bust of Pallas	0	0	0	0	wings,animal,eyes,undead,slayer,flying
-60	Origami Towel Crane	crane1.gif	block,other0	makeshift crane	can of starch	3	1	0	2	wings
+44	Sweet Nutcracker	familiar44.gif	combat0,other0	sweet nutcracker	metal mandible	2	3	0	2	wearsclothes,haseyes,robot
+45	Pet Rock	familiar45.gif	none	pet rock	pet rock &quot;Snooty&quot; disguise	0	0	0	0	haseyes
+46	Snowy Owl	familiar46.gif	combat0	sleeping snowy owl	Pretty Predator Clawicure Kit	3	3	3	3	animal,haseyes,haswings,bite
+47	Teddy Bear	familiar47.gif	other0	teddy bear	teddy bear sewing kit	3	2	0	1	animal,haseyes
+48	Ninja Pirate Zombie Robot	npzr.gif	combat0,block,delevel,hp0,mp0,meat1,other0	ninja pirate zombie robot	rhesus monkey	3	3	3	3	technological,wearsclothes,haseyes,robot,undead,evil,fast
+49	Sleazy Gravy Fairy	slgfairy.gif	combat1,item0	pregnant oily golden mushroom	hot pink lipstick	3	3	2	1	sleaze,haseyes,haswings,flies
+50	Wild Hare	hare.gif	item0,meat0,stat0,hp1,mp1,other1	March hat	miniature dormouse	1	3	2	0	animal,haseyes,fast
+51	Wind-up Chattering Teeth	chatteeth.gif	combat0	wind-up chattering teeth	diamond-studded fronts	3	0	2	1	robot,bite
+52	Spirit Hobo	ghobo.gif	combat0,mp0,stat0	homeless hobo spirit	weegee sqouija	2	1	3	0	hashands,haseyes,undead
+53	Astral Badger	badger.gif	combat0,drop	astral badger	badger badge	3	0	2	3	animal,hashands,haseyes
+54	Comma Chameleon	commacha.gif	variable	Comma Chameleon egg		0	0	0	2	hashands,animal,haseyes
+55	Misshapen Animal Skeleton	animskel.gif	combat0,combat1,delevel	misshapen animal skeleton	bone collar	3	2	1	2	hashands,haseyes,undead,evil,bite
+56	Scary Death Orb	orb.gif	combat1	scary death orb	tuning fork	3	2	1	0	technological,robot,fast,evil
+57	Jitterbug	jitterbug.gif	item0,meat0	jitterbug larva	bottle of perfume	1	3	2	2	animal,haseyes,fast
+58	Nervous Tick	tick.gif	stat0,meat0	nervous tick egg	spoon!	0	3	2	2	animal,haseyes,fast,bite
+59	Reassembled Blackbird	blackbird2.gif	other1	reassembled blackbird	tiny bust of Pallas	0	0	0	0	haswings,animal,haseyes,undead,flies
+60	Origami Towel Crane	crane1.gif	block,other0	makeshift crane	can of starch	3	1	0	2	haswings
 61	Ninja Snowflake	snowflake.gif	combat1	frigid mote	icicle katana	3	0	3	3
-62	Evil Teddy Bear	teddybear.gif	combat0,block	evil teddy bear	evil teddy bear sewing kit	3	2	0	1	eyes,evil,biting
-63	Toothsome Rock	pettoothrock.gif	none	toothsome rock	pet rock &quot;Groucho&quot; disguise	0	0	0	0	eyes
+62	Evil Teddy Bear	teddybear.gif	combat0,block	evil teddy bear	evil teddy bear sewing kit	3	2	0	1	haseyes,evil,bite
+63	Toothsome Rock	pettoothrock.gif	none	toothsome rock	pet rock &quot;Groucho&quot; disguise	0	0	0	0	haseyes
 64
-65	Ancient Yuletide Troll	crimbotroll.gif	hp1,mp1,stat0,drop	yuletide troll chrysalis	giant book of ancient carols	2	3	1	0	hands,eyes,evil
-66	Dandy Lion	dandylion.gif	hp1,mp1,item0	dandy lion cub	woolen cravat	0	3	2	1	sleazy,animal,eyes
-67	O.A.F.	oaf.gif	none	Deactivated O. A. F.	hardware upgrade	0	0	0	0	mechanical,robot,eyes,evil
-68	Penguin Goodfella	goodfella.gif	delevel,stat0,drop	bad penguin egg	tasteful black bow tie	3	2	1	0	wings,animal,eyes,sleazy,evil
-69	Jumpsuited Hound Dog	hounddog.gif	item0	pompadour'd puppy	blue suede shoes	1	3	3	2	hands,clothes,animal,eyes,biting
-70	Green Pixie	pictsie.gif	combat0,item0,drop	bottled green pixie	green pixie spog	3	2	0	2	hands,clothes,wings,eyes,quick,hot
-71	Ragamuffin Imp	ragimp.gif	combat1	pile of smoking rags		3	3	3	3	hands,clothes,wings,eyes,hot
-72	Exotic Parrot	parrot.gif	passive	exotic parrot egg	cracker	3	3	2	0	wings,animal,eyes,sleazy,hot,biting
-73	Wizard Action Figure	waf.gif	combat1,delevel,hp0,stat0,item0	wizard action figure	mint-condition magic wand	2	3	2	2	hands,clothes,eyes
-74	Gluttonous Green Ghost	ggg.gif	combat0,mp0,stat0,other1	class five ecto-larva	plastic bib	2	3	3	1	hands,eyes,sleazy,undead,slayer,evil,biting
-75	Casagnova Gnome	cassagnome.gif	item0,meat0	siesta-ing Casagnova gnome	miniature castagnets	0	1	3	2	hands,clothes,eyes,sleazy
-76	Hunchbacked Minion	hunchback.gif	stat0,meat0	unemployed hunchbacked minion	miniature Jacob's ladder	1	3	0	2	hands,clothes,eyes
-77	Crimbo P. R. E. S. S. I. E.	pressiebot.gif	combat0,stat0,block,delevel,mp0,other0	Crimbo P. R. E. S. S. I. E.	metallic foil bow	3	2	0	1	mechanical,hands,eyes,robot
-78	Bulky Buddy Box	wcb.gif	none	Bulky Buddy Box		0	0	0	0	mechanical
-79	Teddy Borg	teddyborg.gif	other0	teddy borg	teddy borg sewing kit	3	2	0	1	mechanical,robot,eyes,evil,biting
-80	RoboGoose	robogoose.gif	combat0,block,delevel,hp0,drop	deactivated RoboGoose	overclocked avian microprocessor	2	3	1	0	mechanical,wings,animal,eyes,robot,flying
-81	El Vibrato Megadrone	megadrone.gif	variable	El Vibrato Megadrone		3	3	3	3	mechanical,robot
-82	Mad Hatrack	hatrack.gif	variable	sane hatrack		3	0	1	2	clothes,eyes
-83	Adorable Seal Larva	seallarva.gif	combat0,hp0,variable	adorable seal larva	pretty pink bow	3	2	1	2	animal,eyes
-84	Untamed Turtle	untamed.gif	block,variable	untamable turtle	smiley-face sticker	0	0	0	3	animal,eyes,biting
-85	Animated Macaroni Duck	macaroniduck.gif	combat0,mp0,variable	macaroni duck	farfalle bow tie	2	2	2	2	wings,animal,eyes,flying
-86	Pet Cheezling	cheezblob.gif	hp1,mp1,variable	friendly cheez blob	jalape&ntilde;o slices	2	2	0	2	eyes,sleazy
+65	Ancient Yuletide Troll	crimbotroll.gif	hp1,mp1,stat0,drop	yuletide troll chrysalis	giant book of ancient carols	2	3	1	0	hashands,haseyes,evil
+66	Dandy Lion	dandylion.gif	hp1,mp1,item0	dandy lion cub	woolen cravat	0	3	2	1	sleaze,animal,haseyes
+67	O.A.F.	oaf.gif	none	Deactivated O. A. F.	hardware upgrade	0	0	0	0	technological,robot,haseyes,evil
+68	Penguin Goodfella	goodfella.gif	delevel,stat0,drop	bad penguin egg	tasteful black bow tie	3	2	1	0	haswings,animal,haseyes,sleaze,evil
+69	Jumpsuited Hound Dog	hounddog.gif	item0	pompadour'd puppy	blue suede shoes	1	3	3	2	hashands,wearsclothes,animal,haseyes,bite
+70	Green Pixie	pictsie.gif	combat0,item0,drop	bottled green pixie	green pixie spog	3	2	0	2	hashands,wearsclothes,haswings,haseyes,fast,hot
+71	Ragamuffin Imp	ragimp.gif	combat1	pile of smoking rags		3	3	3	3	hashands,wearsclothes,haswings,haseyes,hot
+72	Exotic Parrot	parrot.gif	passive	exotic parrot egg	cracker	3	3	2	0	haswings,animal,haseyes,sleaze,hot,bite
+73	Wizard Action Figure	waf.gif	combat1,delevel,hp0,stat0,item0	wizard action figure	mint-condition magic wand	2	3	2	2	hashands,wearsclothes,haseyes
+74	Gluttonous Green Ghost	ggg.gif	combat0,mp0,stat0,other1	class five ecto-larva	plastic bib	2	3	3	1	hashands,haseyes,sleaze,undead,evil,bite
+75	Casagnova Gnome	cassagnome.gif	item0,meat0	siesta-ing Casagnova gnome	miniature castagnets	0	1	3	2	hashands,wearsclothes,haseyes,sleaze
+76	Hunchbacked Minion	hunchback.gif	stat0,meat0	unemployed hunchbacked minion	miniature Jacob's ladder	1	3	0	2	hashands,wearsclothes,haseyes
+77	Crimbo P. R. E. S. S. I. E.	pressiebot.gif	combat0,stat0,block,delevel,mp0,other0	Crimbo P. R. E. S. S. I. E.	metallic foil bow	3	2	0	1	technological,hashands,haseyes,robot
+78	Bulky Buddy Box	wcb.gif	none	Bulky Buddy Box		0	0	0	0	technological
+79	Teddy Borg	teddyborg.gif	other0	teddy borg	teddy borg sewing kit	3	2	0	1	technological,robot,haseyes,evil,bite
+80	RoboGoose	robogoose.gif	combat0,block,delevel,hp0,drop	deactivated RoboGoose	overclocked avian microprocessor	2	3	1	0	technological,haswings,animal,haseyes,robot,flies
+81	El Vibrato Megadrone	megadrone.gif	variable	El Vibrato Megadrone		3	3	3	3	technological,robot
+82	Mad Hatrack	hatrack.gif	variable	sane hatrack		3	0	1	2	wearsclothes,haseyes
+83	Adorable Seal Larva	seallarva.gif	combat0,hp0,variable	adorable seal larva	pretty pink bow	3	2	1	2	animal,haseyes
+84	Untamed Turtle	untamed.gif	block,variable	untamable turtle	smiley-face sticker	0	0	0	3	animal,haseyes,bite
+85	Animated Macaroni Duck	macaroniduck.gif	combat0,mp0,variable	macaroni duck	farfalle bow tie	2	2	2	2	haswings,animal,haseyes,flies
+86	Pet Cheezling	cheezblob.gif	hp1,mp1,variable	friendly cheez blob	jalape&ntilde;o slices	2	2	0	2	haseyes,sleaze
 87	Autonomous Disco Ball	discoball.gif	combat0,delevel,variable	unusual disco ball	stick-on mini solar panels	3	2	1	0	robot
-88	Mariachi Chihuahua	chihuahua.gif	combat0,variable	stray chihuahua	tiny sombrero	3	2	1	0	animal,eyes,evil
-89	Hobo Monkey	hobomonkey.gif	meat0,meat1	hobo monkey	tiny bindle	0	3	3	3	hands,clothes,animal,eyes
-90	Llama Lama	llama.gif	stat0,delevel,drop	llama lama cria	zen motorcycle	1	2	3	2	animal,eyes
-91	Cotton Candy Carnie	cccarnie.gif	block,hp1,mp1,drop	cotton candy cocoon	cotton candy cordial	0	2	2	3	eyes
-92	Disembodied Hand	dishand.gif	combat0,variable	spooky rattling cigar box		3	2	0	2	hands,undead,slayer
-93	Black Cat	blackcat.gif	none	black kitten		0	0	0	0	animal,eyes,evil,biting
-94	Uniclops	uniclops.gif	stat0,meat0	uniclops egg	eye 'n' horn shampoo	2	1	2	3	animal,eyes,quick
-95	Psychedelic Bear	dancebear.gif	item0,meat0	passed-out psychedelic bear	psychedelic bubble wand	1	3	2	1	animal,eyes
-96	Baby Mutant Rattlesnake	rattlesnake.gif	combat0,stat0	mutant rattlesnake egg	rattlesnake enrager	3	2	1	0	animal,eyes
-97	Mutant Fire Ant	fireant.gif	combat1,item0	mutant fire ant egg	ant antidepressant	3	2	0	2	animal,eyes,biting
-98	Mutant Cactus Bud	cactusbud.gif	combat0,meat0	mutant cactus bud	cactus monocle	3	0	2	2	eyes
-99	Mutant Gila Monster	gilamonster.gif	combat0,other0,hp1,mp1	mutant gila monster egg	Jawmaster 2000&trade;	3	0	2	2	animal,eyes,biting
-100	Cuddlefish	cuddlefish.gif	block,hp1,mp1,underwater	baby cuddlefish	six-armed sweater	0	1	3	3	animal,eyes
-101	Sugar Fruit Fairy	sugarfairy.gif	stat0,item0,other1,drop	candy cornucopia	tiny ballet slippers	0	3	3	2	clothes,eyes,wings,flying
-102	Imitation Crab	crab.gif	combat0,underwater	imitation crab zoea	imitation whetstone	3	1	2	2	animal,eyes,quick
-103	Pair of Ragged Claws	raggedclaws.gif	combat0,combat1,delevel	pair of ragged claws	radioactive chew toy	1	1	1	1	hands,undead,quick,evil
-104	Magic Dragonfish	dragonfishfam.gif	passive,underwater	magic dragonfish fry	fin-bit wax	1	1	2	0	animal,eyes
-105	Frumious Bandersnatch	bandersnatch.gif	other0,variable,stat0	Apathargic Bandersnatch	aquaviolet jub-jub bird	3	2	2	0	wings,animal,eyes,quick
-106	Midget Clownfish	midgetclownfish.gif	combat1,mp0,underwater	midget clownfish	half-height unicycle	0	1	2	2	animal,eyes
-107	Syncopated Turtle	syncturtle.gif	item0	syncopated turtle	metrognome	0	2	3	2	animal,eyes,quick
-108	Grinning Turtle	grinturtle.gif	stat0	grinning turtle	security blankie	1	0	0	3	animal,eyes,sleazy,biting
-109	Purse Rat	purserat.gif	passive	designer handbag	tiny cell phone	0	0	0	0	animal,eyes,biting
-110	Wereturtle	turtle.gif	combat1	sleeping wereturtle	bottle of moontan lotion	3	1	0	2	animal,eyes
-111	Baby Sandworm	babyworm.gif	stat1,drop	infant sandworm	string of dingle balls	1	2	2	3	animal,clothes
-112	Slimeling	slimeling.gif	combat0,mp0,item0,other1,drop	squirming Slime larva	undissolvable contact lenses	3	3	2	2	eyes,sleazy
-113	He-Boulder	heboulder.gif	other0,hp1,mp1,meat0	floaty stone sphere	quadroculars	3	3	2	1	eyes
-114	Rock Lobster	rocklobster.gif	combat1,mp0,underwater,drop	rock lobster	extra-strength rubber bands	3	2	2	1	animal,eyes
-115	Urchin Urchin	urchin.gif	underwater,meat0	urchin roe	pet anemone	3	3	0	2	animal,eyes
-116	Grouper Groupie	grouper2.gif	underwater,item0	grouper fangirl	gill rings	0	2	3	2	clothes,animal,eyes,sleazy
+88	Mariachi Chihuahua	chihuahua.gif	combat0,variable	stray chihuahua	tiny sombrero	3	2	1	0	animal,haseyes,evil
+89	Hobo Monkey	hobomonkey.gif	meat0,meat1	hobo monkey	tiny bindle	0	3	3	3	hashands,wearsclothes,animal,haseyes
+90	Llama Lama	llama.gif	stat0,delevel,drop	llama lama cria	zen motorcycle	1	2	3	2	animal,haseyes
+91	Cotton Candy Carnie	cccarnie.gif	block,hp1,mp1,drop	cotton candy cocoon	cotton candy cordial	0	2	2	3	haseyes
+92	Disembodied Hand	dishand.gif	combat0,variable	spooky rattling cigar box		3	2	0	2	hashands,undead
+93	Black Cat	blackcat.gif	none	black kitten		0	0	0	0	animal,haseyes,evil,bite
+94	Uniclops	uniclops.gif	stat0,meat0	uniclops egg	eye 'n' horn shampoo	2	1	2	3	animal,haseyes,fast
+95	Psychedelic Bear	dancebear.gif	item0,meat0	passed-out psychedelic bear	psychedelic bubble wand	1	3	2	1	animal,haseyes
+96	Baby Mutant Rattlesnake	rattlesnake.gif	combat0,stat0	mutant rattlesnake egg	rattlesnake enrager	3	2	1	0	animal,haseyes
+97	Mutant Fire Ant	fireant.gif	combat1,item0	mutant fire ant egg	ant antidepressant	3	2	0	2	animal,haseyes,bite
+98	Mutant Cactus Bud	cactusbud.gif	combat0,meat0	mutant cactus bud	cactus monocle	3	0	2	2	haseyes
+99	Mutant Gila Monster	gilamonster.gif	combat0,other0,hp1,mp1	mutant gila monster egg	Jawmaster 2000&trade;	3	0	2	2	animal,haseyes,bite
+100	Cuddlefish	cuddlefish.gif	block,hp1,mp1,underwater	baby cuddlefish	six-armed sweater	0	1	3	3	animal,haseyes
+101	Sugar Fruit Fairy	sugarfairy.gif	stat0,item0,other1,drop	candy cornucopia	tiny ballet slippers	0	3	3	2	wearsclothes,haseyes,haswings,flies
+102	Imitation Crab	crab.gif	combat0,underwater	imitation crab zoea	imitation whetstone	3	1	2	2	animal,haseyes,fast
+103	Pair of Ragged Claws	raggedclaws.gif	combat0,combat1,delevel	pair of ragged claws	radioactive chew toy	1	1	1	1	hashands,undead,fast,evil
+104	Magic Dragonfish	dragonfishfam.gif	passive,underwater	magic dragonfish fry	fin-bit wax	1	1	2	0	animal,haseyes
+105	Frumious Bandersnatch	bandersnatch.gif	other0,variable,stat0	Apathargic Bandersnatch	aquaviolet jub-jub bird	3	2	2	0	haswings,animal,haseyes,fast
+106	Midget Clownfish	midgetclownfish.gif	combat1,mp0,underwater	midget clownfish	half-height unicycle	0	1	2	2	animal,haseyes
+107	Syncopated Turtle	syncturtle.gif	item0	syncopated turtle	metrognome	0	2	3	2	animal,haseyes,fast
+108	Grinning Turtle	grinturtle.gif	stat0	grinning turtle	security blankie	1	0	0	3	animal,haseyes,sleaze,bite
+109	Purse Rat	purserat.gif	passive	designer handbag	tiny cell phone	0	0	0	0	animal,haseyes,bite
+110	Wereturtle	turtle.gif	combat1	sleeping wereturtle	bottle of moontan lotion	3	1	0	2	animal,haseyes
+111	Baby Sandworm	babyworm.gif	stat1,drop	infant sandworm	string of dingle balls	1	2	2	3	animal,wearsclothes
+112	Slimeling	slimeling.gif	combat0,mp0,item0,other1,drop	squirming Slime larva	undissolvable contact lenses	3	3	2	2	haseyes,sleaze
+113	He-Boulder	heboulder.gif	other0,hp1,mp1,meat0	floaty stone sphere	quadroculars	3	3	2	1	haseyes
+114	Rock Lobster	rocklobster.gif	combat1,mp0,underwater,drop	rock lobster	extra-strength rubber bands	3	2	2	1	animal,haseyes
+115	Urchin Urchin	urchin.gif	underwater,meat0	urchin roe	pet anemone	3	3	0	2	animal,haseyes
+116	Grouper Groupie	grouper2.gif	underwater,item0	grouper fangirl	gill rings	0	2	3	2	wearsclothes,animal,haseyes,sleaze
 117	Squamous Gibberer	gibberer.gif	block,hp1,mp1,other1,underwater	squamous polyp	unspeakable lozenges	1	2	2	3
-118	Dancing Frog	dancfrog.gif	item0,meat0	perfectly ordinary frog	miniature tophat	1	2	2	3	clothes,hands,animal,eyes
-119	Chauvinist Pig	chauvpig.gif	stat0,meat0	hungover chauvinist pig	bottle of Cochon Noir	0	3	2	1	animal,eyes,sleazy
-120	Stocking Mimic	smimic.gif	combat0,delevel,hp0,mp0,other0,meat1,drop	suspicious stocking	bag of many confections	0	0	0	0	eyes
-121	Snow Angel	snowangel.gif	combat1,mp0	pile of loose snow	snow halo	2	1	3	2	wings,biting
-122	Jack-in-the-Box	jackinthebox.gif	stat0,item0,other1	Jack-in-the-box	brass crank handle	0	0	0	0	mechanical,eyes,quick
-123	BRICKO chick	brickochick.gif	combat0,drop	BRICKO egg	extra-heavy BRICKO brick	1	2	2	1	wings,animal,eyes
-124	Baby Bugged Bugbear	babybugbug.gif	block,other0,drop,variable	panicked kernel	bugged beanie	0	0	0	0	hands,mechanical,eyes,quick,biting
+118	Dancing Frog	dancfrog.gif	item0,meat0	perfectly ordinary frog	miniature tophat	1	2	2	3	wearsclothes,hashands,animal,haseyes
+119	Chauvinist Pig	chauvpig.gif	stat0,meat0	hungover chauvinist pig	bottle of Cochon Noir	0	3	2	1	animal,haseyes,sleaze
+120	Stocking Mimic	smimic.gif	combat0,delevel,hp0,mp0,other0,meat1,drop	suspicious stocking	bag of many confections	0	0	0	0	haseyes
+121	Snow Angel	snowangel.gif	combat1,mp0	pile of loose snow	snow halo	2	1	3	2	haswings,bite
+122	Jack-in-the-Box	jackinthebox.gif	stat0,item0,other1	Jack-in-the-box	brass crank handle	0	0	0	0	technological,haseyes,fast
+123	BRICKO chick	brickochick.gif	combat0,drop	BRICKO egg	extra-heavy BRICKO brick	1	2	2	1	haswings,animal,haseyes
+124	Baby Bugged Bugbear	babybugbug.gif	block,other0,drop,variable	panicked kernel	bugged beanie	0	0	0	0	hashands,technological,haseyes,fast,bite
 125	Money-Making Goblin	mmgoblin.gif	none			0	0	0	0
 126	Floating Eye	lower_e.gif	none			0	0	0	0
 127	Vampire Bat	jubjubbird.gif	none			0	0	0	0
@@ -163,86 +163,86 @@
 131	Worm Doctor	larva.gif	none			0	0	0	0
 132	Snowhitman	snowhitman.gif	none			0	0	0	0
 133	Plastic Grocery Bag	grocbag.gif	none			0	0	0	0
-134	Underworld Bonsai	uwbonsai.gif	combat1,mp0	Underworld sapling	miniature pruning shears	3	1	2	0	eyes,evil
-135	Rogue Program	tronguy.gif	combat0,mp0,drop	glowing frisbee	portable motorcycle	3	2	2	0	eyes,mechanical,clothes,quick
-136	Mini-Hipster	minihipster.gif	combat0,delevel,stat2,hp0,mp0,meat1,other1,variable	Schmalz's First Prize Beer	ironic moustache	0	3	2	1	hands,clothes,eyes
-137	Pottery Barn Owl	sp_owl.gif	combat1,hp1,mp1,drop	pottery barn owl figurine	affordable teak perch	3	1	2	0	wings,animal,eyes,flying
-138	Hippo Ballerina	hippo.gif	combat1,block,delevel,item0,meat0	hippo tutu	immense ballet shoes	3	2	3	0	clothes,animal,eyes
-139	Knob Goblin Organ Grinder	organgoblin.gif	combat1,meat0,other1,drop	organ grinder	microwave stogie	0	3	2	1	hands,eyes,evil
-140	Piano Cat	pianocat.gif	item0,meat0	sleeping piano cat	kitty sheet music	2	3	2	0	hands,animal,eyes,biting
-141	Dramatic Hedgehog	dramahog.gif	stat0,meat0	rehearsing dramatic hedgehog	tiny prop sword	2	3	0	2	animal,eyes
-142	Smiling Rat	smilerat.gif	stat0	smiling rat	rat tooth polish	1	3	1	0	hands,animal,eyes,biting
-143	Robot Reindeer	roboreindeer.gif	combat0,hp0,drop,variable	hibernating robot reindeer	S.L.E.I.G.H.B.E.L.L.S.	3	3	3	3	mechanical,robot,eyes
+134	Underworld Bonsai	uwbonsai.gif	combat1,mp0	Underworld sapling	miniature pruning shears	3	1	2	0	haseyes,evil
+135	Rogue Program	tronguy.gif	combat0,mp0,drop	glowing frisbee	portable motorcycle	3	2	2	0	haseyes,technological,wearsclothes,fast
+136	Mini-Hipster	minihipster.gif	combat0,delevel,stat2,hp0,mp0,meat1,other1,variable	Schmalz's First Prize Beer	ironic moustache	0	3	2	1	hashands,wearsclothes,haseyes
+137	Pottery Barn Owl	sp_owl.gif	combat1,hp1,mp1,drop	pottery barn owl figurine	affordable teak perch	3	1	2	0	haswings,animal,haseyes,flies
+138	Hippo Ballerina	hippo.gif	combat1,block,delevel,item0,meat0	hippo tutu	immense ballet shoes	3	2	3	0	wearsclothes,animal,haseyes
+139	Knob Goblin Organ Grinder	organgoblin.gif	combat1,meat0,other1,drop	organ grinder	microwave stogie	0	3	2	1	hashands,haseyes,evil
+140	Piano Cat	pianocat.gif	item0,meat0	sleeping piano cat	kitty sheet music	2	3	2	0	hashands,animal,haseyes,bite
+141	Dramatic Hedgehog	dramahog.gif	stat0,meat0	rehearsing dramatic hedgehog	tiny prop sword	2	3	0	2	animal,haseyes
+142	Smiling Rat	smilerat.gif	stat0	smiling rat	rat tooth polish	1	3	1	0	hashands,animal,haseyes,bite
+143	Robot Reindeer	roboreindeer.gif	combat0,hp0,drop,variable	hibernating robot reindeer	S.L.E.I.G.H.B.E.L.L.S.	3	3	3	3	technological,robot,haseyes
 144	Holiday Log	holidaylog.gif	none	holiday log		0	0	0	0
 145
-146	Obtuse Angel	obtuseangel.gif	other0,item0,drop	a cute angel	quake of arrows	2	0	3	1	hands,wings,eyes
-147	Reconstituted Crow	blackbird1.gif	other1	reconstituted crow		0	0	0	0	wings,animal,eyes,undead,slayer,flying
-148	Li'l Xenomorph	lilxeno.gif	stat0,drop,variable	mysterious chest	tiny top hat and cane	3	2	1	3	hands,animal,eyes,biting
-149	Dataspider	dataspider.gif	combat0,mp0	squirming egg sac	solid state loom	2	1	2	3	mechanical,animal,eyes,robot,quick
-150	Pair of Stomping Boots	stompboots.gif	combat0,item0,drop	fairy-worn boots	stomp box	3	0	2	2	eyes
-151	Feral Kobold	kobold.gif	combat0	newborn kobold	slightly thicker filthy rags	3	1	1	1	hands,eyes,evil
-152	Fancypants Scarecrow	pantscrow2.gif	variable	stuffed-shirt scarecrow		0	0	0	0	clothes,eyes
+146	Obtuse Angel	obtuseangel.gif	other0,item0,drop	a cute angel	quake of arrows	2	0	3	1	hashands,haswings,haseyes
+147	Reconstituted Crow	blackbird1.gif	other1	reconstituted crow		0	0	0	0	haswings,animal,haseyes,undead,flies
+148	Li'l Xenomorph	lilxeno.gif	stat0,drop,variable	mysterious chest	tiny top hat and cane	3	2	1	3	hashands,animal,haseyes,bite
+149	Dataspider	dataspider.gif	combat0,mp0	squirming egg sac	solid state loom	2	1	2	3	technological,animal,haseyes,robot,fast
+150	Pair of Stomping Boots	stompboots.gif	combat0,item0,drop	fairy-worn boots	stomp box	3	0	2	2	haseyes
+151	Feral Kobold	kobold.gif	combat0	newborn kobold	slightly thicker filthy rags	3	1	1	1	hashands,haseyes,evil
+152	Fancypants Scarecrow	pantscrow2.gif	variable	stuffed-shirt scarecrow		0	0	0	0	wearsclothes,haseyes
 153
-154	Bloovian Groose	groose.gif	stat0,meat0,drop	The Groose in the Hoose	spruce juice	2	2	1	3	sleazy,animal,eyes
-155	Blavious Kloop	kloop.gif	item0,meat0,drop	The Kloop in the Coop	miniscule beatbox	0	3	2	1	hands,eyes,evil
-156	Peppermint Rhino	pep_rhino.gif	item0,item3	peppermint rhino baby	licorice boa	1	3	1	0	animal,eyes
-157	Tickle-Me Emilio	emiliofam.gif	combat0,combat1,delevel,hp0,mp0,meat1,stat0	Tickle-Me Emilio	tiny do-rag	3	1	1	0	eyes,sleazy
-158	Steam-Powered Cheerleader	cheerleader.gif	delevel,item0	KoLHS Pep Squad Box	school spirit socket set	2	3	2	0	clothes,mechanical,hands,eyes,robot
-159	Happy Medium	medium_0.gif	other0,stat0,drop	Small Medium	crystal decanter	0	3	2	2	clothes,hands,eyes
-160	Artistic Goth Kid	crayongoth.gif	other1,stat0	Moping Artistic Goth Kid	little wooden mannequin	0	2	2	3	clothes,eyes,hands
-161	Flaming Face	flameface.gif	combat1	hot egg	flaming nose	3	2	2	1	eyes,hot
-162	Reagnimated Gnome	frankengnome.gif	item0,variable	Unagnimated Gnome		0	0	0	0	hands,clothes,eyes,undead,slayer
-163	Hovering Skull	talkskull.gif	combat0,stat0	talkative skull	shiny gold fronts	2	2	3	1	eyes,undead,slayer,biting
-164	Mini-Skulldozer	minidozer.gif	combat1,block	skulldozer egg	ribcage rollcage	2	1	3	0	mechanical,eyes,undead,slayer
-165	Angry Jung Man	jungman.gif	item0,meat0,drop	dreaming Jung man	Little Crimson Book	2	2	1	1	hands,clothes,eyes
-166	Unconscious Collective	uc.gif	stat0,meat0,drop	avatar of the Unconscious Collective	blue canary nightlight	2	1	1	3	eyes,hands
-167	Nanorhino	nanorhino.gif	combat0,combat1,delevel,other0	deactivated nanobots	nanorhino credit card	3	1	1	3	mechanical,animal,eyes,robot
-168	Oily Woim	woim.gif	passive	woim	woimbook	2	1	3	1	animal,sleazy
-169	Homemade Robot	homemadebot.gif	none	homemade robot	homemade robot gear	0	0	0	0	mechanical,robot,hands,eyes,quick
-170	MiniMechaElf	mechaelf.gif	combat0	Deactivated MiniMechaElf	MiniMechaElf Laser Punch Missile Launcher	3	2	0	1	mechanical,robot,hands,eyes
-171	Gelatinous Cubeling	gcube.gif	delevel,item0,drop	dried gelatinous cube	pile of dungeon junk	2	3	0	1	eyes
+154	Bloovian Groose	groose.gif	stat0,meat0,drop	The Groose in the Hoose	spruce juice	2	2	1	3	sleaze,animal,haseyes
+155	Blavious Kloop	kloop.gif	item0,meat0,drop	The Kloop in the Coop	miniscule beatbox	0	3	2	1	hashands,haseyes,evil
+156	Peppermint Rhino	pep_rhino.gif	item0,item3	peppermint rhino baby	licorice boa	1	3	1	0	animal,haseyes
+157	Tickle-Me Emilio	emiliofam.gif	combat0,combat1,delevel,hp0,mp0,meat1,stat0	Tickle-Me Emilio	tiny do-rag	3	1	1	0	haseyes,sleaze
+158	Steam-Powered Cheerleader	cheerleader.gif	delevel,item0	KoLHS Pep Squad Box	school spirit socket set	2	3	2	0	wearsclothes,technological,hashands,haseyes,robot
+159	Happy Medium	medium_0.gif	other0,stat0,drop	Small Medium	crystal decanter	0	3	2	2	wearsclothes,hashands,haseyes
+160	Artistic Goth Kid	crayongoth.gif	other1,stat0	Moping Artistic Goth Kid	little wooden mannequin	0	2	2	3	wearsclothes,haseyes,hashands
+161	Flaming Face	flameface.gif	combat1	hot egg	flaming nose	3	2	2	1	haseyes,hot
+162	Reagnimated Gnome	frankengnome.gif	item0,variable	Unagnimated Gnome		0	0	0	0	hashands,wearsclothes,haseyes,undead
+163	Hovering Skull	talkskull.gif	combat0,stat0	talkative skull	shiny gold fronts	2	2	3	1	haseyes,undead,bite
+164	Mini-Skulldozer	minidozer.gif	combat1,block	skulldozer egg	ribcage rollcage	2	1	3	0	technological,haseyes,undead
+165	Angry Jung Man	jungman.gif	item0,meat0,drop	dreaming Jung man	Little Crimson Book	2	2	1	1	hashands,wearsclothes,haseyes
+166	Unconscious Collective	uc.gif	stat0,meat0,drop	avatar of the Unconscious Collective	blue canary nightlight	2	1	1	3	haseyes,hashands
+167	Nanorhino	nanorhino.gif	combat0,combat1,delevel,other0	deactivated nanobots	nanorhino credit card	3	1	1	3	technological,animal,haseyes,robot
+168	Oily Woim	woim.gif	passive	woim	woimbook	2	1	3	1	animal,sleaze
+169	Homemade Robot	homemadebot.gif	none	homemade robot	homemade robot gear	0	0	0	0	technological,robot,hashands,haseyes,fast
+170	MiniMechaElf	mechaelf.gif	combat0	Deactivated MiniMechaElf	MiniMechaElf Laser Punch Missile Launcher	3	2	0	1	technological,robot,hashands,haseyes
+171	Gelatinous Cubeling	gcube.gif	delevel,item0,drop	dried gelatinous cube	pile of dungeon junk	2	3	0	1	haseyes
 172	Adorable Space Buddy	starbuddy.gif	combat1,hp1,mp1,underwater	Star Spawn	cute bow from beyond the stars	1	2	3	3
 173	Nosy Nose	nosynose.gif	delevel,other0	wriggling severed nose	nosy nose ringy ring	1	3	1	2
-174	Mini-Adventurer	miniadv0.gif	variable	adventurer clone egg	mini-Mr. Accessory	2	2	2	2	hands,clothes,eyes
-175	Mechanical Songbird	mechbird.gif	item0	unwound mechanical songbird	shiny brass tailfeathers	1	2	2	0	wings,mechanical,animal,eyes,robot,quick,flying
-176	Reanimated Reanimator	reanimator.gif	stat0,other0,variable	deanimated reanimator's coffin	flask of embalming fluid	2	3	2	0	hands,clothes,eyes,undead,slayer
-177	Warbear Drone	wbdronefam.gif	combat0,combat1	warbear drone assembler	warbear drone codes	3	2	2	0	mechanical,robot,quick,evil
-178	Grimstone Golem	grimgolem.gif	item0,meat0,drop	hibernating Grimstone Golem	grimstone galoshes	0	2	3	3	eyes,evil
-179	Grim Brother	grimbrother.gif	stat0,meat0,drop	praying Grim Brother	Grim Brothers' story book	3	2	0	3	hands,clothes,eyes
-180	Miniature Sword & Martini Guy	smguy.gif	combat0,stat0,drop	Anniversary Miniature Sword & Martini Guy	really tiny cocktail shaker	3	3	2	2	clothes
-181	Putty Buddy	puttybuddy.gif	combat1,hp0	deactivated putty buddy	putty coat	3	1	2	1	eyes,sleazy
-182	Twitching Space Critter	spacebeastlet.gif	combat1,mp0	twitching space egg	ramekin of space nuts	3	1	1	1	animal,eyes,quick
-183	Galloping Grill	galgrill.gif	combat1,mp0,stat1,drop	still grill	box of hickory chips	3	1	2	0	eyes,hot,quick
+174	Mini-Adventurer	miniadv0.gif	variable	adventurer clone egg	mini-Mr. Accessory	2	2	2	2	hashands,wearsclothes,haseyes
+175	Mechanical Songbird	mechbird.gif	item0	unwound mechanical songbird	shiny brass tailfeathers	1	2	2	0	haswings,technological,animal,haseyes,robot,fast,flies
+176	Reanimated Reanimator	reanimator.gif	stat0,other0,variable	deanimated reanimator's coffin	flask of embalming fluid	2	3	2	0	hashands,wearsclothes,haseyes,undead
+177	Warbear Drone	wbdronefam.gif	combat0,combat1	warbear drone assembler	warbear drone codes	3	2	2	0	technological,robot,fast,evil
+178	Grimstone Golem	grimgolem.gif	item0,meat0,drop	hibernating Grimstone Golem	grimstone galoshes	0	2	3	3	haseyes,evil
+179	Grim Brother	grimbrother.gif	stat0,meat0,drop	praying Grim Brother	Grim Brothers' story book	3	2	0	3	hashands,wearsclothes,haseyes
+180	Miniature Sword & Martini Guy	smguy.gif	combat0,stat0,drop	Anniversary Miniature Sword & Martini Guy	really tiny cocktail shaker	3	3	2	2	wearsclothes
+181	Putty Buddy	puttybuddy.gif	combat1,hp0	deactivated putty buddy	putty coat	3	1	2	1	haseyes,sleaze
+182	Twitching Space Critter	spacebeastlet.gif	combat1,mp0	twitching space egg	ramekin of space nuts	3	1	1	1	animal,haseyes,fast
+183	Galloping Grill	galgrill.gif	combat1,mp0,stat1,drop	still grill	box of hickory chips	3	1	2	0	haseyes,hot,fast
 184
 185	Helix Fossil	foss_amm.gif	delevel,combat0,hp1,mp1	strange helix fossil	S.S. Ticket	0	0	0	3
-186	Xiblaxian Holo-Companion	holobuddy.gif	block,passive	Xiblaxian holo-buddy simcode	Xiblaxian holo-bowtie	1	2	1	2	eyes,mechanical
-187	Baby Z-Rex	babyzrex.gif	combat1,stat0	zombie dinosaur egg	french-fry grabber	3	0	0	0	hands,animal,eyes,undead,slayer,biting
-188	Fist Turkey	fistturkey.gif	combat0,item0,meat1,stat2,drop	fist turkey outline	brass turkey knuckles	3	2	2	3	wings,animal,eyes,evil
-189	Crimbo Shrub	crimboshrub.gif	combat1,stat0,other1,variable	Crimbo sapling	even more tinsel	1	3	2	0	eyes
-190	Mini-Crimbot	minicrimbot.gif	variable	Mini-Crimbot crate	heavy-duty Crimbot aerial	3	3	3	0	mechanical,robot,eyes
-191	Topiary Skunk	topiskunk.gif	combat1,hp1	topiary skunk	topiary noseplugs	1	2	0	1	animal,eyes
-192	Golden Monkey	goldmonkey.gif	stat0,meat0,drop	golden monkey statuette	golden banana	1	2	3	0	hands,animal,eyes,quick
-193	Adventurous Spelunker	spelunker.gif	combat0,item0,meat0,drop	Professor of Spelunkology	Stembridge sidearm	3	3	3	3	hands,clothes,eyes
-194	Sludgepuppy	sludgepuppy.gif	combat1,block	inert sludgepuppy	lead collar	1	3	3	0	animal,eyes,sleazy
-195	Baby Mayonnaise Wasp	mayowasp.gif	combat1	newly-hatched mayonnaise wasp	mayo pump	2	2	3	1	sleazy,wings,animal,eyes,quick
-196	Puck Man	puckman.gif	block,hp1,mp1,other1,drop	yellow puck	orange boxing gloves	1	2	2	3	biting
-197	Ms. Puck Man	mspuckman.gif	block,hp1,mp1,other1,drop	yellow puck with a bow on it	blue pumps	1	2	2	3	clothes,biting
-198	Lil' Barrel Mimic	barrelmimic.gif	stat0,hp1,mp1,drop	tiny barrel	brass bung spigot	1	2	1	3	eyes
-199	Machine Elf	machelf.gif	other0,stat3,drop	machine elf capsule	self-dribbling basketball	1	2	3	1	hands,eyes,mechanical,quick
-200	Choctopus	choctopus.gif	hp1,mp1,item0	Gratitude chocolate (octopus-filled)	chocolate bowtie	1	3	3	3	animal,eyes
-201	Rockin' Robin	rockinrobin.gif	stat0,item0,drop	basking robin	tiny domino mask	3	3	3	3	wings,animal,eyes
-202	Restless Cow Skull	cowskull.gif	combat1,block	shuddering cow skull	rhinestone cowhorn	3	1	1	1	eyes,undead,slayer,evil,hot,biting
-203	Intergnat	intergnat.gif	item0,combat0,other0,mp1,drop	disconnected intergnat	high-speed upgrade	1	3	2	2	wings,animal,eyes,biting,bug,flying
-204	Software Bug	softwarebug.gif	none	software bug	missing semicolon	0	0	0	0	mechanical,eyes,biting
-205	Bark Scorpion	barkscorp.gif	combat0	baby bark scorpion	tiny baby scorpion	3	1	2	3	animal,eyes
-206	Trick-or-Treating Tot	tottot.gif	hp1,mp1	li'l orphan tot	li'l knight costume	1	3	2	3	hands,clothes,eyes
-207	Chocolate Lab	chocolab.gif	item0	chocolate puppy	chocolate leash	1	1	1	1	animal,eyes,biting
-208	Bad Vibe	lilbadvibe.gif	none	pet bad vibe	black gallstone	0	0	0	0	eyes
-209	Space Jellyfish	spacejelly.gif	underwater,delevel,drop	space planula	space jellybicycle	3	3	2	3	animal,flying
-210	Optimistic Candle	opticandle.gif	stat0,item0,drop	hopeful candle	pewter candlestick	2	3	3	3	eyes,hot
-211	Robortender	robotender.gif	meat0,drop	unpowered Robortender	toggle switch (Bartend)	3	3	1	1	hands,eyes,mechanical,robot
-212	Cute Meteor	cutemeteor.gif	passive,combat1	cute meteoroid	meteor shower cap	1	1	1	1	eyes,hot
-213	XO Skeleton	xoskeleton.gif	item0,hp1,mp1,drop	xo-skeleton-in-a-box	exo-xo-skeleton-skeleton	1	3	2	2	hands,eyes,undead,slayer
+186	Xiblaxian Holo-Companion	holobuddy.gif	block,passive	Xiblaxian holo-buddy simcode	Xiblaxian holo-bowtie	1	2	1	2	haseyes,technological
+187	Baby Z-Rex	babyzrex.gif	combat1,stat0	zombie dinosaur egg	french-fry grabber	3	0	0	0	hashands,animal,haseyes,undead,bite
+188	Fist Turkey	fistturkey.gif	combat0,item0,meat1,stat2,drop	fist turkey outline	brass turkey knuckles	3	2	2	3	haswings,animal,haseyes,evil
+189	Crimbo Shrub	crimboshrub.gif	combat1,stat0,other1,variable	Crimbo sapling	even more tinsel	1	3	2	0	haseyes
+190	Mini-Crimbot	minicrimbot.gif	variable	Mini-Crimbot crate	heavy-duty Crimbot aerial	3	3	3	0	technological,robot,haseyes
+191	Topiary Skunk	topiskunk.gif	combat1,hp1	topiary skunk	topiary noseplugs	1	2	0	1	animal,haseyes
+192	Golden Monkey	goldmonkey.gif	stat0,meat0,drop	golden monkey statuette	golden banana	1	2	3	0	hashands,animal,haseyes,fast
+193	Adventurous Spelunker	spelunker.gif	combat0,item0,meat0,drop	Professor of Spelunkology	Stembridge sidearm	3	3	3	3	hashands,wearsclothes,haseyes
+194	Sludgepuppy	sludgepuppy.gif	combat1,block	inert sludgepuppy	lead collar	1	3	3	0	animal,haseyes,sleaze
+195	Baby Mayonnaise Wasp	mayowasp.gif	combat1	newly-hatched mayonnaise wasp	mayo pump	2	2	3	1	sleaze,haswings,animal,haseyes,fast
+196	Puck Man	puckman.gif	block,hp1,mp1,other1,drop	yellow puck	orange boxing gloves	1	2	2	3	bite
+197	Ms. Puck Man	mspuckman.gif	block,hp1,mp1,other1,drop	yellow puck with a bow on it	blue pumps	1	2	2	3	wearsclothes,bite
+198	Lil' Barrel Mimic	barrelmimic.gif	stat0,hp1,mp1,drop	tiny barrel	brass bung spigot	1	2	1	3	haseyes
+199	Machine Elf	machelf.gif	other0,stat3,drop	machine elf capsule	self-dribbling basketball	1	2	3	1	hashands,haseyes,technological,fast
+200	Choctopus	choctopus.gif	hp1,mp1,item0	Gratitude chocolate (octopus-filled)	chocolate bowtie	1	3	3	3	animal,haseyes
+201	Rockin' Robin	rockinrobin.gif	stat0,item0,drop	basking robin	tiny domino mask	3	3	3	3	haswings,animal,haseyes
+202	Restless Cow Skull	cowskull.gif	combat1,block	shuddering cow skull	rhinestone cowhorn	3	1	1	1	haseyes,undead,evil,hot,bite
+203	Intergnat	intergnat.gif	item0,combat0,other0,mp1,drop	disconnected intergnat	high-speed upgrade	1	3	2	2	haswings,animal,haseyes,bite,insect,flies
+204	Software Bug	softwarebug.gif	none	software bug	missing semicolon	0	0	0	0	technological,haseyes,bite
+205	Bark Scorpion	barkscorp.gif	combat0	baby bark scorpion	tiny baby scorpion	3	1	2	3	animal,haseyes
+206	Trick-or-Treating Tot	tottot.gif	hp1,mp1	li'l orphan tot	li'l knight costume	1	3	2	3	hashands,wearsclothes,haseyes
+207	Chocolate Lab	chocolab.gif	item0	chocolate puppy	chocolate leash	1	1	1	1	animal,haseyes,bite
+208	Bad Vibe	lilbadvibe.gif	none	pet bad vibe	black gallstone	0	0	0	0	haseyes
+209	Space Jellyfish	spacejelly.gif	underwater,delevel,drop	space planula	space jellybicycle	3	3	2	3	animal,flies
+210	Optimistic Candle	opticandle.gif	stat0,item0,drop	hopeful candle	pewter candlestick	2	3	3	3	haseyes,hot
+211	Robortender	robotender.gif	meat0,drop	unpowered Robortender	toggle switch (Bartend)	3	3	1	1	hashands,haseyes,technological,robot
+212	Cute Meteor	cutemeteor.gif	passive,combat1	cute meteoroid	meteor shower cap	1	1	1	1	haseyes,hot
+213	XO Skeleton	xoskeleton.gif	item0,hp1,mp1,drop	xo-skeleton-in-a-box	exo-xo-skeleton-skeleton	1	3	2	2	hashands,haseyes,undead
 214	Garbage Fire	dumpsterfire.gif	item0,hp1,mp1,drop	kerosene-soaked skip	fireproof skip lid	1	2	1	1	hot
 215	Globmule	pokefam1.gif	none	Globmule		0	0	0	0	pokefam
 216	Bluzzard	pokefam2.gif	none	Bluzzard		0	0	0	0	pokefam
@@ -289,30 +289,30 @@
 257	Slotter	pokefam43.gif	none	Slotter		0	0	0	0	pokefam
 258	Shudder	pokefam44.gif	none	Shudder		0	0	0	0	pokefam
 259	Glamare	pokefam45.gif	none	Glamare		0	0	0	0	pokefam
-260	Unspeakachu	pokefam46.gif	combat0,mp0	Unspeakachu		3	3	1	3	animal,quick,evil
-261	Stooper	pokefam47.gif	none	Stooper		1	3	2	1	animal,eyes,biting
-262	Disgeist	pokefam48.gif	passive	Disgeist		2	2	2	3	clothes,eyes,undead
-263	Bowlet	pokefam49.gif	combat0,item0	Bowlet		2	1	2	2	wings,animal,quick,flying
-264	Cornbeefadon	pokefam50.gif	stat0,meat0	Cornbeefadon		2	2	2	2	animal,eyes,biting
-265	Mu	pokefam8675309.gif	combat1,passive	Mu		3	2	3	2	animal,eyes,quick
-266	God Lobster	godlob.gif	stat0,variable,underwater	God Lobster Egg		0	0	0	0	animal,eyes,evil
-267	Cat Burglar	catburglar.gif	item0,meat0	kitten burglar	burglar/sleep mask	1	3	2	3	animal,eyes,sleazy,quick,biting,clothes
-268	Party Mouse	partymouse.gif	stat0,drop	party pup	party mouse hat	1	1	2	1	animal,eyes,biting
-269	Yule Hound	yulehound.gif	hp1,mp1	yule pup	Crimbo dog sweater	2	3	1	1	animal,eyes
-270	Sausage Golem	saugrindgolem.gif	combat1,mp0	sausage golem	jar of magical relish	3	1	1	1	sleazy,hands
-271	Elf Operative	elfopelf.gif	stat0,item0,drop	elf sleeper agent	red-and-green microcamera	3	3	2	2	clothes,eyes
-272	Plastic Pirate Skull	pr_rogerskull.gif	delevel,hp1,mp1	Red Roger's skull	plastic pirate hat	0	0	0	0	eyes
-273	Pet Coral	petcoral.gif	none,underwater	piece of coral		0	0	0	0	eyes
-274	Pocket Professor	lilprofessoron.gif	item0,mp1	packaged Pocket Professor	Pocket Professor memory chip	0	2	2	3	mechanical,robot
-275	Red-Nosed Snapper	redsnapper.gif	item0,underwater	red-spotted snapper roe	tinsel fin	3	3	3	3	animal,eyes
-276	Antique Nutcracker	nutcfigure.gif	stat0,drop	antique nutcracker figurine	nutcracking pliers	1	2	3	2	clothes,biting
-277	Piranha Plant	piranhaplant.gif	combat,stat0	pristine piranha seed	plastic piranha pot	3	3	3	3	biting
-278	Left-Hand Man	lhmlarva.gif	none	sinistral homunculus		1	1	1	1	hands
-279	Melodramedary	camelcalf.gif	stat0,hp1,mp1	baby camelCalf	dromedary drinking helmet	3	3	0	0	animal,biting,eyes
-280	Ghost of Crimbo Carols	cghost_carols.gif	item0,other0	gregarious ghostling		0	0	0	0	eyes,undead
-281	Ghost of Crimbo Cheer	cghost_cheer.gif	stat0,other1	grinning ghostling		0	0	0	0	eyes,undead
-282	Ghost of Crimbo Commerce	cghost_commerce.gif	meat0,other0	greedy ghostling		0	0	0	0	eyes,undead
-283	Shorter-Order Cook	shortchef.gif	combat0,combat1,delevel,drop	shortest-order cook	blue plate	3	3	1	1	animal,clothes,eyes,hot,hands
+260	Unspeakachu	pokefam46.gif	combat0,mp0	Unspeakachu		3	3	1	3	animal,fast,evil
+261	Stooper	pokefam47.gif	none	Stooper		1	3	2	1	animal,haseyes,bite
+262	Disgeist	pokefam48.gif	passive	Disgeist		2	2	2	3	wearsclothes,haseyes,undead
+263	Bowlet	pokefam49.gif	combat0,item0	Bowlet		2	1	2	2	haswings,animal,fast,flies
+264	Cornbeefadon	pokefam50.gif	stat0,meat0	Cornbeefadon		2	2	2	2	animal,haseyes,bite
+265	Mu	pokefam8675309.gif	combat1,passive	Mu		3	2	3	2	animal,haseyes,fast
+266	God Lobster	godlob.gif	stat0,variable,underwater	God Lobster Egg		0	0	0	0	animal,haseyes,evil
+267	Cat Burglar	catburglar.gif	item0,meat0	kitten burglar	burglar/sleep mask	1	3	2	3	animal,haseyes,sleaze,fast,bite,wearsclothes
+268	Party Mouse	partymouse.gif	stat0,drop	party pup	party mouse hat	1	1	2	1	animal,haseyes,bite
+269	Yule Hound	yulehound.gif	hp1,mp1	yule pup	Crimbo dog sweater	2	3	1	1	animal,haseyes
+270	Sausage Golem	saugrindgolem.gif	combat1,mp0	sausage golem	jar of magical relish	3	1	1	1	sleaze,hashands
+271	Elf Operative	elfopelf.gif	stat0,item0,drop	elf sleeper agent	red-and-green microcamera	3	3	2	2	wearsclothes,haseyes
+272	Plastic Pirate Skull	pr_rogerskull.gif	delevel,hp1,mp1	Red Roger's skull	plastic pirate hat	0	0	0	0	haseyes
+273	Pet Coral	petcoral.gif	none,underwater	piece of coral		0	0	0	0	haseyes
+274	Pocket Professor	lilprofessoron.gif	item0,mp1	packaged Pocket Professor	Pocket Professor memory chip	0	2	2	3	technological,robot
+275	Red-Nosed Snapper	redsnapper.gif	item0,underwater	red-spotted snapper roe	tinsel fin	3	3	3	3	animal,haseyes
+276	Antique Nutcracker	nutcfigure.gif	stat0,drop	antique nutcracker figurine	nutcracking pliers	1	2	3	2	wearsclothes,bite
+277	Piranha Plant	piranhaplant.gif	combat,stat0	pristine piranha seed	plastic piranha pot	3	3	3	3	bite
+278	Left-Hand Man	lhmlarva.gif	none	sinistral homunculus		1	1	1	1	hashands
+279	Melodramedary	camelcalf.gif	stat0,hp1,mp1	baby camelCalf	dromedary drinking helmet	3	3	0	0	animal,bite,haseyes
+280	Ghost of Crimbo Carols	cghost_carols.gif	item0,other0	gregarious ghostling		0	0	0	0	haseyes,undead
+281	Ghost of Crimbo Cheer	cghost_cheer.gif	stat0,other1	grinning ghostling		0	0	0	0	haseyes,undead
+282	Ghost of Crimbo Commerce	cghost_commerce.gif	meat0,other0	greedy ghostling		0	0	0	0	haseyes,undead
+283	Shorter-Order Cook	shortchef.gif	combat0,combat1,delevel,drop	shortest-order cook	blue plate	3	3	1	1	animal,wearsclothes,haseyes,hot,hashands
 284	Vampire Vintner	vampvint.gif	item2,combat0,hp0,drop	bottled Vampire Vintner	French-Transylvanian Dictionary	2	3	2	3	undead
 285	Arachnelf	arachnelf.gif	none	festive egg sac	Site Alpha ID badge	3	1	3	1
 286	Synthetic Rock	synthrock.gif	none	synthetic rock		0	0	0	0

--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -36,7 +36,7 @@
 4	Angry Goat	familiar4.gif	combat0,combat1	goat	prosthetic forehead	3	0	2	1	animal,haseyes,fast,bite
 5	Sabre-Toothed Lime	familiar5.gif	combat0	sabre-toothed lime cub	tiny shaker of salt	3	0	2	1	bite
 6	Fuzzy Dice	familiar6.gif	combat0,delevel,meat1,mp0,hp0	fuzzy dice	meatcar model	2	2	2	2
-7	Spooky Pirate Skeleton	familiar7.gif	combat1,delevel	spooky pirate skeleton	blundarrrbus	2	3	1	0	hashands,haseyes,undead
+7	Spooky Pirate Skeleton	familiar7.gif	combat1,delevel	spooky pirate skeleton	blundarrrbus	2	3	1	0	hashands,haseyes,undead,cantalk
 8	Barrrnacle	familiar8.gif	delevel,underwater	barrrnacle	sucky decal	0	2	1	3	animal
 9	Howling Balloon Monkey	familiar9.gif	combat0,mp0	balloon monkey	tiny balloon knife	1	3	2	0	animal
 10	Stab Bat	familiar10.gif	combat0	rewinged stab bat	shock collar	3	2	1	0	animal,haseyes,haswings,evil,fast,flies
@@ -77,7 +77,7 @@
 45	Pet Rock	familiar45.gif	none	pet rock	pet rock &quot;Snooty&quot; disguise	0	0	0	0	haseyes
 46	Snowy Owl	familiar46.gif	combat0	sleeping snowy owl	Pretty Predator Clawicure Kit	3	3	3	3	animal,haseyes,haswings,bite
 47	Teddy Bear	familiar47.gif	other0	teddy bear	teddy bear sewing kit	3	2	0	1	animal,haseyes
-48	Ninja Pirate Zombie Robot	npzr.gif	combat0,block,delevel,hp0,mp0,meat1,other0	ninja pirate zombie robot	rhesus monkey	3	3	3	3	technological,wearsclothes,haseyes,robot,undead,evil,fast
+48	Ninja Pirate Zombie Robot	npzr.gif	combat0,block,delevel,hp0,mp0,meat1,other0	ninja pirate zombie robot	rhesus monkey	3	3	3	3	technological,wearsclothes,haseyes,robot,undead,evil,fast,cantalk
 49	Sleazy Gravy Fairy	slgfairy.gif	combat1,item0	pregnant oily golden mushroom	hot pink lipstick	3	3	2	1	sleaze,haseyes,haswings,flies
 50	Wild Hare	hare.gif	item0,meat0,stat0,hp1,mp1,other1	March hat	miniature dormouse	1	3	2	0	animal,haseyes,fast
 51	Wind-up Chattering Teeth	chatteeth.gif	combat0	wind-up chattering teeth	diamond-studded fronts	3	0	2	1	robot,bite
@@ -92,16 +92,16 @@
 60	Origami Towel Crane	crane1.gif	block,other0	makeshift crane	can of starch	3	1	0	2	haswings
 61	Ninja Snowflake	snowflake.gif	combat1	frigid mote	icicle katana	3	0	3	3
 62	Evil Teddy Bear	teddybear.gif	combat0,block	evil teddy bear	evil teddy bear sewing kit	3	2	0	1	haseyes,evil,bite
-63	Toothsome Rock	pettoothrock.gif	none	toothsome rock	pet rock &quot;Groucho&quot; disguise	0	0	0	0	haseyes
+63	Toothsome Rock	pettoothrock.gif	none	toothsome rock	pet rock &quot;Groucho&quot; disguise	0	0	0	0	haseyes,bite
 64
 65	Ancient Yuletide Troll	crimbotroll.gif	hp1,mp1,stat0,drop	yuletide troll chrysalis	giant book of ancient carols	2	3	1	0	hashands,haseyes,evil
 66	Dandy Lion	dandylion.gif	hp1,mp1,item0	dandy lion cub	woolen cravat	0	3	2	1	sleaze,animal,haseyes
-67	O.A.F.	oaf.gif	none	Deactivated O. A. F.	hardware upgrade	0	0	0	0	technological,robot,haseyes,evil
+67	O.A.F.	oaf.gif	none	Deactivated O. A. F.	hardware upgrade	0	0	0	0	technological,robot,haseyes,evil,cantalk
 68	Penguin Goodfella	goodfella.gif	delevel,stat0,drop	bad penguin egg	tasteful black bow tie	3	2	1	0	haswings,animal,haseyes,sleaze,evil
 69	Jumpsuited Hound Dog	hounddog.gif	item0	pompadour'd puppy	blue suede shoes	1	3	3	2	hashands,wearsclothes,animal,haseyes,bite
 70	Green Pixie	pictsie.gif	combat0,item0,drop	bottled green pixie	green pixie spog	3	2	0	2	hashands,wearsclothes,haswings,haseyes,fast,hot
 71	Ragamuffin Imp	ragimp.gif	combat1	pile of smoking rags		3	3	3	3	hashands,wearsclothes,haswings,haseyes,hot
-72	Exotic Parrot	parrot.gif	passive	exotic parrot egg	cracker	3	3	2	0	haswings,animal,haseyes,sleaze,hot,bite
+72	Exotic Parrot	parrot.gif	passive	exotic parrot egg	cracker	3	3	2	0	haswings,animal,haseyes,sleaze,hot,bite,cantalk
 73	Wizard Action Figure	waf.gif	combat1,delevel,hp0,stat0,item0	wizard action figure	mint-condition magic wand	2	3	2	2	hashands,wearsclothes,haseyes
 74	Gluttonous Green Ghost	ggg.gif	combat0,mp0,stat0,other1	class five ecto-larva	plastic bib	2	3	3	1	hashands,haseyes,sleaze,undead,evil,bite
 75	Casagnova Gnome	cassagnome.gif	item0,meat0	siesta-ing Casagnova gnome	miniature castagnets	0	1	3	2	hashands,wearsclothes,haseyes,sleaze
@@ -112,7 +112,7 @@
 80	RoboGoose	robogoose.gif	combat0,block,delevel,hp0,drop	deactivated RoboGoose	overclocked avian microprocessor	2	3	1	0	technological,haswings,animal,haseyes,robot,flies
 81	El Vibrato Megadrone	megadrone.gif	variable	El Vibrato Megadrone		3	3	3	3	technological,robot
 82	Mad Hatrack	hatrack.gif	variable	sane hatrack		3	0	1	2	wearsclothes,haseyes
-83	Adorable Seal Larva	seallarva.gif	combat0,hp0,variable	adorable seal larva	pretty pink bow	3	2	1	2	animal,haseyes
+83	Adorable Seal Larva	seallarva.gif	combat0,hp0,variable	adorable seal larva	pretty pink bow	3	2	1	2	animal,haseyes,bite
 84	Untamed Turtle	untamed.gif	block,variable	untamable turtle	smiley-face sticker	0	0	0	3	animal,haseyes,bite
 85	Animated Macaroni Duck	macaroniduck.gif	combat0,mp0,variable	macaroni duck	farfalle bow tie	2	2	2	2	haswings,animal,haseyes,flies
 86	Pet Cheezling	cheezblob.gif	hp1,mp1,variable	friendly cheez blob	jalape&ntilde;o slices	2	2	0	2	haseyes,sleaze
@@ -130,7 +130,7 @@
 98	Mutant Cactus Bud	cactusbud.gif	combat0,meat0	mutant cactus bud	cactus monocle	3	0	2	2	haseyes
 99	Mutant Gila Monster	gilamonster.gif	combat0,other0,hp1,mp1	mutant gila monster egg	Jawmaster 2000&trade;	3	0	2	2	animal,haseyes,bite
 100	Cuddlefish	cuddlefish.gif	block,hp1,mp1,underwater	baby cuddlefish	six-armed sweater	0	1	3	3	animal,haseyes
-101	Sugar Fruit Fairy	sugarfairy.gif	stat0,item0,other1,drop	candy cornucopia	tiny ballet slippers	0	3	3	2	wearsclothes,haseyes,haswings,flies
+101	Sugar Fruit Fairy	sugarfairy.gif	stat0,item0,other1,drop	candy cornucopia	tiny ballet slippers	0	3	3	2	wearsclothes,haseyes,haswings,flies,cantalk
 102	Imitation Crab	crab.gif	combat0,underwater	imitation crab zoea	imitation whetstone	3	1	2	2	animal,haseyes,fast
 103	Pair of Ragged Claws	raggedclaws.gif	combat0,combat1,delevel	pair of ragged claws	radioactive chew toy	1	1	1	1	hashands,undead,fast,evil
 104	Magic Dragonfish	dragonfishfam.gif	passive,underwater	magic dragonfish fry	fin-bit wax	1	1	2	0	animal,haseyes
@@ -146,7 +146,7 @@
 114	Rock Lobster	rocklobster.gif	combat1,mp0,underwater,drop	rock lobster	extra-strength rubber bands	3	2	2	1	animal,haseyes
 115	Urchin Urchin	urchin.gif	underwater,meat0	urchin roe	pet anemone	3	3	0	2	animal,haseyes
 116	Grouper Groupie	grouper2.gif	underwater,item0	grouper fangirl	gill rings	0	2	3	2	wearsclothes,animal,haseyes,sleaze
-117	Squamous Gibberer	gibberer.gif	block,hp1,mp1,other1,underwater	squamous polyp	unspeakable lozenges	1	2	2	3	spooky,evil,reallyevil
+117	Squamous Gibberer	gibberer.gif	block,hp1,mp1,other1,underwater	squamous polyp	unspeakable lozenges	1	2	2	3	spooky,evil,reallyevil,cantalk
 118	Dancing Frog	dancfrog.gif	item0,meat0	perfectly ordinary frog	miniature tophat	1	2	2	3	wearsclothes,hashands,animal,haseyes
 119	Chauvinist Pig	chauvpig.gif	stat0,meat0	hungover chauvinist pig	bottle of Cochon Noir	0	3	2	1	animal,haseyes,sleaze
 120	Stocking Mimic	smimic.gif	combat0,delevel,hp0,mp0,other0,meat1,drop	suspicious stocking	bag of many confections	0	0	0	0	phallic,haseyes,object,isclothes
@@ -164,8 +164,8 @@
 132	Snowhitman	snowhitman.gif	none			0	0	0	0
 133	Plastic Grocery Bag	grocbag.gif	none			0	0	0	0
 134	Underworld Bonsai	uwbonsai.gif	combat1,mp0	Underworld sapling	miniature pruning shears	3	1	2	0	haseyes,evil
-135	Rogue Program	tronguy.gif	combat0,mp0,drop	glowing frisbee	portable motorcycle	3	2	2	0	haseyes,technological,wearsclothes,fast
-136	Mini-Hipster	minihipster.gif	combat0,delevel,stat2,hp0,mp0,meat1,other1,variable	Schmalz's First Prize Beer	ironic moustache	0	3	2	1	hashands,wearsclothes,haseyes
+135	Rogue Program	tronguy.gif	combat0,mp0,drop	glowing frisbee	portable motorcycle	3	2	2	0	haseyes,technological,wearsclothes,fast,cantalk
+136	Mini-Hipster	minihipster.gif	combat0,delevel,stat2,hp0,mp0,meat1,other1,variable	Schmalz's First Prize Beer	ironic moustache	0	3	2	1	hashands,wearsclothes,haseyes,cantalk
 137	Pottery Barn Owl	sp_owl.gif	combat1,hp1,mp1,drop	pottery barn owl figurine	affordable teak perch	3	1	2	0	haswings,animal,haseyes,flies
 138	Hippo Ballerina	hippo.gif	combat1,block,delevel,item0,meat0	hippo tutu	immense ballet shoes	3	2	3	0	wearsclothes,animal,haseyes
 139	Knob Goblin Organ Grinder	organgoblin.gif	combat1,meat0,other1,drop	organ grinder	microwave stogie	0	3	2	1	hashands,haseyes,evil
@@ -173,7 +173,7 @@
 141	Dramatic Hedgehog	dramahog.gif	stat0,meat0	rehearsing dramatic hedgehog	tiny prop sword	2	3	0	2	animal,haseyes
 142	Smiling Rat	smilerat.gif	stat0	smiling rat	rat tooth polish	1	3	1	0	hashands,animal,haseyes,bite
 143	Robot Reindeer	roboreindeer.gif	combat0,hp0,drop,variable	hibernating robot reindeer	S.L.E.I.G.H.B.E.L.L.S.	3	3	3	3	technological,robot,haseyes
-144	Holiday Log	holidaylog.gif	none	holiday log		0	0	0	0
+144	Holiday Log	holidaylog.gif	none	holiday log		0	0	0	0	hot
 145
 146	Obtuse Angel	obtuseangel.gif	other0,item0,drop	a cute angel	quake of arrows	2	0	3	1	hashands,haswings,haseyes
 147	Reconstituted Crow	blackbird1.gif	other1	reconstituted crow		0	0	0	0	haswings,animal,haseyes,undead,flies
@@ -181,21 +181,21 @@
 149	Dataspider	dataspider.gif	combat0,mp0	squirming egg sac	solid state loom	2	1	2	3	technological,animal,haseyes,robot,fast
 150	Pair of Stomping Boots	stompboots.gif	combat0,item0,drop	fairy-worn boots	stomp box	3	0	2	2	object,haseyes,isclothes
 151	Feral Kobold	kobold.gif	combat0	newborn kobold	slightly thicker filthy rags	3	1	1	1	hashands,haseyes,evil
-152	Fancypants Scarecrow	pantscrow2.gif	variable	stuffed-shirt scarecrow		0	0	0	0	wearsclothes,haseyes
+152	Fancypants Scarecrow	pantscrow2.gif	variable	stuffed-shirt scarecrow		0	0	0	0	wearsclothes,haseyes,cantalk
 153
 154	Bloovian Groose	groose.gif	stat0,meat0,drop	The Groose in the Hoose	spruce juice	2	2	1	3	sleaze,animal,haseyes
 155	Blavious Kloop	kloop.gif	item0,meat0,drop	The Kloop in the Coop	miniscule beatbox	0	3	2	1	hashands,haseyes,evil
 156	Peppermint Rhino	pep_rhino.gif	item0,item3	peppermint rhino baby	licorice boa	1	3	1	0	animal,haseyes
 157	Tickle-Me Emilio	emiliofam.gif	combat0,combat1,delevel,hp0,mp0,meat1,stat0	Tickle-Me Emilio	tiny do-rag	3	1	1	0	haseyes,sleaze
-158	Steam-Powered Cheerleader	cheerleader.gif	delevel,item0	KoLHS Pep Squad Box	school spirit socket set	2	3	2	0	wearsclothes,technological,hashands,haseyes,robot
-159	Happy Medium	medium_0.gif	other0,stat0,drop	Small Medium	crystal decanter	0	3	2	2	wearsclothes,hashands,haseyes
-160	Artistic Goth Kid	crayongoth.gif	other1,stat0	Moping Artistic Goth Kid	little wooden mannequin	0	2	2	3	wearsclothes,haseyes,hashands
+158	Steam-Powered Cheerleader	cheerleader.gif	delevel,item0	KoLHS Pep Squad Box	school spirit socket set	2	3	2	0	wearsclothes,technological,hashands,haseyes,robot,cantalk
+159	Happy Medium	medium_0.gif	other0,stat0,drop	Small Medium	crystal decanter	0	3	2	2	wearsclothes,hashands,haseyes,cantalk
+160	Artistic Goth Kid	crayongoth.gif	other1,stat0	Moping Artistic Goth Kid	little wooden mannequin	0	2	2	3	wearsclothes,haseyes,hashands,cantalk
 161	Flaming Face	flameface.gif	combat1	hot egg	flaming nose	3	2	2	1	haseyes,hot
 162	Reagnimated Gnome	frankengnome.gif	item0,variable	Unagnimated Gnome		0	0	0	0	hashands,wearsclothes,haseyes,undead
 163	Hovering Skull	talkskull.gif	combat0,stat0	talkative skull	shiny gold fronts	2	2	3	1	haseyes,undead,bite
 164	Mini-Skulldozer	minidozer.gif	combat1,block	skulldozer egg	ribcage rollcage	2	1	3	0	technological,haseyes,undead
-165	Angry Jung Man	jungman.gif	item0,meat0,drop	dreaming Jung man	Little Crimson Book	2	2	1	1	hashands,wearsclothes,haseyes
-166	Unconscious Collective	uc.gif	stat0,meat0,drop	avatar of the Unconscious Collective	blue canary nightlight	2	1	1	3	haseyes,hashands
+165	Angry Jung Man	jungman.gif	item0,meat0,drop	dreaming Jung man	Little Crimson Book	2	2	1	1	hashands,wearsclothes,haseyes,cantalk
+166	Unconscious Collective	uc.gif	stat0,meat0,drop	avatar of the Unconscious Collective	blue canary nightlight	2	1	1	3	haseyes,hashands,cantalk
 167	Nanorhino	nanorhino.gif	combat0,combat1,delevel,other0	deactivated nanobots	nanorhino credit card	3	1	1	3	technological,animal,haseyes,robot
 168	Oily Woim	woim.gif	passive	woim	woimbook	2	1	3	1	animal,sleaze
 169	Homemade Robot	homemadebot.gif	none	homemade robot	homemade robot gear	0	0	0	0	technological,robot,hashands,haseyes,fast
@@ -203,26 +203,26 @@
 171	Gelatinous Cubeling	gcube.gif	delevel,item0,drop	dried gelatinous cube	pile of dungeon junk	2	3	0	1	object,haseyes,polygonal
 172	Adorable Space Buddy	starbuddy.gif	combat1,hp1,mp1,underwater	Star Spawn	cute bow from beyond the stars	1	2	3	3
 173	Nosy Nose	nosynose.gif	delevel,other0	wriggling severed nose	nosy nose ringy ring	1	3	1	2
-174	Mini-Adventurer	miniadv0.gif	variable	adventurer clone egg	mini-Mr. Accessory	2	2	2	2	hashands,wearsclothes,haseyes
+174	Mini-Adventurer	miniadv0.gif	variable	adventurer clone egg	mini-Mr. Accessory	2	2	2	2	hashands,wearsclothes,haseyes,cantalk
 175	Mechanical Songbird	mechbird.gif	item0	unwound mechanical songbird	shiny brass tailfeathers	1	2	2	0	haswings,technological,animal,haseyes,robot,fast,flies
-176	Reanimated Reanimator	reanimator.gif	stat0,other0,variable	deanimated reanimator's coffin	flask of embalming fluid	2	3	2	0	hashands,wearsclothes,haseyes,undead
+176	Reanimated Reanimator	reanimator.gif	stat0,other0,variable	deanimated reanimator's coffin	flask of embalming fluid	2	3	2	0	hashands,wearsclothes,haseyes,undead,cantalk
 177	Warbear Drone	wbdronefam.gif	combat0,combat1	warbear drone assembler	warbear drone codes	3	2	2	0	technological,robot,fast,evil
 178	Grimstone Golem	grimgolem.gif	item0,meat0,drop	hibernating Grimstone Golem	grimstone galoshes	0	2	3	3	haseyes,evil
-179	Grim Brother	grimbrother.gif	stat0,meat0,drop	praying Grim Brother	Grim Brothers' story book	3	2	0	3	hashands,wearsclothes,haseyes
+179	Grim Brother	grimbrother.gif	stat0,meat0,drop	praying Grim Brother	Grim Brothers' story book	3	2	0	3	hashands,wearsclothes,haseyes,cantalk
 180	Miniature Sword & Martini Guy	smguy.gif	combat0,stat0,drop	Anniversary Miniature Sword & Martini Guy	really tiny cocktail shaker	3	3	2	2	wearsclothes
 181	Putty Buddy	puttybuddy.gif	combat1,hp0	deactivated putty buddy	putty coat	3	1	2	1	haseyes,sleaze
 182	Twitching Space Critter	spacebeastlet.gif	combat1,mp0	twitching space egg	ramekin of space nuts	3	1	1	1	animal,haseyes,fast
-183	Galloping Grill	galgrill.gif	combat1,mp0,stat1,drop	still grill	box of hickory chips	3	1	2	0	haseyes,hot,fast
+183	Galloping Grill	galgrill.gif	combat1,mp0,stat1,drop	still grill	box of hickory chips	3	1	2	0	haseyes,hot,fast,cantalk
 184
 185	Helix Fossil	foss_amm.gif	delevel,combat0,hp1,mp1	strange helix fossil	S.S. Ticket	0	0	0	3
 186	Xiblaxian Holo-Companion	holobuddy.gif	block,passive	Xiblaxian holo-buddy simcode	Xiblaxian holo-bowtie	1	2	1	2	haseyes,technological
 187	Baby Z-Rex	babyzrex.gif	combat1,stat0	zombie dinosaur egg	french-fry grabber	3	0	0	0	hashands,animal,haseyes,undead,bite
 188	Fist Turkey	fistturkey.gif	combat0,item0,meat1,stat2,drop	fist turkey outline	brass turkey knuckles	3	2	2	3	haswings,animal,haseyes,evil
-189	Crimbo Shrub	crimboshrub.gif	combat1,stat0,other1,variable	Crimbo sapling	even more tinsel	1	3	2	0	haseyes
+189	Crimbo Shrub	crimboshrub.gif	combat1,stat0,other1,variable	Crimbo sapling	even more tinsel	1	3	2	0	haseyes,cantalk
 190	Mini-Crimbot	minicrimbot.gif	variable	Mini-Crimbot crate	heavy-duty Crimbot aerial	3	3	3	0	technological,robot,haseyes
 191	Topiary Skunk	topiskunk.gif	combat1,hp1	topiary skunk	topiary noseplugs	1	2	0	1	animal,haseyes
 192	Golden Monkey	goldmonkey.gif	stat0,meat0,drop	golden monkey statuette	golden banana	1	2	3	0	hashands,animal,haseyes,fast
-193	Adventurous Spelunker	spelunker.gif	combat0,item0,meat0,drop	Professor of Spelunkology	Stembridge sidearm	3	3	3	3	hashands,wearsclothes,haseyes
+193	Adventurous Spelunker	spelunker.gif	combat0,item0,meat0,drop	Professor of Spelunkology	Stembridge sidearm	3	3	3	3	hashands,wearsclothes,haseyes,cantalk
 194	Sludgepuppy	sludgepuppy.gif	combat1,block	inert sludgepuppy	lead collar	1	3	3	0	animal,haseyes,sleaze
 195	Baby Mayonnaise Wasp	mayowasp.gif	combat1	newly-hatched mayonnaise wasp	mayo pump	2	2	3	1	sleaze,haswings,animal,haseyes,fast
 196	Puck Man	puckman.gif	block,hp1,mp1,other1,drop	yellow puck	orange boxing gloves	1	2	2	3	bite
@@ -232,15 +232,15 @@
 200	Choctopus	choctopus.gif	hp1,mp1,item0	Gratitude chocolate (octopus-filled)	chocolate bowtie	1	3	3	3	animal,haseyes
 201	Rockin' Robin	rockinrobin.gif	stat0,item0,drop	basking robin	tiny domino mask	3	3	3	3	haswings,animal,haseyes
 202	Restless Cow Skull	cowskull.gif	combat1,block	shuddering cow skull	rhinestone cowhorn	3	1	1	1	haseyes,undead,evil,hot,bite
-203	Intergnat	intergnat.gif	item0,combat0,other0,mp1,drop	disconnected intergnat	high-speed upgrade	1	3	2	2	haswings,animal,haseyes,bite,insect,flies
+203	Intergnat	intergnat.gif	item0,combat0,other0,mp1,drop	disconnected intergnat	high-speed upgrade	1	3	2	2	haswings,animal,haseyes,bite,insect,flies,cantalk
 204	Software Bug	softwarebug.gif	none	software bug	missing semicolon	0	0	0	0	technological,haseyes,bite
 205	Bark Scorpion	barkscorp.gif	combat0	baby bark scorpion	tiny baby scorpion	3	1	2	3	animal,haseyes
-206	Trick-or-Treating Tot	tottot.gif	hp1,mp1	li'l orphan tot	li'l knight costume	1	3	2	3	hashands,wearsclothes,haseyes
+206	Trick-or-Treating Tot	tottot.gif	hp1,mp1	li'l orphan tot	li'l knight costume	1	3	2	3	hashands,wearsclothes,haseyes,cantalk
 207	Chocolate Lab	chocolab.gif	item0	chocolate puppy	chocolate leash	1	1	1	1	animal,haseyes,bite
-208	Bad Vibe	lilbadvibe.gif	none	pet bad vibe	black gallstone	0	0	0	0	haseyes
-209	Space Jellyfish	spacejelly.gif	underwater,delevel,drop	space planula	space jellybicycle	3	3	2	3	animal,flies
-210	Optimistic Candle	opticandle.gif	stat0,item0,drop	hopeful candle	pewter candlestick	2	3	3	3	haseyes,hot
-211	Robortender	robotender.gif	meat0,drop	unpowered Robortender	toggle switch (Bartend)	3	3	1	1	hashands,haseyes,technological,robot
+208	Bad Vibe	lilbadvibe.gif	none	pet bad vibe	black gallstone	0	0	0	0	haseyes,evil,cantalk
+209	Space Jellyfish	spacejelly.gif	underwater,delevel,drop	space planula	space jellybicycle	3	3	2	3	animal,flies,evil
+210	Optimistic Candle	opticandle.gif	stat0,item0,drop	hopeful candle	pewter candlestick	2	3	3	3	haseyes,hot,cantalk
+211	Robortender	robotender.gif	meat0,drop	unpowered Robortender	toggle switch (Bartend)	3	3	1	1	hashands,haseyes,technological,robot,cantalk
 212	Cute Meteor	cutemeteor.gif	passive,combat1	cute meteoroid	meteor shower cap	1	1	1	1	haseyes,hot
 213	XO Skeleton	xoskeleton.gif	item0,hp1,mp1,drop	xo-skeleton-in-a-box	exo-xo-skeleton-skeleton	1	3	2	2	hashands,haseyes,undead
 214	Garbage Fire	dumpsterfire.gif	item0,hp1,mp1,drop	kerosene-soaked skip	fireproof skip lid	1	2	1	1	hot
@@ -300,8 +300,8 @@
 268	Party Mouse	partymouse.gif	stat0,drop	party pup	party mouse hat	1	1	2	1	animal,haseyes,bite
 269	Yule Hound	yulehound.gif	hp1,mp1	yule pup	Crimbo dog sweater	2	3	1	1	animal,haseyes
 270	Sausage Golem	saugrindgolem.gif	combat1,mp0	sausage golem	jar of magical relish	3	1	1	1	sleaze,hashands
-271	Elf Operative	elfopelf.gif	stat0,item0,drop	elf sleeper agent	red-and-green microcamera	3	3	2	2	wearsclothes,haseyes
-272	Plastic Pirate Skull	pr_rogerskull.gif	delevel,hp1,mp1	Red Roger's skull	plastic pirate hat	0	0	0	0	haseyes
+271	Elf Operative	elfopelf.gif	stat0,item0,drop	elf sleeper agent	red-and-green microcamera	3	3	2	2	wearsclothes,haseyes,cantalk
+272	Plastic Pirate Skull	pr_rogerskull.gif	delevel,hp1,mp1	Red Roger's skull	plastic pirate hat	0	0	0	0	haseyes,cantalk
 273	Pet Coral	petcoral.gif	none,underwater	piece of coral		0	0	0	0	haseyes
 274	Pocket Professor	lilprofessoron.gif	item0,mp1	packaged Pocket Professor	Pocket Professor memory chip	0	2	2	3	technological,robot
 275	Red-Nosed Snapper	redsnapper.gif	item0,underwater	red-spotted snapper roe	tinsel fin	3	3	3	3	animal,haseyes
@@ -318,6 +318,6 @@
 286	Synthetic Rock	synthrock.gif	none	synthetic rock		0	0	0	0
 287	Grey Goose	greygoose.gif	item0	grey gosling	grey down vest	1	2	3	3
 288	Cookbookbat	bbat_fam.gif	item1,drop	mummified entombed cookbookbat	cookbookbat book	0	3	2	3
-289	Mini-Trainbot	tbot_on.gif	combat1,hp1,mp1	deactivated mini-Trainbot	overloaded Yule battery	3	2	3	1
+289	Mini-Trainbot	tbot_on.gif	combat1,hp1,mp1	deactivated mini-Trainbot	overloaded Yule battery	3	2	3	1	hashands
 290	Hobo in Sheep's Clothing	hobosheep.gif	stat0,item0,drop	unoccupied sheep suit	half-height cigar	1	3	3	2
 291	Pixel Rock	pixelrock.gif	none	pixel rock		0	0	0	0

--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -146,10 +146,10 @@
 114	Rock Lobster	rocklobster.gif	combat1,mp0,underwater,drop	rock lobster	extra-strength rubber bands	3	2	2	1	animal,haseyes
 115	Urchin Urchin	urchin.gif	underwater,meat0	urchin roe	pet anemone	3	3	0	2	animal,haseyes
 116	Grouper Groupie	grouper2.gif	underwater,item0	grouper fangirl	gill rings	0	2	3	2	wearsclothes,animal,haseyes,sleaze
-117	Squamous Gibberer	gibberer.gif	block,hp1,mp1,other1,underwater	squamous polyp	unspeakable lozenges	1	2	2	3
+117	Squamous Gibberer	gibberer.gif	block,hp1,mp1,other1,underwater	squamous polyp	unspeakable lozenges	1	2	2	3	spooky,evil,reallyevil
 118	Dancing Frog	dancfrog.gif	item0,meat0	perfectly ordinary frog	miniature tophat	1	2	2	3	wearsclothes,hashands,animal,haseyes
 119	Chauvinist Pig	chauvpig.gif	stat0,meat0	hungover chauvinist pig	bottle of Cochon Noir	0	3	2	1	animal,haseyes,sleaze
-120	Stocking Mimic	smimic.gif	combat0,delevel,hp0,mp0,other0,meat1,drop	suspicious stocking	bag of many confections	0	0	0	0	haseyes
+120	Stocking Mimic	smimic.gif	combat0,delevel,hp0,mp0,other0,meat1,drop	suspicious stocking	bag of many confections	0	0	0	0	phallic,haseyes,object,isclothes
 121	Snow Angel	snowangel.gif	combat1,mp0	pile of loose snow	snow halo	2	1	3	2	haswings,bite
 122	Jack-in-the-Box	jackinthebox.gif	stat0,item0,other1	Jack-in-the-box	brass crank handle	0	0	0	0	technological,haseyes,fast
 123	BRICKO chick	brickochick.gif	combat0,drop	BRICKO egg	extra-heavy BRICKO brick	1	2	2	1	haswings,animal,haseyes
@@ -179,7 +179,7 @@
 147	Reconstituted Crow	blackbird1.gif	other1	reconstituted crow		0	0	0	0	haswings,animal,haseyes,undead,flies
 148	Li'l Xenomorph	lilxeno.gif	stat0,drop,variable	mysterious chest	tiny top hat and cane	3	2	1	3	hashands,animal,haseyes,bite
 149	Dataspider	dataspider.gif	combat0,mp0	squirming egg sac	solid state loom	2	1	2	3	technological,animal,haseyes,robot,fast
-150	Pair of Stomping Boots	stompboots.gif	combat0,item0,drop	fairy-worn boots	stomp box	3	0	2	2	haseyes
+150	Pair of Stomping Boots	stompboots.gif	combat0,item0,drop	fairy-worn boots	stomp box	3	0	2	2	object,haseyes,isclothes
 151	Feral Kobold	kobold.gif	combat0	newborn kobold	slightly thicker filthy rags	3	1	1	1	hashands,haseyes,evil
 152	Fancypants Scarecrow	pantscrow2.gif	variable	stuffed-shirt scarecrow		0	0	0	0	wearsclothes,haseyes
 153
@@ -200,7 +200,7 @@
 168	Oily Woim	woim.gif	passive	woim	woimbook	2	1	3	1	animal,sleaze
 169	Homemade Robot	homemadebot.gif	none	homemade robot	homemade robot gear	0	0	0	0	technological,robot,hashands,haseyes,fast
 170	MiniMechaElf	mechaelf.gif	combat0	Deactivated MiniMechaElf	MiniMechaElf Laser Punch Missile Launcher	3	2	0	1	technological,robot,hashands,haseyes
-171	Gelatinous Cubeling	gcube.gif	delevel,item0,drop	dried gelatinous cube	pile of dungeon junk	2	3	0	1	haseyes
+171	Gelatinous Cubeling	gcube.gif	delevel,item0,drop	dried gelatinous cube	pile of dungeon junk	2	3	0	1	object,haseyes,polygonal
 172	Adorable Space Buddy	starbuddy.gif	combat1,hp1,mp1,underwater	Star Spawn	cute bow from beyond the stars	1	2	3	3
 173	Nosy Nose	nosynose.gif	delevel,other0	wriggling severed nose	nosy nose ringy ring	1	3	1	2
 174	Mini-Adventurer	miniadv0.gif	variable	adventurer clone egg	mini-Mr. Accessory	2	2	2	2	hashands,wearsclothes,haseyes
@@ -273,7 +273,7 @@
 241	Ched	pokefam27.gif	none	Ched		0	0	0	0	pokefam
 242	Gazelleton	pokefam28.gif	none	Gazelleton		0	0	0	0	pokefam
 243	Mechamelion	pokefam29.gif	none	Mechamelion		0	0	0	0	pokefam
-244	Bicycle	pokefam30.gif	none	Bicycle		0	0	0	0	pokefam
+244	Bicycle	pokefam30.gif	none	Bicycle		0	0	0	0	pokefam,phallic,object,cold
 245	Vamprey	pokefam31.gif	none	Vamprey		0	0	0	0	pokefam
 246	Wullabye	pokefam32.gif	none	Wullabye		0	0	0	0	pokefam
 247	Nursine	pokefam33.gif	none	Nursine		0	0	0	0	pokefam
@@ -295,7 +295,7 @@
 263	Bowlet	pokefam49.gif	combat0,item0	Bowlet		2	1	2	2	haswings,animal,fast,flies
 264	Cornbeefadon	pokefam50.gif	stat0,meat0	Cornbeefadon		2	2	2	2	animal,haseyes,bite
 265	Mu	pokefam8675309.gif	combat1,passive	Mu		3	2	3	2	animal,haseyes,fast
-266	God Lobster	godlob.gif	stat0,variable,underwater	God Lobster Egg		0	0	0	0	animal,haseyes,evil
+266	God Lobster	godlob.gif	stat0,variable,underwater	God Lobster Egg		0	0	0	0	animal,haseyes,spooky,evil,reallyevil
 267	Cat Burglar	catburglar.gif	item0,meat0	kitten burglar	burglar/sleep mask	1	3	2	3	animal,haseyes,sleaze,fast,bite,wearsclothes
 268	Party Mouse	partymouse.gif	stat0,drop	party pup	party mouse hat	1	1	2	1	animal,haseyes,bite
 269	Yule Hound	yulehound.gif	hp1,mp1	yule pup	Crimbo dog sweater	2	3	1	1	animal,haseyes

--- a/src/net/sourceforge/kolmafia/request/MummeryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MummeryRequest.java
@@ -71,7 +71,7 @@ public class MummeryRequest extends GenericRequest {
     switch (choice) {
       case 1 -> {
         mod1 = 15;
-        if (FamiliarDatabase.hasAttribute(familiarId, "hands")) {
+        if (FamiliarDatabase.hasAttribute(familiarId, "hashands")) {
           mod1 = 30;
         }
         mods += "Meat Drop: [" + mod1 + "*fam(" + familiar + ")],";
@@ -79,7 +79,7 @@ public class MummeryRequest extends GenericRequest {
       case 2 -> {
         mod1 = 4;
         mod2 = 5;
-        if (FamiliarDatabase.hasAttribute(familiarId, "wings")) {
+        if (FamiliarDatabase.hasAttribute(familiarId, "haswings")) {
           mod1 = 6;
           mod2 = 10;
         }
@@ -103,14 +103,14 @@ public class MummeryRequest extends GenericRequest {
       }
       case 4 -> {
         mod1 = 15;
-        if (FamiliarDatabase.hasAttribute(familiarId, "clothes")) {
+        if (FamiliarDatabase.hasAttribute(familiarId, "wearsclothes")) {
           mod1 = 25;
         }
         mods += "Item Drop: [" + mod1 + "*fam(" + familiar + ")],";
       }
       case 5 -> {
         mod1 = 3;
-        if (FamiliarDatabase.hasAttribute(familiarId, "eyes")) {
+        if (FamiliarDatabase.hasAttribute(familiarId, "haseyes")) {
           mod1 = 4;
         }
         mods += "Experience (Mysticality): [" + mod1 + "*fam(" + familiar + ")],";
@@ -118,7 +118,7 @@ public class MummeryRequest extends GenericRequest {
       case 6 -> {
         mod1 = 8;
         mod2 = 10;
-        if (FamiliarDatabase.hasAttribute(familiarId, "mechanical")) {
+        if (FamiliarDatabase.hasAttribute(familiarId, "technological")) {
           mod1 = 18;
           mod2 = 20;
         }
@@ -135,7 +135,7 @@ public class MummeryRequest extends GenericRequest {
       }
       case 7 -> {
         mod1 = 2;
-        if (FamiliarDatabase.hasAttribute(familiarId, "sleazy")) {
+        if (FamiliarDatabase.hasAttribute(familiarId, "sleaze")) {
           mod1 = 4;
         }
         mods += "Experience (Moxie): [" + mod1 + "*fam(" + familiar + ")],";

--- a/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
+++ b/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
@@ -141,8 +141,8 @@ public class ModifierExpressionTest {
   @ParameterizedTest
   @CsvSource({
     "animal, 1",
-    "eyes, 1",
-    "flying, 0",
+    "haseyes, 1",
+    "flies, 0",
   })
   public void canDetectFamiliarAttribute(String attr, String expected) {
     var cleanups = withFamiliar(FamiliarPool.ADORABLE_SEAL_LARVA);

--- a/test/root/expected/TestFamiliarProxy.ash.out
+++ b/test/root/expected/TestFamiliarProxy.ash.out
@@ -1,4 +1,4 @@
-eyes
+haseyes
 false
 0
 false


### PR DESCRIPTION
With the advent of the stillsuit, there are many more relevant tags than just those for the mumming trunk, and there have also been several leaks as to what the tags' ingame names are.

Standardise the mumming trunk names, and add a few additional known tags.

Remove the "slayer" tag -- Zombie Slayer now just uses "undead" to check familiars.

Add the "cantalk" attribute, which allows familiars to tell you what is in the miniature crystal ball, and also to give you myst in the stillsuit.