### PR TITLE
Reset lastNoncombatXXX on ascension.

### DIFF
--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -1432,7 +1432,11 @@ public class Preferences {
   }
 
   public static boolean isResetOnAscension(String name) {
-    return resetOnAscensionSet.contains(name);
+    // yearbookCameraUpgrades and deferred points prefs are not really reset on ascension, just
+    // incremented.
+    return name.equals("muffinOnOrder")
+        || name.equals("bwApronMealsEaten")
+        || resetOnAscensionSet.contains(name);
   }
 
   private static void deferredPoints(String prop, String defprop, int max) {

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -9,6 +9,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -375,6 +376,30 @@ public class Preferences {
         "lastFriarsElbowNC",
         "lastFriarsHeartNC",
         "lastFriarsNeckNC",
+        "lastNoncombat15",
+        "lastNoncombat257",
+        "lastNoncombat270",
+        "lastNoncombat273",
+        "lastNoncombat280",
+        "lastNoncombat297",
+        "lastNoncombat322",
+        "lastNoncombat323",
+        "lastNoncombat324",
+        "lastNoncombat341",
+        "lastNoncombat343",
+        "lastNoncombat384",
+        "lastNoncombat386",
+        "lastNoncombat391",
+        "lastNoncombat405",
+        "lastNoncombat406",
+        "lastNoncombat439",
+        "lastNoncombat440",
+        "lastNoncombat441",
+        "lastNoncombat450",
+        "lastNoncombat533",
+        "lastNoncombat539",
+        "lastNoncombat540",
+        "lastNoncombat541",
         "lastShadowForgeUnlockAdventure",
         "lastTrainsetConfiguration",
         "lastZapperWandExplosionDay",
@@ -578,6 +603,9 @@ public class Preferences {
         "youRobotScavenged",
         "youRobotTop",
       };
+
+  private static final Set<String> resetOnAscensionSet =
+      new HashSet<>(Arrays.asList(resetOnAscension));
 
   // Obsolete properties.
   private static final String[] obsoleteProperties =
@@ -1401,6 +1429,10 @@ public class Preferences {
   public static boolean isDaily(String name) {
     return (name.startsWith("_") && !legacyNonDailies.contains(name))
         || legacyDailies.contains(name);
+  }
+
+  public static boolean isResetOnAscension(String name) {
+    return resetOnAscensionSet.contains(name);
   }
 
   private static void deferredPoints(String prop, String defprop, int max) {

--- a/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
@@ -563,12 +563,13 @@ public class DataFileConsistencyTest {
   }
 
   @Test
-  public void everyForceNoncombatZoneHasDefault() {
+  public void everyForceNoncombatZoneHasDefaultAndResetsOnAscension() {
     for (var adventure : AdventureDatabase.getAsLockableListModel()) {
       if (adventure.getAdventureNumber() < 0) continue;
 
       var pref = "lastNoncombat" + adventure.getAdventureNumber();
       assertThat(Preferences.containsDefault(pref), is(adventure.getForceNoncombat() > 0));
+      assertThat(Preferences.isResetOnAscension(pref), is(adventure.getForceNoncombat() > 0));
     }
   }
 

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class PreferencesTest {
   private final String USER_NAME = "PreferencesTestFakeUser";
@@ -479,6 +481,21 @@ class PreferencesTest {
     String prefName = "autoLogin";
     boolean result = Preferences.containsDefault(prefName);
     assertTrue(result, "default not in defaultsSet for pref " + prefName);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "choiceAdventure2, false",
+    "8BitScore, true",
+    "lastNoncombat15, true",
+    "yearbookCameraUpgrades, false",
+    "noobPoints, false",
+    "bwApronMealsEaten, true",
+    "muffinOnOrder, true",
+    "nonExistentPref, false"
+  })
+  void isResetOnAscension(String name, boolean expected) {
+    assertEquals(Preferences.isResetOnAscension(name), expected);
   }
 
   @Test


### PR DESCRIPTION
The `lastNoncombatXXX` preferences should reset on ascension, as `turns_spent` also resets to 0.

This PR makes that change, adds an `isResetOnAscension` function, and adds a consistency test to ensure the array is updated in the future.