### PR TITLE
Finish support for ShopRow Coinmasters

### DIFF
--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11789,13 +11789,13 @@
 11761	Secrets of the Master Egg Hunters	943549721	book5.gif	usable	t	0	copies of Secrets of the Master Egg Hunters
 11762	Secrets of the Master Egg Hunters (used)	216321799	book5.gif	reusable		0	used copies of Secrets of the Master Egg Hunters
 11763	How to Lose Friends and Attract Snakes	465814056	book3.gif	usable	t	0	copies of How to Lose Friends and Attract Snakes
-11764	How to Lose Friends and Attract Snakes (used)	953745853	book3.gif	reusable		0	used copies of How to Lose Friends and Attract Sna
+11764	How to Lose Friends and Attract Snakes (used)	953745853	book3.gif	reusable		0	used copies of How to Lose Friends and Attract Snakes
 11765	Covert Ops for Kids	484772100	book2.gif	usable	t	0	copies of Covert Ops for Kids
 11766	Covert Ops for Kids (used)	700189532	book2.gif	reusable		0	used copies of Covert Ops for Kids
 11767	Holiday Multitasking	555431420	book3.gif	usable	t	0	copies of Holiday Multitasking
 11768	Holiday Multitasking (used)	639002731	book3.gif	reusable		0	used copies of Holiday Multitasking
 11769	Hoyle's Guide to Reindeer Games	429457903	book4.gif	usable	t	0	copies of Hoyle's Guide to Reindeer Games
-11770
+11770	Hoyle's Guide to Reindeer Games (used)	145669836	book4.gif	reusable		0	used copies of Hoyle's Guide to Reindeer Games
 11771	lucky moai statuette	232982896	chiatiki.gif	usable	t	0
 11772	egg gun	530204511	egggun.gif	weapon	t	0
 11773	lucky army helmet	759962296	luckyhelmet.gif	hat	t	0

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -11451,6 +11451,8 @@ Item	cotton candy cocoon	Free Pull
 # cotton candy skoshe: Restores 15-30 HP and MP
 # cotton candy smidgen: Restores 11-23 HP and MP
 # counterfeit city
+Item	Covert Ops for Kids	Skill: "Hide From Seekers"
+Item	Covert Ops for Kids (used)	Skill: "Hide From Seekers"
 # cracked stone sphere: Mysterious, Deprecated
 # crappy camera: Makes a copy of a monster to fight later
 # crappy camera: (when it works)
@@ -11836,6 +11838,8 @@ Item	Hodgman's journal #3: Pumping Tin	Skill: "Abs of Tin"
 Item	Hodgman's journal #4: View From The Big Top	Skill: "Marginally Insane"
 Item	Holiday Fun!	Free Pull
 Item	Holiday Hal's Happy-Time Fun Book!	Skill: "Summon Holiday Fun!"
+Item	Holiday Multitasking	Skill: "Holiday Multitasking"
+Item	Holiday Multitasking (used)	Skill: "Holiday Multitasking"
 # holo-bomber: Deals 5,000 Physical Damage
 # holo-platoon: Deals 5,000 Physical Damage
 # holo-tank: Deals 5,000 Physical Damage
@@ -11855,8 +11859,12 @@ Item	Horsery contract	Free Pull
 # hot spore pod: Briefly improves your <font color = red>Hot</font> spells
 Item	How To Get Bigger Without Really Trying	Skill: "Get Big"
 Item	How to Hold a Grudge	Skill: "Chip on your Shoulder"
+Item	How to Lose Friends and Attract Snakes	Skill: "Attract Snakes"
+Item	How to Lose Friends and Attract Snakes (used)	Skill: "Attract Snakes"
 # How to Play Othello: Teaches you how to play Othello better
 Item	How to Tolerate Jerks	Skill: "Thick-Skinned"
+Item	Hoyle's Guide to Reindeer Games	Skill: "Reindeer Games"
+Item	Hoyle's Guide to Reindeer Games (used)	Skill: "Reindeer Games"
 Item	Huggler Radio	Free Pull
 # human musk: Banish an enemy for the rest of the day
 Item	hungover chauvinist pig	Free Pull
@@ -12405,6 +12413,8 @@ Item	Scurvy and Sobriety Prevention	Skill: "Prevent Scurvy and Sobriety"
 Item	seal tooth	Effect: "Bloody Hand", Effect Duration: 3
 Item	seal-blubber candle	Class: "Seal Clubber"
 # sealhide snare: Stuns your opponent for a few rounds
+Item	Secrets of the Master Egg Hunters	Skill: "Master Egg Hunter"
+Item	Secrets of the Master Egg Hunters (used)	Skill: "Master Egg Hunter"
 # self-defense training: Increases your Bat-Armor
 Item	Sensual Massage for Creeps	Skill: "Inappropriate Backrub"
 # Sept-Ember Censer: Generate 7 embers each day to magically consume


### PR DESCRIPTION
This should (almost) complete support for ShopRow style Coinmasters

- coinmaster.txt contains new-style shop.php entries with up to 5 currencies per item sold
- (when we visit shop.php, we will detect new items - and currencies - and log such.)
- CoinmastersFrame has a new ShopRowPanel class which supports that kind of Coinmaster.
- As do CoinmasterData and CoinMasterRequest.

I haven't actually tested how/if multi-ingredient CoinmasterPurchaseRequests work.
Those would show up in the Creatable panel of the ItemManager.
I should do that...

Take a look at Crimbo24FactoryRequest.java to see just how easy it is to code this, compared to the previous Coinmasters that have multiple currencies that are NOT specified in coinmasters.txt

I could write tests for various components of this effort (like NPCPurchaseRequest.parseShopInventory).
And, having done that, I should figure out how to parse the Mystic, who has a variant format of shop.php with rows.
And maybe I could make a creation method - like the Kiwi Kwiki Mart - into a CoinMaster.

I'd prefer to do those things in a follow up PR.
I need a break from coding. :)