### PR TITLE
feat: dump mini kiwi items

### DIFF
--- a/src/data/coinmasters.txt
+++ b/src/data/coinmasters.txt
@@ -1210,3 +1210,18 @@ Elf Guard Toy and Munitions Factory	buy	150	replica Elf Guard medal	ROW1428
 Elf Guard Toy and Munitions Factory	buy	400	Lil' Snowball Factory	ROW1429
 Elf Guard Toy and Munitions Factory	buy	1000	Elf Guard safety bear	ROW1440
 Elf Guard Toy and Munitions Factory	buy	2000	Elf Guard temporary (permanent) tattoo	ROW1430
+
+#Kiwi Kwiki Mart	unknown	mini kiwi bikini	mini kiwi (2)	ROW1477
+#Kiwi Kwiki Mart	unknown	mini kiwitini	mini kiwi	ROW1478
+#Kiwi Kwiki Mart	unknown	mini kiwitini	mini kiwi	ROW1479
+#Kiwi Kwiki Mart	unknown	mini kiwi invisible dirigible	mini kiwi (3)	ROW1480
+#Kiwi Kwiki Mart	unknown	mini kiwi aioli	mini kiwi (5)	ROW1481
+#Kiwi Kwiki Mart	unknown	mini kiwi silicon tiepin	mini kiwi (3)	ROW1482
+#Kiwi Kwiki Mart	unknown	mini kiwi tipi	mini kiwi	ROW1483
+#Kiwi Kwiki Mart	unknown	mini kiwi intoxicating spirits	mini kiwi (3)	ROW1484
+#Kiwi Kwiki Mart	unknown	mini kiwi illicit antibiotic	mini kiwi (3)	ROW1485
+#Kiwi Kwiki Mart	unknown	mini kiwi antimilitaristic hippy petition	mini kiwi (3)	ROW1486
+#Kiwi Kwiki Mart	unknown	mini kiwi whipping stick	mini kiwi (4)	ROW1487
+#Kiwi Kwiki Mart	unknown	mini kiwi icepick	mini kiwi (4)	ROW1488
+#Kiwi Kwiki Mart	unknown	mini kiwi-flavored aspirin-injecting lipstick	mini kiwi (3)	ROW1489
+#Kiwi Kwiki Mart	unknown	mini kiwi digitized cookies	mini kiwi (3)	ROW1490

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -2203,6 +2203,7 @@ user	_mimeArmyShotglassUsed	false
 user	_mimicEggsDonated	0
 user	_mimicEggsObtained	0
 user	_miniMartiniDrops	0
+user	_miniKiwiDrops	0
 user	_missGravesVermouthDrunk	false
 user	_missileLauncherUsed	false
 user	_molehillMountainUsed	false

--- a/src/data/equipment.txt
+++ b/src/data/equipment.txt
@@ -1406,6 +1406,7 @@ Mer-kin switchblade	200	Mus: 85	2-handed switchblade
 mercenary pistol	50	Mox: 10	1-handed pistol
 mercenary rifle	150	Mox: 30	2-handed rifle
 Meteoid ice beam	80	Mox: 25	1-handed gun
+mini kiwi icepick	0	Mus: 0	1-handed 
 miniature deck cannon	200	Mox: 85	2-handed handcannon
 miracle whip	10	Mus: 0	2-handed whip
 Mjolnir Jr.	200	Mys: 85	1-handed utensil
@@ -2113,6 +2114,7 @@ Microplushie: Otakulone	5	none
 Microplushie: Raverdrine	5	none
 Microplushie: Sororitrate	5	none
 mime pocket probe	10	none
+mini kiwi whipping stick	0	none
 mini-zeppelin	10	none
 miniature candle	100	none
 miniature stuffed Goth Giant	10	none
@@ -2872,6 +2874,8 @@ mime army insignia (sanitation)	10	Mys: 200
 mime-proof sunglasses	10	none
 miming boots	50	none
 miming gloves	50	none
+mini kiwi bikini	0	none
+mini kiwi silicon tiepin	0	none
 mini-marshmallow dispenser	100	none
 mirrored aviator shades	50	none
 molten medallion	160	Mys: 65

--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -329,3 +329,4 @@
 297	Pet Anchor	anchor.gif	none	pet anchor		0	0	0	0
 298
 299	Chest Mimic	mimicchest.gif	item0,meat0	baby chest mimic	googly chest eyes	1	2	2	3	haseyes
+300	Mini Kiwi	kiwi_kiwi.gif		mini kiwi egg		0	0	0	0

--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -329,4 +329,4 @@
 297	Pet Anchor	anchor.gif	none	pet anchor		0	0	0	0
 298
 299	Chest Mimic	mimicchest.gif	item0,meat0	baby chest mimic	googly chest eyes	1	2	2	3	haseyes
-300	Mini Kiwi	kiwi_kiwi.gif		mini kiwi egg		0	0	0	0
+300	Mini Kiwi	kiwi_kiwi.gif	stat0,meat0,drop	mini kiwi egg		0	0	0	0

--- a/src/data/fullness.txt
+++ b/src/data/fullness.txt
@@ -615,6 +615,8 @@ mime army rations	4	15	EPIC	30-34	40-50	40-50	40-50
 mince pie	2	1	awesome	8-10	10-20	0	0	leftovers, 20 Thanksgetting (Variable +meat, +item, +familiar weight, +all res)
 mind flayer corpse	5	1	crappy	5	0	21-25	0
 mineapple	2	1	good	4-6	10-20	10-20	10-20
+mini kiwi	1	1	decent	0	0	0	0	Unspaded
+mini kiwi digitized cookies	1	1	awesome	0	0	0	0	Unspaded
 Miserable Pie	2	1	awesome	7-9	0	0	7-9	50 Smithsness Dinner (+10 Smithsness)
 mixed wildflower greens	1	10	good	2-4	25-30	0	0
 mole mol&eacute;	3	4	good	7-8	10-14	10-14	10-14

--- a/src/data/inebriety.txt
+++ b/src/data/inebriety.txt
@@ -453,6 +453,8 @@ mid-level medieval mead	1	7	awesome	4-6	20-30	20-30	20-30	20-30 MP, WINE
 Middle of the Road&trade; brand whiskey	2	1	good	4-5	5-10	5-10	5-10
 mime army wine	4	15	EPIC	30-34	40-50	40-50	40-50
 mimosette	3	3	good	5-10	16-20	0	0
+mini kiwi intoxicating spirits	1	1	awesome	0	0	0	0	Unspaded
+mini kiwitini	1	1	good	0	0	0	0	Unspaded
 mini-martini	1	11	crappy	1	0	0	0	11 It's Not Even Funny, MARTINI
 Mint Yulep	2	2	EPIC	10-13	25-50	10-20	10-20
 Miss Graves' vermouth	2	4	EPIC	15-17	10-20	10-20	10-20

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11616,6 +11616,20 @@
 11588	yam mayo	878600079	nutramekin.gif	food	t,d	11	ramekins of yam mayo
 11589	yam burrito	855430740	burrito.gif	food	t,d	11
 11590
-11591
-11592
+11591	mini kiwi egg	845486056	kiwi_egg.gif	grow	t	0
+11592	aviator goggles	628912777	goggles.gif	familiar	t,d	75
 11593	Thwaitgold Illinigina illinoiensis model	257510677	thwaitilli.gif	none		0
+11594	mini kiwi	940910612	kiwi_minikiwi.gif	food, paste, cook, mix	t,d	5
+11595	mini kiwi bikini	705305695	kiwi_bikini.gif	accessory	t,d	11
+11596	mini kiwitini	263511672	martini.gif	drink	t,d	11
+11597	mini kiwi invisible dirigible	718055433	kiwi_dirigible.gif	familiar	t,d	30
+11598	mini kiwi aioli	863064561	ramekin.gif	usable	t,d	11
+11599	mini kiwi silicon tiepin	701181594	kiwi_tiepin.gif	accessory	t,d	40
+11600	mini kiwi tipi	496300747	kiwi_tipi.gif	usable	t,d	11
+11601	mini kiwi digitized cookies	733008951	10101.gif	food	t,d	11
+11602	mini kiwi intoxicating spirits	774169937	beerbottle.gif	drink	t,d	11
+11603	mini kiwi antimilitaristic hippy petition	779505307	document.gif	potion, usable	t,d	11
+11604	mini kiwi illicit antibiotic	459688276	kiwi_pill.gif	potion, usable	t,d	11
+11605	mini kiwi whipping stick	128063299	kiwi_stick.gif	offhand	t,d	11
+11606	mini kiwi icepick	956877502	kiwi_icepick.gif	weapon	t,d	11
+11607	mini kiwi-flavored aspirin-injecting lipstick	406308925	kiwi_lipstick.gif	potion, usable	t,d	11

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -1653,6 +1653,7 @@ Item	mercenary pistol	Muscle: +10, Mysticality: +10, Moxie: +10, Never Fumble
 Item	mercenary rifle	Ranged Damage: +20, Initiative: +50
 # Meteoid ice beam: On Critical:  Freeze Opponent
 Item	Meteoid ice beam	Cold Damage: +20, Critical Hit Percent: +10
+Item	mini kiwi icepick	Booze Drop: +30
 Item	miniature deck cannon	Ranged Damage: +25, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20
 Item	miracle whip	Initiative: +50, Weapon Damage: +50, Item Drop: +50, Meat Drop: +100, Lasts Until Rollover
 # Mjolnir Jr.
@@ -2455,6 +2456,7 @@ Item	Microplushie: Hobomosome	Stench Resistance: +1
 Item	Microplushie: Otakulone	Maximum MP: +4
 Item	Microplushie: Raverdrine	Maximum HP: +8
 Item	Microplushie: Sororitrate	Sleaze Damage: +2
+Item	mini kiwi whipping stick	Sleaze Damage: +5, Experience: +2
 # mini-zeppelin
 Item	miniature candle	Experience: +3, Item Drop: +20, Lasts Until Rollover
 # miniature stuffed Goth Giant
@@ -3355,6 +3357,8 @@ Item	mime army insignia (sanitation)	Single Equip
 Item	mime-proof sunglasses	Single Equip
 Item	miming boots	Damage Reduction: 10, Spooky Resistance: +3, Single Equip
 Item	miming gloves	Damage Reduction: 10, Sleaze Resistance: +3, Single Equip
+Item	mini kiwi bikini	Moxie: +11, Sleaze Damage: +20, Sleaze Spell Damage: +40
+Item	mini kiwi silicon tiepin	Initiative: +30, Mysticality: +3, Moxie: +3
 Item	mini-marshmallow dispenser	Maximum HP: +30, Maximum MP: +30, HP Regen Min: 6, HP Regen Max: 8, MP Regen Min: 6, MP Regen Max: 8
 # mirrored aviator shades: Kill 10% More Skeletons
 Item	mirrored aviator shades	Moxie: +15, Single Equip
@@ -5312,6 +5316,7 @@ Effect	Ashen	Combat Rate: -15
 Effect	Ashen Burps	Monster Level: +15
 Effect	Aspect of the GravyPlum Fairy	Item Drop: +10
 Effect	Aspect of the Twinklefairy	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Weapon Damage: +5, Spell Damage: +5
+Effect	Aspirinated Lips	HP Regen Min: 40, HP Regen Max: 50
 Effect	Ass Over Teakettle	Initiative: +50
 Effect	Assaulted with Pepper	Monster Level: +20
 Effect	Astral Shell	Damage Absorption: +80, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1
@@ -6409,6 +6414,7 @@ Effect	Highland Sheen	Moxie: +10
 Effect	Hip to Be Square Dancin'	Item Drop: +10
 Effect	[1872]Hip to the Jive	Avatar: "hep cat"
 Effect	[1701]Hip to the Jive	Experience (familiar): +2, Familiar Weight: +10, Familiar Damage: +20
+Effect	Hippy Antimilitarism	Combat Rate: -10
 Effect	Hippy Flavor	Mysticality: +15
 Effect	Hippy Stench	Combat Rate: +5
 Effect	Hobo Flavor	Stench Damage: +10, Stench Resistance: +2
@@ -6509,6 +6515,7 @@ Effect	In Vino Vires	Muscle Percent: +50, Mysticality Percent: +50, Moxie Percen
 # In Your Cups: Whoah...
 Effect	Inappropriate Spirit	Sleaze Damage: +20, Sleaze Spell Damage: +20
 Effect	Incensed	Mysticality: +10
+Effect	Incredibly Healthy	Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Stench Resistance: +3, Spooky Resistance: +3
 Effect	Incredibly Hulking	Muscle Percent: +200
 Effect	Incredibly Well Lit	Item Drop: +50, Meat Drop: +100
 Effect	Indescribable Flavor	Spell Damage: +30
@@ -9502,6 +9509,7 @@ Item	McLeod's Hard Haggis-Ade	Effect: "Hagg-ard", Effect Duration: 20
 Item	meadeorite	Effect: "Meadulla Oblongota", Effect Duration: 40
 Item	melon-infused sake	Effect: "Warm Belly", Effect Duration: 1
 Item	mentholated wine	Effect: "Christmessy", Effect Duration: 20
+Item	mini kiwitini	Effect: "Green Peace", Effect Duration: 15
 Item	mini-martini	Effect: "It's Not Even Funny", Effect Duration: 11
 Item	Mohobo	Effect: "Mo' Hobo", Effect Duration: 5
 Item	Moonshine Mohobo	Effect: "Mo' Hobo", Effect Duration: 10
@@ -10399,6 +10407,9 @@ Item	Mick's IcyVapoHotness Rub	Effect: "Extreme Muscle Relaxation", Effect Durat
 Item	military candy cane	Effect: "Militarily Minted", Effect Duration: 10
 Item	Milk Studs	Effect: "Milk Studly", Effect Duration: 15
 Item	mime army camouflage kit	Effect: "Mimeoflage", Effect Duration: 30
+Item	mini kiwi antimilitaristic hippy petition	Effect: "Hippy Antimilitarism", Effect Duration: 5
+Item	mini kiwi illicit antibiotic	Effect: "Incredibly Healthy", Effect Duration: 5
+Item	mini kiwi-flavored aspirin-injecting lipstick	Effect: "Aspirinated Lips", Effect Duration: 5
 Item	miniature power pill	Effect: "Pill Power", Effect Duration: 30
 Item	mocking turtle	Effect: "Tortious", Effect Duration: 15
 Item	monkey barf	Effect: "Barfpits", Effect Duration: 1
@@ -11138,6 +11149,7 @@ Item	autumn dollar	Effect: "Bet Your Autumn Dollar", Effect Duration: 30
 Item	autumn leaf	Effect: "Crunching Leaves", Effect Duration: 20
 Item	autumn years wisdom	Effect: "Wisdom of the Autumn Years", Effect Duration: 30
 Item	avatar of the Unconscious Collective	Free Pull
+# aviator goggles: Makes your mini kiwi lay mini kiwis more often
 Item	baby camelCalf	Free Pull
 Item	baby chest mimic	Free Pull
 Item	bad penguin egg	Free Pull
@@ -11949,6 +11961,8 @@ Item	Merc Core Field Manual: Sanity Maintenance	Skill: "Hypersane"
 # mime army challenge coin: Flip it.  I'm sure it's safe.
 # mime army shotglass: Your first 1-drunkenness booze item of the day doesn't count
 # mime eraser: Instantly destroy a mime in the Cheerless Spire
+Item	mini kiwi egg	Free Pull
+Item	mini kiwi invisible dirigible	Familiar Weight: -20, Generic
 # miniature boiler: Deals 20-40 Physical Damage
 # Miniborg beeper: Deals 20-25 Physical Damage and hurts you a little bit
 # Miniborg beeper: (doesn't go away when used)

--- a/src/data/statuseffects.txt
+++ b/src/data/statuseffects.txt
@@ -2919,3 +2919,6 @@
 2916	Eye of Sleaze	eye_sleaze.gif	8fab7c874601648ba09185b0e0adae17	neutral	none
 2917	Eye of Fear	eye_spooky.gif	ad97eb06bbd69f2ff5747e24378ab817	neutral	none
 2918	Eye of Stench	eye_stench.gif	9665117fd2b2f156506de27fd6572a5e	neutral	none
+2919	Hippy Antimilitarism	document.gif	e044e8b109d64a10ec19598920f846e8	neutral	none	use 1 mini kiwi antimilitaristic hippy petition
+2920	Incredibly Healthy	kiwi_pill.gif	8fa125fb5bcb1a66079b1ff970d7e5fd	neutral	none	use 1 mini kiwi illicit antibiotic
+2921	Aspirinated Lips	kiwi_lipstick.gif	9e5dfff0ab057887d958c0fb5609c2c1	neutral	none	use 1 mini kiwi-flavored aspirin-injecting lipstick

--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -1194,6 +1194,9 @@ public class FamiliarData implements Comparable<FamiliarData> {
             "maps",
             "_mapToACandyRichBlockDrops",
             -1));
+    DROP_FAMILIARS.add(
+        new DropInfo(
+            FamiliarPool.MINI_KIWI, ItemPool.MINI_KIWI, "mini kiwis", "_miniKiwiDrops", -1));
   }
 
   public static DropInfo getDropInfo(int id) {

--- a/src/net/sourceforge/kolmafia/objectpool/FamiliarPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/FamiliarPool.java
@@ -130,6 +130,7 @@ public class FamiliarPool {
   public static final int HOBO_IN_SHEEPS_CLOTHING = 290;
   public static final int PATRIOTIC_EAGLE = 293;
   public static final int JILL_OF_ALL_TRADES = 294;
+  public static final int MINI_KIWI = 300;
 
   private FamiliarPool() {}
 }

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3754,6 +3754,7 @@ public class ItemPool {
   public static final int MAYAM_CALENDAR = 11572;
   public static final int YAM_BATTERY = 11582;
   public static final int STUFFED_YAM_STINKBOMB = 11583;
+  public static final int MINI_KIWI = 11594;
 
   private ItemPool() {}
 

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -3413,6 +3413,11 @@ public class ResultProcessor {
           Preferences.increment("_mapToACandyRichBlockDrops", 1);
         }
         break;
+      case ItemPool.MINI_KIWI:
+        if (adventureResults && KoLCharacter.currentFamiliar.getId() == FamiliarPool.MINI_KIWI) {
+          Preferences.increment("_miniKiwiDrops", 1);
+        }
+        break;
     }
 
     // Gaining items can achieve goals.


### PR DESCRIPTION
Kiwi shop failed parsing, bit more work needed there.

When the mini kiwi drops eggs, you don't get a "You acquire" message at the moment, but that'll probably get fixed.