### PR TITLE
fix: incorrect ID for Victor's Spoils

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3070,9 +3070,9 @@ public class ItemPool {
   public static final int AFFIRMATION_HATE = 9485;
   public static final int AFFIRMATION_COOKIE = 9486;
   public static final int LICENSE_TO_KILL = 9487;
-  public static final int VICTOR_SPOILS = 9493;
-  public static final int CAN_OF_MINIONS_BE_GONE = 9498;
+  public static final int VICTOR_SPOILS = 9489;
   public static final int KREMLIN_BRIEFCASE = 9493;
+  public static final int CAN_OF_MINIONS_BE_GONE = 9498;
   public static final int LICENSE_TO_CHILL = 9503;
   public static final int CELSIUS_233 = 9504;
   public static final int CELSIUS_233_SINGED = 9505;


### PR DESCRIPTION
Had the same ID as KGB so was somewhat noticeable. What more errors could be in this file?