### PR TITLE
More support for coinmasters that sell skills

### DIFF
--- a/src/net/sourceforge/kolmafia/AdventureResult.java
+++ b/src/net/sourceforge/kolmafia/AdventureResult.java
@@ -511,6 +511,13 @@ public class AdventureResult implements Comparable<AdventureResult>, Cloneable {
     return -1;
   }
 
+  public int getSkillId() {
+    if (this.priority == Priority.SKILL) {
+      return this.id;
+    }
+    return -1;
+  }
+
   /**
    * Accessor method to retrieve the total value associated with the result. In the event of substat
    * points, this returns the total subpoints within the <code>AdventureResult</code>; in the event

--- a/src/net/sourceforge/kolmafia/request/coinmaster/CoinMasterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/CoinMasterRequest.java
@@ -23,6 +23,7 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.request.NPCPurchaseRequest;
 import net.sourceforge.kolmafia.request.TransferItemRequest;
+import net.sourceforge.kolmafia.session.ResponseTextParser;
 import net.sourceforge.kolmafia.session.ResultProcessor;
 import net.sourceforge.kolmafia.shop.ShopRequest;
 import net.sourceforge.kolmafia.shop.ShopRow;
@@ -251,6 +252,13 @@ public class CoinMasterRequest extends GenericRequest {
 
     if (this.responseText.contains("You don't have that many of that item")) {
       KoLmafia.updateDisplay(MafiaState.ERROR, "You don't have that many of that item to turn in.");
+    }
+
+    if (KoLmafia.permitsContinue()) {
+      AdventureResult item = this.row.getItem();
+      if (item.isSkill()) {
+        ResponseTextParser.learnSkill(item.getSkillId());
+      }
     }
   }
 
@@ -636,7 +644,11 @@ public class CoinMasterRequest extends GenericRequest {
       ResultProcessor.processResult(cost.getInstance(-price));
     }
 
-    data.purchasedItem(ItemPool.get(shopRow.getItem().getItemId(), count), false);
+    AdventureResult item = shopRow.getItem();
+    // You can purchase skills, which are not items.
+    if (item.isItem()) {
+      data.purchasedItem(ItemPool.get(item.getItemId(), count), false);
+    }
   }
 
   public static final void sellStuff(final CoinmasterData data, final String urlString) {

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/CoinMasterShopRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/CoinMasterShopRequest.java
@@ -24,8 +24,11 @@ public class CoinMasterShopRequest extends CoinMasterRequest {
     this.quantity = quantity;
     this.addFormField("whichrow", String.valueOf(row.getRow()));
     this.addFormField("quantity", String.valueOf(quantity));
+
     // We want to parse the balance for virtual currencies
-    if (data.getProperty() == null) {
+    // We want the full responseText if we are buying a skill
+    AdventureResult item = row.getItem();
+    if (data.getProperty() == null && !item.isSkill()) {
       this.addFormField("ajax", "1");
     }
   }

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/TicketCounterRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/TicketCounterRequest.java
@@ -26,7 +26,8 @@ public abstract class TicketCounterRequest extends CoinMasterShopRequest {
           .withItem(TICKET)
           .withShopRowFields(master, SHOPID)
           .withCanBuyItem(TicketCounterRequest::canBuyItem)
-          .withVisitShop(TicketCounterRequest::visitShop);
+          .withVisitShop(TicketCounterRequest::visitShop)
+          .withAccessible(TicketCounterRequest::accessible);
 
   private static Boolean canBuyItem(final Integer itemId) {
     return switch (itemId) {

--- a/src/net/sourceforge/kolmafia/request/concoction/shop/Crimbo16Request.java
+++ b/src/net/sourceforge/kolmafia/request/concoction/shop/Crimbo16Request.java
@@ -45,8 +45,4 @@ public class Crimbo16Request extends CreateItemRequest {
 
     ShopRequest.parseResponse(urlString, responseText);
   }
-
-  public static String accessible() {
-    return "Crimbo is gone";
-  }
 }

--- a/src/net/sourceforge/kolmafia/session/ResponseTextParser.java
+++ b/src/net/sourceforge/kolmafia/session/ResponseTextParser.java
@@ -929,40 +929,6 @@ public class ResponseTextParser {
       }
     }
 
-    if (KoLCharacter.inNuclearAutumn()) {
-      int cost =
-          switch (skillId) {
-            case SkillPool.BOILING_TEAR_DUCTS,
-                SkillPool.PROJECTILE_SALIVARY_GLANDS,
-                SkillPool.TRANSLUCENT_SKIN,
-                SkillPool.SKUNK_GLANDS,
-                SkillPool.THROAT_REFRIDGERANT,
-                SkillPool.INTERNAL_SODA_MACHINE -> 30;
-            case SkillPool.STEROID_BLADDER,
-                SkillPool.MAGIC_SWEAT,
-                SkillPool.FLAPPY_EARS,
-                SkillPool.SELF_COMBING_HAIR,
-                SkillPool.INTRACRANIAL_EYE,
-                SkillPool.MIND_BULLETS,
-                SkillPool.EXTRA_KIDNEY,
-                SkillPool.EXTRA_GALL_BLADDER -> 60;
-            case SkillPool.EXTRA_MUSCLES,
-                SkillPool.ADIPOSE_POLYMERS,
-                SkillPool.METALLIC_SKIN,
-                SkillPool.HYPNO_EYES,
-                SkillPool.EXTRA_BRAIN,
-                SkillPool.MAGNETIC_EARS,
-                SkillPool.EXTREMELY_PUNCHABLE_FACE,
-                SkillPool.FIREFLY_ABDOMEN,
-                SkillPool.BONE_SPRINGS,
-                SkillPool.SQUID_GLANDS -> 90;
-            case SkillPool.SUCKER_FINGERS, SkillPool.BACKWARDS_KNEES -> 120;
-            default -> 0;
-          };
-
-      ResultProcessor.processResult(ItemPool.get(ItemPool.RAD, -cost));
-    }
-
     UseSkillRequest skill = UseSkillRequest.getUnmodifiedInstance(skillId);
     if (skill == null) {
       SkillDatabase.registerSkill(skillId);

--- a/src/net/sourceforge/kolmafia/shop/ShopRequest.java
+++ b/src/net/sourceforge/kolmafia/shop/ShopRequest.java
@@ -282,7 +282,11 @@ public class ShopRequest extends GenericRequest {
 
       // Shops can sell skills
       if (item.isSkill()) {
-        newShopItems |= learnSkill(shopId, shopName, item, costs, row, newShopItems, force);
+        // If we know this row
+        ShopRow existing = ShopRowDatabase.getShopRow(row);
+        if (existing == null || force) {
+          newShopItems |= learnSkill(shopId, shopName, item, costs, row, newShopItems, force);
+        }
         continue;
       }
 
@@ -483,11 +487,16 @@ public class ShopRequest extends GenericRequest {
         buf.append(cost.getPluralName(price));
       }
     }
-    buf.append(" for ");
     AdventureResult item = shopRow.getItem();
-    buf.append(count * item.getCount());
-    buf.append(" ");
-    buf.append(item.getPluralName(count));
+    if (item.isItem()) {
+      buf.append(" for ");
+      buf.append(count * item.getCount());
+      buf.append(" ");
+      buf.append(item.getPluralName(count));
+    } else if (item.isSkill()) {
+      buf.append(" to learn ");
+      buf.append(item.getName());
+    }
 
     RequestLogger.updateSessionLog();
     RequestLogger.updateSessionLog(buf.toString());

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -1456,7 +1456,19 @@ public abstract class RuntimeLibrary {
     params =
         List.of(
             namedParam("master", DataTypes.COINMASTER_TYPE),
+            namedParam("skill", DataTypes.SKILL_TYPE));
+    functions.add(new LibraryFunction("sells_skill", DataTypes.BOOLEAN_TYPE, params));
+
+    params =
+        List.of(
+            namedParam("master", DataTypes.COINMASTER_TYPE),
             namedParam("item", DataTypes.ITEM_TYPE));
+    functions.add(new LibraryFunction("sell_price", DataTypes.INT_TYPE, params));
+
+    params =
+        List.of(
+            namedParam("master", DataTypes.COINMASTER_TYPE),
+            namedParam("skill", DataTypes.SKILL_TYPE));
     functions.add(new LibraryFunction("sell_price", DataTypes.INT_TYPE, params));
 
     params = List.of(namedParam("item", DataTypes.ITEM_TYPE));
@@ -6512,9 +6524,25 @@ public abstract class RuntimeLibrary {
     return DataTypes.makeBooleanValue(data != null && data.canBuyItem((int) item.intValue()));
   }
 
-  public static Value sell_price(ScriptRuntime controller, final Value master, final Value item) {
+  public static Value sells_skill(ScriptRuntime controller, final Value master, final Value skill) {
     CoinmasterData data = (CoinmasterData) master.rawValue();
-    return DataTypes.makeIntValue(data != null ? data.getBuyPrice((int) item.intValue()) : 0);
+    int skillId = (int) skill.intValue();
+    return DataTypes.makeBooleanValue(data != null && data.skillBuyPrice(skillId) != null);
+  }
+
+  public static Value sell_price(ScriptRuntime controller, final Value master, final Value thing) {
+    CoinmasterData data = (CoinmasterData) master.rawValue();
+    int id = (int) thing.intValue();
+    AdventureResult value =
+        (data == null)
+            ? null
+            : switch (thing.getType().getType()) {
+              case TypeSpec.ITEM -> data.itemBuyPrice(id);
+              case TypeSpec.SKILL -> data.skillBuyPrice(id);
+              default -> null;
+            };
+
+    return DataTypes.makeIntValue(value == null ? 0 : value.getCount());
   }
 
   public static Value historical_price(ScriptRuntime controller, final Value item) {

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -1080,6 +1080,16 @@ public class Player {
   }
 
   /**
+   * Ensures player does not have a skill
+   *
+   * @param skillName Skill to ensure is removed
+   * @return Removes the skill if it was gained
+   */
+  public static Cleanups withoutSkill(final String skillName) {
+    return withoutSkill(SkillDatabase.getSkillId(skillName));
+  }
+
+  /**
    * Sets player's substats to given values.
    *
    * @param muscle Muscle substats

--- a/test/net/sourceforge/kolmafia/CoinmasterDataTest.java
+++ b/test/net/sourceforge/kolmafia/CoinmasterDataTest.java
@@ -1,9 +1,16 @@
 package net.sourceforge.kolmafia;
 
+import static internal.helpers.Player.withPath;
+import static internal.helpers.Player.withSkill;
+import static internal.helpers.Player.withoutSkill;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import internal.helpers.Cleanups;
+import net.sourceforge.kolmafia.AscensionPath.Path;
+import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.request.coinmaster.CoinMasterRequest;
+import net.sourceforge.kolmafia.request.coinmaster.shop.GeneticFiddlingRequest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -23,6 +30,29 @@ class CoinmasterDataTest {
     void notAccessibleIfParentZoneIsRemoved(final String zone) {
       var data = new CoinmasterData("test", "test", CoinMasterRequest.class).inZone(zone);
       assertThat(data.isAccessible(), is(false));
+    }
+  }
+
+  @Nested
+  class AvailableSkill {
+    @Test
+    void withUnknownSkill() {
+      var data = GeneticFiddlingRequest.DATA;
+      var cleanups =
+          new Cleanups(withPath(Path.NUCLEAR_AUTUMN), withoutSkill(SkillPool.EXTRA_MUSCLES));
+      try (cleanups) {
+        assertThat(data.availableSkill(SkillPool.EXTRA_MUSCLES), is(true));
+      }
+    }
+
+    @Test
+    void withKnownSkill() {
+      var data = GeneticFiddlingRequest.DATA;
+      var cleanups =
+          new Cleanups(withPath(Path.NUCLEAR_AUTUMN), withSkill(SkillPool.EXTRA_MUSCLES));
+      try (cleanups) {
+        assertThat(data.availableSkill(SkillPool.EXTRA_MUSCLES), is(false));
+      }
     }
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -1939,4 +1939,51 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
       assertThat(execute("is_banished($phylum[none])").trim(), is("Returned: false"));
     }
   }
+
+  @Nested
+  class SkillCoinmasters {
+    @Test
+    void sellsSkillWorks() {
+      assertThat(
+          execute("sells_skill($coinmaster[Genetic Fiddling], $skill[Boiling Tear Ducts])").trim(),
+          is("Returned: true"));
+      assertThat(
+          execute("sells_skill($coinmaster[Genetic Fiddling], $skill[Magic Sweat])").trim(),
+          is("Returned: true"));
+      assertThat(
+          execute("sells_skill($coinmaster[Genetic Fiddling], $skill[Extra Brain])").trim(),
+          is("Returned: true"));
+      assertThat(
+          execute("sells_skill($coinmaster[Genetic Fiddling], $skill[Sucker Fingers])").trim(),
+          is("Returned: true"));
+      assertThat(
+          execute("sells_skill($coinmaster[Genetic Fiddling], $skill[Stream of sauce])").trim(),
+          is("Returned: false"));
+      assertThat(
+          execute("sells_skill($coinmaster[Kiwi Kwiki Mart], $skill[Boiling Tear Ducts])").trim(),
+          is("Returned: false"));
+    }
+
+    @Test
+    void sellPriceWorks() {
+      assertThat(
+          execute("sell_price($coinmaster[Genetic Fiddling], $skill[Boiling Tear Ducts])").trim(),
+          is("Returned: 30"));
+      assertThat(
+          execute("sell_price($coinmaster[Genetic Fiddling], $skill[Magic Sweat])").trim(),
+          is("Returned: 60"));
+      assertThat(
+          execute("sell_price($coinmaster[Genetic Fiddling], $skill[Extra Brain])").trim(),
+          is("Returned: 90"));
+      assertThat(
+          execute("sell_price($coinmaster[Genetic Fiddling], $skill[Sucker Fingers])").trim(),
+          is("Returned: 120"));
+      assertThat(
+          execute("sell_price($coinmaster[Genetic Fiddling], $skill[Stream of sauce])").trim(),
+          is("Returned: 0"));
+      assertThat(
+          execute("sell_price($coinmaster[Kiwi Kwiki Mart], $skill[Boiling Tear Ducts])").trim(),
+          is("Returned: 0"));
+    }
+  }
 }


### PR DESCRIPTION
Using the Genetic Fiddling coinmaster (shopid=mutate), pretty much finished supprt for coinmasters that sell skills.

1) added boolean availableSkill(int skillId) to CoinmasterData. 
Assumption is only new ShopRow coinmasters will support it.
There must be a ShopRow with the result item being a skill with that skillId.
And if you already have the skill, it is no longer "available".
2) If a coinmaster has addition requirements, it can use "withAvailableSkill" to override it.
GeneticFiddlingRequst doesn't need to to that. I assume.
3) added AdventureResult skillBuyPrice(int skillId) to CoinmasterData
Assumption is that only new ShopRow coinmasters will support it.
Assumption is there is only one "cost".
This returns that cost.
4) CoinMasterRequest only calls purchasedItem for a purchase.
It only calls RequestProcessor.learnSkill in processResults; an external request (like a GenericRequest) learns it elsewhere.
5) No need for ResponseTextParser to have special code to remove rads when you learn a Nuclear Autumn skill.
6) I added a Genetic Fiddling panel to the CoinmastersFrame. It LOOKS good, but is otherwise untested.
7) Added ASH functions:
```
boolean sells_skill($coinmaster[Genetic Fiddling], $skill[Boiling Tear Ducts]) returns true
int sell_price($coinmaster[Genetic Fiddling], $skill[Boiling Tear Ducts]) returns 30.
```
8) I have tests for visiting and buying from "whichshop=mutate" using either a CoinMasterRequest or a GenericRequest.
9) I have tests for the new ASH functions.
10) I have tests for CoinmasterData.availableSkill

I suppose that ASH would like a
```
boolean buy(coinmaster, skill)
```

Later. Maybe.
