### PR TITLE
Add new IOTM, unbound and bound

### DIFF
--- a/src/data/equipment.txt
+++ b/src/data/equipment.txt
@@ -3152,6 +3152,7 @@ spirit bell	0	none
 spooky glove	60	Mys: 15
 Spookyraven signet	100	Mys: 10
 spring boots	0	none
+spring shoes	0	none
 Spring Bros. ID badge	0	none
 stained glass spectacles	120	Mys: 40
 stained glass suspenders	120	Mus: 40

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11570,3 +11570,5 @@
 11542	mimic egg	646626465	mimicegg.gif	usable	q	0
 11543	Crimbuccaneer war standard	823960598	c23_pirateflag.gif	offhand		0
 11544	Elf Guard war standard	679660460	c23_elfflag.gif	offhand		0
+11545	in-the-box spring shoes	809348020	springshoes_box.gif	usable	t	0
+11546	spring shoes	533142596	springshoes.gif	accessory		0

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11572,3 +11572,5 @@
 11544	Elf Guard war standard	679660460	c23_elfflag.gif	offhand		0
 11545	in-the-box spring shoes	809348020	springshoes_box.gif	usable	t	0
 11546	spring shoes	533142596	springshoes.gif	accessory		0
+11547	ultra-soft ferns	979781148	softfern.gif	potion	t,d	10
+11548	crunchy brush	865877671	drybrush.gif	potion	t,d	10

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -5733,6 +5733,7 @@ Effect	Crotchety, Pining	Muscle Percent: +100
 Effect	Crud&eacute;	Sleaze Damage: +5
 Effect	Cruisin' for a Bruisin'	Weapon Damage Percent: +100
 Effect	Crunching Leaves	Combat Rate: +5, Item Drop: +25
+Effect	Crunchy Steps	Combat Rate: +5
 Effect	Crusty Head	Damage Reduction: 10
 Effect	Crying, Dying	Item Drop: +60
 Effect	Crystalleyesd	Avatar: "The Plumber"
@@ -7845,6 +7846,7 @@ Effect	Twinkly Weapon	Weapon Damage: +3
 Effect	Twist and an Eye	Maximum MP: +50
 Effect	Two Car Bar Rag	Avatar: "craggy bartender"
 Effect	Two Left Feet	Moxie: -5
+Effect	Ultra-Soft Steps	Combat Rate: -5
 # Ultrahydrated: Glug, Glug
 Effect	Unbarking Dogs	Familiar Weight: +10
 Effect	Uncaged Power	Maximum MP: +50, MP Regen Min: 5, MP Regen Max: 8
@@ -9914,6 +9916,7 @@ Item	Crimbo fudge	Effect: "Busy Bein' Delicious", Effect Duration: 5
 Item	Crimbo peppermint bark	Effect: "Peppermint Bite", Effect Duration: 5
 Item	Crimbot battery	Effect: "Batteries Included", Effect Duration: 50
 Item	crude crudit&eacute;s	Effect: "Crud&eacute;", Effect Duration: 10
+Item	crunchy brush	Effect: "Crunchy Steps", Effect Duration: 5
 Item	CSA bravery badge	Effect: "Standard Issue Bravery", Effect Duration: 20
 Item	cube of billiard chalk	Effect: "Chalked Weapon", Effect Duration: 10
 Item	cuppa Alacri tea	Effect: "Alacri Tea", Effect Duration: 30
@@ -10720,6 +10723,7 @@ Item	turtle pheromones	Effect: "Eau de Tortue", Effect Duration: 30
 Item	turtle voicebox	Effect: "Song of the Southern Turtle", Effect Duration: 15
 Item	twinkly nuggets	Effect: "Twinkly Weapon", Effect Duration: 5
 Item	twinkly powder	Effect: "Twinklebritches", Effect Duration: 5
+Item	ultra-soft ferns	Effect: "Ultra-Soft Steps", Effect Duration: 5
 Item	Ultrasoldier Serum	Effect: "Army of One", Effect Duration: 50
 Item	Uncle Greenspan's Bathroom Finance Guide	Effect: "Buy!  Sell!  Buy!  Sell!", Effect Duration: 100
 Item	unfinished pleasure	Effect: "Pleasant Forecast", Effect Duration: 20

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -3685,6 +3685,8 @@ Item	spiky turtle shoulderpads	Damage Absorption: +75, Single Equip, Thorns: 2
 Item	spirit bell	Muscle: +5, Mysticality: +5, Maximum HP: +10, Maximum MP: +10, Class: "Turtle Tamer"
 Item	spooky glove	Never Fumble, Moxie: +5, Spooky Damage: +5
 Item	Spookyraven signet	Spooky Resistance: +2, Stench Damage: +15, Stench Spell Damage: +15, Single Equip
+# spring shoes: Nature springs up after each step
+Item	spring shoes	Initiative: +100, Moxie Percent: +20, Critical Hit Percent: +50
 Item	stained glass spectacles	Experience (Mysticality): +3, Spooky Resistance: +3, Spooky Damage: +5, Single Equip
 Item	stained glass suspenders	Muscle Percent: +20, Hot Resistance: +3, Hot Damage: +5, Single Equip
 Item	stainless steel scarf	Spell Damage: +20, Monster Level: +20, Mysticality Percent: +15, Single Equip
@@ -11715,6 +11717,7 @@ Item	imbued seal-blubber candle	Class: "Seal Clubber"
 # incriminating evidence: Take it downtown to Gotpork P. D.
 Item	infant sandworm	Free Pull
 # infinite BACON machine: Generate 100 BACON per day
+Item	in-the-box spring shoes	Free Pull
 # ingot turtle: Deals 90-110 <font color=red>Hot Damage</font> and changes your opponent's element to Hot
 Item	Inigo's Incantation of Inspiration	Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration"
 Item	Inigo's Incantation of Inspiration (crumpled)	Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration"

--- a/src/data/statuseffects.txt
+++ b/src/data/statuseffects.txt
@@ -2897,3 +2897,7 @@
 2894	Fishing for Meat	fish.gif	e4d466137ef5993f2c987f4e50090204	neutral	none
 2895	Bubbly	orb.gif	900f6bfb97055c5040a2e86766a8ebee	neutral	none
 2896	Well Fed	apronbox.gif	d8ccf1611c0556c0bb623b83146dfa36	neutral	none
+2897
+2898
+2899	Ultra-Soft Steps	softfern.gif	ea08a91c456c3dead7a11092f0bb1213	neutral	none	use 1 ultra-soft ferns
+2900	Crunchy Steps	drybrush.gif	b32c6ab90bda5197d973908ac94fbde4	neutral	none	use 1 crunchy brush


### PR DESCRIPTION
Also add crunchy leaves and ultra-soft moss.

Note that the session log says this:
```
11548	crunchy brush	865877671	drybrush.gif	potion, usable	t,d	10
11547	ultra-soft ferns	979781148	softfern.gif	potion, usable	t,d	10
```
but potions are by default multiple.

In fact:
```
add to closet: 1 ultra-soft ferns

take from closet: 1 ultra-soft ferns
ultra-soft ferns is multiusable, but KoLmafia thought it was not
You acquire an item: ultra-soft ferns
```

That's a bug in DebugDatabase.

I'll investigate, but I don't think it's a blocker for this PR, although it will fix future erroneous item submissions.

Edit: I also wonder how many potions marked "usable" in items.txt are actually "multiple"?
All the more reason to put that investigation into another PR.