### PR TITLE
fix: read split modifiers by tags

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -10336,7 +10336,7 @@ public abstract class RuntimeLibrary {
 
     for (ModifierValue mVal : ModifierDatabase.splitModifiers(arg.toString())) {
       var modifierName = mVal.getName();
-      var modifier = ModifierDatabase.byCaselessName(modifierName);
+      var modifier = ModifierDatabase.getModifierByName(modifierName);
       if (modifier == null) {
         // splitModifiers doesn't validate the passed-in string, so just drop it
         continue;

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -1232,6 +1232,23 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
                  Unarmed =>
                  """));
     }
+
+    @Test
+    void parsesModifiersWithDifferentNamesToTags() {
+      String input =
+          "split_modifiers(\"Experience (Muscle): +11, Experience (Mysticality): +9, Experience (Moxie): +7, Damage Reduction: 24\")";
+      String output = execute(input);
+      assertThat(
+          output,
+          is(
+              """
+                 Returned: aggregate string [modifier]
+                 Damage Reduction => 24
+                 Moxie Experience => +7
+                 Muscle Experience => +11
+                 Mysticality Experience => +9
+                 """));
+    }
   }
 
   @Nested


### PR DESCRIPTION
As reported in https://kolmafia.us/threads/stat-experience-modifiers-written-oddly-in-certain-tracking-preferences.30003/

A potential phase 2 would involve removing "tag" as being distinct from "name", simplifying the codebase a bit. That is more complicated than this change, and I'm also not sure why they're separate in the first place.

