### PR TITLE
Specify toolchain manager

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,15 @@
+plugins {
+	id("org.gradle.toolchains.foojay-resolver") version "0.9.0"
+}
+
+toolchainManagement {
+	jvm {
+		javaRepositories {
+			repository("foojay") {
+				resolverClass = org.gradle.toolchains.foojay.FoojayToolchainResolver
+			}
+		}
+	}
+}
+
 rootProject.name = 'KoLmafia'


### PR DESCRIPTION
Since https://github.com/kolmafia/kolmafia/pull/2687 I have not been able to build the application without this configuration present. I found it via gradle's documentation.

https://docs.gradle.org/current/userguide/toolchains.html#sec:provisioning
