### PR TITLE
Add missing gnome adv gain activation string

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -411,6 +411,7 @@ public class FightRequest extends GenericRequest {
           "alphabetizes your recycling",
           "bundles your recycling for you",
           "changes the litter in your Familiar-Gro Terrarium",
+          "cleans all your unfolded laundry",
           "cleans your gutters",
           "clears your browser history",
           "does all that tedious campsite cleaning you were going to do today",


### PR DESCRIPTION
Captain Scotch posted a list of activation strings he found when running Gnome during Crimbo in a bug report on the forums. His list contains this one string that I didn't ever get myself.