### PR TITLE
When not logged in, who cares if shadowLabyrinthGoal is unset

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/panel/ChoiceOptionsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/ChoiceOptionsPanel.java
@@ -1132,7 +1132,7 @@ public class ChoiceOptionsPanel extends JTabbedPane implements Listener {
     String shadowLabyrinthSetting = Preferences.getString("shadowLabyrinthGoal");
     this.shadowLabyrinthSelect.setSelectedIndex(
         switch (shadowLabyrinthSetting) {
-          case "browser" -> 0;
+          case "browser", "" -> 0;
           case "muscle" -> 1;
           case "mysticality" -> 2;
           case "moxie" -> 3;
@@ -1142,7 +1142,7 @@ public class ChoiceOptionsPanel extends JTabbedPane implements Listener {
           case "resistance" -> 7;
           default -> {
             System.out.println(
-                "Invalid setting " + shadowLabyrinthSetting + " for shadowLabyrinthGoal.");
+                "Invalid setting '" + shadowLabyrinthSetting + "' for shadowLabyrinthGoal.");
             yield 0;
           }
         });


### PR DESCRIPTION
shadowLabyrinthGoal defaults to "browser".
It has a variety of other settings, and if you set it to a bogus value, we print
```
Invalid setting  for shadowLabyrinthGoal.
```
to stdout.

You also get this when opening the gCLI while not logged in, since you don't have any user preferences, and an empty setting will trigger that message.

That is completely useless. Treat "" as if it were "browser" - which is the value in defaults.txt.
Voila! No more irritating message on my terminal.