### PR TITLE
Represent JS undefined as void, not string

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/javascript/AshStub.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/AshStub.java
@@ -17,6 +17,7 @@ import org.mozilla.javascript.BaseFunction;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.NativeJavaObject;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.Undefined;
 
 public abstract class AshStub extends BaseFunction {
   private static final long serialVersionUID = 1L;
@@ -84,6 +85,9 @@ public abstract class AshStub extends BaseFunction {
     // to force a match. This is mainly relevant for empty arrays and records.
     List<Value> ashArgs = new ArrayList<>();
     for (final Object original : args) {
+      if (Undefined.isUndefined(original)) {
+        throw controller.runtimeException("Passing undefined to an ASH function is not supported.");
+      }
       Value coerced = coercer.fromJava(original);
       if (coerced == null
           || (coerced.getType() instanceof AggregateType agg

--- a/src/net/sourceforge/kolmafia/textui/javascript/ValueConverter.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/ValueConverter.java
@@ -23,8 +23,22 @@ import org.mozilla.javascript.NativeArray;
 import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.Undefined;
 
 public class ValueConverter {
+  /* This is the closest thing that we have to undefined in our Value type system. Since javascript
+   * void functions return undefined, and we currently don't support undefined values as parameters,
+   * this is good enough for now.
+   */
+  private static final Type UNDEFINED_TYPE = new Type("undefined", TypeSpec.VOID);
+  private static final Value UNDEFINED =
+      new Value(UNDEFINED_TYPE) {
+        @Override
+        public String toString() {
+          return "undefined";
+        }
+      };
+
   private final Context cx;
   private final Scriptable scope;
 
@@ -217,6 +231,8 @@ public class ValueConverter {
       return convertNativeArray((NativeArray) object, typeHint);
     } else if (object instanceof Value) {
       return (Value) object;
+    } else if (Undefined.isUndefined(object)) {
+      return UNDEFINED;
     } else {
       return DataTypes.makeStringValue(object.toString());
     }

--- a/test/net/sourceforge/kolmafia/textui/command/JavaScriptCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/JavaScriptCommandTest.java
@@ -26,7 +26,7 @@ public class JavaScriptCommandTest extends AbstractCommandTestBase {
     public void printsUndefined() {
       String output = execute("undefined");
 
-      assertThat(output, startsWith("Returned: org.mozilla.javascript.Undefined"));
+      assertThat(output, startsWith("Returned: undefined"));
     }
 
     @Test


### PR DESCRIPTION
Currently, JS `undefined` is silently converted into a string representation of Rhino's Undefined instance.
This can in theory lead to wrong function invocations if the target type is a string.

Instead, return a special undefined value with a special undefined VOID type. This prints as undefined in the console, to make it transparent what is going on.
Other than that, it behaves as void. This is consistent with JS methods returning `undefined` if no value was returned, and TypeScript void methods returning `undefined`.

To prevent any confusion, forbid undefined values from being passed to Ash functions (for now).