### PR TITLE
pingLoginThreshold property. Calculate average pin in floating point.

### DIFF
--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -66,7 +66,8 @@ public class LoginManager {
 
     // The user wants to measure ping speed.
     var result = PingManager.runPingTest();
-    KoLmafia.updateDisplay("Ping test: average delay is " + result.getAverage() + " msecs.");
+    KoLmafia.updateDisplay(
+        "Ping test: average delay is " + Math.round(result.getAverage()) + " msecs.");
 
     // See if the Ping tested a suitable page
     if (!result.isSaveable()) {
@@ -76,7 +77,7 @@ public class LoginManager {
     }
 
     // See whether user wants to check ping speed.
-    long average = result.getAverage();
+    double average = result.getAverage();
     String checkType = Preferences.getString("pingLoginCheck");
     String error = "";
     switch (checkType) {
@@ -96,14 +97,14 @@ public class LoginManager {
         // The user wants to be "close" to the best ping seen.
         // Get the shortest ping test time we've seen. If the ping test we
         // just ran is the first, that will be it.
-        double threshold = 1.0 + Preferences.getFloat("pingLoginGood");
+        double threshold = 1.0 + Preferences.getDouble("pingLoginThreshold");
         var shortest = PingTest.parseProperty("pingShortest");
-        long desired = (long) Math.floor(shortest.getAverage() * threshold);
+        double desired = threshold * shortest.getAverage();
         if (average <= desired) {
           return true;
         }
         // Either no threshold is set or this connection is too slow.
-        error = "you want no more than " + String.valueOf(desired) + " msec";
+        error = "you want no more than " + String.valueOf(Math.round(desired)) + " msec";
         // Alert the user.
       }
       default -> {
@@ -207,13 +208,13 @@ public class LoginManager {
     return LoginRequest.relogin();
   }
 
-  private static StringBuilder reportFailure(long average, String error) {
+  private static StringBuilder reportFailure(double average, String error) {
     // Report a ping failure. The caller will decide how to craft a
     // dialog to report it to the user.
 
     StringBuilder buf = new StringBuilder();
     buf.append("This connection has an average ping time of ");
-    buf.append(String.valueOf(average));
+    buf.append(String.valueOf(Math.round(average)));
     buf.append(" msec");
     if (!error.equals("")) {
       buf.append(", but ");

--- a/src/net/sourceforge/kolmafia/session/PingManager.java
+++ b/src/net/sourceforge/kolmafia/session/PingManager.java
@@ -88,12 +88,12 @@ public class PingManager {
       return this.bytes;
     }
 
-    public long getAverage() {
-      return this.count == 0 ? 0 : this.total / this.count;
+    public double getAverage() {
+      return this.count == 0 ? 0 : (this.total * 1.0 / this.count);
     }
 
-    public long getBPS() {
-      return this.total == 0 ? 0 : (this.bytes * 1000) / this.total;
+    public double getBPS() {
+      return this.total == 0 ? 0 : (this.bytes * 1000.0) / this.total;
     }
 
     public String toString() {
@@ -109,8 +109,9 @@ public class PingManager {
       buf.append(String.valueOf(this.total));
       buf.append(":");
       buf.append(String.valueOf(this.getBytes()));
+      // Redundant, in that the user can calculate it from total & count
       buf.append(":");
-      buf.append(String.valueOf(this.getAverage()));
+      buf.append(String.valueOf(Math.round(this.getAverage())));
       return buf.toString();
     }
 
@@ -131,11 +132,11 @@ public class PingManager {
         return;
       }
 
-      long average = this.getAverage();
+      double average = this.getAverage();
       PingTest shortest = PingTest.parseProperty("pingShortest");
-      long shortestAverage = shortest.getAverage();
+      double shortestAverage = shortest.getAverage();
       PingTest longest = PingTest.parseProperty("pingLongest");
-      long longestAverage = longest.getAverage();
+      double longestAverage = longest.getAverage();
 
       // If the historical data are for a different page than we now
       // require, reset them and start fresh with this test.

--- a/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
@@ -258,7 +258,7 @@ public class OptionsFrame extends GenericFrame {
           message.append(" requests to ");
           message.append(latest.getPage());
           message.append(" average time was ");
-          message.append(String.valueOf(latest.getAverage()));
+          message.append(String.valueOf(Math.round(latest.getAverage())));
           message.append(" msec.");
           this.setText(message.toString());
         }

--- a/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
@@ -76,9 +76,9 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
       message.append("Observed average ping times to ");
       message.append(shortest.getPage());
       message.append(" range from ");
-      message.append(String.valueOf(shortest.getAverage()));
+      message.append(String.valueOf(Math.round(shortest.getAverage())));
       message.append("-");
-      message.append(String.valueOf(longest.getAverage()));
+      message.append(String.valueOf(Math.round(longest.getAverage())));
       message.append(" msec.");
       this.setText(message.toString());
     }

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -10291,9 +10291,9 @@ public abstract class RuntimeLibrary {
     // bytes
     rec.aset(5, DataTypes.makeIntValue(result.getBytes()), interpreter);
     // average
-    rec.aset(6, DataTypes.makeIntValue(result.getAverage()), interpreter);
+    rec.aset(6, DataTypes.makeIntValue(Math.round(result.getAverage())), interpreter);
     // bps
-    rec.aset(7, DataTypes.makeIntValue(result.getBPS()), interpreter);
+    rec.aset(7, DataTypes.makeIntValue(Math.round(result.getBPS())), interpreter);
 
     return rec;
   }

--- a/src/net/sourceforge/kolmafia/textui/command/PingCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/PingCommand.java
@@ -60,9 +60,9 @@ public class PingCommand extends AbstractCommand {
             + " msec apiece (total = "
             + result.getTotal()
             + ", average = "
-            + result.getAverage()
+            + Math.round(result.getAverage())
             + ") = "
-            + result.getBPS()
+            + Math.round(result.getBPS())
             + " bytes/second");
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -1177,7 +1177,7 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
               total => 283
               bytes => 19620
               average => 28
-              bps => 69328
+              bps => 69329
               """));
       }
     }


### PR DESCRIPTION
1) Login ping test configuration uses pingLoginThreshold, but when calculating it, we looked up pingLoginGood. Huh?
2) "average" and "bps" are calculated by the division of two ints. Do the calculation in floating point.
3) Similarly, threshold is a double, so use double value of average, not integer.
4) When presenting average and bps to user, use Math.round, rather than Math.floor.