### PR TITLE
feat: add checkstyle to prevent uncommented switch fallthroughs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,12 @@ plugins {
 	id 'org.ajoberstar.grgit' version '5.2.2'
 	id 'org.panteleyev.jpackageplugin' version '1.6.0'
 	id "com.github.ben-manes.versions" version "0.51.0" // enables ./gradlew dependencyUpdates for outdated
+
+	id 'checkstyle'
+}
+
+checkstyle {
+	toolVersion = '10.21.1'
 }
 
 sourceSets {
@@ -98,6 +104,8 @@ dependencies {
 	implementation 'com.jgoodies:jgoodies-binding:2.13.0'
 	implementation 'org.eclipse.jgit:org.eclipse.jgit:6.10.0.202406032230-r'
 	implementation 'org.eclipse.jgit:org.eclipse.jgit.ssh.apache:6.10.0.202406032230-r'
+
+	checkstyle "com.puppycrawl.tools:checkstyle:${checkstyle.toolVersion}"
 }
 
 application {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Minimal checkstyle configuration for Kolmafia: switch defaults and fallthroughs only, with
+    basic suppression support.
+
+    The Google checkstyle configuration is at:
+        https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml
+    if you want the pain of trying to apply that across the board.
+ -->
+
+<module name="Checker">
+
+  <property name="charset" value="UTF-8"/>
+
+  <property name="severity" value="${org.checkstyle.kolmafia.severity}" default="warning"/>
+
+  <property name="fileExtensions" value="java, properties, xml"/>
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/filefilters/index.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+
+  <module name="SuppressWarningsFilter"/>
+
+  <module name="TreeWalker">
+    <module name="MissingSwitchDefault"/>
+    <module name="FallThrough"/>
+
+    <module name="SuppressWarningsHolder" />
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)" />
+      <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)" />
+      <property name="checkFormat" value="$1" />
+    </module>
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="commentFormat" value="CHECKSTYLE.SUPPRESS\: ([\w\|]+)"/>
+      <!-- $1 refers to the first match group in the regex defined in commentFormat -->
+      <property name="checkFormat" value="$1"/>
+      <!-- The check is suppressed in the next line of code after the comment -->
+      <property name="influenceFormat" value="1"/>
+    </module>
+  </module>
+</module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -4,7 +4,7 @@
           "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
-    Minimal checkstyle configuration for Kolmafia: switch defaults and fallthroughs only, with
+    Minimal checkstyle configuration for Kolmafia: switch fallthroughs only, with
     basic suppression support.
 
     The Google checkstyle configuration is at:
@@ -16,7 +16,7 @@
 
   <property name="charset" value="UTF-8"/>
 
-  <property name="severity" value="${org.checkstyle.kolmafia.severity}" default="warning"/>
+  <property name="severity" value="${org.checkstyle.kolmafia.severity}" default="error"/>
 
   <property name="fileExtensions" value="java, properties, xml"/>
   <!-- Excludes all 'module-info.java' files              -->
@@ -28,8 +28,9 @@
   <module name="SuppressWarningsFilter"/>
 
   <module name="TreeWalker">
-    <module name="MissingSwitchDefault"/>
-    <module name="FallThrough"/>
+    <module name="FallThrough">
+      <property name="reliefPattern" value="(?i)falls?[ -]?thr(u|ough)"/>
+    </module>
 
     <module name="SuppressWarningsHolder" />
     <module name="SuppressionCommentFilter">


### PR DESCRIPTION
A follow-up to #2612: ziz helpfully provided a minimal checkstyle config, so I've added a linter to the build.

Deliberate fall-throughs require a preceding comment (e.g. `// Fall through`) to not fail the build.

Checkstyle is configured to only test for exactly this problem we are having (convenient!) and can be run with `gradlew checkstyleMain`, `gradlew checkstyleLib`, and `gradlew checkstyleTest`, and will run as part of `gradlew check`.