### PR TITLE
desert beach is accessible in KoE, Shadow Rifts are not

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -886,7 +886,7 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
         // need payphone in inventory or to be in ASoL
         return false;
       }
-      
+
       if (KoLCharacter.isKingdomOfExploathing()) {
         // KoE gets no access to it regardless for some reason known only to KoL devs.
         return false;

--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -886,6 +886,11 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
         // need payphone in inventory or to be in ASoL
         return false;
       }
+      
+      if (KoLCharacter.isKingdomOfExploathing()) {
+        // KoE gets no access to it regardless for some reason known only to KoL devs.
+        return false;
+      }
 
       // These are "place.php" visits.
       ShadowRift rift = ShadowRift.findAdventureName(this.adventureName);

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -3627,10 +3627,6 @@ public abstract class KoLCharacter {
   }
 
   public static final boolean desertBeachAccessible() {
-    if (KoLCharacter.isKingdomOfExploathing()) {
-      return false;
-    }
-
     // Temporary code to allow Mafia to catch up with the fact that unlock is a flag
     if (Preferences.getInteger("lastDesertUnlock") != KoLCharacter.getAscensions()) {
       if (InventoryManager.getCount(ItemPool.BITCHIN_MEATCAR) > 0
@@ -3640,7 +3636,8 @@ public abstract class KoLCharacter {
           || Preferences.getString("peteMotorbikeGasTank").equals("Large Capacity Tank")
           || QuestDatabase.isQuestFinished(Quest.MEATCAR)
           || KoLCharacter.kingLiberated()
-          || KoLCharacter.isEd()) {
+          || KoLCharacter.isEd()
+          || KoLCharacter.isKingdomOfExploathing()) {
         Preferences.setInteger("lastDesertUnlock", KoLCharacter.getAscensions());
       }
     }


### PR DESCRIPTION
See https://kol.coldfront.net/thekolwiki/index.php/Kingdom_of_Exploathing/Map
It's there, always has been since the path was live.
The blame for those lines is weird for me. It says they were last touched 11 years ago which is impossible as KoE is only 4 years old.
Lines 1150-1157 in KoLAdventure.java already handle the differences between the regular Desert Beach and the KoE "Fragment" of Desert Beach from what I can see (correct me if I am wrong).

Shadow Rifts have been confirmed to exist in the Right Side of the Tracks and Mt McLargeHuge (possibly other places too) in the KoE path but don't allow you to adventure in them for reasons known only to the KoL dev team.