### PR TITLE
Make champagne/squint double cached passive effects.

### DIFF
--- a/src/net/sourceforge/kolmafia/ModifierType.java
+++ b/src/net/sourceforge/kolmafia/ModifierType.java
@@ -66,6 +66,7 @@ public enum ModifierType {
   MUTEX_GENERIC,
   MUTEX_I,
   MUTEX_E,
+  PASSIVES,
   GENERATED,
   NONE;
 

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -819,7 +819,7 @@ public class Modifiers {
   public void applyPassiveModifiers(final boolean debug) {
     if (Modifiers.cachedPassiveModifiers == null) {
       Modifiers.cachedPassiveModifiers =
-          new Modifiers(new Lookup(ModifierType.GENERATED, "cachedPassives"));
+          new Modifiers(new Lookup(ModifierType.PASSIVES, "cachedPassives"));
       PreferenceListenerRegistry.registerPreferenceListener(
           new String[] {"(skill)", "kingLiberated"}, () -> Modifiers.availableSkillsChanged = true);
     }

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -168,7 +168,8 @@ public class ModifierDatabase {
           ModifierType.SKILL,
           ModifierType.SYNERGY,
           ModifierType.THRONE,
-          ModifierType.UNBREAKABLE_UMBRELLA);
+          ModifierType.UNBREAKABLE_UMBRELLA,
+          ModifierType.PASSIVES);
 
   public static void ensureModifierDatabaseInitialised() {
     if (modifierTypesByName.isEmpty()) {

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -32,6 +32,7 @@ import net.sourceforge.kolmafia.modifiers.Lookup;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
@@ -223,6 +224,19 @@ public class ModifiersTest {
     }
 
     @Test
+    public void squintDoublesPassive() {
+      var cleanups =
+          new Cleanups(
+              withEffect(EffectPool.STEELY_EYED_SQUINT), withSkill(SkillPool.OBSERVATIOGN));
+
+      try (cleanups) {
+        KoLCharacter.recalculateAdjustments();
+        Modifiers mods = KoLCharacter.getCurrentModifiers();
+        assertThat(mods.getDouble(DoubleModifier.ITEMDROP), equalTo(20.0));
+      }
+    }
+
+    @Test
     public void champagneDoublesEffect() {
       var cleanups =
           new Cleanups(
@@ -234,6 +248,21 @@ public class ModifiersTest {
         KoLCharacter.recalculateAdjustments();
         Modifiers mods = KoLCharacter.getCurrentModifiers();
         assertThat(mods.getDouble(DoubleModifier.ITEMDROP), equalTo(300.0));
+      }
+    }
+
+    @Test
+    public void champagneDoublesPassive() {
+      var cleanups =
+          new Cleanups(
+              withEquipped(Slot.WEAPON, ItemPool.BROKEN_CHAMPAGNE),
+              withProperty("garbageChampagneCharge", 11),
+              withSkill(SkillPool.OBSERVATIOGN));
+
+      try (cleanups) {
+        KoLCharacter.recalculateAdjustments();
+        Modifiers mods = KoLCharacter.getCurrentModifiers();
+        assertThat(mods.getDouble(DoubleModifier.ITEMDROP), equalTo(20.0));
       }
     }
 


### PR DESCRIPTION
In certain cases, the cached passives optimization was failing to double with modifier doublers, because "GENERATED" type modifiers aren't generally doubled. This PR breaks it out into a new modifier type and makes that type doubled. This fixes a bug I was encountering in CS right after donning an outfit with squint on.