### PR TITLE
timein successfully after canceling ping test

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
+++ b/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
@@ -806,6 +806,7 @@ public class KoLmafiaCLI {
     new TestCommand().register("test");
     new ThrowItemCommand().register("throw");
     new TimeinCommand().register("timein").register("relog").register("relogin");
+    new TimeoutCommand().register("timeout");
     new TimeSpinnerCommand().register("timespinner");
     new ToggleCommand().register("toggle");
     new TowerDoorCommand().register("tower").register("lowkey");

--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -1851,9 +1851,28 @@ public class GenericRequest implements Runnable {
         return false;
       }
 
-      String oldpwd = this.getFormField("pwd");
+      // KoL redirects us to login.php if we submit a request after KoL has
+      // silently timed us out. In this case, we have a password hash from
+      // the previous login, but when we log in again, we'll get a new one.
+      //
+      // If we want to resubmit a request that contains a  password hash,
+      // we'll have to replace the old one with the new one.
+
+      String oldpwd = GenericRequest.passwordHash;
+
       if (LoginRequest.executeTimeInRequest(this.getURLString(), this.redirectLocation)) {
         if (this.data.isEmpty()) {
+          // GenericRequest.passwordHash is set when we log in.  If it is "",
+          // we are not logged in - and we know it.  If it is not that, we are
+          // either currently logged in, or KoL has silently logged us out and
+          // we have not yet logged in and learned a new one.
+          if (oldpwd.equals("")) {
+            // See if there is a password hash in the request's URL
+            String formpwd = this.getFormField("pwd");
+            if (formpwd != null && !formpwd.equals("")) {
+              oldpwd = formpwd;
+            }
+          }
           if (!oldpwd.equals("")) {
             String newpwd = GenericRequest.passwordHash;
             this.formURLString =

--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -1851,18 +1851,21 @@ public class GenericRequest implements Runnable {
         return false;
       }
 
-      String oldpwd = GenericRequest.passwordHashValue;
+      String oldpwd = this.getFormField("pwd");
       if (LoginRequest.executeTimeInRequest(this.getURLString(), this.redirectLocation)) {
         if (this.data.isEmpty()) {
-          String newpwd = GenericRequest.passwordHashValue;
-          this.formURLString =
-              StringUtilities.singleStringReplace(this.formURLString, oldpwd, newpwd);
+          if (!oldpwd.equals("")) {
+            String newpwd = GenericRequest.passwordHash;
+            this.formURLString =
+                StringUtilities.singleStringReplace(this.formURLString, oldpwd, newpwd);
+          }
           this.formURL = null;
         } else {
           this.dataChanged = true;
         }
         return false;
       }
+      this.redirectHandled = true;
 
       return true;
     }

--- a/src/net/sourceforge/kolmafia/request/LoginRequest.java
+++ b/src/net/sourceforge/kolmafia/request/LoginRequest.java
@@ -201,6 +201,7 @@ public class LoginRequest extends GenericRequest {
 
   public static final void setLoggedOut() {
     LoginRequest.completedLogin = false;
+    LoginRequest.lastLoginAttempt = 0;
   }
 
   public static final void processLoginRequest(final GenericRequest request) {

--- a/src/net/sourceforge/kolmafia/request/LoginRequest.java
+++ b/src/net/sourceforge/kolmafia/request/LoginRequest.java
@@ -199,6 +199,10 @@ public class LoginRequest extends GenericRequest {
     return LoginRequest.completedLogin;
   }
 
+  public static final void setLoggedOut() {
+    LoginRequest.completedLogin = false;
+  }
+
   public static final void processLoginRequest(final GenericRequest request) {
     if (request.redirectLocation == null) {
       return;
@@ -226,8 +230,9 @@ public class LoginRequest extends GenericRequest {
 
     // Optionally do a ping and check the connection.
     // Returns true if it is acceptable.
+    // Returns false if it is unacceptable and we are logged out.
     if (!LoginManager.ping()) {
-      // LoginManager logged out and may have logged in again.
+      // LoginManager left us logged out
       LoginRequest.lastLoginAttempt = 0;
       return;
     }

--- a/src/net/sourceforge/kolmafia/request/LogoutRequest.java
+++ b/src/net/sourceforge/kolmafia/request/LogoutRequest.java
@@ -55,6 +55,7 @@ public class LogoutRequest extends GenericRequest {
   @Override
   public void processResults() {
     LogoutRequest.lastResponse = this.responseText;
+    LoginRequest.setLoggedOut();
   }
 
   public static final String getLastResponse() {

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -116,7 +116,7 @@ public class LoginManager {
       // If this was from a timein, we still have a GUI and can submit URLs which
       // need a pwd. Save a bogus pwd which will be replaced by a real one if we
       // eventually time in and accept a ping.
-      GenericRequest.passwordHash = "bogus";
+      GenericRequest.passwordHash = "ThisIsAnEntirelyBogusPasswordHash";
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -113,6 +113,10 @@ public class LoginManager {
     // If the user canceled, log out
     if (confirmed == null) {
       RequestThread.postRequest(new LogoutRequest());
+      // If this was from a timein, we still have a GUI and can submit URLs which
+      // need a pwd. Save a bogus pwd which will be replaced by a real one if we
+      // eventually time in and accept a ping.
+      GenericRequest.passwordHash = "bogus";
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -123,8 +123,7 @@ public class LoginManager {
 
     // The user finds the ping time unacceptable.
     RequestThread.postRequest(new LogoutRequest());
-    LoginRequest.relogin();
-    return false;
+    return LoginRequest.relogin();
   }
 
   public static void login(String username) {

--- a/src/net/sourceforge/kolmafia/textui/command/TimeoutCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TimeoutCommand.java
@@ -5,7 +5,7 @@ import net.sourceforge.kolmafia.request.LogoutRequest;
 
 public class TimeoutCommand extends AbstractCommand {
   public TimeoutCommand() {
-    this.usage = " - log out and log in again, preserving character state";
+    this.usage = " - log out, leaving GUI and character state intact";
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/textui/command/TimeoutCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TimeoutCommand.java
@@ -1,0 +1,15 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import net.sourceforge.kolmafia.RequestThread;
+import net.sourceforge.kolmafia.request.LogoutRequest;
+
+public class TimeoutCommand extends AbstractCommand {
+  public TimeoutCommand() {
+    this.usage = " - log out and log in again, preserving character state";
+  }
+
+  @Override
+  public void run(final String cmd, String parameters) {
+    RequestThread.postRequest(new LogoutRequest());
+  }
+}


### PR DESCRIPTION
1) Added a "timeout" command which simply calls logout.php, rather than doing a full logout and shutting down everything. This is the equivalent to KoL having silently logged you out when you time out your session.
2) When timing in, replace the password hash (as seen in the pwd field of the URL, rather than whatever the current password hash is) with the current password hash. This lets timing in a GET request with a a password hash (like a storage pull) work a lot better.
3) Executing a logout.php request leaves you not-logged-in.
4) relogin following a logout returns true or false, depending on whether the login succeeded.