### PR TITLE
Abort ping test if pings are too long

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -101,6 +101,7 @@ global	pingDefaultTestPage	api
 global	pingDefaultTestPings	10
 global	pingLatest
 global	pingLogin	true
+global	pingLoginAbort	1:10
 global	pingLoginCheck	none
 global	pingLoginCount	0
 global	pingLoginFail	confirm

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -101,7 +101,7 @@ global	pingDefaultTestPage	api
 global	pingDefaultTestPings	10
 global	pingLatest
 global	pingLogin	true
-global	pingLoginAbort	
+global	pingLoginAbort	1:10
 global	pingLoginCheck	none
 global	pingLoginCount	0
 global	pingLoginFail	confirm

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -101,7 +101,7 @@ global	pingDefaultTestPage	api
 global	pingDefaultTestPings	10
 global	pingLatest
 global	pingLogin	true
-global	pingLoginAbort	1:10
+global	pingLoginAbort	
 global	pingLoginCheck	none
 global	pingLoginCount	0
 global	pingLoginFail	confirm

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -73,8 +73,7 @@ public class LoginManager {
       return true;
     }
 
-    KoLmafia.updateDisplay(
-        "Ping test: average delay is " + Math.floor(result.getAverage()) + " msecs.");
+    KoLmafia.updateDisplay("Ping test: average delay is " + result.getAverage() + " msecs.");
 
     // See if the Ping tested a suitable page
     if (!result.isSaveable()) {
@@ -111,7 +110,7 @@ public class LoginManager {
           return true;
         }
         // Either no threshold is set or this connection is too slow.
-        error = "you want no more than " + String.valueOf(Math.floor(desired)) + " msec";
+        error = "you want no more than " + String.valueOf(desired) + " msec";
         // Alert the user.
       }
       default -> {
@@ -236,7 +235,7 @@ public class LoginManager {
 
     StringBuilder buf = new StringBuilder();
     buf.append("This connection has an average ping time of ");
-    buf.append(String.valueOf(Math.round(average)));
+    buf.append(String.valueOf(average));
     buf.append(" msec");
     if (!error.equals("")) {
       buf.append(", but ");

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -32,6 +32,7 @@ import net.sourceforge.kolmafia.request.PasswordHashRequest;
 import net.sourceforge.kolmafia.request.RelayRequest;
 import net.sourceforge.kolmafia.scripts.git.GitManager;
 import net.sourceforge.kolmafia.scripts.svn.SVNManager;
+import net.sourceforge.kolmafia.session.PingManager.PingAbortTrigger;
 import net.sourceforge.kolmafia.session.PingManager.PingTest;
 import net.sourceforge.kolmafia.swingui.GenericFrame;
 import net.sourceforge.kolmafia.utilities.InputFieldUtilities;
@@ -117,6 +118,21 @@ public class LoginManager {
         // The user is happy with any connection
         return true;
       }
+    }
+
+    // If the ping test aborted because times exceeded a user-defined
+    // trigger, log that.
+    PingAbortTrigger trigger = result.getTrigger();
+    if (trigger != null) {
+      StringBuilder buf = new StringBuilder();
+      buf.append("Ping test aborted because ");
+      buf.append(String.valueOf(trigger.getCount()));
+      buf.append(" pings exceeded ");
+      var shortest = PingTest.parseProperty("pingShortest");
+      double limit = trigger.getFactor() * shortest.getAverage();
+      buf.append(String.valueOf(limit));
+      buf.append(" msec.");
+      KoLmafia.updateDisplay(buf.toString());
     }
 
     // Perhaps the user wants to automatically retry for a certain

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -73,7 +73,7 @@ public class LoginManager {
     }
 
     KoLmafia.updateDisplay(
-        "Ping test: average delay is " + Math.round(result.getAverage()) + " msecs.");
+        "Ping test: average delay is " + Math.floor(result.getAverage()) + " msecs.");
 
     // See if the Ping tested a suitable page
     if (!result.isSaveable()) {
@@ -110,7 +110,7 @@ public class LoginManager {
           return true;
         }
         // Either no threshold is set or this connection is too slow.
-        error = "you want no more than " + String.valueOf(Math.round(desired)) + " msec";
+        error = "you want no more than " + String.valueOf(Math.floor(desired)) + " msec";
         // Alert the user.
       }
       default -> {

--- a/src/net/sourceforge/kolmafia/session/PingManager.java
+++ b/src/net/sourceforge/kolmafia/session/PingManager.java
@@ -256,15 +256,18 @@ public class PingManager {
       return triggers;
     }
 
-    public static void save(Set<PingAbortTrigger> aborts) {
+    public static void save(Set<PingAbortTrigger> triggers) {
       StringBuilder buffer = new StringBuilder();
-      for (PingAbortTrigger abort : aborts) {
+      for (PingAbortTrigger trigger : triggers) {
+        if (trigger.count < 1 || trigger.factor < 1) {
+          continue;
+        }
         if (buffer.length() > 0) {
           buffer.append("|");
         }
-        buffer.append(String.valueOf(abort.count));
+        buffer.append(String.valueOf(trigger.count));
         buffer.append(":");
-        buffer.append(String.valueOf(abort.factor));
+        buffer.append(String.valueOf(trigger.factor));
       }
       Preferences.setString("pingLoginAbort", buffer.toString());
     }
@@ -305,10 +308,6 @@ public class PingManager {
       PingAbortTrigger trigger = entry.getKey();
       int count = trigger.getCount();
       int factor = trigger.getFactor();
-      // Sanity check.
-      if (count == 0 || factor == 0) {
-        continue;
-      }
       if (elapsed >= average * factor) {
         // This ping applies. Increment count.
         int seen = entry.getValue() + 1;

--- a/src/net/sourceforge/kolmafia/session/PingManager.java
+++ b/src/net/sourceforge/kolmafia/session/PingManager.java
@@ -176,11 +176,11 @@ public class PingManager {
     }
   }
 
-  public static class PingTestAbort implements Comparable<PingTestAbort> {
+  public static class PingAbortTrigger implements Comparable<PingAbortTrigger> {
     private int count;
     private int factor;
 
-    public PingTestAbort(int count, int factor) {
+    public PingAbortTrigger(int count, int factor) {
       this.count = count;
       this.factor = factor;
     }
@@ -201,16 +201,18 @@ public class PingManager {
       this.factor = factor;
     }
 
-    public int compareTo(final PingTestAbort o) {
+    public int compareTo(final PingAbortTrigger o) {
       if (o == null) {
         throw new ClassCastException();
       }
-      return this.factor < o.factor ? -1 : this.factor == o.factor ? 0 : 1;
+      return this.factor < o.factor
+          ? -1
+          : this.factor > o.factor ? 1 : this.count < o.count ? -1 : this.count > o.count ? 1 : 0;
     }
 
     @Override
     public boolean equals(Object obj) {
-      if (obj instanceof PingTestAbort o) {
+      if (obj instanceof PingAbortTrigger o) {
         return this.count == o.count && this.factor == o.factor;
       }
       return false;
@@ -221,15 +223,15 @@ public class PingManager {
       return this.count * 1000 + this.factor;
     }
 
-    public static Set<PingTestAbort> load() {
-      Set<PingTestAbort> aborts = new TreeSet<>();
+    public static Set<PingAbortTrigger> load() {
+      Set<PingAbortTrigger> aborts = new TreeSet<>();
       for (String value : Preferences.getString("pingLoginAbort").split("\\s*\\|\\s*")) {
         int index = value.indexOf(":");
         if (index != -1) {
           int count = StringUtilities.parseInt(value.substring(0, index));
           int factor = StringUtilities.parseInt(value.substring(index + 1));
           if (count > 0 && factor > 0) {
-            aborts.add(new PingTestAbort(count, factor));
+            aborts.add(new PingAbortTrigger(count, factor));
           }
         }
       }
@@ -237,9 +239,9 @@ public class PingManager {
       return aborts;
     }
 
-    public static void save(Set<PingTestAbort> aborts) {
+    public static void save(Set<PingAbortTrigger> aborts) {
       StringBuilder buffer = new StringBuilder();
-      for (PingTestAbort abort : aborts) {
+      for (PingAbortTrigger abort : aborts) {
         if (buffer.length() > 0) {
           buffer.append("|");
         }

--- a/src/net/sourceforge/kolmafia/session/PingManager.java
+++ b/src/net/sourceforge/kolmafia/session/PingManager.java
@@ -130,7 +130,7 @@ public class PingManager {
       buf.append(String.valueOf(this.getBytes()));
       // Redundant, in that the user can calculate it from total & count
       buf.append(":");
-      buf.append(String.valueOf(Math.floor(this.getAverage())));
+      buf.append(String.valueOf(this.getAverage()));
       return buf.toString();
     }
 

--- a/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
@@ -258,7 +258,7 @@ public class OptionsFrame extends GenericFrame {
           message.append(" requests to ");
           message.append(latest.getPage());
           message.append(" average time was ");
-          message.append(String.valueOf(Math.round(latest.getAverage())));
+          message.append(String.valueOf(latest.getAverage()));
           message.append(" msec.");
           this.setText(message.toString());
         }

--- a/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
@@ -95,9 +95,9 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
       message.append("Observed average ping times to ");
       message.append(shortest.getPage());
       message.append(" range from ");
-      message.append(String.valueOf(Math.round(shortest.getAverage())));
+      message.append(String.valueOf(shortest.getAverage()));
       message.append("-");
-      message.append(String.valueOf(Math.round(longest.getAverage())));
+      message.append(String.valueOf(longest.getAverage()));
       message.append(" msec.");
       this.setText(message.toString());
     }

--- a/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
@@ -141,7 +141,6 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
 
     public PingAbortTriggerPanel() {
       Border blackLine = BorderFactory.createLineBorder(Color.black);
-      ;
       this.setBorder(blackLine);
       this.setLayout(new BoxLayout(this, BoxLayout.PAGE_AXIS));
       this.loadConfiguration();
@@ -248,6 +247,7 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
 
       public final PingAbortTrigger trigger;
       private final JTextField countField;
+      private final JLabel countLabel;
       private final JTextField factorField;
       private final JButton plusButton;
       private final JButton minusButton;
@@ -257,10 +257,12 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
         this.setLayout(new FlowLayout(FlowLayout.LEFT, 1, 1));
 
         this.add(new JLabel("Retry if "));
-        this.countField = new JTextField(String.valueOf(trigger.getCount()), 2);
+        this.countField = new JTextField("0", 2);
         this.countField.addFocusListener(this);
         this.add(this.countField);
-        this.add(new JLabel(" pings exceed "));
+        this.countLabel = new JLabel("");
+        this.add(countLabel);
+        this.setCount(trigger.getCount());
         this.factorField = new JTextField(String.valueOf(trigger.getFactor()), 2);
         this.factorField.addFocusListener(this);
         this.add(this.factorField);
@@ -282,6 +284,7 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
       public void setCount(final int count) {
         this.trigger.setCount(count);
         this.countField.setText(String.valueOf(count));
+        this.countLabel.setText(count == 1 ? " ping exceeds " : " pings exceed ");
       }
 
       public void setFactor(final int factor) {

--- a/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/PingOptionsPanel.java
@@ -1,18 +1,36 @@
 package net.sourceforge.kolmafia.swingui.panel;
 
+import java.awt.Color;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.ActionListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.border.Border;
+import net.java.dev.spellcast.utilities.JComponentUtilities;
+import net.sourceforge.kolmafia.listener.Listener;
+import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.PingManager.PingTest;
+import net.sourceforge.kolmafia.session.PingManager.PingTestAbort;
 import net.sourceforge.kolmafia.swingui.widget.PreferenceButtonGroup;
 import net.sourceforge.kolmafia.swingui.widget.PreferenceCheckBox;
 import net.sourceforge.kolmafia.swingui.widget.PreferenceFloatTextField;
 import net.sourceforge.kolmafia.swingui.widget.PreferenceIntegerTextField;
 import net.sourceforge.kolmafia.swingui.widget.PreferenceTextArea;
+import net.sourceforge.kolmafia.utilities.InputFieldUtilities;
 
 public class PingOptionsPanel extends ConfigQueueingPanel {
 
@@ -58,6 +76,7 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
             "login",
             "logout",
             "confirm"));
+    this.queue(new PingLoginAbortPanel());
 
     this.makeLayout();
   }
@@ -114,6 +133,182 @@ public class PingOptionsPanel extends ConfigQueueingPanel {
     @Override
     public Dimension getMaximumSize() {
       return this.getPreferredSize();
+    }
+  }
+
+  private static class PingLoginAbortPanel extends JPanel implements Listener {
+    int rowCount = 0;
+
+    public PingLoginAbortPanel() {
+      Border blackLine = BorderFactory.createLineBorder(Color.black);
+      ;
+      this.setBorder(blackLine);
+      this.setLayout(new BoxLayout(this, BoxLayout.PAGE_AXIS));
+      this.loadConfiguration();
+
+      PreferenceListenerRegistry.registerPreferenceListener("pingLoginAbort", this);
+    }
+
+    @Override
+    public Dimension getMaximumSize() {
+      return this.getPreferredSize();
+    }
+
+    private void loadConfiguration() {
+      Set<PingTestAbort> aborts = PingTestAbort.load();
+
+      if (aborts.size() == 0) {
+        aborts.add(new PingTestAbort(0, 0));
+      }
+
+      this.removeAll();
+      for (var abort : aborts) {
+        this.addRow(abort);
+      }
+    }
+
+    private void saveConfiguration() {
+      Set<PingTestAbort> aborts =
+          Arrays.stream(this.getComponents())
+              .filter(item -> item instanceof PingTestAbortRow)
+              .map(item -> ((PingTestAbortRow) item).abort)
+              .filter(abort -> abort.getCount() != 0 && abort.getFactor() != 0)
+              .collect(Collectors.toCollection(TreeSet::new));
+
+      PingTestAbort.save(aborts);
+    }
+
+    private void addRow(PingTestAbort abort) {
+      this.add(new PingTestAbortRow(abort));
+      this.rowCount++;
+    }
+
+    private int rowIndex(PingTestAbortRow row) {
+      var components = this.getComponents();
+      for (int i = 0; i < components.length; ++i) {
+        if (components[i] == row) {
+          return i;
+        }
+      }
+      return -1;
+    }
+
+    public void addRowAfter(PingTestAbortRow row) {
+      int index = rowIndex(row);
+      if (index != -1) {
+        this.addRow(new PingTestAbort(0, 0));
+        this.revalidate();
+        this.repaint();
+      }
+    }
+
+    public void removeRow(PingTestAbortRow row) {
+      // Zero out the abort for this row
+      row.setCount(0);
+      row.setFactor(0);
+
+      // Saving the configuration ignores zeroed aborts
+      this.saveConfiguration();
+
+      // Do not remove the last row.
+      if (rowCount == 1) {
+        return;
+      }
+
+      // Find the row in the JPanel
+      int index = rowIndex(row);
+      if (index == -1) {
+        // This should not happen
+        return;
+      }
+
+      // Remove the row and repaint
+      this.remove(index);
+      this.rowCount--;
+      this.revalidate();
+      this.repaint();
+    }
+
+    public void abortChanged(PingTestAbort abort) {
+      if (abort.getCount() > 0 && abort.getFactor() > 0) {
+        this.saveConfiguration();
+      }
+    }
+
+    @Override
+    public void update() {
+      this.loadConfiguration();
+      this.revalidate();
+      this.repaint();
+    }
+
+    private class PingTestAbortRow extends JPanel implements FocusListener {
+      static final ImageIcon plusIcon = JComponentUtilities.getImage("icon_plus.gif");
+      static final ImageIcon minusIcon = JComponentUtilities.getImage("icon_minus.gif");
+
+      public final PingTestAbort abort;
+      private final JTextField countField;
+      private final JTextField factorField;
+      private final JButton plusButton;
+      private final JButton minusButton;
+
+      public PingTestAbortRow(PingTestAbort abort) {
+        this.abort = abort;
+        this.setLayout(new FlowLayout(FlowLayout.LEFT, 1, 1));
+
+        this.add(new JLabel("Retry if "));
+        this.countField = new JTextField(String.valueOf(abort.getCount()), 2);
+        this.countField.addFocusListener(this);
+        this.add(this.countField);
+        this.add(new JLabel(" pings exceed "));
+        this.factorField = new JTextField(String.valueOf(abort.getFactor()), 2);
+        this.factorField.addFocusListener(this);
+        this.add(this.factorField);
+        this.add(new JLabel(" times average historical ping"));
+        this.plusButton = new JButton(plusIcon);
+        this.plusButton.addActionListener(
+            e -> {
+              PingLoginAbortPanel.this.addRowAfter(this);
+            });
+        this.add(plusButton);
+        this.minusButton = new JButton(minusIcon);
+        this.minusButton.addActionListener(
+            e -> {
+              PingLoginAbortPanel.this.removeRow(this);
+            });
+        this.add(minusButton);
+      }
+
+      public void setCount(final int count) {
+        this.abort.setCount(count);
+        this.countField.setText(String.valueOf(count));
+      }
+
+      public void setFactor(final int factor) {
+        this.abort.setFactor(factor);
+        this.factorField.setText(String.valueOf(factor));
+      }
+
+      @Override
+      public void focusLost(final FocusEvent e) {
+        Component component = e.getComponent();
+        if (component == this.countField) {
+          int newValue = InputFieldUtilities.getValue(this.countField, 0);
+          if (newValue != this.abort.getCount()) {
+            this.abort.setCount(newValue);
+            PingLoginAbortPanel.this.abortChanged(this.abort);
+          }
+        } else if (component == this.factorField) {
+          int newValue = InputFieldUtilities.getValue(this.factorField, 0);
+          if (newValue != this.abort.getFactor()) {
+            this.abort.setFactor(newValue);
+            PingLoginAbortPanel.this.abortChanged(this.abort);
+          }
+        }
+      }
+
+      @Override
+      public void focusGained(final FocusEvent e) {}
     }
   }
 }


### PR DESCRIPTION
Shiverwarp complained recently that he was getting login ping test times of 23000+ msec and it was taking seemingly forever to login. I sympathize; I usually get <30 msec and the longest I've see in a 10-ping test is a bit more than 800 - which would still be an intolerably slow connection. And to think it took 10 pings to get that "average".

I can't imagine what caused Shiverwarp's insanely bad connection, but if it took 4 minutes to run the first test and decide it is time to retry, seems to me that we could recognize way earlier - as early as the very first ping - that this connection is a no-go.

1) Comparing ping average times with goals and thresholds in floating point seems right, but displaying them as integers, calculated either by Math.round() or Math.floor(), is problematic. If your threshold calculation says you cannot exceed 30.2 msec and you generate 30.4, it will fail, and using Math.round, will report "you wanted 30 msec but got 30 msec, so it failed".  I changed it to display floating point results in floating point. So far, it always seems to display with a single digit to the right of the decimal point, which seems fine.

2) If you get a really slow connection, it will be obvious early on that it will be too slow.
Allow configuration for "PingAbortTrigger" triggers.

If "pingTestAbort" has "4:3|1:10", you are specifying:

Retry if 4 pings exceed 3 times average historical ping
Retry if 1 ping exceeds 10 times average historical ping

Default is "1:10"

On the PingOptionsPanel, you can add rows to specify additional abort triggers or delete rows to remove them. If you try to delete the last row, it just zeroes it - which will leave the property empty.

I think the GUI is pretty spiffy.

PingManager now checks those triggers after each ping it submits. If that results in any trigger firing - 4 exceeding 3 times historical average or 1 exceeding 10 times historical average, from the above example - PingManager aborts the ping test and returns the test with the trigger that fired to LoginManager.

Could be that the aborted ping test was still good enough, but if not, it reports that the ping test aborted and it moves on to the next timein attempt.