### PR TITLE
Fix Concoction compareTo contract violation.

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/Concoction.java
+++ b/src/net/sourceforge/kolmafia/objectpool/Concoction.java
@@ -472,6 +472,9 @@ public class Concoction implements Comparable<Concoction> {
     }
 
     // Sort helpers to the top next.
+    if ((this.isHelper() && (o.isHelper()))) {
+      return nameCheckCompare(o);
+    }
     if (this.isHelper()) {
       return -1;
     } else if (o.isHelper()) {

--- a/src/net/sourceforge/kolmafia/objectpool/Concoction.java
+++ b/src/net/sourceforge/kolmafia/objectpool/Concoction.java
@@ -472,7 +472,7 @@ public class Concoction implements Comparable<Concoction> {
     }
 
     // Sort helpers by name if more than one helper.
-    if ((this.isHelper() && (o.isHelper()))) {
+    if (this.isHelper() && o.isHelper()) {
       return nameCheckCompare(o);
     }
     // Sort helpers to the top next.

--- a/src/net/sourceforge/kolmafia/objectpool/Concoction.java
+++ b/src/net/sourceforge/kolmafia/objectpool/Concoction.java
@@ -471,10 +471,11 @@ public class Concoction implements Comparable<Concoction> {
       return 1;
     }
 
-    // Sort helpers to the top next.
+    // Sort helpers by name if more than one helper.
     if ((this.isHelper() && (o.isHelper()))) {
       return nameCheckCompare(o);
     }
+    // Sort helpers to the top next.
     if (this.isHelper()) {
       return -1;
     } else if (o.isHelper()) {

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -2608,8 +2608,9 @@ public class DebugDatabase {
     }
   }
 
-  // Helper method to force normalize Concoction comparisons to [-1, 0, 1] before testing
-  private static int sgn(int value) {
+  // Helper method to force normalize Concoction comparisons to [-1, 0, 1] before testing contract.
+  // Visible for unit testing
+  public static int sgn(int value) {
     return Integer.compare(value, 0);
   }
 

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -2608,12 +2608,6 @@ public class DebugDatabase {
     }
   }
 
-  // Helper method to force normalize Concoction comparisons to [-1, 0, 1] before testing contract.
-  // Visible for unit testing
-  public static int sgn(int value) {
-    return Integer.compare(value, 0);
-  }
-
   // Helper method to append item id
   private static String getIString(Concoction con) {
     return "[" + con.getItemId() + "] " + con;
@@ -2641,7 +2635,7 @@ public class DebugDatabase {
     result = new int[maxIndex][maxIndex];
     for (i = 0; i < maxIndex; ++i) {
       for (int j = 0; j < maxIndex; ++j) {
-        result[i][j] = sgn(ids[i].compareTo(ids[j]));
+        result[i][j] = Integer.signum(ids[i].compareTo(ids[j]));
       }
     }
     // sgn(x.compareTo(y)) == -sgn(y.compareTo(x)

--- a/test/net/sourceforge/kolmafia/objectpool/ConcoctionTest.java
+++ b/test/net/sourceforge/kolmafia/objectpool/ConcoctionTest.java
@@ -11,7 +11,6 @@ import static internal.helpers.Player.withProperty;
 import static internal.helpers.Player.withRange;
 import static internal.helpers.Player.withSign;
 import static internal.helpers.Player.withSkill;
-import static net.sourceforge.kolmafia.persistence.DebugDatabase.sgn;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.hamcrest.Matchers.equalTo;
@@ -136,8 +135,8 @@ public class ConcoctionTest {
     Concoction mayo = ConcoctionPool.get(ItemPool.MAYODIOL);
     assertNotNull(whet);
     assertNotNull(mayo);
-    int one = sgn(whet.compareTo(mayo));
-    int two = sgn(mayo.compareTo(whet));
+    int one = Integer.signum(whet.compareTo(mayo));
+    int two = Integer.signum(mayo.compareTo(whet));
     assertEquals(one, -two);
   }
 

--- a/test/net/sourceforge/kolmafia/objectpool/ConcoctionTest.java
+++ b/test/net/sourceforge/kolmafia/objectpool/ConcoctionTest.java
@@ -11,11 +11,14 @@ import static internal.helpers.Player.withProperty;
 import static internal.helpers.Player.withRange;
 import static internal.helpers.Player.withSign;
 import static internal.helpers.Player.withSkill;
+import static net.sourceforge.kolmafia.persistence.DebugDatabase.sgn;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import internal.helpers.Cleanups;
 import java.util.Arrays;
@@ -125,6 +128,17 @@ public class ConcoctionTest {
           isFancy,
           equalTo(hasFancyIngredient));
     }
+  }
+
+  @Test
+  public void checkCompareContractForHelpers() {
+    Concoction whet = ConcoctionPool.get(ItemPool.WHETSTONE);
+    Concoction mayo = ConcoctionPool.get(ItemPool.MAYODIOL);
+    assertNotNull(whet);
+    assertNotNull(mayo);
+    int one = sgn(whet.compareTo(mayo));
+    int two = sgn(mayo.compareTo(whet));
+    assertEquals(one, -two);
   }
 
   @Nested


### PR DESCRIPTION
The gCLI command checkconcoction checks the compareTo contract for concoctions.

Without this fix several comparisons fail, for example, "Failed comparing (quasi symmetry) [11107] whet stone and [8262] Mayodiol".  All of the failures involve helpers.

The test fails without the proposed fix and passes with it.  Furthermore, after the fix checkconcoction shows no failures.

This fix will change the behavior of any sorted list of concoctions that contains two or more helpers.