### PR TITLE
Coinmasters can live in zones, if zone is Removed coinmaster is automatically inaccessible

### DIFF
--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -1165,7 +1165,7 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
     if (this.rootZone == null && this.zone != null) {
       this.rootZone = AdventureDatabase.getRootZone(this.zone);
     }
-    return this.rootZone == null ? "" : this.rootZone;
+    return this.rootZone;
   }
 
   @Override
@@ -1244,7 +1244,7 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
 
   public String accessible() {
     // Returns an error reason or null
-    if (this.getRootZone().equals("Removed")) {
+    if ("Removed".equals(this.getRootZone())) {
       return "Zone is no longer accessible";
     }
 

--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -14,6 +14,7 @@ import net.sourceforge.kolmafia.AdventureResult.AdventureLongCountResult;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.ConcoctionPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.CoinmastersDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -54,6 +55,7 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   private Pattern tokenPattern = null;
   private AdventureResult item = null;
   private String property = null;
+  private String zone = null;
 
   // For (old style) Coinmasters that deal with "rows", a map from item id to row number
   private Map<Integer, Integer> itemRows = null;
@@ -90,6 +92,7 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   public String pluralToken = null;
   private AdventureResult tokenItem = null;
   private Set<AdventureResult> currencies = null;
+  private String rootZone = null;
 
   // Functional fields to obviate overriding methods
   private Function<Integer, Integer> getBuyPrice = this::getBuyPriceInternal;
@@ -714,6 +717,11 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
         .withCountPattern(GenericRequest.QUANTITY_PATTERN);
   }
 
+  public CoinmasterData inZone(String zone) {
+    this.zone = zone;
+    return this;
+  }
+
   // Getters for mandatory fields
 
   public final String getMaster() {
@@ -1153,6 +1161,13 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
     ConcoctionPool.set(new Concoction(this.token, this.property));
   }
 
+  public String getRootZone() {
+    if (this.rootZone == null && this.zone != null) {
+      this.rootZone = AdventureDatabase.getRootZone(this.zone);
+    }
+    return this.rootZone == null ? "" : this.rootZone;
+  }
+
   @Override
   public String toString() {
     return this.master;
@@ -1229,6 +1244,9 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
 
   public String accessible() {
     // Returns an error reason or null
+    if (this.getRootZone().equals("Removed")) {
+      return "Zone is no longer accessible";
+    }
 
     Class<? extends CoinMasterRequest> requestClass = this.getRequestClass();
     Class<?>[] parameters = new Class<?>[0];

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24BarRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24BarRequest.java
@@ -10,6 +10,7 @@ public class Crimbo24BarRequest extends CoinMasterRequest {
 
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "crimbo24_bar", Crimbo24BarRequest.class)
+          .inZone("Crimbo24")
           .withNewShopRowFields(master, "crimbo24_bar")
           .withNeedsPasswordHash(true);
 
@@ -41,10 +42,6 @@ public class Crimbo24BarRequest extends CoinMasterRequest {
 
     // Parse current coin balances
     CoinMasterRequest.parseBalance(data, responseText);
-  }
-
-  public static String accessible() {
-    return "Crimbo Island has faded into the mists.";
   }
 
   public static final boolean registerRequest(final String urlString) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24CafeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24CafeRequest.java
@@ -10,6 +10,7 @@ public class Crimbo24CafeRequest extends CoinMasterRequest {
 
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "crimbo24_cafe", Crimbo24CafeRequest.class)
+          .inZone("Crimbo24")
           .withNewShopRowFields(master, "crimbo24_cafe")
           .withNeedsPasswordHash(true);
 
@@ -41,10 +42,6 @@ public class Crimbo24CafeRequest extends CoinMasterRequest {
 
     // Parse current coin balances
     CoinMasterRequest.parseBalance(data, responseText);
-  }
-
-  public static String accessible() {
-    return "Crimbo Island has faded into the mists.";
   }
 
   public static final boolean registerRequest(final String urlString) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24FactoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24FactoryRequest.java
@@ -10,6 +10,7 @@ public class Crimbo24FactoryRequest extends CoinMasterRequest {
 
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "crimbo24_factory", Crimbo24FactoryRequest.class)
+          .inZone("Crimbo24")
           .withNewShopRowFields(master, "crimbo24_factory")
           .withNeedsPasswordHash(true);
 
@@ -41,10 +42,6 @@ public class Crimbo24FactoryRequest extends CoinMasterRequest {
 
     // Parse current coin balances
     CoinMasterRequest.parseBalance(data, responseText);
-  }
-
-  public static String accessible() {
-    return "Crimbo Island has faded into the mists.";
   }
 
   public static final boolean registerRequest(final String urlString) {

--- a/test/net/sourceforge/kolmafia/CoinmasterDataTest.java
+++ b/test/net/sourceforge/kolmafia/CoinmasterDataTest.java
@@ -1,0 +1,28 @@
+package net.sourceforge.kolmafia;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import net.sourceforge.kolmafia.request.coinmaster.CoinMasterRequest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CoinmasterDataTest {
+  @Nested
+  class InZone {
+    @Test
+    void withoutZoneAccessibleByDefault() {
+      var data = new CoinmasterData("test", "test", CoinMasterRequest.class);
+      assertThat(data.isAccessible(), is(true));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Crimbo24", "Removed"})
+    void notAccessibleIfParentZoneIsRemoved(final String zone) {
+      var data = new CoinmasterData("test", "test", CoinMasterRequest.class).inZone(zone);
+      assertThat(data.isAccessible(), is(false));
+    }
+  }
+}


### PR DESCRIPTION
As discussed in a previous PR

- **Allow coinmasters to live in zones, and use zone removal for accessibility unless overwritten**
- **Use coinmaster zone to eliminate crimbo24 coinmasters**
- **Do not rely on blank string meaning null:**
