### PR TITLE
feat: upgrade to Rhino 1.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ dependencies {
 	implementation 'org.slf4j:slf4j-nop:2.0.16'
 	implementation 'org.fusesource.jansi:jansi:2.4.1'
 	implementation 'com.alibaba.fastjson2:fastjson2:2.0.53'
-	implementation 'org.mozilla:rhino:1.7.15'
+	implementation 'org.mozilla:rhino:1.8.0'
 	implementation 'org.swinglabs:swingx:1.0'
 	implementation 'org.tmatesoft.svnkit:svnkit:1.10.11'
 	implementation 'com.jgoodies:jgoodies-binding:2.13.0'

--- a/test/net/sourceforge/kolmafia/textui/command/JavaScriptCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/JavaScriptCommandTest.java
@@ -120,8 +120,7 @@ public class JavaScriptCommandTest extends AbstractCommandTestBase {
 
     @Test
     public void nullCoalescing() {
-      // Rhino doesn't support `a ?? b` yet.
-      String output = execute("null || true");
+      String output = execute("null ?? true");
 
       assertThat(output, equalTo("""
               Returned: true


### PR DESCRIPTION
Rhino 1.8 was released a few days ago: it has `String.matchAll` and a whole bunch of other modern JavaScript stuff: default parameters, null coalescing, findLast, most of proxy and reflect and promises, generators, symbol keys and many other things most scripters won't use.