### PR TITLE
arena stats for Mini Kiwi

### DIFF
--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -329,4 +329,4 @@
 297	Pet Anchor	anchor.gif	none	pet anchor		0	0	0	0
 298
 299	Chest Mimic	mimicchest.gif	item0,meat0	baby chest mimic	googly chest eyes	1	2	2	3	haseyes
-300	Mini Kiwi	kiwi_kiwi.gif	stat0,meat0,drop	mini kiwi egg	aviator goggles	0	0	0	0
+300	Mini Kiwi	kiwi_kiwi.gif	stat0,meat0,drop	mini kiwi egg	aviator goggles	3	3	3	1


### PR DESCRIPTION
```
Results for Mini Kiwi after 12 trials using 144 turns:

Contest         XP[1]   XP[2]   XP[3]  Original Rank Derived Rank

Cage Match      24      30      48           0              3
Scavenger Hunt  24      24      25           0              3
Obstacle Course 24      27      55           0              3
Hide and Seek   24      24      24           0              1
```