### PR TITLE
Refresh modifiers when lifting Standard restrictions.

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -2948,6 +2948,8 @@ public abstract class KoLCharacter {
     FloristRequest.reset();
     RequestThread.postRequest(new FloristRequest());
 
+    KoLCharacter.recalculateAdjustments();
+
     // If you have the ItemManagerFrame open, there are four panels which
     // display food, booze, spleen items, and potions. These enable buttons and
     // filter what is shown based on character state: whether your character
@@ -3038,6 +3040,7 @@ public abstract class KoLCharacter {
     if (KoLCharacter.inRonin != inRonin) {
       KoLCharacter.inRonin = inRonin;
       NamedListenerRegistry.fireChange("(ronin)");
+      KoLCharacter.recalculateAdjustments();
     }
   }
 

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -845,7 +845,8 @@ public class Modifiers {
       Modifiers.cachedPassiveModifiers =
           new Modifiers(new Lookup(ModifierType.PASSIVES, "cachedPassives"));
       PreferenceListenerRegistry.registerPreferenceListener(
-          new String[] {"(skill)", "kingLiberated"}, () -> Modifiers.availableSkillsChanged());
+          new String[] {"(skill)", "kingLiberated", "(ronin)"},
+          () -> Modifiers.availableSkillsChanged());
     }
     if (KoLCharacter.getAvailableSkillIds().isEmpty()) {
       // We probably haven't loaded the player's skills yet. Avoid populating

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -598,5 +598,30 @@ public class KoLCharacterTest {
         assertThat(KoLCharacter.getInebriety(), is(10));
       }
     }
+
+    @Test
+    void liberatingKingEnablesStandardRestrictedSkills() {
+      try (var cleanups =
+          new Cleanups(
+              withProperty("kingLiberated"),
+              withPath(Path.STANDARD),
+              withSkill(SkillPool.DRINKING_TO_DRINK))) {
+        assertThat(KoLCharacter.getLiverCapacity(), is(14));
+        KoLCharacter.liberateKing();
+        assertThat(KoLCharacter.getLiverCapacity(), is(15));
+      }
+    }
+  }
+
+  @Nested
+  class RoninBreak {
+    @Test
+    void breakingRoninEnablesStandardRestrictedSkills() {
+      try (var cleanups = new Cleanups(withRonin(true), withSkill(SkillPool.DRINKING_TO_DRINK))) {
+        assertThat(KoLCharacter.getLiverCapacity(), is(14));
+        KoLCharacter.setRonin(false);
+        assertThat(KoLCharacter.getLiverCapacity(), is(15));
+      }
+    }
   }
 }


### PR DESCRIPTION
When liberating the king or breaking ronin, previously permed skills that are too old for Standard restrictions will be available again.

I'm not actually sure off-hand whether Mafia knows a priori if those skills are permed but unusable, or if we need to fetch the charsheet first. I know there have been occasional issues with KoL not showing them in the past.

(Also, to be clear: I don't have any reason to think this is a comprehensive fix for the liver
mismatch problem, but it's definitely a deficiency that we should address.)