### PR TITLE
feat: add .editorconfig to root of repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.txt]
+indent_style = tab


### PR DESCRIPTION
This should fix issues with tools being unaware that .txt data files have tab indents.

ASH and JS scripts are inconsistent with regards to tabs / spaces. The * default could instead be *.java.

Ref #2266, #2272.