### PR TITLE
feat: also test on Java 21

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        java: [17]
+        java: [17, 21]
 
     name: Run Checks
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -61,7 +61,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-          check_name: "Test Report (${{ matrix.os }})"
+          check_name: "Test Report (${{ matrix.os }}, Java ${{ matrix.java }})"
           report_paths: "**/build/test-results/test/TEST-*.xml"
 
       - name: Publish Coverage Report


### PR DESCRIPTION
There was discussion in https://kolmafia.us/threads/support-for-java-21-new-lts.29522/#post-175419 on moving to Java 21 (and in https://kolmafia.us/threads/r28087-whats-changed-create-json-api-for-relay-scripts-by-phulin-in.29967/ on using https://github.com/simdjson/simdjson-java which requires Java 18).

This is a necessary precursor for that (unless we do a "big bang" 17 -> 21 change I'd prefer to avoid).