### PR TITLE
Double mods of sleeved cards with Offhand Remarkable

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -5581,25 +5581,32 @@ public abstract class KoLCharacter {
   private static void addOffhandRemarkable(
       Map<Slot, AdventureResult> equipment, Modifiers newModifiers) {
     var offhand = equipment.get(Slot.OFFHAND);
-    addOffhandRemarkable(offhand, newModifiers);
+    addOffhandRemarkable(equipment, offhand, newModifiers);
     // and also offhand items that are equipped on the familiar
     var famItem = equipment.get(Slot.FAMILIAR);
-    addOffhandRemarkable(famItem, newModifiers);
+    addOffhandRemarkable(equipment, famItem, newModifiers);
   }
 
-  private static void addOffhandRemarkable(AdventureResult item, Modifiers newModifiers) {
-    if (item != null
-        && item != EquipmentRequest.UNEQUIP
-        && ItemDatabase.getConsumptionType(item.id) == ConsumptionType.OFFHAND) {
-      if (item.id != ItemPool.LATTE_MUG) {
-        var mods = ModifierDatabase.getItemModifiers(item.id);
+  private static void addOffhandRemarkable(
+      Map<Slot, AdventureResult> equipment, AdventureResult item, Modifiers newModifiers) {
+    if (item == null
+        || item == EquipmentRequest.UNEQUIP
+        || ItemDatabase.getConsumptionType(item.id) != ConsumptionType.OFFHAND
+        || item.id == ItemPool.LATTE_MUG) {
+      return;
+    }
+
+    // use sleeved card as source of modifiers if applicable
+    if (item.id == ItemPool.CARD_SLEEVE) {
+      item = equipment.get(Slot.CARDSLEEVE);
+    }
+
+    var mods = ModifierDatabase.getItemModifiers(item.id);
+    addModifiersWithOffHandRemarkable(newModifiers, mods);
+    for (var modeable : Modeable.values()) {
+      if (item.id == modeable.getItemId()) {
+        mods = ModifierDatabase.getModifiers(modeable.getModifierType(), modeable.getState());
         addModifiersWithOffHandRemarkable(newModifiers, mods);
-        for (var modeable : Modeable.values()) {
-          if (item.id == modeable.getItemId()) {
-            mods = ModifierDatabase.getModifiers(modeable.getModifierType(), modeable.getState());
-            addModifiersWithOffHandRemarkable(newModifiers, mods);
-          }
-        }
       }
     }
   }

--- a/src/net/sourceforge/kolmafia/request/EquipmentRequest.java
+++ b/src/net/sourceforge/kolmafia/request/EquipmentRequest.java
@@ -367,7 +367,7 @@ public class EquipmentRequest extends PasswordHashRequest {
 
     if (this.equipmentType != ConsumptionType.CARD) {
       this.error =
-          "You can't slide a " + ItemDatabase.getItemName(this.itemId) + " into a card sleeze.";
+          "You can't slide a " + ItemDatabase.getItemName(this.itemId) + " into a card sleeve.";
       return;
     }
 

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -1147,6 +1147,22 @@ public class ModifiersTest {
         assertThat(current.getDouble(DoubleModifier.ITEMDROP), equalTo(50.0));
       }
     }
+
+    @Test
+    public void doublesSleevedCard() {
+      var cleanups =
+          new Cleanups(
+              withEquipped(Slot.OFFHAND, ItemPool.CARD_SLEEVE),
+              withEquipped(Slot.CARDSLEEVE, "Alice's Army Foil Lanceman"),
+              withEffect(EffectPool.OFFHAND_REMARKABLE));
+
+      try (cleanups) {
+        KoLCharacter.recalculateAdjustments(false);
+        Modifiers current = KoLCharacter.getCurrentModifiers();
+
+        assertThat(current.getDouble(DoubleModifier.PVP_FIGHTS), equalTo(12.0));
+      }
+    }
   }
 
   @Nested

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -1975,4 +1975,22 @@ public class MaximizerTest {
       }
     }
   }
+
+  @Nested
+  class CardSleeve {
+    @Test
+    public void suggestCardSleeveSlot() {
+      var cleanups =
+          new Cleanups(
+              withEquippableItem("card sleeve"),
+              withEquippableItem("sturdy cane"),
+              withEquippableItem("Alice's Army Foil Lanceman"));
+
+      try (cleanups) {
+        assertTrue(maximize("PvP Fights"));
+        recommendedSlotIs(Slot.OFFHAND, "card sleeve");
+        recommendedSlotIs(Slot.CARDSLEEVE, "Alice's Army Foil Lanceman");
+      }
+    }
+  }
 }


### PR DESCRIPTION
This change ensures that the modifiers of the sleeved card is considered instead of the card sleeve itself.

I've also included a maximizer test because I initially suspected this as the source of the problem. It seemed worthwhile to keep as I could not find any other obvious tests for the card sleeve slot.