### PR TITLE
feat: add source terminal to campground after replica used

### DIFF
--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -6103,6 +6103,10 @@ public class UseItemRequest extends GenericRequest {
         }
         return;
 
+      case ItemPool.REPLICA_SOURCE_TERMINAL:
+        CampgroundRequest.setCampgroundItem(ItemPool.SOURCE_TERMINAL, 1);
+        break;
+
       case ItemPool.REPLICA_WITCHESS_SET:
         Preferences.setBoolean("replicaWitchessSetAvailable", true);
         break;


### PR DESCRIPTION
Not sure this will fix it, but there's an issue where Mafia doesn't accept the `terminal` commands immediately after you use the replica Source terminal -- only after you view your campground.