### PR TITLE
Update AbsorbCommandTest.java

### DIFF
--- a/test/net/sourceforge/kolmafia/textui/command/AbsorbCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AbsorbCommandTest.java
@@ -11,7 +11,7 @@ import static internal.helpers.Player.withUsedAbsorbs;
 import static internal.matchers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import internal.helpers.Cleanups;
 import internal.network.FakeHttpClientBuilder;
@@ -128,7 +128,12 @@ public class AbsorbCommandTest extends AbstractCommandTestBase {
     }
 
     var requests = client.getRequests();
-    assertThat(requests.size(), equalTo(16)); // 15 items + 1 charpane
+    // Under some circumstances loading the charpane will trigger a request for the image
+    // gladiatar.gif.  So this request should have 15 responses for the absorb, one for the charpane
+    // and perhaps one for the image
+    assertTrue(
+        requests.size() >= 16,
+        "Unexpected number of responses: " + requests.size()); // 15 items + 1 charpane
   }
 
   @Test


### PR DESCRIPTION
While attempting to prove my hypothesis concerning failed tests in https://github.com/kolmafia/kolmafia/pull/1889 I ran 1889 so that Gradle only used one fork.  I got some surprising test failures.  I then ran the main branch tests with only one fork and got a failure in AbsorbCommandTest (which also occurred in 1889).  The test absorbs 15 items and expects the client that managed it to have 16 responses - 15 for the absorptions and one for a call to get the charpane.  The test failed because there were 17 responses.  The debugger identified the additional response as a fetch of the image https://d2uyhvukfffg5a.cloudfront.net/otherimages/gladiatar.gif  This is reasonable given that the charpane HTML used in the test referenced the image.

I don't know whether FakeHttpClientBuilder can leak or not.  But if it can then one explanation is that another test loaded the image.  Using one fork changed the order tests were run in and caused this failure.  The other test doesn't care how many responses there were to the request client.

This fix makes it so the test doesn't care whether there is a response for the image, or not.  Another fix would be to delete the check for the response count.  I could argue that checking that does not effect the robustness of the non-test code.  Verifying that FakeHttpClientBuilder cannot leak via image caching or fixing that is another possibility.