### PR TITLE
missing `break` in numberology case of switch statement

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -2882,6 +2882,7 @@ public abstract class ChoiceControl {
           if (NumberologyManager.numberologyPrize(result).startsWith("fight")) {
             KoLAdventure.clearLocation();
           }
+          break;
         }
 
       case 1118:


### PR DESCRIPTION
Looks like this was introduced in #2590 and, scrolling through the PR, no other breaks were missed.