### PR TITLE
allow ASH main function to have a vararg

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
+++ b/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
@@ -549,7 +549,7 @@ public class KoLmafiaCLI {
         .register("call")
         .register("run")
         .register("exec")
-        .register("exececute")
+        .register("execute")
         .register("load")
         .register("start")
         .register("profile");

--- a/src/net/sourceforge/kolmafia/textui/AshRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/AshRuntime.java
@@ -325,12 +325,16 @@ public class AshRuntime extends AbstractRuntime {
 
       for (int i = index; parameters != null && i < parameters.length; ++i) {
         Object input = parameters[i];
+        Value value = null;
         try {
-          varValues.add(DataTypes.coerceValue(paramType, input, false));
+          value = DataTypes.coerceValue(paramType, input, false);
         } catch (Exception e) {
+        }
+        if (value == null) {
           RequestLogger.printLine("Bad " + paramType.toString() + " value: \"" + input + "\"");
           return false;
         }
+        varValues.add(value);
       }
 
       // Put them into an Array value

--- a/src/net/sourceforge/kolmafia/textui/AshRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/AshRuntime.java
@@ -265,7 +265,7 @@ public class AshRuntime extends AbstractRuntime {
     return result;
   }
 
-  private boolean requestUserParams(
+  boolean requestUserParams(
       final Function targetFunction, final Object[] parameters, Object[] values) {
     int args = parameters == null ? 0 : parameters.length;
     Type type = null;

--- a/src/net/sourceforge/kolmafia/textui/AshRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/AshRuntime.java
@@ -17,12 +17,14 @@ import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.SendMailRequest;
+import net.sourceforge.kolmafia.textui.parsetree.ArrayValue;
 import net.sourceforge.kolmafia.textui.parsetree.Evaluable;
 import net.sourceforge.kolmafia.textui.parsetree.Function;
 import net.sourceforge.kolmafia.textui.parsetree.FunctionList;
 import net.sourceforge.kolmafia.textui.parsetree.Scope;
 import net.sourceforge.kolmafia.textui.parsetree.Type;
 import net.sourceforge.kolmafia.textui.parsetree.Value;
+import net.sourceforge.kolmafia.textui.parsetree.VarArgType;
 import net.sourceforge.kolmafia.textui.parsetree.VariableList;
 import net.sourceforge.kolmafia.textui.parsetree.VariableReference;
 import net.sourceforge.kolmafia.utilities.CharacterEntities;
@@ -272,6 +274,13 @@ public class AshRuntime extends AbstractRuntime {
     for (VariableReference param : targetFunction.getVariableReferences()) {
       type = param.getType();
 
+      // ASH allows a function to have a single vararg parameter as the
+      // last one. If we have found such a parameter, the user wants to
+      // accumulate all remaining arguments into an array.
+      if (type instanceof VarArgType) {
+        break;
+      }
+
       String name = param.getName();
       Value value = null;
 
@@ -305,6 +314,30 @@ public class AshRuntime extends AbstractRuntime {
       }
 
       values[++index] = value;
+    }
+
+    if (type instanceof VarArgType vat) {
+      // The type of the array is the datatype of the vararg
+      Type paramType = vat.getDataType();
+
+      // Collect the values
+      List<Value> varValues = new ArrayList<>();
+
+      for (int i = index; parameters != null && i < parameters.length; ++i) {
+        Object input = parameters[i];
+        try {
+          varValues.add(DataTypes.coerceValue(paramType, input, false));
+        } catch (Exception e) {
+          RequestLogger.printLine("Bad " + paramType.toString() + " value: \"" + input + "\"");
+          return false;
+        }
+      }
+
+      // Put them into an Array value
+      Value value = new ArrayValue(vat, varValues);
+
+      values[++index] = value;
+      return true;
     }
 
     if (index < args && type != null) {

--- a/src/net/sourceforge/kolmafia/textui/command/CallScriptCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/CallScriptCommand.java
@@ -38,12 +38,12 @@ public class CallScriptCommand extends AbstractCommand {
       String[] arguments = null;
 
       parameters = parameters.trim();
+
+      // See if 'parameters' match a script file name in any of the allowed directories.
       List<File> scriptMatches = KoLmafiaCLI.findScriptFile(parameters);
 
-      // If still no script was found, perhaps it's the
-      // secret invocation of the "#x script" that allows a
-      // script to be run multiple times.
-
+      // If no script was found, see if it starts with #x, which specifies a run count.
+      // *** I hate the following code.
       if (scriptMatches.size() == 0) {
         String runCountString = parameters.split(" ")[0];
         boolean hasMultipleRuns = runCountString.endsWith("x");
@@ -65,20 +65,22 @@ public class CallScriptCommand extends AbstractCommand {
         }
       }
 
-      // Maybe the more ambiguous invocation of an ASH script
-      // which does not use parentheses?
-
+      // If still no script was found, see if the script has arguments.
+      // *** File names can have spaces. The following code assumes that
+      // *** the first space separates the filename from the arguments.
       if (scriptMatches.size() == 0) {
         int spaceIndex = parameters.indexOf(" ");
         if (spaceIndex != -1) {
           String argumentString = parameters.substring(spaceIndex + 1).trim();
           if (argumentString.startsWith("(") && argumentString.endsWith(")")) {
+            // Split (arg, arg, ...) into a list of arguments
             argumentString = argumentString.substring(1, argumentString.length() - 1);
             arguments = argumentString.split(",");
             for (int i = 0; i < arguments.length; i++) {
               arguments[i] = arguments[i].trim();
             }
           } else {
+            // Without parentheses, the parameters are a single string
             arguments = new String[] {argumentString};
           }
 
@@ -202,7 +204,7 @@ public class CallScriptCommand extends AbstractCommand {
       } else {
         if (arguments != null) {
           KoLmafia.updateDisplay(
-              MafiaState.ERROR, "You can only specify arguments for an ASH script");
+              MafiaState.ERROR, "You can only specify arguments for an ASH or JS script");
           return;
         }
 

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
@@ -114,9 +114,9 @@ public abstract class Function extends Symbol {
       }
 
       Type thisParamType = thisParam.getType();
-      if (thisParamType instanceof VarArgType) {
+      if (thisParamType instanceof VarArgType vat) {
         thisVararg = thisParam;
-        thisParamType = ((VarArgType) thisParamType).getDataType();
+        thisParamType = vat.getDataType();
       }
 
       VariableReference thatParam;
@@ -131,9 +131,9 @@ public abstract class Function extends Symbol {
       }
 
       Type thatParamType = thatParam.getType();
-      if (thatParamType instanceof VarArgType) {
+      if (thatParamType instanceof VarArgType vat) {
         thatVararg = thatParam;
-        thatParamType = ((VarArgType) thatParamType).getDataType();
+        thatParamType = vat.getDataType();
       }
 
       // If types don't agree, nothing more to look at
@@ -218,9 +218,9 @@ public abstract class Function extends Symbol {
       Type valueType = currentValue.getType();
 
       // If have found the vararg, remember it.
-      if (vararg == null && paramType instanceof VarArgType) {
+      if (vararg == null && paramType instanceof VarArgType vat) {
         vararg = currentParam;
-        varargType = ((VarArgType) paramType);
+        varargType = vat;
       }
 
       // Only one vararg is allowed. It must be at the end.
@@ -310,10 +310,10 @@ public abstract class Function extends Symbol {
       Value value = null;
 
       Type paramType = paramVarRef.getType();
-      if (paramType instanceof VarArgType) {
+      if (paramType instanceof VarArgType vat) {
         // If this is a vararg, it consumes all remaining values
         if (paramCount >= valueCount) {
-          value = new ArrayValue((VarArgType) paramType, Collections.emptyList());
+          value = new ArrayValue(vat, Collections.emptyList());
         } else {
           value = (Value) values[paramCount];
           if (!paramType.equals(value.getType())) {
@@ -323,7 +323,7 @@ public abstract class Function extends Symbol {
               varValues.add((Value) values[index]);
             }
             // Put them into an Array value
-            value = new ArrayValue((VarArgType) paramType, varValues);
+            value = new ArrayValue(vat, varValues);
           } else {
             // User explicitly passed us an array
           }

--- a/test/net/sourceforge/kolmafia/textui/AshRuntimeTest.java
+++ b/test/net/sourceforge/kolmafia/textui/AshRuntimeTest.java
@@ -1,9 +1,13 @@
 package net.sourceforge.kolmafia.textui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.List;
+import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.textui.parsetree.Function;
 import net.sourceforge.kolmafia.textui.parsetree.Type;
 import net.sourceforge.kolmafia.textui.parsetree.UserDefinedFunction;
@@ -143,6 +147,30 @@ public class AshRuntimeTest {
         assertEquals("foo", content[0].contentString);
         assertEquals("bar", content[1].contentString);
         assertEquals("baz", content[2].contentString);
+      }
+
+      // void main(int... args)
+      Function main3 =
+          new UserDefinedFunction(
+              "main",
+              DataTypes.VOID_TYPE,
+              List.of(makeVariableReference(new VarArgType(DataTypes.ITEM_TYPE), "args")),
+              null);
+
+      @Test
+      void noParameterAndBogusOptionalParameter() {
+        Object[] parameters = {"bogus"};
+        Object[] values = new Object[2];
+        values[0] = runtime;
+        ByteArrayOutputStream ostream = new ByteArrayOutputStream();
+        try (PrintStream out = new PrintStream(ostream, true)) {
+          RequestLogger.openCustom(out);
+          boolean result = runtime.requestUserParams(main3, parameters, values);
+          String output = ostream.toString().trim();
+          RequestLogger.closeCustom();
+          assertFalse(result);
+          assertEquals("Bad item value: \"bogus\"", output);
+        }
       }
     }
   }

--- a/test/net/sourceforge/kolmafia/textui/AshRuntimeTest.java
+++ b/test/net/sourceforge/kolmafia/textui/AshRuntimeTest.java
@@ -1,0 +1,149 @@
+package net.sourceforge.kolmafia.textui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import net.sourceforge.kolmafia.textui.parsetree.Function;
+import net.sourceforge.kolmafia.textui.parsetree.Type;
+import net.sourceforge.kolmafia.textui.parsetree.UserDefinedFunction;
+import net.sourceforge.kolmafia.textui.parsetree.Value;
+import net.sourceforge.kolmafia.textui.parsetree.VarArgType;
+import net.sourceforge.kolmafia.textui.parsetree.Variable;
+import net.sourceforge.kolmafia.textui.parsetree.VariableReference;
+import org.eclipse.lsp4j.Location;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class AshRuntimeTest {
+  @Nested
+  class RequestUserParams {
+    AshRuntime runtime = new AshRuntime();
+
+    // boolean requestUserParams(
+    //     final Function targetFunction,
+    //     final Object[] parameters,
+    //     Object[] values)
+    //
+    // parameters is an array of Strings from user input
+    // values is an array of parsed Values from parameters
+    // values[0] is the AshRuntime interpreter
+
+    VariableReference makeVariableReference(Type type, String name) {
+      Location location = null;
+      Variable variable = new Variable(name, type, location);
+      return new VariableReference(location, variable);
+    }
+
+    @Nested
+    class VarArgs {
+      // void main(string command, int... args)
+      Function main1 =
+          new UserDefinedFunction(
+              "main",
+              DataTypes.VOID_TYPE,
+              List.of(
+                  makeVariableReference(DataTypes.STRING_TYPE, "command"),
+                  makeVariableReference(new VarArgType(DataTypes.INT_TYPE), "args")),
+              null);
+
+      @Test
+      void requiredParameterAndZeroOptionalParameters() {
+        Object[] parameters = {"list"};
+        Object[] values = new Object[3];
+        values[0] = runtime;
+        boolean result = runtime.requestUserParams(main1, parameters, values);
+        assertTrue(result);
+        assertTrue(values[1] instanceof Value);
+        Value value1 = (Value) values[1];
+        assertEquals(DataTypes.STRING_TYPE, value1.getType());
+        assertEquals("list", value1.toString());
+        assertTrue(values[2] instanceof Value);
+        Value value2 = (Value) values[2];
+        assertTrue(value2.getType() instanceof VarArgType);
+        assertTrue(value2.content instanceof Value[]);
+        Value[] content = (Value[]) value2.content;
+        assertEquals(0, content.length);
+      }
+
+      @Test
+      void requiredParameterAndOptionalParameters() {
+        Object[] parameters = {"list", "10", "20", "30"};
+        Object[] values = new Object[3];
+        values[0] = runtime;
+        boolean result = runtime.requestUserParams(main1, parameters, values);
+        assertTrue(result);
+        assertTrue(values[1] instanceof Value);
+        Value value1 = (Value) values[1];
+        assertEquals(DataTypes.STRING_TYPE, value1.getType());
+        assertEquals("list", value1.toString());
+        assertTrue(values[2] instanceof Value);
+        Value value2 = (Value) values[2];
+        assertTrue(value2.getType() instanceof VarArgType);
+        assertTrue(value2.content instanceof Value[]);
+        Value[] content = (Value[]) value2.content;
+        assertEquals(3, content.length);
+        assertEquals(10, content[0].contentLong);
+        assertEquals(20, content[1].contentLong);
+        assertEquals(30, content[2].contentLong);
+      }
+
+      // void main(string... params)
+      Function main2 =
+          new UserDefinedFunction(
+              "main",
+              DataTypes.VOID_TYPE,
+              List.of(makeVariableReference(new VarArgType(DataTypes.STRING_TYPE), "params")),
+              null);
+
+      @Test
+      void noRequiredParameterAndZeroOptionalParameters() {
+        Object[] parameters = {};
+        Object[] values = new Object[2];
+        values[0] = runtime;
+        boolean result = runtime.requestUserParams(main2, parameters, values);
+        assertTrue(result);
+        assertTrue(values[1] instanceof Value);
+        Value value1 = (Value) values[1];
+        assertTrue(value1.getType() instanceof VarArgType);
+        assertTrue(value1.content instanceof Value[]);
+        Value[] content = (Value[]) value1.content;
+        assertEquals(0, content.length);
+      }
+
+      @Test
+      void noRequiredParameterAndOneOptionalParameters() {
+        Object[] parameters = {"foo bar baz"};
+        Object[] values = new Object[2];
+        values[0] = runtime;
+        boolean result = runtime.requestUserParams(main2, parameters, values);
+        assertTrue(result);
+        assertTrue(values[1] instanceof Value);
+        Value value1 = (Value) values[1];
+        assertTrue(value1.getType() instanceof VarArgType);
+        assertTrue(value1.content instanceof Value[]);
+        Value[] content = (Value[]) value1.content;
+        assertEquals(1, content.length);
+        assertEquals("foo bar baz", content[0].contentString);
+      }
+
+      @Test
+      void noRequiredParameterAndThreeOptionalParameters() {
+        Object[] parameters = {"foo", "bar", "baz"};
+        Object[] values = new Object[2];
+        values[0] = runtime;
+        boolean result = runtime.requestUserParams(main2, parameters, values);
+        assertTrue(result);
+        assertTrue(values[1] instanceof Value);
+        Value value1 = (Value) values[1];
+        assertTrue(value1.getType() instanceof VarArgType);
+        assertTrue(value1.content instanceof Value[]);
+        Value[] content = (Value[]) value1.content;
+        assertEquals(3, content.length);
+        assertEquals("foo", content[0].contentString);
+        assertEquals("bar", content[1].contentString);
+        assertEquals("baz", content[2].contentString);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This script:
```
void main(string op, int... args)
{
    int result = 1;
    print("op = '" + op + "' args = " + count(args));
    foreach i, arg in args {
	switch (op) {
	case "+":
	    result += arg;
	    break;
	case "-":
	    result -= arg;
	    break;
	case "*":
	    result *= arg;
	    break;
	}
    }
    print("result = " + result);
}
```
Has a main function with a required "string" arg and an optional array of ints.
It yields:
```
> call vargi -

op = '-' args = 0
result = 1

> call vargi (+, 2, 4, 6)

op = '+' args = 3
result = 13

> call vargi (*, 2, 4, 6, 8, 10)

op = '*' args = 5
result = 3840
```
Note that if I omit the required "op" argument it will prompt me for a string.
It will not prompt me for the array of ints.

This script:
```
void main(string... params)
{
    foreach i, param in params {
	print("param = " + param);
    }
}
```
has no required arguments. It yields:
```
> call vargi2 ten twenty thirty zero

param = ten twenty thirty zero

> call vargi2

> call vargi2 (foo, bar, baz)

param = foo
param = bar
param = baz
```
It will not prompt for the string array