### PR TITLE
feat: change fact strings to be more thorough

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/FactDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/FactDatabase.java
@@ -174,7 +174,12 @@ public class FactDatabase {
 
     @Override
     public String toString() {
-      return this.value;
+      return switch (this.type) {
+        case HP -> this.value + "% HP restore";
+        case MP -> this.value + "% MP restore";
+        case STATS -> this.value + " substats";
+        default -> this.value;
+      };
     }
 
     public boolean isGummi() {

--- a/test/net/sourceforge/kolmafia/persistence/FactDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/FactDatabaseTest.java
@@ -106,7 +106,15 @@ class FactDatabaseTest {
     "SEAL_CLUBBER, NONE, Octorok, EFFECT, Egg-stortionary Tactics (10)",
     "PASTAMANCER, NONE, Jacob's adder, EFFECT, Egg-stortionary Tactics (10)",
     "PASTAMANCER, NONE, Black Crayon Penguin, MEAT, 149 Meat",
-    "DISCO_BANDIT, SMALL, Bob Racecar, EFFECT, Feeling Excited (15)"
+    "DISCO_BANDIT, SMALL, Bob Racecar, EFFECT, Feeling Excited (15)",
+    "SEAL_CLUBBER, NONE, BASIC Elemental, STATS, +1 all substats",
+    "SEAL_CLUBBER, NONE, poutine ooze, STATS, +3 all substats",
+    "SEAL_CLUBBER, NONE, Assembly Elemental, STATS, +3 muscle substats",
+    "SEAL_CLUBBER, NONE, amorphous blob, MODIFIER, Experience (familiar): +1",
+    "SEAL_CLUBBER, NONE, Alphabet Giant, MODIFIER, Item Drop: +25",
+    "SEAL_CLUBBER, NONE, Family Jewels, ITEM, line (3)",
+    "SEAL_CLUBBER, NONE, angry mushroom guy, HP, 50% HP restore",
+    "SEAL_CLUBBER, NONE, ancestral Spookyraven portrait, MP, 20% MP restore",
   })
   void picksCorrectFact(
       final AscensionClass ascensionClass,

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -1287,7 +1287,7 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
   class BookOfFacts {
     @ParameterizedTest
     @CsvSource({
-      "ACCORDION_THIEF, CRAZY_RANDOM_SUMMER, topiary golem, stats, +1 all",
+      "ACCORDION_THIEF, CRAZY_RANDOM_SUMMER, topiary golem, stats, +1 all substats",
       "TURTLE_TAMER, OXYGENARIAN, Blooper, meat, 10 Meat",
       "PASTAMANCER, COMMUNITY_SERVICE, bookbat, modifier, Experience (familiar): +1",
       "SEAL_CLUBBER, KINGDOM_OF_EXPLOATHING, Jefferson pilot, item, foon"


### PR DESCRIPTION
Now that #2707 exposes these to non-scripters, make the fact strings more self-explanatory.

This will break scripts that were relying on exact string matches, but I haven't found one that does that -- things like `numeric_fact` are more popular.