### PR TITLE
Make place names clickable in relay browser after a /go command"

### DIFF
--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -3709,6 +3709,23 @@ public class RelayRequest extends PasswordHashRequest {
     }
   }
 
+  private static Pattern GO_CMD =
+      Pattern.compile("\"<font color=green>Sending you to (.*?)\\.<!--js\\((.*?)\\)-->");
+
+  private static String decorateGoCommands(String chatText) {
+    var matcher = GO_CMD.matcher(chatText);
+
+    if (!matcher.find()) return chatText;
+
+    return chatText.substring(0, matcher.start(1))
+        + "<span style=\\\"cursor:pointer;\\\" onclick=\\\""
+        + matcher.group(2)
+        + ";\\\">"
+        + matcher.group(1)
+        + "</span>"
+        + chatText.substring(matcher.end(1));
+  }
+
   private void handleChat() {
     String path = this.getPath();
     boolean tabbedChat = path.contains("j=1");
@@ -3728,6 +3745,8 @@ public class RelayRequest extends PasswordHashRequest {
       if (tabbedChat && chatText.startsWith("{")) {
         ChatPoller.handleNewChat(chatText, this.getFormField("graf"), ChatPoller.localLastSeen);
       }
+
+      chatText = decorateGoCommands(chatText);
     }
 
     if (Preferences.getBoolean("relayFormatsChatText")) {

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -37,6 +37,8 @@ import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.VYKEACompanionData;
 import net.sourceforge.kolmafia.VYKEACompanionData.VYKEACompanionType;
 import net.sourceforge.kolmafia.ZodiacSign;
+import net.sourceforge.kolmafia.chat.ChatManager;
+import net.sourceforge.kolmafia.chat.EnableMessage;
 import net.sourceforge.kolmafia.combat.MonsterStatusTracker;
 import net.sourceforge.kolmafia.equipment.Slot;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
@@ -2760,5 +2762,24 @@ public class Player {
   public static Cleanups withFightRequestPokefam() {
     FightRequest.pokefam = true;
     return new Cleanups(() -> FightRequest.pokefam = false);
+  }
+
+  /**
+   * Sets the current chat channel
+   *
+   * @param channel Channel to use
+   * @return set the channel to the previous value
+   */
+  public static Cleanups withChatChannel(final String channel) {
+    var old = ChatManager.getCurrentChannel();
+    ChatManager.processChannelEnable(new EnableMessage(channel, true));
+    return new Cleanups(
+        () -> {
+          if (old == null) {
+            ChatManager.dispose();
+          } else {
+            ChatManager.processChannelEnable(new EnableMessage(old, true));
+          }
+        });
   }
 }

--- a/test/net/sourceforge/kolmafia/request/RelayRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/RelayRequestTest.java
@@ -666,8 +666,14 @@ public class RelayRequestTest {
       ;
     }
 
-    @Test
-    public void decoratesGoCommands() {
+    @ParameterizedTest
+    @CsvSource(
+        delimiter = '|',
+        value = {
+          "{\"output\":\"<font color=green>Sending you to Kremlin's Greatest Briefcase.<!--js(top.mainpane.location.href='/place.php?whichplace=kgb')--></font>\",\"msgs\":[]}|{\"output\":\"<font color=green>Sending you to <span style=\\\"cursor:pointer;\\\" onclick=\\\"top.mainpane.location.href='/place.php?whichplace=kgb';\\\">Kremlin's Greatest Briefcase</span>.<!--js(top.mainpane.location.href='/place.php?whichplace=kgb')--></font>\",\"msgs\":[]}",
+          "{\"output\":\"<font color=green>Sorry, I don't know how to take you to 'ssdjhfjksdfhsd' (or Funkytown, for that matter.)</font>\",\"msgs\":[]}|{\"output\":\"<font color=green>Sorry, I don't know how to take you to 'ssdjhfjksdfhsd' (or Funkytown, for that matter.)</font>\",\"msgs\":[]}"
+        })
+    public void decoratesGoCommands(final String input, final String expected) {
       var builder = new FakeHttpClientBuilder();
       var cleanups =
           new Cleanups(
@@ -675,9 +681,7 @@ public class RelayRequestTest {
               withChatChannel("clan"),
               withProperty("chatLiterate", true));
 
-      builder.client.addResponse(
-          200,
-          "{\"output\":\"<font color=green>Sending you to Kremlin's Greatest Briefcase.<!--js(top.mainpane.location.href='/place.php?whichplace=kgb')--></font>\",\"msgs\":[]}");
+      builder.client.addResponse(200, input);
 
       try (cleanups) {
         var req = new RelayRequest(false);
@@ -685,10 +689,7 @@ public class RelayRequestTest {
         req.addFormField("graf", "/go test");
         req.run();
 
-        assertThat(
-            req.responseText,
-            equalTo(
-                "{\"output\":\"<font color=green>Sending you to <span style=\\\"cursor:pointer;\\\" onclick=\\\"top.mainpane.location.href='/place.php?whichplace=kgb';\\\">Kremlin's Greatest Briefcase</span>.<!--js(top.mainpane.location.href='/place.php?whichplace=kgb')--></font>\",\"msgs\":[]}"));
+        assertThat(req.responseText, equalTo(expected));
       }
     }
   }


### PR DESCRIPTION
- **Decorate /go output in chat pane (so that I can click to go again)**
- **Add test**

Allows the placename to be clicked here to repeat the action of navigation. This is really useful for me to be able to repeat an action over and over, maybe others will find it useful.

<img width="166" alt="Screenshot 2025-02-13 at 15 51 30" src="https://github.com/user-attachments/assets/d21ca85c-b5dd-441d-bfd8-88b931d25b5d" />

EDIT: As the tests here touch aspects of chat for the first time it inadvertently brings our coverage over 40%!
