### PR TITLE
feat: add function `is_banished(phylum)`

### DIFF
--- a/src/net/sourceforge/kolmafia/session/BanishManager.java
+++ b/src/net/sourceforge/kolmafia/session/BanishManager.java
@@ -17,6 +17,7 @@ import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.combat.MonsterStatusTracker;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
+import net.sourceforge.kolmafia.persistence.MonsterDatabase.Phylum;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.StandardRequest;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
@@ -503,9 +504,13 @@ public class BanishManager {
     if (data.isNoBanish()) {
       return false;
     }
+    return isBanishedPhylum(data.getPhylum());
+  }
+
+  public static boolean isBanishedPhylum(final Phylum phylum) {
     return banishedPhyla.stream()
         .filter(m -> m.banisher().isEffective())
-        .anyMatch(m -> m.banished().equalsIgnoreCase(data.getPhylum().toString()));
+        .anyMatch(m -> m.banished().equalsIgnoreCase(phylum.toString()));
   }
 
   public static Banisher[] banishedBy(final MonsterData data) {

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -2880,6 +2880,9 @@ public abstract class RuntimeLibrary {
     params = List.of(namedParam("monster", DataTypes.MONSTER_TYPE));
     functions.add(new LibraryFunction("is_banished", DataTypes.BOOLEAN_TYPE, params));
 
+    params = List.of(namedParam("phylum", DataTypes.PHYLUM_TYPE));
+    functions.add(new LibraryFunction("is_banished", DataTypes.BOOLEAN_TYPE, params));
+
     params = List.of(namedParam("monster", DataTypes.MONSTER_TYPE));
     functions.add(
         new LibraryFunction("banished_by", new AggregateType(DataTypes.STRING_TYPE, 0), params));
@@ -9808,11 +9811,21 @@ public abstract class RuntimeLibrary {
   }
 
   public static Value is_banished(ScriptRuntime controller, final Value arg) {
-    MonsterData monster = (MonsterData) arg.rawValue();
-    if (monster == null) {
+    if (arg.getType().equals(TypeSpec.MONSTER)) {
+      MonsterData monster = (MonsterData) arg.rawValue();
+      if (monster == null) {
+        return DataTypes.FALSE_VALUE;
+      }
+      return DataTypes.makeBooleanValue(BanishManager.isBanished(monster.getName()));
+    } else if (arg.getType().equals(TypeSpec.PHYLUM)) {
+      Phylum phylum = (Phylum) arg.rawValue();
+      if (phylum == null) {
+        return DataTypes.FALSE_VALUE;
+      }
+      return DataTypes.makeBooleanValue(BanishManager.isBanishedPhylum(phylum));
+    } else {
       return DataTypes.FALSE_VALUE;
     }
-    return DataTypes.makeBooleanValue(BanishManager.isBanished(monster.getName()));
   }
 
   public static Value banished_by(ScriptRuntime controller, final Value arg) {

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -1850,6 +1850,8 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
       assertThat(execute("is_banished($phylum[undead])").trim(), is("Returned: true"));
       assertThat(execute("is_banished($monster[zombie process])").trim(), is("Returned: false"));
       assertThat(execute("is_banished($phylum[construct])").trim(), is("Returned: false"));
+      assertThat(execute("is_banished($monster[none])").trim(), is("Returned: false"));
+      assertThat(execute("is_banished($phylum[none])").trim(), is("Returned: false"));
     }
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -8,7 +8,9 @@ import static internal.helpers.Networking.html;
 import static internal.helpers.Networking.json;
 import static internal.helpers.Player.withAdventuresLeft;
 import static internal.helpers.Player.withAdventuresSpent;
+import static internal.helpers.Player.withBanishedPhyla;
 import static internal.helpers.Player.withClass;
+import static internal.helpers.Player.withCurrentRun;
 import static internal.helpers.Player.withDay;
 import static internal.helpers.Player.withEffect;
 import static internal.helpers.Player.withEquippableItem;
@@ -1835,6 +1837,19 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
       assertThat(execute("free_cooks()").trim(), is("Returned: 1"));
       assertThat(execute("free_mixes()").trim(), is("Returned: 2"));
       assertThat(execute("free_smiths()").trim(), is("Returned: 9"));
+    }
+  }
+
+  @Test
+  void determinesBanishes() {
+    var cleanups =
+        new Cleanups(withCurrentRun(128), withBanishedPhyla("undead:Patriotic Screech:119"));
+
+    try (cleanups) {
+      assertThat(execute("is_banished($monster[ghuol])").trim(), is("Returned: true"));
+      assertThat(execute("is_banished($phylum[undead])").trim(), is("Returned: true"));
+      assertThat(execute("is_banished($monster[zombie process])").trim(), is("Returned: false"));
+      assertThat(execute("is_banished($phylum[construct])").trim(), is("Returned: false"));
     }
   }
 }


### PR DESCRIPTION
It's helpful to know whether a phylum is banished without parsing the preference.