### PR TITLE
Buffer needs a StringBuffer for content.

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -6634,7 +6634,7 @@ public abstract class RuntimeLibrary {
         || FightRequest.choiceFollowsFight) {
       return RuntimeLibrary.run_choice(controller, new Value(-1));
     }
-    return new Value(DataTypes.BUFFER_TYPE, "");
+    return new Value(DataTypes.BUFFER_TYPE, "", new StringBuffer());
   }
 
   public static Value stun_skill(ScriptRuntime controller) {


### PR DESCRIPTION
This was causing an NPE when JS code called runTurn.