### PR TITLE
Improve /q. Allow ping tests to (events) and (status)

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -107,6 +107,7 @@ global	pingLoginGoal	0
 global	pingLoginThreshold	0.2
 global	pingLongest
 global	pingShortest
+global	pingStealthyTimein	false
 global	pingTestPage	api.php
 global	pingTestPings	10
 global	previousNotifyList	<>

--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -1617,7 +1617,11 @@ public abstract class KoLmafia {
    * Utility. The method used to decode a saved password. This should be called whenever a new
    * password intends to be stored in the global file.
    */
-  public static final String getSaveState(final String loginname) {
+  public static final String getSaveState(String loginname) {
+    if (loginname.contains("/q")) {
+      loginname = StringUtilities.globalStringReplace(loginname, "/q", "");
+    }
+
     String password = Preferences.getString(loginname, "saveState");
     if (password == null || password.length() == 0 || password.contains("/")) {
       return null;

--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -752,6 +752,10 @@ public class GenericRequest implements Runnable {
     return this.formURLString;
   }
 
+  public String getPage() {
+    return this.baseURLString;
+  }
+
   public String getBasePath() {
     String path = this.formURLString;
     if (path == null) {

--- a/src/net/sourceforge/kolmafia/session/PingManager.java
+++ b/src/net/sourceforge/kolmafia/session/PingManager.java
@@ -20,12 +20,22 @@ public class PingManager {
     private long high = 0L;
     private long bytes = 0L;
 
+    private static String normalizePage(String page) {
+      // Backwards compatibility; we no longer save ".php",
+      // but saved properties may include it.
+      int php = page.indexOf(".php");
+      if (php != -1) {
+        page = page.substring(0, php);
+      }
+      return page;
+    }
+
     public PingTest() {
-      this("api.php");
+      this("api");
     }
 
     public PingTest(String page) {
-      this.page = page;
+      this.page = normalizePage(page);
     }
 
     private PingTest(String page, long count, long total, long low, long high, long bytes) {
@@ -105,9 +115,9 @@ public class PingManager {
     }
 
     public boolean isSaveable() {
-      String defaultPage = Preferences.getString("pingDefaultTestPage");
-      int defaultPings = Preferences.getInteger("pingDefaultTestPings");
-      return this.page.equals(defaultPage) && this.count >= defaultPings;
+      String defaultPage = normalizePage(Preferences.getString("pingDefaultTestPage"));
+
+      return this.getPage().equals(defaultPage);
     }
 
     public void save() {
@@ -116,8 +126,7 @@ public class PingManager {
       // Always save the last ping results
       Preferences.setString("pingLatest", value);
 
-      // Only save in historical properties if we tested the default
-      // page and there are enough pings.
+      // Only save in historical properties if we tested the default page
       if (!this.isSaveable()) {
         return;
       }
@@ -146,14 +155,14 @@ public class PingManager {
     public static PingTest parseProperty(String property) {
       String value = Preferences.getString(property);
       String[] values = value.split(":");
-      String page = "api.php";
+      String page = "api";
       long count = 0L;
       long low = 0L;
       long high = 0L;
       long total = 0L;
       long bytes = 0L;
       if (values.length >= 4) {
-        page = values[0];
+        page = normalizePage(values[0]);
         count = StringUtilities.parseLong(values[1]);
         low = StringUtilities.parseLong(values[2]);
         high = StringUtilities.parseLong(values[3]);

--- a/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
@@ -180,7 +180,14 @@ public class OptionsFrame extends GenericFrame {
         super();
         this.queue(
             new PreferenceButtonGroup(
-                "pingTestPage", "KoL page to ping: ", true, "api.php", "council.php", "main.php"));
+                "pingTestPage",
+                "KoL page to ping: ",
+                true,
+                "api",
+                "(events)",
+                "(status)",
+                "council",
+                "main"));
         this.queue(
             new PreferenceIntegerTextField(
                 "pingTestPings", 4, "How many times to ping that page."));

--- a/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
@@ -29,9 +29,11 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
             "pingDefaultTestPage",
             "KoL page to ping: ",
             true,
-            "api.php",
-            "council.php",
-            "main.php"));
+            "api",
+            "(events)",
+            "(status)",
+            "council",
+            "main"));
     this.queue(
         new PreferenceIntegerTextField(
             "pingDefaultTestPings", 4, "How many times to ping that page."));
@@ -46,8 +48,15 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
         new PreferenceIntegerTextField(
             "pingLoginCount", 4, "Attempted ping checks before giving up"));
     this.queue(
+        new PreferenceCheckBox(
+            "pingStealthyTimein", "When timing in to reconnect, use stealth mode (/q)"));
+    this.queue(
         new PreferenceButtonGroup(
-            "pingLoginFail", "Action after failed ping check: ", true, "login", "logout"));
+            "pingLoginFail",
+            "Action after failed sequence of ping checks: ",
+            true,
+            "login",
+            "logout"));
 
     this.makeLayout();
   }

--- a/src/net/sourceforge/kolmafia/textui/command/PingCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/PingCommand.java
@@ -10,7 +10,7 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 public class PingCommand extends AbstractCommand {
   public PingCommand() {
     this.usage =
-        " [count [(api|council|main) [verbose]]] - run a ping test with specified number of pings";
+        " [count [(api|status|events|council|main) [verbose]]] - run a ping test with specified number of pings";
   }
 
   @Override
@@ -27,13 +27,18 @@ public class PingCommand extends AbstractCommand {
         count = StringUtilities.parseInt(countString);
       }
       if (split.length > 1) {
-        switch (split[1]) {
+        String target = split[1];
+        switch (target) {
           case "api", "council", "main" -> {
-            page = split[1] + ".php";
+            // PingManager does not require .php any more.
+            page = target;
+          }
+          case "events", "status" -> {
+            page = "(" + target + ")";
           }
           default -> {
             KoLmafia.updateDisplay(
-                MafiaState.ERROR, "'" + split[1] + "' is not a valid page to ping.");
+                MafiaState.ERROR, "'" + target + "' is not a valid page to ping.");
             return;
           }
         }

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -1170,7 +1170,7 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
             is(
                 """
               Returned: record {string page; int count; int low; int high; int total; int bytes; int average; int bps;}
-              page => api.php
+              page => api
               count => 10
               low => 26
               high => 31


### PR DESCRIPTION
1) Fixed login command to allow /q
   Finds saved password for name without /q
   LoginRequest obeys /q

2) Preference pingStealthyTimein (boolean) specifies whether logging in with same request (e.g. timing in) uses /q
   (Stealth mode checkbox - stealthLogin - still works))
   You can manipulate this property in Connection Options in either LoginFrame or Preferences/General

3) When redirect, store base URL only as page;
   afterlife.php?realworld-1 -> afterlife.php

4) Changed saved ping page to be "api", "council", or "main". I.e., without the .php
   I attempted backwards compatibility with historical properties which have the page listed with .php; strip it off when read property, omit it when write property.
   Add (events) and (status) as available ping pages.
       api.php?what=events&for=KoLmafia
       api.php?what=status&for=KoLmafia
   In the "ping" command, page keywords are api, events, status, council, and main
   Irrat's script does the equivalent of "ping 5 events"

5) When a ping is redirected, redirect to the full URL, but save the page as just the form. So, "afterlife.php?realworld=1" (which I assume is the page if you have not yet entered Valhalla) will save the last ping as "afterlife.php".
Which we have no specific support for.
This is untested. I'd like to see it myself. Maybe in a week.