### PR TITLE
feat: cheer-o-vend is accessible with cheer

### DIFF
--- a/src/data/coinmasters.txt
+++ b/src/data/coinmasters.txt
@@ -860,7 +860,7 @@ Cheer-o-Vend 3000	buy	15	cheer-o-gram	ROW969
 Cheer-o-Vend 3000	buy	100	cheerful antler hat	ROW970
 Cheer-o-Vend 3000	buy	100	cheerful Crimbo sweater	ROW971
 Cheer-o-Vend 3000	buy	100	cheerful pajama pants	ROW972
-Cheer-o-Vend 3000	buy	150	warehouse key	ROW979
+# Cheer-o-Vend 3000	buy	150	warehouse key	ROW979
 Cheer-o-Vend 3000	buy	1000	The Journal of Mime Science Vol. 1	ROW973
 Cheer-o-Vend 3000	buy	1000	The Journal of Mime Science Vol. 2	ROW974
 Cheer-o-Vend 3000	buy	1000	The Journal of Mime Science Vol. 3	ROW975

--- a/src/net/sourceforge/kolmafia/request/Crimbo17Request.java
+++ b/src/net/sourceforge/kolmafia/request/Crimbo17Request.java
@@ -4,6 +4,7 @@ import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.CoinmasterData;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 
 public class Crimbo17Request extends CoinMasterRequest {
@@ -73,7 +74,11 @@ public class Crimbo17Request extends CoinMasterRequest {
   }
 
   public static String accessible() {
-    return "Crimbo is gone";
+    int cheer = CHEER.getCount(KoLConstants.inventory);
+    if (cheer == 0) {
+      return "You need some crystalline cheer.";
+    }
+    return null;
   }
 
   public static final boolean registerRequest(final String urlString) {


### PR DESCRIPTION
The Cheer-O-Vend is accessible with crystalline cheer.

You can't buy warehouse keys any more.

You can buy the skillbooks only if you participated in the event and got "sufficiently far". What does this mean? It's a mystery.