### PR TITLE
feat: override rhino encoding provider instead of content-types.properties

### DIFF
--- a/src/data/content-types.properties
+++ b/src/data/content-types.properties
@@ -1,1 +1,0 @@
-# Don't recognise any content types

--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -13,7 +13,6 @@ import java.io.RandomAccessFile;
 import java.math.BigInteger;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -115,7 +114,6 @@ import net.sourceforge.kolmafia.swingui.listener.LicenseDisplayListener;
 import net.sourceforge.kolmafia.swingui.panel.GearChangePanel;
 import net.sourceforge.kolmafia.swingui.panel.GenericPanel;
 import net.sourceforge.kolmafia.textui.AshRuntime;
-import net.sourceforge.kolmafia.utilities.FileUtilities;
 import net.sourceforge.kolmafia.utilities.LockableListFactory;
 import net.sourceforge.kolmafia.utilities.LogStream;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
@@ -135,23 +133,11 @@ public abstract class KoLmafia {
     System.setProperty("com.apple.mrj.application.live-resize", "true");
     System.setProperty("com.apple.mrj.application.growbox.intrudes", "false");
     System.setProperty("java.net.preferIPv4Stack", "true");
-    // override content types to avoid a Rhino problem
-    // see https://github.com/mozilla/rhino/issues/1232
-    ensureContentTypes();
 
     if (SwinglessUIUtils.isSwingAvailable()) {
       JEditorPane.registerEditorKitForContentType("text/html", RequestEditorKit.class.getName());
     }
     System.setProperty("apple.laf.useScreenMenuBar", "true");
-  }
-
-  protected static void ensureContentTypes() {
-    var contentTypesFile = KoLConstants.DATA_LOCATION.toPath().resolve("content-types.properties");
-    if (!Files.exists(contentTypesFile)) {
-      FileUtilities.loadLibrary(
-          KoLConstants.DATA_LOCATION, KoLConstants.DATA_DIRECTORY, "content-types.properties");
-    }
-    System.setProperty("content.types.user.table", contentTypesFile.toString());
   }
 
   public static String currentIterationString = "";

--- a/test/internal/extensions/ClearSharedStateAfter.java
+++ b/test/internal/extensions/ClearSharedStateAfter.java
@@ -24,13 +24,7 @@ public class ClearSharedStateAfter implements AfterAllCallback {
     // pulvereport.txt comes from a disabled test of DebugDatabase
     // test_stringbuffer_function_with_consstring.txt comes from the CustomScript
     // stringbuffer_function_with_consstring.js
-    // content-types.properties comes from initialization to get around a Rhino issue noted in
-    // https://github.com/mozilla/rhino/issues/1232
-    String[] filesToDelete = {
-      "pulvereport.txt",
-      "test_stringbuffer_function_with_consstring.txt",
-      "content-types.properties"
-    };
+    String[] filesToDelete = {"pulvereport.txt", "test_stringbuffer_function_with_consstring.txt"};
     for (String s : filesToDelete) {
       Path dest = Paths.get(KoLConstants.ROOT_LOCATION + "/data/" + s);
       dest.toFile().delete();

--- a/test/net/sourceforge/kolmafia/CustomScriptTest.java
+++ b/test/net/sourceforge/kolmafia/CustomScriptTest.java
@@ -41,8 +41,6 @@ class CustomScriptTest {
     ContactManager.registerPlayerId("heeheehee", "354981");
     StaticEntity.overrideRevision(10000);
     TurnCounter.clearCounters();
-    // This is needed to make sure js test scripts work on Ubuntu when data/ is cleaned
-    KoLmafia.ensureContentTypes();
   }
 
   @AfterEach


### PR DESCRIPTION
Alternative to #784 now that https://github.com/mozilla/rhino/issues/1232 is in.