### PR TITLE
fix: don't crash on an <img> with no src attribute

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -6538,7 +6538,7 @@ public class FightRequest extends GenericRequest {
 
     if (inode != null) {
       var src = inode.getAttributeByName("src");
-      if (src.endsWith("factbook.gif")) {
+      if (src != null && src.endsWith("factbook.gif")) {
         // log if it's a fact
         var text = node.getText().toString();
         if (!(text.contains("rythm") || text.contains("rhythm"))) {


### PR DESCRIPTION
Should fix https://kolmafia.us/threads/missing-img-src-with-ocrs-hilarious-modifier.29263/

No test because no HTML.