### PR TITLE
fix: allow a pre-adventure script to adventure

### DIFF
--- a/src/net/sourceforge/kolmafia/combat/CombatActionManager.java
+++ b/src/net/sourceforge/kolmafia/combat/CombatActionManager.java
@@ -534,7 +534,7 @@ public abstract class CombatActionManager {
       String combo = DiscoCombatHelper.disambiguateCombo(name);
       if (combo == null) {
         KoLmafia.updateDisplay(MafiaState.ABORT, "Invalid combo '" + name + "' requested");
-        Macrofier.resetMacroOverride();
+        Macrofier.resetErroringMacro();
         return "skip";
       }
       return "combo " + combo;

--- a/src/net/sourceforge/kolmafia/combat/Macrofier.java
+++ b/src/net/sourceforge/kolmafia/combat/Macrofier.java
@@ -631,14 +631,10 @@ public class Macrofier {
     public MacroOverride(String macroOverride, ScriptRuntime macroInterpreter) {
       this.macroOverride = macroOverride;
       this.macroInterpreter = macroInterpreter;
-      setJavaScriptVariables(Macrofier.macroFunction, Macrofier.macroScope, Macrofier.macroThisArg);
-    }
-
-    public void setJavaScriptVariables(
-        BaseFunction macroFunction, Scriptable macroScope, Scriptable macroThisArg) {
-      this.macroFunction = macroFunction;
-      this.macroScope = macroScope;
-      this.macroThisArg = macroThisArg;
+      // Set JavaScript variables from global storage
+      this.macroFunction = Macrofier.macroFunction;
+      this.macroScope = Macrofier.macroScope;
+      this.macroThisArg = Macrofier.macroThisArg;
     }
 
     public String macroOverride;

--- a/test/net/sourceforge/kolmafia/combat/CombatActionManagerTest.java
+++ b/test/net/sourceforge/kolmafia/combat/CombatActionManagerTest.java
@@ -1,0 +1,20 @@
+package net.sourceforge.kolmafia.combat;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class CombatActionManagerTest {
+  @Test
+  public void invalidDiscoComboResetMacro() {
+    Macrofier.setMacroOverride("combo invalid;", null);
+    assertThat(CombatActionManager.getShortCombatOptionName(Macrofier.macrofy()), equalTo("skip"));
+    var nextAction = CombatActionManager.getShortCombatOptionName(Macrofier.macrofy());
+    assertThat(nextAction, containsString("attack"));
+    assertThat(nextAction, not(containsString("combo")));
+    assertThat(nextAction, not(containsString("skip")));
+  }
+}

--- a/test/net/sourceforge/kolmafia/combat/CombatActionManagerTest.java
+++ b/test/net/sourceforge/kolmafia/combat/CombatActionManagerTest.java
@@ -9,12 +9,24 @@ import org.junit.jupiter.api.Test;
 
 public class CombatActionManagerTest {
   @Test
+  public void defaultBehaviourIsAttack() {
+    assertThat(
+        CombatActionManager.getShortCombatOptionName(Macrofier.macrofy()),
+        containsString("attack"));
+  }
+
+  @Test
   public void invalidDiscoComboResetMacro() {
-    Macrofier.setMacroOverride("combo invalid;", null);
-    assertThat(CombatActionManager.getShortCombatOptionName(Macrofier.macrofy()), equalTo("skip"));
-    var nextAction = CombatActionManager.getShortCombatOptionName(Macrofier.macrofy());
-    assertThat(nextAction, containsString("attack"));
-    assertThat(nextAction, not(containsString("combo")));
-    assertThat(nextAction, not(containsString("skip")));
+    try {
+      Macrofier.setMacroOverride("combo invalid;", null);
+      assertThat(
+          CombatActionManager.getShortCombatOptionName(Macrofier.macrofy()), equalTo("skip"));
+      var nextAction = CombatActionManager.getShortCombatOptionName(Macrofier.macrofy());
+      assertThat(nextAction, containsString("attack"));
+      assertThat(nextAction, not(containsString("combo")));
+      assertThat(nextAction, not(containsString("skip")));
+    } finally {
+      Macrofier.resetMacroOverride();
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/combat/MacrofierTest.java
+++ b/test/net/sourceforge/kolmafia/combat/MacrofierTest.java
@@ -1,0 +1,19 @@
+package net.sourceforge.kolmafia.combat;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class MacrofierTest {
+  @Test
+  public void stackingMacrosKeepsOriginalOverride() {
+    // example: an adv1 call
+    Macrofier.setMacroOverride("abort;", null);
+    // example: a pre-adventure script
+    Macrofier.setMacroOverride(null, null);
+    // reset from the pre-adventure script
+    Macrofier.resetMacroOverride();
+    assertThat(Macrofier.macrofy(), equalTo("abort;"));
+  }
+}


### PR DESCRIPTION
A pre-adventure script may want to adventure (e.g. to pick up Shadow Waters before going to a zone requiring high item drop). Under the current implementation, the pre-adventure adventure clears the filter function from the later adventure. Fix this.