### PR TITLE
Fix skill type for Ravenous Pounce.

### DIFF
--- a/src/data/classskills.txt
+++ b/src/data/classskills.txt
@@ -1122,7 +1122,7 @@
 12007	Indefatigable	wallshield.gif	0	0	0	7
 12008	Skullcracker	brokeskull.gif	0	0	0	8
 12009	Neurogourmet	realbrain.gif	0	0	0	9
-12010	Ravenous Pounce	gashes.gif	5	2	0	10
+12010	Ravenous Pounce	gashes.gif	8	2	0	10
 
 # Anger of the Zombie
 


### PR DESCRIPTION
This is a combat skill with a passive effect.

In particular, this was previously correctly categorized, since Stomach Capacity was not a modifier until recently.

It probably makes sense to add a test to guard against adding a non-passive skill that has an associated modifier, although with new skills, this is less likely to be an issue (since modifier tracking simply won't work if implemented as the wrong type).