### PR TITLE
feat: eldritch tentacles after 11 are not free

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -2014,6 +2014,7 @@ user	_edDefeats	0
 user	_edLashCount	0
 user	_eldritchHorrorEvoked	false
 user	_eldritchTentacleFought	false
+user	_eldritchTentaclesFoughtToday	0
 user	_elfGuardCookingUsed	0
 user	_elronsCasts	0
 user	_emberingHulkFought	false

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -4265,7 +4265,10 @@ public class FightRequest extends GenericRequest {
         case "wumpus" -> WumpusManager.reset();
         case "Baron von Ratsworth" -> TavernRequest.addTavernLocation('6');
         case "the invader" -> Preferences.setBoolean("spaceInvaderDefeated", true);
-        case "Eldritch Tentacle" -> Preferences.increment("eldritchTentaclesFought", 1);
+        case "Eldritch Tentacle" -> {
+          Preferences.increment("eldritchTentaclesFought", 1);
+          Preferences.increment("_eldritchTentaclesFoughtToday", 1);
+        }
         case "Glass Jack Hummel" -> {
           Preferences.setBoolean("pirateRealmUnlockedSpyglass", true);
           QuestDatabase.setQuestIfBetter(Quest.PIRATEREALM, 16);


### PR DESCRIPTION
> A new trivial update has been posted: Only the first 11 Eldritch Tentacles you fight in a day will be free fights, going forward.

Add a pref to track this.