### PR TITLE
fix: eagle preferences, daily preferences

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -300,6 +300,7 @@ user	badMoonEncounter48	false
 user	bagOTricksCharges	0
 user	ballpitBonus	1
 user	banishedMonsters	
+user	banishedPhyla	
 user	banishingShoutMonsters
 user	bankedKarma	0
 user	barrelShrineUnlocked	false

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -63,6 +63,8 @@ public class Preferences {
   private static final Set<String> perUserGlobalSet = new HashSet<>();
   private static final Set<String> onlyResetOnRollover =
       new TreeSet<>(List.of("ascensionsToday", "potatoAlarmClockUsed"));
+  private static final Set<String> legacyNonDailies =
+      new TreeSet<>(List.of("_shortOrderCookCharge"));
   private static final Set<String> legacyDailies =
       new TreeSet<>(
           List.of(
@@ -93,6 +95,7 @@ public class Preferences {
               "rageGlandVented",
               "reagentSummons",
               "romanticTarget",
+              "screechCombats",
               "seaodesFound",
               "spiceMelangeUsed",
               "spookyPuttyCopiesMade",
@@ -1357,7 +1360,8 @@ public class Preferences {
   }
 
   public static boolean isDaily(String name) {
-    return name.startsWith("_") || legacyDailies.contains(name);
+    return (name.startsWith("_") && !legacyNonDailies.contains(name))
+        || legacyDailies.contains(name);
   }
 
   private static void deferredPoints(String prop, String defprop, int max) {

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -10272,7 +10272,7 @@ public class FightRequest extends GenericRequest {
       case SkillPool.RED_WHITE_BLUE_BLAST:
         if (responseText.contains("fires off a thrilling, patriotic")) {
           Preferences.setString("rwbMonster", MonsterStatusTracker.getLastMonsterName());
-          Preferences.setInteger("rwbMonsterCount", 3);
+          Preferences.setInteger("rwbMonsterCount", 2);
           KoLAdventure lastLocation = KoLAdventure.lastVisitedLocation();
           if (lastLocation != null) {
             Preferences.setString("rwbLocation", lastLocation.getAdventureName());

--- a/test/net/sourceforge/kolmafia/AreaCombatDataTest.java
+++ b/test/net/sourceforge/kolmafia/AreaCombatDataTest.java
@@ -732,7 +732,7 @@ public class AreaCombatDataTest {
           new Cleanups(
               withProperty("rwbLocation", "The Smut Orc Logging Camp"),
               withProperty("rwbMonster", "smut orc jacker"),
-              withProperty("rwbMonsterCount", 3));
+              withProperty("rwbMonsterCount", 2));
 
       try (cleanups) {
         Map<MonsterData, Double> appearanceRates = SMUT_ORC_CAMP.getMonsterData(true);
@@ -753,7 +753,7 @@ public class AreaCombatDataTest {
           new Cleanups(
               withProperty("rwbLocation", "The Smut Orc Logging Camp"),
               withProperty("rwbMonster", "smut orc jacker"),
-              withProperty("rwbMonsterCount", 3),
+              withProperty("rwbMonsterCount", 2),
               withProperty("_gallapagosMonster", "smut orc nailer"));
 
       try (cleanups) {

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -410,11 +410,15 @@ class PreferencesTest {
     String legacyDaily = "nunsVisits";
     String newStyleDaily = "_SomeDailyThing";
     String notADaily = "somePrefName";
+    String legacyNonDaily = "_shortOrderCookCharge";
     assertTrue(
         Preferences.isDaily(legacyDaily), legacyDaily + " should be a Daily pref, but isn't");
     assertTrue(
         Preferences.isDaily(newStyleDaily), newStyleDaily + " should be a Daily pref, but isn't");
     assertFalse(Preferences.isDaily(notADaily), notADaily + " should not be a Daily pref, but is");
+    assertFalse(
+        Preferences.isDaily(legacyNonDaily),
+        legacyNonDaily + " should not be a Daily pref, but is");
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/request/FightRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FightRequestTest.java
@@ -2196,7 +2196,7 @@ public class FightRequestTest {
             "request/test_fight_red_white_blue.html", "fight.php?action=skill&whichskill=7450");
 
         assertThat("rwbMonster", isSetTo("raging bull"));
-        assertThat("rwbMonsterCount", isSetTo(3));
+        assertThat("rwbMonsterCount", isSetTo(2));
         assertThat("rwbLocation", isSetTo("South of the Border"));
       }
     }
@@ -2207,7 +2207,7 @@ public class FightRequestTest {
           new Cleanups(
               withFight(0),
               withProperty("rwbMonster", "raging bull"),
-              withProperty("rwbMonsterCount", 3),
+              withProperty("rwbMonsterCount", 2),
               withProperty("rwbLocation", "South of the Border"),
               withNextMonster("raging bull"));
 
@@ -2215,7 +2215,7 @@ public class FightRequestTest {
         parseCombatData("request/test_fight_red_white_blue_after.html");
 
         assertThat("rwbMonster", isSetTo("raging bull"));
-        assertThat("rwbMonsterCount", isSetTo(2));
+        assertThat("rwbMonsterCount", isSetTo(1));
       }
     }
   }


### PR DESCRIPTION
* rwbMonsterCount should begin at 2, not 3
* screechCombats is reset daily
* _shortOrderCookCharge is not reset daily

I considered renaming the preferences straight -- `screechCombats` is only used in TourGuide that I can see, but `_shortOrderCookCharge` is used more widely.