### PR TITLE
New ASH functions: join_strings() is inverse of split_string()

### DIFF
--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -847,4 +847,64 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
       assertThat(output, containsString("Returned: " + value));
     }
   }
+
+  @Nested
+  class SplitJoinStrings {
+    String input1 = "line1\\nline2\\nline3";
+    String input2 = "foo bar baz";
+
+    @Test
+    void canSplitOnNewLine() {
+      String input = "string str = \"" + input1 + "\"; split_string(str)";
+      String output = execute(input);
+      assertThat(
+          output,
+          is(
+              """
+              Returned: aggregate string [3]
+              0 => line1
+              1 => line2
+              2 => line3
+              """));
+    }
+
+    @Test
+    void canSplitOnSpace() {
+      String input = "string str = \"" + input2 + "\"; split_string(str, \" \")";
+      String output = execute(input);
+      assertThat(
+          output,
+          is(
+              """
+              Returned: aggregate string [3]
+              0 => foo
+              1 => bar
+              2 => baz
+              """));
+    }
+
+    @Test
+    void canSplitJoinOnNewLine() {
+      String input = "string str = \"" + input1 + "\"; split_string(str).join_strings()";
+      String output = execute(input);
+      assertThat(
+          output,
+          is(
+              """
+              Returned: line1
+              line2
+              line3
+              """));
+    }
+
+    @Test
+    void canSplitJoinOnSpace() {
+      String input =
+          "string str = \"" + input2 + "\"; split_string(str, \" \").join_strings(\" \")";
+      String output = execute(input);
+      assertThat(output, is("""
+              Returned: foo bar baz
+              """));
+    }
+  }
 }


### PR DESCRIPTION
Just as we have:

string[] array = split_string(string input);
=> split input on new-lines and return array

string[] array = split_string(string input, string pattern)
=> split input on pattern and return array

Now we have:

string output = join_strings(string[] array)
=> Join strings in array with new-lines

string output = join_strings(string[] array, string joiner)
=> Join strings in array with chosen separator