### PR TITLE
feat: improvements to running small

### DIFF
--- a/src/data/adventures.txt
+++ b/src/data/adventures.txt
@@ -363,9 +363,9 @@ The Grey Goo Impact Site	adventure=552	DiffLevel: unknown Env: unknown Stat: 0	T
 
 # A Shrunken Adventurer Am I path
 
-Your Campground from a bug's Perspective	adventure=568	DiffLevel: mid Env: outdoor Stat: 0	Fight in the Dirt
-Your Campground from a bug's Perspective	adventure=569	DiffLevel: mid Env: outdoor Stat: 0	Fight in the Tall Grass
-Your Campground from a bug's Perspective	adventure=570	DiffLevel: mid Env: outdoor Stat: 0	Fight in the Very Tall Grass
+Your Campground From a Bug's Perspective	adventure=568	DiffLevel: mid Env: outdoor Stat: 0	Fight in the Dirt
+Your Campground From a Bug's Perspective	adventure=569	DiffLevel: mid Env: outdoor Stat: 0	Fight in the Tall Grass
+Your Campground From a Bug's Perspective	adventure=570	DiffLevel: mid Env: outdoor Stat: 0	Fight in the Very Tall Grass
 
 # Zodiac sign areas
 

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -12510,6 +12510,7 @@ Path	License to Adventure	Weapon Damage Percent: [50*pref(bondWpn)], Initiative:
 Path	Dark Gyffte	Maximum HP: [20+20*pref(darkGyfftePoints)]
 Path	You, Robot	Energy: +1
 Path	Quantum Terrarium	Familiar Weight: [min(2*L,20)]
+Path	A Shrunken Adventurer Am I	Muscle Limit: 1, Mysticality Limit: 1, Moxie Limit: 1
 
 # Horsery
 Horsery	normal horse	Initiative: +10, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10

--- a/src/data/zonelist.txt
+++ b/src/data/zonelist.txt
@@ -75,7 +75,7 @@ KOL High School	Town	KOL High School	KOLHS
 Exploathing	Exploathing	Kingdom of Exploathing	Kingdom of Exploathing
 Mothership	Mothership	The Bugbear Mothership	Bugbear Invasion
 The Grey Goo Impact Site	The Grey Goo Impact Site	Grey Goo	Grey Goo
-Your Campground from a bug's Perspective	Campground	Shrunken Campground	A Shrunken Adventurer Am I
+Your Campground From a Bug's Perspective	Campground	Shrunken Campground	A Shrunken Adventurer Am I
 
 # Zodiac Signs
 

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -1759,7 +1759,8 @@ public abstract class KoLCharacter {
     if (KoLConstants.chateau.contains(ChateauRequest.CHATEAU_FAN)) freerests += 5;
     if (StandardRequest.isAllowed(RestrictedItemType.ITEMS, "Distant Woods Getaway Brochure")
         && Preferences.getBoolean("getawayCampsiteUnlocked")) ++freerests;
-    if (KoLCharacter.hasSkill(SkillPool.LONG_WINTERS_NAP)) freerests += 5;
+    if (StandardRequest.isAllowed(RestrictedItemType.SKILLS, "Long Winter's Nap")
+        && KoLCharacter.hasSkill(SkillPool.LONG_WINTERS_NAP)) freerests += 5;
     if (InventoryManager.getCount(ItemPool.MOTHERS_NECKLACE) > 0
         || KoLCharacter.hasEquipped(ItemPool.MOTHERS_NECKLACE)) freerests += 5;
     if (InventoryManager.getCount(ItemPool.CINCHO_DE_MAYO) > 0

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -602,6 +602,8 @@ public abstract class KoLCharacter {
       limit = 5;
     } else if (KoLCharacter.isPlumber()) {
       limit = 20;
+    } else if (KoLCharacter.inSmallcore()) {
+      limit = 2;
     } else if (KoLCharacter.inBadMoon()) {
       if (KoLCharacter.hasSkill(SkillPool.PRIDE)) {
         limit -= 1;
@@ -723,6 +725,8 @@ public abstract class KoLCharacter {
       }
     } else if (KoLCharacter.isVampyre()) {
       limit = 4;
+    } else if (KoLCharacter.inSmallcore()) {
+      limit = 1;
     }
 
     if (KoLCharacter.hasSkill(SkillPool.STEEL_LIVER)) {

--- a/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
@@ -1486,6 +1486,11 @@ public class CampgroundRequest extends GenericRequest {
       return;
     }
 
+    if (KoLCharacter.inSmallcore()) {
+      // hard to parse
+      return;
+    }
+
     Matcher m = HOUSING_PATTERN.matcher(responseText);
     if (!m.find()) {
       KoLmafia.updateDisplay(MafiaState.ERROR, "Unable to parse housing!");

--- a/src/net/sourceforge/kolmafia/request/CharPaneRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CharPaneRequest.java
@@ -492,6 +492,11 @@ public class CharPaneRequest extends GenericRequest {
 
   private static void handleStatPoints(final String responseText, final Pattern pattern)
       throws Exception {
+    if (KoLCharacter.inSmallcore()) {
+      // trust api.php
+      return;
+    }
+
     Matcher statMatcher = pattern.matcher(responseText);
     if (!statMatcher.find()) {
       return;


### PR DESCRIPTION
The way stats work in Small is that your black stats are capped at 1, but your level is uncapped.

Implement this by ignoring charsheet requests, trusting api.php for the stats, and adding a modifier that limits your stats to 1. This makes maximizer + numberology work as desired (i.e. maximizer treats percentage buffs as acting on 1, numberology gets your level correct).

Limit fullness and inebriety.

Skip parsing campground for now. I have HTMLs, I will get back to it later. Your housing never shows up -- it's just "rest in the dirt", but we could parse whether you have free rests left.

Don't count Long Winter's Nap if it's out of standard, which it is now.