### PR TITLE
feat: witchess set is still visible in lol even if replica unused

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1167,6 +1167,7 @@ user	pyramidPosition	1
 user	pyramidBombUsed	false
 user	replicaChateauAvailable	false
 user	replicaNeverendingPartyAlways	false
+user	replicaWitchessSetAvailable	false
 user	retroCapeSuperhero	vampire
 user	retroCapeWashingInstructions	hold
 user	rockinRobinProgress	25

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -1140,7 +1140,8 @@ public class Maximizer {
           duration = 30;
           usesRemaining = Preferences.getBoolean("_grimBuff") ? 0 : 1;
         } else if (cmd.equals("witchess")) {
-          if (!KoLCharacter.inLegacyOfLoathing()
+          if (!(KoLCharacter.inLegacyOfLoathing()
+                  && Preferences.getBoolean("replicaWitchessSetAvailable"))
               && !StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Witchess Set")) {
             continue;
           }

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3613,6 +3613,7 @@ public class ItemPool {
   public static final int REPLICA_ROBORTENDER = 11236;
   public static final int REPLICA_NEVERENDING_PARTY_INVITE = 11237;
   public static final int REPLICA_GOD_LOBSTER = 11239;
+  public static final int REPLICA_SAUSAGE_O_MATIC = 11241;
   public static final int REPLICA_CAMELCALF = 11243;
   public static final int REPLICA_POWERFUL_GLOVE = 11244;
   public static final int REPLICA_GREY_GOSLING = 11250;

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -6060,6 +6060,10 @@ public class UseItemRequest extends GenericRequest {
           Preferences.setBoolean("_replicaSmithsTomeUsed", true);
         }
         return;
+
+      case ItemPool.REPLICA_WITCHESS_SET:
+        Preferences.setBoolean("replicaWitchessSetAvailable", true);
+        break;
     }
 
     if (CampgroundRequest.isWorkshedItem(itemId)) {

--- a/src/net/sourceforge/kolmafia/request/WitchessRequest.java
+++ b/src/net/sourceforge/kolmafia/request/WitchessRequest.java
@@ -15,11 +15,16 @@ public class WitchessRequest extends GenericRequest {
 
   @Override
   public void run() {
-    if (!(KoLCharacter.inLegacyOfLoathing()
-            && Preferences.getBoolean("replicaWitchessSetAvailable"))
-        && !StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Witchess Set")) {
-      KoLmafia.updateDisplay("Witchess is too old to use in your current path.");
-      return;
+    if (KoLCharacter.inLegacyOfLoathing()) {
+      if (!Preferences.getBoolean("replicaWitchessSetAvailable")) {
+        KoLmafia.updateDisplay("You need to use a replica Witchess Set first.");
+        return;
+      }
+    } else {
+      if (!StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Witchess Set")) {
+        KoLmafia.updateDisplay("Witchess is too old to use in your current path.");
+        return;
+      }
     }
     if (Preferences.getBoolean("_witchessBuff")) {
       KoLmafia.updateDisplay("You already got your Witchess buff today.");

--- a/src/net/sourceforge/kolmafia/request/WitchessRequest.java
+++ b/src/net/sourceforge/kolmafia/request/WitchessRequest.java
@@ -15,7 +15,8 @@ public class WitchessRequest extends GenericRequest {
 
   @Override
   public void run() {
-    if (!KoLCharacter.inLegacyOfLoathing()
+    if (!(KoLCharacter.inLegacyOfLoathing()
+            && Preferences.getBoolean("replicaWitchessSetAvailable"))
         && !StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Witchess Set")) {
       KoLmafia.updateDisplay("Witchess is too old to use in your current path.");
       return;

--- a/src/net/sourceforge/kolmafia/swingui/panel/DailyDeedsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/DailyDeedsPanel.java
@@ -2526,7 +2526,8 @@ public class DailyDeedsPanel extends Box implements Listener {
               && !KoLCharacter.inBadMoon();
       boolean wc =
           KoLConstants.campground.contains(ItemPool.get(ItemPool.WITCHESS_SET, 1))
-              && StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Witchess Set")
+              && (StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Witchess Set")
+                  || KoLCharacter.inLegacyOfLoathing())
               && !KoLCharacter.getLimitMode().limitCampground()
               && !KoLCharacter.inBadMoon();
       boolean et = !(Preferences.getBoolean("_eldritchTentacleFought"));
@@ -2550,8 +2551,10 @@ public class DailyDeedsPanel extends Box implements Listener {
               && !KoLCharacter.getLimitMode().limitZone("Town")
               && !KoLCharacter.inBadMoon();
       boolean sg =
-          StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Kramco Sausage-o-Matic™")
-              && InventoryManager.hasItem(ItemPool.SAUSAGE_O_MATIC);
+          (StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Kramco Sausage-o-Matic™")
+                  && InventoryManager.hasItem(ItemPool.SAUSAGE_O_MATIC))
+              || (KoLCharacter.inLegacyOfLoathing()
+                  && InventoryManager.hasItem(ItemPool.REPLICA_SAUSAGE_O_MATIC));
       boolean gm =
           StandardRequest.isAllowed(RestrictedItemType.ITEMS, "[glitch season reward name]")
               && InventoryManager.hasItem(ItemPool.GLITCH_ITEM)
@@ -3704,14 +3707,16 @@ public class DailyDeedsPanel extends Box implements Listener {
     public void update() {
       boolean bm = KoLCharacter.inBadMoon();
       boolean kf = KoLCharacter.kingLiberated();
-      boolean have =
-          InventoryManager.getCount(ItemPool.DECK_OF_EVERY_CARD) > 0
-              || (KoLCharacter.inLegacyOfLoathing()
-                  && InventoryManager.getCount(ItemPool.REPLICA_DECK_OF_EVERY_CARD) > 0);
+      boolean haveNormal = InventoryManager.getCount(ItemPool.DECK_OF_EVERY_CARD) > 0;
+      boolean haveReplica =
+          KoLCharacter.inLegacyOfLoathing()
+              && InventoryManager.getCount(ItemPool.REPLICA_DECK_OF_EVERY_CARD) > 0;
       boolean nocards = Preferences.getInteger("_deckCardsDrawn") >= 15;
-      boolean allowed = StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Deck of Every Card");
+      boolean allowedNormal =
+          StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Deck of Every Card");
       boolean limited = KoLCharacter.getLimitMode().limitItem(ItemPool.DECK_OF_EVERY_CARD);
-      this.setShown((!bm || kf) && (have || nocards) && allowed && !limited);
+      this.setShown(
+          (!bm || kf) && (((haveNormal || nocards) && allowedNormal) || haveReplica) && !limited);
       if (nocards) {
         this.setText("You have drawn all your cards today");
         box.setVisible(false);
@@ -3951,8 +3956,12 @@ public class DailyDeedsPanel extends Box implements Listener {
       boolean bm = KoLCharacter.inBadMoon();
       boolean kf = KoLCharacter.kingLiberated();
       boolean noenhance = Preferences.getInteger("_sourceTerminalEnhanceUses") >= limit;
-      boolean have = !Preferences.getString("sourceTerminalEnhanceKnown").equals("");
-      boolean allowed = StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Source terminal");
+      boolean have =
+          KoLConstants.campground.contains(ItemPool.get(ItemPool.SOURCE_TERMINAL, 1))
+              && !Preferences.getString("sourceTerminalEnhanceKnown").equals("");
+      boolean allowed =
+          StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Source terminal")
+              || KoLCharacter.inLegacyOfLoathing();
       boolean limited = KoLCharacter.getLimitMode().limitCampground();
       this.setShown((!bm || kf) && have && allowed && !limited);
       if (noenhance) {
@@ -4035,8 +4044,12 @@ public class DailyDeedsPanel extends Box implements Listener {
     public void update() {
       boolean bm = KoLCharacter.inBadMoon();
       boolean kf = KoLCharacter.kingLiberated();
-      boolean have = !Preferences.getString("sourceTerminalEnquiryKnown").equals("");
-      boolean allowed = StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Source terminal");
+      boolean have =
+          KoLConstants.campground.contains(ItemPool.get(ItemPool.SOURCE_TERMINAL, 1))
+              && !Preferences.getString("sourceTerminalEnquiryKnown").equals("");
+      boolean allowed =
+          StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Source terminal")
+              || KoLCharacter.inLegacyOfLoathing();
       boolean limited = KoLCharacter.getLimitMode().limitCampground();
       this.setShown((!bm || kf) && have && allowed && !limited);
       box.setEnabled(true);
@@ -4120,8 +4133,12 @@ public class DailyDeedsPanel extends Box implements Listener {
     public void update() {
       boolean bm = KoLCharacter.inBadMoon();
       boolean kf = KoLCharacter.kingLiberated();
-      boolean have = !Preferences.getString("sourceTerminalExtrudeKnown").equals("");
-      boolean allowed = StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Source terminal");
+      boolean have =
+          KoLConstants.campground.contains(ItemPool.get(ItemPool.SOURCE_TERMINAL, 1))
+              && !Preferences.getString("sourceTerminalExtrudeKnown").equals("");
+      boolean allowed =
+          StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Source terminal")
+              || KoLCharacter.inLegacyOfLoathing();
       boolean limited = KoLCharacter.getLimitMode().limitCampground();
       int extrudes = Preferences.getInteger("_sourceTerminalExtrudes");
       boolean noextrude = extrudes >= 3;
@@ -4210,8 +4227,12 @@ public class DailyDeedsPanel extends Box implements Listener {
       String educate2 = Preferences.getString("sourceTerminalEducate2");
       boolean bm = KoLCharacter.inBadMoon();
       boolean kf = KoLCharacter.kingLiberated();
-      boolean have = !Preferences.getString("sourceTerminalEducateKnown").equals("");
-      boolean allowed = StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Source terminal");
+      boolean have =
+          KoLConstants.campground.contains(ItemPool.get(ItemPool.SOURCE_TERMINAL, 1))
+              && !Preferences.getString("sourceTerminalEducateKnown").equals("");
+      boolean allowed =
+          StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Source terminal")
+              || KoLCharacter.inLegacyOfLoathing();
       boolean limited = KoLCharacter.getLimitMode().limitCampground();
       this.setShown((!bm || kf) && have && allowed && !limited);
       box.setEnabled(true);
@@ -4274,8 +4295,12 @@ public class DailyDeedsPanel extends Box implements Listener {
       int duplicateLimit = 1 + (KoLCharacter.inTheSource() ? 4 : 0);
       boolean bm = KoLCharacter.inBadMoon();
       boolean kf = KoLCharacter.kingLiberated();
-      boolean have = !Preferences.getString("sourceTerminalEducateKnown").equals("");
-      boolean allowed = StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Source terminal");
+      boolean have =
+          KoLConstants.campground.contains(ItemPool.get(ItemPool.SOURCE_TERMINAL, 1))
+              && !Preferences.getString("sourceTerminalEducateKnown").equals("");
+      boolean allowed =
+          StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Source terminal")
+              || KoLCharacter.inLegacyOfLoathing();
       boolean limited = KoLCharacter.getLimitMode().limitCampground();
       this.setShown((!bm || kf) && have && allowed && !limited);
 

--- a/src/net/sourceforge/kolmafia/swingui/panel/DailyDeedsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/DailyDeedsPanel.java
@@ -3716,8 +3716,7 @@ public class DailyDeedsPanel extends Box implements Listener {
       boolean allowedNormal =
           StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Deck of Every Card");
       boolean limited = KoLCharacter.getLimitMode().limitItem(ItemPool.DECK_OF_EVERY_CARD);
-      this.setShown(
-          (!bm || kf) && (((haveNormal || nocards) && allowedNormal) || haveReplica) && !limited);
+      this.setShown((!bm || kf) && ((haveNormal && allowedNormal) || haveReplica) && !limited);
       if (nocards) {
         this.setText("You have drawn all your cards today");
         box.setVisible(false);

--- a/src/net/sourceforge/kolmafia/swingui/panel/DailyDeedsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/DailyDeedsPanel.java
@@ -2527,7 +2527,8 @@ public class DailyDeedsPanel extends Box implements Listener {
       boolean wc =
           KoLConstants.campground.contains(ItemPool.get(ItemPool.WITCHESS_SET, 1))
               && (StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Witchess Set")
-                  || KoLCharacter.inLegacyOfLoathing())
+                  || KoLCharacter.inLegacyOfLoathing()
+                      && Preferences.getBoolean("replicaWitchessSetAvailable"))
               && !KoLCharacter.getLimitMode().limitCampground()
               && !KoLCharacter.inBadMoon();
       boolean et = !(Preferences.getBoolean("_eldritchTentacleFought"));

--- a/src/net/sourceforge/kolmafia/textui/command/WitchessCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/WitchessCommand.java
@@ -15,7 +15,8 @@ public class WitchessCommand extends AbstractCommand {
 
   @Override
   public void run(final String cmd, final String parameters) {
-    if (!KoLCharacter.inLegacyOfLoathing()
+    if (!(KoLCharacter.inLegacyOfLoathing()
+            && Preferences.getBoolean("replicaWitchessSetAvailable"))
         && !StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Witchess Set")) {
       return;
     }

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -1794,6 +1794,7 @@ public class MaximizerTest {
           new Cleanups(
               withPath(Path.LEGACY_OF_LOATHING),
               withRestricted(true),
+              withProperty("replicaWitchessSetAvailable", true),
               withNotAllowedInStandard(RestrictedItemType.ITEMS, "Witchess Set"),
               withWitchess);
 


### PR DESCRIPTION
We need to add a preference for actually using the replica Witchess set, because if you have one already it shows in your campsite, but you can't use it.

Also correctly show Witchess and Source Terminal in Daily Deeds if present.