### PR TITLE
Fix processing private chat messages when user has a space in their name

### DIFF
--- a/src/net/sourceforge/kolmafia/chat/ChatManager.java
+++ b/src/net/sourceforge/kolmafia/chat/ChatManager.java
@@ -307,6 +307,7 @@ public abstract class ChatManager {
     }
 
     String content = message.getContent();
+    String destination = recipient;
 
     if (recipient == null) {
       ChatManager.processCommand(sender, content, recipient);
@@ -320,15 +321,13 @@ public abstract class ChatManager {
     } else if (recipient.equals("/talkie")) {
       // Allow chatbot scripts to process talkie messages
       ChatManager.processCommand(sender, content, recipient);
-    } else if (Preferences.getBoolean("chatBeep")
-        && (StringUtilities.globalStringReplace(KoLCharacter.getUserName(), " ", "_")
-            .equalsIgnoreCase(recipient))) {
-      Toolkit.getDefaultToolkit().beep();
-    }
+    } else if (StringUtilities.globalStringReplace(KoLCharacter.getUserName(), " ", "_")
+        .equalsIgnoreCase(recipient)) {
 
-    String destination = recipient;
+      if (Preferences.getBoolean("chatBeep")) {
+        Toolkit.getDefaultToolkit().beep();
+      }
 
-    if (KoLCharacter.getUserName().equals(recipient)) {
       if (ChatManager.triviaGameActive) {
         if (!ChatManager.triviaGameContacts.contains(message.getSender())) {
           ChatManager.triviaGameContacts.add(message.getSender());

--- a/src/net/sourceforge/kolmafia/chat/ChatMessage.java
+++ b/src/net/sourceforge/kolmafia/chat/ChatMessage.java
@@ -96,7 +96,7 @@ public class ChatMessage {
         forTag.put("color", "black");
         object.put("for", forTag);
         object.put("msg", this.content);
-        object.put("time", this.date.getTime());
+        object.put("time", this.date.getTime() / 1000);
         return object;
       } catch (JSONException e) {
         return null;

--- a/test/net/sourceforge/kolmafia/chat/ChatMessageTest.java
+++ b/test/net/sourceforge/kolmafia/chat/ChatMessageTest.java
@@ -39,7 +39,7 @@ public class ChatMessageTest {
     assertNotNull(jso);
     String ep1 =
         "{\"msg\":\"content\",\"for\":{\"color\":\"black\",\"name\":\"recipient\",\"id\":\"recipient\"},\"time\":";
-    String ep2 = Long.toString(testMessage.getDate().getTime());
+    String ep2 = Long.toString(testMessage.getDate().getTime() / 1000);
     String ep3 =
         ",\"type\":\"private\",\"who\":{\"color\":\"black\",\"name\":\"sender\",\"id\":\"sender\"}}";
     assertEquals(jso.toString(), ep1 + ep2 + ep3);


### PR DESCRIPTION
When processing an incoming message, the ChatManager checks whether the recipient equals the currently running user, and takes that as a sign to handle the message as a private message. However, the `recipient` has spaces replaced with underscores, so if the current user has spaces in their usernames, that check won't match.

There is already the same check for triggering a bell in the chat window, and it seems nicer to pull that blocks together anyway.

This PR includes another tiny fix for injecting messages into mchat (e.g. those sent from the GUI chat), which requires timestamps to be in seconds, not millis. 