### PR TITLE
add message for april band instrument playing to session log and only…

### DIFF
--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -1612,6 +1612,7 @@ public class UseItemRequest extends GenericRequest {
   public static void parseAprilPlay(final String urlString, final String responseText) {
     // inventory.php?iid=11567&action=aprilplay
     var itemId = StringUtilities.extractIidFromURL(urlString);
+    AdventureResult item = ItemPool.get(itemId, -1);
     // each item can be used three times per day, and getting additional copies doesn't help
     String preference;
     switch (itemId) {
@@ -1645,6 +1646,9 @@ public class UseItemRequest extends GenericRequest {
       return;
     }
 
+    String message = "Playing " + item.getName();
+    RequestLogger.printLine(message);
+    RequestLogger.updateSessionLog(message);
     Preferences.increment(preference, 1, 3, false);
   }
 

--- a/src/net/sourceforge/kolmafia/textui/command/AprilBandCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AprilBandCommand.java
@@ -145,8 +145,6 @@ public class AprilBandCommand extends AbstractCommand {
       return;
     }
 
-    KoLmafia.updateDisplay("Playing " + item.getName());
-
     var request =
         new GenericRequest(
             "inventory.php?action=aprilplay&iid="


### PR DESCRIPTION
… on success

This moves the message from AprilBandCommand.java to UseItemRequest.java, which includes various checks for success.
Adding this to the session logs makes it able to parse Apriling instrument usage for run logs