### PR TITLE
feat: update jgit to 6.10 to avoid vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,8 +94,8 @@ dependencies {
 	implementation 'org.swinglabs:swingx:1.0'
 	implementation 'org.tmatesoft.svnkit:svnkit:1.10.7'
 	implementation 'com.jgoodies:jgoodies-binding:2.13.0'
-	implementation 'org.eclipse.jgit:org.eclipse.jgit:6.3.0.202209071007-r'
-	implementation 'org.eclipse.jgit:org.eclipse.jgit.ssh.apache:6.3.0.202209071007-r'
+	implementation 'org.eclipse.jgit:org.eclipse.jgit:6.10.0.202406032230-r'
+	implementation 'org.eclipse.jgit:org.eclipse.jgit.ssh.apache:6.10.0.202406032230-r'
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ plugins {
 	id 'net.nemerosa.versioning' version '3.0.0'
 	id 'org.ajoberstar.grgit' version '5.2.1'
 	id 'org.panteleyev.jpackageplugin' version '1.6.0'
+	id "com.github.ben-manes.versions" version "0.51.0" // enables ./gradlew dependencyUpdates for outdated
 }
 
 sourceSets {

--- a/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
@@ -663,6 +663,11 @@ public class GitManager extends ScriptManager {
     public boolean isCancelled() {
       return false;
     }
+
+    @Override
+    public void showDuration(boolean b) {
+      // say nothing
+    }
   }
 
   public record RepoDetails(String repoUrl, String branchName) {}

--- a/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
@@ -184,7 +184,7 @@ public class GitManager extends ScriptManager {
         return false;
       }
 
-      if (diffs.size() == 0) {
+      if (diffs.isEmpty()) {
         RequestLogger.printLine("No changes");
         return false;
       }
@@ -226,7 +226,7 @@ public class GitManager extends ScriptManager {
     var success = result.getRebaseResult().getStatus().isSuccessful();
     if (!success) {
       // the rebase failed. Does the user have any local changes?
-      var hasLocal = git.diff().call().size() != 0;
+      var hasLocal = !git.diff().call().isEmpty();
       if (!hasLocal) return false;
       KoLmafia.updateDisplay("Detected local changes in " + folder + ". Attempting to merge.");
       // add all files
@@ -632,7 +632,7 @@ public class GitManager extends ScriptManager {
     if (json.isEmpty()) return projectPath;
     var manifest = json.get();
     var root = manifest.optString(MANIFEST_ROOTDIR, "");
-    if (root.length() == 0) return projectPath;
+    if (root.isEmpty()) return projectPath;
     // deny absolute paths or folder escapes
     if (root.startsWith("/") || root.startsWith("\\") || root.contains("..")) return projectPath;
     return projectPath.resolve(root);


### PR DESCRIPTION
Checkmarx reports CVE-2023-4759, a vulnerability in jgit < 6.7, which allows overwriting any file on a case-insensitive filesystem.

Update to latest to fix this.