### PR TITLE
feat: stats for post-crimbo foods

### DIFF
--- a/src/data/fullness.txt
+++ b/src/data/fullness.txt
@@ -996,7 +996,7 @@ tempura radish bento box with inky squid sauce	5	1	EPIC	24-32	5-15	75-95	5-15	80
 tempura radish bento box with mer-kin weaksauce	5	1	EPIC	24-32	5-15	5-15	75-95	80 Fishy
 tempura radish bento box with peanut sauce	5	1	EPIC	24-32	5-15	5-15	5-15	80 Fishy
 tempura radish bento box with peppermint eel sauce	5	1	EPIC	24-32	55-75	55-75	65-85	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
-Thanksgiving ration	3	5	EPIC	0	0	0	0	Unspaded
+Thanksgiving ration	3	5	EPIC	24-30	20-60	20-60	20-60
 thanksgiving turkey	2	1	awesome	8-10	10-20	0	0	leftovers, 20 Thanksgetting (Variable +meat, +item, +familiar weight, +all res)
 The Plumber's mushroom stew	3	6	EPIC	21-24	15-30	15-30	15-30	-1 drunkenness
 They liver popsicle	1	4	awesome	4-5	10-20	10-20	10-20	100 You Liver

--- a/src/data/inebriety.txt
+++ b/src/data/inebriety.txt
@@ -248,7 +248,7 @@ dusty bottle of Port	1	1	decent	2	0	0	0	10 Full of Vinegar (+weapon damage), WIN
 dusty bottle of Zinfandel	2	1	good	5-7	10-15	10-15	10-15	WINE
 Earth and Firewater	2	4	awesome	6-7	0	20-30	0	10 Elemental Mastery (+5 Prismatic Dam)
 Earth, Wind and Firewater	2	8	awesome	8-9	0	30-40	0	15 Elemental Mastery (+5 Prismatic Dam)
-Easter eggnog	3	5	EPIC	0	0	0	0	Unspaded
+Easter eggnog	3	5	EPIC	24-30	20-60	20-60	20-60
 Easter grasshopper	2	1	EPIC	0	0	0	0	Unspaded
 Ecto-Cooler	1	6	awesome	3-4	5-10	5-10	5-10	30 Booing Radly (+50 dmg vs. Ghosts)
 ecto-nog	3	1	decent	3-6	5-6	5-6	5-6


### PR DESCRIPTION
They're at the level of the Dreadsylvania edibles, but with a vastly lower level requirement.

Decent pulls for turnbloat but unlikely to be worthwhile for most people.