### PR TITLE
Don't print if in a fight for florist check

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FloristRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FloristRequest.java
@@ -165,7 +165,7 @@ public class FloristRequest extends GenericRequest {
   }
 
   public static void checkFloristAvailable() {
-    if (GenericRequest.abortIfInFightOrChoice()) {
+    if (GenericRequest.abortIfInFightOrChoice(true)) {
       return;
     }
 

--- a/src/net/sourceforge/kolmafia/request/FloristRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FloristRequest.java
@@ -198,6 +198,8 @@ public class FloristRequest extends GenericRequest {
       return;
     }
 
+    PlaceRequest forestVisit = new PlaceRequest("forestvillage", "fv_friar", true);
+    RequestThread.postRequest(forestVisit);
     super.run();
   }
 


### PR DESCRIPTION
I caused some "You are currently in a choice." or "You are currently in a fight." spam from scripts like tourguide that call florist_available() regularly.

Also busta found an issue, we still need to hit fv_friar before doing the request or it may not succeed. I removed that thinking it was an optimization to not hit the page unnecessarily but it was necessary.