### PR TITLE
Update dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,9 @@ plugins {
 	id 'java'
 
 	id 'com.diffplug.spotless' version '6.23.3'
-	id 'com.github.johnrengelman.shadow' version '8.1.1'
-	id 'net.nemerosa.versioning' version '3.0.0'
-	id 'org.ajoberstar.grgit' version '5.2.1'
+	id 'com.gradleup.shadow' version '8.3.0'
+	id 'net.nemerosa.versioning' version '3.1.0'
+	id 'org.ajoberstar.grgit' version '5.2.2'
 	id 'org.panteleyev.jpackageplugin' version '1.6.0'
 	id "com.github.ben-manes.versions" version "0.51.0" // enables ./gradlew dependencyUpdates for outdated
 }
@@ -56,15 +56,15 @@ repositories {
 
 dependencies {
 	// Use JUnit Jupiter for running JUnit5 tests.
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.2'
-	testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.10.2'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.11.0'
 
-	testImplementation 'org.hamcrest:hamcrest:2.2'
+	testImplementation 'org.hamcrest:hamcrest:3.0'
 	testImplementation 'com.spotify:hamcrest-optional:1.3.2'
-	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
-	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.2'
-	testImplementation 'org.mockito:mockito-core:5.12.0'
-	testImplementation('org.eclipse.xtext:org.eclipse.xtext.xbase.lib:2.12.0') {
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.0'
+	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.11.0'
+	testImplementation 'org.mockito:mockito-core:5.13.0'
+	testImplementation('org.eclipse.xtext:org.eclipse.xtext.xbase.lib:2.36.0') {
 		because 'assertion errors including Location/Range/Position need it'
 	}
 	testImplementation 'org.junit-pioneer:junit-pioneer:2.2.0'
@@ -74,8 +74,8 @@ dependencies {
 	implementation 'com.formdev:flatlaf-swingx:1.6.5'
 	// Optional runtime deps for svnkit
 	runtimeOnly 'com.trilead:trilead-ssh2:1.0.0-build222'
-	runtimeOnly 'net.java.dev.jna:jna:5.6.0'
-	runtimeOnly 'net.java.dev.jna:jna-platform:5.6.0'
+	runtimeOnly 'net.java.dev.jna:jna:5.14.0'
+	runtimeOnly 'net.java.dev.jna:jna-platform:5.14.0'
 
 	libImplementation 'org.swinglabs:swingx:1.0'
 
@@ -83,16 +83,16 @@ dependencies {
 		builtBy 'compileLibJava'
 	}
 
-	implementation 'net.sourceforge.htmlcleaner:htmlcleaner:2.26'
-	implementation('org.eclipse.lsp4j:org.eclipse.lsp4j:0.12.0') {
+	implementation 'net.sourceforge.htmlcleaner:htmlcleaner:2.29'
+	implementation('org.eclipse.lsp4j:org.eclipse.lsp4j:0.23.1') {
 		exclude group: 'org.eclipse.xtend', module: 'org.eclipse.xtend.lib'
 	}
-	implementation 'org.slf4j:slf4j-nop:2.0.7'
-	implementation 'org.fusesource.jansi:jansi:2.4.0'
-	implementation 'org.json:json:20220320'
+	implementation 'org.slf4j:slf4j-nop:2.0.16'
+	implementation 'org.fusesource.jansi:jansi:2.4.1'
+	implementation 'org.json:json:20240303'
 	implementation 'org.mozilla:rhino:1.7.15'
 	implementation 'org.swinglabs:swingx:1.0'
-	implementation 'org.tmatesoft.svnkit:svnkit:1.10.7'
+	implementation 'org.tmatesoft.svnkit:svnkit:1.10.11'
 	implementation 'com.jgoodies:jgoodies-binding:2.13.0'
 	implementation 'org.eclipse.jgit:org.eclipse.jgit:6.10.0.202406032230-r'
 	implementation 'org.eclipse.jgit:org.eclipse.jgit.ssh.apache:6.10.0.202406032230-r'


### PR DESCRIPTION
Most of these are only minor version bumps, but there were a handful of major version changes.

Most notably: the maintainer for shadow has changed, along with the package naming.

Hamcrest 3.0 looks like the main backwards incompatible change is that it's ratcheted up the minimum Java version to require at least Java 8. Since we're building with Java 17, this is a non-issue.

There were a handful of major version changes in dependencies that I'm not sure we're ready for (flatlaf and swingx were the two that I recall), and a couple of dependencies where the latest version is marked as beta or alpha (spotless, slf4j-nop).