### PR TITLE
Crimbo24 coinmasters are Removed. Use 'inZone' for older Crimbo coinmasters.

### DIFF
--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -1161,8 +1161,15 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
     ConcoctionPool.set(new Concoction(this.token, this.property));
   }
 
+  public String getZone() {
+    return this.zone;
+  }
+
   public String getRootZone() {
-    if (this.rootZone == null && this.zone != null) {
+    if (this.zone == null) {
+      // Reset, for testing
+      this.rootZone = null;
+    } else if (this.rootZone == null) {
       this.rootZone = AdventureDatabase.getRootZone(this.zone);
     }
     return this.rootZone;

--- a/src/net/sourceforge/kolmafia/request/coinmaster/CRIMBCOGiftShopRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/CRIMBCOGiftShopRequest.java
@@ -15,6 +15,7 @@ public class CRIMBCOGiftShopRequest extends CoinMasterRequest {
 
   public static final CoinmasterData CRIMBCO_GIFT_SHOP =
       new CoinmasterData(master, "CRIMBCO", CRIMBCOGiftShopRequest.class)
+          .inZone("Crimbo10")
           .withToken("CRIMBCO scrip")
           .withTokenTest("You don't have any CRIMBCO scrip")
           .withTokenPattern(TOKEN_PATTERN)
@@ -75,9 +76,5 @@ public class CRIMBCOGiftShopRequest extends CoinMasterRequest {
     }
 
     return CoinMasterRequest.registerRequest(CRIMBCO_GIFT_SHOP, urlString);
-  }
-
-  public static String accessible() {
-    return "The CRIMBCO Gift Shop is not available";
   }
 }

--- a/src/net/sourceforge/kolmafia/request/coinmaster/Crimbo11Request.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/Crimbo11Request.java
@@ -23,6 +23,7 @@ public class Crimbo11Request extends CoinMasterRequest {
 
   public static final CoinmasterData CRIMBO11 =
       new CoinmasterData(master, "crimbo11", Crimbo11Request.class)
+          .inZone("Crimbo11")
           .withToken("Candy Credit")
           .withTokenPattern(TOKEN_PATTERN)
           .withProperty("availableCandyCredits")
@@ -225,9 +226,5 @@ public class Crimbo11Request extends CoinMasterRequest {
     }
 
     return CoinMasterRequest.registerRequest(CRIMBO11, urlString);
-  }
-
-  public static String accessible() {
-    return "Candy Credits are no longer exchangeable";
   }
 }

--- a/src/net/sourceforge/kolmafia/request/coinmaster/CrimboCartelRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/CrimboCartelRequest.java
@@ -16,6 +16,7 @@ public class CrimboCartelRequest extends CoinMasterRequest {
 
   public static final CoinmasterData CRIMBO_CARTEL =
       new CoinmasterData(master, "cartel", CrimboCartelRequest.class) {}.withToken("Crimbuck")
+          .inZone("Crimbo09")
           .withTokenTest("You do not currently have any Crimbux")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(CRIMBUCK)
@@ -84,9 +85,5 @@ public class CrimboCartelRequest extends CoinMasterRequest {
     }
 
     return CoinMasterRequest.registerRequest(CRIMBO_CARTEL, urlString);
-  }
-
-  public static String accessible() {
-    return "The Crimbo Cartel is not available";
   }
 }

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo14Request.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo14Request.java
@@ -16,6 +16,7 @@ public class Crimbo14Request extends CoinMasterRequest {
 
   public static final CoinmasterData CRIMBO14 =
       new CoinmasterData(master, "crimbo14", Crimbo14Request.class)
+          .inZone("Crimbo14")
           .withToken("Crimbo Credit")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(CRIMBO_CREDIT)
@@ -65,9 +66,5 @@ public class Crimbo14Request extends CoinMasterRequest {
     }
 
     return CoinMasterRequest.registerRequest(CRIMBO14, urlString);
-  }
-
-  public static String accessible() {
-    return "Crimbo Credits are no longer exchangeable";
   }
 }

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo17Request.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo17Request.java
@@ -17,6 +17,7 @@ public class Crimbo17Request extends CoinMasterRequest {
 
   public static final CoinmasterData CRIMBO17 =
       new CoinmasterData(master, "crimbo17", Crimbo17Request.class)
+          .inZone("Crimbo17")
           .withToken("crystalline cheer")
           .withTokenTest("no crystalline cheer")
           .withTokenPattern(CHEER_PATTERN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20BoozeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20BoozeRequest.java
@@ -17,6 +17,7 @@ public class Crimbo20BoozeRequest extends CoinMasterRequest {
 
   public static final CoinmasterData CRIMBO20BOOZE =
       new CoinmasterData(master, "crimbo20booze", Crimbo20BoozeRequest.class)
+          .inZone("Crimbo20")
           .withToken("donated booze")
           .withTokenTest("no boxes of donated booze")
           .withTokenPattern(TOKEN_PATTERN)
@@ -72,10 +73,6 @@ public class Crimbo20BoozeRequest extends CoinMasterRequest {
 
     // Parse current coin balances
     CoinMasterRequest.parseBalance(data, responseText);
-  }
-
-  public static String accessible() {
-    return "Crimbo is gone";
   }
 
   public static final boolean registerRequest(final String urlString) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20CandyRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20CandyRequest.java
@@ -17,6 +17,7 @@ public class Crimbo20CandyRequest extends CoinMasterRequest {
 
   public static final CoinmasterData CRIMBO20CANDY =
       new CoinmasterData(master, "crimbo20candy", Crimbo20CandyRequest.class)
+          .inZone("Crimbo20")
           .withToken("donated candy")
           .withTokenTest("no boxes of donated candy")
           .withTokenPattern(TOKEN_PATTERN)
@@ -72,10 +73,6 @@ public class Crimbo20CandyRequest extends CoinMasterRequest {
 
     // Parse current coin balances
     CoinMasterRequest.parseBalance(data, responseText);
-  }
-
-  public static String accessible() {
-    return "Crimbo is gone";
   }
 
   public static final boolean registerRequest(final String urlString) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20FoodRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20FoodRequest.java
@@ -17,6 +17,7 @@ public class Crimbo20FoodRequest extends CoinMasterRequest {
 
   public static final CoinmasterData CRIMBO20FOOD =
       new CoinmasterData(master, "crimbo20food", Crimbo20FoodRequest.class)
+          .inZone("Crimbo20")
           .withToken("donated food")
           .withTokenTest("no piles of donated food")
           .withTokenPattern(TOKEN_PATTERN)
@@ -72,10 +73,6 @@ public class Crimbo20FoodRequest extends CoinMasterRequest {
 
     // Parse current coin balances
     CoinMasterRequest.parseBalance(data, responseText);
-  }
-
-  public static String accessible() {
-    return "Crimbo is gone";
   }
 
   public static final boolean registerRequest(final String urlString) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfArmoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfArmoryRequest.java
@@ -17,6 +17,7 @@ public class Crimbo23ElfArmoryRequest extends CoinMasterRequest {
 
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "crimbo23_elf_armory", Crimbo23ElfArmoryRequest.class)
+          .inZone("Crimbo23")
           .withToken("Elf Army machine parts")
           .withTokenTest("no piles of Elf Army machine parts")
           .withItem(TOKEN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfBarRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfBarRequest.java
@@ -16,6 +16,7 @@ public class Crimbo23ElfBarRequest extends CoinMasterRequest {
 
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "crimbo23_elf_bar", Crimbo23ElfBarRequest.class)
+          .inZone("Crimbo23")
           .withToken("Elf Guard MPC")
           .withTokenTest("no Elf Guard MPCs")
           .withTokenPattern(TOKEN_PATTERN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfCafeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfCafeRequest.java
@@ -16,6 +16,7 @@ public class Crimbo23ElfCafeRequest extends CoinMasterRequest {
 
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "crimbo23_elf_cafe", Crimbo23ElfCafeRequest.class)
+          .inZone("Crimbo23")
           .withToken("Elf Guard MPC")
           .withTokenTest("no Elf Guard MPCs")
           .withTokenPattern(TOKEN_PATTERN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfFactoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfFactoryRequest.java
@@ -16,6 +16,7 @@ public class Crimbo23ElfFactoryRequest extends CoinMasterRequest {
 
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "crimbo23_elf_factory", Crimbo23ElfFactoryRequest.class)
+          .inZone("Crimbo23")
           .withToken("Elf Guard MPC")
           .withTokenTest("no Elf Guard MPCs")
           .withTokenPattern(TOKEN_PATTERN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateArmoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateArmoryRequest.java
@@ -17,6 +17,7 @@ public class Crimbo23PirateArmoryRequest extends CoinMasterRequest {
 
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "crimbo23_pirate_armory", Crimbo23PirateArmoryRequest.class)
+          .inZone("Crimbo23")
           .withToken("Crimbuccaneer flotsam")
           .withTokenTest("no piles of Crimbuccaneer flotsam")
           .withItem(TOKEN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateBarRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateBarRequest.java
@@ -17,6 +17,7 @@ public class Crimbo23PirateBarRequest extends CoinMasterRequest {
 
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "crimbo23_pirate_bar", Crimbo23PirateBarRequest.class)
+          .inZone("Crimbo23")
           .withToken("Crimbuccaneer piece of 12")
           .withTokenTest("no Crimbuccaneer pieces of 12")
           .withTokenPattern(TOKEN_PATTERN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateCafeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateCafeRequest.java
@@ -17,6 +17,7 @@ public class Crimbo23PirateCafeRequest extends CoinMasterRequest {
 
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "crimbo23_pirate_cafe", Crimbo23PirateCafeRequest.class)
+          .inZone("Crimbo23")
           .withToken("Crimbuccaneer piece of 12")
           .withTokenTest("no Crimbuccaneer pieces of 12")
           .withTokenPattern(TOKEN_PATTERN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateFactoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateFactoryRequest.java
@@ -17,6 +17,7 @@ public class Crimbo23PirateFactoryRequest extends CoinMasterRequest {
 
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "crimbo23_pirate_factory", Crimbo23PirateFactoryRequest.class)
+          .inZone("Crimbo23")
           .withToken("Crimbuccaneer piece of 12")
           .withTokenTest("no Crimbuccaneer pieces of 12")
           .withTokenPattern(TOKEN_PATTERN)

--- a/src/net/sourceforge/kolmafia/swingui/CoinmastersFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/CoinmastersFrame.java
@@ -611,21 +611,6 @@ public class CoinmastersFrame extends GenericFrame implements ChangeListener {
     panel.add(warbearBoxPanel);
     this.selectorPanel.addPanel(warbearBoxPanel.getPanelSelector(), panel);
 
-    panel = new JPanel(new BorderLayout());
-    crimbo24BarPanel = new Crimbo24BarPanel();
-    panel.add(crimbo24BarPanel);
-    this.selectorPanel.addPanel(crimbo24BarPanel.getPanelSelector(), panel);
-
-    panel = new JPanel(new BorderLayout());
-    crimbo24CafePanel = new Crimbo24CafePanel();
-    panel.add(crimbo24CafePanel);
-    this.selectorPanel.addPanel(crimbo24CafePanel.getPanelSelector(), panel);
-
-    panel = new JPanel(new BorderLayout());
-    crimbo24FactoryPanel = new Crimbo24FactoryPanel();
-    panel.add(crimbo24FactoryPanel);
-    this.selectorPanel.addPanel(crimbo24FactoryPanel.getPanelSelector(), panel);
-
     // Removed coinmasters
     this.selectorPanel.addSeparator();
     this.selectorPanel.addCategory("Removed");
@@ -714,6 +699,21 @@ public class CoinmastersFrame extends GenericFrame implements ChangeListener {
     crimbo23PirateFactoryPanel = new Crimbo23PirateFactoryPanel();
     panel.add(crimbo23PirateFactoryPanel);
     this.selectorPanel.addPanel(crimbo23PirateFactoryPanel.getPanelSelector(), panel);
+
+    panel = new JPanel(new BorderLayout());
+    crimbo24BarPanel = new Crimbo24BarPanel();
+    panel.add(crimbo24BarPanel);
+    this.selectorPanel.addPanel(crimbo24BarPanel.getPanelSelector(), panel);
+
+    panel = new JPanel(new BorderLayout());
+    crimbo24CafePanel = new Crimbo24CafePanel();
+    panel.add(crimbo24CafePanel);
+    this.selectorPanel.addPanel(crimbo24CafePanel.getPanelSelector(), panel);
+
+    panel = new JPanel(new BorderLayout());
+    crimbo24FactoryPanel = new Crimbo24FactoryPanel();
+    panel.add(crimbo24FactoryPanel);
+    this.selectorPanel.addPanel(crimbo24FactoryPanel.getPanelSelector(), panel);
 
     this.selectorPanel.addChangeListener(this);
     this.selectorPanel.setSelectedIndex(Preferences.getInteger("coinMasterIndex"));

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -2655,6 +2655,12 @@ public class Player {
     return new Cleanups(() -> data.setDisabled(false));
   }
 
+  public static Cleanups withZonelessCoinmaster(CoinmasterData data) {
+    String zone = data.getZone();
+    data.inZone(null).getRootZone();
+    return new Cleanups(() -> data.inZone(zone));
+  }
+
   public static Cleanups withoutCoinmasterBuyItem(CoinmasterData data, AdventureResult item) {
     List<AdventureResult> buyItems = data.getBuyItems();
     if (!buyItems.contains(item)) {

--- a/test/net/sourceforge/kolmafia/request/CoinMasterRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/CoinMasterRequestTest.java
@@ -7,6 +7,7 @@ import static internal.helpers.Player.withHttpClientBuilder;
 import static internal.helpers.Player.withItem;
 import static internal.helpers.Player.withPath;
 import static internal.helpers.Player.withProperty;
+import static internal.helpers.Player.withZonelessCoinmaster;
 import static internal.helpers.Player.withoutCoinmasterBuyItem;
 import static internal.helpers.Player.withoutCoinmasterSellItem;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -98,6 +99,7 @@ public class CoinMasterRequestTest {
               withHttpClientBuilder(builder),
               withPath(Path.STANDARD),
               withDisabledCoinmaster(Crimbo23ElfArmoryRequest.DATA),
+              withZonelessCoinmaster(Crimbo23ElfArmoryRequest.DATA),
               withProperty("crimbo23ArmoryControl", "elf"));
       try (cleanups) {
         client.addResponse(200, html("request/test_armory_elf_visit.html"));
@@ -141,6 +143,7 @@ public class CoinMasterRequestTest {
                   Crimbo23ElfArmoryRequest.DATA, ItemPool.get(ItemPool.KELFLAR_VEST)),
               withoutCoinmasterBuyItem(
                   Crimbo23ElfArmoryRequest.DATA, ItemPool.get(ItemPool.ELF_GUARD_HONOR_PRESENT)),
+              withZonelessCoinmaster(Crimbo23ElfArmoryRequest.DATA),
               withProperty("crimbo23ArmoryControl", "elf"));
       try (cleanups) {
         client.addResponse(200, html("request/test_armory_elf_visit.html"));
@@ -195,6 +198,7 @@ public class CoinMasterRequestTest {
           new Cleanups(
               withHttpClientBuilder(builder),
               withPath(Path.STANDARD),
+              withZonelessCoinmaster(Crimbo23ElfArmoryRequest.DATA),
               withProperty("crimbo23ArmoryControl", "elf"),
               withItem(ItemPool.ELF_GUARD_COMMANDEERING_GLOVES, 14),
               withItem(ItemPool.KELFLAR_VEST, 25),
@@ -231,6 +235,7 @@ public class CoinMasterRequestTest {
           new Cleanups(
               withHttpClientBuilder(builder),
               withPath(Path.STANDARD),
+              withZonelessCoinmaster(Crimbo23ElfArmoryRequest.DATA),
               withProperty("crimbo23ArmoryControl", "elf"),
               withItem(ItemPool.ELF_GUARD_COMMANDEERING_GLOVES, 14),
               withItem(ItemPool.KELFLAR_VEST, 25),
@@ -268,6 +273,7 @@ public class CoinMasterRequestTest {
           new Cleanups(
               withHttpClientBuilder(builder),
               withPath(Path.STANDARD),
+              withZonelessCoinmaster(Crimbo23ElfArmoryRequest.DATA),
               withProperty("crimbo23ArmoryControl", "elf"),
               withItem(ItemPool.ELF_GUARD_HONOR_PRESENT, 0),
               withItem(ItemPool.ELF_ARMY_MACHINE_PARTS, 277));
@@ -314,6 +320,7 @@ public class CoinMasterRequestTest {
           new Cleanups(
               withHttpClientBuilder(builder),
               withPath(Path.STANDARD),
+              withZonelessCoinmaster(Crimbo23ElfArmoryRequest.DATA),
               withProperty("crimbo23ArmoryControl", "elf"),
               withItem(ItemPool.ELF_GUARD_HONOR_PRESENT, 0),
               withItem(ItemPool.ELF_ARMY_MACHINE_PARTS, 277));
@@ -361,6 +368,7 @@ public class CoinMasterRequestTest {
           new Cleanups(
               withHttpClientBuilder(builder),
               withPath(Path.STANDARD),
+              withZonelessCoinmaster(Crimbo23ElfArmoryRequest.DATA),
               withProperty("crimbo23ArmoryControl", "elf"),
               withItem(ItemPool.ELF_GUARD_COMMANDEERING_GLOVES, 14),
               withItem(ItemPool.ELF_ARMY_MACHINE_PARTS, 49));
@@ -408,6 +416,7 @@ public class CoinMasterRequestTest {
           new Cleanups(
               withHttpClientBuilder(builder),
               withPath(Path.STANDARD),
+              withZonelessCoinmaster(Crimbo23ElfArmoryRequest.DATA),
               withProperty("crimbo23ArmoryControl", "elf"),
               withItem(ItemPool.ELF_GUARD_COMMANDEERING_GLOVES, 14),
               withItem(ItemPool.ELF_ARMY_MACHINE_PARTS, 49));


### PR DESCRIPTION
I added inZone for previous Crimbo coinmasters and (mostly) removed their "accessible" functions.
(I retained the ones for Crimbo23, since they were interesting examples - accessibility depending on which war faction controlled them)

I moved the Crimbo24 shops to the Removed section of the CoinmastersFrame.

And, guess what: we had 11 tests that assumed Crimbo23 coinmasters were accessible.
It controlled that using the accessible() function, but the zone now overrides that.