### PR TITLE
Optional ping test at login

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -97,6 +97,10 @@ global	macroLens	false
 global	mementoListActive	false
 global	mergeHobopolisChat	false
 global	pingLatest
+global	pingLogin	true
+global	pingLoginCheck	threshold
+global	pingLoginGoal	0
+global	pingLoginThreshold	0.2
 global	pingLongest
 global	pingShortest
 global	previousNotifyList	<>

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -98,7 +98,7 @@ global	mementoListActive	false
 global	mergeHobopolisChat	false
 global	pingLatest
 global	pingLogin	true
-global	pingLoginCheck	threshold
+global	pingLoginCheck	none
 global	pingLoginGoal	0
 global	pingLoginThreshold	0.2
 global	pingLongest

--- a/src/net/sourceforge/kolmafia/request/LoginRequest.java
+++ b/src/net/sourceforge/kolmafia/request/LoginRequest.java
@@ -104,8 +104,8 @@ public class LoginRequest extends GenericRequest {
       return;
     }
 
-    // Too many login attempts in too short a span of time.	 Please
-    // wait a minute (Literally, like, one minute.	Sixty seconds.)
+    // Too many login attempts in too short a span of time. Please
+    // wait a minute (Literally, like, one minute. Sixty seconds.)
     // and try again.
 
     // Whoops -- it looks like you had a recent session open that
@@ -165,6 +165,16 @@ public class LoginRequest extends GenericRequest {
     return LoginRequest.completedLogin;
   }
 
+  public static final boolean relogin() {
+    if (LoginRequest.lastRequest == null) {
+      return false;
+    }
+
+    RequestThread.postRequest(LoginRequest.lastRequest);
+
+    return LoginRequest.completedLogin;
+  }
+
   public static final void isLoggingIn(final boolean isLoggingIn) {
     LoginRequest.isLoggingIn = isLoggingIn;
   }
@@ -199,6 +209,13 @@ public class LoginRequest extends GenericRequest {
     }
 
     if (name.contains("..")) {
+      return;
+    }
+
+    // Optionally do a ping and check the connection.
+    // Returns true if it is acceptable.
+    if (!LoginManager.ping()) {
+      // LoginManager logged out and may have logged in again.
       return;
     }
 

--- a/src/net/sourceforge/kolmafia/request/PingRequest.java
+++ b/src/net/sourceforge/kolmafia/request/PingRequest.java
@@ -23,8 +23,9 @@ public class PingRequest extends GenericRequest {
 
   private boolean isSafeToRun() {
     return switch (this.pingURL) {
-      case "main.php" -> !GenericRequest.abortIfInFightOrChoice(true);
+      case "main.php", "council.php" -> !GenericRequest.abortIfInFightOrChoice(true);
       case "api.php" -> true;
+      case "afterlife.php" -> true;
       default -> false;
     };
   }
@@ -43,10 +44,18 @@ public class PingRequest extends GenericRequest {
     super.run();
 
     // We can get redirected if we are logged out or in Valhalla
-    if (this.redirectLocation == null) {}
+    if (this.redirectLocation != null) {
+      this.constructURLString(this.redirectLocation, false);
+      this.startTime = System.currentTimeMillis();
+      this.pingURL = this.redirectLocation;
+      super.run();
+    }
 
     // We can have an empty responseText on a timeout or I/O error
-    if (this.responseText == null) {}
+    if (this.responseText == null) {
+      // leave endTime at 0
+      return;
+    }
 
     this.endTime = System.currentTimeMillis();
   }

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -106,8 +106,18 @@ public class LoginManager {
     buf.append(".");
     buf.append(" Press 'Yes' if you are satisfied with the current connection.");
     buf.append(" Press 'No' to log out and back in to try for a better connection.");
+    buf.append(" Press 'Cancel' to simply log out.");
 
-    if (InputFieldUtilities.confirm(buf.toString())) {
+    Boolean confirmed = InputFieldUtilities.yesNoCancelDialog(buf.toString());
+
+    // If the user canceled, log out
+    if (confirmed == null) {
+      RequestThread.postRequest(new LogoutRequest());
+      return false;
+    }
+
+    // If the user said "Yes", accept it.
+    if (confirmed) {
       return true;
     }
 

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -26,12 +26,15 @@ import net.sourceforge.kolmafia.request.FalloutShelterRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.request.HermitRequest;
 import net.sourceforge.kolmafia.request.LoginRequest;
+import net.sourceforge.kolmafia.request.LogoutRequest;
 import net.sourceforge.kolmafia.request.MallPurchaseRequest;
 import net.sourceforge.kolmafia.request.PasswordHashRequest;
 import net.sourceforge.kolmafia.request.RelayRequest;
 import net.sourceforge.kolmafia.scripts.git.GitManager;
 import net.sourceforge.kolmafia.scripts.svn.SVNManager;
+import net.sourceforge.kolmafia.session.PingManager.PingTest;
 import net.sourceforge.kolmafia.swingui.GenericFrame;
+import net.sourceforge.kolmafia.utilities.InputFieldUtilities;
 
 public class LoginManager {
 
@@ -40,6 +43,79 @@ public class LoginManager {
   private static boolean svnLoginUpdateNotFinished = true;
 
   private LoginManager() {}
+
+  public static boolean ping() {
+    // Optionally run a ping test and check connection speed.
+    // Return true if the connection is acceptable.
+
+    // If user does not want to measure ping speed, good enough
+    if (!Preferences.getBoolean("pingLogin")) {
+      return true;
+    }
+
+    // The user wants to measure ping speed.
+    var result = PingManager.runPingTest();
+    KoLmafia.updateDisplay("Ping test: average delay is " + result.getAverage() + " msecs.");
+
+    // See whether user wants to check ping speed.
+    long average = result.getAverage();
+    String error = "";
+    switch (Preferences.getString("pingLoginCheck")) {
+      case "goal" -> {
+        // The user has set a specific goal, presumably based on observation.
+        int goal = Preferences.getInteger("pingLoginGoal");
+        if (goal > 0) {
+          if (average <= goal) {
+            return true;
+          }
+          error = "you want no more than " + String.valueOf(goal) + " msec";
+        }
+        // Either no goal is set or this connection is too slow.
+        // Alert the user.
+      }
+      case "threshold" -> {
+        // The user wants to be "close" to the best ping seen.
+        // Get the shortest ping test time we've seen. If the ping test we
+        // just ran is the first, that will be it.
+        double threshold = 1.0 + Preferences.getFloat("pingLoginGood");
+        var shortest = PingTest.parseProperty("pingShortest");
+        long desired = (long) Math.floor(shortest.getAverage() * threshold);
+        if (average <= desired) {
+          return true;
+        }
+        // Either no threshold is set or this connection is too slow.
+        error = "you want no more than " + String.valueOf(desired) + " msec";
+        // Alert the user.
+      }
+      default -> {
+        // The user is happy with any connection
+        return true;
+      }
+    }
+
+    // InputFieldUtilities.confirm works either headless or with a Swing dialog
+
+    StringBuilder buf = new StringBuilder();
+    buf.append("This connection has an average ping time of ");
+    buf.append(String.valueOf(average));
+    buf.append(" msec");
+    if (!error.equals("")) {
+      buf.append(", but ");
+      buf.append(error);
+    }
+    buf.append(".");
+    buf.append(" Press 'Yes' if you are satisfied with the current connection.");
+    buf.append(" Press 'No' to log out and back in to try for a better connection.");
+
+    if (InputFieldUtilities.confirm(buf.toString())) {
+      return true;
+    }
+
+    // The user finds the ping time unacceptable.
+    RequestThread.postRequest(new LogoutRequest());
+    LoginRequest.relogin();
+    return false;
+  }
 
   public static void login(String username) {
     try {

--- a/src/net/sourceforge/kolmafia/session/PingManager.java
+++ b/src/net/sourceforge/kolmafia/session/PingManager.java
@@ -153,6 +153,11 @@ public class PingManager {
     }
   }
 
+  public static PingTest runPingTest() {
+    // Run a ping test that qualifies to be saved in ping history.
+    return runPingTest(MINIMUM_HISTORY_PINGS, DEFAULT_PAGE, false);
+  }
+
   public static PingTest runPingTest(int count, String page, boolean verbose) {
     PingTest result = new PingTest(page);
 

--- a/src/net/sourceforge/kolmafia/swingui/LoginFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/LoginFrame.java
@@ -20,11 +20,16 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.LoginRequest;
 import net.sourceforge.kolmafia.swingui.listener.DefaultComponentFocusTraversalPolicy;
 import net.sourceforge.kolmafia.swingui.listener.ThreadedListener;
+import net.sourceforge.kolmafia.swingui.panel.ConfigQueueingPanel;
 import net.sourceforge.kolmafia.swingui.panel.GenericPanel;
 import net.sourceforge.kolmafia.swingui.panel.LabeledPanel;
 import net.sourceforge.kolmafia.swingui.panel.OptionsPanel;
 import net.sourceforge.kolmafia.swingui.widget.AutoHighlightTextField;
 import net.sourceforge.kolmafia.swingui.widget.EditableAutoFilterComboBox;
+import net.sourceforge.kolmafia.swingui.widget.PreferenceButtonGroup;
+import net.sourceforge.kolmafia.swingui.widget.PreferenceCheckBox;
+import net.sourceforge.kolmafia.swingui.widget.PreferenceFloatTextField;
+import net.sourceforge.kolmafia.swingui.widget.PreferenceIntegerTextField;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class LoginFrame extends GenericFrame {
@@ -380,20 +385,25 @@ public class LoginFrame extends GenericFrame {
     }
   }
 
-  private static class ConnectionOptionsPanel extends OptionsPanel {
-    private final String[][] options = {
-      {"useDevProxyServer", "Use devproxy.kingdomofloathing.com to login"},
-    };
+  private static class ConnectionOptionsPanel extends ConfigQueueingPanel {
 
     public ConnectionOptionsPanel() {
-      super(new Dimension(20, 20), new Dimension(250, 20));
+      super();
 
-      this.setOptions(this.options);
-    }
+      this.queue(
+          new PreferenceCheckBox(
+              "useDevProxyServer", "Use devproxy.kingdomofloathing.com to login"));
+      this.queue(
+          new PreferenceCheckBox("pingLogin", "Run ping test at login to measure connection lag"));
+      this.queue(
+          new PreferenceButtonGroup(
+              "pingLoginCheck", "Login ping check type: ", true, "none", "goal", "threshold"));
+      this.queue(new PreferenceIntegerTextField("pingLoginGoal", 0, "Maximum average measured lag"));
+      this.queue(
+          new PreferenceFloatTextField(
+              "pingLoginThreshold", 0, "Allowed threshold above minimum historical lag"));
 
-    @Override
-    public void setEnabled(final boolean isEnabled) {
-      super.setEnabled(isEnabled);
+      this.makeLayout();
     }
   }
 

--- a/src/net/sourceforge/kolmafia/swingui/LoginFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/LoginFrame.java
@@ -398,7 +398,8 @@ public class LoginFrame extends GenericFrame {
       this.queue(
           new PreferenceButtonGroup(
               "pingLoginCheck", "Login ping check type: ", true, "none", "goal", "threshold"));
-      this.queue(new PreferenceIntegerTextField("pingLoginGoal", 0, "Maximum average measured lag"));
+      this.queue(
+          new PreferenceIntegerTextField("pingLoginGoal", 0, "Maximum average measured lag"));
       this.queue(
           new PreferenceFloatTextField(
               "pingLoginThreshold", 0, "Allowed threshold above minimum historical lag"));

--- a/src/net/sourceforge/kolmafia/swingui/widget/PreferenceButtonGroup.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/PreferenceButtonGroup.java
@@ -12,10 +12,19 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 public class PreferenceButtonGroup extends JPanel implements Listener {
   private final String pref;
   private final SmartButtonGroup group;
+  private final boolean settingUsesButtons;
+  private final String[] buttons;
 
   public PreferenceButtonGroup(String pref, String message, String... buttons) {
+    this(pref, message, false, buttons);
+  }
+
+  public PreferenceButtonGroup(
+      String pref, String message, boolean settingUsesButtons, String... buttons) {
     this.pref = pref;
     this.group = new SmartButtonGroup(this);
+    this.settingUsesButtons = settingUsesButtons;
+    this.buttons = buttons;
 
     configure();
     makeLayout(message, buttons);
@@ -24,7 +33,15 @@ public class PreferenceButtonGroup extends JPanel implements Listener {
   private void configure() {
     this.setLayout(new FlowLayout(FlowLayout.LEADING, 0, 0));
     PreferenceListenerRegistry.registerPreferenceListener(pref, this);
-    this.group.setActionListener(e -> Preferences.setInteger(pref, this.group.getSelectedIndex()));
+    this.group.setActionListener(
+        e -> {
+          int index = this.group.getSelectedIndex();
+          if (this.settingUsesButtons) {
+            Preferences.setString(pref, buttons[index]);
+          } else {
+            Preferences.setInteger(pref, index);
+          }
+        });
   }
 
   private void makeLayout(String message, String... buttons) {
@@ -43,7 +60,19 @@ public class PreferenceButtonGroup extends JPanel implements Listener {
 
   @Override
   public void update() {
-    this.group.setSelectedIndex(Preferences.getInteger(pref));
+    int index = 0;
+    if (this.settingUsesButtons) {
+      String button = Preferences.getString(pref);
+      for (int i = 0; i < buttons.length; ++i) {
+        if (button.equals(buttons[i])) {
+          index = i;
+          break;
+        }
+      }
+    } else {
+      index = Preferences.getInteger(pref);
+    }
+    this.group.setSelectedIndex(index);
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/swingui/widget/PreferenceFloatTextField.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/PreferenceFloatTextField.java
@@ -1,0 +1,115 @@
+package net.sourceforge.kolmafia.swingui.widget;
+
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import javax.swing.Box;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.SwingConstants;
+import javax.swing.ToolTipManager;
+import net.sourceforge.kolmafia.KoLGUIConstants;
+import net.sourceforge.kolmafia.listener.Listener;
+import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.utilities.InputFieldUtilities;
+
+public class PreferenceFloatTextField extends JPanel implements Listener, FocusListener {
+  private final String pref;
+  private final JTextField field;
+  private final String tooltip;
+
+  private final JCheckBox box = new JCheckBox();
+
+  public PreferenceFloatTextField(String pref, int size, String message) {
+    this(pref, size, message, null);
+  }
+
+  public PreferenceFloatTextField(String pref, int size, String message, String tip) {
+    this.pref = pref;
+    this.tooltip = tip;
+
+    this.field = new JTextField(size);
+    this.field.addFocusListener(this);
+
+    configure();
+    makeLayout(message);
+  }
+
+  private void configure() {
+    this.setLayout(new FlowLayout(FlowLayout.LEFT, 1, 1));
+    PreferenceListenerRegistry.registerPreferenceListener(pref, this);
+  }
+
+  private void makeLayout(String message) {
+    this.add(this.field);
+    JLabel label = new JLabel(message, SwingConstants.LEFT);
+    label.setLabelFor(this.field);
+    label.setVerticalAlignment(SwingConstants.TOP);
+    this.add(label);
+
+    if (tooltip != null) {
+      this.addToolTip(tooltip);
+    }
+
+    update();
+  }
+
+  public JTextField getTextField() {
+    return this.field;
+  }
+
+  @Override
+  public void update() {
+    this.actionCancelled();
+  }
+
+  @Override
+  public Dimension getMaximumSize() {
+    return this.getPreferredSize();
+  }
+
+  public void actionConfirmed() {
+    Preferences.setDouble(this.pref, InputFieldUtilities.getValue(this.field, 0.0));
+  }
+
+  public void actionCancelled() {
+    this.field.setText(String.valueOf(Preferences.getDouble(this.pref)));
+  }
+
+  @Override
+  public void focusLost(final FocusEvent e) {
+    this.actionConfirmed();
+  }
+
+  @Override
+  public void focusGained(final FocusEvent e) {}
+
+  private void addToolTip(String tooltip) {
+    this.add(Box.createHorizontalStrut(3));
+    JLabel label = new JLabel("[");
+    label.setFont(KoLGUIConstants.DEFAULT_FONT);
+    this.add(label);
+
+    label = new JLabel("<html><u>?</u></html>");
+    this.add(label);
+    label.setForeground(Color.blue.darker());
+    label.setFont(KoLGUIConstants.DEFAULT_FONT);
+    label.setCursor(new Cursor(Cursor.HAND_CURSOR));
+    label.setToolTipText(tooltip);
+
+    // show the tooltip with no delay, don't dismiss while hovered
+    ToolTipManager.sharedInstance().registerComponent(label);
+    ToolTipManager.sharedInstance().setInitialDelay(0);
+    ToolTipManager.sharedInstance().setDismissDelay(Integer.MAX_VALUE);
+
+    label = new JLabel("]");
+    label.setFont(KoLGUIConstants.DEFAULT_FONT);
+    this.add(label);
+  }
+}

--- a/src/net/sourceforge/kolmafia/textui/command/PingCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/PingCommand.java
@@ -8,7 +8,8 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class PingCommand extends AbstractCommand {
   public PingCommand() {
-    this.usage = " [count [(api|main) [verbose]]] - run a ping test with specified number of pings";
+    this.usage =
+        " [count [(api|council|main) [verbose]]] - run a ping test with specified number of pings";
   }
 
   @Override
@@ -26,7 +27,7 @@ public class PingCommand extends AbstractCommand {
       }
       if (split.length > 1) {
         switch (split[1]) {
-          case "api", "main" -> {
+          case "api", "council", "main" -> {
             page = split[1] + ".php";
           }
           default -> {

--- a/src/net/sourceforge/kolmafia/utilities/InputFieldUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/InputFieldUtilities.java
@@ -307,6 +307,21 @@ public class InputFieldUtilities {
     return defaultValue;
   }
 
+  /**
+   * Utility method which retrieves a float value from the given field. In the event that the field
+   * does not contain an integer value, the default value provided will be returned instead.
+   */
+  public static final double getValue(final JTextField field, final double defaultValue) {
+    String currentValue = field.getText();
+
+    if (currentValue == null || currentValue.length() == 0 || currentValue.equals("*")) {
+      return defaultValue;
+    }
+
+    double result = StringUtilities.parseDouble(currentValue);
+    return result == 0 ? defaultValue : result;
+  }
+
   public static final Integer getQuantity(final String title, final int maximumValue) {
     return InputFieldUtilities.getQuantity(title, maximumValue, maximumValue);
   }

--- a/src/net/sourceforge/kolmafia/utilities/InputFieldUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/InputFieldUtilities.java
@@ -67,6 +67,33 @@ public class InputFieldUtilities {
             JOptionPane.YES_NO_OPTION);
   }
 
+  public static final Boolean yesNoCancelDialog(final String message) {
+    if (StaticEntity.isHeadless()) {
+      RequestLogger.printLine(message);
+      RequestLogger.printLine("(Y/N, leave blank to cancel)");
+
+      String reply = KoLmafiaCLI.DEFAULT_SHELL.getNextLine(" > ");
+      String option = reply.trim().toLowerCase();
+      return switch (option) {
+        case "y" -> true;
+        case "n" -> false;
+        default -> null;
+      };
+    }
+
+    var result =
+        JOptionPane.showConfirmDialog(
+            InputFieldUtilities.activeWindow,
+            StringUtilities.basicTextWrap(message),
+            "",
+            JOptionPane.YES_NO_CANCEL_OPTION);
+    return switch (result) {
+      case JOptionPane.YES_OPTION -> true;
+      case JOptionPane.NO_OPTION -> false;
+      default -> null;
+    };
+  }
+
   public static final String input(final String message) {
     if (StaticEntity.isHeadless()) {
       RequestLogger.printLine(message);


### PR DESCRIPTION
1) Four new settings:
- pingLogin - (boolean) run a ping test at login before refreshing session.
Prints result to gCLI.
- pingLoginCheck - none, goal, threshold
(Only if pingLogin is true) Require average lag to be below goal or historical minimum + threshold
- pingLoginGoal - (int) msecs
- pingLoginThreshold - (float) fractional percent above historical lowest average
2) You can configure these on the Connection tab of the LoginFrame
3) When you log in, run a ping test (if configured) - 10 requests to api.php
If you have a pingLoginCheck configured, the average is compared to your goal or threshold.
If it succeeds, session login completes
If it fails, you are told what the average lag was and what your configured maximum lag is and are asked if you are OK with that.
- Yes - login completes as above
- No - you are logged out and re-logged in - which will trigger another ping test with confirmation, if necessary.
- Cancel (or just close the dialog) - log out and stay on the Login Frame
4) If ping redirects - as api.does to afterlife.php if you are in Valhalla - PingRequest sets its ping URL to the redirect location and resubmits the request. You will thus end up doing a ping test for valhalla.php ...
5) For fun (well, because Irrat's script does it), I now allow "council", in addition to "api" and "main". It has the same "can't be in a fight or choice" restriction as "main". "api" continues to be the best.