### PR TITLE
Fix ItemManager display of CoinMasterPurchaseRequests

### DIFF
--- a/src/data/allshoprows.txt
+++ b/src/data/allshoprows.txt
@@ -1366,3 +1366,6 @@ Crimbo24 Factory	ROW1545	clovermint	Spirit of St. Patrick's Day (50)	Spirit of C
 Crimbo24 Factory	ROW1546	nylon Christmas stockings	Spirit of Veteran's Day (200)	Spirit of Christmas (150)
 Crimbo24 Factory	ROW1547	tattoo of two turkeys	Spirit of Thanksgiving (300)	Spirit of Christmas (300)
 Crimbo24 Factory	ROW1548	Hoyle's Guide to Reindeer Games	Spirit of Christmas (500)
+Hack Market	ROW1549	Synapse Blaster	500 Meat
+Hack Market	ROW1556	eXpand	500 Meat
+Hack Market	ROW1557	drenchrome 2.0	500 Meat

--- a/src/data/shoprows.txt
+++ b/src/data/shoprows.txt
@@ -1547,3 +1547,12 @@
 1546	row	nylon Christmas stockings	Crimbo24 Factory
 1547	row	tattoo of two turkeys	Crimbo24 Factory
 1548	row	Hoyle's Guide to Reindeer Games	Crimbo24 Factory
+1549	npc	Synapse Blaster	Hack Market
+1550
+1551
+1552
+1553
+1554
+1555
+1556	npc	eXpand	Hack Market
+1557	npc	drenchrome 2.0	Hack Market

--- a/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
@@ -524,7 +524,7 @@ public class ListCellRendererFactory {
           if (costs.length == 1) {
             AdventureResult cost = costs[0];
             int count = cost.getCount();
-            String currency = purchaseRequest.getCurrency(count);
+            String currency = purchaseRequest.getCurrency(1);
             if (!currency.startsWith("(")) {
               stringForm.append(count);
               stringForm.append(" ");


### PR DESCRIPTION
1) CoinMasterPurchaseRequest.getCurrency(count) was correct, back when it ignored the "count" argument.
But when I changed that method to actually account for buying that many items - so that the MallSearchFrame would give pretty results - it screwed up the display in the ItemManager usable panels. Those now need to request (1).
2) And why not add the Hack Market rows to shoprows.txt and allshoprows.txt, as long as I have a trivial PR?