### PR TITLE
Add 'to consume' checkbox to UseItemEnqueuePanel

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -657,6 +657,7 @@ user	encountersUntilNEPChoice	7
 user	encountersUntilSRChoice	11
 user	enamorangMonster
 user	enamorangMonsterTurn
+user	enqueueForConsumption	true
 user	ensorcelee
 user	ensorceleeLevel	0
 user	entauntaunedColdRes	0

--- a/src/net/sourceforge/kolmafia/swingui/panel/ItemManagePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/ItemManagePanel.java
@@ -387,7 +387,10 @@ public abstract class ItemManagePanel<E, S extends JComponent> extends Scrollabl
       }
       case USE_MULTIPLE -> {
         int standard = itemCount;
-        if (!message.equals("Feed") && !message.equals("Queue")) {
+        boolean obeyConsumptionLimits =
+            !message.equals("Feed")
+                && (!message.equals("Queue") || Preferences.getBoolean("enqueueForConsumption"));
+        if (obeyConsumptionLimits) {
           if (item instanceof Concoction c) {
             int previous = 0, capacity = itemCount, unit = 0, shotglass = 0;
 

--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
@@ -114,7 +114,8 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
     this.getElementList().setVisibleRowCount(6);
     this.getElementList().setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 
-    this.filters = new JCheckBox[potions ? 4 : 8];
+    int filterCount = (potions ? 4 : 8) + (this.hasCreationQueue ? 1 : 0);
+    this.filters = new JCheckBox[filterCount];
 
     this.filters[0] = new JCheckBox("no create");
     this.filters[1] = new TurnFreeCheckbox();
@@ -122,12 +123,18 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
 
     if (potions) {
       this.filters[3] = new EffectNameCheckbox();
+      if (this.hasCreationQueue) {
+        this.filters[4] = new ToConsumeCheckbox();
+      }
     } else {
       this.filters[3] = new JCheckBox("+mus only");
       this.filters[4] = new JCheckBox("+mys only");
       this.filters[5] = new JCheckBox("+mox only");
       this.filters[6] = new PerUnitCheckBox(type);
       this.filters[7] = new ByRoomCheckbox();
+      if (this.hasCreationQueue) {
+        this.filters[8] = new ToConsumeCheckbox();
+      }
     }
 
     for (JCheckBox checkbox : this.filters) {
@@ -139,24 +146,34 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
     JPanel column2 = new JPanel(new BorderLayout());
     JPanel column3 = new JPanel(new BorderLayout());
     JPanel column4 = new JPanel(new BorderLayout());
+    JPanel column5 = new JPanel(new BorderLayout());
 
     column1.add(this.filters[0], BorderLayout.NORTH);
     column2.add(this.filters[1], BorderLayout.NORTH);
     column3.add(this.filters[2], BorderLayout.NORTH);
     if (potions) {
       column4.add(this.filters[3], BorderLayout.NORTH);
+      if (this.hasCreationQueue) {
+        column5.add(this.filters[4], BorderLayout.NORTH);
+      }
     } else {
       column1.add(this.filters[3], BorderLayout.CENTER);
       column2.add(this.filters[4], BorderLayout.CENTER);
       column3.add(this.filters[5], BorderLayout.CENTER);
       column4.add(this.filters[6], BorderLayout.NORTH);
       column4.add(this.filters[7], BorderLayout.CENTER);
+      if (this.hasCreationQueue) {
+        column5.add(this.filters[8], BorderLayout.NORTH);
+      }
     }
 
     filterPanel.add(column1);
     filterPanel.add(column2);
     filterPanel.add(column3);
     filterPanel.add(column4);
+    if (this.hasCreationQueue) {
+      filterPanel.add(column5);
+    }
 
     // Set the height of the filter panel to be just a wee bit taller than two checkboxes need
     filterPanel.setPreferredSize(
@@ -972,6 +989,17 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
     protected void handleClick() {
       ConcoctionDatabase.getUsables().sort();
     }
+  }
+
+  private static class ToConsumeCheckbox extends PreferenceListenerCheckBox {
+    public ToConsumeCheckbox() {
+      super("to consume", "enqueueForConsumption");
+
+      this.setToolTipText("Enqueue obeys consumption limits.");
+    }
+
+    @Override
+    protected void handleClick() {}
   }
 
   private static class RefreshListener extends ThreadedListener {


### PR DESCRIPTION
In the Usables section of the ItemManager, you can queue items to be consumed immediately or to be created.
If the former, we limit the number you can queue to the usable amount, obeying consumption limits.
If the latter, we ignore consumption limits and you can queue as many as you have ingredients for.

A new checkbox - "to consume" - controls this behavior.
A new preference - enqueueForConsumption - (default is true) is linked to the checkbox.