### PR TITLE
Fix ccs parser unable to handle multiple closing brackets

### DIFF
--- a/src/net/sourceforge/kolmafia/combat/CustomCombatLookup.java
+++ b/src/net/sourceforge/kolmafia/combat/CustomCombatLookup.java
@@ -171,7 +171,7 @@ public class CustomCombatLookup extends DefaultMutableTreeNode {
         indent.setLength(0);
 
         // Skip malformed lines
-        int close = line.indexOf("]");
+        int close = line.lastIndexOf("]");
         if (close == -1) {
           KoLmafia.updateDisplay("Malformed encounter key in CCS at line " + lineNumber);
           encounterKey = "ignore";

--- a/test/net/sourceforge/kolmafia/CustomCombatScriptTest.java
+++ b/test/net/sourceforge/kolmafia/CustomCombatScriptTest.java
@@ -1,0 +1,43 @@
+package net.sourceforge.kolmafia;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import net.sourceforge.kolmafia.combat.CustomCombatLookup;
+import org.junit.jupiter.api.Test;
+
+public class CustomCombatScriptTest {
+  @Test
+  public void canHandleMultipleClosingBrackets() {
+    // https://wiki.kolmafia.us/index.php/Custom_Combat_Script#Using_ASH_Constants_in_CCS
+    String source =
+        """
+            [ $element[ spooky ] $item[ hobo nickel ] ]
+            skill entangling noodles
+            skill weapon of the pastalord""";
+
+    CustomCombatLookup lookup = new CustomCombatLookup();
+    lookup.addEncounterKey("default");
+
+    try (var reader = new BufferedReader(new StringReader(source))) {
+      lookup.load(reader);
+
+      ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+      try (PrintStream out = new PrintStream(outputStream, true)) {
+        lookup.store(out);
+      }
+
+      assertThat(outputStream.toString(StandardCharsets.UTF_8), containsString(source));
+    } catch (IOException e) {
+      fail("Exception in loading Custom Combat Script:" + e.toString());
+    }
+  }
+}


### PR DESCRIPTION
The following example from wiki will fail as mafia finds the first closing bracket and early exits.
This is just a small fix, I'm not personally interested in the whole ccs of mafia.

https://wiki.kolmafia.us/index.php/Custom_Combat_Script#Using_ASH_Constants_in_CCS

```
[ $element[ spooky ] $item[ hobo nickel ] ]
skill entangling noodles
skill weapon of the pastalord
```

turns into

```
[ $element[ spooky ]
skill entangling noodles
skill weapon of the pastalord
```

The first commit is a failing test. The second commit is the fix.

As a small note, I did notice that the following is appended to the macro. But it's a little out of scope of what I intended to fix and isn't as big a problem. Probably caused only if a default action isn't defined. This bug wasn't introduced by my change.

```
[ default ]
attackattack with weapon
```
