### PR TITLE
fix: check for dependencies relative to manifest root

### DIFF
--- a/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
@@ -205,7 +205,7 @@ public class GitManager extends ScriptManager {
           }
         }
 
-        if (DEPENDENCIES.equals(diff.getNewPath())) {
+        if (DEPENDENCIES.equals(newRelPath.toString())) {
           checkDependencies = true;
         }
       }


### PR DESCRIPTION
Fixes an issue with [autoscend](https://github.com/loathers/autoscend).

Currently, we're checking to see if a `dependencies.txt` relative to the root of the repo has changed, instead of relative to the manifest root. It just so happens that everything except autoscend had a build process whereby a `dependencies.txt` in the root was copied to the final folder -- but autoscend only has one in the `RELEASE` folder.