### PR TITLE
fix: getaway doesn't give free rests when not in standard

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -1752,7 +1752,8 @@ public abstract class KoLCharacter {
     if (KoLCharacter.hasSkill(SkillPool.FOOD_COMA)) freerests += 10;
     if (KoLCharacter.hasSkill(SkillPool.DOG_TIRED)) freerests += 5;
     if (KoLConstants.chateau.contains(ChateauRequest.CHATEAU_FAN)) freerests += 5;
-    if (Preferences.getBoolean("getawayCampsiteUnlocked")) ++freerests;
+    if (StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Distant Woods Getaway Brochure")
+        && Preferences.getBoolean("getawayCampsiteUnlocked")) ++freerests;
     if (KoLCharacter.hasSkill(SkillPool.LONG_WINTERS_NAP)) freerests += 5;
     if (InventoryManager.getCount(ItemPool.MOTHERS_NECKLACE) > 0
         || KoLCharacter.hasEquipped(ItemPool.MOTHERS_NECKLACE)) freerests += 5;


### PR DESCRIPTION
Or so I assume, it makes the numbers work better.

The numbers still don't quite work because KoL doesn't have Long Winter's Nap in the `standard.php` page, but also it doesn't work (I presume, because the food/booze/candy summoning skills says they're too old).