### PR TITLE
Check circadianAdv instead of resolutionAdv when adding circadian rhythms to rollover adventures

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -5435,7 +5435,7 @@ public abstract class KoLCharacter {
           ItemPool.RESOLUTION_ADVENTUROUS);
     }
     var circadianAdv = Preferences.getInteger("_circadianRhythmsAdventures");
-    if (resolutionAdv > 0) {
+    if (circadianAdv > 0) {
       newModifiers.addDouble(
           DoubleModifier.ADVENTURES,
           circadianAdv,


### PR DESCRIPTION
Otherwise, you won't see circadian rhythms unless you have used be more adventurous as well.