### PR TITLE
fix: when building jar, use runtimeClasspath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,7 +195,7 @@ jar {
 	}
 
 	from {
-		configurations.implementation.collect {
+		configurations.runtimeClasspath.collect {
 			it.isDirectory() ? it : zipTree(it)
 		}
 	} {


### PR DESCRIPTION
Fallout from #2178, but I think this is the right way to do it anyway.