### PR TITLE
Add daily limit for Lil' Snowball Factory

### DIFF
--- a/src/data/dailylimits.txt
+++ b/src/data/dailylimits.txt
@@ -325,6 +325,7 @@ Use	jar of psychoses (The Old Man)	_psychoJarUsed
 Use	jar of psychoses (The Pretentious Artist)	_psychoJarUsed
 Use	jar of psychoses (The Suspicious-Looking Guy)	_psychoJarUsed
 Use	jingle bell	_jingleBellUsed
+Use	Lil' Snowball Factory	_snowballFactoryUsed
 Use	lodestone	_lodestoneUsed
 Use	lupine appetite hormones	_lupineHormonesUsed
 Use	meatball machine	_meatballMachineUsed


### PR DESCRIPTION
Running breakfast was causing OOM issues due to a missing daily limit for the new snowball factory. My system crashed last night and this minor addition appears to have solved the issue as breakfast ran fine on login. I manually reset the _snowballFactoryUsed pref to false and ran breakfast again without issue.