### PR TITLE
Record Literals

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -34,6 +34,7 @@ import net.sourceforge.kolmafia.textui.parsetree.BasicScript;
 import net.sourceforge.kolmafia.textui.parsetree.Catch;
 import net.sourceforge.kolmafia.textui.parsetree.Command;
 import net.sourceforge.kolmafia.textui.parsetree.CompositeReference;
+import net.sourceforge.kolmafia.textui.parsetree.CompositeType;
 import net.sourceforge.kolmafia.textui.parsetree.Concatenate;
 import net.sourceforge.kolmafia.textui.parsetree.Conditional;
 import net.sourceforge.kolmafia.textui.parsetree.Else;
@@ -59,6 +60,7 @@ import net.sourceforge.kolmafia.textui.parsetree.Operation;
 import net.sourceforge.kolmafia.textui.parsetree.Operator;
 import net.sourceforge.kolmafia.textui.parsetree.ParseTreeNode.TypedNode;
 import net.sourceforge.kolmafia.textui.parsetree.PluralValue;
+import net.sourceforge.kolmafia.textui.parsetree.RecordLiteral;
 import net.sourceforge.kolmafia.textui.parsetree.RecordType;
 import net.sourceforge.kolmafia.textui.parsetree.RecordType.BadRecordType;
 import net.sourceforge.kolmafia.textui.parsetree.RepeatUntilLoop;
@@ -604,9 +606,8 @@ public class Parser {
       }
 
       if (this.currentToken().equals("{")) {
-        if (t.getBaseType() instanceof AggregateType) {
-          result.addCommand(
-              this.parseAggregateLiteral(result, (AggregateType) t.getBaseType()), this);
+        if (t.getBaseType() instanceof CompositeType ct) {
+          result.addCommand(this.parseCompositeLiteral(result, ct), this);
         } else {
           if (!t.isBad()) {
             nodeErrors.submitError(
@@ -615,7 +616,7 @@ public class Parser {
                     "Aggregate type required to make an aggregate literal"));
           }
 
-          this.parseAggregateLiteral(result, badAggregateType());
+          this.parseCompositeLiteral(result, badAggregateType());
         }
       } else {
         // Found a type but no function or variable to tie it to
@@ -768,6 +769,126 @@ public class Parser {
     }
 
     return rec;
+  }
+
+  /**
+   * Parses the content of a record literal, e.g., `{name:"Judy", age:40, married:false}`.
+   *
+   * <p>The presence of the opening bracket "{" is ALWAYS assumed when entering this method, and as
+   * such, MUST be checked before calling it. This method will never return null.
+   */
+  private Evaluable parseRecordLiteral(final BasicScope scope, final RecordType rec)
+      throws InterruptedException {
+    final ErrorManager recordLiteralErrors = new ErrorManager();
+
+    Token recordLiteralStartToken = this.currentToken();
+
+    this.readToken(); // read {
+
+    List<String> keys = new ArrayList<>();
+    List<Evaluable> values = new ArrayList<>();
+
+    Position previousPosition = null;
+    while (this.madeProgress(previousPosition, previousPosition = this.getCurrentPosition())) {
+      if (this.atEndOfFile()) {
+        recordLiteralErrors.submitSyntaxError(this.unexpectedTokenError("}", this.currentToken()));
+        break;
+      }
+
+      if (this.currentToken().equals("}")) {
+        if (keys.isEmpty()) {
+          recordLiteralErrors.submitError(
+              this.error(this.currentToken(), "Record field(s) expected"));
+        }
+
+        this.readToken(); // read }
+        break;
+      }
+
+      // Get a field name
+      Token fieldName = this.currentToken();
+      if (fieldName.equals(":")) {
+        recordLiteralErrors.submitSyntaxError(this.error(fieldName, "Field name expected"));
+        // don't read
+      } else if (!this.parseIdentifier(fieldName.content)) {
+        recordLiteralErrors.submitSyntaxError(
+            this.error(fieldName, "Invalid field name '" + fieldName + "'"));
+        // don't read
+      } else if (keys.contains(fieldName)) {
+        recordLiteralErrors.submitError(
+            this.error(fieldName, "Field name '" + fieldName + "' is already defined"));
+        this.readToken(); // read field name
+      } else {
+        this.readToken(); // read field name
+      }
+
+      // The "key" must be a valid field name
+      Value fieldIndex = rec.getFieldIndex(fieldName.content);
+      if (fieldIndex == null) {
+        recordLiteralErrors.submitSyntaxError(this.error(fieldName, "Invalid field name"));
+      }
+
+      if (this.currentToken().equals(":")) {
+        this.readToken(); // read :
+      } else {
+        recordLiteralErrors.submitSyntaxError(this.unexpectedTokenError(":", this.currentToken()));
+      }
+
+      Type dataType = rec.getDataType(fieldIndex);
+      Evaluable rhs;
+
+      if (this.currentToken().equals("{")) {
+        if (dataType instanceof CompositeType ct) {
+          rhs = this.parseCompositeLiteral(scope, ct);
+        } else {
+          rhs = this.parseCompositeLiteral(scope, badAggregateType());
+        }
+      } else {
+        rhs = this.parseExpression(scope);
+      }
+
+      if (rhs == null) {
+        Location errorLocation = this.makeLocation(this.currentToken());
+
+        recordLiteralErrors.submitSyntaxError(
+            this.error(
+                errorLocation,
+                "Script parsing error; couldn't figure out value of record field value"));
+
+        rhs = Value.locate(errorLocation, Value.BAD_VALUE);
+      }
+
+      // Check that value is valid via validCoercion
+      rhs = this.autoCoerceValue(dataType, rhs, scope);
+
+      if (!Operator.validCoercion(dataType, rhs.getType(), "assign")) {
+        recordLiteralErrors.submitError(
+            this.error(
+                rhs.getLocation(),
+                "Invalid record literal; cannot assign value of type "
+                    + rhs.getType().toString()
+                    + " to field of type "
+                    + dataType.toString()));
+      }
+
+      keys.add(fieldName.content);
+      values.add(rhs);
+
+      // Move on to the next value
+      if (this.currentToken().equals(",")) {
+        this.readToken(); // read ,
+      } else if (!this.currentToken().equals("}")) {
+        recordLiteralErrors.submitSyntaxError(this.unexpectedTokenError("}", this.currentToken()));
+      }
+    }
+
+    Location recordLiteralLocation =
+        this.makeLocation(recordLiteralStartToken, this.peekPreviousToken());
+
+    Value result =
+        recordLiteralErrors.sawError() ? Value.BAD_VALUE : new RecordLiteral(rec, keys, values);
+
+    return Value.locate(recordLiteralLocation, result);
   }
 
   private Function parseFunction(final Type functionType, final Scope parentScope)
@@ -1002,8 +1123,8 @@ public class Parser {
     Type t = lhs.target.getType();
     Type ltype = t.getBaseType();
     if (this.currentToken().equals("{")) {
-      if (ltype instanceof AggregateType) {
-        result = this.parseAggregateLiteral(scope, (AggregateType) ltype);
+      if (ltype instanceof CompositeType ct) {
+        result = this.parseCompositeLiteral(scope, ct);
       } else {
         if (!ltype.isBad()) {
           Location errorLocation = this.makeLocation(this.currentToken());
@@ -1011,10 +1132,10 @@ public class Parser {
           initializationErrors.submitError(
               this.error(
                   errorLocation,
-                  "Cannot initialize " + lhs + " of type " + t + " with an aggregate literal"));
+                  "Cannot initialize " + lhs + " of type " + t + " with a composite literal"));
         }
 
-        result = this.parseAggregateLiteral(scope, badAggregateType());
+        result = this.parseCompositeLiteral(scope, badAggregateType());
       }
     } else {
       result = this.parseExpression(scope);
@@ -1303,6 +1424,23 @@ public class Parser {
   }
 
   /**
+   * Parses the content of a composite literal: array, map, or record
+   *
+   * <p>The presence of the opening bracket "{" is ALWAYS assumed when entering this method, and as
+   * such, MUST be checked before calling it. This method will never return null.
+   */
+  private Evaluable parseCompositeLiteral(final BasicScope scope, final Type comp)
+      throws InterruptedException {
+    if (comp instanceof AggregateType at) {
+      return this.parseAggregateLiteral(scope, at);
+    }
+    if (comp instanceof RecordType rt) {
+      return this.parseRecordLiteral(scope, rt);
+    }
+    return null;
+  }
+
+  /**
    * Parses the content of an aggregate literal, e.g., `{1:true, 2:false, 3:false}`.
    *
    * <p>The presence of the opening bracket "{" is ALWAYS assumed when entering this method, and as
@@ -1357,8 +1495,8 @@ public class Parser {
                   this.currentToken(), "Expected a key of type " + index + ", found an aggregate"));
         }
 
-        if (dataType instanceof AggregateType) {
-          lhs = this.parseAggregateLiteral(scope, (AggregateType) dataType);
+        if (dataType instanceof CompositeType ct) {
+          lhs = this.parseCompositeLiteral(scope, ct);
         } else {
           if (!aggr.isBad()) {
             Location errorLocation = this.makeLocation(this.currentToken());
@@ -1366,10 +1504,10 @@ public class Parser {
             aggregateLiteralErrors.submitError(
                 this.error(
                     errorLocation,
-                    "Expected an element of type " + dataType.toString() + ", found an aggregate"));
+                    "Expected an element of type " + dataType.toString() + ", found a composite"));
           }
 
-          lhs = this.parseAggregateLiteral(scope, badAggregateType());
+          lhs = this.parseCompositeLiteral(scope, badAggregateType());
         }
       } else {
         lhs = this.parseExpression(scope);
@@ -1450,8 +1588,8 @@ public class Parser {
       Evaluable rhs;
 
       if (this.currentToken().equals("{")) {
-        if (dataType instanceof AggregateType) {
-          rhs = this.parseAggregateLiteral(scope, (AggregateType) dataType);
+        if (dataType instanceof CompositeType ct) {
+          rhs = this.parseCompositeLiteral(scope, ct);
         } else {
           if (!aggr.isBad()) {
             Location errorLocation = this.makeLocation(this.currentToken());
@@ -1459,10 +1597,10 @@ public class Parser {
             aggregateLiteralErrors.submitError(
                 this.error(
                     errorLocation,
-                    "Expected a value of type " + dataType.toString() + ", found an aggregate"));
+                    "Expected a value of type " + dataType.toString() + ", found a composite"));
           }
 
-          rhs = this.parseAggregateLiteral(scope, badAggregateType());
+          rhs = this.parseCompositeLiteral(scope, badAggregateType());
         }
       } else {
         rhs = this.parseExpression(scope);
@@ -3058,19 +3196,19 @@ public class Parser {
         if (this.currentToken().equals(",")) {
           val = Value.locate(this.makeZeroWidthLocation(), DataTypes.VOID_VALUE);
         } else if (this.currentToken().equals("{")) {
-          if (expected instanceof AggregateType) {
-            val = this.parseAggregateLiteral(scope, (AggregateType) expected);
+          if (expected instanceof CompositeType ct) {
+            val = this.parseCompositeLiteral(scope, ct);
           } else {
             fieldErrors.submitError(
                 this.error(
                     this.currentToken(),
-                    "Aggregate literal found when "
+                    "Composite literal found when "
                         + expected
                         + " expected for field #"
                         + (param + 1)
                         + errorMessageFieldName));
 
-            val = this.parseAggregateLiteral(scope, badAggregateType());
+            val = this.parseCompositeLiteral(scope, badAggregateType());
           }
         } else {
           val = this.parseExpression(scope);
@@ -3355,11 +3493,11 @@ public class Parser {
     final ErrorManager assignmentErrors = new ErrorManager();
 
     Type ltype = lhs.getType().getBaseType();
-    boolean isAggregate = (ltype instanceof AggregateType);
+    boolean isComposite = (ltype instanceof CompositeType);
 
-    if (isAggregate && !operStr.equals("=")) {
+    if (isComposite && !operStr.equals("=")) {
       assignmentErrors.submitError(
-          this.error(operStr, "Cannot use '" + operStr + "' on an aggregate"));
+          this.error(operStr, "Cannot use '" + operStr + "' on a composite"));
     }
 
     Operator oper = new Operator(this.makeLocation(operStr), operStr.content, this);
@@ -3368,15 +3506,15 @@ public class Parser {
     Evaluable rhs;
 
     if (this.currentToken().equals("{")) {
-      if (isAggregate) {
-        rhs = this.parseAggregateLiteral(scope, (AggregateType) ltype);
+      if (isComposite) {
+        rhs = this.parseCompositeLiteral(scope, (CompositeType) ltype);
       } else {
         Location errorLocation = this.makeLocation(this.currentToken());
 
         assignmentErrors.submitError(
-            this.error(errorLocation, "Cannot use an aggregate literal for type " + lhs.getType()));
+            this.error(errorLocation, "Cannot use a composite literal for type " + lhs.getType()));
 
-        rhs = this.parseAggregateLiteral(scope, badAggregateType());
+        rhs = this.parseCompositeLiteral(scope, badAggregateType());
       }
     } else {
       rhs = this.parseExpression(scope);

--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -814,9 +814,9 @@ public class Parser {
         recordLiteralErrors.submitSyntaxError(
             this.error(fieldName, "Invalid field name '" + fieldName + "'"));
         // don't read
-      } else if (keys.contains(fieldName)) {
+      } else if (keys.contains(fieldName.content)) {
         recordLiteralErrors.submitError(
-            this.error(fieldName, "Field name '" + fieldName + "' is already defined"));
+            this.error(fieldName, "Field name '" + fieldName + "' is already set"));
         this.readToken(); // read field name
       } else {
         this.readToken(); // read field name
@@ -825,7 +825,8 @@ public class Parser {
       // The "key" must be a valid field name
       Value fieldIndex = rec.getFieldIndex(fieldName.content);
       if (fieldIndex == null) {
-        recordLiteralErrors.submitSyntaxError(this.error(fieldName, "Invalid field name"));
+        recordLiteralErrors.submitSyntaxError(
+            this.error(fieldName, "Field name '" + fieldName + "' is not valid"));
       }
 
       if (this.currentToken().equals(":")) {

--- a/src/net/sourceforge/kolmafia/textui/parsetree/RecordLiteral.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/RecordLiteral.java
@@ -1,0 +1,62 @@
+package net.sourceforge.kolmafia.textui.parsetree;
+
+import java.util.Iterator;
+import java.util.List;
+import net.sourceforge.kolmafia.textui.AshRuntime;
+
+public class RecordLiteral extends RecordValue {
+  private RecordValue rec = null;
+  private final List<String> keys;
+  private final List<Evaluable> values;
+
+  public RecordLiteral(
+      final RecordType type, final List<String> keys, final List<Evaluable> values) {
+    super(type);
+    this.keys = keys;
+    this.values = values;
+  }
+
+  @Override
+  public Value aref(final Value key, final AshRuntime interpreter) {
+    return null;
+  }
+
+  @Override
+  public Value aref(final int index, final AshRuntime interpreter) {
+    return null;
+  }
+
+  @Override
+  public void aset(final Value key, final Value val, final AshRuntime interpreter) {
+    throw interpreter.runtimeException("Cannot assign to a record literal field");
+  }
+
+  @Override
+  public void aset(final int index, final Value val, final AshRuntime interpreter) {
+    throw interpreter.runtimeException("Cannot assign to a record literal field");
+  }
+
+  @Override
+  public Value remove(final Value key, final AshRuntime interpreter) {
+    throw interpreter.runtimeException("Cannot assign to a record literal field");
+  }
+
+  @Override
+  public void clear() {}
+
+  @Override
+  public Value execute(final AshRuntime interpreter) {
+    this.rec = (RecordValue) this.type.initialValue();
+
+    Iterator<String> keyIterator = this.keys.iterator();
+    Iterator<Evaluable> valIterator = this.values.iterator();
+
+    while (keyIterator.hasNext() && valIterator.hasNext()) {
+      Value key = this.getRecordType().getFieldIndex(keyIterator.next());
+      Value val = valIterator.next().execute(interpreter);
+      this.rec.aset(key, val);
+    }
+
+    return this.rec;
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/parsetree/AggregateLiteralTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/AggregateLiteralTest.java
@@ -167,7 +167,7 @@ public class AggregateLiteralTest {
         invalid(
             "Unexpected aggregate in array literal",
             "boolean[5]{ true, true, false, {true}, false }",
-            "Expected an element of type boolean, found an aggregate",
+            "Expected an element of type boolean, found a composite",
             // we currently can't read past the "{" before throwing the exception
             // "char 32 to char 38"),
             "char 32 to char 33",
@@ -187,7 +187,7 @@ public class AggregateLiteralTest {
         invalid(
             "Unexpected aggregate in map literal: as a value",
             "boolean[5]{ 0:true, 1:true, 2:false, 3:{true}, 4:false }",
-            "Expected a value of type boolean, found an aggregate",
+            "Expected a value of type boolean, found a composite",
             // we currently can't read past the "{" before throwing the exception
             // "char 40 to char 46"),
             "char 40 to char 41",

--- a/test/net/sourceforge/kolmafia/textui/parsetree/AssignmentTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/AssignmentTest.java
@@ -81,7 +81,7 @@ public class AssignmentTest {
             "Aggregate assignment to primitive",
             // What is this, C?
             "int x; x = {1};",
-            "Cannot use an aggregate literal for type int",
+            "Cannot use a composite literal for type int",
             // we currently can't read past the "{" before throwing the exception
             // "char 12 to char 15"),
             "char 12 to char 13"),
@@ -93,7 +93,7 @@ public class AssignmentTest {
         invalid(
             "Compound assignment to aggregate",
             "int[4] x; x += 1;",
-            "Cannot use '+=' on an aggregate",
+            "Cannot use '+=' on a composite",
             "char 13 to char 15"),
         valid(
             "Aggregate assignment to aggregate",
@@ -107,7 +107,7 @@ public class AssignmentTest {
         invalid(
             "brace assignment of primitive",
             "int x = {1}",
-            "Cannot initialize x of type int with an aggregate literal",
+            "Cannot initialize x of type int with a composite literal",
             // we currently can't read past the "{" before throwing the exception
             // "char 9 to char 12"),
             "char 9 to char 10",

--- a/test/net/sourceforge/kolmafia/textui/parsetree/RecordLiteralTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/RecordLiteralTest.java
@@ -1,0 +1,66 @@
+package net.sourceforge.kolmafia.textui.parsetree;
+
+import static net.sourceforge.kolmafia.textui.ScriptData.invalid;
+
+import java.util.stream.Stream;
+import net.sourceforge.kolmafia.textui.ParserTest;
+import net.sourceforge.kolmafia.textui.ScriptData;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class RecordLiteralTest {
+  public static Stream<ScriptData> data() {
+    return Stream.of(
+        invalid(
+            "Record fields expected",
+            "record r {int x;} rec = {}",
+            "Record field(s) expected",
+            "char 26 to char 27"),
+        invalid(
+            "Valid field name expected",
+            "record r {int x;} rec = {123",
+            "Invalid field name '123'",
+            "char 26 to char 29"),
+        invalid(
+            "Record field name expected",
+            "record r {int x;} rec = {:1}",
+            "Field name expected",
+            "char 26 to char 27"),
+        invalid(
+            "Defined record fields expected",
+            "record r {int x;} rec = {y:12}",
+            "Field name 'y' is not valid",
+            "char 26 to char 27"),
+        invalid(
+            "Non-duplicate record fields expected",
+            "record r {int x;} rec = {x:1, x:2}",
+            "Field name 'x' is already set",
+            "char 31 to char 32"),
+        invalid(
+            "Colon expected",
+            "record r {int x;} rec = {x}",
+            "Expected :, found }",
+            "char 27 to char 28"),
+        invalid(
+            "Value expected",
+            "record r {int x;} rec = {x:}",
+            "Script parsing error; couldn't figure out value of record field value",
+            "char 28 to char 29"),
+        invalid(
+            "Coercable value expected",
+            "record r {int x;} rec = {x:\"foo\"}",
+            "Invalid record literal; cannot assign value of type string to field of type int",
+            "char 28 to char 33"),
+        invalid(
+            "Comma or } expected",
+            "record r {int x;} rec = {x:1 y}",
+            "Expected }, found y",
+            "char 30 to char 31"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testScriptValidity(ScriptData script) {
+    ParserTest.testScriptValidity(script);
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/parsetree/RecordValueTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/RecordValueTest.java
@@ -62,7 +62,7 @@ public class RecordValueTest {
         invalid(
             "new with unexpected aggregate field",
             "record r {int a;}; new r({1,2});",
-            "Aggregate literal found when int expected for field #1 (a)",
+            "Composite literal found when int expected for field #1 (a)",
             // we currently can't read any further than the "{"
             // "char 26 to char 31"),
             "char 26 to char 27"),

--- a/test/root/expected/record_literals.ash.out
+++ b/test/root/expected/record_literals.ash.out
@@ -1,0 +1,11 @@
+point1: x = 1 y = 2
+point2: x = 13 y = 31
+point3: x = 3 y = 4
+pa1 has 3 points
+pa1[0]: x = 1 y = 2
+pa1[1]: x = 10 y = 20
+pa1[2]: x = 100 y = 200
+pm1 has 3 points
+pm1[1]: x = 1 y = 2
+pm1[3]: x = 10 y = 20
+pm1[5]: x = 100 y = 200

--- a/test/root/scripts/record_literals.ash
+++ b/test/root/scripts/record_literals.ash
@@ -1,0 +1,73 @@
+record Point
+{
+    int x;
+    int y;
+};
+
+Point printPoint(string name, Point p)
+{
+    print(name + ": x = " + p.x + " y = " + p.y);
+    return p;
+}
+
+Point point1 = { x: 1, y : 2 };
+Point point2 = new Point(13, 31);
+Point point3 = { y: 4, x : 3 };
+
+printPoint("point1", point1);
+printPoint("point2", point2);
+printPoint("point3", point3);
+
+record PointArray
+{
+    string name;
+    Point[] points;
+};
+
+PointArray printPointArray(PointArray pa)
+{
+    print(pa.name + " has " + count(pa.points) + " points");
+    foreach n, p in pa.points {
+	string id = pa.name + "[" + n + "]";
+	printPoint(id, p);
+    }
+    return pa;
+}
+
+PointArray pa1 = {
+ name : "pa1",
+ points : {
+     { x : 1, y : 2 },
+     new Point(10, 20),
+     { x : 100, y : 200 }
+ }
+};
+
+printPointArray(pa1);
+
+record PointMap
+{
+    string name;
+    Point[int] points;
+};
+
+PointMap printPointMap(PointMap pm)
+{
+    print(pm.name + " has " + count(pm.points) + " points");
+    foreach n, p in pm.points {
+	string id = pm.name + "[" + n + "]";
+	printPoint(id, p);
+    }
+    return pm;
+}
+
+PointMap pm1 = {
+ name : "pm1",
+ points : {
+    1 : { x : 1, y : 2 },
+    3 : new Point(10, 20),
+    5 : { x : 100, y : 200 }
+ }
+};
+
+printPointMap(pm1);


### PR DESCRIPTION
(I include the following under CustomScriptTest)

This script:
```
record Point
{
    int x;
    int y;
};

Point printPoint(string name, Point p)
{
    print(name + ": x = " + p.x + " y = " + p.y);
    return p;
}

Point point1 = { x: 1, y : 2 };
Point point2 = new Point(13, 31);
Point point3 = { y: 4, x : 3 };

printPoint("point1", point1);
printPoint("point2", point2);
printPoint("point3", point3);

record PointArray
{
    string name;
    Point[] points;
};

PointArray printPointArray(PointArray pa)
{
    print(pa.name + " has " + count(pa.points) + " points");
    foreach n, p in pa.points {
	string id = pa.name + "[" + n + "]";
	printPoint(id, p);
    }
    return pa;
}

PointArray pa1 = {
 name : "pa1",
 points : {
     { x : 1, y : 2 },
     new Point(10, 20),
     { x : 100, y : 200 }
 }
};

printPointArray(pa1);

record PointMap
{
    string name;
    Point[int] points;
};

PointMap printPointMap(PointMap pm)
{
    print(pm.name + " has " + count(pm.points) + " points");
    foreach n, p in pm.points {
	string id = pm.name + "[" + n + "]";
	printPoint(id, p);
    }
    return pm;
}

PointMap pm1 = {
 name : "pm1",
 points : {
    1 : { x : 1, y : 2 },
    3 : new Point(10, 20),
    5 : { x : 100, y : 200 }
 }
};

printPointMap(pm1);
```
yields:
```
point1: x = 1 y = 2
point2: x = 13 y = 31
point3: x = 3 y = 4
pa1 has 3 points
pa1[0]: x = 1 y = 2
pa1[1]: x = 10 y = 20
pa1[2]: x = 100 y = 200
pm1 has 3 points
pm1[1]: x = 1 y = 2
pm1[3]: x = 10 y = 20
pm1[5]: x = 100 y = 200
```
Note that I include record literals inside record literals and inside map and array literals, and vice versa.
Note that I demonstrate that a record literal is interchangeable with a "new REC(FIELDS...)" call.

Note lastly that I ran VMF today - which extensively uses map and array literals - with no compilation or execution errors.

I also created RecordLiteralTest to test all the error cases.