### PR TITLE
Improve tracking of shadow brick against unkillable monsters

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -10614,6 +10614,7 @@ public class FightRequest extends GenericRequest {
 
     boolean itemSuccess = isItemSuccess(responseText);
     boolean itemRunawaySuccess = isItemRunawaySuccess(responseText);
+    boolean itemLimitMaxedOut = false;
 
     switch (itemId) {
       default:
@@ -10909,6 +10910,17 @@ public class FightRequest extends GenericRequest {
         }
         break;
 
+      case ItemPool.SHADOW_BRICK:
+        // Using against a monster that cannot be insta-killed will still count towards the limit
+        if (responseText.contains("It strikes a glancing blow")) {
+          itemSuccess = true;
+        }
+        if (responseText.contains(
+            "You can't bear to use any more of those horrible things today")) {
+          itemLimitMaxedOut = true;
+        }
+        break;
+
       case ItemPool.PEPPERMINT_BOMB:
         if (responseText.contains("at least until they can wash their hands")) {
           BanishManager.banishCurrentMonster(Banisher.PEPPERMINT_BOMB);
@@ -10998,11 +11010,15 @@ public class FightRequest extends GenericRequest {
       }
     }
 
-    if (itemSuccess || itemRunawaySuccess) {
+    if (itemSuccess || itemRunawaySuccess || itemLimitMaxedOut) {
       var limit = DailyLimitType.USE.getDailyLimit(itemId);
 
       if (limit != null) {
-        limit.increment();
+        if (itemLimitMaxedOut) {
+          limit.setToMax();
+        } else {
+          limit.increment();
+        }
       }
     }
 


### PR DESCRIPTION
When using a shadow brick against a monster that cannot be insta-killed, it still counts against the limit.

The check needs to be added outside the "If these items succeed, then the second one won't actually do anything" block, because against such monsters, the shadow brick can indeed be dual-used (and counts twice):

![image](https://github.com/kolmafia/kolmafia/assets/1388972/e47f6bdb-843f-4f8e-bb02-50b87cebce19)


With the fix, the following situations are tracked correctly:

* Dual-using against a monster that can be insta-killed (single use should work equivalently):
```
Encounter: Fallen Archfiend
...
Round 1: That Buff Guy uses the shadow brick and uses the shadow brick!
...
Round 2: That Buff Guy wins the fight!
...
Preference _shadowBricksUsed changed from 8 to 9
...
This combat did not cost a turn
```

* Dual-using against Eldritch Tentacle:
```
Round 0: That Buff Guy uses the shadow brick and uses the shadow brick!
Encounter: Eldritch Tentacle
Round 2: Eldritch Tentacle takes 69 damage.
Round 2: Eldritch Tentacle takes 69 damage.
...
Preference _shadowBricksUsed changed from 9 to 10
Preference _shadowBricksUsed changed from 10 to 11
```

* Using when already maxed out (but was mistracked by a kolmafia version that did not have this fix):
```
Encounter: Fallen Archfiend
Round 0: That Buff Guy wins initiative!
Round 1: You lose 1 hit point
Round 1: That Buff Guy uses the shadow brick!
KoLmafia thinks it is round 2 but KoL thinks it is round 1
Preference _shadowBricksUsed changed from 11 to 13
```