### PR TITLE
Register currencies when initialize coinmasters

### DIFF
--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -1103,6 +1103,14 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
     }
   }
 
+  public void registerCurrencies() {
+    for (AdventureResult currency : this.currencies()) {
+      if (currency.isItem()) {
+        CoinmastersDatabase.registerCurrency(currency);
+      }
+    }
+  }
+
   public void registerPropertyToken() {
     if (this.property == null) {
       return;

--- a/src/net/sourceforge/kolmafia/CoinmasterRegistry.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterRegistry.java
@@ -197,6 +197,7 @@ public abstract class CoinmasterRegistry {
       CoinmasterData cm = COINMASTERS[i];
       MASTERS[i] = StringUtilities.getCanonicalName(cm.getMaster());
       NICKNAMES[i] = StringUtilities.getCanonicalName(cm.getNickname());
+      cm.registerCurrencies();
       cm.registerPurchaseRequests();
       cm.registerPropertyToken();
     }

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3836,11 +3836,6 @@ public class ItemPool {
   public static final int PIRATE_DINGHY = 11705;
   public static final int ANCHOR_BOMB = 11706;
   public static final int SILKY_PIRATE_DRAWERS = 11707;
-  public static final int SPIRIT_OF_EASTER = 11717;
-  public static final int SPIRIT_OF_ST_PATRICKS_DAY = 11718;
-  public static final int SPIRIT_OF_VETERANS_DAY = 11719;
-  public static final int SPIRIT_OF_THANKSGIVING = 11720;
-  public static final int SPIRIT_OF_CHRISTMAS = 11721;
   public static final int PUMPKIN_SPICE_WHORL = 11746;
   public static final int CANDY_EGG_DEVILER = 11774;
 

--- a/src/net/sourceforge/kolmafia/persistence/CoinmastersDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/CoinmastersDatabase.java
@@ -3,9 +3,11 @@ package net.sourceforge.kolmafia.persistence;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.TreeMap;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.CoinmasterData;
@@ -54,6 +56,21 @@ public class CoinmastersDatabase {
 
   public static final String getRowShop(final int row) {
     return rowShop.get(row);
+  }
+
+  // All items that are used as a "currency": traded in to acquire a different item.
+  public static final Set<Integer> allCurrencies = new HashSet<>();
+
+  public static void registerCurrency(final AdventureResult currency) {
+    allCurrencies.add(currency.getItemId());
+  }
+
+  public static boolean isCurrency(final AdventureResult item) {
+    return isCurrency(item.getItemId());
+  }
+
+  public static boolean isCurrency(final int itemId) {
+    return allCurrencies.contains(itemId);
   }
 
   // *** Old style "shop.php" (and other) Coinmasters

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -1411,7 +1411,7 @@ public class ResultProcessor {
         break;
     }
 
-    if (CoinmastersDatabase.isCurrency(itemId)) {
+    if (CoinmastersDatabase.isCurrency(result)) {
       NamedListenerRegistry.fireChange("(coinmaster)");
     }
 

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -32,6 +32,7 @@ import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
+import net.sourceforge.kolmafia.persistence.CoinmastersDatabase;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.persistence.DebugDatabase;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
@@ -1330,85 +1331,6 @@ public class ResultProcessor {
     // handled here.
 
     switch (itemId) {
-      case ItemPool.GG_TICKET:
-      case ItemPool.SNACK_VOUCHER:
-      case ItemPool.LUNAR_ISOTOPE:
-      case ItemPool.ODD_SILVER_COIN:
-      case ItemPool.BEACH_BUCK:
-      case ItemPool.WORTHLESS_TRINKET:
-      case ItemPool.WORTHLESS_GEWGAW:
-      case ItemPool.WORTHLESS_KNICK_KNACK:
-      case ItemPool.YETI_FUR:
-      case ItemPool.LUCRE:
-      case ItemPool.SAND_DOLLAR:
-      case ItemPool.CRIMBUCK:
-      case ItemPool.BONE_CHIPS:
-      case ItemPool.CRIMBCO_SCRIP:
-      case ItemPool.AWOL_COMMENDATION:
-      case ItemPool.MR_ACCESSORY:
-      case ItemPool.UNCLE_BUCK:
-      case ItemPool.FAT_LOOT_TOKEN:
-      case ItemPool.FUDGECULE:
-      case ItemPool.FDKOL_COMMENDATION:
-      case ItemPool.WARBEAR_WHOSIT:
-      case ItemPool.KRUEGERAND:
-      case ItemPool.SHIP_TRIP_SCRIP:
-      case ItemPool.CHRONER:
-      case ItemPool.BURT:
-      case ItemPool.FRESHWATER_FISHBONE:
-      case ItemPool.CRIMBO_CREDIT:
-      case ItemPool.TOPIARY_NUGGLET:
-      case ItemPool.FUNFUNDS:
-      case ItemPool.TOXIC_GLOBULE:
-      case ItemPool.VOLCOINO:
-      case ItemPool.BACON:
-      case ItemPool.COP_DOLLAR:
-      case ItemPool.PRICELESS_DIAMOND:
-      case ItemPool.CRYSTALLINE_CHEER:
-      case ItemPool.STICK_OF_FIREWOOD:
-      case ItemPool.RARE_MEAT_ISOTOPE:
-      case ItemPool.WHITE_PIXEL:
-      case ItemPool.DRIPLET:
-      case ItemPool.GUZZLRBUCK:
-        // BatFellow currencies
-      case ItemPool.INCRIMINATING_EVIDENCE:
-      case ItemPool.DANGEROUS_CHEMICALS:
-      case ItemPool.KIDNAPPED_ORPHAN:
-      case ItemPool.HIGH_GRADE_METAL:
-      case ItemPool.HIGH_TENSILE_STRENGTH_FIBERS:
-      case ItemPool.HIGH_GRADE_EXPLOSIVES:
-        // The Traveling Trader usually wants twinkly wads
-      case ItemPool.TWINKLY_WAD:
-        // You can trade tokens for tickets
-      case ItemPool.GG_TOKEN:
-        // You can go to spaaace with a transponder
-      case ItemPool.TRANSPORTER_TRANSPONDER:
-        // Lathe-worthy woods
-      case ItemPool.FLIMSY_HARDWOOD_SCRAPS:
-      case ItemPool.DREADSYLVANIAN_HEMLOCK:
-      case ItemPool.SWEATY_BALSAM:
-      case ItemPool.ANCIENT_REDWOOD:
-      case ItemPool.WORMWOOD_STICK:
-      case ItemPool.PURPLEHEART_LOGS:
-      case ItemPool.DRIPWOOD_SLAB:
-        // Speakeasy currencies
-      case ItemPool.MILK_CAP:
-      case ItemPool.DRINK_CHIT:
-      case ItemPool.REPLICA_MR_ACCESSORY:
-        // Crimbo23 currencies
-      case ItemPool.ELF_GUARD_MPC:
-      case ItemPool.ELF_ARMY_MACHINE_PARTS:
-      case ItemPool.CRIMBUCCANEER_PIECE_OF_12:
-      case ItemPool.CRIMBUCCANEER_FLOTSAM:
-        // Crimbo24 currencies
-      case ItemPool.SPIRIT_OF_EASTER:
-      case ItemPool.SPIRIT_OF_ST_PATRICKS_DAY:
-      case ItemPool.SPIRIT_OF_VETERANS_DAY:
-      case ItemPool.SPIRIT_OF_THANKSGIVING:
-      case ItemPool.SPIRIT_OF_CHRISTMAS:
-        NamedListenerRegistry.fireChange("(coinmaster)");
-        break;
-
       case ItemPool.FAKE_HAND:
         NamedListenerRegistry.fireChange("(fakehands)");
         break;
@@ -1487,6 +1409,10 @@ public class ResultProcessor {
       case ItemPool.SHADOW_STICK:
         RufusManager.handleShadowItems(result.getName());
         break;
+    }
+
+    if (CoinmastersDatabase.isCurrency(itemId)) {
+      NamedListenerRegistry.fireChange("(coinmaster)");
     }
 
     if (StandardRewardDatabase.isPulverizedStandardReward(itemId)) {

--- a/test/net/sourceforge/kolmafia/request/CoinMasterRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/CoinMasterRequestTest.java
@@ -152,15 +152,9 @@ public class CoinMasterRequestTest {
             text.contains("Elf Guard Armory\tsell\t3\tElf Guard commandeering gloves\tROW1412"));
         assertFalse(
             text.contains("Elf Guard Armory\tsell\t3\tElf Guard officer's sidearm\tROW1413"));
-        // assertTrue(text.contains("Elf Guard Armory\tsell\t3\tKelflar vest\tROW1415"));
-        assertTrue(
-            text.contains("Elf Guard Armory\tROW1415\tElf Army machine parts (3)\tKelflar vest"));
+        assertTrue(text.contains("Elf Guard Armory\tsell\t3\tKelflar vest\tROW1415"));
         assertFalse(text.contains("Elf Guard Armory\tsell\t3\tElf Guard mouthknife\tROW1416"));
-        // assertTrue(text.contains("Elf Guard Armory\tbuy\t200\tElf Guard honor
-        // present\tROW1411"));
-        assertTrue(
-            text.contains(
-                "Elf Guard Armory\tROW1411\tElf Guard honor present\tElf Army machine parts"));
+        assertTrue(text.contains("Elf Guard Armory\tbuy\t200\tElf Guard honor present\tROW1411"));
 
         var requests = client.getRequests();
         assertThat(requests, hasSize(1));


### PR DESCRIPTION
CoinmasterRegistry will call CoinmastersDatabase to register all the currencies of each coinmaster.
ResultProcessor will fire (coinmaster) - which alerts CoinmastersFrame - whenever you gain or lose a currency.

It did that before, but currencies used to be switch labels, rather than being found via a Set lookup.

One less thing to remember to do when implementing a new Coinmaster...