### PR TITLE
Call recalculateAdjustments after loading skills.

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -695,6 +695,8 @@ public abstract class KoLmafia {
     // It would be nice to not have to do this
     IslandManager.ensureUpdatedBigIsland();
 
+    KoLCharacter.recalculateAdjustments();
+
     KoLmafia.setIsRefreshing(false);
   }
 

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -842,6 +842,11 @@ public class Modifiers {
       PreferenceListenerRegistry.registerPreferenceListener(
           new String[] {"(skill)", "kingLiberated"}, () -> Modifiers.availableSkillsChanged = true);
     }
+    if (KoLCharacter.getAvailableSkillIds().isEmpty()) {
+      // We probably haven't loaded the player's skills yet. Avoid populating
+      // availablePassiveSkillModifiersByVariable with two empty lists.
+      return;
+    }
 
     if (debug
         || Modifiers.availableSkillsChanged

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -1853,6 +1853,32 @@ public class Player {
   }
 
   /**
+   * Sets next response to a GenericRequest Note that this uses its own FakeHttpClientBuilder so
+   * getRequests() will not work on one set separately
+   *
+   * @param responseMap Map of responses, keyed by request.
+   * @return Cleans up so this response is not given afterwards.
+   */
+  public static Cleanups withResponseMap(final Map<String, FakeHttpResponse<String>> responseMap) {
+    var old = HttpUtilities.getClientBuilder();
+    var builder = new FakeHttpClientBuilder();
+    HttpUtilities.setClientBuilder(() -> builder);
+    GenericRequest.resetClient();
+    GenericRequest.sessionId = "TEST"; // we fake the client, so "run" the requests
+
+    for (var entry : responseMap.entrySet()) {
+      builder.client.addResponse(entry.getKey(), entry.getValue());
+    }
+
+    return new Cleanups(
+        () -> {
+          GenericRequest.sessionId = null;
+          HttpUtilities.setClientBuilder(() -> old);
+          GenericRequest.resetClient();
+        });
+  }
+
+  /**
    * Visits a choice with a given choice and response
    *
    * @param choice Choice to set

--- a/test/internal/network/FakeHttpClient.java
+++ b/test/internal/network/FakeHttpClient.java
@@ -32,6 +32,7 @@ public class FakeHttpClient extends HttpClient {
 
   private final List<HttpRequest> requests = new ArrayList<>();
   private final Queue<FakeHttpResponse<String>> responses = new LinkedList<>();
+  private final Map<String, FakeHttpResponse<String>> responseMap = new HashMap<>();
 
   public void addResponse(int responseCode, String response) {
     addResponse(responseCode, new HashMap<>(), response);
@@ -43,6 +44,10 @@ public class FakeHttpClient extends HttpClient {
 
   public void addResponse(FakeHttpResponse<String> response) {
     responses.add(response);
+  }
+
+  public void addResponse(String uri, FakeHttpResponse<String> response) {
+    responseMap.put(uri, response);
   }
 
   public List<HttpRequest> getRequests() {
@@ -111,7 +116,7 @@ public class FakeHttpClient extends HttpClient {
   public <T> HttpResponse<T> send(HttpRequest request, BodyHandler<T> responseBodyHandler)
       throws IOException, InterruptedException {
     this.requests.add(request);
-    var response = responses.poll();
+    var response = responseMap.getOrDefault(request.uri().toString(), responses.poll());
 
     var responseCode = response != null ? response.statusCode() : 0;
     var headers = response != null ? response.rawHeaders() : new HashMap<String, List<String>>();

--- a/test/net/sourceforge/kolmafia/KoLmafiaTest.java
+++ b/test/net/sourceforge/kolmafia/KoLmafiaTest.java
@@ -1,6 +1,8 @@
 package net.sourceforge.kolmafia;
 
+import static internal.helpers.Networking.html;
 import static internal.helpers.Player.withItem;
+import static internal.helpers.Player.withResponseMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -8,8 +10,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import internal.helpers.Cleanups;
+import internal.network.FakeHttpResponse;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,6 +55,23 @@ public class KoLmafiaTest {
 
       assertThat(requirements, hasSize(1));
       assertEquals(2, requirements.get(0).getCount());
+    }
+  }
+
+  @Test
+  public void refreshSessionSetsPassiveModifiers() {
+    // This charsheet contains Stomach of Steel.
+    var cleanups =
+        new Cleanups(
+            withResponseMap(
+                Map.of(
+                    "https://www.kingdomofloathing.com:443/charsheet.php",
+                    new FakeHttpResponse<>(200, html("request/test_charsheet_normal.html")))));
+
+    try (cleanups) {
+      assertEquals(15, KoLCharacter.getStomachCapacity());
+      KoLmafia.refreshSession();
+      assertEquals(20, KoLCharacter.getStomachCapacity());
     }
   }
 }


### PR DESCRIPTION
This also includes a couple more changes to make sure that we don't accidentally populate availablePassiveSkillModifiersByVariable before we have any skills ready.

This doesn't handle the scenario where the skills list changes, but it should handle the most common scenarios (login, kingLiberated come to mind).