### PR TITLE
Check Standard restrictions for AdventureResults by the item's dataName

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -47,7 +47,6 @@ import net.sourceforge.kolmafia.request.PyramidRequest;
 import net.sourceforge.kolmafia.request.QuestLogRequest;
 import net.sourceforge.kolmafia.request.RichardRequest;
 import net.sourceforge.kolmafia.request.SpelunkyRequest;
-import net.sourceforge.kolmafia.request.StandardRequest;
 import net.sourceforge.kolmafia.request.TavernRequest;
 import net.sourceforge.kolmafia.request.UntinkerRequest;
 import net.sourceforge.kolmafia.request.UseItemRequest;
@@ -734,9 +733,7 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
     // Some zones/areas are available via items.
     AdventureResult item = AdventureDatabase.zoneGeneratingItem(this.zone);
     // If it is from an item, Standard restrictions may apply.
-    if (item != null
-        && KoLCharacter.getRestricted()
-        && !StandardRequest.isAllowed(RestrictedItemType.ITEMS, item.getName())) {
+    if (item != null && KoLCharacter.getRestricted() && !ItemDatabase.isAllowed(item)) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/maximizer/CheckedItem.java
+++ b/src/net/sourceforge/kolmafia/maximizer/CheckedItem.java
@@ -4,7 +4,6 @@ import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLmafia;
-import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.ConcoctionPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -14,7 +13,6 @@ import net.sourceforge.kolmafia.persistence.MallPriceDatabase;
 import net.sourceforge.kolmafia.persistence.NPCStoreDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.MrStoreRequest;
-import net.sourceforge.kolmafia.request.StandardRequest;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.session.MallPriceManager;
 
@@ -101,7 +99,7 @@ public class CheckedItem extends AdventureResult {
       return;
     }
 
-    if (!StandardRequest.isAllowed(RestrictedItemType.ITEMS, itemName)) {
+    if (!ItemDatabase.isAllowed(this)) {
       // Unallowed items can't be bought or pulled, though the original code
       // just reset everything to zero
 

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -1281,7 +1281,7 @@ public class Maximizer {
             continue;
           }
 
-          if (!StandardRequest.isAllowed(RestrictedItemType.ITEMS, iname)) {
+          if (!ItemDatabase.isAllowed(item)) {
             continue;
           }
 

--- a/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
@@ -1332,7 +1332,7 @@ public class ConcoctionDatabase {
           && ar.getItemId() > 0
           && item.getPrice() <= 0
           && ConsumablesDatabase.meetsLevelRequirement(item.getName())
-          && StandardRequest.isAllowed(RestrictedItemType.ITEMS, ar.getName())) {
+          && ItemDatabase.isAllowed(ar)) {
         item.setPullable(
             Math.min(
                 ar.getCount(KoLConstants.storage) - item.queuedPulls,

--- a/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
@@ -2423,6 +2423,10 @@ public class ItemDatabase {
     };
   }
 
+  public static boolean isAllowed(final AdventureResult ar) {
+    return ItemDatabase.isAllowed(ar.getItemId());
+  }
+
   public static boolean isAllowed(final int itemId) {
     return StandardRequest.isAllowed(RestrictedItemType.ITEMS, ItemDatabase.getDataName(itemId));
   }

--- a/src/net/sourceforge/kolmafia/session/BreakfastManager.java
+++ b/src/net/sourceforge/kolmafia/session/BreakfastManager.java
@@ -874,7 +874,7 @@ public class BreakfastManager {
     AdventureResult plant = ItemPool.get("potted power plant", 1);
 
     if (!InventoryManager.hasItem(plant)
-        || !StandardRequest.isAllowed(RestrictedItemType.ITEMS, plant.getName())
+        || !ItemDatabase.isAllowed(plant)
         || KoLCharacter.inGLover()) {
       return;
     }
@@ -914,7 +914,7 @@ public class BreakfastManager {
     AdventureResult book = ItemPool.get(ItemPool.THE_BIG_BOOK_OF_EVERY_SKILL, 1);
 
     if (!InventoryManager.hasItem(book)
-        || !StandardRequest.isAllowed(RestrictedItemType.ITEMS, book.getName())
+        || !ItemDatabase.isAllowed(book)
         || KoLCharacter.inBeecore()) {
       return;
     }

--- a/src/net/sourceforge/kolmafia/session/InventoryManager.java
+++ b/src/net/sourceforge/kolmafia/session/InventoryManager.java
@@ -20,7 +20,6 @@ import net.sourceforge.kolmafia.KoLmafiaCLI;
 import net.sourceforge.kolmafia.ModifierType;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
-import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.SpecialOutfit.Checkpoint;
 import net.sourceforge.kolmafia.equipment.Slot;
 import net.sourceforge.kolmafia.equipment.SlotSet;
@@ -53,7 +52,6 @@ import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.request.HermitRequest;
 import net.sourceforge.kolmafia.request.PurchaseRequest;
 import net.sourceforge.kolmafia.request.SewerRequest;
-import net.sourceforge.kolmafia.request.StandardRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
 import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.request.UntinkerRequest;
@@ -195,7 +193,7 @@ public abstract class InventoryManager {
     }
 
     // If this item is restricted, ignore it entirely.
-    if (!StandardRequest.isAllowed(RestrictedItemType.ITEMS, item.getName())) {
+    if (!ItemDatabase.isAllowed(item)) {
       return 0;
     }
 
@@ -572,7 +570,7 @@ public abstract class InventoryManager {
       return item.getCount(KoLConstants.inventory) > 0 ? "" : null;
     }
 
-    boolean isRestricted = !StandardRequest.isAllowed(RestrictedItemType.ITEMS, item.getName());
+    boolean isRestricted = !ItemDatabase.isAllowed(item);
     CraftingType mixingMethod = ConcoctionDatabase.getMixingMethod(item);
     boolean coinmasterCreation = mixingMethod == CraftingType.COINMASTER;
     boolean shouldUseCoinmasters = InventoryManager.canUseCoinmasters(itemId);
@@ -1587,7 +1585,7 @@ public abstract class InventoryManager {
 
     // The Crown of Thrones is not trendy, but double check anyway
     AdventureResult item = InventoryManager.CROWN_OF_THRONES;
-    if (!StandardRequest.isAllowed(RestrictedItemType.ITEMS, item.getName())) {
+    if (!ItemDatabase.isAllowed(item)) {
       return;
     }
 
@@ -1612,7 +1610,7 @@ public abstract class InventoryManager {
 
     // Check if the Buddy Bjorn is Trendy
     AdventureResult item = InventoryManager.BUDDY_BJORN;
-    if (!StandardRequest.isAllowed(RestrictedItemType.ITEMS, item.getName())) {
+    if (!ItemDatabase.isAllowed(item)) {
       return;
     }
 

--- a/src/net/sourceforge/kolmafia/swingui/ItemManageFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/ItemManageFrame.java
@@ -26,7 +26,6 @@ import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestThread;
-import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.listener.Listener;
 import net.sourceforge.kolmafia.listener.NamedListenerRegistry;
 import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
@@ -37,7 +36,6 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.ClosetRequest;
 import net.sourceforge.kolmafia.request.ClosetRequest.ClosetRequestType;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
-import net.sourceforge.kolmafia.request.StandardRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
 import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.session.StoreManager;
@@ -502,8 +500,7 @@ public class ItemManageFrame extends GenericFrame {
       if (KoLCharacter.isTrendy() || KoLCharacter.getRestricted()) {
         for (int i = 0; i < items.length; ++i) {
           AdventureResult item = items[i];
-          String itemName = item.getName();
-          if (!StandardRequest.isAllowed(RestrictedItemType.ITEMS, itemName)) {
+          if (!ItemDatabase.isAllowed(item)) {
             items[i] = null;
           }
         }

--- a/src/net/sourceforge/kolmafia/swingui/panel/ItemManagePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/ItemManagePanel.java
@@ -19,7 +19,6 @@ import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.Modifiers;
 import net.sourceforge.kolmafia.RequestThread;
-import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -39,7 +38,6 @@ import net.sourceforge.kolmafia.request.DisplayCaseRequest;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.ManageStoreRequest;
 import net.sourceforge.kolmafia.request.PulverizeRequest;
-import net.sourceforge.kolmafia.request.StandardRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
 import net.sourceforge.kolmafia.request.UseItemRequest;
 import net.sourceforge.kolmafia.session.EquipmentManager;
@@ -840,16 +838,16 @@ public abstract class ItemManagePanel<E, S extends JComponent> extends Scrollabl
         }
       }
 
-      if (isVisibleWithFilter && !StandardRequest.isAllowed(RestrictedItemType.ITEMS, name)) {
+      if (itemId < 1) {
+        return ItemManagePanel.this.filters == null && super.isVisible(element);
+      }
+
+      if (isVisibleWithFilter && !ItemDatabase.isAllowed(itemId)) {
         isVisibleWithFilter = !FilterItemField.this.instyle;
       }
 
       if (!isVisibleWithFilter) {
         return false;
-      }
-
-      if (itemId < 1) {
-        return ItemManagePanel.this.filters == null && super.isVisible(element);
       }
 
       if (!FilterItemField.this.notrade && !ItemDatabase.isTradeable(itemId)) {

--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
@@ -612,8 +612,7 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
 
       if (item != null) {
         // Apparently, Cafe items are allowed, whether or not they are in Standard
-        if (creation.getPrice() <= 0
-            && !StandardRequest.isAllowed(RestrictedItemType.ITEMS, item.getDataName())) {
+        if (creation.getPrice() <= 0 && !ItemDatabase.isAllowed(item)) {
           return false;
         }
 

--- a/src/net/sourceforge/kolmafia/textui/command/StorageCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/StorageCommand.java
@@ -8,11 +8,10 @@ import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestThread;
-import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.SpecialOutfit;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
+import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.ItemFinder;
-import net.sourceforge.kolmafia.request.StandardRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
 import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
 import net.sourceforge.kolmafia.session.EquipmentManager;
@@ -178,7 +177,7 @@ public class StorageCommand extends AbstractCommand {
         items[i] = item.getInstance(storageCount);
       }
 
-      if (!StandardRequest.isAllowed(RestrictedItemType.ITEMS, itemName)) {
+      if (!ItemDatabase.isAllowed(item)) {
         KoLmafia.updateDisplay(itemName + " is not allowed right now.");
         items[i] = null;
       }

--- a/test/internal/helpers/Maximizer.java
+++ b/test/internal/helpers/Maximizer.java
@@ -1,6 +1,7 @@
 package internal.helpers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.EnumSet;
@@ -34,6 +35,12 @@ public class Maximizer {
         PriceLevel.DONT_CHECK,
         false,
         EnumSet.allOf(filterType.class));
+  }
+
+  public static void maximizeAny(String maximizerString) {
+    MaximizerFrame.expressionSelect.setSelectedItem(maximizerString);
+    net.sourceforge.kolmafia.maximizer.Maximizer.maximize(
+        EquipScope.SPECULATE_ANY, 0, PriceLevel.DONT_CHECK, false, EnumSet.allOf(filterType.class));
   }
 
   public static double modFor(Modifier modifier) {
@@ -80,9 +87,20 @@ public class Maximizer {
     Optional<Boost> found =
         getBoosts().stream()
             .filter(Boost::isEquipment)
+            .filter(b -> b.getItem() != null)
             .filter(b -> (itemId == b.getItem().getItemId()))
             .findAny();
     assertTrue(found.isPresent(), "Expected " + itemId + " to be recommended, but it was not");
+  }
+
+  public static void doesNotRecommend(int itemId) {
+    Optional<Boost> found =
+        getBoosts().stream()
+            .filter(Boost::isEquipment)
+            .filter(b -> b.getItem() != null)
+            .filter(b -> (itemId == b.getItem().getItemId()))
+            .findAny();
+    assertFalse(found.isPresent(), "Expected " + itemId + " to not be recommended, but it was");
   }
 
   public static boolean someBoostIs(Predicate<Boost> predicate) {

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -1,9 +1,11 @@
 package net.sourceforge.kolmafia.maximizer;
 
 import static internal.helpers.Maximizer.commandStartsWith;
+import static internal.helpers.Maximizer.doesNotRecommend;
 import static internal.helpers.Maximizer.getBoosts;
 import static internal.helpers.Maximizer.getSlot;
 import static internal.helpers.Maximizer.maximize;
+import static internal.helpers.Maximizer.maximizeAny;
 import static internal.helpers.Maximizer.modFor;
 import static internal.helpers.Maximizer.recommendedSlotIs;
 import static internal.helpers.Maximizer.recommendedSlotIsUnchanged;
@@ -18,6 +20,7 @@ import static internal.helpers.Player.withEquipped;
 import static internal.helpers.Player.withFamiliar;
 import static internal.helpers.Player.withFamiliarInTerrarium;
 import static internal.helpers.Player.withItem;
+import static internal.helpers.Player.withItemInStorage;
 import static internal.helpers.Player.withLocation;
 import static internal.helpers.Player.withMeat;
 import static internal.helpers.Player.withNotAllowedInStandard;
@@ -1247,6 +1250,32 @@ public class MaximizerTest {
         assertTrue(maximize("meat -acc1 -acc2"));
         recommendedSlotIs(Slot.ACCESSORY3, "backup camera");
         assertTrue(someBoostIs(x -> commandStartsWith(x, "backupcamera meat")));
+      }
+    }
+
+    @Test
+    public void shouldSuggestPullableCameraIfNotRestricted() {
+      final var cleanups =
+          new Cleanups(withItemInStorage("backup camera"), withProperty("backupCameraMode", "ml"));
+      try (cleanups) {
+        maximizeAny("meat");
+        recommends(ItemPool.BACKUP_CAMERA);
+        assertTrue(someBoostIs(x -> commandStartsWith(x, "pull")));
+      }
+    }
+
+    @Test
+    public void shouldNotSuggestPullableCameraIfRestricted() {
+      final var cleanups =
+          new Cleanups(
+              withItemInStorage("backup camera"),
+              withProperty("backupCameraMode", "ml"),
+              withRestricted(true),
+              withNotAllowedInStandard(RestrictedItemType.ITEMS, "backup camera"));
+
+      try (cleanups) {
+        maximizeAny("meat");
+        doesNotRecommend(ItemPool.BACKUP_CAMERA);
       }
     }
 


### PR DESCRIPTION
You have to look up Standard restrictions using a String.
For items, that is the item's dataName.
We have many instances of using a constant item name. That works.

However, we have a number of instances where we have an AdventureResult and use the  "name" field - which is not fine for Modeables like the backup camera, Jurassic Parka, or unbreakeable umbrella, where KoLmafia's name includes the mode, for user convenience.

ItemDatabase has an "isAllowed" method which accepts an itemId and looks up the dataName to pass to StandardRequest.

I added an "isAllowed" method which accepts an AdventureResult, extracts the itemId, and calls that method.
I changed all places which extract the name from an AdventureResult to call isAllowed to simply call the new method.

Net result:

- ItemManager no longer shows the backup camera in Storage if you are in a Standard Run
- Maximizer no longer suggests pulling the backup camera if you are in a Standard run.