### PR TITLE
fix: change fact order for myst / moxie stats

### DIFF
--- a/src/data/bookoffacts.txt
+++ b/src/data/bookoffacts.txt
@@ -68,8 +68,8 @@ Weird	MP	25
 Weird	Item	flaming feather	frozen feather	frightful feather	fetid feather	flirtatious feather
 
 None	Stats	3	muscle
-None	Stats	3	mysticality
 None	Stats	3	moxie
+None	Stats	3	mysticality
 None	HP	10
 None	MP	10
 None	Modifier	Experience (familiar): +1

--- a/test/net/sourceforge/kolmafia/persistence/FactDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/FactDatabaseTest.java
@@ -115,6 +115,9 @@ class FactDatabaseTest {
     "SEAL_CLUBBER, NONE, Family Jewels, ITEM, line (3)",
     "SEAL_CLUBBER, NONE, angry mushroom guy, HP, 50% HP restore",
     "SEAL_CLUBBER, NONE, ancestral Spookyraven portrait, MP, 20% MP restore",
+    "TURTLE_TAMER, STANDARD, Mob Penguin hitman, STATS, +3 moxie substats",
+    "TURTLE_TAMER, STANDARD, Candied Yam Golem, STATS, +3 mysticality substats",
+    "TURTLE_TAMER, NONE, amateur elf, STATS, +10 moxie substats",
   })
   void picksCorrectFact(
       final AscensionClass ascensionClass,


### PR DESCRIPTION
As seen in https://github.com/loathers/BOFASpading/blob/main/bofa_data.php#L3976

Reported by Veracity in https://kolmafia.us/threads/r28327-whats-changed-feat-change-fact-strings-to-be-more-thorough-by-midgleyc-in-2715-full-changelog-r28326-r28327.30284/#post-176238