### PR TITLE
Improve shoprow data file generation

### DIFF
--- a/src/data/shoprows.txt
+++ b/src/data/shoprows.txt
@@ -1,14 +1,14 @@
 1
-3	coin	FDKOL tattoo	FDKOL Tent
-4	coin	fireman's helmet	FDKOL Tent
-7	coin	fire axe	FDKOL Tent
-8	coin	enchanted fire extinguisher	FDKOL Tent
-9	coin	Hjodor's Guide to Arctic Dalmatians	FDKOL Tent
-11	coin	FDKOL fire hose	FDKOL Tent
-12	coin	bottle of fire	FDKOL Tent
-13	coin	penguin skin	The Trapper
-14	coin	yak skin	The Trapper
-15	coin	hippopotamus skin	The Trapper
+3	buy	FDKOL tattoo	FDKOL Tent
+4	buy	fireman's helmet	FDKOL Tent
+7	buy	fire axe	FDKOL Tent
+8	buy	enchanted fire extinguisher	FDKOL Tent
+9	buy	Hjodor's Guide to Arctic Dalmatians	FDKOL Tent
+11	buy	FDKOL fire hose	FDKOL Tent
+12	buy	bottle of fire	FDKOL Tent
+13	buy	penguin skin	The Trapper
+14	buy	yak skin	The Trapper
+15	buy	hippopotamus skin	The Trapper
 26	conc	white pixel	PIXEL
 27	conc	red pixel potion	PIXEL
 28	conc	blue pixel potion	PIXEL
@@ -75,17 +75,17 @@
 90	conc	Nachojito	JARLS
 91	conc	Le Roi	JARLS
 92	conc	Over Easy Rider	JARLS
-93	coin	Boris's key	Vending Machine
-94	coin	Jarlsberg's key	Vending Machine
-95	coin	Sneaky Pete's key	Vending Machine
-96	coin	Boris's ring	Vending Machine
-97	coin	Jarlsberg's earring	Vending Machine
-98	coin	Sneaky Pete's breath spray	Vending Machine
-99	coin	potato sprout	Vending Machine
-100	coin	dried gelatinous cube	Vending Machine
-101	coin	Spellbook: Walberg's Dim Bulb	Vending Machine
-102	coin	Spellbook: Singer's Faithful Ocelot	Vending Machine
-103	coin	Spellbook: Drescher's Annoying Noise	Vending Machine
+93	buy	Boris's key	Vending Machine
+94	buy	Jarlsberg's key	Vending Machine
+95	buy	Sneaky Pete's key	Vending Machine
+96	buy	Boris's ring	Vending Machine
+97	buy	Jarlsberg's earring	Vending Machine
+98	buy	Sneaky Pete's breath spray	Vending Machine
+99	buy	potato sprout	Vending Machine
+100	buy	dried gelatinous cube	Vending Machine
+101	buy	Spellbook: Walberg's Dim Bulb	Vending Machine
+102	buy	Spellbook: Singer's Faithful Ocelot	Vending Machine
+103	buy	Spellbook: Drescher's Annoying Noise	Vending Machine
 104	conc	Staff of the Healthy Breakfast	JARLS
 105	conc	Staff of the Staff of Life	JARLS
 106	conc	Staff of the Light Lunch	JARLS
@@ -125,18 +125,18 @@
 143	conc	star stiletto	STARCHART
 144	conc	star boomerang	STARCHART
 145	conc	star spatula	STARCHART
-146	coin	Tales of Dread	The Terrified Eagle Inn
-147	coin	Dreadsylvanian skeleton key	The Terrified Eagle Inn
-148	coin	Official Seal of Dreadsylvania	The Terrified Eagle Inn
-149	coin	Dreadsylvanian stew	The Terrified Eagle Inn
-150	coin	white Dreadsylvanian	The Terrified Eagle Inn
-151	coin	brass Dreadsylvanian flask	The Terrified Eagle Inn
-152	coin	silver Dreadsylvanian flask	The Terrified Eagle Inn
-153	coin	dreadful fedora	The Terrified Eagle Inn
-154	coin	dreadful sweater	The Terrified Eagle Inn
-155	coin	dreadful glove	The Terrified Eagle Inn
-156	coin	hot Dreadsylvanian cocoa	The Terrified Eagle Inn
-157	coin	folder (tranquil landscape)	The Terrified Eagle Inn
+146	buy	Tales of Dread	The Terrified Eagle Inn
+147	buy	Dreadsylvanian skeleton key	The Terrified Eagle Inn
+148	buy	Official Seal of Dreadsylvania	The Terrified Eagle Inn
+149	buy	Dreadsylvanian stew	The Terrified Eagle Inn
+150	buy	white Dreadsylvanian	The Terrified Eagle Inn
+151	buy	brass Dreadsylvanian flask	The Terrified Eagle Inn
+152	buy	silver Dreadsylvanian flask	The Terrified Eagle Inn
+153	buy	dreadful fedora	The Terrified Eagle Inn
+154	buy	dreadful sweater	The Terrified Eagle Inn
+155	buy	dreadful glove	The Terrified Eagle Inn
+156	buy	hot Dreadsylvanian cocoa	The Terrified Eagle Inn
+157	buy	folder (tranquil landscape)	The Terrified Eagle Inn
 158	conc	miniature suspension bridge	SHOPCLASS
 159	conc	Staff of the Lunch Lady	SHOPCLASS
 160	conc	universal key	SHOPCLASS
@@ -155,14 +155,14 @@
 173	npc	Cursed Punch	The Hidden Tavern
 174	npc	Bowl of Scorpions	The Hidden Tavern
 175	npc	Fog Murderer	The Hidden Tavern
-176	coin	dinghy plans	The Shore, Inc. Gift Shop
-177	coin	fuzzy dice	The Shore, Inc. Gift Shop
-178	coin	meat globe	The Shore, Inc. Gift Shop
-179	coin	cheap toaster	The Shore, Inc. Gift Shop
-180	coin	dude ranch souvenir crate	The Shore, Inc. Gift Shop
-181	coin	tropical island souvenir crate	The Shore, Inc. Gift Shop
-182	coin	ski resort souvenir crate	The Shore, Inc. Gift Shop
-183	coin	UV-resistant compass	The Shore, Inc. Gift Shop
+176	buy	dinghy plans	The Shore, Inc. Gift Shop
+177	buy	fuzzy dice	The Shore, Inc. Gift Shop
+178	buy	meat globe	The Shore, Inc. Gift Shop
+179	buy	cheap toaster	The Shore, Inc. Gift Shop
+180	buy	dude ranch souvenir crate	The Shore, Inc. Gift Shop
+181	buy	tropical island souvenir crate	The Shore, Inc. Gift Shop
+182	buy	ski resort souvenir crate	The Shore, Inc. Gift Shop
+183	buy	UV-resistant compass	The Shore, Inc. Gift Shop
 184	conc	junk junk	JUNK
 185	conc	junk band	JUNK
 186	conc	junk trunks	JUNK
@@ -172,27 +172,27 @@
 190	conc	swordzall	JUNK
 191	conc	arm buzzer	JUNK
 192	conc	boilgun	JUNK
-193	coin	Mint-in-box Moonthril Circlet	Isotope Smithery
-194	coin	Mint-in-box Moonthril Flamberge	Isotope Smithery
-195	coin	Mint-in-box Moonthril Longbow	Isotope Smithery
-196	coin	Mint-in-box Moonthril Greaves	Isotope Smithery
-197	coin	Mint-in-box Moonthril Cuirass	Isotope Smithery
-198	coin	plush alielf	Dollhawker's Emporium
-199	coin	plush dogcat	Dollhawker's Emporium
-200	coin	plush hamsterpus	Dollhawker's Emporium
-201	coin	plush ferrelf	Dollhawker's Emporium
-202	coin	plush mutated alielf	Dollhawker's Emporium
-203	coin	plush alien hamsterpus	Dollhawker's Emporium
-204	coin	plush mutated alielephant	Dollhawker's Emporium
-205	coin	Saison du Lune	Lunar Lunch-o-Mat
-206	coin	Moonthril Schnapps	Lunar Lunch-o-Mat
-207	coin	Wrecked Generator	Lunar Lunch-o-Mat
-208	coin	Spaghetti with Moonballs	Lunar Lunch-o-Mat
-209	coin	Crepes a la Lune	Lunar Lunch-o-Mat
-210	coin	Moon Pie	Lunar Lunch-o-Mat
-211	coin	Comet Pop	Lunar Lunch-o-Mat
-212	coin	Flan in the Moon	Lunar Lunch-o-Mat
-213	coin	1/6th Pound Cake	Lunar Lunch-o-Mat
+193	buy	Mint-in-box Moonthril Circlet	Isotope Smithery
+194	buy	Mint-in-box Moonthril Flamberge	Isotope Smithery
+195	buy	Mint-in-box Moonthril Longbow	Isotope Smithery
+196	buy	Mint-in-box Moonthril Greaves	Isotope Smithery
+197	buy	Mint-in-box Moonthril Cuirass	Isotope Smithery
+198	buy	plush alielf	Dollhawker's Emporium
+199	buy	plush dogcat	Dollhawker's Emporium
+200	buy	plush hamsterpus	Dollhawker's Emporium
+201	buy	plush ferrelf	Dollhawker's Emporium
+202	buy	plush mutated alielf	Dollhawker's Emporium
+203	buy	plush alien hamsterpus	Dollhawker's Emporium
+204	buy	plush mutated alielephant	Dollhawker's Emporium
+205	buy	Saison du Lune	Lunar Lunch-o-Mat
+206	buy	Moonthril Schnapps	Lunar Lunch-o-Mat
+207	buy	Wrecked Generator	Lunar Lunch-o-Mat
+208	buy	Spaghetti with Moonballs	Lunar Lunch-o-Mat
+209	buy	Crepes a la Lune	Lunar Lunch-o-Mat
+210	buy	Moon Pie	Lunar Lunch-o-Mat
+211	buy	Comet Pop	Lunar Lunch-o-Mat
+212	buy	Flan in the Moon	Lunar Lunch-o-Mat
+213	buy	1/6th Pound Cake	Lunar Lunch-o-Mat
 214	conc	can of Br&uuml;talbr&auml;u	BEER
 215	conc	can of Drooling Monk	BEER
 216	conc	can of Impetuous Scofflaw	BEER
@@ -200,12 +200,12 @@
 218	conc	bottle of Professor Beer	BEER
 219	conc	bottle of Rapier Witbier	BEER
 220	conc	artisanal homebrew gift package	BEER
-221	coin	warbear helm fragment	Warbear Black Box
-222	coin	warbear trouser fragment	Warbear Black Box
-223	coin	warbear accoutrements chunk	Warbear Black Box
-224	coin	blind-packed die-cast metal toy	Warbear Black Box
-225	coin	warbear requisition box	Warbear Black Box
-226	coin	warbear officer requisition box	Warbear Black Box
+221	buy	warbear helm fragment	Warbear Black Box
+222	buy	warbear trouser fragment	Warbear Black Box
+223	buy	warbear accoutrements chunk	Warbear Black Box
+224	buy	blind-packed die-cast metal toy	Warbear Black Box
+225	buy	warbear requisition box	Warbear Black Box
+226	buy	warbear officer requisition box	Warbear Black Box
 227	conc	snow cleats	WINTER
 228	conc	liquid ice pack	WINTER
 229	conc	snow boards	WINTER
@@ -221,15 +221,15 @@
 239	conc	snow belt	WINTER
 240	conc	ice nine	WINTER
 241	conc	snow fort	WINTER
-242	coin	warbear dress greaves	Warbear Black Box
-243	coin	warbear dress bracers	Warbear Black Box
-244	coin	warbear dress helmet	Warbear Black Box
-245	coin	cinnamon cannoli	Paul's Boutique
-246	coin	expensive champagne	Paul's Boutique
-247	coin	polo trophy	Paul's Boutique
-248	coin	fancy oil painting	Paul's Boutique
-249	coin	solid gold rosary	Paul's Boutique
-250	coin	ornate dowsing rod	Paul's Boutique
+242	buy	warbear dress greaves	Warbear Black Box
+243	buy	warbear dress bracers	Warbear Black Box
+244	buy	warbear dress helmet	Warbear Black Box
+245	buy	cinnamon cannoli	Paul's Boutique
+246	buy	expensive champagne	Paul's Boutique
+247	buy	polo trophy	Paul's Boutique
+248	buy	fancy oil painting	Paul's Boutique
+249	buy	solid gold rosary	Paul's Boutique
+250	buy	ornate dowsing rod	Paul's Boutique
 251	conc	smudge stick	RUMPLE
 252	conc	portable wall	RUMPLE
 253	conc	large tankard of ale	RUMPLE
@@ -262,43 +262,43 @@
 287	npc	exotic parrot egg	The Black Market
 288	npc	spare kidney	The Black Market
 289	npc	Red Zeppelin ticket	The Black Market
-290	coin	Red Zeppelin ticket	The Black Market
+290	buy	Red Zeppelin ticket	The Black Market
 291	conc	liquid bread	BEER
-292	coin	sewing kit	Vending Machine
-293	coin	regular-size brogurt	The Frozen Brogurt Stand
-294	coin	super-size brogurt	The Frozen Brogurt Stand
-295	coin	broberry brogurt	The Frozen Brogurt Stand
-296	coin	brocolate brogurt	The Frozen Brogurt Stand
-297	coin	French bronilla brogurt	The Frozen Brogurt Stand
-298	coin	Taco Dan's Basic Taco Dan Taco	Taco Dan's Taco Stand
-299	coin	Pastaco shell	Taco Dan's Taco Stand
-300	coin	Taco Dan's Super Taco-Riffic Taco Sauce!	Taco Dan's Taco Stand
-301	coin	Taco Dan's Taco Fish Fish Taco	Taco Dan's Taco Stand
-302	coin	History's Most Offensive Jokes, Vol. IX	Buff Jimmy's Souvenir Shop
-303	coin	Now You're Cooking With Grease	Buff Jimmy's Souvenir Shop
-304	coin	Sloppy Seconds Diner Employee Handbook	Buff Jimmy's Souvenir Shop
-305	coin	Brogre brorts	Buff Jimmy's Souvenir Shop
-306	coin	Brogre brolo shirt	Buff Jimmy's Souvenir Shop
-307	coin	Brogre bucket hat	Buff Jimmy's Souvenir Shop
-308	coin	Spring Break Beach tattoo coupon	Buff Jimmy's Souvenir Shop
-309	coin	one-day ticket to Spring Break Beach	Buff Jimmy's Souvenir Shop
-310	coin	industrial strength anti-fungal spray	Buff Jimmy's Souvenir Shop
-311	coin	strange helix fossil	The Neandermall
-312	coin	rack of dinosaur ribs	The Neandermall
-313	coin	scotch on the rocks	The Neandermall
-314	coin	yabba dabba doo rag	The Neandermall
-315	coin	wooly loincloth	The Neandermall
-316	coin	dog ointment	Legitimate Shoe Repair, Inc.
-317	coin	gumshoes	Legitimate Shoe Repair, Inc.
-318	coin	flapper floppers	Legitimate Shoe Repair, Inc.
-319	coin	sneakeasies	Legitimate Shoe Repair, Inc.
-320	coin	fishbone catcher's mitt	Freshwater Fishbonery
-321	coin	fishbone kneepads	Freshwater Fishbonery
-322	coin	fishbone corset	Freshwater Fishbonery
-323	coin	fishbone fins	Freshwater Fishbonery
-324	coin	fishbone facemask	Freshwater Fishbonery
-325	coin	fishbone bracers	Freshwater Fishbonery
-326	coin	fishbone belt	Freshwater Fishbonery
+292	buy	sewing kit	Vending Machine
+293	buy	regular-size brogurt	The Frozen Brogurt Stand
+294	buy	super-size brogurt	The Frozen Brogurt Stand
+295	buy	broberry brogurt	The Frozen Brogurt Stand
+296	buy	brocolate brogurt	The Frozen Brogurt Stand
+297	buy	French bronilla brogurt	The Frozen Brogurt Stand
+298	buy	Taco Dan's Basic Taco Dan Taco	Taco Dan's Taco Stand
+299	buy	Pastaco shell	Taco Dan's Taco Stand
+300	buy	Taco Dan's Super Taco-Riffic Taco Sauce!	Taco Dan's Taco Stand
+301	buy	Taco Dan's Taco Fish Fish Taco	Taco Dan's Taco Stand
+302	buy	History's Most Offensive Jokes, Vol. IX	Buff Jimmy's Souvenir Shop
+303	buy	Now You're Cooking With Grease	Buff Jimmy's Souvenir Shop
+304	buy	Sloppy Seconds Diner Employee Handbook	Buff Jimmy's Souvenir Shop
+305	buy	Brogre brorts	Buff Jimmy's Souvenir Shop
+306	buy	Brogre brolo shirt	Buff Jimmy's Souvenir Shop
+307	buy	Brogre bucket hat	Buff Jimmy's Souvenir Shop
+308	buy	Spring Break Beach tattoo coupon	Buff Jimmy's Souvenir Shop
+309	buy	one-day ticket to Spring Break Beach	Buff Jimmy's Souvenir Shop
+310	buy	industrial strength anti-fungal spray	Buff Jimmy's Souvenir Shop
+311	buy	strange helix fossil	The Neandermall
+312	buy	rack of dinosaur ribs	The Neandermall
+313	buy	scotch on the rocks	The Neandermall
+314	buy	yabba dabba doo rag	The Neandermall
+315	buy	wooly loincloth	The Neandermall
+316	buy	dog ointment	Legitimate Shoe Repair, Inc.
+317	buy	gumshoes	Legitimate Shoe Repair, Inc.
+318	buy	flapper floppers	Legitimate Shoe Repair, Inc.
+319	buy	sneakeasies	Legitimate Shoe Repair, Inc.
+320	buy	fishbone catcher's mitt	Freshwater Fishbonery
+321	buy	fishbone kneepads	Freshwater Fishbonery
+322	buy	fishbone corset	Freshwater Fishbonery
+323	buy	fishbone fins	Freshwater Fishbonery
+324	buy	fishbone facemask	Freshwater Fishbonery
+325	buy	fishbone bracers	Freshwater Fishbonery
+326	buy	fishbone belt	Freshwater Fishbonery
 327	conc	sugar shotgun	SUGAR_FOLDING
 328	conc	sugar shillelagh	SUGAR_FOLDING
 329	conc	sugar shank	SUGAR_FOLDING
@@ -313,65 +313,65 @@
 338	conc	Xiblaxian space-whiskey	FIVE_D
 339	conc	Xiblaxian ultraburrito	FIVE_D
 340	conc	Xiblaxian residence-cube	FIVE_D
-341	coin	warm war shawarma	The SHAWARMA Initiative
-342	coin	initiative shawarma	The SHAWARMA Initiative
-343	coin	karma shawarma	The SHAWARMA Initiative
-344	coin	Jungle Juice	The Canteen
-345	coin	Amnesiac Ale	The Canteen
-346	coin	Highest Bitter	The Canteen
-347	coin	mercenary pistol	The Armory
-348	coin	mercenary rifle	The Armory
-349	coin	specialty ammo bandolier	The Armory
-350	coin	Merc Core deployment orders	The Armory
-351	coin	Merc Core Field Manual: Sanity Maintenance	The Armory
-352	coin	Merc Core Field Manual: Intimidation Techniques	The Armory
-353	coin	Merc Core challenge coin	The Armory
-354	coin	unidentifiable dried fruit	The Applecalypse Store
-355	coin	flat cider	The Applecalypse Store
-356	coin	iShield	The Applecalypse Store
-357	coin	white earbuds	The Applecalypse Store
-358	coin	iFlail	The Applecalypse Store
-359	coin	finger cuffs	Arcade Ticket Counter
-360	coin	little parachute guy	Arcade Ticket Counter
-361	coin	superduperball	Arcade Ticket Counter
-363	coin	coffee pixie stick	Arcade Ticket Counter
-364	coin	plastic spider ring	Arcade Ticket Counter
-365	coin	sinister demon mask	Arcade Ticket Counter
-366	coin	cheap plastic kazoo	Arcade Ticket Counter
-367	coin	inflatable baseball bat	Arcade Ticket Counter
-368	coin	googly-star hat	Arcade Ticket Counter
-369	coin	googly-ball hat	Arcade Ticket Counter
-370	coin	googly-heart hat	Arcade Ticket Counter
-371	coin	Game Grid valued membership card	Arcade Ticket Counter
-372	coin	super-sweet boom box	Arcade Ticket Counter
-373	coin	Space Trip safety headphones	Arcade Ticket Counter
-374	coin	Dungeon Fist gauntlet	Arcade Ticket Counter
-375	coin	streetfighting champion's belt	Arcade Ticket Counter
-376	coin	Meteoid ice beam	Arcade Ticket Counter
-377	coin	folder (Jackass Plumber)	Arcade Ticket Counter
-378	coin	Agent Mauve	The Armory
-389	coin	CURRENCY	Crimbo 2014
-390	coin	CURRENCY	Crimbo 2014
-391	coin	CURRENCY (2)	Crimbo 2014
-392	coin	CURRENCY (2)	Crimbo 2014
-393	coin	CURRENCY (3)	Crimbo 2014
-394	coin	CURRENCY (3)	Crimbo 2014
-395	coin	CURRENCY (4)	Crimbo 2014
-396	coin	CURRENCY (5)	Crimbo 2014
-397	coin	CURRENCY	Crimbo 2014
-398	coin	choco-Crimbot	Crimbo 2014
-399	coin	smart watch	Crimbo 2014
-400	coin	augmented-reality shades	Crimbo 2014
-401	coin	toy Crimbot mega face	Crimbo 2014
-402	coin	toy Crimbot power glove	Crimbo 2014
-403	coin	toy Crimbot super fist	Crimbo 2014
-404	coin	toy Crimbot rocket legs	Crimbo 2014
-405	coin	Crimbot battery	Crimbo 2014
-406	coin	Crimbot ROM: Rapid Prototyping	Crimbo 2014
-407	coin	Crimbot ROM: Mathematical Precision	Crimbo 2014
-408	coin	Crimbot ROM: Ruthless Efficiency	Crimbo 2014
-409	coin	Mini-Crimbot crate	Crimbo 2014
-410	coin	fitness wristband	Crimbo 2014
+341	buy	warm war shawarma	The SHAWARMA Initiative
+342	buy	initiative shawarma	The SHAWARMA Initiative
+343	buy	karma shawarma	The SHAWARMA Initiative
+344	buy	Jungle Juice	The Canteen
+345	buy	Amnesiac Ale	The Canteen
+346	buy	Highest Bitter	The Canteen
+347	buy	mercenary pistol	The Armory
+348	buy	mercenary rifle	The Armory
+349	buy	specialty ammo bandolier	The Armory
+350	buy	Merc Core deployment orders	The Armory
+351	buy	Merc Core Field Manual: Sanity Maintenance	The Armory
+352	buy	Merc Core Field Manual: Intimidation Techniques	The Armory
+353	buy	Merc Core challenge coin	The Armory
+354	buy	unidentifiable dried fruit	The Applecalypse Store
+355	buy	flat cider	The Applecalypse Store
+356	buy	iShield	The Applecalypse Store
+357	buy	white earbuds	The Applecalypse Store
+358	buy	iFlail	The Applecalypse Store
+359	buy	finger cuffs	Arcade Ticket Counter
+360	buy	little parachute guy	Arcade Ticket Counter
+361	buy	superduperball	Arcade Ticket Counter
+363	buy	coffee pixie stick	Arcade Ticket Counter
+364	buy	plastic spider ring	Arcade Ticket Counter
+365	buy	sinister demon mask	Arcade Ticket Counter
+366	buy	cheap plastic kazoo	Arcade Ticket Counter
+367	buy	inflatable baseball bat	Arcade Ticket Counter
+368	buy	googly-star hat	Arcade Ticket Counter
+369	buy	googly-ball hat	Arcade Ticket Counter
+370	buy	googly-heart hat	Arcade Ticket Counter
+371	buy	Game Grid valued membership card	Arcade Ticket Counter
+372	buy	super-sweet boom box	Arcade Ticket Counter
+373	buy	Space Trip safety headphones	Arcade Ticket Counter
+374	buy	Dungeon Fist gauntlet	Arcade Ticket Counter
+375	buy	streetfighting champion's belt	Arcade Ticket Counter
+376	buy	Meteoid ice beam	Arcade Ticket Counter
+377	buy	folder (Jackass Plumber)	Arcade Ticket Counter
+378	buy	Agent Mauve	The Armory
+389	sell	CURRENCY	Crimbo 2014
+390	sell	CURRENCY	Crimbo 2014
+391	sell	CURRENCY (2)	Crimbo 2014
+392	sell	CURRENCY (2)	Crimbo 2014
+393	sell	CURRENCY (3)	Crimbo 2014
+394	sell	CURRENCY (3)	Crimbo 2014
+395	sell	CURRENCY (4)	Crimbo 2014
+396	sell	CURRENCY (5)	Crimbo 2014
+397	sell	CURRENCY	Crimbo 2014
+398	buy	choco-Crimbot	Crimbo 2014
+399	buy	smart watch	Crimbo 2014
+400	buy	augmented-reality shades	Crimbo 2014
+401	buy	toy Crimbot mega face	Crimbo 2014
+402	buy	toy Crimbot power glove	Crimbo 2014
+403	buy	toy Crimbot super fist	Crimbo 2014
+404	buy	toy Crimbot rocket legs	Crimbo 2014
+405	buy	Crimbot battery	Crimbo 2014
+406	buy	Crimbot ROM: Rapid Prototyping	Crimbo 2014
+407	buy	Crimbot ROM: Mathematical Precision	Crimbo 2014
+408	buy	Crimbot ROM: Ruthless Efficiency	Crimbo 2014
+409	buy	Mini-Crimbot crate	Crimbo 2014
+410	buy	fitness wristband	Crimbo 2014
 411	npc	electric muscle stimulator	Chateau Mantenga Gift Shop
 412	npc	foreign language tapes	Chateau Mantenga Gift Shop
 413	npc	bowl of potpourri	Chateau Mantenga Gift Shop
@@ -382,23 +382,23 @@
 418	npc	continental juice bar	Chateau Mantenga Gift Shop
 419	npc	fancy stationery set	Chateau Mantenga Gift Shop
 420	npc	alpine watercolor set	Chateau Mantenga Gift Shop
-421	coin	tope&eacute;	Topiary Nuggletcrafting
-422	coin	topiary necktie	Topiary Nuggletcrafting
-423	coin	topiary tights	Topiary Nuggletcrafting
-424	coin	bowl of topioca	Topiary Nuggletcrafting
-425	coin	topiary skunk	Topiary Nuggletcrafting
-426	coin	mummified fig	Everything Under the World
-427	coin	mummified loaf of bread	Everything Under the World
-428	coin	mummified beef haunch	Everything Under the World
-429	coin	linen bandages	Everything Under the World
-430	coin	cotton bandages	Everything Under the World
-431	coin	silk bandages	Everything Under the World
-432	coin	spirit beer	Everything Under the World
-433	coin	sacramental wine	Everything Under the World
-434	coin	talisman of Thoth	Everything Under the World
-435	coin	ancient cure-all	Everything Under the World
-436	coin	holy spring water	Everything Under the World
-439	coin	talisman of Renenutet	Everything Under the World
+421	buy	tope&eacute;	Topiary Nuggletcrafting
+422	buy	topiary necktie	Topiary Nuggletcrafting
+423	buy	topiary tights	Topiary Nuggletcrafting
+424	buy	bowl of topioca	Topiary Nuggletcrafting
+425	buy	topiary skunk	Topiary Nuggletcrafting
+426	buy	mummified fig	Everything Under the World
+427	buy	mummified loaf of bread	Everything Under the World
+428	buy	mummified beef haunch	Everything Under the World
+429	buy	linen bandages	Everything Under the World
+430	buy	cotton bandages	Everything Under the World
+431	buy	silk bandages	Everything Under the World
+432	buy	spirit beer	Everything Under the World
+433	buy	sacramental wine	Everything Under the World
+434	buy	talisman of Thoth	Everything Under the World
+435	buy	ancient cure-all	Everything Under the World
+436	buy	holy spring water	Everything Under the World
+439	buy	talisman of Renenutet	Everything Under the World
 466	npc	suede shortsword	Armory and Leggery
 467	npc	bamboo bokuto	Armory and Leggery
 468	npc	25-meat staff	Armory and Leggery
@@ -615,32 +615,32 @@
 687	npc	macroplane grater	Armory and Leggery
 688	npc	bastard baster	Armory and Leggery
 689	npc	obsidian nutcracker	Armory and Leggery
-690	coin	invisible potion	Ni&ntilde;a Store
-691	coin	time shuriken	Ni&ntilde;a Store
-692	coin	ninjammies	Ni&ntilde;a Store
-693	coin	talisman of Horus	Everything Under the World
+690	buy	invisible potion	Ni&ntilde;a Store
+691	buy	time shuriken	Ni&ntilde;a Store
+692	buy	ninjammies	Ni&ntilde;a Store
+693	buy	talisman of Horus	Everything Under the World
 694	npc	anti-anti-antidote	Doc Galaktik's Medicine Show
 695	npc	Doc Galaktik's Pungent Unguent	Doc Galaktik's Medicine Show
 696	npc	Doc Galaktik's Homeopathic Elixir	Doc Galaktik's Medicine Show
 697	npc	Doc Galaktik's Invigorating Tonic	Doc Galaktik's Medicine Show
 698	npc	Doc Galaktik's Vitality Serum	Doc Galaktik's Medicine Show
-699	coin	Dinsey food-cone	The Dinsey Company Store
-700	coin	Dinsey Whinskey	The Dinsey Company Store
-701	coin	Dinsey face paint	The Dinsey Company Store
-702	coin	stinky fannypack	The Dinsey Company Store
-703	coin	garbage sticker	The Dinsey Company Store
-704	coin	hazmat helmet	The Dinsey Company Store
-705	coin	Scratch-and-Sniff Guide to Dinseylandfill	The Dinsey Company Store
-706	coin	Trash, a Memoir	The Dinsey Company Store
-707	coin	Dinsey Maintenance Manual	The Dinsey Company Store
-708	coin	Dinsey tattoo kit	The Dinsey Company Store
-709	coin	toxo	Toxic Chemistry
-710	coin	Lemonade-235	Toxic Chemistry
-711	coin	isotophat	Toxic Chemistry
-712	coin	Three Mile Island shorts	Toxic Chemistry
-713	coin	toxic mop	Toxic Chemistry
-714	coin	inert sludgepuppy	Toxic Chemistry
-715	coin	one-day ticket to Dinseylandfill	The Dinsey Company Store
+699	buy	Dinsey food-cone	The Dinsey Company Store
+700	buy	Dinsey Whinskey	The Dinsey Company Store
+701	buy	Dinsey face paint	The Dinsey Company Store
+702	buy	stinky fannypack	The Dinsey Company Store
+703	buy	garbage sticker	The Dinsey Company Store
+704	buy	hazmat helmet	The Dinsey Company Store
+705	buy	Scratch-and-Sniff Guide to Dinseylandfill	The Dinsey Company Store
+706	buy	Trash, a Memoir	The Dinsey Company Store
+707	buy	Dinsey Maintenance Manual	The Dinsey Company Store
+708	buy	Dinsey tattoo kit	The Dinsey Company Store
+709	buy	toxo	Toxic Chemistry
+710	buy	Lemonade-235	Toxic Chemistry
+711	buy	isotophat	Toxic Chemistry
+712	buy	Three Mile Island shorts	Toxic Chemistry
+713	buy	toxic mop	Toxic Chemistry
+714	buy	inert sludgepuppy	Toxic Chemistry
+715	buy	one-day ticket to Dinseylandfill	The Dinsey Company Store
 716	npc	Mayonex	The Mayo Clinic
 717	npc	Mayodiol	The Mayo Clinic
 718	npc	Mayostat	The Mayo Clinic
@@ -667,79 +667,79 @@
 740	npc	Gnollish casserole dish	Madeline's Baking Supply
 741	npc	rolling pin	Madeline's Baking Supply
 742	npc	unrolling pin	Madeline's Baking Supply
-744	coin	liquid rhinestones	Disco GiftCo
-745	coin	disco biscuit	Disco GiftCo
-746	coin	Quaatorade&trade;	Disco GiftCo
-747	coin	biker's hat	Disco GiftCo
-748	coin	feathered headdress	Disco GiftCo
-749	coin	electrician's hardhat	Disco GiftCo
-750	coin	Lava Miner's Daughter	Disco GiftCo
-751	coin	Psycho From The Heat	Disco GiftCo
-752	coin	The Firegate Tapes	Disco GiftCo
-753	coin	&quot;DEBBIE&quot; tattoo kit	Disco GiftCo
-754	coin	one-day ticket to That 70s Volcano	Disco GiftCo
-755	coin	portable Othello set	Ye Newe Souvenir Shoppe
-756	coin	rotten tomato	Ye Newe Souvenir Shoppe
-757	coin	Twelve Night Energy	Ye Newe Souvenir Shoppe
-758	coin	Yorick	Ye Newe Souvenir Shoppe
-763	coin	shoulder-warming lotion	Wal-Mart
-764	coin	iceberg lettuce	Wal-Mart
-765	coin	ice wine	Wal-Mart
-766	coin	Wal-Mart snowglobe	Wal-Mart
-767	coin	Wal-Mart nametag	Wal-Mart
-768	coin	Wal-Mart overalls	Wal-Mart
-769	coin	To Build an Igloo	Wal-Mart
-770	coin	The Chill of the Wild	Wal-Mart
-771	coin	Wal-Mart tattoo kit	Wal-Mart
-772	coin	Cold Fang	Wal-Mart
-773	coin	one-day ticket to The Glaciest	Wal-Mart
-774	coin	bottle of Bloodweiser	The Terrified Eagle Inn
-775	coin	electric Kool-Aid	The Terrified Eagle Inn
+744	buy	liquid rhinestones	Disco GiftCo
+745	buy	disco biscuit	Disco GiftCo
+746	buy	Quaatorade&trade;	Disco GiftCo
+747	buy	biker's hat	Disco GiftCo
+748	buy	feathered headdress	Disco GiftCo
+749	buy	electrician's hardhat	Disco GiftCo
+750	buy	Lava Miner's Daughter	Disco GiftCo
+751	buy	Psycho From The Heat	Disco GiftCo
+752	buy	The Firegate Tapes	Disco GiftCo
+753	buy	&quot;DEBBIE&quot; tattoo kit	Disco GiftCo
+754	buy	one-day ticket to That 70s Volcano	Disco GiftCo
+755	buy	portable Othello set	Ye Newe Souvenir Shoppe
+756	buy	rotten tomato	Ye Newe Souvenir Shoppe
+757	buy	Twelve Night Energy	Ye Newe Souvenir Shoppe
+758	buy	Yorick	Ye Newe Souvenir Shoppe
+763	buy	shoulder-warming lotion	Wal-Mart
+764	buy	iceberg lettuce	Wal-Mart
+765	buy	ice wine	Wal-Mart
+766	buy	Wal-Mart snowglobe	Wal-Mart
+767	buy	Wal-Mart nametag	Wal-Mart
+768	buy	Wal-Mart overalls	Wal-Mart
+769	buy	To Build an Igloo	Wal-Mart
+770	buy	The Chill of the Wild	Wal-Mart
+771	buy	Wal-Mart tattoo kit	Wal-Mart
+772	buy	Cold Fang	Wal-Mart
+773	buy	one-day ticket to The Glaciest	Wal-Mart
+774	buy	bottle of Bloodweiser	The Terrified Eagle Inn
+775	buy	electric Kool-Aid	The Terrified Eagle Inn
 776	conc	That 70s Cologne	DUTYFREE
 777	conc	Wal-Mart &quot;diamond&quot; ring	DUTYFREE
 778	conc	Puffstone cigar	DUTYFREE
 779	conc	Conspiracy&trade; mascara	DUTYFREE
 780	conc	Spring Break Beach &quot;swimsuit&quot;	DUTYFREE
 781	conc	airplane tattoo	DUTYFREE
-782	coin	bat-oomerang	Bat-Fabricator
-783	coin	bat-jute	Bat-Fabricator
-784	coin	bat-o-mite	Bat-Fabricator
-785	coin	experimental gene therapy	ChemiCorp
-787	coin	ultracoagulator	ChemiCorp
-788	coin	self-defense training	Gotpork P. D.
-789	coin	fingerprint dusting kit	Gotpork P. D.
-790	coin	confidence-building hug	Gotpork Orphanage
-791	coin	exploding kickball	Gotpork Orphanage
-792	coin	western-style skinning knife	LT&T Gift Shop
-793	coin	Shrub's Premium Baked Beans	LT&T Gift Shop
-794	coin	reliable sixgun	LT&T Gift Shop
-795	coin	steel knuckles	LT&T Gift Shop
-796	coin	Tales of Western Braggadoccio	LT&T Gift Shop
-797	coin	Hell and How I Bent It	LT&T Gift Shop
-798	coin	The Western Look	LT&T Gift Shop
-799	coin	LT&T tattoo kit	LT&T Gift Shop
-800	coin	Western Slang Vol. 1: Violence	LT&T Gift Shop
-801	coin	Western Slang Vol. 2: Cooking	LT&T Gift Shop
-802	coin	Western Slang Vol. 3: Fraud	LT&T Gift Shop
-803	coin	inflatable LT&T telegraph office	LT&T Gift Shop
+782	buy	bat-oomerang	Bat-Fabricator
+783	buy	bat-jute	Bat-Fabricator
+784	buy	bat-o-mite	Bat-Fabricator
+785	buy	experimental gene therapy	ChemiCorp
+787	buy	ultracoagulator	ChemiCorp
+788	buy	self-defense training	Gotpork P. D.
+789	buy	fingerprint dusting kit	Gotpork P. D.
+790	buy	confidence-building hug	Gotpork Orphanage
+791	buy	exploding kickball	Gotpork Orphanage
+792	buy	western-style skinning knife	LT&T Gift Shop
+793	buy	Shrub's Premium Baked Beans	LT&T Gift Shop
+794	buy	reliable sixgun	LT&T Gift Shop
+795	buy	steel knuckles	LT&T Gift Shop
+796	buy	Tales of Western Braggadoccio	LT&T Gift Shop
+797	buy	Hell and How I Bent It	LT&T Gift Shop
+798	buy	The Western Look	LT&T Gift Shop
+799	buy	LT&T tattoo kit	LT&T Gift Shop
+800	buy	Western Slang Vol. 1: Violence	LT&T Gift Shop
+801	buy	Western Slang Vol. 2: Cooking	LT&T Gift Shop
+802	buy	Western Slang Vol. 3: Fraud	LT&T Gift Shop
+803	buy	inflatable LT&T telegraph office	LT&T Gift Shop
 817	npc	high-test fishing line	The General Store
 818	npc	fishin' hat	Armory and Leggery
-821	coin	viral video	Internet Meme Shop
-822	coin	internet point	Internet Meme Shop
-823	coin	meme generator	Internet Meme Shop
-824	coin	plus one	Internet Meme Shop
-825	coin	gallon of milk	Internet Meme Shop
-826	coin	print screen button	Internet Meme Shop
-827	coin	daily dungeon malware	Internet Meme Shop
-828	coin	infinite BACON machine	Internet Meme Shop
-829	coin	First Post shirt package	Internet Meme Shop
-830	coin	detective roscoe	Precinct Materiel Division
-834	coin	shoe gum	Precinct Materiel Division
-835	coin	Falcon&trade; Maltese Liquor	Precinct Materiel Division
-836	coin	noir fedora	Precinct Materiel Division
-837	coin	trench coat	Precinct Materiel Division
-838	coin	detective tattoo	Precinct Materiel Division
-839	coin	hardboiled egg	Precinct Materiel Division
+821	buy	viral video	Internet Meme Shop
+822	buy	internet point	Internet Meme Shop
+823	buy	meme generator	Internet Meme Shop
+824	buy	plus one	Internet Meme Shop
+825	buy	gallon of milk	Internet Meme Shop
+826	buy	print screen button	Internet Meme Shop
+827	buy	daily dungeon malware	Internet Meme Shop
+828	buy	infinite BACON machine	Internet Meme Shop
+829	buy	First Post shirt package	Internet Meme Shop
+830	buy	detective roscoe	Precinct Materiel Division
+834	buy	shoe gum	Precinct Materiel Division
+835	buy	Falcon&trade; Maltese Liquor	Precinct Materiel Division
+836	buy	noir fedora	Precinct Materiel Division
+837	buy	trench coat	Precinct Materiel Division
+838	buy	detective tattoo	Precinct Materiel Division
+839	buy	hardboiled egg	Precinct Materiel Division
 843	npc	lead umbrella	Fallout Shelter Medical Supply
 844	npc	Rad-B-Gone (1 lb.)	Fallout Shelter Medical Supply
 845	npc	Rad-Pro (1 oz.)	Fallout Shelter Medical Supply
@@ -751,31 +751,31 @@
 851	npc	EMD holo-record	Underground Record Store
 880	npc	The Pigs holo-record	Underground Record Store
 881	npc	Drunk Uncles holo-record	Underground Record Store
-883	coin	KoL Con 13 snowglobe	KoL Con 13 Merch Table
-884	coin	potted tea tree	KoL Con 13 Merch Table
-885	coin	Xi Receiver Unit	KoL Con 13 Merch Table
-886	coin	Gordon Beer's Beer Garden Catalog	KoL Con 13 Merch Table
-887	coin	Tome of Rad Libs	KoL Con 13 Merch Table
-888	coin	Gygaxian Libram	KoL Con 13 Merch Table
-889	coin	hippo tutu	KoL Con 13 Merch Table
+883	buy	KoL Con 13 snowglobe	KoL Con 13 Merch Table
+884	buy	potted tea tree	KoL Con 13 Merch Table
+885	buy	Xi Receiver Unit	KoL Con 13 Merch Table
+886	buy	Gordon Beer's Beer Garden Catalog	KoL Con 13 Merch Table
+887	buy	Tome of Rad Libs	KoL Con 13 Merch Table
+888	buy	Gygaxian Libram	KoL Con 13 Merch Table
+889	buy	hippo tutu	KoL Con 13 Merch Table
 890	npc	li'l unicorn costume	The General Store
 891	npc	li'l candy corn costume	The General Store
 892	npc	li'l eyeball costume	Fallout Shelter Medical Supply
 893	npc	li'l robot costume	Fallout Shelter Electronics Supply
 894	npc	li'l liberty costume	Underground Record Store
-895	coin	Twitching Television Tattoo	KoL Con 13 Merch Table
+895	buy	Twitching Television Tattoo	KoL Con 13 Merch Table
 896	npc	li'l candy corn costume	Fallout Shelter Medical Supply
 897	npc	li'l unicorn costume	Underground Record Store
 898	npc	li'l knight costume	Fallout Shelter Electronics Supply
-899	coin	mini-marshmallow dispenser	A traveling Thanksgiving salesman
-900	coin	glass casserole dish	A traveling Thanksgiving salesman
-901	coin	stuffing fluffer	A traveling Thanksgiving salesman
-902	coin	can opener	A traveling Thanksgiving salesman
-903	coin	turkey blaster	A traveling Thanksgiving salesman
-904	coin	glass pie plate	A traveling Thanksgiving salesman
-905	coin	potato masher	A traveling Thanksgiving salesman
-906	coin	gravy boat	A traveling Thanksgiving salesman
-907	coin	bread mold	A traveling Thanksgiving salesman
+899	buy	mini-marshmallow dispenser	A traveling Thanksgiving salesman
+900	buy	glass casserole dish	A traveling Thanksgiving salesman
+901	buy	stuffing fluffer	A traveling Thanksgiving salesman
+902	buy	can opener	A traveling Thanksgiving salesman
+903	buy	turkey blaster	A traveling Thanksgiving salesman
+904	buy	glass pie plate	A traveling Thanksgiving salesman
+905	buy	potato masher	A traveling Thanksgiving salesman
+906	buy	gravy boat	A traveling Thanksgiving salesman
+907	buy	bread mold	A traveling Thanksgiving salesman
 908	npc	antique accordion	Uncle P's Antiques
 911	conc	hambrosier	CRIMBO16
 912	conc	chakra-mental wine	CRIMBO16
@@ -795,15 +795,15 @@
 940	conc	spant shield	SPANT
 941	conc	spant shoulderpads	SPANT
 942	conc	spant backplate	SPANT
-943	coin	Aldebaran sardines	Spacegate Fabrication Facility
-944	coin	Centauri fish wine	Spacegate Fabrication Facility
-945	coin	powdered oxygen	Spacegate Fabrication Facility
-947	coin	portable Spacegate	Spacegate Fabrication Facility
-948	coin	Spacegate scientist's insignia	Spacegate Fabrication Facility
-949	coin	Spacegate military insignia	Spacegate Fabrication Facility
-950	coin	Spacegate diplomat's insignia	Spacegate Fabrication Facility
-951	coin	Spacegate emergency disintegrator	Spacegate Fabrication Facility
-952	coin	Spacegate Initiative tattoo unit	Spacegate Fabrication Facility
+943	buy	Aldebaran sardines	Spacegate Fabrication Facility
+944	buy	Centauri fish wine	Spacegate Fabrication Facility
+945	buy	powdered oxygen	Spacegate Fabrication Facility
+947	buy	portable Spacegate	Spacegate Fabrication Facility
+948	buy	Spacegate scientist's insignia	Spacegate Fabrication Facility
+949	buy	Spacegate military insignia	Spacegate Fabrication Facility
+950	buy	Spacegate diplomat's insignia	Spacegate Fabrication Facility
+951	buy	Spacegate emergency disintegrator	Spacegate Fabrication Facility
+952	buy	Spacegate Initiative tattoo unit	Spacegate Fabrication Facility
 953	conc	pair of candy glasses	XO
 955	conc	jug of booze	XO
 956	conc	Hide-rox&trade; cookie	XO
@@ -815,51 +815,51 @@
 962	conc	pearl necklace	XO
 963	conc	amorphous blob	XO
 964	conc	giant amorphous blob	XO
-966	coin	stale cheer wine	Cheer-o-Vend 3000
-967	coin	stale Cheer-E-Os	Cheer-o-Vend 3000
-968	coin	Cheer-Up soda	Cheer-o-Vend 3000
-969	coin	cheer-o-gram	Cheer-o-Vend 3000
-970	coin	cheerful antler hat	Cheer-o-Vend 3000
-971	coin	cheerful Crimbo sweater	Cheer-o-Vend 3000
-972	coin	cheerful pajama pants	Cheer-o-Vend 3000
-973	coin	The Journal of Mime Science Vol. 1	Cheer-o-Vend 3000
-974	coin	The Journal of Mime Science Vol. 2	Cheer-o-Vend 3000
-975	coin	The Journal of Mime Science Vol. 3	Cheer-o-Vend 3000
-976	coin	The Journal of Mime Science Vol. 4	Cheer-o-Vend 3000
-977	coin	The Journal of Mime Science Vol. 5	Cheer-o-Vend 3000
-978	coin	The Journal of Mime Science Vol. 6	Cheer-o-Vend 3000
-992	coin	metandienone	The Pok&eacute;mporium
-993	coin	riboflavin	The Pok&eacute;mporium
-994	coin	bronze	The Pok&eacute;mporium
-995	coin	piracetam	The Pok&eacute;mporium
-996	coin	ultracalcium	The Pok&eacute;mporium
-997	coin	ginseng	The Pok&eacute;mporium
-998	coin	Team Avarice cap	The Pok&eacute;mporium
-999	coin	Team Sloth cap	The Pok&eacute;mporium
-1000	coin	Team Wrath cap	The Pok&eacute;mporium
-1001	coin	Mu cap	The Pok&eacute;mporium
+966	buy	stale cheer wine	Cheer-o-Vend 3000
+967	buy	stale Cheer-E-Os	Cheer-o-Vend 3000
+968	buy	Cheer-Up soda	Cheer-o-Vend 3000
+969	buy	cheer-o-gram	Cheer-o-Vend 3000
+970	buy	cheerful antler hat	Cheer-o-Vend 3000
+971	buy	cheerful Crimbo sweater	Cheer-o-Vend 3000
+972	buy	cheerful pajama pants	Cheer-o-Vend 3000
+973	buy	The Journal of Mime Science Vol. 1	Cheer-o-Vend 3000
+974	buy	The Journal of Mime Science Vol. 2	Cheer-o-Vend 3000
+975	buy	The Journal of Mime Science Vol. 3	Cheer-o-Vend 3000
+976	buy	The Journal of Mime Science Vol. 4	Cheer-o-Vend 3000
+977	buy	The Journal of Mime Science Vol. 5	Cheer-o-Vend 3000
+978	buy	The Journal of Mime Science Vol. 6	Cheer-o-Vend 3000
+992	buy	metandienone	The Pok&eacute;mporium
+993	buy	riboflavin	The Pok&eacute;mporium
+994	buy	bronze	The Pok&eacute;mporium
+995	buy	piracetam	The Pok&eacute;mporium
+996	buy	ultracalcium	The Pok&eacute;mporium
+997	buy	ginseng	The Pok&eacute;mporium
+998	buy	Team Avarice cap	The Pok&eacute;mporium
+999	buy	Team Sloth cap	The Pok&eacute;mporium
+1000	buy	Team Wrath cap	The Pok&eacute;mporium
+1001	buy	Mu cap	The Pok&eacute;mporium
 1002	npc	green rocket	The General Store
-1003	coin	FantasyRealm key	FantasyRealm Rubee&trade; Store
-1004	coin	LyleCo premium pickaxe	FantasyRealm Rubee&trade; Store
-1005	coin	LyleCo premium rope	FantasyRealm Rubee&trade; Store
-1007	coin	LyleCo premium monocle	FantasyRealm Rubee&trade; Store
-1008	coin	LyleCo premium magnifying glass	FantasyRealm Rubee&trade; Store
-1009	coin	FantasyRealm tattoo kit	FantasyRealm Rubee&trade; Store
-1010	coin	LyleCo Contractor's Manual	FantasyRealm Rubee&trade; Store
-1011	coin	FantasyRealm turkey leg	FantasyRealm Rubee&trade; Store
-1012	coin	FantasyRealm mead	FantasyRealm Rubee&trade; Store
-1013	coin	map to the Towering Mountains	FantasyRealm Rubee&trade; Store
-1014	coin	map to the Mystic Wood	FantasyRealm Rubee&trade; Store
-1015	coin	map to the Putrid Swamp	FantasyRealm Rubee&trade; Store
-1016	coin	map to the Cursed Village	FantasyRealm Rubee&trade; Store
-1017	coin	map to the Sprawling Cemetery	FantasyRealm Rubee&trade; Store
-1018	coin	FantasyRealm guest pass	FantasyRealm Rubee&trade; Store
-1019	coin	gattoo	G-Mart
-1020	coin	A-Boo glue	G-Mart
-1021	coin	crude oil congealer	G-Mart
-1022	coin	good guava	G-Mart
-1023	coin	gin and ginger	G-Mart
-1024	coin	gaseous gravy	G-Mart
+1003	buy	FantasyRealm key	FantasyRealm Rubee&trade; Store
+1004	buy	LyleCo premium pickaxe	FantasyRealm Rubee&trade; Store
+1005	buy	LyleCo premium rope	FantasyRealm Rubee&trade; Store
+1007	buy	LyleCo premium monocle	FantasyRealm Rubee&trade; Store
+1008	buy	LyleCo premium magnifying glass	FantasyRealm Rubee&trade; Store
+1009	buy	FantasyRealm tattoo kit	FantasyRealm Rubee&trade; Store
+1010	buy	LyleCo Contractor's Manual	FantasyRealm Rubee&trade; Store
+1011	buy	FantasyRealm turkey leg	FantasyRealm Rubee&trade; Store
+1012	buy	FantasyRealm mead	FantasyRealm Rubee&trade; Store
+1013	buy	map to the Towering Mountains	FantasyRealm Rubee&trade; Store
+1014	buy	map to the Mystic Wood	FantasyRealm Rubee&trade; Store
+1015	buy	map to the Putrid Swamp	FantasyRealm Rubee&trade; Store
+1016	buy	map to the Cursed Village	FantasyRealm Rubee&trade; Store
+1017	buy	map to the Sprawling Cemetery	FantasyRealm Rubee&trade; Store
+1018	buy	FantasyRealm guest pass	FantasyRealm Rubee&trade; Store
+1019	buy	gattoo	G-Mart
+1020	buy	A-Boo glue	G-Mart
+1021	buy	crude oil congealer	G-Mart
+1022	buy	good guava	G-Mart
+1023	buy	gin and ginger	G-Mart
+1024	buy	gaseous gravy	G-Mart
 1025	conc	slime fedora	SLIEMCE
 1026	conc	slime knuckles	SLIEMCE
 1027	conc	slime waders	SLIEMCE
@@ -874,53 +874,53 @@
 1037	npc	Carol of the Thrills	Crimbo Town Gift-O-Mat
 1039	npc	Crimbolex watch	Crimbo Town Gift-O-Mat
 1040	npc	Crimbo tattoo kit	Crimbo Town Gift-O-Mat
-1053	coin	crabsicle	PirateRealm Fun-a-Log
-1054	coin	bottle of dark rhum	PirateRealm Fun-a-Log
-1055	coin	bottle of extra-dark rhum	PirateRealm Fun-a-Log
-1056	coin	bottle of super-extra-dark rhum	PirateRealm Fun-a-Log
-1057	coin	pirate shaving cream	PirateRealm Fun-a-Log
-1058	coin	conquistador's breastplate	PirateRealm Fun-a-Log
-1059	coin	pirate radio ring	PirateRealm Fun-a-Log
-1060	coin	Island Drinkin', a Tiki Mixology Odyssey	PirateRealm Fun-a-Log
-1061	coin	Red Roger tattoo kit	PirateRealm Fun-a-Log
-1062	coin	plush sea serpent	PirateRealm Fun-a-Log
-1063	coin	piratical blunderbuss	PirateRealm Fun-a-Log
-1064	coin	PirateRealm party hat	PirateRealm Fun-a-Log
-1065	coin	pirate fork	PirateRealm Fun-a-Log
-1066	coin	Scurvy and Sobriety Prevention	PirateRealm Fun-a-Log
-1067	coin	PirateRealm guest pass	PirateRealm Fun-a-Log
-1068	coin	lucky gold ring	PirateRealm Fun-a-Log
-1069	coin	whittled flail	Your Campfire
-1070	coin	whittled wand	Your Campfire
-1071	coin	whittled flute	Your Campfire
-1072	coin	whittled bear figurine	Your Campfire
-1073	coin	whittled owl figurine	Your Campfire
-1074	coin	whittled fox figurine	Your Campfire
-1075	coin	whittled walking stick	Your Campfire
-1076	coin	campfire hot dog	Your Campfire
-1077	coin	campfire baked potato	Your Campfire
-1078	coin	campfire s'more	Your Campfire
-1079	coin	campfire beans	Your Campfire
-1080	coin	campfire stew	Your Campfire
-1081	coin	campfire coffee	Your Campfire
-1083	coin	burnt stick	Your Campfire
-1084	coin	whittled tiara	Your Campfire
-1085	coin	whittled shorts	Your Campfire
-1086	coin	bundle of firewood	Your Campfire
-1087	coin	campfire smoke	Your Campfire
-1088	coin	space shield	Cosmic Ray's Bazaar
-1089	coin	signal jammer	Cosmic Ray's Bazaar
-1090	coin	digital key	Cosmic Ray's Bazaar
-1091	coin	low-pressure oxygen tank	Cosmic Ray's Bazaar
-1092	coin	Wand of Nagamar	Cosmic Ray's Bazaar
-1093	coin	Boris's key	Cosmic Ray's Bazaar
-1094	coin	Jarlsberg's key	Cosmic Ray's Bazaar
-1095	coin	Sneaky Pete's key	Cosmic Ray's Bazaar
-1096	coin	rare Meat isotope	Cosmic Ray's Bazaar
-1097	coin	antique accordion	Cosmic Ray's Bazaar
-1098	coin	space chowder	Cosmic Ray's Bazaar
-1099	coin	space wine	Cosmic Ray's Bazaar
-1100	coin	lucky-ish pill	Cosmic Ray's Bazaar
+1053	buy	crabsicle	PirateRealm Fun-a-Log
+1054	buy	bottle of dark rhum	PirateRealm Fun-a-Log
+1055	buy	bottle of extra-dark rhum	PirateRealm Fun-a-Log
+1056	buy	bottle of super-extra-dark rhum	PirateRealm Fun-a-Log
+1057	buy	pirate shaving cream	PirateRealm Fun-a-Log
+1058	buy	conquistador's breastplate	PirateRealm Fun-a-Log
+1059	buy	pirate radio ring	PirateRealm Fun-a-Log
+1060	buy	Island Drinkin', a Tiki Mixology Odyssey	PirateRealm Fun-a-Log
+1061	buy	Red Roger tattoo kit	PirateRealm Fun-a-Log
+1062	buy	plush sea serpent	PirateRealm Fun-a-Log
+1063	buy	piratical blunderbuss	PirateRealm Fun-a-Log
+1064	buy	PirateRealm party hat	PirateRealm Fun-a-Log
+1065	buy	pirate fork	PirateRealm Fun-a-Log
+1066	buy	Scurvy and Sobriety Prevention	PirateRealm Fun-a-Log
+1067	buy	PirateRealm guest pass	PirateRealm Fun-a-Log
+1068	buy	lucky gold ring	PirateRealm Fun-a-Log
+1069	buy	whittled flail	Your Campfire
+1070	buy	whittled wand	Your Campfire
+1071	buy	whittled flute	Your Campfire
+1072	buy	whittled bear figurine	Your Campfire
+1073	buy	whittled owl figurine	Your Campfire
+1074	buy	whittled fox figurine	Your Campfire
+1075	buy	whittled walking stick	Your Campfire
+1076	buy	campfire hot dog	Your Campfire
+1077	buy	campfire baked potato	Your Campfire
+1078	buy	campfire s'more	Your Campfire
+1079	buy	campfire beans	Your Campfire
+1080	buy	campfire stew	Your Campfire
+1081	buy	campfire coffee	Your Campfire
+1083	buy	burnt stick	Your Campfire
+1084	buy	whittled tiara	Your Campfire
+1085	buy	whittled shorts	Your Campfire
+1086	buy	bundle of firewood	Your Campfire
+1087	buy	campfire smoke	Your Campfire
+1088	buy	space shield	Cosmic Ray's Bazaar
+1089	buy	signal jammer	Cosmic Ray's Bazaar
+1090	buy	digital key	Cosmic Ray's Bazaar
+1091	buy	low-pressure oxygen tank	Cosmic Ray's Bazaar
+1092	buy	Wand of Nagamar	Cosmic Ray's Bazaar
+1093	buy	Boris's key	Cosmic Ray's Bazaar
+1094	buy	Jarlsberg's key	Cosmic Ray's Bazaar
+1095	buy	Sneaky Pete's key	Cosmic Ray's Bazaar
+1096	buy	rare Meat isotope	Cosmic Ray's Bazaar
+1097	buy	antique accordion	Cosmic Ray's Bazaar
+1098	buy	space chowder	Cosmic Ray's Bazaar
+1099	buy	space wine	Cosmic Ray's Bazaar
+1100	buy	lucky-ish pill	Cosmic Ray's Bazaar
 1101	npc	bowl of mernudo	The Crimbo Cafe
 1103	npc	fishelada	The Crimbo Cafe
 1104	npc	ojo de pez burrito	The Crimbo Cafe
@@ -936,46 +936,46 @@
 1114	conc	antique nutcracker pants	KRINGLE
 1128	npc	Drip harness	Drip Institute Armory
 1129	npc	drippy truncheon	Drip Institute Armory
-1130	coin	drippy khakis	Drip Institute Armory
+1130	buy	drippy khakis	Drip Institute Armory
 1131	npc	drippy nugget	Drip Institute Cafeteria
-1132	coin	drippy shield	Drip Institute Armory
-1133	coin	deluxe mushroom	Mushroom District Item Shop
-1134	coin	mushroom	Mushroom District Item Shop
-1135	coin	super deluxe mushroom	Mushroom District Item Shop
-1136	coin	fizzy soda	Mushroom District Item Shop
-1137	coin	healthy juice	Mushroom District Item Shop
-1138	coin	hammer	Mushroom District Gear Shop
-1139	coin	heavy hammer	Mushroom District Gear Shop
-1140	coin	fire flower	Mushroom District Gear Shop
-1141	coin	bonfire flower	Mushroom District Gear Shop
-1143	coin	fancy boots	Mushroom District Gear Shop
-1144	coin	cape	Mushroom District Gear Shop
-1145	coin	back shell	Mushroom District Gear Shop
-1146	coin	spiky back shell	Mushroom District Gear Shop
-1147	coin	power pants	Mushroom District Gear Shop
-1148	coin	bony back shell	Mushroom District Gear Shop
-1149	coin	frosty button	Mushroom District Gear Shop
-1150	coin	blooper ink	Mushroom District Item Shop
+1132	buy	drippy shield	Drip Institute Armory
+1133	buy	deluxe mushroom	Mushroom District Item Shop
+1134	buy	mushroom	Mushroom District Item Shop
+1135	buy	super deluxe mushroom	Mushroom District Item Shop
+1136	buy	fizzy soda	Mushroom District Item Shop
+1137	buy	healthy juice	Mushroom District Item Shop
+1138	buy	hammer	Mushroom District Gear Shop
+1139	buy	heavy hammer	Mushroom District Gear Shop
+1140	buy	fire flower	Mushroom District Gear Shop
+1141	buy	bonfire flower	Mushroom District Gear Shop
+1143	buy	fancy boots	Mushroom District Gear Shop
+1144	buy	cape	Mushroom District Gear Shop
+1145	buy	back shell	Mushroom District Gear Shop
+1146	buy	spiky back shell	Mushroom District Gear Shop
+1147	buy	power pants	Mushroom District Gear Shop
+1148	buy	bony back shell	Mushroom District Gear Shop
+1149	buy	frosty button	Mushroom District Gear Shop
+1150	buy	blooper ink	Mushroom District Item Shop
 1151	npc	glass of drippy wine	Drip Institute Cafeteria
 1152	npc	drippy caviar	Drip Institute Cafeteria
-1153	coin	Guzzlr hat	Guzzlr Company Store Website
-1154	coin	Guzzlr shoes	Guzzlr Company Store Website
-1155	coin	Guzzlr pants	Guzzlr Company Store Website
-1156	coin	Guzzlr souvenir stein	Guzzlr Company Store Website
-1157	coin	Guzzlr tattoo kit	Guzzlr Company Store Website
-1158	coin	Never Don't Stop Not Striving	Guzzlr Company Store Website
+1153	buy	Guzzlr hat	Guzzlr Company Store Website
+1154	buy	Guzzlr shoes	Guzzlr Company Store Website
+1155	buy	Guzzlr pants	Guzzlr Company Store Website
+1156	buy	Guzzlr souvenir stein	Guzzlr Company Store Website
+1157	buy	Guzzlr tattoo kit	Guzzlr Company Store Website
+1158	buy	Never Don't Stop Not Striving	Guzzlr Company Store Website
 1159	npc	Drip Institute petri dish	Drip Institute Cafeteria
-1160	coin	birch battery	Your SpinMaster&trade; lathe
-1161	coin	ebony epee	Your SpinMaster&trade; lathe
-1162	coin	weeping willow wand	Your SpinMaster&trade; lathe
-1163	coin	beechwood blowgun	Your SpinMaster&trade; lathe
-1164	coin	maple magnet	Your SpinMaster&trade; lathe
-1165	coin	hemlock helm	Your SpinMaster&trade; lathe
-1166	coin	balsam barrel	Your SpinMaster&trade; lathe
-1167	coin	redwood rain stick	Your SpinMaster&trade; lathe
-1168	coin	purpleheart &quot;pants&quot;	Your SpinMaster&trade; lathe
-1169	coin	wormwood wedding ring	Your SpinMaster&trade; lathe
-1170	coin	drippy diadem	Your SpinMaster&trade; lathe
+1160	buy	birch battery	Your SpinMaster&trade; lathe
+1161	buy	ebony epee	Your SpinMaster&trade; lathe
+1162	buy	weeping willow wand	Your SpinMaster&trade; lathe
+1163	buy	beechwood blowgun	Your SpinMaster&trade; lathe
+1164	buy	maple magnet	Your SpinMaster&trade; lathe
+1165	buy	hemlock helm	Your SpinMaster&trade; lathe
+1166	buy	balsam barrel	Your SpinMaster&trade; lathe
+1167	buy	redwood rain stick	Your SpinMaster&trade; lathe
+1168	buy	purpleheart &quot;pants&quot;	Your SpinMaster&trade; lathe
+1169	buy	wormwood wedding ring	Your SpinMaster&trade; lathe
+1170	buy	drippy diadem	Your SpinMaster&trade; lathe
 1171	npc	&quot;reusable&quot; grocery bag	The Black and White and Red All Over Market
 1172	npc	cardboard wine carrier	The Black and White and Red All Over Market
 1173	npc	antique candy bucket	The Black and White and Red All Over Market
@@ -988,32 +988,32 @@
 1180	npc	Crimbo Cheer tattoo kit	The Black and White and Red All Over Market
 1181	npc	Crimbo Carol tattoo kit	The Black and White and Red All Over Market
 1182	npc	Crimbo Commerce tattoo kit	The Black and White and Red All Over Market
-1183	coin	food drive button	Elf Food Drive
-1184	coin	booze drive button	Elf Booze Drive
-1185	coin	candy drive button	Elf Candy Drive
-1186	coin	food mailing list	Elf Food Drive
-1187	coin	booze mailing list	Elf Booze Drive
-1188	coin	candy mailing list	Elf Candy Drive
-1189	coin	fruit bat	Elf Candy Drive
-1190	coin	tinsel orb	Elf Candy Drive
-1191	coin	Crimbo stockings	Elf Booze Drive
-1192	coin	poncho de azucar	Elf Booze Drive
-1193	coin	snowpack	Elf Food Drive
-1194	coin	Satan hat	Elf Food Drive
-1195	coin	The Night Before Crimbo, Ch. 1	Elf Food Drive
-1196	coin	The Night Before Crimbo, Ch. 2	Elf Food Drive
-1197	coin	The Night Before Crimbo, Ch. 3	Elf Booze Drive
-1198	coin	The Night Before Crimbo, Ch. 4	Elf Booze Drive
-1199	coin	The Night Before Crimbo, Ch. 5	Elf Candy Drive
+1183	buy	food drive button	Elf Food Drive
+1184	buy	booze drive button	Elf Booze Drive
+1185	buy	candy drive button	Elf Candy Drive
+1186	buy	food mailing list	Elf Food Drive
+1187	buy	booze mailing list	Elf Booze Drive
+1188	buy	candy mailing list	Elf Candy Drive
+1189	buy	fruit bat	Elf Candy Drive
+1190	buy	tinsel orb	Elf Candy Drive
+1191	buy	Crimbo stockings	Elf Booze Drive
+1192	buy	poncho de azucar	Elf Booze Drive
+1193	buy	snowpack	Elf Food Drive
+1194	buy	Satan hat	Elf Food Drive
+1195	buy	The Night Before Crimbo, Ch. 1	Elf Food Drive
+1196	buy	The Night Before Crimbo, Ch. 2	Elf Food Drive
+1197	buy	The Night Before Crimbo, Ch. 3	Elf Booze Drive
+1198	buy	The Night Before Crimbo, Ch. 4	Elf Booze Drive
+1199	buy	The Night Before Crimbo, Ch. 5	Elf Candy Drive
 1201	npc	stuffed red and green pepper (stale)	The Crimbo Cafe
 1202	npc	cranberry margarita (brackish)	The Crimbo Cafe
-1204	coin	miniature goose mask	Elf Booze Drive
-1205	coin	tiny glowing red nose	Elf Food Drive
-1206	coin	fuzzy polar bear ears	Elf Candy Drive
-1207	coin	The Night Before Crimbo, Ch. 6	Elf Candy Drive
-1209	coin	drive-thru burger	Elf Food Drive
-1210	coin	Boulevardier cocktail	Elf Booze Drive
-1211	coin	Hotwire&trade; brand candy rope	Elf Candy Drive
+1204	buy	miniature goose mask	Elf Booze Drive
+1205	buy	tiny glowing red nose	Elf Food Drive
+1206	buy	fuzzy polar bear ears	Elf Candy Drive
+1207	buy	The Night Before Crimbo, Ch. 6	Elf Candy Drive
+1209	buy	drive-thru burger	Elf Food Drive
+1210	buy	Boulevardier cocktail	Elf Booze Drive
+1211	buy	Hotwire&trade; brand candy rope	Elf Candy Drive
 1247	npc	fedora-mounted fountain	Clan Underground Fireworks Shop
 1248	npc	sombrero-mounted sparkler	Clan Underground Fireworks Shop
 1249	npc	porkpie-mounted popper	Clan Underground Fireworks Shop
@@ -1034,22 +1034,22 @@
 1264	npc	clear Russian	The Crimbo Cafe
 1265	npc	black Crimbo ball	Ornament Stand
 1266	npc	white Crimbo ball	Ornament Stand
-1279	coin	dinosaur pheromone kit	Dino World Gift Shop (The Dinostaur)
-1280	coin	pterodactyl rifle	Dino World Gift Shop (The Dinostaur)
-1281	coin	birdseed hat	Dino World Gift Shop (The Dinostaur)
-1282	coin	flatusaur gasmask	Dino World Gift Shop (The Dinostaur)
-1283	coin	dinosaur dart	Dino World Gift Shop (The Dinostaur)
-1284	coin	Dino DNAde&trade;	Dino World Gift Shop (The Dinostaur)
-1285	coin	dinosaur repellent	Dino World Gift Shop (The Dinostaur)
-1286	coin	camouflage vest	Dino World Gift Shop (The Dinostaur)
-1287	coin	reflective vest	Dino World Gift Shop (The Dinostaur)
-1288	coin	stuffed dinosaur	Dino World Gift Shop (The Dinostaur)
-1289	coin	Charleston Choo-Choo	Fancy Dan the Cocktail Man
-1290	coin	Velvet Veil	Fancy Dan the Cocktail Man
-1291	coin	Marltini	Fancy Dan the Cocktail Man
-1292	coin	Strong, Silent Type	Fancy Dan the Cocktail Man
-1293	coin	Mysterious Stranger	Fancy Dan the Cocktail Man
-1294	coin	Champagne Shimmy	Fancy Dan the Cocktail Man
+1279	buy	dinosaur pheromone kit	Dino World Gift Shop (The Dinostaur)
+1280	buy	pterodactyl rifle	Dino World Gift Shop (The Dinostaur)
+1281	buy	birdseed hat	Dino World Gift Shop (The Dinostaur)
+1282	buy	flatusaur gasmask	Dino World Gift Shop (The Dinostaur)
+1283	buy	dinosaur dart	Dino World Gift Shop (The Dinostaur)
+1284	buy	Dino DNAde&trade;	Dino World Gift Shop (The Dinostaur)
+1285	buy	dinosaur repellent	Dino World Gift Shop (The Dinostaur)
+1286	buy	camouflage vest	Dino World Gift Shop (The Dinostaur)
+1287	buy	reflective vest	Dino World Gift Shop (The Dinostaur)
+1288	buy	stuffed dinosaur	Dino World Gift Shop (The Dinostaur)
+1289	buy	Charleston Choo-Choo	Fancy Dan the Cocktail Man
+1290	buy	Velvet Veil	Fancy Dan the Cocktail Man
+1291	buy	Marltini	Fancy Dan the Cocktail Man
+1292	buy	Strong, Silent Type	Fancy Dan the Cocktail Man
+1293	buy	Mysterious Stranger	Fancy Dan the Cocktail Man
+1294	buy	Champagne Shimmy	Fancy Dan the Cocktail Man
 1307	conc	pixel bread	PIXEL
 1308	conc	pixel whiskey	PIXEL
 1309	conc	shadow chef's hat	SHADOW_FORGE
@@ -1061,122 +1061,122 @@
 1316	conc	shadow martini	SHADOW_FORGE
 1317	conc	shadow pill	SHADOW_FORGE
 1318	conc	shadow needle	SHADOW_FORGE
-1319	coin	replica Dark Jill-O-Lantern	Replica Mr. Store
-1320	coin	replica hand turkey outline	Replica Mr. Store
-1321	coin	replica crimbo elfling	Replica Mr. Store
-1322	coin	replica pygmy bugbear shaman	Replica Mr. Store
-1323	coin	replica miniature gravy-covered maypole	Replica Mr. Store
-1324	coin	replica wax lips	Replica Mr. Store
-1325	coin	replica Tome of Snowcone Summoning	Replica Mr. Store
-1326	coin	replica plastic pumpkin bucket	Replica Mr. Store
-1328	coin	replica jewel-eyed wizard hat	Replica Mr. Store
-1329	coin	replica bottle-rocket crossbow	Replica Mr. Store
-1330	coin	replica navel ring of navel gazing	Replica Mr. Store
-1331	coin	replica V for Vivala mask	Replica Mr. Store
-1332	coin	replica little box of fireworks	Replica Mr. Store
-1333	coin	replica Libram of Resolutions	Replica Mr. Store
-1334	coin	replica cotton candy cocoon	Replica Mr. Store
-1335	coin	replica Elvish sunglasses	Replica Mr. Store
-1336	coin	replica Greatest American Pants	Replica Mr. Store
-1337	coin	replica organ grinder	Replica Mr. Store
-1338	coin	replica Juju Mojo Mask	Replica Mr. Store
-1339	coin	replica cute angel	Replica Mr. Store
-1340	coin	replica Camp Scout backpack	Replica Mr. Store
-1341	coin	replica deactivated nanobots	Replica Mr. Store
-1342	coin	replica haiku katana	Replica Mr. Store
-1343	coin	replica Apathargic Bandersnatch	Replica Mr. Store
-1344	coin	replica squamous polyp	Replica Mr. Store
-1345	coin	replica Operation Patriot Shield	Replica Mr. Store
-1346	coin	replica plastic vampire fangs	Replica Mr. Store
-1347	coin	replica Smith's Tome	Replica Mr. Store
-1348	coin	replica over-the-shoulder Folder Holder	Replica Mr. Store
-1349	coin	replica Order of the Green Thumb Order Form	Replica Mr. Store
-1350	coin	replica Little Geneticist DNA-Splicing Lab	Replica Mr. Store
-1351	coin	replica still grill	Replica Mr. Store
-1352	coin	replica Crimbo sapling	Replica Mr. Store
-1353	coin	replica yellow puck	Replica Mr. Store
-1354	coin	replica Chateau Mantegna room key	Replica Mr. Store
-1355	coin	replica Deck of Every Card	Replica Mr. Store
-1356	coin	replica Source terminal	Replica Mr. Store
-1357	coin	replica disconnected intergnat	Replica Mr. Store
-1358	coin	replica Witchess Set	Replica Mr. Store
-1359	coin	replica genie bottle	Replica Mr. Store
-1360	coin	replica space planula	Replica Mr. Store
-1361	coin	replica unpowered Robortender	Replica Mr. Store
-1362	coin	replica Neverending Party invitation envelope	Replica Mr. Store
-1363	coin	replica January's Garbage Tote	Replica Mr. Store
-1364	coin	replica God Lobster Egg	Replica Mr. Store
-1365	coin	replica Kramco Sausage-o-Matic&trade;	Replica Mr. Store
-1366	coin	replica Fourth of May Cosplay Saber	Replica Mr. Store
-1367	coin	replica hewn moon-rune spoon	Replica Mr. Store
-1368	coin	replica baby camelCalf	Replica Mr. Store
-1369	coin	replica Powerful Glove	Replica Mr. Store
-1370	coin	replica Cargo Cultist Shorts	Replica Mr. Store
-1371	coin	replica emotion chip	Replica Mr. Store
-1372	coin	replica miniature crystal ball	Replica Mr. Store
-1373	coin	replica industrial fire extinguisher	Replica Mr. Store
-1374	coin	replica Jurassic Parka	Replica Mr. Store
-1375	coin	replica grey gosling	Replica Mr. Store
-1376	coin	replica designer sweatpants	Replica Mr. Store
-1377	coin	replica Cincho de Mayo	Replica Mr. Store
-1378	coin	&quot;I survived Y2K&quot; T-Shirt	Mr. Store 2002
-1379	coin	Spooky VHS Tape	Mr. Store 2002
-1380	coin	Letter from Carrie Bradshaw	Mr. Store 2002
-1381	coin	pro skateboard	Mr. Store 2002
-1382	coin	Mr. Accessaturday	Mr. Store 2002
-1383	coin	Meat Butler	Mr. Store 2002
-1384	coin	Loathing Idol Microphone	Mr. Store 2002
-1385	coin	Charter: Nellyville	Mr. Store 2002
-1386	coin	Manual of Secret Door Detection	Mr. Store 2002
-1387	coin	Flash Liquidizer Ultra Dousing Accessory	Mr. Store 2002
-1388	coin	Amulet of Perpetual Darkness	Mr. Store 2002
-1389	coin	Giant black monolith	Mr. Store 2002
-1390	coin	Crimbo cookie sheet	Mr. Store 2002
-1391	coin	Replica 2002 Mr. Store Catalog	Replica Mr. Store
-1392	coin	replica sleeping patriotic eagle	Replica Mr. Store
+1319	buy	replica Dark Jill-O-Lantern	Replica Mr. Store
+1320	buy	replica hand turkey outline	Replica Mr. Store
+1321	buy	replica crimbo elfling	Replica Mr. Store
+1322	buy	replica pygmy bugbear shaman	Replica Mr. Store
+1323	buy	replica miniature gravy-covered maypole	Replica Mr. Store
+1324	buy	replica wax lips	Replica Mr. Store
+1325	buy	replica Tome of Snowcone Summoning	Replica Mr. Store
+1326	buy	replica plastic pumpkin bucket	Replica Mr. Store
+1328	buy	replica jewel-eyed wizard hat	Replica Mr. Store
+1329	buy	replica bottle-rocket crossbow	Replica Mr. Store
+1330	buy	replica navel ring of navel gazing	Replica Mr. Store
+1331	buy	replica V for Vivala mask	Replica Mr. Store
+1332	buy	replica little box of fireworks	Replica Mr. Store
+1333	buy	replica Libram of Resolutions	Replica Mr. Store
+1334	buy	replica cotton candy cocoon	Replica Mr. Store
+1335	buy	replica Elvish sunglasses	Replica Mr. Store
+1336	buy	replica Greatest American Pants	Replica Mr. Store
+1337	buy	replica organ grinder	Replica Mr. Store
+1338	buy	replica Juju Mojo Mask	Replica Mr. Store
+1339	buy	replica cute angel	Replica Mr. Store
+1340	buy	replica Camp Scout backpack	Replica Mr. Store
+1341	buy	replica deactivated nanobots	Replica Mr. Store
+1342	buy	replica haiku katana	Replica Mr. Store
+1343	buy	replica Apathargic Bandersnatch	Replica Mr. Store
+1344	buy	replica squamous polyp	Replica Mr. Store
+1345	buy	replica Operation Patriot Shield	Replica Mr. Store
+1346	buy	replica plastic vampire fangs	Replica Mr. Store
+1347	buy	replica Smith's Tome	Replica Mr. Store
+1348	buy	replica over-the-shoulder Folder Holder	Replica Mr. Store
+1349	buy	replica Order of the Green Thumb Order Form	Replica Mr. Store
+1350	buy	replica Little Geneticist DNA-Splicing Lab	Replica Mr. Store
+1351	buy	replica still grill	Replica Mr. Store
+1352	buy	replica Crimbo sapling	Replica Mr. Store
+1353	buy	replica yellow puck	Replica Mr. Store
+1354	buy	replica Chateau Mantegna room key	Replica Mr. Store
+1355	buy	replica Deck of Every Card	Replica Mr. Store
+1356	buy	replica Source terminal	Replica Mr. Store
+1357	buy	replica disconnected intergnat	Replica Mr. Store
+1358	buy	replica Witchess Set	Replica Mr. Store
+1359	buy	replica genie bottle	Replica Mr. Store
+1360	buy	replica space planula	Replica Mr. Store
+1361	buy	replica unpowered Robortender	Replica Mr. Store
+1362	buy	replica Neverending Party invitation envelope	Replica Mr. Store
+1363	buy	replica January's Garbage Tote	Replica Mr. Store
+1364	buy	replica God Lobster Egg	Replica Mr. Store
+1365	buy	replica Kramco Sausage-o-Matic&trade;	Replica Mr. Store
+1366	buy	replica Fourth of May Cosplay Saber	Replica Mr. Store
+1367	buy	replica hewn moon-rune spoon	Replica Mr. Store
+1368	buy	replica baby camelCalf	Replica Mr. Store
+1369	buy	replica Powerful Glove	Replica Mr. Store
+1370	buy	replica Cargo Cultist Shorts	Replica Mr. Store
+1371	buy	replica emotion chip	Replica Mr. Store
+1372	buy	replica miniature crystal ball	Replica Mr. Store
+1373	buy	replica industrial fire extinguisher	Replica Mr. Store
+1374	buy	replica Jurassic Parka	Replica Mr. Store
+1375	buy	replica grey gosling	Replica Mr. Store
+1376	buy	replica designer sweatpants	Replica Mr. Store
+1377	buy	replica Cincho de Mayo	Replica Mr. Store
+1378	buy	&quot;I survived Y2K&quot; T-Shirt	Mr. Store 2002
+1379	buy	Spooky VHS Tape	Mr. Store 2002
+1380	buy	Letter from Carrie Bradshaw	Mr. Store 2002
+1381	buy	pro skateboard	Mr. Store 2002
+1382	buy	Mr. Accessaturday	Mr. Store 2002
+1383	buy	Meat Butler	Mr. Store 2002
+1384	buy	Loathing Idol Microphone	Mr. Store 2002
+1385	buy	Charter: Nellyville	Mr. Store 2002
+1386	buy	Manual of Secret Door Detection	Mr. Store 2002
+1387	buy	Flash Liquidizer Ultra Dousing Accessory	Mr. Store 2002
+1388	buy	Amulet of Perpetual Darkness	Mr. Store 2002
+1389	buy	Giant black monolith	Mr. Store 2002
+1390	buy	Crimbo cookie sheet	Mr. Store 2002
+1391	buy	Replica 2002 Mr. Store Catalog	Replica Mr. Store
+1392	buy	replica sleeping patriotic eagle	Replica Mr. Store
 1393	conc	cat o' nine teeth	FIXODENT
 1394	conc	toothy trousers	FIXODENT
 1395	conc	tooth cap	FIXODENT
-1396	coin	replica august scepter	Replica Mr. Store
-1397	coin	crated wardrobe-o-matic	KoL Con 13 Merch Table
-1399	coin	sugarplum ration	Elf Guard Mess Hall
-1400	coin	gingerbread nylons	Elf Guard Mess Hall
-1401	coin	rum-soaked fruitcake	Elf Guard Mess Hall
-1402	coin	candied lime	Crimbuccaneer Grub Hall
-1403	coin	gingerbread pirate	Crimbuccaneer Grub Hall
-1404	coin	fruit-stuffed rumcake	Crimbuccaneer Grub Hall
-1405	coin	mulled wine	Elf Guard Officers' Club
-1406	coin	Swedish coffee	Elf Guard Officers' Club
-1407	coin	canteen of eggnog	Elf Guard Officers' Club
-1408	coin	hot wine	Crimbuccaneer Bar
-1409	coin	Jamaican coffee	Crimbuccaneer Bar
-1410	coin	flask of egggrog	Crimbuccaneer Bar
-1411	coin	Elf Guard honor present	Elf Guard Armory
-1412	coin	CURRENCY (3)	Elf Guard Armory
-1413	coin	CURRENCY (3)	Elf Guard Armory
-1415	coin	CURRENCY (3)	Elf Guard Armory
-1416	coin	CURRENCY (3)	Elf Guard Armory
-1417	coin	Crimbuccaneer premium booty sack	Crimbuccaneer Junkworks
-1418	coin	CURRENCY (3)	Crimbuccaneer Junkworks
-1420	coin	CURRENCY (3)	Crimbuccaneer Junkworks
-1421	coin	CURRENCY (3)	Crimbuccaneer Junkworks
-1422	coin	CURRENCY (3)	Crimbuccaneer Junkworks
-1424	coin	trick coin	Elf Guard Toy and Munitions Factory
-1425	coin	Elf Guard squirtgun	Elf Guard Toy and Munitions Factory
-1426	coin	chest of &quot;pirate gold&quot;	Elf Guard Toy and Munitions Factory
-1427	coin	sequin-encrusted sweater	Elf Guard Toy and Munitions Factory
-1428	coin	replica Elf Guard medal	Elf Guard Toy and Munitions Factory
-1429	coin	Lil' Snowball Factory	Elf Guard Toy and Munitions Factory
-1430	coin	Elf Guard temporary (permanent) tattoo	Elf Guard Toy and Munitions Factory
-1431	coin	prank Crimbo card	Crimbuccaneer Foundry
-1432	coin	Crimbuccaneer squirtblunderbuss	Crimbuccaneer Foundry
-1433	coin	My First Paycheck envelope	Crimbuccaneer Foundry
-1434	coin	barnacle-encrusted sweater	Crimbuccaneer Foundry
-1435	coin	Crimbuccaneer nose ring	Crimbuccaneer Foundry
-1436	coin	pet anchor	Crimbuccaneer Foundry
-1437	coin	Crimbuccaneer tattoo gift certificate	Crimbuccaneer Foundry
-1440	coin	Elf Guard safety bear	Elf Guard Toy and Munitions Factory
-1441	coin	stuffed kraken	Crimbuccaneer Foundry
+1396	buy	replica august scepter	Replica Mr. Store
+1397	buy	crated wardrobe-o-matic	KoL Con 13 Merch Table
+1399	buy	sugarplum ration	Elf Guard Mess Hall
+1400	buy	gingerbread nylons	Elf Guard Mess Hall
+1401	buy	rum-soaked fruitcake	Elf Guard Mess Hall
+1402	buy	candied lime	Crimbuccaneer Grub Hall
+1403	buy	gingerbread pirate	Crimbuccaneer Grub Hall
+1404	buy	fruit-stuffed rumcake	Crimbuccaneer Grub Hall
+1405	buy	mulled wine	Elf Guard Officers' Club
+1406	buy	Swedish coffee	Elf Guard Officers' Club
+1407	buy	canteen of eggnog	Elf Guard Officers' Club
+1408	buy	hot wine	Crimbuccaneer Bar
+1409	buy	Jamaican coffee	Crimbuccaneer Bar
+1410	buy	flask of egggrog	Crimbuccaneer Bar
+1411	buy	Elf Guard honor present	Elf Guard Armory
+1412	sell	CURRENCY (3)	Elf Guard Armory
+1413	sell	CURRENCY (3)	Elf Guard Armory
+1415	sell	CURRENCY (3)	Elf Guard Armory
+1416	sell	CURRENCY (3)	Elf Guard Armory
+1417	buy	Crimbuccaneer premium booty sack	Crimbuccaneer Junkworks
+1418	sell	CURRENCY (3)	Crimbuccaneer Junkworks
+1420	sell	CURRENCY (3)	Crimbuccaneer Junkworks
+1421	sell	CURRENCY (3)	Crimbuccaneer Junkworks
+1422	sell	CURRENCY (3)	Crimbuccaneer Junkworks
+1424	buy	trick coin	Elf Guard Toy and Munitions Factory
+1425	buy	Elf Guard squirtgun	Elf Guard Toy and Munitions Factory
+1426	buy	chest of &quot;pirate gold&quot;	Elf Guard Toy and Munitions Factory
+1427	buy	sequin-encrusted sweater	Elf Guard Toy and Munitions Factory
+1428	buy	replica Elf Guard medal	Elf Guard Toy and Munitions Factory
+1429	buy	Lil' Snowball Factory	Elf Guard Toy and Munitions Factory
+1430	buy	Elf Guard temporary (permanent) tattoo	Elf Guard Toy and Munitions Factory
+1431	buy	prank Crimbo card	Crimbuccaneer Foundry
+1432	buy	Crimbuccaneer squirtblunderbuss	Crimbuccaneer Foundry
+1433	buy	My First Paycheck envelope	Crimbuccaneer Foundry
+1434	buy	barnacle-encrusted sweater	Crimbuccaneer Foundry
+1435	buy	Crimbuccaneer nose ring	Crimbuccaneer Foundry
+1436	buy	pet anchor	Crimbuccaneer Foundry
+1437	buy	Crimbuccaneer tattoo gift certificate	Crimbuccaneer Foundry
+1440	buy	Elf Guard safety bear	Elf Guard Toy and Munitions Factory
+1441	buy	stuffed kraken	Crimbuccaneer Foundry
 1467	conc	biphasic molecular oculus	TINKERING_BENCH
 1468	conc	triphasic molecular oculus	TINKERING_BENCH
 1469	conc	high-tension exoskeleton	TINKERING_BENCH
@@ -1201,42 +1201,42 @@
 1488	conc	mini kiwi icepick	KIWI
 1489	conc	mini kiwi-flavored aspirin-injecting lipstick	KIWI
 1490	conc	mini kiwi digitized cookies	KIWI
-1509	coin	unevolved organism	KoL Con 13 Merch Table
-1510	coin	blade of dismemberment	Sept-Ember Censer
-1511	coin	miniature Embering Hulk	Sept-Ember Censer
-1512	coin	Mmm-brr! brand mouthwash	Sept-Ember Censer
-1513	coin	Septapus summoning charm	Sept-Ember Censer
-1514	coin	structural ember	Sept-Ember Censer
-1515	coin	embers-only jacket	Sept-Ember Censer
-1516	coin	bembershoot	Sept-Ember Censer
-1517	coin	wheel of camembert	Sept-Ember Censer
-1518	coin	hat of remembering	Sept-Ember Censer
-1519	coin	throwin' ember	Sept-Ember Censer
-1520	coin	head of emberg lettuce	Sept-Ember Censer
-1521	coin	Easter grasshopper	Crimbo24 Bar
-1522	coin	Irish eggnog	Crimbo24 Bar
-1523	coin	canteen of jungle juice	Crimbo24 Bar
-1524	coin	turchucken	Crimbo24 Bar
-1525	coin	mechanically-mulled cider	Crimbo24 Bar
-1526	coin	holiday trip around the world	Crimbo24 Bar
-1527	coin	chocolate ostrich egg	Crimbo24 Cafe
-1528	coin	candied beef and cabbage	Crimbo24 Cafe
-1529	coin	candy rations	Crimbo24 Cafe
-1530	coin	double-candied yams	Crimbo24 Cafe
-1531	coin	Christmas ham	Crimbo24 Cafe
-1532	coin	holiday smorgasbord	Crimbo24 Cafe
-1533	coin	Secrets of the Master Egg Hunters	Crimbo24 Factory
-1534	coin	How to Lose Friends and Attract Snakes	Crimbo24 Factory
-1535	coin	Covert Ops for Kids	Crimbo24 Factory
-1536	coin	Holiday Multitasking	Crimbo24 Factory
-1537	coin	egg gun	Crimbo24 Factory
-1538	coin	lucky moai statuette	Crimbo24 Factory
-1540	coin	lucky army helmet	Crimbo24 Factory
-1541	coin	candy egg deviler	Crimbo24 Factory
-1542	coin	lucky napkin	Crimbo24 Factory
-1543	coin	Thanksgiving ration	Crimbo24 Factory
-1544	coin	Easter eggnog	Crimbo24 Factory
-1545	coin	clovermint	Crimbo24 Factory
-1546	coin	nylon Christmas stockings	Crimbo24 Factory
-1547	coin	tattoo of two turkeys	Crimbo24 Factory
-1548	coin	Hoyle's Guide to Reindeer Games	Crimbo24 Factory
+1509	buy	unevolved organism	KoL Con 13 Merch Table
+1510	buy	blade of dismemberment	Sept-Ember Censer
+1511	buy	miniature Embering Hulk	Sept-Ember Censer
+1512	buy	Mmm-brr! brand mouthwash	Sept-Ember Censer
+1513	buy	Septapus summoning charm	Sept-Ember Censer
+1514	buy	structural ember	Sept-Ember Censer
+1515	buy	embers-only jacket	Sept-Ember Censer
+1516	buy	bembershoot	Sept-Ember Censer
+1517	buy	wheel of camembert	Sept-Ember Censer
+1518	buy	hat of remembering	Sept-Ember Censer
+1519	buy	throwin' ember	Sept-Ember Censer
+1520	buy	head of emberg lettuce	Sept-Ember Censer
+1521	row	Easter grasshopper	Crimbo24 Bar
+1522	row	Irish eggnog	Crimbo24 Bar
+1523	row	canteen of jungle juice	Crimbo24 Bar
+1524	row	turchucken	Crimbo24 Bar
+1525	row	mechanically-mulled cider	Crimbo24 Bar
+1526	row	holiday trip around the world	Crimbo24 Bar
+1527	row	chocolate ostrich egg	Crimbo24 Cafe
+1528	row	candied beef and cabbage	Crimbo24 Cafe
+1529	row	candy rations	Crimbo24 Cafe
+1530	row	double-candied yams	Crimbo24 Cafe
+1531	row	Christmas ham	Crimbo24 Cafe
+1532	row	holiday smorgasbord	Crimbo24 Cafe
+1533	row	Secrets of the Master Egg Hunters	Crimbo24 Factory
+1534	row	How to Lose Friends and Attract Snakes	Crimbo24 Factory
+1535	row	Covert Ops for Kids	Crimbo24 Factory
+1536	row	Holiday Multitasking	Crimbo24 Factory
+1537	row	egg gun	Crimbo24 Factory
+1538	row	lucky moai statuette	Crimbo24 Factory
+1540	row	lucky army helmet	Crimbo24 Factory
+1541	row	candy egg deviler	Crimbo24 Factory
+1542	row	lucky napkin	Crimbo24 Factory
+1543	row	Thanksgiving ration	Crimbo24 Factory
+1544	row	Easter eggnog	Crimbo24 Factory
+1545	row	clovermint	Crimbo24 Factory
+1546	row	nylon Christmas stockings	Crimbo24 Factory
+1547	row	tattoo of two turkeys	Crimbo24 Factory
+1548	row	Hoyle's Guide to Reindeer Games	Crimbo24 Factory

--- a/src/net/sourceforge/kolmafia/persistence/CoinmastersDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/CoinmastersDatabase.java
@@ -165,7 +165,7 @@ public class CoinmastersDatabase {
           }
           int row = shopRow.getRow();
           if (row != 0) {
-            ShopRowDatabase.registerShopRow(row, "coin", shopRow.getItem(), master);
+            ShopRowDatabase.registerShopRow(row, "row", shopRow.getItem(), master);
           }
           List<ShopRow> rows = shopRows.get(master);
           if (rows == null) {
@@ -204,7 +204,7 @@ public class CoinmastersDatabase {
           map.put(iitemId, iprice);
 
           if (row != null) {
-            ShopRowDatabase.registerShopRow(row, "coin", item, master);
+            ShopRowDatabase.registerShopRow(row, "buy", item, master);
           }
         } else if (type.equals("sell")) {
           List<AdventureResult> list = getOrMakeList(master, sellItems);
@@ -215,7 +215,7 @@ public class CoinmastersDatabase {
 
           if (row != null) {
             AdventureResult currency = AdventureResult.tallyItem("CURRENCY", price, false);
-            ShopRowDatabase.registerShopRow(row, "coin", currency, master);
+            ShopRowDatabase.registerShopRow(row, "sell", currency, master);
           }
         }
       }

--- a/src/net/sourceforge/kolmafia/persistence/ShopRowDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ShopRowDatabase.java
@@ -22,6 +22,17 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class ShopRowDatabase {
 
+  enum Mode {
+    NONE, // Do nothing
+    READ, // Read data file into data structure
+    BUILD // Populate data structure from other data
+  }
+
+  // If we eventually need this internally, set to Mode.READ
+  // If you want to regenerate the data file, set to Mode.BUILD
+  // recompile, log in, and "test write-shoprows"
+  public static Mode mode = Mode.NONE;
+
   private ShopRowDatabase() {}
 
   record ShopRowData(int row, String type, AdventureResult item, String shopName) {
@@ -41,17 +52,19 @@ public class ShopRowDatabase {
   public static Map<Integer, ShopRowData> shopRowData = new TreeMap<>();
 
   public static void registerShopRow(int row, String type, AdventureResult item, String shopName) {
-    ShopRowData data = new ShopRowData(row, type, item, shopName);
-    shopRowData.put(row, data);
+    if (mode == Mode.BUILD) {
+      ShopRowData data = new ShopRowData(row, type, item, shopName);
+      shopRowData.put(row, data);
+    }
   }
 
   public static void registerShopRow(ShopRow shopRow, String type, String shopName) {
-    System.out.println("register " + type + " row " + shopRow.getRow());
+
     registerShopRow(shopRow.getRow(), type, shopRow.getItem(), shopName);
   }
 
   private static final Pattern MEAT_PATTERN = Pattern.compile("([\\d,]+) Meat");
-  private static final Pattern CURRENCY_PATTERN = Pattern.compile("CURRENCY \\(([\\d,]+)\\)");
+  private static final Pattern CURRENCY_PATTERN = Pattern.compile("CURRENCY(?: \\(([\\d,]+)\\))?");
 
   public static AdventureResult parseItemOrMeat(final String s) {
     Matcher meatMatcher = MEAT_PATTERN.matcher(s);
@@ -60,8 +73,9 @@ public class ShopRowDatabase {
     }
     Matcher currencyMatcher = CURRENCY_PATTERN.matcher(s);
     if (currencyMatcher.find()) {
-      return AdventureResult.tallyItem(
-          "CURRENCY", StringUtilities.parseInt(currencyMatcher.group(1)), false);
+      String countString = currencyMatcher.group(1);
+      int count = (countString == null) ? 1 : StringUtilities.parseInt(countString);
+      return AdventureResult.tallyItem("CURRENCY", count, false);
     }
     return AdventureResult.parseItem(s, false);
   }
@@ -80,6 +94,20 @@ public class ShopRowDatabase {
   }
 
   static {
+    switch (mode) {
+      case READ -> {
+        // Read existing data file
+        readShopRowDataFile();
+      }
+      case BUILD -> {
+        // Create empty data file
+        writeShopRowDataFile();
+      }
+      case NONE -> {}
+    }
+  }
+
+  public static void readShopRowDataFile() {
     try (BufferedReader reader =
         FileUtilities.getVersionedReader("shoprows.txt", KoLConstants.SHOPROWS_VERSION)) {
       String[] data;


### PR DESCRIPTION
1) I added a "mode" for ShopRowDatabase:
- Mode.NONE - (default) Do not read or generate shoprows.txt
- Mode.BUILD - do not read shoprows.txt, but generate database from other files
- Mode.READ - read the datafile if, eventually, we need to use it internally
2) I split "coin" into "buy", "sell" (old-style coinmasters) and "row" (new-style coinmasters)
conc  = 284
npc = 337
buy = 576
sell = 17
row = 27
Total = 1241 rows