### PR TITLE
LoL and 2002 Mr Store fixes

### DIFF
--- a/src/data/coinmasters.txt
+++ b/src/data/coinmasters.txt
@@ -1142,7 +1142,7 @@ Replica Mr. Store	buy	1	replica designer sweatpants	ROW1376
 Replica Mr. Store	buy	1	replica grey gosling	ROW1375
 Replica Mr. Store	buy	1	replica Jurassic Parka	ROW1374
 Replica Mr. Store	buy	1	replica Cincho de Mayo	ROW1377
-Replica Mr. Store	buy	1	Replica 2002 Mr. Store	ROW1391
+Replica Mr. Store	buy	1	Replica 2002 Mr. Store Catalog	ROW1391
 
 # Mr. Store 2002
 

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11214,7 +11214,7 @@
 11186	cursed monkey's paw	617234158	monkeypaw0.gif	accessory		0
 11187	cursed monkey glove	144539345	monkeyglove.gif	usable	t	0
 11188	shadow candy	408964450	nopic.gif	none		0
-11189	replica Mr. Accessory	341989211	replicamra.gif	none	q	0
+11189	replica Mr. Accessory	341989211	replicamra.gif	none	q	0	replica Mr. Accessories
 11190	replica Dark Jill-O-Lantern	844290698	jilldark.gif	grow	q	0
 11191	replica hand turkey outline	643478560	hand.gif	grow	q	0
 11192	replica crimbo elfling	258450480	elfling.gif	grow	q	0
@@ -11278,7 +11278,7 @@
 11250	replica grey gosling	716923546	greygosling.gif	grow	q	0
 11251	replica designer sweatpants	152213403	sweats.gif	pants	q	0
 11252	replica plastic pumpkin bucket	127836800	punkin.gif	familiar	q	0
-11253	replica Ten Dollars	751729776	dinobuck.gif	usable	t	0
+11253	replica Ten Dollars	751729776	dinobuck.gif	multiple	t	0
 11254	replica Cincho de Mayo	512079504	cincho.gif	accessory	q	0
 11255	Thwaitgold splendor beetle statuette	854195085	thwaitsplendor.gif	none		0
 11256	shrink-wrapped 2002 Mr. Store Catalog	520858825	2002catalog.gif	usable	t	0
@@ -11298,7 +11298,7 @@
 11270	Spooky VHS Tape	754348768	2002vhs.gif	none, combat	t,d	50
 11271	scroll of minor invulnerability	873755113	scroll2.gif	potion, usable	t,d	10
 11272	Lapis Lazuli	460775590	lapis.gif	usable	t,d	100
-11273	Eye Agate	556792213	agate.gif	usable	t,d	100
+11273	Eye Agate	556792213	agate.gif	multiple	t,d	100
 11274	Azurite	560374993	azurite.gif	usable	t,d	100
 11275	Arrow (+1)	391510123	arrow_normal.gif	none, combat	t,d	10
 11276	scroll of protection from lycanthropes	545555359	scroll3.gif	potion, usable	t,d	10

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -4997,6 +4997,7 @@ Item	hobo fortress blueprints	Base Resting HP: +84, Base Resting MP: +85
 Item	house of twigs and spit	Base Resting HP: +59, Base Resting MP: +60
 Item	Lazybones&trade; recliner	Spooky Resistance: +2
 # Loudmouth Larry Lamprey
+Item	Meat Butler	Adventures: +4
 # meat golem
 Item	Meat maid	Adventures: +4
 Item	Newbiesport&trade; tent	Base Resting HP: +9, Base Resting MP: +10

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3624,6 +3624,7 @@ public class ItemPool {
   public static final int REPLICA_TEN_DOLLARS = 11253;
   public static final int REPLICA_CINCHO_DE_MAYO = 11254;
   public static final int MR_STORE_2002_CATALOG = 11257;
+  public static final int MEAT_BUTLER = 11262;
   public static final int LOATHING_IDOL_MICROPHONE = 11263;
   public static final int CHARTER_NELLYVILLE = 11264;
   public static final int FLASH_LIQUIDIZER_ULTRA_DOUSING_ACCESSORY = 11266;

--- a/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
@@ -94,6 +94,7 @@ public class CampgroundRequest extends GenericRequest {
           // Inside dwelling: maids
           ItemPool.MAID,
           ItemPool.CLOCKWORK_MAID,
+          ItemPool.MEAT_BUTLER,
 
           // Inside dwelling: miscellaneous
           // (Certificate of Participation)
@@ -1522,8 +1523,10 @@ public class CampgroundRequest extends GenericRequest {
     if (startIndex > 0 && endIndex > 0) {
       var relevantResponse = responseText.substring(startIndex, endIndex);
 
-      boolean maidFound = findImage(relevantResponse, "maid.gif", ItemPool.MAID);
-      if (!maidFound) findImage(relevantResponse, "maid2.gif", ItemPool.CLOCKWORK_MAID);
+      // Three mutually exclusive dwelling servants
+      if (findImage(relevantResponse, "maid.gif", ItemPool.MAID)
+          || findImage(relevantResponse, "maid2.gif", ItemPool.CLOCKWORK_MAID)
+          || findImage(relevantResponse, "butler.gif", ItemPool.MEAT_BUTLER)) {}
 
       Matcher m = FURNISHING_PATTERN.matcher(relevantResponse);
       while (m.find()) {

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -570,6 +570,7 @@ public class UseItemRequest extends GenericRequest {
       case ItemPool.CLOCKWORK_BARTENDER:
       case ItemPool.MAID:
       case ItemPool.CLOCKWORK_MAID:
+      case ItemPool.MEAT_BUTLER:
       case ItemPool.SCARECROW:
       case ItemPool.MEAT_GOLEM:
       case ItemPool.MEAT_GLOBE:
@@ -3666,7 +3667,6 @@ public class UseItemRequest extends GenericRequest {
 
       case ItemPool.SCARECROW:
       case ItemPool.MEAT_GOLEM:
-      case ItemPool.MAID:
       case ItemPool.BLACK_BLUE_LIGHT:
       case ItemPool.LOUDMOUTH_LARRY:
       case ItemPool.PLASMA_BALL:
@@ -3680,13 +3680,34 @@ public class UseItemRequest extends GenericRequest {
         CampgroundRequest.setCampgroundItem(itemId, 1);
         break;
 
+      case ItemPool.MAID:
+        if (responseText.contains("You've already got")) {
+          return;
+        }
+
+        CampgroundRequest.removeCampgroundItem(ItemPool.get(ItemPool.MEAT_BUTLER, 1));
+        CampgroundRequest.removeCampgroundItem(ItemPool.get(ItemPool.CLOCKWORK_MAID, 1));
+        CampgroundRequest.setCampgroundItem(ItemPool.MAID, 1);
+        break;
+
       case ItemPool.CLOCKWORK_MAID:
         if (responseText.contains("You've already got")) {
           return;
         }
 
+        CampgroundRequest.removeCampgroundItem(ItemPool.get(ItemPool.MEAT_BUTLER, 1));
         CampgroundRequest.removeCampgroundItem(ItemPool.get(ItemPool.MAID, 1));
         CampgroundRequest.setCampgroundItem(ItemPool.CLOCKWORK_MAID, 1);
+        break;
+
+      case ItemPool.MEAT_BUTLER:
+        if (responseText.contains("You've already got")) {
+          return;
+        }
+
+        CampgroundRequest.removeCampgroundItem(ItemPool.get(ItemPool.MAID, 1));
+        CampgroundRequest.removeCampgroundItem(ItemPool.get(ItemPool.CLOCKWORK_MAID, 1));
+        CampgroundRequest.setCampgroundItem(ItemPool.MEAT_BUTLER, 1);
         break;
 
       case ItemPool.BEANBAG_CHAIR:
@@ -4876,8 +4897,14 @@ public class UseItemRequest extends GenericRequest {
         break;
 
       case ItemPool.REPLICA_TEN_DOLLARS:
-        // Get success text
-        Preferences.increment("legacyPoints", 1, 19, false);
+        // You hand your replica ten dollars to some guy who tells you to &quot;pay, pal&quot; and
+        // are now entitled to an extra replica Mr. Accessory in future Legacy of Loathing runs.
+        // You hand your replica ten dollars to some guy who tells you to &quot;pay, pal&quot; and
+        // are now entitled to some extra replica Mr. Accessory in future Legacy of Loathing runs.
+        if (!responseText.contains("extra replica Mr. Accessor")) {
+          return;
+        }
+        Preferences.increment("legacyPoints", count, 19, false);
         break;
 
       case ItemPool.ESSENCE_OF_ANNOYANCE:

--- a/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
@@ -1046,6 +1046,7 @@ public abstract class UseLinkDecorator {
             return new UseLink(itemId, 1, "use", "inv_use.php?which=3&whichitem=", false);
 
           case ItemPool.MR_STORE_2002_CATALOG:
+          case ItemPool.REPLICA_MR_STORE_2002_CATALOG:
 
             // Not inline, since the redirection to a
             // shop doesn't work ajaxified.


### PR DESCRIPTION
1) Fix typo on coinmaster inventory for Replica Mr. Store
2) Replica Ten Dollars is multi-usable.
Multi vs. single use have subtly different messages.
When multi-using, must increment legacyPoints by the number used.
3) Meat Butler is the third (mutually exclusive) Rollover adventure-granting dwelling attendent.
3) Replica Mr. Store Catalog leads to shop.php so cannot have an in-line use link.