### PR TITLE
feat: add concoctions for Mayam resonances

### DIFF
--- a/src/data/concoctions.txt
+++ b/src/data/concoctions.txt
@@ -3325,3 +3325,13 @@ yam martini	MIX	bottle of vodka	yam
 sweet potato punch	ACOCK	coconut shell	yam martini
 Southern yam	ACOCK	little paper umbrella	yam martini
 sweet potato o' mine	ACOCK	magical ice cube	yam martini
+
+Mayam spinach	MAYAM
+yam and swiss	MAYAM
+yam cannon	MAYAM
+tiny yam cannon	MAYAM
+yam battery	MAYAM
+stuffed yam stinkbomb	MAYAM
+furry yam buckler	MAYAM
+thansgiving bomb	MAYAM
+yamtility belt	MAYAM

--- a/src/data/statuseffects.txt
+++ b/src/data/statuseffects.txt
@@ -2908,8 +2908,8 @@
 2905	Big Eyes	yameye.gif	591a425ca0ccb96788051388c5e581eb	neutral	none
 2906	Vessel of Magic	yamvessel.gif	b05746e8d34ef035bb7785fec0969265	neutral	none
 2907	Walled In	wallshield.gif	ac00a12dba132bffe22567b7c63ba2c8	neutral	none
-2908	Caught Yam-Handed	yam.gif	7804213456259ccd0588f39945748e05	neutral	none
-2909	Memories of Cheesier Age	yamcheese.gif	69a72a96a895bef2a452fe02a5b7a0fc	neutral	none
+2908	Caught Yam-Handed	yam.gif	7804213456259ccd0588f39945748e05	neutral	none	mayam resonance caught yam-handed
+2909	Memories of Cheesier Age	yamcheese.gif	69a72a96a895bef2a452fe02a5b7a0fc	neutral	none	mayam resonance memories of cheesier age
 2910	Eye of Moxie	eye_moxie.gif	04e76c36a6a6c546028e284476108294	neutral	none
 2911	Eye of Muscle	eye_muscle.gif	7970bfd6b6333e51ef9ad1aaa55287c7	neutral	none
 2912	Eye of Mysticality	eye_mysticality.gif	b46f79af7d02565f572256eed2fd72ca	neutral	none

--- a/src/net/sourceforge/kolmafia/KoLConstants.java
+++ b/src/net/sourceforge/kolmafia/KoLConstants.java
@@ -523,6 +523,7 @@ public interface KoLConstants extends UtilityConstants {
     FIXODENT, // Items made from fixodent
     BURNING_LEAVES, // Items made at the Pile of Burning Leaves
     TINKERING_BENCH, // Items made at the Tinkering Bench
+    MAYAM, // Items made at the Mayam Calendar
   }
 
   enum CraftingRequirements {

--- a/src/net/sourceforge/kolmafia/objectpool/Concoction.java
+++ b/src/net/sourceforge/kolmafia/objectpool/Concoction.java
@@ -26,6 +26,7 @@ import net.sourceforge.kolmafia.request.ClanLoungeRequest;
 import net.sourceforge.kolmafia.request.ClanLoungeRequest.SpeakeasyDrink;
 import net.sourceforge.kolmafia.request.CombineMeatRequest;
 import net.sourceforge.kolmafia.request.CreateItemRequest;
+import net.sourceforge.kolmafia.request.MayamRequest;
 import net.sourceforge.kolmafia.request.PurchaseRequest;
 import net.sourceforge.kolmafia.request.StillSuitRequest;
 import net.sourceforge.kolmafia.request.TinkeringBenchRequest;
@@ -1100,6 +1101,8 @@ public class Concoction implements Comparable<Concoction> {
         return StillSuitRequest.canMake() ? 1 : 0;
       case BURNING_LEAVES:
         return BurningLeavesRequest.canMake(this);
+      case MAYAM:
+        return MayamRequest.canMake(this) ? 1 : 0;
     }
 
     if (needToMake <= 0) { // Have enough on hand already.

--- a/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
@@ -2034,6 +2034,15 @@ public class ConcoctionDatabase {
           "Only a mild-mannered professor can work at their Tinkering Bench.");
     }
 
+    // Making stuff with the Mayam Calendar is always allowed
+
+    if (InventoryManager.hasItem(ItemPool.MAYAM_CALENDAR)) {
+      permitNoCost(CraftingType.MAYAM);
+    } else {
+      ConcoctionDatabase.EXCUSE.put(
+          CraftingType.MAYAM, "You need to have a Mayam Calendar to make that.");
+    }
+
     // Other creatability flags
 
     if (KoLCharacter.isTorsoAware()) {
@@ -2398,6 +2407,7 @@ public class ConcoctionDatabase {
       case FIXODENT -> result.append("Craft with Teeth");
       case BURNING_LEAVES -> result.append("Pile of Burning Leaves");
       case TINKERING_BENCH -> result.append("Tinkering Bench");
+      case MAYAM -> result.append("Mayam Calendar");
     }
     if (result.isEmpty()) {
       result.append("[unknown method of creation]");
@@ -2833,6 +2843,7 @@ public class ConcoctionDatabase {
       case "FIXODENT" -> ConcoctionDatabase.mixingMethod = CraftingType.FIXODENT;
       case "BURNING_LEAVES" -> ConcoctionDatabase.mixingMethod = CraftingType.BURNING_LEAVES;
       case "TINKERING_BENCH" -> ConcoctionDatabase.mixingMethod = CraftingType.TINKERING_BENCH;
+      case "MAYAM" -> ConcoctionDatabase.mixingMethod = CraftingType.MAYAM;
       default -> {
         if (mix.startsWith("ROW")) {
           ConcoctionDatabase.row = StringUtilities.parseInt(mix.substring(3));

--- a/src/net/sourceforge/kolmafia/request/CreateItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CreateItemRequest.java
@@ -265,6 +265,7 @@ public class CreateItemRequest extends GenericRequest implements Comparable<Crea
       case FIXODENT -> new FixodentRequest(conc);
       case BURNING_LEAVES -> new BurningLeavesRequest(conc);
       case TINKERING_BENCH -> new TinkeringBenchRequest(conc);
+      case MAYAM -> new MayamRequest(conc);
       default -> new CreateItemRequest(conc);
     };
   }

--- a/src/net/sourceforge/kolmafia/request/MayamRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MayamRequest.java
@@ -6,7 +6,7 @@ import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.textui.command.MayamCommand;
 
 public class MayamRequest extends CreateItemRequest {
-  private static MayamCommand _mayamCommand = new MayamCommand();
+  private static MayamCommand mayamCommand = new MayamCommand();
 
   public MayamRequest(final Concoction conc) {
     super("choice.php", conc);
@@ -18,13 +18,13 @@ public class MayamRequest extends CreateItemRequest {
 
     KoLmafia.updateDisplay("Creating 1 " + name + "...");
 
-    _mayamCommand.run("mayam", "resonance " + name);
+    mayamCommand.run("mayam", "resonance " + name);
     ConcoctionDatabase.refreshConcoctions(false);
   }
 
   public static boolean canMake(final Concoction conc) {
     String name = conc.getName().toLowerCase();
 
-    return _mayamCommand.availableResonances().contains(name);
+    return mayamCommand.availableResonances().contains(name);
   }
 }

--- a/src/net/sourceforge/kolmafia/request/MayamRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MayamRequest.java
@@ -1,0 +1,30 @@
+package net.sourceforge.kolmafia.request;
+
+import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.objectpool.Concoction;
+import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
+import net.sourceforge.kolmafia.textui.command.MayamCommand;
+
+public class MayamRequest extends CreateItemRequest {
+  private static MayamCommand _mayamCommand = new MayamCommand();
+
+  public MayamRequest(final Concoction conc) {
+    super("choice.php", conc);
+  }
+
+  @Override
+  public void run() {
+    String name = this.getName();
+
+    KoLmafia.updateDisplay("Creating 1 " + name + "...");
+
+    _mayamCommand.run("mayam", "resonance " + name);
+    ConcoctionDatabase.refreshConcoctions(false);
+  }
+
+  public static boolean canMake(final Concoction conc) {
+    String name = conc.getName().toLowerCase();
+
+    return _mayamCommand.availableResonances().contains(name);
+  }
+}

--- a/src/net/sourceforge/kolmafia/textui/command/MayamCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/MayamCommand.java
@@ -182,7 +182,7 @@ public class MayamCommand extends AbstractCommand {
     }
   }
 
-  private List<String> availableResonances() {
+  public List<String> availableResonances() {
     var available = new ArrayList<String>();
 
     var ring1 = unusedForRing(1);


### PR DESCRIPTION
An inverse of the normal style: here a Request calls a Command, instead of a Command calling the Request.

Given the command already existed I thought this was reasonable to avoid rewriting it.