### PR TITLE
No Campground in WereProfessor. Improved Fulminate warning

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -831,7 +831,8 @@ public abstract class KoLmafia {
     if (!KoLCharacter.getLimitMode().limitCampground()
         && !KoLCharacter.isEd()
         && !KoLCharacter.inNuclearAutumn()
-        && !KoLCharacter.inRobocore()) {
+        && !KoLCharacter.inRobocore()
+        && !KoLCharacter.inWereProfessor()) {
       KoLmafia.updateDisplay("Retrieving campground data...");
       if (!KoLCharacter.isVampyre()) {
         RequestThread.postRequest(new CampgroundRequest("inspectdwelling"));

--- a/src/net/sourceforge/kolmafia/objectpool/Concoction.java
+++ b/src/net/sourceforge/kolmafia/objectpool/Concoction.java
@@ -29,6 +29,7 @@ import net.sourceforge.kolmafia.request.CreateItemRequest;
 import net.sourceforge.kolmafia.request.PurchaseRequest;
 import net.sourceforge.kolmafia.request.StillSuitRequest;
 import net.sourceforge.kolmafia.request.TinkeringBenchRequest;
+import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 /**
@@ -628,6 +629,15 @@ public class Concoction implements Comparable<Concoction> {
 
   public void setPurchaseRequest(final PurchaseRequest purchaseRequest) {
     this.purchaseRequest = purchaseRequest;
+  }
+
+  public boolean hasIngredients() {
+    for (AdventureResult ingredient : this.ingredientArray) {
+      if (InventoryManager.getCount(ingredient) == 0) {
+        return false;
+      }
+    }
+    return true;
   }
 
   public boolean hasIngredients(final AdventureResult[] ingredients) {

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -2391,6 +2391,7 @@ public class ItemPool {
   public static final int DETARTRATED_ANHYDROUS_SUBLICALC = 7489;
   public static final int TRIATOMACEOUS_DUST = 7490;
   public static final int BOTTLE_OF_CHATEAU_DE_VINEGAR = 7491;
+  public static final int BLASTING_SODA = 7492;
   public static final int UNSTABLE_FULMINATE = 7493;
   public static final int WINE_BOMB = 7494;
   public static final int MORTAR_DISSOLVING_RECIPE = 7495;

--- a/src/net/sourceforge/kolmafia/session/LightsOutManager.java
+++ b/src/net/sourceforge/kolmafia/session/LightsOutManager.java
@@ -28,7 +28,9 @@ public class LightsOutManager {
 
   public static boolean lightsOutNow() {
     int totalTurns = KoLCharacter.getTurnsPlayed();
-    return totalTurns % 37 == 0 && Preferences.getInteger("lastLightsOutTurn") != totalTurns;
+    return totalTurns > 0
+        && totalTurns % 37 == 0
+        && Preferences.getInteger("lastLightsOutTurn") != totalTurns;
   }
 
   public static void report() {

--- a/test/net/sourceforge/kolmafia/request/RelayRequestWarningsTest.java
+++ b/test/net/sourceforge/kolmafia/request/RelayRequestWarningsTest.java
@@ -11,7 +11,9 @@ import static internal.helpers.Player.withItem;
 import static internal.helpers.Player.withPath;
 import static internal.helpers.Player.withProperty;
 import static internal.helpers.Player.withQuestProgress;
+import static internal.helpers.Player.withRange;
 import static internal.helpers.Player.withStats;
+import static internal.helpers.Player.withTurnsPlayed;
 import static internal.helpers.Player.withUnequipped;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -533,6 +535,147 @@ public class RelayRequestWarningsTest {
             "You are about to plant an enchanted bean without wearing your spring shoes."
                 + " If you are sure you wish to plant without it, click the icon on the left to do so."
                 + " If you want to put the shoes on first, click the icon on the right.";
+        assertEquals(expected, request.lastWarning);
+      }
+    }
+  }
+
+  @Nested
+  class UnstableFulminate {
+    private static final KoLAdventure A_BOO_PEAK =
+        AdventureDatabase.getAdventureByName("A-Boo Peak");
+    private static final KoLAdventure BOILER_ROOM =
+        AdventureDatabase.getAdventureByName("The Haunted Boiler Room");
+
+    private static final Confirm confirm = Confirm.BOILER;
+    private static final AdventureResult UNSTABLE_FULMINATE =
+        ItemPool.get(ItemPool.UNSTABLE_FULMINATE);
+    private static final AdventureResult BOTTLE_OF_CHATEAU_DE_VINEGAR =
+        ItemPool.get(ItemPool.BOTTLE_OF_CHATEAU_DE_VINEGAR);
+    private static final AdventureResult BLASTING_SODA = ItemPool.get(ItemPool.BLASTING_SODA);
+    private static final AdventureResult WINE_BOMB = ItemPool.get(ItemPool.WINE_BOMB);
+
+    // xyzzy
+
+    @Test
+    public void noWarningIfNotInBoilerRoom() {
+      var cleanups = new Cleanups();
+      try (cleanups) {
+        RelayRequest request = new RelayRequest(false);
+        request.constructURLString(adventureURL(A_BOO_PEAK, null), false);
+        // No warning needed if you are not in the Haunted Boiler Room
+        assertFalse(request.sendBoilerWarning());
+      }
+    }
+
+    @Test
+    public void noWarningIfSummoningChamberOpen() {
+      var cleanups =
+          new Cleanups(
+              withEquippableItem(UNSTABLE_FULMINATE), withQuestProgress(Quest.MANOR, "step3"));
+      try (cleanups) {
+        RelayRequest request = new RelayRequest(false);
+        request.constructURLString(adventureURL(BOILER_ROOM, null), false);
+        // No warning needed if Summoning Chamber already open
+        assertFalse(request.sendBoilerWarning());
+      }
+    }
+
+    @Test
+    public void noWarningIfLightsOutDue() {
+      var cleanups = new Cleanups(withProperty("lastLightsOutTurn", 37), withTurnsPlayed(74));
+      try (cleanups) {
+        RelayRequest request = new RelayRequest(false);
+        request.constructURLString(adventureURL(BOILER_ROOM, null), false);
+        // No warning needed if Lights Out is about to trigger
+        assertFalse(request.sendBoilerWarning());
+      }
+    }
+
+    @Test
+    public void noWarningWithWineBombInInventory() {
+      var cleanups = new Cleanups(withItem(ItemPool.WINE_BOMB));
+      try (cleanups) {
+        RelayRequest request = new RelayRequest(false);
+        request.constructURLString(adventureURL(BOILER_ROOM, null), false);
+        // If already made a wine bomb, no warning
+        assertFalse(request.sendBoilerWarning());
+      }
+    }
+
+    @Test
+    public void noWarningIfConfirmed() {
+      var cleanups = new Cleanups();
+      try (cleanups) {
+        RelayRequest request = new RelayRequest(false);
+        request.constructURLString(adventureURL(BOILER_ROOM, confirm), false);
+        // No warning needed if this a resubmission with confirmation
+        assertFalse(request.sendBoilerWarning());
+      }
+    }
+
+    @Test
+    public void noWarningIfUnstableFulminateEquipped() {
+      var cleanups = new Cleanups(withEquipped(Slot.OFFHAND, UNSTABLE_FULMINATE));
+      try (cleanups) {
+        RelayRequest request = new RelayRequest(false);
+        request.constructURLString(adventureURL(BOILER_ROOM, null), false);
+        // No warning needed if unstable fulminate already equipped
+        assertFalse(request.sendBoilerWarning());
+      }
+    }
+
+    @Test
+    public void noWarningIfNoFulminateAndMissingIngredients() {
+      var cleanups = new Cleanups();
+      try (cleanups) {
+        RelayRequest request = new RelayRequest(false);
+        request.constructURLString(adventureURL(BOILER_ROOM, null), false);
+        // No warning needed if unstable fulminate already equipped
+        assertFalse(request.sendBoilerWarning());
+      }
+    }
+
+    @Test
+    public void noWarningIfNoFulminateAndNoRange() {
+      var cleanups = new Cleanups(withItem(BOTTLE_OF_CHATEAU_DE_VINEGAR), withItem(BLASTING_SODA));
+      try (cleanups) {
+        RelayRequest request = new RelayRequest(false);
+        request.constructURLString(adventureURL(BOILER_ROOM, null), false);
+        // No warning needed if unstable fulminate already equipped
+        assertFalse(request.sendBoilerWarning());
+      }
+    }
+
+    @Test
+    public void warningIfCanMakeFulminate() {
+      var cleanups =
+          new Cleanups(
+              withRange(), withItem(BOTTLE_OF_CHATEAU_DE_VINEGAR), withItem(BLASTING_SODA));
+      try (cleanups) {
+        RelayRequest request = new RelayRequest(false);
+        request.constructURLString(adventureURL(BOILER_ROOM, null), false);
+        assertTrue(request.sendBoilerWarning());
+        String expected =
+            "You are about to adventure in the Haunted Boiler Room, but do not have unstable fulminate equipped."
+                + " You don't have that item, but you have the ingredients and could make it."
+                + " If you don't want to bother doing this, click the icon on the left to proceed."
+                + " If you want to make the fulminate now, click the icon on the right.";
+        assertEquals(expected, request.lastWarning);
+      }
+    }
+
+    @Test
+    public void warningIfEquippableUnstableFulminate() {
+      var cleanups = new Cleanups(withEquippableItem(UNSTABLE_FULMINATE));
+      try (cleanups) {
+        RelayRequest request = new RelayRequest(false);
+        request.constructURLString(adventureURL(BOILER_ROOM, null), false);
+        assertTrue(request.sendBoilerWarning());
+        String expected =
+            "You are about to adventure in the Haunted Boiler Room, but do not have unstable fulminate equipped."
+                + " If you are sure you want to do this, click the icon on the left to proceed."
+                + " If you want to equip the fulminate first, click the icon on the right.";
         assertEquals(expected, request.lastWarning);
       }
     }

--- a/test/net/sourceforge/kolmafia/request/RelayRequestWarningsTest.java
+++ b/test/net/sourceforge/kolmafia/request/RelayRequestWarningsTest.java
@@ -555,11 +555,9 @@ public class RelayRequestWarningsTest {
     private static final AdventureResult BLASTING_SODA = ItemPool.get(ItemPool.BLASTING_SODA);
     private static final AdventureResult WINE_BOMB = ItemPool.get(ItemPool.WINE_BOMB);
 
-    // xyzzy
-
     @Test
     public void noWarningIfNotInBoilerRoom() {
-      var cleanups = new Cleanups();
+      var cleanups = new Cleanups(withTurnsPlayed(3));
       try (cleanups) {
         RelayRequest request = new RelayRequest(false);
         request.constructURLString(adventureURL(A_BOO_PEAK, null), false);
@@ -570,9 +568,7 @@ public class RelayRequestWarningsTest {
 
     @Test
     public void noWarningIfSummoningChamberOpen() {
-      var cleanups =
-          new Cleanups(
-              withEquippableItem(UNSTABLE_FULMINATE), withQuestProgress(Quest.MANOR, "step3"));
+      var cleanups = new Cleanups(withTurnsPlayed(2), withQuestProgress(Quest.MANOR, "step3"));
       try (cleanups) {
         RelayRequest request = new RelayRequest(false);
         request.constructURLString(adventureURL(BOILER_ROOM, null), false);
@@ -583,7 +579,7 @@ public class RelayRequestWarningsTest {
 
     @Test
     public void noWarningIfLightsOutDue() {
-      var cleanups = new Cleanups(withProperty("lastLightsOutTurn", 37), withTurnsPlayed(74));
+      var cleanups = new Cleanups(withTurnsPlayed(74), withProperty("lastLightsOutTurn", 37));
       try (cleanups) {
         RelayRequest request = new RelayRequest(false);
         request.constructURLString(adventureURL(BOILER_ROOM, null), false);
@@ -593,8 +589,19 @@ public class RelayRequestWarningsTest {
     }
 
     @Test
+    public void noWarningIfVoteMonsterDue() {
+      var cleanups = new Cleanups(withTurnsPlayed(23), withProperty("lastVoteMonsterTurn", 12));
+      try (cleanups) {
+        RelayRequest request = new RelayRequest(false);
+        request.constructURLString(adventureURL(BOILER_ROOM, null), false);
+        // No warning needed if a Vote Monster is about to appear
+        assertFalse(request.sendBoilerWarning());
+      }
+    }
+
+    @Test
     public void noWarningWithWineBombInInventory() {
-      var cleanups = new Cleanups(withItem(ItemPool.WINE_BOMB));
+      var cleanups = new Cleanups(withTurnsPlayed(2), withItem(ItemPool.WINE_BOMB));
       try (cleanups) {
         RelayRequest request = new RelayRequest(false);
         request.constructURLString(adventureURL(BOILER_ROOM, null), false);
@@ -605,7 +612,7 @@ public class RelayRequestWarningsTest {
 
     @Test
     public void noWarningIfConfirmed() {
-      var cleanups = new Cleanups();
+      var cleanups = new Cleanups(withTurnsPlayed(2));
       try (cleanups) {
         RelayRequest request = new RelayRequest(false);
         request.constructURLString(adventureURL(BOILER_ROOM, confirm), false);
@@ -616,7 +623,8 @@ public class RelayRequestWarningsTest {
 
     @Test
     public void noWarningIfUnstableFulminateEquipped() {
-      var cleanups = new Cleanups(withEquipped(Slot.OFFHAND, UNSTABLE_FULMINATE));
+      var cleanups =
+          new Cleanups(withTurnsPlayed(2), withEquipped(Slot.OFFHAND, UNSTABLE_FULMINATE));
       try (cleanups) {
         RelayRequest request = new RelayRequest(false);
         request.constructURLString(adventureURL(BOILER_ROOM, null), false);
@@ -627,7 +635,7 @@ public class RelayRequestWarningsTest {
 
     @Test
     public void noWarningIfNoFulminateAndMissingIngredients() {
-      var cleanups = new Cleanups();
+      var cleanups = new Cleanups(withTurnsPlayed(2));
       try (cleanups) {
         RelayRequest request = new RelayRequest(false);
         request.constructURLString(adventureURL(BOILER_ROOM, null), false);
@@ -638,7 +646,9 @@ public class RelayRequestWarningsTest {
 
     @Test
     public void noWarningIfNoFulminateAndNoRange() {
-      var cleanups = new Cleanups(withItem(BOTTLE_OF_CHATEAU_DE_VINEGAR), withItem(BLASTING_SODA));
+      var cleanups =
+          new Cleanups(
+              withTurnsPlayed(2), withItem(BOTTLE_OF_CHATEAU_DE_VINEGAR), withItem(BLASTING_SODA));
       try (cleanups) {
         RelayRequest request = new RelayRequest(false);
         request.constructURLString(adventureURL(BOILER_ROOM, null), false);
@@ -651,7 +661,10 @@ public class RelayRequestWarningsTest {
     public void warningIfCanMakeFulminate() {
       var cleanups =
           new Cleanups(
-              withRange(), withItem(BOTTLE_OF_CHATEAU_DE_VINEGAR), withItem(BLASTING_SODA));
+              withTurnsPlayed(2),
+              withRange(),
+              withItem(BOTTLE_OF_CHATEAU_DE_VINEGAR),
+              withItem(BLASTING_SODA));
       try (cleanups) {
         RelayRequest request = new RelayRequest(false);
         request.constructURLString(adventureURL(BOILER_ROOM, null), false);
@@ -667,7 +680,7 @@ public class RelayRequestWarningsTest {
 
     @Test
     public void warningIfEquippableUnstableFulminate() {
-      var cleanups = new Cleanups(withEquippableItem(UNSTABLE_FULMINATE));
+      var cleanups = new Cleanups(withTurnsPlayed(2), withEquippableItem(UNSTABLE_FULMINATE));
       try (cleanups) {
         RelayRequest request = new RelayRequest(false);
         request.constructURLString(adventureURL(BOILER_ROOM, null), false);


### PR DESCRIPTION
1) No Campground if WereProfessor.
You can still buy and use a Dramatic range, and it is needed to make unstable fulminate.
We can't see it in the campground, but, fortunately, the "hasRange" property exists.
2) Don't warn that you don't have unstable fulminate equipped if you don't have it or can't make it.
3) If you have it but not equipped, offer to equip it.
4) If you don't have it but can make it, offer to make it.