### PR TITLE
familiar stats and monster typo

### DIFF
--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -324,8 +324,8 @@
 292
 293	Patriotic Eagle	pateagle.gif	combat0,stat1,mp0	sleeping patriotic eagle	claw-held flag	0	0	0	0
 294	Jill-of-All-Trades	darkjill2f.gif	stat0,stat1,item0,meat0,combat0,drop,block,delevel,hp0,meat1,hp1,mp1,variable	Dark Jill-of-All-Trades	LED candle	1	2	3	3	organic,sentient,orb,haseyes,object,vegetable,food,edible,evil,spooky,hot,bite
-295	Flaming Leafcutter Ant	al_ant.gif	hp1,mp1,combat1	smoldering leafcutter ant egg		0	0	0	0	insect,haseyes,animal,bite,hot
-296	Rigging Snake	rigsnake.gif	combat0,delevel	baby rigging snake	rigging knot	0	0	0	0
+295	Flaming Leafcutter Ant	al_ant.gif	hp1,mp1,combat1	smoldering leafcutter ant egg		2	3	3	1	insect,haseyes,animal,bite,hot
+296	Rigging Snake	rigsnake.gif	combat0,delevel	baby rigging snake	rigging knot	3	1	1	1
 297	Pet Anchor	anchor.gif	none	pet anchor		0	0	0	0
 298
-299	Chest Mimic	mimicchest.gif	item0,meat0	baby chest mimic	googly chest eyes	0	0	0	0
+299	Chest Mimic	mimicchest.gif	item0,meat0	baby chest mimic	googly chest eyes	1	2	2	3

--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -2552,7 +2552,7 @@ five skeleton invaders	1005	bigskeleton5.gif	Atk: 150 Def: 135 HP: 150 Init: 50 
 ten skeletons	1006	skel10.gif	Atk: 300 Def: 270 HP: 300 Init: 50 P: undead	bag of bones (100)
 25 skeletons	1007	skel25.gif	NOCOPY NOMANUEL Atk: 700 Def: 630 HP: 700	2 bag of bones (m100)
 100 skeletons	1008	skel100.gif	NOCOPY NOMANUEL Atk: 1500 Def: 1350 HP: 1500	4-6 bag of bones (m100)
-Rene C. Corman (Skeleton Invasion)	1009	reneccorman.gif	NOCOPY NOMANUEL Atk: 500 Def: 500 HP: 500 Manuel: "Rene C. Corman" Wiki: "Rene C. Corman (The Cannon Museum)"	Stabonic scroll (n100)
+Rene C. Corman (Skeleton Invasion)	1009	reneccorman.gif	NOCOPY NOMANUEL Atk: 500 Def: 500 HP: 500 Wiki: "Rene C. Corman (The Cannon Museum)"	Stabonic scroll (n100)
 
 # CRIMBCO cubicles (Crimbo 2010)
 disorganized files	1037	c10files.gif	NOCOPY NOMANUEL Scale: 0 Init: 100	10 CRIMBCO scrip (m100)

--- a/src/net/sourceforge/kolmafia/swingui/FamiliarTrainingFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/FamiliarTrainingFrame.java
@@ -1879,11 +1879,22 @@ public class FamiliarTrainingFrame extends GenericFrame {
       //
       // Therefore, we can simply equip the new item.
 
-      if (next != null) {
+      if (next != null && next.getItemId() != -1) {
         FamiliarTrainingFrame.results.append("Putting on " + next.getName() + "<br>");
         RequestThread.postRequest(new EquipmentRequest(next, slot));
         this.setItem(slot, next);
-      } else if (current != null) {
+        return;
+      }
+
+      // Sanity check
+      if (next != null) {
+        // Internal error: non-null item but itemId == -1
+        // Treat it like removing the current item
+        System.out.println("Internal error: itemId = -1 in slot " + slot);
+        StaticEntity.printStackTrace();
+      }
+
+      if (current != null) {
         FamiliarTrainingFrame.results.append("Taking off " + current.getName() + "<br>");
         RequestThread.postRequest(new EquipmentRequest(EquipmentRequest.UNEQUIP, slot));
         this.setItem(slot, null);
@@ -1980,7 +1991,13 @@ public class FamiliarTrainingFrame extends GenericFrame {
     }
 
     private void getAccessoryGearSets(
-        final int weight, final AdventureResult item, final AdventureResult hat) {
+        final int weight, AdventureResult item, final AdventureResult hat) {
+      if (item != null && item.getItemId() == -1) {
+        System.out.println("Internal error: familiar item has itemId = -1");
+        StaticEntity.printStackTrace();
+        item = null;
+      }
+
       // No matter how many Tiny Plastic Objects we have, a
       // configuration with none equipped is legal
       this.addGearSet(weight, null, null, null, item, hat);


### PR DESCRIPTION
1) Rene C. Corman (Skeleton Invasion) is marked ```NOMANUEL```. It is unnecessary (and incorrect) for it to also have ```Manuel: "Rene C. Corman"```
2) Familiar training stats:
```
Results for Flaming Leafcutter Ant after 12 trials using 144 turns:

Cage Match      47      64      48           0              2
Scavenger Hunt  36      48      63           0              3
Obstacle Course 43      61      65           0              3
Hide and Seek   71      12      18           0              1
```
```
Results for Rigging Snake after 12 trials using 144 turns:

Contest         XP[1]   XP[2]   XP[3]  Original Rank Derived Rank

Cage Match      36      51      56           0             3
Scavenger Hunt  62      60      27           0             1
Obstacle Course 67      42       9           0             1
Hide and Seek   65      45      21           0             1
```
```
Results for Chest Mimic after 12 trials using 144 turns:

Contest         XP[1]   XP[2]   XP[3]  Original Rank Derived Rank

Cage Match      59      64      35           0              2
Scavenger Hunt  46      66      46           0              2
Obstacle Course 46      63      58           0              2
Hide and Seek   36      46      61           0              3
```
That was done starting from weight 10 (per my Shorter-Order Cook). It generated internal errors until I added debugging code.
```
Cage Match      57      52      27           2              1
Scavenger Hunt  41      54      54           2              2
Obstacle Course 44      55      45           2              2
Hide and Seek   28      38      59           3              3
```
That was done starting with weight 20 (after full training). It generated no internal errors - even though I had not identified the root cause. I'm using this one.

3) Internal errors from the FamiliarTrainingFrame?
It was passing an AdventureResult with itemId -1 ro EquipmentRequest.
I cannot see how that happens, since that module uses null to mean "no item".

I added code to treat such an AdventureResult as null - and I got messages and stack traces, but no internal errors.

I added code to try and track down where that bogus AdventureResult was being generated - and it no longer happens.

So, I have not identified the root case, but I will try again next aftercore.
I left in the debug code.
Rats.

