### PR TITLE
fix: various items are not pullable in LoL

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/CheckedItem.java
+++ b/src/net/sourceforge/kolmafia/maximizer/CheckedItem.java
@@ -120,7 +120,8 @@ public class CheckedItem extends AdventureResult {
           this.buyableFlag = true;
         }
       }
-    } else if (!KoLCharacter.isHardcore()) {
+    } else if (!KoLCharacter.isHardcore()
+        && (!KoLCharacter.inLegacyOfLoathing() || InventoryManager.pullableInLoL(itemId))) {
       // consider pulling
       this.pullable = this.getCount(KoLConstants.storage);
 

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3355,6 +3355,7 @@ public class ItemPool {
   public static final int PEPPERMINT_EEL_SAUCE = 10416;
   public static final int GREEN_AND_RED_BEAN = 10417;
   public static final int TEMPURA_GREEN_AND_RED_BEAN = 10425;
+  public static final int RETROSPECS = 10432;
   public static final int BIRD_A_DAY_CALENDAR = 10434;
   public static final int POWERFUL_GLOVE = 10438;
   public static final int DRIP_HARNESS = 10441;

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -19,7 +19,10 @@ import static internal.helpers.Player.withEquippableItem;
 import static internal.helpers.Player.withEquipped;
 import static internal.helpers.Player.withFamiliar;
 import static internal.helpers.Player.withFamiliarInTerrarium;
+import static internal.helpers.Player.withHardcore;
+import static internal.helpers.Player.withInteractivity;
 import static internal.helpers.Player.withItem;
+import static internal.helpers.Player.withItemInFreepulls;
 import static internal.helpers.Player.withItemInStorage;
 import static internal.helpers.Player.withLocation;
 import static internal.helpers.Player.withMeat;
@@ -2079,6 +2082,38 @@ public class MaximizerTest {
         assertTrue(maximize("PvP Fights"));
         recommendedSlotIs(Slot.OFFHAND, "card sleeve");
         recommendedSlotIs(Slot.CARDSLEEVE, "Alice's Army Foil Lanceman");
+      }
+    }
+  }
+
+  @Nested
+  class LegacyOfLoathing {
+    @Test
+    public void shouldNotSuggestPullingEquipmentInLegacyOfLoathing() {
+      var cleanups =
+          new Cleanups(
+              withPath(Path.LEGACY_OF_LOATHING),
+              withItemInStorage(ItemPool.POWERFUL_GLOVE),
+              withInteractivity(false));
+
+      try (cleanups) {
+        maximizeAny("hp");
+        assertFalse(someBoostIs(b -> commandStartsWith(b, "pull")));
+      }
+    }
+
+    @Test
+    public void shouldNotSuggestPullingFreePullsInLegacyOfLoathingHardcore() {
+      var cleanups =
+          new Cleanups(
+              withPath(Path.LEGACY_OF_LOATHING),
+              withItemInFreepulls(ItemPool.RETROSPECS),
+              withHardcore(),
+              withInteractivity(false));
+
+      try (cleanups) {
+        maximizeAny("mus");
+        assertFalse(someBoostIs(b -> b.toString().startsWith("free pull")));
       }
     }
   }


### PR DESCRIPTION
As reported in https://kolmafia.us/threads/in-legacy-of-loathing-hc-runs-maximiser-considers-free-pulls-that-cant-be-pulled-due-to-path-restrictions.29581/ and https://kolmafia.us/threads/maximizer-reports-retrospecs-as-free-pull-in-legacy-of-loathing-but-they-cannot-be-pulled.29393/ among others.

Not sure if the list is exactly correct as I don't think we store the original item types, but the tests cover the cases people wanted fixed.