### PR TITLE
Use 'shopId' rather than 'nickname' in coinmasters

### DIFF
--- a/src/data/shops.txt
+++ b/src/data/shops.txt
@@ -13,14 +13,12 @@ batman_orphanage	Gotpork Orphanage	COIN
 batman_pd	Gotpork P. D.	COIN
 beergarden	Beer Garden	CONC	BEER
 blackmarket	The Black Market	NPCCOIN
-boutique	Paul's Boutique	COIN
-brogurt	The Frozen Brogurt Stand	COIN
 bugbear	Bugbear Bakery	NPC
 campfire	Your Campfire	COIN
-canteen	The Canteen	COIN
 caveshop	The Neandermall	COIN
 chateau	Chateau Mantegna Gift Shop	NPC
 chinatown	Chinatown Shops	NPC
+cindy	Paul's Boutique	COIN
 conmerch	KoL Con 13 Merch Table	COIN
 crimbo12	Uncle Crimbo's Futuristic Trailer	CONC	CRIMBO12
 crimbo14	Crimbo 2014	COIN
@@ -54,11 +52,13 @@ damachine	Vending Machine	COIN
 detective	Precinct Materiel Division	COIN
 dino	Dino World Gift Shop (The Dinostaur)	COIN
 doc	Doc Galaktik's Medicine Show	NPC
-dollhawker	Dollhawker's Emporium	COIN
-dreadsylvania	The Terrified Eagle Inn	COIN
 driparmory	Drip Institute Armory	NPCCOIN
 dripcafeteria	Drip Institute Cafeteria	NPC
+dv	The Terrified Eagle Inn	COIN
 edunder_shopshop	Everything Under the World	COIN
+elvishp1	Isotope Smithery	COIN
+elvishp2	Dollhawker's Emporium	COIN
+elvishp3	Lunar Lunch-o-Mat	COIN
 exploathing	Cosmic Ray's Bazaar	COIN
 fantasyrealm	FantasyRealm Rubee&trade; Store	COIN
 fdkol	FDKOL Requisitions Tent	NPCCOIN
@@ -78,7 +78,6 @@ guzzlr	Guzzlr Company Store Website	COIN
 hiddentavern	The Hidden Tavern	NPC
 hippy	Hippy Store (Pre-War)	NPC
 infernodisco	Disco GiftCo	COIN
-isotopesmithery	Isotope Smithery	COIN
 jarl	Jarlsberg's Cosmic Kitchen	CONC	JARLS
 jewelers	Little Canadia Jewelers	NPC
 junkmagazine	Worse Homes and Gardens	CONC	JUNK
@@ -90,7 +89,6 @@ kolhs_shop	Shop Class (After School)	CONC	SHOPCLASS
 landfillstore	The Dinsey Company Store	COIN
 lathe	Your SpinMaster&trade; lathe	COIN
 ltt	LT&T Gift Shop	COIN
-lunarlunch	Lunar Lunch-o-Mat	COIN
 madeline	Madeline's Baking Supply	NPC
 mariogear	Mushroom District Gear Shop	COIN
 marioitems	Mushroom District Item Shop	COIN
@@ -105,13 +103,16 @@ olivers	Fancy Dan the Cocktail Man	COIN
 piraterealm	PirateRealm Fun-a-Log	COIN
 pokefam	The Pok&eacute;mporium	COIN
 rumple	Rumplestiltskin's Workshop	CONC	RUMPLE
+sbb_brogurt	The Frozen Brogurt Stand	COIN
 sbb_jimmy	Buff Jimmy's Souvenir Shop	COIN
+sbb_taco	Taco Dan's Taco Stand	COIN
 september	Sept-Ember Censer	COIN
 shadowforge	The Shadow Forge	CONC	SHADOW_FORGE
 shakeshop	Ye Newe Souvenir Shoppe	COIN
 shoeshop	Legitimate Shoe Repair, Inc.	COIN
 shore	The Shore, Inc. Gift Shop	COIN
 si_shop1	The SHAWARMA Initiative	COIN
+si_shop2	The Canteen	COIN
 snackbar	Huggler Memorial Colosseum Snack Bar	NPC
 snowgarden	Winter Gardening	CONC	WINTER
 spacegate	Spacegate Fabrication Facility	COIN
@@ -119,7 +120,6 @@ spant	Spant Bit Assembly	CONC	SPANT
 starchart	A Star Chart	CONC	STARCHART
 still	Nash Crosby's Still	CONC	STILL
 sugarsheets	Sugar Sheet Folding	CONC	SUGAR_FOLDING
-taco_dan	Taco Dan's Taco Stand	COIN
 thankshop	A traveling Thanksgiving salesman	COIN
 topiary	Topiary Nuggletcrafting	COIN
 town_giftshop.php	Gift Shop	NPC

--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -50,6 +50,10 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   private final Class<? extends CoinMasterRequest> requestClass;
 
   // Optional fields
+
+  // For shop.php Coinmasters
+  private String shopId = null;
+
   // The token(s) that you exchange for items.
   private String token = null;
   private String tokenTest = null;
@@ -115,6 +119,20 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   }
 
   // Fluid field construction
+
+  /**
+   * Defines the token used by the coinmaster,
+   *
+   * <p>A coinmaster deals in currencies other than Meat. If there is only one such currency, we
+   * call it the "token"
+   *
+   * @param token - Token used
+   * @return this - Allows fluid chaining of fields
+   */
+  public CoinmasterData withShopId(String shopId) {
+    this.shopId = shopId;
+    return this;
+  }
 
   /**
    * Defines the token used by the coinmaster,
@@ -657,9 +675,10 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   }
 
   /**
-   * Populates the nine fields for a standard <code>shop.php</code> coinmaster that uses row #s.
+   * Populates the ten fields for a standard <code>shop.php</code> coinmaster that uses row #s.
    *
    * <ul>
+   *   <li>shopId
    *   <li>itemRows
    *   <li>buyURL
    *   <li>buyAction
@@ -681,7 +700,8 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
    * @return this - Allows fluid chaining of fields
    */
   public CoinmasterData withShopRowFields(String master, String shopId) {
-    return this.withItemRows(master)
+    return this.withShopId(shopId)
+        .withItemRows(master)
         .withBuyURL("shop.php?whichshop=" + shopId)
         .withBuyAction("buyitem")
         .withBuyItems(master)
@@ -693,9 +713,10 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   }
 
   /**
-   * Populates the seven fields for a new <code>shop.php</code> coinmaster that uses row #s.
+   * Populates the eight fields for a new <code>shop.php</code> coinmaster that uses row #s.
    *
    * <ul>
+   *   <li>shopId
    *   <li>shopRows from <code>coinmasters.txt</code>
    *   <li>buyURL
    *   <li>buyAction
@@ -710,7 +731,8 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
    * @return this - Allows fluid chaining of fields
    */
   public CoinmasterData withNewShopRowFields(String master, String shopId) {
-    return this.withShopRows(master)
+    return this.withShopId(shopId)
+        .withShopRows(master)
         .withBuyURL("shop.php?whichshop=" + shopId)
         .withBuyAction("buyitem")
         .withItemField("whichrow")
@@ -748,6 +770,10 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   }
 
   // Getters for optional fields
+
+  public final String getShopId() {
+    return this.shopId;
+  }
 
   public final String getTokenTest() {
     return this.tokenTest;

--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -1165,14 +1165,17 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
 
   public void registerShop() {
     if (this.buyURL.startsWith("shop.php")) {
-      ShopDatabase.registerShop(this.nickname, this.master, SHOP.COIN);
+      ShopDatabase.registerShop(this.shopId, this.master, SHOP.COIN);
     }
   }
 
   public void registerShopRows() {
+    if (this.shopId == null) {
+      return;
+    }
     if (this.shopRows != null) {
       for (ShopRow shopRow : this.shopRows) {
-        ShopRowDatabase.registerShopRow(shopRow, this.nickname);
+        ShopRowDatabase.registerShopRow(shopRow, this.shopId);
       }
     }
     if (this.buyItems != null) {
@@ -1182,7 +1185,7 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
         if (row != 0) {
           AdventureResult price = this.itemBuyPrice(itemId);
           ShopRow shopRow = new ShopRow(row, item.getInstance(1), price);
-          ShopRowDatabase.registerShopRow(shopRow, this.nickname);
+          ShopRowDatabase.registerShopRow(shopRow, this.shopId);
         }
       }
     }
@@ -1193,7 +1196,7 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
         if (row != 0) {
           AdventureResult price = this.itemSellPrice(itemId);
           ShopRow shopRow = new ShopRow(row, price, item);
-          ShopRowDatabase.registerShopRow(shopRow, this.nickname);
+          ShopRowDatabase.registerShopRow(shopRow, this.shopId);
         }
       }
     }

--- a/src/net/sourceforge/kolmafia/persistence/CoinmastersDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/CoinmastersDatabase.java
@@ -358,14 +358,14 @@ public class CoinmastersDatabase {
     return (result.size() > 0) ? result : null;
   }
 
-  public static final CoinMasterPurchaseRequest getFirstPurchaseRequest(final int itemId) {
+  public static final CoinMasterPurchaseRequest getAccessiblePurchaseRequest(final int itemId) {
     List<CoinMasterPurchaseRequest> items = getAllPurchaseRequests(itemId);
     if (items == null) {
       return null;
     }
 
     for (var request : items) {
-      if (request.getData().accessible() == null) {
+      if (request.getData().isAccessible()) {
         return request;
       }
     }
@@ -392,8 +392,19 @@ public class CoinmastersDatabase {
   }
 
   public static final boolean contains(final int itemId, boolean validate) {
-    CoinMasterPurchaseRequest item = getFirstPurchaseRequest(itemId);
-    return item != null && (!validate || item.availableItem());
+    List<CoinMasterPurchaseRequest> items = getAllPurchaseRequests(itemId);
+    if (items == null || items.size() == 0) {
+      return false;
+    }
+    if (!validate) {
+      return true;
+    }
+    for (var item : items) {
+      if (item.availableItem()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   // *** For testing

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/BuffJimmyRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/BuffJimmyRequest.java
@@ -16,7 +16,7 @@ public class BuffJimmyRequest extends CoinMasterRequest {
   public static final AdventureResult COIN = ItemPool.get(ItemPool.BEACH_BUCK, 1);
 
   public static final CoinmasterData BUFF_JIMMY =
-      new CoinmasterData(master, "sbb_jimmy", BuffJimmyRequest.class)
+      new CoinmasterData(master, "BuffJimmy", BuffJimmyRequest.class)
           .withToken("Beach Buck")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ChemiCorpRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ChemiCorpRequest.java
@@ -18,7 +18,7 @@ public class ChemiCorpRequest extends CoinMasterRequest {
   public static final AdventureResult COIN = ItemPool.get(ItemPool.DANGEROUS_CHEMICALS, 1);
 
   public static final CoinmasterData CHEMICORP =
-      new CoinmasterData(master, "batman_chemicorp", ChemiCorpRequest.class)
+      new CoinmasterData(master, "ChemiCorp", ChemiCorpRequest.class)
           .withToken("dangerous chemicals")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfArmoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfArmoryRequest.java
@@ -53,7 +53,7 @@ public class Crimbo23ElfArmoryRequest extends CoinMasterRequest {
   }
 
   public static void parseResponse(final String location, final String responseText) {
-    if (!location.contains("whichshop=" + DATA.getNickname())) {
+    if (!location.contains("whichshop=" + DATA.getShopId())) {
       return;
     }
 
@@ -82,8 +82,7 @@ public class Crimbo23ElfArmoryRequest extends CoinMasterRequest {
   }
 
   public static final boolean registerRequest(final String urlString) {
-    if (!urlString.startsWith("shop.php")
-        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+    if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=" + DATA.getShopId())) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfBarRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfBarRequest.java
@@ -46,7 +46,7 @@ public class Crimbo23ElfBarRequest extends CoinMasterRequest {
   }
 
   public static void parseResponse(final String location, final String responseText) {
-    if (!location.contains("whichshop=" + DATA.getNickname())) {
+    if (!location.contains("whichshop=" + DATA.getShopId())) {
       return;
     }
 
@@ -77,8 +77,7 @@ public class Crimbo23ElfBarRequest extends CoinMasterRequest {
   }
 
   public static final boolean registerRequest(final String urlString) {
-    if (!urlString.startsWith("shop.php")
-        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+    if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=" + DATA.getShopId())) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfCafeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfCafeRequest.java
@@ -46,7 +46,7 @@ public class Crimbo23ElfCafeRequest extends CoinMasterRequest {
   }
 
   public static void parseResponse(final String location, final String responseText) {
-    if (!location.contains("whichshop=" + DATA.getNickname())) {
+    if (!location.contains("whichshop=" + DATA.getShopId())) {
       return;
     }
 
@@ -77,8 +77,7 @@ public class Crimbo23ElfCafeRequest extends CoinMasterRequest {
   }
 
   public static final boolean registerRequest(final String urlString) {
-    if (!urlString.startsWith("shop.php")
-        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+    if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=" + DATA.getShopId())) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfFactoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfFactoryRequest.java
@@ -46,7 +46,7 @@ public class Crimbo23ElfFactoryRequest extends CoinMasterRequest {
   }
 
   public static void parseResponse(final String location, final String responseText) {
-    if (!location.contains("whichshop=" + DATA.getNickname())) {
+    if (!location.contains("whichshop=" + DATA.getShopId())) {
       return;
     }
 
@@ -77,8 +77,7 @@ public class Crimbo23ElfFactoryRequest extends CoinMasterRequest {
   }
 
   public static final boolean registerRequest(final String urlString) {
-    if (!urlString.startsWith("shop.php")
-        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+    if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=" + DATA.getShopId())) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateArmoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateArmoryRequest.java
@@ -53,7 +53,7 @@ public class Crimbo23PirateArmoryRequest extends CoinMasterRequest {
   }
 
   public static void parseResponse(final String location, final String responseText) {
-    if (!location.contains("whichshop=" + DATA.getNickname())) {
+    if (!location.contains("whichshop=" + DATA.getShopId())) {
       return;
     }
 
@@ -82,8 +82,7 @@ public class Crimbo23PirateArmoryRequest extends CoinMasterRequest {
   }
 
   public static final boolean registerRequest(final String urlString) {
-    if (!urlString.startsWith("shop.php")
-        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+    if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=" + DATA.getShopId())) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateBarRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateBarRequest.java
@@ -47,7 +47,7 @@ public class Crimbo23PirateBarRequest extends CoinMasterRequest {
   }
 
   public static void parseResponse(final String location, final String responseText) {
-    if (!location.contains("whichshop=" + DATA.getNickname())) {
+    if (!location.contains("whichshop=" + DATA.getShopId())) {
       return;
     }
 
@@ -78,8 +78,7 @@ public class Crimbo23PirateBarRequest extends CoinMasterRequest {
   }
 
   public static final boolean registerRequest(final String urlString) {
-    if (!urlString.startsWith("shop.php")
-        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+    if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=" + DATA.getShopId())) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateCafeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateCafeRequest.java
@@ -47,7 +47,7 @@ public class Crimbo23PirateCafeRequest extends CoinMasterRequest {
   }
 
   public static void parseResponse(final String location, final String responseText) {
-    if (!location.contains("whichshop=" + DATA.getNickname())) {
+    if (!location.contains("whichshop=" + DATA.getShopId())) {
       return;
     }
 
@@ -78,8 +78,7 @@ public class Crimbo23PirateCafeRequest extends CoinMasterRequest {
   }
 
   public static final boolean registerRequest(final String urlString) {
-    if (!urlString.startsWith("shop.php")
-        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+    if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=" + DATA.getShopId())) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateFactoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateFactoryRequest.java
@@ -47,7 +47,7 @@ public class Crimbo23PirateFactoryRequest extends CoinMasterRequest {
   }
 
   public static void parseResponse(final String location, final String responseText) {
-    if (!location.contains("whichshop=" + DATA.getNickname())) {
+    if (!location.contains("whichshop=" + DATA.getShopId())) {
       return;
     }
 
@@ -78,8 +78,7 @@ public class Crimbo23PirateFactoryRequest extends CoinMasterRequest {
   }
 
   public static final boolean registerRequest(final String urlString) {
-    if (!urlString.startsWith("shop.php")
-        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+    if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=" + DATA.getShopId())) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24BarRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24BarRequest.java
@@ -28,7 +28,7 @@ public class Crimbo24BarRequest extends CoinMasterRequest {
   }
 
   public static void parseResponse(final String location, final String responseText) {
-    if (!location.contains("whichshop=" + DATA.getNickname())) {
+    if (!location.contains("whichshop=" + DATA.getShopId())) {
       return;
     }
 
@@ -45,8 +45,7 @@ public class Crimbo24BarRequest extends CoinMasterRequest {
   }
 
   public static final boolean registerRequest(final String urlString) {
-    if (!urlString.startsWith("shop.php")
-        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+    if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=" + DATA.getShopId())) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24CafeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24CafeRequest.java
@@ -28,7 +28,7 @@ public class Crimbo24CafeRequest extends CoinMasterRequest {
   }
 
   public static void parseResponse(final String location, final String responseText) {
-    if (!location.contains("whichshop=" + DATA.getNickname())) {
+    if (!location.contains("whichshop=" + DATA.getShopId())) {
       return;
     }
 
@@ -45,8 +45,7 @@ public class Crimbo24CafeRequest extends CoinMasterRequest {
   }
 
   public static final boolean registerRequest(final String urlString) {
-    if (!urlString.startsWith("shop.php")
-        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+    if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=" + DATA.getShopId())) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24FactoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24FactoryRequest.java
@@ -28,7 +28,7 @@ public class Crimbo24FactoryRequest extends CoinMasterRequest {
   }
 
   public static void parseResponse(final String location, final String responseText) {
-    if (!location.contains("whichshop=" + DATA.getNickname())) {
+    if (!location.contains("whichshop=" + DATA.getShopId())) {
       return;
     }
 
@@ -45,8 +45,7 @@ public class Crimbo24FactoryRequest extends CoinMasterRequest {
   }
 
   public static final boolean registerRequest(final String urlString) {
-    if (!urlString.startsWith("shop.php")
-        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+    if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=" + DATA.getShopId())) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DedigitizerRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DedigitizerRequest.java
@@ -31,7 +31,7 @@ public class DedigitizerRequest extends CoinMasterRequest {
   }
 
   public static void parseResponse(final String location, final String responseText) {
-    if (!location.contains("whichshop=" + DATA.getNickname())) {
+    if (!location.contains("whichshop=" + DATA.getShopId())) {
       return;
     }
 
@@ -55,8 +55,7 @@ public class DedigitizerRequest extends CoinMasterRequest {
   }
 
   public static final boolean registerRequest(final String urlString) {
-    if (!urlString.startsWith("shop.php")
-        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+    if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=" + DATA.getShopId())) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DinostaurRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DinostaurRequest.java
@@ -15,7 +15,7 @@ public class DinostaurRequest extends CoinMasterRequest {
   public static final AdventureResult COIN = ItemPool.get(ItemPool.DINODOLLAR, 1);
 
   public static final CoinmasterData DINOSTAUR =
-      new CoinmasterData(master, "dino", DinostaurRequest.class)
+      new CoinmasterData(master, "Dinostaur", DinostaurRequest.class)
           .withToken("Dinodollar")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DinseyCompanyStoreRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DinseyCompanyStoreRequest.java
@@ -16,7 +16,7 @@ public class DinseyCompanyStoreRequest extends CoinMasterRequest {
   public static final AdventureResult COIN = ItemPool.get(ItemPool.FUNFUNDS, 1);
 
   public static final CoinmasterData DINSEY_COMPANY_STORE =
-      new CoinmasterData(master, "landfillstore", DinseyCompanyStoreRequest.class)
+      new CoinmasterData(master, "DinseyStore", DinseyCompanyStoreRequest.class)
           .withToken("FunFunds&trade;")
           .withPluralToken("FunFunds&trade;")
           .withTokenPattern(TOKEN_PATTERN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DiscoGiftCoRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DiscoGiftCoRequest.java
@@ -16,7 +16,7 @@ public class DiscoGiftCoRequest extends CoinMasterRequest {
   public static final AdventureResult COIN = ItemPool.get(ItemPool.VOLCOINO, 1);
 
   public static final CoinmasterData DISCO_GIFTCO =
-      new CoinmasterData(master, "infernodisco", DiscoGiftCoRequest.class)
+      new CoinmasterData(master, "DiscoGiftCo", DiscoGiftCoRequest.class)
           .withToken("Volcoino")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/EdShopRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/EdShopRequest.java
@@ -16,7 +16,7 @@ public class EdShopRequest extends CoinMasterRequest {
   public static final AdventureResult KA = ItemPool.get(ItemPool.KA_COIN, 1);
 
   public static final CoinmasterData EDSHOP =
-      new CoinmasterData(master, "edunder_shopshop", EdShopRequest.class)
+      new CoinmasterData(master, "Everything Under the World", EdShopRequest.class)
           .withToken("Ka coin")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(KA)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/FDKOLRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/FDKOLRequest.java
@@ -18,7 +18,7 @@ public class FDKOLRequest extends CoinMasterRequest {
   private static final Pattern TOKEN_PATTERN = Pattern.compile("<td>([\\d,]+) FDKOL commendation");
 
   public static final CoinmasterData FDKOL =
-      new CoinmasterData(master, "fdkol", FDKOLRequest.class)
+      new CoinmasterData(master, "FDKOL", FDKOLRequest.class)
           .withToken("FDKOL commendation")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(FDKOL_TOKEN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/FancyDanRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/FancyDanRequest.java
@@ -43,7 +43,7 @@ public class FancyDanRequest extends CoinMasterRequest {
   }
 
   public static final CoinmasterData FANCY_DAN =
-      new CoinmasterData(master, "olivers", FancyDanRequest.class)
+      new CoinmasterData(master, "Speakeasy", FancyDanRequest.class)
           .withShopRowFields(master, "olivers")
           .withBuyPrices()
           .withItemBuyPrice(FancyDanRequest::itemBuyPrice)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/FishboneryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/FishboneryRequest.java
@@ -16,7 +16,7 @@ public class FishboneryRequest extends CoinMasterRequest {
       ItemPool.get(ItemPool.FRESHWATER_FISHBONE);
 
   public static final CoinmasterData FISHBONERY =
-      new CoinmasterData(master, "fishbones", FishboneryRequest.class)
+      new CoinmasterData(master, "Fishbonery", FishboneryRequest.class)
           .withToken("freshwater fishbone")
           .withTokenTest("no freshwater fishbones")
           .withTokenPattern(TOKEN_PATTERN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/FunALogRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/FunALogRequest.java
@@ -16,7 +16,7 @@ public class FunALogRequest extends CoinMasterRequest {
       Pattern.compile("<b>You have ([\\d,]+) FunPoints?\\.</b>");
 
   public static final CoinmasterData FUN_A_LOG =
-      new CoinmasterData(master, "piraterealm", FunALogRequest.class)
+      new CoinmasterData(master, "Fun-a-Log", FunALogRequest.class)
           .withToken("FunPoint")
           .withTokenTest("You have no FunPoints")
           .withTokenPattern(TOKEN_PATTERN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/GotporkOrphanageRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/GotporkOrphanageRequest.java
@@ -18,7 +18,7 @@ public class GotporkOrphanageRequest extends CoinMasterRequest {
   public static final AdventureResult COIN = ItemPool.get(ItemPool.KIDNAPPED_ORPHAN, 1);
 
   public static final CoinmasterData GOTPORK_ORPHANAGE =
-      new CoinmasterData(master, "batman_orphanage", GotporkOrphanageRequest.class)
+      new CoinmasterData(master, "Gotpork Orphanage", GotporkOrphanageRequest.class)
           .withToken("kidnapped orphan")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/GotporkPDRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/GotporkPDRequest.java
@@ -19,7 +19,7 @@ public class GotporkPDRequest extends CoinMasterRequest {
   public static final AdventureResult COIN = ItemPool.get(ItemPool.INCRIMINATING_EVIDENCE, 1);
 
   public static final CoinmasterData GOTPORK_PD =
-      new CoinmasterData(master, "batman_pd", GotporkPDRequest.class)
+      new CoinmasterData(master, "Gotpork P. D.", GotporkPDRequest.class)
           .withToken("incriminating evidence")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/KiwiKwikiMartRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/KiwiKwikiMartRequest.java
@@ -38,7 +38,7 @@ public class KiwiKwikiMartRequest extends CoinMasterRequest {
   }
 
   public static void parseResponse(final String location, final String responseText) {
-    if (!location.contains("whichshop=" + DATA.getNickname())) {
+    if (!location.contains("whichshop=" + DATA.getShopId())) {
       return;
     }
 
@@ -69,8 +69,7 @@ public class KiwiKwikiMartRequest extends CoinMasterRequest {
   }
 
   public static final boolean registerRequest(final String urlString) {
-    if (!urlString.startsWith("shop.php")
-        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+    if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=" + DATA.getShopId())) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/LTTRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/LTTRequest.java
@@ -14,7 +14,7 @@ public class LTTRequest extends CoinMasterRequest {
   public static final AdventureResult COIN = ItemPool.get(ItemPool.BUFFALO_DIME, 1);
 
   public static final CoinmasterData LTT =
-      new CoinmasterData(master, "ltt", LTTRequest.class)
+      new CoinmasterData(master, "LT&T Gift Shop", LTTRequest.class)
           .withToken("buffalo dime")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/MrStore2002Request.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/MrStore2002Request.java
@@ -21,7 +21,7 @@ public class MrStore2002Request extends CoinMasterRequest {
       Pattern.compile("<b>You have ([\\d,]+) Mr. Store 2002 Credit");
 
   public static final CoinmasterData MR_STORE_2002 =
-      new CoinmasterData(master, "mrstore2002", MrStore2002Request.class)
+      new CoinmasterData(master, "Mr. Store 2002", MrStore2002Request.class)
           .withToken("Mr. Store 2002 Credit")
           .withTokenPattern(TOKEN_PATTERN)
           .withProperty("availableMrStore2002Credits")

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/NuggletCraftingRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/NuggletCraftingRequest.java
@@ -15,7 +15,7 @@ public class NuggletCraftingRequest extends CoinMasterRequest {
   public static final AdventureResult TOPIARY_NUGGLET = ItemPool.get(ItemPool.TOPIARY_NUGGLET, 1);
 
   public static final CoinmasterData NUGGLETCRAFTING =
-      new CoinmasterData(master, "topiary", NuggletCraftingRequest.class)
+      new CoinmasterData(master, "NuggletCrafting", NuggletCraftingRequest.class)
           .withToken("topiary nugglet")
           .withTokenTest("no topiary nugglets")
           .withTokenPattern(TOKEN_PATTERN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/PrecinctRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/PrecinctRequest.java
@@ -14,7 +14,7 @@ public class PrecinctRequest extends CoinMasterRequest {
   public static final AdventureResult DOLLAR = ItemPool.get(ItemPool.COP_DOLLAR, 1);
 
   public static final CoinmasterData PRECINCT =
-      new CoinmasterData(master, "detective", PrecinctRequest.class)
+      new CoinmasterData(master, "Precinct Materiel Division", PrecinctRequest.class)
           .withToken("cop dollar")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(DOLLAR)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/PrimordialSoupKitchenRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/PrimordialSoupKitchenRequest.java
@@ -28,7 +28,7 @@ public class PrimordialSoupKitchenRequest extends CoinMasterRequest {
   }
 
   public static void parseResponse(final String location, final String responseText) {
-    if (!location.contains("whichshop=" + DATA.getNickname())) {
+    if (!location.contains("whichshop=" + DATA.getShopId())) {
       return;
     }
 
@@ -52,8 +52,7 @@ public class PrimordialSoupKitchenRequest extends CoinMasterRequest {
   }
 
   public static final boolean registerRequest(final String urlString) {
-    if (!urlString.startsWith("shop.php")
-        || !urlString.contains("whichshop=" + DATA.getNickname())) {
+    if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=" + DATA.getShopId())) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ReplicaMrStoreRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ReplicaMrStoreRequest.java
@@ -23,7 +23,7 @@ public class ReplicaMrStoreRequest extends CoinMasterRequest {
   public static final AdventureResult COIN = ItemPool.get(ItemPool.REPLICA_MR_ACCESSORY, 1);
 
   public static final CoinmasterData REPLICA_MR_STORE =
-      new CoinmasterData(master, "mrreplica", ReplicaMrStoreRequest.class)
+      new CoinmasterData(master, "Replica Mr. Store", ReplicaMrStoreRequest.class)
           .withToken("replica Mr. Accessory")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/RubeeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/RubeeRequest.java
@@ -19,7 +19,7 @@ public class RubeeRequest extends CoinMasterRequest {
   public static final AdventureResult COIN = ItemPool.get(ItemPool.RUBEE, 1);
 
   public static final CoinmasterData RUBEE =
-      new CoinmasterData(master, "fantasyrealm", RubeeRequest.class)
+      new CoinmasterData(master, "FantasyRealm Store", RubeeRequest.class)
           .withToken("Rubee&trade;")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/SHAWARMARequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/SHAWARMARequest.java
@@ -16,7 +16,7 @@ public class SHAWARMARequest extends CoinMasterRequest {
   public static final AdventureResult COIN = ItemPool.get(ItemPool.COINSPIRACY, 1);
 
   public static final CoinmasterData SHAWARMA =
-      new CoinmasterData(master, "si_shop1", SHAWARMARequest.class)
+      new CoinmasterData(master, "SHAWARMA", SHAWARMARequest.class)
           .withToken("Coinspiracy")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/SeptEmberCenserRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/SeptEmberCenserRequest.java
@@ -16,7 +16,7 @@ public class SeptEmberCenserRequest extends CoinMasterRequest {
   private static final Pattern TOKEN_PATTERN = Pattern.compile("<b>You have ([\\d,]+) Ember");
 
   public static final CoinmasterData SEPTEMBER_CENSER =
-      new CoinmasterData(master, "september", SeptEmberCenserRequest.class)
+      new CoinmasterData(master, "Sept-Ember Censer", SeptEmberCenserRequest.class)
           .withToken("Ember")
           .withTokenPattern(TOKEN_PATTERN)
           .withProperty("availableSeptEmbers")

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ToxicChemistryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ToxicChemistryRequest.java
@@ -15,7 +15,7 @@ public class ToxicChemistryRequest extends CoinMasterRequest {
   public static final AdventureResult TOXIC_GLOBULE = ItemPool.get(ItemPool.TOXIC_GLOBULE, 1);
 
   public static final CoinmasterData TOXIC_CHEMISTRY =
-      new CoinmasterData(master, "toxic", ToxicChemistryRequest.class)
+      new CoinmasterData(master, "ToxicChemistry", ToxicChemistryRequest.class)
           .withToken("toxic globule")
           .withTokenTest("no toxic globules")
           .withTokenPattern(TOKEN_PATTERN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/VendingMachineRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/VendingMachineRequest.java
@@ -16,7 +16,7 @@ public class VendingMachineRequest extends CoinMasterRequest {
   public static final AdventureResult FAT_LOOT_TOKEN = ItemPool.get(ItemPool.FAT_LOOT_TOKEN, 1);
 
   public static final CoinmasterData VENDING_MACHINE =
-      new CoinmasterData(master, "damachine", VendingMachineRequest.class)
+      new CoinmasterData(master, "vendingmachine", VendingMachineRequest.class)
           .withToken("fat loot token")
           .withTokenTest("no fat loot tokens")
           .withTokenPattern(TOKEN_PATTERN)

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/WalMartRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/WalMartRequest.java
@@ -17,7 +17,7 @@ public class WalMartRequest extends CoinMasterRequest {
   public static final AdventureResult COIN = ItemPool.get(ItemPool.WALMART_GIFT_CERTIFICATE, 1);
 
   public static final CoinmasterData WALMART =
-      new CoinmasterData(master, "glaciest", WalMartRequest.class)
+      new CoinmasterData(master, "Wal-Mart", WalMartRequest.class)
           .withToken("Wal-Mart gift certificate")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)

--- a/src/net/sourceforge/kolmafia/shop/ShopDatabase.java
+++ b/src/net/sourceforge/kolmafia/shop/ShopDatabase.java
@@ -168,10 +168,11 @@ public class ShopDatabase {
       String printMe =
           "Shop name '"
               + shopName
-              + "' for shop id ' "
+              + "' for shop id '"
               + shopId
-              + " already used for "
-              + existingShopId;
+              + "' already used for '"
+              + existingShopId
+              + "'";
       RequestLogger.printLine(printMe);
       RequestLogger.updateSessionLog(printMe);
     }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -1903,6 +1903,7 @@ public class ProxyRecordValue extends RecordValue {
             .add("buys", DataTypes.BOOLEAN_TYPE)
             .add("sells", DataTypes.BOOLEAN_TYPE)
             .add("nickname", DataTypes.STRING_TYPE)
+            .add("shopid", DataTypes.STRING_TYPE)
             .finish("coinmaster proxy");
 
     public CoinmasterProxy(Value obj) {
@@ -1940,6 +1941,10 @@ public class ProxyRecordValue extends RecordValue {
 
     public String get_nickname() {
       return this.content != null ? ((CoinmasterData) this.content).getNickname() : "";
+    }
+
+    public String get_shopid() {
+      return this.content != null ? ((CoinmasterData) this.content).getShopId() : "";
     }
   }
 

--- a/test/net/sourceforge/kolmafia/persistence/CoinmastersDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/CoinmastersDatabaseTest.java
@@ -1,0 +1,59 @@
+package net.sourceforge.kolmafia.persistence;
+
+import static internal.helpers.Player.withEffect;
+import static internal.helpers.Player.withQuestProgress;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import internal.helpers.Cleanups;
+import net.sourceforge.kolmafia.AdventureResult;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.persistence.QuestDatabase.Quest;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class CoinmastersDatabaseTest {
+  @BeforeAll
+  static void beforeAll() {
+    KoLCharacter.reset("CoinmastersDatabaseTest");
+  }
+
+  @BeforeAll
+  static void beforeEach() {
+    Preferences.reset("CoinmastersDatabaseTest");
+  }
+
+  @Nested
+  class Contains {
+    static final AdventureResult WRECKED_GENERATOR = ItemPool.get("Wrecked Generator", 1);
+
+    @Test
+    public void containsWithoutValidationWorks() {
+      var cleanups =
+          new Cleanups(
+              withQuestProgress(Quest.GENERATOR, QuestDatabase.UNSTARTED),
+              withEffect("Transpondent", 0));
+      int itemId = WRECKED_GENERATOR.getItemId();
+      try (cleanups) {
+        assertTrue(CoinmastersDatabase.contains(itemId, false));
+        assertFalse(CoinmastersDatabase.contains(itemId, true));
+      }
+    }
+
+    @Test
+    public void containsWithValidationWorks() {
+      var cleanups =
+          new Cleanups(
+              withQuestProgress(Quest.GENERATOR, QuestDatabase.FINISHED),
+              withEffect("Transpondent", 20));
+      int itemId = WRECKED_GENERATOR.getItemId();
+      try (cleanups) {
+        assertTrue(CoinmastersDatabase.contains(itemId, false));
+        assertTrue(CoinmastersDatabase.contains(itemId, true));
+      }
+    }
+  }
+}

--- a/test/net/sourceforge/kolmafia/session/MallPriceManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/MallPriceManagerTest.java
@@ -184,7 +184,7 @@ public class MallPriceManagerTest {
   }
 
   private void addCoinMasterItem(int itemId, List<PurchaseRequest> list) {
-    PurchaseRequest item = CoinmastersDatabase.getFirstPurchaseRequest(itemId);
+    PurchaseRequest item = CoinmastersDatabase.getAccessiblePurchaseRequest(itemId);
     if (item != null) {
       list.add(item);
     }


### PR DESCRIPTION
1) Add a ```shopId``` field to CoinmasterData.  Set that for shop.php coinmasters.
Use ```getShopId()``` rather than ```getNickname()``` when checking if the URL pertains to a particular coinmaster.
Restore the previous nicknames to all coinmasters for which I had changed it to be the shopId.
Add .shopid proxy record field.
```
> ash $coinmaster[The Dinsey Company Store]

Returned: The Dinsey Company Store
token => FunFunds™
item => FunFunds™
property =>
available_tokens => 0
buys => false
sells => true
nickname => DinseyStore
shopid => landfillstore
```
2) Fix some incorrect shopids. (!)
3) CoinmastersDatabase.contains now works as before if validate == false.