### PR TITLE
Preferences to always add or overwrite svn files

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -157,6 +157,8 @@ global	showAllRequests	false
 global	showExceptionalRequests	false
 global	statusDropdown	0
 global	stealthLogin	true
+global	svnAlwaysAdd	false
+global	svnAlwaysOverwrite	false
 global	svnInstallDependencies	true
 global	svnShowCommitMessages	false
 global	svnThreadPoolSize	2

--- a/src/net/sourceforge/kolmafia/scripts/svn/SVNManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/svn/SVNManager.java
@@ -707,13 +707,14 @@ public class SVNManager extends ScriptManager {
       message.append(
           "<br><b>Only click yes if you trust the author.</b>"
               + "<p>Clicking no will stop the files from being added locally. (until you checkout the project again)");
-      if (JOptionPane.showConfirmDialog(
-              null,
-              message.toString(),
-              "SVN wants to add new files",
-              JOptionPane.YES_NO_OPTION,
-              JOptionPane.WARNING_MESSAGE)
-          == JOptionPane.YES_OPTION) {
+      if (Preferences.getBoolean("svnAlwaysAdd")
+          || JOptionPane.showConfirmDialog(
+                  null,
+                  message.toString(),
+                  "SVN wants to add new files",
+                  JOptionPane.YES_NO_OPTION,
+                  JOptionPane.WARNING_MESSAGE)
+              == JOptionPane.YES_OPTION) {
         skipFiles.clear();
       }
     }
@@ -808,13 +809,14 @@ public class SVNManager extends ScriptManager {
       message.append(
           "<br>Checking out this project will result in some local files (described above) being overwritten."
               + "<p>Click yes to overwrite them, no to skip installing them.");
-      if (JOptionPane.showConfirmDialog(
-              null,
-              message.toString(),
-              "SVN checkout wants to overwrite local files",
-              JOptionPane.YES_NO_OPTION,
-              JOptionPane.WARNING_MESSAGE)
-          == JOptionPane.YES_OPTION) {
+      if (Preferences.getBoolean("svnAlwaysOverwrite")
+          || JOptionPane.showConfirmDialog(
+                  null,
+                  message.toString(),
+                  "SVN checkout wants to overwrite local files",
+                  JOptionPane.YES_NO_OPTION,
+                  JOptionPane.WARNING_MESSAGE)
+              == JOptionPane.YES_OPTION) {
         skipFiles.clear();
       }
     }


### PR DESCRIPTION
Add opt-in settings to force svn manager to always add or overwrite files rather than requesting user confirmation.

I run mafia in in cli mode so I have no way to confirm these dialogs (which cause a headless error if in cli mode).