### PR TITLE
Fix appearance_rates calculation regression.

### DIFF
--- a/src/net/sourceforge/kolmafia/AreaCombatData.java
+++ b/src/net/sourceforge/kolmafia/AreaCombatData.java
@@ -864,11 +864,7 @@ public class AreaCombatData {
       return this.combats;
     }
 
-    double pct = this.combats;
-
-    if (stateful) {
-      pct += KoLCharacter.getCombatRateAdjustment();
-    }
+    double pct = this.combats + KoLCharacter.getCombatRateAdjustment();
 
     return Math.max(0.0, Math.min(100.0, pct));
   }

--- a/test/net/sourceforge/kolmafia/AreaCombatDataTest.java
+++ b/test/net/sourceforge/kolmafia/AreaCombatDataTest.java
@@ -116,6 +116,15 @@ public class AreaCombatDataTest {
   }
 
   @Test
+  public void nonstatefulDataWithNonzeroCombatRate() {
+    try (var cleanup = withEffect(EffectPool.TAUNT_OF_HORUS)) {
+      Map<MonsterData, Double> appearanceRates =
+          AdventureDatabase.getAreaCombatData("Sonofa Beach").getMonsterData();
+      assertThat(appearanceRates, hasEntry(MonsterDatabase.findMonster("lobsterfrogman"), 30.0));
+    }
+  }
+
+  @Test
   public void saberCopy() {
     var cleanups =
         new Cleanups(


### PR DESCRIPTION
This was introduced by #326 several years back, as verified by building the old revision and executing the corresponding ASH function, both at that revision and the preceding one (to confirm prior behavior).

The refactor bundled all calculations that depended on the current character's state, even though combat rate modifiers should be applied uniformly. This leads to inconsistent results, as reported by lrrat (https://kolmafia.us/threads/29297/).