### PR TITLE
Let runtime library functions ambiguate their parameter names

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -192,6 +192,8 @@ import net.sourceforge.kolmafia.textui.parsetree.RecordType;
 import net.sourceforge.kolmafia.textui.parsetree.RecordValue;
 import net.sourceforge.kolmafia.textui.parsetree.Type;
 import net.sourceforge.kolmafia.textui.parsetree.Value;
+import net.sourceforge.kolmafia.textui.parsetree.Variable;
+import net.sourceforge.kolmafia.textui.parsetree.VariableReference;
 import net.sourceforge.kolmafia.utilities.CharacterEntities;
 import net.sourceforge.kolmafia.utilities.ChoiceUtilities;
 import net.sourceforge.kolmafia.utilities.FileUtilities;
@@ -330,8 +332,13 @@ public abstract class RuntimeLibrary {
     return RuntimeLibrary.functions;
   }
 
+  private static VariableReference namedParam(String name, Type type) {
+    return new VariableReference(null, new Variable(name, type, null));
+  }
+
   static {
     Type[] params;
+    List<VariableReference> namedParams;
 
     // Basic utility functions which print information
     // or allow for easy testing.
@@ -820,32 +827,56 @@ public abstract class RuntimeLibrary {
     params = new Type[] {DataTypes.ITEM_TYPE};
     functions.add(new LibraryFunction("buy", DataTypes.BOOLEAN_TYPE, params));
 
-    params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.INT_TYPE};
-    functions.add(new LibraryFunction("buy", DataTypes.BOOLEAN_TYPE, params));
+    namedParams =
+        List.of(
+            namedParam("item", DataTypes.ITEM_TYPE), namedParam("quantity", DataTypes.INT_TYPE));
+    functions.add(new LibraryFunction("buy", DataTypes.BOOLEAN_TYPE, namedParams));
 
-    params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.INT_TYPE, DataTypes.INT_TYPE};
-    functions.add(new LibraryFunction("buy", DataTypes.INT_TYPE, params));
+    namedParams =
+        List.of(
+            namedParam("item", DataTypes.ITEM_TYPE),
+            namedParam("quantity", DataTypes.INT_TYPE),
+            namedParam("price", DataTypes.INT_TYPE));
+    functions.add(new LibraryFunction("buy", DataTypes.INT_TYPE, namedParams));
 
-    params = new Type[] {DataTypes.INT_TYPE, DataTypes.ITEM_TYPE};
-    functions.add(new LibraryFunction("buy", DataTypes.BOOLEAN_TYPE, params));
+    namedParams =
+        List.of(
+            namedParam("quantity", DataTypes.INT_TYPE), namedParam("item", DataTypes.ITEM_TYPE));
+    functions.add(new LibraryFunction("buy", DataTypes.BOOLEAN_TYPE, namedParams));
 
-    params = new Type[] {DataTypes.INT_TYPE, DataTypes.ITEM_TYPE, DataTypes.INT_TYPE};
-    functions.add(new LibraryFunction("buy", DataTypes.INT_TYPE, params));
+    namedParams =
+        List.of(
+            namedParam("quantity", DataTypes.INT_TYPE),
+            namedParam("item", DataTypes.ITEM_TYPE),
+            namedParam("price", DataTypes.INT_TYPE));
+    functions.add(new LibraryFunction("buy", DataTypes.INT_TYPE, namedParams));
 
     params = new Type[] {DataTypes.ITEM_TYPE};
     functions.add(new LibraryFunction("buy_using_storage", DataTypes.BOOLEAN_TYPE, params));
 
-    params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.INT_TYPE};
-    functions.add(new LibraryFunction("buy_using_storage", DataTypes.BOOLEAN_TYPE, params));
+    namedParams =
+        List.of(
+            namedParam("item", DataTypes.ITEM_TYPE), namedParam("quantity", DataTypes.INT_TYPE));
+    functions.add(new LibraryFunction("buy_using_storage", DataTypes.BOOLEAN_TYPE, namedParams));
 
-    params = new Type[] {DataTypes.ITEM_TYPE, DataTypes.INT_TYPE, DataTypes.INT_TYPE};
-    functions.add(new LibraryFunction("buy_using_storage", DataTypes.INT_TYPE, params));
+    namedParams =
+        List.of(
+            namedParam("item", DataTypes.ITEM_TYPE),
+            namedParam("quantity", DataTypes.INT_TYPE),
+            namedParam("price", DataTypes.INT_TYPE));
+    functions.add(new LibraryFunction("buy_using_storage", DataTypes.INT_TYPE, namedParams));
 
-    params = new Type[] {DataTypes.INT_TYPE, DataTypes.ITEM_TYPE};
-    functions.add(new LibraryFunction("buy_using_storage", DataTypes.BOOLEAN_TYPE, params));
+    namedParams =
+        List.of(
+            namedParam("quantity", DataTypes.INT_TYPE), namedParam("item", DataTypes.ITEM_TYPE));
+    functions.add(new LibraryFunction("buy_using_storage", DataTypes.BOOLEAN_TYPE, namedParams));
 
-    params = new Type[] {DataTypes.INT_TYPE, DataTypes.ITEM_TYPE, DataTypes.INT_TYPE};
-    functions.add(new LibraryFunction("buy_using_storage", DataTypes.INT_TYPE, params));
+    namedParams =
+        List.of(
+            namedParam("quantity", DataTypes.INT_TYPE),
+            namedParam("item", DataTypes.ITEM_TYPE),
+            namedParam("price", DataTypes.INT_TYPE));
+    functions.add(new LibraryFunction("buy_using_storage", DataTypes.INT_TYPE, namedParams));
 
     params = new Type[] {DataTypes.COINMASTER_TYPE};
     functions.add(new LibraryFunction("is_accessible", DataTypes.BOOLEAN_TYPE, params));
@@ -856,8 +887,12 @@ public abstract class RuntimeLibrary {
     params = new Type[] {DataTypes.COINMASTER_TYPE};
     functions.add(new LibraryFunction("visit", DataTypes.BOOLEAN_TYPE, params));
 
-    params = new Type[] {DataTypes.COINMASTER_TYPE, DataTypes.INT_TYPE, DataTypes.ITEM_TYPE};
-    functions.add(new LibraryFunction("buy", DataTypes.BOOLEAN_TYPE, params));
+    namedParams =
+        List.of(
+            namedParam("coinmaster", DataTypes.COINMASTER_TYPE),
+            namedParam("quantity", DataTypes.INT_TYPE),
+            namedParam("item", DataTypes.ITEM_TYPE));
+    functions.add(new LibraryFunction("buy", DataTypes.BOOLEAN_TYPE, namedParams));
 
     params = new Type[] {DataTypes.COINMASTER_TYPE, DataTypes.INT_TYPE, DataTypes.ITEM_TYPE};
     functions.add(new LibraryFunction("sell", DataTypes.BOOLEAN_TYPE, params));
@@ -1701,11 +1736,11 @@ public abstract class RuntimeLibrary {
 
     // Equipment functions.
 
-    params = new Type[] {DataTypes.ITEM_TYPE};
-    functions.add(new LibraryFunction("can_equip", DataTypes.BOOLEAN_TYPE, params));
+    namedParams = List.of(namedParam("equipment", DataTypes.ITEM_TYPE));
+    functions.add(new LibraryFunction("can_equip", DataTypes.BOOLEAN_TYPE, namedParams));
 
-    params = new Type[] {DataTypes.FAMILIAR_TYPE};
-    functions.add(new LibraryFunction("can_equip", DataTypes.BOOLEAN_TYPE, params));
+    namedParams = List.of(namedParam("familiar", DataTypes.FAMILIAR_TYPE));
+    functions.add(new LibraryFunction("can_equip", DataTypes.BOOLEAN_TYPE, namedParams));
 
     params = new Type[] {DataTypes.FAMILIAR_TYPE, DataTypes.ITEM_TYPE};
     functions.add(new LibraryFunction("can_equip", DataTypes.BOOLEAN_TYPE, params));

--- a/src/net/sourceforge/kolmafia/textui/TypescriptDefinition.java
+++ b/src/net/sourceforge/kolmafia/textui/TypescriptDefinition.java
@@ -36,21 +36,6 @@ public class TypescriptDefinition {
   private static final String combatFilterType =
       "string | ((round: number, monster: Monster, text: string) => string)";
 
-  private static final Map<String, List<String>> descriptiveParamNames =
-      Map.ofEntries(
-          Map.entry("canEquip[Item]", List.of("equipment")),
-          Map.entry("canEquip[Familiar]", List.of("familiar")),
-          Map.entry("canEquip[Familiar, Item]", List.of("familiar", "equipment")),
-          Map.entry("buy[Item,number]", List.of("item", "quantity")),
-          Map.entry("buy[Item,number,number]", List.of("item", "quantity", "price")),
-          Map.entry("buy[number,Item,number]", List.of("quantity", "item", "price")),
-          Map.entry("buy[number,Item]", List.of("quantity", "item")),
-          Map.entry("buy[Coinmaster,number,Item]", List.of("coinmaster", "quantity", "item")),
-          Map.entry("buyUsingStorage[Item,number]", List.of("item", "quantity")),
-          Map.entry("buyUsingStorage[Item,number,number]", List.of("item", "quantity", "price")),
-          Map.entry("buyUsingStorage[number,Item,number]", List.of("quantity", "item", "price")),
-          Map.entry("buyUsingStorage[number,Item]", List.of("quantity", "item")));
-
   private static final Map<String, String> descriptiveFieldTypes =
       Map.ofEntries(
           Map.entry("Bounty.location", "Location"),
@@ -135,8 +120,7 @@ public class TypescriptDefinition {
     var name = JavascriptRuntime.toCamelCase(f.getName());
     var type = getReturnType(f);
     var paramTypes = getParamTypes(f);
-    var overrideKey = String.format("%s[%s]", name, String.join(",", paramTypes));
-    var paramNames = descriptiveParamNames.getOrDefault(overrideKey, f.getParameterNames());
+    var paramNames = f.getParameterNames();
     var variadicParams = getVariadicParams(f);
 
     var params =


### PR DESCRIPTION
This commit is part of #2284, but given that it affects not only the Javascript system, I've decided to pull it out into a separate PR.

---

In cases where a runtime library function has multiple overloads with the same arity, the parameter names cannot be nicely resolved from the implementation function, because they have different meaning depending on the selected type signature.
Instead of hardcoding this in TypescriptDefinition, let function definition include parameter names where this makes sense.

Unfortunately, this requires some extra pass-through constructors in LibraryFunction. At least one of them can resolved once we switch to JDK22 and statements before the this() call are allowed.

These parameter names will also show up in ashref/jsref, but unfortunately the reflection-based parameter names don't show up, because KoLmafia is only compiled with the required `-parameters` switch for tests and tsDef (see [build.gradle#L285-L289](https://github.com/kolmafia/kolmafia/blob/83c9e15ddf56c478778399086b489294ef513fce/build.gradle#L285-L289)). Is there a good reason not to enable this generally?