### PR TITLE
Of all comparison operators, composite values only allow equality operators

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/parsetree/CompositeValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/CompositeValue.java
@@ -20,32 +20,9 @@ public abstract class CompositeValue extends Value {
 
   // Subclasses of CompositeValue must redefine equality.
   // equals() and equalsIgnoreCase will use that definition
-  // compareTo and compareToIgnoreCase will also use that,
-  // unless the subclasses do something more.
 
   @Override
   protected abstract boolean equals(final Object o, boolean ignoreCase);
-
-  @Override
-  protected int compareTo(final Value o, final boolean ignoreCase) {
-    if (o == null) {
-      throw new NullPointerException();
-    }
-
-    // If the objects are identical Objects, save a lot of work
-    if (this == o) {
-      return 0;
-    }
-
-    // Subclasses of CompositeValue must redefine equality.
-    // Let that kick in first.
-    if (this.equals(o, ignoreCase)) {
-      return 0;
-    }
-
-    // Otherwise, defer to Value's compareTo method.
-    return super.compareTo(o, ignoreCase);
-  }
 
   public Value aref(final Value key) {
     return this.aref(key, null);

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Value.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Value.java
@@ -274,16 +274,23 @@ public class Value implements TypedNode, Comparable<Value> {
       return 0;
     }
 
+    Type type = this.getType().getBaseType();
+    Type otype = o.getType().getBaseType();
+
+    // Composite values cannot be compared
+    if (!type.isPrimitive() || !otype.isPrimitive()) {
+      throw new ClassCastException();
+    }
+
     // If both Vykeas, defer to Vykea compareTo. Otherwise, compare as normal
-    if (this.getType().equals(DataTypes.VYKEA_TYPE) && o.getType().equals(DataTypes.VYKEA_TYPE)) {
+    if (type.equals(DataTypes.VYKEA_TYPE) && otype.equals(DataTypes.VYKEA_TYPE)) {
       VYKEACompanionData v1 = (VYKEACompanionData) (this.content);
       VYKEACompanionData v2 = (VYKEACompanionData) (o.content);
       return v1.compareTo(v2);
     }
 
     // Prefer to order monsters by ID. If they both have id 0, then fall back to string comparison.
-    if (this.getType().equals(DataTypes.MONSTER_TYPE)
-        && o.getType().equals(DataTypes.MONSTER_TYPE)) {
+    if (type.equals(DataTypes.MONSTER_TYPE) && otype.equals(DataTypes.MONSTER_TYPE)) {
       int cmp = Long.compare(this.contentLong, o.contentLong);
       if (cmp != 0 || !this.isStringLike()) {
         return cmp;


### PR DESCRIPTION
With composites, allow "==", "!=", and "≈".
Other comparisons - "<", "<=", ">", ">=" - are meaningless and generate a compile-time error.

This simplifies things a lot: CompositeType no longer needs a compareTo method.