### PR TITLE
Patriotic Eagle & Peace Turkey arena stats

### DIFF
--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -322,7 +322,7 @@
 290	Hobo in Sheep's Clothing	hobosheep.gif	stat0,item0,drop	unoccupied sheep suit	half-height cigar	1	3	3	2	haseyes,wearsclothes
 291	Pixel Rock	pixelrock.gif	none	pixel rock		0	0	0	0	mineral,cute,haseyes,hard
 292
-293	Patriotic Eagle	pateagle.gif	combat0,stat1,mp0	sleeping patriotic eagle	claw-held flag	0	0	0	0
+293	Patriotic Eagle	pateagle.gif	combat0,stat1,mp0	sleeping patriotic eagle	claw-held flag	3	3	1	2
 294	Jill-of-All-Trades	darkjill2f.gif	stat0,stat1,item0,meat0,combat0,drop,block,delevel,hp0,meat1,hp1,mp1,variable	Dark Jill-of-All-Trades	LED candle	1	2	3	3	organic,sentient,orb,haseyes,object,vegetable,food,edible,evil,spooky,hot,bite
 295	Flaming Leafcutter Ant	al_ant.gif	hp1,mp1,combat1	smoldering leafcutter ant egg		2	3	3	1	insect,haseyes,animal,bite,hot
 296	Rigging Snake	rigsnake.gif	combat0,delevel	baby rigging snake	rigging knot	3	1	1	1
@@ -335,7 +335,7 @@
 303	Burly Bodyguard	bodyguard.gif	combat0,block	baby bodyguard	bodyguard badge	0	0	0	0
 304	Doll Moll	molldoll.gif	combat0,meat	Doll Moll violin case	tiny Tina gun	3	3	2	2
 305	Emberiza Aureola	emberbird.gif	combat1	ember egg	tiny ember	0	0	0	0
-306	Peace Turkey	pto_fam.gif	drop,delevel,block,passive,other1,hp1,mp1	peace turkey outline	tie-dye headband	0	0	0	0
+306	Peace Turkey	pto_fam.gif	drop,delevel,block,passive,other1,hp1,mp1	peace turkey outline	tie-dye headband	0	3	1	3
 307	quantum entangler	qf.gif	block	quantized familiar	quantum watch	2	2	2	3	object
 308	golden pet rock	ts_goldrock.gif	none	golden pet rock		0	0	0	0
 309


### PR DESCRIPTION
```
Results for Patriotic Eagle after 12 trials using 144 turns:

Contest         XP[1]   XP[2]   XP[3]  Original Rank Derived Rank
Cage Match      36      42      66           0            3
Scavenger Hunt  47      59      66           0            3
Obstacle Course 61      49      15           0            1
Hide and Seek   50      66      38           0            2

Results for Peace Turkey after 12 trials using 109 turns:

Contest         XP[1]   XP[2]   XP[3]  Original Rank Derived Rank
Cage Match       0       0       0           0            0
Scavenger Hunt  30      44      61           0            3
Obstacle Course 57      46       0           0            1
Hide and Seek   26      40      60           0            3
```
There are two more familiars - which I don't have, yet - to do this for.

Emberiza Aureola - I need 11 more embering hunks to make one. Which is to say, 11 more once-per-day fights with an Embering Hulk
Burly Bodyguard - I guess I need to make an Avant Guard run. It didn't sound fun, so I skipped it, but, heh - free familiar.

By the way, a fun feature of familiar training: for contests that the familiar sucks in, we log the message in the session log - and don't bother with that contest any more.

```
[7305] Cake-Shaped Arena
Familiar: Tratchell, the 30 lb. Peace Turkey
Opponent: Scurvy Cur, the 20 lb. Sabre-Toothed Lime
Contest: Ultimate Cage Match
Tratchell refuses to participate in such a violent event. That's just not his bag, man.
Tratchell lost.
```