### PR TITLE
itemBuyPrice returns null for an unsold item

### DIFF
--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -1177,9 +1177,9 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
 
   private AdventureResult itemBuyPriceInternal(final Integer itemId) {
     int price = this.getBuyPrice(itemId);
-    return this.item == null
-        ? this.getTokenItem().getInstance(price)
-        : this.item.getInstance(price);
+    return this.item != null
+        ? this.item.getInstance(price)
+        : this.token != null ? this.getTokenItem().getInstance(price) : null;
   }
 
   public AdventureResult skillBuyPrice(final Integer skillId) {
@@ -1212,6 +1212,7 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
         }
       } else if (this.buyItems != null) {
         for (AdventureResult item : this.buyItems) {
+          AdventureResult price = this.itemBuyPrice(item.getItemId());
           this.currencies.add(this.itemBuyPrice(item.getItemId()));
         }
       }

--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -1212,7 +1212,6 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
         }
       } else if (this.buyItems != null) {
         for (AdventureResult item : this.buyItems) {
-          AdventureResult price = this.itemBuyPrice(item.getItemId());
           this.currencies.add(this.itemBuyPrice(item.getItemId()));
         }
       }

--- a/test/net/sourceforge/kolmafia/CoinmasterDataTest.java
+++ b/test/net/sourceforge/kolmafia/CoinmasterDataTest.java
@@ -5,11 +5,16 @@ import static internal.helpers.Player.withSkill;
 import static internal.helpers.Player.withoutSkill;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import internal.helpers.Cleanups;
 import net.sourceforge.kolmafia.AscensionPath.Path;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.request.coinmaster.CoinMasterRequest;
+import net.sourceforge.kolmafia.request.coinmaster.shop.Crimbo24CafeRequest;
+import net.sourceforge.kolmafia.request.coinmaster.shop.DinseyCompanyStoreRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.GeneticFiddlingRequest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -53,6 +58,34 @@ class CoinmasterDataTest {
       try (cleanups) {
         assertThat(data.availableSkill(SkillPool.EXTRA_MUSCLES), is(false));
       }
+    }
+  }
+
+  @Nested
+  class ItemBuyPrice {
+    @Test
+    void withKnownItem() {
+      var data = DinseyCompanyStoreRequest.DINSEY_COMPANY_STORE;
+      var price = data.itemBuyPrice(ItemPool.DINSEY_TICKET);
+      assertNotNull(price);
+      assertThat(price.getCount(), is(20));
+    }
+
+    @Test
+    void withNonShopRowCoinmasterUnsoldItem() {
+      var data = DinseyCompanyStoreRequest.DINSEY_COMPANY_STORE;
+      var price = data.itemBuyPrice(ItemPool.SEAL_TOOTH);
+      assertNotNull(price);
+      assertThat(price.getCount(), is(0));
+    }
+
+    @Test
+    void withShopRowCoinmasterUnsoldItem() {
+      var data = Crimbo24CafeRequest.DATA;
+      var price = data.itemBuyPrice(ItemPool.DINSEY_TICKET);
+      // *** ShopRow coinmasters can have multiple currencies
+      // *** For an unknown item, what currency?
+      assertNull(price);
     }
   }
 }


### PR DESCRIPTION
getBuyPrice returns 0 for an unsold item.
itemBuyPrice returns an AdventureResult of the shop's "currency" with the buy price.

That's OK for a shop with a single currency.
Shops with multiple currencies need to override that method and return an adventure result with the correct currency.
(Mr. Store does that, for example.)

What about ShopRow shops which might have multiple currencies and also items that have multiple costs?
What IS the "buy price" for an item that costs X of item 1 and Y of item 2?

This is primarily an issue for ASH - which has no support for coinmasters like that.
That will be a design issue for the future...

For now, if a shop has neither an "item" or a "token" and does not override itemBuyPrice - which includes the Crimbo24 shops, at least - itemBuyPrice returns null and callers thereof have to understand that.

Therefore, since ASH ```sell_price``` calls ```itemBuyPrice```  - and returns 0 if it gets a null - it will no longer experience an NPE if given a bogus item for a ShopRow coinmaster.