### PR TITLE
Add CBB quest ingredient tracking.

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1918,6 +1918,7 @@ user	_cookbookbatRecipeDrops	false
 user	_cookbookbatCombatsUntilNewQuest	0
 user	_cookbookbatQuestLastLocation
 user	_cookbookbatQuestMonster
+user	_cookbookbatQuestIngredient
 user	_corruptedStardustUsed	false
 user	_cosmicBowlingSkillsUsed	0
 user	_cosmicSixPackConjured	false

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -8578,11 +8578,11 @@ public class FightRequest extends GenericRequest {
 
   private static final Pattern[] COOKBOOKBAT_QUEST = {
     Pattern.compile(
-        "\"As I recall, .*? was common in (?<location>.*?), back in my day\\. +Perhaps if you kill an? (?<monster>.*?), you'll find one\\.\""),
+        "\"As I recall, (?<ingredient>.*?) was common in (?<location>.*?), back in my day\\. +Perhaps if you kill an? (?<monster>.*?), you'll find one\\.\""),
     Pattern.compile(
-        "\"If memory serves, .*? was very popular in (?<location>.*?), during my time\\. +Perhaps if you find an? (?<monster>.*?), you'll collect one\\,\""),
+        "\"If memory serves, (?<ingredient>.*?) was very popular in (?<location>.*?), during my time\\. +Perhaps if you find an? (?<monster>.*?), you'll collect one\\,\""),
     Pattern.compile(
-        "\"My recollection is that .*? was often collected from an? (?<monster>.*?)\\. +If I recall correctly, you can hunt them in (?<location>.*?)\\.\"")
+        "\"My recollection is that (?<ingredient>.*?) was often collected from an? (?<monster>.*?)\\. +If I recall correctly, you can hunt them in (?<location>.*?)\\.\"")
   };
 
   private static final Pattern[] COOKBOOKBAT_QUEST_REMINDER = {
@@ -8621,6 +8621,10 @@ public class FightRequest extends GenericRequest {
             String locationName = matcher.group("location");
             Preferences.setString("_cookbookbatQuestLastLocation", locationName);
           }
+          if (p.toString().contains("<ingredient>")) {
+            String ingredientName = matcher.group("ingredient");
+            Preferences.setString("_cookbookbatQuestIngredient", ingredientName);
+          }
           if (patterns == COOKBOOKBAT_QUEST) {
             Preferences.setInteger("_cookbookbatCombatsUntilNewQuest", 6);
           }
@@ -8633,6 +8637,7 @@ public class FightRequest extends GenericRequest {
       Matcher matcher = p.matcher(text);
       if (matcher.find()) {
         Preferences.setString("_cookbookbatQuestMonster", "");
+        Preferences.setString("_cookbookbatQuestIngredient", "");
         return true;
       }
     }

--- a/test/net/sourceforge/kolmafia/request/FightRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FightRequestTest.java
@@ -222,26 +222,34 @@ public class FightRequestTest {
 
     @ParameterizedTest
     @CsvSource({
-      "test_fight_cookbookbat_quest_new_1.html,false,skullery maid,The Haunted Kitchen",
-      "test_fight_cookbookbat_quest_new_2.html,false,crate,Noob Cave",
-      "test_fight_cookbookbat_quest_new_3.html,false,novelty tropical skeleton,The Skeleton Store",
-      "test_fight_cookbookbat_quest_reminder_1.html,true,,The Haunted Kitchen",
-      "test_fight_cookbookbat_quest_reminder_2.html,true,crate,",
-      "test_fight_cookbookbat_quest_reminder_3.html,true,horrible tourist family,Barf Mountain",
+      "test_fight_cookbookbat_quest_new_1.html,false,skullery maid,The Haunted Kitchen,Vegetable of Jarlsberg",
+      "test_fight_cookbookbat_quest_new_2.html,false,crate,Noob Cave,Yeast of Boris",
+      "test_fight_cookbookbat_quest_new_3.html,false,novelty tropical skeleton,The Skeleton Store,St. Sneaky Pete's Whey",
+      "test_fight_cookbookbat_quest_reminder_1.html,true,,The Haunted Kitchen,",
+      "test_fight_cookbookbat_quest_reminder_2.html,true,crate,,",
+      "test_fight_cookbookbat_quest_reminder_3.html,true,horrible tourist family,Barf Mountain,",
     })
     public void handlesQuest(
-        String file, boolean isReminder, String monsterName, String locationName) {
+        String file,
+        boolean isReminder,
+        String monsterName,
+        String locationName,
+        String ingredientName) {
+      if (monsterName == null) monsterName = "";
+      if (locationName == null) locationName = "";
+      if (ingredientName == null) ingredientName = "";
       var cleanups =
           new Cleanups(
               withFamiliar(FamiliarPool.COOKBOOKBAT),
               withProperty("_cookbookbatQuestMonster", ""),
               withProperty("_cookbookbatQuestLastLocation", ""),
+              withProperty("_cookbookbatQuestIngredient", ""),
               withProperty("_cookbookbatCombatsUntilNewQuest", 2));
       try (cleanups) {
         parseCombatData("request/" + file);
-        assertThat("_cookbookbatQuestMonster", isSetTo(monsterName == null ? "" : monsterName));
-        assertThat(
-            "_cookbookbatQuestLastLocation", isSetTo(locationName == null ? "" : locationName));
+        assertThat("_cookbookbatQuestMonster", isSetTo(monsterName));
+        assertThat("_cookbookbatQuestLastLocation", isSetTo(locationName));
+        assertThat("_cookbookbatQuestIngredient", isSetTo(ingredientName));
         assertThat("_cookbookbatCombatsUntilNewQuest", isSetTo(isReminder ? 1 : 5));
       }
     }
@@ -253,11 +261,13 @@ public class FightRequestTest {
               withFamiliar(FamiliarPool.COOKBOOKBAT),
               withProperty("_cookbookbatQuestMonster", "skullery maid"),
               withProperty("_cookbookbatQuestLastLocation", "The Haunted Kitchen"),
+              withProperty("_cookbookbatQuestIngredient", "Vegetable of Jarlsberg"),
               withProperty("_cookbookbatCombatsUntilNewQuest", 3));
       try (cleanups) {
         parseCombatData("request/test_fight_cookbookbat_quest_complete.html");
         assertThat("_cookbookbatQuestMonster", isSetTo(""));
         assertThat("_cookbookbatQuestLastLocation", isSetTo("The Haunted Kitchen"));
+        assertThat("_cookbookbatQuestIngredient", isSetTo(""));
         assertThat("_cookbookbatCombatsUntilNewQuest", isSetTo(2));
       }
     }
@@ -308,11 +318,13 @@ public class FightRequestTest {
               withFamiliar(FamiliarPool.COOKBOOKBAT),
               withProperty("_cookbookbatQuestMonster", "crate"),
               withProperty("_cookbookbatQuestLastLocation", "Noob Cave"),
+              withProperty("_cookbookbatQuestIngredient", "Vegetable of Jarlsberg"),
               withLastLocation((KoLAdventure) null));
       try (cleanups) {
         parseCombatData("request/test_fight_win.html");
         assertThat("_cookbookbatQuestMonster", isSetTo("crate"));
         assertThat("_cookbookbatQuestLastLocation", isSetTo("Noob Cave"));
+        assertThat("_cookbookbatQuestIngredient", isSetTo("Vegetable of Jarlsberg"));
       }
     }
   }

--- a/test/net/sourceforge/kolmafia/request/FightRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FightRequestTest.java
@@ -225,9 +225,9 @@ public class FightRequestTest {
       "test_fight_cookbookbat_quest_new_1.html,false,skullery maid,The Haunted Kitchen,Vegetable of Jarlsberg",
       "test_fight_cookbookbat_quest_new_2.html,false,crate,Noob Cave,Yeast of Boris",
       "test_fight_cookbookbat_quest_new_3.html,false,novelty tropical skeleton,The Skeleton Store,St. Sneaky Pete's Whey",
-      "test_fight_cookbookbat_quest_reminder_1.html,true,,The Haunted Kitchen,",
-      "test_fight_cookbookbat_quest_reminder_2.html,true,crate,,",
-      "test_fight_cookbookbat_quest_reminder_3.html,true,horrible tourist family,Barf Mountain,",
+      "test_fight_cookbookbat_quest_reminder_1.html,true,'',The Haunted Kitchen,''",
+      "test_fight_cookbookbat_quest_reminder_2.html,true,crate,'',''",
+      "test_fight_cookbookbat_quest_reminder_3.html,true,horrible tourist family,Barf Mountain,''",
     })
     public void handlesQuest(
         String file,
@@ -235,9 +235,6 @@ public class FightRequestTest {
         String monsterName,
         String locationName,
         String ingredientName) {
-      if (monsterName == null) monsterName = "";
-      if (locationName == null) locationName = "";
-      if (ingredientName == null) ingredientName = "";
       var cleanups =
           new Cleanups(
               withFamiliar(FamiliarPool.COOKBOOKBAT),
@@ -294,8 +291,6 @@ public class FightRequestTest {
         boolean inLocation,
         int newInitial,
         int newExpected) {
-      if (monsterName == null) monsterName = "";
-      if (locationName == null) locationName = "";
       var cleanups =
           new Cleanups(
               withFamiliar(FamiliarPool.COOKBOOKBAT),


### PR DESCRIPTION
Neglected this in the original PRs. Cookbookbat announces which ingredient the quest will result in, which is useful information for the user/scripts to have.