### PR TITLE
Add exception for Citizen of a Zone as removable

### DIFF
--- a/src/net/sourceforge/kolmafia/request/UneffectRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UneffectRequest.java
@@ -206,6 +206,9 @@ public class UneffectRequest extends GenericRequest {
   }
 
   public static final boolean isRemovableIntrinsic(final int effectId) {
+    if (EffectPool.CITIZEN_OF_A_ZONE == effectId) {
+      return true;
+    }
     return !"".equals(getUneffectSkill(effectId));
   }
 


### PR DESCRIPTION
Prior to this change:
```
> uneffect citizen of a zone

Citizen of a Zone is intrinsic and cannot be removed.
```
After:
```
> uneffect citizen of a zone

Citizen of a Zone has no specific item or skill for removal. Trying generics...
Using soft green whatever...
Citizen of a Zone removed.
```