### PR TITLE
Fix Nuclear Autumn stomach size

### DIFF
--- a/src/net/sourceforge/kolmafia/AscensionPath.java
+++ b/src/net/sourceforge/kolmafia/AscensionPath.java
@@ -41,7 +41,7 @@ public class AscensionPath {
     AVATAR_OF_WEST_OF_LOATHING("Avatar of West of Loathing", 26, false, "badge", "an"),
     THE_SOURCE("The Source", 27, false, "ss_datasiphon", "a", "sourcePoints", 0, false),
     NUCLEAR_AUTUMN(
-        "Nuclear Autumn", 28, false, "radiation", "a", "nuclearAutumnPoints", 23, false, 5, 2, 3),
+        "Nuclear Autumn", 28, false, "radiation", "a", "nuclearAutumnPoints", 23, false, 3, 2, 3),
     GELATINOUS_NOOB("Gelatinous Noob", 29, true, "gcube", "a", "noobPoints", 20, true),
     LICENSE_TO_ADVENTURE(
         "License to Adventure", 30, false, "briefcase", "a", "bondPoints", 24, true, 0, 2, 15),

--- a/test/net/sourceforge/kolmafia/request/EatItemRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/EatItemRequestTest.java
@@ -270,7 +270,7 @@ class EatItemRequestTest {
       var cleanups = new Cleanups(withFullness(0));
       if (inNA) cleanups.add(withPath(AscensionPath.Path.NUCLEAR_AUTUMN));
       try (cleanups) {
-        assertThat(EatItemRequest.maximumUses(ItemPool.TOAST), is(inNA ? 5 : 15));
+        assertThat(EatItemRequest.maximumUses(ItemPool.TOAST), is(inNA ? 3 : 15));
         if (inNA) {
           assertThat(EatItemRequest.maximumUses(ItemPool.BROWSER_COOKIE), is(0));
           assertThat(DrinkItemRequest.limiter, is("your narrow, mutated throat"));


### PR DESCRIPTION
Currently mafia thinks that the fullness limit in Nuclear Autumn starts at 5.

This PR corrects that to the real size, which is 3.

I've tested this locally, let me know if this isn't actually the best way to go about fixing this though.