### PR TITLE
feat: photo booth command

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -2302,6 +2302,8 @@ user	_peteJumpedShark	0
 user	_petePartyThrown	false
 user	_petePeeledOut	0
 user	_peteRiotIncited	false
+user	_photoBoothEffects	0
+user	_photoBoothEquipment	0
 user	_photocopyUsed	false
 user	_pickyTweezersUsed	false
 user	_pickleJuiceDrunk	false

--- a/src/data/equipment.txt
+++ b/src/data/equipment.txt
@@ -3130,7 +3130,7 @@ shadow monocle	0	none
 shamanic beads	125	Mys: 47
 shark tooth necklace	200	Mys: 85
 Sheriff badge	0	none
-Sheriff moustache	0	none
+Sheriff moustache	10	none
 shin gourds	100	none
 shining halo	50	none
 shiny hood ornament	190	Mys: 80

--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -332,6 +332,6 @@
 300	Mini Kiwi	kiwi_kiwi.gif	stat0,meat0,drop	mini kiwi egg	aviator goggles	3	3	3	1
 301	Proto-Protozoa	protoproto.gif	combat1	proto-proto-protozoa	extra ooze	0	0	0	0
 302	Evolving Organism	bacteria.gif	combat1,hp1,mp1,block,variable	unevolved organism	extra DNA	0	0	0	0
-303	Burly Bodyguard	bodyguard.gif	combat1,block	baby bodyguard	bodyguard badge	0	0	0	0
-304	Doll Moll	molldoll.gif	combat1,meat	Doll Moll violin case	tiny Tina gun	0	0	0	0
+303	Burly Bodyguard	bodyguard.gif	combat0,block	baby bodyguard	bodyguard badge	0	0	0	0
+304	Doll Moll	molldoll.gif	combat0,meat	Doll Moll violin case	tiny Tina gun	0	0	0	0
 305	Emberiza Aureola	emberbird.gif	combat1	ember egg	tiny ember	0	0	0	0

--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -2168,7 +2168,7 @@ shadow cauldron	2302	shadowcauldron.gif	FREE BOSS NOCOPY Atk: [300+5*pref(_shado
 shadow matrix	2303	shadowmatrix.gif	FREE BOSS NOCOPY Atk: [300+5*pref(_shadowRiftCombats)] Def: [300+5*pref(_shadowRiftCombats)] HP: [500+10*pref(_shadowRiftCombats)] Init: 1000 P: horror Phys: 100 Elem: [min(pref(_shadowRiftCombats),90)] Article: a	shadow flame (100)	shadow skin (100)
 
 # august scepter (Aug 2023)
-Tooth Golem	2336	toothgolem.gif	Scale: ? Cap: ? Floor: ? Init: -10000 P: construct Article: a	loose teeth (100)	loose teeth (100)	loose teeth (100)	loose teeth (100)	fixodent (50)
+Tooth Golem	2336	toothgolem.gif	Scale: ? Cap: 10000 Floor: ? Init: -10000 P: construct Article: a	loose teeth (100)	loose teeth (100)	loose teeth (100)	loose teeth (100)	fixodent (50)
 
 # A Guide to Burning Leaves (Nov 2023)
 flaming leaflet	2389	leaflet.gif	FREE NOCOPY Atk: 11 Def: 11 HP: 11 Init: 11 P: plant E: hot Article: a	inflammable leaf (100)	inflammable leaf (75)	inflammable leaf (50)	inflammable leaf (25)	inflammable leaf (10)	inflammable leaf (5)	inflammable leaf (1)
@@ -2176,7 +2176,7 @@ flaming monstera	2390	monstera.gif	FREE NOCOPY Scale: 0 Cap: ? Floor: ? Init: 50
 leaviathan	2391	leaviathan.gif	FREE NOCOPY Scale: 25 Cap: ? Floor: ? HP: 2500 Init: -10000 P: plant EA: hot Article: the	flaming leaf crown (100)	100-150 inflammable leaf (m100)
 
 # Sept-Ember Censer (Sep 2024)
-Embering Hulk	2453	emberhulk.gif	NOCOPY Scale: 11 Cap: ? Floor: ? Init: -10000 P: elemental E: hot Article: an	embering hunk (c0)
+Embering Hulk	2453	emberhulk.gif	NOCOPY Scale: 11 Cap: 10000 Floor: ? Init: -10000 P: elemental E: hot Article: an	embering hunk (c0)
 
 # KoL Con
 

--- a/src/data/statuseffects.txt
+++ b/src/data/statuseffects.txt
@@ -2929,6 +2929,6 @@
 2926	Burning Mouth	embercheese.gif	077bfdc23982be1c734fa7a8f47791a4	neutral	none	eat 1 wheel of camembert
 2927	Lettuce Rejoice	emberlettuce.gif	74fff3d37b73461779ee2a24ef4cf34b	neutral	none
 2928	Batty	batwing.gif	6fef7da0c7eb9763f63d3dcf002f9e8a	neutral	none
-2929	Wild and Westy!	cowboyboots.gif	b5f7e03c415eee2ee0cfd74105468c32	neutral	none
-2930	Towering Muscles	stronggnome.gif	ae32f8a8b0a2868710d497d6939e6ea7	neutral	none
-2931	Spaced Out	celesteyes.gif	67ec6215eff43af9f0373ff2c69cde99	neutral	none
+2929	Wild and Westy!	cowboyboots.gif	b5f7e03c415eee2ee0cfd74105468c32	neutral	none	photobooth effect wild
+2930	Towering Muscles	stronggnome.gif	ae32f8a8b0a2868710d497d6939e6ea7	neutral	none	photobooth effect tower
+2931	Spaced Out	celesteyes.gif	67ec6215eff43af9f0373ff2c69cde99	neutral	none	photobooth effect space

--- a/src/data/zonelist.txt
+++ b/src/data/zonelist.txt
@@ -64,6 +64,8 @@ Clan Basement	Clan Basement	Clan Basement
 Hobopolis	Clan Basement	Hobopolis
 Dreadsylvania	Clan Basement	Dreadsylvania
 
+Clan VIP Lounge	Clan VIP Lounge	Clan VIP Lounge
+
 # Nemesis
 
 Nemesis Cave	Mountain	Nemesis Cave

--- a/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
+++ b/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
@@ -738,6 +738,7 @@ public class KoLmafiaCLI {
     new OutfitCommand().register("outfit");
     new PandaCommand().register("panda");
     new PastaThrallCommand().register("thralls");
+    new PhotoBoothCommand().register("photobooth");
     new PillKeeperCommand().register("pillkeeper");
     new PingCommand().register("ping");
     new PingPongCommand().register("pingpong");

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -1296,6 +1296,25 @@ public class Maximizer {
           duration = 30;
         } else if (cmd.startsWith("aprilband ")) {
           item = ItemPool.get(ItemPool.APRILING_BAND_HELMET, 1);
+        } else if (cmd.startsWith("mayam ")) {
+          item = ItemPool.get(ItemPool.MAYAM_CALENDAR, 1);
+        } else if (cmd.startsWith("photobooth effect ")) {
+          if (KoLCharacter.inBadMoon()) {
+            continue;
+          } else if (!StandardRequest.isAllowed(RestrictedItemType.CLAN_ITEMS, "Photo Booth")) {
+            continue;
+          } else if (limitMode.limitClan()) {
+            continue;
+          } else if (!haveVipKey) {
+            if (includeAll) {
+              text = "( get access to the VIP lounge )";
+              cmd = "";
+            } else continue;
+          } else if (Preferences.getInteger("_photoBoothEffects") >= 3) {
+            cmd = "";
+          }
+          duration = 50;
+          usesRemaining = 3 - Preferences.getInteger("_photoBoothEffects");
         }
 
         if (item != null) {

--- a/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
@@ -6290,6 +6290,16 @@ public abstract class ChoiceAdventures {
         new ChoiceOption("30 turns of +5% combat chance", 2),
         new ChoiceOption("30 turns of +50% item drop", 3),
         new ChoiceOption("30 turns of +3 exp, +4 stench/sleaze res", 4));
+
+    // Clan Photo Booth - Get your photo taken
+    new ChoiceAdventure(
+        1534,
+        "Clan VIP Lounge",
+        "Clan Photo Booth - Get your photo taken",
+        new ChoiceOption("50 turns of +50% init, +10 moxie, +3 moxie exp, -5% combat", 1),
+        new ChoiceOption("50 turns of +50HP, +10 muscle, +3 muscle exp, +5% combat", 2),
+        new ChoiceOption("50 turns of +50MP, +10 myst, +3 myst exp, +10-30 mp regen", 3),
+        new ChoiceOption("skip adventure", 6));
   }
 
   // This array is used by the ChoiceOptionsPanel to provide all the GUI configurable choices.

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -5003,6 +5003,16 @@ public abstract class ChoiceControl {
             Preferences.increment("bwApronMealsEaten");
           }
         }
+      case 1534:
+        // Clan Photo Booth - Get your photo taken
+        if (ChoiceManager.lastDecision != 6 && text.contains("You select")) {
+          Preferences.increment("_photoBoothEffects");
+        }
+      case 1535:
+        // Clan Photo Booth - Borrow a prop
+        if (ChoiceManager.lastDecision != 12 && text.contains("You grab your prop")) {
+          Preferences.increment("_photoBoothEquipment");
+        }
     }
   }
 
@@ -10162,6 +10172,10 @@ public abstract class ChoiceControl {
       case 1523: // Research Bench
       case 1526: // Conduct the Band
       case 1527: // Consider the Calendar
+      case 1533: // Clan Photo Booth
+      case 1534: // Clan Photo Booth - Get your photo taken
+      case 1535: // Clan Photo Booth - Borrow a prop
+      case 1536: // Clan Photo Booth - Take a group photo
         return true;
 
       default:

--- a/src/net/sourceforge/kolmafia/textui/command/PhotoBoothCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/PhotoBoothCommand.java
@@ -1,0 +1,118 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import net.sourceforge.kolmafia.KoLConstants.MafiaState;
+import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.RequestThread;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.ClanLoungeRequest;
+import net.sourceforge.kolmafia.request.GenericRequest;
+
+public class PhotoBoothCommand extends AbstractCommand {
+  public PhotoBoothCommand() {
+    this.usage = " effect [ wild | tower | space ] | item [ item ] - get an effect or item";
+  }
+
+  @Override
+  public void run(final String cmd, String parameters) {
+    String[] params = parameters.split(" ", 2);
+
+    switch (params[0]) {
+      case "effect" -> effect(params);
+      case "item", "prop" -> item(params);
+      default -> KoLmafia.updateDisplay(MafiaState.ERROR, "Usage: photobooth" + this.usage);
+    }
+  }
+
+  private boolean lacksPhotoBooth() {
+    if (!ClanLoungeRequest.hasClanLoungeItem(ItemPool.get(ItemPool.CLAN_PHOTO_BOOTH))) {
+      KoLmafia.updateDisplay(MafiaState.ERROR, "Your clan needs a photo booth.");
+      return true;
+    }
+    return false;
+  }
+
+  private void effect(String[] params) {
+    if (lacksPhotoBooth()) return;
+
+    int effects = Preferences.getInteger("_photoBoothEffects");
+    if (effects >= 3) {
+      KoLmafia.updateDisplay(MafiaState.ERROR, "You cannot get any more effects.");
+      return;
+    }
+
+    String parameter;
+    if (params.length < 2 || (parameter = params[1].trim()).isEmpty()) {
+      KoLmafia.updateDisplay(MafiaState.ERROR, "Which effect do you want?");
+      return;
+    }
+
+    int choice;
+    if (parameter.startsWith("wild")) {
+      choice = 1;
+    } else if (parameter.startsWith("tower")) {
+      choice = 2;
+    } else if (parameter.startsWith("space")) {
+      choice = 3;
+    } else {
+      KoLmafia.updateDisplay(
+          MafiaState.ERROR, "I don't understand what effect " + parameter + " is.");
+      return;
+    }
+
+    RequestThread.postRequest(new GenericRequest("clan_viplounge.php?action=photobooth"));
+    RequestThread.postRequest(new GenericRequest("choice.php?whichchoice=1533&option=1"));
+    RequestThread.postRequest(new GenericRequest("choice.php?whichchoice=1534&option=" + choice));
+    RequestThread.postRequest(new GenericRequest("choice.php?whichchoice=1533&option=6"));
+  }
+
+  private void item(String[] params) {
+    if (lacksPhotoBooth()) return;
+
+    int equip = Preferences.getInteger("_photoBoothEquipment");
+    if (equip >= 3) {
+      KoLmafia.updateDisplay(MafiaState.ERROR, "You cannot get any more props.");
+      return;
+    }
+
+    String parameter;
+    if (params.length < 2 || (parameter = params[1].trim()).isEmpty()) {
+      KoLmafia.updateDisplay(MafiaState.ERROR, "Which item do you want?");
+      return;
+    }
+
+    int choice;
+    if (parameter.startsWith("photo") || parameter.contains("list")) {
+      choice = 1;
+    } else if (parameter.contains("arrow")) {
+      choice = 2;
+    } else if (parameter.contains("beard")) {
+      choice = 3;
+    } else if (parameter.startsWith("astronaut") || parameter.contains("helmet")) {
+      choice = 4;
+    } else if (parameter.startsWith("cheap") || parameter.contains("pipe")) {
+      choice = 5;
+    } else if (parameter.startsWith("over") || parameter.contains("monocle")) {
+      choice = 6;
+    } else if (parameter.startsWith("giant") || parameter.contains("bow")) {
+      choice = 7;
+    } else if (parameter.startsWith("feather") || parameter.contains("boa")) {
+      choice = 8;
+    } else if (parameter.contains("badge")) {
+      choice = 9;
+    } else if (parameter.contains("pistol")) {
+      choice = 10;
+    } else if (parameter.contains("moustache")) {
+      choice = 11;
+    } else {
+      KoLmafia.updateDisplay(
+          MafiaState.ERROR, "I don't understand what item " + parameter + " is.");
+      return;
+    }
+
+    RequestThread.postRequest(new GenericRequest("clan_viplounge.php?action=photobooth"));
+    RequestThread.postRequest(new GenericRequest("choice.php?whichchoice=1533&option=2"));
+    RequestThread.postRequest(new GenericRequest("choice.php?whichchoice=1535&option=" + choice));
+    RequestThread.postRequest(new GenericRequest("choice.php?whichchoice=1533&option=6"));
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/command/PhotoBoothCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/PhotoBoothCommandTest.java
@@ -1,0 +1,187 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static internal.helpers.HttpClientWrapper.getRequests;
+import static internal.helpers.Networking.assertPostRequest;
+import static internal.helpers.Player.withClanLoungeItem;
+import static internal.helpers.Player.withProperty;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+
+import internal.helpers.Cleanups;
+import internal.helpers.HttpClientWrapper;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.FightRequest;
+import net.sourceforge.kolmafia.session.ChoiceManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class PhotoBoothCommandTest extends AbstractCommandTestBase {
+  @BeforeAll
+  public static void beforeAll() {
+    KoLCharacter.reset("PhotoBoothCommandTest");
+    Preferences.reset("PhotoBoothCommandTest");
+    ChoiceManager.handlingChoice = false;
+    FightRequest.currentRound = 0;
+  }
+
+  public PhotoBoothCommandTest() {
+    this.command = "photobooth";
+  }
+
+  private Cleanups withBooth() {
+    return withClanLoungeItem(ItemPool.CLAN_PHOTO_BOOTH);
+  }
+
+  @Test
+  void usage() {
+    String output = execute("");
+    assertThat(output, containsString("Usage: photobooth"));
+  }
+
+  @Nested
+  class Effect {
+    @Test
+    void requiresBooth() {
+      String output = execute("effect");
+      assertThat(output, containsString("Your clan needs a photo booth."));
+    }
+
+    @Test
+    void requiresEffectsAvailable() {
+      var cleanups = new Cleanups(withBooth(), withProperty("_photoBoothEffects", 3));
+
+      try (cleanups) {
+        String output = execute("effect");
+        assertThat(output, containsString("You cannot get any more effects."));
+      }
+    }
+
+    @Test
+    void requiresEffect() {
+      var cleanups = withBooth();
+
+      try (cleanups) {
+        String output = execute("effect");
+        assertThat(output, containsString("Which effect do you want?"));
+      }
+    }
+
+    @Test
+    void requiresValidEffect() {
+      var cleanups = withBooth();
+
+      try (cleanups) {
+        String output = execute("effect luck");
+        assertThat(output, containsString("I don't understand what effect luck is"));
+      }
+    }
+  }
+
+  @Nested
+  class Item {
+    @Test
+    void requiresBooth() {
+      String output = execute("item");
+      assertThat(output, containsString("Your clan needs a photo booth."));
+    }
+
+    @Test
+    void requiresPropsAvailable() {
+      var cleanups = new Cleanups(withBooth(), withProperty("_photoBoothEquipment", 3));
+
+      try (cleanups) {
+        String output = execute("item");
+        assertThat(output, containsString("You cannot get any more props."));
+      }
+    }
+
+    @Test
+    void requiresItem() {
+      var cleanups = withBooth();
+
+      try (cleanups) {
+        String output = execute("item");
+        assertThat(output, containsString("Which item do you want?"));
+      }
+    }
+
+    @Test
+    void requiresValidItem() {
+      var cleanups = withBooth();
+
+      try (cleanups) {
+        String output = execute("item fancy hat");
+        assertThat(output, containsString("I don't understand what item fancy hat is."));
+      }
+    }
+  }
+
+  @Nested
+  class Success {
+    @BeforeEach
+    public void beforeEach() {
+      HttpClientWrapper.setupFakeClient();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      "effect wild, 1",
+      "effect tower, 2",
+      "effect space, 3",
+    })
+    void effect(String params, int choice) {
+      var cleanups = withBooth();
+
+      try (cleanups) {
+        execute(params);
+        var requests = getRequests();
+
+        assertThat(requests, hasSize(4));
+
+        assertPostRequest(requests.get(0), "/clan_viplounge.php", "action=photobooth");
+        assertPostRequest(requests.get(1), "/choice.php", containsString("&option=1"));
+        assertPostRequest(requests.get(2), "/choice.php", containsString("&option=" + choice));
+        assertPostRequest(requests.get(3), "/choice.php", containsString("&option=6"));
+        assertContinueState();
+      }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      "item photo booth supply list, 1",
+      "item fake arrow-through-the-head, 2",
+      "item fake huge beard, 3",
+      "item astronaut helmet, 4",
+      "item cheap plastic pipe, 5",
+      "item oversized monocle on a stick, 6",
+      "item giant bow tie, 7",
+      "item feather boa, 8",
+      "item Sheriff badge, 9",
+      "item Sheriff pistol, 10",
+      "item Sheriff moustache, 11",
+    })
+    void item(String params, int choice) {
+      var cleanups = withBooth();
+
+      try (cleanups) {
+        execute(params);
+        var requests = getRequests();
+
+        assertThat(requests, hasSize(4));
+
+        assertPostRequest(requests.get(0), "/clan_viplounge.php", "action=photobooth");
+        assertPostRequest(requests.get(1), "/choice.php", containsString("&option=2"));
+        assertPostRequest(requests.get(2), "/choice.php", containsString("&option=" + choice));
+        assertPostRequest(requests.get(3), "/choice.php", containsString("&option=6"));
+        assertContinueState();
+      }
+    }
+  }
+}


### PR DESCRIPTION
A casual implementation: if your clan doesn't have the relevant item unlocked, it just silently fails. I figure 99% of users will be going to BAFH which will soon have everything unlocked, so I'm not interested in implementing a more thorough solution.