### PR TITLE
feat: add preferences for jill drops

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -991,6 +991,7 @@ user	latteUnlocks	cinnamon,pumpkin,vanilla
 user	lawOfAveragesAvailable	true
 user	lawOfAveragesCost	1000
 user	leafletCompleted	false
+user	ledCandleDropped	false
 user	legacyPoints	0
 user	libramSkillsHardcore	none
 user	libramSkillsSoftcore	none
@@ -2103,6 +2104,8 @@ user	_mafiaMiddleFingerRingUsed	false
 user	_mafiaThumbRingAdvs	0
 user	_managerialManipulationUsed	false
 user	_mansquitoSerumUsed	false
+user	_mapToACandyRichBlockDrops	0
+user	_mapToACandyRichBlockUsed	false
 user	_maydayDropped	false
 user	_mayflowerDrops	0
 user	_mayflySummons	0

--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -323,4 +323,4 @@
 291	Pixel Rock	pixelrock.gif	none	pixel rock		0	0	0	0
 292
 293	Patriotic Eagle	pateagle.gif	combat0,stat1,mp0	sleeping patriotic eagle	claw-held flag	0	0	0	0
-294	Jill-of-All-Trades	darkjill2f.gif	stat0,stat1,item0,meat0,combat0,block,delevel,hp0,meat1,variable	Dark Jill-of-All-Trades	LED candle	1	2	3	3	organic,sentient,orb,haseyes,object,vegetable,food,edible,evil,spooky,hot,bite
+294	Jill-of-All-Trades	darkjill2f.gif	stat0,stat1,item0,meat0,combat0,drop,block,delevel,hp0,meat1,hp1,mp1,variable	Dark Jill-of-All-Trades	LED candle	1	2	3	3	organic,sentient,orb,haseyes,object,vegetable,food,edible,evil,spooky,hot,bite

--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -1193,7 +1193,7 @@ public class FamiliarData implements Comparable<FamiliarData> {
             ItemPool.MAP_TO_A_CANDY_RICH_BLOCK,
             "maps",
             "_mapToACandyRichBlockDrops",
-            3));
+            -1));
   }
 
   public static DropInfo getDropInfo(int id) {

--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -1187,6 +1187,13 @@ public class FamiliarData implements Comparable<FamiliarData> {
             "grubby wool",
             "_grubbyWoolDrops",
             -1));
+    DROP_FAMILIARS.add(
+        new DropInfo(
+            FamiliarPool.JILL_OF_ALL_TRADES,
+            ItemPool.MAP_TO_A_CANDY_RICH_BLOCK,
+            "maps",
+            "_mapToACandyRichBlockDrops",
+            3));
   }
 
   public static DropInfo getDropInfo(int id) {

--- a/src/net/sourceforge/kolmafia/objectpool/FamiliarPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/FamiliarPool.java
@@ -128,6 +128,7 @@ public class FamiliarPool {
   public static final int COOKBOOKBAT = 288;
   public static final int HOBO_IN_SHEEPS_CLOTHING = 290;
   public static final int PATRIOTIC_EAGLE = 293;
+  public static final int JILL_OF_ALL_TRADES = 294;
 
   private FamiliarPool() {}
 }

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3678,6 +3678,8 @@ public class ItemPool {
   public static final int RESIDUAL_CHITIN_PASTE = 11327;
   public static final int BOOK_OF_FACTS = 11333;
   public static final int BOOK_OF_FACTS_DOG_EARED = 11334;
+  public static final int LED_CANDLE = 11336;
+  public static final int MAP_TO_A_CANDY_RICH_BLOCK = 11337;
 
   private ItemPool() {}
 

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -359,6 +359,7 @@ public class Preferences {
         "latteModifier",
         "latteUnlocks",
         "leafletCompleted",
+        "ledCandleDropped",
         "locketPhylum",
         "lockPicked",
         "louvreLayout",

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -6133,6 +6133,11 @@ public class UseItemRequest extends GenericRequest {
         // There's a deafening Bwoom-woob-woob-woob and then an ominous hum fills the air.
         CampgroundRequest.setCampgroundItem(ItemPool.GIANT_BLACK_MONOLITH, 1);
         break;
+
+      case ItemPool.MAP_TO_A_CANDY_RICH_BLOCK:
+        Preferences.setBoolean("_mapToACandyRichBlockUsed", true);
+        break;
+
       case ItemPool.VAN_KEY:
         // When the player has a NEP Booze/Food quest active, up to 11 bags or keys can be opened
         if (Preferences.getString("_questPartyFairQuest").equals("food")

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -9350,6 +9350,7 @@ public abstract class ChoiceControl {
       case 1494: // Examine S.I.T. Course Certificate
       case 1495: // Get Some Training
       case 1501: // Make a Wish
+      case 1509: // Adjust Jill-of-All-Trades Lighting
         return true;
 
       default:

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -3384,6 +3384,19 @@ public class ResultProcessor {
       case ItemPool.REPLICA_CINCHO_DE_MAYO:
         InventoryManager.addCinchoDeMayoSkills();
         break;
+
+      case ItemPool.LED_CANDLE:
+        if (adventureResults
+            && KoLCharacter.currentFamiliar.getId() == FamiliarPool.JILL_OF_ALL_TRADES) {
+          Preferences.setBoolean("ledCandleDropped", true);
+        }
+        break;
+      case ItemPool.MAP_TO_A_CANDY_RICH_BLOCK:
+        if (adventureResults
+            && KoLCharacter.currentFamiliar.getId() == FamiliarPool.JILL_OF_ALL_TRADES) {
+          Preferences.increment("_mapToACandyRichBlockDrops", 1);
+        }
+        break;
     }
 
     // Gaining items can achieve goals.


### PR DESCRIPTION
Not certain that maps cap at 3 drops, but that's the highest currently reported. It might be unlimited.

Preference for LED candle setting / command / modifiers to come later.