### PR TITLE
Fix name mismatches in encounters.txt.

### DIFF
--- a/src/data/encounters.txt
+++ b/src/data/encounters.txt
@@ -212,7 +212,9 @@ Hero's Field	TURTLE	Blue Monday
 Megalo-City	TURTLE	Blue Monday
 The Fungus Plains	TURTLE	Blue Monday
 Vanya's Castle	TURTLE	Blue Monday
-A Battlefield	TURTLE	Capital!
+Battlefield (No Uniform)	TURTLE	Capital!
+Battlefield (Cloaca Uniform)	TURTLE	Capital!
+Battlefield (Dyspepsi Uniform)	TURTLE	Capital!
 A Maze of Sewer Tunnels	TURTLE	Training Day
 Hobopolis Town Square	TURTLE	Training Day
 Burnbarrel Blvd.	TURTLE	Training Day
@@ -227,9 +229,10 @@ The Degrassi Knoll Restroom	TURTLE	A Rolling Turtle Gathers No Moss
 The Degrassi Knoll Bakery	TURTLE	A Rolling Turtle Gathers No Moss
 The Degrassi Knoll Gym	TURTLE	A Rolling Turtle Gathers No Moss
 The Degrassi Knoll Garage	TURTLE	A Rolling Turtle Gathers No Moss
-Orcish Frat House	TURTLE	The Horror...
+Frat House	TURTLE	The Horror...
+Frat House (Frat Disguise)	TURTLE	The Horror...
 The Haunted Boiler Room	TURTLE	Slow Road to Hell
-Outskirts of Cobb's Knob	TURTLE	C'mere, Little Fella
+The Outskirts of Cobb's Knob	TURTLE	C'mere, Little Fella
 Oil Peak	TURTLE	The Real Victims
 Barrrney's Barrr	TURTLE	Like That Time in Tortuga
 The Haunted Gallery	TURTLE	Cleansing your Palette
@@ -242,9 +245,10 @@ The Haunted Conservatory	TURTLE	Turtles of the Universe
 The Spooky Forest	TURTLE	O Turtle Were Art Thou
 The Outer Compound	TURTLE	Allow 6-8 Weeks For Delivery
 The Haunted Pantry	TURTLE	Kick the Can
-The Hippy Camp	TURTLE	Turtles All The Way Around
+Hippy Camp	TURTLE	Turtles All The Way Around
+Hippy Camp (Hippy Disguise)	TURTLE	Turtles All The Way Around
 The eXtreme Slope	TURTLE	More eXtreme Than Usual
-South of The Border	TURTLE	Jewel in the Rough
+South of the Border	TURTLE	Jewel in the Rough
 Guano Junction	TURTLE	The worst kind of drowning
 *	TURTLE	Even Tamer Than Usual
 *	TURTLE	Never Break the Chain

--- a/src/net/sourceforge/kolmafia/session/EncounterManager.java
+++ b/src/net/sourceforge/kolmafia/session/EncounterManager.java
@@ -103,8 +103,14 @@ public abstract class EncounterManager {
     resetEncounters();
   }
 
-  private static void resetEncounters() {
+  /**
+   * Reset encounter database from encounters.txt
+   *
+   * @return Whether the reset was fully successful
+   */
+  public static boolean resetEncounters() {
     ArrayList<Encounter> encounters = new ArrayList<>();
+    boolean success = true;
 
     try (BufferedReader reader =
         FileUtilities.getVersionedReader("encounters.txt", KoLConstants.ENCOUNTERS_VERSION)) {
@@ -113,6 +119,7 @@ public abstract class EncounterManager {
       while ((data = FileUtilities.readData(reader)) != null) {
         if (!data[0].equals("*") && !AdventureDatabase.validateAdventureArea(data[0])) {
           RequestLogger.printLine("Invalid adventure area: \"" + data[0] + "\"");
+          success = false;
           continue;
         }
 
@@ -120,9 +127,11 @@ public abstract class EncounterManager {
       }
     } catch (IOException e) {
       StaticEntity.printStackTrace(e);
+      success = false;
     }
 
     specialEncounters = encounters.toArray(new Encounter[encounters.size()]);
+    return success;
   }
 
   /** Utility method used to register a given adventure in the running adventure summary. */

--- a/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
@@ -569,4 +569,21 @@ public class DataFileConsistencyTest {
       assertThat(Preferences.containsDefault(pref), is(adventure.getForceNoncombat() > 0));
     }
   }
+
+  @Test
+  public void everyEncounterIsInAZone() {
+    try (BufferedReader reader =
+        FileUtilities.getVersionedReader("encounters.txt", KoLConstants.ENCOUNTERS_VERSION)) {
+      String[] data;
+
+      while ((data = FileUtilities.readData(reader)) != null) {
+        assertThat(
+            "Couldn't validate zone " + data[0] + " for encounter " + data[2] + ".",
+            data[0].equals("*") || AdventureDatabase.validateAdventureArea(data[0]),
+            is(true));
+      }
+    } catch (IOException e) {
+      fail("Couldn't read from encounters.txt");
+    }
+  }
 }

--- a/test/net/sourceforge/kolmafia/session/EncounterManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/EncounterManagerTest.java
@@ -107,6 +107,11 @@ class EncounterManagerTest {
   }
 
   @Test
+  void resetEncountersSucceeds() {
+    assertThat(EncounterManager.resetEncounters(), is(true));
+  }
+
+  @Test
   void findEncounterByName() {
     var enc = EncounterManager.findEncounter("With a Clatter");
 


### PR DESCRIPTION
#2459 had some mismatches between encounters.txt and adventures.txt, which caused error messages on opening mafia and for some encounters to fail to load.