### PR TITLE
Correct 3 wrong nohookah flags in statuseffects.txt

### DIFF
--- a/src/data/statuseffects.txt
+++ b/src/data/statuseffects.txt
@@ -2581,7 +2581,7 @@
 2579	You Have Ever Seen The Rain	saucedrops.gif	1811ff37102a4be344fc634b73d30d34	good	none	use 1 redwood rain stick
 2580	Goo Vibrations	greygooball.gif	e31c54ee309cf40ebc6f7c00982ad46f	neutral	none
 2581	Wary	archedeyebrow.gif	796f91fe28ae74fa96189fa17bbf37d7	good	none	cargo effect Wary
-2582	Joke-Mad	angry.gif	90db65d923857548df90f5e4990201cd	neutral	nohookah	cargo effect Joke-Mad
+2582	Joke-Mad	angry.gif	90db65d923857548df90f5e4990201cd	neutral	none	cargo effect Joke-Mad
 2583	Sizzlin' Hand	pocket.gif	8065d54cd3fb8d39583c7f2a426ddd8a	good	nohookah	cargo effect Sizzlin' Hand
 2584	Frosty Hand	pocket.gif	5e365d8957c31ca063c4aa66c0b60640	good	none	cargo effect Frosty Hand
 2585	Foul Hand	pocket.gif	45ecc3be7f43ed1d9de42551173d8cd1	good	none	cargo effect Foul Hand
@@ -2593,8 +2593,8 @@
 2591	Sigils of Yeg	yeg_sigils.gif	90fca24c71336a9d068f8ebdfd590026	neutral	nohookah	use 1 Yeg's Motel hand soap
 2592	Breath of Yeg	yeg_breath.gif	6cfee0050e393ded4a718abbbfb12a91	neutral	nohookah	use 1 Yeg's Motel mouthwash
 2593	Yeg's Power	yeg_blessing.gif	5540baf46ed3a15e3b7abdf07d1af4a0	neutral	nohookah	summon 13
-2594	Barely Visible	pocket.gif	ca9f21774a3b01ecfee07b90c6731ab9	neutral	nohookah	cargo effect Barely Visible
-2595	Very Attractive	louder.gif	c3e2a8c1687a3573d1ee3c76b91c1098	neutral	nohookah	cargo effect Very Attractive
+2594	Barely Visible	pocket.gif	ca9f21774a3b01ecfee07b90c6731ab9	neutral	none	cargo effect Barely Visible
+2595	Very Attractive	louder.gif	c3e2a8c1687a3573d1ee3c76b91c1098	neutral	none	cargo effect Very Attractive
 2596	Finding Stuff	eyes.gif	bc571a98e78b819e9342aff772f12052	good	none	cargo effect Finding Stuff
 2597	Yeg's Keeping	yeg_blessing.gif	6d4a6243a23f3fbd8bbb41da7185a475	neutral	nohookah
 2598	All Chipped Up	earthpan3.gif	2ce277562fd55d6fabbfcc516c8e1249	good	none	eat 1 chocolate chip muffin


### PR DESCRIPTION
These 3 effects are wishable. The CLI reports:

You acquire an effect: Joke-Mad (20)
Joke-Mad is wishable, but KoLmafia thought it was not
You acquire an effect: Barely Visible (20)
Barely Visible is wishable, but KoLmafia thought it was not
You acquire an effect: Very Attractive (20)
Very Attractive is wishable, but KoLmafia thought it was not

These were changed in commit 535109e1f5b1ccb16968e1e4073ff98fa9a7891d - perhaps they assumed all the cargo cultist shorts buffs were not wishable.