### PR TITLE
feat: more cyber items

### DIFF
--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -340,3 +340,4 @@
 308	golden pet rock	ts_goldrock.gif	none	golden pet rock		0	0	0	0
 309
 310	Profane Parrot	ts_parrot2.gif	block,combat1	sleeping profane parrot	profane eye patch	0	0	0	0
+311	Significant Bit	cr_sbit.gif	variable	insignificant bit	parity bit	0	0	0	0

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11233,7 +11233,7 @@
 11205	replica cotton candy cocoon	405092970	cccoccoon.gif	grow	q	0
 11206	replica Elvish sunglasses	238031926	elvisshades.gif	accessory	q	0
 11207	replica squamous polyp	554034719	polyp.gif	grow	q	0
-11208
+11208	replica floaty stone sphere	819748385	beholderegg.gif	grow	q	0
 11209	replica Greatest American Pants	676766688	gapants.gif	pants	q	0
 11210	replica organ grinder	799236688	grinder.gif	grow	q	0
 11211	replica Juju Mojo Mask	154667577	jujumask.gif	accessory	q	0
@@ -11813,7 +11813,6 @@
 11785	McHugeLarge right pole	282816137	skipole2.gif	weapon	q	0
 11786	McHugeLarge left ski	210105166	ski1.gif	accessory	q	0
 11787	McHugeLarge right ski	796918007	ski2.gif	accessory	q	0
-11787
 11788	1	525329942	cr_1.gif	none	t,d	1
 11789	0	591340391	cr_0.gif	none	t,d	2
 11790	eXpand	312628661	pill4.gif	spleen, usable	t,d	10
@@ -11835,26 +11834,26 @@
 11806	malware injector	891017174	syringe.gif	offhand	t,d	60
 11807	CyberRealm keycode	211842512	cr_keycode.gif	usable	t	0
 11808	server room key	865269521	cr_key.gif	none		0
-11809
-11810
+11809	3d printed server room key	411166757	cr_3dkey.gif	usable	t	0
+11810	dedigitizer schematic: 3d printed server room key	600797572	cr_schematic.gif	none	t,d	25
 11811	logic grenade	782107563	cr_grenade.gif	none, combat	t,d	30
 11812	psilocyber mushroom	546956019	cr_shroom.gif	spleen, usable	t,d	10
-11813	dedigitizer schematic: SLEEP(5) rom chip	216913421	cr_schematic.gif	none	t,d	30
+11813	dedigitizer schematic: SLEEP(5) rom chip	216913421	cr_schematic.gif	none	t	0
 11814
 11815
-11816	dedigitizer schematic: insignificant bit	872901303	cr_schematic.gif	none	t,d	30
+11816	dedigitizer schematic: insignificant bit	872901303	cr_schematic.gif	none	t	0
 11817
 11818
-11819	dedigitizer schematic: geofencing shield	345860648	cr_schematic.gif	none	t,d	30
-11820	dedigitizer schematic: virtual cybertattoo	258125297	cr_schematic.gif	none	t,d	30
+11819	dedigitizer schematic: geofencing shield	345860648	cr_schematic.gif	none	t	0
+11820	dedigitizer schematic: virtual cybertattoo	258125297	cr_schematic.gif	none	t	0
 11821	SLEEP(5) rom chip	745418066	cr_romchip.gif	usable	t	0
 11822
 11823
-11824
-11825
+11824	insignificant bit	979112735	cr_ibit.gif	grow	t	0
+11825	parity bit	827552498	cr_paritybit.gif	familiar	t,d	75
 11826
 11827
-11828	geofencing shield	517384017	cr_shield.gif	offhand	t,d	200
+11828	geofencing shield	517384017	cr_shield.gif	offhand	t	0
 11829	virtual cybertattoo	757337801	cr_tat.gif	usable	t	0
 11830	ninja rope	351796064	ninjarope.gif	none	q	0	coils of ninja rope
 11831	ninja crampons	876430936	crampons.gif	none	q	0

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -12279,6 +12279,7 @@ Item	panicked kernel	Free Pull
 Item	pantogram	Free Pull
 # paperclip sproinger: Stuns your opponent for a couple of rounds and deals 10-15 Physical Damage
 Item	paranormal ricotta	Class: "Pastamancer"
+Item	parity bit	Familiar Weight: +5
 Item	Party Planning on a Budget	Skill: "Budget Conscious"
 Item	passed-out psychedelic bear	Free Pull
 # patchouli incense stick: Weakens enemies a little bit

--- a/src/data/monsterparts.txt
+++ b/src/data/monsterparts.txt
@@ -2277,7 +2277,7 @@
 2454	redhat hacker	avatar	arm	head	leg	torso
 2455
 2456	greenhat hacker	avatar	arm	head	leg	torso
-2457
+2457	purplehat hacker	avatar	arm	head	leg	torso
 2458	greyhat hacker	avatar	arm	head	leg	torso
 2459	firewall	fire
 2460	ICE barrier	barrier


### PR DESCRIPTION
Some of the dedigitizer items are now no-discard.

The geofencing shield is now no-discard, which means it can't be mirror copied.