### PR TITLE
fix: cook / mix items are affected by food / booze drops

### DIFF
--- a/src/net/sourceforge/kolmafia/AreaCombatData.java
+++ b/src/net/sourceforge/kolmafia/AreaCombatData.java
@@ -1013,9 +1013,9 @@ public class AreaCombatData {
       int itemId = drop.item().getItemId();
       double itemBonus = 0.0;
 
-      if (ItemDatabase.isFood(itemId)) {
+      if (ItemDatabase.isFood(itemId) || ItemDatabase.isCookable(itemId)) {
         itemBonus += KoLCharacter.currentNumericModifier(DoubleModifier.FOODDROP) / 100.0;
-      } else if (ItemDatabase.isBooze(itemId)) {
+      } else if (ItemDatabase.isBooze(itemId) || ItemDatabase.isMixable(itemId)) {
         itemBonus += KoLCharacter.currentNumericModifier(DoubleModifier.BOOZEDROP) / 100.0;
       } else if (ItemDatabase.isCandyItem(itemId)) {
         itemBonus += KoLCharacter.currentNumericModifier(DoubleModifier.CANDYDROP) / 100.0;

--- a/src/net/sourceforge/kolmafia/objectpool/EffectPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/EffectPool.java
@@ -271,6 +271,7 @@ public class EffectPool {
   public static final int MUFFLED = 1546;
   public static final int BORED_WITH_EXPLOSIONS = 1557;
   public static final int SOME_PIGS = 1640;
+  public static final int INFERNAL_THIRST = 1702;
   public static final int CONFIDENCE = 1791;
   public static final int PURR_OF_THE_FELINE = 1800;
   public static final int TAUNT_OF_HORUS = 1812;
@@ -363,6 +364,7 @@ public class EffectPool {
   public static final int LUCKY = 2693;
   public static final int ON_THE_TRAIL = 2694;
   public static final int BUZZED_ON_DISTILLATE = 2720;
+  public static final int WHET_APPETITE = 2724;
   public static final int PING_PONG_PROWESS = 2768;
   public static final int PING_PONG_PERSISTENCE = 2769;
   public static final int SHADOW_AFFINITY = 2802;

--- a/test/net/sourceforge/kolmafia/AreaCombatDataTest.java
+++ b/test/net/sourceforge/kolmafia/AreaCombatDataTest.java
@@ -823,6 +823,30 @@ public class AreaCombatDataTest {
         assertThat(data, containsString("empty greasepaint tube (bounty)"));
       }
     }
+
+    @Test
+    void cookingIngredientsAreAffectedByFoodDrops() {
+      var cleanups = withEffect(EffectPool.WHET_APPETITE);
+
+      try (cleanups) {
+        var lab = AdventureDatabase.getAreaCombatData("Cobb's Knob Laboratory");
+
+        var data = lab.toString(true);
+        assertThat(data, containsString("scrumptious reagent 50%"));
+      }
+    }
+
+    @Test
+    void mixingIngredientsAreAffectedByBoozeDrops() {
+      var cleanups = withEffect(EffectPool.INFERNAL_THIRST);
+
+      try (cleanups) {
+        var iceHotel = AdventureDatabase.getAreaCombatData("The Ice Hotel");
+
+        var data = iceHotel.toString(true);
+        assertThat(data, containsString("perfect ice cube 90%"));
+      }
+    }
   }
 
   @Nested


### PR DESCRIPTION
As reported in https://kolmafia.us/threads/booze-not-recognized-on-booze-ingredients.29694/.