### PR TITLE
When 'dump' composite result of 'ash' command, entity encode values

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -3238,7 +3238,11 @@ public abstract class RuntimeLibrary {
     Value[] keys = obj.keys();
     for (Value key : keys) {
       Value v = obj.aref(key);
-      String line = indent + key + " => " + v;
+      String value = v.toString();
+      if (!addToSessionStream) {
+        value = StringUtilities.getEntityEncode(value);
+      }
+      String line = indent + key + " => " + value;
 
       if (addToSessionStream) {
         RuntimeLibrary.print(new AshRuntime(), new Value(line), color);


### PR DESCRIPTION
Previous:

```
> ash git_info("Veracity0-spacegate")

Returned: record {string url; string branch; string commit; string last_changed_author; string last_changed_date;}
url => https://github.com/Veracity0/spacegate.git
branch => main
commit => 897cbf723cf571e9f48e1ea359b0a8cec04ea509
last_changed_author => Veracity0 83725298+Veracity0@users.noreply.github.com>
83725298+Veracity0@users.noreply.github.com>last_changed_date => Thu Mar 23 10:03:55 2023 GMT-04:00
```

Now:

```
> ash git_info("Veracity0-spacegate")

Returned: record {string url; string branch; string commit; string last_changed_author; string last_changed_date;}
url => https://github.com/Veracity0/spacegate.git
branch => main
commit => 897cbf723cf571e9f48e1ea359b0a8cec04ea509
last_changed_author => Veracity0 <83725298+Veracity0@users.noreply.github.com>
last_changed_date => Thu Mar 23 10:03:55 2023 GMT-04:00
```