### PR TITLE
feat: mark items that can also be used in combat

### DIFF
--- a/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
@@ -536,7 +536,15 @@ public enum DoubleModifier implements Modifier {
       "Free Rests",
       Pattern.compile("Rest Without Spending an Adventure \\((\\d+)x / day\\)"),
       Pattern.compile("Free Rests: " + EXPR)),
-  LEAVES("Leaves", Pattern.compile("Leaves: " + EXPR));
+  LEAVES("Leaves", Pattern.compile("Leaves: " + EXPR)),
+  ELF_WARFARE_EFFECTIVENESS(
+      "Elf Warfare Effectiveness",
+      Pattern.compile("([+-]\\d+) Elf Warfare Effectiveness"),
+      Pattern.compile("Elf Warfare Effectiveness: " + EXPR)),
+  PIRATE_WARFARE_EFFECTIVENESS(
+      "Pirate Warfare Effectiveness",
+      Pattern.compile("([+-]\\d+) Pirate Warfare Effectiveness"),
+      Pattern.compile("Pirate Warfare Effectiveness: " + EXPR));
 
   private final String name;
   private final Pattern[] descPatterns;

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -671,6 +671,9 @@ public class DebugDatabase {
     if (text.contains("Cocktailcrafting ingredient")) {
       attributes.add(Attribute.MIX);
     }
+    if (text.contains("can also be used in combat")) {
+      attributes.add(Attribute.COMBAT);
+    }
     return attributes;
   }
 


### PR DESCRIPTION
Add Elf / Pirate Warfare Effectiveness modifiers.

Will add to items / effects after #2099.