### PR TITLE
WereProfessor can do COOK and MIX. Track Advance Researched monsters

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1640,6 +1640,7 @@ user	warehouseProgress	0
 user	watchedPreferences
 user	waxMonster
 user	welcomeBackAdv	0
+user	wereProfessorAdvancedResearch
 user	wereProfessorBite	0
 user	wereProfessorKick	0
 user	wereProfessorLiver	0

--- a/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
@@ -583,6 +583,7 @@ public class SkillPool {
   public static final int SURPRISINGLY_SWEET_STAB = 7489;
   public static final int LAY_AN_EGG = 7494;
   public static final int SPRING_KICK = 7501;
+  public static final int ADVANCED_RESEARCH = 7512;
   public static final int DART_PART1 = 7513;
   public static final int DART_PART2 = 7514;
   public static final int DART_PART3 = 7515;

--- a/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
@@ -1680,7 +1680,7 @@ public class ConcoctionDatabase {
     // Cooking is permitted, so long as the person has an oven or a
     // range installed in their kitchen
 
-    if (KoLCharacter.hasOven() || KoLCharacter.hasRange()) {
+    if (KoLCharacter.hasOven() || KoLCharacter.hasRange() || KoLCharacter.inWereProfessor()) {
       permitNoCost(CraftingType.COOK);
     }
     ConcoctionDatabase.EXCUSE.put(CraftingType.COOK, "You cannot cook without an oven or a range.");
@@ -1763,7 +1763,9 @@ public class ConcoctionDatabase {
     // Mixing is permitted, so long as the person has a shaker or a
     // cocktailcrafting kit installed in their kitchen
 
-    if (KoLCharacter.hasShaker() || KoLCharacter.hasCocktailKit()) {
+    if (KoLCharacter.hasShaker()
+        || KoLCharacter.hasCocktailKit()
+        || KoLCharacter.inWereProfessor()) {
       permitNoCost(CraftingType.MIX);
     }
     ConcoctionDatabase.EXCUSE.put(

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -539,6 +539,7 @@ public class Preferences {
         "vintnerWineType",
         "violetFogLayout",
         "waxMonster",
+        "wereProfessorAdvancedResearch",
         "wereProfessorBite",
         "wereProfessorKick",
         "wereProfessorLiver",

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -12,9 +12,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.AdventureResult.AdventureLongCountResult;
 import net.sourceforge.kolmafia.AreaCombatData;
@@ -846,6 +848,12 @@ public class FightRequest extends GenericRequest {
         && !IslandManager.isBattlefieldMonster()
         && !QuestDatabase.isQuestFinished(QuestDatabase.Quest.ISLAND_WAR)
         && !KoLCharacter.inGLover();
+  }
+
+  public static final boolean canPerformAdvancedResearch() {
+    return KoLCharacter.isMildManneredProfessor()
+        && (KoLCharacter.hasEquipped(ItemPool.BIPHASIC_MOLECULAR_OCULUS)
+            || KoLCharacter.hasEquipped(ItemPool.TRIPHASIC_MOLECULAR_OCULUS));
   }
 
   public static void initializeAfterFight() {
@@ -7394,6 +7402,32 @@ public class FightRequest extends GenericRequest {
     }
   }
 
+  private static Set<Integer> getAdvancedResearchedMonsters() {
+    String value = Preferences.getString("wereProfessorAdvancedResearch");
+    Set<Integer> monsterIds =
+        Arrays.stream(value.split("\\s*,\\s*"))
+            .filter(s -> s != null && !s.isEmpty())
+            .map(Integer::valueOf)
+            .filter(i -> i != 0)
+            .collect(Collectors.toCollection(TreeSet::new));
+    return monsterIds;
+  }
+
+  public static boolean hasResearchedMonster(int monsterId) {
+    var monsterIds = getAdvancedResearchedMonsters();
+    return monsterIds.contains(monsterId);
+  }
+
+  private static void saveResearchedMonster(Set<Integer> monsterIds, int monsterId) {
+    if (!monsterIds.contains(monsterId)) {
+      monsterIds.add(monsterId);
+      String value =
+          new TreeSet<Integer>(monsterIds)
+              .stream().map(Object::toString).collect(Collectors.joining(","));
+      Preferences.setString("wereProfessorAdvancedResearch", value);
+    }
+  }
+
   private static void checkResearchPoints(String str, TagStatus status) {
     // If we had a property that stored monsters we've done Advanced
     // Research on, we could update it here.
@@ -7409,17 +7443,16 @@ public class FightRequest extends GenericRequest {
     if (str.contains("(You gain 5 research points)")) {
       FightRequest.logText("(You gain 5 research points)", status);
       Preferences.increment("wereProfessorResearchPoints", 5);
-      return;
-    }
-    if (str.contains("(You gain 10 research points)")) {
+    } else if (str.contains("(You gain 10 research points)")) {
       FightRequest.logText("(You gain 10 research points)", status);
       Preferences.increment("wereProfessorResearchPoints", 10);
-      return;
     }
     // "You've already researched this particular species in an advanced way."
-    if (str.equals("You've already researched this particular species in an advanced way.")) {
+    else if (!str.equals("You've already researched this particular species in an advanced way.")) {
       return;
     }
+    // We attempted - and maybe succeeded at doing - Advanced Research on this monster
+    saveResearchedMonster(getAdvancedResearchedMonsters(), status.monsterId);
   }
 
   private static void handleLuckyGoldRing(String str, TagStatus status) {

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -7409,7 +7409,7 @@ public class FightRequest extends GenericRequest {
             .filter(s -> s != null && !s.isEmpty())
             .map(Integer::valueOf)
             .filter(i -> i != 0)
-            .collect(Collectors.toCollection(TreeSet::new));
+            .collect(Collectors.toSet());
     return monsterIds;
   }
 

--- a/src/net/sourceforge/kolmafia/webui/FightDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/FightDecorator.java
@@ -300,11 +300,7 @@ public class FightDecorator {
     if (!FightRequest.hasResearchedMonster(monster.getId())) {
       return;
     }
-    String form = matcher.group(0);
-    String replacement =
-        StringUtilities.singleStringReplace(
-            form, "class=button", " disabled style='color=gray' class=button");
-    buffer.replace(matcher.start(), matcher.end(), replacement);
+    buffer.delete(matcher.start(), matcher.end());
   }
 
   private static void decorateHauntedKitchen(final StringBuffer buffer) {

--- a/src/net/sourceforge/kolmafia/webui/StationaryButtonDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/StationaryButtonDecorator.java
@@ -474,6 +474,10 @@ public class StationaryButtonDecorator {
       StationaryButtonDecorator.addFightButton(actionBuffer, "steal", FightRequest.canStillSteal());
     }
 
+    if (FightRequest.canPerformAdvancedResearch()) {
+      StationaryButtonDecorator.addFightButton(actionBuffer, "7512", true);
+    }
+
     if (KoLCharacter.isAccordionThief() && buffer.indexOf("Steal Accordion") != -1) {
       StationaryButtonDecorator.addFightButton(actionBuffer, "steal accordion", true);
     }
@@ -716,6 +720,10 @@ public class StationaryButtonDecorator {
               !KoLConstants.activeEffects.contains(EVERYTHING_LOOKS_YELLOW);
           case SkillPool.MOTIF -> isEnabled =
               !KoLConstants.activeEffects.contains(EVERYTHING_LOOKS_BLUE);
+          case SkillPool.ADVANCED_RESEARCH -> {
+            var monster = MonsterStatusTracker.getLastMonster();
+            isEnabled = monster != null && !FightRequest.hasResearchedMonster(monster.getId());
+          }
         }
       }
     }

--- a/test/net/sourceforge/kolmafia/request/FightRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FightRequestTest.java
@@ -2652,6 +2652,7 @@ public class FightRequestTest {
               withPath(Path.WEREPROFESSOR),
               withIntrinsicEffect(EffectPool.MILD_MANNERED_PROFESSOR),
               withProperty("wereProfessorResearchPoints", 11),
+              withProperty("wereProfessorAdvancedResearch", "1000,10,30,20"),
               withFight(0));
       try (cleanups) {
         String html = html("request/test_fight_research_initial.html");
@@ -2659,6 +2660,7 @@ public class FightRequestTest {
         FightRequest.registerRequest(true, url);
         FightRequest.processResults(null, null, html);
         assertThat("wereProfessorResearchPoints", isSetTo(12));
+        assertThat("wereProfessorAdvancedResearch", isSetTo("1000,10,30,20"));
       }
     }
 
@@ -2669,6 +2671,7 @@ public class FightRequestTest {
               withPath(Path.WEREPROFESSOR),
               withIntrinsicEffect(EffectPool.MILD_MANNERED_PROFESSOR),
               withProperty("wereProfessorResearchPoints", 11),
+              withProperty("wereProfessorAdvancedResearch", "1000,10,30,20"),
               withFight(1));
       try (cleanups) {
         String html = html("request/test_fight_research_advanced_success.html");
@@ -2676,6 +2679,7 @@ public class FightRequestTest {
         FightRequest.registerRequest(true, url);
         FightRequest.processResults(null, null, html);
         assertThat("wereProfessorResearchPoints", isSetTo(21));
+        assertThat("wereProfessorAdvancedResearch", isSetTo("10,20,30,539,1000"));
       }
     }
 
@@ -2686,6 +2690,7 @@ public class FightRequestTest {
               withPath(Path.WEREPROFESSOR),
               withIntrinsicEffect(EffectPool.MILD_MANNERED_PROFESSOR),
               withProperty("wereProfessorResearchPoints", 11),
+              withProperty("wereProfessorAdvancedResearch", "1000,10,30,20"),
               withFight(1));
       try (cleanups) {
         String html = html("request/test_fight_research_advanced_failed.html");
@@ -2693,6 +2698,7 @@ public class FightRequestTest {
         FightRequest.registerRequest(true, url);
         FightRequest.processResults(null, null, html);
         assertThat("wereProfessorResearchPoints", isSetTo(11));
+        assertThat("wereProfessorAdvancedResearch", isSetTo("10,20,30,539,1000"));
       }
     }
   }


### PR DESCRIPTION
1) WereProfessor does not need to buy a range or cocktailcrafting kit to do basic COOK or MIX concoctions. That includes Cookbat food. You presumably still need one for advanced recipes, like unstable fulminate, but I have not checked yet.
2) wereProfessorAdvancedResearch is a (sorted by monsterId) property of comma separated monsterIds that your Mild Mannered Professor has done Advance Research on.
3) If you are a Mild-Mannered Professor equipped with an oculus, Stationary buttons now include an "advanced research" button. This will be disabled if you have already researched this monster.
4) Similarly for KoL's built-in "Advanced Research" button. Since attempting to use it will give an error message, we'll just delete it.