### PR TITLE
set ownsFloristFriar to true if it is owned

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1129,6 +1129,7 @@ user	optimisticCandleProgress	25
 user	oscusSodaUsed	false
 user	outrageousSombreroUsed	false
 user	overgrownLotAvailable	false
+user	ownsFloristFriar	false
 user	ownsSpeakeasy	false
 user	palindomeDudesDefeated	0
 user	parasolUsed	0

--- a/src/net/sourceforge/kolmafia/request/FloristRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FloristRequest.java
@@ -225,6 +225,10 @@ public class FloristRequest extends GenericRequest {
       return;
     }
 
+    if (responseText.contains("The Florist Friar's Cottage")) {
+      FloristRequest.setHaveFlorist(true);
+    }
+
     switch (FloristRequest.getOption(urlString)) {
       case 1 -> {
         int plant = FloristRequest.getPlant(urlString);
@@ -259,9 +263,6 @@ public class FloristRequest extends GenericRequest {
         return;
       }
       case 4 -> {
-        if (responseText.contains("The Florist Friar's Cottage")) {
-          FloristRequest.setHaveFlorist(true);
-        }
         FloristRequest.floristPlants.clear();
         Matcher matcher = FloristRequest.FLOWER_PATTERN.matcher(responseText);
         while (matcher.find()) {

--- a/src/net/sourceforge/kolmafia/request/FloristRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FloristRequest.java
@@ -208,6 +208,9 @@ public class FloristRequest extends GenericRequest {
   public static void setHaveFlorist(final boolean haveFlorist) {
     FloristRequest.floristChecked = true;
     FloristRequest.haveFlorist = haveFlorist;
+    if (haveFlorist) {
+      Preferences.setBoolean("ownsFloristFriar", true);
+    }
   }
 
   public static final List<Florist> getPlants(String location) {

--- a/src/net/sourceforge/kolmafia/request/FloristRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FloristRequest.java
@@ -208,7 +208,7 @@ public class FloristRequest extends GenericRequest {
   public static void setHaveFlorist(final boolean haveFlorist) {
     FloristRequest.floristChecked = true;
     FloristRequest.haveFlorist = haveFlorist;
-    if (haveFlorist) {
+    if (haveFlorist && KoLCharacter.ascensionPath != Path.LEGACY_OF_LOATHING) {
       Preferences.setBoolean("ownsFloristFriar", true);
     }
   }

--- a/src/net/sourceforge/kolmafia/request/FloristRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FloristRequest.java
@@ -208,7 +208,7 @@ public class FloristRequest extends GenericRequest {
   public static void setHaveFlorist(final boolean haveFlorist) {
     FloristRequest.floristChecked = true;
     FloristRequest.haveFlorist = haveFlorist;
-    if (haveFlorist && KoLCharacter.ascensionPath != Path.LEGACY_OF_LOATHING) {
+    if (haveFlorist && !KoLCharacter.inLegacyOfLoathing()) {
       Preferences.setBoolean("ownsFloristFriar", true);
     }
   }


### PR DESCRIPTION
This will allow scripts like [av-snapshot](https://github.com/m-e-meyer/av-snapshot) or [greenbox](https://github.com/loathers/greenbox) to report the florist friar as owned even if florist_available() returns false, such as a post community service run where the forest is inaccessible.

Also always set it as available if you can get into the choice instead of only on selecting choice 4