### PR TITLE
UseItemEnqueuePanel can queue items with itemId < 0

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
@@ -2428,7 +2428,8 @@ public class ItemDatabase {
   }
 
   public static boolean isAllowed(final int itemId) {
-    return StandardRequest.isAllowed(RestrictedItemType.ITEMS, ItemDatabase.getDataName(itemId));
+    return itemId < 1
+        || StandardRequest.isAllowed(RestrictedItemType.ITEMS, ItemDatabase.getDataName(itemId));
   }
 
   public static boolean isAllowedInStandard(final int itemId) {


### PR DESCRIPTION
... which means they have no dataName and cannot be Standard restricted.