### PR TITLE
Don't try to dereference a none location (NPE).

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -4284,7 +4284,7 @@ public abstract class RuntimeLibrary {
       }
     }
 
-    if (value.getType().equals(DataTypes.LOCATION_TYPE)) {
+    if (value.getType().equals(DataTypes.LOCATION_TYPE) && value.content != null) {
       return new Value(((KoLAdventure) value.content).getAdventureNumber());
     }
 

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -28,8 +28,10 @@ import static internal.helpers.Player.withTrackedMonsters;
 import static internal.helpers.Player.withTrackedPhyla;
 import static internal.helpers.Player.withTurnsPlayed;
 import static internal.helpers.Player.withValueOfAdventure;
+import static org.hamcrest.CoreMatchers.both;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -1551,6 +1553,30 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
         var output = execute("curse($item[disco ball], \"StuBorn\")");
         assertThat(output, startsWith("The disco ball cannot be used for cursing"));
       }
+    }
+  }
+
+  @Nested
+  class ToInt {
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+          "item",
+          "familiar",
+          "location",
+          "skill",
+          "effect",
+          "class",
+          "monster",
+          "thrall",
+          "servant",
+          "vykea",
+          "path"
+        })
+    void worksOnNoneValues(String type) {
+      assertThat(
+          execute("$" + type + "[none].to_int()"),
+          both(startsWith("Returned: ")).and(not(containsString("Script execution aborted"))));
     }
   }
 }


### PR DESCRIPTION
Should be self-explanatory. I am not sure what the difference is between CoreMatchers and Matchers in the tests is; happy to change that if necessary.