### PR TITLE
Improve (vararg) function matching

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/javascript/AshStub.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/AshStub.java
@@ -62,9 +62,7 @@ public abstract class AshStub extends BaseFunction {
           }
         }
 
-        // Check for match with no vararg, then match with vararg.
-        if (testFunction.paramsMatch(coercedArgs, matchType, /* vararg= */ false)
-            || testFunction.paramsMatch(coercedArgs, matchType, /* vararg= */ true)) {
+        if (testFunction.paramsMatch(coercedArgs, matchType)) {
           return testFunction;
         }
       }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/BasicScope.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/BasicScope.java
@@ -144,42 +144,24 @@ public abstract class BasicScope extends Command {
     Function result = null;
 
     if (matchType == MatchType.ANY || matchType == MatchType.EXACT) {
-      // Exact, no vararg
-      result = this.findFunction(functions, name, params, MatchType.EXACT, false);
-      if (result != null) {
-        return result;
-      }
-
-      // Exact, vararg
-      result = this.findFunction(functions, name, params, MatchType.EXACT, true);
+      // Exact
+      result = this.findFunction(functions, name, params, MatchType.EXACT);
       if (result != null) {
         return result;
       }
     }
 
     if (matchType == MatchType.ANY || matchType == MatchType.BASE) {
-      // Base, no vararg
-      result = this.findFunction(functions, name, params, MatchType.BASE, false);
-      if (result != null) {
-        return result;
-      }
-
-      // Base, vararg
-      result = this.findFunction(functions, name, params, MatchType.BASE, true);
+      // Base
+      result = this.findFunction(functions, name, params, MatchType.BASE);
       if (result != null) {
         return result;
       }
     }
 
     if (matchType == MatchType.ANY || matchType == MatchType.COERCE) {
-      // Coerce, no vararg
-      result = this.findFunction(functions, name, params, MatchType.COERCE, false);
-      if (result != null) {
-        return result;
-      }
-
-      // Coerce, vararg
-      result = this.findFunction(functions, name, params, MatchType.COERCE, true);
+      // Coerce
+      result = this.findFunction(functions, name, params, MatchType.COERCE);
       if (result != null) {
         return result;
       }
@@ -192,11 +174,10 @@ public abstract class BasicScope extends Command {
       final Function[] functions,
       final String name,
       final List<Evaluable> params,
-      final MatchType match,
-      final boolean vararg) {
+      final MatchType match) {
     // Search the function list for a match
     for (Function function : functions) {
-      if (function.paramsMatch(params, match, vararg)) {
+      if (function.paramsMatch(params, match)) {
         return function;
       }
     }
@@ -205,7 +186,7 @@ public abstract class BasicScope extends Command {
     BasicScope parent = this.getParentScope();
     if (parent != null) {
       Function[] parentFunctions = parent.functions.findFunctions(name);
-      return parent.findFunction(parentFunctions, name, params, match, vararg);
+      return parent.findFunction(parentFunctions, name, params, match);
     }
 
     return null;

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
@@ -258,14 +258,18 @@ public abstract class Function extends Symbol {
       }
     }
 
-    if (refIterator.hasNext()) {
-      // If the next parameter is a vararg, this is
-      // allowed if we ran out of parameters.
+    if (vararg == null && refIterator.hasNext()) {
+      // If the next parameter is a vararg, and there was none yet,
+      // this is allowed if we ran out of parameters.
       VariableReference currentParam = refIterator.next();
       Type paramType = currentParam.getType();
 
       if (paramType instanceof VarArgType) {
         vararg = currentParam;
+      } else {
+        // we read the last parameter, but it was not a vararg and we don't
+        // have a value for it, so this is a mismatch
+        return false;
       }
     }
 

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
@@ -264,7 +264,6 @@ public abstract class Function extends Symbol {
 
       if (paramType instanceof VarArgType) {
         vararg = currentParam;
-        matched = true;
       }
     }
 

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
@@ -168,8 +168,12 @@ public abstract class Function extends Symbol {
       VariableReference currentParam = refIterator.next();
       Type paramType = currentParam.getType();
 
-      if (paramType == null || paramType instanceof VarArgType) {
+      if (paramType == null) {
         return false;
+      }
+      if (paramType instanceof VarArgType) {
+        throw new IllegalStateException(
+            "VarArgType should not be present in non-vararg function. This is a bug.");
       }
 
       TypedNode currentValue = valIterator.next();
@@ -265,8 +269,13 @@ public abstract class Function extends Symbol {
       }
     }
 
-    if (vararg == null || refIterator.hasNext() || valIterator.hasNext()) {
+    if (refIterator.hasNext() || valIterator.hasNext()) {
       return false;
+    }
+
+    if (vararg == null) {
+      throw new IllegalStateException(
+          "VarArgType should be present in vararg function. This is a bug.");
     }
 
     return true;

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
@@ -13,6 +13,7 @@ public abstract class Function extends Symbol {
   protected Type type;
   protected List<VariableReference> variableReferences;
   private String signature;
+  private boolean hasVarArg;
 
   public Function(
       final String name,
@@ -21,7 +22,7 @@ public abstract class Function extends Symbol {
       final Location location) {
     super(name, location);
     this.type = type;
-    this.variableReferences = variableReferences;
+    setVariableReferences(variableReferences);
   }
 
   public Function(final String name, final Type type) {
@@ -38,6 +39,7 @@ public abstract class Function extends Symbol {
 
   public void setVariableReferences(final List<VariableReference> variableReferences) {
     this.variableReferences = variableReferences;
+    this.hasVarArg = variableReferences.stream().anyMatch(v -> v.getType() instanceof VarArgType);
   }
 
   public String getSignature() {
@@ -152,9 +154,8 @@ public abstract class Function extends Symbol {
     return false;
   }
 
-  public boolean paramsMatch(
-      final List<? extends TypedNode> params, MatchType match, boolean vararg) {
-    return (vararg)
+  public boolean paramsMatch(final List<? extends TypedNode> params, MatchType match) {
+    return (this.hasVarArg)
         ? this.paramsMatchVararg(params, match)
         : this.paramsMatchNoVararg(params, match);
   }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
@@ -162,15 +162,13 @@ public abstract class Function extends Symbol {
   private boolean paramsMatchNoVararg(final List<? extends TypedNode> params, MatchType match) {
     Iterator<VariableReference> refIterator = this.getVariableReferences().iterator();
     Iterator<? extends TypedNode> valIterator = params.iterator();
-    boolean matched = true;
 
-    while (matched && refIterator.hasNext() && valIterator.hasNext()) {
+    while (refIterator.hasNext() && valIterator.hasNext()) {
       VariableReference currentParam = refIterator.next();
       Type paramType = currentParam.getType();
 
       if (paramType == null || paramType instanceof VarArgType) {
-        matched = false;
-        break;
+        return false;
       }
 
       TypedNode currentValue = valIterator.next();
@@ -179,25 +177,25 @@ public abstract class Function extends Symbol {
       switch (match) {
         case EXACT:
           if (!currentParam.getRawType().equals(currentValue.getRawType())) {
-            matched = false;
+            return false;
           }
           break;
 
         case BASE:
           if (!paramType.equals(valueType)) {
-            matched = false;
+            return false;
           }
           break;
 
         case COERCE:
           if (!Operator.validCoercion(paramType, valueType, "parameter")) {
-            matched = false;
+            return false;
           }
           break;
       }
     }
 
-    if (matched && !refIterator.hasNext() && !valIterator.hasNext()) {
+    if (!refIterator.hasNext() && !valIterator.hasNext()) {
       return true;
     }
     return false;
@@ -206,11 +204,10 @@ public abstract class Function extends Symbol {
   private boolean paramsMatchVararg(final List<? extends TypedNode> params, MatchType match) {
     Iterator<VariableReference> refIterator = this.getVariableReferences().iterator();
     Iterator<? extends TypedNode> valIterator = params.iterator();
-    boolean matched = true;
     VariableReference vararg = null;
     VarArgType varargType = null;
 
-    while (matched && (vararg != null || refIterator.hasNext()) && valIterator.hasNext()) {
+    while ((vararg != null || refIterator.hasNext()) && valIterator.hasNext()) {
       // A VarArg parameter will consume all remaining values
       VariableReference currentParam = (vararg != null) ? vararg : refIterator.next();
       Type paramType = currentParam.getType();
@@ -225,14 +222,13 @@ public abstract class Function extends Symbol {
 
       // Only one vararg is allowed. It must be at the end.
       if (vararg != null && refIterator.hasNext()) {
-        matched = false;
-        break;
+        return false;
       }
 
       switch (match) {
         case EXACT:
           if (!paramType.equals(valueType)) {
-            matched = false;
+            return false;
           }
           break;
 
@@ -241,7 +237,7 @@ public abstract class Function extends Symbol {
             paramType = varargType.getDataType();
           }
           if (!paramType.equals(valueType)) {
-            matched = false;
+            return false;
           }
           break;
 
@@ -250,7 +246,7 @@ public abstract class Function extends Symbol {
             paramType = varargType.getDataType();
           }
           if (!Operator.validCoercion(paramType, valueType, "parameter")) {
-            matched = false;
+            return false;
           }
           break;
       }
@@ -267,7 +263,7 @@ public abstract class Function extends Symbol {
       }
     }
 
-    if (matched && vararg != null && !refIterator.hasNext() && !valIterator.hasNext()) {
+    if (vararg != null && !refIterator.hasNext() && !valIterator.hasNext()) {
       return true;
     }
 

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
@@ -195,10 +195,11 @@ public abstract class Function extends Symbol {
       }
     }
 
-    if (!refIterator.hasNext() && !valIterator.hasNext()) {
-      return true;
+    if (refIterator.hasNext() || valIterator.hasNext()) {
+      return false;
     }
-    return false;
+
+    return true;
   }
 
   private boolean paramsMatchVararg(final List<? extends TypedNode> params, MatchType match) {
@@ -263,11 +264,11 @@ public abstract class Function extends Symbol {
       }
     }
 
-    if (vararg != null && !refIterator.hasNext() && !valIterator.hasNext()) {
-      return true;
+    if (vararg == null || refIterator.hasNext() || valIterator.hasNext()) {
+      return false;
     }
 
-    return false;
+    return true;
   }
 
   public void printDisabledMessage(AshRuntime interpreter) {

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
@@ -98,22 +98,17 @@ public abstract class Function extends Symbol {
   }
 
   public boolean varargsClash(final Function that) {
+    if (!this.hasVarArg || !that.hasVarArg) {
+      return false;
+    }
+
     Iterator<VariableReference> thisIterator = this.getVariableReferences().iterator();
     Iterator<VariableReference> thatIterator = that.getVariableReferences().iterator();
     VariableReference thisVararg = null;
     VariableReference thatVararg = null;
 
     while (thisIterator.hasNext() || thatIterator.hasNext()) {
-      VariableReference thisParam;
-      if (!thisIterator.hasNext()) {
-        // If this function ran out of arguments without seeing a vararg, no clash
-        if (thisVararg == null) {
-          return false;
-        }
-        thisParam = thisVararg;
-      } else {
-        thisParam = thisIterator.next();
-      }
+      VariableReference thisParam = !thisIterator.hasNext() ? thisVararg : thisIterator.next();
 
       Type thisParamType = thisParam.getType();
       if (thisParamType instanceof VarArgType vat) {
@@ -121,16 +116,7 @@ public abstract class Function extends Symbol {
         thisParamType = vat.getDataType();
       }
 
-      VariableReference thatParam;
-      if (!thatIterator.hasNext()) {
-        // If that function ran out of arguments without seeing a vararg, no clash
-        if (thatVararg == null) {
-          return false;
-        }
-        thatParam = thatVararg;
-      } else {
-        thatParam = thatIterator.next();
-      }
+      VariableReference thatParam = !thatIterator.hasNext() ? thatVararg : thatIterator.next();
 
       Type thatParamType = thatParam.getType();
       if (thatParamType instanceof VarArgType vat) {

--- a/test/net/sourceforge/kolmafia/textui/parsetree/FunctionTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/FunctionTest.java
@@ -383,8 +383,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE, vararg(DataTypes.STRING_TYPE));
           makeValues(DataTypes.STRING_TYPE);
-          // this should actually return false, but is currently behaving wrong
-          assertTrue(f.paramsMatch(values, MatchType.EXACT, true));
+          assertFalse(f.paramsMatch(values, MatchType.EXACT, true));
         }
       }
 
@@ -604,8 +603,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE, vararg(DataTypes.STRING_TYPE));
           makeValues(DataTypes.STRING_TYPE);
-          // this should actually return false, but is currently behaving wrong
-          assertTrue(f.paramsMatch(values, MatchType.BASE, true));
+          assertFalse(f.paramsMatch(values, MatchType.BASE, true));
         }
       }
 
@@ -824,8 +822,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE, vararg(DataTypes.STRING_TYPE));
           makeValues(DataTypes.STRING_TYPE);
-          // this should actually return false, but is currently behaving wrong
-          assertTrue(f.paramsMatch(values, MatchType.COERCE, true));
+          assertFalse(f.paramsMatch(values, MatchType.COERCE, true));
         }
       }
 

--- a/test/net/sourceforge/kolmafia/textui/parsetree/FunctionTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/FunctionTest.java
@@ -211,7 +211,7 @@ public class FunctionTest {
                 DataTypes.STRING_TYPE,
                 vararg(DataTypes.INT_TYPE),
                 vararg(DataTypes.INT_TYPE));
-        makeValues(DataTypes.STRING_TYPE);
+        makeValues(DataTypes.STRING_TYPE, DataTypes.INT_TYPE, DataTypes.INT_TYPE);
         assertFalse(f.paramsMatch(values, MatchType.EXACT, true));
       }
 
@@ -225,7 +225,7 @@ public class FunctionTest {
                 DataTypes.STRING_TYPE,
                 vararg(DataTypes.INT_TYPE),
                 DataTypes.STRING_TYPE);
-        makeValues(DataTypes.STRING_TYPE);
+        makeValues(DataTypes.STRING_TYPE, DataTypes.INT_TYPE, DataTypes.STRING_TYPE);
         assertFalse(f.paramsMatch(values, MatchType.EXACT, true));
       }
     }

--- a/test/net/sourceforge/kolmafia/textui/parsetree/FunctionTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/FunctionTest.java
@@ -212,7 +212,7 @@ public class FunctionTest {
                 vararg(DataTypes.INT_TYPE),
                 vararg(DataTypes.INT_TYPE));
         makeValues(DataTypes.STRING_TYPE, DataTypes.INT_TYPE, DataTypes.INT_TYPE);
-        assertFalse(f.paramsMatch(values, MatchType.EXACT, true));
+        assertFalse(f.paramsMatch(values, MatchType.EXACT));
       }
 
       // The function has a varargs followed by another parameter
@@ -226,7 +226,7 @@ public class FunctionTest {
                 vararg(DataTypes.INT_TYPE),
                 DataTypes.STRING_TYPE);
         makeValues(DataTypes.STRING_TYPE, DataTypes.INT_TYPE, DataTypes.STRING_TYPE);
-        assertFalse(f.paramsMatch(values, MatchType.EXACT, true));
+        assertFalse(f.paramsMatch(values, MatchType.EXACT));
       }
     }
 
@@ -241,7 +241,7 @@ public class FunctionTest {
         void int_int() {
           Function f = makeFunction("f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE);
           makeValues(DataTypes.INT_TYPE);
-          assertTrue(f.paramsMatch(values, MatchType.EXACT, false));
+          assertTrue(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // Two ints are required, one int is provided
@@ -250,7 +250,7 @@ public class FunctionTest {
           Function f =
               makeFunction("f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE, DataTypes.INT_TYPE);
           makeValues(DataTypes.INT_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.EXACT, false));
+          assertFalse(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // One int is required, two are provided
@@ -258,7 +258,7 @@ public class FunctionTest {
         void int_int2() {
           Function f = makeFunction("f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE);
           makeValues(DataTypes.INT_TYPE, DataTypes.INT_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.EXACT, false));
+          assertFalse(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // int is required, typedef int is provided
@@ -267,7 +267,7 @@ public class FunctionTest {
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           Function f = makeFunction("f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE);
           makeValues(td);
-          assertFalse(f.paramsMatch(values, MatchType.EXACT, false));
+          assertFalse(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // float is required, int is provided
@@ -275,7 +275,7 @@ public class FunctionTest {
         void float_int() {
           Function f = makeFunction("f", DataTypes.VOID_TYPE, DataTypes.FLOAT_TYPE);
           makeValues(DataTypes.INT_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.EXACT, false));
+          assertFalse(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // typedef int is required, int is provided
@@ -284,7 +284,7 @@ public class FunctionTest {
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           Function f = makeFunction("f", DataTypes.VOID_TYPE, td);
           makeValues(DataTypes.INT_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.EXACT, false));
+          assertFalse(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // typedef int is required, same typedef int is provided
@@ -293,7 +293,7 @@ public class FunctionTest {
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           Function f = makeFunction("f", DataTypes.VOID_TYPE, td);
           makeValues(td);
-          assertTrue(f.paramsMatch(values, MatchType.EXACT, false));
+          assertTrue(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // typedef int is required, different typedef int is provided
@@ -303,7 +303,7 @@ public class FunctionTest {
           TypeDef td2 = new TypeDef("td2", DataTypes.INT_TYPE, null);
           Function f = makeFunction("f", DataTypes.VOID_TYPE, td1);
           makeValues(td2);
-          assertFalse(f.paramsMatch(values, MatchType.EXACT, false));
+          assertFalse(f.paramsMatch(values, MatchType.EXACT));
         }
       }
 
@@ -322,7 +322,7 @@ public class FunctionTest {
           // We are not testing whether function argument types match,
           // but whether this function will accept these values.
           // A vararg is happy to have size zero.
-          assertTrue(f.paramsMatch(values, MatchType.EXACT, true));
+          assertTrue(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // vararg allowed, one matching arg provided
@@ -332,7 +332,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, DataTypes.INT_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.EXACT, true));
+          assertFalse(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // vararg allowed, typedef int is provided
@@ -341,7 +341,7 @@ public class FunctionTest {
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           Function f = makeFunction("f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE);
           makeValues(td);
-          assertFalse(f.paramsMatch(values, MatchType.EXACT, false));
+          assertFalse(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // vararg allowed, two matching args provided
@@ -351,7 +351,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, DataTypes.INT_TYPE, DataTypes.INT_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.EXACT, true));
+          assertFalse(f.paramsMatch(values, MatchType.EXACT));
         }
 
         @Test
@@ -360,7 +360,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, DataTypes.STRING_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.EXACT, true));
+          assertFalse(f.paramsMatch(values, MatchType.EXACT));
         }
 
         @Test
@@ -373,7 +373,7 @@ public class FunctionTest {
                   DataTypes.STRING_TYPE,
                   vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.EXACT, true));
+          assertFalse(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // vararg allowed, no matching args provided, args before vararg mismatch
@@ -383,7 +383,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE, vararg(DataTypes.STRING_TYPE));
           makeValues(DataTypes.STRING_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.EXACT, true));
+          assertFalse(f.paramsMatch(values, MatchType.EXACT));
         }
       }
 
@@ -400,7 +400,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, array(DataTypes.INT_TYPE));
-          assertTrue(f.paramsMatch(values, MatchType.EXACT, true));
+          assertTrue(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // vararg allowed, an array of matching typedef ints is provided
@@ -411,7 +411,7 @@ public class FunctionTest {
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           makeValues(DataTypes.STRING_TYPE, array(td));
-          assertFalse(f.paramsMatch(values, MatchType.EXACT, true));
+          assertFalse(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // vararg allowed, a map of matching ints is provided
@@ -421,7 +421,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, aggregate(DataTypes.INT_TYPE, DataTypes.INT_TYPE));
-          assertTrue(f.paramsMatch(values, MatchType.EXACT, true));
+          assertTrue(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // vararg allowed, a map of matching ints is provided
@@ -432,7 +432,7 @@ public class FunctionTest {
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           makeValues(DataTypes.STRING_TYPE, aggregate(DataTypes.INT_TYPE, td));
-          assertFalse(f.paramsMatch(values, MatchType.EXACT, true));
+          assertFalse(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // vararg allowed, a typedef array of matching ints is provided
@@ -445,7 +445,7 @@ public class FunctionTest {
           makeValues(DataTypes.STRING_TYPE, tda);
           // Since we are matching parameters, any aggregate that holds the
           // appropriate data type is fine.
-          assertTrue(f.paramsMatch(values, MatchType.EXACT, true));
+          assertTrue(f.paramsMatch(values, MatchType.EXACT));
         }
 
         // vararg allowed, a typedef map of matching ints is provided
@@ -458,7 +458,7 @@ public class FunctionTest {
           makeValues(DataTypes.STRING_TYPE, tdm);
           // Since we are matching parameters, any aggregate that holds the
           // appropriate data type is fine.
-          assertTrue(f.paramsMatch(values, MatchType.EXACT, true));
+          assertTrue(f.paramsMatch(values, MatchType.EXACT));
         }
       }
     }
@@ -474,7 +474,7 @@ public class FunctionTest {
         void int_int() {
           Function f = makeFunction("f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE);
           makeValues(DataTypes.INT_TYPE);
-          assertTrue(f.paramsMatch(values, MatchType.BASE, false));
+          assertTrue(f.paramsMatch(values, MatchType.BASE));
         }
 
         // Two ints are required, one int is provided
@@ -483,7 +483,7 @@ public class FunctionTest {
           Function f =
               makeFunction("f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE, DataTypes.INT_TYPE);
           makeValues(DataTypes.INT_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.BASE, false));
+          assertFalse(f.paramsMatch(values, MatchType.BASE));
         }
 
         // One int is required, two are provided
@@ -491,7 +491,7 @@ public class FunctionTest {
         void int_int2() {
           Function f = makeFunction("f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE);
           makeValues(DataTypes.INT_TYPE, DataTypes.INT_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.BASE, false));
+          assertFalse(f.paramsMatch(values, MatchType.BASE));
         }
 
         // int is required, typedef int is provided
@@ -500,7 +500,7 @@ public class FunctionTest {
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           Function f = makeFunction("f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE);
           makeValues(td);
-          assertTrue(f.paramsMatch(values, MatchType.BASE, false));
+          assertTrue(f.paramsMatch(values, MatchType.BASE));
         }
 
         // float is required, int is provided
@@ -508,7 +508,7 @@ public class FunctionTest {
         void float_int() {
           Function f = makeFunction("f", DataTypes.VOID_TYPE, DataTypes.FLOAT_TYPE);
           makeValues(DataTypes.INT_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.BASE, false));
+          assertFalse(f.paramsMatch(values, MatchType.BASE));
         }
 
         // typedef int is required, int is provided
@@ -517,7 +517,7 @@ public class FunctionTest {
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           Function f = makeFunction("f", DataTypes.VOID_TYPE, td);
           makeValues(DataTypes.INT_TYPE);
-          assertTrue(f.paramsMatch(values, MatchType.BASE, false));
+          assertTrue(f.paramsMatch(values, MatchType.BASE));
         }
 
         // typedef int is required, same typedef int is provided
@@ -526,7 +526,7 @@ public class FunctionTest {
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           Function f = makeFunction("f", DataTypes.VOID_TYPE, td);
           makeValues(td);
-          assertTrue(f.paramsMatch(values, MatchType.BASE, false));
+          assertTrue(f.paramsMatch(values, MatchType.BASE));
         }
 
         // typedef int is required, different typedef int is provided
@@ -536,7 +536,7 @@ public class FunctionTest {
           TypeDef td2 = new TypeDef("td2", DataTypes.INT_TYPE, null);
           Function f = makeFunction("f", DataTypes.VOID_TYPE, td1);
           makeValues(td2);
-          assertTrue(f.paramsMatch(values, MatchType.BASE, false));
+          assertTrue(f.paramsMatch(values, MatchType.BASE));
         }
       }
 
@@ -555,7 +555,7 @@ public class FunctionTest {
           // We are not testing whether function argument types match,
           // but whether this function will accept these values.
           // A vararg is happy to have size zero.
-          assertTrue(f.paramsMatch(values, MatchType.BASE, true));
+          assertTrue(f.paramsMatch(values, MatchType.BASE));
         }
 
         // vararg allowed, one matching arg provided
@@ -565,7 +565,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, DataTypes.INT_TYPE);
-          assertTrue(f.paramsMatch(values, MatchType.BASE, true));
+          assertTrue(f.paramsMatch(values, MatchType.BASE));
         }
 
         // vararg allowed, two matching args provided
@@ -575,7 +575,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, DataTypes.INT_TYPE, DataTypes.INT_TYPE);
-          assertTrue(f.paramsMatch(values, MatchType.BASE, true));
+          assertTrue(f.paramsMatch(values, MatchType.BASE));
         }
 
         // vararg allowed, typedef int is provided
@@ -584,7 +584,7 @@ public class FunctionTest {
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           Function f = makeFunction("f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE);
           makeValues(td);
-          assertTrue(f.paramsMatch(values, MatchType.BASE, false));
+          assertTrue(f.paramsMatch(values, MatchType.BASE));
         }
 
         @Test
@@ -593,7 +593,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, DataTypes.STRING_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.BASE, true));
+          assertFalse(f.paramsMatch(values, MatchType.BASE));
         }
 
         // vararg allowed, no matching args provided, args before vararg mismatch
@@ -603,7 +603,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE, vararg(DataTypes.STRING_TYPE));
           makeValues(DataTypes.STRING_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.BASE, true));
+          assertFalse(f.paramsMatch(values, MatchType.BASE));
         }
       }
 
@@ -618,7 +618,7 @@ public class FunctionTest {
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, array(DataTypes.INT_TYPE));
           // *** This is EXACT. Why does BASE match not accept this?
-          assertFalse(f.paramsMatch(values, MatchType.BASE, true));
+          assertFalse(f.paramsMatch(values, MatchType.BASE));
         }
 
         // vararg allowed, an array of matching typedef ints is provided
@@ -630,7 +630,7 @@ public class FunctionTest {
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           makeValues(DataTypes.STRING_TYPE, array(td));
           // *** Why does BASE match not accept this?
-          assertFalse(f.paramsMatch(values, MatchType.BASE, true));
+          assertFalse(f.paramsMatch(values, MatchType.BASE));
         }
 
         // vararg allowed, a map of matching ints is provided
@@ -641,7 +641,7 @@ public class FunctionTest {
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, aggregate(DataTypes.INT_TYPE, DataTypes.INT_TYPE));
           // *** This is EXACT. Why does BASE match not accept this?
-          assertFalse(f.paramsMatch(values, MatchType.BASE, true));
+          assertFalse(f.paramsMatch(values, MatchType.BASE));
         }
 
         // vararg allowed, a map of matching ints is provided
@@ -653,7 +653,7 @@ public class FunctionTest {
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           makeValues(DataTypes.STRING_TYPE, aggregate(DataTypes.INT_TYPE, td));
           // *** Why does BASE match not accept this?
-          assertFalse(f.paramsMatch(values, MatchType.BASE, true));
+          assertFalse(f.paramsMatch(values, MatchType.BASE));
         }
 
         // vararg allowed, a typedef array of matching ints is provided
@@ -665,7 +665,7 @@ public class FunctionTest {
           TypeDef tda = new TypeDef("tda", array(DataTypes.INT_TYPE), null);
           makeValues(DataTypes.STRING_TYPE, tda);
           // *** Why does BASE match not accept this?
-          assertFalse(f.paramsMatch(values, MatchType.BASE, true));
+          assertFalse(f.paramsMatch(values, MatchType.BASE));
         }
 
         // vararg allowed, a typedef map of matching ints is provided
@@ -677,7 +677,7 @@ public class FunctionTest {
           TypeDef tdm = new TypeDef("tdm", aggregate(DataTypes.INT_TYPE, DataTypes.INT_TYPE), null);
           makeValues(DataTypes.STRING_TYPE, tdm);
           // *** Why does BASE match not accept this?
-          assertFalse(f.paramsMatch(values, MatchType.BASE, true));
+          assertFalse(f.paramsMatch(values, MatchType.BASE));
         }
       }
     }
@@ -693,7 +693,7 @@ public class FunctionTest {
         void int_int() {
           Function f = makeFunction("f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE);
           makeValues(DataTypes.INT_TYPE);
-          assertTrue(f.paramsMatch(values, MatchType.COERCE, false));
+          assertTrue(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // Two ints are required, one int is provided
@@ -702,7 +702,7 @@ public class FunctionTest {
           Function f =
               makeFunction("f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE, DataTypes.INT_TYPE);
           makeValues(DataTypes.INT_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.COERCE, false));
+          assertFalse(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // One int is required, two are provided
@@ -710,7 +710,7 @@ public class FunctionTest {
         void int_int2() {
           Function f = makeFunction("f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE);
           makeValues(DataTypes.INT_TYPE, DataTypes.INT_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.COERCE, false));
+          assertFalse(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // int is required, typedef int is provided
@@ -719,7 +719,7 @@ public class FunctionTest {
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           Function f = makeFunction("f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE);
           makeValues(td);
-          assertTrue(f.paramsMatch(values, MatchType.COERCE, false));
+          assertTrue(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // float is required, int is provided
@@ -727,7 +727,7 @@ public class FunctionTest {
         void float_int() {
           Function f = makeFunction("f", DataTypes.VOID_TYPE, DataTypes.FLOAT_TYPE);
           makeValues(DataTypes.INT_TYPE);
-          assertTrue(f.paramsMatch(values, MatchType.COERCE, false));
+          assertTrue(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // typedef int is required, int is provided
@@ -736,7 +736,7 @@ public class FunctionTest {
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           Function f = makeFunction("f", DataTypes.VOID_TYPE, td);
           makeValues(DataTypes.INT_TYPE);
-          assertTrue(f.paramsMatch(values, MatchType.COERCE, false));
+          assertTrue(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // typedef int is required, same typedef int is provided
@@ -745,7 +745,7 @@ public class FunctionTest {
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           Function f = makeFunction("f", DataTypes.VOID_TYPE, td);
           makeValues(td);
-          assertTrue(f.paramsMatch(values, MatchType.COERCE, false));
+          assertTrue(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // typedef int is required, different typedef int is provided
@@ -755,7 +755,7 @@ public class FunctionTest {
           TypeDef td2 = new TypeDef("td2", DataTypes.INT_TYPE, null);
           Function f = makeFunction("f", DataTypes.VOID_TYPE, td1);
           makeValues(td2);
-          assertTrue(f.paramsMatch(values, MatchType.COERCE, false));
+          assertTrue(f.paramsMatch(values, MatchType.COERCE));
         }
       }
 
@@ -774,7 +774,7 @@ public class FunctionTest {
           // We are not testing whether function argument types match,
           // but whether this function will accept these values.
           // A vararg is happy to have size zero.
-          assertTrue(f.paramsMatch(values, MatchType.COERCE, true));
+          assertTrue(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // vararg allowed, one matching arg provided
@@ -784,7 +784,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, DataTypes.INT_TYPE);
-          assertTrue(f.paramsMatch(values, MatchType.COERCE, true));
+          assertTrue(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // vararg allowed, two matching args provided
@@ -794,7 +794,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, DataTypes.INT_TYPE, DataTypes.INT_TYPE);
-          assertTrue(f.paramsMatch(values, MatchType.COERCE, true));
+          assertTrue(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // vararg allowed, typedef int is provided
@@ -803,7 +803,7 @@ public class FunctionTest {
           TypeDef td = new TypeDef("td", DataTypes.INT_TYPE, null);
           Function f = makeFunction("f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE);
           makeValues(td);
-          assertTrue(f.paramsMatch(values, MatchType.BASE, false));
+          assertTrue(f.paramsMatch(values, MatchType.BASE));
         }
 
         @Test
@@ -812,7 +812,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, DataTypes.STRING_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.COERCE, true));
+          assertFalse(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // vararg allowed, no matching args provided, args before vararg mismatch
@@ -822,7 +822,7 @@ public class FunctionTest {
               makeFunction(
                   "f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE, vararg(DataTypes.STRING_TYPE));
           makeValues(DataTypes.STRING_TYPE);
-          assertFalse(f.paramsMatch(values, MatchType.COERCE, true));
+          assertFalse(f.paramsMatch(values, MatchType.COERCE));
         }
       }
 
@@ -838,7 +838,7 @@ public class FunctionTest {
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, array(DataTypes.INT_TYPE));
           // *** aggregates are not coercable.
-          assertFalse(f.paramsMatch(values, MatchType.COERCE, false));
+          assertFalse(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // vararg allowed, an array of matching typedef ints is provided
@@ -851,7 +851,7 @@ public class FunctionTest {
           makeValues(DataTypes.STRING_TYPE, array(td));
           // *** aggregates are not coercable.
           // *** Why does COERCE match not accept this?
-          assertFalse(f.paramsMatch(values, MatchType.COERCE, true));
+          assertFalse(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // vararg allowed, a map of matching ints is provided
@@ -862,7 +862,7 @@ public class FunctionTest {
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, aggregate(DataTypes.INT_TYPE, DataTypes.INT_TYPE));
           // *** aggregates are not coercable.
-          assertFalse(f.paramsMatch(values, MatchType.COERCE, true));
+          assertFalse(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // vararg allowed, a map of matching ints is provided
@@ -875,7 +875,7 @@ public class FunctionTest {
           makeValues(DataTypes.STRING_TYPE, aggregate(DataTypes.INT_TYPE, td));
           // *** aggregates are not coercable.
           // *** Why does COERCE match not accept this?
-          assertFalse(f.paramsMatch(values, MatchType.COERCE, true));
+          assertFalse(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // vararg allowed, a typedef array of matching ints is provided
@@ -887,7 +887,7 @@ public class FunctionTest {
           TypeDef tda = new TypeDef("tda", array(DataTypes.INT_TYPE), null);
           makeValues(DataTypes.STRING_TYPE, tda);
           // *** aggregates are not coercable.
-          assertFalse(f.paramsMatch(values, MatchType.COERCE, true));
+          assertFalse(f.paramsMatch(values, MatchType.COERCE));
         }
 
         // vararg allowed, a typedef map of matching ints is provided
@@ -899,7 +899,7 @@ public class FunctionTest {
           TypeDef tdm = new TypeDef("tdm", aggregate(DataTypes.INT_TYPE, DataTypes.INT_TYPE), null);
           makeValues(DataTypes.STRING_TYPE, tdm);
           // *** aggregates are not coercable.
-          assertFalse(f.paramsMatch(values, MatchType.COERCE, true));
+          assertFalse(f.paramsMatch(values, MatchType.COERCE));
         }
       }
     }

--- a/test/net/sourceforge/kolmafia/textui/parsetree/FunctionTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/FunctionTest.java
@@ -375,6 +375,17 @@ public class FunctionTest {
           makeValues(DataTypes.STRING_TYPE);
           assertFalse(f.paramsMatch(values, MatchType.EXACT, true));
         }
+
+        // vararg allowed, no matching args provided, args before vararg mismatch
+        @Test
+        void mismatched_value_for_param_before_vararg() {
+          Function f =
+              makeFunction(
+                  "f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE, vararg(DataTypes.STRING_TYPE));
+          makeValues(DataTypes.STRING_TYPE);
+          // this should actually return false, but is currently behaving wrong
+          assertTrue(f.paramsMatch(values, MatchType.EXACT, true));
+        }
       }
 
       @Disabled("behaviour is currently wrong")
@@ -585,6 +596,17 @@ public class FunctionTest {
           makeValues(DataTypes.STRING_TYPE, DataTypes.STRING_TYPE);
           assertFalse(f.paramsMatch(values, MatchType.BASE, true));
         }
+
+        // vararg allowed, no matching args provided, args before vararg mismatch
+        @Test
+        void mismatched_value_for_param_before_vararg() {
+          Function f =
+              makeFunction(
+                  "f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE, vararg(DataTypes.STRING_TYPE));
+          makeValues(DataTypes.STRING_TYPE);
+          // this should actually return false, but is currently behaving wrong
+          assertTrue(f.paramsMatch(values, MatchType.BASE, true));
+        }
       }
 
       @Disabled("behaviour is currently wrong")
@@ -793,6 +815,17 @@ public class FunctionTest {
                   "f", DataTypes.VOID_TYPE, DataTypes.STRING_TYPE, vararg(DataTypes.INT_TYPE));
           makeValues(DataTypes.STRING_TYPE, DataTypes.STRING_TYPE);
           assertFalse(f.paramsMatch(values, MatchType.COERCE, true));
+        }
+
+        // vararg allowed, no matching args provided, args before vararg mismatch
+        @Test
+        void mismatched_value_for_param_before_vararg() {
+          Function f =
+              makeFunction(
+                  "f", DataTypes.VOID_TYPE, DataTypes.INT_TYPE, vararg(DataTypes.STRING_TYPE));
+          makeValues(DataTypes.STRING_TYPE);
+          // this should actually return false, but is currently behaving wrong
+          assertTrue(f.paramsMatch(values, MatchType.COERCE, true));
         }
       }
 

--- a/test/net/sourceforge/kolmafia/textui/parsetree/FunctionTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/FunctionTest.java
@@ -362,6 +362,19 @@ public class FunctionTest {
           makeValues(DataTypes.STRING_TYPE, DataTypes.STRING_TYPE);
           assertFalse(f.paramsMatch(values, MatchType.EXACT, true));
         }
+
+        @Test
+        void missing_value_for_param_before_vararg() {
+          Function f =
+              makeFunction(
+                  "f",
+                  DataTypes.VOID_TYPE,
+                  DataTypes.STRING_TYPE,
+                  DataTypes.STRING_TYPE,
+                  vararg(DataTypes.INT_TYPE));
+          makeValues(DataTypes.STRING_TYPE);
+          assertFalse(f.paramsMatch(values, MatchType.EXACT, true));
+        }
       }
 
       @Disabled("behaviour is currently wrong")


### PR DESCRIPTION
This PR fixes one minor bug in function parameter matching (if a function gets zero arguments for a vararg parameter, it ignores all previous (un)matched parameters). See before and after tests for the change in behavior.

Additionally, it improves parameter matching by ~~a) short-circuiting some scenarios that mismatch a lot when checking multiple overloads of a given function, and b)~~ letting the function know itself whether it has variadic parameters, instead of letting the caller check both scenarios.

I'm aware that this PR mixes several topics, so let me know if you want me to split it up. As you probably know, I'm happy to do a lot of granular PRs, but these are kind of related, so having that bunch in one squashed commit makes sense.