### PR TITLE
Changing form requires concoction refresh. Drop transformed outfit pieces from checkpoints.

### DIFF
--- a/src/net/sourceforge/kolmafia/request/TinkeringBenchRequest.java
+++ b/src/net/sourceforge/kolmafia/request/TinkeringBenchRequest.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.SpecialOutfit;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.ConcoctionPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -95,6 +96,15 @@ public class TinkeringBenchRequest extends CreateItemRequest {
     // Attempt to retrieve the ingredients
     if (!this.makeIngredients()) {
       return;
+    }
+
+    // CreateItemRequest makes an outfit Checkpoint in its item creation
+    // loop. If we were wearing an item which we are upgrading, we don't
+    // want it to try to equip it, find it is gone, and try to make
+    // another one. It won't be possible, but its wasted effort and
+    // obfuscates the logging.
+    for (AdventureResult item : this.concoction.getIngredients()) {
+      SpecialOutfit.forgetEquipment(item);
     }
 
     KoLmafia.updateDisplay("Creating 1 " + this.getName() + "...");

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -6744,6 +6744,16 @@ public abstract class ChoiceControl {
           break;
         }
 
+      case 1520:
+        // Well, come on
+        // -> Lose Savage Beast and gain Mild-Mannered Professor
+      case 1521:
+        // Turn and face the strange
+        // -> Lose Mild-Mannered Professor and gain Savage Beast
+        // In either case, access to the Tinkering Bench changes
+        ConcoctionDatabase.refreshConcoctions();
+        break;
+
       case 1523:
         // Research Bench
         ResearchBenchRequest.postChoice2(urlString, text);


### PR DESCRIPTION
1) If you are wearing a high-tension exoskeleton and ask the Item Manager to create (and equip) a irresponsible-tension exoskeleton - and have the required 2 smashed scientific equipment - KoLmafia is happy to unequip the item and upgrade it.
The issue is that CreateItemRequest creates an outfit checkpoint around creations and it wants to re-equip the original exo- skeleton after creating it. In fact, it tries to re-make it - which fails, since it is no longer a valid creation.

Now we remove the ingredients from checkpoints - for TinkeringBenchRequest equipment - after we tinker.

2) You can only tinker as a Mild-Mannered Professor. When you transform to a Savage Beast - or vice versa - refresh concoctions so that Tinkering Bench items disappear and reappear as appropriate.

I suppose I could write some tests. I did turn on DEBUG logging when I did change 1 - with exoskeletons, and again, after I made the fix, with quick-release items.