### PR TITLE
Put TopMenuStyle detection under a debug flag

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -36,6 +36,7 @@ global	debugBuy	false
 global	debugConsequences	false
 global	debugFoxtrotRemoval	false
 global	debugPathnames	true
+global	debugTopMenuStyle	false
 global	defaultBorderColor	blue
 global	defaultDropdown1	0
 global	defaultDropdown2	1

--- a/src/net/sourceforge/kolmafia/webui/TopMenuDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/TopMenuDecorator.java
@@ -23,20 +23,22 @@ public abstract class TopMenuDecorator {
       return;
     }
 
-    var style =
-        buffer.indexOf("awesomemenu.php") != -1
-            ? TopMenuStyle.FANCY
-            : buffer.indexOf("Function:") != -1 ? TopMenuStyle.COMPACT : TopMenuStyle.NORMAL;
+    if (Preferences.getBoolean("debugTopMenuStyle")) {
+      var style =
+          buffer.indexOf("awesomemenu.php") != -1
+              ? TopMenuStyle.FANCY
+              : buffer.indexOf("Function:") != -1 ? TopMenuStyle.COMPACT : TopMenuStyle.NORMAL;
 
-    if (style != GenericRequest.topMenuStyle) {
-      String message =
-          "We think topmenu style is "
-              + GenericRequest.topMenuStyle
-              + " but it is actually "
-              + style;
-      RequestLogger.printLine(message);
-      RequestLogger.updateSessionLog(message);
-      GenericRequest.topMenuStyle = style;
+      if (style != GenericRequest.topMenuStyle) {
+        String message =
+            "We think topmenu style is "
+                + GenericRequest.topMenuStyle
+                + " but it is actually "
+                + style;
+        RequestLogger.printLine(message);
+        RequestLogger.updateSessionLog(message);
+        GenericRequest.topMenuStyle = style;
+      }
     }
 
     switch (GenericRequest.topMenuStyle) {

--- a/test/net/sourceforge/kolmafia/webui/TopMenuDecoratorTest.java
+++ b/test/net/sourceforge/kolmafia/webui/TopMenuDecoratorTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import internal.helpers.Cleanups;
 import internal.helpers.RequestLoggerOutput;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.RequestEditorKit;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.GenericRequest;
@@ -20,6 +21,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Enum;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
@@ -53,12 +56,13 @@ class TopMenuDecoratorTest {
       };
     }
 
-    @CartesianTest
-    void awesomeMenuIsAwesome(
-        @Values(strings = {"Veracity", "Captain Scotch"}) String player, @Enum TopMenuStyle style) {
+    @ParameterizedTest
+    @ValueSource(strings = {"Veracity", "Captain Scotch"})
+    void awesomeMenuIsAwesome(String player) {
       var cleanups =
           new Cleanups(
-              withTopMenuStyle(style),
+              withTopMenuStyle(TopMenuStyle.FANCY),
+              withProperty("debugTopMenuStyle", true),
               withProperty("relayAddsQuickScripts", true),
               withProperty("scriptlist", "restore hp | restore mp"));
       try (cleanups) {
@@ -66,14 +70,14 @@ class TopMenuDecoratorTest {
         String input = html("request/" + playerToTextFile(player) + ".html");
         String output = RequestEditorKit.getFeatureRichHTML(location, input);
 
-        // We detected that we have an awesomemenu and corrected it
+        // We detected that we have an awesomemenu
         assertEquals(TopMenuStyle.FANCY, GenericRequest.topMenuStyle);
 
         // We inserted a "quick scripts" dropdown
         assertTrue(output.contains("scriptbar"));
 
-        // We do not test for a relay script menu because that looks the
-        // "relay" directory for scripts starting with "relay_".
+        // We do not test for a relay script menu because that looks in
+        // the "relay" directory for scripts starting with "relay_".
 
         // Given that the response text is from awesomemenu.php, we are
         // only doing the RIGHT thing if TopMenuStype is FANCY, but
@@ -86,6 +90,7 @@ class TopMenuDecoratorTest {
       var cleanups =
           new Cleanups(
               withTopMenuStyle(TopMenuStyle.FANCY),
+              withProperty("debugTopMenuStyle", true),
               withProperty("relayAddsQuickScripts", true),
               withProperty("scriptlist", "restore hp | restore mp"));
       try (cleanups) {
@@ -103,11 +108,76 @@ class TopMenuDecoratorTest {
   }
 
   @Nested
+  class CompactMenu {
+    @Test
+    void compactMenuIsCompact() {
+      var cleanups =
+          new Cleanups(
+              withTopMenuStyle(TopMenuStyle.COMPACT),
+              withProperty("relayAddsQuickScripts", true),
+              withProperty("scriptlist", "restore hp | restore mp"));
+      try (cleanups) {
+        String location = "topmenu.php";
+        String input = html("request/test_compact_topmenu.html");
+        String output = RequestEditorKit.getFeatureRichHTML(location, input);
+
+        // We mafiatized the GOTO menu
+        for (String[] item : KoLConstants.GOTO_MENU) {
+          String tag = item[0];
+          assertTrue(output.contains(tag));
+        }
+
+        // We inserted a "quick scripts" dropdown
+        assertTrue(output.contains("scriptbar"));
+
+        // We do not test for a relay script menu because that looks in
+        // the "relay" directory for scripts starting with "relay_".
+
+        // Given that the response text is from awesomemenu.php, we are
+        // only doing the RIGHT thing if TopMenuStype is FANCY, but
+        // there is no way to check that here.
+      }
+    }
+  }
+
+  @Nested
+  class NormalMenu {
+    @Test
+    void normalMenuIsNormal() {
+      var cleanups =
+          new Cleanups(
+              withTopMenuStyle(TopMenuStyle.NORMAL),
+              withProperty("relayAddsQuickScripts", true),
+              withProperty("scriptlist", "restore hp | restore mp"));
+      try (cleanups) {
+        String location = "topmenu.php";
+        String input = html("request/test_normal_topmenu.html");
+        String output = RequestEditorKit.getFeatureRichHTML(location, input);
+
+        // We inserted a "quick scripts" dropdown
+        assertTrue(output.contains("scriptbar"));
+
+        // We do not test for a relay script menu because that looks in
+        // the "relay" directory for scripts starting with "relay_".
+
+        // Given that the response text is from awesomemenu.php, we are
+        // only doing the RIGHT thing if TopMenuStype is FANCY, but
+        // there is no way to check that here.
+      }
+    }
+  }
+
+  @Nested
   class MenuStyle {
     @CartesianTest
     void canDeriveMenuStyle(
         @Values(strings = {"normal", "compact", "fancy"}) String styleName,
         @Enum TopMenuStyle style) {
+
+      // Debug code to check/correct TopMenuStyle every time we decorate
+      // the topmenu found a bug, but is no longer needed. Therefore, it
+      // is now under the "debugTopMenuStyle" property.
+
       String location = "";
       var actualStyle = TopMenuStyle.UNKNOWN;
       switch (styleName) {
@@ -132,6 +202,7 @@ class TopMenuDecoratorTest {
       var cleanups =
           new Cleanups(
               withTopMenuStyle(style),
+              withProperty("debugTopMenuStyle", true),
               withProperty("relayAddsQuickScripts", true),
               withProperty("scriptlist", "restore hp | restore mp"));
       try (cleanups) {
@@ -152,8 +223,8 @@ class TopMenuDecoratorTest {
         // We insert a "quick scripts" dropdown for all three menu styles
         assertTrue(decorated.contains("scriptbar"));
 
-        // We do not test for a relay script menu because that looks the
-        // "relay" directory for scripts starting with "relay_".
+        // We do not test for a relay script menu because that looks in
+        // the "relay" directory for scripts starting with "relay_".
       }
     }
   }


### PR DESCRIPTION
Captain Scotch and others noticed that their "relay scripts" dropdown occasionally disappeared from their awesomemenu.

Since we only set topmenu style in three places:
1) MoonPhaseRequest
2) Visiting Interface tab in account.php
3) Changing menu style in account.php

this was confusing.

I inserted debug code to deduce the topmenu style from the responseText every time we decorated it to add the relay scripts dropdown.

Turns out that "visiting interface tab in account.php" was broken: KoL had changed the tag on the radio button, so if you had the "fancy" style selected, we'd think it was "normal".

With that fixed - and there are now extensive tests in AccountRequestTest - everything seems to be peachy.

Doing text searches to deduce menu style every time we decorate it is (again) no longer necessary.

I considered just ripping out that code, but I left it in under a debug conditional, controlled by debugTopMenuStyle, just in case we want to test with it in the future.