### PR TITLE
More Crimbo24 tweaks

### DIFF
--- a/src/data/concoctions.txt
+++ b/src/data/concoctions.txt
@@ -3399,3 +3399,4 @@ gravyskin buckler	ASMITH	buckler buckle	gravy skin
 gravyskin hat	ASMITH	basic meat helmet	gravy skin
 gravyskin pants	ASMITH	pants kit	gravy skin
 gravyskin skirt	ASMITH	skirt / kilt kit	gravy skin
+perfect Christmas scarf	SUSE	ragged wool yarn (50)

--- a/src/data/equipment.txt
+++ b/src/data/equipment.txt
@@ -3425,6 +3425,7 @@ tiny plastic hypodermic bugbear	10	none
 tiny plastic Iiti Kitty	10	none
 tiny plastic Jared the Duskwalker	10	none
 tiny plastic Jarlsberg	30	none
+tiny plastic Jedediah and Boiling Cloud	10	none
 tiny plastic K.R.A.M.P.U.S.	10	none
 tiny plastic killer bee	10	none
 tiny plastic Knob Goblin bean counter	10	none

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11740,7 +11740,7 @@
 11712	tiny plastic Easter Island Bunny	910030772	c24tpa.gif	accessory	t	0	tiny plastic Easter Island Bunnies
 11713	tiny plastic St. Patrick	427726670	c24tpbee.gif	accessory	t	0
 11714	tiny plastic Colonel Brando	148356375	c24tptres.gif	accessory	t	0
-11715
+11715	tiny plastic Jedediah and Boiling Cloud	357579052	c24tp444.gif	accessory	t	0
 11716
 11717	Spirit of Easter	756560474	spirit_easter.gif	none		0	Spirits of Easter
 11718	Spirit of St. Patrick's Day	655322653	spirit_stpatrick.gif	none		0	Spirits of St. Patrick's Day

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -3961,6 +3961,7 @@ Item	tiny plastic hypodermic bugbear	Monster Level: +1
 Item	tiny plastic Iiti Kitty	Monster Level: +1
 Item	tiny plastic Jared the Duskwalker	Monster Level: +1
 Item	tiny plastic Jarlsberg	Mysticality: +5, Muscle: +3, Moxie: +3
+Item	tiny plastic Jedediah and Boiling Cloud	Weapon Damage: +3
 Item	tiny plastic K.R.A.M.P.U.S.	Weapon Damage: +5, Spooky Damage: +1, Stench Damage: +1, Hot Damage: +1, Cold Damage: +1, Sleaze Damage: +1
 Item	tiny plastic killer bee	Familiar Weight: +1
 Item	tiny plastic Knob Goblin bean counter	Monster Level: +1
@@ -6633,6 +6634,7 @@ Effect	Jay Walking	Avatar: ""Handyman" Jay Android"
 # Jazz Hands
 Effect	Je Ne Sais Porquoise	Moxie Percent: +50, Meat Drop: +6, Item Drop: +5
 Effect	Jeffersonian	Avatar: "Jefferson pilot"
+Effect	Jelly-Coated Insides	Experience: +5, Muscle Percent: +50, Mysticality Percent: +50, Moxie Percent: +50
 # Jelly Combed: Makes you harder to hit (when underwater)
 Effect	Jerky, Boy	Mysticality Percent: +25
 Effect	Jiggu... What?	Mana Cost: +100

--- a/src/data/statuseffects.txt
+++ b/src/data/statuseffects.txt
@@ -2942,7 +2942,7 @@
 2939	Rummy	candy.gif	df0db5d253af5a2e71afd14cc6ed80d0	neutral	none	use 1 rum ball
 2940	LIDARed	lidarcandle.gif	b34429042b32da133c148957b526aafb	neutral	none	use 1 LIDAR candle
 2941	All Cut Up	fence.gif	f08f52dd911edcd4ef8a1cd952ced281	neutral	none
-2942
+2942	Jelly-Coated Insides	infinitejelly.gif	141eee7dc193eac1bccfd1d87398ea76	neutral	none
 2943	Candied Devil	candyegg.gif	8e5858ba1620c6ef09ee0a32ae5e13fe	neutral	none	use 1 deviled candy egg
 2944
 2945	Attracting Snakes	tinysnake.gif	09921a7a4230ada9a833ca92b1b453dd	neutral	none	cast 1 Attract Snakes

--- a/src/net/sourceforge/kolmafia/request/EatItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/EatItemRequest.java
@@ -1027,6 +1027,11 @@ public class EatItemRequest extends UseItemRequest {
       Preferences.decrement("whetstonesUsed", chargesUsed);
     }
 
+    // You slather the chocolate chip muffin with festive Christmas jelly.
+    if (responseText.contains("festive Christmas jelly")) {
+      EatItemRequest.logConsumption("Your Bowl of Infinite Jelly kicked in");
+    }
+
     // Satisfied, you let loose a nasty magnesium-flavored belch.
     if (responseText.contains("magnesium-flavored belch")) {
       EatItemRequest.logConsumption("Your milk of magnesium kicked in");

--- a/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
@@ -6343,7 +6343,7 @@ public abstract class ChoiceAdventures {
         1542,
         "Holiday Islands",
         "The Malevolent Spirit of the Holiday",
-        new ChoiceOption("fight ???", 1),
+        new ChoiceOption("fight \"Santa Claus\"", 1),
         new ChoiceOption("get Spirits of Christmas scaling with spooky resistance", 2),
         new ChoiceOption("skip adventure", 3));
   }


### PR DESCRIPTION
1) You can create a perfect Christmas scarf by using a single ragged wool yarn - which uses up 50 of them.
2) tiny plastic Jedediah and Boiling Cloud
3) Bowl of Infinite Jelly passively increases the adventure gain of one food a day and gives you 10 turns of the Jelly-Coated Insides status effect.
4) Christmas Island choice adventure option 1 is 'fight "Santa Clause"'