### PR TITLE
Address passive skill cache race condition.

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -3758,6 +3758,7 @@ public abstract class KoLCharacter {
     KoLConstants.availableSkills.add(skill);
     KoLConstants.availableSkillsSet.add(skillId);
     PreferenceListenerRegistry.firePreferenceChanged("(skill)");
+    Modifiers.availableSkillsChanged();
 
     switch (SkillDatabase.getSkillType(skillId)) {
       case PASSIVE -> {

--- a/src/net/sourceforge/kolmafia/request/CharSheetRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CharSheetRequest.java
@@ -328,6 +328,9 @@ public class CharSheetRequest extends GenericRequest {
     KoLCharacter.setPermedSkills(permedSkillSet);
     KoLCharacter.setHardcorePermedSkills(hardcorePermedSkillSet);
 
+    // Update modifiers.
+    KoLCharacter.recalculateAdjustments();
+
     // Update uneffect methods and heal amounts for updated skills
     UneffectRequest.reset();
     HPRestoreItemList.updateHealthRestored();

--- a/src/net/sourceforge/kolmafia/session/ResponseTextParser.java
+++ b/src/net/sourceforge/kolmafia/session/ResponseTextParser.java
@@ -8,7 +8,6 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
-import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
@@ -994,7 +993,6 @@ public class ResponseTextParser {
     if (SkillDatabase.isBookshelfSkill(skillId)) {
       KoLCharacter.setBookshelf(true);
     }
-    PreferenceListenerRegistry.firePreferenceChanged("(skill)");
 
     if (skillId == SkillPool.POWER_PLUS) {
       KoLCharacter.recalculateAdjustments();


### PR DESCRIPTION
This change does a few things:

- Explicitly update Modifiers.availableSkillsChanged when receiving a new skill, instead of relying on the preference listener, as that may be deferred (as we've updated the KoLmafiaTest case to cover).

- Explicitly invoke recalculateAdjustments after parsing the charsheet. This addresses messages on login about detecting free rests from campground.php.

- Add some synchronization to Modifiers.java to prevent potential data races.

- Remove redundant firePreferenceListener("(skill)") from ResponseTextParser, since that's already done several lines above in the addAvailableSkill call.

Note that I explicitly did _not_ call recalculateAdjustments() inside addAvailableSkill() because that would result in quadratic time behavior whenever KoLCharacter.setAvailableSkills() is invoked.