### PR TITLE
_beachTides is global and defaults to -1

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -181,6 +181,7 @@ global	userAgent
 global	verboseSpeakeasy	false
 global	verboseFloundry	false
 global	wrapLongLines	true
+global	_beachTides	-1
 global	_g9Effect	0
 global	_gitUpdated	false
 global	_svnRepoFileFetched	false
@@ -1715,7 +1716,6 @@ user	_beachCombing	false
 user	_beachHeadsUsed
 user	_beachLayout
 user	_beachMinutes
-user	_beachTides	0
 user	_beanCannonUses	0
 user	_bearHugs	0
 user	_beerLensDrops	0

--- a/test/net/sourceforge/kolmafia/session/BeachManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/BeachManagerTest.java
@@ -48,7 +48,7 @@ public class BeachManagerTest {
             withHandlingChoice(1388),
             withProperty("_beachCombing", false),
             withProperty("_beachMinutes", 0),
-            withProperty("_beachTides", 0),
+            withProperty("_beachTides", -1),
             withProperty("_beachLayout", ""));
 
     ByteArrayOutputStream ostream = new ByteArrayOutputStream();
@@ -74,7 +74,6 @@ public class BeachManagerTest {
       assertEquals(
           "3:rrrrrrrrrr,4:rrrrrrrrrr,5:rrrrrrrrrr,6:rrrrrrrrrr,7:rrrrrrrrrr,8:rrrrrrrrrr,9:rrrrrWrrrr,10:rrrrrrrrrr",
           Preferences.getString("_beachLayout"));
-      assertEquals(2, Preferences.getInteger("_beachTides"));
     }
   }
 


### PR DESCRIPTION
1) Beach tides apply to everybody. Therefore, make _beachTides a global pref, not a user pref
2) The Wiki says they can cover up to 4 rows and rise and fall 1 row per day in a 9-day cycle.
Thus: 0, 1, 2, 3, 4, 3, 2, 1, 0, ...
Which means that 1 day out of 9, row 1 will be available to comb.
Therefore, the default for _beachTides is -1, and will be set to 0-4 when we parse a beach map.