### PR TITLE
Update gitattributes to make our stats on GitHub nicer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 gradlew text eol=lf
-test/root/** text eol=lf
+test/root/** text eol=lf linguist-documentation
 test/root/**/*.png binary
 test/root/**/*.gif binary
 test/root/**/*.ser binary
+lib/** linguist-vendored


### PR DESCRIPTION
This will stop counting test HTML in our language stats, as well as looking at vendored libraries for the same
