### PR TITLE
Remove unnecessary constructors for CoinMasterRequest classes

### DIFF
--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -332,9 +332,9 @@
 300	Mini Kiwi	kiwi_kiwi.gif	stat0,meat0,drop	mini kiwi egg	aviator goggles	3	3	3	1
 301	Proto-Protozoa	protoproto.gif	combat1	proto-proto-protozoa	extra ooze	0	0	0	3
 302	Evolving Organism	bacteria.gif	combat1,hp1,mp1,block,variable	unevolved organism	extra DNA	3	1	2	0
-303	Burly Bodyguard	bodyguard.gif	combat0,block	baby bodyguard	bodyguard badge	0	0	0	0
+303	Burly Bodyguard	bodyguard.gif	combat0,block	baby bodyguard	bodyguard badge	3	3	3	3
 304	Doll Moll	molldoll.gif	combat0,meat	Doll Moll violin case	tiny Tina gun	3	3	2	2
-305	Emberiza Aureola	emberbird.gif	combat1	ember egg	tiny ember	0	0	0	0
+305	Emberiza Aureola	emberbird.gif	combat1	ember egg	tiny ember	0	1	2	3
 306	Peace Turkey	pto_fam.gif	drop,delevel,block,passive,other1,hp1,mp1	peace turkey outline	tie-dye headband	0	3	1	3
 307	quantum entangler	qf.gif	block	quantized familiar	quantum watch	2	2	2	3	object
 308	golden pet rock	ts_goldrock.gif	none	golden pet rock		0	0	0	0

--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -128,10 +128,9 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   /**
    * Defines the token used by the coinmaster,
    *
-   * <p>A coinmaster deals in currencies other than Meat. If there is only one such currency, we
-   * call it the "token"
+   * <p>A shop.php coinmaster needs a shopId
    *
-   * @param token - Token used
+   * @param shopId - whichshop=SHOPID
    * @return this - Allows fluid chaining of fields
    */
   public CoinmasterData withShopId(String shopId) {
@@ -1124,7 +1123,11 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   public Set<AdventureResult> currencies() {
     if (this.currencies == null) {
       this.currencies = new TreeSet<>();
-      if (this.shopRows != null) {
+      if (this.master.equals("Hermit")) {
+        // Unlike other coinmasters, buyitems is not initialized until
+        // the shop is first visited.
+        this.currencies.add(HermitRequest.WORTHLESS_ITEM);
+      } else if (this.shopRows != null) {
         for (ShopRow shopRow : this.shopRows) {
           for (AdventureResult cost : shopRow.getCosts()) {
             this.currencies.add(cost);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/AWOLQuartermasterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/AWOLQuartermasterRequest.java
@@ -43,14 +43,6 @@ public class AWOLQuartermasterRequest extends CoinMasterRequest {
     super(AWOL, buying, attachments);
   }
 
-  public AWOLQuartermasterRequest(final boolean buying, final AdventureResult attachment) {
-    super(AWOL, buying, attachment);
-  }
-
-  public AWOLQuartermasterRequest(final boolean buying, final int itemId, final int quantity) {
-    super(AWOL, buying, itemId, quantity);
-  }
-
   @Override
   public void run() {
     if (this.attachments != null) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/AltarOfBonesRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/AltarOfBonesRequest.java
@@ -34,12 +34,9 @@ public class AltarOfBonesRequest extends CoinMasterRequest {
     super(ALTAR_OF_BONES, buying, attachments);
   }
 
-  public AltarOfBonesRequest(final boolean buying, final AdventureResult attachment) {
-    super(ALTAR_OF_BONES, buying, attachment);
-  }
-
-  public AltarOfBonesRequest(final boolean buying, final int itemId, final int quantity) {
-    super(ALTAR_OF_BONES, buying, itemId, quantity);
+  @Override
+  public void processResults() {
+    parseResponse(this.getURLString(), this.responseText);
   }
 
   public static void parseResponse(final String urlString, final String responseText) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/BURTRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/BURTRequest.java
@@ -51,14 +51,6 @@ public class BURTRequest extends CoinMasterRequest {
     super(BURT, buying, attachments);
   }
 
-  public BURTRequest(final boolean buying, final AdventureResult attachment) {
-    super(BURT, buying, attachment);
-  }
-
-  public BURTRequest(final boolean buying, final int itemId, final int quantity) {
-    super(BURT, buying, itemId, quantity);
-  }
-
   @Override
   public void setItem(final AdventureResult item) {
     // The item field is the buy price; the number of BURTS spent

--- a/src/net/sourceforge/kolmafia/request/coinmaster/BigBrotherRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/BigBrotherRequest.java
@@ -87,14 +87,6 @@ public class BigBrotherRequest extends CoinMasterRequest {
     super(BIG_BROTHER, buying, attachments);
   }
 
-  public BigBrotherRequest(final boolean buying, final AdventureResult attachment) {
-    super(BIG_BROTHER, buying, attachment);
-  }
-
-  public BigBrotherRequest(final boolean buying, final int itemId, final int quantity) {
-    super(BIG_BROTHER, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/BountyHunterHunterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/BountyHunterHunterRequest.java
@@ -52,14 +52,6 @@ public class BountyHunterHunterRequest extends CoinMasterRequest {
     super(BHH, buying, attachments);
   }
 
-  public BountyHunterHunterRequest(final boolean buying, final AdventureResult attachment) {
-    super(BHH, buying, attachment);
-  }
-
-  public BountyHunterHunterRequest(final boolean buying, final int itemId, final int quantity) {
-    super(BHH, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/CRIMBCOGiftShopRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/CRIMBCOGiftShopRequest.java
@@ -37,14 +37,6 @@ public class CRIMBCOGiftShopRequest extends CoinMasterRequest {
     super(CRIMBCO_GIFT_SHOP, buying, attachments);
   }
 
-  public CRIMBCOGiftShopRequest(final boolean buying, final AdventureResult attachment) {
-    super(CRIMBCO_GIFT_SHOP, buying, attachment);
-  }
-
-  public CRIMBCOGiftShopRequest(final boolean buying, final int itemId, final int quantity) {
-    super(CRIMBCO_GIFT_SHOP, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/CoinMasterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/CoinMasterRequest.java
@@ -67,6 +67,18 @@ public class CoinMasterRequest extends GenericRequest {
     this.attachments = attachments;
   }
 
+  // Convenience constructors, overridden by the handful of subclasses that need them.
+
+  public CoinMasterRequest(
+      final CoinmasterData data, final boolean buying, final AdventureResult attachment) {
+    this(data, buying, new AdventureResult[] {attachment});
+  }
+
+  public CoinMasterRequest(
+      final CoinmasterData data, final boolean buying, final int itemId, final int quantity) {
+    this(data, buying, ItemPool.get(itemId, quantity));
+  }
+
   public final void setQuantity(final int quantity) {
     this.quantity = quantity;
     if (this.attachments != null) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/CoinMasterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/CoinMasterRequest.java
@@ -67,16 +67,6 @@ public class CoinMasterRequest extends GenericRequest {
     this.attachments = attachments;
   }
 
-  public CoinMasterRequest(
-      final CoinmasterData data, final boolean buying, final AdventureResult attachment) {
-    this(data, buying, new AdventureResult[] {attachment});
-  }
-
-  public CoinMasterRequest(
-      final CoinmasterData data, final boolean buying, final int itemId, final int quantity) {
-    this(data, buying, ItemPool.get(itemId, quantity));
-  }
-
   public final void setQuantity(final int quantity) {
     this.quantity = quantity;
     if (this.attachments != null) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/Crimbo11Request.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/Crimbo11Request.java
@@ -49,14 +49,6 @@ public class Crimbo11Request extends CoinMasterRequest {
     super(CRIMBO11, buying, attachments);
   }
 
-  public Crimbo11Request(final boolean buying, final AdventureResult attachment) {
-    super(CRIMBO11, buying, attachment);
-  }
-
-  public Crimbo11Request(final boolean buying, final int itemId, final int quantity) {
-    super(CRIMBO11, buying, itemId, quantity);
-  }
-
   private static String placeString(final String urlString) {
     String place = GenericRequest.getPlace(urlString);
     if (place == null) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/CrimboCartelRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/CrimboCartelRequest.java
@@ -50,14 +50,6 @@ public class CrimboCartelRequest extends CoinMasterRequest {
     super(CRIMBO_CARTEL, buying, attachments);
   }
 
-  public CrimboCartelRequest(final boolean buying, final AdventureResult attachment) {
-    super(CRIMBO_CARTEL, buying, attachment);
-  }
-
-  public CrimboCartelRequest(final boolean buying, final int itemId, final int quantity) {
-    super(CRIMBO_CARTEL, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/DimemasterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/DimemasterRequest.java
@@ -58,14 +58,6 @@ public class DimemasterRequest extends CoinMasterRequest {
     super(HIPPY, buying, attachments);
   }
 
-  public DimemasterRequest(final boolean buying, final AdventureResult attachment) {
-    super(HIPPY, buying, attachment);
-  }
-
-  public DimemasterRequest(final boolean buying, final int itemId, final int quantity) {
-    super(HIPPY, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     CoinMasterRequest.parseResponse(HIPPY, this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/FreeSnackRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/FreeSnackRequest.java
@@ -36,6 +36,10 @@ public class FreeSnackRequest extends CoinMasterRequest {
     super(FREESNACKS, buying, attachments);
   }
 
+  private FreeSnackRequest(final int itemId, final int quantity) {
+    super(FREESNACKS, true, itemId, quantity);
+  }
+
   @Override
   public void processResults() {
     GameShoppeRequest.parseResponse(this.getURLString(), this.responseText);
@@ -49,8 +53,7 @@ public class FreeSnackRequest extends CoinMasterRequest {
   }
 
   public static final void buy(final int itemId, final int count) {
-    RequestThread.postRequest(
-        new FreeSnackRequest(true, new AdventureResult[] {ItemPool.get(itemId, count)}));
+    RequestThread.postRequest(new FreeSnackRequest(itemId, count));
   }
 
   public static String accessible() {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/FreeSnackRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/FreeSnackRequest.java
@@ -36,14 +36,6 @@ public class FreeSnackRequest extends CoinMasterRequest {
     super(FREESNACKS, buying, attachments);
   }
 
-  public FreeSnackRequest(final boolean buying, final AdventureResult attachment) {
-    super(FREESNACKS, buying, attachment);
-  }
-
-  public FreeSnackRequest(final boolean buying, final int itemId, final int quantity) {
-    super(FREESNACKS, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     GameShoppeRequest.parseResponse(this.getURLString(), this.responseText);
@@ -57,7 +49,8 @@ public class FreeSnackRequest extends CoinMasterRequest {
   }
 
   public static final void buy(final int itemId, final int count) {
-    RequestThread.postRequest(new FreeSnackRequest(true, itemId, count));
+    RequestThread.postRequest(
+        new FreeSnackRequest(true, new AdventureResult[] {ItemPool.get(itemId, count)}));
   }
 
   public static String accessible() {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/FudgeWandRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/FudgeWandRequest.java
@@ -70,14 +70,6 @@ public class FudgeWandRequest extends CoinMasterRequest {
     super(FUDGEWAND, buying, attachments);
   }
 
-  public FudgeWandRequest(final boolean buying, final AdventureResult attachment) {
-    super(FUDGEWAND, buying, attachment);
-  }
-
-  public FudgeWandRequest(final boolean buying, final int itemId, final int quantity) {
-    super(FUDGEWAND, buying, itemId, quantity);
-  }
-
   @Override
   public void setItem(final AdventureResult item) {
     int itemId = item.getItemId();

--- a/src/net/sourceforge/kolmafia/request/coinmaster/GameShoppeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/GameShoppeRequest.java
@@ -45,14 +45,6 @@ public class GameShoppeRequest extends CoinMasterRequest {
     super(GAMESHOPPE, buying, attachments);
   }
 
-  public GameShoppeRequest(final boolean buying, final AdventureResult attachment) {
-    super(GAMESHOPPE, buying, attachment);
-  }
-
-  public GameShoppeRequest(final boolean buying, final int itemId, final int quantity) {
-    super(GAMESHOPPE, buying, itemId, quantity);
-  }
-
   public static String canBuy() {
     if (KoLCharacter.isHardcore()) {
       return "You are in Hardcore and the credit reader is broken.";

--- a/src/net/sourceforge/kolmafia/request/coinmaster/HermitRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/HermitRequest.java
@@ -77,7 +77,7 @@ public class HermitRequest extends CoinMasterRequest {
   }
 
   public HermitRequest(final int itemId, final int quantity) {
-    this(true, new AdventureResult[] {ItemPool.get(itemId, quantity)});
+    super(HERMIT, true, itemId, quantity);
   }
 
   private static void registerHermitItem(final int itemId, final int count) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/HermitRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/HermitRequest.java
@@ -76,16 +76,8 @@ public class HermitRequest extends CoinMasterRequest {
     super(HERMIT, buying, attachments);
   }
 
-  public HermitRequest(final boolean buying, final AdventureResult attachment) {
-    super(HERMIT, buying, attachment);
-  }
-
-  public HermitRequest(final boolean buying, final int itemId, final int quantity) {
-    super(HERMIT, buying, itemId, quantity);
-  }
-
   public HermitRequest(final int itemId, final int quantity) {
-    this(true, itemId, quantity);
+    this(true, new AdventureResult[] {ItemPool.get(itemId, quantity)});
   }
 
   private static void registerHermitItem(final int itemId, final int count) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/MrStoreRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/MrStoreRequest.java
@@ -62,14 +62,6 @@ public class MrStoreRequest extends CoinMasterRequest {
     super(MR_STORE, buying, attachments);
   }
 
-  public MrStoreRequest(final boolean buying, final AdventureResult attachment) {
-    super(MR_STORE, buying, attachment);
-  }
-
-  public MrStoreRequest(final boolean buying, final int itemId, final int quantity) {
-    super(MR_STORE, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     String responseText = this.responseText;

--- a/src/net/sourceforge/kolmafia/request/coinmaster/QuartersmasterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/QuartersmasterRequest.java
@@ -58,14 +58,6 @@ public class QuartersmasterRequest extends CoinMasterRequest {
     super(FRATBOY, buying, attachments);
   }
 
-  public QuartersmasterRequest(final boolean buying, final AdventureResult attachment) {
-    super(FRATBOY, buying, attachment);
-  }
-
-  public QuartersmasterRequest(final boolean buying, final int itemId, final int quantity) {
-    super(FRATBOY, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     CoinMasterRequest.parseResponse(FRATBOY, this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/SwaggerShopRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/SwaggerShopRequest.java
@@ -146,14 +146,6 @@ public class SwaggerShopRequest extends CoinMasterRequest {
     super(SWAGGER_SHOP, buying, attachments);
   }
 
-  public SwaggerShopRequest(final boolean buying, final AdventureResult attachment) {
-    super(SWAGGER_SHOP, buying, attachment);
-  }
-
-  public SwaggerShopRequest(final boolean buying, final int itemId, final int quantity) {
-    super(SWAGGER_SHOP, buying, itemId, quantity);
-  }
-
   @Override
   public void run() {
     if (this.action != null) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/TravelingTraderRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/TravelingTraderRequest.java
@@ -45,14 +45,6 @@ public class TravelingTraderRequest extends CoinMasterRequest {
     super(TRAVELER, buying, attachments);
   }
 
-  public TravelingTraderRequest(final boolean buying, final AdventureResult attachment) {
-    super(TRAVELER, buying, attachment);
-  }
-
-  public TravelingTraderRequest(final boolean buying, final int itemId, final int quantity) {
-    super(TRAVELER, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     if (this.responseText.length() == 0) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/AppleStoreRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/AppleStoreRequest.java
@@ -34,14 +34,6 @@ public class AppleStoreRequest extends CoinMasterRequest {
     super(APPLE_STORE, buying, attachments);
   }
 
-  public AppleStoreRequest(final boolean buying, final AdventureResult attachment) {
-    super(APPLE_STORE, buying, attachment);
-  }
-
-  public AppleStoreRequest(final boolean buying, final int itemId, final int quantity) {
-    super(APPLE_STORE, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ArmoryAndLeggeryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ArmoryAndLeggeryRequest.java
@@ -100,14 +100,6 @@ public class ArmoryAndLeggeryRequest extends CoinMasterRequest {
     super(ARMORY_AND_LEGGERY, buying, attachments);
   }
 
-  public ArmoryAndLeggeryRequest(final boolean buying, final AdventureResult attachment) {
-    super(ARMORY_AND_LEGGERY, buying, attachment);
-  }
-
-  public ArmoryAndLeggeryRequest(final boolean buying, final int itemId, final int quantity) {
-    super(ARMORY_AND_LEGGERY, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ArmoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ArmoryRequest.java
@@ -32,14 +32,6 @@ public class ArmoryRequest extends CoinMasterRequest {
     super(ARMORY, buying, attachments);
   }
 
-  public ArmoryRequest(final boolean buying, final AdventureResult attachment) {
-    super(ARMORY, buying, attachment);
-  }
-
-  public ArmoryRequest(final boolean buying, final int itemId, final int quantity) {
-    super(ARMORY, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/BatFabricatorRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/BatFabricatorRequest.java
@@ -42,14 +42,6 @@ public class BatFabricatorRequest extends CoinMasterRequest {
     super(BAT_FABRICATOR, buying, attachments);
   }
 
-  public BatFabricatorRequest(final boolean buying, final AdventureResult attachment) {
-    super(BAT_FABRICATOR, buying, attachment);
-  }
-
-  public BatFabricatorRequest(final boolean buying, final int itemId, final int quantity) {
-    super(BAT_FABRICATOR, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/BlackMarketRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/BlackMarketRequest.java
@@ -45,14 +45,6 @@ public class BlackMarketRequest extends CoinMasterRequest {
     super(BLACK_MARKET, buying, attachments);
   }
 
-  public BlackMarketRequest(final boolean buying, final AdventureResult attachment) {
-    super(BLACK_MARKET, buying, attachment);
-  }
-
-  public BlackMarketRequest(final boolean buying, final int itemId, final int quantity) {
-    super(BLACK_MARKET, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/BoutiqueRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/BoutiqueRequest.java
@@ -31,14 +31,6 @@ public class BoutiqueRequest extends CoinMasterRequest {
     super(BOUTIQUE, buying, attachments);
   }
 
-  public BoutiqueRequest(final boolean buying, final AdventureResult attachment) {
-    super(BOUTIQUE, buying, attachment);
-  }
-
-  public BoutiqueRequest(final boolean buying, final int itemId, final int quantity) {
-    super(BOUTIQUE, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/BrogurtRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/BrogurtRequest.java
@@ -46,14 +46,6 @@ public class BrogurtRequest extends CoinMasterRequest {
     super(BROGURT, buying, attachments);
   }
 
-  public BrogurtRequest(final boolean buying, final AdventureResult attachment) {
-    super(BROGURT, buying, attachment);
-  }
-
-  public BrogurtRequest(final boolean buying, final int itemId, final int quantity) {
-    super(BROGURT, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/BuffJimmyRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/BuffJimmyRequest.java
@@ -32,14 +32,6 @@ public class BuffJimmyRequest extends CoinMasterRequest {
     super(BUFF_JIMMY, buying, attachments);
   }
 
-  public BuffJimmyRequest(final boolean buying, final AdventureResult attachment) {
-    super(BUFF_JIMMY, buying, attachment);
-  }
-
-  public BuffJimmyRequest(final boolean buying, final int itemId, final int quantity) {
-    super(BUFF_JIMMY, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/CanteenRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/CanteenRequest.java
@@ -32,14 +32,6 @@ public class CanteenRequest extends CoinMasterRequest {
     super(CANTEEN, buying, attachments);
   }
 
-  public CanteenRequest(final boolean buying, final AdventureResult attachment) {
-    super(CANTEEN, buying, attachment);
-  }
-
-  public CanteenRequest(final boolean buying, final int itemId, final int quantity) {
-    super(CANTEEN, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ChemiCorpRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ChemiCorpRequest.java
@@ -48,14 +48,6 @@ public class ChemiCorpRequest extends CoinMasterRequest {
     super(CHEMICORP, buying, attachments);
   }
 
-  public ChemiCorpRequest(final boolean buying, final AdventureResult attachment) {
-    super(CHEMICORP, buying, attachment);
-  }
-
-  public ChemiCorpRequest(final boolean buying, final int itemId, final int quantity) {
-    super(CHEMICORP, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/CosmicRaysBazaarRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/CosmicRaysBazaarRequest.java
@@ -57,20 +57,8 @@ public class CosmicRaysBazaarRequest extends CoinMasterRequest {
     super(COSMIC_RAYS_BAZAAR);
   }
 
-  public CosmicRaysBazaarRequest(final String action) {
-    super(COSMIC_RAYS_BAZAAR, action);
-  }
-
   public CosmicRaysBazaarRequest(final boolean buying, final AdventureResult[] attachments) {
     super(COSMIC_RAYS_BAZAAR, buying, attachments);
-  }
-
-  public CosmicRaysBazaarRequest(final boolean buying, final AdventureResult attachment) {
-    super(COSMIC_RAYS_BAZAAR, buying, attachment);
-  }
-
-  public CosmicRaysBazaarRequest(final boolean buying, final int itemId, final int quantity) {
-    super(COSMIC_RAYS_BAZAAR, buying, itemId, quantity);
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo14Request.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo14Request.java
@@ -35,14 +35,6 @@ public class Crimbo14Request extends CoinMasterRequest {
     super(CRIMBO14, buying, attachments);
   }
 
-  public Crimbo14Request(final boolean buying, final AdventureResult attachment) {
-    super(CRIMBO14, buying, attachment);
-  }
-
-  public Crimbo14Request(final boolean buying, final int itemId, final int quantity) {
-    super(CRIMBO14, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo17Request.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo17Request.java
@@ -47,14 +47,6 @@ public class Crimbo17Request extends CoinMasterRequest {
     super(CRIMBO17, buying, attachments);
   }
 
-  public Crimbo17Request(final boolean buying, final AdventureResult attachment) {
-    super(CRIMBO17, buying, attachment);
-  }
-
-  public Crimbo17Request(final boolean buying, final int itemId, final int quantity) {
-    super(CRIMBO17, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20BoozeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20BoozeRequest.java
@@ -45,14 +45,6 @@ public class Crimbo20BoozeRequest extends CoinMasterRequest {
     super(CRIMBO20BOOZE, buying, attachments);
   }
 
-  public Crimbo20BoozeRequest(final boolean buying, final AdventureResult attachment) {
-    super(CRIMBO20BOOZE, buying, attachment);
-  }
-
-  public Crimbo20BoozeRequest(final boolean buying, final int itemId, final int quantity) {
-    super(CRIMBO20BOOZE, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20CandyRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20CandyRequest.java
@@ -45,14 +45,6 @@ public class Crimbo20CandyRequest extends CoinMasterRequest {
     super(CRIMBO20CANDY, buying, attachments);
   }
 
-  public Crimbo20CandyRequest(final boolean buying, final AdventureResult attachment) {
-    super(CRIMBO20CANDY, buying, attachment);
-  }
-
-  public Crimbo20CandyRequest(final boolean buying, final int itemId, final int quantity) {
-    super(CRIMBO20CANDY, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20FoodRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo20FoodRequest.java
@@ -45,14 +45,6 @@ public class Crimbo20FoodRequest extends CoinMasterRequest {
     super(CRIMBO20FOOD, buying, attachments);
   }
 
-  public Crimbo20FoodRequest(final boolean buying, final AdventureResult attachment) {
-    super(CRIMBO20FOOD, buying, attachment);
-  }
-
-  public Crimbo20FoodRequest(final boolean buying, final int itemId, final int quantity) {
-    super(CRIMBO20FOOD, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfArmoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfArmoryRequest.java
@@ -41,14 +41,6 @@ public class Crimbo23ElfArmoryRequest extends CoinMasterRequest {
     super(DATA, buying, attachments);
   }
 
-  public Crimbo23ElfArmoryRequest(final boolean buying, final AdventureResult attachment) {
-    super(DATA, buying, attachment);
-  }
-
-  public Crimbo23ElfArmoryRequest(final boolean buying, final int itemId, final int quantity) {
-    super(DATA, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     String responseText = this.responseText;

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfBarRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfBarRequest.java
@@ -33,14 +33,6 @@ public class Crimbo23ElfBarRequest extends CoinMasterRequest {
     super(DATA, buying, attachments);
   }
 
-  public Crimbo23ElfBarRequest(final boolean buying, final AdventureResult attachment) {
-    super(DATA, buying, attachment);
-  }
-
-  public Crimbo23ElfBarRequest(final boolean buying, final int itemId, final int quantity) {
-    super(DATA, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     String responseText = this.responseText;

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfCafeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfCafeRequest.java
@@ -33,14 +33,6 @@ public class Crimbo23ElfCafeRequest extends CoinMasterRequest {
     super(DATA, buying, attachments);
   }
 
-  public Crimbo23ElfCafeRequest(final boolean buying, final AdventureResult attachment) {
-    super(DATA, buying, attachment);
-  }
-
-  public Crimbo23ElfCafeRequest(final boolean buying, final int itemId, final int quantity) {
-    super(DATA, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     String responseText = this.responseText;

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfFactoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23ElfFactoryRequest.java
@@ -33,14 +33,6 @@ public class Crimbo23ElfFactoryRequest extends CoinMasterRequest {
     super(DATA, buying, attachments);
   }
 
-  public Crimbo23ElfFactoryRequest(final boolean buying, final AdventureResult attachment) {
-    super(DATA, buying, attachment);
-  }
-
-  public Crimbo23ElfFactoryRequest(final boolean buying, final int itemId, final int quantity) {
-    super(DATA, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     String responseText = this.responseText;

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateArmoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateArmoryRequest.java
@@ -41,14 +41,6 @@ public class Crimbo23PirateArmoryRequest extends CoinMasterRequest {
     super(DATA, buying, attachments);
   }
 
-  public Crimbo23PirateArmoryRequest(final boolean buying, final AdventureResult attachment) {
-    super(DATA, buying, attachment);
-  }
-
-  public Crimbo23PirateArmoryRequest(final boolean buying, final int itemId, final int quantity) {
-    super(DATA, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     String responseText = this.responseText;

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateBarRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateBarRequest.java
@@ -34,14 +34,6 @@ public class Crimbo23PirateBarRequest extends CoinMasterRequest {
     super(DATA, buying, attachments);
   }
 
-  public Crimbo23PirateBarRequest(final boolean buying, final AdventureResult attachment) {
-    super(DATA, buying, attachment);
-  }
-
-  public Crimbo23PirateBarRequest(final boolean buying, final int itemId, final int quantity) {
-    super(DATA, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     String responseText = this.responseText;

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateCafeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateCafeRequest.java
@@ -34,14 +34,6 @@ public class Crimbo23PirateCafeRequest extends CoinMasterRequest {
     super(DATA, buying, attachments);
   }
 
-  public Crimbo23PirateCafeRequest(final boolean buying, final AdventureResult attachment) {
-    super(DATA, buying, attachment);
-  }
-
-  public Crimbo23PirateCafeRequest(final boolean buying, final int itemId, final int quantity) {
-    super(DATA, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     String responseText = this.responseText;

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateFactoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/Crimbo23PirateFactoryRequest.java
@@ -34,14 +34,6 @@ public class Crimbo23PirateFactoryRequest extends CoinMasterRequest {
     super(DATA, buying, attachments);
   }
 
-  public Crimbo23PirateFactoryRequest(final boolean buying, final AdventureResult attachment) {
-    super(DATA, buying, attachment);
-  }
-
-  public Crimbo23PirateFactoryRequest(final boolean buying, final int itemId, final int quantity) {
-    super(DATA, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     String responseText = this.responseText;

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DinostaurRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DinostaurRequest.java
@@ -31,14 +31,6 @@ public class DinostaurRequest extends CoinMasterRequest {
     super(DINOSTAUR, buying, attachments);
   }
 
-  public DinostaurRequest(final boolean buying, final AdventureResult attachment) {
-    super(DINOSTAUR, buying, attachment);
-  }
-
-  public DinostaurRequest(final boolean buying, final int itemId, final int quantity) {
-    super(DINOSTAUR, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DinseyCompanyStoreRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DinseyCompanyStoreRequest.java
@@ -33,14 +33,6 @@ public class DinseyCompanyStoreRequest extends CoinMasterRequest {
     super(DINSEY_COMPANY_STORE, buying, attachments);
   }
 
-  public DinseyCompanyStoreRequest(final boolean buying, final AdventureResult attachment) {
-    super(DINSEY_COMPANY_STORE, buying, attachment);
-  }
-
-  public DinseyCompanyStoreRequest(final boolean buying, final int itemId, final int quantity) {
-    super(DINSEY_COMPANY_STORE, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DiscoGiftCoRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DiscoGiftCoRequest.java
@@ -32,14 +32,6 @@ public class DiscoGiftCoRequest extends CoinMasterRequest {
     super(DISCO_GIFTCO, buying, attachments);
   }
 
-  public DiscoGiftCoRequest(final boolean buying, final AdventureResult attachment) {
-    super(DISCO_GIFTCO, buying, attachment);
-  }
-
-  public DiscoGiftCoRequest(final boolean buying, final int itemId, final int quantity) {
-    super(DISCO_GIFTCO, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DollHawkerRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DollHawkerRequest.java
@@ -28,14 +28,6 @@ public class DollHawkerRequest extends CoinMasterRequest {
     super(DOLLHAWKER, buying, attachments);
   }
 
-  public DollHawkerRequest(final boolean buying, final AdventureResult attachment) {
-    super(DOLLHAWKER, buying, attachment);
-  }
-
-  public DollHawkerRequest(final boolean buying, final int itemId, final int quantity) {
-    super(DOLLHAWKER, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/DripArmoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/DripArmoryRequest.java
@@ -42,14 +42,6 @@ public class DripArmoryRequest extends CoinMasterRequest {
     super(DRIP_ARMORY, buying, attachments);
   }
 
-  public DripArmoryRequest(final boolean buying, final AdventureResult attachment) {
-    super(DRIP_ARMORY, buying, attachment);
-  }
-
-  public DripArmoryRequest(final boolean buying, final int itemId, final int quantity) {
-    super(DRIP_ARMORY, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/EdShopRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/EdShopRequest.java
@@ -32,14 +32,6 @@ public class EdShopRequest extends CoinMasterRequest {
     super(EDSHOP, buying, attachments);
   }
 
-  public EdShopRequest(final boolean buying, final AdventureResult attachment) {
-    super(EDSHOP, buying, attachment);
-  }
-
-  public EdShopRequest(final boolean buying, final int itemId, final int quantity) {
-    super(EDSHOP, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/FDKOLRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/FDKOLRequest.java
@@ -31,14 +31,6 @@ public class FDKOLRequest extends CoinMasterRequest {
     super(FDKOL, buying, attachments);
   }
 
-  public FDKOLRequest(final boolean buying, final AdventureResult attachment) {
-    super(FDKOL, buying, attachment);
-  }
-
-  public FDKOLRequest(final boolean buying, final int itemId, final int quantity) {
-    super(FDKOL, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/FancyDanRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/FancyDanRequest.java
@@ -58,20 +58,8 @@ public class FancyDanRequest extends CoinMasterRequest {
     super(FANCY_DAN);
   }
 
-  public FancyDanRequest(final String action) {
-    super(FANCY_DAN, action);
-  }
-
   public FancyDanRequest(final boolean buying, final AdventureResult[] attachments) {
     super(FANCY_DAN, buying, attachments);
-  }
-
-  public FancyDanRequest(final boolean buying, final AdventureResult attachment) {
-    super(FANCY_DAN, buying, attachment);
-  }
-
-  public FancyDanRequest(final boolean buying, final int itemId, final int quantity) {
-    super(FANCY_DAN, buying, itemId, quantity);
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/FishboneryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/FishboneryRequest.java
@@ -33,14 +33,6 @@ public class FishboneryRequest extends CoinMasterRequest {
     super(FISHBONERY, buying, attachments);
   }
 
-  public FishboneryRequest(final boolean buying, final AdventureResult attachment) {
-    super(FISHBONERY, buying, attachment);
-  }
-
-  public FishboneryRequest(final boolean buying, final int itemId, final int quantity) {
-    super(FISHBONERY, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/FunALogRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/FunALogRequest.java
@@ -58,14 +58,6 @@ public class FunALogRequest extends CoinMasterRequest {
     super(FUN_A_LOG, buying, attachments);
   }
 
-  public FunALogRequest(final boolean buying, final AdventureResult attachment) {
-    super(FUN_A_LOG, buying, attachment);
-  }
-
-  public FunALogRequest(final boolean buying, final int itemId, final int quantity) {
-    super(FUN_A_LOG, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/GMartRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/GMartRequest.java
@@ -31,14 +31,6 @@ public class GMartRequest extends CoinMasterRequest {
     super(GMART, buying, attachments);
   }
 
-  public GMartRequest(final boolean buying, final AdventureResult attachment) {
-    super(GMART, buying, attachment);
-  }
-
-  public GMartRequest(final boolean buying, final int itemId, final int quantity) {
-    super(GMART, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/GotporkOrphanageRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/GotporkOrphanageRequest.java
@@ -48,14 +48,6 @@ public class GotporkOrphanageRequest extends CoinMasterRequest {
     super(GOTPORK_ORPHANAGE, buying, attachments);
   }
 
-  public GotporkOrphanageRequest(final boolean buying, final AdventureResult attachment) {
-    super(GOTPORK_ORPHANAGE, buying, attachment);
-  }
-
-  public GotporkOrphanageRequest(final boolean buying, final int itemId, final int quantity) {
-    super(GOTPORK_ORPHANAGE, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/GotporkPDRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/GotporkPDRequest.java
@@ -49,14 +49,6 @@ public class GotporkPDRequest extends CoinMasterRequest {
     super(GOTPORK_PD, buying, attachments);
   }
 
-  public GotporkPDRequest(final boolean buying, final AdventureResult attachment) {
-    super(GOTPORK_PD, buying, attachment);
-  }
-
-  public GotporkPDRequest(final boolean buying, final int itemId, final int quantity) {
-    super(GOTPORK_PD, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/GuzzlrRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/GuzzlrRequest.java
@@ -31,14 +31,6 @@ public class GuzzlrRequest extends CoinMasterRequest {
     super(GUZZLR, buying, attachments);
   }
 
-  public GuzzlrRequest(final boolean buying, final AdventureResult attachment) {
-    super(GUZZLR, buying, attachment);
-  }
-
-  public GuzzlrRequest(final boolean buying, final int itemId, final int quantity) {
-    super(GUZZLR, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/IsotopeSmitheryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/IsotopeSmitheryRequest.java
@@ -28,14 +28,6 @@ public class IsotopeSmitheryRequest extends CoinMasterRequest {
     super(ISOTOPE_SMITHERY, buying, attachments);
   }
 
-  public IsotopeSmitheryRequest(final boolean buying, final AdventureResult attachment) {
-    super(ISOTOPE_SMITHERY, buying, attachment);
-  }
-
-  public IsotopeSmitheryRequest(final boolean buying, final int itemId, final int quantity) {
-    super(ISOTOPE_SMITHERY, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/LTTRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/LTTRequest.java
@@ -30,14 +30,6 @@ public class LTTRequest extends CoinMasterRequest {
     super(LTT, buying, attachments);
   }
 
-  public LTTRequest(final boolean buying, final AdventureResult attachment) {
-    super(LTT, buying, attachment);
-  }
-
-  public LTTRequest(final boolean buying, final int itemId, final int quantity) {
-    super(LTT, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/LunarLunchRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/LunarLunchRequest.java
@@ -28,14 +28,6 @@ public class LunarLunchRequest extends CoinMasterRequest {
     super(LUNAR_LUNCH, buying, attachments);
   }
 
-  public LunarLunchRequest(final boolean buying, final AdventureResult attachment) {
-    super(LUNAR_LUNCH, buying, attachment);
-  }
-
-  public LunarLunchRequest(final boolean buying, final int itemId, final int quantity) {
-    super(LUNAR_LUNCH, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/MemeShopRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/MemeShopRequest.java
@@ -59,14 +59,6 @@ public class MemeShopRequest extends CoinMasterRequest {
     super(BACON_STORE, buying, attachments);
   }
 
-  public MemeShopRequest(final boolean buying, final AdventureResult attachment) {
-    super(BACON_STORE, buying, attachment);
-  }
-
-  public MemeShopRequest(final boolean buying, final int itemId, final int quantity) {
-    super(BACON_STORE, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/MerchTableRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/MerchTableRequest.java
@@ -70,20 +70,8 @@ public class MerchTableRequest extends CoinMasterRequest {
     super(MERCH_TABLE);
   }
 
-  public MerchTableRequest(final String action) {
-    super(MERCH_TABLE, action);
-  }
-
   public MerchTableRequest(final boolean buying, final AdventureResult[] attachments) {
     super(MERCH_TABLE, buying, attachments);
-  }
-
-  public MerchTableRequest(final boolean buying, final AdventureResult attachment) {
-    super(MERCH_TABLE, buying, attachment);
-  }
-
-  public MerchTableRequest(final boolean buying, final int itemId, final int quantity) {
-    super(MERCH_TABLE, buying, itemId, quantity);
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/MrStore2002Request.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/MrStore2002Request.java
@@ -39,14 +39,6 @@ public class MrStore2002Request extends CoinMasterRequest {
     super(MR_STORE_2002, buying, attachments);
   }
 
-  public MrStore2002Request(final boolean buying, final AdventureResult attachment) {
-    super(MR_STORE_2002, buying, attachment);
-  }
-
-  public MrStore2002Request(final boolean buying, final int itemId, final int quantity) {
-    super(MR_STORE_2002, buying, itemId, quantity);
-  }
-
   public static int catalogToUse() {
     if (InventoryManager.hasItem(ItemPool.MR_STORE_2002_CATALOG)) {
       return ItemPool.MR_STORE_2002_CATALOG;

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/NeandermallRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/NeandermallRequest.java
@@ -34,14 +34,6 @@ public class NeandermallRequest extends CoinMasterRequest {
     super(NEANDERMALL, buying, attachments);
   }
 
-  public NeandermallRequest(final boolean buying, final AdventureResult attachment) {
-    super(NEANDERMALL, buying, attachment);
-  }
-
-  public NeandermallRequest(final boolean buying, final int itemId, final int quantity) {
-    super(NEANDERMALL, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/NinjaStoreRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/NinjaStoreRequest.java
@@ -34,14 +34,6 @@ public class NinjaStoreRequest extends CoinMasterRequest {
     super(NINJA_STORE, buying, attachments);
   }
 
-  public NinjaStoreRequest(final boolean buying, final AdventureResult attachment) {
-    super(NINJA_STORE, buying, attachment);
-  }
-
-  public NinjaStoreRequest(final boolean buying, final int itemId, final int quantity) {
-    super(NINJA_STORE, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/NuggletCraftingRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/NuggletCraftingRequest.java
@@ -32,14 +32,6 @@ public class NuggletCraftingRequest extends CoinMasterRequest {
     super(NUGGLETCRAFTING, buying, attachments);
   }
 
-  public NuggletCraftingRequest(final boolean buying, final AdventureResult attachment) {
-    super(NUGGLETCRAFTING, buying, attachment);
-  }
-
-  public NuggletCraftingRequest(final boolean buying, final int itemId, final int quantity) {
-    super(NUGGLETCRAFTING, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/PlumberGearRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/PlumberGearRequest.java
@@ -32,14 +32,6 @@ public class PlumberGearRequest extends CoinMasterRequest {
     super(PLUMBER_GEAR, buying, attachments);
   }
 
-  public PlumberGearRequest(final boolean buying, final AdventureResult attachment) {
-    super(PLUMBER_GEAR, buying, attachment);
-  }
-
-  public PlumberGearRequest(final boolean buying, final int itemId, final int quantity) {
-    super(PLUMBER_GEAR, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/PlumberItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/PlumberItemRequest.java
@@ -32,14 +32,6 @@ public class PlumberItemRequest extends CoinMasterRequest {
     super(PLUMBER_ITEMS, buying, attachments);
   }
 
-  public PlumberItemRequest(final boolean buying, final AdventureResult attachment) {
-    super(PLUMBER_ITEMS, buying, attachment);
-  }
-
-  public PlumberItemRequest(final boolean buying, final int itemId, final int quantity) {
-    super(PLUMBER_ITEMS, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/PokemporiumRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/PokemporiumRequest.java
@@ -46,14 +46,6 @@ public class PokemporiumRequest extends CoinMasterRequest {
     super(POKEMPORIUM, buying, attachments);
   }
 
-  public PokemporiumRequest(final boolean buying, final AdventureResult attachment) {
-    super(POKEMPORIUM, buying, attachment);
-  }
-
-  public PokemporiumRequest(final boolean buying, final int itemId, final int quantity) {
-    super(POKEMPORIUM, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/PrecinctRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/PrecinctRequest.java
@@ -30,14 +30,6 @@ public class PrecinctRequest extends CoinMasterRequest {
     super(PRECINCT, buying, attachments);
   }
 
-  public PrecinctRequest(final boolean buying, final AdventureResult attachment) {
-    super(PRECINCT, buying, attachment);
-  }
-
-  public PrecinctRequest(final boolean buying, final int itemId, final int quantity) {
-    super(PRECINCT, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ReplicaMrStoreRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ReplicaMrStoreRequest.java
@@ -43,14 +43,6 @@ public class ReplicaMrStoreRequest extends CoinMasterRequest {
     super(REPLICA_MR_STORE, buying, attachments);
   }
 
-  public ReplicaMrStoreRequest(final boolean buying, final AdventureResult attachment) {
-    super(REPLICA_MR_STORE, buying, attachment);
-  }
-
-  public ReplicaMrStoreRequest(final boolean buying, final int itemId, final int quantity) {
-    super(REPLICA_MR_STORE, buying, itemId, quantity);
-  }
-
   private static final Map<Integer, Integer> itemToYear =
       Map.ofEntries(
           Map.entry(ItemPool.REPLICA_DARK_JILL, 2004),

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/RubeeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/RubeeRequest.java
@@ -35,14 +35,6 @@ public class RubeeRequest extends CoinMasterRequest {
     super(RUBEE, buying, attachments);
   }
 
-  public RubeeRequest(final boolean buying, final AdventureResult attachment) {
-    super(RUBEE, buying, attachment);
-  }
-
-  public RubeeRequest(final boolean buying, final int itemId, final int quantity) {
-    super(RUBEE, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/SHAWARMARequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/SHAWARMARequest.java
@@ -32,14 +32,6 @@ public class SHAWARMARequest extends CoinMasterRequest {
     super(SHAWARMA, buying, attachments);
   }
 
-  public SHAWARMARequest(final boolean buying, final AdventureResult attachment) {
-    super(SHAWARMA, buying, attachment);
-  }
-
-  public SHAWARMARequest(final boolean buying, final int itemId, final int quantity) {
-    super(SHAWARMA, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/SeptEmberCenserRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/SeptEmberCenserRequest.java
@@ -33,14 +33,6 @@ public class SeptEmberCenserRequest extends CoinMasterRequest {
     super(SEPTEMBER_CENSER, buying, attachments);
   }
 
-  public SeptEmberCenserRequest(final boolean buying, final AdventureResult attachment) {
-    super(SEPTEMBER_CENSER, buying, attachment);
-  }
-
-  public SeptEmberCenserRequest(final boolean buying, final int itemId, final int quantity) {
-    super(SEPTEMBER_CENSER, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ShoeRepairRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ShoeRepairRequest.java
@@ -34,14 +34,6 @@ public class ShoeRepairRequest extends CoinMasterRequest {
     super(SHOE_REPAIR, buying, attachments);
   }
 
-  public ShoeRepairRequest(final boolean buying, final AdventureResult attachment) {
-    super(SHOE_REPAIR, buying, attachment);
-  }
-
-  public ShoeRepairRequest(final boolean buying, final int itemId, final int quantity) {
-    super(SHOE_REPAIR, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ShoreGiftShopRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ShoreGiftShopRequest.java
@@ -53,14 +53,6 @@ public class ShoreGiftShopRequest extends CoinMasterRequest {
     super(SHORE_GIFT_SHOP, buying, attachments);
   }
 
-  public ShoreGiftShopRequest(final boolean buying, final AdventureResult attachment) {
-    super(SHORE_GIFT_SHOP, buying, attachment);
-  }
-
-  public ShoreGiftShopRequest(final boolean buying, final int itemId, final int quantity) {
-    super(SHORE_GIFT_SHOP, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/SpacegateFabricationRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/SpacegateFabricationRequest.java
@@ -33,14 +33,6 @@ public class SpacegateFabricationRequest extends CoinMasterRequest {
     super(SPACEGATE_STORE, buying, attachments);
   }
 
-  public SpacegateFabricationRequest(final boolean buying, final AdventureResult attachment) {
-    super(SPACEGATE_STORE, buying, attachment);
-  }
-
-  public SpacegateFabricationRequest(final boolean buying, final int itemId, final int quantity) {
-    super(SPACEGATE_STORE, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/SpinMasterLatheRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/SpinMasterLatheRequest.java
@@ -67,20 +67,8 @@ public class SpinMasterLatheRequest extends CoinMasterRequest {
     super(YOUR_SPINMASTER_LATHE);
   }
 
-  public SpinMasterLatheRequest(final String action) {
-    super(YOUR_SPINMASTER_LATHE, action);
-  }
-
   public SpinMasterLatheRequest(final boolean buying, final AdventureResult[] attachments) {
     super(YOUR_SPINMASTER_LATHE, buying, attachments);
-  }
-
-  public SpinMasterLatheRequest(final boolean buying, final AdventureResult attachment) {
-    super(YOUR_SPINMASTER_LATHE, buying, attachment);
-  }
-
-  public SpinMasterLatheRequest(final boolean buying, final int itemId, final int quantity) {
-    super(YOUR_SPINMASTER_LATHE, buying, itemId, quantity);
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/TacoDanRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/TacoDanRequest.java
@@ -42,14 +42,6 @@ public class TacoDanRequest extends CoinMasterRequest {
     super(TACO_DAN, buying, attachments);
   }
 
-  public TacoDanRequest(final boolean buying, final AdventureResult attachment) {
-    super(TACO_DAN, buying, attachment);
-  }
-
-  public TacoDanRequest(final boolean buying, final int itemId, final int quantity) {
-    super(TACO_DAN, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/TerrifiedEagleInnRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/TerrifiedEagleInnRequest.java
@@ -45,14 +45,6 @@ public class TerrifiedEagleInnRequest extends CoinMasterRequest {
     super(TERRIFIED_EAGLE_INN, buying, attachments);
   }
 
-  public TerrifiedEagleInnRequest(final boolean buying, final AdventureResult attachment) {
-    super(TERRIFIED_EAGLE_INN, buying, attachment);
-  }
-
-  public TerrifiedEagleInnRequest(final boolean buying, final int itemId, final int quantity) {
-    super(TERRIFIED_EAGLE_INN, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ThankShopRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ThankShopRequest.java
@@ -29,14 +29,6 @@ public class ThankShopRequest extends CoinMasterRequest {
     super(CASHEW_STORE, buying, attachments);
   }
 
-  public ThankShopRequest(final boolean buying, final AdventureResult attachment) {
-    super(CASHEW_STORE, buying, attachment);
-  }
-
-  public ThankShopRequest(final boolean buying, final int itemId, final int quantity) {
-    super(CASHEW_STORE, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/TicketCounterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/TicketCounterRequest.java
@@ -51,14 +51,6 @@ public class TicketCounterRequest extends CoinMasterRequest {
     super(TICKET_COUNTER, buying, attachments);
   }
 
-  public TicketCounterRequest(final boolean buying, final AdventureResult attachment) {
-    super(TICKET_COUNTER, buying, attachment);
-  }
-
-  public TicketCounterRequest(final boolean buying, final int itemId, final int quantity) {
-    super(TICKET_COUNTER, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ToxicChemistryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ToxicChemistryRequest.java
@@ -32,14 +32,6 @@ public class ToxicChemistryRequest extends CoinMasterRequest {
     super(TOXIC_CHEMISTRY, buying, attachments);
   }
 
-  public ToxicChemistryRequest(final boolean buying, final AdventureResult attachment) {
-    super(TOXIC_CHEMISTRY, buying, attachment);
-  }
-
-  public ToxicChemistryRequest(final boolean buying, final int itemId, final int quantity) {
-    super(TOXIC_CHEMISTRY, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/TrapperRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/TrapperRequest.java
@@ -38,7 +38,7 @@ public class TrapperRequest extends CoinMasterRequest {
   }
 
   public TrapperRequest(final int itemId, final int quantity) {
-    this(true, new AdventureResult[] {ItemPool.get(itemId, quantity)});
+    super(TRAPPER, true, itemId, quantity);
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/TrapperRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/TrapperRequest.java
@@ -37,16 +37,8 @@ public class TrapperRequest extends CoinMasterRequest {
     super(TRAPPER, buying, attachments);
   }
 
-  public TrapperRequest(final boolean buying, final AdventureResult attachment) {
-    super(TRAPPER, buying, attachment);
-  }
-
-  public TrapperRequest(final boolean buying, final int itemId, final int quantity) {
-    super(TRAPPER, buying, itemId, quantity);
-  }
-
   public TrapperRequest(final int itemId, final int quantity) {
-    this(true, itemId, quantity);
+    this(true, new AdventureResult[] {ItemPool.get(itemId, quantity)});
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/VendingMachineRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/VendingMachineRequest.java
@@ -42,14 +42,6 @@ public class VendingMachineRequest extends CoinMasterRequest {
     super(VENDING_MACHINE, buying, attachments);
   }
 
-  public VendingMachineRequest(final boolean buying, final AdventureResult attachment) {
-    super(VENDING_MACHINE, buying, attachment);
-  }
-
-  public VendingMachineRequest(final boolean buying, final int itemId, final int quantity) {
-    super(VENDING_MACHINE, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/WalMartRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/WalMartRequest.java
@@ -33,14 +33,6 @@ public class WalMartRequest extends CoinMasterRequest {
     super(WALMART, buying, attachments);
   }
 
-  public WalMartRequest(final boolean buying, final AdventureResult attachment) {
-    super(WALMART, buying, attachment);
-  }
-
-  public WalMartRequest(final boolean buying, final int itemId, final int quantity) {
-    super(WALMART, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/WarbearBoxRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/WarbearBoxRequest.java
@@ -32,14 +32,6 @@ public class WarbearBoxRequest extends CoinMasterRequest {
     super(WARBEARBOX, buying, attachments);
   }
 
-  public WarbearBoxRequest(final boolean buying, final AdventureResult attachment) {
-    super(WARBEARBOX, buying, attachment);
-  }
-
-  public WarbearBoxRequest(final boolean buying, final int itemId, final int quantity) {
-    super(WARBEARBOX, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/YeNeweSouvenirShoppeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/YeNeweSouvenirShoppeRequest.java
@@ -34,14 +34,6 @@ public class YeNeweSouvenirShoppeRequest extends CoinMasterRequest {
     super(SHAKE_SHOP, buying, attachments);
   }
 
-  public YeNeweSouvenirShoppeRequest(final boolean buying, final AdventureResult attachment) {
-    super(SHAKE_SHOP, buying, attachment);
-  }
-
-  public YeNeweSouvenirShoppeRequest(final boolean buying, final int itemId, final int quantity) {
-    super(SHAKE_SHOP, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/YourCampfireRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/YourCampfireRequest.java
@@ -33,14 +33,6 @@ public class YourCampfireRequest extends CoinMasterRequest {
     super(YOUR_CAMPFIRE, buying, attachments);
   }
 
-  public YourCampfireRequest(final boolean buying, final AdventureResult attachment) {
-    super(YOUR_CAMPFIRE, buying, attachment);
-  }
-
-  public YourCampfireRequest(final boolean buying, final int itemId, final int quantity) {
-    super(YOUR_CAMPFIRE, buying, itemId, quantity);
-  }
-
   @Override
   public void processResults() {
     ShopRequest.parseResponse(this.getURLString(), this.responseText);

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -1113,11 +1113,11 @@ public class ResultProcessor {
 
     if (result.isItem()) {
       // Do special processing when you get certain items
-      ResultProcessor.gainItem(adventureResults, result);
-
       if (HermitRequest.isWorthlessItem(result.getItemId())) {
         result = HermitRequest.WORTHLESS_ITEM.getInstance(result.getCount());
       }
+
+      ResultProcessor.gainItem(adventureResults, result);
 
       return false;
     }

--- a/test/net/sourceforge/kolmafia/request/CoinMasterRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/CoinMasterRequestTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import internal.helpers.Cleanups;
 import internal.helpers.SessionLoggerOutput;
 import internal.network.FakeHttpClientBuilder;
+import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -282,7 +283,8 @@ public class CoinMasterRequestTest {
         client.addResponse(200, "");
 
         var buy =
-            new Crimbo23ElfArmoryRequest(true, ItemPool.get(ItemPool.ELF_GUARD_HONOR_PRESENT, 1));
+            new Crimbo23ElfArmoryRequest(
+                true, new AdventureResult[] {ItemPool.get(ItemPool.ELF_GUARD_HONOR_PRESENT, 1)});
         buy.run();
 
         var text = SessionLoggerOutput.stopStream();
@@ -378,7 +380,8 @@ public class CoinMasterRequestTest {
 
         var buy =
             new Crimbo23ElfArmoryRequest(
-                false, ItemPool.get(ItemPool.ELF_GUARD_COMMANDEERING_GLOVES, 13));
+                false,
+                new AdventureResult[] {ItemPool.get(ItemPool.ELF_GUARD_COMMANDEERING_GLOVES, 13)});
         buy.run();
 
         var text = SessionLoggerOutput.stopStream();

--- a/test/net/sourceforge/kolmafia/request/MrStore2002RequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/MrStore2002RequestTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.is;
 
 import internal.helpers.Cleanups;
 import internal.network.FakeHttpClientBuilder;
+import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -88,7 +89,11 @@ public class MrStore2002RequestTest {
       client.addResponse(200, ""); // api.php
 
       var request =
-          new MrStore2002Request(true, ItemPool.FLASH_LIQUIDIZER_ULTRA_DOUSING_ACCESSORY, 1);
+          new MrStore2002Request(
+              true,
+              new AdventureResult[] {
+                ItemPool.get(ItemPool.FLASH_LIQUIDIZER_ULTRA_DOUSING_ACCESSORY, 1)
+              });
       request.run();
 
       assertThat("_2002MrStoreCreditsCollected", isSetTo(true));


### PR DESCRIPTION
1) Gaining (or using) a worthless item did not fire the (coinmaster) signal.
That's because the HermitRequest did not initialize its buyItems until The Hermit was visited for the first time.
2) AltarOfBonesClass had a bug: it provided a parseResponse method - which is called by ResponseTextParser for an "external" request - but it did not have a processResults which would call it for an "internal" request.
3) After I freed the king in my first 30 turns today, I spend the turns to train the last two familiars.
```
Results for Burly Bodyguard after 12 trials using 144 turns:

Contest         XP[1]   XP[2]   XP[3]  Original Rank Derived Rank
Cage Match      24      39      55           0            
3Scavenger Hunt 25      40      56           0            3
Obstacle Course 25      35      54           0            3
Hide and Seek   25      42      55           0            3

Results for Emberiza Aureola after 12 trials using 109 turns:

Contest         XP[1]   XP[2]   XP[3]  Original Rank Derived Rank
Cage Match       0       0       0           0            0
Scavenger Hunt  61      36       5           0            1
Obstacle Course 59      62      20           0            2
Hide and Seek   26      46      59           0            3
```
4) CoinMasterRequest constuctor simplification:

Every Coinmaster must provide two constructors:
```
  public CoinMasterRequest(final CoinmasterData data)
```
 for a simple visit to the "buy" URL.

And either this:
```
  public CoinMasterRequest(final CoinmasterData data, final boolean buying, final AdventureResult[] attachments)
```
for coinmasters with "buy" and "sell" items, or:

```
  public CoinMasterRequest(final CoinmasterData data, final ShopRow row, final int quantity)
```
for a new-style "ROW" coinmaster.

Those three constructors can be created via reflection for use by user requests, via the "coinmaster" command or the CoinmastersFrame.

For the handful of coinmasters with extra actions (Mr. Store, Bounty Hunter Hunter):
```
  public CoinMasterRequest(final CoinmasterData data, final String action)
```

If your CoinMasterRequest class wants an additional constructor, the class can implement it in terms of one or the other transaction constructors.

I got rid of the never-used constructors in CoinMasterRequest and all its subclasses.
