### PR TITLE
feat: add banished_by function, fix fencepost issue

### DIFF
--- a/src/net/sourceforge/kolmafia/session/BanishManager.java
+++ b/src/net/sourceforge/kolmafia/session/BanishManager.java
@@ -222,7 +222,7 @@ public class BanishManager {
     }
   }
 
-  public static Set<Banished> getBanishedSet(Banisher banisher) {
+  private static Set<Banished> getBanishedSet(Banisher banisher) {
     return switch (banisher.getBanishType()) {
       case MONSTER -> banishedMonsters;
       case PHYLUM -> banishedPhyla;
@@ -251,7 +251,7 @@ public class BanishManager {
     banished.clear();
 
     String banishes = Preferences.getString(prefName);
-    if (banishes.length() == 0) {
+    if (banishes.isEmpty()) {
       return;
     }
 
@@ -491,6 +491,29 @@ public class BanishManager {
         .anyMatch(m -> m.banished().equalsIgnoreCase(data.getPhylum().toString()));
   }
 
+  public static Banisher[] banishedBy(final MonsterData data) {
+    BanishManager.recalculate();
+
+    if (data == null) {
+      return new Banisher[0];
+    }
+    if (data.isNoBanish()) {
+      return new Banisher[0];
+    }
+
+    var monsterBanishes =
+        banishedMonsters.stream()
+            .filter(m -> m.banisher().isEffective())
+            .filter(m -> m.banished().equalsIgnoreCase(data.getName()));
+    var phylaBanishes =
+        banishedPhyla.stream()
+            .filter(m -> m.banisher().isEffective())
+            .filter(m -> m.banished().equalsIgnoreCase(data.getPhylum().toString()));
+    return Stream.concat(monsterBanishes, phylaBanishes)
+        .map(Banished::banisher)
+        .toArray(Banisher[]::new);
+  }
+
   private static int countBanishes(final Banisher banisher) {
     Set<Banished> banished = getBanishedSet(banisher);
     return (int) banished.stream().filter(m -> m.banisher() == banisher).count();
@@ -521,7 +544,7 @@ public class BanishManager {
 
   public static String getFirstBanished(Banisher banisher) {
     var banished = getBanished(banisher);
-    return (banished.size() > 0) ? banished.get(0) : null;
+    return !banished.isEmpty() ? banished.get(0) : null;
   }
 
   public static String[][] getBanishedMonsterData() {

--- a/src/net/sourceforge/kolmafia/session/BanishManager.java
+++ b/src/net/sourceforge/kolmafia/session/BanishManager.java
@@ -201,7 +201,7 @@ public class BanishManager {
 
     public boolean isValid() {
       return switch (banisher.getResetType()) {
-        case TURN_RESET, TURN_ROLLOVER_RESET -> turnsLeft() >= 0;
+        case TURN_RESET, TURN_ROLLOVER_RESET -> turnsLeft() > 0;
         case COSMIC_BOWLING_BALL_RESET -> Preferences.getInteger("cosmicBowlingBallReturnCombats")
             > 0;
         default -> true;

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -2412,6 +2412,10 @@ public abstract class RuntimeLibrary {
     params = new Type[] {DataTypes.MONSTER_TYPE};
     functions.add(new LibraryFunction("is_banished", DataTypes.BOOLEAN_TYPE, params));
 
+    params = new Type[] {DataTypes.MONSTER_TYPE};
+    functions.add(
+        new LibraryFunction("banished_by", new AggregateType(DataTypes.STRING_TYPE, 0), params));
+
     params = new Type[] {};
     functions.add(new LibraryFunction("jump_chance", DataTypes.INT_TYPE, params));
 
@@ -9007,6 +9011,20 @@ public abstract class RuntimeLibrary {
       return DataTypes.FALSE_VALUE;
     }
     return DataTypes.makeBooleanValue(BanishManager.isBanished(monster.getName()));
+  }
+
+  public static Value banished_by(ScriptRuntime controller, final Value arg) {
+    MonsterData monster = (MonsterData) arg.rawValue();
+    var banishedBy = BanishManager.banishedBy(monster);
+
+    AggregateType type = new AggregateType(DataTypes.STRING_TYPE, banishedBy.length);
+    ArrayValue value = new ArrayValue(type);
+
+    for (int i = 0; i < banishedBy.length; i++) {
+      value.aset(new Value(i), DataTypes.makeStringValue(banishedBy[i].getName()));
+    }
+
+    return value;
   }
 
   public static Value jump_chance(ScriptRuntime controller) {

--- a/test/net/sourceforge/kolmafia/session/BanishManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/BanishManagerTest.java
@@ -430,8 +430,8 @@ class BanishManagerTest {
 
     @ParameterizedTest
     @CsvSource({
-      "153, true",
-      "154, false",
+      "152, true",
+      "153, false",
     })
     void banishMonsterCorrectOnTurnCost(final int turns, final boolean banished) {
       var cleanups = new Cleanups(withCurrentRun(123), withProperty("banishedMonsters"));

--- a/test/net/sourceforge/kolmafia/session/BanishManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/BanishManagerTest.java
@@ -9,6 +9,7 @@ import static internal.helpers.Player.withRestricted;
 import static internal.matchers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -626,6 +627,29 @@ class BanishManagerTest {
 
         assertFalse(BanishManager.isBanished("angry tourist"));
       }
+    }
+  }
+
+  @Test
+  void getsBanishedBy() {
+    var cleanups =
+        new Cleanups(
+            withCurrentRun(13),
+            withProperty(
+                "banishedMonsters", "fluffy bunny:louder than bomb:11:fluffy bunny:snokebomb:12"),
+            withProperty("banishedPhyla", "beast:Patriotic Screech:11"));
+
+    try (cleanups) {
+      BanishManager.loadBanished();
+
+      var bunny = MonsterDatabase.findMonster("fluffy bunny");
+      var banishers = BanishManager.banishedBy(bunny);
+
+      assertThat(banishers.length, equalTo(3));
+      assertThat(
+          banishers,
+          arrayContainingInAnyOrder(
+              Banisher.LOUDER_THAN_BOMB, Banisher.SNOKEBOMB, Banisher.PATRIOTIC_SCREECH));
     }
   }
 


### PR DESCRIPTION
Two changes, both garbo-inspired (see https://github.com/loathers/garbage-collector/pull/1607 for some context).

Fix a fencepost issue with banishers. If I banish a fluffy bunny on turn 30 with Snokebomb, after I have played turn 60 it is no longer banished -- if I play another turn, I may encounter it.

Add a function for getting which banishers have currently banished a monster. You can do this yourself by parsing `banishedMonsters` and `banishedPhyla`, but the code is not very clean, and also you need to force Mafia to recalculate the preferences before you start to ensure banishes expire properly.