### PR TITLE
Add 'confirm' option on a ping check failure

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -102,7 +102,7 @@ global	pingLatest
 global	pingLogin	true
 global	pingLoginCheck	none
 global	pingLoginCount	0
-global	pingLoginFail	login
+global	pingLoginFail	confirm
 global	pingLoginGoal	0
 global	pingLoginThreshold	0.2
 global	pingLongest

--- a/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
@@ -53,10 +53,11 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
     this.queue(
         new PreferenceButtonGroup(
             "pingLoginFail",
-            "Action after failed sequence of ping checks: ",
+            "Action after ping check failure: ",
             true,
             "login",
-            "logout"));
+            "logout",
+            "confirm"));
 
     this.makeLayout();
   }


### PR DESCRIPTION
Now that KoL has rolled back (for now) their attempt to assign a new server to each request, login ping testing is again valuable. This PR provides (probably) the last feature it needs.

Once you have configured ping testing with either a goal or a threshold, you're probably good to go; odds are, you'll probably get a good server fairly soon. But, if you are using a mobile computer and connecting via different networks, the historical data we use to decide if you have a "good" connection may be inadequate; a slower network connection may not allow you to achieve a desire fixed "goal". If you have a "threshold" configured, you're probably still good - assuming you reset your historical data so that you can learn a new "average" ping that fits your new network.

This PR adds a new option for what to do on a "failed" ping test - one in which we re-tried the configured number of times but just couldn't get a good enough connection.

"confirm" will pop up a dialog in this case.

If you had a "goal" set, it will commiserate and point you to Preferences/General/Connection Options, and let you finish logging in after you click "OK".

If you had a "threshold" set, it will also mention that, perhaps, simply clearing your historical ping data will let KoLmafia re-learn it, as needed, from your current network. Again, it will point to Preferences/General/Connection Options, but will give you a Yes/No option to clear your historical ping data immediately.

It seems likely to me that a user with a "threshold" set could just click "Yes" and carry on without worrying about changing configuration. If you don't like the connection you ended up with, going to Connection Options and clicking "Time In" will try for a better connection - as will typing "timein" or "relogin" or "relog" into the gCLI.