### PR TITLE
feat: crimbo zones are 100% combat with NCs every 11 adventures

### DIFF
--- a/src/data/adventures.txt
+++ b/src/data/adventures.txt
@@ -440,8 +440,8 @@ Tammy's Offshore Platform	adventure=536	DiffLevel: unknown Env: underwater Stat:
 Tammy's Offshore Platform	adventure=537	DiffLevel: unknown Env: underwater Stat: 0	The Wreck of the H. M. S. Kringle
 Tammy's Offshore Platform	adventure=538	DiffLevel: unknown Env: underwater Stat: 0	The Impenetrable Kelp-Holly Forest
 
-Holiday Islands	adventure=588	DiffLevel: mid Env: outdoor Stat: 0	Easter Island
-Holiday Islands	adventure=589	DiffLevel: mid Env: outdoor Stat: 0	St. Patrick's Day Island
+Holiday Islands	adventure=588	DiffLevel: mid Env: outdoor Stat: 0 ForceNoncombat: 11	Easter Island
+Holiday Islands	adventure=589	DiffLevel: mid Env: outdoor Stat: 0 ForceNoncombat: 11	St. Patrick's Day Island
 
 Crimbo23	adventure=575	DiffLevel: mid Env: indoor Stat: 0	Abuela's Cottage (Contested)
 Crimbo23	adventure=576	DiffLevel: mid Env: indoor Stat: 0	The Embattled Factory

--- a/src/data/combats.txt
+++ b/src/data/combats.txt
@@ -255,7 +255,7 @@ Special Ops	-1	Black Ops Bugbear
 Spookiest Adventurer Contest	100	Ghostpuncher	Plague Chef	Batburglar	Arthur Frankenstein: 0
 Spooky Fright Factory	100	bow-making mummy	Cookie-baking Thing from Beyond Time	gift-wrapping vampire	skeletal reindeer	stocking-stuffing zombie	toy-making creature from the Gray Lagoon
 Spring Bros. Solenoids	95	Spring Bros. security robot	automated solenoid press	janitor robot
-St. Patrick's Day Island	95	giant snake	giant potato	giant potato snake
+St. Patrick's Day Island	100	giant snake	giant potato	giant potato snake
 Stinkiest Adventurer Contest	100	Granola Barbarian	Cheese Wizard	Assassin	Odorous Humongous: 0
 Strongest Adventurer Contest	100	Macho Man	Iron Chef	Entire Shoplifter	Mr. Loathing: 0
 Summoning Chamber	100	Lord Spookyraven

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -3488,3 +3488,5 @@ user	lastNoncombat533	0
 user	lastNoncombat539	0
 user	lastNoncombat540	0
 user	lastNoncombat541	0
+user	lastNoncombat588	0
+user	lastNoncombat589	0

--- a/src/data/equipment.txt
+++ b/src/data/equipment.txt
@@ -884,6 +884,7 @@ Othello's military jacket	150	Mus: 40
 PARTY HARD T-shirt	10	none
 pirate shirt	50	Mus: 10
 poncho de azucar	200	Mox: 75
+potato jacket	150	Mus: 40
 Private Pepper's Lonely Hearts Club Jacket	130	Mus: 50
 Professor What T-Shirt	10	none
 psycho sweater	100	Mus: 35

--- a/src/data/fullness.txt
+++ b/src/data/fullness.txt
@@ -286,6 +286,7 @@ dire fudgesicle	2	1	decent	2-4	0	8-10	0	lose 2 HP
 Disc-Shaped Nutrition Unit	4	5	decent	6-9	0	0	0
 disco biscuit	1	6	EPIC	6-7	0	0	20-30	100 Buttermilk Boogie (+50% mox, +50 init, +20-40 HP regen)
 Double Bacon Beelzeburger	3	1	decent	4-6	15-20	-15-20	0
+double-candied yams	2	1	EPIC	0	0	0	0	Unspaded
 dragon snaps	1	1	crappy	1	0	0	5-10	5 Oh Snap (+10 mox exp)
 Dreadsylvanian cold pocket	4	26	EPIC	36-40	30-50	30-50	30-50	200 Dreadful Chill (+5 Sleaze/Stench Res)
 Dreadsylvanian hot pocket	4	26	EPIC	36-40	30-50	30-50	30-50	200 Dreadful Heat (+5 Cold/Spooky Res)
@@ -483,6 +484,7 @@ Hide-rox&trade; cookie	1	1	awesome	3-5	0	20-30	0	30 Broken Bone Nubs (+50% Myst,
 high-calorie sugar substitute	1	4	awesome	3-4	0	20-25	0
 hippy herbal tea	1	1	decent	2	0	4-7	0	BEVERAGE, 5 Sleepy (-30% mus)
 holiday cheese log	3	1	good	8-10	10-20	10-20	10-20	Stands Alone (+10 Stench dmg)
+holiday smorgasbord	4	5	EPIC	0	0	0	0	Unspaded
 honey bun of Boris	1	1	EPIC	5-7	20-40	0	0	30 Motherly Loved (+5 Muscle, +50% Muscle, +5 Cold Res)
 honey-dew	2	2	good	4-7	13-15	0	0	10 Mmmmmelon (+30% item drop)
 honey-drenched ham slice	1	1	decent	1-2	1-5	1-5	1-5

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11753,7 +11753,7 @@
 11725	moaiball	728604035	moaieye.gif	offhand	t	0
 11726	half-digested rat	445778415	halfdigrat.gif	none, combat	t,d	15
 11727	four-leaf potato sprout	990121184	fourleafsprout.gif	potion, usable	t,d	22
-11728
+11728	potato jacket	623781707	potatojacket.gif	shirt	t	0
 11729
 11730
 11731
@@ -11781,15 +11781,15 @@
 11753	chocolate ostrich egg	477352862	chocegg.gif	food	t,d	75
 11754	candied beef and cabbage	942057727	crimboscraps.gif	food	t,d	75	plates of candied beef and cabbage
 11755	candy rations	995325513	crimbotin.gif	food	t,d	75	candy rations
-11756
+11756	double-candied yams	699171863	casserole.gif	food	t,d	75	platters of double-candied yams
 11757	Christmas ham	535336050	ham.gif	food	t,d	75
-11758
+11758	holiday smorgasbord	259131327	partytray.gif	food	t,d	250
 11759
 11760
 11761	Secrets of the Master Egg Hunters	943549721	book5.gif	usable	t	0	copies of Secrets of the Master Egg Hunters
 11762	Secrets of the Master Egg Hunters (used)	216321799	book5.gif	usable		0	used copies of Secrets of the Master Egg Hunters
-11763	How to Lose Friends and Attract Snakes	465814056	book3.gif	usable	t	0	How to Lose Friends and Attract Snakes
-11764	How to Lose Friends and Attract Snakes (used)	465814056	book3.gif	usable	t	0	copies of How to Lose Friends and Attract Snakes
+11763	How to Lose Friends and Attract Snakes	465814056	book3.gif	usable	t	0	copies of How to Lose Friends and Attract Snakes
+11764	How to Lose Friends and Attract Snakes (used)	465814056	book3.gif	usable	t	0	used copies of How to Lose Friends and Attract Sna
 11765
 11766
 11767

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -1055,6 +1055,7 @@ Item	Othello's military jacket	Othello Skill: +10
 Item	PARTY HARD T-shirt	Muscle Limit: 100, Mysticality Limit: 100, Moxie Limit: 100
 Item	pirate shirt	Moxie: +3
 Item	poncho de azucar	Adventures: +5, Stench Damage: +30, Class: "Accordion Thief"
+Item	potato jacket	Hot Damage: +20, Cold Resistance: +3, Meat Drop: +15
 # Private Pepper's Lonely Hearts Club Jacket: 50% Discount on Gift Packages
 Item	Professor What T-Shirt	MP Regen Min: 1, MP Regen Max: 2
 Item	psycho sweater	Weapon Damage Percent: +20, Spell Damage Percent: +20
@@ -9090,6 +9091,7 @@ Item	diabolic pizza	Lasts Until Rollover
 # dinner roll: Selling Price: <b>1 Meat.</b><p><center><b><font color=blue>Deals Physical Damage based on your Muscle when used as a combat item
 Item	Dinsey food-cone	Effect: "The Dinsey Way", Effect Duration: 30
 Item	disco biscuit	Effect: "Buttermilk Boogie", Effect Duration: 100
+Item	double-candied yams	Effect: "Grateful, But Spelled With a Dollar Sign", Effect Duration: 40
 Item	dragon snaps	Effect: "Oh Snap", Effect Duration: 5
 Item	Dreadsylvanian cold pocket	Effect: "Dreadful Chill", Effect Duration: 200
 Item	Dreadsylvanian hot pocket	Effect: "Dreadful Heat", Effect Duration: 200

--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -2401,12 +2401,12 @@ Crimbuccaneer privateer	2436	cbprivateer.gif	NOWISH Scale: ? Init: -10000 P: pir
 # Crimbo 2024 (December 2024)
 feral bunny	2475	feralbunny.gif	Scale: 5 Init: 100 P: beast Article: a	Spirit of Easter (c100)	coney haunch (15)
 chocolate chicken	2476	chocken.gif	Scale: 5 Init: 150 P: beast Article: a	Spirit of Easter (c100)	dark chocolate egg (15)
-moai	2477	moai.gif	Scale: 5 Init: -10000 P: construct Article: a	Spirit of Easter (c100)	moai toai (15)	moaiball (0)
+moai	2477	moai.gif	Scale: 5 Init: -10000 P: construct Article: a	Spirit of Easter (c100)	moai toai (15)	moaiball (f0.1)
 Easter Island Bunny	2464	moaibunny.gif	NOCOPY NOMANUEL Scale: 10 HP: 300 Init: -10000 P: construct Article: the
 
-giant snake	2478	bigsnake.gif	Scale: 5 Init: 200 P: beast	Spirit of St. Patrick's Day (c100)	half-digested rat (0)
-giant potato	2479	bigpotato.gif	Scale: 5 Init: 50 P: plant Article: a	Spirit of St. Patrick's Day (c100)	four-leaf potato sprout (0)
-giant potato snake	2480	potatosnake.gif	Scale: 5 Init: 150 P: beast Article: a	Spirit of St. Patrick's Day (c100)	half-digested rat (0)	four-leaf potato sprout (0)
+giant snake	2478	bigsnake.gif	Scale: 5 Init: 200 P: beast	Spirit of St. Patrick's Day (c100)	half-digested rat (10)
+giant potato	2479	bigpotato.gif	Scale: 5 Init: 50 P: plant Article: a	Spirit of St. Patrick's Day (c100)	four-leaf potato sprout (10)	potato jacket (f0.1)
+giant potato snake	2480	potatosnake.gif	Scale: 5 Init: 150 P: beast Article: a	Spirit of St. Patrick's Day (c100)	half-digested rat (5)	four-leaf potato sprout (5)
 
 
 # Old Events

--- a/src/data/statuseffects.txt
+++ b/src/data/statuseffects.txt
@@ -2947,9 +2947,9 @@
 2944
 2945	Attracting Snakes	tinysnake.gif	09921a7a4230ada9a833ca92b1b453dd	neutral	none	cast 1 Attract Snakes
 2946	Hiding From Seekers	darkvision.gif	18b4a2010721b16d9e85da10fdaaa515	neutral	none	cast 1 Hide From Seekers
-2947	Resurrection of the Flesh	eggstripe.gif	08ec7462372b8ebe2450d19525415b22	neutral	none	eat 1 chocolate ostrich egg
-2948	Green-Blooded	clover.gif	9fe9e62146de9f83356ab168d864beb9	neutral	none	eat 1 candied beef and cabbage
-2949	Toured of Duty	bountyrifle.gif	88f72e98917d2bf21d3dcdf0a8007570	neutral	none	drink 1 canteen of jungle juice
-2950	Grateful, But Spelled With a Dollar Sign	dollarsign.gif	d327b4c6b31dce1f0a7435f37da24878	neutral	none	drink 1 turchucken
-2951	Eyesies on the Pressies	darkgift.gif	1ee7baeab92f07b17d7619ea62b6d167	neutral	none	eat 1 Christmas ham
+2947	Resurrection of the Flesh	eggstripe.gif	08ec7462372b8ebe2450d19525415b22	neutral	none	eat 1 chocolate ostrich egg|drink 1 Easter grasshopper
+2948	Green-Blooded	clover.gif	9fe9e62146de9f83356ab168d864beb9	neutral	none	eat 1 candied beef and cabbage|drink 1 Irish eggnog
+2949	Toured of Duty	bountyrifle.gif	88f72e98917d2bf21d3dcdf0a8007570	neutral	none	eat 1 candy rations|drink 1 canteen of jungle juice
+2950	Grateful, But Spelled With a Dollar Sign	dollarsign.gif	d327b4c6b31dce1f0a7435f37da24878	neutral	none	eat 1 double-candied yams|drink 1 turchucken
+2951	Eyesies on the Pressies	darkgift.gif	1ee7baeab92f07b17d7619ea62b6d167	neutral	none	eat 1 Christmas ham|drink 1 mechanically-mulled cider
 2952	Herder, Bitter, Fester, Stranger	darkchocegg.gif	a8a929d23d6d0676bf31e4e3e2c25d1d	neutral	none	use 1 dark chocolate egg

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -403,6 +403,8 @@ public class Preferences {
         "lastNoncombat539",
         "lastNoncombat540",
         "lastNoncombat541",
+        "lastNoncombat588",
+        "lastNoncombat589",
         "lastShadowForgeUnlockAdventure",
         "lastTrainsetConfiguration",
         "lastZapperWandExplosionDay",


### PR DESCRIPTION
Also you can reduce the combat rate to get more NCs like the Spooky
Forest.

Update items from mall, assume rares are 0.1% because it's looking that way.