### PR TITLE
WereProfessor tweaks

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1649,6 +1649,7 @@ user	wereProfessorPoints	0
 user	wereProfessorRend	0
 user	wereProfessorResearchPoints	0
 user	wereProfessorStomach	0
+user	wereProfessorTransformTurns	0
 user	whetstonesUsed	0
 user	wildfireBarrelCaulked	false
 user	wildfireDusted	false

--- a/src/net/sourceforge/kolmafia/AscensionClass.java
+++ b/src/net/sourceforge/kolmafia/AscensionClass.java
@@ -57,7 +57,8 @@ public enum AscensionClass {
   GREY_GOO("Grey Goo", 27, "greygooring", -1, Path.GREY_YOU, null, 0, 0, 0),
   PIG_SKINNER("Pig Skinner", 28, "football2", 0, Path.SHADOWS_OVER_LOATHING),
   CHEESE_WIZARD("Cheese Wizard", 29, "jarl_cheeseslice", 1, Path.SHADOWS_OVER_LOATHING),
-  JAZZ_AGENT("Jazz Agent", 30, "motif", 2, Path.SHADOWS_OVER_LOATHING, "Drum Roll");
+  JAZZ_AGENT("Jazz Agent", 30, "motif", 2, Path.SHADOWS_OVER_LOATHING, "Drum Roll"),
+  WEREPROFESSOR("WereProfessor", 31, "intrinsic_prof", 0, Path.WEREPROFESSOR);
 
   public static final List<AscensionClass> standardClasses =
       Arrays.asList(

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -547,6 +547,7 @@ public class Preferences {
         "wereProfessorRend",
         "wereProfessorResearchPoints",
         "wereProfessorStomach",
+        "wereProfessorTransformTurns",
         "whetstonesUsed",
         "wildfireBarrelCaulked",
         "wildfireDusted",

--- a/src/net/sourceforge/kolmafia/request/AfterLifeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AfterLifeRequest.java
@@ -348,6 +348,10 @@ public class AfterLifeRequest extends GenericRequest {
           case 24 -> builder.append("Vampyre");
           case 25 -> builder.append("Plumber");
           case 27 -> builder.append("Grey Goo");
+          case 28 -> builder.append("Pig Skinner");
+          case 29 -> builder.append("Cheese Wizard");
+          case 30 -> builder.append("Jazz Agent");
+          case 31 -> builder.append("WereProfessor");
           default -> {
             builder.append("(Class ");
             builder.append(pclass);

--- a/src/net/sourceforge/kolmafia/request/CharPaneRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CharPaneRequest.java
@@ -267,7 +267,7 @@ public class CharPaneRequest extends GenericRequest {
 
     CharPaneRequest.checkNoncombatForcers(responseText);
 
-    CharPaneRequest.checkResearchPoints(responseText);
+    CharPaneRequest.checkWereProfessor(responseText);
 
     // Mana cost adjustment may have changed
 
@@ -1527,16 +1527,28 @@ public class CharPaneRequest extends GenericRequest {
       Pattern.compile(
           "<td align=right>Research(?: Points)?:</td><td align=left><b>([^<]+)</b></font></td>");
 
-  public static void checkResearchPoints(final String responseText) {
+  // <td align=right>Until Transform:</td><td align=left><b>25</b></font></td>
+  // <td align=right>Tranform:</td><td align=left><b>11</b></font></td>
+
+  private static final Pattern TRANSFORM =
+      Pattern.compile(
+          "<td align=right>(?:Until )?Trans?form:</td><td align=left><b>([^<]+)</b></font></td>");
+
+  public static void checkWereProfessor(final String responseText) {
     if (!KoLCharacter.inWereProfessor()) {
       return;
     }
 
-    Matcher matcher = RP.matcher(responseText);
-
-    if (matcher.find()) {
+    Matcher rmatcher = RP.matcher(responseText);
+    if (rmatcher.find()) {
       Preferences.setInteger(
-          "wereProfessorResearchPoints", StringUtilities.parseInt(matcher.group(1)));
+          "wereProfessorResearchPoints", StringUtilities.parseInt(rmatcher.group(1)));
+    }
+
+    Matcher tmatcher = TRANSFORM.matcher(responseText);
+    if (tmatcher.find()) {
+      Preferences.setInteger(
+          "wereProfessorTransformTurns", StringUtilities.parseInt(tmatcher.group(1)));
     }
   }
 

--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -2124,7 +2124,7 @@ public class RelayRequest extends PasswordHashRequest {
   }
 
   public boolean sendBoilerWarning() {
-    // If it's already confirmed, then allow it this time.
+    // If already confirmed, then allow it this time.
     if (this.getFormField(Confirm.BOILER) != null) {
       return false;
     }
@@ -2185,6 +2185,12 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // They don't have it, but perhaps they can make it.
+
+    // If already confirmed, then allow it this time.
+    if (this.getFormField(Confirm.BOILER2) != null) {
+      return false;
+    }
+
     Concoction recipe = ConcoctionPool.get(ItemPool.UNSTABLE_FULMINATE);
     if (!recipe.hasIngredients()) {
       // If they don't have the ingredients for unstable fulminate, it's a
@@ -2223,6 +2229,12 @@ public class RelayRequest extends PasswordHashRequest {
     }
 
     // They don't have a range installed, but perhaps they own one.
+
+    // If already confirmed, then allow it this time.
+    if (this.getFormField(Confirm.BOILER3) != null) {
+      return false;
+    }
+
     if (InventoryManager.getCount(ItemPool.RANGE) > 0) {
       // They have a range in inventory but forgot to install it.
       // We can fix that.

--- a/src/net/sourceforge/kolmafia/session/EquipmentManager.java
+++ b/src/net/sourceforge/kolmafia/session/EquipmentManager.java
@@ -2181,7 +2181,7 @@ public class EquipmentManager {
   }
 
   public static final boolean meetsStatRequirements(final int itemId) {
-    if (KoLCharacter.inSmallcore()) {
+    if (KoLCharacter.inSmallcore() || KoLCharacter.isMildManneredProfessor()) {
       // stat requirements are ignored
       return true;
     }

--- a/test/net/sourceforge/kolmafia/request/CharPaneRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/CharPaneRequestTest.java
@@ -286,26 +286,32 @@ class CharPaneRequestTest {
   }
 
   @Nested
-  class ResearchPoints {
+  class WereProfessor {
     @Test
-    void canTrackResearchPoints() {
+    void canTrackWereProfessorStats() {
       var cleanups =
           new Cleanups(
-              withPath(Path.WEREPROFESSOR), withProperty("wereProfessorResearchPoints", 11));
+              withPath(Path.WEREPROFESSOR),
+              withProperty("wereProfessorResearchPoints", 11),
+              withProperty("wereProfessorTransformTurns", 5));
       try (cleanups) {
         CharPaneRequest.processResults(html("request/test_charpane_research.html"));
         assertThat("wereProfessorResearchPoints", isSetTo(74));
+        assertThat("wereProfessorTransformTurns", isSetTo(25));
       }
     }
 
     @Test
-    void canTrackCompactResearchPoints() {
+    void canTrackCompactWereProfessorStats() {
       var cleanups =
           new Cleanups(
-              withPath(Path.WEREPROFESSOR), withProperty("wereProfessorResearchPoints", 11));
+              withPath(Path.WEREPROFESSOR),
+              withProperty("wereProfessorResearchPoints", 11),
+              withProperty("wereProfessorTransformTurns", 5));
       try (cleanups) {
         CharPaneRequest.processResults(html("request/test_charpane_compact_research.html"));
         assertThat("wereProfessorResearchPoints", isSetTo(15));
+        assertThat("wereProfessorTransformTurns", isSetTo(11));
       }
     }
   }

--- a/test/net/sourceforge/kolmafia/request/RelayRequestWarningsTest.java
+++ b/test/net/sourceforge/kolmafia/request/RelayRequestWarningsTest.java
@@ -547,7 +547,6 @@ public class RelayRequestWarningsTest {
     private static final KoLAdventure BOILER_ROOM =
         AdventureDatabase.getAdventureByName("The Haunted Boiler Room");
 
-    private static final Confirm confirm = Confirm.BOILER;
     private static final AdventureResult UNSTABLE_FULMINATE =
         ItemPool.get(ItemPool.UNSTABLE_FULMINATE);
     private static final AdventureResult BOTTLE_OF_CHATEAU_DE_VINEGAR =
@@ -615,7 +614,7 @@ public class RelayRequestWarningsTest {
       var cleanups = new Cleanups(withTurnsPlayed(2));
       try (cleanups) {
         RelayRequest request = new RelayRequest(false);
-        request.constructURLString(adventureURL(BOILER_ROOM, confirm), false);
+        request.constructURLString(adventureURL(BOILER_ROOM, Confirm.BOILER), false);
         // No warning needed if this a resubmission with confirmation
         assertFalse(request.sendBoilerWarning());
       }
@@ -658,6 +657,22 @@ public class RelayRequestWarningsTest {
     }
 
     @Test
+    public void noWarningIfNoMakeConfirmed() {
+      var cleanups =
+          new Cleanups(
+              withTurnsPlayed(2),
+              withRange(),
+              withItem(BOTTLE_OF_CHATEAU_DE_VINEGAR),
+              withItem(BLASTING_SODA));
+      try (cleanups) {
+        RelayRequest request = new RelayRequest(false);
+        request.constructURLString(adventureURL(BOILER_ROOM, Confirm.BOILER2), false);
+        // No warning needed if this a resubmission with confirmation
+        assertFalse(request.sendBoilerWarning());
+      }
+    }
+
+    @Test
     public void warningIfCanMakeFulminate() {
       var cleanups =
           new Cleanups(
@@ -675,6 +690,22 @@ public class RelayRequestWarningsTest {
                 + " If you don't want to bother doing this, click the icon on the left to proceed."
                 + " If you want to make the fulminate now, click the icon on the right.";
         assertEquals(expected, request.lastWarning);
+      }
+    }
+
+    @Test
+    public void noWarningIfNoInstallConfirmed() {
+      var cleanups =
+          new Cleanups(
+              withTurnsPlayed(2),
+              withItem(ItemPool.RANGE),
+              withItem(BOTTLE_OF_CHATEAU_DE_VINEGAR),
+              withItem(BLASTING_SODA));
+      try (cleanups) {
+        RelayRequest request = new RelayRequest(false);
+        request.constructURLString(adventureURL(BOILER_ROOM, Confirm.BOILER3), false);
+        // No warning needed if this a resubmission with confirmation
+        assertFalse(request.sendBoilerWarning());
       }
     }
 

--- a/test/net/sourceforge/kolmafia/request/RelayRequestWarningsTest.java
+++ b/test/net/sourceforge/kolmafia/request/RelayRequestWarningsTest.java
@@ -679,6 +679,28 @@ public class RelayRequestWarningsTest {
     }
 
     @Test
+    public void warningIfCanInstallRange() {
+      var cleanups =
+          new Cleanups(
+              withTurnsPlayed(2),
+              withItem(ItemPool.RANGE),
+              withItem(BOTTLE_OF_CHATEAU_DE_VINEGAR),
+              withItem(BLASTING_SODA));
+      try (cleanups) {
+        RelayRequest request = new RelayRequest(false);
+        request.constructURLString(adventureURL(BOILER_ROOM, null), false);
+        assertTrue(request.sendBoilerWarning());
+        String expected =
+            "You are about to adventure in the Haunted Boiler Room, but do not have unstable fulminate equipped."
+                + " You don't have that item, but you have the ingredients and could make it."
+                + " It requires a Dramatic range, and you own onee, but it is not installed."
+                + " If you don't want to bother doing this, click the icon on the left to proceed."
+                + " If you want to install the Dramatic range in your kitchen, click the icon on the right.";
+        assertEquals(expected, request.lastWarning);
+      }
+    }
+
+    @Test
     public void warningIfEquippableUnstableFulminate() {
       var cleanups = new Cleanups(withTurnsPlayed(2), withEquippableItem(UNSTABLE_FULMINATE));
       try (cleanups) {


### PR DESCRIPTION
1) The WereProfessor is class 31.
2) A Mild-Mannered Professor has no equipment stat requirements.
3) Parse Turns until Transform from the charpane and save in "wereProfessorTransformTurns".
This will not be useful for scripting, but will suffice for a Relay Browser warning.
4) unstable fulminate warning will work if you have ingredients and dramatic range in inventory.
I've been bitten by this.
5) relay warning if potentially entering a fight as your last turn as a Mild-Mannered Professor and you have enough Research Points to learn something.

For a later PR:

Track turns until Transform without depending on charpane.