### PR TITLE
feat: add crimbo 23 zones, monsters, etc.

### DIFF
--- a/src/data/adventures.txt
+++ b/src/data/adventures.txt
@@ -438,6 +438,10 @@ Tammy's Offshore Platform	adventure=536	DiffLevel: unknown Env: underwater Stat:
 Tammy's Offshore Platform	adventure=537	DiffLevel: unknown Env: underwater Stat: 0	The Wreck of the H. M. S. Kringle
 Tammy's Offshore Platform	adventure=538	DiffLevel: unknown Env: underwater Stat: 0	The Impenetrable Kelp-Holly Forest
 
+Crimbo23	adventure=577	DiffLevel: mid Env: indoor Stat: 0	The Bar At War
+Crimbo23	adventure=578	DiffLevel: mid Env: indoor Stat: 0	A Cafe Divided
+Crimbo23	adventure=579	DiffLevel: mid Env: indoor Stat: 0	The Armory Up In Arms
+
 Crimbo22	adventure=559	DiffLevel: mid Env: indoor Stat: 0 nowander	Crimbo Train (Caboose)
 Crimbo22	adventure=560	DiffLevel: mid Env: indoor Stat: 0 nowander	Crimbo Train (Passenger Car)
 Crimbo22	adventure=561	DiffLevel: mid Env: indoor Stat: 0 nowander	Crimbo Train (Dining Car)

--- a/src/data/classskills.txt
+++ b/src/data/classskills.txt
@@ -256,9 +256,10 @@
 227	Chitinous Soul	chitinpowder.gif	0	0	0	Max Level: 11
 228	Just the Facts	factbook.gif	0	0	0
 229	Elf Guard Cooking	fruitcake.gif	0	0	0
-230
+230	Old-School Cocktailcrafting	martini.gif	0	0	0
 231
 232	Fruit Recognition	cherry.gif	0	0	0
+233	Elf Guard Relaxation Techniques	sleepy.gif	0	0	0
 
 # Skills available to Clubbers
 

--- a/src/data/coinmasters.txt
+++ b/src/data/coinmasters.txt
@@ -1161,3 +1161,22 @@ Mr. Store 2002	buy	1	Flash Liquidizer Ultra Dousing Accessory	ROW1387
 Mr. Store 2002	buy	1	Amulet of Perpetual Darkness	ROW1388
 Mr. Store 2002	buy	1	Giant black monolith	ROW1389
 Mr. Store 2002	buy	1	Crimbo cookie sheet	ROW1390
+
+# Crimbo 2023
+
+Crimbuccaneer Foundry	buy	10	prank Crimbo card	ROW1431
+Crimbuccaneer Foundry	buy	20	Crimbuccaneer squirtblunderbuss	ROW1432
+Crimbuccaneer Foundry	buy	40	My First Paycheck envelope	ROW1433
+Crimbuccaneer Foundry	buy	80	barnacle-encrusted sweater	ROW1434
+Crimbuccaneer Foundry	buy	150	Crimbuccaneer nose ring	ROW1435
+Crimbuccaneer Foundry	buy	400	pet anchor	ROW1436
+Crimbuccaneer Foundry	buy	2000	Crimbuccaneer tattoo gift certificate	ROW1437
+Crimbuccaneer Foundry	buy	1000	stuffed kraken	ROW1441
+
+Crimbuccaneer Bar	buy	5	hot wine	ROW1408
+Crimbuccaneer Bar	buy	20	Jamaican coffee	ROW1409
+Crimbuccaneer Bar	buy	10	flask of egggrog	ROW1410
+
+Elf Guard Mess Hall	buy	5	sugarplum ration	ROW1399
+Elf Guard Mess Hall	buy	20	gingerbread nylons	ROW1400
+Elf Guard Mess Hall	buy	10	rum-soaked fruitcake	ROW1401

--- a/src/data/combats.txt
+++ b/src/data/combats.txt
@@ -42,6 +42,7 @@
 2nd Floor, Shiawase-Mitsuhama Building	100	salaryninja	security robot	yakuza guard
 3rd Floor, Shiawase-Mitsuhama Building	100	salaryninja	security robot	yakuza guard
 A Barroom Brawl	100	drunken 7-foot dwarf	plastered frat orc	skeleton with a mop	unemployed knob goblin	werecougar
+A Cafe Divided	100	Crimbuccaneer military school dropout	Crimbuccaneer new recruit	Crimbuccaneer privateer	Elf Guard conscript	Elf Guard convict	Elf Guard private	Crimbuccaneer fruit plunderer	Crimbuccaneer retiree	Crimbuccaneer whalehunter	Elf Guard desserter	Elf Guard provisioner	Elf Guard steward
 A Crater Full of Space Beasts	100	space beast	space beast matriarch: 0
 A Crowd of (Element) Adventurers	100
 A Crowd of (Stat) Adventurers	100
@@ -263,8 +264,10 @@ The Ancient Burial Ground	100	skeleton	vampire
 The Ancient Hobo Burial Ground	-1	Spooky hobo	Zombo: 0
 The Archwizard's Tower	0	Archwizard: 0
 The Arid, Extra-Dry Desert	100	cactuary	giant giant giant centipede	plaque of locusts	rock scorpion	swarm of fire ants
+The Armory Up In Arms	100	Crimbuccaneer military school dropout	Crimbuccaneer new recruit	Crimbuccaneer privateer	Elf Guard conscript	Elf Guard convict	Elf Guard private	Crimbuccaneer carpenter	Crimbuccaneer freebooter	Crimbuccaneer scrimshander	Elf Guard arctic seal	Elf Guard armorer	Elf Guard Red and White Beret
 The Bandit Crossroads	100	fantasy bandit
 The Barrow Mounds	100	barrow wraith?
+The Bar At War	100	Crimbuccaneer military school dropout	Crimbuccaneer new recruit	Crimbuccaneer privateer	Elf Guard conscript	Elf Guard convict	Elf Guard private	Crimbuccaneer bar brawler	Crimbuccaneer barrrback	Crimbuccaneer grognard	Elf Guard chemist	Elf Guard sanitation officer	Elf Guard shore leave specialist
 The Bat Hole Entrance	100	albino bat	pine bat	regular old bat
 The Batrat and Ratbat Burrow	100	batrat	ratbat	screambat: 0	Batsnake: 0
 The Battlefield (Frat Uniform)	100	Bailey's Beetle	Green Ops Soldier	Mobile Armored Sweat Lodge	War Hippy Airborne Commander	War Hippy Baker	War Hippy Dread Squad	War Hippy Elder Shaman	War Hippy Elite Fire Spinner	War Hippy Elite Rigger	War Hippy Fire Spinner	War Hippy F.R.O.G.	War Hippy Green Gourmet	War Hippy Homeopath	War Hippy Infantryman	War Hippy Naturopathic Homeopath	War Hippy Rigger	War Hippy Shaman	War Hippy Sky Captain	War Hippy Windtalker	C.A.R.N.I.V.O.R.E. Operative: 0	Glass of Orange Juice: 0	Neil: 0	Slow Talkin' Elliot: 0	Zim Merman: 0	The Big Wisniewski: 0

--- a/src/data/equipment.txt
+++ b/src/data/equipment.txt
@@ -1158,6 +1158,7 @@ electric crutch	30	Mus: 0	1-handed staff
 elegant nightstick	90	Mus: 30	1-handed club
 elephant stinger	75	Mus: 22	2-handed spear
 elevenderizing hammer	115	Mus: 11	1-handed club
+Elf Guard broom	100	Mus: 0	2-handed polearm
 Elf Guard mouthknife	50	Mus: 0	1-handed knife
 elf ploughshare	100	Mus: 0	1-handed sword
 elven tambourine	100	Mox: 0	1-handed rattle

--- a/src/data/fullness.txt
+++ b/src/data/fullness.txt
@@ -403,7 +403,7 @@ gingerbread massacre	3	1	decent	3-6	5-6	5-6	5-6	10 Sugar Rush
 gingerbread mug	2	1	decent	3-4	2-4	2-4	2-4
 gingerbread mutant bugbear	1	1	good	1-5	10-20	10-20	10-20	10 Festive Radiation (+5% all stats)
 Gingerbread Nutrition Block	4	1	decent	6-10	0	0	0	20 Forbear, Warbears! (+40 WarBear Armor Penetration)
-gingerbread nylons	3	1	awesome	0	0	0	0	Unspaded
+gingerbread nylons	3	1	awesome	12	0	0	0	50 Stocking Stuffer (increase drops on Crimbo battlefields)
 gingerbread robot	2	1	awesome	7-11	0	0	0	20 Gingerbread Robust (+100% all stats)
 gingerbread stir-fry	3	1	decent	3-7	0	0	0	10 Sugar Rush
 glass of baboon milk	1	2	decent	2	3-5	0	0	BEVERAGE
@@ -674,7 +674,7 @@ penguin focaccia bread	7	1	good	18-24	21-38	21-38	21-38
 peppermint donut	1	1	good	0	0	0	0	Unspaded
 Peppermint Nutrition Block	3	1	decent	3-6	0	0	0	10 Forbear, Warbears! (+40 WarBear Armor Penetration)
 peppermint patty	2	2	EPIC	9-12	10-20	10-20	10-20
-peppermint tack	2	1	EPIC	0	0	0	0	Unspaded
+peppermint tack	2	1	EPIC	12	0	0	0
 perfect breakfast	5	1	good	14-16	20-30	40-50	0
 perfect chef salad	5	1	good	14-16	10-20	40-50	10-20
 perfect sandwich	5	1	good	14-16	10-20	40-50	10-20
@@ -773,7 +773,7 @@ root beer	1	1	awesome	4	5-10	5-10	5-10	BEVERAGE, 20-30 MP
 rotting beefsteak	3	1	awesome	9-10	0	0	0	30 Cowrruption (+200% weapon dmg, +200% spell dmg, muscle limited to 30, moxie limited to 30)
 royal jelly	1	1	crappy	1	10-15	0	0
 royal jelly taco	1	1	decent	2	4-20	0	0
-rum-soaked fruitcake	5	1	awesome	0	0	0	0	Unspaded
+rum-soaked fruitcake	5	1	awesome	25	0	0	0	100 Rum of Darkness (+5 Elf Warfare Effectiveness)
 S.T.L.T.	4	4	awesome	10-15	10-30	10-30	13-27
 s'more	1	1	crappy	1	0	0	0
 salacious crumbs	3	1	decent	5-7	0	0	15-20
@@ -905,10 +905,10 @@ sublime nachos	6	1	awesome	22-26	10-20	40-50	10-20
 sublime stew	6	1	awesome	22-26	0	40-50	20-30
 succulent marrow	3	1	decent	5-7	25-30	0	0
 suddenly salad!	5	1	EPIC	60-80	0	220-400	0
-sugarplum ration	5	1	awesome	0	0	0	0	Unspaded
+sugarplum ration	5	1	awesome	23	0	0	0	50 Sugarplum Visions (more pieces of 12 from Crimbuccaneers)
 suggestive strozzapreti	5	7	awesome	16-19	0	0	20-30
 sun-dried tofu	2	3	crappy	2-4	0	0	0	gain Deadened Palate or lose Oversaturated Palate
-sundae ration	2	1	EPIC	0	0	0	0	Unspaded
+sundae ration	2	1	EPIC	14	0	0	0
 super good fruit	1	1	awesome	5	0	10-20	0
 super ka-bob	3	11	awesome	12-15	30-38	0	0
 super salad	3	11	awesome	13-16	30-50	32-40	31-40	SALAD
@@ -1059,7 +1059,7 @@ weird gazelle steak	10	1	awesome	40	0	0	0	1 Gaze of the Gazelle (+200% Spell Dam
 wet dog	3	1	awesome	11-13	0	0	0	30 Hangdog (+20 Init, +30 Sleaze Dam, +3 Hot/Stench Res)
 wet stew	6	1	good	12-15	16-19	0	0
 whalecake	4	1	EPIC	0	0	0	0	Unspaded
-whalesteak	3	1	EPIC	0	0	0	0	Unspaded
+whalesteak	3	1	EPIC	18	0	0	0
 white chocolate and tomato pizza	3	2	decent	3-9	0	0	0	PIZZA
 white chocolate chip brownies	2	5	awesome	5-8	0	41-58	0
 white chocolate chip cookies	2	1	decent	2-5	0	11-13	0

--- a/src/data/inebriety.txt
+++ b/src/data/inebriety.txt
@@ -291,7 +291,7 @@ Flaming Mohobo	2	8	awesome	8-9	15-20	15-20	15-20	15 Mo' Hobo (+10 Hobo power)
 flaming mushroom wine	3	6	awesome	10-14	12-15	0	0	WINE
 Flaming Sazerorc	2	8	awesome	8-9	30-40	0	0	15 Orc Chops (+50 Muscle)
 flask of Amontillado	4	4	awesome	10-15	10-30	15-30	10-30
-flask of egggrog	5	1	awesome	0	0	0	0	Unspaded
+flask of egggrog	5	1	awesome	0	0	0	0	Unspaded, 100 Grogged For Battle (+5 Pirate Warfare Effectiveness)
 flask of moonshine	2	1	awesome	9-11	50-70	50-70	50-70
 flask of peppermint schnapps	1	1	decent	1	0	0	0
 flask of port	2	1	awesome	6-8	20-30	5-10	5-10	WINE
@@ -377,7 +377,7 @@ hot mint schnocolate	1	1	good	2-4	5-10	5-10	5-10	25 Alpine Mintiness (+25 HP/MP,
 Hot Socks	3	1	awesome	10-14	0	0	0	50 Hip to the Jive (+2 Familiar experience, +10 Familiar Weight, +20 Familiar Damage)
 hot toady	4	4	decent	6-10	7-8	7-8	7-8
 hot watered rum	3	1	good	9-10	0	0	0
-hot wine	4	1	awesome	0	0	0	0	Unspaded
+hot wine	4	1	awesome	0	0	0	0	Unspaded, 50 In a Stealin' Mood (more MPCs from Elf Guards)
 Humanitini	2	1	good	4-5	5-10	5-10	5-10	Restores HP, MARTINI
 Hundred Headed IPA	2	13	awesome	9-11	15-30	15-30	15-30	20 Hoppyness (+100% Initiative)
 Ice Island Long Tea	4	1	EPIC	18-22	15-30	15-30	15-30
@@ -400,7 +400,7 @@ Island Thunderstorm	4	1	awesome	0	0	0	0	Unspaded 20 Tiki Thoughtfulness (+100% M
 Isotope Nog	4	5	decent	6-11	0	0	0
 Jack-O-Lantern beer	2	1	awesome	7-9	0	0	10-20	30 Toothy Grin (+5 familiar weight)
 Jackhammer	2	4	awesome	6-7	20-30	0	0	10 Mortarfied (+100 DA)
-Jamaican coffee	3	1	awesome	0	0	0	0	Unspaded
+Jamaican coffee	3	1	awesome	12	0	0	0	50 Jamaican' Me Acquisitive (increase drops on Crimbo battlefields)
 jar of fermented pickle juice	5	13	EPIC	29-34	80-100	80-100	80-100	-5 spleen
 jar of squeeze	7	8	awesome	25-30	25-45	25-45	25-45
 Jeppson's Malort	3	1	EPIC	22-26	10-20	10-20	10-20
@@ -493,7 +493,7 @@ Nog-on-the-Cob	3	1	awesome	12	15-30	15-30	15-30	20 Sulfurous Sinuses (+3 Stench 
 non-aged vinegar	2	4	awesome	6-7	5-10	5-10	5-10	40 Sour Grapes (+40% Item Drop)
 nothingtini	1	1	good	2-4	0	0	0	40 Nothing Happened (+20 Monster Level), MARTINI
 ocean motion	4	4	good	10-14	25-27	8-10	0
-officer's nog	2	1	EPIC	0	0	0	0	Unspaded
+officer's nog	2	1	EPIC	14	0	0	0
 Oh, the Humanitini	2	8	awesome	8-9	15-20	15-20	15-20	Restores HP, MARTINI
 Oil Nog	4	5	decent	7-9	0	0	0
 oily mushroom wine	3	7	awesome	12-17	14-15	12-15	12-15	WINE
@@ -556,7 +556,7 @@ Radberry Rip wine cooler	2	1	good	6	7-8	0	0
 Ralph IX cognac	6	15	EPIC	55-59	228-300	228-300	228-300
 Ram's Face Lager	1	2	decent	2	8-10	0	0	4-8 MP, BEER
 red ale	2	1	good	5-7	0	0	10-20	40 Putting the Pro in Proletariat (+50% Moxie, +25 ranged damage), BEER
-red and white claret	2	1	awesome	0	0	0	0	Unspaded
+red and white claret	2	1	awesome	10	0	0	0
 red drunki-bear	4	6	EPIC	22-26	200-240	0	0	4 Fullness 80 Gummiheart (+100 Muscle)
 Red Dwarf	2	1	good	4-5	0	10-20	0	5 World's Shortest Giant (+2 Prismatic Res)
 red red wine	2	4	decent	3-5	0	0	10-20	10-20 HP, WINE

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11444,7 +11444,7 @@
 11416
 11417
 11418
-11419
+11419	Elf Guard broom	761011803	egbroom.gif	weapon	t	0
 11420	Crimbuccaneer tavern swab	587885280	crimbucmop.gif	weapon	t	0
 11421	Elf Guard hangover cure	520317664	egcure.gif	usable	t	0
 11422	old-school pirate grog	716801313	crimbuctankard.gif	drink, mix	t	0
@@ -11457,7 +11457,7 @@
 11429	Elf Guard Field Manual: Culinary Arts	798908594	book.gif	usable	t	0
 11430	whalesteak	273792733	grilledsteak.gif	food, cook	t	0
 11431	whalegun	574080275	whalegun.gif	weapon, paste	t	0
-11432
+11432	Cocktails of the Age of Sail	493870843	book4.gif	usable	t	0
 11433	Elf Guard payroll bag	682179450	egmoneybag.gif	usable	t	0
 11434	Elf Guard clipboard	409196611	egclipboard.gif	offhand	t	0
 11435	pegfinger	731849980	pegfinger.gif	accessory	t	0
@@ -11476,10 +11476,10 @@
 11448
 11449
 11450	The Encyclopedia of Fruit	966029305	book3.gif	usable	t	0
-11451
+11451	punching mirror	911655077	crimbucmirror.gif	usable	t	0
 11452	ancient Elf dessert spoon	231753264	egspoon.gif	weapon	t	0
 11453	Elf Guard SCUBA tank	303906801	elfscuba.gif	container	t	0
-11454
+11454	Elf Guard Field Manual: Wilderness Sleeping	424878071	book.gif	usable	t	0
 11455	free boots	184381676	crimbucboots.gif	accessory	t	0
 11456
 11457	Elvish underarmor	818267349	egarmor.gif	accessory	t	0

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11522,10 +11522,10 @@
 11494
 11495	stuffed kraken	165429188	crimbuckraken.gif	offhand	g	0
 11496
-11497
-11498
+11497	Elf Guard Field Manual: Culinary Arts (used)	894142436	book.gif	usable		0
+11498	Cocktails of the Age of Sail (used)	332132489	book4.gif	usable		0
 11499
-11500
+11500	The Encyclopedia of Fruit (used)	413436542	book3.gif	usable		0
 11501
 11502	military candy cane	132951284	pep_bigcane.gif	potion, usable	t,d	5
 11503	groggipop	933817198	neutronpop.gif	potion, usable	t,d	5

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -11208,6 +11208,7 @@ Item	closed-circuit phone system	Free Pull
 # coal snakeskin: Adds Spooky Damage to kicks with your cowboy boots
 # cocktail napkin: Deals 20-40 <font color=red>Hot Damage</font>
 Item	Cocktails of the Age of Sail	Skill: "Old-School Cocktailcrafting"
+Item	Cocktails of the Age of Sail (used)	Skill: "Old-School Cocktailcrafting"
 # cocoa of youth: Extend the duration of up to 10 of your effects by 5 Adventures
 Item	coffee sprite	Free Pull
 # cold clusterbomb: Deals <font color=blue>Cold Damage</font> based on your highest stat
@@ -11389,6 +11390,7 @@ Item	electronic Brain Trainer game	Skill: "Brain Games"
 # electronics kit: Shocks your opponent, weakening and briefly stunning them.<p>Also restores 30-40 MP.
 # eleven-foot pole: You know...  For traps.
 Item	Elf Guard Field Manual: Culinary Arts	Skill: "Elf Guard Cooking"
+Item	Elf Guard Field Manual: Culinary Arts (used)	Skill: "Elf Guard Cooking"
 Item	Elf Guard Field Manual: Wilderness Sleeping	Skill: "Elf Guard Relaxation Techniques"
 # Elf Guard hangover cure: Reduces your Drunkenness by 5 (1 after Crimbo)
 # Elf Guard hangover cure: (limit 1x / day)
@@ -12344,6 +12346,7 @@ Item	the Crymbich Manuscript	Skill: "Ancient Crymbo Lore"
 Item	the Crymbich Manuscript (used)	Skill: "Ancient Crymbo Lore"
 # The Emperor's new cookie: So delicious!
 Item	The Encyclopedia of Fruit	Skill: "Fruit Recognition"
+Item	The Encyclopedia of Fruit (used)	Skill: "Fruit Recognition"
 # The Fingernail of the Thing in the Basement: Jeremy Science will be interested in this
 Item	The Firegate Tapes	Skill: "Firegate"
 Item	The Fun-Guy Cold Weather Bartender's Guide	Skill: "Perfect Freeze"

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -1012,9 +1012,8 @@ Item	icing poncho	Cold Damage: +25, Cold Spell Damage: +25, Food Drop: +50
 Item	junk-mail shirt	Muscle: +4, Mysticality: +4, Moxie: +4
 Item	Jurassic Parka	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Spooky Resistance: 1, Stench Resistance: 1, Hot Resistance: 1, Cold Resistance: 1, Sleaze Resistance: 1
 Item	Kashmir sweater	Hot Damage: +10, Hot Spell Damage: +10
-# Kelflar vest: +3 Elf Warfare Effectiveness
 # Kelflar vest: 75% Chance of Preventing Negative Status Attacks
-Item	Kelflar vest	Damage Reduction: 5
+Item	Kelflar vest	Elf Warfare Effectiveness: +3, Damage Reduction: 5
 Item	Kiss the Knob apron	Maximum MP: +5
 Item	Knob Goblin elite shirt	Muscle: +3
 Item	KoL Con 13 T-shirt	Sleaze Resistance: +2, Experience Percent (Moxie): +5
@@ -1374,8 +1373,7 @@ Item	elegant nightstick	Maximum HP: +30, Maximum MP: +15
 # elephant stinger: 50% chance of poisoning opponent.
 Item	elephant stinger	Muscle: +3
 Item	elevenderizing hammer	Muscle: +11, Mysticality: +11, Moxie: +11, Weapon Damage: +11
-# Elf Guard mouthknife: +3 Elf Warfare Effectiveness
-Item	Elf Guard mouthknife	Moxie Percent: +20
+Item	Elf Guard mouthknife	Elf Warfare Effectiveness: +3, Moxie Percent: +20
 Item	elven tambourine	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2
 # elven whittling knife: On Critical:  Whittles enemy down
 Item	evil paper umbrella	Monster Level: +1
@@ -1790,8 +1788,7 @@ Item	Saucepanic	Experience (Mysticality): +2, Smithsness: +5, Class: "Sauceror",
 Item	savory crossbow	Moxie: +4
 Item	savory staff	Mysticality: +4
 Item	savory sword	Muscle: +4
-# sawed-off blunderbuss: +3 Pirate Warfare Effectiveness
-Item	sawed-off blunderbuss	Muscle: +3, Mysticality: +3, Moxie: +3, Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3
+Item	sawed-off blunderbuss	Pirate Warfare Effectiveness: +3, Muscle: +3, Mysticality: +3, Moxie: +3, Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3
 Item	scepter of the Skeleton Lord	Moxie Percent: +50, Adventures: +3, PvP Fights: +3, Single Equip
 # scorpion whip: 50% chance of poisoning opponent.
 Item	scorpion whip	Weapon Damage: +13
@@ -1814,9 +1811,8 @@ Item	Shakespeare's Sister's Accordion	Mana Cost: [-1*(1+skill(Accordion Apprecia
 # sharpened spoon
 Item	Sheila Take a Crossbow	HP Regen Min: 1, HP Regen Max: 2, MP Regen Min: 1, MP Regen Max: 2, Pickpocket Chance: +5, Smithsness: +5, Initiative: [K]
 Item	shiny butcherknife	Spell Damage: +8
-# shipwright's hammer: +3 Pirate Warfare Effectiveness
 # shipwright's hammer: +30% Damage vs. Skeletons
-Item	shipwright's hammer	Weapon Damage Percent: +30
+Item	shipwright's hammer	Pirate Warfare Effectiveness: +3, Weapon Damage Percent: +30
 Item	shooting morning star	Muscle Percent: +15, Hot Damage: +15, Weakens Monster, Single Equip
 Item	short-handled mop	Stench Damage: +10, Sleaze Damage: +10
 Item	shotgun	Ranged Damage: +10
@@ -2044,8 +2040,7 @@ Item	warbear oil pan	Hot Spell Damage: +10, Sleaze Spell Damage: +10, Class: "Sa
 Item	weeping willow wand	Spell Damage Percent: +100, Mysticality: +25, Experience (Mysticality): +5, Lasts Until Rollover
 Item	weighted paperclip chain	Weapon Damage: +12
 Item	western-style skinning knife	Weapon Damage: +5, Hat Drop: +10
-# whalegun: +10 Pirate Warfare Effectiveness
-Item	whalegun	Monster Level: +10, Weapon Damage: +100
+Item	whalegun	Pirate Warfare Effectiveness: +10, Monster Level: +10, Weapon Damage: +100
 Item	White Dragon Fang	Muscle Percent: +9, Mysticality Percent: +9, Moxie Percent: +9, Spooky Damage: +9, Stench Damage: +9, Hot Damage: +9, Cold Damage: +9, Sleaze Damage: +9, MP Regen Min: 9, MP Regen Max: 9
 Item	white sword	Muscle: +2
 Item	white whip	Experience: +1
@@ -2938,11 +2933,9 @@ Item	CRIMBCO lanyard	Single Equip
 Item	Crimbolex watch	Adventures: +5, PvP Fights: +5, Rollover Effect: "Watched Over", Rollover Effect Duration: 100, Single Equip, Nonstackable Watch
 # Crimbomega drive chain: Allows use of LUBE in combat
 Item	Crimbomega drive chain	Moxie: +5, Sleaze Damage: +20, Sleaze Spell Damage: +20, Crimbot Outfit Power: +1, Single Equip
-# Crimbuccaneer fledges (disintegrating): +10 Pirate Warfare Effectiveness
-Item	Crimbuccaneer fledges (disintegrating)	PvP Fights: +9, Single Equip
-# Crimbuccaneer fledges (mint): +1 Pirate Warfare Effectiveness
-# Crimbuccaneer nose ring: +5 Pirate Warfare Effectiveness
-Item	Crimbuccaneer nose ring	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Potion Drop: +25
+Item	Crimbuccaneer fledges (disintegrating)	Pirate Warfare Effectiveness: +10, PvP Fights: +9, Single Equip
+Item	Crimbuccaneer fledges (mint)	Pirate Warfare Effectiveness: +1
+Item	Crimbuccaneer nose ring	Pirate Warfare Effectiveness: +5, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Potion Drop: +25
 Item	Crimbuccaneer runebone	Mysticality Percent: +25, Spell Damage: +50, Single Equip
 # crusty hula hoop: 75% Chance of Preventing Negative Status Attacks
 Item	crusty hula hoop	Mysticality Percent: +15, Spell Damage: +50, Single Equip
@@ -3010,7 +3003,7 @@ Item	eerie fetish	Spooky Resistance: +4, Single Equip
 Item	Eight Days a Week Pill Keeper	Maximum HP: +20, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 10, MP Regen Max: 15, Muscle: +10, Mysticality: +10, Moxie: +10
 # El Vibrato translator
 Item	elevennis shoes	Muscle: +11, Mysticality: +11, Moxie: +11, Maximum HP: +11, Maximum MP: +11
-# Elf Guard insignia (private): +1 Elf Warfare Effectiveness
+Item	Elf Guard insignia (private)	Elf Warfare Effectiveness: +1
 Item	Elmley shades	Muscle: +12, Critical Hit Percent: +3, Single Equip
 Item	elven socks	Muscle: +1, Cold Resistance: +1
 # Elvish sunglasses: Lets you Rock Out
@@ -7134,7 +7127,7 @@ Effect	Rootin' Around	Candy Drop: +25
 Effect	Rosewater Mark	Mysticality: +10, Spell Damage: +10, Experience (Mysticality): +2
 Effect	Rotten Memories	Stench Damage: +15
 Effect	Ruby-ous	Initiative: +150, Weapon Damage: +10
-# Rum of Darkness: +5 Elf Warfare Effectiveness
+Effect	Rum of Darkness	Elf Warfare Effectiveness: +5
 Effect	Rumpel-pumped	Muscle Percent: +400, Mysticality Percent: +400, Moxie Percent: +400
 Effect	Rushin' Hands	Weapon Damage: +3
 Effect	Rushtacean'	Initiative: +50
@@ -7910,8 +7903,7 @@ Effect	Wet Rub	HP Regen Min: 16, HP Regen Max: 20
 # Wet Willied: Your familiar can breathe underwater
 Effect	Wet Willied	Underwater Familiar
 # What Are The Odds!?: All item drop rolls will be 50%
-# Whalethoughts: +10 Elf Warfare Effectiveness
-# Whalethoughts: +10 Pirate Warfare Effectiveness
+Effect	Whalethoughts	Elf Warfare Effectiveness: +10, Pirate Warfare Effectiveness: +10
 Effect	What's That Smell?	Stench Damage: +3
 Effect	When the Plague Hits Your Eye	Avatar: "Plague Chef"
 Effect	Whet Appetite	Food Drop: +100

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -1373,6 +1373,8 @@ Item	elegant nightstick	Maximum HP: +30, Maximum MP: +15
 # elephant stinger: 50% chance of poisoning opponent.
 Item	elephant stinger	Muscle: +3
 Item	elevenderizing hammer	Muscle: +11, Mysticality: +11, Moxie: +11, Weapon Damage: +11
+# Elf Guard broom: Helps clean up the Bar at War
+Item	Elf Guard broom	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Weakens Monster
 Item	Elf Guard mouthknife	Elf Warfare Effectiveness: +3, Moxie Percent: +20
 Item	elven tambourine	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2
 # elven whittling knife: On Critical:  Whittles enemy down
@@ -8157,6 +8159,7 @@ Skill	Eldritch Intellect	Spooky Spell Damage: +1, Spooky Resistance: +1
 Skill	Elemental Obliviousness	Cold Resistance: +2, Hot Resistance: +2, Sleaze Resistance: +2, Spooky Resistance: +2, Stench Resistance: +2
 Skill	Elemental Wards	Cold Resistance: +1, Hot Resistance: +1, Sleaze Resistance: +1, Spooky Resistance: +1, Stench Resistance: +1
 # Elf Guard Cooking: Cook 3x per day without using an Adventure
+Skill	Elf Guard Relaxation Techniques	Free Rests: 3
 # Emotionally Chipped: Gives you access to emotions
 Skill	Ensorcel	Maximum HP: -20
 Skill	Envy	Item Drop: +30, Meat Drop: -25
@@ -8339,6 +8342,7 @@ Skill	Object Permanence	Mysticality: +5
 Skill	Object Quasi-Permanence	Item Drop: +10
 Skill	Oily Scalp	Sleaze Damage: +7
 Skill	Okay Seriously, This is the Last Spleen	Spleen Capacity: +5
+# Old-School Cocktailcrafting: Make 3 cocktails per day without spending an Adventure
 Skill	Olfactory Burnout	Stench Resistance: +3
 Skill	Olfactory Cortex	Stench Resistance: +3
 Skill	Ominous Substrate	Spooky Damage: +10
@@ -11203,6 +11207,7 @@ Item	closed-circuit phone system	Free Pull
 # clutch of dodecapede eggs: Weakens enemies somewhat as it poisons them
 # coal snakeskin: Adds Spooky Damage to kicks with your cowboy boots
 # cocktail napkin: Deals 20-40 <font color=red>Hot Damage</font>
+Item	Cocktails of the Age of Sail	Skill: "Old-School Cocktailcrafting"
 # cocoa of youth: Extend the duration of up to 10 of your effects by 5 Adventures
 Item	coffee sprite	Free Pull
 # cold clusterbomb: Deals <font color=blue>Cold Damage</font> based on your highest stat
@@ -11384,6 +11389,7 @@ Item	electronic Brain Trainer game	Skill: "Brain Games"
 # electronics kit: Shocks your opponent, weakening and briefly stunning them.<p>Also restores 30-40 MP.
 # eleven-foot pole: You know...  For traps.
 Item	Elf Guard Field Manual: Culinary Arts	Skill: "Elf Guard Cooking"
+Item	Elf Guard Field Manual: Wilderness Sleeping	Skill: "Elf Guard Relaxation Techniques"
 # Elf Guard hangover cure: Reduces your Drunkenness by 5 (1 after Crimbo)
 # Elf Guard hangover cure: (limit 1x / day)
 # Elf Guard payroll bag: Contains a bunch of Elf Guard MPCs
@@ -12028,6 +12034,7 @@ Item	Psycho From The Heat	Skill: "Pyromania"
 # pufferfish spine: Poisons your opponent, and using additional ones makes the poison way worse
 # pumpkin bomb: Vaporizes an enemy and causes all of its items to drop
 # pumpkin carriage: <b>Allows Travel to Desert Beach</b>
+# punching mirror: Punch it for 5 PvP fights per day
 Item	puppet strings	Free Pull
 # pygmy blowgun: Poisons enemies, dealing damage over multiple rounds
 Item	pygmy bugbear shaman	Free Pull

--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -2334,16 +2334,30 @@ automated bearing foundry	2403	jetfoundry.gif	Scale: 1 Cap: 1000 Init: -10000 P:
 clerical robot	2404	jetcleric.gif	Scale: 3 Cap: 1000 Init: -10000 P: construct	automa-bot parts (40)	clerical automa-core (f10)
 
 # Crimbo 2023 (December 2023)
-Crimbuccaneer carpenter	2432	cbcarpenter.gif
-Crimbuccaneer freebooter	2430	cbboots.gif
-Crimbuccaneer military school dropout	2405	cbdropout.gif
-Crimbuccaneer new recruit	2395	cbrecruit.gif
-Crimbuccaneer privateer	2436	cbprivateer.gif
-Crimbuccaneer scrimshander	2431	cbscrimshander.gif
-Crimbuccaneer whalehunter	2428	cbwhaler.gif
-Elf Guard conscript	2392	egconscript.gif
-Elf Guard convict	2393	egconvict.gif
-Elf Guard private	2394	egprivate.gif
+Elf Guard conscript	2392	egconscript.gif		Elf Guard patrol cap (c0)
+Elf Guard convict	2393	egconvict.gif		Elf Guard hotpants (c0)
+Elf Guard private	2394	egprivate.gif		Elf Guard insignia (private) (c0)
+Crimbuccaneer new recruit	2395	cbrecruit.gif		Crimbuccaneer tricorn (c0)
+Crimbuccaneer military school dropout	2405	cbdropout.gif		Crimbuccaneer breeches (c0)
+Crimbuccaneer barrrback	2418	cbbarback.gif		sawed-off blunderbuss (c0)	Crimbuccaneer tavern swab (c0)
+Crimbuccaneer grognard	2419	cbgrognard.gif		old-school pirate grog (c0)	Cocktails of the Age of Sail (c0)
+Crimbuccaneer bar brawler	2420	cbbrawler.gif		grog nuts (c0)	punching mirror (c0)
+Elf Guard sanitation officer	2421	egjanitor.gif		peppermint bomb (c0)	Elf Guard broom (c0)
+Elf Guard chemist	2422	egchemist.gif		bottle of gin (0)	bottle of rum (0)	bottle of vodka (0)	bottle of tequila (0)	bottle of whiskey (0)	boxed wine (0)	Elf Guard hangover cure (c0)
+Elf Guard shore leave specialist	2423	egshoreleave.gif		officer's nog (c0)	Elf Guard Field Manual: Wilderness Sleeping (c0)
+Elf Guard desserter	2424	egdessert.gif		sundae ration (c0)	ancient Elf dessert spoon (c0)
+Elf Guard provisioner	2425	egprovisioner.gif		peppermint tack (c0)	Elf Guard Field Manual: Culinary Arts (c0)
+Elf Guard steward	2426	egsteward.gif		Elf Guard payroll bag (c0)	Elf Guard clipboard (c0)
+Crimbuccaneer fruit plunderer	2427	cbfruit.gif		plum (c0)	orange (c0)	lemon (c0)	cherry (c0)	strawberry (c0)	pear (c0)	lemon (c0)	grapefruit (c0)	lime (c0)	raspberry (c0)	kumquat (c0)	peach (c0)	papaya (c0)	kiwi (c0)	blackberry (c0)	tangerine (c0)	The Encyclopedia of Fruit (c0)
+Crimbuccaneer whalehunter	2428	cbwhaler.gif		whalesteak (c0)	whalegun (c0)
+Crimbuccaneer retiree	2429	cbretiree.gif		pegfinger (c0)	Crimbuccaneer fledges (disintegrating) (c0)
+Crimbuccaneer freebooter	2430	cbboots.gif		cannonbomb (c0)	free boots (c0)
+Crimbuccaneer scrimshander	2431	cbscrimshander.gif		whale cerebrospinal fluid (c0)	Crimbuccaneer runebone (c0)
+Crimbuccaneer carpenter	2432	cbcarpenter.gif		shipwright's hammer (c0)	gunwale (c0)
+Elf Guard arctic seal	2433	egseal.gif		Elf guard mouthknife (c0)	Elf Guard SCUBA tank (c0)
+Elf Guard armorer	2434	egarmorer.gif		Kelflar vest (c0)	Elvish underarmor (c0)
+Elf Guard Red and White Beret	2435	egberet.gif		red and white claret (c0)	Elf Guard red and white beret (c0)
+Crimbuccaneer privateer	2436	cbprivateer.gif		Crimbuccaneer fledges (mint) (c0)
 
 # Old Events
 

--- a/src/data/npcstores.txt
+++ b/src/data/npcstores.txt
@@ -466,20 +466,3 @@ The Crimbo Cafe	crimbo21cafe	clear Russian	50	ROW1264
 
 Ornament Stand	crimbo21ornaments	black Crimbo ball	100	ROW1265
 Ornament Stand	crimbo21ornaments	white Crimbo ball	100	ROW1266
-
-Crimbuccaneer Foundry	buy	10	prank Crimbo card	ROW1431
-Crimbuccaneer Foundry	buy	20	Crimbuccaneer squirtblunderbuss	ROW1432
-Crimbuccaneer Foundry	buy	40	My First Paycheck envelope	ROW1433
-Crimbuccaneer Foundry	buy	80	barnacle-encrusted sweater	ROW1434
-Crimbuccaneer Foundry	buy	150	Crimbuccaneer nose ring	ROW1435
-Crimbuccaneer Foundry	buy	400	pet anchor	ROW1436
-Crimbuccaneer Foundry	buy	2000	Crimbuccaneer tattoo gift certificate	ROW1437
-Crimbuccaneer Foundry	buy	1000	stuffed kraken	ROW1441
-
-Crimbuccaneer Bar	buy	5	hot wine	ROW1408
-Crimbuccaneer Bar	buy	20	Jamaican coffee	ROW1409
-Crimbuccaneer Bar	buy	10	flask of egggrog	ROW1410
-
-Elf Guard Mess Hall	buy	5	sugarplum ration	ROW1399
-Elf Guard Mess Hall	buy	20	gingerbread nylons	ROW1400
-Elf Guard Mess Hall	buy	10	rum-soaked fruitcake	ROW1401

--- a/src/data/zapgroups.txt
+++ b/src/data/zapgroups.txt
@@ -215,3 +215,5 @@ fancy tophat, fancy tuxedo pants, fancy black tie
 bow staff, bowlegged pants, bowler
 bätzle, menudo ravioli, ratini
 boring spaghetti, Knob stroganoff, Knob stuffed shells
+Elf Guard patrol cap, Elf Guard hotpants
+Crimbuccaneer breeches, Crimbuccaneer tricorn

--- a/src/data/zonelist.txt
+++ b/src/data/zonelist.txt
@@ -178,6 +178,7 @@ Override	Unsorted	Discoveries
 Events	Events	Events
 
 Twitch	Town	Time-Twitching Tower
+Crimbo23	Holiday	Christmas 2023
 
 # The following zones are all retired Events or Holidays
 

--- a/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
@@ -438,4 +438,22 @@ public class DataFileConsistencyTest {
       fail("Couldn't read from " + file);
     }
   }
+
+  @Test
+  public void npcStoresShouldSellItems() {
+    String file = "npcstores.txt";
+    int version = 2;
+    String[] fields;
+    try (BufferedReader reader = FileUtilities.getVersionedReader(file, version)) {
+      while ((fields = FileUtilities.readData(reader)) != null) {
+        String item = fields[2];
+        var id = ItemDatabase.getExactItemId(item);
+        if (id == -1) {
+          fail("unrecognised item " + item);
+        }
+      }
+    } catch (IOException e) {
+      fail("Couldn't read from " + file);
+    }
+  }
 }


### PR DESCRIPTION
Jam all the monsters (non-outfit + outfit) in the zones like The Exploaded Battlefield.

Almost all drops are conditional. The non-outfit drops increase in rate with the number of adventures spent in any Crimbo zones. The outfit drops probably ignore item drop increasers, and are rare besides.