### PR TITLE
add souvenir flag

### DIFF
--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11327,6 +11327,6 @@
 11299
 11300	sleeping patriotic eagle	916117380	pateagle_sleep.gif	grow	t	0
 11301	claw-held flag	498722729	flag2.gif	familiar	t,d	10
-11302	souvenir flag	557635312	flag1.gif	usable	t,d	10	souvenir flags
+11302	souvenir flag	557635312	flag1.gif	usable	t,d	10
 11303	name change form	541643472	namechange.gif	usable	t	0
 11304	replica sleeping patriotic eagle	552435162	pateagle_sleep.gif	grow	t	0

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11327,6 +11327,6 @@
 11299
 11300	sleeping patriotic eagle	916117380	pateagle_sleep.gif	grow	t	0
 11301	claw-held flag	498722729	flag2.gif	familiar	t,d	10
-11302	souvenir flag	557635312	flag1.gif	usable	t,d	10
+11302	souvenir flag	557635312	flag1.gif	usable	t,d	10	souvenir flags
 11303	name change form	541643472	namechange.gif	usable	t	0
 11304	replica sleeping patriotic eagle	552435162	pateagle_sleep.gif	grow	t	0

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11327,6 +11327,6 @@
 11299
 11300	sleeping patriotic eagle	916117380	pateagle_sleep.gif	grow	t	0
 11301	claw-held flag	498722729	flag2.gif	familiar	t,d	10
-11302
+11302	souvenir flag	557635312	flag1.gif	usable	t,d	10
 11303	name change form	541643472	namechange.gif	usable	t	0
 11304	replica sleeping patriotic eagle	552435162	pateagle_sleep.gif	grow	t	0

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11327,6 +11327,6 @@
 11299
 11300	sleeping patriotic eagle	916117380	pateagle_sleep.gif	grow	t	0
 11301	claw-held flag	498722729	flag2.gif	familiar	t,d	10
-11302	souvenir flag	557635312	flag1.gif	usable	t,d	10
+11302	souvenir flag	557635312	flag1.gif	multiple	t,d	10
 11303	name change form	541643472	namechange.gif	usable	t	0
 11304	replica sleeping patriotic eagle	552435162	pateagle_sleep.gif	grow	t	0


### PR DESCRIPTION
Drops only on Dependence Day with the Patriotic Eagle as active familiar (looks like a 5% drop from cursory spading). No idea if anything else needs added.
Cosmetic item by the looks of things (adds flags to your profile page).