### PR TITLE
refactor: share code between MonsterData and RequestEditorKit

### DIFF
--- a/src/net/sourceforge/kolmafia/AreaCombatData.java
+++ b/src/net/sourceforge/kolmafia/AreaCombatData.java
@@ -24,6 +24,7 @@ import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase.Element;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase.Phylum;
 import net.sourceforge.kolmafia.persistence.MonsterDrop;
+import net.sourceforge.kolmafia.persistence.MonsterDrop.DropFlag;
 import net.sourceforge.kolmafia.persistence.QuestDatabase;
 import net.sourceforge.kolmafia.persistence.QuestDatabase.Quest;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -1117,6 +1118,9 @@ public class AreaCombatData {
       String rate1 = this.format(dropRate);
       String rate2 = this.format(effectiveDropRate);
 
+      if (drop.flag() == DropFlag.MULTI_DROP) {
+        buffer.append(drop.itemCount() + " ");
+      }
       buffer.append(drop.item().getName());
       switch (drop.flag()) {
         case UNKNOWN_RATE -> buffer.append(" (unknown drop rate)");
@@ -1155,6 +1159,7 @@ public class AreaCombatData {
           }
         }
         case STEAL_ACCORDION -> buffer.append(" (stealable accordion)");
+        case MULTI_DROP -> buffer.append(" (multidrop)");
         default -> {
           if (stealing) {
             buffer.append(" ");

--- a/src/net/sourceforge/kolmafia/MonsterData.java
+++ b/src/net/sourceforge/kolmafia/MonsterData.java
@@ -1239,20 +1239,20 @@ public class MonsterData extends AdventureResult {
   // Accessors for the various attributes of a monster,
   // ***********************************************************
 
-  private MonsterExpression compile(Object expr) {
-    return MonsterExpression.getInstance((String) expr, this.getName());
+  private MonsterExpression compile(String expr) {
+    return MonsterExpression.getInstance(expr, this.getName());
   }
 
   private int evaluate(Object obj, int value) {
     if (obj != null) {
-      if (obj instanceof Integer) {
-        return (Integer) obj;
+      if (obj instanceof Integer i) {
+        return i;
       }
-      if (obj instanceof String) {
-        obj = compile(obj);
+      if (obj instanceof String s) {
+        obj = compile(s);
       }
-      if (obj instanceof MonsterExpression) {
-        return (int) (((MonsterExpression) obj).eval());
+      if (obj instanceof MonsterExpression me) {
+        return (int) me.eval();
       }
     }
     return value;
@@ -1340,8 +1340,8 @@ public class MonsterData extends AdventureResult {
       }
       return (int) Math.floor(Math.max(1, hp + ML()) * getBeeosity());
     }
-    if (this.health instanceof String) {
-      this.health = compile(this.health);
+    if (this.health instanceof String s) {
+      this.health = compile(s);
     }
     return Math.max(1, (int) (((MonsterExpression) this.health).eval() * getBeeosity()));
   }
@@ -1397,8 +1397,8 @@ public class MonsterData extends AdventureResult {
       }
       return (int) Math.floor(Math.max(1, attack + ML()) * getBeeosity());
     }
-    if (this.attack instanceof String) {
-      this.attack = compile(this.attack);
+    if (this.attack instanceof String s) {
+      this.attack = compile(s);
     }
     return Math.max(1, (int) (((MonsterExpression) this.attack).eval() * getBeeosity()));
   }
@@ -1458,8 +1458,8 @@ public class MonsterData extends AdventureResult {
       return (int)
           Math.floor(Math.max(1, defense + ML()) * getBeeosity() * (1 - reduceMonsterDefense));
     }
-    if (this.defense instanceof String) {
-      this.defense = compile(this.defense);
+    if (this.defense instanceof String s) {
+      this.defense = compile(s);
     }
     return Math.max(
         1,
@@ -1835,7 +1835,7 @@ public class MonsterData extends AdventureResult {
     }
 
     if (!items.isEmpty()) {
-      buffer.append("<br />Item Drops: ").append(String.join(", ", items));
+      buffer.append("<br />Drops: ").append(String.join(", ", items));
     }
   }
 

--- a/src/net/sourceforge/kolmafia/MonsterData.java
+++ b/src/net/sourceforge/kolmafia/MonsterData.java
@@ -1843,6 +1843,30 @@ public class MonsterData extends AdventureResult {
     return drop.itemCount().isEmpty() ? "" : drop.itemCount() + " ";
   }
 
+  public void appendMeat(StringBuilder buffer) {
+    int minMeat = this.getMinMeat();
+    int maxMeat = this.getMaxMeat();
+    if (maxMeat > 0) {
+      buffer.append("<br />Meat: ");
+      buffer.append(minMeat);
+      buffer.append(" - ");
+      buffer.append(maxMeat);
+    }
+  }
+
+  public void appendSprinkles(StringBuilder buffer) {
+    int minSprinkles = this.getMinSprinkles();
+    int maxSprinkles = this.getMaxSprinkles();
+    if (maxSprinkles > 0) {
+      buffer.append("<br />Sprinkles: ");
+      buffer.append(minSprinkles);
+      if (maxSprinkles != minSprinkles) {
+        buffer.append(" - ");
+        buffer.append(maxSprinkles);
+      }
+    }
+  }
+
   public MonsterData transform() {
     // Clone the monster so we don't munge the template
     MonsterData monster;
@@ -2180,25 +2204,9 @@ public class MonsterData extends AdventureResult {
       buffer.append("<br />This monster is of The Drip. ");
     }
 
-    int minMeat = this.getMinMeat();
-    int maxMeat = this.getMaxMeat();
-    if (maxMeat > 0) {
-      buffer.append("<br />Meat: ");
-      buffer.append(minMeat);
-      buffer.append(" - ");
-      buffer.append(maxMeat);
-    }
+    this.appendMeat(buffer);
 
-    int minSprinkles = this.getMinSprinkles();
-    int maxSprinkles = this.getMaxSprinkles();
-    if (maxSprinkles > 0) {
-      buffer.append("<br />Sprinkles: ");
-      buffer.append(minSprinkles);
-      if (maxSprinkles != minSprinkles) {
-        buffer.append(" - ");
-        buffer.append(maxSprinkles);
-      }
-    }
+    this.appendSprinkles(buffer);
 
     stats.appendItemDrops(buffer);
 

--- a/src/net/sourceforge/kolmafia/MonsterData.java
+++ b/src/net/sourceforge/kolmafia/MonsterData.java
@@ -1843,26 +1843,42 @@ public class MonsterData extends AdventureResult {
     return drop.itemCount().isEmpty() ? "" : drop.itemCount() + " ";
   }
 
-  public void appendMeat(StringBuilder buffer) {
+  void appendMeat(StringBuilder buffer) {
+    this.appendMeat(buffer, false);
+  }
+
+  public void appendMeat(StringBuilder buffer, boolean stateful) {
     int minMeat = this.getMinMeat();
     int maxMeat = this.getMaxMeat();
     if (maxMeat > 0) {
+      double modifier =
+          stateful
+              ? Math.max(0.0, (KoLCharacter.getMeatDropPercentAdjustment() + 100.0) / 100.0)
+              : 1.0;
       buffer.append("<br />Meat: ");
-      buffer.append(minMeat);
+      buffer.append((int) Math.floor(minMeat * modifier));
       buffer.append(" - ");
-      buffer.append(maxMeat);
+      buffer.append((int) Math.floor(maxMeat * modifier));
     }
   }
 
-  public void appendSprinkles(StringBuilder buffer) {
+  void appendSprinkles(StringBuilder buffer) {
+    this.appendSprinkles(buffer, false);
+  }
+
+  public void appendSprinkles(StringBuilder buffer, boolean stateful) {
     int minSprinkles = this.getMinSprinkles();
     int maxSprinkles = this.getMaxSprinkles();
     if (maxSprinkles > 0) {
+      double modifier =
+          stateful
+              ? Math.max(0.0, (KoLCharacter.getSprinkleDropPercentAdjustment() + 100.0) / 100.0)
+              : 1.0;
       buffer.append("<br />Sprinkles: ");
-      buffer.append(minSprinkles);
+      buffer.append((int) Math.floor(minSprinkles * modifier));
       if (maxSprinkles != minSprinkles) {
         buffer.append(" - ");
-        buffer.append(maxSprinkles);
+        buffer.append((int) Math.ceil(maxSprinkles * modifier));
       }
     }
   }

--- a/src/net/sourceforge/kolmafia/MonsterData.java
+++ b/src/net/sourceforge/kolmafia/MonsterData.java
@@ -1813,7 +1813,7 @@ public class MonsterData extends AdventureResult {
                           (rawRate >= 1 || rawRate == 0)
                               ? String.valueOf((int) rawRate)
                               : String.valueOf(rawRate);
-                      var itemCount = drop.itemCount().isEmpty() ? "" : drop.itemCount() + " ";
+                      var itemCount = makeItemCount(drop);
                       return itemCount
                           + drop.item().getName()
                           + " ("
@@ -1837,6 +1837,10 @@ public class MonsterData extends AdventureResult {
     if (!items.isEmpty()) {
       buffer.append("<br />Item Drops: ").append(String.join(", ", items));
     }
+  }
+
+  private String makeItemCount(MonsterDrop drop) {
+    return drop.itemCount().isEmpty() ? "" : drop.itemCount() + " ";
   }
 
   public MonsterData transform() {

--- a/src/net/sourceforge/kolmafia/RequestEditorKit.java
+++ b/src/net/sourceforge/kolmafia/RequestEditorKit.java
@@ -1439,29 +1439,9 @@ public class RequestEditorKit extends HTMLEditorKit {
 
     monster.appendItemDrops(monsterData);
 
-    int minMeat = monster.getMinMeat();
-    int maxMeat = monster.getMaxMeat();
-    if (maxMeat > 0) {
-      double modifier =
-          Math.max(0.0, (KoLCharacter.getMeatDropPercentAdjustment() + 100.0) / 100.0);
-      monsterData.append("<br />Meat: ");
-      monsterData.append((int) Math.floor(minMeat * modifier));
-      monsterData.append("-");
-      monsterData.append((int) Math.floor(maxMeat * modifier));
-    }
+    monster.appendMeat(monsterData, true);
 
-    int minSprinkles = monster.getMinSprinkles();
-    int maxSprinkles = monster.getMaxSprinkles();
-    if (maxSprinkles > 0) {
-      double modifier =
-          Math.max(0.0, (KoLCharacter.getSprinkleDropPercentAdjustment() + 100.0) / 100.0);
-      monsterData.append("<br />Sprinkles: ");
-      monsterData.append((int) Math.floor(minSprinkles * modifier));
-      if (maxSprinkles != minSprinkles) {
-        monsterData.append("-");
-        monsterData.append((int) Math.ceil(maxSprinkles * modifier));
-      }
-    }
+    monster.appendSprinkles(monsterData, true);
 
     IslandDecorator.appendMissingGremlinTool(monster, monsterData);
 

--- a/src/net/sourceforge/kolmafia/RequestEditorKit.java
+++ b/src/net/sourceforge/kolmafia/RequestEditorKit.java
@@ -10,7 +10,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -34,10 +33,8 @@ import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
-import net.sourceforge.kolmafia.persistence.BountyDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
-import net.sourceforge.kolmafia.persistence.MonsterDrop;
 import net.sourceforge.kolmafia.persistence.QuestDatabase;
 import net.sourceforge.kolmafia.persistence.QuestDatabase.Quest;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -1403,7 +1400,7 @@ public class RequestEditorKit extends HTMLEditorKit {
     }
     int insertionPointForData = combatIndex + 7;
 
-    StringBuffer monsterData = new StringBuffer("<font size=2 color=gray>");
+    StringBuilder monsterData = new StringBuilder("<font size=2 color=gray>");
     monsterData.append("<br />HP: ");
     monsterData.append(MonsterStatusTracker.getMonsterHealth());
     monsterData.append(", Atk: ");
@@ -1440,57 +1437,7 @@ public class RequestEditorKit extends HTMLEditorKit {
       monsterData.append(danceMoveStatus);
     }
 
-    List<MonsterDrop> items = monster.getItems();
-    if (!items.isEmpty()) {
-      monsterData.append("<br />Drops: ");
-      for (int i = 0; i < items.size(); ++i) {
-        if (i != 0) {
-          monsterData.append(", ");
-        }
-        MonsterDrop drop = items.get(i);
-        double rawRate = drop.chance();
-        String rate =
-            (rawRate >= 1 || rawRate == 0)
-                ? String.valueOf((int) rawRate)
-                : String.valueOf(rawRate);
-        monsterData.append(drop.item().getName());
-        switch (drop.flag()) {
-          case PICKPOCKET_ONLY -> {
-            monsterData.append(" (");
-            monsterData.append(rate);
-            monsterData.append(" pp only)");
-          }
-          case NO_PICKPOCKET -> {
-            monsterData.append(" (");
-            monsterData.append(rate);
-            monsterData.append(" no pp)");
-          }
-          case CONDITIONAL -> {
-            monsterData.append(" (");
-            monsterData.append(rate);
-            monsterData.append(" cond)");
-          }
-          case FIXED -> {
-            monsterData.append(" (");
-            monsterData.append(rate);
-            monsterData.append(" no mod)");
-          }
-          case STEAL_ACCORDION -> monsterData.append(" (stealable accordion)");
-          default -> {
-            monsterData.append(" (");
-            monsterData.append(rate);
-            monsterData.append(")");
-          }
-        }
-      }
-    }
-
-    String bounty = BountyDatabase.getNameByMonster(monsterName);
-    if (bounty != null) {
-      monsterData.append(items.isEmpty() ? "<br />Drops: " : ", ");
-      monsterData.append(bounty);
-      monsterData.append(" (bounty)");
-    }
+    monster.appendItemDrops(monsterData);
 
     int minMeat = monster.getMinMeat();
     int maxMeat = monster.getMaxMeat();
@@ -1523,7 +1470,7 @@ public class RequestEditorKit extends HTMLEditorKit {
     }
 
     monsterData.append("</font>");
-    buffer.insert(insertionPointForData, monsterData.toString());
+    buffer.insert(insertionPointForData, monsterData);
 
     // Insert color for monster element
     MonsterDatabase.Element monsterElement = monster.getDefenseElement();

--- a/src/net/sourceforge/kolmafia/objectpool/EffectPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/EffectPool.java
@@ -265,6 +265,7 @@ public class EffectPool {
   public static final int MERRY_SMITHSNESS = 1476;
   public static final int SMITHSNESS_CHEER = 1479;
   public static final int REASSURED = 1492;
+  public static final int FROSTY = 1499;
   public static final int HARE_BRAINED = 1515;
   public static final int UNMUFFLED = 1545;
   public static final int MUFFLED = 1546;
@@ -300,6 +301,7 @@ public class EffectPool {
   public static final int LUCKY_STRUCK = 2133;
   public static final int MINISTRATIONS_IN_THE_DARK = 2134;
   public static final int SUPERDRIFTING = 2135;
+  public static final int SPRINKLE_SENSE = 2154;
   public static final int SYNTHESIS_HOT = 2165;
   public static final int SYNTHESIS_COLD = 2166;
   public static final int SYNTHESIS_PUNGENT = 2167;

--- a/src/net/sourceforge/kolmafia/request/SpelunkyRequest.java
+++ b/src/net/sourceforge/kolmafia/request/SpelunkyRequest.java
@@ -909,7 +909,7 @@ public class SpelunkyRequest extends GenericRequest {
     buffer.insert(index, section);
   }
 
-  public static void decorateSpelunkyMonster(final StringBuffer buffer) {
+  public static void decorateSpelunkyMonster(final StringBuilder buffer) {
     // Simplified, since Skills, Elemental Damage, and Bonus
     // Critical Hits are not applicable
 

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -183,6 +183,7 @@ public class ResultProcessor {
                   case STEAL_ACCORDION -> "Pickpocketed item "
                       + name
                       + " which is marked as accordion steal.";
+                  case MULTI_DROP -> "Pickpocketed item " + name + " which is marked as multidrop.";
                   default -> null;
                 };
             if (message != null) {

--- a/src/net/sourceforge/kolmafia/webui/IslandDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/IslandDecorator.java
@@ -233,7 +233,7 @@ public class IslandDecorator {
   }
 
   public static final void appendMissingGremlinTool(
-      MonsterData monster, final StringBuffer buffer) {
+      MonsterData monster, final StringBuilder buffer) {
     GremlinTool tool = badGremlins.get(monster.getId());
     if (tool == null) {
       return;

--- a/test/net/sourceforge/kolmafia/MonsterDataTest.java
+++ b/test/net/sourceforge/kolmafia/MonsterDataTest.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia;
 
+import static internal.helpers.Player.withEffect;
 import static internal.helpers.Player.withMoxie;
 import static internal.helpers.Player.withProperty;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -13,10 +14,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import internal.helpers.Cleanups;
+import internal.helpers.Player;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
 import net.sourceforge.kolmafia.MonsterData.Attribute;
+import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase.Element;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase.Phylum;
@@ -399,6 +402,20 @@ public class MonsterDataTest {
 
       assertThat(builder.toString(), equalTo("<br />Meat: 800 - 1200"));
     }
+
+    @Test
+    void statefulMeatDropsAreRenderedWithBonuses() {
+      var monster = MonsterDatabase.findMonster("Knob Goblin Embezzler");
+
+      var cleanups = Player.withEffect(EffectPool.FROSTY);
+
+      try (cleanups) {
+        var builder = new StringBuilder();
+        monster.appendMeat(builder, true);
+
+        assertThat(builder.toString(), equalTo("<br />Meat: 2400 - 3600"));
+      }
+    }
   }
 
   @Nested
@@ -425,6 +442,25 @@ public class MonsterDataTest {
       monster.appendSprinkles(builder);
 
       assertThat(builder.toString(), equalTo("<br />Sprinkles: " + dropString));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      "gingerbread finance bro, '42 - 48'",
+      "Judge Fudge, '150'",
+    })
+    void statefulSprinkleDropsAreRenderedWithBonuses(
+        final String monsterName, final String dropString) {
+      var monster = MonsterDatabase.findMonster(monsterName);
+
+      var cleanups = withEffect(EffectPool.SPRINKLE_SENSE);
+
+      try (cleanups) {
+        var builder = new StringBuilder();
+        monster.appendSprinkles(builder, true);
+
+        assertThat(builder.toString(), equalTo("<br />Sprinkles: " + dropString));
+      }
     }
   }
 

--- a/test/net/sourceforge/kolmafia/MonsterDataTest.java
+++ b/test/net/sourceforge/kolmafia/MonsterDataTest.java
@@ -379,6 +379,56 @@ public class MonsterDataTest {
   }
 
   @Nested
+  class MeatDrops {
+    @Test
+    void monsterWithoutMeatDisplaysNothing() {
+      var monster = MonsterDatabase.findMonster("giant amorphous blob");
+
+      var builder = new StringBuilder();
+      monster.appendMeat(builder);
+
+      assertThat(builder.toString(), not(containsString("Meat: ")));
+    }
+
+    @Test
+    void meatDropsAreRenderedWithoutBonuses() {
+      var monster = MonsterDatabase.findMonster("Knob Goblin Embezzler");
+
+      var builder = new StringBuilder();
+      monster.appendMeat(builder);
+
+      assertThat(builder.toString(), equalTo("<br />Meat: 800 - 1200"));
+    }
+  }
+
+  @Nested
+  class SprinkleDrops {
+    @Test
+    void monsterWithoutSprinklesDisplaysNothing() {
+      var monster = MonsterDatabase.findMonster("giant amorphous blob");
+
+      var builder = new StringBuilder();
+      monster.appendSprinkles(builder);
+
+      assertThat(builder.toString(), not(containsString("Sprinkles: ")));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      "gingerbread finance bro, '28 - 32'",
+      "Judge Fudge, '100'",
+    })
+    void sprinkleDropsAreRenderedWithoutBonuses(final String monsterName, final String dropString) {
+      var monster = MonsterDatabase.findMonster(monsterName);
+
+      var builder = new StringBuilder();
+      monster.appendSprinkles(builder);
+
+      assertThat(builder.toString(), equalTo("<br />Sprinkles: " + dropString));
+    }
+  }
+
+  @Nested
   class ShouldSteal {
     @Test
     public void shouldntStealIfNoItems() {

--- a/test/net/sourceforge/kolmafia/MonsterDataTest.java
+++ b/test/net/sourceforge/kolmafia/MonsterDataTest.java
@@ -347,7 +347,7 @@ public class MonsterDataTest {
       var builder = new StringBuilder();
       monster.appendItemDrops(builder);
 
-      assertThat(builder.toString(), not(containsString("Item Drops: ")));
+      assertThat(builder.toString(), not(containsString("Drops: ")));
     }
 
     @ParameterizedTest
@@ -374,7 +374,7 @@ public class MonsterDataTest {
       var builder = new StringBuilder();
       monster.appendItemDrops(builder);
 
-      assertThat(builder.toString(), equalTo("<br />Item Drops: " + itemDropString));
+      assertThat(builder.toString(), equalTo("<br />Drops: " + itemDropString));
     }
   }
 

--- a/test/net/sourceforge/kolmafia/MonsterDataTest.java
+++ b/test/net/sourceforge/kolmafia/MonsterDataTest.java
@@ -4,6 +4,7 @@ import static internal.helpers.Player.withMoxie;
 import static internal.helpers.Player.withProperty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -339,6 +340,16 @@ public class MonsterDataTest {
 
   @Nested
   class ItemDrops {
+    @Test
+    void noItemDrops() {
+      var monster = MonsterDatabase.findMonster("giant amorphous blob");
+
+      var builder = new StringBuilder();
+      monster.appendItemDrops(builder);
+
+      assertThat(builder.toString(), not(containsString("Item Drops: ")));
+    }
+
     @ParameterizedTest
     @CsvSource({
       // Test regular drops
@@ -346,6 +357,8 @@ public class MonsterDataTest {
       "skeleton with a mop, 'beer-soaked mop (10), ice-cold Willer (30), ice-cold Willer (30)'",
       // Test mix of pp and no pp
       "Dr. Awkward, 'Drowsy Sword (100 no pp), Staff of Fats (100 no pp), fumble formula (5 pp only)'",
+      // Test mix of normal and accordion
+      "bar, 'bar skin (35), baritone accordion (stealable accordion)'",
       // Test mix of item drops and bounty drops
       "novelty tropical skeleton, 'cherry (0), cherry (0), grapefruit (0), grapefruit (0), orange (0), orange (0), strawberry (0), strawberry (0), lemon (0), lemon (0), novelty fruit hat (0 cond), cherry stem (bounty)'",
       // Test fractional drops


### PR DESCRIPTION
A follow-up to #2053: the tested code in MonsterData wasn't the code displayed in the Relay Browser, as that's not shared.

Share it.

This leads to a small change in display: from "800-1200" to "800 - 1200" (spaces around the dash). I think, given the likely length of the item drop section, this looks better.