### PR TITLE
Allow root/relay to be deleted after testing

### DIFF
--- a/test/internal/extensions/ClearSharedStateAfter.java
+++ b/test/internal/extensions/ClearSharedStateAfter.java
@@ -1,6 +1,7 @@
 package internal.extensions;
 
 import static internal.extensions.CheckNested.isNested;
+import static internal.helpers.Utilities.verboseDelete;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -29,7 +30,7 @@ public class ClearSharedStateAfter implements AfterAllCallback {
     };
     for (String s : filesToDelete) {
       Path dest = Paths.get(KoLConstants.ROOT_LOCATION + "/data/" + s);
-      dest.toFile().delete();
+      verboseDelete(dest);
     }
   }
 }

--- a/test/internal/extensions/ClearSharedStateBefore.java
+++ b/test/internal/extensions/ClearSharedStateBefore.java
@@ -70,23 +70,22 @@ public class ClearSharedStateBefore implements BeforeAllCallback {
 
   public static void deleteDirectoriesAndContents() {
     // These are the directories and files in test\root that are under git control.  Everything
-    // else is fair game for deletion after testing.  Keep relay as well since at least one test
-    // assumes relay had content created when mafia starts up.
-    String[] keepersArray = {"ccs", "data", "expected", "request", "relay", "scripts", "README"};
+    // else is fair game for deletion after testing.
+    String[] keepersArray = {"ccs", "data", "expected", "request", "scripts", "README"};
     List<String> keepersList = new ArrayList<>(Arrays.asList(keepersArray));
     // Get list of things in test\root and iterate, deleting as appropriate
     File root = KoLConstants.ROOT_LOCATION;
     String[] contents = root.list();
-    for (String content : contents) {
-      if (!keepersList.contains(content) && !(content.toLowerCase().startsWith("debug"))) {
-        Path pathToBeDeleted = new File(root, content).toPath();
-        try {
-          Files.walk(pathToBeDeleted)
-              .sorted(Comparator.reverseOrder())
-              .map(Path::toFile)
-              .forEach(File::delete);
-        } catch (IOException e) {
-          e.printStackTrace();
+    if (contents != null) {
+      for (String content : contents) {
+        if (!keepersList.contains(content) && !(content.toLowerCase().startsWith("debug"))) {
+          Path pathToBeDeleted = new File(root, content).toPath();
+          try (var walker = Files.walk(pathToBeDeleted)) {
+            walker.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+          } catch (IOException e) {
+            System.out.println(
+                "Unexpected exception when walking root/ for deletions: " + e.getMessage());
+          }
         }
       }
     }

--- a/test/net/sourceforge/kolmafia/request/RelayRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/RelayRequestTest.java
@@ -9,7 +9,6 @@ import java.io.File;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.utilities.FileUtilities;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class RelayRequestTest {
@@ -19,7 +18,6 @@ public class RelayRequestTest {
    * the only test that breaks when that happens. Duplicate the code that loads the relay directory
    * here so that the directory will be present when the test is run.
    */
-  @BeforeEach
   public void initializeRelayFileDirectory() {
     for (int i = 0; i < KoLConstants.RELAY_FILES.length; ++i) {
       FileUtilities.loadLibrary(
@@ -29,6 +27,7 @@ public class RelayRequestTest {
 
   @Test
   public void findVariousRelayFilesOrNot() {
+    initializeRelayFileDirectory();
     File f;
     f = RelayRequest.findRelayFile("thisIsNotAPipe");
     assertNotNull(f, "Allowed to find a new file.");

--- a/test/net/sourceforge/kolmafia/request/RelayRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/RelayRequestTest.java
@@ -1,12 +1,31 @@
 package net.sourceforge.kolmafia.request;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.utilities.FileUtilities;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class RelayRequestTest {
+
+  /**
+   * The global clean up code will delete root/relay since relay is not under Git control. This is
+   * the only test that breaks when that happens. Duplicate the code that loads the relay directory
+   * here so that the directory will be present when the test is run.
+   */
+  @BeforeEach
+  public void initializeRelayFileDirectory() {
+    for (int i = 0; i < KoLConstants.RELAY_FILES.length; ++i) {
+      FileUtilities.loadLibrary(
+          KoLConstants.RELAY_LOCATION, KoLConstants.RELAY_DIRECTORY, KoLConstants.RELAY_FILES[i]);
+    }
+  }
 
   @Test
   public void findVariousRelayFilesOrNot() {


### PR DESCRIPTION
If root/relay is always deleted then only one existing test fails.

This reinitializes root/relay for the test that must have it.

This deletes root/relay at the end of all tests.

The other changes are related to suggestions from static code analysis.