### PR TITLE
Dedigitizer coinmaster

### DIFF
--- a/src/data/coinmasters.txt
+++ b/src/data/coinmasters.txt
@@ -1300,5 +1300,24 @@ The Dedigitizer	ROW1558	visual packet sniffer	1 (16)
 The Dedigitizer	ROW1577	synthetic coffee	1 (8)	0 (8)
 The Dedigitizer	ROW1578	iDrops	1 (16)	0 (16)
 The Dedigitizer	ROW1567	cybeer	1 (32)	dedigitizer schematic: cybeer
+The Dedigitizer	ROW1566	cyburger	1 (32)	dedigitizer schematic: cyburger
+The Dedigitizer	ROW1568	psilocyber mushroom	1 (32)	dedigitizer schematic: psilocyber mushroom
+The Dedigitizer	ROW1550	brute force hammer	1 (32)	0 (8)	dedigitizer schematic: brute force hammer
+The Dedigitizer	ROW1561	digibritches	1 (32)	0 (16)	dedigitizer schematic: digibritches
+The Dedigitizer	ROW1554	pocket GPU	1 (32)	0 (16)	dedigitizer schematic: pocket GPU
 The Dedigitizer	ROW1563	zero-trust tanktop	1 (32)	0 (32)	dedigitizer schematic: zero-trust tanktop
+The Dedigitizer	ROW1565	familiar-in-the-middle wrapper	1 (64)	0 (16)	dedigitizer schematic: familiar-in-the-middle wrapper
+The Dedigitizer	ROW1562	cryptocloak	1 (64)	0 (32)	dedigitizer schematic: cryptocloak
+The Dedigitizer	ROW1552	cybervisor	1 (64)	0 (32)	dedigitizer schematic: cybervisor
+The Dedigitizer	ROW1555	malware injector	1 (64)	0 (32)	dedigitizer schematic: malware injector
+The Dedigitizer	ROW1564	trojan horseshoe	1 (128)	0 (32)	dedigitizer schematic: trojan horseshoe
+# The Dedigitizer	ROW1579	3d printed server room key	1 (X)	0 (X)	dedigitizer schematic: 3d printed server room key
+The Dedigitizer	ROW1553	retro floppy disk	1 (128)	0 (64)	dedigitizer schematic: retro floppy disk
 The Dedigitizer	ROW1574	geofencing rapier	1 (256)	dedigitizer schematic: geofencing rapier
+The Dedigitizer	ROW1575	geofencing shield	1 (256)	dedigitizer schematic: geofencing shield
+The Dedigitizer	ROW1573	hashing vise	1 (256)	dedigitizer schematic: hashing vise
+The Dedigitizer	ROW1572	insignificant bit	1 (256)	dedigitizer schematic: insignificant bit
+The Dedigitizer	ROW1570	OVERCLOCK(10) rom chip	1 (256)	0 (64)	dedigitizer schematic: OVERCLOCK(10) rom chip
+The Dedigitizer	ROW1569	SLEEP(5) rom chip	1 (256)	0 (64)	dedigitizer schematic: SLEEP(5) rom chip
+# The Dedigitizer	ROW1571	STATS+++ rom chip	1 (X)	0 (X)	dedigitizer schematic: STATS+++ rom chip
+The Dedigitizer	ROW1576	virtual cybertattoo	1 (512)	0 (128)	dedigitizer schematic: virtual cybertattoo

--- a/src/net/sourceforge/kolmafia/CoinmasterRegistry.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterRegistry.java
@@ -46,6 +46,7 @@ import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo23PirateFactoryReq
 import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo24BarRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo24CafeRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo24FactoryRequest;
+import net.sourceforge.kolmafia.request.coinmaster.shop.DedigitizerRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.DinostaurRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.DinseyCompanyStoreRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.DiscoGiftCoRequest;
@@ -132,6 +133,7 @@ public abstract class CoinmasterRegistry {
         Crimbo24CafeRequest.DATA,
         Crimbo24FactoryRequest.DATA,
         CrimboCartelRequest.CRIMBO_CARTEL,
+        DedigitizerRequest.DATA,
         DimemasterRequest.HIPPY,
         DinostaurRequest.DINOSTAUR,
         DinseyCompanyStoreRequest.DINSEY_COMPANY_STORE,

--- a/src/net/sourceforge/kolmafia/RequestLogger.java
+++ b/src/net/sourceforge/kolmafia/RequestLogger.java
@@ -54,6 +54,7 @@ import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo23PirateFactoryReq
 import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo24BarRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo24CafeRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo24FactoryRequest;
+import net.sourceforge.kolmafia.request.coinmaster.shop.DedigitizerRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.DinostaurRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.DinseyCompanyStoreRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.DiscoGiftCoRequest;
@@ -1169,6 +1170,12 @@ public class RequestLogger extends NullStream {
 
     if ((isExternal || request instanceof CurseRequest)
         && CurseRequest.registerRequest(urlString)) {
+      RequestLogger.wasLastRequestSimple = false;
+      return;
+    }
+
+    if ((isExternal || request instanceof DedigitizerRequest)
+        && DedigitizerRequest.registerRequest(urlString)) {
       RequestLogger.wasLastRequestSimple = false;
       return;
     }

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3848,6 +3848,8 @@ public class ItemPool {
   public static final int MCHUGELARGE_RIGHT_POLE = 11785;
   public static final int MCHUGELARGE_LEFT_SKI = 11786;
   public static final int MCHUGELARGE_RIGHT_SKI = 11787;
+  public static final int ONE = 11788;
+  public static final int ZERO = 11789;
   public static final int CR_KEYCODE = 11807;
   public static final int SERVER_KEY = 11808;
 

--- a/src/net/sourceforge/kolmafia/request/NPCPurchaseRequest.java
+++ b/src/net/sourceforge/kolmafia/request/NPCPurchaseRequest.java
@@ -55,6 +55,7 @@ import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo23PirateFactoryReq
 import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo24BarRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo24CafeRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo24FactoryRequest;
+import net.sourceforge.kolmafia.request.coinmaster.shop.DedigitizerRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.DinostaurRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.DinseyCompanyStoreRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.DiscoGiftCoRequest;
@@ -877,6 +878,10 @@ public class NPCPurchaseRequest extends PurchaseRequest {
       Crimbo24FactoryRequest.parseResponse(urlString, responseText);
     }
 
+    if (shopId.equals("cyber_dedigitizer")) {
+      DedigitizerRequest.parseResponse(urlString, responseText);
+    }
+
     if (shopId.equals("edunder_shopshop")) {
       EdShopRequest.parseResponse(urlString, responseText);
       return;
@@ -1556,6 +1561,10 @@ public class NPCPurchaseRequest extends PurchaseRequest {
 
       if (shopId.equals("crimbo24_factory")) {
         Crimbo24FactoryRequest.registerRequest(urlString);
+      }
+
+      if (shopId.equals("cyber_dedigitizer")) {
+        DedigitizerRequest.registerRequest(urlString);
       }
 
       if (shopId.equals("edunder_shopshop")) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DedigitizerRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DedigitizerRequest.java
@@ -1,0 +1,66 @@
+package net.sourceforge.kolmafia.request.coinmaster.shop;
+
+import net.sourceforge.kolmafia.AdventureResult;
+import net.sourceforge.kolmafia.CoinmasterData;
+import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.request.GenericRequest;
+import net.sourceforge.kolmafia.request.coinmaster.CoinMasterRequest;
+import net.sourceforge.kolmafia.shop.ShopRow;
+
+public class DedigitizerRequest extends CoinMasterRequest {
+  public static final String master = "The Dedigitizer";
+  public static final AdventureResult SERVER_ROOM_KEY = ItemPool.get(ItemPool.SERVER_KEY, 1);
+
+  public static final CoinmasterData DATA =
+      new CoinmasterData(master, "cyber_dedigitizer", DedigitizerRequest.class)
+          .withNewShopRowFields(master, "cyber_dedigitizer")
+          .withNeedsPasswordHash(true);
+
+  public DedigitizerRequest() {
+    super(DATA);
+  }
+
+  public DedigitizerRequest(final ShopRow row, final int count) {
+    super(DATA, row, count);
+  }
+
+  @Override
+  public void processResults() {
+    parseResponse(this.getURLString(), this.responseText);
+  }
+
+  public static void parseResponse(final String location, final String responseText) {
+    if (!location.contains("whichshop=" + DATA.getNickname())) {
+      return;
+    }
+
+    CoinmasterData data = DATA;
+
+    String action = GenericRequest.getAction(location);
+    if (action != null) {
+      CoinMasterRequest.parseResponse(data, location, responseText);
+      return;
+    }
+
+    // Parse current coin balances
+    CoinMasterRequest.parseBalance(data, responseText);
+  }
+
+  public static String accessible() {
+    int serverRoomKey = SERVER_ROOM_KEY.getCount(KoLConstants.inventory);
+    if (serverRoomKey == 0) {
+      return "You don't have a server room key in inventory.";
+    }
+    return null;
+  }
+
+  public static final boolean registerRequest(final String urlString) {
+    if (!urlString.startsWith("shop.php")
+        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+      return false;
+    }
+
+    return CoinMasterRequest.registerRequest(DATA, urlString, true);
+  }
+}

--- a/src/net/sourceforge/kolmafia/swingui/CoinmastersFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/CoinmastersFrame.java
@@ -78,6 +78,7 @@ import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo23PirateFactoryReq
 import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo24BarRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo24CafeRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo24FactoryRequest;
+import net.sourceforge.kolmafia.request.coinmaster.shop.DedigitizerRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.DinostaurRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.DinseyCompanyStoreRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.DiscoGiftCoRequest;
@@ -177,6 +178,7 @@ public class CoinmastersFrame extends GenericFrame implements ChangeListener {
   private CoinmasterPanel crimbo24CafePanel = null;
   private CoinmasterPanel crimbo24FactoryPanel = null;
   private CoinmasterPanel crimboCartelPanel = null;
+  private CoinmasterPanel dedigitizerPanel = null;
   private CoinmasterPanel dimemasterPanel = null;
   private CoinmasterPanel dinostaurPanel = null;
   private CoinmasterPanel dinseyCompanyStorePanel = null;
@@ -366,6 +368,11 @@ public class CoinmastersFrame extends GenericFrame implements ChangeListener {
     bigBrotherPanel = new BigBrotherPanel();
     panel.add(bigBrotherPanel);
     this.selectorPanel.addPanel(bigBrotherPanel.getPanelSelector(), panel);
+
+    panel = new JPanel(new BorderLayout());
+    dedigitizerPanel = new DedigitizerPanel();
+    panel.add(dedigitizerPanel);
+    this.selectorPanel.addPanel(dedigitizerPanel.getPanelSelector(), panel);
 
     panel = new JPanel(new BorderLayout());
     terrifiedEagleInnPanel = new TerrifiedEagleInnPanel();
@@ -1025,6 +1032,37 @@ public class CoinmastersFrame extends GenericFrame implements ChangeListener {
   private class BigBrotherPanel extends CoinmasterPanel {
     public BigBrotherPanel() {
       super(BigBrotherRequest.BIG_BROTHER);
+    }
+  }
+
+  private class DedigitizerPanel extends CoinmasterPanel {
+    private static AdventureResult ONE = ItemPool.get(ItemPool.ONE);
+    private static AdventureResult ZERO = ItemPool.get(ItemPool.ZERO);
+
+    public DedigitizerPanel() {
+      super(DedigitizerRequest.DATA);
+    }
+
+    @Override
+    public void setTitle(final StringBuffer buffer) {
+      this.standardTitle(buffer);
+
+      // Only show 0's and 1's. Everything also requires a schematic,
+      // but there are 27 of them and the title will be cluttered. Rows
+      // will be greyed out if you don't have the required schematic
+
+      int count1 = InventoryManager.getCount(ONE);
+      buffer.append(" (");
+      buffer.append(count1);
+      buffer.append(" ");
+      buffer.append(ONE.getPluralName(count1));
+      buffer.append(")");
+      int count0 = InventoryManager.getCount(ZERO);
+      buffer.append(" (");
+      buffer.append(count0);
+      buffer.append(" ");
+      buffer.append(ZERO.getPluralName(count0));
+      buffer.append(")");
     }
   }
 


### PR DESCRIPTION
I got the recipes from the Wiki and the ROWs from "/buy xxx".
The Wiki does not have the recipes for ```3d printed server room key``` or ```STATS+++ rom chip```, but I got the ROWs.

We'll need to add those two items in a followup PR.

I put the Dedigitizer in the "Aftercore" section of the CoinmastersFrame.
Perhaps it should go in the IOTM section.

Also, we'll need to fix "accessible" once we figure out how to handle the 3d printed server room key.
It's a day pass, so it will require the sort of "access granted today" code that other day passes have.