### PR TITLE
feat: add Jsoup, translate FightRequest to Jsoup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,7 @@ dependencies {
 	}
 
 	implementation 'net.sourceforge.htmlcleaner:htmlcleaner:2.29'
+	implementation 'org.jsoup:jsoup:1.18.3'
 	implementation('org.eclipse.lsp4j:org.eclipse.lsp4j:0.23.1') {
 		exclude group: 'org.eclipse.xtend', module: 'org.eclipse.xtend.lib'
 	}

--- a/src/net/sourceforge/kolmafia/request/FamTeamRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FamTeamRequest.java
@@ -17,9 +17,8 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.ResultProcessor;
 import net.sourceforge.kolmafia.utilities.HTMLParserUtils;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
-import org.htmlcleaner.CleanerProperties;
-import org.htmlcleaner.HtmlCleaner;
-import org.htmlcleaner.TagNode;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
 
 public class FamTeamRequest extends GenericRequest {
   private static final Pattern ACTIVE_PATTERN =
@@ -251,17 +250,9 @@ public class FamTeamRequest extends GenericRequest {
     return true;
   }
 
-  // Make an HTML cleaner
-  private static final HtmlCleaner cleaner = HTMLParserUtils.configureDefaultParser();
-
-  static {
-    CleanerProperties props = cleaner.getProperties();
-    // prune things, perhaps
-  }
-
-  private static TagNode cleanPokeTeamHTML(final String text) {
+  private static Element cleanPokeTeamHTML(final String text) {
     // Clean the HTML on this response page
-    return cleaner.clean(text);
+    return Jsoup.parse(text);
   }
 
   /*
@@ -303,7 +294,7 @@ public class FamTeamRequest extends GenericRequest {
   */
 
   private static void parsePokeTeamData(final String famtable, boolean logit) {
-    TagNode node = FamTeamRequest.cleanPokeTeamHTML(famtable);
+    Element node = FamTeamRequest.cleanPokeTeamHTML(famtable);
     if (node == null) {
       return;
     }

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -5765,9 +5764,8 @@ public class FightRequest extends GenericRequest {
     // <center><b>a fleet woodsman's Team:</b>
 
     for (Element bnode : node.children().select("b")) {
-      // something is very weird with this cleaning
       var parent = bnode.parent();
-      if (getContentNodeText(parent).contains(" Team:")) {
+      if (bnode.wholeText().contains(" Team:")) {
         return parent;
       }
     }
@@ -5790,24 +5788,11 @@ public class FightRequest extends GenericRequest {
     // allow regular node processing to glean whatever it wants
     // from what remains.
 
-    Iterator<? extends Node> it = node.childNodes().iterator();
     boolean done = false;
     int pokindex = 0;
-    while (it.hasNext() && !done) {
-      Node child = it.next();
-      if (child instanceof Element tnode) {
-        String name = tnode.tagName();
-
-        // Each familiar is in a table
-        if (name.equals("table")) {
-          FightRequest.processPokefam(++pokindex, tnode, status);
-        } else if (name.equals("b")) {
-          if (tnode.wholeText().equals("Your Team")) {
-            done = true;
-          }
-        }
-      }
-      it.remove();
+    // Each familiar is in a table
+    for (var child : node.select("table")) {
+      FightRequest.processPokefam(++pokindex, child, status);
     }
 
     HTMLParserUtils.logHTML(node);

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -123,11 +123,12 @@ import net.sourceforge.kolmafia.webui.DiscoCombatHelper;
 import net.sourceforge.kolmafia.webui.HobopolisDecorator;
 import net.sourceforge.kolmafia.webui.NemesisDecorator;
 import net.sourceforge.kolmafia.webui.VillainLairDecorator;
-import org.htmlcleaner.BaseToken;
-import org.htmlcleaner.CommentNode;
-import org.htmlcleaner.ContentNode;
-import org.htmlcleaner.HtmlCleaner;
-import org.htmlcleaner.TagNode;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Comment;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+import org.jsoup.select.Elements;
 
 @SuppressWarnings("incomplete-switch")
 public class FightRequest extends GenericRequest {
@@ -717,9 +718,6 @@ public class FightRequest extends GenericRequest {
   static {
     FightRequest.COMBAT_START.setTimeZone(TimeZone.getTimeZone("GMT"));
   }
-
-  // Make an HTML cleaner
-  private static final HtmlCleaner cleaner = HTMLParserUtils.configureDefaultParser();
 
   /**
    * Constructs a new <code>FightRequest</code>. User settings will be used to determine the kind of
@@ -5056,9 +5054,9 @@ public class FightRequest extends GenericRequest {
   }
 
   private static boolean extractVerse(
-      final TagNode node, final StringBuffer buffer, final String tag) {
+      final Element node, final StringBuffer buffer, final String tag) {
     boolean hasTag = false;
-    String nodeName = node.getName();
+    String nodeName = node.tagName();
 
     if (nodeName.equals("br")) {
       buffer.append(" / ");
@@ -5068,10 +5066,10 @@ public class FightRequest extends GenericRequest {
       hasTag = true;
     }
 
-    for (BaseToken child : node.getAllChildren()) {
-      if (child instanceof ContentNode cn) {
-        buffer.append(cn.getContent());
-      } else if (child instanceof TagNode tn) {
+    for (Node child : node.childNodes()) {
+      if (child instanceof TextNode cn) {
+        buffer.append(cn.getWholeText());
+      } else if (child instanceof Element tn) {
         hasTag |= FightRequest.extractVerse(tn, buffer, tag);
       }
     }
@@ -5080,7 +5078,7 @@ public class FightRequest extends GenericRequest {
   }
 
   private static void processHaikuResult(
-      final TagNode node, final TagNode inode, final String image, final TagStatus status) {
+      final Element node, final Element inode, final String image, final TagStatus status) {
     if (image.equals(status.familiar)
         || image.equals(status.enthroned)
         || image.equals(status.bjorned)) {
@@ -5230,7 +5228,7 @@ public class FightRequest extends GenericRequest {
   }
 
   private static void processMachineElfResult(
-      final TagNode node, final TagNode inode, final String image, final TagStatus status) {
+      final Element node, final Element inode, final String image, final TagStatus status) {
     if (image.equals(status.familiar)
         || image.equals(status.enthroned)
         || image.equals(status.bjorned)) {
@@ -5307,7 +5305,7 @@ public class FightRequest extends GenericRequest {
     }
   }
 
-  private static int parseVerseDamage(final TagNode inode) {
+  private static int parseVerseDamage(final Element inode) {
     if (inode == null) {
       return 0;
     }
@@ -5318,8 +5316,8 @@ public class FightRequest extends GenericRequest {
     }
 
     // Look for Damage: title in the image
-    String title = inode.getAttributeByName("title");
-    if (title == null || !title.startsWith("Damage: ")) {
+    String title = inode.attr("title");
+    if (!title.startsWith("Damage: ")) {
       return 0;
     }
 
@@ -5333,7 +5331,7 @@ public class FightRequest extends GenericRequest {
     return damage;
   }
 
-  private static boolean foundVerseDamage(final TagNode inode, final TagStatus status) {
+  private static boolean foundVerseDamage(final Element inode, final TagStatus status) {
     int damage = parseVerseDamage(inode);
     if (damage == 0) {
       return false;
@@ -5346,7 +5344,7 @@ public class FightRequest extends GenericRequest {
   }
 
   private static void processAnapestResult(
-      final TagNode node, final TagNode inode, final String image, final TagStatus status) {
+      final Element node, final Element inode, final String image, final TagStatus status) {
     if (image.equals(status.familiar)
         || image.equals(status.enthroned)
         || image.equals(status.bjorned)) {
@@ -5716,7 +5714,7 @@ public class FightRequest extends GenericRequest {
   }
 
   private static void processNormalResults(final String text, final Matcher macroMatcher) {
-    TagNode fight =
+    Element fight =
         FightRequest.pokefam ? parseFamBattleHTML(text, true) : parseFightHTML(text, true);
     if (fight == null) {
       // Do normal result processing and hope for the best.
@@ -5744,15 +5742,15 @@ public class FightRequest extends GenericRequest {
   }
 
   public static final void parseFamBattleHTML(final String text) {
-    TagNode node = FightRequest.parseFamBattleHTML(text, false);
+    Element node = FightRequest.parseFamBattleHTML(text, false);
     HTMLParserUtils.logHTML(node);
     FightRequest.processFamBattle(node, new TagStatus());
     HTMLParserUtils.logHTML(node);
   }
 
-  private static TagNode parseFamBattleHTML(String text, boolean logIt) {
+  private static Element parseFamBattleHTML(String text, boolean logIt) {
     // Clean the HTML on the Fight page
-    TagNode node = FightRequest.cleanFightHTML(text);
+    Element node = FightRequest.cleanFightHTML(text);
     if (node == null) {
       if (logIt) {
         RequestLogger.printLine("HTML cleaning failed.");
@@ -5766,21 +5764,18 @@ public class FightRequest extends GenericRequest {
     //
     // <center><b>a fleet woodsman's Team:</b>
 
-    for (Object bnode : node.getElementListByName("b", true)) {
-      // Should be unnecessary. We need a more modern version of this package
-      if (bnode instanceof TagNode b) {
-        // something is very weird with this cleaning
-        var parent = b.getParent();
-        if (getContentNodeText(parent).contains(" Team:")) {
-          return parent;
-        }
+    for (Element bnode : node.children().select("b")) {
+      // something is very weird with this cleaning
+      var parent = bnode.parent();
+      if (getContentNodeText(parent).contains(" Team:")) {
+        return parent;
       }
     }
 
     return null;
   }
 
-  public static final void processFamBattle(final TagNode node, final TagStatus status) {
+  public static final void processFamBattle(final Element node, final TagStatus status) {
     // The node is a "center" node with the following children:
     //
     // <b>XXX's Team:</b>
@@ -5795,19 +5790,19 @@ public class FightRequest extends GenericRequest {
     // allow regular node processing to glean whatever it wants
     // from what remains.
 
-    Iterator<? extends BaseToken> it = node.getAllChildren().iterator();
+    Iterator<? extends Node> it = node.childNodes().iterator();
     boolean done = false;
     int pokindex = 0;
     while (it.hasNext() && !done) {
-      BaseToken child = it.next();
-      if (child instanceof TagNode tnode) {
-        String name = tnode.getName();
+      Node child = it.next();
+      if (child instanceof Element tnode) {
+        String name = tnode.tagName();
 
         // Each familiar is in a table
         if (name.equals("table")) {
           FightRequest.processPokefam(++pokindex, tnode, status);
         } else if (name.equals("b")) {
-          if (tnode.getText().toString().equals("Your Team")) {
+          if (tnode.wholeText().equals("Your Team")) {
             done = true;
           }
         }
@@ -5890,18 +5885,15 @@ public class FightRequest extends GenericRequest {
              &nbsp;
   */
 
-  public static final String imgToString(final TagNode node) {
+  public static final String imgToString(final Element node) {
     if (node == null) {
       return "";
     }
 
-    if (!node.getName().equals("img")) {
+    if (!node.tagName().equals("img")) {
       return "";
     }
-    String src = node.getAttributeByName("src");
-    if (src == null) {
-      return "";
-    }
+    String src = node.attr("src");
     int index = src.lastIndexOf("/");
     if (index == -1) {
       return src;
@@ -5912,7 +5904,7 @@ public class FightRequest extends GenericRequest {
   private static final int ULTIMATE = "ULTIMATE: ".length();
 
   public static final void processPokefam(
-      final int index, final TagNode node, final TagStatus status) {
+      final int index, final Element node, final TagStatus status) {
     // For now only look at the familiar at the very beginning of the fight.
     //
     // Certainly, don't call FamiliarDatabase to check the attributes of a familiar
@@ -5938,9 +5930,9 @@ public class FightRequest extends GenericRequest {
     FightRequest.parsePokefam(node, myteam, !myteam);
   }
 
-  public static final void parsePokefam(final TagNode node, boolean myFamiliar, boolean moveSpans) {
+  public static final void parsePokefam(final Element node, boolean myFamiliar, boolean moveSpans) {
     // Get all the rows from the table
-    TagNode[] rows = node.getElementsByName("tr", true);
+    Elements rows = node.children().select("tr");
 
     // Row 1: familiar image, familiar name, power, attribute, hp
     String image = "";
@@ -5950,29 +5942,29 @@ public class FightRequest extends GenericRequest {
     String attribute = "None";
     int hp = 0;
 
-    TagNode[] row1Tags = rows[0].getChildTags();
+    Elements row1Tags = rows.get(0).children();
     int td = 1;
-    for (TagNode tdnode : row1Tags) {
+    for (Element tdnode : row1Tags) {
       switch (td++) {
         case 1 -> {
           // Familiar Image:
-          TagNode inode = tdnode.findElementByName("img", true);
+          Element inode = tdnode.children().select("img").first();
           image = imgToString(inode);
         }
         case 2 -> {
           // Familiar name
-          name = tdnode.getText().toString();
+          name = tdnode.wholeText();
         }
         case 3 -> {
           // Familiar power: one image (blacksword.gif) per
-          power = tdnode.getElementsByName("img", true).length;
+          power = tdnode.children().select("img").size();
         }
         case 4 -> {
           // Familiar attribute: distinct images, can have two
-          TagNode[] inodes = tdnode.getElementsByName("img", true);
-          for (TagNode inode : inodes) {
-            String title = inode.getAttributeByName("title");
-            if (title != null) {
+          Elements inodes = tdnode.children().select("img");
+          for (Element inode : inodes) {
+            String title = inode.attr("title");
+            if (!title.isEmpty()) {
               int colon = title.indexOf(":");
               String aname = title.substring(0, colon);
               attributes.add(aname);
@@ -5981,7 +5973,7 @@ public class FightRequest extends GenericRequest {
         }
         case 5 -> {
           // Familiar HP: one image (blackheart.gif) per
-          hp = tdnode.getElementsByName("img", true).length;
+          hp = tdnode.children().select("img").size();
         }
       }
     }
@@ -5990,9 +5982,9 @@ public class FightRequest extends GenericRequest {
     int level = 0;
     String race = "";
 
-    TagNode[] row2Tags = rows[1].getChildTags();
-    if (row2Tags.length > 0) {
-      String famtype = row2Tags[0].getText().toString();
+    Elements row2Tags = rows.get(1).children();
+    if (row2Tags.size() > 0) {
+      String famtype = row2Tags.get(0).wholeText();
       level = StringUtilities.parseInt(famtype.substring(4, 5));
       race = famtype.substring(6);
     }
@@ -6018,29 +6010,29 @@ public class FightRequest extends GenericRequest {
     String[] actions = new String[3];
     String[] descriptions = new String[3];
 
-    TagNode[] row4Tags = rows[3].getChildTags();
-    if (row4Tags.length > 1) {
-      TagNode tdnode = row4Tags[1];
+    Elements row4Tags = rows.get(3).children();
+    if (row4Tags.size() > 1) {
+      Element tdnode = row4Tags.get(1);
       if (moveSpans) {
         // Enemy team
         // <span title="Deal 5 damage to the frontmost enemy.">
         //  [ULTIMATE: Deluxe Impale]
         // also used on famteam.php for your own team
-        TagNode[] spans = tdnode.getElementsByName("span", false);
-        for (int i = 0; i < spans.length; ++i) {
+        Elements spans = tdnode.select(">span");
+        for (int i = 0; i < spans.size(); ++i) {
           // <span style="background-color: lightblue;">
           //   <b>
           //     <span title="Heal the frontmost ally by [power]. (This is what the enemy team will
           // do next round.)">
           //        [Hug]
 
-          TagNode span = spans[i];
-          if (span.getAttributeByName("title") == null) {
+          Element span = spans.get(i);
+          if (span.attr("title").isEmpty()) {
             // Next action is nested
             // *** remember that this is the designated enemy move?
-            span = span.findElementByName("span", true);
+            span = span.children().select("span").first();
           }
-          String str = span.getText().toString();
+          String str = span.wholeText();
           if (str.startsWith("[")) {
             int start = 1 + (i == 2 ? ULTIMATE : 0);
             moves[i] = str.substring(start, str.length() - 1);
@@ -6051,20 +6043,20 @@ public class FightRequest extends GenericRequest {
         // Your team
         // <input title="Knock the frontmost enemy to the back." class="button skb" type="submit"
         // value="Tackle" name="famaction[tackle-7]">
-        TagNode[] inputs = rows[3].getElementsByName("input", true);
+        Elements inputs = rows.get(3).children().select("input");
         int move = 0;
-        for (TagNode input : inputs) {
-          String type = input.getAttributeByName("class");
-          if (type == null || !type.startsWith("button")) {
+        for (Element input : inputs) {
+          String type = input.attr("class");
+          if (!type.startsWith("button")) {
             continue;
           }
-          String str = input.getAttributeByName("value");
-          String action = input.getAttributeByName("name");
-          String description = input.getAttributeByName("title");
+          String str = input.attr("value");
+          String action = input.attr("name");
+          String description = input.attr("title");
           if (move == 2) {
             str = str.substring(ULTIMATE);
           }
-          if (action != null) {
+          if (!action.isEmpty()) {
             // "famaction[tackle-7]"
             int lb = action.indexOf("[");
             int dash = action.indexOf("-");
@@ -6106,9 +6098,9 @@ public class FightRequest extends GenericRequest {
     HTMLParserUtils.logHTML(parseFightHTML(text, false));
   }
 
-  private static TagNode parseFightHTML(String text, boolean logIt) {
+  private static Element parseFightHTML(String text, boolean logIt) {
     // Clean the HTML on the Fight page
-    TagNode node = FightRequest.cleanFightHTML(text);
+    Element node = FightRequest.cleanFightHTML(text);
     if (node == null) {
       if (logIt) {
         RequestLogger.printLine("HTML cleaning failed.");
@@ -6117,7 +6109,7 @@ public class FightRequest extends GenericRequest {
     }
 
     // Find the monster tag
-    TagNode mon = findMonsterTag(node, logIt);
+    Element mon = findMonsterTag(node, logIt);
     if (mon != null) {
       return findFightNode(mon, logIt);
     }
@@ -6130,9 +6122,9 @@ public class FightRequest extends GenericRequest {
     // We (probably) want the second <center> tag; the first one
     // holds the whole combat table
 
-    TagNode[] nodes = node.getElementsByName("center", true);
-    if (nodes != null && nodes.length >= 2) {
-      return nodes[1].getParent();
+    Elements nodes = node.children().select("center");
+    if (nodes.size() >= 2) {
+      return nodes.get(1).parent();
     }
 
     if (logIt) {
@@ -6142,19 +6134,19 @@ public class FightRequest extends GenericRequest {
     return null;
   }
 
-  private static TagNode cleanFightHTML(final String text) {
+  private static Element cleanFightHTML(final String text) {
     // Clean the HTML on this fight response page
-    return cleaner.clean(text);
+    return Jsoup.parse(text);
   }
 
-  private static TagNode findMonsterTag(final TagNode node, final boolean logIt) {
+  private static Element findMonsterTag(final Element node, final boolean logIt) {
     // Look first for 'monpic' image.
     // All haiku monsters and most normal monsters have that.
-    TagNode mon = node.findElementByAttValue("id", "monpic", true, false);
+    Element mon = node.selectFirst("#monpic");
 
     // If that fails, look for 'monname' span.
     if (mon == null) {
-      mon = node.findElementByAttValue("id", "monname", true, false);
+      mon = node.selectFirst("#monname");
     }
 
     if (mon == null && logIt) {
@@ -6164,17 +6156,17 @@ public class FightRequest extends GenericRequest {
     return mon;
   }
 
-  private static TagNode findFightNode(final TagNode mon, final boolean logIt) {
+  private static Element findFightNode(final Element mon, final boolean logIt) {
     // Walk up the tree and find <center>
     //
     // The parent of that node has everything interesting about the
     // fight.
-    TagNode fight = mon;
+    Element fight = mon;
     while (fight != null) {
-      fight = fight.getParent();
-      if (fight != null && fight.getName().equals("center")) {
+      fight = fight.parent();
+      if (fight != null && fight.tagName().equals("center")) {
         // One more level
-        return fight.getParent();
+        return fight.parent();
       }
     }
 
@@ -6185,13 +6177,13 @@ public class FightRequest extends GenericRequest {
     return null;
   }
 
-  // Utility to reproduce the behavior of TagNode.getText() from the
+  // Utility to reproduce the behavior of Element.getText() from the
   // earlier version we upgraded from.
-  private static String getContentNodeText(TagNode node) {
+  private static String getContentNodeText(Element node) {
     StringBuilder text = new StringBuilder();
-    for (Object item : node.getAllChildren()) {
-      if (item instanceof ContentNode cn) {
-        text.append(cn.getContent());
+    for (Node item : node.childNodes()) {
+      if (item instanceof TextNode cn) {
+        text.append(cn.getWholeText());
       }
     }
     return text.toString();
@@ -6254,8 +6246,8 @@ public class FightRequest extends GenericRequest {
     }
   }
 
-  private static void processNode(final TagNode node, final TagStatus status) {
-    String name = node.getName();
+  private static void processNode(final Element node, final TagStatus status) {
+    String name = node.tagName();
     // StringBuffer action = status.action;
 
     // Skip html links
@@ -6271,7 +6263,7 @@ public class FightRequest extends GenericRequest {
 
     /// node-specific processing
     if (name.equals("script")) {
-      Matcher m = CLEESH_PATTERN.matcher(node.getText());
+      Matcher m = CLEESH_PATTERN.matcher(node.wholeText());
       if (!m.find()) {
         return;
       }
@@ -6291,40 +6283,40 @@ public class FightRequest extends GenericRequest {
     }
 
     if (name.equals("table")) {
-      String id = node.getAttributeByName("id");
-      if (id != null && id.equals("monpic")) {
+      String id = node.attr("id");
+      if (id.equals("monpic")) {
         // Don't process the monster picture
         return;
       }
 
       // Items have "rel" strings.
-      String cl = node.getAttributeByName("class");
-      String rel = node.getAttributeByName("rel");
-      if (cl != null && cl.equals("item") && rel != null) {
+      String cl = node.attr("class");
+      String rel = node.attr("rel");
+      if (cl.equals("item") && !rel.isEmpty()) {
         AdventureResult result = ItemDatabase.itemFromRelString(rel);
         ResultProcessor.processItem(true, "You acquire an item:", result, null);
-        if (node.getText().toString().startsWith("Item unequipped")) {
+        if (node.wholeText().startsWith("Item unequipped")) {
           EquipmentManager.discardEquipment(result);
         }
         return;
       }
 
       if (status.famaction) {
-        TagNode inode = node.findElementByName("img", true);
+        Element inode = node.children().select("img").first();
         FightRequest.processFamiliarAction(node, inode, status);
         return;
       }
 
-      TagNode[] tables = node.getElementsByName("table", true);
-      for (TagNode table : tables) {
-        table.getParent().removeChild(table);
+      Elements tables = node.children().select("table");
+      for (Element table : tables) {
+        table.remove();
       }
 
       if (FightRequest.processTable(node, status)) {
         FightRequest.processChildren(node, status);
       }
 
-      for (TagNode table : tables) {
+      for (Element table : tables) {
         FightRequest.processNode(table, status);
       }
 
@@ -6516,16 +6508,16 @@ public class FightRequest extends GenericRequest {
     FightRequest.processChildren(node, status);
   }
 
-  private static void processChildren(final TagNode node, final TagStatus status) {
+  private static void processChildren(final Element node, final TagStatus status) {
     StringBuffer action = status.action;
-    for (BaseToken child : node.getAllChildren()) {
-      if (child instanceof CommentNode object) {
+    for (Node child : node.childNodes()) {
+      if (child instanceof Comment object) {
         FightRequest.processComment(object, status);
         continue;
       }
 
-      if (child instanceof ContentNode object) {
-        String str = object.getContent().trim();
+      if (child instanceof TextNode object) {
+        String str = object.getWholeText().trim();
 
         if (str.isEmpty()) {
           continue;
@@ -6581,9 +6573,9 @@ public class FightRequest extends GenericRequest {
         }
 
         if (str.startsWith("You acquire a skill")) {
-          TagNode bnode = node.findElementByName("b", true);
+          Element bnode = node.children().select("b").first();
           if (bnode != null) {
-            String skill = bnode.getText().toString();
+            String skill = bnode.wholeText();
             FightRequest.logSkillAcquisition(skill, status);
             ResponseTextParser.learnSkill(skill);
           }
@@ -6604,33 +6596,33 @@ public class FightRequest extends GenericRequest {
         continue;
       }
 
-      if (child instanceof TagNode object) {
+      if (child instanceof Element object) {
         FightRequest.processNode(object, status);
       }
     }
   }
 
-  private static boolean processTable(TagNode node, TagStatus status) {
+  private static boolean processTable(Element node, TagStatus status) {
     // Tables often appear in fight results to hold images.
-    TagNode inode = node.findElementByName("img", true);
-    String onclick = null;
+    Element inode = node.children().select("img").first();
+    String onclick = "";
 
     if (inode != null) {
-      var src = inode.getAttributeByName("src");
-      String alt = inode.getAttributeByName("alt");
-      if (alt != null && alt.startsWith("Enemy's")) {
+      var src = inode.attr("src");
+      String alt = inode.attr("alt");
+      if (alt.startsWith("Enemy's")) {
         // This is Monster Manuel stuff
         int attack = 0, defense = 0, hp = 0;
-        TagNode[] cells = node.getElementsByName("td", true);
-        for (int i = 0; i < cells.length; i++) {
-          TagNode cell = cells[i];
-          TagNode img = cell.findElementByName("img", false);
+        Elements cells = node.children().select("td");
+        for (int i = 0; i < cells.size(); i++) {
+          Element cell = cells.get(i);
+          Element img = cell.selectFirst(">img");
           if (img == null) continue;
-          String stat = img.getAttributeByName("alt");
-          if (stat == null || !stat.startsWith("Enemy's")) continue;
+          String stat = img.attr("alt");
+          if (!stat.startsWith("Enemy's")) continue;
           i++;
-          cell = cells[i];
-          int value = StringUtilities.parseInt(cell.getText().toString());
+          cell = cells.get(i);
+          int value = StringUtilities.parseInt(cell.wholeText());
           switch (stat) {
             case "Enemy's Attack Power" -> attack = value;
             case "Enemy's Defense" -> defense = value;
@@ -6641,13 +6633,13 @@ public class FightRequest extends GenericRequest {
         return false;
       }
 
-      onclick = inode.getAttributeByName("onclick");
+      onclick = inode.attr("onclick");
     }
 
     if (status.dolphin) {
       status.dolphin = false;
 
-      if (onclick == null) {
+      if (onclick.isEmpty()) {
         return false;
       }
 
@@ -6677,7 +6669,7 @@ public class FightRequest extends GenericRequest {
     }
 
     StringBuffer action = status.action;
-    String str = node.getText().toString();
+    String str = node.wholeText();
 
     if (inode == null) {
       FightRequest.handleRaver(str, status);
@@ -6730,7 +6722,7 @@ public class FightRequest extends GenericRequest {
     }
 
     // Look for items and effects first
-    if (onclick != null) {
+    if (!onclick.isEmpty()) {
       if (onclick.startsWith("descitem") && !str.contains("An item drops:")) {
         Matcher m = INT_PATTERN.matcher(onclick);
         if (!m.find()) {
@@ -6756,9 +6748,9 @@ public class FightRequest extends GenericRequest {
 
       if (onclick.contains("desc_skill.php")) {
         if (str.startsWith("You acquire a skill")) {
-          TagNode bnode = node.findElementByName("b", true);
+          Element bnode = node.children().select("b").first();
           if (bnode != null) {
-            String skill = bnode.getText().toString();
+            String skill = bnode.wholeText();
             FightRequest.logSkillAcquisition(skill, status);
             ResponseTextParser.learnSkill(skill);
           }
@@ -6832,9 +6824,9 @@ public class FightRequest extends GenericRequest {
       }
     }
 
-    String src = inode.getAttributeByName("src");
+    String src = inode.attr("src");
 
-    if (src == null) return false;
+    if (src.isEmpty()) return false;
 
     String image = src.substring(src.lastIndexOf("/") + 1);
 
@@ -6847,10 +6839,12 @@ public class FightRequest extends GenericRequest {
     }
 
     // Attempt to identify combat items
-    String itemName = inode.getAttributeByName("title");
-    int itemId = ItemDatabase.getItemId(itemName);
-    if (itemId != -1 && image.equals(ItemDatabase.getImage(itemId))) {
-      status.lastCombatItem = itemId;
+    String itemName = inode.attr("title");
+    if (!itemName.isEmpty()) {
+      int itemId = ItemDatabase.getItemId(itemName);
+      if (itemId != -1 && image.equals(ItemDatabase.getImage(itemId))) {
+        status.lastCombatItem = itemId;
+      }
     }
 
     if (status.limitmode == LimitMode.BATMAN
@@ -7093,16 +7087,16 @@ public class FightRequest extends GenericRequest {
   private static final Pattern SECONDS_PATTERN = Pattern.compile("(\\d+)\\.(\\d+) Seconds Saved!");
 
   private static boolean handleGrimstone(
-      final TagNode node, final TagNode inode, final TagStatus status) {
+      final Element node, final Element inode, final TagStatus status) {
 
     if (!status.won) return false;
     if (inode == null) return false;
 
-    String src = inode.getAttributeByName("src");
-    if (src == null) return false;
+    String src = inode.attr("src");
+    if (src.isEmpty()) return false;
 
     String image = src.substring(src.lastIndexOf("/") + 1);
-    String text = node.getText().toString();
+    String text = node.wholeText();
 
     switch (image) {
       case "trophy.gif" -> {
@@ -7228,12 +7222,12 @@ public class FightRequest extends GenericRequest {
     }
   }
 
-  private static boolean handleEldritchHorror(TagNode node, TagStatus status) {
+  private static boolean handleEldritchHorror(Element node, TagStatus status) {
     if (!status.eldritchHorror) {
       return false;
     }
 
-    String str = node.getText().toString();
+    String str = node.wholeText();
 
     if (str.startsWith("You hear in your mind")
         || str.startsWith("Sssshhsssblllrrggghsssssggggrrgglsssshhssslblgl is done with you")) {
@@ -7308,14 +7302,14 @@ public class FightRequest extends GenericRequest {
   public static final Pattern KISS_PATTERN =
       Pattern.compile("(\\d+) kiss(?:es)? for winning(?: \\+(\\d+) for difficulty)?");
 
-  private static boolean handleKisses(TagNode node, TagStatus status) {
-    TagNode span = node.findElementByName("span", true);
+  private static boolean handleKisses(Element node, TagStatus status) {
+    Element span = node.children().select("span").first();
     if (span == null) {
       return false;
     }
 
-    String title = span.getAttributeByName("title");
-    if (title == null || !title.contains("kiss")) {
+    String title = span.attr("title");
+    if (!title.contains("kiss")) {
       return false;
     }
 
@@ -7324,7 +7318,7 @@ public class FightRequest extends GenericRequest {
       return true;
     }
 
-    String str = span.getText().toString();
+    String str = span.wholeText();
 
     // Log the actual kiss message
     FightRequest.logText(str, status);
@@ -7365,12 +7359,12 @@ public class FightRequest extends GenericRequest {
 
   public static final Pattern CRIMBO_PATTERN = Pattern.compile("It's from (.*?)!");
 
-  private static boolean handleCrimboPresent(TagNode node, TagStatus status) {
+  private static boolean handleCrimboPresent(Element node, TagStatus status) {
     if (!status.crimbo) {
       return false;
     }
 
-    String str = node.getText().toString();
+    String str = node.wholeText();
 
     Matcher matcher = FightRequest.CRIMBO_PATTERN.matcher(str);
     if (!matcher.find()) {
@@ -7384,8 +7378,8 @@ public class FightRequest extends GenericRequest {
 
   public static final Pattern CHAKRA_PATTERN = Pattern.compile("This Chakra is now (\\d+)% clean.");
 
-  private static boolean handleChakra(TagNode node, TagStatus status) {
-    String str = node.getText().toString();
+  private static boolean handleChakra(Element node, TagStatus status) {
+    String str = node.wholeText();
 
     Matcher matcher = FightRequest.CHAKRA_PATTERN.matcher(str);
     if (!matcher.find()) {
@@ -7430,14 +7424,14 @@ public class FightRequest extends GenericRequest {
     return true;
   }
 
-  private static void handleVillainLairRadio(TagNode node, TagStatus status) {
+  private static void handleVillainLairRadio(Element node, TagStatus status) {
     if (!KoLCharacter.inBondcore()) {
       return;
     }
     if (!status.location.equals("Super Villain's Lair")) {
       return;
     }
-    String str = node.getText().toString();
+    String str = node.wholeText();
     if (str.contains("crackle")) {
       FightRequest.logText(str);
       VillainLairDecorator.parseColorClue(str);
@@ -7507,8 +7501,8 @@ public class FightRequest extends GenericRequest {
     }
   }
 
-  private static boolean handleProselytization(TagNode node, TagStatus status) {
-    String str = node.getText().toString();
+  private static boolean handleProselytization(Element node, TagStatus status) {
+    String str = node.wholeText();
 
     Matcher matcher = FightRequest.PROSELYTIZATION_PATTERN.matcher(str);
     if (!matcher.find()) {
@@ -7525,16 +7519,16 @@ public class FightRequest extends GenericRequest {
     return true;
   }
 
-  private static void processComments(TagNode node, TagStatus status) {
-    for (BaseToken child : node.getAllChildren()) {
-      if (child instanceof CommentNode object) {
+  private static void processComments(Element node, TagStatus status) {
+    for (Node child : node.childNodes()) {
+      if (child instanceof Comment object) {
         FightRequest.processComment(object, status);
       }
     }
   }
 
-  private static void processComment(CommentNode object, TagStatus status) {
-    String content = object.getContent().trim();
+  private static void processComment(Comment object, TagStatus status) {
+    String content = object.getData().trim();
     if (content.equals("familiarmessage")) {
       status.famaction = true;
     } else if (content.equals("WINWINWIN")) {
@@ -7563,7 +7557,7 @@ public class FightRequest extends GenericRequest {
     // macroaction: comment handled elsewhere
   }
 
-  private static void processFamiliarAction(TagNode node, TagNode inode, TagStatus status) {
+  private static void processFamiliarAction(Element node, Element inode, TagStatus status) {
     status.famaction = false;
 
     String image = imgToString(inode);
@@ -7584,9 +7578,9 @@ public class FightRequest extends GenericRequest {
     // This will also remove the table text from the node text and
     // thus improve the message we log.
 
-    TagNode[] tables = node.getElementsByName("table", true);
-    for (TagNode table : tables) {
-      table.getParent().removeChild(table);
+    Elements tables = node.children().select("table");
+    for (Element table : tables) {
+      table.remove();
     }
 
     // Always separate multiple lines with slashes
@@ -7601,10 +7595,10 @@ public class FightRequest extends GenericRequest {
 
     // For some unknown reason, gladiator moves are tagged as <!--familiarmessage-->
     if (str.startsWith("New Special Move Unlocked")) {
-      TagNode bnode = node.findElementByName("b", true);
+      Element bnode = node.children().select("b").first();
       if (bnode != null) {
         FightRequest.logText(text, status);
-        String skill = bnode.getText().toString();
+        String skill = bnode.wholeText();
         ResponseTextParser.learnCombatMove(skill);
       }
       return;
@@ -7678,7 +7672,7 @@ public class FightRequest extends GenericRequest {
     }
 
     // Now process additional familiar actions
-    for (TagNode table : tables) {
+    for (Element table : tables) {
       FightRequest.processNode(table, status);
     }
   }
@@ -11141,7 +11135,7 @@ public class FightRequest extends GenericRequest {
   }
 
   public static void registerPokefamMove(int num, String move, String action, String description) {
-    if (action == null) {
+    if (action == null || action.isEmpty()) {
       return;
     }
 

--- a/src/net/sourceforge/kolmafia/utilities/HTMLParserUtils.java
+++ b/src/net/sourceforge/kolmafia/utilities/HTMLParserUtils.java
@@ -1,14 +1,13 @@
 package net.sourceforge.kolmafia.utilities;
 
-import java.util.Iterator;
-import java.util.Map;
 import net.sourceforge.kolmafia.RequestLogger;
-import org.htmlcleaner.BaseToken;
 import org.htmlcleaner.CleanerProperties;
-import org.htmlcleaner.CommentNode;
-import org.htmlcleaner.ContentNode;
 import org.htmlcleaner.HtmlCleaner;
-import org.htmlcleaner.TagNode;
+import org.jsoup.nodes.Attributes;
+import org.jsoup.nodes.Comment;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
 
 public class HTMLParserUtils {
   private HTMLParserUtils() {}
@@ -26,15 +25,15 @@ public class HTMLParserUtils {
 
   // Log cleaned HTML
 
-  public static final void logHTML(final TagNode node) {
+  public static final void logHTML(final Element node) {
     if (node != null) {
       StringBuffer buffer = new StringBuffer();
       HTMLParserUtils.logHTML(node, buffer, 0);
     }
   }
 
-  private static void logHTML(final TagNode node, final StringBuffer buffer, int level) {
-    String name = node.getName();
+  private static void logHTML(final Element node, final StringBuffer buffer, int level) {
+    String name = node.tagName();
 
     // Skip scripts
     if (name.equals("script")) {
@@ -45,12 +44,9 @@ public class HTMLParserUtils {
     HTMLParserUtils.printTag(buffer, node);
     RequestLogger.updateDebugLog(buffer.toString());
 
-    Iterator<? extends BaseToken> it = node.getAllChildren().iterator();
-    while (it.hasNext()) {
-      BaseToken child = it.next();
-
-      if (child instanceof CommentNode object) {
-        String content = object.getContent();
+    for (Node child : node.childNodes()) {
+      if (child instanceof Comment object) {
+        String content = object.getData();
         HTMLParserUtils.indent(buffer, level + 1);
         buffer.append("<!--");
         buffer.append(content);
@@ -59,8 +55,8 @@ public class HTMLParserUtils {
         continue;
       }
 
-      if (child instanceof ContentNode object) {
-        String content = object.getContent().trim();
+      if (child instanceof TextNode object) {
+        String content = object.getWholeText().trim();
         if (content.equals("")) {
           continue;
         }
@@ -71,7 +67,7 @@ public class HTMLParserUtils {
         continue;
       }
 
-      if (child instanceof TagNode object) {
+      if (child instanceof Element object) {
         HTMLParserUtils.logHTML(object, buffer, level + 1);
       }
     }
@@ -85,23 +81,19 @@ public class HTMLParserUtils {
     }
   }
 
-  private static void printTag(final StringBuffer buffer, TagNode node) {
-    String name = node.getName();
-    Map<String, String> attributes = node.getAttributes();
+  private static void printTag(final StringBuffer buffer, Element node) {
+    String name = node.tagName();
+    Attributes attributes = node.attributes();
 
     buffer.append("<");
     buffer.append(name);
 
-    if (!attributes.isEmpty()) {
-      Iterator<String> it = attributes.keySet().iterator();
-      while (it.hasNext()) {
-        String key = it.next();
-        buffer.append(" ");
-        buffer.append(key);
-        buffer.append("=\"");
-        buffer.append(attributes.get(key));
-        buffer.append("\"");
-      }
+    for (var attr : attributes) {
+      buffer.append(" ");
+      buffer.append(attr.getKey());
+      buffer.append("=\"");
+      buffer.append(attr.getValue());
+      buffer.append("\"");
     }
     buffer.append(">");
   }


### PR DESCRIPTION
Slightly less weird cleaned HTML, easier debugging, similar speed. I hope to convert some of the regex matching to HTML parsing. We need to keep HtmlCleaner for the exposed `xpath` function; it also seems faster for the other xpath cases.

Good thing I wrote the pokefam tests, those functions have changed quite a lot.

Converted robotically with no attempt at using extra features:
```
new HtmlCleaner().clean -> Jsoup.parse
TagNode -> Element
TagNode.getName() -> Element.tagName()
TagNode.getAllChildren() -> Element.childNodes() // children() is just Elements
TagNode.getAttributeByName(X) -> Element.attr(X) // returns blank string instead of null on missing
TagNode.getAttributes() -> Element.attributes() // not a map, but can be iterated over
TagNode.getElementListByName("X", true) -> Element.children().select("X") // need children() to avoid matching current element
TagNode.getElementListByName("X", false) -> Element.select(">X")
TagNode.getElementsByName("X", true) -> Element.children().select("X") // need children() to avoid matching current element // need .size() instead of .length
TagNode.getElementsByName("X", false) -> Element.select(">X") // need .size() instead of .length
TagNode.getChildTags() -> Element.children()
TagNode.getText().toString() -> Element.wholeText() // text() collapses spaces
TagNode.getParent() -> Element.parent()
TagNode.getParent().removeChild(X) -> X.remove()
TagNode.findElementByName("X", true) -> Element.children().select("X").first()
TagNode.findElementByName("X", false) -> Element.selectFirst(">X")
TagNode.findElementByAttValue("X", "Y", true, false) -> Element.children().select("[X=Y]").first()
TagNode.findElementByAttValue("X", "Y", false, false) -> Element.selectFirst(">[X=Y]")
TagNode.evaluateXPath(X) -> Element.selectXpath(X, Node.class) // jsoup cannot select attributes (e.g. @href), html cleaner will accept invalid xpath (e.g. input[@type='checkbox']@checked)
BaseToken -> Node
BaseToken.getName() -> Node.nodeName() // in case you don't know whether you've got a comment or an actual node
ContentNode -> TextNode
ContentNode.getContent() -> TextNode.getWholeText() // text() collapses spaces
CommentNode -> Comment
CommentNode.getContent() -> Comment.getData()
```