### PR TITLE
Restore kludge when purchasing from Coinmasters using a PurchaseRequest

### DIFF
--- a/src/net/sourceforge/kolmafia/request/coinmaster/CoinMasterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/CoinMasterRequest.java
@@ -78,6 +78,11 @@ public class CoinMasterRequest extends GenericRequest {
 
   public final void setQuantity(final int quantity) {
     this.quantity = quantity;
+    if (this.attachments != null) {
+      // Kludge for the use of CoinmasterPurchaseRequest
+      AdventureResult ar = this.attachments[0];
+      this.attachments[0] = ar.getInstance(quantity);
+    }
   }
 
   public static void visit(final CoinmasterData data) {
@@ -176,11 +181,7 @@ public class CoinMasterRequest extends GenericRequest {
     if (singleton) {
       count = TransferItemRequest.keepSingleton(item, count);
     }
-    String countField = this.data.getCountField();
-    if (countField != null) {
-      this.addFormField(countField, String.valueOf(count));
-    }
-    return count;
+    return this.setCount(count);
   }
 
   public int setCount(int count) {


### PR DESCRIPTION
I removed the so-labeled  kludge when I added ShopRow purchases, but, by golly, it really is necessary when purchasing from a PurchaseRequest.

What if you have a CoinMasterRequest with multiple AdventureResult attachments?
Presumably, that never uses CoinMasterRequest.setQuantity().