### PR TITLE
If multiple (available) NPC stores sell an item, show all in Mall Search results

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/CoinmastersDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/CoinmastersDatabase.java
@@ -337,12 +337,12 @@ public class CoinmastersDatabase {
   }
 
   public static final List<CoinMasterPurchaseRequest> getAllPurchaseRequests(final int itemId) {
+    List<CoinMasterPurchaseRequest> result = new ArrayList<>();
+
     List<CoinMasterPurchaseRequest> items = COINMASTER_ITEMS.get(itemId);
     if (items == null || items.size() == 0) {
-      return null;
+      return result;
     }
-
-    List<CoinMasterPurchaseRequest> result = new ArrayList<>();
 
     for (var request : items) {
       // *** For testing
@@ -355,7 +355,7 @@ public class CoinmastersDatabase {
       result.add(request);
     }
 
-    return (result.size() > 0) ? result : null;
+    return result;
   }
 
   public static final CoinMasterPurchaseRequest getAccessiblePurchaseRequest(final int itemId) {

--- a/src/net/sourceforge/kolmafia/persistence/NPCStoreDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/NPCStoreDatabase.java
@@ -110,22 +110,22 @@ public class NPCStoreDatabase {
   }
 
   public static final List<NPCPurchaseRequest> getAvailablePurchaseRequests(final int itemId) {
+    List<NPCPurchaseRequest> result = new ArrayList<>();
+
     List<NPCPurchaseRequest> items = NPCStoreDatabase.NPC_ITEMS.get(itemId);
     if (items == null || items.size() == 0) {
-      return null;
+      return result;
     }
-
-    List<NPCPurchaseRequest> result = new ArrayList<>();
 
     for (var item : items) {
       boolean canPurchase = canPurchase(item.getStoreId(), item.getShopName(), itemId);
-      item.setCanPurchase(canPurchase);
       if (canPurchase) {
+        item.setCanPurchase(true);
         result.add(item);
       }
     }
 
-    return (result.size() > 0) ? result : null;
+    return result;
   }
 
   public static final PurchaseRequest getPurchaseRequest(final int itemId) {

--- a/src/net/sourceforge/kolmafia/persistence/NPCStoreDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/NPCStoreDatabase.java
@@ -2,6 +2,7 @@ package net.sourceforge.kolmafia.persistence;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -106,6 +107,25 @@ public class NPCStoreDatabase {
             ? "Barrrtleby's Barrrgain Books (Bees Hate You)"
             : "Barrrtleby's Barrrgain Books")
         : NPCStoreDatabase.storeNameById.get(storeId);
+  }
+
+  public static final List<NPCPurchaseRequest> getAvailablePurchaseRequests(final int itemId) {
+    List<NPCPurchaseRequest> items = NPCStoreDatabase.NPC_ITEMS.get(itemId);
+    if (items == null || items.size() == 0) {
+      return null;
+    }
+
+    List<NPCPurchaseRequest> result = new ArrayList<>();
+
+    for (var item : items) {
+      boolean canPurchase = canPurchase(item.getStoreId(), item.getShopName(), itemId);
+      item.setCanPurchase(canPurchase);
+      if (canPurchase) {
+        result.add(item);
+      }
+    }
+
+    return (result.size() > 0) ? result : null;
   }
 
   public static final PurchaseRequest getPurchaseRequest(final int itemId) {

--- a/src/net/sourceforge/kolmafia/request/MallSearchRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MallSearchRequest.java
@@ -503,11 +503,9 @@ public class MallSearchRequest extends GenericRequest {
   }
 
   private void addNPCStoreItem(final int itemId) {
-    if (NPCStoreDatabase.contains(itemId, false)) {
-      PurchaseRequest item = NPCStoreDatabase.getPurchaseRequest(itemId);
-      if (!this.results.contains(item)) {
-        this.results.add(item);
-      }
+    var items = NPCStoreDatabase.getAvailablePurchaseRequests(itemId);
+    if (items != null) {
+      this.results.addAll(items);
     }
   }
 

--- a/src/net/sourceforge/kolmafia/request/MallSearchRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MallSearchRequest.java
@@ -504,16 +504,12 @@ public class MallSearchRequest extends GenericRequest {
 
   private void addNPCStoreItem(final int itemId) {
     var items = NPCStoreDatabase.getAvailablePurchaseRequests(itemId);
-    if (items != null) {
-      this.results.addAll(items);
-    }
+    this.results.addAll(items);
   }
 
   private void addCoinMasterItem(final int itemId) {
     var items = CoinmastersDatabase.getAllPurchaseRequests(itemId);
-    if (items != null) {
-      this.results.addAll(items);
-    }
+    this.results.addAll(items);
   }
 
   private void finalizeList(final List<String> itemNames) {

--- a/src/net/sourceforge/kolmafia/shop/ShopRequest.java
+++ b/src/net/sourceforge/kolmafia/shop/ShopRequest.java
@@ -179,7 +179,7 @@ public class ShopRequest extends GenericRequest {
       }
 
       // *** CoinmastersDatabase assumes that multiple stores can sell a particular item.
-      if (CoinmastersDatabase.getAllPurchaseRequests(id) != null && !force) {
+      if (CoinmastersDatabase.getAllPurchaseRequests(id).size() > 0 && !force) {
         continue;
       }
 


### PR DESCRIPTION
For example, from ```test row-duplicate-items```:
```
Degrassi Knoll Bakery and Hardware Store	ROW600	wad of dough	50 Meat
Bugbear Bakery	ROW678	wad of dough	50 Meat
Madeline's Baking Supply	ROW737	wad of dough	40 Meat
```
If you are in a Knoll sign, have the Bugbear Costume, and have met Madeline, all three shops are available.
Any of those conditions NOT true, the corresponding shop is not available.

This PR shows all available NPC purchase requests in the Mall Search frame when you search for "wad of dough".

Hmm. The previous behavior showed the last unavailable purchase request, if none were available.
Is that right? If you don't have Degrassi Knoll available, nothing you can do will open it. It seems like luck - or perhaps the order of shops in npcstores.txt - that determines what you will get.