### PR TITLE
Quest.PirateRealm

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -2342,6 +2342,7 @@ user	_questPartyFair	unstarted
 user	_questPartyFairItemsOpened	0
 user	_questPartyFairProgress
 user	_questPartyFairQuest
+user	_questPirateRealm	unstarted
 user	_radlibSummons	0
 user	_raindohCopiesMade	0
 user	_rainStickUsed	false

--- a/src/data/questslog.txt
+++ b/src/data/questslog.txt
@@ -130,3 +130,7 @@ questGuzzlr	Guzzlr.  Low Effort, High ABV.	(various messages)	Deliver the 	(no c
 
 # Rufus 
 questRufus	Rufus's Goofin'	Rufus wants	Call Rufus 	(no completion message)
+
+# PirateRealm
+# This is a fake quest, it is useful to treat like a quest but doesn't have an entry in the quest log.
+_questPirateRealm	PirateRealm	(no message)	(no message)	(no message)	(no message)	(no message)	(no message)	(no message)	(no message)	(no message)	(no message)	(no message)	(no message)	(no message)	(no message)	(no message)	(no message)	(no message)	(no message)

--- a/src/net/sourceforge/kolmafia/persistence/QuestDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/QuestDatabase.java
@@ -118,6 +118,7 @@ public class QuestDatabase {
     MAELSTROM("questMaelstromOfLovers"),
     GLACIER("questGlacierOfJerks"),
     RUFUS("questRufus"),
+    PIRATEREALM("_questPirateRealm"),
     ;
 
     private final String pref;
@@ -1073,6 +1074,12 @@ public class QuestDatabase {
     return Preferences.getString(quest.getPref());
   }
 
+  private static String stepToProgress(int step) {
+    if (step < 0) return QuestDatabase.UNSTARTED;
+    if (step == 0) return QuestDatabase.STARTED;
+    return "step" + step;
+  }
+
   public static void setQuest(Quest quest, String progress) {
     Preferences.setString(quest.getPref(), progress);
   }
@@ -1082,6 +1089,10 @@ public class QuestDatabase {
       return;
     }
     QuestDatabase.setQuestIfBetter(quest.getPref(), progress);
+  }
+
+  public static void setQuestIfBetter(Quest quest, int step) {
+    QuestDatabase.setQuestIfBetter(quest, stepToProgress(step));
   }
 
   private static void setQuestIfBetter(String pref, String status) {

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -4254,8 +4254,14 @@ public class FightRequest extends GenericRequest {
           Preferences.setBoolean("pirateRealmUnlockedFlag", true);
           QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 16);
         }
-        case "giant giant crab" -> Preferences.setBoolean("pirateRealmUnlockedCrabsicle", true);
-        case "jungle titan" -> Preferences.setBoolean("pirateRealmUnlockedBreastplate", true);
+        case "giant giant crab" -> {
+          Preferences.setBoolean("pirateRealmUnlockedCrabsicle", true);
+          QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 6);
+        }
+        case "jungle titan" -> {
+          Preferences.setBoolean("pirateRealmUnlockedBreastplate", true);
+          QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 11);
+        }
         case "plastic pirate" -> Preferences.increment(
             "pirateRealmPlasticPiratesDefeated", 1, 50, false);
         case "pirate radio" -> {

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -4246,13 +4246,22 @@ public class FightRequest extends GenericRequest {
         case "Baron von Ratsworth" -> TavernRequest.addTavernLocation('6');
         case "the invader" -> Preferences.setBoolean("spaceInvaderDefeated", true);
         case "Eldritch Tentacle" -> Preferences.increment("eldritchTentaclesFought", 1);
-        case "Glass Jack Hummel" -> Preferences.setBoolean("pirateRealmUnlockedSpyglass", true);
-        case "Red Roger" -> Preferences.setBoolean("pirateRealmUnlockedFlag", true);
+        case "Glass Jack Hummel" -> {
+          Preferences.setBoolean("pirateRealmUnlockedSpyglass", true);
+          QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 16);
+        }
+        case "Red Roger" -> {
+          Preferences.setBoolean("pirateRealmUnlockedFlag", true);
+          QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 16);
+        }
         case "giant giant crab" -> Preferences.setBoolean("pirateRealmUnlockedCrabsicle", true);
         case "jungle titan" -> Preferences.setBoolean("pirateRealmUnlockedBreastplate", true);
         case "plastic pirate" -> Preferences.increment(
             "pirateRealmPlasticPiratesDefeated", 1, 50, false);
-        case "pirate radio" -> Preferences.setBoolean("pirateRealmUnlockedRadioRing", true);
+        case "pirate radio" -> {
+          Preferences.setBoolean("pirateRealmUnlockedRadioRing", true);
+          QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 16);
+        }
       }
 
       if (KoLCharacter.hasEquipped(ItemPool.BONE_ABACUS, Slot.OFFHAND)

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -11016,7 +11016,10 @@ public class FightRequest extends GenericRequest {
         Preferences.setBoolean("_pirateRealmWindicleUsed", true);
 
         if (responseText.contains("Your foe is blown clear of the island") || itemRunawaySuccess) {
-          Preferences.increment("_pirateRealmIslandMonstersDefeated", 3);
+          var defeated = Preferences.increment("_pirateRealmIslandMonstersDefeated", 3);
+          if (defeated >= (QuestManager.getPirateRealmIslandNumber() < 2 ? 4 : 9)) {
+            QuestManager.setPirateRealmIslandQuestProgress(3);
+          }
         }
 
         break;

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -4216,7 +4216,10 @@ public class FightRequest extends GenericRequest {
 
       // Track monsters defeated on the current PirateRealm island
       if (adventure == AdventurePool.PIRATEREALM_ISLAND) {
-        Preferences.increment("_pirateRealmIslandMonstersDefeated");
+        var defeated = Preferences.increment("_pirateRealmIslandMonstersDefeated");
+        if (defeated == (QuestManager.getPirateRealmIslandNumber() < 2 ? 4 : 9)) {
+          QuestManager.setPirateRealmIslandQuestProgress(3);
+        }
       }
 
       if (IslandManager.isBattlefieldMonster(monsterName)) {

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -425,6 +425,7 @@ public abstract class ChoiceControl {
         break;
 
       case 1350:
+        // Time to Set Sail!
         QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 1);
         break;
 
@@ -442,6 +443,7 @@ public abstract class ChoiceControl {
         }
 
       case 1355:
+        //  Land Ho!
         {
           // Step 3 -> 4, 8 -> 9 or 13 -> 14
           QuestManager.setPirateRealmIslandQuestProgress(2);

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -424,32 +424,6 @@ public abstract class ChoiceControl {
         BastilleBattalionManager.preChoice(urlString, request);
         break;
 
-      case 1350:
-        // Time to Set Sail!
-        QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 1);
-        break;
-
-      case 1352: //  Island #1, Who Are You?
-      case 1353: //  What's Behind Island #2?
-      case 1354: //  Third Island's the Charm
-        {
-          // Advance quest progress
-          QuestManager.setPirateRealmIslandQuestProgress(choice - 1352, 0);
-          // Reset per-island flags
-          Preferences.setInteger("_pirateRealmIslandMonstersDefeated", 0);
-          Preferences.setInteger("_pirateRealmSailingTurns", 0);
-          Preferences.setBoolean("_pirateRealmWindicleUsed", false);
-          break;
-        }
-
-      case 1355:
-        //  Land Ho!
-        {
-          // Step 3 -> 4, 8 -> 9 or 13 -> 14
-          QuestManager.setPirateRealmIslandQuestProgress(2);
-          break;
-        }
-
       case 1356: // Smooth Sailing
       case 1357: // High Tide, Low Morale
       case 1360: // Like Shops in the Night
@@ -4305,6 +4279,27 @@ public abstract class ChoiceControl {
                 case 5 -> 9;
                 default -> 0;
               });
+          break;
+        }
+
+      case 1352: //  Island #1, Who Are You?
+      case 1353: //  What's Behind Island #2?
+      case 1354: //  Third Island's the Charm
+        {
+          // Advance quest progress
+          QuestManager.setPirateRealmIslandQuestProgress(ChoiceManager.lastChoice - 1352, 0);
+          // Reset per-island flags
+          Preferences.setInteger("_pirateRealmIslandMonstersDefeated", 0);
+          Preferences.setInteger("_pirateRealmSailingTurns", 0);
+          Preferences.setBoolean("_pirateRealmWindicleUsed", false);
+          break;
+        }
+
+      case 1355:
+        //  Land Ho!
+        {
+          // Step 3 -> 4, 8 -> 9 or 13 -> 14
+          QuestManager.setPirateRealmIslandQuestProgress(2);
           break;
         }
 

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -4355,15 +4355,33 @@ public abstract class ChoiceControl {
         }
         break;
 
+      case 1369, // The Battle (Island) Is Won
+          1370, // Skull's Well That Ends Skull
+          1371, // The Key Takeaway
+          1385: // Just Desserts
+        {
+          QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 6);
+          break;
+        }
+
       case 1372: // You Can See Clearly Now
         {
           Preferences.setBoolean("pirateRealmUnlockedRhum", true);
+          QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 6);
           break;
         }
 
       case 1375: // A Close Shave
         {
           Preferences.setBoolean("pirateRealmUnlockedShavingCream", true);
+          QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 11);
+          break;
+        }
+
+      case 1376, // Your Empire of Dirt
+          1377: // A Dreaded Sunny Day
+        {
+          QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 11);
           break;
         }
 
@@ -4386,6 +4404,7 @@ public abstract class ChoiceControl {
       case 1383: // Parole
         {
           Preferences.setBoolean("pirateRealmUnlockedThirdCrewmate", true);
+          QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 11);
           break;
         }
 

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -445,6 +445,7 @@ public abstract class ChoiceControl {
         {
           // Step 3 -> 4, 8 -> 9 or 13 -> 14
           QuestManager.setPirateRealmIslandQuestProgress(2);
+          break;
         }
 
       case 1356: // Smooth Sailing

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -4369,6 +4369,7 @@ public abstract class ChoiceControl {
         {
           if (text.contains("Island Drinkin' skillbook")) {
             Preferences.setBoolean("pirateRealmUnlockedTikiSkillbook", true);
+            QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 16);
           }
           break;
         }
@@ -4376,6 +4377,7 @@ public abstract class ChoiceControl {
       case 1380: // Temple's Grand End
         {
           Preferences.setBoolean("pirateRealmUnlockedTattoo", true);
+          QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 16);
           break;
         }
 
@@ -4388,6 +4390,7 @@ public abstract class ChoiceControl {
       case 1384: // The Calm After the Storm
         {
           Preferences.setBoolean("pirateRealmUnlockedAnemometer", true);
+          QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 16);
           break;
         }
 

--- a/src/net/sourceforge/kolmafia/session/QuestManager.java
+++ b/src/net/sourceforge/kolmafia/session/QuestManager.java
@@ -795,13 +795,39 @@ public class QuestManager {
     Preferences.setString("_frMonstersKilled", kills.toString());
   }
 
+  /**
+   * Determine PirateRealm island number from current quest step
+   *
+   * @return PirateRealm island number (zero-indexed)
+   */
+  public static int getPirateRealmIslandNumber() {
+    if (QuestDatabase.isQuestBefore(Quest.PIRATEREALM, "step7")) return 0;
+    if (QuestDatabase.isQuestBefore(Quest.PIRATEREALM, "step12")) return 1;
+    return 2;
+  }
+
+  public static void setPirateRealmIslandQuestProgress(final int progress) {
+    var island = getPirateRealmIslandNumber();
+    setPirateRealmIslandQuestProgress(island, progress);
+  }
+
+  public static void setPirateRealmIslandQuestProgress(final int island, final int progress) {
+    QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, (island * 5) + 2 + progress);
+  }
+
   private static void handlePirateRealmChange(final String location, final String responseText) {
     if (!Preferences.getBoolean("prAlways")) {
       Preferences.setBoolean("_prToday", true);
     }
 
+    if (responseText.contains("You grab an eyepatch")) {
+      QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, QuestDatabase.STARTED);
+    }
+
     // Cleared the last island
     if (responseText.contains("an envelope with your name on it")) {
+      QuestDatabase.setQuest(Quest.PIRATEREALM, QuestDatabase.FINISHED);
+
       if (responseText.contains("piratical blunderbuss")) {
         Preferences.setBoolean("pirateRealmUnlockedBlunderbuss", true);
       }

--- a/src/net/sourceforge/kolmafia/session/QuestManager.java
+++ b/src/net/sourceforge/kolmafia/session/QuestManager.java
@@ -821,11 +821,19 @@ public class QuestManager {
     }
 
     if (responseText.contains("You grab an eyepatch")) {
+      // Acquired your eyepatch
       QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, QuestDatabase.STARTED);
-    }
-
-    // Cleared the last island
-    if (responseText.contains("an envelope with your name on it")) {
+    } else if (responseText.contains("sail1.gif")) {
+      // Assembled your crew
+      QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 1);
+    } else if (responseText.contains("sail2.gif")) {
+      // Cleared the first island
+      QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 6);
+    } else if (responseText.contains("sail3.gif")) {
+      // Cleared the second island
+      QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 11);
+    } else if (responseText.contains("an envelope with your name on it")) {
+      // Cleared the final island
       QuestDatabase.setQuest(Quest.PIRATEREALM, QuestDatabase.FINISHED);
 
       if (responseText.contains("piratical blunderbuss")) {


### PR DESCRIPTION
The goal here is to create a Quest in the KoLmafia format for a journey through PirateRealm. Thanks to @Shiverwarp for helping me flesh out a step plan.

<details>
  <summary>Step plan hidden here for brevity (click to view)</summary>

  ```
 unstarted: We have not yet acquired our eyepatch
 started: We have acquired our eyepatch, but We have not yet finished choosing all our "start pirate realm" things (ship, crew, curio)
 step 1: We've chosen all our starting equipment, but have not yet chosen our first island
  
  // Island 1
 step 2: We have chosen our first island, We are in the process of sailing to the first island (sailing turns are less than our ship speed)
 step 3: We have finished our sailing turns for the first island, but we have not yet seen the Land Ho NC for the first island
 step 4: We have seen  the land ho NC for first island, and are in the process of doing the 4 combats on the first island
 step 5: we have completed the 4 combats, and have the final encounter of the first island available
 step 6: we have completed the final encounter of the first island, but have not yet chosen our second island
  
  // Island 2
  step 7: we have chosen our second island, we are in the process of sailing to the second island (sailing turns are less than our ship speed)
  step 8: We have finished our sailing turns for the second island, but we have not yet seen the Land Ho NC for the second island
  step 9: We have seen the land ho NC for second island, and are in the process of doing the 4 combats on the second island
  step 10: we have completed the 4 combats on the second island, and have the final encounter of the second island available
  step 11: we have completed the final encounter of the second island, but have not yet chosen our third and final island
  
  // Island 3
  step 12: we have chosen our third and final island, we are in the process of sailing to the third island (sailing turns are less than our ship speed)
  step 13: We have finished our sailing turns for the third island, but we have not yet seen the Land Ho NC for the third island
  step 14: We have seen the land ho NC for final island, and are in the process of doing the 9 combats on the second island
  step 15: we have completed the 9 combats on the final island, and have the final encounter of the third and final island available
  step 16: we have completed the final encounter of the final island, we have not yet gotten our funalog
  
  finished: piraterealm complete for the day
  ```
</details>

In the course of writing this I have realised that Quests are usually exclusively reserved for things that appear in the quest log. This doesn't and I've had to work around that by adding a fake entry to the questlogs.txt datafile. Do we think that is ok? Using the Quest progress utilities is so useful here.
