### PR TITLE
fix: change messages referring to jenkins to not

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![release](https://img.shields.io/github/v/release/kolmafia/kolmafia?color=blueviolet&label=%F0%9F%8D%B8%20release)](https://github.com/kolmafia/kolmafia/releases/latest)
 [![minimum java](https://img.shields.io/static/v1?label=min%20java&message=v17&color=%23007396&logo=java)](https://adoptium.net/)
-[![jenkins](https://ci.kolmafia.us/job/Kolmafia/badge/icon?style=flat)](https://ci.kolmafia.us/job/Kolmafia/lastBuild/)
 [![codecov](https://img.shields.io/codecov/c/github/kolmafia/kolmafia?logo=codecov&token=9Z41LO29KF)](https://codecov.io/github/kolmafia/kolmafia)
 [![forums](https://img.shields.io/static/v1?label=forums&message=join%20discussion&color=informational)](https://kolmafia.us)
 [![wiki](https://img.shields.io/static/v1?label=wiki&message=documentation&color=informational)](https://wiki.kolmafia.us)

--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -5560,7 +5560,7 @@ public class Parser {
   private AshDiagnostic sinceError(
       final String current, final String target, final Range directiveRange) {
     String template =
-        "'%s' requires revision r%s of kolmafia or higher (current: r%s).  Up-to-date builds can be found at https://ci.kolmafia.us/.";
+        "'%s' requires revision r%s of kolmafia or higher (current: r%s).  Up-to-date builds can be found at https://github.com/kolmafia/kolmafia/releases/.";
 
     return this.error(directiveRange, String.format(template, this.shortFileName, target, current));
   }

--- a/src/net/sourceforge/kolmafia/textui/command/UpdateDataCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/UpdateDataCommand.java
@@ -29,6 +29,6 @@ public class UpdateDataCommand extends AbstractCommand {
 
     KoLmafia.updateDisplay(
         MafiaState.ABORT,
-        "\"update\" doesn't do what you think it does.	Please visit kolmafia.us and download a daily build if you'd like to keep KoLmafia up-to-date between major releases.");
+        "\"update\" doesn't do what you think it does.	Please visit https://github.com/kolmafia/kolmafia/releases/ and download a daily build.");
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/parsetree/DirectiveTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/DirectiveTest.java
@@ -65,7 +65,7 @@ public class DirectiveTest {
         invalid(
             "since fails for high revision",
             "since r2000000000;",
-            "'null' requires revision r2000000000 of kolmafia or higher (current: r10000).  Up-to-date builds can be found at https://ci.kolmafia.us/.",
+            "'null' requires revision r2000000000 of kolmafia or higher (current: r10000).  Up-to-date builds can be found at https://github.com/kolmafia/kolmafia/releases/.",
             "char 1 to char 18"),
         invalid("Invalid since version", "since 10;", "invalid 'since' format", "char 1 to char 9"),
         valid(


### PR DESCRIPTION
Remove Jenkins mention from README.

Don't mention major releases, as we only do daily builds.