### PR TITLE
fix: don't try to read thorns / damage aura from in-game description

### DIFF
--- a/src/data/adventures.txt
+++ b/src/data/adventures.txt
@@ -82,7 +82,7 @@ BatHole	adventure=32	DiffLevel: low Env: underground Stat: 13	The Batrat and Rat
 BatHole	adventure=33	DiffLevel: low Env: underground Stat: 13	The Beanbat Chamber	1 enchanted bean
 BatHole	adventure=34	DiffLevel: low Env: underground Stat: 13	The Boss Bat's Lair
 
-Knob	adventure=114	DiffLevel: low Env: outdoor Stat: 0	The Outskirts of Cobb's Knob	1 chef's hat|1 Knob Goblin encryption key|1 pretentious paintbrush|+1 Knob Goblin lunchbox|1 bone with a price tag on it
+Knob	adventure=114	DiffLevel: low Env: outdoor Stat: 0	The Outskirts of Cobb's Knob	1 chef's hat|1 Knob Goblin Encryption Key|1 pretentious paintbrush|+1 Knob Goblin lunchbox|1 bone with a price tag on it
 Knob	adventure=257	DiffLevel: low Env: underground Stat: 25	Cobb's Knob Barracks	Knob Goblin elite helm, Knob Goblin elite pants, Knob Goblin elite polearm
 Knob	adventure=258	DiffLevel: low Env: underground Stat: 20	Cobb's Knob Kitchens	Knob Goblin elite helm, Knob Goblin elite pants, Knob Goblin elite polearm
 Knob	adventure=259	DiffLevel: low Env: underground Stat: 25	Cobb's Knob Harem	outfit|outfit, 1 Knob Goblin perfume|+3 scented massage oil

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -2466,7 +2466,7 @@
 2438	scented massage oil	530550627	vial.gif	usable, combat	t	0	vials of scented massage oil
 2439	poltergeist-in-the-jar-o	844616801	moonshine.gif	none, combat	t	0	poltergeists-in-the-jars-o
 2440	unnatural gas	180343585	moonshine.gif	none, combat	t	0	jars of unnatural gas
-2441	Knob Goblin encryption key	591787452	page.gif	none	q	0
+2441	Knob Goblin Encryption Key	591787452	page.gif	none	q	0
 2442	Cobb's Knob map	325883819	map.gif	usable	q	0
 2443	pink glowstick	199035416	glowstick.gif	accessory		0	pink glowstyx
 2444	Supernova Champagne	150158476	champagne.gif	drink	t,d	180	bottles of Supernova Champagne

--- a/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
@@ -516,19 +516,9 @@ public enum DoubleModifier implements Modifier {
       "Booze Fairy Effectiveness", Pattern.compile("Booze Fairy Effectiveness: " + EXPR)),
   CANDY_FAIRY_EFFECTIVENESS(
       "Candy Fairy Effectiveness", Pattern.compile("Candy Fairy Effectiveness: " + EXPR)),
-  DAMAGE_AURA(
-      "Damage Aura",
-      Pattern.compile("Deals (.*) (each|every) round"),
-      Pattern.compile("Damage Aura: " + EXPR)),
+  DAMAGE_AURA("Damage Aura", Pattern.compile("Damage Aura: " + EXPR)),
   SPORADIC_DAMAGE_AURA("Sporadic Damage Aura", Pattern.compile("Sporadic Damage Aura: " + EXPR)),
-  THORNS(
-      "Thorns",
-      new Pattern[] {
-        Pattern.compile("Damages Attacking Opponents?"),
-        Pattern.compile("Damages enemies who hit you"),
-        Pattern.compile("Deals (.*) to attackers")
-      },
-      Pattern.compile("Thorns: " + EXPR)),
+  THORNS("Thorns", Pattern.compile("Thorns: " + EXPR)),
   SPORADIC_THORNS("Sporadic Thorns", Pattern.compile("Sporadic Thorns: " + EXPR)),
   STOMACH_CAPACITY(
       "Stomach Capacity",

--- a/src/net/sourceforge/kolmafia/session/BadMoonManager.java
+++ b/src/net/sourceforge/kolmafia/session/BadMoonManager.java
@@ -49,7 +49,7 @@ public abstract class BadMoonManager {
     new Encounter(
         "O Goblin, Where Art Thou?",
         "Outskirts of Cobb's Knob",
-        "receiving Knob Goblin encryption key",
+        "receiving Knob Goblin Encryption Key",
         EffectPool.get(EffectPool.MINIONED, 10),
         "Muscle +20, Mysticality -5, Moxie -5",
         Type.STAT1,


### PR DESCRIPTION
As mentioned in #1982:
* don't try to read thorns / damage aura from the game, as we use a custom valuation
* rename Knob Goblin Encryption Key, as the case has changed in-game 