### PR TITLE
Monsters scale based on mainstat not highest stat

### DIFF
--- a/src/net/sourceforge/kolmafia/Expression.java
+++ b/src/net/sourceforge/kolmafia/Expression.java
@@ -353,7 +353,7 @@ public class Expression {
         case '\u0089' -> v = FightRequest.dreadKisses("Castle");
 
           // Valid with MonsterExpression:
-        case '\u0090' -> v = KoLCharacter.getAdjustedHighestStat();
+        case '\u0090' -> v = KoLCharacter.getAdjustedMainstat();
 
           // Valid with RestoreExpression:
         case '\u0091' -> v = KoLCharacter.getMaximumMP();

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -1950,12 +1950,6 @@ public abstract class KoLCharacter {
     return KoLCharacter.adjustedStats[2];
   }
 
-  public static final int getAdjustedHighestStat() {
-    return Math.max(
-        Math.max(KoLCharacter.getAdjustedMuscle(), KoLCharacter.getAdjustedMysticality()),
-        KoLCharacter.getAdjustedMoxie());
-  }
-
   public static final int getBaseMainstat() {
     return switch (KoLCharacter.mainStat()) {
       case MUSCLE -> getBaseMuscle();


### PR DESCRIPTION
KoLmafia has two ways to handle scaling monsters.
Most use the Scale: parameters in monsters.txt but a few use monster expressions.

For monsters using the Scale: parameters, MonsterData.calculateExp() uses the character's buffed mainstat to calculate Exp.

For monsters using a monster expression, the STAT variable is used to calcuate Exp. This evaluates to the characters highest buffed stat.

There are not many monsters in monsters.txt that use the STAT variable in a monster expression to calculate Exp, and many of them are not wishable (and therefore not easily testable). I tested fighting a roller-scating muse on a DB with these buffed stats:

Muscle: 31
Mysticality: 136 (36)
Moxie: 46 (43)

and got these substats

You gain 4 Fortitude.
You gain 3 Wizardliness.
You gain 7 Cheek.

This is consistent with mainstat/4 but not consistent with highest_stat/4

The commit that introduced this behaviour
( 5cb9cfe4e99285e70f3af0e5a2649eea6b8c76fa ) says "Scaling monsters give stats based on your highest stat" but does not give any reason to suggest this should be different for these monsters than the ones using the Scale: parameter.

The STAT variable in monster expressions is only used for calculating Exp, nothing else. I believe using the highest stat instead of the character's main stat was just a mistake that has gone unnoticed because they're usually the same thing.

If anyone is able to test any of the other scaling monsters in monsters.txt that use a monster expression that would be helpful. The dreadsylvania werewolves should be easy enough to test but the woods are finished in my clan dungeon right now and I couldn't find another clan to test in.