### PR TITLE
fix: don't cache banished / tracked monsters internally

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1650,6 +1650,8 @@ user	tomeSummons	0
 user	totalCharitableDonations	0
 user	trackLightsOut	false
 user	trackVoteMonster	false
+user	trackedMonsters
+user	trackedPhyla
 user	trainsetConfiguration	
 user	trainsetPosition	0
 user	turtleBlessingTurns	0

--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -593,8 +593,7 @@ public abstract class KoLmafia {
     VYKEACompanionData.initialize(false);
     ConsequenceManager.updateOneDesc();
 
-    // Make sure Banishes are loaded before removing them
-    BanishManager.loadBanished();
+    // Remove spent banishes
     BanishManager.resetRollover();
 
     // Remove spent tracks
@@ -755,9 +754,6 @@ public abstract class KoLmafia {
 
     // Retrieve the contents of the closet.
     ClosetRequest.refresh();
-
-    // Load Banished monsters
-    BanishManager.loadBanished();
 
     // Retrieve Custom Outfit list
     if (!KoLCharacter.getLimitMode().limitOutfits()) {

--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -597,8 +597,7 @@ public abstract class KoLmafia {
     BanishManager.loadBanished();
     BanishManager.resetRollover();
 
-    // Make sure Tracks are loaded before removing them
-    TrackManager.loadTracked();
+    // Remove spent tracks
     TrackManager.resetRollover();
 
     // Libram summoning skills now costs 1 MP again

--- a/src/net/sourceforge/kolmafia/session/LoginManager.java
+++ b/src/net/sourceforge/kolmafia/session/LoginManager.java
@@ -410,7 +410,6 @@ public class LoginManager {
     StoreManager.clearCache();
     DisplayCaseManager.clearCache();
     ClanManager.clearCache(true);
-    BanishManager.clearCache();
 
     CampgroundRequest.reset();
     ChateauRequest.reset();

--- a/src/net/sourceforge/kolmafia/session/TrackManager.java
+++ b/src/net/sourceforge/kolmafia/session/TrackManager.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -20,9 +21,6 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 @SuppressWarnings("incomplete-switch")
 public class TrackManager {
-  private static final Set<Tracked> trackedMonsters = new LinkedHashSet<>();
-  private static final Set<Tracked> trackedPhyla = new LinkedHashSet<>();
-
   private TrackManager() {}
 
   private enum TrackType {
@@ -185,40 +183,14 @@ public class TrackManager {
     }
   }
 
-  private static Set<Tracked> getTrackedSet(Tracker tracker) {
-    return switch (tracker.getTrackType()) {
-      case MONSTER -> trackedMonsters;
-      case PHYLUM -> trackedPhyla;
-    };
-  }
-
-  public static void clearCache() {
-    TrackManager.trackedMonsters.clear();
-    TrackManager.trackedPhyla.clear();
-  }
-
-  public static void loadTracked() {
-    TrackManager.loadTrackedMonsters();
-    TrackManager.loadTrackedPhyla();
-  }
-
-  static void loadTrackedMonsters() {
-    loadTrackedX("trackedMonsters", TrackManager.trackedMonsters);
-  }
-
-  static void loadTrackedPhyla() {
-    loadTrackedX("trackedPhyla", TrackManager.trackedPhyla);
-  }
-
-  private static void loadTrackedX(String prefName, Set<Tracked> tracked) {
-    tracked.clear();
-
+  private static Set<Tracked> prefToSet(String prefName) {
     String tracks = Preferences.getString(prefName);
     if (tracks.isEmpty()) {
-      return;
+      return new LinkedHashSet<>();
     }
 
     StringTokenizer tokens = new StringTokenizer(tracks, ":");
+    var set = new LinkedHashSet<Tracked>();
 
     while (tokens.hasMoreTokens()) {
       String monsterName = tokens.nextToken();
@@ -234,26 +206,23 @@ public class TrackManager {
         continue;
       }
 
-      TrackManager.addTracked(monsterName, tracker, turnTracked);
+      var tracked = new Tracked(monsterName, tracker, turnTracked);
+      set.add(tracked);
     }
+    return set;
   }
 
-  private static void saveTrackedMonsters() {
-    Preferences.setString(
-        "trackedMonsters",
-        trackedMonsters.stream()
-            .flatMap(m -> Stream.of(m.tracked(), m.tracker().getName(), m.turnTracked()))
-            .map(Object::toString)
-            .collect(Collectors.joining(":")));
+  private static String setToPref(Set<Tracked> tracked) {
+    return tracked.stream()
+        .flatMap(m -> Stream.of(m.tracked(), m.tracker().getName(), m.turnTracked()))
+        .map(Object::toString)
+        .collect(Collectors.joining(":"));
   }
 
-  private static void saveTrackedPhyla() {
-    Preferences.setString(
-        "trackedPhyla",
-        trackedPhyla.stream()
-            .flatMap(m -> Stream.of(m.tracked(), m.tracker().getName(), m.turnTracked()))
-            .map(Object::toString)
-            .collect(Collectors.joining(":")));
+  private static void updatePref(String pref, Consumer<Set<Tracked>> func) {
+    var set = prefToSet(pref);
+    func.accept(set);
+    Preferences.setString(pref, setToPref(set));
   }
 
   /**
@@ -262,10 +231,8 @@ public class TrackManager {
    * @param predicate Predicate dictating removal
    */
   private static void resetIf(Predicate<Tracked> predicate) {
-    TrackManager.trackedMonsters.removeIf(predicate);
-    TrackManager.saveTrackedMonsters();
-    TrackManager.trackedPhyla.removeIf(predicate);
-    TrackManager.saveTrackedPhyla();
+    updatePref("trackedMonsters", m -> m.removeIf(predicate));
+    updatePref("trackedPhyla", m -> m.removeIf(predicate));
   }
 
   /**
@@ -359,7 +326,12 @@ public class TrackManager {
       return;
     }
 
-    getTrackedSet(tracker).add(tracked);
+    var pref =
+        switch (tracker.getTrackType()) {
+          case MONSTER -> "trackedMonsters";
+          case PHYLUM -> "trackedPhyla";
+        };
+    updatePref(pref, x -> x.add(tracked));
   }
 
   private static void removeTrack(final Tracker tracker) {
@@ -369,8 +341,10 @@ public class TrackManager {
   public static long countCopies(final String monster) {
     TrackManager.recalculate();
 
+    var monsters = prefToSet("trackedMonsters");
+
     var monsterCopies =
-        trackedMonsters.stream()
+        monsters.stream()
             .filter(m -> m.tracked().equalsIgnoreCase(monster) && m.tracker().isEffective())
             .mapToInt(t -> t.tracker().copies)
             .sum();
@@ -379,8 +353,11 @@ public class TrackManager {
     if (data == null) {
       return monsterCopies;
     }
+
+    var phyla = prefToSet("trackedPhyla");
+
     var phylaCopies =
-        trackedPhyla.stream()
+        phyla.stream()
             .filter(m -> m.tracker().isEffective())
             .filter(m -> m.tracked().equalsIgnoreCase(data.getPhylum().toString()))
             .mapToInt(t -> t.tracker().copies)
@@ -391,8 +368,10 @@ public class TrackManager {
   public static boolean isQueueIgnored(final String monster) {
     TrackManager.recalculate();
 
+    var monsters = prefToSet("trackedMonsters");
+
     // there is no way for a phyla copy to make the monster ignore queue
-    return trackedMonsters.stream()
+    return monsters.stream()
         .anyMatch(
             m ->
                 m.tracker().isIgnoreQueue()
@@ -401,18 +380,21 @@ public class TrackManager {
   }
 
   public static Tracker[] trackedBy(final MonsterData data) {
-    TrackManager.recalculate();
-
     if (data == null) {
       return new Tracker[0];
     }
 
+    TrackManager.recalculate();
+
+    var monsters = prefToSet("trackedMonsters");
+    var phyla = prefToSet("trackedPhyla");
+
     var monsterTracks =
-        trackedMonsters.stream()
+        monsters.stream()
             .filter(m -> m.tracked().equalsIgnoreCase(data.getName()))
             .filter(m -> m.tracker().isEffective());
     var phylaTracks =
-        trackedPhyla.stream()
+        phyla.stream()
             .filter(m -> m.tracked().equalsIgnoreCase(data.getPhylum().toString()))
             .filter(m -> m.tracker().isEffective());
     return Stream.concat(monsterTracks, phylaTracks).map(Tracked::tracker).toArray(Tracker[]::new);

--- a/src/net/sourceforge/kolmafia/textui/command/RefreshStatusCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/RefreshStatusCommand.java
@@ -17,7 +17,6 @@ import net.sourceforge.kolmafia.request.ManageStoreRequest;
 import net.sourceforge.kolmafia.request.QuantumTerrariumRequest;
 import net.sourceforge.kolmafia.request.QuestLogRequest;
 import net.sourceforge.kolmafia.request.StorageRequest;
-import net.sourceforge.kolmafia.session.BanishManager;
 import net.sourceforge.kolmafia.session.InventoryManager;
 
 public class RefreshStatusCommand extends AbstractCommand {
@@ -73,9 +72,6 @@ public class RefreshStatusCommand extends AbstractCommand {
       return;
     } else if (parameters.equals("concoctions")) {
       ConcoctionDatabase.refreshConcoctions(true);
-      return;
-    } else if (parameters.equals("banishes")) {
-      BanishManager.loadBanished();
       return;
     } else {
       KoLmafia.updateDisplay(MafiaState.ERROR, parameters + " cannot be refreshed.");

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -56,7 +56,6 @@ import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.request.GenericRequest.TopMenuStyle;
 import net.sourceforge.kolmafia.request.StandardRequest;
 import net.sourceforge.kolmafia.request.coinmaster.HermitRequest;
-import net.sourceforge.kolmafia.session.BanishManager;
 import net.sourceforge.kolmafia.session.ChoiceControl;
 import net.sourceforge.kolmafia.session.ChoiceManager;
 import net.sourceforge.kolmafia.session.ClanManager;
@@ -2608,9 +2607,7 @@ public class Player {
    * @return Returns value to previous value
    */
   public static Cleanups withBanishedMonsters(String contents) {
-    var preference = withProperty("banishedMonsters", contents);
-    BanishManager.loadBanished();
-    return new Cleanups(preference, new Cleanups(BanishManager::loadBanished));
+    return withProperty("banishedMonsters", contents);
   }
 
   /**
@@ -2620,9 +2617,7 @@ public class Player {
    * @return Returns value to previous value
    */
   public static Cleanups withBanishedPhyla(String contents) {
-    var preference = withProperty("banishedPhyla", contents);
-    BanishManager.loadBanished();
-    return new Cleanups(preference, new Cleanups(BanishManager::loadBanished));
+    return withProperty("banishedPhyla", contents);
   }
 
   /**

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -65,7 +65,6 @@ import net.sourceforge.kolmafia.session.EquipmentRequirement;
 import net.sourceforge.kolmafia.session.LimitMode;
 import net.sourceforge.kolmafia.session.ResultProcessor;
 import net.sourceforge.kolmafia.session.StoreManager;
-import net.sourceforge.kolmafia.session.TrackManager;
 import net.sourceforge.kolmafia.session.TurnCounter;
 import net.sourceforge.kolmafia.utilities.HttpUtilities;
 import net.sourceforge.kolmafia.utilities.Statics;
@@ -2633,9 +2632,7 @@ public class Player {
    * @return Returns value to previous value
    */
   public static Cleanups withTrackedMonsters(String contents) {
-    var preference = withProperty("trackedMonsters", contents);
-    TrackManager.loadTracked();
-    return new Cleanups(preference, new Cleanups(TrackManager::loadTracked));
+    return withProperty("trackedMonsters", contents);
   }
 
   /**
@@ -2645,9 +2642,7 @@ public class Player {
    * @return Returns value to previous value
    */
   public static Cleanups withTrackedPhyla(String contents) {
-    var preference = withProperty("trackedPhyla", contents);
-    TrackManager.loadTracked();
-    return new Cleanups(preference, new Cleanups(TrackManager::loadTracked));
+    return withProperty("trackedPhyla", contents);
   }
 
   public static Cleanups withDisabledCoinmaster(CoinmasterData data) {

--- a/test/net/sourceforge/kolmafia/session/BanishManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/BanishManagerTest.java
@@ -28,7 +28,6 @@ import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.session.BanishManager.Banisher;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,12 +41,6 @@ class BanishManagerTest {
   public void beforeEach() {
     KoLCharacter.reset("BanishManagerTest");
     Preferences.reset("BanishManagerTest");
-    BanishManager.clearCache();
-  }
-
-  @AfterAll
-  public static void cleanup() {
-    BanishManager.clearCache();
   }
 
   private static final MonsterData CRATE = MonsterDatabase.findMonster("crate");
@@ -62,36 +55,6 @@ class BanishManagerTest {
   private static final MonsterData TACO_CAT = MonsterDatabase.findMonster("Taco Cat");
   private static final MonsterData MAGICAL_FRUIT_BAT =
       MonsterDatabase.findMonster("magical fruit bat");
-
-  @Nested
-  class ClearCache {
-    @Test
-    void clearCache() {
-      var cleanups =
-          new Cleanups(
-              withCurrentRun(128), withBanishedMonsters("fluffy bunny:Be a Mind Master:119"));
-
-      try (cleanups) {
-        assertTrue(BanishManager.isBanished("fluffy bunny"));
-        BanishManager.clearCache();
-
-        assertFalse(BanishManager.isBanished("fluffy bunny"));
-      }
-    }
-
-    @Test
-    void clearCachePhyla() {
-      var cleanups =
-          new Cleanups(withCurrentRun(128), withBanishedPhyla("beast:Patriotic Screech:119"));
-
-      try (cleanups) {
-        assertTrue(BanishManager.isBanished("fluffy bunny"));
-        BanishManager.clearCache();
-
-        assertFalse(BanishManager.isBanished("fluffy bunny"));
-      }
-    }
-  }
 
   @Nested
   class LoadBanished {

--- a/test/net/sourceforge/kolmafia/session/ResultProcessorTest.java
+++ b/test/net/sourceforge/kolmafia/session/ResultProcessorTest.java
@@ -59,7 +59,6 @@ public class ResultProcessorTest {
   public void beforeEach() {
     KoLCharacter.reset("ResultProcessorTest");
     Preferences.reset("ResultProcessorTest");
-    BanishManager.clearCache();
     InventoryManager.resetInventory();
   }
 

--- a/test/net/sourceforge/kolmafia/session/TrackManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/TrackManagerTest.java
@@ -21,7 +21,6 @@ import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.session.TrackManager.Tracker;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -34,12 +33,6 @@ class TrackManagerTest {
   public void beforeEach() {
     KoLCharacter.reset("TrackManagerTest");
     Preferences.reset("TrackManagerTest");
-    TrackManager.clearCache();
-  }
-
-  @AfterAll
-  public static void cleanup() {
-    TrackManager.clearCache();
   }
 
   private static final MonsterData CRATE = MonsterDatabase.findMonster("crate");
@@ -70,37 +63,6 @@ class TrackManagerTest {
 
   private boolean isTracked(String monster) {
     return TrackManager.countCopies(monster) > 0;
-  }
-
-  @Nested
-  class ClearCache {
-    @Test
-    void clearCache() {
-      var cleanups =
-          new Cleanups(
-              withCurrentRun(128), withTrackedMonsters("fluffy bunny:Transcendent Olfaction:119"));
-
-      try (cleanups) {
-        assertTrue(isTracked("fluffy bunny"));
-        TrackManager.clearCache();
-
-        assertFalse(isTracked("fluffy bunny"));
-      }
-    }
-
-    @Test
-    void clearCachePhyla() {
-      var cleanups =
-          new Cleanups(
-              withCurrentRun(128), withSnapper(), withTrackedPhyla("beast:Red-Nosed Snapper:119"));
-
-      try (cleanups) {
-        assertTrue(isTracked("fluffy bunny"));
-        TrackManager.clearCache();
-
-        assertFalse(isTracked("fluffy bunny"));
-      }
-    }
   }
 
   @Nested


### PR DESCRIPTION
As raised in https://kolmafia.us/threads/trackedmonsters-resets-on-login.30177/, tracked / banished monsters are reset on login, probably due to reading from the internal cache before resetting the preference.

Move to a single source of truth for banished / tracked monsters / phyla (the preference).