### PR TITLE
Log when we open and close a session

### DIFF
--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -421,6 +421,11 @@ public class LoginManager {
 
     RequestLogger.openSessionLog();
 
+    // Log when a session is started
+
+    RequestLogger.updateSessionLog();
+    RequestLogger.updateSessionLog("Initializing session for " + username + "...");
+
     // Perform requests to read current character's data
 
     KoLmafia.refreshSession();

--- a/src/net/sourceforge/kolmafia/session/LogoutManager.java
+++ b/src/net/sourceforge/kolmafia/session/LogoutManager.java
@@ -133,6 +133,11 @@ public class LogoutManager {
     AdventureQueueDatabase.serialize();
     AdventureSpentDatabase.serialize();
 
+    // Log the user session is ending
+
+    RequestLogger.updateSessionLog();
+    RequestLogger.updateSessionLog("Closing session for " + userName + "...");
+
     // Clear out user data
 
     RequestLogger.closeSessionLog();


### PR DESCRIPTION
https://kolmafia.us/threads/log-when-a-client-session-starts-and-ends.29143/

The biggest usecase of this for me currently, is to figure out when mafia exited abnormally and try to recover the player state from that, ignoring the remainder of the file. Such as recovering daily preferences.

Its also a bit weird that there's nothing definite indicating when a session started or ended.