### PR TITLE
fix: bump skills version to 6

### DIFF
--- a/src/data/classskills.txt
+++ b/src/data/classskills.txt
@@ -1,7 +1,7 @@
 6
 # Syntax is:
 # id	Name	image	Tags	MP Cost	Duration[	Attributes]
-# Type are a comma separated list of:
+# Tags are a comma separated list of:
 #     passive
 #     combat
 #     nc (noncombat)

--- a/src/data/classskills.txt
+++ b/src/data/classskills.txt
@@ -1,4 +1,4 @@
-5
+6
 # Syntax is:
 # id	Name	image	Tags	MP Cost	Duration[	Attributes]
 # Type are a comma separated list of:

--- a/src/net/sourceforge/kolmafia/KoLConstants.java
+++ b/src/net/sourceforge/kolmafia/KoLConstants.java
@@ -194,7 +194,7 @@ public interface KoLConstants extends UtilityConstants {
   int BUFFBOTS_VERSION = 1;
   int CAFE_BOOZE_VERSION = 1;
   int CAFE_FOOD_VERSION = 1;
-  int CLASSSKILLS_VERSION = 5;
+  int CLASSSKILLS_VERSION = 6;
   int COINMASTERS_VERSION = 2;
   int COMBATS_VERSION = 1;
   int CONCOCTIONS_VERSION = 3;

--- a/test/net/sourceforge/kolmafia/DataFileMechanicsTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileMechanicsTest.java
@@ -29,7 +29,7 @@ public class DataFileMechanicsTest {
         Arguments.of("buffbots.txt", 1, 3, 3),
         Arguments.of("cafe_booze.txt", 1, 2, 2),
         Arguments.of("cafe_food.txt", 1, 2, 2),
-        Arguments.of("classskills.txt", 4, 6, 7),
+        Arguments.of("classskills.txt", 5, 6, 7),
         Arguments.of("coinmasters.txt", 2, 4, 5),
         // combats.txt too complex
         // concoctions.txt too complex

--- a/test/net/sourceforge/kolmafia/DataFileMechanicsTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileMechanicsTest.java
@@ -29,7 +29,7 @@ public class DataFileMechanicsTest {
         Arguments.of("buffbots.txt", 1, 3, 3),
         Arguments.of("cafe_booze.txt", 1, 2, 2),
         Arguments.of("cafe_food.txt", 1, 2, 2),
-        Arguments.of("classskills.txt", 5, 6, 7),
+        Arguments.of("classskills.txt", 6, 6, 7),
         Arguments.of("coinmasters.txt", 2, 4, 5),
         // combats.txt too complex
         // concoctions.txt too complex
@@ -57,8 +57,8 @@ public class DataFileMechanicsTest {
         Arguments.of("questscouncil.txt", 1, 3, 5),
         // questslogs.txt is too complex
         Arguments.of("restores.txt", 2, 7, 8),
-        Arguments.of("spleenhit.txt", 1, 8, 9),
-        Arguments.of("statuseffects.txt", 1, 6, 7),
+        Arguments.of("spleenhit.txt", 3, 8, 9),
+        Arguments.of("statuseffects.txt", 4, 6, 7),
         Arguments.of("TCRS.astral_consumables.txt", 0, 4, 4),
         Arguments.of("TCRS.astral_pets.txt", 0, 4, 4),
         // zapgroups.txt is too simple


### PR DESCRIPTION
This should have gone in with #2149 -- I changed the format, so I should also have bumped the version number.