### PR TITLE
Export each function separately to ease automocking

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/TypescriptDefinition.java
+++ b/src/net/sourceforge/kolmafia/textui/TypescriptDefinition.java
@@ -155,7 +155,11 @@ public class TypescriptDefinition {
     return getFunctions()
         .map(Symbol::getName)
         .distinct()
-        .map(f -> String.format("module.exports.%s = warn;", JavascriptRuntime.toCamelCase(f)))
+        .map(
+            f ->
+                String.format(
+                    "module.exports.%1$s = function %1$s() { throw new Error(`Cannot access the KoLmafia standard library from a normal JavaScript context.`); };",
+                    JavascriptRuntime.toCamelCase(f)))
         .toList();
   }
 
@@ -368,9 +372,7 @@ public class TypescriptDefinition {
 
   public static String getHeaderFileContents() {
     return Stream.of(
-            List.of(
-                "const warn = () => { throw new Error(`Cannot access the KoLmafia standard library from a normal JavaScript context.`); }",
-                "module.exports.sessionStorage = {};"),
+            List.of("module.exports.sessionStorage = {};"),
             getFunctionHeaders(),
             getMafiaClassHeaders())
         .flatMap(Collection::stream)


### PR DESCRIPTION
Alongside typescript definitions we create a header file that will be imported when someone tries to load the kolmafia typescript library outside of KoLmafia. Each function simply throws an error.

So far, a single function was exported under all function names. This prevents a feature employed by some testing libaries called automocking, where each function is automatically replaced with a mocked version, because all functions then reference the same mock. Instead, export a separate function for each library function, and use named function syntax to ensure the function objects have a name.