### PR TITLE
fix: familiars should be specified by string

### DIFF
--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -959,12 +959,12 @@ public class Modifiers {
     }
     var hareAdv = Preferences.getInteger("_hareAdv");
     if (hareAdv > 0) {
-      this.addDouble(DoubleModifier.ADVENTURES, hareAdv, ModifierType.FAMILIAR, FamiliarPool.HARE);
+      this.addDouble(DoubleModifier.ADVENTURES, hareAdv, ModifierType.FAMILIAR, "Wild Hare");
     }
     var gibberAdv = Preferences.getInteger("_gibbererAdv");
     if (gibberAdv > 0) {
       this.addDouble(
-          DoubleModifier.ADVENTURES, gibberAdv, ModifierType.FAMILIAR, FamiliarPool.GIBBERER);
+          DoubleModifier.ADVENTURES, gibberAdv, ModifierType.FAMILIAR, "Squamous Gibberer");
     }
     var usedBorrowedTime = Preferences.getBoolean("_borrowedTimeUsed");
     if (usedBorrowedTime) {

--- a/test/net/sourceforge/kolmafia/DebugModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/DebugModifiersTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class DebugModifiersTest {
   private static Matcher<String> containsDebugRow(
@@ -570,6 +572,15 @@ public class DebugModifiersTest {
             withAllEquipped(ItemPool.SUGAR_SHIRT, ItemPool.MIME_ARMY_INSIGNIA_INFANTRY))) {
       evaluateDebugModifiers(DoubleModifier.MUS_EXPERIENCE);
       assertThat(output(), containsDebugRow("Class", "EXP", 5.0, 5.0));
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({"_hareAdv,Wild Hare", "_gibbererAdv,Squamous Gibberer"})
+  void listsFamiliarAdventures(String preference, String familiar) {
+    try (var cleanups = new Cleanups(withProperty(preference, 6))) {
+      evaluateDebugModifiers(DoubleModifier.ADVENTURES);
+      assertThat(output(), containsDebugRow("Familiar", familiar, 6.0, 6.0));
     }
   }
 }


### PR DESCRIPTION
Found this while working on adding free rests as modifiers.