### PR TITLE
fix: jill bonuses

### DIFF
--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -293,7 +293,7 @@
 261	Stooper	pokefam47.gif	none	Stooper		1	3	2	1	animal,haseyes,bite
 262	Disgeist	pokefam48.gif	passive	Disgeist		2	2	2	3	wearsclothes,haseyes,undead
 263	Bowlet	pokefam49.gif	combat0,item0	Bowlet		2	1	2	2	haswings,animal,fast,flies
-264	Cornbeefadon	pokefam50.gif	stat0,meat0	Cornbeefadon		2	2	2	2	animal,haseyes,bite
+264	Cornbeefadon	pokefam50.gif	item0,meat0	Cornbeefadon		2	2	2	2	animal,haseyes,bite
 265	Mu	pokefam8675309.gif	combat1,passive	Mu		3	2	3	2	animal,haseyes,fast
 266	God Lobster	godlob.gif	stat0,variable,underwater	God Lobster Egg		0	0	0	0	animal,haseyes,spooky,evil,reallyevil
 267	Cat Burglar	catburglar.gif	item0,meat0	kitten burglar	burglar/sleep mask	1	3	2	3	animal,haseyes,sleaze,fast,bite,wearsclothes

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -4628,6 +4628,7 @@ Familiar	Exotic Parrot	Hot Resistance: [floor((W+19)/20)], Cold Resistance: [flo
 Familiar	Happy Medium	Initiative: [W]
 Familiar	Hobo Monkey	Leprechaun: 1.25
 Familiar	Jumpsuited Hound Dog	Fairy: 1.25, Combat Rate: [min(5,floor(W/6))]
+Familiar	Jill-of-All-Trades	Volleyball or Sombrero
 Familiar	Llama Lama	Volleyball: 0.5
 Familiar	Magic Dragonfish	Spell Damage Percent: [min(2*W,100^env(underwater)*100)]
 Familiar	Mechanical Songbird	Fairy Effectiveness: [1.0+0.5*zone(Dreadsylvania)]

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -4357,7 +4357,7 @@ Item	kill screen	Random Monster Modifiers: +1, Generic
 Item	kitty sheet music	Familiar Weight: +5
 Item	lead collar	Familiar Weight: +5
 Item	lead necklace	Familiar Weight: +3, Generic
-Item	LED candle	Familiar Weight: +5, Fairy: [0.5*pref(ledCandleMode,disco)], Leprechaun: [0.5*pref(ledCandleMode,ultraviolet)], Volleyball Effectiveness: [0.5*pref(ledCandleMode,reading)], Sombrero Effectiveness: [0.5*pref(ledCandleMode,reading)]
+Item	LED candle	Familiar Weight: +5, Fairy: [1.5*pref(ledCandleMode,disco)], Leprechaun: [1.5*pref(ledCandleMode,ultraviolet)], Volleyball Effectiveness: [1.5*pref(ledCandleMode,reading)], Sombrero Effectiveness: [1.5*pref(ledCandleMode,reading)]
 # Li'l Businessman Kit: Lets your familiar make deals
 Item	Li'l Businessman Kit	Meat Drop: +5, Item Drop: +5, Generic
 Item	li'l candy corn costume	Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot"

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -1106,6 +1106,9 @@ public class Modifiers {
     int cap = (int) this.getDouble(DoubleModifier.FAMILIAR_WEIGHT_CAP);
     int cappedWeight = (cap == 0) ? weight : Math.min(weight, cap);
 
+    double volleyFactor = 0.0;
+    double sombreroFactor = 0.0;
+
     double effective = cappedWeight * this.getDouble(DoubleModifier.VOLLEYBALL_WEIGHT);
     if (effective == 0.0 && FamiliarDatabase.isVolleyType(familiarId)) {
       effective = weight;
@@ -1171,7 +1174,7 @@ public class Modifiers {
             ModifierType.TUNED_VOLLEYBALL,
             race);
       } else {
-        this.addDouble(DoubleModifier.EXPERIENCE, factor, ModifierType.VOLLEYBALL, race);
+        volleyFactor = factor;
       }
     }
 
@@ -1185,13 +1188,25 @@ public class Modifiers {
       if (factor == 0.0) factor = 1.0;
       // currentML is always >= 4, so we don't need to check for negatives
       int maxStats = 230;
-      this.addDouble(
-          DoubleModifier.EXPERIENCE,
+      sombreroFactor =
           Math.min(
               Math.max(factor * (Modifiers.currentML / 4) * (0.1 + 0.005 * effective), 1),
-              maxStats),
-          ModifierType.FAMILIAR,
-          race);
+              maxStats);
+    }
+
+    if (this.getBoolean(BooleanModifier.VOLLEYBALL_OR_SOMBRERO)) {
+      if (volleyFactor > sombreroFactor) {
+        this.addDouble(DoubleModifier.EXPERIENCE, volleyFactor, ModifierType.VOLLEYBALL, race);
+      } else {
+        this.addDouble(DoubleModifier.EXPERIENCE, sombreroFactor, ModifierType.FAMILIAR, race);
+      }
+    } else {
+      if (volleyFactor > 0) {
+        this.addDouble(DoubleModifier.EXPERIENCE, volleyFactor, ModifierType.VOLLEYBALL, race);
+      }
+      if (sombreroFactor > 0) {
+        this.addDouble(DoubleModifier.EXPERIENCE, sombreroFactor, ModifierType.FAMILIAR, race);
+      }
     }
 
     effective = cappedWeight * this.getDouble(DoubleModifier.LEPRECHAUN_WEIGHT);

--- a/src/net/sourceforge/kolmafia/modifiers/BooleanModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/BooleanModifier.java
@@ -64,7 +64,8 @@ public enum BooleanModifier implements Modifier {
   LOOK_LIKE_A_PIRATE("Pirate", Pattern.compile("Look like a Pirate")),
   BREAKABLE("Breakable", Pattern.compile("Breakable")),
   DROPS_ITEMS("Drops Items", Pattern.compile("Drops Items")),
-  DROPS_MEAT("Drops Meat", Pattern.compile("Drops Meat"));
+  DROPS_MEAT("Drops Meat", Pattern.compile("Drops Meat")),
+  VOLLEYBALL_OR_SOMBRERO("Volleyball or Sombrero", Pattern.compile("Volleyball or Sombrero"));
   private final String name;
   private final Pattern[] descPatterns;
   private final Pattern tagPattern;

--- a/src/net/sourceforge/kolmafia/objectpool/FamiliarPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/FamiliarPool.java
@@ -2,6 +2,7 @@ package net.sourceforge.kolmafia.objectpool;
 
 public class FamiliarPool {
   public static final int MOSQUITO = 1;
+  public static final int LEPRECHAUN = 2;
   public static final int POTATO = 3;
   public static final int GOAT = 4;
   public static final int LIME = 5;

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -51,6 +51,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class ModifiersTest {
+  private Double fairyFunction(final double weight) {
+    return Math.max(Math.sqrt(55 * weight) + weight - 3, 0);
+  }
+
+  private Double lepFunction(final double weight) {
+    return 2 * fairyFunction(weight);
+  }
 
   @Test
   public void patriotShieldClassModifiers() {
@@ -1018,10 +1025,6 @@ public class ModifiersTest {
 
   @Nested
   class FairyFamiliars {
-    private Double fairyFunction(final double weight) {
-      return Math.max(Math.sqrt(55 * weight) + weight - 3, 0);
-    }
-
     private Modifiers getFamiliarMods(final int weight) {
       Modifiers familiarMods = new Modifiers();
       var fam = KoLCharacter.getFamiliar();
@@ -1189,6 +1192,80 @@ public class ModifiersTest {
 
         assertThat(current.getDouble(DoubleModifier.MOX_EXPERIENCE_PCT), equalTo(25.0));
         assertThat(current.getDouble(DoubleModifier.MANA_COST), equalTo(-3.0));
+      }
+    }
+  }
+
+  @Nested
+  class Familiars {
+    @Test
+    void volleyballGivesExperience() {
+      var cleanups = withFamiliar(FamiliarPool.BLOOD_FACED_VOLLEYBALL, 100);
+
+      try (cleanups) {
+        Modifiers current = KoLCharacter.getCurrentModifiers();
+        assertThat(current.getDouble(DoubleModifier.EXPERIENCE), equalTo(4.0));
+      }
+    }
+
+    @Test
+    void sombreroGivesExperience() {
+      var cleanups = withFamiliar(FamiliarPool.SOMBRERO, 100);
+
+      try (cleanups) {
+        Modifiers current = KoLCharacter.getCurrentModifiers();
+        assertThat(current.getDouble(DoubleModifier.EXPERIENCE), equalTo(1.0));
+      }
+    }
+
+    @Test
+    void gravyFairyGivesItem() {
+      var cleanups = withFamiliar(FamiliarPool.BABY_GRAVY_FAIRY, 100);
+
+      try (cleanups) {
+        Modifiers current = KoLCharacter.getCurrentModifiers();
+        assertThat(current.getDouble(DoubleModifier.ITEMDROP), closeTo(fairyFunction(10), 0.001));
+      }
+    }
+
+    @Test
+    void leprechaunGivesMeat() {
+      var cleanups = withFamiliar(FamiliarPool.LEPRECHAUN, 100);
+
+      try (cleanups) {
+        Modifiers current = KoLCharacter.getCurrentModifiers();
+        assertThat(current.getDouble(DoubleModifier.MEATDROP), closeTo(lepFunction(10), 0.001));
+      }
+    }
+  }
+
+  @Nested
+  class JillOfAllTrades {
+    @Test
+    void nakedJillIsAOneTimesLepVolleyFairy() {
+      var cleanups = withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 100);
+
+      try (cleanups) {
+        Modifiers current = KoLCharacter.getCurrentModifiers();
+
+        assertThat(current.getDouble(DoubleModifier.ITEMDROP), closeTo(fairyFunction(10), 0.001));
+        assertThat(current.getDouble(DoubleModifier.MEATDROP), closeTo(lepFunction(10), 0.001));
+        assertThat(current.getDouble(DoubleModifier.EXPERIENCE), equalTo(4.0));
+      }
+    }
+
+    @Test
+    void atHighMLJillIsASombrero() {
+      var cleanups =
+          new Cleanups(
+              withLocation("The Briniest Deepests"),
+              withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 100));
+
+      try (cleanups) {
+        Modifiers current = KoLCharacter.getCurrentModifiers();
+
+        // 400 ML
+        assertThat(current.getDouble(DoubleModifier.EXPERIENCE), closeTo(15.0, 0.001));
       }
     }
   }

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -130,17 +130,15 @@ public class ModifiersTest {
     }
   }
 
-  @Test
-  public void intrinsicSpicinessModifiers() {
-    var cleanups = withClass(AscensionClass.SAUCEROR);
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11})
+  public void intrinsicSpicinessModifiers(int level) {
+    int myst = (level == 1) ? 0 : (level - 1) * (level - 1) + 4;
+    var cleanups = new Cleanups(withClass(AscensionClass.SAUCEROR), withStats(0, myst, 0));
 
     try (cleanups) {
-      for (int i = 1; i <= 11; i++) {
-        int myst = (i == 1) ? 0 : (i - 1) * (i - 1) + 4;
-        KoLCharacter.setStatPoints(0, 0, myst, (long) myst * myst, 0, 0);
-        Modifiers mods = ModifierDatabase.getModifiers(ModifierType.SKILL, "Intrinsic Spiciness");
-        assertEquals(Math.min(i, 10), mods.getDouble(DoubleModifier.SAUCE_SPELL_DAMAGE));
-      }
+      Modifiers mods = ModifierDatabase.getModifiers(ModifierType.SKILL, "Intrinsic Spiciness");
+      assertEquals(Math.min(level, 10), mods.getDouble(DoubleModifier.SAUCE_SPELL_DAMAGE));
     }
   }
 

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -132,12 +132,15 @@ public class ModifiersTest {
 
   @Test
   public void intrinsicSpicinessModifiers() {
-    KoLCharacter.setAscensionClass(AscensionClass.SAUCEROR);
-    for (int i = 1; i <= 11; i++) {
-      int myst = (i == 1) ? 0 : (i - 1) * (i - 1) + 4;
-      KoLCharacter.setStatPoints(0, 0, myst, (long) myst * myst, 0, 0);
-      Modifiers mods = ModifierDatabase.getModifiers(ModifierType.SKILL, "Intrinsic Spiciness");
-      assertEquals(Math.min(i, 10), mods.getDouble(DoubleModifier.SAUCE_SPELL_DAMAGE));
+    var cleanups = withClass(AscensionClass.SAUCEROR);
+
+    try (cleanups) {
+      for (int i = 1; i <= 11; i++) {
+        int myst = (i == 1) ? 0 : (i - 1) * (i - 1) + 4;
+        KoLCharacter.setStatPoints(0, 0, myst, (long) myst * myst, 0, 0);
+        Modifiers mods = ModifierDatabase.getModifiers(ModifierType.SKILL, "Intrinsic Spiciness");
+        assertEquals(Math.min(i, 10), mods.getDouble(DoubleModifier.SAUCE_SPELL_DAMAGE));
+      }
     }
   }
 
@@ -1247,6 +1250,13 @@ public class ModifiersTest {
 
   @Nested
   class JillOfAllTrades {
+    @BeforeAll
+    static void beforeAll() {
+      // clearer to set here than in every volleyball test
+      // there's a leak somewhere
+      Modifiers.setLocation(null);
+    }
+
     @Test
     void nakedJillIsAOneTimesFairy() {
       var cleanups = withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 100);

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -51,6 +51,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class ModifiersTest {
+  @BeforeAll
+  static void beforeAll() {
+    KoLCharacter.reset("ModifiersTest");
+    Preferences.reset("ModifiersTest");
+  }
+
   private Double fairyFunction(final double weight) {
     return Math.max(Math.sqrt(55 * weight) + weight - 3, 0);
   }
@@ -1242,15 +1248,83 @@ public class ModifiersTest {
   @Nested
   class JillOfAllTrades {
     @Test
-    void nakedJillIsAOneTimesLepVolleyFairy() {
+    void nakedJillIsAOneTimesFairy() {
       var cleanups = withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 100);
 
       try (cleanups) {
         Modifiers current = KoLCharacter.getCurrentModifiers();
 
         assertThat(current.getDouble(DoubleModifier.ITEMDROP), closeTo(fairyFunction(10), 0.001));
+      }
+    }
+
+    @Test
+    void configuredCandleMakesJillABetterFairy() {
+      // 5-lbs Jill because candle is +5 lb
+      var cleanups =
+          new Cleanups(
+              withProperty("ledCandleMode", "disco"),
+              withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 25),
+              withEquipped(Slot.FAMILIAR, ItemPool.LED_CANDLE));
+
+      try (cleanups) {
+        Modifiers current = KoLCharacter.getCurrentModifiers();
+
+        assertThat(current.getDouble(DoubleModifier.ITEMDROP), closeTo(fairyFunction(15), 0.001));
+      }
+    }
+
+    @Test
+    void nakedJillIsAOneTimesLep() {
+      var cleanups = withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 100);
+
+      try (cleanups) {
+        Modifiers current = KoLCharacter.getCurrentModifiers();
+
         assertThat(current.getDouble(DoubleModifier.MEATDROP), closeTo(lepFunction(10), 0.001));
+      }
+    }
+
+    @Test
+    void configuredCandleMakesJillABetterLep() {
+      // 5-lbs Jill because candle is +5 lb
+      var cleanups =
+          new Cleanups(
+              withProperty("ledCandleMode", "ultraviolet"),
+              withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 25),
+              withEquipped(Slot.FAMILIAR, ItemPool.LED_CANDLE));
+
+      try (cleanups) {
+        Modifiers current = KoLCharacter.getCurrentModifiers();
+
+        assertThat(current.getDouble(DoubleModifier.MEATDROP), closeTo(lepFunction(15), 0.001));
+      }
+    }
+
+    @Test
+    void nakedJillIsAOneTimesVolley() {
+      var cleanups = withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 100);
+
+      try (cleanups) {
+        Modifiers current = KoLCharacter.getCurrentModifiers();
+
         assertThat(current.getDouble(DoubleModifier.EXPERIENCE), equalTo(4.0));
+      }
+    }
+
+    @Test
+    void configuredCandleMakesJillABetterVolley() {
+      // 5-lbs Jill because candle is +5 lb
+      var cleanups =
+          new Cleanups(
+              withProperty("ledCandleMode", "reading"),
+              withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 25),
+              withEquipped(Slot.FAMILIAR, ItemPool.LED_CANDLE));
+
+      try (cleanups) {
+        Modifiers current = KoLCharacter.getCurrentModifiers();
+
+        assertThat(current.getDouble(DoubleModifier.EXPERIENCE), closeTo(6.0, 0.001));
       }
     }
 
@@ -1266,6 +1340,23 @@ public class ModifiersTest {
 
         // 400 ML
         assertThat(current.getDouble(DoubleModifier.EXPERIENCE), closeTo(15.0, 0.001));
+      }
+    }
+
+    @Test
+    void configuredCandleMakesJillABetterSombrero() {
+      // 5-lbs Jill because candle is +5 lb
+      var cleanups =
+          new Cleanups(
+              withLocation("The Briniest Deepests"),
+              withProperty("ledCandleMode", "reading"),
+              withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 25),
+              withEquipped(Slot.FAMILIAR, ItemPool.LED_CANDLE));
+
+      try (cleanups) {
+        Modifiers current = KoLCharacter.getCurrentModifiers();
+
+        assertThat(current.getDouble(DoubleModifier.EXPERIENCE), closeTo(22.5, 0.001));
       }
     }
   }

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -1257,9 +1257,20 @@ public class ModifiersTest {
       Modifiers.setLocation(null);
     }
 
+    private Cleanups withJill(int weight) {
+      return withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, weight * weight);
+    }
+
+    private Cleanups withJillAndCandle(int weight, String candleSetting) {
+      return new Cleanups(
+          withProperty("ledCandleMode", candleSetting),
+          withJill(weight),
+          withEquipped(Slot.FAMILIAR, ItemPool.LED_CANDLE));
+    }
+
     @Test
     void nakedJillIsAOneTimesFairy() {
-      var cleanups = withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 100);
+      var cleanups = withJill(10);
 
       try (cleanups) {
         Modifiers current = KoLCharacter.getCurrentModifiers();
@@ -1271,11 +1282,7 @@ public class ModifiersTest {
     @Test
     void configuredCandleMakesJillABetterFairy() {
       // 5-lbs Jill because candle is +5 lb
-      var cleanups =
-          new Cleanups(
-              withProperty("ledCandleMode", "disco"),
-              withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 25),
-              withEquipped(Slot.FAMILIAR, ItemPool.LED_CANDLE));
+      var cleanups = withJillAndCandle(5, "disco");
 
       try (cleanups) {
         Modifiers current = KoLCharacter.getCurrentModifiers();
@@ -1286,7 +1293,7 @@ public class ModifiersTest {
 
     @Test
     void nakedJillIsAOneTimesLep() {
-      var cleanups = withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 100);
+      var cleanups = withJill(10);
 
       try (cleanups) {
         Modifiers current = KoLCharacter.getCurrentModifiers();
@@ -1298,11 +1305,7 @@ public class ModifiersTest {
     @Test
     void configuredCandleMakesJillABetterLep() {
       // 5-lbs Jill because candle is +5 lb
-      var cleanups =
-          new Cleanups(
-              withProperty("ledCandleMode", "ultraviolet"),
-              withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 25),
-              withEquipped(Slot.FAMILIAR, ItemPool.LED_CANDLE));
+      var cleanups = withJillAndCandle(5, "ultraviolet");
 
       try (cleanups) {
         Modifiers current = KoLCharacter.getCurrentModifiers();
@@ -1313,7 +1316,7 @@ public class ModifiersTest {
 
     @Test
     void nakedJillIsAOneTimesVolley() {
-      var cleanups = withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 100);
+      var cleanups = withJill(10);
 
       try (cleanups) {
         Modifiers current = KoLCharacter.getCurrentModifiers();
@@ -1325,11 +1328,7 @@ public class ModifiersTest {
     @Test
     void configuredCandleMakesJillABetterVolley() {
       // 5-lbs Jill because candle is +5 lb
-      var cleanups =
-          new Cleanups(
-              withProperty("ledCandleMode", "reading"),
-              withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 25),
-              withEquipped(Slot.FAMILIAR, ItemPool.LED_CANDLE));
+      var cleanups = withJillAndCandle(5, "reading");
 
       try (cleanups) {
         Modifiers current = KoLCharacter.getCurrentModifiers();
@@ -1340,10 +1339,7 @@ public class ModifiersTest {
 
     @Test
     void atHighMLJillIsASombrero() {
-      var cleanups =
-          new Cleanups(
-              withLocation("The Briniest Deepests"),
-              withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 100));
+      var cleanups = new Cleanups(withLocation("The Briniest Deepests"), withJill(10));
 
       try (cleanups) {
         Modifiers current = KoLCharacter.getCurrentModifiers();
@@ -1357,11 +1353,7 @@ public class ModifiersTest {
     void configuredCandleMakesJillABetterSombrero() {
       // 5-lbs Jill because candle is +5 lb
       var cleanups =
-          new Cleanups(
-              withLocation("The Briniest Deepests"),
-              withProperty("ledCandleMode", "reading"),
-              withFamiliar(FamiliarPool.JILL_OF_ALL_TRADES, 25),
-              withEquipped(Slot.FAMILIAR, ItemPool.LED_CANDLE));
+          new Cleanups(withLocation("The Briniest Deepests"), withJillAndCandle(5, "reading"));
 
       try (cleanups) {
         Modifiers current = KoLCharacter.getCurrentModifiers();


### PR DESCRIPTION
Extract from #2027 to fix Jill.

I think we'll want to require `Volleyball:` modifiers instead of defaulting to 1 if the familiar is the right type, but that can go later. This is the only way I can see to fix e.g. God Lobster's Ring meaning the lobster is treated as a -1x Volleyball, instead of a 0x Volleyball.