### PR TITLE
 On the dev server, always check the buyScript when acquiring an item. devsters can't use the mall anyway

### DIFF
--- a/src/net/sourceforge/kolmafia/session/InventoryManager.java
+++ b/src/net/sourceforge/kolmafia/session/InventoryManager.java
@@ -848,7 +848,9 @@ public abstract class InventoryManager {
     // ingredients needed to create the item
 
     if (shouldUseMall && !scriptSaysBuy && !InventoryManager.hasAnyIngredient(itemId)) {
-      if (creator == null) {
+      // On the dev server it's always useful to check the buyScript because items can be magicked
+      // into existence.
+      if (creator == null && !KoLmafia.usingDevServer()) {
         if (sim) {
           return "buy";
         }


### PR DESCRIPTION
This is a huge QoL thing for doing dev work! With a suitable buyScript in place, I can write a script to test something and just use `acquire`. Or `acquire` from the command line. I can use the maximizer!