### PR TITLE
Throw when a Promise did not resolve or reject

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
@@ -313,15 +313,19 @@ public class JavascriptRuntime extends AbstractRuntime {
     promiseScope.put("promise", promiseScope, promise);
     cx.evaluateString(
         promiseScope,
-        "promise.then((ret) => promiseReturnValue = ret, (err) => promiseError = err)",
+        "promise.then((ret) => promiseReturnValue = ret, (err) => promiseRejectedValue = err)",
         "promise resolver",
         0,
         null);
-    if (promiseScope.has("promiseError", promiseScope)) {
-      Object promiseError = promiseScope.get("promiseError", promiseScope);
-      throw new JavaScriptException(promiseError, null, 0);
+    if (promiseScope.has("promiseRejectedValue", promiseScope)) {
+      Object promiseRejectedValue = promiseScope.get("promiseRejectedValue", promiseScope);
+      throw new JavaScriptException(promiseRejectedValue, null, 0);
     }
-    return promiseScope.get("promiseReturnValue", promiseScope);
+    if (promiseScope.has("promiseReturnValue", promiseScope)) {
+      return promiseScope.get("promiseReturnValue", promiseScope);
+    }
+    // without an event loop, there is no way that this promise might resolve in the future
+    throw new JavaScriptException("Promise did not resolve or reject", null, 0);
   }
 
   private Value executeRun(

--- a/test/root/expected/promise_unresolved_main.js.out
+++ b/test/root/expected/promise_unresolved_main.js.out
@@ -1,0 +1,1 @@
+JavaScript exception: Promise did not resolve or reject

--- a/test/root/scripts/promise_unresolved_main.js
+++ b/test/root/scripts/promise_unresolved_main.js
@@ -1,0 +1,5 @@
+module.exports = {
+  main: () => new Promise(() => {
+    // This promise is never resolved.
+  })
+};


### PR DESCRIPTION
This is a small follow-up for #2159:

So far, Promises returned from a script can only be resolved or rejected. If they are neither yet, they will never resolve, so we should throw an exception in that case instead of returning null.

Note: this might change, if KoLmafia ever gets some event loop (which arguably might not be very likely 😄)