### PR TITLE
PHPMTRandom fix

### DIFF
--- a/src/net/sourceforge/kolmafia/utilities/PHPMTRandom.java
+++ b/src/net/sourceforge/kolmafia/utilities/PHPMTRandom.java
@@ -90,7 +90,9 @@ public class PHPMTRandom extends Random {
   }
 
   void reload() {
-    for (int i = 0; i < STATE_LENGTH; i++) {
+    int state_shift = index - STATE_LENGTH;
+
+    for (int i = state_shift; i < state_shift + STATE_LENGTH; i++) {
       long value = twist(state.get(i + PERIOD), state.get(i), state.get(i + 1));
       state.add(value);
     }

--- a/test/net/sourceforge/kolmafia/utilities/PHPMTRandomTest.java
+++ b/test/net/sourceforge/kolmafia/utilities/PHPMTRandomTest.java
@@ -42,4 +42,13 @@ class PHPMTRandomTest {
     assertThat(rng.nextInt(10, 20), is(11));
     assertThat(rng.nextInt(-5, 100), is(32));
   }
+
+  @Test
+  void nextIntAfter700Calls() {
+    var rng = new PHPMTRandom(768);
+    for (int i = 0; i < 700; i++) {
+      rng.nextInt();
+    }
+    assertThat(rng.nextInt(), equalTo(49898254));
+  }
 }


### PR DESCRIPTION
In the current implementation, reload always twisted the same values since the new numbers are appended to state, not overwritten. This creates a generator with a period of 624 which just loops through the first 624 numbers continuously.

The fix is to take latest STATE_LENGTH values of a state into account instead of the first ones.