### PR TITLE
No alert when find defective token

### DIFF
--- a/src/net/sourceforge/kolmafia/request/ArcadeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ArcadeRequest.java
@@ -16,7 +16,6 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.ChoiceManager;
 import net.sourceforge.kolmafia.session.ResultProcessor;
 import net.sourceforge.kolmafia.utilities.ChoiceUtilities;
-import net.sourceforge.kolmafia.utilities.InputFieldUtilities;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class ArcadeRequest extends GenericRequest {
@@ -98,9 +97,6 @@ public class ArcadeRequest extends GenericRequest {
     if (action.equals("arcade_plumber")) {
       // We visited Jackass Plumber for the day
       Preferences.setBoolean("_defectiveTokenChecked", true);
-      if (responseText.contains("defective Game Grid token")) {
-        InputFieldUtilities.alert("You found a defective Game Grid token!");
-      }
       return;
     }
   }


### PR DESCRIPTION
I fired off a script and left my computer for a couple of hours.
When I returned, I found the script paused because KoLmafia just had to post a dialog box informing me I'd found a defective Game Grid token, requiring an "OK" confirmation.

Years ago, that might have been exciting. Once.

Now, it is, dare I say, annoying.