### PR TITLE
Fix typo in aprilband command usage

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/command/AprilBandCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AprilBandCommand.java
@@ -13,7 +13,7 @@ import net.sourceforge.kolmafia.session.InventoryManager;
 public class AprilBandCommand extends AbstractCommand {
   public AprilBandCommand() {
     this.usage =
-        "effect [nc|c|drop] | item [instrument] | play [instrument] - participate in the apriling band";
+        " effect [nc|c|drop] | item [instrument] | play [instrument] - participate in the apriling band";
   }
 
   private boolean lacksHelmet() {


### PR DESCRIPTION
The usage string as is makes the help print out as
`aprilbandeffect [nc|c|drop] | item [instrument] | play [instrument] - participate in the apriling band`