### PR TITLE
feat: add boolean modifiers for extra pickpockets and negative status resists

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -278,9 +278,8 @@ Item	Hairpiece On Fire	Cold Resistance: +2, Adventures: +4, Smithsness: +5, Maxi
 Item	hangman's hood	Muscle: +50, Weapon Damage: +50, Damage Reduction: 10
 Item	hardened slime hat	Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Damage Reduction: 10, Muscle Percent: +20, Familiar Effect: "1xFairy"
 Item	Hat O' Nine Tails	Moxie Percent: +9
-# hazmat helmet: 75% Chance of Preventing Negative Status Attacks
 # hazmat helmet: Changes Your Avatar
-Item	hazmat helmet	Damage Absorption: +50, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 40, HP Regen Max: 60
+Item	hazmat helmet	Damage Absorption: +50, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 40, HP Regen Max: 60, Negative Status Resist
 Item	head-mounted Trainbot	Item Drop: +5, Maximum MP: +5, Moxie: +5
 Item	headlamp	Item Drop: +15, Lasts Until Rollover
 Item	heavy crown	Muscle: +5, Mysticality: +5, Moxie: +5, Familiar Damage: +5, Initiative: +15, Familiar Effect: "atk, 1xGhuol, cap 27"
@@ -1021,8 +1020,7 @@ Item	icing poncho	Cold Damage: +25, Cold Spell Damage: +25, Food Drop: +50
 Item	junk-mail shirt	Muscle: +4, Mysticality: +4, Moxie: +4
 Item	Jurassic Parka	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Spooky Resistance: 1, Stench Resistance: 1, Hot Resistance: 1, Cold Resistance: 1, Sleaze Resistance: 1
 Item	Kashmir sweater	Hot Damage: +10, Hot Spell Damage: +10
-# Kelflar vest: 75% Chance of Preventing Negative Status Attacks
-Item	Kelflar vest	Elf Warfare Effectiveness: +3, Damage Reduction: 5
+Item	Kelflar vest	Elf Warfare Effectiveness: +3, Damage Reduction: 5, Negative Status Resist
 Item	Kiss the Knob apron	Maximum MP: +5
 Item	Knob Goblin elite shirt	Muscle: +3
 Item	KoL Con 13 T-shirt	Sleaze Resistance: +2, Experience Percent (Moxie): +5
@@ -2120,8 +2118,7 @@ Item	Adventurer bobblehead	Muscle Percent: [pref(nuclearAutumnPoints)], Mystical
 Item	aerogel attache case	Pickpocket Chance: +10, Stench Damage: +10, Drops Items
 Item	ancient calendar	Adventures: +3, Damage Reduction: 4
 Item	ancient hot dog wrapper	HP Regen Min: 25, HP Regen Max: 30, MP Regen Min: 25, MP Regen Max: 30
-# ancient stone head: 75% Chance of Preventing Negative Status Attacks
-Item	ancient stone head	Damage Reduction: 5
+Item	ancient stone head	Negative Status Resist, Damage Reduction: 5
 # anniversary balloon
 Item	anniversary chutney sculpture	Muscle: +1, Mysticality: +1, Moxie: +1
 Item	antique candy bucket	Candy Drop: +50, Lasts Until Rollover
@@ -2431,8 +2428,7 @@ Item	Mer-kin takebag	Item Drop: [5+10*env(underwater)]
 Item	mesquito proboscis	Maximum MP: +5, Mysticality: [3*L]
 # meteorb: Contributes Hot Damage to your spells
 Item	meteorb	Mysticality: +5, Maximum MP: +10
-# meteorite guard: 75% Chance of Preventing Negative Status Attacks
-Item	meteorite guard	Stench Resistance: +3, Hot Resistance: +3, Damage Reduction: 9
+Item	meteorite guard	Stench Resistance: +3, Hot Resistance: +3, Negative Status Resist, Damage Reduction: 9
 Item	Microplushie: Bropane	Weapon Damage: +3
 Item	Microplushie: Dorkonide	Muscle: +1, Mysticality: +1, Moxie: +1
 Item	Microplushie: Ermahgerdic Acid	Hot Damage: +2
@@ -2837,8 +2833,7 @@ Item	bejeweled accordion strap	Maximum HP: +25, Maximum MP: +25, Class: "Accordi
 Item	bejeweled cufflinks	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Single Equip
 Item	bejeweled pledge pin	Maximum HP: +40, Single Equip
 Item	Belt of Howling Anger	PvP Fights: +3, Critical Hit Percent: +3, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Single Equip
-# Belt of Loathing: 75% Chance of Preventing Negative Status Attacks
-Item	Belt of Loathing	Damage Reduction: 20, Familiar Weight: +10, Single Equip, Cloathing
+Item	Belt of Loathing	Damage Reduction: 20, Familiar Weight: +10, Negative Status Resist, Single Equip, Cloathing
 Item	belt of Ogrekind	Muscle: +15, Muscle Percent: +25, Experience (Muscle): +5, Single Equip
 # bewitching boots: Slight Cute Resistance
 Item	bewitching boots	Meat Drop: +10, Synergetic
@@ -2855,8 +2850,7 @@ Item	blackberry combat boots	Muscle: +10, Maximum HP: +45, Weapon Damage: +5, Si
 Item	blackberry galoshes	Muscle: +7, Mysticality: +7, Moxie: +7, Single Equip
 Item	blackberry moccasins	Moxie: +8, Initiative: +25, Damage Reduction: 3, Single Equip
 Item	blackberry slippers	Mysticality: +10, Spell Damage: +10, Spell Damage Percent: +5, Single Equip
-# Bling of the New Wave: 1 Additional Pickpocket Attempt
-Item	Bling of the New Wave	Moxie: +11, HP Regen Min: 5, HP Regen Max: 9, MP Regen Min: 5, MP Regen Max: 9, Class: "Disco Bandit", Single Equip
+Item	Bling of the New Wave	Moxie: +11, HP Regen Min: 5, HP Regen Max: 9, MP Regen Min: 5, MP Regen Max: 9, Extra Pickpocket, Class: "Disco Bandit", Single Equip
 Item	Blue Diamond of Honesty	Muscle: +7, Mysticality: +7, Moxie: +7, Item Drop: +9, Single Equip
 Item	blue glowstick	Maximum MP: +5, Moxie: -3, Raveosity: +1
 Item	blue plastic baby	Maximum HP: +5, Maximum MP: +5, Single Equip
@@ -2964,8 +2958,7 @@ Item	Crimbuccaneer fledges (disintegrating)	Pirate Warfare Effectiveness: +10, P
 Item	Crimbuccaneer fledges (mint)	Pirate Warfare Effectiveness: +1
 Item	Crimbuccaneer nose ring	Pirate Warfare Effectiveness: +5, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Potion Drop: +25
 Item	Crimbuccaneer runebone	Mysticality Percent: +25, Spell Damage: +50, Single Equip
-# crusty hula hoop: 75% Chance of Preventing Negative Status Attacks
-Item	crusty hula hoop	Mysticality Percent: +15, Spell Damage: +50, Single Equip
+Item	crusty hula hoop	Mysticality Percent: +15, Spell Damage: +50, Negative Status Resist, Single Equip
 Item	crying statue earrings	Muscle: +5, Maximum HP: +100, Single Equip, Lasts Until Rollover
 # crystal belt buckle: Improves your ability to align chakras
 Item	crystal belt buckle	Maximum MP: +25, Spell Damage: +10
@@ -3130,8 +3123,7 @@ Item	giant designer sunglasses	Moxie Percent: -10, Single Equip
 # giant diamond ring
 # giant motorcycle boots: +10 Damage vs. Ghosts
 Item	giant motorcycle boots	Muscle: +5, Single Equip
-# giant pinky ring: 75% Chance of Preventing Negative Status Attacks
-Item	giant pinky ring	Single Equip
+Item	giant pinky ring	Negative Status Resist, Single Equip
 Item	gingerbeard	Single Equip, Adventures: [6+(3*event(December))]
 Item	gingerservo	Muscle Percent: +25, HP Regen Min: 6, HP Regen Max: 12, PvP Fights: +6, Single Equip
 # Girdle of Hatred: Tightenable
@@ -3145,8 +3137,7 @@ Item	gnatwing earring	Initiative: +15, Mysticality: +6
 Item	gnoll-tooth necklace	Muscle: +5
 Item	gold detective badge	Maximum HP: +40, Maximum MP: +40, Item Drop: +20, Meat Drop: +30
 Item	gold skull ring	PvP Fights: +7, Single Equip
-# gold wedding ring: 75% Chance of Preventing Negative Status Attacks
-Item	gold wedding ring	Adventures: +1, Single Equip
+Item	gold wedding ring	Adventures: +1, Negative Status Resist, Single Equip
 Item	Golden Mr. Accessory	Muscle: +15, Mysticality: +15, Moxie: +15, Softcore Only
 Item	Golden Mr. Eh?	Muscle: +12, Mysticality: +12, Moxie: +12
 Item	gory drippy orb	Drippy Damage: +5
@@ -3355,9 +3346,7 @@ Item	monster bait	Combat Rate: +5, Single Equip
 Item	monstrous monocle	Spooky Resistance: +1, Item Drop: +5, Synergetic
 # mood ring
 Item	moon-amber necklace	Spell Damage Percent: +50, Maximum MP: +200, Mysticality Percent: [5*G], Single Equip
-# moss marlinspike: 75% Chance of Preventing Negative Status Attacks
-# moss marlinspike: Gives you an additional Pickpocketing attempt
-Item	moss marlinspike	Moxie: +10, Single Equip
+Item	moss marlinspike	Moxie: +10, Negative Status Resist, Extra Pickpocket, Single Equip
 # moss medal: Lets you impress your pasta thrall
 Item	moss medal	Experience (Mysticality): +2, Spooky Resistance: +2, Single Equip
 Item	mother's necklace	Adventures: +3, Never Fumble
@@ -3502,9 +3491,8 @@ Item	Powerful Glove	Maximum MP: +10, Maximum HP: +20, Weapon Damage Percent: +25
 Item	primitive alien necklace	Experience: +5, Cold Damage: +25, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4
 # pro skateboard: Do some awesome moves in combat!
 Item	pro skateboard	Weapon Damage: +10, Moxie Percent: +10
-# Protects-Your-Junk: 75% Chance of Preventing Negative Status Attacks
 # Protects-Your-Junk: Grants Protection from Dreadsylvanian Curses
-Item	Protects-Your-Junk	Damage Reduction: 20, Single Equip
+Item	Protects-Your-Junk	Negative Status Resist, Damage Reduction: 20, Single Equip
 Item	psychic's amulet	Spell Damage: +10, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1
 Item	pulled porquoise earring	Moxie: +9, Never Fumble
 Item	pulled porquoise pendant	Moxie: +10, Meat Drop: +15, Single Equip

--- a/src/net/sourceforge/kolmafia/modifiers/BooleanModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/BooleanModifier.java
@@ -65,7 +65,18 @@ public enum BooleanModifier implements Modifier {
   BREAKABLE("Breakable", Pattern.compile("Breakable")),
   DROPS_ITEMS("Drops Items", Pattern.compile("Drops Items")),
   DROPS_MEAT("Drops Meat", Pattern.compile("Drops Meat")),
-  VOLLEYBALL_OR_SOMBRERO("Volleyball or Sombrero", Pattern.compile("Volleyball or Sombrero"));
+  VOLLEYBALL_OR_SOMBRERO("Volleyball or Sombrero", Pattern.compile("Volleyball or Sombrero")),
+  EXTRA_PICKPOCKET(
+      "Extra Pickpocket",
+      new Pattern[] {
+        Pattern.compile("Gives you an additional Pickpocketing attempt"),
+        Pattern.compile("1 Additional Pickpocket Attempt")
+      },
+      Pattern.compile("Extra Pickpocket")),
+  NEGATIVE_STATUS_RESIST(
+      "Negative Status Resist",
+      Pattern.compile("75% Chance of Preventing Negative Status Attacks"),
+      Pattern.compile("Negative Status Resist"));
   private final String name;
   private final Pattern[] descPatterns;
   private final Pattern tagPattern;


### PR DESCRIPTION
Neither stack with other equipment that offer the same modifiers: no matter how many "75% chance to resist negative statuses" you have, it's still 75%. Similarly, having both "extra pickpocket" items still only gives you one extra pickpocket.

Add the negative status resist because there are enough of them that we may as well track it. Add the pickpockets because this is absurdly good in certain fringe scenarios, and it's easier to stay aware of it if Mafia tracks it explicitly.