### PR TITLE
fix: remove some debug logs around weird javascript null -> ASH stuff

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -3247,7 +3247,7 @@ public abstract class RuntimeLibrary {
     Value[] keys = obj.keys();
     for (Value key : keys) {
       Value v = obj.aref(key);
-      String value = v.toString();
+      String value = v == null ? null : v.toString();
       if (!addToSessionStream) {
         value = StringUtilities.getEntityEncode(value);
       }
@@ -3258,8 +3258,8 @@ public abstract class RuntimeLibrary {
       } else {
         RequestLogger.printLine(line);
       }
-      if (v instanceof CompositeValue) {
-        RuntimeLibrary.dump((CompositeValue) v, indent + "\u00A0\u00A0", color, addToSessionStream);
+      if (v instanceof CompositeValue cv) {
+        RuntimeLibrary.dump(cv, indent + "\u00A0\u00A0", color, addToSessionStream);
       }
     }
   }

--- a/src/net/sourceforge/kolmafia/textui/javascript/ValueConverter.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/ValueConverter.java
@@ -180,7 +180,8 @@ public class ValueConverter {
       }
     }
 
-    Type elementType = fromJava(nativeArray.get(0)).getType();
+    Value firstElement = fromJava(nativeArray.get(0));
+    Type elementType = firstElement == null ? DataTypes.ANY_TYPE : firstElement.getType();
     List<Value> result = new ArrayList<>();
     for (Object element : nativeArray) {
       result.add(fromJava(element));

--- a/test/net/sourceforge/kolmafia/textui/command/JavaScriptCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/JavaScriptCommandTest.java
@@ -1,0 +1,67 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class JavaScriptCommandTest extends AbstractCommandTestBase {
+  public JavaScriptCommandTest() {
+    this.command = "js";
+  }
+
+  @Nested
+  class WeirdNullInteractions {
+    @Test
+    public void printsNull() {
+      String output = execute("null");
+
+      assertThat(output, containsString("Returned: null"));
+    }
+
+    @Test
+    public void printsUndefined() {
+      String output = execute("undefined");
+
+      assertThat(output, startsWith("Returned: org.mozilla.javascript.Undefined"));
+    }
+
+    @Test
+    public void emptyArray() {
+      String output = execute("[]");
+
+      assertThat(output, startsWith("Returned: aggregate null [0]"));
+    }
+
+    @Test
+    public void nullContainingArray() {
+      String output = execute("[\"hello\", null]");
+
+      assertThat(
+          output,
+          equalTo(
+              """
+          Returned: aggregate string [2]
+          0 => hello
+          1 => null
+          """));
+    }
+
+    @Test
+    public void nullStartingArray() {
+      String output = execute("[null, \"hello\"]");
+
+      assertThat(
+          output,
+          equalTo(
+              """
+          Returned: aggregate null [2]
+          0 => null
+          1 => hello
+          """));
+    }
+  }
+}


### PR DESCRIPTION
As in https://kolmafia.us/threads/debug-log-printed-with-arrays-containing-nulls-or-undefined.29236/

Avoid debug log errors. Have reasonable behaviour: print "null", have array as "any": given this not showing up before I think printing in the CLI is the only use-case.