### PR TITLE
return unknown class instead of null in my_class

### DIFF
--- a/src/net/sourceforge/kolmafia/AscensionClass.java
+++ b/src/net/sourceforge/kolmafia/AscensionClass.java
@@ -13,6 +13,7 @@ import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.preferences.Preferences;
 
 public enum AscensionClass {
+  UNKNOWN("Unknown", -2),
   ASTRAL_SPIRIT("Astral Spirit", -1),
   SEAL_CLUBBER("Seal Clubber", 1, "club", 0, Path.NONE, "Club Foot"),
   TURTLE_TAMER("Turtle Tamer", 2, "turtle", 0, Path.NONE, "Shell Up"),
@@ -101,18 +102,18 @@ public enum AscensionClass {
   }
 
   public static AscensionClass find(final String name) {
-    if (name == null || name.equals("")) return null;
+    if (name == null || name.equals("")) return UNKNOWN;
 
     String lowerCaseName = name.toLowerCase();
 
     return Arrays.stream(values())
         .filter(a -> a.getName().toLowerCase().contains(lowerCaseName))
         .findFirst()
-        .orElse(null);
+        .orElse(UNKNOWN);
   }
 
   public static AscensionClass find(int id) {
-    return Arrays.stream(values()).filter(a -> a.getId() == id).findAny().orElse(null);
+    return Arrays.stream(values()).filter(a -> a.getId() == id).findAny().orElse(UNKNOWN);
   }
 
   AscensionClass(

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -176,7 +176,7 @@ public abstract class KoLCharacter {
   // Things which can change over the course of playing
 
   private static List<String> avatar = Collections.emptyList();
-  private static AscensionClass ascensionClass = null;
+  private static AscensionClass ascensionClass = AscensionClass.UNKNOWN;
   private static Gender gender = Gender.UNKNOWN;
   public static int AWOLtattoo = 0;
 
@@ -346,7 +346,7 @@ public abstract class KoLCharacter {
   }
 
   public static final void reset(boolean newCharacter) {
-    KoLCharacter.ascensionClass = null;
+    KoLCharacter.ascensionClass = AscensionClass.UNKNOWN;
 
     KoLCharacter.gender = Gender.UNKNOWN;
     KoLCharacter.currentLevel = 1;
@@ -795,7 +795,7 @@ public abstract class KoLCharacter {
    * @return The index of the prime stat
    */
   public static final int getPrimeIndex() {
-    return ascensionClass == null ? 0 : ascensionClass.getPrimeStatIndex();
+    return ascensionClass == AscensionClass.UNKNOWN ? 0 : ascensionClass.getPrimeStatIndex();
   }
 
   /**

--- a/test/net/sourceforge/kolmafia/AscensionClassTest.java
+++ b/test/net/sourceforge/kolmafia/AscensionClassTest.java
@@ -48,11 +48,11 @@ class AscensionClassTest {
 
   @ParameterizedTest
   @CsvSource({
-    ",",
-    "\"\",",
+    ", UNKNOWN",
+    "\"\", UNKNOWN",
     "AvAtAr Of BoRiS, AVATAR_OF_BORIS",
     "Avatar of Boris, AVATAR_OF_BORIS",
-    "Smavatar of Shmoris,",
+    "Smavatar of Shmoris, UNKNOWN",
   })
   void canFindByName(final String name, final AscensionClass clazz) {
     assertThat(AscensionClass.find(name), equalTo(clazz));
@@ -61,7 +61,7 @@ class AscensionClassTest {
   @ParameterizedTest
   @CsvSource({
     "2, TURTLE_TAMER",
-    "69696969,",
+    "69696969, UNKNOWN",
   })
   void canFindById(final int id, final AscensionClass clazz) {
     assertThat(AscensionClass.find(id), equalTo(clazz));


### PR DESCRIPTION
When the ascension class is unknown (during first few days of a new path), my_class() returning null causes multiple scripts to fail (TourGuide and CHIT that I know of).
So, instead of setting the current class to null when it is unknown, set it to a class called unknown.