### PR TITLE
feat: mimic familiar skeleton

### DIFF
--- a/src/data/classskills.txt
+++ b/src/data/classskills.txt
@@ -1048,6 +1048,10 @@
 7488	Surprisingly Sweet Slash	ccsword_slash.gif	5	0	0
 7489	Surprisingly Sweet Stab	ccsword_sharp.gif	5	0	0
 7490	The Old One-Two (Kick)	crimbucboots.gif	5	0	0
+7491
+7492
+7493	Shoot, Gunwale Whalegun, Shoot!	whalegungun.gif	5	0	0
+7494	%fn, lay an egg	mimicegg.gif	5	0	0
 
 # Skills granted by books on your Mystical Bookshelf
 # These skills were renumbered.  This section kept for historical purposes only.

--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -325,5 +325,7 @@
 293	Patriotic Eagle	pateagle.gif	combat0,stat1,mp0	sleeping patriotic eagle	claw-held flag	0	0	0	0
 294	Jill-of-All-Trades	darkjill2f.gif	stat0,stat1,item0,meat0,combat0,drop,block,delevel,hp0,meat1,hp1,mp1,variable	Dark Jill-of-All-Trades	LED candle	1	2	3	3	organic,sentient,orb,haseyes,object,vegetable,food,edible,evil,spooky,hot,bite
 295	Flaming Leafcutter Ant	al_ant.gif	hp1,mp1,combat1	smoldering leafcutter ant egg		0	0	0	0	insect,haseyes,animal,bite,hot
-296	Rigging Snake	rigsnake.gif		baby rigging snake		0	0	0	0
-297	Pet Anchor	anchor.gif		pet anchor		0	0	0	0
+296	Rigging Snake	rigsnake.gif	combat0,delevel	baby rigging snake	rigging knot	0	0	0	0
+297	Pet Anchor	anchor.gif	none	pet anchor		0	0	0	0
+298
+299	Chest Mimic	mimicchest.gif	item0,meat0	baby chest mimic	googly chest eyes	0	0	0	0

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11565,8 +11565,8 @@
 11537
 11538
 11539
-11540
-11541
-11542
+11540	baby chest mimic	584086799	mimicbaby.gif	grow	t	0
+11541	googly chest eyes	343119773	eyes.gif	familiar	t	0
+11542	mimic egg	646626465	mimicegg.gif	usable	q	0
 11543	Crimbuccaneer war standard	823960598	c23_pirateflag.gif	offhand		0
 11544	Elf Guard war standard	679660460	c23_elfflag.gif	offhand		0

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -11052,6 +11052,7 @@ Item	autumn leaf	Effect: "Crunching Leaves", Effect Duration: 20
 Item	autumn years wisdom	Effect: "Wisdom of the Autumn Years", Effect Duration: 30
 Item	avatar of the Unconscious Collective	Free Pull
 Item	baby camelCalf	Free Pull
+Item	baby chest mimic	Free Pull
 Item	bad penguin egg	Free Pull
 # bag of airline peanuts: Deals 6-10 Physical Damage
 # bag of gross foreign snacks: Deals <font color=green>Stench Damage</font> every round to every monster you fight today in the zone where you used it
@@ -11575,6 +11576,7 @@ Item	golden monkey statuette	Free Pull
 # golden ring: Weakens enemies a lot
 # goodberry: Restores all of your HP
 # Goodfella contract: Make your Goodfella an offer he can't refuse
+Item	googly chest eyes	Familiar Weight: +5
 # GOTO: Lets you escape from combat without spending an Adventure
 # GOTO: (Maybe)
 # government booze shipment: Send 50 donated booze to another player (limit 1 per recipient per day)


### PR DESCRIPTION
Just the data files, also some other stuff we missed earlier.

Familiar gives a skill for 50 XP, usable 11 times per day. It copies a monster. You can read it from the mimic egg description, but you can have multiple monsters copied at once, multiple times. So it's not something we can reuse from elsewhere ;) 