### PR TITLE
Support large numbers from/to Javascript runtime

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/javascript/JavascriptNumbers.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/JavascriptNumbers.java
@@ -1,0 +1,23 @@
+package net.sourceforge.kolmafia.textui.javascript;
+
+/** This mimics the behavior of the Rhino NativeNumber class */
+@SuppressWarnings("UnnecessaryUnboxing")
+public class JavascriptNumbers {
+
+  /**
+   * @see https://www.ecma-international.org/ecma-262/6.0/#sec-number.max_safe_integer
+   */
+  private static final double MAX_SAFE_INTEGER = 9007199254740991.0; // Math.pow(2, 53) - 1
+
+  private static final double MIN_SAFE_INTEGER = -MAX_SAFE_INTEGER;
+
+  private static boolean isDoubleInteger(Double d) {
+    return !d.isInfinite() && !d.isNaN() && (Math.floor(d.doubleValue()) == d.doubleValue());
+  }
+
+  static boolean isDoubleSafeInteger(Double d) {
+    return isDoubleInteger(d)
+        && (d.doubleValue() <= MAX_SAFE_INTEGER)
+        && (d.doubleValue() >= MIN_SAFE_INTEGER);
+  }
+}

--- a/src/net/sourceforge/kolmafia/textui/javascript/ValueConverter.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/ValueConverter.java
@@ -200,7 +200,7 @@ public class ValueConverter {
         || object instanceof Double d && JavascriptNumbers.isDoubleSafeInteger(d)) {
       return DataTypes.makeIntValue(((Number) object).longValue());
     } else if (object instanceof Float || object instanceof Double) {
-      return DataTypes.makeFloatValue(((Number) object).floatValue());
+      return DataTypes.makeFloatValue(((Number) object).doubleValue());
     } else if (object instanceof String) {
       return DataTypes.makeStringValue((String) object);
     } else if (object instanceof StringBuffer || object instanceof ConsString) {

--- a/src/net/sourceforge/kolmafia/textui/javascript/ValueConverter.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/ValueConverter.java
@@ -193,13 +193,14 @@ public class ValueConverter {
     if (object == null) return null;
     else if (object instanceof Boolean) {
       return DataTypes.makeBooleanValue((Boolean) object);
-    } else if (object instanceof Float || object instanceof Double) {
-      return DataTypes.makeFloatValue(((Number) object).floatValue());
     } else if (object instanceof Byte
         || object instanceof Short
         || object instanceof Integer
-        || object instanceof Long) {
+        || object instanceof Long
+        || object instanceof Double d && JavascriptNumbers.isDoubleSafeInteger(d)) {
       return DataTypes.makeIntValue(((Number) object).longValue());
+    } else if (object instanceof Float || object instanceof Double) {
+      return DataTypes.makeFloatValue(((Number) object).floatValue());
     } else if (object instanceof String) {
       return DataTypes.makeStringValue((String) object);
     } else if (object instanceof StringBuffer || object instanceof ConsString) {

--- a/test/net/sourceforge/kolmafia/textui/javascript/AshInteropTest.java
+++ b/test/net/sourceforge/kolmafia/textui/javascript/AshInteropTest.java
@@ -77,7 +77,7 @@ public class AshInteropTest {
     String testDate = "2023-03-03 00:00:00 -0600";
     String dateFormat = "yyyy-MM-dd HH:mm:ss Z";
     long timeStamp = 1677823200000L;
-    double approx = 1677823180800.0;
+    double approx = 1677823200000.0;
     var js =
         new JavascriptRuntime("dateToTimestamp(\"" + dateFormat + "\" , \"" + testDate + "\")");
     assertNotNull(js, "JavascriptRuntime returned null.");

--- a/test/root/expected/large_integers.js.out
+++ b/test/root/expected/large_integers.js.out
@@ -8,5 +8,5 @@
 
 {"value":9007199254740992,"isSafeInteger":false,"asString":"9007199254740992","asKolmafiaString":"9007199254740992.0","stringsEqual":false}
 {"value":11.5,"isSafeInteger":false,"asString":"11.5","asKolmafiaString":"11.5","stringsEqual":true}
-{"value":1.1,"isSafeInteger":false,"asString":"1.1","asKolmafiaString":"1.100000023841858","stringsEqual":false}
-{"value":2147483648.5,"isSafeInteger":false,"asString":"2147483648.5","asKolmafiaString":"2147483648.0","stringsEqual":false}
+{"value":1.1,"isSafeInteger":false,"asString":"1.1","asKolmafiaString":"1.1","stringsEqual":true}
+{"value":2147483648.5,"isSafeInteger":false,"asString":"2147483648.5","asKolmafiaString":"2147483648.5","stringsEqual":true}

--- a/test/root/expected/large_integers.js.out
+++ b/test/root/expected/large_integers.js.out
@@ -1,10 +1,10 @@
-{"value":11,"isSafeInteger":true,"asString":"11","asKolmafiaString":"11","stringsEqual":true}
-{"value":11,"isSafeInteger":true,"asString":"11","asKolmafiaString":"11","stringsEqual":true}
-{"value":2147483647,"isSafeInteger":true,"asString":"2147483647","asKolmafiaString":"2147483647","stringsEqual":true}
-{"value":2147483648,"isSafeInteger":true,"asString":"2147483648","asKolmafiaString":"2147483648.0","stringsEqual":false}
-{"value":2147483648,"isSafeInteger":true,"asString":"2147483648","asKolmafiaString":"2147483648.0","stringsEqual":false}
-{"value":11111111111,"isSafeInteger":true,"asString":"11111111111","asKolmafiaString":"11111110656.0","stringsEqual":false}
-{"value":9007199254740991,"isSafeInteger":true,"asString":"9007199254740991","asKolmafiaString":"9007199254740992.0","stringsEqual":false}
+{"value":11,"isSafeInteger":true,"asString":"11","asKolmafiaString":"11","stringsEqual":true,"delimitedString":"11"}
+{"value":11,"isSafeInteger":true,"asString":"11","asKolmafiaString":"11","stringsEqual":true,"delimitedString":"11"}
+{"value":2147483647,"isSafeInteger":true,"asString":"2147483647","asKolmafiaString":"2147483647","stringsEqual":true,"delimitedString":"2,147,483,647"}
+{"value":2147483648,"isSafeInteger":true,"asString":"2147483648","asKolmafiaString":"2147483648","stringsEqual":true,"delimitedString":"2,147,483,648"}
+{"value":2147483648,"isSafeInteger":true,"asString":"2147483648","asKolmafiaString":"2147483648","stringsEqual":true,"delimitedString":"2,147,483,648"}
+{"value":11111111111,"isSafeInteger":true,"asString":"11111111111","asKolmafiaString":"11111111111","stringsEqual":true,"delimitedString":"11,111,111,111"}
+{"value":9007199254740991,"isSafeInteger":true,"asString":"9007199254740991","asKolmafiaString":"9007199254740991","stringsEqual":true,"delimitedString":"9,007,199,254,740,991"}
 
 {"value":9007199254740992,"isSafeInteger":false,"asString":"9007199254740992","asKolmafiaString":"9007199254740992.0","stringsEqual":false}
 {"value":11.5,"isSafeInteger":false,"asString":"11.5","asKolmafiaString":"11.5","stringsEqual":true}

--- a/test/root/expected/large_integers.js.out
+++ b/test/root/expected/large_integers.js.out
@@ -1,0 +1,12 @@
+{"value":11,"isSafeInteger":true,"asString":"11","asKolmafiaString":"11","stringsEqual":true}
+{"value":11,"isSafeInteger":true,"asString":"11","asKolmafiaString":"11","stringsEqual":true}
+{"value":2147483647,"isSafeInteger":true,"asString":"2147483647","asKolmafiaString":"2147483647","stringsEqual":true}
+{"value":2147483648,"isSafeInteger":true,"asString":"2147483648","asKolmafiaString":"2147483648.0","stringsEqual":false}
+{"value":2147483648,"isSafeInteger":true,"asString":"2147483648","asKolmafiaString":"2147483648.0","stringsEqual":false}
+{"value":11111111111,"isSafeInteger":true,"asString":"11111111111","asKolmafiaString":"11111110656.0","stringsEqual":false}
+{"value":9007199254740991,"isSafeInteger":true,"asString":"9007199254740991","asKolmafiaString":"9007199254740992.0","stringsEqual":false}
+
+{"value":9007199254740992,"isSafeInteger":false,"asString":"9007199254740992","asKolmafiaString":"9007199254740992.0","stringsEqual":false}
+{"value":11.5,"isSafeInteger":false,"asString":"11.5","asKolmafiaString":"11.5","stringsEqual":true}
+{"value":1.1,"isSafeInteger":false,"asString":"1.1","asKolmafiaString":"1.100000023841858","stringsEqual":false}
+{"value":2147483648.5,"isSafeInteger":false,"asString":"2147483648.5","asKolmafiaString":"2147483648.0","stringsEqual":false}

--- a/test/root/scripts/large_integers.js
+++ b/test/root/scripts/large_integers.js
@@ -25,10 +25,10 @@ const {print, toString: kolmafiaToString} = require("kolmafia");
 print("");
 
 [
-  9007199254740992, // JavaScript Number.MAX_SAFE_INTEGER + 1, this will not be converted to a long, but to a float
-  11.5, // this will be a float and can be represented
-  1.1, // this will be a float, but is not a real number, so will be weird string in java
-  2147483648.5, // this will be a float but is too large to be represented accurately
+  9007199254740992, // JavaScript Number.MAX_SAFE_INTEGER + 1, this will not be converted to a long, but to a double
+  11.5, // this will be a double
+  1.1, // this will be a double
+  2147483648.5, // this will be a double
 ].forEach((value) => {
   const asString = String(value);
   const asKolmafiaString = kolmafiaToString(value);

--- a/test/root/scripts/large_integers.js
+++ b/test/root/scripts/large_integers.js
@@ -11,12 +11,14 @@ const {print, toString: kolmafiaToString} = require("kolmafia");
 ].forEach((value) => {
   const asString = String(value);
   const asKolmafiaString = kolmafiaToString(value);
+  const delimitedString = kolmafiaToString(value, "%,d");
   print(JSON.stringify({
     value,
     isSafeInteger: Number.isSafeInteger(value),
     asString,
     asKolmafiaString,
     stringsEqual: asString === asKolmafiaString,
+    delimitedString,
   }));
 });
 

--- a/test/root/scripts/large_integers.js
+++ b/test/root/scripts/large_integers.js
@@ -1,0 +1,40 @@
+const {print, toString: kolmafiaToString} = require("kolmafia");
+
+[
+  11,
+  11.0,
+  2147483647, // Java Integer.MAX_VALUE
+  2147483648, // Java Integer.MAX_VALUE + 1
+  2147483648.0,
+  11_111_111_111,
+  9007199254740991, // JavaScript Number.MAX_SAFE_INTEGER
+].forEach((value) => {
+  const asString = String(value);
+  const asKolmafiaString = kolmafiaToString(value);
+  print(JSON.stringify({
+    value,
+    isSafeInteger: Number.isSafeInteger(value),
+    asString,
+    asKolmafiaString,
+    stringsEqual: asString === asKolmafiaString,
+  }));
+});
+
+print("");
+
+[
+  9007199254740992, // JavaScript Number.MAX_SAFE_INTEGER + 1, this will not be converted to a long, but to a float
+  11.5, // this will be a float and can be represented
+  1.1, // this will be a float, but is not a real number, so will be weird string in java
+  2147483648.5, // this will be a float but is too large to be represented accurately
+].forEach((value) => {
+  const asString = String(value);
+  const asKolmafiaString = kolmafiaToString(value);
+  print(JSON.stringify({
+    value,
+    isSafeInteger: Number.isSafeInteger(value),
+    asString,
+    asKolmafiaString,
+    stringsEqual: asString === asKolmafiaString,
+  }));
+});


### PR DESCRIPTION
The Rhino javascript engine passes integers larger than `Integer.MAX_VALUE` as `Double`, because they cannot be represented as `Integer`. Since we already use `long` for integer values, pass all numbers that are "safe integers" based on Javascript's Number.isSafeInteger as `long`, instead of converting them to a `float` value that cannot even correctly represent many of the larger integer values.

I added a test in a separate commit, so you can easily compare the behavior before and after the change.

Update: also, use double precision for non-integer numbers, since TYPE_FLOAT uses `double` internally anyway. 