### PR TITLE
Cherry Picking for test

### DIFF
--- a/test/internal/helpers/Utilities.java
+++ b/test/internal/helpers/Utilities.java
@@ -1,0 +1,27 @@
+package internal.helpers;
+
+import java.io.File;
+
+public class Utilities {
+  public static void verboseDelete(String name) {
+    File deleteMe = new File(name);
+    verboseDelete(deleteMe);
+  }
+
+  public static void verboseDelete(File deleteMe) {
+    String fileName = deleteMe.toString();
+    if (deleteMe.exists()) {
+      try {
+        boolean deleted = deleteMe.delete();
+        if (!deleted) {
+          System.out.println(
+              fileName
+                  + " not deleted but no exception thrown. Still exists? "
+                  + deleteMe.exists());
+        }
+      } catch (Exception e) {
+        System.out.println(fileName + " not deleted with exception " + e);
+      }
+    }
+  }
+}

--- a/test/net/sourceforge/kolmafia/persistence/MallPriceDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/MallPriceDatabaseTest.java
@@ -1,9 +1,15 @@
 package net.sourceforge.kolmafia.persistence;
 
-import static com.spotify.hamcrest.optional.OptionalMatchers.*;
+import static com.spotify.hamcrest.optional.OptionalMatchers.optionalWithValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
 
+import internal.helpers.Utilities;
 import internal.network.FakeHttpClientBuilder;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -16,8 +22,11 @@ import org.junit.jupiter.api.Test;
 public class MallPriceDatabaseTest {
 
   @BeforeAll
-  public static void beforeAll() {
+  public static void beforeEach() {
     MallPriceDatabase.savePricesToFile = false;
+    String MallPriceFileName = "data/" + "mallprices.txt";
+    Utilities.verboseDelete(MallPriceFileName);
+    MallPriceDatabase.updatePrices(MallPriceFileName);
   }
 
   @AfterAll
@@ -52,6 +61,7 @@ public class MallPriceDatabaseTest {
 
   @Test
   void writesDataInItemIdOrder() {
+
     MallPriceDatabase.recordPrice(600, 5, true);
     MallPriceDatabase.recordPrice(607, 50, true);
     MallPriceDatabase.recordPrice(555, 500, true);


### PR DESCRIPTION
verboseDelete proved very helpful to me when checking for test leakage exposed when the number of forks gradle used was changed.  The leakage from MallPriceDatabaseTest was discovered and fixed as part of #1811 

This copies that code from the now reverted PR.  This seemed like the easiest way to preserve it and not forget it.