### PR TITLE
Add to_buffer(string) and use it when initializing a buffer

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -1003,7 +1003,8 @@ public class Parser {
             functionName.content, functionType, variableReferences, functionLocation);
 
     if (f.overridesLibraryFunction()) {
-      functionErrors.submitError(this.overridesLibraryFunctionError(f));
+      String buffer = "Function '" + f.getSignature() + "' overrides a library function.";
+      this.warning(f.getLocation(), buffer);
     }
 
     UserDefinedFunction existing = parentScope.findFunction(f);
@@ -5534,11 +5535,6 @@ public class Parser {
 
   private AshDiagnostic multiplyDefinedFunctionError(final Function f) {
     String buffer = "Function '" + f.getSignature() + "' defined multiple times.";
-    return this.error(f.getLocation(), buffer);
-  }
-
-  private AshDiagnostic overridesLibraryFunctionError(final Function f) {
-    String buffer = "Function '" + f.getSignature() + "' overrides a library function.";
     return this.error(f.getLocation(), buffer);
   }
 

--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia.textui;
 
+import static net.sourceforge.kolmafia.textui.DataTypes.BUFFER_TYPE;
 import static net.sourceforge.kolmafia.textui.DataTypes.PATH_TYPE;
 import static net.sourceforge.kolmafia.textui.parsetree.AggregateType.badAggregateType;
 import static net.sourceforge.kolmafia.textui.parsetree.VariableReference.badVariableReference;
@@ -1188,7 +1189,7 @@ public class Parser {
       }
     }
 
-    if (ltype.equals(PATH_TYPE)) {
+    if (ltype.equals(PATH_TYPE) || ltype.equals(BUFFER_TYPE)) {
       Function target = scope.findFunction(name, params, MatchType.COERCE);
       if (target != null && target.getType().equals(ltype)) {
         return new FunctionCall(rhs.getLocation(), target, params, this);

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -534,7 +534,7 @@ public abstract class RuntimeLibrary {
     params = new Type[] {DataTypes.FLOAT_TYPE};
     functions.add(new LibraryFunction("to_float", DataTypes.FLOAT_TYPE, params));
 
-    params = new Type[] {DataTypes.STRING_TYPE};
+    params = new Type[] {DataTypes.STRICT_STRING_TYPE};
     functions.add(new LibraryFunction("to_buffer", DataTypes.BUFFER_TYPE, params));
 
     params = new Type[] {DataTypes.STRICT_STRING_TYPE};

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -534,6 +534,9 @@ public abstract class RuntimeLibrary {
     params = new Type[] {DataTypes.FLOAT_TYPE};
     functions.add(new LibraryFunction("to_float", DataTypes.FLOAT_TYPE, params));
 
+    params = new Type[] {DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("to_buffer", DataTypes.BUFFER_TYPE, params));
+
     params = new Type[] {DataTypes.STRICT_STRING_TYPE};
     functions.add(new LibraryFunction("to_item", DataTypes.ITEM_TYPE, params));
     params = new Type[] {DataTypes.INT_TYPE};
@@ -3399,8 +3402,11 @@ public abstract class RuntimeLibrary {
 
   public static Value visit_url(ScriptRuntime controller) {
     RelayRequest relayRequest = controller.getRelayRequest();
+    StringBuffer buffer = new StringBuffer();
+    Value returnValue = new Value(DataTypes.BUFFER_TYPE, "", buffer);
+
     if (relayRequest == null) {
-      return new Value(DataTypes.BUFFER_TYPE, "", new StringBuffer());
+      return returnValue;
     }
 
     while (true) {
@@ -3414,11 +3420,10 @@ public abstract class RuntimeLibrary {
       }
     }
 
-    StringBuffer buffer = new StringBuffer();
     if (relayRequest.responseText != null) {
       buffer.append(relayRequest.responseText);
     }
-    return new Value(DataTypes.BUFFER_TYPE, "", buffer);
+    return returnValue;
   }
 
   public static Value visit_url(ScriptRuntime controller, final Value string) {
@@ -3529,11 +3534,13 @@ public abstract class RuntimeLibrary {
   public static Value to_string(ScriptRuntime controller, Value val) {
     // This function previously just returned val, except in the
     // case of buffers in which case it's necessary to capture the
-    // current string value of the buffer.	That works fine in most
-    // cases, but NOT if the value ever gets used as a key in a
-    // map; having a key that's actually an int (for example) in a
-    // string map causes the map ordering to become inconsistent,
-    // because int Values compare differently than string Values.
+    // current string value of the buffer.
+    //
+    // That works fine in most cases, but NOT if the value ever gets
+    // used as a key in a map; having a key that's actually an int (for
+    // example) in a string map causes the map ordering to become
+    // inconsistent, because int Values compare differently than string
+    // Values.
     return val.toStringValue();
   }
 
@@ -3604,6 +3611,12 @@ public abstract class RuntimeLibrary {
     }
 
     return value.toFloatValue();
+  }
+
+  public static Value to_buffer(ScriptRuntime controller, final Value value) {
+    String string = value.toString();
+    StringBuffer buffer = new StringBuffer(string);
+    return new Value(DataTypes.BUFFER_TYPE, "", buffer);
   }
 
   public static Value to_item(ScriptRuntime controller, final Value value) {

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -534,7 +534,9 @@ public abstract class RuntimeLibrary {
     params = new Type[] {DataTypes.FLOAT_TYPE};
     functions.add(new LibraryFunction("to_float", DataTypes.FLOAT_TYPE, params));
 
-    params = new Type[] {DataTypes.STRICT_STRING_TYPE};
+    params = new Type[] {DataTypes.STRING_TYPE};
+    functions.add(new LibraryFunction("to_buffer", DataTypes.BUFFER_TYPE, params));
+    params = new Type[] {DataTypes.BUFFER_TYPE};
     functions.add(new LibraryFunction("to_buffer", DataTypes.BUFFER_TYPE, params));
 
     params = new Type[] {DataTypes.STRICT_STRING_TYPE};
@@ -3614,9 +3616,12 @@ public abstract class RuntimeLibrary {
   }
 
   public static Value to_buffer(ScriptRuntime controller, final Value value) {
-    String string = value.toString();
-    StringBuffer buffer = new StringBuffer(string);
-    return new Value(DataTypes.BUFFER_TYPE, "", buffer);
+    if (value.getType().equals(TypeSpec.STRING)) {
+      String string = value.toString();
+      return new Value(DataTypes.BUFFER_TYPE, "", new StringBuffer(string));
+    }
+    StringBuffer buffer = (StringBuffer) value.rawValue();
+    return new Value(DataTypes.BUFFER_TYPE, "", new StringBuffer(buffer));
   }
 
   public static Value to_item(ScriptRuntime controller, final Value value) {

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -547,6 +547,17 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
     }
   }
 
+  @Nested
+  class BufferFunctions {
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"buffer b = \"Initial content\"; (b.to_string() == \"Initial content\")"})
+    void stringCanInitializeBuffer(String command) {
+      String output = execute(command);
+      assertThat(output, endsWith("Returned: true\n"));
+    }
+  }
+
   @Test
   void environmentIsLowercase() {
     String output = execute("($location[Noob Cave].environment == 'underground')");

--- a/test/net/sourceforge/kolmafia/textui/parsetree/UserDefinedFunctionTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/UserDefinedFunctionTest.java
@@ -111,11 +111,14 @@ public class UserDefinedFunctionTest {
             "void f(int ... a, float b) {}",
             "The vararg parameter must be the last one",
             "char 19 to char 24"),
+        // Overriding a library function is now a warning, not an error.
+        /*
         invalid(
             "Basic function overrides library",
             "void round(float n) {}",
             "Function 'round(float)' overrides a library function.",
             "char 6 to char 20"),
+        */
         invalid(
             "Basic function defined multiple times",
             "void f() {} void f() {}",

--- a/test/root/expected/to_buffer_test.ash.out
+++ b/test/root/expected/to_buffer_test.ash.out
@@ -1,0 +1,8 @@
+Function 'to_buffer(string)' overrides a library function. (to_buffer_test.ash, line 2, char 8 to char 33)
+initial = 'Initial content 1'
+buf1 content = 'Initial content 1'
+buf1a content = 'Initial content 1'
+initial = 'Initial content 2'
+buf2 content = 'Initial content 2'
+initial = 'Heavy Rains'
+buf3 content = 'Heavy Rains'

--- a/test/root/scripts/to_buffer_test.ash
+++ b/test/root/scripts/to_buffer_test.ash
@@ -1,0 +1,20 @@
+// The following should generate a warning
+buffer to_buffer(string initial)
+{
+    print("initial = '" + initial + "'");
+    buffer buf;
+    buf.append(initial);
+    return buf;
+}
+
+buffer buf1 = to_buffer("Initial content 1");
+print("buf1 content = '" + buf1.to_string() + "'");
+
+buffer buf1a = to_buffer(buf1);
+print("buf1a content = '" + buf1a.to_string() + "'");
+
+buffer buf2 = "Initial content 2";
+print("buf2 content = '" + buf2.to_string() + "'");
+
+buffer buf3 = $path[Heavy Rains];
+print("buf3 content = '" + buf3.to_string() + "'");


### PR DESCRIPTION
I've wanted to be able to do this for a long time:

```
buffer b = "Initial contents";
```

Now I can.

I also moved creation of the (buffer) return value of visit_url() to the top of the method, rather than duplicating the creation in two places.