### PR TITLE
Parse shops with tokens as currency. Fix Coinmaster bugs.

### DIFF
--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -790,6 +790,14 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
     return row;
   }
 
+  public final Integer getItemIdOrRow(int itemId) {
+    if (this.itemRows == null) {
+      return itemId;
+    }
+    Integer row = this.itemRows.get(itemId);
+    return row;
+  }
+
   public final boolean hasRow(int row) {
     if (this.itemRows == null) {
       return false;

--- a/src/net/sourceforge/kolmafia/request/CoinMasterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CoinMasterRequest.java
@@ -164,7 +164,7 @@ public class CoinMasterRequest extends GenericRequest {
     String itemField = this.data.getItemField();
     if (itemField != null) {
       int itemId = item.getItemId();
-      this.addFormField(itemField, String.valueOf(this.data.getRow(itemId)));
+      this.addFormField(itemField, String.valueOf(data.getItemIdOrRow(itemId)));
     }
   }
 
@@ -193,7 +193,7 @@ public class CoinMasterRequest extends GenericRequest {
     CoinmasterData data = this.data;
 
     // See if the Coin Master is accessible
-    boolean justVisiting = attachments == null;
+    boolean justVisiting = this.attachments == null && this.row == null;
     if (!justVisiting) {
       String reason = data.accessible();
       if (reason != null) {

--- a/test/net/sourceforge/kolmafia/ShopRowTest.java
+++ b/test/net/sourceforge/kolmafia/ShopRowTest.java
@@ -161,6 +161,35 @@ public class ShopRowTest {
   }
 
   @Nested
+  class SeptEmberCenser {
+    // shop.php?whichshop=september
+    // test_shop_september.html
+
+    static AdventureResult ember = AdventureResult.tallyItem("Ember", 1, false);
+
+    // Sept-Ember Censer	ROW1516	bembershoot	Ember
+    // Sept-Ember Censer	ROW1510	blade of dismemberment	Ember
+    // Sept-Ember Censer	ROW1515	embers-only jacket	Ember
+    // Sept-Ember Censer	ROW1518	hat of remembering	Ember
+    // Sept-Ember Censer	ROW1517	wheel of camembert	Ember
+    // Sept-Ember Censer	ROW1512	Mmm-brr! brand mouthwash	Ember (2)
+    // Sept-Ember Censer	ROW1520	head of emberg lettuce	Ember (2)
+    // Sept-Ember Censer	ROW1513	Septapus summoning charm	Ember (2)
+    // Sept-Ember Censer	ROW1519	throwin' ember	Ember (2)
+    // Sept-Ember Censer	ROW1514	structural ember	Ember (4)
+    // Sept-Ember Censer	ROW1511	miniature Embering Hulk	Ember (6)
+
+    @Test
+    public void canParseSeptEmberCenser() {
+      String html = html("request/test_shop_september.html");
+      var inventory = ShopRow.parseShop(html, true);
+      var currencies = currencies(inventory);
+      assertEquals(11, inventory.size());
+      assertEquals(11, currencies.get(ember));
+    }
+  }
+
+  @Nested
   class PrimordialSoupKitchen {
     static AdventureResult chroner = new AdventureResult("Chroner", 1, false);
     static AdventureResult bisque = new AdventureResult("bacteria bisque", 1);

--- a/test/root/request/test_shop_september.html
+++ b/test/root/request/test_shop_september.html
@@ -1,0 +1,281 @@
+<html><head>
+<script language=Javascript>
+<!--
+if (parent.frames.length == 0) location.href="game.php";
+//-->
+</script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/jquery-1.5.1.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/keybinds.min.2.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/window.20111231.js"></script>
+<script language="javascript">function chatFocus(){if(top.chatpane.document.chatform.graf) top.chatpane.document.chatform.graf.focus();}
+if (typeof defaultBind != 'undefined') { defaultBind(47, 2, chatFocus); defaultBind(190, 2, chatFocus);defaultBind(191, 2, chatFocus); defaultBind(47, 8, chatFocus);defaultBind(190, 8, chatFocus); defaultBind(191, 8, chatFocus); }</script><script language="javascript">
+	function updateParseItem(iid, field, info) {
+		var tbl = $('#ic'+iid);
+		var data = parseItem(tbl);
+		if (!data) return;
+		data[field] = info;
+		var out = [];
+		for (i in data) {
+			if (!data.hasOwnProperty(i)) continue;
+			out.push(i+'='+data[i]);
+		}
+		tbl.attr('rel', out.join('&'));
+	}
+	function parseItem(tbl) {
+		tbl = $(tbl);
+		var rel = tbl.attr('rel');
+		var data = {};
+		if (!rel) return data;
+		var parts = rel.split('&');
+		for (i in parts) {
+			if (!parts.hasOwnProperty(i)) continue;
+			var kv = parts[i].split('=');
+			tbl.data(kv[0], kv[1]);
+			data[kv[0]] = kv[1];
+		}
+		return data;
+	}
+</script><script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/pop_query.20230713.js"></script>
+<script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/ircm.20230626.js"></script>
+<script type="text/javascript">
+var tp = top;
+function pop_ircm_contents(i, some) {
+	var contents = '',
+		shown = 0,
+		da = '&nbsp;<a href="#" rel="?" class="small dojaxy">[some]</a>&nbsp;<a href="#" rel="',
+		db = '" class="small dojaxy">[all]</a>',
+		dc = '<div style="width:100%; padding-bottom: 3px;" rel="',
+		dd = '<a href="#" rel="1" class="small dojaxy">[';
+	one = 'one'; ss=some;
+if (i.d==1 && i.s>0) { shown++; 
+contents += dc + 'sellstuff.php?action=sell&ajax=1&type=quant&whichitem%5B%5D=IID&howmany=NUM&pwd=03a27ad2d8f28b0f40edb05fdc492c40" id="pircm_'+i.id+'"><b>Auto-Sell ('+i.s+' meat):</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'inventory.php?action=closetpush&ajax=1&whichitem=IID&qty=NUM&pwd=03a27ad2d8f28b0f40edb05fdc492c40" id="pircm_'+i.id+'"><b>Closet:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0 && i.g==0 && i.t==1) { shown++; 
+contents += dc + 'managestore.php?action=additem&qty1=NUM&item1=IID&price1=&limit1=&ajax=1&pwd=03a27ad2d8f28b0f40edb05fdc492c40" id="pircm_'+i.id+'"><b>Stock in Mall:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'managecollection.php?action=put&ajax=1&whichitem1=IID&howmany1=NUM&pwd=03a27ad2d8f28b0f40edb05fdc492c40" id="pircm_'+i.id+'"><b>Add to Display Case:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0 && i.t==1) { shown++; 
+contents += dc + 'clan_stash.php?action=addgoodies&ajax=1&item1=IID&qty1=NUM&pwd=03a27ad2d8f28b0f40edb05fdc492c40" id="pircm_'+i.id+'"><b>Contribute to Clan:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && !i.ac) { shown++; 
+contents += dc + 'inv_'+(i.u=="a"?"redir":(lab=(i.u=="u"?"use":(i.u=="e"?"eat":(i.u=="b"?"booze":(i.u=="s"?"spleen":"equip"))))))+'.php?ajax=1&whichitem=IID&itemquantity=NUM&quantity=NUM'+(i.u=="q"?"&action=equip":"")+'&pwd=03a27ad2d8f28b0f40edb05fdc492c40" id="pircm_'+i.id+'"><b>'+ucfirst(unescape(i.ou ? i.ou.replace(/\+/g," ") : (lab=="booze"?"drink":lab)))+':</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=1&ajax=1&whichitem=IID&action=equip&pwd=03a27ad2d8f28b0f40edb05fdc492c40" id="pircm_'+i.id+'"><b>Equip (slot 1):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=2&ajax=1&whichitem=IID&action=equip&pwd=03a27ad2d8f28b0f40edb05fdc492c40" id="pircm_'+i.id+'"><b>Equip (slot 2):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=3&ajax=1&whichitem=IID&action=equip&pwd=03a27ad2d8f28b0f40edb05fdc492c40" id="pircm_'+i.id+'"><b>Equip (slot 3):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+
+	return [contents, shown];
+}
+tp=top
+var todo = [];
+function nextAction() {
+	var next_todo = todo.shift();
+	if (next_todo) {
+		eval(next_todo);
+	}
+}
+function dojax(dourl, afterFunc, hoverCaller, failureFunc, method, params) {
+	$.ajax({
+		type: method || 'GET', url: dourl, cache: false,
+		data: params || null,
+		global: false,
+		success: function (out) {
+			nextAction();
+			if (out.match(/no\|/)) {
+				var parts = out.split(/\|/);
+				if (failureFunc) failureFunc(parts[1]);
+				else if (window.dojaxFailure) window.dojaxFailure(parts[1]);
+				else if (tp.chatpane.handleMessage) tp.chatpane.handleMessage({type: 'event', msg: 'Oops!  Sorry, Dave, you appear to be ' + parts[1]});
+				else  $('#ChatWindow').append('<font color="green">Oops!  Sorry, Dave, you appear to be ' + parts[1] + '.</font><br />' + "\n");
+				return;
+			}
+
+			if (hoverCaller)  {
+				float_results(hoverCaller, out);
+				if (afterFunc) { afterFunc(out); }
+				return;
+			}
+$(tp.mainpane.document).find("#effdiv").remove(); if(!window.dontscroll || (window.dontscroll && dontscroll==0)) { window.scroll(0,0);}
+			var $eff = $(tp.mainpane.document).find('#effdiv');
+			if ($eff.length == 0) {
+				var d = tp.mainpane.document.createElement('DIV');
+				d.id = 'effdiv';
+				var b = tp.mainpane.document.body;
+				if ($('#content_').length > 0) {
+					b = $('#content_ div:first')[0];
+				}
+				b.insertBefore(d, b.firstChild);
+				$eff = $(d);
+			}
+			$eff.find('a[name="effdivtop"]').remove().end()
+				.prepend('<a name="effdivtop"></a><center>' + out + '</center>').css('display','block');
+			if (!window.dontscroll || (window.dontscroll && dontscroll==0)) {
+				tp.mainpane.document.location = tp.mainpane.document.location + "#effdivtop";
+			}
+			if (afterFunc) { afterFunc(out); }
+		}
+	});
+}
+</script>	<link rel="stylesheet" type="text/css" href="https://d2uyhvukfffg5a.cloudfront.net/styles.20230117d.css">
+<style> body * { image-rendering: auto!important;} </style><style type='text/css'>
+.faded {
+	zoom: 1;
+	filter: alpha(opacity=35);
+	opacity: 0.35;
+	-khtml-opacity: 0.35; 
+    -moz-opacity: 0.35;
+}
+</style>
+
+</head>
+
+<body>
+<script src="https://d2uyhvukfffg5a.cloudfront.net/scripts/jquery.ui.tooltip.min.js?v=12"></script>
+<style>
+	.ui-helper-hidden-accessible {display: none; }
+	.tip { 
+		/*max-height: 300px;  */
+		overflow: auto;
+		background-color: white; 
+		border: 1px solid black;
+   		display:none;
+    	width:350px;
+    	padding:10px;
+    	color:black;
+    	z-index: 99;
+		position: absolute;
+	}
+	#loading {
+		position: fixed; top: 0px; right: 0px; padding: 2px; background-color: blue; color: white; display: none; z-index: 100; 
+	}
+</style>
+<div id="loading">Loading description...</div>
+<script>
+	var boom;
+	var cur_tip;
+	var invtip = function(callback) {
+		if (cur_tip == $(this).attr('rel')) return null;
+		//$('#loading').show();
+		var d = $('<div>Loading...</div>');
+		cur_tip = $(this).attr('rel');
+		$.get($(this).attr('rel'), function (res) {
+			var h = res.replace(/[\s\S]*<div id="description"/m,'<div').replace(/<script[\s\S]*/,'')+'</div>'
+			$('#loading').remove();
+			setTimeout(function () {
+			callback(h);
+			}, 500);
+		});
+		return "Loading description...";
+	};
+	var tooltip_options = {
+		content: invtip, 
+		show: {delay: 250, duration: 10},
+		hide: {delay: 5000000, duration: 100},
+		position: {collision: 'flipfit', at: 'right' },
+		open: function (e, ui) {
+			clearTimeout(boom);
+			$('.ui-tooltip').each(function () {
+				if ($(ui.tooltip).attr('id') != $(this).attr('id')) $(this).remove();
+			});
+		},
+		close : function (e) {
+			var killme  = function () { $('.tip').remove(); cur_tip = null; };
+			boom = setTimeout(function () { $('.tip').remove(); cur_tip = null; }, 1000);
+			$('.tip').hover(
+				function () { clearTimeout(boom); },
+				killme
+			);
+		},
+		tooltipClass: 'tip'
+	};
+	jQuery(function ($) {
+		if ($('.pop').tooltip) {
+		   	$('.pop').attr('title','').tooltip(tooltip_options);
+		}
+		var uia = function (e) {
+			e.preventDefault();
+			var p = $(this).parents('.ui-tooltip');
+			$.get($(this).attr('href'), function (res) {
+				p.empty().append(res);
+			});
+		};
+		var ua = navigator.userAgent,
+			        cname = (ua.match(/iP(hone|ad)/i)) ? "touchend" : "click";
+		$(document).bind(cname, function (e) {
+			if ($(e.target).parents('.ui-tooltip').length || $(e.target).is('.ircm')) return;
+			 $('.tip').remove(); cur_tip = null; 
+		});
+		$(document).bind('contextmenu',function (e) {
+			 $('.tip').remove(); cur_tip = null; 
+		});
+		if ($(document).live) $('.ui-tooltip a').live('click',uia);
+		else if ($.on) $(document).on('click', '.ui-tooltip a', uia);
+	});
+</script>
+<centeR><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="background-color: blue" align=center ><b style="color: white">Sept-Ember Censer</b></td></tr><tr><td style="padding: 5px; border: 1px solid blue;"><center><table><tr><td><center><table width=80%><tr><td valign=top><img src=https://d2uyhvukfffg5a.cloudfront.net/otherimages/../itemimages/embercenser.gif width=30 height=30 alt="Your Sept-Ember Censer" title="Your Sept-Ember Censer"></td><td valign=top><center><b>Your Sept-Ember Censer</b></center><p>You stoke the flames in your censer and contemplate what to make with the remaining embers. </td></tr></table><form name=bigform action=shop.php method=post><input type=hidden name=pwd value=03a27ad2d8f28b0f40edb05fdc492c40><input type=hidden name=whichshop value="september"><input type=hidden name=action value=buyitem><br><table cellspacing=2 cellpadding=0><tr><td></td><td colspan=2 align=center><b>Item:</b> (click for description)</td><td colspan=10 align=center><b>Price:</b></td></tr><tr rel="11649"><td valign=center><input type=radio name=whichrow value=1516></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/emberella.gif" class="hand pop" rel="desc_item.php?whichitem=402598302" onClick='javascript:descitem(402598302)'></td><td valign=center><a onClick='javascript:descitem(402598302)'><b>bembershoot</b>&nbsp;&nbsp;&nbsp;&nbsp;</a></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/ember.gif" /></td><td><b>1</b>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td valign=center><input class="button doit multibuy "  type=button rel='shop.php?whichshop=september&action=buyitem&quantity=1&whichrow=1516&pwd=03a27ad2d8f28b0f40edb05fdc492c40' value='Buy'></td></tr><tr rel="11643"><td valign=center><input type=radio name=whichrow value=1510></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/embersword.gif" class="hand pop" rel="desc_item.php?whichitem=514450928" onClick='javascript:descitem(514450928)'></td><td valign=center><a onClick='javascript:descitem(514450928)'><b>blade of dismemberment</b>&nbsp;&nbsp;&nbsp;&nbsp;</a></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/ember.gif" /></td><td><b>1</b>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td valign=center><input class="button doit multibuy "  type=button rel='shop.php?whichshop=september&action=buyitem&quantity=1&whichrow=1510&pwd=03a27ad2d8f28b0f40edb05fdc492c40' value='Buy'></td></tr><tr rel="11648"><td valign=center><input type=radio name=whichrow value=1515></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/emberjacket.gif" class="hand pop" rel="desc_item.php?whichitem=778179676" onClick='javascript:descitem(778179676)'></td><td valign=center><a onClick='javascript:descitem(778179676)'><b>embers-only jacket</b>&nbsp;&nbsp;&nbsp;&nbsp;</a></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/ember.gif" /></td><td><b>1</b>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td valign=center><input class="button doit multibuy "  type=button rel='shop.php?whichshop=september&action=buyitem&quantity=1&whichrow=1515&pwd=03a27ad2d8f28b0f40edb05fdc492c40' value='Buy'></td></tr><tr rel="11651"><td valign=center><input type=radio name=whichrow value=1518></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/emberhat.gif" class="hand pop" rel="desc_item.php?whichitem=912871310" onClick='javascript:descitem(912871310)'></td><td valign=center><a onClick='javascript:descitem(912871310)'><b>hat of remembering</b>&nbsp;&nbsp;&nbsp;&nbsp;</a></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/ember.gif" /></td><td><b>1</b>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td valign=center><input class="button doit multibuy "  type=button rel='shop.php?whichshop=september&action=buyitem&quantity=1&whichrow=1518&pwd=03a27ad2d8f28b0f40edb05fdc492c40' value='Buy'></td></tr><tr rel="11650"><td valign=center><input type=radio name=whichrow value=1517></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/embercheese.gif" class="hand pop" rel="desc_item.php?whichitem=665272067" onClick='javascript:descitem(665272067)'></td><td valign=center><a onClick='javascript:descitem(665272067)'><b>wheel of camembert </b>&nbsp;&nbsp;&nbsp;&nbsp;</a></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/ember.gif" /></td><td><b>1</b>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td valign=center><input class="button doit multibuy "  type=button rel='shop.php?whichshop=september&action=buyitem&quantity=1&whichrow=1517&pwd=03a27ad2d8f28b0f40edb05fdc492c40' value='Buy'></td></tr><tr rel="11645"><td valign=center><input type=radio name=whichrow value=1512></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/emberbottle.gif" class="hand pop" rel="desc_item.php?whichitem=406085040" onClick='javascript:descitem(406085040)'></td><td valign=center><a onClick='javascript:descitem(406085040)'><b>Mmm-brr! brand mouthwash</b>&nbsp;&nbsp;&nbsp;&nbsp;</a></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/ember.gif" /></td><td><b>2</b>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td valign=center><input class="button doit multibuy "  type=button rel='shop.php?whichshop=september&action=buyitem&quantity=1&whichrow=1512&pwd=03a27ad2d8f28b0f40edb05fdc492c40' value='Buy'></td></tr><tr rel="11653"><td valign=center><input type=radio name=whichrow value=1520></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/emberlettuce.gif" class="hand pop" rel="desc_item.php?whichitem=931508825" onClick='javascript:descitem(931508825)'></td><td valign=center><a onClick='javascript:descitem(931508825)'><b>head of emberg lettuce</b>&nbsp;&nbsp;&nbsp;&nbsp;</a></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/ember.gif" /></td><td><b>2</b>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td valign=center><input class="button doit multibuy "  type=button rel='shop.php?whichshop=september&action=buyitem&quantity=1&whichrow=1520&pwd=03a27ad2d8f28b0f40edb05fdc492c40' value='Buy'></td></tr><tr rel="11646"><td valign=center><input type=radio name=whichrow value=1513></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/emberpus.gif" class="hand pop" rel="desc_item.php?whichitem=185891232" onClick='javascript:descitem(185891232)'></td><td valign=center><a onClick='javascript:descitem(185891232)'><b>Septapus summoning charm</b>&nbsp;&nbsp;&nbsp;&nbsp;</a></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/ember.gif" /></td><td><b>2</b>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td valign=center><input class="button doit multibuy "  type=button rel='shop.php?whichshop=september&action=buyitem&quantity=1&whichrow=1513&pwd=03a27ad2d8f28b0f40edb05fdc492c40' value='Buy'></td></tr><tr rel="11652"><td valign=center><input type=radio name=whichrow value=1519></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/emberchunk.gif" class="hand pop" rel="desc_item.php?whichitem=214089388" onClick='javascript:descitem(214089388)'></td><td valign=center><a onClick='javascript:descitem(214089388)'><b>throwin' ember</b>&nbsp;&nbsp;&nbsp;&nbsp;</a></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/ember.gif" /></td><td><b>2</b>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td valign=center><input class="button doit multibuy "  type=button rel='shop.php?whichshop=september&action=buyitem&quantity=1&whichrow=1519&pwd=03a27ad2d8f28b0f40edb05fdc492c40' value='Buy'></td></tr><tr rel="11647"><td valign=center><input type=radio name=whichrow value=1514></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/emberboard.gif" class="hand pop" rel="desc_item.php?whichitem=251613605" onClick='javascript:descitem(251613605)'></td><td valign=center><a onClick='javascript:descitem(251613605)'><b>structural ember</b>&nbsp;&nbsp;&nbsp;&nbsp;</a></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/ember.gif" /></td><td><b>4</b>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td valign=center><input class="button doit multibuy "  type=button rel='shop.php?whichshop=september&action=buyitem&quantity=1&whichrow=1514&pwd=03a27ad2d8f28b0f40edb05fdc492c40' value='Buy'></td></tr><tr rel="11644"><td valign=center><input type=radio name=whichrow value=1511></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/emberhulk.gif" class="hand pop" rel="desc_item.php?whichitem=522091732" onClick='javascript:descitem(522091732)'></td><td valign=center><a onClick='javascript:descitem(522091732)'><b>miniature Embering Hulk</b>&nbsp;&nbsp;&nbsp;&nbsp;</a></td><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/ember.gif" /></td><td><b>6</b>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td valign=center><input class="button doit multibuy "  type=button rel='shop.php?whichshop=september&action=buyitem&quantity=1&whichrow=1511&pwd=03a27ad2d8f28b0f40edb05fdc492c40' value='Buy'></td></tr></table><center><input class=button type=submit value="Buy Item"> <input class=text type=text name=quantity size=2 value=1></center></form></form><div id="ass" style="font-size: .8em; text-align: center; width: 100%">*Right-Click to Multi-Buy</div><p><b>You have 490 Embers.</b></p><p><a href="inventory.php">Back to Inventory</a></center></td></tr></table></center></td></tr><tr><td height=4></td></tr></table></center><script>
+jQuery(function ($) {
+	var ass = false;
+	$('.doit').bind('contextmenu', function (e) {
+		e.preventDefault();
+		var l = $(this);
+		pop_query(l, 'How Many?', 'Buy', function (num) {
+			var url = l.attr('rel');
+			url = url.replace(/quantity=1/, 'quantity=' + num);
+			parent.mainpane.location=url;
+		})
+	}).each(function () {
+		//$(this).val($(this).val() + '*');
+		ass = true;
+	}).click(function (e) {
+		e.preventDefault();
+		if (e.shiftKey) {
+			var t= this;
+			setTimeout(function () { $(t).trigger('contextmenu');}, 500);
+			return;
+		}
+		var url = $(this).attr('rel');
+		parent.mainpane.location=url;
+	});
+
+	if (!ass) { $('#ass').hide() }
+
+});
+</script>
+</body></html>


### PR DESCRIPTION
1) Hermit was failing because we were not passing in a valid item id. I fixed that.
2) Supposedly Quartersmaster is failing.

I wondered if it is because it has a token, rather than an actual item as currency.
I don't have access to the island at war, at the moment, but the Sept-Ember Censer also uses a token.
I tried that out and it failed because it was passing an item ID instead of a row ID. I fixed that.
There seems to be no issue with tokens...

I think the Quartersmaster was failing for the same reason as the Hermit, but I can't test it.
3) I made ShopRow parsing detect shops that sell items for tokens, rather than items.
I have a test for that, and it can parse the Sept-Ember Censer now.
