### PR TITLE
feat: add pledge allegiance modifiers to location proxy record 

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -2821,9 +2821,6 @@ public abstract class RuntimeLibrary {
 
     params = new Type[] {DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("monkey_paw", DataTypes.BOOLEAN_TYPE, params));
-
-    params = new Type[] {DataTypes.LOCATION_TYPE};
-    functions.add(new LibraryFunction("pledge_allegiance_effect", DataTypes.STRING_TYPE, params));
   }
 
   public static Method findMethod(final String name, final Class<?>[] args)
@@ -10090,37 +10087,5 @@ public abstract class RuntimeLibrary {
     var req = new MonkeyPawRequest(wish);
     RequestThread.postRequest(req);
     return req.responseText != null && !req.responseText.contains("impossible");
-  }
-
-  public static Value pledge_allegiance_effect(ScriptRuntime controller, final Value arg) {
-    KoLAdventure adventure = (KoLAdventure) arg.rawValue();
-    var id = adventure.getAdventureNumber();
-    var mod = id % 10;
-    var strEffect =
-        switch (id % 10) {
-          case 0 -> "Item Drop: 30, Spooky Damage: 10, Spooky Spell Damage: 10";
-          case 1 -> "Item Drop: 15, Meat Drop: 25, Stench Damage: 10, Stench Spell Damage: 10";
-          case 2 -> "Meat Drop: 50, Hot Damage: 10, Hot Spell Damage: 10";
-          case 3 -> "Meat Drop: 25, All Resistance: 2, Cold Damage: 10, Cold Spell Damage: 10";
-          case 4 -> "All Resistance: 4, Sleaze Damage: 10, Sleaze Spell Damage: 10";
-          case 5 -> "All Resistance: 2, Spooky Damage: 10, Spooky Spell Damage: 10, MP Regen Min: 10, MP Regen Max: 15";
-          case 6 -> "Stench Damage: 10, Stench Spell Damage: 10, MP Regen Min: 20, MP Regen Max: 30";
-          case 7 -> "Initiative: 50, Hot Damage: 10, Hot Spell Damage: 10, MP Regen Min: 10, MP Regen Max: 15";
-          case 8 -> "Initiative: 100, Cold Damage: 10, Cold Spell Damage: 10";
-          case 9 -> "Item Drop: 15, Initiative: 50, Sleaze Damage: 10, Sleaze Spell Damage: 10";
-          default -> throw new IllegalStateException("Unexpected value: " + mod);
-        };
-    var statEffect =
-        switch (id % 9) {
-          case 0, 7, 8 -> "";
-          case 1 -> ", Mysticality: 10";
-          case 2 -> ", Moxie: 10";
-          case 3 -> ", Muscle Percent: 10";
-          case 4 -> ", Mysticality Percent: 10";
-          case 5 -> ", Moxie Percent: 10";
-          case 6 -> ", Muscle: 10";
-          default -> throw new IllegalStateException("Unexpected value: " + mod);
-        };
-    return DataTypes.makeStringValue(strEffect + statEffect);
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -2821,6 +2821,9 @@ public abstract class RuntimeLibrary {
 
     params = new Type[] {DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("monkey_paw", DataTypes.BOOLEAN_TYPE, params));
+
+    params = new Type[] {DataTypes.LOCATION_TYPE};
+    functions.add(new LibraryFunction("pledge_allegiance_effect", DataTypes.STRING_TYPE, params));
   }
 
   public static Method findMethod(final String name, final Class<?>[] args)
@@ -10087,5 +10090,37 @@ public abstract class RuntimeLibrary {
     var req = new MonkeyPawRequest(wish);
     RequestThread.postRequest(req);
     return req.responseText != null && !req.responseText.contains("impossible");
+  }
+
+  public static Value pledge_allegiance_effect(ScriptRuntime controller, final Value arg) {
+    KoLAdventure adventure = (KoLAdventure) arg.rawValue();
+    var id = adventure.getAdventureNumber();
+    var mod = id % 10;
+    var strEffect =
+        switch (id % 10) {
+          case 0 -> "Item Drop: 30, Spooky Damage: 10, Spooky Spell Damage: 10";
+          case 1 -> "Item Drop: 15, Meat Drop: 25, Stench Damage: 10, Stench Spell Damage: 10";
+          case 2 -> "Meat Drop: 50, Hot Damage: 10, Hot Spell Damage: 10";
+          case 3 -> "Meat Drop: 25, All Resistance: 2, Cold Damage: 10, Cold Spell Damage: 10";
+          case 4 -> "All Resistance: 4, Sleaze Damage: 10, Sleaze Spell Damage: 10";
+          case 5 -> "All Resistance: 2, Spooky Damage: 10, Spooky Spell Damage: 10, MP Regen Min: 10, MP Regen Max: 15";
+          case 6 -> "Stench Damage: 10, Stench Spell Damage: 10, MP Regen Min: 20, MP Regen Max: 30";
+          case 7 -> "Initiative: 50, Hot Damage: 10, Hot Spell Damage: 10, MP Regen Min: 10, MP Regen Max: 15";
+          case 8 -> "Initiative: 100, Cold Damage: 10, Cold Spell Damage: 10";
+          case 9 -> "Item Drop: 15, Initiative: 50, Sleaze Damage: 10, Sleaze Spell Damage: 10";
+          default -> throw new IllegalStateException("Unexpected value: " + mod);
+        };
+    var statEffect =
+        switch (id % 9) {
+          case 0, 7, 8 -> "";
+          case 1 -> ", Mysticality: 10";
+          case 2 -> ", Moxie: 10";
+          case 3 -> ", Muscle Percent: 10";
+          case 4 -> ", Mysticality Percent: 10";
+          case 5 -> ", Moxie Percent: 10";
+          case 6 -> ", Muscle: 10";
+          default -> throw new IllegalStateException("Unexpected value: " + mod);
+        };
+    return DataTypes.makeStringValue(strEffect + statEffect);
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -1379,6 +1379,7 @@ public class ProxyRecordValue extends RecordValue {
             .add("poison", DataTypes.INT_TYPE)
             .add("water_level", DataTypes.INT_TYPE)
             .add("wanderers", DataTypes.BOOLEAN_TYPE)
+            .add("pledge_allegiance", DataTypes.STRING_TYPE)
             .finish("location proxy");
 
     public LocationProxy(Value obj) {
@@ -1528,6 +1529,54 @@ public class ProxyRecordValue extends RecordValue {
       }
 
       return WildfireCampRequest.getFireLevel((KoLAdventure) this.content);
+    }
+
+    public String get_pledge_allegiance() {
+      var id = get_id();
+      if (id < 0) return "";
+      var mod = id % 10;
+      var strEffect =
+          switch (id % 10) {
+            case 0 -> "Item Drop: 30, Spooky Damage: 10, Spooky Spell Damage: 10";
+            case 1 -> "Item Drop: 15, Meat Drop: 25, Stench Damage: 10, Stench Spell Damage: 10";
+            case 2 -> "Meat Drop: 50, Hot Damage: 10, Hot Spell Damage: 10";
+            case 3 -> "Meat Drop: 25, "
+                + all_resistance(2)
+                + ", Cold Damage: 10, Cold Spell Damage: 10";
+            case 4 -> all_resistance(4) + ", Sleaze Damage: 10, Sleaze Spell Damage: 10";
+            case 5 -> all_resistance(2)
+                + ", Spooky Damage: 10, Spooky Spell Damage: 10, MP Regen Min: 10, MP Regen Max: 15";
+            case 6 -> "Stench Damage: 10, Stench Spell Damage: 10, MP Regen Min: 20, MP Regen Max: 30";
+            case 7 -> "Initiative: 50, Hot Damage: 10, Hot Spell Damage: 10, MP Regen Min: 10, MP Regen Max: 15";
+            case 8 -> "Initiative: 100, Cold Damage: 10, Cold Spell Damage: 10";
+            case 9 -> "Item Drop: 15, Initiative: 50, Sleaze Damage: 10, Sleaze Spell Damage: 10";
+            default -> throw new IllegalStateException("Unexpected value: " + mod);
+          };
+      var statEffect =
+          switch (id % 9) {
+            case 0, 7, 8 -> "";
+            case 1 -> ", Mysticality: 10";
+            case 2 -> ", Moxie: 10";
+            case 3 -> ", Muscle Percent: 10";
+            case 4 -> ", Mysticality Percent: 10";
+            case 5 -> ", Moxie Percent: 10";
+            case 6 -> ", Muscle: 10";
+            default -> throw new IllegalStateException("Unexpected value: " + mod);
+          };
+      return strEffect + statEffect;
+    }
+
+    private String all_resistance(int amt) {
+      return "Hot Resistance: "
+          + amt
+          + ", Cold Resistance: "
+          + amt
+          + ", Spooky Resistance: "
+          + amt
+          + ", Stench Resistance: "
+          + amt
+          + ", Sleaze Resistance: "
+          + amt;
     }
   }
 

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -923,7 +923,7 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
   class PledgeAllegiance {
     @Test
     void pledgeAllegiance() {
-      String input = "pledge_allegiance_effect($location[Noob Cave])";
+      String input = "$location[Noob Cave].pledge_allegiance";
       String output = execute(input);
       assertThat(
           output,
@@ -935,13 +935,25 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
 
     @Test
     void pledgeAllegianceComplex() {
-      String input = "pledge_allegiance_effect($location[Hobopolis Town Square])";
+      String input = "$location[Hobopolis Town Square].pledge_allegiance";
       String output = execute(input);
       assertThat(
           output,
           is(
               """
           Returned: Initiative: 50, Hot Damage: 10, Hot Spell Damage: 10, MP Regen Min: 10, MP Regen Max: 15, Moxie Percent: 10
+          """));
+    }
+
+    @Test
+    void pledgeAllegianceResistance() {
+      String input = "$location[Outskirts of Camp Logging Camp].pledge_allegiance";
+      String output = execute(input);
+      assertThat(
+          output,
+          is(
+              """
+          Returned: Meat Drop: 25, Hot Resistance: 2, Cold Resistance: 2, Spooky Resistance: 2, Stench Resistance: 2, Sleaze Resistance: 2, Cold Damage: 10, Cold Spell Damage: 10
           """));
     }
   }

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -918,4 +918,31 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
               """));
     }
   }
+
+  @Nested
+  class PledgeAllegiance {
+    @Test
+    void pledgeAllegiance() {
+      String input = "pledge_allegiance_effect($location[Noob Cave])";
+      String output = execute(input);
+      assertThat(
+          output,
+          is(
+              """
+          Returned: Item Drop: 30, Spooky Damage: 10, Spooky Spell Damage: 10, Muscle: 10
+          """));
+    }
+
+    @Test
+    void pledgeAllegianceComplex() {
+      String input = "pledge_allegiance_effect($location[Hobopolis Town Square])";
+      String output = execute(input);
+      assertThat(
+          output,
+          is(
+              """
+          Returned: Initiative: 50, Hot Damage: 10, Hot Spell Damage: 10, MP Regen Min: 10, MP Regen Max: 15, Moxie Percent: 10
+          """));
+    }
+  }
 }


### PR DESCRIPTION
Add `$location[].pledge_allegiance` modifiers value.

Outputs a string, modifier-like (but with "All Res" instead of spelled out), of the effect you would get. If there's a nicer way of doing this, let me know: I wanted to make it nice for human readers.

Targeted at people like me who use the GCLI a lot. I expect other people will use Guide or a script or whatever.