### PR TITLE
ASH record equality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,7 @@ test {
 	systemProperty 'line.separator', '\n'
 	systemProperty 'junit.jupiter.extensions.autodetection.enabled', true
 	systemProperty 'useCWDasROOT', true
+	systemProperty 'file.encoding', 'UTF-8'
 	workingDir 'test/root'
 
 	testLogging.showStandardStreams = true

--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -839,7 +839,7 @@ public class Parser {
       Evaluable rhs;
 
       if (this.currentToken().equals("{")) {
-        if (dataType instanceof CompositeType ct) {
+        if (dataType.getBaseType() instanceof CompositeType ct) {
           rhs = this.parseCompositeLiteral(scope, ct);
         } else {
           rhs = this.parseCompositeLiteral(scope, badAggregateType());

--- a/src/net/sourceforge/kolmafia/textui/parsetree/AggregateValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/AggregateValue.java
@@ -5,6 +5,45 @@ public abstract class AggregateValue extends CompositeValue {
     super(type);
   }
 
+  // The only comparison we implement is equality; we define no
+  // "natural order" for an aggregate value.
+  //
+  // Value implements equals and equalsIgnoreCase in terms of
+  // equals(Value value, boolean ignoreCase)
+  //
+  // Therefore, that is the only method we need to implement here
+
+  @Override
+  protected boolean equals(final Object o, boolean ignoreCase) {
+    // No object equals null
+    if (o == null) {
+      return false;
+    }
+
+    // If the objects are identical Objects, easy equality
+    if (this == o) {
+      return true;
+    }
+
+    // The Parser enforces this at compile time, but...
+    if (!(o instanceof AggregateValue)) {
+      return false;
+    }
+
+    AggregateValue av = (AggregateValue) o;
+
+    if (!this.type.equals(av.getType())) {
+      return false;
+    }
+
+    // Shallow equality: we don't actually look at the contents.
+    if (this.count() == av.count()) {
+      return true;
+    }
+
+    return false;
+  }
+
   public Type getDataType() {
     return ((AggregateType) this.type).getDataType();
   }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/CompositeValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/CompositeValue.java
@@ -18,6 +18,35 @@ public abstract class CompositeValue extends Value {
     return (CompositeType) this.type;
   }
 
+  // Subclasses of CompositeValue must redefine equality.
+  // equals() and equalsIgnoreCase will use that definition
+  // compareTo and compareToIgnoreCase will also use that,
+  // unless the subclasses do something more.
+
+  @Override
+  protected abstract boolean equals(final Object o, boolean ignoreCase);
+
+  @Override
+  protected int compareTo(final Value o, final boolean ignoreCase) {
+    if (o == null) {
+      throw new NullPointerException();
+    }
+
+    // If the objects are identical Objects, save a lot of work
+    if (this == o) {
+      return 0;
+    }
+
+    // Subclasses of CompositeValue must redefine equality.
+    // Let that kick in first.
+    if (this.equals(o, ignoreCase)) {
+      return 0;
+    }
+
+    // Otherwise, defer to Value's compareTo method.
+    return super.compareTo(o, ignoreCase);
+  }
+
   public Value aref(final Value key) {
     return this.aref(key, null);
   }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Operator.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Operator.java
@@ -258,12 +258,13 @@ public class Operator extends Command {
 
     var result =
         switch (this.operator) {
-              case "==", Parser.APPROX -> c == 0;
-              case "!=" -> c != 0;
-              case ">=" -> c >= 0;
-              case "<=" -> c <= 0;
-              case ">" -> c > 0;
-              case "<" -> c < 0;
+              case "==" -> leftValue.equals(rightValue);
+              case "!=" -> !leftValue.equals(rightValue);
+              case Parser.APPROX -> leftValue.equalsIgnoreCase(rightValue);
+              case ">=" -> leftValue.compareTo(rightValue) >= 0;
+              case "<=" -> leftValue.compareTo(rightValue) <= 0;
+              case ">" -> leftValue.compareTo(rightValue) > 0;
+              case "<" -> leftValue.compareTo(rightValue) < 0;
               default -> false;
             }
             ? DataTypes.TRUE_VALUE

--- a/src/net/sourceforge/kolmafia/textui/parsetree/RecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/RecordValue.java
@@ -32,37 +32,35 @@ public class RecordValue extends CompositeValue {
   // The only comparison we implement is equality; we define no
   // "natural order" for a record value.
   //
-  // Value implements equals, compareTo, and compreToIgnoreCase in terms
-  // of compareTo(Value value, boolean ignoreCase)
+  // Value implements equals and equalsIgnoreCase in terms of
+  // equals(Value value, boolean ignoreCase)
   //
   // Therefore, that is the only method we need to implement here
 
   @Override
-  protected int compareTo(final Value o, boolean ignoreCase) {
-    // Per the implementation contract of Comparable.compareTo()
+  protected boolean equals(final Object o, boolean ignoreCase) {
+    // No object equals null
     if (o == null) {
-      throw new NullPointerException();
+      return false;
     }
 
-    // If the objects are identical Objects, save a lot of work
+    // If the objects are identical Objects, easy equality
     if (this == o) {
-      return 0;
+      return true;
     }
 
-    // Per the implementation contract of Comparable.compareTo()
     // The Parser enforces this at compile time, but...
     if (!(o instanceof RecordValue)) {
-      throw new ClassCastException();
+      return false;
     }
 
     RecordValue orv = (RecordValue) o;
 
     // The objects must both have the same record type.
     // The Parser does not (currently) enforce this.
-    // Otherwise, it could be a ClassCastException
     RecordType type = this.getRecordType();
     if (!type.equals(orv.getRecordType())) {
-      return -1;
+      return false;
     }
 
     // The fields must all be equal.
@@ -72,32 +70,21 @@ public class RecordValue extends CompositeValue {
 
     // Compare each field
     for (int index = 0; index < dataTypes.length; ++index) {
-      Type dataType = dataTypes[index].getBaseType();
       Value field = fields[index];
       Value ofield = ofields[index];
 
-      // If the fields are identical objects, easy equals
+      // If the objects are identical Objects, easy equality
       if (field == ofield) {
         continue;
       }
 
-      // Unless we do a deep comparison, we cannot look inside aggregates
-      // Require that they have the same size, at least
-      if (dataType instanceof AggregateType) {
-        if (field.count() != ofield.count()) {
-          return -1;
-        }
-        continue;
-      }
-
-      // Any other field type - including another record - has a
-      // functional equality operation.
-      if (field.compareTo(ofield, ignoreCase) != 0) {
-        return -1;
+      // The fields must be equal, per the data type's definition of equality.
+      if (!field.equals(ofield, ignoreCase)) {
+        return false;
       }
     }
 
-    return 0;
+    return true;
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Value.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Value.java
@@ -264,9 +264,14 @@ public class Value implements TypedNode, Comparable<Value> {
     return this.compareTo(o, true);
   }
 
-  private int compareTo(final Value o, final boolean ignoreCase) {
+  protected int compareTo(final Value o, final boolean ignoreCase) {
     if (o == null) {
-      throw new ClassCastException();
+      throw new NullPointerException();
+    }
+
+    // If the objects are identical Objects, save a lot of work
+    if (this == o) {
+      return 0;
     }
 
     // If both Vykeas, defer to Vykea compareTo. Otherwise, compare as normal

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Value.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Value.java
@@ -315,7 +315,15 @@ public class Value implements TypedNode, Comparable<Value> {
 
   @Override
   public boolean equals(final Object o) {
-    return o instanceof Value v && this.compareTo(v) == 0;
+    return this.equals(o, false);
+  }
+
+  public boolean equalsIgnoreCase(final Object o) {
+    return this.equals(o, true);
+  }
+
+  protected boolean equals(final Object o, boolean ignoreCase) {
+    return o instanceof Value v && this.compareTo(v, ignoreCase) == 0;
   }
 
   @Override

--- a/test/net/sourceforge/kolmafia/textui/parsetree/ValueTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/ValueTest.java
@@ -26,7 +26,7 @@ class ValueTest {
   void compareToNull() {
     var value = new Value(true);
     //noinspection ResultOfMethodCallIgnored
-    assertThrows(ClassCastException.class, () -> value.compareTo(null));
+    assertThrows(NullPointerException.class, () -> value.compareTo(null));
   }
 
   @Nested

--- a/test/root/expected/record-equality.ash.out
+++ b/test/root/expected/record-equality.ash.out
@@ -1,0 +1,26 @@
+seal tooth
+seal-skull helmet
+equals = false
+-------
+zero = seal tooth (0)
+one = seal tooth (1)
+two = seal tooth (1)
+three = seal-skull helmet (1)
+zero == one: false
+one == one: true
+one == two: true
+one == three: false
+-------
+strec1.str = ABC
+strec2.str = abc
+strec1 == strec2: false
+strec1 ≈ strec2: true
+-------
+iarec1.ia = [1,2,3]
+iarec2.ia = [1,2,3]
+iarec3.ia = [1,2,3]
+iarec4.ia = [1,2,3,4]
+iarec1 == iarec1: true
+iarec1 == iarec2: true
+iarec1 == iarec3: true
+iarec1 == iarec4: false

--- a/test/root/expected/record-equality.ash.out
+++ b/test/root/expected/record-equality.ash.out
@@ -14,7 +14,7 @@ one == three: false
 strec1.str = ABC
 strec2.str = abc
 strec1 == strec2: false
-strec1 ≈ strec2: true
+strec1 APPROX strec2: true
 -------
 iarec1.ia = [1,2,3]
 iarec2.ia = [1,2,3]

--- a/test/root/expected/record-equality.ash.out
+++ b/test/root/expected/record-equality.ash.out
@@ -14,7 +14,7 @@ one == three: false
 strec1.str = ABC
 strec2.str = abc
 strec1 == strec2: false
-strec1 APPROX strec2: true
+strec1 ≈ strec2: true
 -------
 iarec1.ia = [1,2,3]
 iarec2.ia = [1,2,3]

--- a/test/root/scripts/record-equality.ash
+++ b/test/root/scripts/record-equality.ash
@@ -1,0 +1,81 @@
+item st = $item[seal tooth];
+item sh = $item[seal-skull helmet];
+
+print(st);
+print(sh);
+print("equals = " + (st == sh));
+print("-------");
+
+record rec
+{
+    item it;
+    int count;
+};
+
+string to_string(rec r)
+{
+    return r.it + " (" + r.count + ")";
+}
+
+rec zero = new rec(st, 0);
+rec one = new rec(st, 1);
+rec two = new rec(st, 1);
+rec three = new rec(sh, 1);
+
+print("zero = " + zero);
+print("one = " + one);
+print("two = " + two);
+print("three = " + three);
+print("zero == one: " + (zero == one));
+print("one == one: " + (one == one));
+print("one == two: " + (one == two));
+print("one == three: " + (one == three));
+print("-------");
+
+record strec {
+    string str;
+};
+
+strec strec1 = new strec("ABC");
+strec strec2 = new strec("abc");
+
+print("strec1.str = " + strec1.str);
+print("strec2.str = " + strec2.str);
+print("strec1 == strec2: " + (strec1 == strec2));
+print("strec1 ≈ strec2: " + (strec1 ≈ strec2));
+print("-------");
+
+typedef int[] int_array;
+
+string to_string(int_array ia)
+{
+    buffer buf;
+    buf.append("[");
+    foreach index, val in ia {
+	if (buf.length() > 1) {
+	    buf.append(",");
+	}
+	buf.append(val);
+    }
+    buf.append("]");
+    return buf;
+}
+
+record iarec {
+    int_array ia;
+};
+
+int_array ia1 = {1, 2, 3};
+iarec iarec1 = { ia: ia1 };
+iarec iarec2 = { ia: ia1 };
+iarec iarec3 = { ia: {1, 2, 3} };
+iarec iarec4 = { ia: {1, 2, 3, 4 } };
+
+print("iarec1.ia = " + iarec1.ia);
+print("iarec2.ia = " + iarec2.ia);
+print("iarec3.ia = " + iarec3.ia);
+print("iarec4.ia = " + iarec4.ia);
+print("iarec1 == iarec1: " + (iarec1 == iarec1));
+print("iarec1 == iarec2: " + (iarec1 == iarec2));
+print("iarec1 == iarec3: " + (iarec1 == iarec3));
+print("iarec1 == iarec4: " + (iarec1 == iarec4));

--- a/test/root/scripts/record-equality.ash
+++ b/test/root/scripts/record-equality.ash
@@ -42,7 +42,7 @@ strec strec2 = new strec("abc");
 print("strec1.str = " + strec1.str);
 print("strec2.str = " + strec2.str);
 print("strec1 == strec2: " + (strec1 == strec2));
-print("strec1 APPROX strec2: " + (strec1 ≈ strec2));
+print("strec1 ≈ strec2: " + (strec1 ≈ strec2));
 print("-------");
 
 typedef int[] int_array;

--- a/test/root/scripts/record-equality.ash
+++ b/test/root/scripts/record-equality.ash
@@ -42,7 +42,7 @@ strec strec2 = new strec("abc");
 print("strec1.str = " + strec1.str);
 print("strec2.str = " + strec2.str);
 print("strec1 == strec2: " + (strec1 == strec2));
-print("strec1 ≈ strec2: " + (strec1 ≈ strec2));
+print("strec1 APPROX strec2: " + (strec1 ≈ strec2));
 print("-------");
 
 typedef int[] int_array;


### PR DESCRIPTION
Rather than ASH believing that every record value is equal to any other record value, provide "shallow" equality testing:

1) Must be the same record type
2) All non-composite fields must be identical
3) Field which are, themselves, records must have record-equality
4) Aggregate fields must have the same size.
We do not do a "deep" comparison of aggregate values.
5) If you use the "≈" operator - "approximately equals" or "case insensitive" - string field values are compared thusly.