### PR TITLE
Allow manually fixing banishers

### DIFF
--- a/src/net/sourceforge/kolmafia/session/BanishManager.java
+++ b/src/net/sourceforge/kolmafia/session/BanishManager.java
@@ -531,7 +531,13 @@ public class BanishManager {
   }
 
   public static List<String> getBanishedMonsters() {
-    BanishManager.recalculate();
+    return getBanishedMonsters(true);
+  }
+
+  public static List<String> getBanishedMonsters(final boolean recalculate) {
+    if (recalculate) {
+      BanishManager.recalculate();
+    }
 
     return banishedMonsters.stream().map(Banished::banished).collect(Collectors.toList());
   }

--- a/src/net/sourceforge/kolmafia/swingui/panel/DailyDeedsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/DailyDeedsPanel.java
@@ -3365,7 +3365,7 @@ public class DailyDeedsPanel extends Box implements Listener {
 
     @Override
     public void update() {
-      List<String> list = BanishManager.getBanishedMonsters();
+      List<String> list = BanishManager.getBanishedMonsters(false);
       String text = "Banished monsters: " + String.join(",", list);
 
       this.setText(text);

--- a/src/net/sourceforge/kolmafia/textui/command/RefreshStatusCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/RefreshStatusCommand.java
@@ -17,6 +17,7 @@ import net.sourceforge.kolmafia.request.ManageStoreRequest;
 import net.sourceforge.kolmafia.request.QuantumTerrariumRequest;
 import net.sourceforge.kolmafia.request.QuestLogRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
+import net.sourceforge.kolmafia.session.BanishManager;
 import net.sourceforge.kolmafia.session.InventoryManager;
 
 public class RefreshStatusCommand extends AbstractCommand {
@@ -72,6 +73,9 @@ public class RefreshStatusCommand extends AbstractCommand {
       return;
     } else if (parameters.equals("concoctions")) {
       ConcoctionDatabase.refreshConcoctions(true);
+      return;
+    } else if (parameters.equals("banishes")) {
+      BanishManager.loadBanished();
       return;
     } else {
       KoLmafia.updateDisplay(MafiaState.ERROR, parameters + " cannot be refreshed.");


### PR DESCRIPTION
We manage banishers in memory and persist them to a pref. Because of a listener-related close feedback loop, the moment you edit your banishedMonsters pref to fix a tracking issue, it overwrites it with a representation of the in-memory banisher state. This fixes that, and allows users to manually reload the in-memory state from that pref with `refresh banishes`.
