### PR TITLE
Track Savage Beast mods

### DIFF
--- a/src/data/consequences.txt
+++ b/src/data/consequences.txt
@@ -133,6 +133,7 @@ DESC_EFFECT	Blessing of the Bird		_birdOfTheDayMods=mods
 DESC_EFFECT	Blessing of your favorite Bird		yourFavoriteBirdMods=mods
 DESC_EFFECT	Citizen of a Zone	Citizen of ([^<]*)<	_citizenZone=$1
 DESC_EFFECT	Citizen of a Zone		_citizenZoneMods=mods
+DESC_EFFECT	Savage Beast		_savageBeastMods=mods
 
 DESC_EFFECT	Wine-Fortified	\+(\d+) .*? Damage	vintnerWineLevel=[$1/3]
 DESC_EFFECT	Wine-Hot	\+(\d+) .*? Damage	vintnerWineLevel=[$1/3]

--- a/src/net/sourceforge/kolmafia/objectpool/EffectPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/EffectPool.java
@@ -374,6 +374,7 @@ public class EffectPool {
   public static final int SERENDIPITY = 2833;
   public static final int RECALLING_CIRCADIAN_RHYTHMS = 2846;
   public static final int EVERYTHING_LOOKS_GREEN = 2881;
+  public static final int SAVAGE_BEAST = 2898;
 
   public static final AdventureResult CURSE1_EFFECT = EffectPool.get(EffectPool.ONCE_CURSED);
   public static final AdventureResult CURSE2_EFFECT = EffectPool.get(EffectPool.TWICE_CURSED);

--- a/test/net/sourceforge/kolmafia/session/ConsequenceManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/ConsequenceManagerTest.java
@@ -146,4 +146,20 @@ public class ConsequenceManagerTest {
       }
     }
   }
+
+  @Test
+  public void canParseSavageBeast() {
+    var cleanups = new Cleanups(withProperty("_savageBeastMods"));
+
+    try (cleanups) {
+      var descId = EffectDatabase.getDescriptionId(EffectPool.SAVAGE_BEAST);
+      var responseText = html("request/test_desc_effect_savage_beast.html");
+
+      ConsequenceManager.parseEffectDesc(descId, responseText);
+      assertThat(
+              Preferences.getString("_savageBeastMods"),
+              equalTo(
+                      "Combat Rate: +25, Muscle Percent: 100, Maximum HP Percent: 100, Mysticality Percent: 100, Hot Resistance: 6, Cold Resistance: 6, Stench Resistance: 6, Sleaze Resistance: 6, Spooky Resistance: 6, Item Drop: 75, Monster Level: 50, Moxie Percent: 100, Initiative: 200, Meat Drop: 150, HP Regen Min: 1, HP Regen Max: 1"));
+    }
+  }
 }

--- a/test/root/request/test_desc_effect_savage_beast.html
+++ b/test/root/request/test_desc_effect_savage_beast.html
@@ -1,0 +1,30 @@
+<html><head>
+    <title>Effect Description</title>
+    <script language="Javascript" src="/basics.js"></script><link rel="stylesheet" href="/basics.1.css" /></head>
+<body bgcolor=white text=black link=black alink=black vlink=black>
+<div id="description">
+
+    <font face=Arial,Helvetica size=2><!-- effectid: 2898 --><center><img src="/images/itemimages/intrinsic_beast.gif" width=30 height=30><p><b>Savage Beast</b><p></center><blockquote>You only want three things.  Ripping, tearing, and killing.</blockquote><center><font color=blue><b>Monsters will be incredibly very much more attracted to you<br>Muscle +20%<br>Muscle +30%<br>Muscle +50%<br>Maximum HP +20%<br>Maximum HP +30%<br>Maximum HP +50%<br>Mysticality +20%<br>Mysticality +30%<br>Mysticality +50%<br>So-So Hot Resistance (+2)<br>So-So Cold Resistance (+2)<br>So-So Stench  Resistance (+2)<br>So-So Sleaze Resistance (+2)<br>So-So Spooky Resistance (+2)<br>So-So Hot Resistance (+2)<br>So-So Cold Resistance (+2)<br>So-So Stench  Resistance (+2)<br>So-So Sleaze Resistance (+2)<br>So-So Spooky Resistance (+2)<br>So-So Hot Resistance (+2)<br>So-So Cold Resistance (+2)<br>So-So Stench  Resistance (+2)<br>So-So Sleaze Resistance (+2)<br>So-So Spooky Resistance (+2)<br>+25% Item Drops from Monsters<br>+25% Item Drops from Monsters<br>+25% Item Drops from Monsters<br>+10 to Monster Level<br>+15 to Monster Level<br>+25 to Monster Level<br>Moxie +20%<br>Moxie +30%<br>Moxie +50%<br>+50% Combat Initiative<br>+50% Combat Initiative<br>+100% Combat Initiative<br>+25% Meat from Monsters<br>+50% Meat from Monsters<br>+75% Meat from Monsters<br>Regenerate 1 HP per Adventure<br>You cannot run away from combat</b></font></center></font></font>
+</div>
+<script type="text/javascript">
+    <!--
+    var resizetries = 0;
+    var fsckinresize;
+    setTimeout(fsckinresize = function ()  {
+        var desch = document.getElementById('description').offsetHeight;
+        if (desch < 100 && resizetries < 5) {
+            setTimeout(fsckinresize, 100);
+            resizetries++;
+        }
+        if (desch < 100) desch = 200;
+        //alert('resizing on try #' + resizetries);
+        if (self.resizeTo && window.outerHeight) {
+            self.resizeTo(400, desch + (window.outerHeight - window.innerHeight) + 50);
+        }
+        else if (self.resizeTo ) { self.resizeTo(400, desch+130); }
+        else { window.innerHeight = newh; }
+    }, 100);
+    //-->
+</script>
+</body>
+<script src="/onfocus.1.js"></script></html>


### PR DESCRIPTION
Store the mods for Savage Beast when the description of the effect is parsed. I used the same test as was done for the citizen of a zone effect. I wasn't sure if there was an accessible way to validate the actual modifiers on the effect as opposed to validating the property was updated.