### PR TITLE
Track OVERCLOCKED(10), improve choice spoilers, profane parrot

### DIFF
--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -339,5 +339,5 @@
 307	quantum entangler	qf.gif	block	quantized familiar	quantum watch	0	0	0	0	object
 308	golden pet rock	ts_goldrock.gif	none	golden pet rock		0	0	0	0
 309
-310	Profane Parrot	ts_parrot2.gif	block,combat1	sleeping profane parrot	profane eye patch	0	0	0	0
+310	Profane Parrot	ts_parrot2.gif	block,combat1	sleeping profane parrot	profane eye patch	2	3	2	2
 311	Significant Bit	cr_sbit.gif	variable	insignificant bit	parity bit	0	0	0	0

--- a/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
@@ -130,6 +130,7 @@ public class SkillPool {
   public static final int ELF_GUARD_COOKING = 229;
   public static final int OLD_SCHOOL_COCKTAILCRAFTING = 230;
   public static final int HOLIDAY_MULTITASKING = 240;
+  public static final int OVERCLOCK10 = 243;
   public static final int SUPER_ADVANCED_MEATSMITHING = 1006;
   public static final int WALRUS_TONGUE = 1010;
   public static final int BATTER_UP = 1014;

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -3032,6 +3032,7 @@ public class FightRequest extends GenericRequest {
 
     KoLAdventure location = KoLAdventure.lastVisitedLocation();
     String locationName = (location != null) ? location.getAdventureName() : null;
+    String zone = (location != null) ? location.getZone() : "";
 
     FamiliarData familiar = KoLCharacter.getEffectiveFamiliar();
 
@@ -3453,7 +3454,29 @@ public class FightRequest extends GenericRequest {
       Preferences.setString("lastCopyableMonster", monsterName);
     }
 
-    final boolean free = responseText.contains("FREEFREEFREE");
+    boolean free = responseText.contains("FREEFREEFREE");
+
+    if (zone.equals("Server Room")) {
+      /*
+      if (responseText.contains("...overclock is ending...")) {
+        Preferences.setInteger("_cyberFreeFights", 10);
+      } else if (responseText.contains("...overclock is active...")) {
+        Preferences.increment("_cyberFreeFights", 1, 10, false);
+      }
+      */
+
+      // Something like the above would be nice, but KoL neither has
+      // special text to indicate OVERCLOCK(10) is active, nor does
+      // it include FREEFREEFREE to indicate the fight was free.
+      //
+      // I bug reported those things, but for now, workaround.
+
+      if (KoLCharacter.hasSkill(SkillPool.OVERCLOCK10)
+          && Preferences.getInteger("_cyberFreeFights") < 10) {
+        Preferences.increment("_cyberFreeFights", 1, 10, false);
+        free = true;
+      }
+    }
 
     if (adventure == AdventurePool.OLIVERS_SPEAKEASY_BRAWL) {
       if (responseText.contains(

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -8894,22 +8894,39 @@ public abstract class ChoiceControl {
 
       case 1545 -> { // Cyberzone 1 Half-Way
         Preferences.setInteger("_cyberZone1Turns", 10);
+        incrementCyberFreeFights();
       }
       case 1546 -> { // Cyberzone 1 Final
         Preferences.setInteger("_cyberZone1Turns", 20);
       }
       case 1547 -> { // Cyberzone 2 Half-Way
         Preferences.setInteger("_cyberZone2Turns", 10);
+        incrementCyberFreeFights();
       }
       case 1548 -> { // Cyberzone 2 Final
         Preferences.setInteger("_cyberZone2Turns", 20);
       }
       case 1549 -> { // Cyberzone 3 Half-Way
         Preferences.setInteger("_cyberZone3Turns", 10);
+        incrementCyberFreeFights();
       }
       case 1550 -> { // Cyberzone 3 Final
         Preferences.setInteger("_cyberZone3Turns", 20);
       }
+    }
+  }
+
+  private static void incrementCyberFreeFights() {
+    // The CyberRealm Half-Way non-combats - which are free - consume a
+    // free fight granted by OVERCLOCK(10).
+    // This seems like a KoL bug.
+    //
+    // The CyberRealm Final non-combats are not free. I don't know if
+    // they are made free by OVERCLOCK(10), but in order to see that,
+    // you'd have to install the rom chip and learn the skill AFTER the
+    // Half-Way non-combat of a CyberRealm zone. Not going to happen.
+    if (KoLCharacter.hasSkill(SkillPool.OVERCLOCK10)) {
+      Preferences.increment("_cyberFreeFights", 1, 10, false);
     }
   }
 

--- a/test/root/request/test_fight_old_overclocked_win.html
+++ b/test/root/request/test_fight_old_overclocked_win.html
@@ -1,0 +1,255 @@
+<html><head>
+<script language=Javascript>
+<!--
+if (parent.frames.length == 0) location.href="game.php";
+top.charpane.location.href="charpane.php";
+//-->
+</script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/keybinds.min.2.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/window.20111231.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/jquery-1.3.1.min.js"></script>
+<link href="https://fonts.googleapis.com/css?family=Shadows+Into+Light" rel="stylesheet"><script language="javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/core.js"></script><script src="https://d2uyhvukfffg5a.cloudfront.net/scripts/fight.js"></script>
+<script>
+var onturn = 4;
+
+</script>	<link rel="stylesheet" type="text/css" href="https://d2uyhvukfffg5a.cloudfront.net/styles.20230117d.css">
+<style> body * { image-rendering: auto!important;} </style><style type='text/css'>
+.faded {
+	zoom: 1;
+	filter: alpha(opacity=35);
+	opacity: 0.35;
+	-khtml-opacity: 0.35; 
+    -moz-opacity: 0.35;
+}
+</style>
+
+</head>
+
+<body>
+	<link rel="stylesheet" href="https://unpkg.com/fixedsys-css/css/fixedsys.css">
+	<style>
+		* { font-family: 'fixedsys', "Fixedsys", monospace !important; font-size: 1.05rem; }
+		img { opacity: 0}
+		img.cybered { opacity: 1}
+		.actionbar img  { opacity: 1; filter: invert(0.8); }
+		.actionbar img.cybered  { opacity: 1; filter: invert(0); }
+		select, body{ background-color: black; color: green; }
+		body { margin-top: 8px; }
+		td{ background-color: black; color: green; }
+		input.button, button.button, .button { background-color: black; color: green; border: 1px solid green; font-size: 1.05rem }
+		a, a:link, a:visited, a:active {color: green; }
+		b {color: green; }
+		.spacer { background-color: black !important; }
+		td.page { background-color: black !important; }
+	</style>
+	<script>
+document.addEventListener('DOMContentLoaded', () => {
+    const images = document.getElementsByTagName('img');
+	const cyberit = function () {
+		var img = this;
+		img.removeEventListener('load',cyberit);
+            const canvas = document.createElement('canvas');
+            const ctx = canvas.getContext('2d');
+
+            // Set canvas size to match image
+            canvas.width = img.naturalWidth;
+            canvas.height = img.naturalHeight;
+
+            // Draw image on canvas
+            ctx.drawImage(img, 0, 0);
+
+            // Get image data
+            const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+            const data = imageData.data;
+
+            // Process pixels
+            for (let i = 0; i < data.length; i += 4) {
+                // If pixel is not white (255, 255, 255)
+                if (data[i] < 255 || data[i + 1] < 255 || data[i + 2] < 255) {
+                    data[i] = 0;
+                    data[i + 1] = 255 - data[i+1];
+                    data[i + 2] = 0; // B
+				} else {
+                    data[i] = 0;     // R
+                    data[i + 1] = 0;   // G
+                    data[i + 2] = 0; // B
+				}
+            }
+
+            // Put processed data back
+            ctx.putImageData(imageData, 0, 0);
+
+            // Replace original image with processed version
+            img.src = canvas.toDataURL();
+			img.classList.add('cybered')
+	};
+
+	var cyberprep = function () {
+		var img = this;
+		img.removeEventListener('load',cyberprep);
+		
+		console.log('cyberprepping ' + img.src.substr(0,75));
+			if (img.src.match(/iii/) || img.src.match(/^data:/)) {
+				cyberit.call(img);
+			} else {
+				var news = img.src.replace(/.*\.(com|net)/,'/iii');
+				console.log('changed '+img.src.substr(0,75)+' to '+news);
+				img.src=news+'?dammit='+Math.random();
+				img.addEventListener('load', cyberit);
+			}
+	};
+
+    Array.from(images).forEach(function (img) {
+		if (img.src.match(/blank.gif/)) return;
+		console.log(img.src,img.complete);
+		if (img.complete) cyberprep.call(img);
+		else img.addEventListener('load', cyberprep);
+    });
+});
+	</script>
+	<center><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="background-color: green" align=center ><b style="color: black">Combat!</b></td></tr><tr><td style="padding: 5px; border: 1px solid green;"><center><table><tr><td><center><table><tr><td><div id=monsterpic style='position: relative;'>	<img  id='monpic'   src="https://d2uyhvukfffg5a.cloudfront.net/adventureimages/cr_hotwall.gif" width=200 height=200></div></td><td id='fmsg' valign=center>You're fighting <span id='monname'>a firewall</span></td><!-- MONSTERID: 2459 --><td width=30></td><td id='fstats'><table><tr><td width=30><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/nicesword.gif width=30 height=30 alt="Enemy's Attack Power" title="Enemy's Attack Power"></td><td width=50 valign=center align=left><b><font size=+2>1,170</font></b></td><td><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/sprocket.gif alt="This monster is a Construct" title="This monster is a Construct"></td></tr><tr><td width=30><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/whiteshield.gif width=30 height=30 alt="Enemy's Defense" title="Enemy's Defense"></td><td width=50 valign=center align=left><b><font size=+2>808</font></b></td><td><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/fire.gif width=30 height=30 alt="This monster is Hot.  Hot is weak against Sleaze and Stench." title="This monster is Hot.  Hot is weak against Sleaze and Stench."></td></tr><tr><td width=30><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/hp.gif width=30 height=30 alt="Enemy's Hit Points" title="Enemy's Hit Points"></td><td width=50 valign=center align=left><b><font size=+2>0</font></b></td><td><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/snail.gif alt="Never wins initiative" title="Never wins initiative"></td></tr></table></td></tr></table><br><script type="text/javascript">var monsterstats = {"hp":"0","def":"808","off":"1,170"};</script><table><tr><Td>You envision some 1s in a clump and throw it at your foe for <b>10</b> damage.</td></tr></table><table><tr><Td></td></tr></table><table><tr><Td><p><!--familiarmessage--><center><table><tr><td align=center valign=center><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/pokefam8675309.gif" width=30 height=30></td><td valign=center>Bodolph attacks your foes with some kind of crazy rainbow space laser for <font color=red><b>1</b></font> (<font color=blue><b>+1</b></font>) (<font color=green><b>+1</b></font>) (<font color=gray><b>+1</b></font>) (<font color=blueviolet><b>+1</b></font>) damage.</td></tr></table></center></td></tr></table><p>Your zero-trust tanktop detects some untrusted code and refactors your health code.<center><table><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/hp.gif" height=30 width=30></td><td valign=center class=effect>You gain 186 hit points.</td></tr></table></center><script>var mf = document.getElementById("maskform"); if (mf) mf.style.display="none";</script><script>document.getElementById("dartboardtd").style.display="none";</script><p><center>You win the fight!<!--WINWINWIN--><p><center><table class="item" style="float: none" rel="id=11788&s=1&q=0&d=1&g=0&t=1&n=2&m=0&p=0&u=."><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/cr_1.gif" alt="1" title="1" class=hand onClick='descitem(525329942)' ></td><td valign=center class=effect>You acquire <b>2 1s</b></td></tr></table></center><!--familiarmessage--><center><table><tr><td align=center valign=center><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/lb_beetle.gif" width=30 height=30></td><td valign=center>A love stag beetle brushes up against your ankle affectionately.</td></tr></table></center><center><table><tr><td>You gain 5 Strengthliness.</td></tr></table></center><center><table><tr><td align=center valign=center><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/factbook.gif" width=30 height=30 title="factbook" alt="factbook"></td><td valign=center>These things leave an above-average amount of psychic energy behind after they die.</td></tr></table></center><center><table><tr><td>You gain 4 Mysteriousness.</td></tr></table></center><p>You gain 73 Muscleboundness.<bR>You gain 85 Mysteriousness.<bR>You gain 232 Sarcasm.<bR><p><table><tr><td width=40><img src='https://d2uyhvukfffg5a.cloudfront.net/itemimages/songboombox.gif' /></td><td align='center'>You catch a line from the song playing on your SongBoom&trade; BoomBox:<br />&quot;Food food food food vibrations (Oom bop, bop)&quot;</td></tr></table><p>You collect some leaves from the area.<center><table class="item" style="float: none" rel="id=11341&s=0&q=0&d=0&g=0&t=0&n=1&m=0&p=0&u=."><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/al_leaf.gif" alt="inflammable leaf" title="inflammable leaf" class=hand onClick='descitem(169088498)' ></td><td valign=center class=effect>You acquire an item: <b>inflammable leaf</b></td></tr></table></center><p><a name="end"></a><p>As the battle ends, your cleaver flashes bright <span style="color: green">green</span>.<p>You find some cool bugs and put them in your pocket. Or maybe just one of them. Or some juice. Anyway you get this:<center><table class="item" style="float: none" rel="id=11126&s=30&q=0&d=1&g=0&t=1&n=1&m=1&p=0&u=u"><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/sitfly.gif" alt="flapper fly" title="flapper fly" class=hand onClick='descitem(718706223)' ></td><td valign=center class=effect>You acquire an item: <b>flapper fly</b></td></tr></table></center><p>Your spidey senses tingle and you find a bookshelf door.  There's a treasure behind it.<center><table class="item" style="float: none" rel="id=11276&s=10&q=0&d=1&g=0&t=1&n=1&m=1&p=0&u=u"><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/scroll3.gif" alt="scroll of protection from lycanthropes" title="scroll of protection from lycanthropes" class=hand onClick='descitem(545555359)' ></td><td valign=center class=effect>You acquire an item: <b>scroll of protection from lycanthropes</b></td></tr></table></center><p><a href="adventure.php?snarfblat=585" id='againlink'>Adventure Again (Vermont Outsourcing)</a><p><a href="place.php?whichplace=cyberrealm">Go back to Network Map</a></center><script>parent.charpane.location.href="charpane.php";</script><script language="javascript">
+	function updateParseItem(iid, field, info) {
+		var tbl = $('#ic'+iid);
+		var data = parseItem(tbl);
+		if (!data) return;
+		data[field] = info;
+		var out = [];
+		for (i in data) {
+			if (!data.hasOwnProperty(i)) continue;
+			out.push(i+'='+data[i]);
+		}
+		tbl.attr('rel', out.join('&'));
+	}
+	function parseItem(tbl) {
+		tbl = $(tbl);
+		var rel = tbl.attr('rel');
+		var data = {};
+		if (!rel) return data;
+		var parts = rel.split('&');
+		for (i in parts) {
+			if (!parts.hasOwnProperty(i)) continue;
+			var kv = parts[i].split('=');
+			tbl.data(kv[0], kv[1]);
+			data[kv[0]] = kv[1];
+		}
+		return data;
+	}
+</script><script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/pop_query.20230713.js"></script>
+<script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/ircm.20230626.js"></script>
+<script type="text/javascript">
+var tp = top;
+function pop_ircm_contents(i, some) {
+	var contents = '',
+		shown = 0,
+		da = '&nbsp;<a href="#" rel="?" class="small dojaxy">[some]</a>&nbsp;<a href="#" rel="',
+		db = '" class="small dojaxy">[all]</a>',
+		dc = '<div style="width:100%; padding-bottom: 3px;" rel="',
+		dd = '<a href="#" rel="1" class="small dojaxy">[';
+	one = 'one'; ss=some;
+if (i.d==1 && i.s>0) { shown++; 
+contents += dc + 'sellstuff.php?action=sell&ajax=1&type=quant&whichitem%5B%5D=IID&howmany=NUM&pwd=bbd4693b974f864b23a8013d8561e874" id="pircm_'+i.id+'"><b>Auto-Sell ('+i.s+' meat):</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'inventory.php?action=closetpush&ajax=1&whichitem=IID&qty=NUM&pwd=bbd4693b974f864b23a8013d8561e874" id="pircm_'+i.id+'"><b>Closet:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0 && i.g==0 && i.t==1) { shown++; 
+contents += dc + 'managestore.php?action=additem&qty1=NUM&item1=IID&price1=&limit1=&ajax=1&pwd=bbd4693b974f864b23a8013d8561e874" id="pircm_'+i.id+'"><b>Stock in Mall:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'managecollection.php?action=put&ajax=1&whichitem1=IID&howmany1=NUM&pwd=bbd4693b974f864b23a8013d8561e874" id="pircm_'+i.id+'"><b>Add to Display Case:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0 && i.t==1) { shown++; 
+contents += dc + 'clan_stash.php?action=addgoodies&ajax=1&item1=IID&qty1=NUM&pwd=bbd4693b974f864b23a8013d8561e874" id="pircm_'+i.id+'"><b>Contribute to Clan:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && !i.ac) { shown++; 
+contents += dc + 'inv_'+(i.u=="a"?"redir":(lab=(i.u=="u"?"use":(i.u=="e"?"eat":(i.u=="b"?"booze":(i.u=="s"?"spleen":"equip"))))))+'.php?ajax=1&whichitem=IID&itemquantity=NUM&quantity=NUM'+(i.u=="q"?"&action=equip":"")+'&pwd=bbd4693b974f864b23a8013d8561e874" id="pircm_'+i.id+'"><b>'+ucfirst(unescape(i.ou ? i.ou.replace(/\+/g," ") : (lab=="booze"?"drink":lab)))+':</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=1&ajax=1&whichitem=IID&action=equip&pwd=bbd4693b974f864b23a8013d8561e874" id="pircm_'+i.id+'"><b>Equip (slot 1):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=2&ajax=1&whichitem=IID&action=equip&pwd=bbd4693b974f864b23a8013d8561e874" id="pircm_'+i.id+'"><b>Equip (slot 2):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=3&ajax=1&whichitem=IID&action=equip&pwd=bbd4693b974f864b23a8013d8561e874" id="pircm_'+i.id+'"><b>Equip (slot 3):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+
+	return [contents, shown];
+}
+tp=top
+var todo = [];
+function nextAction() {
+	var next_todo = todo.shift();
+	if (next_todo) {
+		eval(next_todo);
+	}
+}
+function dojax(dourl, afterFunc, hoverCaller, failureFunc, method, params) {
+	$.ajax({
+		type: method || 'GET', url: dourl, cache: false,
+		data: params || null,
+		global: false,
+		success: function (out) {
+			nextAction();
+			if (out.match(/no\|/)) {
+				var parts = out.split(/\|/);
+				if (failureFunc) failureFunc(parts[1]);
+				else if (window.dojaxFailure) window.dojaxFailure(parts[1]);
+				else if (tp.chatpane.handleMessage) tp.chatpane.handleMessage({type: 'event', msg: 'Oops!  Sorry, Dave, you appear to be ' + parts[1]});
+				else  $('#ChatWindow').append('<font color="green">Oops!  Sorry, Dave, you appear to be ' + parts[1] + '.</font><br />' + "\n");
+				return;
+			}
+
+			if (hoverCaller)  {
+				float_results(hoverCaller, out);
+				if (afterFunc) { afterFunc(out); }
+				return;
+			}
+$(tp.mainpane.document).find("#effdiv").remove(); if(!window.dontscroll || (window.dontscroll && dontscroll==0)) { window.scroll(0,0);}
+			var $eff = $(tp.mainpane.document).find('#effdiv');
+			if ($eff.length == 0) {
+				var d = tp.mainpane.document.createElement('DIV');
+				d.id = 'effdiv';
+				var b = tp.mainpane.document.body;
+				if ($('#content_').length > 0) {
+					b = $('#content_ div:first')[0];
+				}
+				b.insertBefore(d, b.firstChild);
+				$eff = $(d);
+			}
+			$eff.find('a[name="effdivtop"]').remove().end()
+				.prepend('<a name="effdivtop"></a><center>' + out + '</center>').css('display','block');
+			if (!window.dontscroll || (window.dontscroll && dontscroll==0)) {
+				tp.mainpane.document.location = tp.mainpane.document.location + "#effdivtop";
+			}
+			if (afterFunc) { afterFunc(out); }
+		}
+	});
+}
+</script></td></tr></table></center></td></tr><tr><td height=4></td></tr></table></center></body></html>


### PR DESCRIPTION
1) If you are in CyberRealm and have OVERCLOCKED(10, track usage in _cyberFreeFights.
There is no FREEFREEFREE in the final round.
I have a workaround - and a comment on how I'd LIKE to do it, if KoL responds to my bug report.
The (free) HalfWay NC also decrements a free fight.
I account for that, but that is also a KoL bug, and we'll have to adjust if they fix it.

2) I improved the choice spoilers for the Half-Way NCs to give you the expected yield of 0's given elemental resistance  (devleaked by CF40) and expected elemental damage (reverse engineered by myself, using the elemental resistance I had when I took the choice.

3) FWIW, I trained the Profane Parrot in the cake arena and derived strengths.