### PR TITLE
simplify 'contains' method in CoinMastersDatabase and NPCStoreDatabase

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/CoinmastersDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/CoinmastersDatabase.java
@@ -360,9 +360,6 @@ public class CoinmastersDatabase {
 
   public static final CoinMasterPurchaseRequest getAccessiblePurchaseRequest(final int itemId) {
     List<CoinMasterPurchaseRequest> items = getAllPurchaseRequests(itemId);
-    if (items == null) {
-      return null;
-    }
 
     for (var request : items) {
       if (request.getData().isAccessible()) {
@@ -392,13 +389,11 @@ public class CoinmastersDatabase {
   }
 
   public static final boolean contains(final int itemId, boolean validate) {
-    List<CoinMasterPurchaseRequest> items = getAllPurchaseRequests(itemId);
-    if (items == null || items.size() == 0) {
-      return false;
-    }
     if (!validate) {
-      return true;
+      return COINMASTER_ITEMS.containsKey(itemId) && COINMASTER_ITEMS.get(itemId).size() > 0;
     }
+
+    List<CoinMasterPurchaseRequest> items = getAllPurchaseRequests(itemId);
     for (var item : items) {
       if (item.availableItem()) {
         return true;

--- a/src/net/sourceforge/kolmafia/persistence/CoinmastersDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/CoinmastersDatabase.java
@@ -374,7 +374,7 @@ public class CoinmastersDatabase {
     var request = COINMASTER_ROWS.get(shopRow);
     if (request != null) {
       // *** For testing
-      if (!request.getData().isDisabled()) {
+      if (request.getData().isDisabled()) {
         return null;
       }
 

--- a/src/net/sourceforge/kolmafia/persistence/NPCStoreDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/NPCStoreDatabase.java
@@ -660,8 +660,11 @@ public class NPCStoreDatabase {
   }
 
   public static final boolean contains(final int itemId, boolean validate) {
+    if (!validate) {
+      return NPC_ITEMS.containsKey(itemId) && NPC_ITEMS.get(itemId).size() > 0;
+    }
     PurchaseRequest item = NPCStoreDatabase.getPurchaseRequest(itemId);
-    return item != null && (!validate || item.canPurchaseIgnoringMeat());
+    return item != null && item.canPurchaseIgnoringMeat();
   }
 
   public static void reset() {

--- a/src/net/sourceforge/kolmafia/request/MallSearchRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MallSearchRequest.java
@@ -503,13 +503,17 @@ public class MallSearchRequest extends GenericRequest {
   }
 
   private void addNPCStoreItem(final int itemId) {
-    var items = NPCStoreDatabase.getAvailablePurchaseRequests(itemId);
-    this.results.addAll(items);
+    if (NPCStoreDatabase.contains(itemId, false)) {
+      var items = NPCStoreDatabase.getAvailablePurchaseRequests(itemId);
+      this.results.addAll(items);
+    }
   }
 
   private void addCoinMasterItem(final int itemId) {
-    var items = CoinmastersDatabase.getAllPurchaseRequests(itemId);
-    this.results.addAll(items);
+    if (CoinmastersDatabase.contains(itemId, false)) {
+      var items = CoinmastersDatabase.getAllPurchaseRequests(itemId);
+      this.results.addAll(items);
+    }
   }
 
   private void finalizeList(final List<String> itemNames) {

--- a/src/net/sourceforge/kolmafia/shop/ShopRequest.java
+++ b/src/net/sourceforge/kolmafia/shop/ShopRequest.java
@@ -173,13 +173,13 @@ public class ShopRequest extends GenericRequest {
       //
       // A shop with multiple currencies per item can be a Coinmaster
 
-      // *** NPCStoreDatabase assumes that only a single store sells a particular item.
-      if (NPCStoreDatabase.getPurchaseRequest(id) != null && !force) {
+      // *** NPCStoreDatabase assumes that multiple stores can sell a particular item.
+      if (NPCStoreDatabase.contains(id, false) && !force) {
         continue;
       }
 
       // *** CoinmastersDatabase assumes that multiple stores can sell a particular item.
-      if (CoinmastersDatabase.getAllPurchaseRequests(id).size() > 0 && !force) {
+      if (CoinmastersDatabase.contains(id, false) && !force) {
         continue;
       }
 

--- a/src/net/sourceforge/kolmafia/shop/ShopRequest.java
+++ b/src/net/sourceforge/kolmafia/shop/ShopRequest.java
@@ -179,7 +179,9 @@ public class ShopRequest extends GenericRequest {
       }
 
       // *** CoinmastersDatabase assumes that multiple stores can sell a particular item.
-      if (CoinmastersDatabase.contains(id, false) && !force) {
+      // The following does not account for "disabled" coinmasters - a testing feature.
+      //    if (CoinmastersDatabase.contains(id, false) && !force) {
+      if (CoinmastersDatabase.getAllPurchaseRequests(id).size() > 0 && !force) {
         continue;
       }
 


### PR DESCRIPTION
This is a continuation of my previous PR.

NPCStoreDatabase.contains(itemId, false) and CoinmastersDatabase.contains(itemId, false) - where the false mean "don't validate" - don't actually need to look at the PurchaseRequests on their HashMultimaps. All they need to look at is if there is at least one PurchaseRequest for the itemId.

MallSearchRequest can then only ask for a list of PurchaseRequests if the appropriate database actually has any.