### PR TITLE
automate login ping tests

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -99,6 +99,8 @@ global	mergeHobopolisChat	false
 global	pingLatest
 global	pingLogin	true
 global	pingLoginCheck	none
+global	pingLoginCount	0
+global	pingLoginFail	login
 global	pingLoginGoal	0
 global	pingLoginThreshold	0.2
 global	pingLongest

--- a/src/net/sourceforge/kolmafia/request/LoginRequest.java
+++ b/src/net/sourceforge/kolmafia/request/LoginRequest.java
@@ -18,6 +18,8 @@ public class LoginRequest extends GenericRequest {
   private static boolean isLoggingIn;
   private static boolean isTimingIn = false;
 
+  public static int loginPingAttempt = 0;
+
   private final String username;
   private final String password;
 
@@ -229,6 +231,14 @@ public class LoginRequest extends GenericRequest {
       return;
     }
 
+    if (name.endsWith("/q")) {
+      name = name.substring(0, name.length() - 2).trim();
+    } else {
+      // Subsequent requests (timeins) using this request
+      // will be in stealth mode.
+      request.addFormField("loginname", name + "/q");
+    }
+
     // Optionally do a ping and check the connection.
     // Returns true if it is acceptable.
     // Returns false if it is unacceptable and we are logged out.
@@ -238,8 +248,10 @@ public class LoginRequest extends GenericRequest {
       return;
     }
 
-    if (name.endsWith("/q")) {
-      name = name.substring(0, name.length() - 2).trim();
+    // Ping testing can recursively login using this request.
+    // Only finish login/timein after the original call
+    if (LoginRequest.loginPingAttempt > 0) {
+      return;
     }
 
     if (LoginRequest.isTimingIn) {

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -42,6 +42,9 @@ public class LoginManager {
   // have completed.
   private static boolean svnLoginUpdateNotFinished = true;
 
+  // A password hash for when we time you out, for use when timing in.
+  public static final String BOGUS_PASSWORD_HASH = "ThisIsAnEntirelyBogusPasswordHash";
+
   private LoginManager() {}
 
   public static boolean ping() {
@@ -123,7 +126,7 @@ public class LoginManager {
       buf.append(String.valueOf(attempt));
       buf.append(" times to get a fast connection");
       if (!error.equals("")) {
-        buf.append("- ");
+        buf.append(" - ");
         buf.append(error);
         buf.append(" - but failed");
       }
@@ -133,7 +136,7 @@ public class LoginManager {
         case "logout":
           KoLmafia.updateDisplay("Giving up and logging out.");
           RequestThread.postRequest(new LogoutRequest());
-          GenericRequest.passwordHash = "ThisIsAnEntirelyBogusPasswordHash";
+          GenericRequest.passwordHash = BOGUS_PASSWORD_HASH;
           return false;
         case "login":
         default:
@@ -165,7 +168,7 @@ public class LoginManager {
       // If this was from a timein, we still have a GUI and can submit URLs which
       // need a pwd. Save a bogus pwd which will be replaced by a real one if we
       // eventually time in and accept a ping.
-      GenericRequest.passwordHash = "ThisIsAnEntirelyBogusPasswordHash";
+      GenericRequest.passwordHash = BOGUS_PASSWORD_HASH;
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -45,6 +45,14 @@ public class LoginManager {
   private LoginManager() {}
 
   public static boolean ping() {
+    try {
+      return ping(++LoginRequest.loginPingAttempt);
+    } finally {
+      --LoginRequest.loginPingAttempt;
+    }
+  }
+
+  private static boolean ping(int attempt) {
     // Optionally run a ping test and check connection speed.
     // Return true if the connection is acceptable.
 
@@ -56,6 +64,13 @@ public class LoginManager {
     // The user wants to measure ping speed.
     var result = PingManager.runPingTest();
     KoLmafia.updateDisplay("Ping test: average delay is " + result.getAverage() + " msecs.");
+
+    // See if the Ping tested a suitable page
+    if (!result.isSaveable()) {
+      // Perhaps we redirected to afterlife.php or something.
+      // We can only compare averages vs. "normal" pages.
+      return true;
+    }
 
     // See whether user wants to check ping speed.
     long average = result.getAverage();
@@ -90,6 +105,40 @@ public class LoginManager {
       default -> {
         // The user is happy with any connection
         return true;
+      }
+    }
+
+    // Perhaps the user wants to automatically retry for a certain
+    // number of connections.
+    int allowed = Preferences.getInteger("pingLoginCount");
+    if (allowed > 0) {
+      if (attempt < allowed) {
+        // The user wants us to try again
+        RequestThread.postRequest(new LogoutRequest());
+        return LoginRequest.relogin();
+      }
+      // We've reached our limit
+      StringBuilder buf = new StringBuilder();
+      buf.append("We've tried ");
+      buf.append(String.valueOf(attempt));
+      buf.append(" times to get a fast connection");
+      if (!error.equals("")) {
+        buf.append("- ");
+        buf.append(error);
+        buf.append(" - but failed");
+      }
+      buf.append(".");
+      KoLmafia.updateDisplay(buf.toString());
+      switch (Preferences.getString("pingLoginFail")) {
+        case "logout":
+          KoLmafia.updateDisplay("Giving up and logging out.");
+          RequestThread.postRequest(new LogoutRequest());
+          GenericRequest.passwordHash = "ThisIsAnEntirelyBogusPasswordHash";
+          return false;
+        case "login":
+        default:
+          KoLmafia.updateDisplay("Accepting the last attempt of " + average + " msec.");
+          return true;
       }
     }
 

--- a/src/net/sourceforge/kolmafia/session/PingManager.java
+++ b/src/net/sourceforge/kolmafia/session/PingManager.java
@@ -107,6 +107,10 @@ public class PingManager {
       return buf.toString();
     }
 
+    public boolean isSaveable() {
+      return this.page.equals(DEFAULT_PAGE) && this.count >= MINIMUM_HISTORY_PINGS;
+    }
+
     public void save() {
       String value = this.toString();
 
@@ -115,7 +119,7 @@ public class PingManager {
 
       // Only save in historical properties if we tested the default
       // page and there are enough pings.
-      if (!this.page.equals(DEFAULT_PAGE) || this.count < MINIMUM_HISTORY_PINGS) {
+      if (!this.isSaveable()) {
         return;
       }
 

--- a/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
@@ -217,10 +217,15 @@ public class OptionsFrame extends GenericFrame {
       private class TimeinRunnable implements Runnable {
         @Override
         public void run() {
-          if (LoginRequest.completedLogin()) {
-            RequestThread.postRequest(new LogoutRequest());
+          try {
+            TimeinButton.this.button.setEnabled(false);
+            if (LoginRequest.completedLogin()) {
+              RequestThread.postRequest(new LogoutRequest());
+            }
+            LoginRequest.retimein();
+          } finally {
+            TimeinButton.this.button.setEnabled(true);
           }
-          LoginRequest.retimein();
         }
       }
     }

--- a/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
@@ -7,6 +7,7 @@ import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.FlowLayout;
 import java.awt.Frame;
 import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
@@ -51,12 +52,16 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLGUIConstants;
 import net.sourceforge.kolmafia.KoLmafiaGUI;
+import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.listener.Listener;
 import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.CampgroundRequest;
+import net.sourceforge.kolmafia.request.LoginRequest;
+import net.sourceforge.kolmafia.request.LogoutRequest;
 import net.sourceforge.kolmafia.request.RelayRequest;
 import net.sourceforge.kolmafia.request.UseSkillRequest;
+import net.sourceforge.kolmafia.session.PingManager.PingTest;
 import net.sourceforge.kolmafia.swingui.button.ThreadedButton;
 import net.sourceforge.kolmafia.swingui.menu.LoadScriptMenuItem;
 import net.sourceforge.kolmafia.swingui.panel.AddCustomDeedsPanel;
@@ -75,6 +80,7 @@ import net.sourceforge.kolmafia.swingui.widget.ListCellRendererFactory;
 import net.sourceforge.kolmafia.swingui.widget.PreferenceButtonGroup;
 import net.sourceforge.kolmafia.swingui.widget.PreferenceCheckBox;
 import net.sourceforge.kolmafia.swingui.widget.PreferenceIntegerTextField;
+import net.sourceforge.kolmafia.swingui.widget.PreferenceTextArea;
 import net.sourceforge.kolmafia.utilities.InputFieldUtilities;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 import net.sourceforge.kolmafia.webui.RelayServer;
@@ -90,7 +96,7 @@ public class OptionsFrame extends GenericFrame {
     selectorPanel.addPanel(" - Item Acquisition", new ItemOptionsPanel(), true);
     selectorPanel.addPanel(" - Maximizer", new MaximizerOptionsPanel(), true);
     selectorPanel.addPanel(" - Session Logs", new SessionLogOptionsPanel(), true);
-    selectorPanel.addPanel(" - Connection Options", new PingOptionsPanel(), true);
+    selectorPanel.addPanel(" - Connection Options", new ConnectionOptionsPanel(), true);
     selectorPanel.addPanel(" - Extra Debugging", new DebugOptionsPanel(), true);
 
     JPanel programsPanel = new JPanel();
@@ -155,6 +161,68 @@ public class OptionsFrame extends GenericFrame {
       };
 
       this.setOptions(options);
+    }
+  }
+
+  static class ConnectionOptionsPanel extends ConfigQueueingPanel {
+    public ConnectionOptionsPanel() {
+      super();
+      this.queue(new PingOptionsPanel());
+      this.queue(this.newSeparator());
+      this.queue(new LatestPingTest());
+      this.queue(new TimeinButton());
+      this.makeLayout();
+    }
+
+    private static class LatestPingTest extends PreferenceTextArea {
+      public LatestPingTest() {
+        super("pingLatest");
+        this.update();
+      }
+
+      @Override
+      public void update() {
+        PingTest latest = PingTest.parseProperty("pingLatest");
+        StringBuilder message = new StringBuilder();
+        message.append("Latest ping test average time was ");
+        message.append(String.valueOf(latest.getAverage()));
+        message.append(" msec.");
+        this.setText(message.toString());
+      }
+    }
+
+    private static class TimeinButton extends JPanel {
+      private final JButton button = new ThreadedButton("Time In", new TimeinRunnable());
+
+      public TimeinButton() {
+        configure();
+        makeLayout();
+      }
+
+      private void configure() {
+        this.setLayout(new FlowLayout(FlowLayout.LEFT, 1, 1));
+      }
+
+      private void makeLayout() {
+        JLabel label = new JLabel("Try for a better connection:");
+        this.add(label);
+        this.add(this.button);
+      }
+
+      @Override
+      public Dimension getMaximumSize() {
+        return this.getPreferredSize();
+      }
+
+      private class TimeinRunnable implements Runnable {
+        @Override
+        public void run() {
+          if (LoginRequest.completedLogin()) {
+            RequestThread.postRequest(new LogoutRequest());
+          }
+          LoginRequest.retimein();
+        }
+      }
     }
   }
 

--- a/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
@@ -27,12 +27,38 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
     this.queue(
         new PreferenceButtonGroup(
             "pingLoginCheck", "Login ping check type: ", true, "none", "goal", "threshold"));
-    this.queue(new PreferenceIntegerTextField("pingLoginGoal", 0, "Maximum average measured lag"));
+    this.queue(new PreferenceIntegerTextField("pingLoginGoal", 4, "Maximum average measured lag"));
     this.queue(
         new PreferenceFloatTextField(
-            "pingLoginThreshold", 0, "Allowed threshold above minimum historical lag"));
+            "pingLoginThreshold", 4, "Allowed threshold above minimum historical lag"));
+    this.queue(
+        new PreferenceIntegerTextField(
+            "pingLoginCount", 4, "Attempted ping checks before giving up"));
+    this.queue(
+        new PreferenceButtonGroup(
+            "pingLoginFail", "Action after failed ping check: ", true, "login", "logout"));
 
     this.makeLayout();
+  }
+
+  private static class PingHistory extends PreferenceTextArea {
+    public PingHistory() {
+      super("pingShortest", "pingLongest");
+      this.update();
+    }
+
+    @Override
+    public void update() {
+      PingTest shortest = PingTest.parseProperty("pingShortest");
+      PingTest longest = PingTest.parseProperty("pingLongest");
+      StringBuilder message = new StringBuilder();
+      message.append("Observed average ping times range from ");
+      message.append(String.valueOf(shortest.getAverage()));
+      message.append("-");
+      message.append(String.valueOf(longest.getAverage()));
+      message.append(" msec.");
+      this.setText(message.toString());
+    }
   }
 
   private static class PingResetButton extends JPanel {
@@ -57,7 +83,7 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
     }
 
     private void makeLayout() {
-      JLabel label = new JLabel("Reset historical ping times");
+      JLabel label = new JLabel("Reset historical ping times:");
       this.add(label);
       this.add(this.button);
     }
@@ -65,26 +91,6 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
     @Override
     public Dimension getMaximumSize() {
       return this.getPreferredSize();
-    }
-  }
-
-  private static class PingHistory extends PreferenceTextArea {
-    public PingHistory() {
-      super("pingShortest", "pingLongest");
-      this.update();
-    }
-
-    @Override
-    public void update() {
-      PingTest shortest = PingTest.parseProperty("pingShortest");
-      PingTest longest = PingTest.parseProperty("pingLongest");
-      StringBuilder message = new StringBuilder();
-      message.append("Observed average ping times range from ");
-      message.append(String.valueOf(shortest.getAverage()));
-      message.append("-");
-      message.append(String.valueOf(longest.getAverage()));
-      message.append(" msec.");
-      this.setText(message.toString());
     }
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/command/TimeinCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TimeinCommand.java
@@ -11,7 +11,9 @@ public class TimeinCommand extends AbstractCommand {
 
   @Override
   public void run(final String cmd, String parameters) {
-    RequestThread.postRequest(new LogoutRequest());
+    if (LoginRequest.completedLogin()) {
+      RequestThread.postRequest(new LogoutRequest());
+    }
     LoginRequest.retimein();
   }
 }


### PR DESCRIPTION
1) Count ping test attempts when you are logging it.
If you get an acceptable ping test on attempt N, only complete login/timein when you unwind back to attempt 1.
2) When timing in to try for a better connection, via timein command or equivalent, only issue logout request if you are currently logged in.
3) When you log in for the first time, if you are in stealth mode (/q), remove that for the purpose of saving actual user name and reading Preferences, as always.
If you did NOT log in with /q, add that to the name field of the LoginRequest, so that all subsequent timeins are done in stealth mode.
4) When doing a ping test at login, if it you got redirected away from api.php (afterlife.php, for example), do not compare the measured ping time with saved historical ping times, which are only api.php.
5) Add 2 new properties:
- pingLoginCount (defaults to 0) the number of times you are willing to let KoLmafia automatically retry ping tests, looking for a successful goal or threshold average. If 0, no automation; a failed test will pop up the usual yes/no/cancel dialog asking if you want to accept, retry, or bail.
- pingLoginFail - logout or login - the action taken if we cannot get a successfull average ping time after pingLoginCount attempts have been made. login means "accept it and remain logged in". logout means "log out in despair" and try again when you timein.
6) These properties are configurable on the Connection Options panel in both the Login Frame and Preferences/General
7) In preferences, that panel has two more lines:
Latest ping test average time was 35 msec.
(That auto-updates each time you execute a ping test - when attempting to timein, for example.)
Try for a better connection: [Time In]
(Press the button to logout (if needed) and time in, using all the options as configured above.