### PR TITLE
You can walk away from Adjust Parka and Configure Umbrella

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -10157,6 +10157,7 @@ public abstract class ChoiceControl {
       case 1460: // Toy Lab
       case 1463: // Reminiscing About Those Monsters You Fought
       case 1476: // Stillsuit
+      case 1481: // Adjust Your Parka
       case 1483: // Direct Autumn-Aton
       case 1484: // Conspicuous Plaque
       case 1485: // Play with your train

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -10156,6 +10156,7 @@ public abstract class ChoiceControl {
       case 1459: // Chem Lab
       case 1460: // Toy Lab
       case 1463: // Reminiscing About Those Monsters You Fought
+      case 1466: // Configure Your Unbreakable Umbrella
       case 1476: // Stillsuit
       case 1481: // Adjust Your Parka
       case 1483: // Direct Autumn-Aton


### PR DESCRIPTION
Should be self-explanatory. This will prevent Adjust Your Parka and Configure Your Unbreakable Umbrella from showing up in the noncombat_queue.