### PR TITLE
fix: reset desertExploration to sub-100 if game says so

### DIFF
--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -839,7 +839,7 @@ hunting seal	684	huntingseal.gif	NOCOPY WANDERER Atk: 95 Def: 85 HP: 120 Init: 5
 Argarggagarg the Dire Hellseal	701	2headseal.gif	NOCOPY WANDERER Atk: 115 Def: 103 HP: 150 Init: 60 P: demon	secret tropical island volcano lair map (100)	Argarggagarg's fang (100)	adorable seal larva (100)
 hellseal pup	779	sealpup.gif	NOBANISH Atk: 85 Def: 76 HP: 85 Init: 85 P: demon Article: a	hellseal whisker (0)	hellseal claw (0)
 mother hellseal	780	motherseal.gif	NOBANISH NOCOPY SUPERLIKELY Atk: [150*1.385^pref(_sealScreeches)] Def: [150*1.385^pref(_sealScreeches)] HP: 150 Exp: [150*1.385^pref(_sealScreeches)/4] Init: [150*1.385^pref(_sealScreeches)] P: demon Article: a	burst hellseal brain (c0)	shredded hellseal hide (c0)	torn hellseal sinew (c0)	hellseal brain (c0)	hellseal hide (c0)	hellseal sinew (c0)	hellseal whisker (c0)	hellseal claw (c0)
-hellseal guardian	781	sealguard.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: demon Article: a	hellseal whisker (0)	hellseal whisker (0)	hellseal claw (0)	hellseal claw (0)
+hellseal guardian	781	sealguard.gif	Atk: 160 Def: 144 HP: 210 Init: 75 P: demon Article: a	hellseal whisker (50)	hellseal whisker (50)	hellseal claw (50)	hellseal claw (50)
 Gorgolok, the Infernal Seal (Inner Sanctum)	21	1_1.gif	BOSS NOCOPY Atk: 27 Def: 24 HP: 30 Init: 60 Meat: 35 P: demon Manuel: "Gorgolok, the Infernal Seal"	Scalp of Gorgolok (100)
 Gorgolok, the Infernal Seal (The Nemesis' Lair)	872	1_2.gif	BOSS NOCOPY Atk: 170 Def: 153 HP: 220 Init: 80 P: demon Manuel: "Gorgolok, the Infernal Seal"	Krakrox's Loincloth (100)
 Gorgolok, the Infernal Seal (Volcanic Cave)	882	1_3.gif	BOSS NOCOPY Atk: 185 Def: 166 HP: 260 Init: 90 P: demon Phys: 25 Elem: 25 Manuel: "Gorgolok, the Infernal Seal"

--- a/src/net/sourceforge/kolmafia/session/QuestManager.java
+++ b/src/net/sourceforge/kolmafia/session/QuestManager.java
@@ -1556,7 +1556,7 @@ public class QuestManager {
 
   private static void setDesertExploration(final int current, final int increment) {
     // If we've already registered complete desert exploration, we're done
-    if (current == 100) {
+    if (current == 100 && increment >= 0) {
       return;
     }
 

--- a/test/net/sourceforge/kolmafia/session/QuestManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/QuestManagerTest.java
@@ -806,6 +806,23 @@ public class QuestManagerTest {
         assertThat("oasisAvailable", isSetTo(true));
       }
     }
+
+    @Test
+    void willDowngradeDesertExplorationOnVisit() {
+      var cleanups =
+          new Cleanups(
+              withProperty("desertExploration", 100), withProperty("oasisAvailable", true));
+      try (cleanups) {
+        var URL = "place.php?whichplace=desertbeach";
+        var responseText = html("request/test_visit_beach_desert_98.html");
+        var request = new GenericRequest(URL);
+        request.responseText = responseText;
+        QuestManager.handleQuestChange(request);
+
+        assertThat("desertExploration", isSetTo(98));
+        assertThat("oasisAvailable", isSetTo(true));
+      }
+    }
   }
 
   /*

--- a/test/root/request/test_visit_beach_desert_98.html
+++ b/test/root/request/test_visit_beach_desert_98.html
@@ -1,0 +1,164 @@
+<html><head>
+<script language=Javascript>
+<!--
+if (parent.frames.length == 0) location.href="game.php";
+//-->
+</script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/keybinds.min.2.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/window.20111231.js"></script>
+<script language="javascript">function chatFocus(){if(top.chatpane.document.chatform.graf) top.chatpane.document.chatform.graf.focus();}
+if (typeof defaultBind != 'undefined') { defaultBind(47, 2, chatFocus); defaultBind(190, 2, chatFocus);defaultBind(191, 2, chatFocus); defaultBind(47, 8, chatFocus);defaultBind(190, 8, chatFocus); defaultBind(191, 8, chatFocus); }</script><script language="javascript">
+	function updateParseItem(iid, field, info) {
+		var tbl = $('#ic'+iid);
+		var data = parseItem(tbl);
+		if (!data) return;
+		data[field] = info;
+		var out = [];
+		for (i in data) {
+			if (!data.hasOwnProperty(i)) continue;
+			out.push(i+'='+data[i]);
+		}
+		tbl.attr('rel', out.join('&'));
+	}
+	function parseItem(tbl) {
+		tbl = $(tbl);
+		var rel = tbl.attr('rel');
+		var data = {};
+		if (!rel) return data;
+		var parts = rel.split('&');
+		for (i in parts) {
+			if (!parts.hasOwnProperty(i)) continue;
+			var kv = parts[i].split('=');
+			tbl.data(kv[0], kv[1]);
+			data[kv[0]] = kv[1];
+		}
+		return data;
+	}
+</script><script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/jquery-1.3.1.min.js"></script>
+<script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/pop_query.20230713.js"></script>
+<script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/ircm.20230626.js"></script>
+<script type="text/javascript">
+var tp = top;
+function pop_ircm_contents(i, some) {
+	var contents = '',
+		shown = 0,
+		da = '&nbsp;<a href="#" rel="?" class="small dojaxy">[some]</a>&nbsp;<a href="#" rel="',
+		db = '" class="small dojaxy">[all]</a>',
+		dc = '<div style="width:100%; padding-bottom: 3px;" rel="',
+		dd = '<a href="#" rel="1" class="small dojaxy">[';
+	one = 'one'; ss=some;
+if (i.d==1 && i.s>0) { shown++; 
+contents += dc + 'sellstuff.php?action=sell&ajax=1&type=quant&whichitem%5B%5D=IID&howmany=NUM&pwd=a2910bcd01d5ba9b828562445b456490" id="pircm_'+i.id+'"><b>Auto-Sell ('+i.s+' meat):</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'inventory.php?action=closetpush&ajax=1&whichitem=IID&qty=NUM&pwd=a2910bcd01d5ba9b828562445b456490" id="pircm_'+i.id+'"><b>Closet:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0 && i.g==0 && i.t==1) { shown++; 
+contents += dc + 'managestore.php?action=additem&qty1=NUM&item1=IID&price1=&limit1=&ajax=1&pwd=a2910bcd01d5ba9b828562445b456490" id="pircm_'+i.id+'"><b>Stock in Mall:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'managecollection.php?action=put&ajax=1&whichitem1=IID&howmany1=NUM&pwd=a2910bcd01d5ba9b828562445b456490" id="pircm_'+i.id+'"><b>Add to Display Case:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && !i.ac) { shown++; 
+contents += dc + 'inv_'+(i.u=="a"?"redir":(lab=(i.u=="u"?"use":(i.u=="e"?"eat":(i.u=="b"?"booze":(i.u=="s"?"spleen":"equip"))))))+'.php?ajax=1&whichitem=IID&itemquantity=NUM&quantity=NUM'+(i.u=="q"?"&action=equip":"")+'&pwd=a2910bcd01d5ba9b828562445b456490" id="pircm_'+i.id+'"><b>'+ucfirst(unescape(i.ou ? i.ou.replace(/\+/g," ") : (lab=="booze"?"drink":lab)))+':</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=1&ajax=1&whichitem=IID&action=equip&pwd=a2910bcd01d5ba9b828562445b456490" id="pircm_'+i.id+'"><b>Equip (slot 1):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=2&ajax=1&whichitem=IID&action=equip&pwd=a2910bcd01d5ba9b828562445b456490" id="pircm_'+i.id+'"><b>Equip (slot 2):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=3&ajax=1&whichitem=IID&action=equip&pwd=a2910bcd01d5ba9b828562445b456490" id="pircm_'+i.id+'"><b>Equip (slot 3):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+
+	return [contents, shown];
+}
+tp=top
+var todo = [];
+function nextAction() {
+	var next_todo = todo.shift();
+	if (next_todo) {
+		eval(next_todo);
+	}
+}
+function dojax(dourl, afterFunc, hoverCaller, failureFunc, method, params) {
+	$.ajax({
+		type: method || 'GET', url: dourl, cache: false,
+		data: params || null,
+		global: false,
+		success: function (out) {
+			nextAction();
+			if (out.match(/no\|/)) {
+				var parts = out.split(/\|/);
+				if (failureFunc) failureFunc(parts[1]);
+				else if (window.dojaxFailure) window.dojaxFailure(parts[1]);
+				else if (tp.chatpane.handleMessage) tp.chatpane.handleMessage({type: 'event', msg: 'Oops!  Sorry, Dave, you appear to be ' + parts[1]});
+				else  $('#ChatWindow').append('<font color="green">Oops!  Sorry, Dave, you appear to be ' + parts[1] + '.</font><br />' + "\n");
+				return;
+			}
+
+			if (hoverCaller)  {
+				float_results(hoverCaller, out);
+				if (afterFunc) { afterFunc(out); }
+				return;
+			}
+$(tp.mainpane.document).find("#effdiv").remove(); if(!window.dontscroll || (window.dontscroll && dontscroll==0)) { window.scroll(0,0);}
+			var $eff = $(tp.mainpane.document).find('#effdiv');
+			if ($eff.length == 0) {
+				var d = tp.mainpane.document.createElement('DIV');
+				d.id = 'effdiv';
+				var b = tp.mainpane.document.body;
+				if ($('#content_').length > 0) {
+					b = $('#content_ div:first')[0];
+				}
+				b.insertBefore(d, b.firstChild);
+				$eff = $(d);
+			}
+			$eff.find('a[name="effdivtop"]').remove().end()
+				.prepend('<a name="effdivtop"></a><center>' + out + '</center>').css('display','block');
+			if (!window.dontscroll || (window.dontscroll && dontscroll==0)) {
+				tp.mainpane.document.location = tp.mainpane.document.location + "#effdivtop";
+			}
+			if (afterFunc) { afterFunc(out); }
+		}
+	});
+}
+</script>	<link rel="stylesheet" type="text/css" href="https://d2uyhvukfffg5a.cloudfront.net/styles.20230117d.css">
+<style type='text/css'>
+.faded {
+	zoom: 1;
+	filter: alpha(opacity=35);
+	opacity: 0.35;
+	-khtml-opacity: 0.35; 
+    -moz-opacity: 0.35;
+}
+</style>
+
+</head>
+
+<body>
+<centeR><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="color: white;" align=center bgcolor=blue><b>Desert Beach</b></td></tr><tr><td style="padding: 5px; border: 1px solid blue;"><center><table><tr><td><center><div id=background  style='position: relative; width:400px;height:500px'  ><img id="place_bg"  src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/desertbeach/desert_background.gif" width=400 height=500 border=0><div id=db_bordertown class="element" style=' position: absolute; top: 275; left: 254; height: 120; width: 100;'><a  href=place.php?whichplace=bordertown><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/1x1trans.gif" width=100 height=120 border=0 alt="Bordertown" title="Bordertown"></a></div><div id=db_giftshop class="element" style=' position: absolute; top: 292; left: 122; height: 49; width: 41;'><a  href=shop.php?whichshop=shore><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/desertbeach/shoregiftshop.gif" width=41 height=49 border=0 alt="The Shore, Inc. Gift Shop" title="The Shore, Inc. Gift Shop"></a></div><div id=db_gnasir class="element" style=' position: absolute; top: 100; left: 250; height: 50; width: 50;'><a  href=place.php?whichplace=desertbeach&action=db_gnasir><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/desertbeach/gnasir.gif" width=50 height=50 border=0 alt="Gnasir's Place" title="Gnasir's Place"></a></div><div id=db_l11desert class="element" style=' position: absolute; top: 150; left: 200; height: 100; width: 100;'><a  href=adventure.php?snarfblat=364><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/desertbeach/ariddesert2.gif" width=100 height=100 border=0 alt="The Arid, Extra-Dry Desert (1)" title="The Arid, Extra-Dry Desert (1)"></a></div><div id=db_l11desertlabel class="element" style='text-align: center; position: absolute; top: 226; left: 200; height: 30; width: 100;'><a style='text-decoration: none; font-size: 11px; padding: 10px; display: block' alt='(98% explored)' title='(98% explored)' href=adventure.php?snarfblat=364><div class="pp"><div><img  alt="(98% explored)" title="(98% explored)" src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/zonefont/lparen.gif" height="10" border="0" /><img  alt='' src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/zonefont/9.gif" height="10" border="0" /><img  alt='' src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/zonefont/8.gif" height="10" border="0" /><img  alt='' src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/zonefont/percent.gif" height="10" border="0" style="margin-right: 4px"/></div><div><img  alt='' src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/zonefont/e.gif" height="10" border="0" /><img  alt='' src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/zonefont/x.gif" height="10" border="0" /><img  alt='' src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/zonefont/p.gif" height="10" border="0" /><img  alt='' src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/zonefont/l.gif" height="10" border="0" /><img  alt='' src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/zonefont/o.gif" height="10" border="0" /><img  alt='' src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/zonefont/r.gif" height="10" border="0" /><img  alt='' src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/zonefont/e.gif" height="10" border="0" /><img  alt='' src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/zonefont/d.gif" height="10" border="0" /><img  alt='' src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/zonefont/rparen.gif" height="10" border="0" /></div></div></a></div><div id=db_nukehouse class="element" style=' position: absolute; top: 250; left: 114; height: 18; width: 27;'><a  href=place.php?whichplace=desertbeach&action=db_nukehouse><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/1x1trans.gif" width=27 height=18 border=0 alt="A Ruined House" title="A Ruined House"></a></div><div id=db_oasis class="element" style=' position: absolute; top: 100; left: 300; height: 100; width: 100;'><a  href=adventure.php?snarfblat=122><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/desertbeach/oasis.gif" width=100 height=100 border=0 alt="An Oasis (1)" title="An Oasis (1)"></a></div><div id=db_shadowrift class="element" style=' position: absolute; top: 10; left: 330; height: 85; width: 84;'><a  href=place.php?whichplace=desertbeach&action=db_shadowrift><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/desertbeach/../sr2.gif" width=84 height=85 border=0 alt="Shadow Rift (1)" title="Shadow Rift (1)"></a></div><div id=db_shore class="element" style=' position: absolute; top: 303; left: -8; height: 80; width: 120;'><a  href=adventure.php?snarfblat=355><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/1x1trans.gif" width=120 height=80 border=0 alt="The Shore, Inc." title="The Shore, Inc."></a></div><div id=db_sotb class="element" style=' position: absolute; top: 414; left: 249; height: 40; width: 110;'><a  href=adventure.php?snarfblat=45><img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/1x1trans.gif" width=110 height=40 border=0 alt="South of the Border (1)" title="South of the Border (1)"></a></div></div><p><a href=main.php>Back to the Main Map</a></center></td></tr></table></center></td></tr><tr><td height=4></td></tr></table></center></body></html>


### PR DESCRIPTION
Sometimes, Mafia will put `desertExploration` to 100 while the game thinks it's still lower. I don't know what causes this.

Correct this on visit to the beach if this occurs.