### PR TITLE
fix: tag the build-triggering commit, not the latest commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,7 @@ jobs:
             releases/*.deb
             releases/*.dmg
           tag_name: r${{ env.KOLMAFIA_VERSION }}
+          target_commitish: ${{ github.sha }}
           name: ${{ env.KOLMAFIA_VERSION }}
           generate_release_notes: true
         env:


### PR DESCRIPTION
Might fix the issue on https://github.com/kolmafia/kolmafia/releases/tag/r28015 / r28014, where a single commit is double-tagged and has two releases, that occurs when builds go out too quickly.

Ref https://github.com/softprops/action-gh-release/issues/392.