### PR TITLE
Fix typos in Mayam concoctions

### DIFF
--- a/src/data/concoctions.txt
+++ b/src/data/concoctions.txt
@@ -3324,7 +3324,7 @@ yam slider	COOK	wad of dough	yam
 yam martini	MIX	bottle of vodka	yam
 sweet potato punch	ACOCK	coconut shell	yam martini
 Southern yam	ACOCK	little paper umbrella	yam martini
-sweet potato o' mine	ACOCK	magical ice cube	yam martini
+sweet potato o' mine	ACOCK	magical ice cubes	yam martini
 
 Mayam spinach	MAYAM
 yam and swiss	MAYAM
@@ -3333,5 +3333,5 @@ tiny yam cannon	MAYAM
 yam battery	MAYAM
 stuffed yam stinkbomb	MAYAM
 furry yam buckler	MAYAM
-thansgiving bomb	MAYAM
+thanksgiving bomb	MAYAM
 yamtility belt	MAYAM


### PR DESCRIPTION
Fixes the following messages that appear in the console:
```
Unknown ingredient (magical ice cube) for concoction: sweet potato o' mine
Unknown concoction: thansgiving bomb
```