### PR TITLE
Deck testing

### DIFF
--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -726,7 +726,7 @@ Twig and Berries	352	twigberry.gif	Atk: 152 Def: 136 HP: 150 Init: 70 Group: 3 P
 undead elbow macaroni	147	macaroni.gif	Atk: 1 Def: 1 HP: 1 Init: 50 Meat: 5 P: undead E: spooky Article: an Wiki: "undead elbow macaroni (monster)"	magicalness-in-a-can (25)
 unemployed knob goblin	1000	lensgoblin.gif	Atk: 6 Def: 5 HP: 5 Init: -10000 Meat: 15 P: goblin EA: hot EA: none Article: an	beer lens (c25)
 unholy diver	745	unholydiver.gif	Atk: 700 Def: 540 HP: 1000 Init: 100 Meat: 250 P: horror Article: an	glowing syringe (c4)	rusty broken diving helmet (n3)	rusty porthole (n2)	rusty rivet (n10)	rusty rivet (n10)	rusty rivet (n2)	rusty rivet (n1)	unholy water (c0)
-upgraded ram	384	ram.gif	Atk: 106 Def: 93 HP: 95 Init: 50 Meat: 100 P: beast ED: cold EA: cold EA: none Article: an	ram horns (5)	ram stick (5)	Ram's Face Lager (30)
+upgraded ram	384	ram.gif	Atk: 106 Def: 93 HP: 95 Init: 50 Meat: 100 P: beast ED: cold EA: cold EA: none Article: an	ram horns (5)	ram stick (5)	Ram's Face Lager (30)	Mt. McLargeHuge oyster (25)
 uppercase Q	937	upper_q.gif	Atk: 61 Def: 51 HP: 81 Init: 80 P: dude Article: an	left parenthesis (40)	right parenthesis (10)	dollar sign (p20)
 urchin urchin	733	urchin.gif	Atk: 400 Def: 315 HP: 600 Init: 20 P: fish Article: an	mermaid's purse (n5)	bazookafish bubble gum (n30)	underwater slingshot (n25)
 vampire bat	350	regbat.gif	Atk: 17 Def: 14 HP: 10 Init: 60 Meat: 40 P: beast EA: hot EA: stench EA: none Article: a	bat wing (15)	batgut (15)	sonar-in-a-biscuit (10)

--- a/src/net/sourceforge/kolmafia/request/DeckOfEveryCardRequest.java
+++ b/src/net/sourceforge/kolmafia/request/DeckOfEveryCardRequest.java
@@ -199,16 +199,17 @@ public class DeckOfEveryCardRequest extends GenericRequest {
     return DeckOfEveryCardRequest.buffToCard.get(buff);
   }
 
-  // Only used in testing
+  // Only used in testing.  Note can return null.
   public static EveryCard getCardById(int id) {
-    EveryCard retVal = idToCard.get(id);
-    if (retVal == null) {
-      retVal = new EveryCard();
-    }
-    return retVal;
+    return idToCard.get(id);
   }
 
   private final EveryCard card;
+
+  // Only used in testing.  Note can return null.
+  public EveryCard getRequestCard() {
+    return card;
+  }
 
   public DeckOfEveryCardRequest() {
     super("choice.php");

--- a/src/net/sourceforge/kolmafia/request/DeckOfEveryCardRequest.java
+++ b/src/net/sourceforge/kolmafia/request/DeckOfEveryCardRequest.java
@@ -199,6 +199,15 @@ public class DeckOfEveryCardRequest extends GenericRequest {
     return DeckOfEveryCardRequest.buffToCard.get(buff);
   }
 
+  // Only used in testing
+  public static EveryCard getCardById(int id) {
+    EveryCard retVal = idToCard.get(id);
+    if (retVal == null) {
+      retVal = new EveryCard();
+    }
+    return retVal;
+  }
+
   private final EveryCard card;
 
   public DeckOfEveryCardRequest() {

--- a/src/net/sourceforge/kolmafia/request/DeckOfEveryCardRequest.java
+++ b/src/net/sourceforge/kolmafia/request/DeckOfEveryCardRequest.java
@@ -200,14 +200,14 @@ public class DeckOfEveryCardRequest extends GenericRequest {
   }
 
   // Only used in testing.  Note can return null.
-  public static EveryCard getCardById(int id) {
+  static EveryCard getCardById(int id) {
     return idToCard.get(id);
   }
 
   private final EveryCard card;
 
   // Only used in testing.  Note can return null.
-  public EveryCard getRequestCard() {
+  EveryCard getRequestCard() {
     return card;
   }
 

--- a/src/net/sourceforge/kolmafia/request/DeckOfEveryCardRequest.java
+++ b/src/net/sourceforge/kolmafia/request/DeckOfEveryCardRequest.java
@@ -167,10 +167,10 @@ public class DeckOfEveryCardRequest extends GenericRequest {
 
   static {
     Set<String> keys = DeckOfEveryCardRequest.canonicalNameToCard.keySet();
-    DeckOfEveryCardRequest.CANONICAL_CARDS_ARRAY = keys.toArray(new String[keys.size()]);
+    DeckOfEveryCardRequest.CANONICAL_CARDS_ARRAY = keys.toArray(new String[0]);
   }
 
-  public static final List<String> getMatchingNames(final String substring) {
+  public static List<String> getMatchingNames(final String substring) {
     return StringUtilities.getMatchingNames(
         DeckOfEveryCardRequest.CANONICAL_CARDS_ARRAY, substring);
   }
@@ -385,7 +385,7 @@ public class DeckOfEveryCardRequest extends GenericRequest {
     // What remains is the set of cards we have drawn.
     StringBuilder buffer = new StringBuilder();
     for (String card : cards) {
-      if (buffer.length() > 0) {
+      if (!buffer.isEmpty()) {
         buffer.append("|");
       }
       buffer.append(card);
@@ -409,7 +409,7 @@ public class DeckOfEveryCardRequest extends GenericRequest {
       int of = cardName.indexOf(" of ");
       String munged = of == -1 ? cardName : ("X" + cardName.substring(of));
       String alt = Preferences.getString("_deckCardsSeen");
-      String neu = alt.length() == 0 ? munged : (alt + "|" + munged);
+      String neu = alt.isEmpty() ? munged : (alt + "|" + munged);
       Preferences.setString("_deckCardsSeen", neu);
 
       EveryCard card =
@@ -470,8 +470,8 @@ public class DeckOfEveryCardRequest extends GenericRequest {
   }
 
   public static class EveryCard {
-    public int id;
-    public String name;
+    public final int id;
+    public final String name;
     private final String stringForm;
 
     public EveryCard(int id, String name) {

--- a/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
@@ -1,0 +1,44 @@
+package net.sourceforge.kolmafia.request;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.persistence.MonsterDatabase;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class DeckOfEveryCardRequestTest {
+  private static final String USERNAME = "DeckOfEvertCardRequestTest";
+
+  @BeforeAll
+  static void beforeAll() {
+    KoLCharacter.reset(USERNAME);
+  }
+
+  @Nested
+  class StaticsCoverage {
+    @Test
+    public void testMatchingNames() {
+      List<String> results = DeckOfEveryCardRequest.getMatchingNames("not a real card name");
+      assertTrue(results.isEmpty());
+      results = DeckOfEveryCardRequest.getMatchingNames(" of ");
+      assertEquals(13, results.size());
+      assertTrue(results.contains("x of spades"));
+      assertTrue(results.contains("x of hearts"));
+      assertTrue(results.contains("x of diamonds"));
+      assertTrue(results.contains("x of clubs"));
+    }
+
+    @Test
+    public void testPhylumToCard() {
+      DeckOfEveryCardRequest.EveryCard card =
+          DeckOfEveryCardRequest.phylumToCard(MonsterDatabase.Phylum.ELF);
+      assertEquals(card.name, "Christmas Card");
+      card = DeckOfEveryCardRequest.phylumToCard(MonsterDatabase.Phylum.PENGUIN);
+      assertEquals(card.name, "Suit Warehouse Discount Card");
+    }
+  }
+}

--- a/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
@@ -1,13 +1,19 @@
 package net.sourceforge.kolmafia.request;
 
+import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.RACING;
+import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.buffToCard;
 import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.canonicalNameToCard;
+import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.getCardById;
 import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.getMatchingNames;
 import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.phylumToCard;
+import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.statToCard;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
@@ -38,20 +44,50 @@ class DeckOfEveryCardRequestTest {
     @Test
     public void testPhylumToCard() {
       DeckOfEveryCardRequest.EveryCard card = phylumToCard(MonsterDatabase.Phylum.ELF);
-      assertEquals(card.name, "Christmas Card");
+      assertEquals(card, getCardById(28));
       card = phylumToCard(MonsterDatabase.Phylum.PENGUIN);
-      assertEquals(card.name, "Suit Warehouse Discount Card");
+      assertEquals(card, getCardById(27));
     }
 
     @Test
     public void testCanonicalName() {
-      String cName = "x of spades";
       String fName = "X of Spades";
-      DeckOfEveryCardRequest.EveryCard card = canonicalNameToCard(cName);
-      assertEquals(card.name, fName);
+      List<String> results = getMatchingNames(fName);
+      assertEquals(1, results.size());
+      DeckOfEveryCardRequest.EveryCard card = canonicalNameToCard(results.getFirst());
+      assertEquals(card, getCardById(4));
     }
 
     @Test
-    public void testGetStatCard() {}
+    public void testInvalidInputGetCardById() {
+      DeckOfEveryCardRequest.EveryCard card = getCardById(-1);
+      assertNull(card);
+      card = getCardById(999);
+      assertNull(card);
+    }
+
+    @Test
+    public void testGetStatCard() {
+      DeckOfEveryCardRequest.EveryCard card = statToCard(KoLConstants.Stat.MOXIE);
+      assertEquals(card, getCardById(69));
+      card = statToCard(KoLConstants.Stat.MUSCLE);
+      assertEquals(card, getCardById(68));
+      card = statToCard(KoLConstants.Stat.MYSTICALITY);
+      assertEquals(card, getCardById(70));
+    }
+
+    @Test
+    public void testBuffToCard() {
+      DeckOfEveryCardRequest.EveryCard card = buffToCard(RACING);
+      assertEquals(card, getCardById(48));
+    }
+
+    @Test
+    public void testRequestFields() {
+      DeckOfEveryCardRequest req = new DeckOfEveryCardRequest();
+      assertNull(req.getRequestCard());
+      req = new DeckOfEveryCardRequest(getCardById(58));
+      assertEquals(req.getRequestCard().id, 58);
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
@@ -1,11 +1,16 @@
 package net.sourceforge.kolmafia.request;
 
+import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.canonicalNameToCard;
+import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.getMatchingNames;
+import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.phylumToCard;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
+import net.sourceforge.kolmafia.utilities.StringUtilities;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -22,9 +27,9 @@ class DeckOfEveryCardRequestTest {
   class StaticsCoverage {
     @Test
     public void testMatchingNames() {
-      List<String> results = DeckOfEveryCardRequest.getMatchingNames("not a real card name");
+      List<String> results = getMatchingNames("not a real card name");
       assertTrue(results.isEmpty());
-      results = DeckOfEveryCardRequest.getMatchingNames(" of ");
+      results = getMatchingNames(" of ");
       assertEquals(13, results.size());
       assertTrue(results.contains("x of spades"));
       assertTrue(results.contains("x of hearts"));
@@ -34,11 +39,18 @@ class DeckOfEveryCardRequestTest {
 
     @Test
     public void testPhylumToCard() {
-      DeckOfEveryCardRequest.EveryCard card =
-          DeckOfEveryCardRequest.phylumToCard(MonsterDatabase.Phylum.ELF);
+      DeckOfEveryCardRequest.EveryCard card = phylumToCard(MonsterDatabase.Phylum.ELF);
       assertEquals(card.name, "Christmas Card");
-      card = DeckOfEveryCardRequest.phylumToCard(MonsterDatabase.Phylum.PENGUIN);
+      card = phylumToCard(MonsterDatabase.Phylum.PENGUIN);
       assertEquals(card.name, "Suit Warehouse Discount Card");
+    }
+
+    @Test
+    public void testCanonicalName() {
+      String friendly = "X of Spades";
+      DeckOfEveryCardRequest.EveryCard card = canonicalNameToCard(friendly);
+      assertNotEquals(card.name, friendly);
+      assertEquals(card.name, StringUtilities.getCanonicalName(friendly));
     }
   }
 }

--- a/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
@@ -8,6 +8,7 @@ import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.getMatchin
 import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.phylumToCard;
 import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.statToCard;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -54,7 +55,7 @@ class DeckOfEveryCardRequestTest {
       String fName = "X of Spades";
       List<String> results = getMatchingNames(fName);
       assertEquals(1, results.size());
-      DeckOfEveryCardRequest.EveryCard card = canonicalNameToCard(results.getFirst());
+      DeckOfEveryCardRequest.EveryCard card = canonicalNameToCard(results.get(0));
       assertEquals(card, getCardById(4));
     }
 
@@ -88,6 +89,21 @@ class DeckOfEveryCardRequestTest {
       assertNull(req.getRequestCard());
       req = new DeckOfEveryCardRequest(getCardById(58));
       assertEquals(req.getRequestCard().id, 58);
+    }
+
+    @Test
+    public void testSomeEveryCardOverrides() {
+      DeckOfEveryCardRequest.EveryCard mickey = getCardById(58);
+      DeckOfEveryCardRequest.EveryCard notMickey = getCardById(59);
+      DeckOfEveryCardRequest.EveryCard copyMickey =
+          new DeckOfEveryCardRequest.EveryCard(mickey.id, mickey.name);
+      // Not simplifying the assertion because this makes it explicit that EveryCard.equals is being
+      // tested
+      assertFalse(mickey.equals(null));
+      assertFalse(mickey.equals(notMickey));
+      assertTrue(mickey.equals(mickey));
+      assertTrue(mickey.equals(copyMickey));
+      assertEquals(mickey.toString(), "1952 Mickey Mantle (58)");
     }
   }
 }

--- a/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
@@ -52,8 +52,6 @@ class DeckOfEveryCardRequestTest {
     }
 
     @Test
-    public void testGetStatCard() {
-
-    }
+    public void testGetStatCard() {}
   }
 }

--- a/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
@@ -1,7 +1,5 @@
 package net.sourceforge.kolmafia.request;
 
-import static internal.helpers.Player.withItem;
-import static internal.helpers.Player.withProperty;
 import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.RACING;
 import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.buffToCard;
 import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.canonicalNameToCard;
@@ -14,11 +12,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import internal.helpers.Cleanups;
 import java.util.List;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
-import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
@@ -109,20 +105,6 @@ class DeckOfEveryCardRequestTest {
       assertTrue(mickey.equals(mickey));
       assertTrue(mickey.equals(copyMickey));
       assertEquals(mickey.toString(), "1952 Mickey Mantle (58)");
-    }
-  }
-
-  // This test tries to actually create and run the request as a platform for investigating
-  // preference changes and thread locks.
-  @Test
-  public void runTheRequest() {
-    final int RACECARDID = 48;
-    DeckOfEveryCardRequest req = new DeckOfEveryCardRequest(getCardById(RACECARDID));
-    assertEquals(req.getRequestCard().id, RACECARDID);
-    var cleanups =
-        new Cleanups(withItem(ItemPool.DECK_OF_EVERY_CARD), withProperty("_deckCardsDrawn", 0));
-    try (cleanups) {
-      req.run();
     }
   }
 }

--- a/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
@@ -1,5 +1,7 @@
 package net.sourceforge.kolmafia.request;
 
+import static internal.helpers.Player.withItem;
+import static internal.helpers.Player.withProperty;
 import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.RACING;
 import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.buffToCard;
 import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.canonicalNameToCard;
@@ -12,9 +14,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import internal.helpers.Cleanups;
 import java.util.List;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
@@ -30,6 +34,7 @@ class DeckOfEveryCardRequestTest {
 
   @Nested
   class StaticsCoverage {
+    // These tests increase coverage but don't necessarily exercise functionality
     @Test
     public void testMatchingNames() {
       List<String> results = getMatchingNames("not a real card name");
@@ -104,6 +109,20 @@ class DeckOfEveryCardRequestTest {
       assertTrue(mickey.equals(mickey));
       assertTrue(mickey.equals(copyMickey));
       assertEquals(mickey.toString(), "1952 Mickey Mantle (58)");
+    }
+  }
+
+  // This test tries to actually create and run the request as a platform for investigating
+  // preference changes and thread locks.
+  @Test
+  public void runTheRequest() {
+    final int RACECARDID = 48;
+    DeckOfEveryCardRequest req = new DeckOfEveryCardRequest(getCardById(RACECARDID));
+    assertEquals(req.getRequestCard().id, RACECARDID);
+    var cleanups =
+        new Cleanups(withItem(ItemPool.DECK_OF_EVERY_CARD), withProperty("_deckCardsDrawn", 0));
+    try (cleanups) {
+      req.run();
     }
   }
 }

--- a/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
@@ -4,13 +4,11 @@ import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.canonicalN
 import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.getMatchingNames;
 import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.phylumToCard;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
-import net.sourceforge.kolmafia.utilities.StringUtilities;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -47,10 +45,15 @@ class DeckOfEveryCardRequestTest {
 
     @Test
     public void testCanonicalName() {
-      String friendly = "X of Spades";
-      DeckOfEveryCardRequest.EveryCard card = canonicalNameToCard(friendly);
-      assertNotEquals(card.name, friendly);
-      assertEquals(card.name, StringUtilities.getCanonicalName(friendly));
+      String cName = "x of spades";
+      String fName = "X of Spades";
+      DeckOfEveryCardRequest.EveryCard card = canonicalNameToCard(cName);
+      assertEquals(card.name, fName);
+    }
+
+    @Test
+    public void testGetStatCard() {
+
     }
   }
 }

--- a/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
@@ -106,5 +106,21 @@ class DeckOfEveryCardRequestTest {
       assertTrue(mickey.equals(copyMickey));
       assertEquals(mickey.toString(), "1952 Mickey Mantle (58)");
     }
+
+    @Test
+    public void testItShouldFollowRedirect() {
+      DeckOfEveryCardRequest req = new DeckOfEveryCardRequest();
+      assertTrue(req.shouldFollowRedirect());
+    }
+
+    @Test
+    public void testGetAdventuresUsed() {
+      DeckOfEveryCardRequest noCard = new DeckOfEveryCardRequest();
+      assertEquals(noCard.getAdventuresUsed(), 1);
+      DeckOfEveryCardRequest notMonster = new DeckOfEveryCardRequest(getCardById(58));
+      assertEquals(notMonster.getAdventuresUsed(), 0);
+      DeckOfEveryCardRequest monster = new DeckOfEveryCardRequest(getCardById(27));
+      assertEquals(monster.getAdventuresUsed(), 1);
+    }
   }
 }


### PR DESCRIPTION
This adds a test for DeckOfEveryCardRequest which had not had test before.  The actual tests are somewhat irrelevant because they are somewhat mechanical in nature but at least coverage is increased.

My long term goal is to use the Deck of Every Card in a test in such a way that the test will help debug the threadlock associated with #1889

While writing the tests I added a couple of helper functions to DeckOfEveryCardRequest and cleaned up some lint.