### PR TITLE
feat: modifier type

### DIFF
--- a/src/net/sourceforge/kolmafia/modifiers/BitmapModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/BitmapModifier.java
@@ -67,6 +67,16 @@ public enum BitmapModifier implements Modifier {
     return name;
   }
 
+  @Override
+  public String getType() {
+    return "numeric";
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
   public static final Set<BitmapModifier> BITMAP_MODIFIERS =
       Collections.unmodifiableSet(EnumSet.allOf(BitmapModifier.class));
 

--- a/src/net/sourceforge/kolmafia/modifiers/BooleanModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/BooleanModifier.java
@@ -103,6 +103,16 @@ public enum BooleanModifier implements Modifier {
     return name;
   }
 
+  @Override
+  public String getType() {
+    return "boolean";
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
   public static final Set<BooleanModifier> BOOLEAN_MODIFIERS =
       Collections.unmodifiableSet(EnumSet.allOf(BooleanModifier.class));
 

--- a/src/net/sourceforge/kolmafia/modifiers/DerivedModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DerivedModifier.java
@@ -41,6 +41,16 @@ public enum DerivedModifier implements Modifier {
     return null;
   }
 
+  @Override
+  public String getType() {
+    return "numeric";
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
   public static final Set<DerivedModifier> DERIVED_MODIFIERS =
       Collections.unmodifiableSet(EnumSet.allOf(DerivedModifier.class));
 

--- a/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
@@ -581,6 +581,16 @@ public enum DoubleModifier implements Modifier {
     return tag;
   }
 
+  @Override
+  public String getType() {
+    return "numeric";
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
   public static final Set<DoubleModifier> DOUBLE_MODIFIERS =
       Collections.unmodifiableSet(EnumSet.allOf(DoubleModifier.class));
 

--- a/src/net/sourceforge/kolmafia/modifiers/Modifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/Modifier.java
@@ -10,4 +10,6 @@ public interface Modifier {
   Pattern getTagPattern();
 
   String getTag();
+
+  String getType();
 }

--- a/src/net/sourceforge/kolmafia/modifiers/StringModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/StringModifier.java
@@ -99,6 +99,16 @@ public enum StringModifier implements Modifier {
     return name;
   }
 
+  @Override
+  public String getType() {
+    return "string";
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
   public static final Set<StringModifier> STRING_MODIFIERS =
       Collections.unmodifiableSet(EnumSet.allOf(StringModifier.class));
 

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -281,6 +282,7 @@ public class ModifierDatabase {
     mods.addAll(Arrays.asList(DerivedModifier.values()));
     mods.addAll(Arrays.asList(StringModifier.values()));
     mods.addAll(Arrays.asList(BooleanModifier.values()));
+    mods.sort(Comparator.comparing(Modifier::getName));
     allModifiers = mods;
     return mods;
   }

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -271,6 +271,33 @@ public class ModifierDatabase {
     return BitmapModifier.byCaselessName(name);
   }
 
+  private static List<Modifier> allModifiers = null;
+
+  public static List<Modifier> allModifiers() {
+    if (allModifiers != null) return allModifiers;
+    List<Modifier> mods = new ArrayList<>();
+    mods.addAll(Arrays.asList(DoubleModifier.values()));
+    mods.addAll(Arrays.asList(BitmapModifier.values()));
+    mods.addAll(Arrays.asList(DerivedModifier.values()));
+    mods.addAll(Arrays.asList(StringModifier.values()));
+    mods.addAll(Arrays.asList(BooleanModifier.values()));
+    allModifiers = mods;
+    return mods;
+  }
+
+  /** Get any modifier by name, ignoring case */
+  public static Modifier byCaselessName(String name) {
+    var num = ModifierDatabase.numericByCaselessName(name);
+    if (num != null) {
+      return num;
+    }
+    var str = StringModifier.byCaselessName(name);
+    if (str != null) {
+      return str;
+    }
+    return BooleanModifier.byCaselessName(name);
+  }
+
   // region: get registered values
 
   public static final Modifiers getItemModifiers(final int id) {

--- a/src/net/sourceforge/kolmafia/textui/DataTypes.java
+++ b/src/net/sourceforge/kolmafia/textui/DataTypes.java
@@ -1030,79 +1030,67 @@ public class DataTypes {
 
   private static String promptForValue(final Type type, final String message, final String name) {
     switch (type.getType()) {
-      case BOOLEAN:
+      case BOOLEAN -> {
         return InputFieldUtilities.input(message, DataTypes.BOOLEANS);
-
-      case LOCATION:
-        {
-          LockableListModel<KoLAdventure> inputs = AdventureDatabase.getAsLockableListModel();
-          KoLAdventure initial =
-              AdventureDatabase.getAdventure(Preferences.getString("lastAdventure"));
-          KoLAdventure value = InputFieldUtilities.input(message, inputs, initial);
-          return value == null ? null : value.getAdventureName();
-        }
-
-      case SKILL:
-        {
-          UseSkillRequest[] inputs =
-              SkillDatabase.getCastableSkills().toArray(new UseSkillRequest[0]);
-          UseSkillRequest value = InputFieldUtilities.input(message, inputs);
-          return value == null ? null : value.getSkillName();
-        }
-
-      case FAMILIAR:
-        {
-          FamiliarData[] inputs = KoLCharacter.usableFamiliars().toArray(new FamiliarData[0]);
-          FamiliarData initial = KoLCharacter.getFamiliar();
-          FamiliarData value = InputFieldUtilities.input(message, inputs, initial);
-          return value == null ? null : value.getRace();
-        }
-
-      case SLOT:
+      }
+      case LOCATION -> {
+        LockableListModel<KoLAdventure> inputs = AdventureDatabase.getAsLockableListModel();
+        KoLAdventure initial =
+            AdventureDatabase.getAdventure(Preferences.getString("lastAdventure"));
+        KoLAdventure value = InputFieldUtilities.input(message, inputs, initial);
+        return value == null ? null : value.getAdventureName();
+      }
+      case SKILL -> {
+        UseSkillRequest[] inputs =
+            SkillDatabase.getCastableSkills().toArray(new UseSkillRequest[0]);
+        UseSkillRequest value = InputFieldUtilities.input(message, inputs);
+        return value == null ? null : value.getSkillName();
+      }
+      case FAMILIAR -> {
+        FamiliarData[] inputs = KoLCharacter.usableFamiliars().toArray(new FamiliarData[0]);
+        FamiliarData initial = KoLCharacter.getFamiliar();
+        FamiliarData value = InputFieldUtilities.input(message, inputs, initial);
+        return value == null ? null : value.getRace();
+      }
+      case SLOT -> {
         return InputFieldUtilities.input(message, SlotSet.NAMES);
-
-      case ELEMENT:
+      }
+      case ELEMENT -> {
         return InputFieldUtilities.input(message, MonsterDatabase.ELEMENT_ARRAY);
-
-      case COINMASTER:
+      }
+      case COINMASTER -> {
         return InputFieldUtilities.input(message, CoinmasterRegistry.MASTERS);
-
-      case PHYLUM:
+      }
+      case PHYLUM -> {
         return InputFieldUtilities.input(message, MonsterDatabase.PHYLUM_ARRAY);
-
-      case THRALL:
+      }
+      case THRALL -> {
         return InputFieldUtilities.input(message, PastaThrallData.THRALL_ARRAY);
-
-      case SERVANT:
+      }
+      case SERVANT -> {
         return InputFieldUtilities.input(message, EdServantData.SERVANT_ARRAY);
-
-      case VYKEA:
+      }
+      case VYKEA -> {
         return InputFieldUtilities.input(message, VYKEACompanionData.VYKEA);
-
-      case PATH:
+      }
+      case PATH -> {
         return InputFieldUtilities.input(message, Path.values()).toString();
-
-      case CLASS:
+      }
+      case CLASS -> {
         return InputFieldUtilities.input(message, AscensionClass.values()).toString();
-
-      case STAT:
+      }
+      case STAT -> {
         return InputFieldUtilities.input(message, DataTypes.STAT_ARRAY);
-
-      case MODIFIER:
+      }
+      case MODIFIER -> {
         return InputFieldUtilities.input(
                 message, ModifierDatabase.allModifiers().toArray(new Modifier[0]))
             .toString();
-
-      case INT:
-      case FLOAT:
-      case STRING:
-      case ITEM:
-      case EFFECT:
-      case MONSTER:
+      }
+      case INT, FLOAT, STRING, ITEM, EFFECT, MONSTER -> {
         return InputFieldUtilities.input(message);
-
-      default:
-        throw new ScriptException("Internal error: Illegal type for main() parameter");
+      }
+      default -> throw new ScriptException("Internal error: Illegal type for main() parameter");
     }
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/DataTypes.java
+++ b/src/net/sourceforge/kolmafia/textui/DataTypes.java
@@ -1021,14 +1021,6 @@ public class DataTypes {
     return value;
   }
 
-  public static final Value makeModifierValue(final Modifier data) {
-    if (data == null) {
-      return DataTypes.MODIFIER_INIT;
-    }
-
-    return new Value(data);
-  }
-
   // Also supply:
   // public static final String promptForValue()
 
@@ -1098,7 +1090,7 @@ public class DataTypes {
 
       case MODIFIER:
         return InputFieldUtilities.input(
-                message, ModifierDatabase.allModifiers().toArray(new Modifier[] {}))
+                message, ModifierDatabase.allModifiers().toArray(new Modifier[0]))
             .toString();
 
       case INT:

--- a/src/net/sourceforge/kolmafia/textui/DataTypes.java
+++ b/src/net/sourceforge/kolmafia/textui/DataTypes.java
@@ -19,11 +19,13 @@ import net.sourceforge.kolmafia.PastaThrallData;
 import net.sourceforge.kolmafia.VYKEACompanionData;
 import net.sourceforge.kolmafia.equipment.Slot;
 import net.sourceforge.kolmafia.equipment.SlotSet;
+import net.sourceforge.kolmafia.modifiers.Modifier;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.BountyDatabase;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
 import net.sourceforge.kolmafia.persistence.FamiliarDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
+import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase.Element;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase.Phylum;
@@ -69,6 +71,7 @@ public class DataTypes {
     SERVANT,
     VYKEA,
     PATH,
+    MODIFIER,
 
     STRICT_STRING,
     AGGREGATE,
@@ -102,6 +105,7 @@ public class DataTypes {
   public static final Type SERVANT_TYPE = new Type("servant", TypeSpec.SERVANT);
   public static final Type VYKEA_TYPE = new Type("vykea", TypeSpec.VYKEA);
   public static final Type PATH_TYPE = new Type("path", TypeSpec.PATH);
+  public static final Type MODIFIER_TYPE = new Type("modifier", TypeSpec.MODIFIER);
 
   public static final Type STRICT_STRING_TYPE = new Type("strict_string", TypeSpec.STRICT_STRING);
   public static final Type AGGREGATE_TYPE = new Type("aggregate", TypeSpec.AGGREGATE);
@@ -206,6 +210,7 @@ public class DataTypes {
   public static final Value VYKEA_INIT =
       new Value(DataTypes.VYKEA_TYPE, 0, "none", VYKEACompanionData.NO_COMPANION);
   public static final Value PATH_INIT = new Value(DataTypes.PATH_TYPE, -1, "none", Path.NONE);
+  public static final Value MODIFIER_INIT = new Value(DataTypes.MODIFIER_TYPE, "none", null);
 
   public static final TypeList enumeratedTypes =
       TypeList.of(
@@ -225,7 +230,8 @@ public class DataTypes {
           THRALL_TYPE,
           SERVANT_TYPE,
           VYKEA_TYPE,
-          PATH_TYPE);
+          PATH_TYPE,
+          MODIFIER_TYPE);
   public static final TypeList simpleTypes =
       TypeList.of(
           VOID_TYPE,
@@ -735,6 +741,23 @@ public class DataTypes {
     return new Value(DataTypes.COINMASTER_TYPE, data.getMaster(), data);
   }
 
+  public static final Value parseModifierValue(String name, final boolean returnDefault) {
+    if (name == null || name.equals("")) {
+      return returnDefault ? DataTypes.MODIFIER_INIT : null;
+    }
+
+    if (name.equalsIgnoreCase("none")) {
+      return DataTypes.MODIFIER_INIT;
+    }
+
+    Modifier content = ModifierDatabase.byCaselessName(name);
+    if (content == null) {
+      return returnDefault ? DataTypes.MODIFIER_INIT : null;
+    }
+
+    return new Value(content);
+  }
+
   public static final Value parseValue(
       final Type type, final String name, final boolean returnDefault) {
     return type.parseValue(name, returnDefault);
@@ -998,6 +1021,14 @@ public class DataTypes {
     return value;
   }
 
+  public static final Value makeModifierValue(final Modifier data) {
+    if (data == null) {
+      return DataTypes.MODIFIER_INIT;
+    }
+
+    return new Value(data);
+  }
+
   // Also supply:
   // public static final String promptForValue()
 
@@ -1064,6 +1095,11 @@ public class DataTypes {
 
       case STAT:
         return InputFieldUtilities.input(message, DataTypes.STAT_ARRAY);
+
+      case MODIFIER:
+        return InputFieldUtilities.input(
+                message, ModifierDatabase.allModifiers().toArray(new Modifier[] {}))
+            .toString();
 
       case INT:
       case FLOAT:

--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -349,6 +349,7 @@ public class Parser {
     reservedWords.add("servant");
     reservedWords.add("vykea");
     reservedWords.add("path");
+    reservedWords.add("modifier");
 
     reservedWords.add("record");
     reservedWords.add("typedef");

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -2460,16 +2460,32 @@ public abstract class RuntimeLibrary {
     params = new Type[] {DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("numeric_modifier", DataTypes.FLOAT_TYPE, params));
 
+    params = new Type[] {DataTypes.MODIFIER_TYPE};
+    functions.add(new LibraryFunction("numeric_modifier", DataTypes.FLOAT_TYPE, params));
+
     params = new Type[] {DataTypes.STRING_TYPE, DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("numeric_modifier", DataTypes.FLOAT_TYPE, params));
 
+    params = new Type[] {DataTypes.STRING_TYPE, DataTypes.MODIFIER_TYPE};
+    functions.add(new LibraryFunction("numeric_modifier", DataTypes.FLOAT_TYPE, params));
+
     params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("numeric_modifier", DataTypes.FLOAT_TYPE, params));
+    ;
+
+    params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.MODIFIER_TYPE};
     functions.add(new LibraryFunction("numeric_modifier", DataTypes.FLOAT_TYPE, params));
 
     params = new Type[] {DataTypes.EFFECT_TYPE, DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("numeric_modifier", DataTypes.FLOAT_TYPE, params));
 
+    params = new Type[] {DataTypes.EFFECT_TYPE, DataTypes.MODIFIER_TYPE};
+    functions.add(new LibraryFunction("numeric_modifier", DataTypes.FLOAT_TYPE, params));
+
     params = new Type[] {DataTypes.SKILL_TYPE, DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("numeric_modifier", DataTypes.FLOAT_TYPE, params));
+
+    params = new Type[] {DataTypes.SKILL_TYPE, DataTypes.MODIFIER_TYPE};
     functions.add(new LibraryFunction("numeric_modifier", DataTypes.FLOAT_TYPE, params));
 
     params =
@@ -2481,52 +2497,103 @@ public abstract class RuntimeLibrary {
     params = new Type[] {DataTypes.THRALL_TYPE, DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("numeric_modifier", DataTypes.FLOAT_TYPE, params));
 
+    params = new Type[] {DataTypes.THRALL_TYPE, DataTypes.MODIFIER_TYPE};
+    functions.add(new LibraryFunction("numeric_modifier", DataTypes.FLOAT_TYPE, params));
+
     params = new Type[] {DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("boolean_modifier", DataTypes.BOOLEAN_TYPE, params));
+
+    params = new Type[] {DataTypes.MODIFIER_TYPE};
     functions.add(new LibraryFunction("boolean_modifier", DataTypes.BOOLEAN_TYPE, params));
 
     params = new Type[] {DataTypes.STRING_TYPE, DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("boolean_modifier", DataTypes.BOOLEAN_TYPE, params));
 
+    params = new Type[] {DataTypes.STRING_TYPE, DataTypes.MODIFIER_TYPE};
+    functions.add(new LibraryFunction("boolean_modifier", DataTypes.BOOLEAN_TYPE, params));
+
     params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("boolean_modifier", DataTypes.BOOLEAN_TYPE, params));
 
+    params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.MODIFIER_TYPE};
+    functions.add(new LibraryFunction("boolean_modifier", DataTypes.BOOLEAN_TYPE, params));
+
     params = new Type[] {DataTypes.EFFECT_TYPE, DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("boolean_modifier", DataTypes.BOOLEAN_TYPE, params));
+
+    params = new Type[] {DataTypes.EFFECT_TYPE, DataTypes.MODIFIER_TYPE};
     functions.add(new LibraryFunction("boolean_modifier", DataTypes.BOOLEAN_TYPE, params));
 
     params = new Type[] {DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("string_modifier", DataTypes.STRING_TYPE, params));
 
+    params = new Type[] {DataTypes.MODIFIER_TYPE};
+    functions.add(new LibraryFunction("string_modifier", DataTypes.STRING_TYPE, params));
+
     params = new Type[] {DataTypes.STRING_TYPE, DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("string_modifier", DataTypes.STRING_TYPE, params));
+
+    params = new Type[] {DataTypes.STRING_TYPE, DataTypes.MODIFIER_TYPE};
     functions.add(new LibraryFunction("string_modifier", DataTypes.STRING_TYPE, params));
 
     params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("string_modifier", DataTypes.STRING_TYPE, params));
 
+    params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.MODIFIER_TYPE};
+    functions.add(new LibraryFunction("string_modifier", DataTypes.STRING_TYPE, params));
+
     params = new Type[] {DataTypes.EFFECT_TYPE, DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("string_modifier", DataTypes.STRING_TYPE, params));
+
+    params = new Type[] {DataTypes.EFFECT_TYPE, DataTypes.MODIFIER_TYPE};
     functions.add(new LibraryFunction("string_modifier", DataTypes.STRING_TYPE, params));
 
     params = new Type[] {DataTypes.STRING_TYPE, DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("effect_modifier", DataTypes.EFFECT_TYPE, params));
 
+    params = new Type[] {DataTypes.STRING_TYPE, DataTypes.MODIFIER_TYPE};
+    functions.add(new LibraryFunction("effect_modifier", DataTypes.EFFECT_TYPE, params));
+
     params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("effect_modifier", DataTypes.EFFECT_TYPE, params));
+
+    params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.MODIFIER_TYPE};
     functions.add(new LibraryFunction("effect_modifier", DataTypes.EFFECT_TYPE, params));
 
     params = new Type[] {DataTypes.STRING_TYPE, DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("class_modifier", DataTypes.CLASS_TYPE, params));
 
+    params = new Type[] {DataTypes.STRING_TYPE, DataTypes.MODIFIER_TYPE};
+    functions.add(new LibraryFunction("class_modifier", DataTypes.CLASS_TYPE, params));
+
     params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("class_modifier", DataTypes.CLASS_TYPE, params));
+
+    params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.MODIFIER_TYPE};
     functions.add(new LibraryFunction("class_modifier", DataTypes.CLASS_TYPE, params));
 
     params = new Type[] {DataTypes.EFFECT_TYPE, DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("monster_modifier", DataTypes.MONSTER_TYPE, params));
 
+    params = new Type[] {DataTypes.EFFECT_TYPE, DataTypes.MODIFIER_TYPE};
+    functions.add(new LibraryFunction("monster_modifier", DataTypes.MONSTER_TYPE, params));
+
     params = new Type[] {DataTypes.STRING_TYPE, DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("skill_modifier", DataTypes.SKILL_TYPE, params));
+
+    params = new Type[] {DataTypes.STRING_TYPE, DataTypes.MODIFIER_TYPE};
     functions.add(new LibraryFunction("skill_modifier", DataTypes.SKILL_TYPE, params));
 
     params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.STRING_TYPE};
     functions.add(new LibraryFunction("skill_modifier", DataTypes.SKILL_TYPE, params));
 
+    params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.MODIFIER_TYPE};
+    functions.add(new LibraryFunction("skill_modifier", DataTypes.SKILL_TYPE, params));
+
     params = new Type[] {DataTypes.EFFECT_TYPE, DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("stat_modifier", DataTypes.STAT_TYPE, params));
+
+    params = new Type[] {DataTypes.EFFECT_TYPE, DataTypes.MODIFIER_TYPE};
     functions.add(new LibraryFunction("stat_modifier", DataTypes.STAT_TYPE, params));
 
     // Quest status inquiries
@@ -9234,9 +9301,48 @@ public abstract class RuntimeLibrary {
     return name;
   }
 
-  public static Value numeric_modifier(ScriptRuntime controller, final Value modifier) {
+  private static Modifier getNumericModifier(ScriptRuntime controller, final Value modifier) {
+    Type type = modifier.getType();
+    if (type.equals(DataTypes.MODIFIER_TYPE)) {
+      Modifier content = (Modifier) modifier.content;
+      if (content.getType().equals("numeric")) {
+        return content;
+      }
+      throw controller.runtimeException("numeric modifier required");
+    }
     String mod = modifier.toString();
-    Modifier realMod = ModifierDatabase.numericByCaselessName(mod);
+    return ModifierDatabase.numericByCaselessName(mod);
+  }
+
+  private static BooleanModifier getBooleanModifier(
+      ScriptRuntime controller, final Value modifier) {
+    Type type = modifier.getType();
+    if (type.equals(DataTypes.MODIFIER_TYPE)) {
+      Modifier content = (Modifier) modifier.content;
+      if (content.getType().equals("boolean")) {
+        return (BooleanModifier) content;
+      }
+      throw controller.runtimeException("boolean modifier required");
+    }
+    String mod = modifier.toString();
+    return BooleanModifier.byCaselessName(mod);
+  }
+
+  private static StringModifier getStringModifier(ScriptRuntime controller, final Value modifier) {
+    Type type = modifier.getType();
+    if (type.equals(DataTypes.MODIFIER_TYPE)) {
+      Modifier content = (Modifier) modifier.content;
+      if (content.getType().equals("string")) {
+        return (StringModifier) content;
+      }
+      throw controller.runtimeException("string modifier required");
+    }
+    String mod = modifier.toString();
+    return StringModifier.byCaselessName(mod);
+  }
+
+  public static Value numeric_modifier(ScriptRuntime controller, final Value modifier) {
+    Modifier realMod = getNumericModifier(controller, modifier);
     return new Value(KoLCharacter.currentNumericModifier(realMod));
   }
 
@@ -9244,8 +9350,7 @@ public abstract class RuntimeLibrary {
       ScriptRuntime controller, final Value arg, final Value modifier) {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
-    String mod = modifier.toString();
-    Modifier realMod = ModifierDatabase.numericByCaselessName(mod);
+    Modifier realMod = getNumericModifier(controller, modifier);
     return new Value(ModifierDatabase.getNumericModifier(type, name, realMod));
   }
 
@@ -9265,8 +9370,7 @@ public abstract class RuntimeLibrary {
   }
 
   public static Value boolean_modifier(ScriptRuntime controller, final Value modifier) {
-    String modName = modifier.toString();
-    BooleanModifier mod = BooleanModifier.byCaselessName(modName);
+    BooleanModifier mod = getBooleanModifier(controller, modifier);
     return DataTypes.makeBooleanValue(KoLCharacter.currentBooleanModifier(mod));
   }
 
@@ -9274,14 +9378,12 @@ public abstract class RuntimeLibrary {
       ScriptRuntime controller, final Value arg, final Value modifier) {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
-    String mod = modifier.toString();
-    BooleanModifier boolMod = BooleanModifier.byCaselessName(mod);
+    BooleanModifier boolMod = getBooleanModifier(controller, modifier);
     return DataTypes.makeBooleanValue(ModifierDatabase.getBooleanModifier(type, name, boolMod));
   }
 
   public static Value string_modifier(ScriptRuntime controller, final Value modifier) {
-    String mod = modifier.toString();
-    StringModifier strMod = StringModifier.byCaselessName(mod);
+    StringModifier strMod = getStringModifier(controller, modifier);
     return new Value(KoLCharacter.currentStringModifier(strMod));
   }
 
@@ -9289,8 +9391,7 @@ public abstract class RuntimeLibrary {
       ScriptRuntime controller, final Value arg, final Value modifier) {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
-    String mod = modifier.toString();
-    StringModifier strMod = StringModifier.byCaselessName(mod);
+    StringModifier strMod = getStringModifier(controller, modifier);
     return new Value(ModifierDatabase.getStringModifier(type, name, strMod));
   }
 
@@ -9298,8 +9399,7 @@ public abstract class RuntimeLibrary {
       ScriptRuntime controller, final Value arg, final Value modifier) {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
-    String mod = modifier.toString();
-    StringModifier strMod = StringModifier.byCaselessName(mod);
+    StringModifier strMod = getStringModifier(controller, modifier);
     return new Value(
         DataTypes.parseEffectValue(ModifierDatabase.getStringModifier(type, name, strMod), true));
   }
@@ -9308,8 +9408,7 @@ public abstract class RuntimeLibrary {
       ScriptRuntime controller, final Value arg, final Value modifier) {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
-    String mod = modifier.toString();
-    StringModifier strMod = StringModifier.byCaselessName(mod);
+    StringModifier strMod = getStringModifier(controller, modifier);
     return new Value(
         DataTypes.parseClassValue(ModifierDatabase.getStringModifier(type, name, strMod), true));
   }
@@ -9318,8 +9417,7 @@ public abstract class RuntimeLibrary {
       ScriptRuntime controller, final Value arg, final Value modifier) {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
-    String mod = modifier.toString();
-    StringModifier strMod = StringModifier.byCaselessName(mod);
+    StringModifier strMod = getStringModifier(controller, modifier);
     return new Value(
         DataTypes.parseSkillValue(ModifierDatabase.getStringModifier(type, name, strMod), true));
   }
@@ -9328,8 +9426,7 @@ public abstract class RuntimeLibrary {
       ScriptRuntime controller, final Value arg, final Value modifier) {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
-    String mod = modifier.toString();
-    StringModifier strMod = StringModifier.byCaselessName(mod);
+    StringModifier strMod = getStringModifier(controller, modifier);
     return new Value(
         DataTypes.parseStatValue(ModifierDatabase.getStringModifier(type, name, strMod), true));
   }
@@ -9338,8 +9435,7 @@ public abstract class RuntimeLibrary {
       ScriptRuntime controller, final Value arg, final Value modifier) {
     ModifierType type = RuntimeLibrary.getModifierType(arg);
     String name = RuntimeLibrary.getModifierName(arg);
-    String mod = modifier.toString();
-    StringModifier strMod = StringModifier.byCaselessName(name);
+    StringModifier strMod = getStringModifier(controller, modifier);
     return new Value(
         DataTypes.parseMonsterValue(ModifierDatabase.getStringModifier(type, name, strMod), true));
   }

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -2596,6 +2596,13 @@ public abstract class RuntimeLibrary {
     params = new Type[] {DataTypes.EFFECT_TYPE, DataTypes.MODIFIER_TYPE};
     functions.add(new LibraryFunction("stat_modifier", DataTypes.STAT_TYPE, params));
 
+    params = new Type[] {DataTypes.STRING_TYPE};
+    functions.add(
+        new LibraryFunction(
+            "split_modifiers",
+            new AggregateType(DataTypes.STRING_TYPE, DataTypes.MODIFIER_TYPE),
+            params));
+
     // Quest status inquiries
 
     params = new Type[] {};
@@ -9438,6 +9445,23 @@ public abstract class RuntimeLibrary {
     StringModifier strMod = getStringModifier(controller, modifier);
     return new Value(
         DataTypes.parseMonsterValue(ModifierDatabase.getStringModifier(type, name, strMod), true));
+  }
+
+  public static Value split_modifiers(ScriptRuntime controller, final Value arg) {
+    AggregateType type = new AggregateType(DataTypes.STRING_TYPE, DataTypes.MODIFIER_TYPE);
+    MapValue value = new MapValue(type);
+
+    for (ModifierValue mVal : ModifierDatabase.splitModifiers(arg.toString())) {
+      var modifierName = mVal.getName();
+      var modifier = ModifierDatabase.byCaselessName(modifierName);
+      if (modifier == null) {
+        // splitModifiers doesn't validate the passed-in string, so just drop it
+        continue;
+      }
+      value.aset(new Value(modifier), new Value(mVal.getValue()));
+    }
+
+    return value;
   }
 
   public static Value white_citadel_available(ScriptRuntime controller) {

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -24,6 +24,7 @@ import net.sourceforge.kolmafia.PastaThrallData;
 import net.sourceforge.kolmafia.PastaThrallData.PastaThrallType;
 import net.sourceforge.kolmafia.PokefamData;
 import net.sourceforge.kolmafia.VYKEACompanionData;
+import net.sourceforge.kolmafia.modifiers.Modifier;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.AdventureQueueDatabase;
@@ -1947,6 +1948,26 @@ public class ProxyRecordValue extends RecordValue {
 
     public SlotProxy(Value obj) {
       super(_type, obj);
+    }
+  }
+
+  public static class ModifierProxy extends ProxyRecordValue {
+    public static final RecordType _type =
+        new RecordBuilder()
+            .add("name", DataTypes.STRING_TYPE)
+            .add("type", DataTypes.STRING_TYPE)
+            .finish("modifier proxy");
+
+    public ModifierProxy(Value obj) {
+      super(_type, obj);
+    }
+
+    public String get_name() {
+      return this.content != null ? ((Modifier) this.content).getName() : "";
+    }
+
+    public String get_type() {
+      return this.content != null ? ((Modifier) this.content).getType() : "";
     }
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
@@ -16,6 +16,7 @@ import net.sourceforge.kolmafia.PastaThrallData;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.VYKEACompanionData;
 import net.sourceforge.kolmafia.equipment.SlotSet;
+import net.sourceforge.kolmafia.modifiers.Modifier;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.BountyDatabase;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
@@ -346,6 +347,12 @@ public class Type extends Symbol {
         case PATH -> DataTypes.makePathValue(path);
         default -> null;
       };
+    }
+    if (object instanceof Modifier modifier) {
+      if (this.type == TypeSpec.MODIFIER) {
+        return new Value(modifier);
+      }
+      return null;
     }
     return null;
   }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
@@ -130,7 +130,16 @@ public class Type extends Symbol {
 
   public boolean isStringLike() {
     return switch (this.getType()) {
-      case STRING, BUFFER, LOCATION, STAT, MONSTER, ELEMENT, COINMASTER, PHYLUM, BOUNTY -> true;
+      case STRING,
+          BUFFER,
+          LOCATION,
+          STAT,
+          MONSTER,
+          ELEMENT,
+          COINMASTER,
+          PHYLUM,
+          BOUNTY,
+          MODIFIER -> true;
       default -> false;
     };
   }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
@@ -362,70 +362,35 @@ public class Type extends Symbol {
 
     List<Value> list = new ArrayList<>();
     switch (this.type) {
-      case BOOLEAN:
-        this.addValues(list, DataTypes.BOOLEANS);
-        break;
-      case ITEM:
+      case BOOLEAN -> this.addValues(list, DataTypes.BOOLEANS);
+      case ITEM -> {
         int limit = ItemDatabase.maxItemId();
         for (int i = 1; i <= limit; ++i) {
           if (i != 13 && ItemDatabase.getItemDataName(i) != null) {
             list.add(DataTypes.makeItemValue(i, true));
           }
         }
-        break;
-      case LOCATION:
-        this.addValues(list, AdventureDatabase.getAsLockableListModel());
-        break;
-      case CLASS:
-        this.addValues(list, AscensionClass.allClasses());
-        break;
-      case STAT:
-        this.addValues(list, DataTypes.STAT_ARRAY, 0, 3);
-        break;
-      case SKILL:
-        this.addValues(list, SkillDatabase.entrySet());
-        break;
-      case EFFECT:
-        this.addValues(list, EffectDatabase.entrySet());
-        break;
-      case FAMILIAR:
-        this.addValues(list, FamiliarDatabase.entrySet());
-        break;
-      case SLOT:
-        this.addValues(list, SlotSet.NAMES);
-        break;
-      case MONSTER:
-        this.addValues(list, MonsterDatabase.valueSet());
-        break;
-      case ELEMENT:
-        this.addValues(list, MonsterDatabase.ELEMENT_ARRAY, 1, -1);
-        break;
-      case COINMASTER:
-        this.addValues(list, CoinmasterRegistry.MASTERS);
-        break;
-      case PHYLUM:
-        this.addValues(list, MonsterDatabase.PHYLUM_ARRAY, 1, -1);
-        break;
-      case BOUNTY:
-        this.addValues(list, BountyDatabase.entrySet());
-        break;
-      case THRALL:
-        this.addValues(list, PastaThrallData.THRALL_ARRAY);
-        break;
-      case SERVANT:
-        this.addValues(list, EdServantData.SERVANT_ARRAY);
-        break;
-      case VYKEA:
-        this.addValues(list, VYKEACompanionData.VYKEA);
-        break;
-      case PATH:
-        this.addValues(list, Path.allPaths());
-        break;
-      case MODIFIER:
-        this.addValues(list, ModifierDatabase.allModifiers());
-        break;
-      default:
+      }
+      case LOCATION -> this.addValues(list, AdventureDatabase.getAsLockableListModel());
+      case CLASS -> this.addValues(list, AscensionClass.allClasses());
+      case STAT -> this.addValues(list, DataTypes.STAT_ARRAY, 0, 3);
+      case SKILL -> this.addValues(list, SkillDatabase.entrySet());
+      case EFFECT -> this.addValues(list, EffectDatabase.entrySet());
+      case FAMILIAR -> this.addValues(list, FamiliarDatabase.entrySet());
+      case SLOT -> this.addValues(list, SlotSet.NAMES);
+      case MONSTER -> this.addValues(list, MonsterDatabase.valueSet());
+      case ELEMENT -> this.addValues(list, MonsterDatabase.ELEMENT_ARRAY, 1, -1);
+      case COINMASTER -> this.addValues(list, CoinmasterRegistry.MASTERS);
+      case PHYLUM -> this.addValues(list, MonsterDatabase.PHYLUM_ARRAY, 1, -1);
+      case BOUNTY -> this.addValues(list, BountyDatabase.entrySet());
+      case THRALL -> this.addValues(list, PastaThrallData.THRALL_ARRAY);
+      case SERVANT -> this.addValues(list, EdServantData.SERVANT_ARRAY);
+      case VYKEA -> this.addValues(list, VYKEACompanionData.VYKEA);
+      case PATH -> this.addValues(list, Path.allPaths());
+      case MODIFIER -> this.addValues(list, ModifierDatabase.allModifiers());
+      default -> {
         return null;
+      }
     }
     this.allValues = new PluralValue(this, list);
     return this.allValues;

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
@@ -21,6 +21,7 @@ import net.sourceforge.kolmafia.persistence.BountyDatabase;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
 import net.sourceforge.kolmafia.persistence.FamiliarDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
+import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import net.sourceforge.kolmafia.persistence.SkillDatabase;
 import net.sourceforge.kolmafia.textui.AshRuntime;
@@ -121,6 +122,9 @@ public class Type extends Symbol {
     if (this.equals(DataTypes.STAT_TYPE)) {
       return ProxyRecordValue.StatProxy._type;
     }
+    if (this.equals(DataTypes.MODIFIER_TYPE)) {
+      return ProxyRecordValue.ModifierProxy._type;
+    }
     return this;
   }
 
@@ -157,6 +161,7 @@ public class Type extends Symbol {
       case SERVANT -> DataTypes.SERVANT_INIT;
       case VYKEA -> DataTypes.VYKEA_INIT;
       case PATH -> DataTypes.PATH_INIT;
+      case MODIFIER -> DataTypes.MODIFIER_INIT;
       default -> null;
     };
   }
@@ -184,6 +189,7 @@ public class Type extends Symbol {
       case SERVANT -> DataTypes.parseServantValue(name, returnDefault);
       case VYKEA -> DataTypes.parseVykeaValue(name, returnDefault);
       case PATH -> DataTypes.parsePathValue(name, returnDefault);
+      case MODIFIER -> DataTypes.parseModifierValue(name, returnDefault);
       default -> null;
     };
   }
@@ -213,6 +219,7 @@ public class Type extends Symbol {
       case PHYLUM -> DataTypes.PHYLUM_INIT;
       case BOUNTY -> DataTypes.BOUNTY_INIT;
       case VYKEA -> DataTypes.VYKEA_INIT;
+      case MODIFIER -> DataTypes.MODIFIER_INIT;
       default -> null;
     };
   }
@@ -397,6 +404,9 @@ public class Type extends Symbol {
         break;
       case PATH:
         this.addValues(list, Path.allPaths());
+        break;
+      case MODIFIER:
+        this.addValues(list, ModifierDatabase.allModifiers());
         break;
       default:
         return null;

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Value.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Value.java
@@ -7,6 +7,7 @@ import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.VYKEACompanionData;
+import net.sourceforge.kolmafia.modifiers.Modifier;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
@@ -97,6 +98,10 @@ public class Value implements TypedNode, Comparable<Value> {
 
   public Value(final Path path) {
     this(DataTypes.PATH_TYPE, path.getId(), path.getName(), path);
+  }
+
+  public Value(final Modifier modifier) {
+    this(DataTypes.MODIFIER_TYPE, modifier.getName(), modifier);
   }
 
   public Value toFloatValue() {
@@ -218,6 +223,7 @@ public class Value implements TypedNode, Comparable<Value> {
       case PHYLUM -> new ProxyRecordValue.PhylumProxy(this);
       case STAT -> new ProxyRecordValue.StatProxy(this);
       case SLOT -> new ProxyRecordValue.SlotProxy(this);
+      case MODIFIER -> new ProxyRecordValue.ModifierProxy(this);
       default -> this;
     };
   }

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -1127,5 +1127,24 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
       String output = execute(input);
       assertThat(output, startsWith("string modifier required"));
     }
+
+    @Test
+    void parsesModifierString() {
+      String input =
+          "split_modifiers(\"Meat Drop: 25, Hot Resistance: 2, Cold Resistance: 2, Unarmed, Cold Damage: 10, Cold Spell Damage: 10\")";
+      String output = execute(input);
+      assertThat(
+          output,
+          is(
+              """
+                 Returned: aggregate string [modifier]
+                 Cold Damage => 10
+                 Cold Resistance => 2
+                 Cold Spell Damage => 10
+                 Hot Resistance => 2
+                 Meat Drop => 25
+                 Unarmed =>
+                 """));
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -1006,6 +1006,14 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
     }
 
     @Test
+    void canGetAllModifiers() {
+      String input = "$modifiers[]";
+      String output = execute(input);
+      assertThat(output, containsString("Four Songs"));
+      assertThat(output, containsString("Meat Drop"));
+    }
+
+    @Test
     void canCallNumericWithModifier() {
       String input = "numeric_modifier($item[ring of the Skeleton Lord], $modifier[Meat Drop])";
       String output = execute(input);

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 
 import internal.helpers.Cleanups;
 import internal.helpers.HttpClientWrapper;
@@ -985,6 +986,146 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
         String output = execute(input);
         assertThat(output, containsString(chance));
       }
+    }
+  }
+
+  @Nested
+  class Modifier {
+    @Test
+    void canGetRecord() {
+      String input = "$modifier[meat drop]";
+      String output = execute(input);
+      assertThat(
+          output,
+          is(
+              """
+                 Returned: Meat Drop
+                 name => Meat Drop
+                 type => numeric
+                 """));
+    }
+
+    @Test
+    void canCallNumericWithModifier() {
+      String input = "numeric_modifier($item[ring of the Skeleton Lord], $modifier[Meat Drop])";
+      String output = execute(input);
+      assertThat(output, is("""
+                 Returned: 50.0
+                 """));
+    }
+
+    @Test
+    void numericErrorsWithWrongModifierType() {
+      String input = "numeric_modifier($item[ring of the Skeleton Lord], $modifier[Unarmed])";
+      String output = execute(input);
+      assertThat(output, startsWith("numeric modifier required"));
+    }
+
+    @Test
+    void canCallBooleanWithModifier() {
+      String input = "boolean_modifier($item[Brimstone Beret], $modifier[Four Songs])";
+      String output = execute(input);
+      assertThat(output, is("""
+                 Returned: true
+                 """));
+    }
+
+    @Test
+    void booleanErrorsWithWrongModifierType() {
+      String input = "boolean_modifier($item[Brimstone Beret], $modifier[Moxie])";
+      String output = execute(input);
+      assertThat(output, startsWith("boolean modifier required"));
+    }
+
+    @Test
+    void canCallStringWithModifier() {
+      String input = "string_modifier(\"Sign:Marmot\", $modifier[Modifiers])";
+      String output = execute(input);
+      assertThat(
+          output,
+          is(
+              """
+                 Returned: Experience Percent (Moxie): +10, Cold Resistance: +1, Hot Resistance: +1, Sleaze Resistance: +1, Spooky Resistance: +1, Stench Resistance: +1
+                 """));
+    }
+
+    @Test
+    void stringErrorsWithWrongModifierType() {
+      String input = "string_modifier(\"Sign:Marmot\", $modifier[Cold Resistance])";
+      String output = execute(input);
+      assertThat(output, startsWith("string modifier required"));
+    }
+
+    @Test
+    void canCallEffectWithModifier() {
+      String input = "effect_modifier($item[blackberry polite], $modifier[Effect])";
+      String output = execute(input);
+      assertThat(output, startsWith("Returned: Blackberry Politeness"));
+    }
+
+    @Test
+    void effectErrorsWithWrongModifierType() {
+      String input = "effect_modifier($item[blackberry polite], $modifier[Meat Drop])";
+      String output = execute(input);
+      assertThat(output, startsWith("string modifier required"));
+    }
+
+    @Test
+    void canCallClassWithModifier() {
+      String input = "class_modifier($item[chintzy noodle ring], $modifier[Class])";
+      String output = execute(input);
+      assertThat(output, startsWith("Returned: Pastamancer"));
+    }
+
+    @Test
+    void classErrorsWithWrongModifierType() {
+      String input = "class_modifier($item[chintzy noodle ring], $modifier[Muscle])";
+      String output = execute(input);
+      assertThat(output, startsWith("string modifier required"));
+    }
+
+    @Test
+    void canCallSkillWithModifier() {
+      String input = "skill_modifier($item[alien source code printout], $modifier[Skill])";
+      String output = execute(input);
+      assertThat(output, startsWith("Returned: Alien Source Code"));
+    }
+
+    @Test
+    void skillErrorsWithWrongModifierType() {
+      String input = "skill_modifier($item[alien source code printout], $modifier[Maximum MP])";
+      String output = execute(input);
+      assertThat(output, startsWith("string modifier required"));
+    }
+
+    @Test
+    void canCallStatWithModifier() {
+      String input = "stat_modifier($effect[Stabilizing Oiliness], $modifier[Equalize])";
+      String output = execute(input);
+      assertThat(output, is("""
+                 Returned: Muscle
+                 """));
+    }
+
+    @Test
+    void statErrorsWithWrongModifierType() {
+      String input = "stat_modifier($effect[Stabilizing Oiliness], $modifier[Muscle])";
+      String output = execute(input);
+      assertThat(output, startsWith("string modifier required"));
+    }
+
+    @Test
+    void canCallMonsterWithModifier() {
+      String input = "monster_modifier($effect[A Lovely Day for a Beatnik], $modifier[Avatar])";
+      String output = execute(input);
+      assertThat(output, startsWith("Returned: Savage Beatnik"));
+    }
+
+    @Test
+    void monsterErrorsWithWrongModifierType() {
+      String input = "monster_modifier($effect[A Lovely Day for a Beatnik], $modifier[Muscle])";
+      String output = execute(input);
+      assertThat(output, startsWith("string modifier required"));
     }
   }
 }


### PR DESCRIPTION
As suggested in #1797, add a `$modifier` type.

The main downside is that `modifier` is used as a variable name in a few common scripts (e.g. some of Ezandora's (Gain, Bastille, Helix Fossil), garbage-collector), and these would need adjusting.

The main upside is improved comprehensibility for modifier code.

Modifiers have a name (same as the string you would previously use), and a type, which is one of "numeric", "string" or "boolean". This tells you which of the other methods you should use to get the value (and what the value is -- float, string or boolean respectively).

Also add a function `split_modifiers` which takes a modifier string (e.g. the string from `$location[].pledge_allegiance`) and returns a map of modifier to string. This can then be parsed, using the types, to extract the values.