### PR TITLE
abort ping test if redirected or no responseText

### DIFF
--- a/src/net/sourceforge/kolmafia/request/PingRequest.java
+++ b/src/net/sourceforge/kolmafia/request/PingRequest.java
@@ -48,18 +48,8 @@ public class PingRequest extends GenericRequest {
     return switch (this.pingURL) {
       case "council", "main" -> !GenericRequest.abortIfInFightOrChoice(true);
       case "api", "(status)", "(events)" -> true;
-        // Only if we are in Valhalla. But, this will only be the case if
-        // KoL redirected us there; the user cannot specify this.
-      case "afterlife.php" -> true;
       default -> false;
     };
-  }
-
-  private static boolean canFollowRedirect(String redirectLocation) {
-    // In Valhalla, we COULD do a ping test on afterlife.php, but since
-    // we can't compare results with any other page, it is pointless.
-    // afterlife.php?realworld=1
-    return false;
   }
 
   @Override
@@ -81,15 +71,10 @@ public class PingRequest extends GenericRequest {
     // - we are in a choice (except api) -> choice.php
     // - we are in Valhalla -> afterlife.php
     if (this.redirectLocation != null) {
-      if (!canFollowRedirect(this.redirectLocation)) {
-        // leave endTime at 0
-        return;
-      }
-      this.constructURLString(this.redirectLocation, false);
-      this.startTime = System.currentTimeMillis();
-      // Switch URL to the page we are redirected to.
-      this.pingURL = this.getPage();
-      super.run();
+      // We COULD do a ping test on afterlife.php, but since we can't
+      // compare the results with any other page, it is pointless.
+      // leave endTime at 0
+      return;
     }
 
     // We can have an empty responseText on a timeout or I/O error

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -66,6 +66,12 @@ public class LoginManager {
 
     // The user wants to measure ping speed.
     var result = PingManager.runPingTest();
+
+    // If the ping test failed, give up; error already logged.
+    if (result.getAverage() == 0) {
+      return true;
+    }
+
     KoLmafia.updateDisplay(
         "Ping test: average delay is " + Math.round(result.getAverage()) + " msecs.");
 


### PR DESCRIPTION
1) If a ping redirects, do not follow the redirection; there is no point in repeatedly pinging choice.php, fight.php, login.php, or even afterlife.php, since we can't compare the results to any unsupported ping page.
2) If a ping fails in a ping test, log the reason - redirect or empty responseText (due to I/O error, we assume) - and abort the test. Do NOT save the (empty - or even partial) ping test in properties.
3) If ping test fails at login, give up searching for a better time. Do not log "this ping test took 0 msec". Instead, depend on the actual failure reason being logged. See 2.