### PR TITLE
feat: update codecov to v5

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -65,11 +65,11 @@ jobs:
           report_paths: "**/build/test-results/test/TEST-*.xml"
 
       - name: Publish Coverage Report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: always()
         with:
           env_vars: OS,JAVA
           name: coverage-${{ matrix.os }}-java-${{ matrix.java }}
-          file: ./build/reports/jacoco/test/jacocoTestReport.xml
+          files: ./build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{secrets.CODECOV_TOKEN}}
 


### PR DESCRIPTION
While https://github.com/awalsh128/cache-apt-pkgs-action/pull/140 was causing the pipeline failures, may as well merge this.

Although the codecov bot hasn't posted -- is there something wrong or is it just that there's no Java code changes here?