### PR TITLE
Ignore failed rests

### DIFF
--- a/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
@@ -1011,9 +1011,9 @@ public class CampgroundRequest extends GenericRequest {
 
     if (action.equals("rest")) {
       // You don't need to rest right now.
-      // #  this does not use a free rest charge,
-      // #  and it does not cost an Adventure if out of free rests,
-      // #  so it should not be counted as a rest
+      //   this does not use a free rest charge,
+      //   and it does not cost an Adventure if out of free rests,
+      //   so it should not be counted as a rest
       if (!responseText.contains("You don't need to rest right now.")) {
         Preferences.increment("timesRested", 1);
       }

--- a/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
@@ -1010,7 +1010,12 @@ public class CampgroundRequest extends GenericRequest {
     }
 
     if (action.equals("rest")) {
-      Preferences.increment("timesRested", 1);
+      // You don't need to rest right now.
+      // 
+      // This does not use a free rest charge, and it does not cost an Adventure if out of free rests, so it should not be counted as a rest.
+      if (!responseText.contains("You don't need to rest right now.")) {
+        Preferences.increment("timesRested", 1);
+      }
 
       // Your black-and-blue light cycles wildly between
       // black and blue, then emits a shower of sparks as it

--- a/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
@@ -1011,8 +1011,9 @@ public class CampgroundRequest extends GenericRequest {
 
     if (action.equals("rest")) {
       // You don't need to rest right now.
-      // 
-      // This does not use a free rest charge, and it does not cost an Adventure if out of free rests, so it should not be counted as a rest.
+      // #  this does not use a free rest charge, 
+      // #  and it does not cost an Adventure if out of free rests, 
+      // #  so it should not be counted as a rest
       if (!responseText.contains("You don't need to rest right now.")) {
         Preferences.increment("timesRested", 1);
       }

--- a/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CampgroundRequest.java
@@ -1011,8 +1011,8 @@ public class CampgroundRequest extends GenericRequest {
 
     if (action.equals("rest")) {
       // You don't need to rest right now.
-      // #  this does not use a free rest charge, 
-      // #  and it does not cost an Adventure if out of free rests, 
+      // #  this does not use a free rest charge,
+      // #  and it does not cost an Adventure if out of free rests,
       // #  so it should not be counted as a rest
       if (!responseText.contains("You don't need to rest right now.")) {
         Preferences.increment("timesRested", 1);

--- a/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
@@ -114,6 +114,22 @@ public class CampgroundRequestTest {
     }
   }
 
+  @Test 
+  void doesNotCountFailedRests() {
+    var cleanups =
+      new Cleanups(
+        // A rest did not get processed by the game, because it is pointless to rest (full HP, full MP, no Beaten Up)
+        withNextResponse(200, html("request/test_do_not_count_failed_rests.html")),
+        withProperty("timesRested", 137));
+
+    try (cleanups) {
+      new GenericRequest("campground.php?action=rest").run();
+      // timesRested did not increase
+      assertThat("timesRested", isSetTo(137));
+      assertThat(OMINOUS_WISDOM.getCount(KoLConstants.activeEffects), is(50));
+    }
+  }
+
   @Nested
   class Pumpkins {
     @Test

--- a/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
@@ -114,13 +114,14 @@ public class CampgroundRequestTest {
     }
   }
 
-  @Test 
+  @Test
   void doesNotCountFailedRests() {
     var cleanups =
-      new Cleanups(
-        // A rest did not get processed by the game, because it is pointless to rest (full HP, full MP, no Beaten Up)
-        withNextResponse(200, html("request/test_do_not_count_failed_rests.html")),
-        withProperty("timesRested", 137));
+        new Cleanups(
+            // A rest did not get processed by the game, because it is pointless to rest
+            // (full HP, full MP, no Beaten Up)
+            withNextResponse(200, html("request/test_do_not_count_failed_rests.html")),
+            withProperty("timesRested", 137));
 
     try (cleanups) {
       new GenericRequest("campground.php?action=rest").run();

--- a/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
@@ -114,19 +114,37 @@ public class CampgroundRequestTest {
     }
   }
 
-  @Test
-  void doesNotCountFailedRests() {
-    var cleanups =
-        new Cleanups(
-            // A rest did not get processed by the game, because it is pointless to rest
-            // (full HP, full MP, no Beaten Up)
-            withNextResponse(200, html("request/test_do_not_count_failed_rests.html")),
-            withProperty("timesRested", 137));
+  @Nested
+  class Rests {
+    @Test
+    void doesNotCountFailedRests() {
+      var cleanups =
+          new Cleanups(
+              // A rest did not get processed by the game, because it is pointless to rest
+              // (full HP, full MP, no Beaten Up)
+              withNextResponse(200, html("request/test_do_not_count_failed_rests.html")),
+              withProperty("timesRested", 137));
 
-    try (cleanups) {
-      new GenericRequest("campground.php?action=rest").run();
-      // timesRested did not increase
-      assertThat("timesRested", isSetTo(137));
+      try (cleanups) {
+        new GenericRequest("campground.php?action=rest").run();
+        // timesRested did not increase
+        assertThat("timesRested", isSetTo(137));
+      }
+    }
+
+    @Test
+    void countsSuccessfulRests() {
+      var cleanups =
+          new Cleanups(
+              // A successful rest
+              withNextResponse(200, html("request/test_count_successful_rests.html")),
+              withProperty("timesRested", 137));
+
+      try (cleanups) {
+        new GenericRequest("campground.php?action=rest").run();
+        // timesRested did increase
+        assertThat("timesRested", isSetTo(138));
+      }
     }
   }
 

--- a/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/CampgroundRequestTest.java
@@ -127,7 +127,6 @@ public class CampgroundRequestTest {
       new GenericRequest("campground.php?action=rest").run();
       // timesRested did not increase
       assertThat("timesRested", isSetTo(137));
-      assertThat(OMINOUS_WISDOM.getCount(KoLConstants.activeEffects), is(50));
     }
   }
 

--- a/test/root/request/test_count_successful_rests.html
+++ b/test/root/request/test_count_successful_rests.html
@@ -1,0 +1,188 @@
+<html>
+
+<head>
+    <script
+        language=Javascript><!--if (parent.frames.length == 0) location.href="game.php";top.charpane.location.href="charpane.php";//--></script>
+    <script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/keybinds.min.2.js"></script>
+    <script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/window.20111231.js"></script>
+    <script
+        language="javascript">function chatFocus() { if (top.chatpane.document.chatform.graf) top.chatpane.document.chatform.graf.focus(); } if (typeof defaultBind != 'undefined') { defaultBind(47, 2, chatFocus); defaultBind(190, 2, chatFocus); defaultBind(191, 2, chatFocus); defaultBind(47, 8, chatFocus); defaultBind(190, 8, chatFocus); defaultBind(191, 8, chatFocus); }</script>
+    <script
+        language="javascript">function updateParseItem(iid, field, info) { var tbl = $('#ic' + iid); var data = parseItem(tbl); if (!data) return; data[field] = info; var out = []; for (i in data) { if (!data.hasOwnProperty(i)) continue; out.push(i + '=' + data[i]); } tbl.attr('rel', out.join('&')); } function parseItem(tbl) { tbl = $(tbl); var rel = tbl.attr('rel'); var data = {}; if (!rel) return data; var parts = rel.split('&'); for (i in parts) { if (!parts.hasOwnProperty(i)) continue; var kv = parts[i].split('='); tbl.data(kv[0], kv[1]); data[kv[0]] = kv[1]; } return data; }</script>
+    <script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/jquery-1.3.1.min.js"></script>
+    <script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/pop_query.20230713.js"></script>
+    <script type="text/javascript"> function pop_ircm(clicked) { return false; } </script>
+    <link rel="stylesheet" type="text/css" href="https://d2uyhvukfffg5a.cloudfront.net/styles.20230117d.css">
+    <style type='text/css'>
+        .faded {
+            zoom: 1;
+            filter: alpha(opacity=35);
+            opacity: 0.35;
+            -khtml-opacity: 0.35;
+            -moz-opacity: 0.35;
+        }
+    </style>
+</head>
+
+<body>
+    <centeR>
+        <table width=95% cellspacing=0 cellpadding=0>
+            <tr>
+                <td style="color: white;" align=center bgcolor=blue><b>Results:</b></td>
+            </tr>
+            <tr>
+                <td style="padding: 5px; border: 1px solid blue;">
+                    <center>
+                        <table>
+                            <tr>
+                                <td>
+                                    <p>You lie down on the floor and rest.
+                                    <p>While you rest, your cincho loosens 25%.<center>
+                                            <table>
+                                                <tr>
+                                                    <td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/hp.gif"
+                                                            height=30 width=30></td>
+                                                    <td valign=center class=effect>You gain 40 hit points.</td>
+                                                </tr>
+                                            </table>
+                                        </center>
+                                        <center>
+                                            <Table>
+                                                <tr>
+                                                    <td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/mp.gif"
+                                                            height=30 width=30></td>
+                                                    <td valign=center class=effect>You gain 40 Mojo Points.</td>
+                                                </tr>
+                                            </table>
+                                        </center>
+                    </center>
+                    <p>You have an incredibly vivid dream in which you're a butterfly, flitting about in the breeze.
+                        When you wake up, you aren't quite sure whether you're an adventurer that dreamt of being a
+                        butterfly, or a butterfly that's dreaming of being an adventurer.
+                    <p>You do feel an overwhelming urge to pollinate something, though.
+                </td>
+            </tr>
+        </table>
+    </center>
+    </td>
+    </tr>
+    <tr>
+        <td height=4></td>
+    </tr>
+    </table>
+    <table width=95% cellspacing=0 cellpadding=0>
+        <tr>
+            <td style="color: white;" align=center bgcolor=blue><b>Your Campsite</b></td>
+        </tr>
+        <tr>
+            <td style="padding: 5px; border: 1px solid blue;">
+                <center>
+                    <table>
+                        <tr>
+                            <td>
+                                <center>
+                                    <table cellspacing=0 cellpadding=0>
+                                        <tr>
+                                            <td height=15 align=center><a
+                                                    href="campground.php?action=inspectdwelling"><img
+                                                        src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/tinyglass.gif"
+                                                        width=15 height=15 border=0></a></td>
+                                            <td></td>
+                                            <td></td>
+                                            <td></td>
+                                            <td></td>
+                                        </tr>
+                                        <tr>
+                                            <td width=100 height=100><a href="campground.php?action=rest"><img
+                                                        src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/rest4.gif"
+                                                        width=100 height=100 border=0 alt="Rest in Your Dwelling (1)"
+                                                        title="Rest in Your Dwelling (1)"></a></td>
+                                            <td width=100 height=100><img
+                                                    src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains3.gif"
+                                                    width=100 height=100></td>
+                                            <td width=100 height=100><img
+                                                    src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains1.gif"
+                                                    width=100 height=100></td>
+                                            <td width=100 height=100><img
+                                                    src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains2.gif"
+                                                    width=100 height=100></td>
+                                            <td width=100 height=100><a href="closet.php"><img
+                                                        src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/closet.gif"
+                                                        width=100 height=100 border=0 alt="Your Colossal Closet"
+                                                        title="Your Colossal Closet"></a></td>
+                                        </tr>
+                                        <tr>
+                                            <td width=100 height=100><a href="campground.php?action=telescope"><img
+                                                        src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/telescope.gif"
+                                                        width=100 height=100 border=0 alt="A Telescope"
+                                                        title="A Telescope"></a></td>
+                                            <td width=100 height=50><img
+                                                    src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/smallblank1.gif"
+                                                    width=100 height=50></td>
+                                            <td width=100 height=100><img
+                                                    src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains2.gif"
+                                                    width=100 height=100></td>
+                                            <td width=100 height=100><a href="trophies.php"><img
+                                                        src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/trophycase.gif"
+                                                        width=100 height=100 border=0 alt="Trophy Case"
+                                                        title="Trophy Case"></a></td>
+                                            <td width=100 height=100><img
+                                                    src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains5.gif"
+                                                    width=100 height=100></td>
+                                        </tr>
+                                        <tr>
+                                            <td width=100 height=100><img
+                                                    src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains6.gif"
+                                                    width=100 height=100></td>
+                                            <td width=100 height=100><a href=campground.php?action=inspectkitchen><img
+                                                        src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/kitchen.gif"
+                                                        width=100 height=100 border=0 alt="Your Kitchen"
+                                                        title="Your Kitchen"></a></td>
+                                            <td width=100 height=100><img
+                                                    src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains1.gif"
+                                                    width=100 height=100></td>
+                                            <td width=100 height=100><a href="familiar.php"><img
+                                                        src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/bigterrarium.gif"
+                                                        width=100 height=100 border=0 alt="Familiar-Gro Terrarium"
+                                                        title="Familiar-Gro Terrarium"></a></td>
+                                            <td width=100 height=100><a href="questlog.php"><img
+                                                        src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/questlog2.gif"
+                                                        width=100 height=100 border=0 alt="Your Quest Log"
+                                                        title="Your Quest Log"></a></td>
+                                        </tr>
+                                        <tr>
+                                            <td width=100 height=100><img
+                                                    src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains8.gif"
+                                                    width=100 height=100></td>
+                                            <td width=100 height=100><img
+                                                    src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains1.gif"
+                                                    width=100 height=100></td>
+                                            <td width=100 height=100><img
+                                                    src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains7.gif"
+                                                    width=100 height=100></td>
+                                            <td width=100 height=100><img
+                                                    src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains9.gif"
+                                                    width=100 height=100></td>
+                                            <td width=100 height=100><img
+                                                    src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains3.gif"
+                                                    width=100 height=100></td>
+                                        </tr>
+                                    </table>
+                                </center>
+                                <center>
+                                    <p><a href="main.php">Back to the Main Map</a>
+                                </center>
+                            </td>
+                        </tr>
+                    </table>
+                </center>
+            </td>
+        </tr>
+        <tr>
+            <td height=4></td>
+        </tr>
+    </table>
+    </center>
+</body>
+
+</html>

--- a/test/root/request/test_do_not_count_failed_rests.html
+++ b/test/root/request/test_do_not_count_failed_rests.html
@@ -1,0 +1,210 @@
+<html>
+    <head>
+        <script language=Javascript>
+            <!--if (parent.frames.length == 0) location.href="game.php";//-->
+        </script>
+        <script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/keybinds.min.2.js"></script>
+        <script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/window.20111231.js"></script>
+        <script language="javascript">
+            function chatFocus(){
+                if(top.chatpane.document.chatform.graf) top.chatpane.document.chatform.graf.focus();
+            }
+            if (typeof defaultBind != 'undefined') { 
+                defaultBind(47, 2, chatFocus); 
+                defaultBind(190, 2, chatFocus);
+                defaultBind(191, 2, chatFocus); 
+                defaultBind(47, 8, chatFocus);
+                defaultBind(190, 8, chatFocus); d
+                efaultBind(191, 8, chatFocus); 
+            }
+        </script>
+        <script language="javascript">
+            function updateParseItem(iid, field, info) {
+                var tbl = $('#ic'+iid);
+                var data = parseItem(tbl);
+                if (!data) return;
+                data[field] = info;
+                var out = [];
+                for (i in data) {
+                    if (!data.hasOwnProperty(i)) continue;
+                    out.push(i+'='+data[i]);
+                }
+                tbl.attr('rel', out.join('&'));
+            }
+            
+            function parseItem(tbl) {
+                tbl = $(tbl);
+                var rel = tbl.attr('rel');
+                var data = {};
+                if (!rel) return data;
+                var parts = rel.split('&');
+                for (i in parts) {
+                    if (!parts.hasOwnProperty(i)) continue;
+                    var kv = parts[i].split('=');
+                    tbl.data(kv[0], kv[1]);
+                    data[kv[0]] = kv[1];
+                }
+                return data;
+            }
+        </script>
+        <script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/jquery-1.3.1.min.js"></script>
+        <script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/pop_query.20230713.js"></script>
+        <script type="text/javascript"> 
+            function pop_ircm(clicked) { 
+                return false; 
+            }
+        </script>	
+        <link rel="stylesheet" type="text/css" href="https://d2uyhvukfffg5a.cloudfront.net/styles.20230117d.css">
+        <style type='text/css'>
+            .faded {
+                zoom: 1;
+                filter: alpha(opacity=35);
+                opacity: 0.35;
+                -khtml-opacity: 0.35;
+                -moz-opacity: 0.35;
+            }
+        </style>
+        </head>
+        <body>
+            <centeR>
+                <table  width=95%  cellspacing=0 cellpadding=0>
+                    <tr>
+                        <td style="color: white;" align=center bgcolor=blue>
+                            <b>Results:</b>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 5px; border: 1px solid blue;">
+                            <center>
+                                <table>
+                                    <tr>
+                                        <td>You don't need to rest right now.</td>
+                                    </tr>
+                                </table>
+                            </center>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td height=4></td>
+                    </tr>
+                </table>
+                <table  width=95%  cellspacing=0 cellpadding=0>
+                    <tr>
+                        <td style="color: white;" align=center bgcolor=blue>
+                            <b>Your Campsite</b>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 5px; border: 1px solid blue;">
+                            <center>
+                                <table>
+                                    <tr>
+                                        <td>
+                                            <center>
+                                                <table cellspacing=0 cellpadding=0>
+                                                    <tr>
+                                                        <td height=15 align=center>
+                                                            <a href="campground.php?action=inspectdwelling">
+                                                                <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/tinyglass.gif" width=15 height=15 border=0>
+                                                            </a>
+                                                        </td>
+                                                        <td></td>
+                                                        <td></td>
+                                                        <td></td>
+                                                        <td></td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td width=100 height=100>
+                                                            <a href="campground.php?action=rest">
+                                                                <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/rest4.gif" width=100 height=100 border=0 alt="Rest in Your Dwelling (1)" title="Rest in Your Dwelling (1)">
+                                                            </a>
+                                                        </td>
+                                                        <td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains3.gif" width=100 height=100></td><td width=100 height=100>
+                                                            <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains1.gif" width=100 height=100>
+                                                        </td>
+                                                        <td width=100 height=100>
+                                                            <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains2.gif" width=100 height=100>
+                                                        </td>
+                                                        <td width=100 height=100>
+                                                            <a href="closet.php">
+                                                                <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/closet.gif" width=100 height=100 border=0 alt="Your Colossal Closet" title="Your Colossal Closet">
+                                                            </a>
+                                                        </td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td width=100 height=100>
+                                                            <a href="campground.php?action=telescope">
+                                                                <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/telescope.gif" width=100 height=100 border=0 alt="A Telescope" title="A Telescope">
+                                                            </a>
+                                                        </td>
+                                                        <td width=100 height=50>
+                                                            <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/smallblank1.gif" width=100 height=50>
+                                                        </td>
+                                                        <td width=100 height=100>
+                                                            <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains2.gif" width=100 height=100>
+                                                        </td>
+                                                        <td width=100 height=100>
+                                                            <a href="trophies.php">
+                                                                <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/trophycase.gif" width=100 height=100 border=0 alt="Trophy Case" title="Trophy Case">
+                                                            </a>
+                                                        </td>
+                                                        <td width=100 height=100><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains5.gif" width=100 height=100></td>
+                                                    </tr>
+                                                    <tr><td width=100 height=100>
+                                                        <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains6.gif" width=100 height=100>
+                                                    </td>
+                                                    <td width=100 height=100>
+                                                        <a href=campground.php?action=inspectkitchen>
+                                                            <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/kitchen.gif" width=100 height=100 border=0 alt="Your Kitchen" title="Your Kitchen">
+                                                        </a>
+                                                    </td>
+                                                    <td width=100 height=100>
+                                                        <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains1.gif" width=100 height=100>
+                                                    </td>
+                                                    <td width=100 height=100>
+                                                        <a href="familiar.php">
+                                                            <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/bigterrarium.gif" width=100 height=100 border=0 alt="Familiar-Gro Terrarium" title="Familiar-Gro Terrarium">
+                                                        </a>
+                                                    </td>
+                                                    <td width=100 height=100>
+                                                        <a href="questlog.php">
+                                                            <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/campground/questlog2.gif" width=100 height=100 border=0 alt="Your Quest Log" title="Your Quest Log">
+                                                        </a>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td width=100 height=100>
+                                                        <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains8.gif" width=100 height=100>
+                                                    </td>
+                                                    <td width=100 height=100>
+                                                        <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains1.gif" width=100 height=100>
+                                                    </td>
+                                                    <td width=100 height=100>
+                                                        <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains7.gif" width=100 height=100>
+                                                    </td>
+                                                    <td width=100 height=100>
+                                                        <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains9.gif" width=100 height=100>
+                                                    </td>
+                                                    <td width=100 height=100>
+                                                        <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/plains/plains3.gif" width=100 height=100>
+                                                    </td>
+                                                </tr>
+                                            </table>
+                                        </center>
+                                        <center>
+                                            <p>
+                                                <a href="main.php">Back to the Main Map</a>
+                                        </center>
+                                    </td>
+                                </tr>
+                            </table>
+                        </center>
+                    </td>
+                </tr>
+                <tr>
+                    <td height=4></td>
+                </tr>
+            </table>
+        </center>
+    </body>
+</html>


### PR DESCRIPTION
If you try to rest when it is pointless to do so (full HP, full MP, no Beaten Up), the game won't let you do it, and will display a message "You don't need to rest right now." instead. This does not decrement the amount of free rests you can use, and this does not subtract an Adventure if you are out of free rests. However, KoLmafia thinks that the rest did happen, and increases timesRested accordingly. This leads to the undercounting of the amount of free rests left (Mafia fixes the data if it sees that a free rest is actually available, but it thinks it is not; however, the information that there is more than one free rest would be lost). The fix is to not increment timesRested in the case of a failed rest.