### PR TITLE
feat: upgrade to new upload / download artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,9 @@ jobs:
         run: ./gradlew --no-daemon jpackage
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: releases
+          name: releases-${{ matrix.os }}
           path: |
             build/releases/*.deb
             build/releases/*.exe
@@ -67,7 +67,7 @@ jobs:
         run: ./gradlew --no-daemon shadowJar
 
       - name: Upload files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/*.jar
@@ -90,15 +90,15 @@ jobs:
           echo "KOLMAFIA_VERSION=$KOLMAFIA_VERSION" >> $GITHUB_ENV
 
       - name: Download binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             dist/*.jar
-            releases/*.deb
-            releases/*.dmg
+            releases-ubuntu-latest/*.deb
+            releases-macos-latest/*.dmg
           tag_name: r${{ env.KOLMAFIA_VERSION }}
           target_commitish: ${{ github.sha }}
           name: ${{ env.KOLMAFIA_VERSION }}


### PR DESCRIPTION
Artifacts are now immutable so different OSs need to download to different places.

Closes #2493.

Tested on https://github.com/midgleyc/kolmafia/actions/runs/11838300139, produced https://github.com/midgleyc/kolmafia/releases/tag/r28125.