### PR TITLE
Explicitly add jgit ssh dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,7 @@ dependencies {
 	implementation 'org.tmatesoft.svnkit:svnkit:1.10.7'
 	implementation 'com.jgoodies:jgoodies-binding:2.13.0'
 	implementation 'org.eclipse.jgit:org.eclipse.jgit:6.3.0.202209071007-r'
+	implementation 'org.eclipse.jgit:org.eclipse.jgit.ssh.apache:6.3.0.202209071007-r'
 }
 
 application {


### PR DESCRIPTION
At some point in my many reconfigurations of my dev environment, git updating just totally stopped working for me. It turns out that the SSH part of JGit can sometimes not be present, which results in a misleading error about timeouts. Explicitly depending on the library fixes this. I had previously kept it in my local changeset but I have now heard reports of others having this issue.
