### PR TITLE
time-twitching toolbelt is not 'Variable'

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -3781,7 +3781,7 @@ Item	Time Lord Badge of Honor	Muscle Limit: 50, Mysticality Limit: 50, Moxie Lim
 # time-twitching toolbelt: Reveals various Time-Forgotten Secrets
 # time-twitching toolbelt: (also in the Time-Twitching Tower)
 # time-twitching toolbelt	Muscle: +15, Mysticality: +15, Moxie: +15, Single Equip, Item Drop: [60*zone(Twitch)], Free Pull: [pref(timeTowerAvailable,true)]
-Item	time-twitching toolbelt	Muscle: +15, Mysticality: +15, Moxie: +15, Single Equip, Item Drop: [60*zone(Twitch)], Variable
+Item	time-twitching toolbelt	Muscle: +15, Mysticality: +15, Moxie: +15, Item Drop: [60*zone(Twitch)], Single Equip
 Item	tin star	Monster Level: +5, Moxie: +3
 Item	tiny die-cast arc-welding Elfborg	Meat Drop: +10
 Item	tiny die-cast Bashful the Reindeer	Sleaze Damage: +1


### PR DESCRIPTION
Aside from the fact that there is no code for it in Modifiers.overrideItem, having it marked as such means the Maximizer and modtrace do not recognize it as a source of Item Drop in zone Twitch. 