### PR TITLE
feat: track august scepter sniff / banish

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -796,6 +796,7 @@ user	hippiesDefeated	0
 user	holidayHalsBookAvailable	true
 user	holidayHalsBookCost	1000
 user	holidaySwagger	0
+user	holdHandsMonster	
 user	homemadeRobotUpgrades	0
 user	homebodylCharges	0
 user	horseryAvailable	false

--- a/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
@@ -570,6 +570,7 @@ public class SkillPool {
   public static final int AUG_29TH_MORE_HERBS_LESS_SALT_DAY = 7480;
   public static final int AUG_30TH_BEACH_DAY = 7481;
   public static final int AUG_31ST_CABERNET_SAUVIGNON_DAY = 7482;
+  public static final int ROAR_LIKE_A_LION = 7483;
   public static final int HOLD_HANDS = 7484;
   public static final int GOOD_SINGING_VOICE = 11016;
   public static final int BANISHING_SHOUT = 11020;

--- a/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
@@ -570,6 +570,7 @@ public class SkillPool {
   public static final int AUG_29TH_MORE_HERBS_LESS_SALT_DAY = 7480;
   public static final int AUG_30TH_BEACH_DAY = 7481;
   public static final int AUG_31ST_CABERNET_SAUVIGNON_DAY = 7482;
+  public static final int HOLD_HANDS = 7484;
   public static final int GOOD_SINGING_VOICE = 11016;
   public static final int BANISHING_SHOUT = 11020;
   public static final int DEMAND_SANDWICH = 11021;

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -107,6 +107,7 @@ public class Preferences {
 
   private static final String[] resetOnAscension =
       new String[] {
+        "_shortOrderCookCharge",
         "8BitBonusTurns",
         "8BitColor",
         "8BitScore",
@@ -456,7 +457,6 @@ public class Preferences {
         "rwbMonsterCount",
         "sausageGrinderUnits",
         "scrapbookCharges",
-        "screechCombats",
         "screencappedMonster",
         "seahorseName",
         "shadowRiftIngress",

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -328,6 +328,7 @@ public class Preferences {
         "hasSushiMat",
         "hermitHax0red",
         "highTopPumped",
+        "holdHandsMonster",
         "homebodylCharges",
         "iceSculptureMonster",
         "intenseCurrents",

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -9444,6 +9444,13 @@ public class FightRequest extends GenericRequest {
         }
         break;
 
+      case SkillPool.ROAR_LIKE_A_LION:
+        if (responseText.contains("release a majestic roar") || skillRunawaySuccess) {
+          skillRunawaySuccess = true;
+          BanishManager.banishMonster(monster, Banisher.ROAR_LIKE_A_LION);
+        }
+        break;
+
       case SkillPool.POCKET_CRUMBS:
         if (responseText.contains("pocket next to the crumbs")) {
           // No casting limit, can drop items up to 10 times a day

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -9339,7 +9339,14 @@ public class FightRequest extends GenericRequest {
 
       case SkillPool.MONKEY_POINT:
         if (responseText.contains("Your monkey paw points at your opponent")) {
-          Preferences.setString("mokeyPointMonster", monsterName);
+          Preferences.setString("monkeyPointMonster", monsterName);
+          skillSuccess = true;
+        }
+        break;
+
+      case SkillPool.HOLD_HANDS:
+        if (responseText.contains("stop the battle for a moment and hold hands with you")) {
+          Preferences.setString("holdHandsMonster", monsterName);
           skillSuccess = true;
         }
         break;

--- a/src/net/sourceforge/kolmafia/session/BanishManager.java
+++ b/src/net/sourceforge/kolmafia/session/BanishManager.java
@@ -99,6 +99,7 @@ public class BanishManager {
     PULLED_INDIGO_TAFFY("pulled indigo taffy", 40, 1, true, Reset.TURN_RESET),
     PUNT("Punt", -1, 1, false, Reset.ROLLOVER_RESET),
     REFLEX_HAMMER("Reflex Hammer", 30, 1, true, Reset.TURN_ROLLOVER_RESET),
+    ROAR_LIKE_A_LION("Roar like a Lion", -1, 1, false, Reset.ROLLOVER_RESET),
     PATRIOTIC_SCREECH("Patriotic Screech", 100, 1, false, Reset.TURN_RESET, BanishType.PHYLUM),
     SABER_FORCE("Saber Force", 30, 1, true, Reset.TURN_ROLLOVER_RESET),
     SHOW_YOUR_BORING_FAMILIAR_PICTURES(


### PR DESCRIPTION
We don't know the specifics of Hold Hands, but track it anyway.

Track Roar like a Lion (banish, lasts until rollover).

Follow-up to  #1899 by fixing the ascension reset.