### PR TITLE
update `MafiaClass` typedefs to use a `this` parameter

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/TypescriptDefinition.java
+++ b/src/net/sourceforge/kolmafia/textui/TypescriptDefinition.java
@@ -175,24 +175,18 @@ public class TypescriptDefinition {
         .toList();
   }
 
-  private static List<String> formatMafiaClassMethods(final String type, final String argType) {
-    boolean isAbstract = (type == null);
+  private static List<String> formatMafiaClassMethods() {
     return List.of(
-        String.format(
-            "    static get%s(name: %s): %s;",
-            isAbstract ? "<T extends MafiaClass>" : "", argType, isAbstract ? "T" : type),
-        String.format(
-            "    static get%s(names: readonly %s[]): %s[];",
-            isAbstract ? "<T extends MafiaClass>" : "", argType, isAbstract ? "T" : type),
-        String.format(
-            "    static all<T %s>(): T[];", isAbstract ? "extends MafiaClass" : "= " + type),
-        String.format("    static none: %s;", isAbstract ? "MafiaClass" : type));
+        "    static get<T extends MafiaClass>(this: { new (): T; }, name: (string | number)): T;",
+        "    static get<T extends MafiaClass>(this: { new (): T; }, names: readonly (string | number)[]): T[];",
+        "    static all<T extends MafiaClass>(this: { new (): T; }): T[];",
+    "    static none: MafiaClass");
   }
 
   private static List<String> getAbstractMafiaClass() {
     var abstractClass = new ArrayList<String>();
     abstractClass.add("declare abstract class MafiaClass {");
-    abstractClass.addAll(formatMafiaClassMethods(null, "(string | number)"));
+    abstractClass.addAll(formatMafiaClassMethods());
     abstractClass.add("}");
     return abstractClass;
   }
@@ -236,7 +230,7 @@ public class TypescriptDefinition {
     // Prepare the methods
     var argType = unionType != null ? unionType : "string";
     if (typesWithNumbers.contains(t)) argType = String.format("(%s | number)", argType);
-    var methods = formatMafiaClassMethods(name, argType);
+    var methods = List.of(String.format("    static none: %s;", name));
 
     var result = new ArrayList<String>();
 

--- a/src/net/sourceforge/kolmafia/textui/TypescriptDefinition.java
+++ b/src/net/sourceforge/kolmafia/textui/TypescriptDefinition.java
@@ -180,7 +180,7 @@ public class TypescriptDefinition {
         "    static get<T extends MafiaClass>(this: { new (): T; }, name: (string | number)): T;",
         "    static get<T extends MafiaClass>(this: { new (): T; }, names: readonly (string | number)[]): T[];",
         "    static all<T extends MafiaClass>(this: { new (): T; }): T[];",
-        "    static none: MafiaClass");
+        "    static none: MafiaClass;");
   }
 
   private static List<String> getAbstractMafiaClass() {

--- a/src/net/sourceforge/kolmafia/textui/TypescriptDefinition.java
+++ b/src/net/sourceforge/kolmafia/textui/TypescriptDefinition.java
@@ -180,7 +180,7 @@ public class TypescriptDefinition {
         "    static get<T extends MafiaClass>(this: { new (): T; }, name: (string | number)): T;",
         "    static get<T extends MafiaClass>(this: { new (): T; }, names: readonly (string | number)[]): T[];",
         "    static all<T extends MafiaClass>(this: { new (): T; }): T[];",
-    "    static none: MafiaClass");
+        "    static none: MafiaClass");
   }
 
   private static List<String> getAbstractMafiaClass() {


### PR DESCRIPTION
`TypescriptDefinitionTest` seems to not be particularly fleshed out, so I'm still thinking about a testing strategy. But this essentially allows us to do use `typeof MafiaClass` as an argument in a function and have `arg.get` return the correct type without type assertions.

I'll need to consult with @gausie once he's awake both about tests and about where `Item.none` et al are defined, because I don't see 'em and I'd like to genericize that as well as something like
```typescript
get none<T extends MafiaClass>(this: { new (): T }): T;
```

EDIT: after playinga round in the typescript playground, it won't work for specifically the `none` getter, and there's also no such thing as an abstract static _or_ a generic getter. Alas!
Still, [linking a quick playground](https://www.typescriptlang.org/play?#code/CYUwxgNghgTiAEUBGBnALjKY30lFK8AslAGYCWUAwtAfAN4BQ8L86Ua5Y8A5iGgB4AKvBAAPNCAB2wQiQrVaKAHwAKNAAtyKAFwN4UkAHd4qgJR6RAXwA0BqAFsQe9DHJSe8AD4GArg6QQGAt4IQBuZlZ2Tm4+QRFxSRk5MkoafBV1LV19QxNzS3hbeycc1Vd3Tx8pf0DggG0AXRDwyJZorkQICGFRCWlZYlTFDLVNbT16A2NTFqKWpoirRlA8OFwleABJSQc+pMH5NM2mVl5+AwB7QwLt3aXGRlJfKWxya7YABwhyNAAhACeVEuDgc+AA6r8NABRFBgKCfEAocoYFwYSohCoeJoMSJga7oeBwNC+GBSABqUAgvgQAF54ItHiwIBdyDwpJc4AA5RLwemkKkoEARZkXMCkuBSNAAZXRHj58AARIqIpFSJzTPipISwBpYPBLqQ2BgAHQob6-VTKsxmXFnchG1S6-W011KgA67sVttOZ3gbI53N59IwNJFrCsoggQrtfodmr1MD59MVNkV8AAZBn4ABCAOckA8iQ+tp+4mkilUmkmz6+FAaJ0S6QyuU8E3ohzmMzhv24JtS2VueUplWlliRkDRhC+3vimCSltDzwAanpzpgPYjY-97ILRZw-MFwtLy3HkXLZMp1JANbrDbnC8HlXbbk7NtVLAvUiJ-ArV7DjDLIwWo6tc8JoEIIAON8HAgE+w6mJEPySJg0aWFBMGSPBPAoAAgvOUAAjYkQmqRMFgCAGiXBAoAwDkWI8E0jC2rSyhIb8QSCiamBGNxIDAL4FGqKWqhYGAdjIZxEB2OQLHKIgYDcMu8CSah8DKao5GUdRtEoPU5CNPAAD8RlKt6xFnMqkTdo8IE4HqMgskIAKIgA4vw0Lzhq9K9IkAwpAo6QEGokTOYiehoC5ICGkMgWbNmqh5LMfLyUIZgWaIXkwHoLwANYckYUjMSlsZ2fApQoFAfAKgABgAJPQQQwJyVg1eGZVgmguoKhVVU3p1urCWcABKIA8NCYifKoNV-FAwDwA1YU3lIjg3mglwADKXEYQRUPgIDmJGABuVbOPAJoAFQ1WY1nhvGqgDRoJZnCB1E3hAlw8ENfr1fQj31AADI0VhhP6RoApcvgAOTrBRMBoFA7jwJoHDI9kC30EtJorU4E5iNoaCEFAMj+oQ5qTiy834vO4BoBARHwN8ID7fAvifMAsHwAA0ptRxQDVGUsDZ45RjGM64ASb0mh9X29XwwtFIBqplWAcCwdKlQssC2oI1KCq+f0ySxccozfUtEVRTFfNBYQ2ZTEltzWMVrGlQSOAIzwABiLxvB89LfcyHGoTkkHQdAWGtnhBFEaWpE1tAFFUTRQT0a2TFCyV4tle4tYHhLrwcKHmFwa2qiqYKdhx1pSe6QrLAYACsZnF+oRRSacSqDnvhoHXRS4Bw3WqE1nLPX6DnAE5UXuWgnnNTAqhLXYw-BJup6sJozUmIqgQgJ8o7juGLce97rycNcSzK27C0cXsa5q1hmsgNr7BSqoOxQTZZWSIS9J1TfNUAzarZK+qtmaSAAArUlQs-XWecDYHACibYKZsooW0RFbYYNtMymAdnJUIN08G+i-lVE+vtvz+1LOXNCoQMLhxLkuKOmAY5nCrgnbSyc6JoiXOneAhDSzZykLnBUWpwJFzodhMuQcK7nTImwmuKcbJMlYPdLuB43TWibqwFuWMqQQHMKvJR9cYCN3Fp+X8ZJW6InbvwcoFp-hAhBGCFAkJNCwnhIiZEqj3wnn7l1DQphl6jzOOPSebkPJZQXlFJeWVe5r3rhoTeSod570iCDSIx8fZnykCaXRCpzAlR0d0fR55zHfgyafd4UgL7AJ1tfXYhA75gJAJA0kVIYHEzQG-XYiiyq6Pfg4BpdwoI5KKd2eAwEr5CiOlJfpgy-71JqgARjsAAJjsAAZiAUAA) so you can see how few type assertions I need.