### PR TITLE
Add functional fields for three CoinmasterData methods

### DIFF
--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -1,13 +1,13 @@
 package net.sourceforge.kolmafia;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.AdventureResult.AdventureLongCountResult;
@@ -106,6 +106,9 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   private Function<Integer, Boolean> canBuyItem = this::canBuyItemInternal;
   private Function<Integer, Boolean> availableItem = this::availableItemInternal;
   private BiConsumer<AdventureResult, Boolean> purchasedItem = this::purchasedItemInternal;
+  private Supplier<String> canBuy = this::canBuyInternal;
+  private Supplier<String> canSell = this::canSellInternal;
+  private Supplier<String> accessible = this::accessibleInternal;
 
   // Constructor for CoinmasterData with only mandatory fields.
   // Optional fields can be added fluidly.
@@ -675,6 +678,42 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   }
 
   /**
+   * Specifies a static method that will be invoked by <code>Boolean
+   * canBuy()</code>
+   *
+   * @param supplier - a Supplier object to be called by canBuy
+   * @return this - Allows fluid chaining of fields
+   */
+  public CoinmasterData withCanBuy(Supplier<String> supplier) {
+    this.canBuy = supplier;
+    return this;
+  }
+
+  /**
+   * Specifies a static method that will be invoked by <code>Boolean
+   * canSell()</code>
+   *
+   * @param supplier - a Supplier object to be called by canSell
+   * @return this - Allows fluid chaining of fields
+   */
+  public CoinmasterData withCanSell(Supplier<String> supplier) {
+    this.canSell = supplier;
+    return this;
+  }
+
+  /**
+   * Specifies a static method that will be invoked by <code>String
+   * accessible()</code>
+   *
+   * @param supplier - a Supplier object to be called by accessible
+   * @return this - Allows fluid chaining of fields
+   */
+  public CoinmasterData withAccessible(Supplier<String> supplier) {
+    this.accessible = supplier;
+    return this;
+  }
+
+  /**
    * Populates the ten fields for a standard <code>shop.php</code> coinmaster that uses row #s.
    *
    * <ul>
@@ -709,7 +748,8 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
         .withItemField("whichrow")
         .withItemPattern(GenericRequest.WHICHROW_PATTERN)
         .withCountField("quantity")
-        .withCountPattern(GenericRequest.QUANTITY_PATTERN);
+        .withCountPattern(GenericRequest.QUANTITY_PATTERN)
+        .withNeedsPasswordHash(true);
   }
 
   /**
@@ -738,7 +778,8 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
         .withItemField("whichrow")
         .withItemPattern(GenericRequest.WHICHROW_PATTERN)
         .withCountField("quantity")
-        .withCountPattern(GenericRequest.QUANTITY_PATTERN);
+        .withCountPattern(GenericRequest.QUANTITY_PATTERN)
+        .withNeedsPasswordHash(true);
   }
 
   public CoinmasterData inZone(String zone) {
@@ -1303,46 +1344,29 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
       return "Zone is no longer accessible";
     }
 
-    Class<? extends CoinMasterRequest> requestClass = this.getRequestClass();
-    Class<?>[] parameters = new Class<?>[0];
+    return this.accessible.get();
+  }
 
-    try {
-      Method method = requestClass.getMethod("accessible", parameters);
-      Object[] args = new Object[0];
-      return (String) method.invoke(null, args);
-    } catch (Exception e) {
-      return null;
-    }
+  public String accessibleInternal() {
+    return null;
   }
 
   public String canSell() {
     // Returns an error reason or null
+    return this.canSell.get();
+  }
 
-    Class<? extends CoinMasterRequest> requestClass = this.getRequestClass();
-    Class<?>[] parameters = new Class<?>[0];
-
-    try {
-      Method method = requestClass.getMethod("canSell", parameters);
-      Object[] args = new Object[0];
-      return (String) method.invoke(null, args);
-    } catch (Exception e) {
-      return null;
-    }
+  public String canSellInternal() {
+    return null;
   }
 
   public String canBuy() {
     // Returns an error reason or null
+    return this.canBuy.get();
+  }
 
-    Class<? extends CoinMasterRequest> requestClass = this.getRequestClass();
-    Class<?>[] parameters = new Class<?>[0];
-
-    try {
-      Method method = requestClass.getMethod("canBuy", parameters);
-      Object[] args = new Object[0];
-      return (String) method.invoke(null, args);
-    } catch (Exception e) {
-      return null;
-    }
+  public String canBuyInternal() {
+    return null;
   }
 
   public void purchasedItem(final AdventureResult item, final Boolean storage) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/AWOLQuartermasterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/AWOLQuartermasterRequest.java
@@ -30,7 +30,8 @@ public class AWOLQuartermasterRequest extends CoinMasterRequest {
           .withItemField("tobuy")
           .withItemPattern(TOBUY_PATTERN)
           .withCountField("howmany")
-          .withCountPattern(GenericRequest.HOWMANY_PATTERN);
+          .withCountPattern(GenericRequest.HOWMANY_PATTERN)
+          .withAccessible(AWOLQuartermasterRequest::accessible);
 
   private static String lastURL = null;
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/AltarOfBonesRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/AltarOfBonesRequest.java
@@ -23,7 +23,8 @@ public class AltarOfBonesRequest extends CoinMasterRequest {
           .withBuyItems(master)
           .withBuyPrices(master)
           .withItemField("whichitem")
-          .withItemPattern(GenericRequest.WHICHITEM_PATTERN);
+          .withItemPattern(GenericRequest.WHICHITEM_PATTERN)
+          .withAccessible(AltarOfBonesRequest::accessible);
 
   public AltarOfBonesRequest() {
     super(ALTAR_OF_BONES);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/BURTRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/BURTRequest.java
@@ -27,7 +27,8 @@ public class BURTRequest extends CoinMasterRequest {
           .withBuyItems(master)
           .withBuyPrices(master)
           .withItemField("itemquantity")
-          .withItemPattern(TOBUY_PATTERN);
+          .withItemPattern(TOBUY_PATTERN)
+          .withAccessible(BURTRequest::accessible);
 
   private static final Map<Integer, Integer> itemByPrice =
       CoinmastersDatabase.invert(BURT.getBuyPrices());

--- a/src/net/sourceforge/kolmafia/request/coinmaster/BigBrotherRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/BigBrotherRequest.java
@@ -41,7 +41,8 @@ public class BigBrotherRequest extends CoinMasterRequest {
           .withItemPattern(GenericRequest.WHICHITEM_PATTERN)
           .withCountField("quantity")
           .withCountPattern(GenericRequest.QUANTITY_PATTERN)
-          .withCanBuyItem(BigBrotherRequest::canBuyItem);
+          .withCanBuyItem(BigBrotherRequest::canBuyItem)
+          .withAccessible(BigBrotherRequest::accessible);
 
   private static Boolean canBuyItem(final Integer itemId) {
     return switch (itemId) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/BountyHunterHunterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/BountyHunterHunterRequest.java
@@ -381,10 +381,6 @@ public class BountyHunterHunterRequest extends CoinMasterRequest {
     }
   }
 
-  public static String accessible() {
-    return null;
-  }
-
   public static final boolean registerRequest(final String urlString) {
     if (!urlString.startsWith("bounty.php")) {
       return false;

--- a/src/net/sourceforge/kolmafia/request/coinmaster/DimemasterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/DimemasterRequest.java
@@ -38,7 +38,8 @@ public class DimemasterRequest extends CoinMasterRequest {
           .withItemPattern(GenericRequest.WHICHITEM_PATTERN)
           .withCountField("quantity")
           .withCountPattern(GenericRequest.QUANTITY_PATTERN)
-          .withCanBuyItem(DimemasterRequest::canBuyItem);
+          .withCanBuyItem(DimemasterRequest::canBuyItem)
+          .withAccessible(DimemasterRequest::accessible);
 
   private static Boolean canBuyItem(final Integer itemId) {
     return switch (itemId) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/FreeSnackRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/FreeSnackRequest.java
@@ -61,6 +61,7 @@ public class FreeSnackRequest extends CoinMasterRequest {
   }
 
   public static String accessible() {
+    // *** Finish this.
     return null;
   }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/FudgeWandRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/FudgeWandRequest.java
@@ -27,7 +27,8 @@ public class FudgeWandRequest extends CoinMasterRequest {
           .withItem(FUDGECULE)
           .withBuyURL("choice.php?whichchoice=562")
           .withBuyItems(master)
-          .withBuyPrices(master);
+          .withBuyPrices(master)
+          .withAccessible(FudgeWandRequest::accessible);
 
   private static String lastURL = null;
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/GameShoppeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/GameShoppeRequest.java
@@ -33,7 +33,9 @@ public class GameShoppeRequest extends CoinMasterRequest {
           .withItemField("whichitem")
           .withItemPattern(GenericRequest.WHICHITEM_PATTERN)
           .withCountField("quantity")
-          .withCountPattern(GenericRequest.QUANTITY_PATTERN);
+          .withCountPattern(GenericRequest.QUANTITY_PATTERN)
+          .withCanBuy(GameShoppeRequest::canBuy)
+          .withAccessible(GameShoppeRequest::accessible);
 
   public GameShoppeRequest() {
     super(GAMESHOPPE);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/HermitRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/HermitRequest.java
@@ -44,7 +44,8 @@ public class HermitRequest extends CoinMasterRequest {
           .withItemField("whichitem")
           .withItemPattern(GenericRequest.WHICHITEM_PATTERN)
           .withCountField("quantity")
-          .withCountPattern(GenericRequest.QUANTITY_PATTERN);
+          .withCountPattern(GenericRequest.QUANTITY_PATTERN)
+          .withAccessible(HermitRequest::accessible);
 
   private static final Pattern CLOVER_PATTERN = Pattern.compile("(\\d+) left in stock for today");
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/MrStoreRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/MrStoreRequest.java
@@ -171,10 +171,6 @@ public class MrStoreRequest extends CoinMasterRequest {
     InventoryManager.countGoldenMrAccesories();
   }
 
-  public static String accessible() {
-    return null;
-  }
-
   public static boolean registerRequest(final String urlString) {
     if (!urlString.startsWith("mrstore.php")) {
       return false;

--- a/src/net/sourceforge/kolmafia/request/coinmaster/QuartersmasterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/QuartersmasterRequest.java
@@ -38,7 +38,8 @@ public class QuartersmasterRequest extends CoinMasterRequest {
           .withItemPattern(GenericRequest.WHICHITEM_PATTERN)
           .withCountField("quantity")
           .withCountPattern(GenericRequest.QUANTITY_PATTERN)
-          .withCanBuyItem(QuartersmasterRequest::canBuyItem);
+          .withCanBuyItem(QuartersmasterRequest::canBuyItem)
+          .withAccessible(QuartersmasterRequest::accessible);
 
   private static Boolean canBuyItem(final Integer itemId) {
     return switch (itemId) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/TicketCounterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/TicketCounterRequest.java
@@ -101,6 +101,7 @@ public class TicketCounterRequest extends CoinMasterRequest {
   }
 
   public static String accessible() {
+    // *** Finish this.
     return null;
   }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/TravelingTraderRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/TravelingTraderRequest.java
@@ -34,7 +34,8 @@ public class TravelingTraderRequest extends CoinMasterRequest {
           .withCountField("quantity")
           .withItemPattern(GenericRequest.QUANTITY_PATTERN)
           .withStorageAction("usehagnk=1")
-          .withTradeAllAction("tradeall=1");
+          .withTradeAllAction("tradeall=1")
+          .withAccessible(TravelingTraderRequest::accessible);
 
   public TravelingTraderRequest() {
     super(TRAVELER);
@@ -187,6 +188,7 @@ public class TravelingTraderRequest extends CoinMasterRequest {
   }
 
   public static String accessible() {
+    // *** Is there something we can do here? Like the Time Twitching Tower.
     return null;
   }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/AppleStoreRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/AppleStoreRequest.java
@@ -22,7 +22,7 @@ public class AppleStoreRequest extends CoinMasterRequest {
           .withTokenPattern(CHRONER_PATTERN)
           .withItem(CHRONER)
           .withShopRowFields(master, "applestore")
-          .withNeedsPasswordHash(true);
+          .withAccessible(AppleStoreRequest::accessible);
 
   public AppleStoreRequest() {
     super(APPLE_STORE);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ArmoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ArmoryRequest.java
@@ -20,7 +20,8 @@ public class ArmoryRequest extends CoinMasterRequest {
           .withToken("Coinspiracy")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
-          .withShopRowFields(master, "si_shop3");
+          .withShopRowFields(master, "si_shop3")
+          .withAccessible(ArmoryRequest::accessible);
 
   public ArmoryRequest() {
     super(ARMORY);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/BatFabricatorRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/BatFabricatorRequest.java
@@ -20,7 +20,8 @@ public class BatFabricatorRequest extends CoinMasterRequest {
   public static final CoinmasterData BAT_FABRICATOR =
       new CoinmasterData(master, "batman_cave", BatFabricatorRequest.class)
           .withShopRowFields(master, "batman_cave")
-          .withItemBuyPrice(BatFabricatorRequest::itemBuyPrice);
+          .withItemBuyPrice(BatFabricatorRequest::itemBuyPrice)
+          .withAccessible(BatFabricatorRequest::accessible);
 
   public static AdventureResult itemBuyPrice(final Integer itemId) {
     int cost = BatManager.hasUpgrade(BatManager.IMPROVED_3D_BAT_PRINTER) ? 2 : 3;

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/BlackMarketRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/BlackMarketRequest.java
@@ -23,7 +23,8 @@ public class BlackMarketRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(TOKEN)
           .withShopRowFields(master, "blackmarket")
-          .withCanBuyItem(BlackMarketRequest::canBuyItem);
+          .withCanBuyItem(BlackMarketRequest::canBuyItem)
+          .withAccessible(BlackMarketRequest::accessible);
 
   private static Boolean canBuyItem(final Integer itemId) {
     AdventureResult item = ItemPool.get(itemId);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/BoutiqueRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/BoutiqueRequest.java
@@ -19,7 +19,8 @@ public class BoutiqueRequest extends CoinMasterRequest {
           .withToken("odd silver coin")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
-          .withShopRowFields(master, "cindy");
+          .withShopRowFields(master, "cindy")
+          .withAccessible(BoutiqueRequest::accessible);
 
   public BoutiqueRequest() {
     super(BOUTIQUE);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/BrogurtRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/BrogurtRequest.java
@@ -21,6 +21,7 @@ public class BrogurtRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
           .withShopRowFields(master, "sbb_brogurt")
+          .withAccessible(BrogurtRequest::accessible)
           .withCanBuyItem(BrogurtRequest::canBuyItem);
 
   private static Boolean canBuyItem(final Integer itemId) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/BuffJimmyRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/BuffJimmyRequest.java
@@ -20,7 +20,8 @@ public class BuffJimmyRequest extends CoinMasterRequest {
           .withToken("Beach Buck")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
-          .withShopRowFields(master, "sbb_jimmy");
+          .withShopRowFields(master, "sbb_jimmy")
+          .withAccessible(BuffJimmyRequest::accessible);
 
   public BuffJimmyRequest() {
     super(BUFF_JIMMY);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/CanteenRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/CanteenRequest.java
@@ -20,7 +20,8 @@ public class CanteenRequest extends CoinMasterRequest {
           .withToken("Coinspiracy")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
-          .withShopRowFields(master, "si_shop2");
+          .withShopRowFields(master, "si_shop2")
+          .withAccessible(CanteenRequest::accessible);
 
   public CanteenRequest() {
     super(CANTEEN);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ChemiCorpRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ChemiCorpRequest.java
@@ -23,7 +23,8 @@ public class ChemiCorpRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
           .withShopRowFields(master, "batman_chemicorp")
-          .withItemBuyPrice(ChemiCorpRequest::itemBuyPrice);
+          .withItemBuyPrice(ChemiCorpRequest::itemBuyPrice)
+          .withAccessible(ChemiCorpRequest::accessible);
 
   private static AdventureResult itemBuyPrice(final Integer itemId) {
     int price = CHEMICORP.getBuyPrices().get(itemId);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/CosmicRaysBazaarRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/CosmicRaysBazaarRequest.java
@@ -24,7 +24,7 @@ public class CosmicRaysBazaarRequest extends CoinMasterRequest {
           .withShopRowFields(master, "exploathing")
           .withBuyPrices()
           .withItemBuyPrice(CosmicRaysBazaarRequest::itemBuyPrice)
-          .withNeedsPasswordHash(true);
+          .withAccessible(CosmicRaysBazaarRequest::accessible);
 
   private static AdventureResult itemBuyPrice(final Integer itemId) {
     return buyCosts.get(itemId);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo17Request.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo17Request.java
@@ -23,8 +23,8 @@ public class Crimbo17Request extends CoinMasterRequest {
           .withTokenPattern(CHEER_PATTERN)
           .withItem(CHEER)
           .withShopRowFields(master, "crimbo17")
-          .withNeedsPasswordHash(true)
-          .withCanBuyItem(Crimbo17Request::canBuyItem);
+          .withCanBuyItem(Crimbo17Request::canBuyItem)
+          .withAccessible(Crimbo17Request::accessible);
 
   private static Boolean canBuyItem(final Integer itemId) {
     return switch (itemId) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20BoozeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20BoozeRequest.java
@@ -23,7 +23,6 @@ public class Crimbo20BoozeRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(TOKEN)
           .withShopRowFields(master, "crimbo20booze")
-          .withNeedsPasswordHash(true)
           .withCanBuyItem(Crimbo20BoozeRequest::canBuyItem);
 
   private static Boolean canBuyItem(final Integer itemId) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20CandyRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20CandyRequest.java
@@ -23,7 +23,6 @@ public class Crimbo20CandyRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(TOKEN)
           .withShopRowFields(master, "crimbo20candy")
-          .withNeedsPasswordHash(true)
           .withCanBuyItem(Crimbo20CandyRequest::canBuyItem);
 
   private static Boolean canBuyItem(final Integer itemId) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20FoodRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20FoodRequest.java
@@ -23,7 +23,6 @@ public class Crimbo20FoodRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(TOKEN)
           .withShopRowFields(master, "crimbo20food")
-          .withNeedsPasswordHash(true)
           .withCanBuyItem(Crimbo20FoodRequest::canBuyItem);
 
   private static Boolean canBuyItem(final Integer itemId) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfArmoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfArmoryRequest.java
@@ -29,7 +29,8 @@ public class Crimbo23ElfArmoryRequest extends CoinMasterRequest {
           .withSellURL("shop.php?whichshop=crimbo23_elf_armory")
           .withSellAction("buyitem")
           .withSellItems(master)
-          .withSellPrices(master);
+          .withSellPrices(master)
+          .withAccessible(Crimbo23ElfArmoryRequest::accessible);
 
   public Crimbo23ElfArmoryRequest() {
     super(DATA);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfBarRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfBarRequest.java
@@ -22,7 +22,7 @@ public class Crimbo23ElfBarRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(TOKEN)
           .withShopRowFields(master, "crimbo23_elf_bar")
-          .withNeedsPasswordHash(true);
+          .withAccessible(Crimbo23ElfBarRequest::accessible);
 
   public Crimbo23ElfBarRequest() {
     super(DATA);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfCafeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfCafeRequest.java
@@ -22,7 +22,7 @@ public class Crimbo23ElfCafeRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(TOKEN)
           .withShopRowFields(master, "crimbo23_elf_cafe")
-          .withNeedsPasswordHash(true);
+          .withAccessible(Crimbo23ElfCafeRequest::accessible);
 
   public Crimbo23ElfCafeRequest() {
     super(DATA);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfFactoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfFactoryRequest.java
@@ -22,7 +22,7 @@ public class Crimbo23ElfFactoryRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(TOKEN)
           .withShopRowFields(master, "crimbo23_elf_factory")
-          .withNeedsPasswordHash(true);
+          .withAccessible(Crimbo23ElfFactoryRequest::accessible);
 
   public Crimbo23ElfFactoryRequest() {
     super(DATA);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateArmoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateArmoryRequest.java
@@ -29,7 +29,8 @@ public class Crimbo23PirateArmoryRequest extends CoinMasterRequest {
           .withSellURL("shop.php?whichshop=crimbo23_pirate_armory")
           .withSellAction("buyitem")
           .withSellItems(master)
-          .withSellPrices(master);
+          .withSellPrices(master)
+          .withAccessible(Crimbo23PirateArmoryRequest::accessible);
 
   public Crimbo23PirateArmoryRequest() {
     super(DATA);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateBarRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateBarRequest.java
@@ -23,7 +23,7 @@ public class Crimbo23PirateBarRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(TOKEN)
           .withShopRowFields(master, "crimbo23_pirate_bar")
-          .withNeedsPasswordHash(true);
+          .withAccessible(Crimbo23PirateBarRequest::accessible);
 
   public Crimbo23PirateBarRequest() {
     super(DATA);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateCafeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateCafeRequest.java
@@ -23,7 +23,7 @@ public class Crimbo23PirateCafeRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(TOKEN)
           .withShopRowFields(master, "crimbo23_pirate_cafe")
-          .withNeedsPasswordHash(true);
+          .withAccessible(Crimbo23PirateCafeRequest::accessible);
 
   public Crimbo23PirateCafeRequest() {
     super(DATA);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateFactoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateFactoryRequest.java
@@ -23,7 +23,7 @@ public class Crimbo23PirateFactoryRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(TOKEN)
           .withShopRowFields(master, "crimbo23_pirate_factory")
-          .withNeedsPasswordHash(true);
+          .withAccessible(Crimbo23PirateFactoryRequest::accessible);
 
   public Crimbo23PirateFactoryRequest() {
     super(DATA);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24BarRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24BarRequest.java
@@ -11,8 +11,7 @@ public class Crimbo24BarRequest extends CoinMasterRequest {
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "crimbo24_bar", Crimbo24BarRequest.class)
           .inZone("Crimbo24")
-          .withNewShopRowFields(master, "crimbo24_bar")
-          .withNeedsPasswordHash(true);
+          .withNewShopRowFields(master, "crimbo24_bar");
 
   public Crimbo24BarRequest() {
     super(DATA);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24CafeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24CafeRequest.java
@@ -11,8 +11,7 @@ public class Crimbo24CafeRequest extends CoinMasterRequest {
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "crimbo24_cafe", Crimbo24CafeRequest.class)
           .inZone("Crimbo24")
-          .withNewShopRowFields(master, "crimbo24_cafe")
-          .withNeedsPasswordHash(true);
+          .withNewShopRowFields(master, "crimbo24_cafe");
 
   public Crimbo24CafeRequest() {
     super(DATA);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24FactoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo24FactoryRequest.java
@@ -11,8 +11,7 @@ public class Crimbo24FactoryRequest extends CoinMasterRequest {
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "crimbo24_factory", Crimbo24FactoryRequest.class)
           .inZone("Crimbo24")
-          .withNewShopRowFields(master, "crimbo24_factory")
-          .withNeedsPasswordHash(true);
+          .withNewShopRowFields(master, "crimbo24_factory");
 
   public Crimbo24FactoryRequest() {
     super(DATA);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DedigitizerRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DedigitizerRequest.java
@@ -15,7 +15,7 @@ public class DedigitizerRequest extends CoinMasterRequest {
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "cyber_dedigitizer", DedigitizerRequest.class)
           .withNewShopRowFields(master, "cyber_dedigitizer")
-          .withNeedsPasswordHash(true);
+          .withAccessible(DedigitizerRequest::accessible);
 
   public DedigitizerRequest() {
     super(DATA);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DinostaurRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DinostaurRequest.java
@@ -19,7 +19,8 @@ public class DinostaurRequest extends CoinMasterRequest {
           .withToken("Dinodollar")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
-          .withShopRowFields(master, "dino");
+          .withShopRowFields(master, "dino")
+          .withAccessible(DinostaurRequest::accessible);
 
   public DinostaurRequest() {
     super(DINOSTAUR);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DinseyCompanyStoreRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DinseyCompanyStoreRequest.java
@@ -21,7 +21,8 @@ public class DinseyCompanyStoreRequest extends CoinMasterRequest {
           .withPluralToken("FunFunds&trade;")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
-          .withShopRowFields(master, "landfillstore");
+          .withShopRowFields(master, "landfillstore")
+          .withAccessible(DinseyCompanyStoreRequest::accessible);
 
   public DinseyCompanyStoreRequest() {
     super(DINSEY_COMPANY_STORE);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DiscoGiftCoRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DiscoGiftCoRequest.java
@@ -20,7 +20,8 @@ public class DiscoGiftCoRequest extends CoinMasterRequest {
           .withToken("Volcoino")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
-          .withShopRowFields(master, "infernodisco");
+          .withShopRowFields(master, "infernodisco")
+          .withAccessible(DiscoGiftCoRequest::accessible);
 
   public DiscoGiftCoRequest() {
     super(DISCO_GIFTCO);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DollHawkerRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DollHawkerRequest.java
@@ -14,7 +14,8 @@ public class DollHawkerRequest extends CoinMasterRequest {
           .withTokenTest("You have 0 lunar isotopes")
           .withTokenPattern(SpaaaceRequest.TOKEN_PATTERN)
           .withItem(SpaaaceRequest.ISOTOPE)
-          .withShopRowFields(master, "elvishp2");
+          .withShopRowFields(master, "elvishp2")
+          .withAccessible(SpaaaceRequest::accessible);
 
   public DollHawkerRequest() {
     super(DOLLHAWKER);
@@ -38,10 +39,6 @@ public class DollHawkerRequest extends CoinMasterRequest {
     }
 
     return CoinMasterRequest.registerRequest(DOLLHAWKER, urlString, true);
-  }
-
-  public static String accessible() {
-    return SpaaaceRequest.accessible();
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DripArmoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DripArmoryRequest.java
@@ -77,10 +77,6 @@ public class DripArmoryRequest extends CoinMasterRequest {
     CoinMasterRequest.parseResponse(data, location, responseText);
   }
 
-  public static String accessible() {
-    return null;
-  }
-
   public static final boolean registerRequest(final String urlString, final boolean noMeat) {
     if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=driparmory")) {
       return false;

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/EdShopRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/EdShopRequest.java
@@ -20,7 +20,8 @@ public class EdShopRequest extends CoinMasterRequest {
           .withToken("Ka coin")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(KA)
-          .withShopRowFields(master, "edunder_shopshop");
+          .withShopRowFields(master, "edunder_shopshop")
+          .withAccessible(EdShopRequest::accessible);
 
   public EdShopRequest() {
     super(EDSHOP);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/FDKOLRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/FDKOLRequest.java
@@ -22,7 +22,8 @@ public class FDKOLRequest extends CoinMasterRequest {
           .withToken("FDKOL commendation")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(FDKOL_TOKEN)
-          .withShopRowFields(master, "fdkol");
+          .withShopRowFields(master, "fdkol")
+          .withAccessible(FDKOLRequest::accessible);
 
   public FDKOLRequest() {
     super(FDKOL);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/FancyDanRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/FancyDanRequest.java
@@ -47,7 +47,7 @@ public class FancyDanRequest extends CoinMasterRequest {
           .withShopRowFields(master, "olivers")
           .withBuyPrices()
           .withItemBuyPrice(FancyDanRequest::itemBuyPrice)
-          .withNeedsPasswordHash(true);
+          .withAccessible(FancyDanRequest::accessible);
 
   private static AdventureResult itemBuyPrice(final Integer itemId) {
     return buyCosts.get(itemId);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/FishboneryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/FishboneryRequest.java
@@ -21,7 +21,8 @@ public class FishboneryRequest extends CoinMasterRequest {
           .withTokenTest("no freshwater fishbones")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(FRESHWATER_FISHBONE)
-          .withShopRowFields(master, "fishbones");
+          .withShopRowFields(master, "fishbones")
+          .withAccessible(FishboneryRequest::accessible);
 
   public FishboneryRequest() {
     super(FISHBONERY);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/FunALogRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/FunALogRequest.java
@@ -22,7 +22,8 @@ public class FunALogRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withProperty("availableFunPoints")
           .withShopRowFields(master, "piraterealm")
-          .withAvailableItem(FunALogRequest::availableItem);
+          .withAvailableItem(FunALogRequest::availableItem)
+          .withAccessible(FunALogRequest::accessible);
 
   private static final Map<Integer, String> ITEM_TO_UNLOCK_PREF =
       Map.ofEntries(

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/GMartRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/GMartRequest.java
@@ -20,7 +20,7 @@ public class GMartRequest extends CoinMasterRequest {
           .withTokenPattern(G_PATTERN)
           .withItem(G)
           .withShopRowFields(master, "glover")
-          .withNeedsPasswordHash(true);
+          .withAccessible(GMartRequest::accessible);
 
   public GMartRequest() {
     super(GMART);
@@ -61,6 +61,7 @@ public class GMartRequest extends CoinMasterRequest {
   }
 
   public static String accessible() {
+    // *** Finish this.
     return null;
   }
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/GotporkOrphanageRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/GotporkOrphanageRequest.java
@@ -23,7 +23,8 @@ public class GotporkOrphanageRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
           .withShopRowFields(master, "batman_orphanage")
-          .withItemBuyPrice(GotporkOrphanageRequest::itemBuyPrice);
+          .withItemBuyPrice(GotporkOrphanageRequest::itemBuyPrice)
+          .withAccessible(GotporkOrphanageRequest::accessible);
 
   private static AdventureResult itemBuyPrice(final Integer itemId) {
     int price = GOTPORK_ORPHANAGE.getBuyPrices().get(itemId);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/GotporkPDRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/GotporkPDRequest.java
@@ -24,7 +24,8 @@ public class GotporkPDRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
           .withShopRowFields(master, "batman_pd")
-          .withItemBuyPrice(GotporkPDRequest::itemBuyPrice);
+          .withItemBuyPrice(GotporkPDRequest::itemBuyPrice)
+          .withAccessible(GotporkPDRequest::accessible);
 
   private static AdventureResult itemBuyPrice(final Integer itemId) {
     int price = GOTPORK_PD.getBuyPrices().get(itemId);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/GuzzlrRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/GuzzlrRequest.java
@@ -20,7 +20,7 @@ public class GuzzlrRequest extends CoinMasterRequest {
           .withTokenPattern(GUZZLR_PATTERN)
           .withItem(GUZZLRBUCK)
           .withShopRowFields(master, "guzzlr")
-          .withNeedsPasswordHash(true);
+          .withAccessible(GuzzlrRequest::accessible);
 
   public GuzzlrRequest() {
     super(GUZZLR);
@@ -61,7 +61,7 @@ public class GuzzlrRequest extends CoinMasterRequest {
   public static String accessible() {
     return InventoryManager.getAccessibleCount(GUZZLRBUCK) > 0
         ? null
-        : "Need access to your Getaway Campsite";
+        : "You have no Guzzlrbucks to spend";
   }
 
   public static final boolean registerRequest(final String urlString) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/IsotopeSmitheryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/IsotopeSmitheryRequest.java
@@ -14,7 +14,8 @@ public class IsotopeSmitheryRequest extends CoinMasterRequest {
           .withTokenTest("You have 0 lunar isotopes")
           .withTokenPattern(SpaaaceRequest.TOKEN_PATTERN)
           .withItem(SpaaaceRequest.ISOTOPE)
-          .withShopRowFields(master, "elvishp1");
+          .withShopRowFields(master, "elvishp1")
+          .withAccessible(SpaaaceRequest::accessible);
 
   public IsotopeSmitheryRequest() {
     super(ISOTOPE_SMITHERY);
@@ -38,10 +39,6 @@ public class IsotopeSmitheryRequest extends CoinMasterRequest {
     }
 
     return CoinMasterRequest.registerRequest(ISOTOPE_SMITHERY, urlString, true);
-  }
-
-  public static String accessible() {
-    return SpaaaceRequest.accessible();
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/KiwiKwikiMartRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/KiwiKwikiMartRequest.java
@@ -13,8 +13,7 @@ public class KiwiKwikiMartRequest extends CoinMasterRequest {
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "kiwi", KiwiKwikiMartRequest.class)
           .withNewShopRowFields(master, "kiwi")
-          .withCanBuyItem(KiwiKwikiMartRequest::canBuyItem)
-          .withNeedsPasswordHash(true);
+          .withCanBuyItem(KiwiKwikiMartRequest::canBuyItem);
 
   public KiwiKwikiMartRequest() {
     super(DATA);
@@ -62,10 +61,6 @@ public class KiwiKwikiMartRequest extends CoinMasterRequest {
 
     // Parse current coin balances
     CoinMasterRequest.parseBalance(data, responseText);
-  }
-
-  public static String accessible() {
-    return null;
   }
 
   public static final boolean registerRequest(final String urlString) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/LTTRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/LTTRequest.java
@@ -18,7 +18,8 @@ public class LTTRequest extends CoinMasterRequest {
           .withToken("buffalo dime")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
-          .withShopRowFields(master, "ltt");
+          .withShopRowFields(master, "ltt")
+          .withAccessible(LTTRequest::accessible);
 
   public LTTRequest() {
     super(LTT);
@@ -65,6 +66,7 @@ public class LTTRequest extends CoinMasterRequest {
   }
 
   public static String accessible() {
+    // *** Finish this.
     return null;
   }
 }

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/LunarLunchRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/LunarLunchRequest.java
@@ -17,7 +17,8 @@ public class LunarLunchRequest extends CoinMasterRequest {
           .withTokenTest("You have 0 lunar isotopes")
           .withTokenPattern(SpaaaceRequest.TOKEN_PATTERN)
           .withItem(SpaaaceRequest.ISOTOPE)
-          .withShopRowFields(master, "elvishp3");
+          .withShopRowFields(master, "elvishp3")
+          .withAccessible(LunarLunchRequest::accessible);
 
   public LunarLunchRequest() {
     super(LUNAR_LUNCH);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/MemeShopRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/MemeShopRequest.java
@@ -20,7 +20,6 @@ public class MemeShopRequest extends CoinMasterRequest {
           .withTokenPattern(BACON_PATTERN)
           .withItem(BACON)
           .withShopRowFields(master, "bacon")
-          .withNeedsPasswordHash(true)
           .withCanBuyItem(MemeShopRequest::canBuyItem)
           .withPurchasedItem(MemeShopRequest::purchasedItem);
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/MerchTableRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/MerchTableRequest.java
@@ -39,7 +39,8 @@ public class MerchTableRequest extends CoinMasterRequest {
           .withShopRowFields(master, "conmerch")
           .withItemRows(CoinmastersDatabase.getOrMakeRows(master))
           .withBuyPrices()
-          .withItemBuyPrice(MerchTableRequest::itemBuyPrice);
+          .withItemBuyPrice(MerchTableRequest::itemBuyPrice)
+          .withAccessible(MerchTableRequest::accessible);
 
   private static AdventureResult itemBuyPrice(final Integer itemId) {
     return buyCosts.get(itemId);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/MrStore2002Request.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/MrStore2002Request.java
@@ -25,7 +25,8 @@ public class MrStore2002Request extends CoinMasterRequest {
           .withToken("Mr. Store 2002 Credit")
           .withTokenPattern(TOKEN_PATTERN)
           .withProperty("availableMrStore2002Credits")
-          .withShopRowFields(master, "mrstore2002");
+          .withShopRowFields(master, "mrstore2002")
+          .withAccessible(MrStore2002Request::accessible);
 
   public MrStore2002Request() {
     super(MR_STORE_2002);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/NeandermallRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/NeandermallRequest.java
@@ -22,7 +22,7 @@ public class NeandermallRequest extends CoinMasterRequest {
           .withTokenPattern(CHRONER_PATTERN)
           .withItem(CHRONER)
           .withShopRowFields(master, "caveshop")
-          .withNeedsPasswordHash(true);
+          .withAccessible(NeandermallRequest::accessible);
 
   public NeandermallRequest() {
     super(NEANDERMALL);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/NinjaStoreRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/NinjaStoreRequest.java
@@ -22,7 +22,7 @@ public class NinjaStoreRequest extends CoinMasterRequest {
           .withTokenPattern(CHRONER_PATTERN)
           .withItem(CHRONER)
           .withShopRowFields(master, "nina")
-          .withNeedsPasswordHash(true);
+          .withAccessible(NinjaStoreRequest::accessible);
 
   public NinjaStoreRequest() {
     super(NINJA_STORE);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/NuggletCraftingRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/NuggletCraftingRequest.java
@@ -20,7 +20,8 @@ public class NuggletCraftingRequest extends CoinMasterRequest {
           .withTokenTest("no topiary nugglets")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(TOPIARY_NUGGLET)
-          .withShopRowFields(master, "topiary");
+          .withShopRowFields(master, "topiary")
+          .withAccessible(NuggletCraftingRequest::accessible);
 
   public NuggletCraftingRequest() {
     super(NUGGLETCRAFTING);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/PlumberGearRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/PlumberGearRequest.java
@@ -21,7 +21,7 @@ public class PlumberGearRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
           .withShopRowFields(master, "mariogear")
-          .withNeedsPasswordHash(true);
+          .withAccessible(PlumberGearRequest::accessible);
 
   public PlumberGearRequest() {
     super(PLUMBER_GEAR);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/PlumberItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/PlumberItemRequest.java
@@ -21,7 +21,7 @@ public class PlumberItemRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
           .withShopRowFields(master, "marioitems")
-          .withNeedsPasswordHash(true);
+          .withAccessible(PlumberItemRequest::accessible);
 
   public PlumberItemRequest() {
     super(PLUMBER_ITEMS);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/PokemporiumRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/PokemporiumRequest.java
@@ -31,7 +31,7 @@ public class PokemporiumRequest extends CoinMasterRequest {
           .withItem(POKEDOLLAR)
           .withShopRowFields(master, "pokefam")
           .withCanBuyItem(PokemporiumRequest::canBuyItem)
-          .withNeedsPasswordHash(true);
+          .withAccessible(PokemporiumRequest::accessible);
 
   private static Boolean canBuyItem(final Integer itemId) {
     return KoLCharacter.inPokefam();

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/PrecinctRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/PrecinctRequest.java
@@ -18,7 +18,8 @@ public class PrecinctRequest extends CoinMasterRequest {
           .withToken("cop dollar")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(DOLLAR)
-          .withShopRowFields(master, "detective");
+          .withShopRowFields(master, "detective")
+          .withAccessible(PrecinctRequest::accessible);
 
   public PrecinctRequest() {
     super(PRECINCT);
@@ -67,6 +68,7 @@ public class PrecinctRequest extends CoinMasterRequest {
   }
 
   public static String accessible() {
+    // *** Finish this.
     return null;
   }
 }

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/PrimordialSoupKitchenRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/PrimordialSoupKitchenRequest.java
@@ -12,7 +12,7 @@ public class PrimordialSoupKitchenRequest extends CoinMasterRequest {
   public static final CoinmasterData DATA =
       new CoinmasterData(master, "twitchsoup", PrimordialSoupKitchenRequest.class)
           .withNewShopRowFields(master, "twitchsoup")
-          .withNeedsPasswordHash(true);
+          .withAccessible(PrimordialSoupKitchenRequest::accessible);
 
   public PrimordialSoupKitchenRequest() {
     super(DATA);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ReplicaMrStoreRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ReplicaMrStoreRequest.java
@@ -29,7 +29,8 @@ public class ReplicaMrStoreRequest extends CoinMasterRequest {
           .withItem(COIN)
           .withShopRowFields(master, "mrreplica")
           .withCanBuyItem(ReplicaMrStoreRequest::canBuyItem)
-          .withAvailableItem(ReplicaMrStoreRequest::availableItem);
+          .withAvailableItem(ReplicaMrStoreRequest::availableItem)
+          .withAccessible(ReplicaMrStoreRequest::accessible);
 
   public ReplicaMrStoreRequest() {
     super(REPLICA_MR_STORE);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/RubeeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/RubeeRequest.java
@@ -23,7 +23,8 @@ public class RubeeRequest extends CoinMasterRequest {
           .withToken("Rubee&trade;")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
-          .withShopRowFields(master, "fantasyrealm");
+          .withShopRowFields(master, "fantasyrealm")
+          .withAccessible(RubeeRequest::accessible);
 
   public RubeeRequest() {
     super(RUBEE);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/SHAWARMARequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/SHAWARMARequest.java
@@ -20,7 +20,8 @@ public class SHAWARMARequest extends CoinMasterRequest {
           .withToken("Coinspiracy")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
-          .withShopRowFields(master, "si_shop1");
+          .withShopRowFields(master, "si_shop1")
+          .withAccessible(SHAWARMARequest::accessible);
 
   public SHAWARMARequest() {
     super(SHAWARMA);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/SeptEmberCenserRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/SeptEmberCenserRequest.java
@@ -20,7 +20,8 @@ public class SeptEmberCenserRequest extends CoinMasterRequest {
           .withToken("Ember")
           .withTokenPattern(TOKEN_PATTERN)
           .withProperty("availableSeptEmbers")
-          .withShopRowFields(master, "september");
+          .withShopRowFields(master, "september")
+          .withAccessible(SeptEmberCenserRequest::accessible);
 
   public SeptEmberCenserRequest() {
     super(SEPTEMBER_CENSER);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ShoeRepairRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ShoeRepairRequest.java
@@ -22,7 +22,7 @@ public class ShoeRepairRequest extends CoinMasterRequest {
           .withTokenPattern(CHRONER_PATTERN)
           .withItem(CHRONER)
           .withShopRowFields(master, "shoeshop")
-          .withNeedsPasswordHash(true);
+          .withAccessible(ShoeRepairRequest::accessible);
 
   public ShoeRepairRequest() {
     super(SHOE_REPAIR);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ShoreGiftShopRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ShoreGiftShopRequest.java
@@ -23,9 +23,9 @@ public class ShoreGiftShopRequest extends CoinMasterRequest {
           .withTokenPattern(SCRIP_PATTERN)
           .withItem(SHIP_TRIP_SCRIP)
           .withShopRowFields(master, "shore")
-          .withNeedsPasswordHash(true)
           .withCanBuyItem(ShoreGiftShopRequest::canBuyItem)
-          .withPurchasedItem(ShoreGiftShopRequest::purchasedItem);
+          .withPurchasedItem(ShoreGiftShopRequest::purchasedItem)
+          .withAccessible(ShoreGiftShopRequest::accessible);
 
   private static Boolean canBuyItem(final Integer itemId) {
     AdventureResult item = ItemPool.get(itemId);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/SpacegateFabricationRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/SpacegateFabricationRequest.java
@@ -22,7 +22,7 @@ public class SpacegateFabricationRequest extends CoinMasterRequest {
           .withTokenPattern(RESEARCH_PATTERN)
           .withItem(RESEARCH)
           .withShopRowFields(master, "spacegate")
-          .withNeedsPasswordHash(true);
+          .withAccessible(SpacegateFabricationRequest::accessible);
 
   public SpacegateFabricationRequest() {
     super(SPACEGATE_STORE);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/SpinMasterLatheRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/SpinMasterLatheRequest.java
@@ -24,7 +24,7 @@ public class SpinMasterLatheRequest extends CoinMasterRequest {
           .withShopRowFields(master, "lathe")
           .withBuyPrices()
           .withItemBuyPrice(SpinMasterLatheRequest::itemBuyPrice)
-          .withNeedsPasswordHash(true);
+          .withAccessible(SpinMasterLatheRequest::accessible);
 
   private static AdventureResult itemBuyPrice(final Integer itemId) {
     return buyCosts.get(itemId);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/SwaggerShopRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/SwaggerShopRequest.java
@@ -108,7 +108,8 @@ public class SwaggerShopRequest extends CoinMasterRequest {
           .withItemPattern(GenericRequest.WHICHITEM_PATTERN)
           .withCanBuyItem(SwaggerShopRequest::canBuyItem)
           .withGetBuyPrice(SwaggerShopRequest::getBuyPrice)
-          .withAvailableItem(SwaggerShopRequest::availableItem);
+          .withAvailableItem(SwaggerShopRequest::availableItem)
+          .withAccessible(SwaggerShopRequest::accessible);
 
   private static Boolean canBuyItem(final Integer itemId) {
     Season season = itemIdToSeason.get(itemId);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/TacoDanRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/TacoDanRequest.java
@@ -21,7 +21,8 @@ public class TacoDanRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
           .withShopRowFields(master, "sbb_taco")
-          .withCanBuyItem(TacoDanRequest::canBuyItem);
+          .withCanBuyItem(TacoDanRequest::canBuyItem)
+          .withAccessible(TacoDanRequest::accessible);
 
   private static Boolean canBuyItem(final Integer itemId) {
     return switch (itemId) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/TerrifiedEagleInnRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/TerrifiedEagleInnRequest.java
@@ -104,10 +104,6 @@ public class TerrifiedEagleInnRequest extends CoinMasterRequest {
     CoinMasterRequest.parseBalance(data, responseText);
   }
 
-  public static String accessible() {
-    return null;
-  }
-
   public static boolean registerRequest(final String urlString) {
     // shop.php?pwd&whichshop=dv
     if (!urlString.startsWith("shop.php") || !urlString.contains("whichshop=dv")) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ThankShopRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ThankShopRequest.java
@@ -18,8 +18,7 @@ public class ThankShopRequest extends CoinMasterRequest {
           .withToken("cashew")
           .withTokenPattern(CASHEW_PATTERN)
           .withItem(CASHEW)
-          .withShopRowFields(master, "thankshop")
-          .withNeedsPasswordHash(true);
+          .withShopRowFields(master, "thankshop");
 
   public ThankShopRequest() {
     super(CASHEW_STORE);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ToxicChemistryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ToxicChemistryRequest.java
@@ -20,7 +20,8 @@ public class ToxicChemistryRequest extends CoinMasterRequest {
           .withTokenTest("no toxic globules")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(TOXIC_GLOBULE)
-          .withShopRowFields(master, "toxic");
+          .withShopRowFields(master, "toxic")
+          .withAccessible(ToxicChemistryRequest::accessible);
 
   public ToxicChemistryRequest() {
     super(TOXIC_CHEMISTRY);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/TrapperRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/TrapperRequest.java
@@ -23,7 +23,8 @@ public class TrapperRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(YETI_FUR)
           .withShopRowFields(master, "trapper")
-          .withBuyItems(master);
+          .withBuyItems(master)
+          .withAccessible(TrapperRequest::accessible);
 
   public TrapperRequest() {
     super(TRAPPER);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/VendingMachineRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/VendingMachineRequest.java
@@ -22,8 +22,8 @@ public class VendingMachineRequest extends CoinMasterRequest {
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(FAT_LOOT_TOKEN)
           .withShopRowFields(master, "damachine")
-          .withNeedsPasswordHash(true)
-          .withCanBuyItem(VendingMachineRequest::canBuyItem);
+          .withCanBuyItem(VendingMachineRequest::canBuyItem)
+          .withAccessible(VendingMachineRequest::accessible);
 
   private static Boolean canBuyItem(final Integer itemId) {
     AdventureResult item = ItemPool.get(itemId);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/WalMartRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/WalMartRequest.java
@@ -21,7 +21,8 @@ public class WalMartRequest extends CoinMasterRequest {
           .withToken("Wal-Mart gift certificate")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(COIN)
-          .withShopRowFields(master, "glaciest");
+          .withShopRowFields(master, "glaciest")
+          .withAccessible(WalMartRequest::accessible);
 
   public WalMartRequest() {
     super(WALMART);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/WarbearBoxRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/WarbearBoxRequest.java
@@ -20,7 +20,8 @@ public class WarbearBoxRequest extends CoinMasterRequest {
           .withToken("warbear whosit")
           .withTokenPattern(TOKEN_PATTERN)
           .withItem(WHOSIT)
-          .withShopRowFields(master, "warbear");
+          .withShopRowFields(master, "warbear")
+          .withAccessible(WarbearBoxRequest::accessible);
 
   public WarbearBoxRequest() {
     super(WARBEARBOX);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/YeNeweSouvenirShoppeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/YeNeweSouvenirShoppeRequest.java
@@ -21,8 +21,8 @@ public class YeNeweSouvenirShoppeRequest extends CoinMasterRequest {
           .withTokenTest("no Chroner")
           .withTokenPattern(CHRONER_PATTERN)
           .withItem(CHRONER)
-          .withNeedsPasswordHash(true)
-          .withShopRowFields(master, "shakeshop");
+          .withShopRowFields(master, "shakeshop")
+          .withAccessible(YeNeweSouvenirShoppeRequest::accessible);
 
   public YeNeweSouvenirShoppeRequest() {
     super(SHAKE_SHOP);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/YourCampfireRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/YourCampfireRequest.java
@@ -22,7 +22,7 @@ public class YourCampfireRequest extends CoinMasterRequest {
           .withTokenPattern(FIREWOOD_PATTERN)
           .withItem(STICK_OF_FIREWOOD)
           .withShopRowFields(master, "campfire")
-          .withNeedsPasswordHash(true);
+          .withAccessible(YourCampfireRequest::accessible);
 
   public YourCampfireRequest() {
     super(YOUR_CAMPFIRE);


### PR DESCRIPTION
1) A number of methods associated with CoinmasterData objects can be specified at compile time using code like this:
```
      new CoinmasterData(master, "swagger", SwaggerShopRequest.class)
          .withToken("swagger")
          .withPluralToken("swagger")
          .withTokenTest("You have 0 swagger")
          .withTokenPattern(TOKEN_PATTERN)
          .withProperty("availableSwagger")
          .withBuyURL("peevpee.php?place=shop")
          .withBuyAction("buy")
          .withBuyItems(master)
          .withBuyPrices(master)
          .withItemField("whichitem")
          .withItemPattern(GenericRequest.WHICHITEM_PATTERN)
          .withCanBuyItem(SwaggerShopRequest::canBuyItem)
          .withGetBuyPrice(SwaggerShopRequest::getBuyPrice)
          .withAvailableItem(SwaggerShopRequest::availableItem);
```
I added three more fluid chaining methods:
```
          .withCanBuy(CLASS::canBuy)
          .withCanSell(CLASS::canSell)
          .withAccessible(CLASS::accessible)
```
Those are all ```Supplier<String>``` - static methods that take no arguments and return a String.

It turns out there is only a single coinmaster which uses canBuy() - GameShoppeRequest.
None use canSell().
Many use accessible().

Previously, we would look up a Method in the request class and call it, if present.
We'd catch the error if the method did not exist.

Therefore, if you didn't need that functionality, don't declare a function.

Back when this capability was created, we used Java 6. Now, as of Java 8, we can use Functional objects and do method lookup at compile time.

I made it so.

2) I made all request classes that had an accessible method use withAccessible.
About six of them had methods which always returned null - but they really should have code to check if you had the item or were in the path, or whatever. I left the methods, but added a "*** Finish this." comment.
3) I noticed that coinmasters which use rows all set "needPasswordHash". That is, apparently, how shop.php works.
Therefore, I added that to the fluid chaining methods which set up shop row fields.

Here's a little test:
```
> ash is_accessible($coinmaster[the dedigitizer])

Returned: false

> ash inaccessible_reason($coinmaster[the dedigitizer])

Returned: You can't access the server room.
```