### PR TITLE
Fix a bunch of warnings

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -59,6 +59,7 @@ import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.session.LimitMode;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
   public static final String[][] DEMON_TYPES = {
     {"Summoning Chamber", "Pies"},

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -109,6 +109,7 @@ import net.sourceforge.kolmafia.webui.DiscoCombatHelper;
  * loosens the coupling between the various aspects of <code>KoLmafia</code>, leading to
  * extensibility.
  */
+@SuppressWarnings("incomplete-switch")
 public abstract class KoLCharacter {
   public enum TurtleBlessing {
     WAR,

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -47,6 +47,7 @@ import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.utilities.Indexed;
 import net.sourceforge.kolmafia.utilities.IntOrString;
 
+@SuppressWarnings("incomplete-switch")
 public class Modifiers {
   // static fields used to compute current modifiers
 

--- a/src/net/sourceforge/kolmafia/MonsterData.java
+++ b/src/net/sourceforge/kolmafia/MonsterData.java
@@ -30,6 +30,7 @@ import net.sourceforge.kolmafia.session.GoalManager;
 import net.sourceforge.kolmafia.session.MonsterManuelManager;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class MonsterData extends AdventureResult {
   public enum Attribute {
     // Non-scaling monsters

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -57,6 +57,7 @@ import net.sourceforge.kolmafia.session.EquipmentManager;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class Evaluator {
   public boolean failed;
   boolean exceeded;

--- a/src/net/sourceforge/kolmafia/objectpool/Concoction.java
+++ b/src/net/sourceforge/kolmafia/objectpool/Concoction.java
@@ -37,6 +37,7 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
  * Internal class used to represent a single concoction. It contains all the information needed to
  * actually make the item.
  */
+@SuppressWarnings("incomplete-switch")
 public class Concoction implements Comparable<Concoction> {
   private String name;
   private final int hashCode;

--- a/src/net/sourceforge/kolmafia/persistence/AscensionSnapshot.java
+++ b/src/net/sourceforge/kolmafia/persistence/AscensionSnapshot.java
@@ -16,6 +16,7 @@ import net.sourceforge.kolmafia.request.AscensionHistoryRequest.AscensionDataFie
 import net.sourceforge.kolmafia.session.ClanManager;
 import net.sourceforge.kolmafia.session.ContactManager;
 
+@SuppressWarnings("incomplete-switch")
 public class AscensionSnapshot {
   public enum AscensionFilter {
     UNKNOWN_TYPE,

--- a/src/net/sourceforge/kolmafia/persistence/CandyDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/CandyDatabase.java
@@ -18,6 +18,7 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.session.MallPriceManager;
 
+@SuppressWarnings("incomplete-switch")
 public class CandyDatabase {
   public static Set<Integer> NO_CANDY = new HashSet<>(); // No candies
   public static Set<Integer> tier0Candy = new HashSet<>(); // Unspaded

--- a/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConcoctionDatabase.java
@@ -67,6 +67,7 @@ import net.sourceforge.kolmafia.swingui.ItemManageFrame;
 import net.sourceforge.kolmafia.utilities.FileUtilities;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class ConcoctionDatabase {
 
   private static final Set<AdventureResult> EMPTY_SET = new HashSet<>();

--- a/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
@@ -35,6 +35,7 @@ import net.sourceforge.kolmafia.utilities.FileUtilities;
 import net.sourceforge.kolmafia.utilities.LogStream;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class EquipmentDatabase {
   private static final Map<Integer, Integer> power = new HashMap<>();
   private static final Map<Integer, Integer> hands = new HashMap<>();

--- a/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemDatabase.java
@@ -586,7 +586,7 @@ public class ItemDatabase {
     ItemDatabase.canonicalNames = newArray;
 
     ItemDatabase.uniqueInitialisms.clear();
-    Map<String, Integer> initialismCounts = new HashMap();
+    Map<String, Integer> initialismCounts = new HashMap<>();
     for (var itemName : ItemDatabase.itemIdSetByName.keySet()) {
       var initialism =
           Arrays.stream(itemName.toLowerCase().split("[ -]"))

--- a/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
+++ b/src/net/sourceforge/kolmafia/persistence/ItemFinder.java
@@ -28,6 +28,7 @@ import net.sourceforge.kolmafia.request.StorageRequest;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class ItemFinder {
   private ItemFinder() {}
 

--- a/src/net/sourceforge/kolmafia/persistence/PocketDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/PocketDatabase.java
@@ -22,6 +22,7 @@ import net.sourceforge.kolmafia.request.CargoCultistShortsRequest;
 import net.sourceforge.kolmafia.utilities.FileUtilities;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class PocketDatabase {
   private PocketDatabase() {}
 

--- a/src/net/sourceforge/kolmafia/request/AccountRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AccountRequest.java
@@ -12,6 +12,7 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+@SuppressWarnings("incomplete-switch")
 public class AccountRequest extends PasswordHashRequest {
   private static final Pattern SELECTED_PATTERN =
       Pattern.compile("selected=\"selected\" value=\"?(\\d+)\"?>");

--- a/src/net/sourceforge/kolmafia/request/AscensionHistoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AscensionHistoryRequest.java
@@ -28,6 +28,7 @@ import net.sourceforge.kolmafia.session.ContactManager;
 import net.sourceforge.kolmafia.utilities.FileUtilities;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class AscensionHistoryRequest extends GenericRequest
     implements Comparable<AscensionHistoryRequest> {
   private static AscensionFilter typeComparator = AscensionFilter.NORMAL;

--- a/src/net/sourceforge/kolmafia/request/CargoCultistShortsRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CargoCultistShortsRequest.java
@@ -119,7 +119,7 @@ public class CargoCultistShortsRequest extends GenericRequest {
 
     // If we are requesting a pocket which leads to a free fight,
     // recover first.
-    if (this.pocket != 0 && this.getMonsterFight(this.pocket) != null) {
+    if (this.pocket != 0 && CargoCultistShortsRequest.getMonsterFight(this.pocket) != null) {
       // set location to "None" for the benefit of
       // betweenBattleScripts
       Preferences.setString("nextAdventure", "None");

--- a/src/net/sourceforge/kolmafia/request/ClanLoungeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ClanLoungeRequest.java
@@ -31,6 +31,7 @@ import net.sourceforge.kolmafia.session.ResultProcessor;
 import net.sourceforge.kolmafia.utilities.InputFieldUtilities;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class ClanLoungeRequest extends GenericRequest {
   public enum Action {
     SEARCH,

--- a/src/net/sourceforge/kolmafia/request/EquipmentRequest.java
+++ b/src/net/sourceforge/kolmafia/request/EquipmentRequest.java
@@ -31,6 +31,7 @@ import net.sourceforge.kolmafia.session.QuestManager;
 import net.sourceforge.kolmafia.session.ResultProcessor;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class EquipmentRequest extends PasswordHashRequest {
   private static final Pattern CELL_PATTERN = Pattern.compile("<td>(.*?)</td>");
 

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -128,6 +128,7 @@ import org.htmlcleaner.ContentNode;
 import org.htmlcleaner.HtmlCleaner;
 import org.htmlcleaner.TagNode;
 
+@SuppressWarnings("incomplete-switch")
 public class FightRequest extends GenericRequest {
   // Character-class permissions
   private static final PauseObject PAUSER = new PauseObject();

--- a/src/net/sourceforge/kolmafia/request/IslandRequest.java
+++ b/src/net/sourceforge/kolmafia/request/IslandRequest.java
@@ -17,6 +17,7 @@ import net.sourceforge.kolmafia.session.IslandManager.Quest;
 import net.sourceforge.kolmafia.session.ResultProcessor;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class IslandRequest extends GenericRequest {
   private static final Pattern OPTION_PATTERN = Pattern.compile("option=(\\d+)");
 

--- a/src/net/sourceforge/kolmafia/request/ProfileRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ProfileRequest.java
@@ -21,6 +21,7 @@ import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.session.ResultProcessor;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class ProfileRequest extends GenericRequest implements Comparable<ProfileRequest> {
   private static final Pattern DATA_PATTERN = Pattern.compile("<td.*?>(.*?)</td>");
   private static final Pattern NUMERIC_PATTERN = Pattern.compile("\\d+");

--- a/src/net/sourceforge/kolmafia/request/SpelunkyRequest.java
+++ b/src/net/sourceforge/kolmafia/request/SpelunkyRequest.java
@@ -31,6 +31,7 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+@SuppressWarnings("incomplete-switch")
 public class SpelunkyRequest extends GenericRequest {
   private static final Pattern MUSCLE_PATTERN =
       Pattern.compile("Mus:</td><td>(?:<font color=blue>|)<b>(\\d+)(?:</font> \\((\\d+)\\)|)</b>");

--- a/src/net/sourceforge/kolmafia/request/StorageRequest.java
+++ b/src/net/sourceforge/kolmafia/request/StorageRequest.java
@@ -31,6 +31,7 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+@SuppressWarnings("incomplete-switch")
 public class StorageRequest extends TransferItemRequest {
   private StorageRequestType moveType;
   private boolean bulkTransfer;

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -67,6 +67,7 @@ import net.sourceforge.kolmafia.textui.command.ZapCommand;
 import net.sourceforge.kolmafia.utilities.InputFieldUtilities;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class UseItemRequest extends GenericRequest {
   public static final AdventureResult INFERNAL_SEAL_CLAW =
       ItemPool.get(ItemPool.INFERNAL_SEAL_CLAW, 1);

--- a/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
@@ -498,12 +498,14 @@ public class GitManager extends ScriptManager {
 
       var lastCommitId = repo.resolve("HEAD");
       var rw = new RevWalk(repo);
-      var commit = rw.parseCommit(lastCommitId);
-      var author = commit.getAuthorIdent();
-      var datetime = getCommitDate(commit, author);
+      try (rw) {
+        var commit = rw.parseCommit(lastCommitId);
+        var author = commit.getAuthorIdent();
+        var datetime = getCommitDate(commit, author);
 
-      return Optional.of(
-          new GitInfo(url, branch, ObjectId.toString(lastCommitId), getAuthor(author), datetime));
+        return Optional.of(
+            new GitInfo(url, branch, ObjectId.toString(lastCommitId), getAuthor(author), datetime));
+      }
     } catch (IOException e) {
       // all or nothing
       return Optional.empty();

--- a/src/net/sourceforge/kolmafia/session/BanishManager.java
+++ b/src/net/sourceforge/kolmafia/session/BanishManager.java
@@ -21,6 +21,7 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.StandardRequest;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class BanishManager {
   private static final Set<Banished> banishedMonsters = new LinkedHashSet<>();
   private static final Set<Banished> banishedPhyla = new LinkedHashSet<>();

--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -35,6 +35,7 @@ import net.sourceforge.kolmafia.utilities.ChoiceUtilities;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 import net.sourceforge.kolmafia.webui.VillainLairDecorator;
 
+@SuppressWarnings("incomplete-switch")
 public abstract class ChoiceManager {
 
   public static boolean handlingChoice = false;

--- a/src/net/sourceforge/kolmafia/session/ClanManager.java
+++ b/src/net/sourceforge/kolmafia/session/ClanManager.java
@@ -115,7 +115,7 @@ public abstract class ClanManager {
   }
 
   // For testing
-  public static void setClan(int clanId, String name) {
+  public static void setClan(int clanId, String clanName) {
     // Drop all saved clan information
     ClanManager.clearCache(true);
 

--- a/src/net/sourceforge/kolmafia/session/DadManager.java
+++ b/src/net/sourceforge/kolmafia/session/DadManager.java
@@ -6,6 +6,7 @@ import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class DadManager {
   // You shake your head and look above the tank, at the window into
   // space. <Clue 1> forms <Clue 2> in the darkness, each more <Clue 3>

--- a/src/net/sourceforge/kolmafia/session/EquipmentManager.java
+++ b/src/net/sourceforge/kolmafia/session/EquipmentManager.java
@@ -46,6 +46,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+@SuppressWarnings("incomplete-switch")
 public class EquipmentManager {
   /** A list of all possible accessories. Is an interior list of equipmentLists for acc1, 2, 3 */
   private static final List<AdventureResult> accessories =

--- a/src/net/sourceforge/kolmafia/session/GreyYouManager.java
+++ b/src/net/sourceforge/kolmafia/session/GreyYouManager.java
@@ -27,6 +27,7 @@ import net.sourceforge.kolmafia.persistence.SkillDatabase.SkillTag;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public abstract class GreyYouManager {
 
   private GreyYouManager() {}

--- a/src/net/sourceforge/kolmafia/session/InventoryManager.java
+++ b/src/net/sourceforge/kolmafia/session/InventoryManager.java
@@ -66,6 +66,7 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+@SuppressWarnings("incomplete-switch")
 public abstract class InventoryManager {
   private static final int BULK_PURCHASE_AMOUNT = 30;
 

--- a/src/net/sourceforge/kolmafia/session/IslandManager.java
+++ b/src/net/sourceforge/kolmafia/session/IslandManager.java
@@ -22,6 +22,7 @@ import net.sourceforge.kolmafia.request.FightRequest.SpecialMonster;
 import net.sourceforge.kolmafia.request.QuartersmasterRequest;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class IslandManager {
   private IslandManager() {}
 

--- a/src/net/sourceforge/kolmafia/session/TrackManager.java
+++ b/src/net/sourceforge/kolmafia/session/TrackManager.java
@@ -18,6 +18,7 @@ import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class TrackManager {
   private static final Set<Tracked> trackedMonsters = new LinkedHashSet<>();
   private static final Set<Tracked> trackedPhyla = new LinkedHashSet<>();

--- a/src/net/sourceforge/kolmafia/session/YouRobotManager.java
+++ b/src/net/sourceforge/kolmafia/session/YouRobotManager.java
@@ -26,6 +26,7 @@ import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.utilities.ChoiceUtilities;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public abstract class YouRobotManager {
 
   private YouRobotManager() {}

--- a/src/net/sourceforge/kolmafia/swingui/FamiliarTrainingFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/FamiliarTrainingFrame.java
@@ -62,6 +62,7 @@ import net.sourceforge.kolmafia.swingui.widget.RequestPane;
 import net.sourceforge.kolmafia.utilities.InputFieldUtilities;
 import net.sourceforge.kolmafia.utilities.LogStream;
 
+@SuppressWarnings("incomplete-switch")
 public class FamiliarTrainingFrame extends GenericFrame {
   private static final Pattern PRIZE_PATTERN =
       Pattern.compile(

--- a/src/net/sourceforge/kolmafia/swingui/panel/ChoiceOptionsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/ChoiceOptionsPanel.java
@@ -46,7 +46,7 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
  * choice adventures.
  */
 public class ChoiceOptionsPanel extends JTabbedPane implements Listener {
-  private final TreeMap<String, ArrayList> choiceMap;
+  private final TreeMap<String, ArrayList<String>> choiceMap;
   private final HashMap<String, ArrayList<JComponent>> selectMap;
   private final CardLayout choiceCards;
   private final JPanel choicePanel;
@@ -423,7 +423,7 @@ public class ChoiceOptionsPanel extends JTabbedPane implements Listener {
 
     this.loadSettings();
 
-    ArrayList optionsList;
+    ArrayList<String> optionsList;
     String[] keys = this.choiceMap.keySet().toArray(new String[0]);
 
     for (int i = 0; i < keys.length; ++i) {
@@ -458,25 +458,25 @@ public class ChoiceOptionsPanel extends JTabbedPane implements Listener {
       this.choiceMap.put(zone, new ArrayList<>());
     }
 
-    ArrayList options = this.choiceMap.get(zone);
+    ArrayList<String> options = this.choiceMap.get(zone);
 
     if (!options.contains(name)) {
       options.add(name);
       this.selectMap.put(name, new ArrayList<>());
     }
 
-    options = this.selectMap.get(name);
-    options.add(option);
+    ArrayList<JComponent> selectOptions = this.selectMap.get(name);
+    selectOptions.add(option);
   }
 
   private class ChoicePanel extends GenericPanel {
-    public ChoicePanel(final ArrayList options) {
+    public ChoicePanel(final ArrayList<String> options) {
       super(new Dimension(150, 20), new Dimension(300, 20));
 
       ArrayList<VerifiableElement> elementList = new ArrayList<>();
 
       for (int i = 0; i < options.size(); ++i) {
-        Object key = options.get(i);
+        String key = options.get(i);
         ArrayList<JComponent> value = ChoiceOptionsPanel.this.selectMap.get(key);
 
         if (value.size() == 1) {
@@ -743,7 +743,7 @@ public class ChoiceOptionsPanel extends JTabbedPane implements Listener {
         return;
       }
 
-      Map map = ChoiceOptionsPanel.this.choiceMap;
+      Map<String, ArrayList<String>> map = ChoiceOptionsPanel.this.choiceMap;
       String parent = location.getParentZone();
       String key = map.containsKey(zone) ? zone : map.containsKey(parent) ? parent : "";
 

--- a/src/net/sourceforge/kolmafia/swingui/panel/DailyDeedsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/DailyDeedsPanel.java
@@ -55,6 +55,7 @@ import net.sourceforge.kolmafia.swingui.CommandDisplayFrame;
 import net.sourceforge.kolmafia.swingui.widget.DisabledItemsComboBox;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class DailyDeedsPanel extends Box implements Listener {
   public static final AdventureResult GREAT_PANTS = ItemPool.get(ItemPool.GREAT_PANTS, 1);
   public static final AdventureResult REPLICA_GREAT_PANTS =

--- a/src/net/sourceforge/kolmafia/swingui/panel/ItemManagePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/ItemManagePanel.java
@@ -48,6 +48,7 @@ import net.sourceforge.kolmafia.swingui.listener.ThreadedListener;
 import net.sourceforge.kolmafia.swingui.widget.AutoFilterTextField;
 import net.sourceforge.kolmafia.utilities.InputFieldUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public abstract class ItemManagePanel<E, S extends JComponent> extends ScrollablePanel<S> {
   public enum QuantityType {
     USE_MULTIPLE,

--- a/src/net/sourceforge/kolmafia/swingui/panel/MallSearchResultsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/MallSearchResultsPanel.java
@@ -74,8 +74,8 @@ public class MallSearchResultsPanel extends JPanel {
     public boolean isVisible(final Object element) {
       if (element instanceof MallPurchaseRequest mpr) {
         int shopId = mpr.getShopId();
-        boolean forbidden = mpr.isForbidden(shopId);
-        boolean ignoring = mpr.isIgnoring(shopId);
+        boolean forbidden = MallPurchaseRequest.isForbidden(shopId);
+        boolean ignoring = MallPurchaseRequest.isIgnoring(shopId);
         if (!forbidden && !ignoring) {
           return true;
         }

--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemDequeuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemDequeuePanel.java
@@ -21,6 +21,7 @@ import net.sourceforge.kolmafia.swingui.listener.ThreadedListener;
 import net.sourceforge.kolmafia.swingui.widget.GenericScrollPane;
 import net.sourceforge.kolmafia.swingui.widget.ListCellRendererFactory;
 
+@SuppressWarnings("incomplete-switch")
 public class UseItemDequeuePanel extends ItemListManagePanel<QueuedConcoction> implements Listener {
   private final JTabbedPane queueTabs;
   private final LockableListModel<QueuedConcoction> queue;

--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
@@ -45,6 +45,7 @@ import net.sourceforge.kolmafia.swingui.listener.ThreadedListener;
 import net.sourceforge.kolmafia.swingui.widget.AutoFilterTextField;
 import net.sourceforge.kolmafia.utilities.InputFieldUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> implements Listener {
   private final JCheckBox[] filters;
   private final JTabbedPane queueTabs;

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -214,7 +214,7 @@ import org.tmatesoft.svn.core.SVNException;
 import org.tmatesoft.svn.core.wc.SVNInfo;
 import org.tmatesoft.svn.core.wc.SVNWCUtil;
 
-@SuppressWarnings("unused")
+@SuppressWarnings({"incomplete-switch", "unused"})
 public abstract class RuntimeLibrary {
   private static final RecordType itemDropRec =
       new RecordType(

--- a/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
@@ -200,6 +200,7 @@ public class TestCommand extends AbstractCommand {
         RequestLogger.printLine("Inside try: checkpoint known = " + saved.known());
       }
       RequestLogger.printLine("Outside try: checkpoint known = " + saved.known());
+      saved.close();
       return;
     }
 

--- a/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
@@ -200,7 +200,6 @@ public class TestCommand extends AbstractCommand {
         RequestLogger.printLine("Inside try: checkpoint known = " + saved.known());
       }
       RequestLogger.printLine("Outside try: checkpoint known = " + saved.known());
-      saved.close();
       return;
     }
 

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Function.java
@@ -9,6 +9,7 @@ import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.textui.AshRuntime;
 import org.eclipse.lsp4j.Location;
 
+@SuppressWarnings("incomplete-switch")
 public abstract class Function extends Symbol {
   protected Type type;
   protected List<VariableReference> variableReferences;

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
@@ -32,6 +32,7 @@ import net.sourceforge.kolmafia.textui.ScriptRuntime;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 import org.eclipse.lsp4j.Location;
 
+@SuppressWarnings("incomplete-switch")
 public class Type extends Symbol {
   public boolean primitive;
   private final TypeSpec type;

--- a/src/net/sourceforge/kolmafia/utilities/WikiUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/WikiUtilities.java
@@ -20,6 +20,7 @@ import net.sourceforge.kolmafia.request.UseSkillRequest;
 import net.sourceforge.kolmafia.session.StoreManager.SoldItem;
 import net.sourceforge.kolmafia.webui.RelayLoader;
 
+@SuppressWarnings("incomplete-switch")
 public class WikiUtilities {
 
   public enum WikiType {

--- a/src/net/sourceforge/kolmafia/webui/TopMenuDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/TopMenuDecorator.java
@@ -12,6 +12,7 @@ import net.sourceforge.kolmafia.request.GenericRequest.TopMenuStyle;
 import net.sourceforge.kolmafia.session.LimitMode;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public abstract class TopMenuDecorator {
   public static final void decorate(final StringBuffer buffer, final String location) {
     if (KoLCharacter.getLimitMode() == LimitMode.BATMAN) {

--- a/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/UseLinkDecorator.java
@@ -46,6 +46,7 @@ import net.sourceforge.kolmafia.session.TurnCounter;
 import net.sourceforge.kolmafia.textui.command.SpeculateCommand;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+@SuppressWarnings("incomplete-switch")
 public abstract class UseLinkDecorator {
   private static final StringBuffer deferred = new StringBuffer();
 

--- a/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
@@ -52,6 +52,7 @@ import org.junit.jupiter.params.provider.MethodSource;
   For instance, items marked as equipment in items.txt should also have
   corresponding entries in equipment.txt.
 */
+@SuppressWarnings("incomplete-switch")
 public class DataFileConsistencyTest {
   @BeforeAll
   public static void init() {

--- a/test/net/sourceforge/kolmafia/FamiliarDataTest.java
+++ b/test/net/sourceforge/kolmafia/FamiliarDataTest.java
@@ -179,9 +179,10 @@ public class FamiliarDataTest {
     var di =
         new FamiliarData.DropInfo(
             FamiliarPool.COOKBOOKBAT, -1, "cookbookbat recipe", "_cookbookbatRecipeDrops", 1);
-    new Cleanups(withProperty("_cookbookbatRecipeDrops", false));
-
-    assertThat(di.dropsToday(), equalTo(0));
+    var cleanups = new Cleanups(withProperty("_cookbookbatRecipeDrops", false));
+    try (cleanups) {
+      assertThat(di.dropsToday(), equalTo(0));
+    }
   }
 
   @Test
@@ -189,9 +190,10 @@ public class FamiliarDataTest {
     var di =
         new FamiliarData.DropInfo(
             FamiliarPool.COOKBOOKBAT, -1, "cookbookbat recipe", "_cookbookbatRecipeDrops", 1);
-    new Cleanups(withProperty("_cookbookbatRecipeDrops", true));
-
-    assertThat(di.dropsToday(), equalTo(1));
+    var cleanups = new Cleanups(withProperty("_cookbookbatRecipeDrops", true));
+    try (cleanups) {
+      assertThat(di.dropsToday(), equalTo(1));
+    }
   }
 
   @Test
@@ -204,9 +206,10 @@ public class FamiliarDataTest {
             "_powerPillDrops",
             Math.min(1 + KoLCharacter.getCurrentDays(), 11));
 
-    new Cleanups(withProperty("_powerPillDrops", 7));
-
-    assertThat(di.dropsToday(), equalTo(7));
+    var cleanups = new Cleanups(withProperty("_powerPillDrops", 7));
+    try (cleanups) {
+      assertThat(di.dropsToday(), equalTo(7));
+    }
   }
 
   @ParameterizedTest

--- a/test/net/sourceforge/kolmafia/session/LoginManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/LoginManagerTest.java
@@ -3,7 +3,6 @@ package net.sourceforge.kolmafia.session;
 import static internal.helpers.Player.withDay;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Month;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/test/net/sourceforge/kolmafia/textui/javascript/StorageTest.java
+++ b/test/net/sourceforge/kolmafia/textui/javascript/StorageTest.java
@@ -3,7 +3,6 @@ package net.sourceforge.kolmafia.textui.javascript;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 

--- a/test/net/sourceforge/kolmafia/utilities/PHPMTRandomTest.java
+++ b/test/net/sourceforge/kolmafia/utilities/PHPMTRandomTest.java
@@ -3,7 +3,6 @@ package net.sourceforge.kolmafia.utilities;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;


### PR DESCRIPTION
I've suppressed 'incomplete-switch' warnings for any class that had them, there were like a thousand of these and I can't imagine they need to be addressed. The second most class of warnings is 'unused' but I think some of those should get looked at so I haven't touched those yet.

The other warnings I resolved reduces the warning count I'm seeing locally from 1373 -> 261

This will be easier to review if you skip the [first commit](https://github.com/kolmafia/kolmafia/pull/2446/commits/7b3fc71a8a9805d289ef4767c20ca64d532e2df1) and look at the [others](https://github.com/kolmafia/kolmafia/pull/2446/files/7b3fc71a8a9805d289ef4767c20ca64d532e2df1..6bd8d94f15d467e9f063d3b9e2d8692f72a37442) separately.