### PR TITLE
Catch exception instead of checking if leaves field is null, field can be empty string

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -6575,7 +6575,12 @@ public abstract class ChoiceControl {
         // Burning Leaves
         {
           String leavesField = request.getFormField("leaves");
-          int leaves = leavesField == null ? 0 : Integer.parseInt(leavesField);
+          int leaves = 0;
+          try {
+            leaves = Integer.parseInt(leavesField);
+          } catch (NumberFormatException ignored) {
+          }
+
           BurningLeavesRequest.postChoice(text, leaves);
           break;
         }

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -6575,12 +6575,7 @@ public abstract class ChoiceControl {
         // Burning Leaves
         {
           String leavesField = request.getFormField("leaves");
-          int leaves = 0;
-          try {
-            leaves = Integer.parseInt(leavesField);
-          } catch (NumberFormatException ignored) {
-          }
-
+          int leaves = StringUtilities.parseInt(leavesField);
           BurningLeavesRequest.postChoice(text, leaves);
           break;
         }


### PR DESCRIPTION
```Unexpected error, debug log printed.
class java.lang.NumberFormatException: For input string: ""
java.lang.NumberFormatException: For input string: ""
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
	at java.base/java.lang.Integer.parseInt(Integer.java:678)
	at java.base/java.lang.Integer.parseInt(Integer.java:786)
	at net.sourceforge.kolmafia.session.ChoiceControl.postChoice2(ChoiceControl.java:6578)
	at net.sourceforge.kolmafia.session.ChoiceManager.postChoice2(ChoiceManager.java:2420)
	at net.sourceforge.kolmafia.request.GenericRequest.processResponse(GenericRequest.java:2229)
	at net.sourceforge.kolmafia.request.GenericRequest.retrieveServerReply(GenericRequest.java:2131)```

Fairly obvious, the "count" of leaves to burn in bonfire is empty by default. If you submit as is, mafia will hiccup.