### PR TITLE
feat: add preference to not error on ambiguous fold

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -597,6 +597,7 @@ user	ensorcelee
 user	ensorceleeLevel	0
 user	entauntaunedColdRes	0
 user	envyfishMonster
+user	errorOnAmbiguousFold	true
 user	essenceOfAnnoyanceAvailable	true
 user	essenceOfAnnoyanceCost	5000
 user	essenceOfBearAvailable	true

--- a/src/net/sourceforge/kolmafia/textui/command/FoldItemCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/FoldItemCommand.java
@@ -127,12 +127,14 @@ public class FoldItemCommand extends AbstractCommand {
       // If we have this item equipped, remember where
       Slot where = KoLCharacter.equipmentSlot(item);
       if (where != Slot.NONE) {
-        if (worn == null) {
+        if (worn != null) {
+          multiple = true;
+        }
+
+        if (where.ordinal() > slot.ordinal()) {
           worn = item;
           wornIndex = sourceIndex;
           slot = where;
-        } else {
-          multiple = true;
         }
       }
 
@@ -191,7 +193,7 @@ public class FoldItemCommand extends AbstractCommand {
     // If nothing in inventory is foldable, consider equipment
     if (source == null) {
       // Too many choices. Let player decide which one
-      if (multiple) {
+      if (multiple && Preferences.getBoolean("errorOnAmbiguousFold")) {
         KoLmafia.updateDisplay(MafiaState.ERROR, "Unequip the item you want to fold into that.");
         return;
       }


### PR DESCRIPTION
Features for the 1%.

Some [garbo](https://github.com/Loathing-Associates-Scripting-Society/garbage-collector) users with multiple stinky cheese items are reporting maximization failures where beginning with multiple stinky cheese items equipped and none in inventory leads to a failure to maximize due to Mafia not being sure which to fold.

Add a preference for this case that always folds the last one slotwise: this will make a given `maximize` command work as it also runs the commands in sequence of slots.