### PR TITLE
Fix ping command not supporting api.php as the value for pingDefaultTestPage

### DIFF
--- a/src/net/sourceforge/kolmafia/request/PingRequest.java
+++ b/src/net/sourceforge/kolmafia/request/PingRequest.java
@@ -2,7 +2,7 @@ package net.sourceforge.kolmafia.request;
 
 public class PingRequest extends GenericRequest {
 
-  private String pingURL = "";
+  private final String pingURL;
   private long startTime = 0L;
   private long endTime = 0L;
 
@@ -12,18 +12,15 @@ public class PingRequest extends GenericRequest {
   // api.php's responseText is about 1/4 the size of main.php's - and
   // measured ping time is about 1/4 as long.
 
-  public PingRequest() {
-    this("api.php");
-  }
-
   public PingRequest(String pingURL) {
     super(pingURLToFormURL(pingURL));
-    this.pingURL = pingURL;
+    this.pingURL = pingURLToFormURL(pingURL);
     this.addFormFields();
   }
 
   private static String pingURLToFormURL(String pingURL) {
     return switch (pingURL) {
+      case "api.php", "council.php", "main.php" -> pingURL;
       case "api", "council", "main" -> pingURL + ".php";
       case "(status)", "(events)" -> "api.php";
         // What is this?
@@ -46,8 +43,9 @@ public class PingRequest extends GenericRequest {
 
   private boolean isSafeToRun() {
     return switch (this.pingURL) {
-      case "council", "main" -> !GenericRequest.abortIfInFightOrChoice(true);
-      case "api", "(status)", "(events)" -> true;
+      case "council", "council.php", "main", "main.php" -> !GenericRequest.abortIfInFightOrChoice(
+          true);
+      case "api", "api.php", "(status)", "(events)" -> true;
       default -> false;
     };
   }
@@ -115,14 +113,6 @@ public class PingRequest extends GenericRequest {
   @Override
   protected boolean shouldFollowRedirect() {
     return false;
-  }
-
-  public long getStartTime() {
-    return this.startTime;
-  }
-
-  public long getEndTime() {
-    return this.startTime;
   }
 
   public long getElapsedTime() {


### PR DESCRIPTION
For users who ran Kolmafia between #1821 and #1828, `pingDefaultTestPage` was set to `api.php` for their default value and likely never changed. For those users, the ping command doesn't work for two reasons:

* PingRequest's generic request URL gets set to `(none)` when it fails to match a string ending in .php
* `isSafeToRun()` returns false for any `pingURL` that ends in .php

Example failure:
```
> get pingDefaultTestPage

api.php

> ping

Ping returned no response; ping test aborted
0 pings to api.php at 0-0 msec apiece (total = 0, average = 0.00) = 0 bytes/second
```
After this change:
```
> ping

10 pings to api.php at 79-95 msec apiece (total = 846, average = 84.60) = 23,191 bytes/second

> ping

10 pings to api at 81-103 msec apiece (total = 910, average = 91.00) = 21,560 bytes/second
```

This PR addresses both issues and makes the command operable again under the above condition. Additionally, I eliminated some warnings in the `PingRequest.java` file.