### PR TITLE
Address warnings / errors from `./gradlew build`.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -278,6 +278,11 @@ tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
 }
 
+tasks.withType(Test) {
+	// Mockito requires dynamic loading for mock creation.
+	jvmArgs("-XX:+EnableDynamicAgentLoading")
+}
+
 task cleanJpackage(type: Delete) {
 	onlyIf {
 		file('build/releases').exists()
@@ -360,6 +365,13 @@ pruneDist.dependsOn getRevision
 // Note that pruneDist relies on getRevision.
 jar.dependsOn pruneDist
 shadowJar.dependsOn pruneDist
+
+startShadowScripts.dependsOn jar
+startScripts.dependsOn jar
+
+distTar.dependsOn shadowJar
+distZip.dependsOn shadowJar
+startScripts.dependsOn shadowJar
 
 jacocoTestReport.dependsOn test
 


### PR DESCRIPTION
There were a few more unspecified dependencies in the build graph.

When targeting Java 21, running tests also starts emitting a nag about dynamic agent loading.