### PR TITLE
MrStore2002Request uses UseItemRequest for better logging

### DIFF
--- a/src/net/sourceforge/kolmafia/request/MrStore2002Request.java
+++ b/src/net/sourceforge/kolmafia/request/MrStore2002Request.java
@@ -105,8 +105,6 @@ public class MrStore2002Request extends CoinMasterRequest {
         KoLmafia.updateDisplay(MafiaState.ERROR, "Failed to redirect to shop.php.");
         return;
       }
-      // Remember that we've collected credits today.
-      Preferences.setBoolean("_2002MrStoreCreditsCollected", true);
     }
 
     // Now run the shop.php request

--- a/src/net/sourceforge/kolmafia/request/MrStore2002Request.java
+++ b/src/net/sourceforge/kolmafia/request/MrStore2002Request.java
@@ -40,7 +40,7 @@ public class MrStore2002Request extends CoinMasterRequest {
     super(MR_STORE_2002, buying, itemId, quantity);
   }
 
-  private static int catalogToUse() {
+  public static int catalogToUse() {
     if (InventoryManager.hasItem(ItemPool.MR_STORE_2002_CATALOG)) {
       return ItemPool.MR_STORE_2002_CATALOG;
     }
@@ -59,21 +59,19 @@ public class MrStore2002Request extends CoinMasterRequest {
   //
   // There are two options:
   //
-  // 1) We could create a UseItemRequest. That does not follow
-  //    redirects.  However, it comes with a bunch of additional
-  //    overhead which we don't need or want.
+  // 1) We could create a UseItemRequest. That can be configured to not
+  //    follow redirects.  It comes with overhead which we don't need,
+  //    but it does log the "use" nicely
   //
   // 2) We could create a GenericRequest, which has no extraneous
   //    overhead. However, as coded, it automatically follows redirects.
-  //    We can override that behavior.
+  //    We can override that behavior, but doing so makes it something
+  //    other than GenericRequest.class, which does not log nicely.
 
   private static GenericRequest useItemRequest(int itemId) {
-    return new GenericRequest("inv_use.php?which=3&ajax=1&whichitem=" + itemId) {
-      @Override
-      protected boolean shouldFollowRedirect() {
-        return false;
-      }
-    };
+    UseItemRequest request = UseItemRequest.getInstance(itemId);
+    request.followRedirect(false);
+    return request;
   }
 
   @Override
@@ -113,6 +111,11 @@ public class MrStore2002Request extends CoinMasterRequest {
 
     // Now run the shop.php request
     super.run();
+  }
+
+  @Override
+  public void processResults() {
+    parseResponse(this.getURLString(), this.responseText);
   }
 
   public static void parseResponse(final String urlString, final String responseText) {

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -6071,7 +6071,6 @@ public class UseItemRequest extends GenericRequest {
 
       case ItemPool.MR_STORE_2002_CATALOG:
       case ItemPool.REPLICA_MR_STORE_2002_CATALOG:
-        Preferences.setBoolean("_2002MrStoreCreditsCollected", true);
         // Using the catalog redirects to "whichshop=mrstore2002".
         // If we followed the redirect, let MrStore2002Request handle it.
         MrStore2002Request.parseResponse(currentURL, responseText);
@@ -6733,7 +6732,14 @@ public class UseItemRequest extends GenericRequest {
           if (sign != ZodiacSign.NONE && urlString.contains("doit=96")) {
             useString = "tuning moon to The " + sign;
           }
+          break;
         }
+
+      case ItemPool.MR_STORE_2002_CATALOG:
+      case ItemPool.REPLICA_MR_STORE_2002_CATALOG:
+        // This redirects to shop.php
+        Preferences.setBoolean("_2002MrStoreCreditsCollected", true);
+        break;
     }
 
     if (useString == null) {

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -142,6 +142,7 @@ public class UseItemRequest extends GenericRequest {
 
   protected static AdventureResult lastItemUsed = null;
   protected static AdventureResult lastHelperUsed = null;
+  protected static String currentURL = "";
   private static int currentItemId = -1;
   private static String lastUrlString = null;
 
@@ -1431,7 +1432,10 @@ public class UseItemRequest extends GenericRequest {
 
   @Override
   public void processResults() {
-    if (this.getPath().startsWith("choice.php")) {
+    // We might have been redirected.
+    UseItemRequest.currentURL = this.getPath();
+
+    if (UseItemRequest.currentURL.startsWith("choice.php")) {
       // We have been redirected. Unlike a redirection to fight.php,
       // which GenericRequest automates in FightRequest.INSTANCE, we
       // automate this ourself in runOneIteration. Item consumption
@@ -6068,6 +6072,9 @@ public class UseItemRequest extends GenericRequest {
       case ItemPool.MR_STORE_2002_CATALOG:
       case ItemPool.REPLICA_MR_STORE_2002_CATALOG:
         Preferences.setBoolean("_2002MrStoreCreditsCollected", true);
+        // Using the catalog redirects to "whichshop=mrstore2002".
+        // If we followed the redirect, let MrStore2002Request handle it.
+        MrStore2002Request.parseResponse(currentURL, responseText);
         return;
 
       case ItemPool.GIANT_BLACK_MONOLITH:

--- a/src/net/sourceforge/kolmafia/session/BreakfastManager.java
+++ b/src/net/sourceforge/kolmafia/session/BreakfastManager.java
@@ -37,6 +37,7 @@ import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.request.GenieRequest;
 import net.sourceforge.kolmafia.request.HermitRequest;
 import net.sourceforge.kolmafia.request.IslandRequest;
+import net.sourceforge.kolmafia.request.MrStore2002Request;
 import net.sourceforge.kolmafia.request.PlaceRequest;
 import net.sourceforge.kolmafia.request.SpinMasterLatheRequest;
 import net.sourceforge.kolmafia.request.StandardRequest;
@@ -381,13 +382,8 @@ public class BreakfastManager {
   }
 
   public static void collect2002MrStoreCredits() {
-    AdventureResult catalogue;
-    if (InventoryManager.hasItem(ItemPool.MR_STORE_2002_CATALOG)) {
-      catalogue = ItemPool.get(ItemPool.MR_STORE_2002_CATALOG, 1);
-    } else if (KoLCharacter.inLegacyOfLoathing()
-        && InventoryManager.hasItem(ItemPool.REPLICA_MR_STORE_2002_CATALOG)) {
-      catalogue = ItemPool.get(ItemPool.REPLICA_MR_STORE_2002_CATALOG, 1);
-    } else {
+    int catalogue = MrStore2002Request.catalogToUse();
+    if (catalogue == 0) {
       return;
     }
 
@@ -396,7 +392,7 @@ public class BreakfastManager {
     }
 
     KoLmafia.updateDisplay("Getting 2002 Mr Store Credits...");
-    RequestThread.postRequest(UseItemRequest.getInstance(catalogue));
+    RequestThread.postRequest(new MrStore2002Request());
   }
 
   public static void useSpinningWheel() {

--- a/test/net/sourceforge/kolmafia/request/MrStore2002RequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/MrStore2002RequestTest.java
@@ -63,7 +63,7 @@ public class MrStore2002RequestTest {
       assertPostRequest(
           requests.get(0),
           "/inv_use.php",
-          "which=3&ajax=1&whichitem=" + ItemPool.MR_STORE_2002_CATALOG);
+          "whichitem=" + ItemPool.MR_STORE_2002_CATALOG + "&ajax=1");
       assertPostRequest(requests.get(1), "/shop.php", "whichshop=mrstore2002");
     }
   }
@@ -100,7 +100,7 @@ public class MrStore2002RequestTest {
       assertPostRequest(
           requests.get(0),
           "/inv_use.php",
-          "which=3&ajax=1&whichitem=" + ItemPool.MR_STORE_2002_CATALOG);
+          "whichitem=" + ItemPool.MR_STORE_2002_CATALOG + "&ajax=1");
       assertPostRequest(
           requests.get(1),
           "/shop.php",
@@ -142,7 +142,7 @@ public class MrStore2002RequestTest {
       assertPostRequest(
           requests.get(1),
           "/inv_use.php",
-          "which=3&ajax=1&whichitem=" + ItemPool.MR_STORE_2002_CATALOG);
+          "whichitem=" + ItemPool.MR_STORE_2002_CATALOG + "&ajax=1");
       assertPostRequest(requests.get(2), "/shop.php", "whichshop=mrstore2002");
     }
   }
@@ -174,7 +174,7 @@ public class MrStore2002RequestTest {
       assertPostRequest(
           requests.get(0),
           "/inv_use.php",
-          "which=3&ajax=1&whichitem=" + ItemPool.REPLICA_MR_STORE_2002_CATALOG);
+          "whichitem=" + ItemPool.REPLICA_MR_STORE_2002_CATALOG + "&ajax=1");
       assertPostRequest(requests.get(1), "/shop.php", "whichshop=mrstore2002");
     }
   }
@@ -206,7 +206,7 @@ public class MrStore2002RequestTest {
       assertPostRequest(
           requests.get(0),
           "/inv_use.php",
-          "which=3&ajax=1&whichitem=" + ItemPool.MR_STORE_2002_CATALOG);
+          "whichitem=" + ItemPool.MR_STORE_2002_CATALOG + "&ajax=1");
       assertPostRequest(requests.get(1), "/shop.php", "whichshop=mrstore2002");
     }
   }


### PR DESCRIPTION
1) If MrStoreRequest uses an over-ridden GenericRequest, it is no longer GenericRequest.class, RequestLogger does not consider it to be an externalRequest, and it logs the raw URL rather than "use XXX". Therefore, use a UseItemRequest and set it to not follow redirects.

2) Breakfast uses a UseItemRequest which does follow redirects, but since that does not parse the shop response, credits do not update. If UseItemRequest.parseConsumption notices that the request was redirected, call MrStore2002Request.parseResponse to parse the shop. Breakfast now updates available credits correctly.

3) Unfortunately, following the redirect does not log the shop.php request nicely. I made Breakfast call MrStore2002Request, not UseItemRequest, and it looks like this in the gCLI:
```
Getting 2002 Mr Store Credits...
Using 1 2002 Mr. Store Catalog...
Finished using 1 2002 Mr. Store Catalog.
Visiting Mr. Store 2002...
Requests complete.
```
and like this in the session log:
```
use 1 2002 Mr. Store Catalog

Visiting Mr. Store 2002
```

4) If you use a catalog from the Relay Browser, UseItemRequest.parseConsumption is not called and we do not set _2002MrStoreCreditsCollected to true. Move setting that property into UseItemRequest.registerRequest.

-----

Using the catalog from the item manager log like this in the gCLI
```
Using 1 2002 Mr. Store Catalog...
Finished using 1 2002 Mr. Store Catalog.
```
and this in the session log:
```
use 1 2002 Mr. Store Catalog

shop.php?whichshop=mrstore2002
```
I don't particularly like that raw URL, but the redirected URL is in the UseItemRequest and therefore RequestLogger passes it to that classes's registerRequest method. I'm not sure how to fix that. Making (redirected) UseItemRequest do something in registerRequest seems like a can of worms.