### PR TITLE
Track a couple of PirateRealm Sailing Encounters

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -426,6 +426,8 @@ public abstract class ChoiceControl {
 
       case 1356: // Smooth Sailing
       case 1357: // High Tide, Low Morale
+      case 1358: // The Starboard is Bare
+      case 1359: // Grog for the Grogless
       case 1360: // Like Shops in the Night
       case 1361: // Avast, a Mast!
       case 1362: // Stormy Weather


### PR DESCRIPTION
These 2 do advance the sailing turns needed to reach the next island too. Looks like the only one which doesn't is the broken ship encounter.