### PR TITLE
fix: only remarkably double real offhands

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -5784,13 +5784,13 @@ public abstract class KoLCharacter {
     addOffhandRemarkable(offhand, newModifiers);
     // and also offhand items that are equipped on the familiar
     var famItem = equipment.get(Slot.FAMILIAR);
-    if (famItem != null && ItemDatabase.getConsumptionType(famItem.id) == ConsumptionType.OFFHAND) {
-      addOffhandRemarkable(famItem, newModifiers);
-    }
+    addOffhandRemarkable(famItem, newModifiers);
   }
 
   private static void addOffhandRemarkable(AdventureResult item, Modifiers newModifiers) {
-    if (item != null && item != EquipmentRequest.UNEQUIP) {
+    if (item != null
+        && item != EquipmentRequest.UNEQUIP
+        && ItemDatabase.getConsumptionType(item.id) == ConsumptionType.OFFHAND) {
       if (item.id != ItemPool.LATTE_MUG) {
         var mods = ModifierDatabase.getItemModifiers(item.id);
         var copyMods = new Modifiers(mods);

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -824,6 +824,7 @@ public class ItemPool {
   public static final int GOLD_BOWLING_BALL = 2766;
   public static final int SOLID_BACONSTONE_EARRING = 2780;
   public static final int BRIMSTONE_BERET = 2813;
+  public static final int BRIMSTONE_BLUDGEON = 2814;
   public static final int BRIMSTONE_BUNKER = 2815;
   public static final int BRIMSTONE_BRACELET = 2818;
   public static final int GRIMACITE_GASMASK = 2819;

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -1086,6 +1086,23 @@ public class ModifiersTest {
     }
 
     @Test
+    public void onlyDoublesOffhandOffhands() {
+      var cleanups =
+          new Cleanups(
+              withSkill(SkillPool.DOUBLE_FISTED_SKULL_SMASHING),
+              withEquipped(ItemPool.BRIMSTONE_BLUDGEON),
+              withEquipped(Slot.OFFHAND, ItemPool.BRIMSTONE_BLUDGEON),
+              withEffect(EffectPool.OFFHAND_REMARKABLE));
+
+      try (cleanups) {
+        KoLCharacter.recalculateAdjustments(false);
+        Modifiers current = KoLCharacter.getCurrentModifiers();
+
+        assertThat(current.getDouble(DoubleModifier.MUS_PCT), equalTo(100.0));
+      }
+    }
+
+    @Test
     public void doublesOffhandsOnFamiliar() {
       var cleanups =
           new Cleanups(


### PR DESCRIPTION
Fix https://kolmafia.us/threads/offhand-remarkable-is-incorrectly-applying-to-weapons-equipped-in-offhand.29172/