### PR TITLE
Stop enforcing G-Lover restrictions for passives.

### DIFF
--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -864,7 +864,6 @@ public class Modifiers {
                 .filter(SkillDatabase::isPassive)
                 .map(UseSkillRequest::getUnmodifiedInstance)
                 .filter(Objects::nonNull)
-                .filter(UseSkillRequest::isEffective)
                 .map(skill -> ModifierDatabase.getModifiers(ModifierType.SKILL, skill.getSkillId()))
                 .filter(Objects::nonNull)
                 .collect(

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -41,7 +41,6 @@ import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.FloristRequest;
 import net.sourceforge.kolmafia.request.FloristRequest.Florist;
 import net.sourceforge.kolmafia.request.StandardRequest;
-import net.sourceforge.kolmafia.request.UseSkillRequest;
 import net.sourceforge.kolmafia.session.AutumnatonManager;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.utilities.Indexed;
@@ -862,9 +861,7 @@ public class Modifiers {
         Modifiers.availablePassiveSkillModifiersByVariable.putAll(
             KoLCharacter.getAvailableSkillIds().stream()
                 .filter(SkillDatabase::isPassive)
-                .map(UseSkillRequest::getUnmodifiedInstance)
-                .filter(Objects::nonNull)
-                .map(skill -> ModifierDatabase.getModifiers(ModifierType.SKILL, skill.getSkillId()))
+                .map(skill -> ModifierDatabase.getModifiers(ModifierType.SKILL, skill))
                 .filter(Objects::nonNull)
                 .collect(
                     Collectors.partitioningBy(

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -163,6 +163,21 @@ public class ModifiersTest {
     assertEquals(-30, mod.getDouble(DoubleModifier.COMBAT_RATE));
   }
 
+  @Test
+  public void PassivesIgnoreGsInGLover() {
+    // Wide-reaching unit test for getModifiers
+    var cleanup = new Cleanups(withPath(Path.GLOVER), withSkill(SkillPool.STEEL_LIVER));
+    Modifiers mods = new Modifiers();
+    try (cleanup) {
+      mods.applyPassiveModifiers(/* debug= */ true);
+
+      // Always has
+      assertEquals(5, mods.getDouble(DoubleModifier.LIVER_CAPACITY));
+    }
+    // Remove liver from passive skill cache.
+    mods.applyPassiveModifiers(/* debug= */ true);
+  }
+
   public static Stream<Arguments> getsRightModifiersNakedHatrack() {
     return Stream.of(
         Arguments.of(FamiliarPool.HATRACK, DoubleModifier.HATDROP),

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -169,7 +169,6 @@ public class ModifiersTest {
     var cleanups = new Cleanups(withPath(Path.GLOVER), withSkill(SkillPool.STEEL_LIVER));
     try (cleanups) {
       mods.applyPassiveModifiers(/* debug= */ true);
-
       assertEquals(5, mods.getDouble(DoubleModifier.LIVER_CAPACITY));
     }
     // Remove liver from passive skill cache.

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -164,14 +164,12 @@ public class ModifiersTest {
   }
 
   @Test
-  public void PassivesIgnoreGsInGLover() {
-    // Wide-reaching unit test for getModifiers
-    var cleanup = new Cleanups(withPath(Path.GLOVER), withSkill(SkillPool.STEEL_LIVER));
+  public void passivesIgnoreGsInGLover() {
     Modifiers mods = new Modifiers();
-    try (cleanup) {
+    var cleanups = new Cleanups(withPath(Path.GLOVER), withSkill(SkillPool.STEEL_LIVER));
+    try (cleanups) {
       mods.applyPassiveModifiers(/* debug= */ true);
 
-      // Always has
       assertEquals(5, mods.getDouble(DoubleModifier.LIVER_CAPACITY));
     }
     // Remove liver from passive skill cache.


### PR DESCRIPTION
According to the wiki, these work as normal; you just can't actively use any skills unless they contain 'G' in their names.

> However, passive skills appear to function normally.

https://kol.coldfront.net/thekolwiki/index.php/G-Lover