### PR TITLE
Support for Crimbo23 Elf and Pirate Armory coinmasters

### DIFF
--- a/src/data/coinmasters.txt
+++ b/src/data/coinmasters.txt
@@ -1164,39 +1164,39 @@ Mr. Store 2002	buy	1	Crimbo cookie sheet	ROW1390
 
 # Crimbo 2023
 
+Crimbuccaneer Bar	buy	5	hot wine	ROW1408
+Crimbuccaneer Bar	buy	20	Jamaican coffee	ROW1409
+Crimbuccaneer Bar	buy	10	flask of egggrog	ROW1410
+
+Crimbuccaneer Junkworks	sell	3	sawed-off blunderbuss	ROW1420
+Crimbuccaneer Junkworks	sell	3	Crimbuccaneer shirt	ROW1418
+Crimbuccaneer Junkworks	sell	3	pegfinger	ROW1422
+Crimbuccaneer Junkworks	sell	3	shipwright's hammer	ROW1421
+Crimbuccaneer Junkworks	buy	200	Crimbuccaneer premium booty sack	ROW1417
+
 Crimbuccaneer Foundry	buy	10	prank Crimbo card	ROW1431
 Crimbuccaneer Foundry	buy	20	Crimbuccaneer squirtblunderbuss	ROW1432
 Crimbuccaneer Foundry	buy	40	My First Paycheck envelope	ROW1433
 Crimbuccaneer Foundry	buy	80	barnacle-encrusted sweater	ROW1434
 Crimbuccaneer Foundry	buy	150	Crimbuccaneer nose ring	ROW1435
 Crimbuccaneer Foundry	buy	400	pet anchor	ROW1436
-Crimbuccaneer Foundry	buy	2000	Crimbuccaneer tattoo gift certificate	ROW1437
 Crimbuccaneer Foundry	buy	1000	stuffed kraken	ROW1441
-
-Crimbuccaneer Bar	buy	5	hot wine	ROW1408
-Crimbuccaneer Bar	buy	20	Jamaican coffee	ROW1409
-Crimbuccaneer Bar	buy	10	flask of egggrog	ROW1410
-
-Crimbuccaneer Junkworks	buy	1	Crimbuccaneer flotsam (3)	ROW1420
-Crimbuccaneer Junkworks	buy	1	Crimbuccaneer flotsam (3)	ROW1418
-Crimbuccaneer Junkworks	buy	1	Crimbuccaneer flotsam (3)	ROW1422
-Crimbuccaneer Junkworks	buy	1	Crimbuccaneer flotsam (3)	ROW1421
-Crimbuccaneer Junkworks	buy	200	Crimbuccaneer premium booty sack	ROW1417
+Crimbuccaneer Foundry	buy	2000	Crimbuccaneer tattoo gift certificate	ROW1437
 
 Elf Guard Mess Hall	buy	5	sugarplum ration	ROW1399
 Elf Guard Mess Hall	buy	20	gingerbread nylons	ROW1400
 Elf Guard Mess Hall	buy	10	rum-soaked fruitcake	ROW1401
 
-Elf Guard Armory	buy	200	Elf Guard honor present	ROW1411
-Elf Guard Armory	buy	1	Elf Army machine parts (3)	ROW1412
-Elf Guard Armory	buy	1	Elf Army machine parts (3)	ROW1413
-Elf Guard Armory	buy	1	Elf Army machine parts (3)	ROW1414
-Elf Guard Armory	buy	1	Elf Army machine parts (3)	ROW1415
-Elf Guard Armory	buy	1	Elf Army machine parts (3)	ROW1416
-
 Elf Guard Officers' Club	buy	5	mulled wine	ROW1405
 Elf Guard Officers' Club	buy	20	Swedish coffee	ROW1406
 Elf Guard Officers' Club	buy	10	canteen of eggnog	ROW1407
+
+# Elf Guard Armory	sell	3	Elf Guard broom	ROW1414
+Elf Guard Armory	sell	3	Elf Guard commandeering gloves	ROW1412
+Elf Guard Armory	sell	3	Elf Guard officer's sidearm	ROW1413
+Elf Guard Armory	sell	3	Kelflar vest	ROW1415
+Elf Guard Armory	sell	3	Elf Guard mouthknife	ROW1416
+Elf Guard Armory	buy	200	Elf Guard honor present	ROW1411
 
 Elf Guard Toy and Munitions Factory	buy	10	trick coin	ROW1424
 Elf Guard Toy and Munitions Factory	buy	20	Elf Guard squirtgun	ROW1425
@@ -1204,5 +1204,5 @@ Elf Guard Toy and Munitions Factory	buy	40	chest of &quot;pirate gold&quot;	ROW1
 Elf Guard Toy and Munitions Factory	buy	80	sequin-encrusted sweater	ROW1427
 Elf Guard Toy and Munitions Factory	buy	150	replica Elf Guard medal	ROW1428
 Elf Guard Toy and Munitions Factory	buy	400	Lil' Snowball Factory	ROW1429
-Elf Guard Toy and Munitions Factory	buy	2000	Elf Guard temporary (permanent) tattoo	ROW1430
 Elf Guard Toy and Munitions Factory	buy	1000	Elf Guard safety bear	ROW1440
+Elf Guard Toy and Munitions Factory	buy	2000	Elf Guard temporary (permanent) tattoo	ROW1430

--- a/src/net/sourceforge/kolmafia/AdventureResult.java
+++ b/src/net/sourceforge/kolmafia/AdventureResult.java
@@ -640,6 +640,17 @@ public class AdventureResult implements Comparable<AdventureResult>, Cloneable {
   }
 
   public static AdventureResult parseItem(final String s, final boolean pseudoAllowed) {
+    // Certain items fountain parentheses. Appending (COUNT) to such is problematic.
+    // For now, if we have an exact match for an item name, use it with a count of 1.
+    int itemId = ItemDatabase.getItemId(s.trim(), 1, false);
+    if (itemId != -1) {
+      AdventureResult item = new AdventureResult(Priority.NONE, s.trim());
+      item.priority = Priority.ITEM;
+      item.id = itemId;
+      item.count = 1;
+      return item;
+    }
+
     StringTokenizer parsedItem = new StringTokenizer(s, "()");
 
     if (parsedItem.countTokens() == 0) {

--- a/src/net/sourceforge/kolmafia/CoinmasterRegistry.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterRegistry.java
@@ -25,9 +25,11 @@ import net.sourceforge.kolmafia.request.Crimbo17Request;
 import net.sourceforge.kolmafia.request.Crimbo20BoozeRequest;
 import net.sourceforge.kolmafia.request.Crimbo20CandyRequest;
 import net.sourceforge.kolmafia.request.Crimbo20FoodRequest;
+import net.sourceforge.kolmafia.request.Crimbo23ElfArmoryRequest;
 import net.sourceforge.kolmafia.request.Crimbo23ElfBarRequest;
 import net.sourceforge.kolmafia.request.Crimbo23ElfCafeRequest;
 import net.sourceforge.kolmafia.request.Crimbo23ElfFactoryRequest;
+import net.sourceforge.kolmafia.request.Crimbo23PirateArmoryRequest;
 import net.sourceforge.kolmafia.request.Crimbo23PirateBarRequest;
 import net.sourceforge.kolmafia.request.Crimbo23PirateFactoryRequest;
 import net.sourceforge.kolmafia.request.CrimboCartelRequest;
@@ -113,9 +115,11 @@ public abstract class CoinmasterRegistry {
         Crimbo20BoozeRequest.CRIMBO20BOOZE,
         Crimbo20CandyRequest.CRIMBO20CANDY,
         Crimbo20FoodRequest.CRIMBO20FOOD,
+        Crimbo23ElfArmoryRequest.DATA,
         Crimbo23ElfBarRequest.DATA,
         Crimbo23ElfCafeRequest.DATA,
         Crimbo23ElfFactoryRequest.DATA,
+        Crimbo23PirateArmoryRequest.DATA,
         Crimbo23PirateBarRequest.DATA,
         Crimbo23PirateFactoryRequest.DATA,
         CrimboCartelRequest.CRIMBO_CARTEL,

--- a/src/net/sourceforge/kolmafia/RequestLogger.java
+++ b/src/net/sourceforge/kolmafia/RequestLogger.java
@@ -951,6 +951,48 @@ public class RequestLogger extends NullStream {
       return;
     }
 
+    if ((isExternal || request instanceof Crimbo23ElfArmoryRequest)
+        && Crimbo23ElfArmoryRequest.registerRequest(urlString)) {
+      RequestLogger.wasLastRequestSimple = false;
+      return;
+    }
+
+    if ((isExternal || request instanceof Crimbo23ElfBarRequest)
+        && Crimbo23ElfBarRequest.registerRequest(urlString)) {
+      RequestLogger.wasLastRequestSimple = false;
+      return;
+    }
+
+    if ((isExternal || request instanceof Crimbo23ElfCafeRequest)
+        && Crimbo23ElfCafeRequest.registerRequest(urlString)) {
+      RequestLogger.wasLastRequestSimple = false;
+      return;
+    }
+
+    if ((isExternal || request instanceof Crimbo23ElfFactoryRequest)
+        && Crimbo23ElfFactoryRequest.registerRequest(urlString)) {
+      RequestLogger.wasLastRequestSimple = false;
+      return;
+    }
+
+    if ((isExternal || request instanceof Crimbo23PirateArmoryRequest)
+        && Crimbo23PirateArmoryRequest.registerRequest(urlString)) {
+      RequestLogger.wasLastRequestSimple = false;
+      return;
+    }
+
+    if ((isExternal || request instanceof Crimbo23PirateBarRequest)
+        && Crimbo23PirateBarRequest.registerRequest(urlString)) {
+      RequestLogger.wasLastRequestSimple = false;
+      return;
+    }
+
+    if ((isExternal || request instanceof Crimbo23PirateFactoryRequest)
+        && Crimbo23PirateFactoryRequest.registerRequest(urlString)) {
+      RequestLogger.wasLastRequestSimple = false;
+      return;
+    }
+
     if ((isExternal || request instanceof CrimboCartelRequest)
         && CrimboCartelRequest.registerRequest(urlString)) {
       RequestLogger.wasLastRequestSimple = false;

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3711,6 +3711,7 @@ public class ItemPool {
   public static final int FUTURISTIC_COLLAR = 11393;
   public static final int ELF_ARMY_MACHINE_PARTS = 11402;
   public static final int CRIMBUCCANEER_RIGGING_LASSO = 11403;
+  public static final int CRIMBUCCANEER_FLOTSAM = 11405;
   public static final int ELF_GUARD_MPC = 11408;
   public static final int CRIMBUCCANEER_PIECE_OF_12 = 11409;
   public static final int PEPPERMINT_BOMB = 11426;

--- a/src/net/sourceforge/kolmafia/request/Crimbo23ElfArmoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/Crimbo23ElfArmoryRequest.java
@@ -1,0 +1,128 @@
+package net.sourceforge.kolmafia.request;
+
+import java.util.regex.Pattern;
+import net.sourceforge.kolmafia.AdventureResult;
+import net.sourceforge.kolmafia.CoinmasterData;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+
+public class Crimbo23ElfArmoryRequest extends CoinMasterRequest {
+  public static final String master = "Elf Guard Armory";
+
+  public static final AdventureResult TOKEN = ItemPool.get(ItemPool.ELF_ARMY_MACHINE_PARTS, 1);
+  private static final Pattern TOKEN_PATTERN =
+      Pattern.compile("<td>([\\d,]+) piles? of Elf Army machine parts</td>");
+
+  public static final CoinmasterData DATA =
+      new CoinmasterData(master, "crimbo23_elf_armory", Crimbo23ElfArmoryRequest.class)
+          .withToken("Elf Army machine parts")
+          .withTokenTest("no piles of Elf Army machine parts")
+          .withItem(TOKEN)
+          .withTokenPattern(TOKEN_PATTERN)
+          .withShopRowFields(master, "crimbo23_elf_armory")
+          // In order to sell 1 item to get 3 piles of Elf Army machine parts,
+          // strangely enough, KoL uses "buyitem"
+          // shop.php?whichshop=crimbo23_elf_armory&action=buyitem&quantity=1&whichrow=1412&pwd
+          .withSellURL("shop.php?whichshop=crimbo23_elf_armory")
+          .withSellAction("buyitem")
+          .withSellItems(master)
+          .withSellPrices(master);
+
+  public Crimbo23ElfArmoryRequest() {
+    super(DATA);
+  }
+
+  public Crimbo23ElfArmoryRequest(final boolean buying, final AdventureResult[] attachments) {
+    super(DATA, buying, attachments);
+  }
+
+  public Crimbo23ElfArmoryRequest(final boolean buying, final AdventureResult attachment) {
+    super(DATA, buying, attachment);
+  }
+
+  public Crimbo23ElfArmoryRequest(final boolean buying, final int itemId, final int quantity) {
+    super(DATA, buying, itemId, quantity);
+  }
+
+  @Override
+  public void processResults() {
+    parseResponse(this.getURLString(), this.responseText);
+  }
+
+  public static void parseResponse(final String location, final String responseText) {
+    if (!location.contains("whichshop=" + DATA.getNickname())) {
+      return;
+    }
+
+    CoinmasterData data = DATA;
+
+    String action = GenericRequest.getAction(location);
+    if (action == null) {
+      // Parse current coin balances
+      CoinMasterRequest.parseBalance(data, responseText);
+      return;
+    }
+
+    // This shop uses "buyitem" for both buying and selling
+    if (!action.equals("buyitem")) {
+      return;
+    }
+
+    int itemId = CoinMasterRequest.extractItemId(DATA, location);
+    if (itemId == -1) {
+      return;
+    }
+
+    AdventureResult item = new AdventureResult(itemId, 1, false);
+    boolean buying = DATA.getBuyItems().contains(item);
+    boolean selling = DATA.getSellItems().contains(item);
+
+    if (buying
+        && !responseText.contains("You don't have enough")
+        && !responseText.contains("Huh?")) {
+      CoinMasterRequest.completePurchase(DATA, location);
+    }
+
+    if (selling && !responseText.contains("You don't have that many")) {
+      CoinMasterRequest.completeSale(DATA, location);
+    }
+
+    CoinMasterRequest.parseBalance(DATA, responseText);
+  }
+
+  public static String accessible() {
+    return null;
+  }
+
+  public static final boolean registerRequest(final String urlString) {
+    if (!urlString.startsWith("shop.php")
+        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+      return false;
+    }
+
+    int itemId = CoinMasterRequest.extractItemId(DATA, urlString);
+    if (itemId == -1) {
+      return true;
+    }
+
+    int count = CoinMasterRequest.extractCount(DATA, urlString);
+    if (count == 0) {
+      count = 1;
+    }
+
+    AdventureResult item = new AdventureResult(itemId, count, false);
+    boolean buying = DATA.getBuyItems().contains(item);
+    boolean selling = DATA.getSellItems().contains(item);
+
+    if (buying) {
+      CoinMasterRequest.buyStuff(DATA, itemId, count, false);
+      return true;
+    }
+
+    if (selling) {
+      CoinMasterRequest.sellStuff(DATA, itemId, count);
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/src/net/sourceforge/kolmafia/request/Crimbo23PirateArmoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/Crimbo23PirateArmoryRequest.java
@@ -1,0 +1,128 @@
+package net.sourceforge.kolmafia.request;
+
+import java.util.regex.Pattern;
+import net.sourceforge.kolmafia.AdventureResult;
+import net.sourceforge.kolmafia.CoinmasterData;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+
+public class Crimbo23PirateArmoryRequest extends CoinMasterRequest {
+  public static final String master = "Crimbuccaneer Junkworks";
+
+  public static final AdventureResult TOKEN = ItemPool.get(ItemPool.CRIMBUCCANEER_FLOTSAM, 1);
+  private static final Pattern TOKEN_PATTERN =
+      Pattern.compile("<td>([\\d,]+) piles? of Crimbuccaneer flotsam</td>");
+
+  public static final CoinmasterData DATA =
+      new CoinmasterData(master, "crimbo23_pirate_armory", Crimbo23PirateArmoryRequest.class)
+          .withToken("Crimbuccaneer flotsam")
+          .withTokenTest("no piles of Crimbuccaneer flotsam")
+          .withItem(TOKEN)
+          .withTokenPattern(TOKEN_PATTERN)
+          .withShopRowFields(master, "crimbo23_pirate_armory")
+          // In order to sell 1 item to get 3 piles of Crimbuccaneer flotsam,
+          // strangely enough, KoL uses "buyitem"
+          // shop.php?whichshop=crimbo23_pirate_armory&action=buyitem&quantity=1&whichrow=1420&pwd
+          .withSellURL("shop.php?whichshop=crimbo23_pirate_armory")
+          .withSellAction("buyitem")
+          .withSellItems(master)
+          .withSellPrices(master);
+
+  public Crimbo23PirateArmoryRequest() {
+    super(DATA);
+  }
+
+  public Crimbo23PirateArmoryRequest(final boolean buying, final AdventureResult[] attachments) {
+    super(DATA, buying, attachments);
+  }
+
+  public Crimbo23PirateArmoryRequest(final boolean buying, final AdventureResult attachment) {
+    super(DATA, buying, attachment);
+  }
+
+  public Crimbo23PirateArmoryRequest(final boolean buying, final int itemId, final int quantity) {
+    super(DATA, buying, itemId, quantity);
+  }
+
+  @Override
+  public void processResults() {
+    parseResponse(this.getURLString(), this.responseText);
+  }
+
+  public static void parseResponse(final String location, final String responseText) {
+    if (!location.contains("whichshop=" + DATA.getNickname())) {
+      return;
+    }
+
+    CoinmasterData data = DATA;
+
+    String action = GenericRequest.getAction(location);
+    if (action == null) {
+      // Parse current coin balances
+      CoinMasterRequest.parseBalance(data, responseText);
+      return;
+    }
+
+    // This shop uses "buyitem" for both buying and selling
+    if (!action.equals("buyitem")) {
+      return;
+    }
+
+    int itemId = CoinMasterRequest.extractItemId(DATA, location);
+    if (itemId == -1) {
+      return;
+    }
+
+    AdventureResult item = new AdventureResult(itemId, 1, false);
+    boolean buying = DATA.getBuyItems().contains(item);
+    boolean selling = DATA.getSellItems().contains(item);
+
+    if (buying
+        && !responseText.contains("You don't have enough")
+        && !responseText.contains("Huh?")) {
+      CoinMasterRequest.completePurchase(DATA, location);
+    }
+
+    if (selling && !responseText.contains("You don't have that many")) {
+      CoinMasterRequest.completeSale(DATA, location);
+    }
+
+    CoinMasterRequest.parseBalance(DATA, responseText);
+  }
+
+  public static String accessible() {
+    return null;
+  }
+
+  public static final boolean registerRequest(final String urlString) {
+    if (!urlString.startsWith("shop.php")
+        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+      return false;
+    }
+
+    int itemId = CoinMasterRequest.extractItemId(DATA, urlString);
+    if (itemId == -1) {
+      return true;
+    }
+
+    int count = CoinMasterRequest.extractCount(DATA, urlString);
+    if (count == 0) {
+      count = 1;
+    }
+
+    AdventureResult item = new AdventureResult(itemId, count, false);
+    boolean buying = DATA.getBuyItems().contains(item);
+    boolean selling = DATA.getSellItems().contains(item);
+
+    if (buying) {
+      CoinMasterRequest.buyStuff(DATA, itemId, count, false);
+      return true;
+    }
+
+    if (selling) {
+      CoinMasterRequest.sellStuff(DATA, itemId, count);
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/src/net/sourceforge/kolmafia/request/NPCPurchaseRequest.java
+++ b/src/net/sourceforge/kolmafia/request/NPCPurchaseRequest.java
@@ -846,6 +846,10 @@ public class NPCPurchaseRequest extends PurchaseRequest {
       Crimbo20FoodRequest.parseResponse(urlString, responseText);
     }
 
+    if (shopId.equals("crimbo23_elf_armory")) {
+      Crimbo23ElfArmoryRequest.parseResponse(urlString, responseText);
+    }
+
     if (shopId.equals("crimbo23_elf_bar")) {
       Crimbo23ElfBarRequest.parseResponse(urlString, responseText);
     }
@@ -856,6 +860,10 @@ public class NPCPurchaseRequest extends PurchaseRequest {
 
     if (shopId.equals("crimbo23_elf_factory")) {
       Crimbo23ElfFactoryRequest.parseResponse(urlString, responseText);
+    }
+
+    if (shopId.equals("crimbo23_pirate_armory")) {
+      Crimbo23PirateArmoryRequest.parseResponse(urlString, responseText);
     }
 
     if (shopId.startsWith("crimbo23_pirate_bar")) {
@@ -1318,6 +1326,34 @@ public class NPCPurchaseRequest extends PurchaseRequest {
 
       if (shopId.equals("crimbo20food")) {
         return Crimbo20FoodRequest.registerRequest(urlString);
+      }
+
+      if (shopId.startsWith("crimbo23_elf_armory")) {
+        Crimbo23ElfArmoryRequest.registerRequest(urlString);
+      }
+
+      if (shopId.equals("crimbo23_elf_bar")) {
+        Crimbo23ElfBarRequest.registerRequest(urlString);
+      }
+
+      if (shopId.equals("crimbo23_elf_cafe")) {
+        Crimbo23ElfCafeRequest.registerRequest(urlString);
+      }
+
+      if (shopId.equals("crimbo23_elf_factory")) {
+        Crimbo23ElfFactoryRequest.registerRequest(urlString);
+      }
+
+      if (shopId.startsWith("crimbo23_pirate_armory")) {
+        Crimbo23PirateArmoryRequest.registerRequest(urlString);
+      }
+
+      if (shopId.startsWith("crimbo23_pirate_bar")) {
+        Crimbo23PirateBarRequest.registerRequest(urlString);
+      }
+
+      if (shopId.startsWith("crimbo23_pirate_factory")) {
+        Crimbo23PirateFactoryRequest.registerRequest(urlString);
       }
 
       if (shopId.equals("edunder_shopshop")) {

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -1386,6 +1386,11 @@ public class ResultProcessor {
       case ItemPool.MILK_CAP:
       case ItemPool.DRINK_CHIT:
       case ItemPool.REPLICA_MR_ACCESSORY:
+        // Crimbo23 currencies
+      case ItemPool.ELF_GUARD_MPC:
+      case ItemPool.ELF_ARMY_MACHINE_PARTS:
+      case ItemPool.CRIMBUCCANEER_PIECE_OF_12:
+      case ItemPool.CRIMBUCCANEER_FLOTSAM:
         NamedListenerRegistry.fireChange("(coinmaster)");
         break;
 

--- a/src/net/sourceforge/kolmafia/swingui/CoinmastersFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/CoinmastersFrame.java
@@ -74,8 +74,10 @@ public class CoinmastersFrame extends GenericFrame implements ChangeListener {
   private CoinmasterPanel crimbo20foodPanel = null;
   private CoinmasterPanel crimbo23ElfBarPanel = null;
   private CoinmasterPanel crimbo23ElfCafePanel = null;
+  private CoinmasterPanel crimbo23ElfArmoryPanel = null;
   private CoinmasterPanel crimbo23ElfFactoryPanel = null;
   private CoinmasterPanel crimbo23PirateBarPanel = null;
+  private CoinmasterPanel crimbo23PirateArmoryPanel = null;
   private CoinmasterPanel crimbo23PirateFactoryPanel = null;
   private CoinmasterPanel crimboCartelPanel = null;
   private CoinmasterPanel dimemasterPanel = null;
@@ -511,6 +513,11 @@ public class CoinmastersFrame extends GenericFrame implements ChangeListener {
     this.selectorPanel.addPanel(crimbo23ElfCafePanel.getPanelSelector(), panel);
 
     panel = new JPanel(new BorderLayout());
+    crimbo23ElfArmoryPanel = new Crimbo23ElfArmoryPanel();
+    panel.add(crimbo23ElfArmoryPanel);
+    this.selectorPanel.addPanel(crimbo23ElfArmoryPanel.getPanelSelector(), panel);
+
+    panel = new JPanel(new BorderLayout());
     crimbo23ElfFactoryPanel = new Crimbo23ElfFactoryPanel();
     panel.add(crimbo23ElfFactoryPanel);
     this.selectorPanel.addPanel(crimbo23ElfFactoryPanel.getPanelSelector(), panel);
@@ -519,6 +526,11 @@ public class CoinmastersFrame extends GenericFrame implements ChangeListener {
     crimbo23PirateBarPanel = new Crimbo23PirateBarPanel();
     panel.add(crimbo23PirateBarPanel);
     this.selectorPanel.addPanel(crimbo23PirateBarPanel.getPanelSelector(), panel);
+
+    panel = new JPanel(new BorderLayout());
+    crimbo23PirateArmoryPanel = new Crimbo23PirateArmoryPanel();
+    panel.add(crimbo23PirateArmoryPanel);
+    this.selectorPanel.addPanel(crimbo23PirateArmoryPanel.getPanelSelector(), panel);
 
     panel = new JPanel(new BorderLayout());
     crimbo23PirateFactoryPanel = new Crimbo23PirateFactoryPanel();
@@ -1498,6 +1510,12 @@ public class CoinmastersFrame extends GenericFrame implements ChangeListener {
     }
   }
 
+  private class Crimbo23ElfArmoryPanel extends CoinmasterPanel {
+    public Crimbo23ElfArmoryPanel() {
+      super(Crimbo23ElfArmoryRequest.DATA);
+    }
+  }
+
   private class Crimbo23ElfFactoryPanel extends CoinmasterPanel {
     public Crimbo23ElfFactoryPanel() {
       super(Crimbo23ElfFactoryRequest.DATA);
@@ -1507,6 +1525,12 @@ public class CoinmastersFrame extends GenericFrame implements ChangeListener {
   private class Crimbo23PirateBarPanel extends CoinmasterPanel {
     public Crimbo23PirateBarPanel() {
       super(Crimbo23PirateBarRequest.DATA);
+    }
+  }
+
+  private class Crimbo23PirateArmoryPanel extends CoinmasterPanel {
+    public Crimbo23PirateArmoryPanel() {
+      super(Crimbo23PirateArmoryRequest.DATA);
     }
   }
 


### PR DESCRIPTION
1) All Crimbo23 coinmasters need registerRequest support
2) Elf Guard temporary (permanent) tattoo has () in its name so does not parse correctly into an AdventureResult
3) Add support for Elf and Pirate Armory coinmasters

Those last two are new, since they use the same action "buyitem" - for both buying and selling.

- I could (should) add a test, since I have saved HTML for selling to the Pirate Armory
- I could (should) move the shared code for this new thing into CoinMasterRequest