### PR TITLE
fix: allow casting disco nap

### DIFF
--- a/src/data/classskills.txt
+++ b/src/data/classskills.txt
@@ -13,7 +13,7 @@
 #     8 (Combat/Passive)
 #     9 (One-at-a-time Noncombat Expression)
 #    10 (One-at-a-time Noncombat Walk)
-#    11 (Noncombat/Passive)
+#    11 (Noncombat healing/Passive)
 
 1	Liver of Steel	liver.gif	0	0	0
 2	Chronic Indigestion	fireball.gif	5	5	0

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -3830,7 +3830,7 @@ public abstract class KoLCharacter {
         KoLConstants.summoningSkills.add(skill);
         LockableListFactory.sort(KoLConstants.summoningSkills);
       }
-      case REMEDY -> {
+      case REMEDY, REMEDY_PASSIVE -> {
         KoLConstants.usableSkills.add(skill);
         LockableListFactory.sort(KoLConstants.usableSkills);
         KoLConstants.remedySkills.add(skill);

--- a/src/net/sourceforge/kolmafia/persistence/SkillDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/SkillDatabase.java
@@ -34,7 +34,7 @@ public class SkillDatabase {
     COMBAT_PASSIVE("combat/passive", 8),
     EXPRESSION("expression", 9),
     WALK("walk", 10),
-    NONCOMBAT_PASSIVE("noncombat/passive", 11);
+    REMEDY_PASSIVE("noncombat/passive", 11);
 
     public final String name;
     public final int number;
@@ -911,7 +911,13 @@ public class SkillDatabase {
     SkillType skillType = SkillDatabase.skillTypeById.get(skillId);
     if (skillType == null) return false;
     return switch (skillType) {
-      case SUMMON, REMEDY, SELF_ONLY, SONG, COMBAT_NONCOMBAT_REMEDY, EXPRESSION -> true;
+      case SUMMON,
+          REMEDY,
+          SELF_ONLY,
+          SONG,
+          COMBAT_NONCOMBAT_REMEDY,
+          EXPRESSION,
+          REMEDY_PASSIVE -> true;
       default -> false;
     };
   }
@@ -925,7 +931,7 @@ public class SkillDatabase {
     // Vampyre skills all have a passive (-hp) effect
     return SkillDatabase.isType(skillId, SkillType.PASSIVE)
         || SkillDatabase.isType(skillId, SkillType.COMBAT_PASSIVE)
-        || SkillDatabase.isType(skillId, SkillType.NONCOMBAT_PASSIVE)
+        || SkillDatabase.isType(skillId, SkillType.REMEDY_PASSIVE)
         || SkillDatabase.isVampyreSkill(skillId);
   }
 
@@ -1341,9 +1347,8 @@ public class SkillDatabase {
     var searchTypes =
         switch (type) {
           case COMBAT -> EnumSet.of(COMBAT, COMBAT_NONCOMBAT_REMEDY, COMBAT_PASSIVE);
-          case REMEDY -> EnumSet.of(REMEDY, COMBAT_NONCOMBAT_REMEDY);
-          case PASSIVE -> EnumSet.of(
-              PASSIVE, SkillType.COMBAT_PASSIVE, SkillType.NONCOMBAT_PASSIVE);
+          case REMEDY -> EnumSet.of(REMEDY, COMBAT_NONCOMBAT_REMEDY, REMEDY_PASSIVE);
+          case PASSIVE -> EnumSet.of(PASSIVE, SkillType.COMBAT_PASSIVE, SkillType.REMEDY_PASSIVE);
           default -> EnumSet.of(type);
         };
     return getSkillsByType(searchTypes, onlyKnown);
@@ -1360,7 +1365,15 @@ public class SkillDatabase {
   public static final List<UseSkillRequest> getCastableSkills(final boolean onlyKnown) {
     return getSkillsByType(
         EnumSet.of(
-            SUMMON, REMEDY, SELF_ONLY, BUFF, SONG, COMBAT_NONCOMBAT_REMEDY, EXPRESSION, WALK),
+            SUMMON,
+            REMEDY,
+            SELF_ONLY,
+            BUFF,
+            SONG,
+            COMBAT_NONCOMBAT_REMEDY,
+            EXPRESSION,
+            WALK,
+            REMEDY_PASSIVE),
         onlyKnown);
   }
 

--- a/src/net/sourceforge/kolmafia/persistence/SkillDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/SkillDatabase.java
@@ -34,7 +34,7 @@ public class SkillDatabase {
     COMBAT_PASSIVE("combat/passive", 8),
     EXPRESSION("expression", 9),
     WALK("walk", 10),
-    REMEDY_PASSIVE("noncombat/passive", 11);
+    REMEDY_PASSIVE("noncombat remedy/passive", 11);
 
     public final String name;
     public final int number;

--- a/test/net/sourceforge/kolmafia/textui/command/UseSkillCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/UseSkillCommandTest.java
@@ -49,4 +49,16 @@ public class UseSkillCommandTest extends AbstractCommandTestBase {
       assertThat(output, containsString("Possible matches:"));
     }
   }
+
+  @Test
+  void canCastDiscoNap() {
+    var cleanups = new Cleanups(withSkill(SkillPool.DISCO_NAP), withMP(100, 100, 100));
+
+    try (cleanups) {
+      String output = execute("disco nap");
+
+      assertContinueState();
+      assertThat(output, containsString("Casting Disco Nap"));
+    }
+  }
 }


### PR DESCRIPTION
Fix from #1968.

I'd like to refactor the types to be more like item types; I think it's gotten rather complicated. Hot fix this issue first, though.

Also going through the code: what is a "normal" skill? By the usage in runtime library, it's a skill that can't be used outside combat? Why is it named the way it is?