### PR TITLE
Add Preference for Extra Time

### DIFF
--- a/src/data/dailylimits.txt
+++ b/src/data/dailylimits.txt
@@ -302,6 +302,7 @@ Use	essential tofu	_essentialTofuUsed
 Use	etched hourglass	_etchedHourglassUsed
 Use	eternal car battery	_eternalCarBatteryUsed
 Use	experimental carbon fiber pasta additive	_pastaAdditive
+Use extra time	_extraTimeUsed	3
 Use	fancy but probably evil chocolate	_chocolatesUsed	3
 Use	fancy chess set	_fancyChessSetUsed
 Use	fancy chocolate	_chocolatesUsed	3

--- a/src/data/dailylimits.txt
+++ b/src/data/dailylimits.txt
@@ -302,7 +302,7 @@ Use	essential tofu	_essentialTofuUsed
 Use	etched hourglass	_etchedHourglassUsed
 Use	eternal car battery	_eternalCarBatteryUsed
 Use	experimental carbon fiber pasta additive	_pastaAdditive
-Use extra time	_extraTimeUsed	3
+Use	extra time	_extraTimeUsed	3
 Use	fancy but probably evil chocolate	_chocolatesUsed	3
 Use	fancy chess set	_fancyChessSetUsed
 Use	fancy chocolate	_chocolatesUsed	3

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1874,6 +1874,7 @@ user	_etchedHourglassUsed	false
 user	_eternalCarBatteryUsed	false
 user	_everfullGlassUsed	false
 user	_expertCornerCutterUsed	0
+user	_extraTimeUsed	0
 user	_eyeAndATwistUsed	false
 user	_fancyChessSetUsed	false
 user	_falloutShelterSpaUsed	false

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3686,6 +3686,7 @@ public class ItemPool {
   public static final int AUTUMNIC_BOMB = 11344;
   public static final int FOREST_CANOPY_BED = 11345;
   public static final int DAY_SHORTENER = 11346;
+  public static final int EXTRA_TIME = 11347;
   public static final int AUTUMNAL_AEGIS = 11348;
   public static final int DISTILLED_RESIN = 11349;
   public static final int SUPER_HEATED_LEAF = 11350;

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -4361,6 +4361,10 @@ public class UseItemRequest extends GenericRequest {
         Preferences.increment("_loveChocolatesUsed");
         break;
 
+      case ItemPool.EXTRA_TIME:
+        Preferences.increment("_extraTimeUsed");
+        break;
+
       case ItemPool.CREEPY_VOODOO_DOLL:
         Preferences.setBoolean("_creepyVoodooDollUsed", true);
         return;


### PR DESCRIPTION
Extra Time (the item you acquire from using Day Shorteners, was not in the Item Pool). Added to that, and also created a preference for it similar to the class chocolates due to the decaying nature of returns when used.