### PR TITLE
Test Fixes

### DIFF
--- a/test/net/sourceforge/kolmafia/session/QuestManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/QuestManagerTest.java
@@ -519,7 +519,9 @@ public class QuestManagerTest {
   /*
    * Level 11 - Palindome
    */
-  static class Palindome {
+
+  @Nested
+  class Palindome {
     @Test
     public void canDetectPalindomeStartInPalindome() {
       assertThat(Quest.PALINDOME, isUnstarted());

--- a/test/net/sourceforge/kolmafia/swingui/panel/DailyDeedsPanelTest.java
+++ b/test/net/sourceforge/kolmafia/swingui/panel/DailyDeedsPanelTest.java
@@ -278,9 +278,14 @@ public class DailyDeedsPanelTest {
 
   @Nested
   class DropsFamiliars {
+
+    @BeforeEach
+    public void beforeEach() {
+      FamiliarData.reset();
+    }
+
     @Test
     public void showsCookbookbat() {
-      FamiliarData.reset();
       var dd = new DailyDeedsPanel.DropsDaily();
       var cleanups = withFamiliarInTerrarium(FamiliarPool.COOKBOOKBAT);
       try (cleanups) {
@@ -291,7 +296,6 @@ public class DailyDeedsPanelTest {
 
     @Test
     public void cookbookbatRecipeDrop() {
-      FamiliarData.reset();
       var dd = new DailyDeedsPanel.DropsDaily();
       var cleanups =
           new Cleanups(

--- a/test/net/sourceforge/kolmafia/swingui/panel/DailyDeedsPanelTest.java
+++ b/test/net/sourceforge/kolmafia/swingui/panel/DailyDeedsPanelTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.Matchers.is;
 import internal.helpers.Cleanups;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.AscensionPath.Path;
+import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -279,6 +280,7 @@ public class DailyDeedsPanelTest {
   class DropsFamiliars {
     @Test
     public void showsCookbookbat() {
+      FamiliarData.reset();
       var dd = new DailyDeedsPanel.DropsDaily();
       var cleanups = withFamiliarInTerrarium(FamiliarPool.COOKBOOKBAT);
       try (cleanups) {
@@ -289,6 +291,7 @@ public class DailyDeedsPanelTest {
 
     @Test
     public void cookbookbatRecipeDrop() {
+      FamiliarData.reset();
       var dd = new DailyDeedsPanel.DropsDaily();
       var cleanups =
           new Cleanups(


### PR DESCRIPTION
In the process of trying to sort out https://github.com/kolmafia/kolmafia/pull/1811 I ran locally with one fork for gradle.  In the past that has given a deterministic test order.  Two tests failed.  I was able to reproduce the failures with 4 forks and when I ran the tests individually  in IntelliJ.  These changes fix that.  

For the one test the test class structure appeared to prevent the beforeEach from running before the test.  That hypothesis was supported by un-initialized preference values in the test according to the debugger.

For the other test the Familiar data was just nonexistent.

This code works individually in my IDE and when running with four forks.