### PR TITLE
Set gradle's java toolchain, fixes some workspaces being unable to compile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -281,6 +281,10 @@ task gitUpdate() {
 java {
 	sourceCompatibility = JavaVersion.toVersion(javaSourceCompatibility)
 	targetCompatibility = JavaVersion.toVersion(javaTargetCompatibility)
+
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(javaTargetCompatibility)
+	}
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
Simple enough change, without this gradle will fail to compile the project for me.

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileLibJava'.
> error: invalid source release: 21
```