### PR TITLE
Put PingOptionsPanel in both LoginFrame and Preferences/General

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
+++ b/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
@@ -755,7 +755,6 @@ public class KoLmafiaCLI {
     new RefreshStatusCommand().register("refresh");
     new RegisterAdventureCommand().register("location");
     new RelayBrowserCommand().register("relay");
-    new ReloginCommand().register("relog").register("relogin");
     new ReminisceCommand().register("reminisce");
     new RepeatLineCommand().register("repeat");
     new RestaurantCommand().register("restaurant").register("brewery").register("microbrewery");
@@ -806,6 +805,7 @@ public class KoLmafiaCLI {
     new TerminalCommand().register("terminal");
     new TestCommand().register("test");
     new ThrowItemCommand().register("throw");
+    new TimeinCommand().register("timein").register("relog").register("relogin");
     new TimeSpinnerCommand().register("timespinner");
     new ToggleCommand().register("toggle");
     new TowerDoorCommand().register("tower").register("lowkey");

--- a/src/net/sourceforge/kolmafia/swingui/LoginFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/LoginFrame.java
@@ -24,12 +24,10 @@ import net.sourceforge.kolmafia.swingui.panel.ConfigQueueingPanel;
 import net.sourceforge.kolmafia.swingui.panel.GenericPanel;
 import net.sourceforge.kolmafia.swingui.panel.LabeledPanel;
 import net.sourceforge.kolmafia.swingui.panel.OptionsPanel;
+import net.sourceforge.kolmafia.swingui.panel.PingOptionsPanel;
 import net.sourceforge.kolmafia.swingui.widget.AutoHighlightTextField;
 import net.sourceforge.kolmafia.swingui.widget.EditableAutoFilterComboBox;
-import net.sourceforge.kolmafia.swingui.widget.PreferenceButtonGroup;
 import net.sourceforge.kolmafia.swingui.widget.PreferenceCheckBox;
-import net.sourceforge.kolmafia.swingui.widget.PreferenceFloatTextField;
-import net.sourceforge.kolmafia.swingui.widget.PreferenceIntegerTextField;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class LoginFrame extends GenericFrame {
@@ -386,24 +384,14 @@ public class LoginFrame extends GenericFrame {
   }
 
   private static class ConnectionOptionsPanel extends ConfigQueueingPanel {
-
     public ConnectionOptionsPanel() {
       super();
 
       this.queue(
           new PreferenceCheckBox(
               "useDevProxyServer", "Use devproxy.kingdomofloathing.com to login"));
-      this.queue(
-          new PreferenceCheckBox("pingLogin", "Run ping test at login to measure connection lag"));
-      this.queue(
-          new PreferenceButtonGroup(
-              "pingLoginCheck", "Login ping check type: ", true, "none", "goal", "threshold"));
-      this.queue(
-          new PreferenceIntegerTextField("pingLoginGoal", 0, "Maximum average measured lag"));
-      this.queue(
-          new PreferenceFloatTextField(
-              "pingLoginThreshold", 0, "Allowed threshold above minimum historical lag"));
-
+      this.queue(this.newSeparator());
+      this.queue(new PingOptionsPanel());
       this.makeLayout();
     }
   }

--- a/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
@@ -66,6 +66,7 @@ import net.sourceforge.kolmafia.swingui.panel.DailyDeedsPanel;
 import net.sourceforge.kolmafia.swingui.panel.DailyDeedsPanel.BuiltinDeed;
 import net.sourceforge.kolmafia.swingui.panel.GenericPanel;
 import net.sourceforge.kolmafia.swingui.panel.OptionsPanel;
+import net.sourceforge.kolmafia.swingui.panel.PingOptionsPanel;
 import net.sourceforge.kolmafia.swingui.panel.ScrollablePanel;
 import net.sourceforge.kolmafia.swingui.widget.AutoHighlightTextField;
 import net.sourceforge.kolmafia.swingui.widget.CollapsibleTextArea;
@@ -89,6 +90,7 @@ public class OptionsFrame extends GenericFrame {
     selectorPanel.addPanel(" - Item Acquisition", new ItemOptionsPanel(), true);
     selectorPanel.addPanel(" - Maximizer", new MaximizerOptionsPanel(), true);
     selectorPanel.addPanel(" - Session Logs", new SessionLogOptionsPanel(), true);
+    selectorPanel.addPanel(" - Connection Options", new PingOptionsPanel(), true);
     selectorPanel.addPanel(" - Extra Debugging", new DebugOptionsPanel(), true);
 
     JPanel programsPanel = new JPanel();

--- a/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
@@ -1,0 +1,48 @@
+package net.sourceforge.kolmafia.swingui.panel;
+
+import net.sourceforge.kolmafia.session.PingManager.PingTest;
+import net.sourceforge.kolmafia.swingui.widget.PreferenceButtonGroup;
+import net.sourceforge.kolmafia.swingui.widget.PreferenceCheckBox;
+import net.sourceforge.kolmafia.swingui.widget.PreferenceFloatTextField;
+import net.sourceforge.kolmafia.swingui.widget.PreferenceIntegerTextField;
+import net.sourceforge.kolmafia.swingui.widget.PreferenceTextArea;
+
+public class PingOptionsPanel extends ConfigQueueingPanel {
+
+  public PingOptionsPanel() {
+    super();
+
+    this.queue(new PingHistory());
+    this.queue(
+        new PreferenceCheckBox("pingLogin", "Run ping test at login to measure connection lag"));
+    this.queue(
+        new PreferenceButtonGroup(
+            "pingLoginCheck", "Login ping check type: ", true, "none", "goal", "threshold"));
+    this.queue(new PreferenceIntegerTextField("pingLoginGoal", 0, "Maximum average measured lag"));
+    this.queue(
+        new PreferenceFloatTextField(
+            "pingLoginThreshold", 0, "Allowed threshold above minimum historical lag"));
+
+    this.makeLayout();
+  }
+
+  private static class PingHistory extends PreferenceTextArea {
+    public PingHistory() {
+      super("pingShortest", "pingLongest");
+      this.update();
+    }
+
+    @Override
+    public void update() {
+      PingTest shortest = PingTest.parseProperty("pingShortest");
+      PingTest longest = PingTest.parseProperty("pingLongest");
+      StringBuilder message = new StringBuilder();
+      message.append("Observed average ping times range from ");
+      message.append(String.valueOf(shortest.getAverage()));
+      message.append("-");
+      message.append(String.valueOf(longest.getAverage()));
+      message.append(" msec.");
+      this.setText(message.toString());
+    }
+  }
+}

--- a/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
@@ -1,5 +1,12 @@
 package net.sourceforge.kolmafia.swingui.panel;
 
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.event.ActionListener;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.PingManager.PingTest;
 import net.sourceforge.kolmafia.swingui.widget.PreferenceButtonGroup;
 import net.sourceforge.kolmafia.swingui.widget.PreferenceCheckBox;
@@ -13,6 +20,8 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
     super();
 
     this.queue(new PingHistory());
+    this.queue(new PingResetButton());
+    this.queue(this.newSeparator());
     this.queue(
         new PreferenceCheckBox("pingLogin", "Run ping test at login to measure connection lag"));
     this.queue(
@@ -24,6 +33,39 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
             "pingLoginThreshold", 0, "Allowed threshold above minimum historical lag"));
 
     this.makeLayout();
+  }
+
+  private static class PingResetButton extends JPanel {
+    private final JButton button = new JButton("Clear");
+
+    public PingResetButton() {
+      configure();
+      makeLayout();
+    }
+
+    private void configure() {
+      this.setLayout(new FlowLayout(FlowLayout.LEFT, 1, 1));
+      this.addActionListener(
+          e -> {
+            Preferences.setString("pingLongest", "");
+            Preferences.setString("pingShortest", "");
+          });
+    }
+
+    public void addActionListener(ActionListener a) {
+      this.button.addActionListener(a);
+    }
+
+    private void makeLayout() {
+      JLabel label = new JLabel("Reset historical ping times");
+      this.add(label);
+      this.add(this.button);
+    }
+
+    @Override
+    public Dimension getMaximumSize() {
+      return this.getPreferredSize();
+    }
   }
 
   private static class PingHistory extends PreferenceTextArea {

--- a/src/net/sourceforge/kolmafia/swingui/widget/PreferenceTextArea.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/PreferenceTextArea.java
@@ -1,0 +1,27 @@
+package net.sourceforge.kolmafia.swingui.widget;
+
+import java.awt.Dimension;
+import javax.swing.JTextArea;
+import net.sourceforge.kolmafia.KoLGUIConstants;
+import net.sourceforge.kolmafia.listener.Listener;
+import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
+
+public abstract class PreferenceTextArea extends JTextArea implements Listener {
+  public PreferenceTextArea(String... prefs) {
+    this.setColumns(40);
+    this.setLineWrap(true);
+    this.setWrapStyleWord(true);
+    this.setEditable(false);
+    this.setOpaque(false);
+    this.setFont(KoLGUIConstants.DEFAULT_FONT);
+
+    for (String pref : prefs) {
+      PreferenceListenerRegistry.registerPreferenceListener(pref, this);
+    }
+  }
+
+  @Override
+  public Dimension getMaximumSize() {
+    return this.getPreferredSize();
+  }
+}

--- a/src/net/sourceforge/kolmafia/textui/command/TimeinCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TimeinCommand.java
@@ -4,8 +4,8 @@ import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.request.LoginRequest;
 import net.sourceforge.kolmafia.request.LogoutRequest;
 
-public class ReloginCommand extends AbstractCommand {
-  public ReloginCommand() {
+public class TimeinCommand extends AbstractCommand {
+  public TimeinCommand() {
     this.usage = " - log out and log in again, preserving character state";
   }
 


### PR DESCRIPTION
It also has a little text are which lists the shortest and longest historical ping tests we've seen.
That auto-updates when the pingLongest and pingShortest properties change.
There is also a button to clear the historical ping data (which verifies that it auto-updates).
You'd use this if you are connecting to a new network or on a new computer.

I also renamed ReloginCommand to TimeinCommand, since that more precisely describes what it does: it logs you out (just like KoL silently does when it times you out) and times you back in (just as we do to recover from KoL's silent logout).
You can use "timein", "relog", or "relogin" to invoke it.