### PR TITLE
Update items.txt

### DIFF
--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -10980,12 +10980,12 @@
 10952	Jurassic Parka	815637689	jparka7.gif	shirt		0
 10953	boxed autumn-aton	129222297	crate.gif	usable	t	0
 10954	autumn-aton	174185886	autumnaton.gif	usable	q	0
-10955	autumn leaf	639910181	leafflavor.gif	potion, usable	t,d	10	autumn leaves
+10955	autumn leaf	639910181	leafflavor.gif	potion	t,d	10	autumn leaves
 10956	AutumnFest ale	195200911	beerbottle.gif	drink	t,d	10	bottles of AutumnFest ale
 10957	autumn sweater-weather sweater	267218508	redsweater.gif	shirt	q	0
 10958	autumn debris shield	659459391	damshield.gif	offhand	q	0
 10959	autumn-spice donut	765851813	powderdonut.gif	food	t,d	11
-10960	autumn dollar	394864972	goldcoin.gif	potion, usable	t,d	1
+10960	autumn dollar	394864972	goldcoin.gif	potion	t,d	1
 10961	autumn leaf pendant	871526580	maplependant.gif	accessory	q	0
 10962	autumn breeze	709263513	cueball.gif	spleen, usable	t,d	15
 10963	autumn years wisdom	794318555	xicrystal.gif	potion	t,d	15


### PR DESCRIPTION
autumn dollar is multiusable, but KoLmafia thought it was not
autumn leaf is multiusable, but KoLmafia thought it was not

I made the usual fix - changing usable to multiple and got a test error saying "multiple" is redundant for potions, so I just deleted usable instead.