### PR TITLE
Command and JSON APIs should return 401 if the password hash is incorrect.

### DIFF
--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -102,6 +102,8 @@ public class RelayRequest extends PasswordHashRequest {
   private static final HashMap<String, File> overrideMap = new HashMap<>();
   private static final Object lock = new Object(); // used to synch
 
+  private static final Pattern HTTP_STATUS_PATTERN = Pattern.compile("^HTTP/1.1 ([0-9]+)");
+
   private static final Pattern STORE_PATTERN =
       Pattern.compile(
           "<tr><td><input name=whichitem type=radio value=([\\d.]+).*?</tr>", Pattern.DOTALL);
@@ -557,14 +559,15 @@ public class RelayRequest extends PasswordHashRequest {
     this.headers.add("Date: " + StringUtilities.formatDate(new Date()));
     this.headers.add("Server: " + StaticEntity.getVersion());
 
-    if (status.contains("302")) {
+    Matcher m = HTTP_STATUS_PATTERN.matcher(status);
+    if (m.find()) {
+      this.responseCode = Integer.parseInt(m.group(1));
+    }
+
+    if (this.responseCode == 302) {
       this.headers.add("Location: " + responseText);
-
-      this.responseCode = 302;
       this.responseText = "";
-    } else if (status.contains("200")) {
-      this.responseCode = 200;
-
+    } else if (this.responseCode == 200) {
       if (responseText == null || responseText.length() == 0) {
         this.responseText = " ";
       } else {
@@ -3408,6 +3411,7 @@ public class RelayRequest extends PasswordHashRequest {
 
     String pwd = this.getFormField("pwd");
     if (pwd == null || !pwd.equals((GenericRequest.passwordHash))) {
+      this.pseudoResponse("HTTP/1.1 403 Forbidden", "");
       return;
     }
 

--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -3411,7 +3411,7 @@ public class RelayRequest extends PasswordHashRequest {
 
     String pwd = this.getFormField("pwd");
     if (pwd == null || !pwd.equals((GenericRequest.passwordHash))) {
-      this.pseudoResponse("HTTP/1.1 403 Forbidden", "");
+      this.pseudoResponse("HTTP/1.1 401 Unauthorized", "");
       return;
     }
 

--- a/test/net/sourceforge/kolmafia/request/RelayRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/RelayRequestTest.java
@@ -8,6 +8,7 @@ import static internal.helpers.Player.withEquipped;
 import static internal.helpers.Player.withHttpClientBuilder;
 import static internal.helpers.Player.withItem;
 import static internal.helpers.Player.withMeat;
+import static internal.helpers.Player.withPasswordHash;
 import static internal.helpers.Player.withProperty;
 import static internal.helpers.Player.withTurnsPlayed;
 import static internal.helpers.Utilities.deleteSerFiles;
@@ -25,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
 import internal.helpers.Cleanups;
+import internal.helpers.RequestLoggerOutput;
 import internal.network.FakeHttpClientBuilder;
 import java.io.File;
 import java.io.IOException;
@@ -150,14 +152,91 @@ public class RelayRequestTest {
   }
 
   @Nested
+  class Command {
+    private RelayRequest makeCommandRequest(String endpoint, String command, String hash) {
+      var rr = new RelayRequest(false);
+      rr.constructURLString(
+          "KoLmafia/" + endpoint + "?cmd=" + command + (hash == null ? "" : "&pwd=" + hash), false);
+      rr.run();
+      return rr;
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      "submitCommand",
+      "redirectedCommand",
+      "polledredirectedCommand",
+      "sideCommand",
+      "specialCommand",
+      "waitSpecialCommand",
+      "parameterizedCommand"
+    })
+    public void failsWithNoHash(String endpoint) {
+      var cleanups = withPasswordHash("xxxx");
+      try (cleanups) {
+        var rr = makeCommandRequest(endpoint, "echo hi", null);
+        assertThat(rr.statusLine, is("HTTP/1.1 403 Forbidden"));
+        assertThat(rr.responseCode, is(403));
+      }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      "submitCommand",
+      "redirectedCommand",
+      "polledredirectedCommand",
+      "sideCommand",
+      "specialCommand",
+      "waitSpecialCommand",
+      "parameterizedCommand"
+    })
+    public void failsWithWrongHash(String endpoint) {
+      var cleanups = withPasswordHash("xxxx");
+      try (cleanups) {
+        var rr = makeCommandRequest(endpoint, "echo hi", "yyy");
+        assertThat(rr.statusLine, is("HTTP/1.1 403 Forbidden"));
+        assertThat(rr.responseCode, is(403));
+      }
+    }
+
+    // TODO: Test polledredirectedCommand and specialCommand here with some asynchronous logic.
+    @ParameterizedTest
+    @CsvSource({
+      "submitCommand,200",
+      "redirectedCommand,302",
+      "sideCommand,302",
+      "waitSpecialCommand,200",
+      "parameterizedCommand,200"
+    })
+    public void succeedsWithRedirect(String endpoint, int statusCode) {
+      var cleanups = withPasswordHash("xxxx");
+      try (cleanups) {
+        RequestLoggerOutput.startStream();
+        var rr = makeCommandRequest(endpoint, "echo hi", "xxxx");
+        var output = RequestLoggerOutput.stopStream();
+
+        assertThat(rr.statusLine, is(statusCode == 200 ? "HTTP/1.1 200 OK" : "HTTP/1.1 302 Found"));
+        assertThat(rr.responseCode, is(statusCode));
+        assertThat(output, is("\n&gt; echo hi\n\nhi\n"));
+      }
+    }
+  }
+
+  @Nested
   class JsonApi {
-    private RelayRequest makeApiRequest(String bodyString) {
+    private RelayRequest makeApiRequest(String bodyString, String hash) {
       var rr = new RelayRequest(false);
       rr.constructURLString("KoLmafia/jsonApi", true);
-      rr.addFormField("pwd", GenericRequest.passwordHash);
+      if (hash != null) {
+        rr.addFormField("pwd", hash);
+      }
       rr.addFormField("body", bodyString);
       rr.run();
       return rr;
+    }
+
+    private RelayRequest makeApiRequest(String bodyString) {
+      return makeApiRequest(bodyString, GenericRequest.passwordHash);
     }
 
     @BeforeAll
@@ -173,6 +252,26 @@ public class RelayRequestTest {
       // has not been found and setting a logged in user breaks the test because the returned JSON
       // is different from what is expected.
       deleteSerFiles("GLOBAL");
+    }
+
+    @Test
+    public void failsWithNoHash() {
+      var cleanups = withPasswordHash("xxxx");
+      try (cleanups) {
+        var rr = makeApiRequest("{}", null);
+        assertThat(rr.statusLine, is("HTTP/1.1 403 Forbidden"));
+        assertThat(rr.responseCode, is(403));
+      }
+    }
+
+    @Test
+    public void failsWithWrongHash() {
+      var cleanups = withPasswordHash("xxxx");
+      try (cleanups) {
+        var rr = makeApiRequest("{}", "yyy");
+        assertThat(rr.statusLine, is("HTTP/1.1 403 Forbidden"));
+        assertThat(rr.responseCode, is(403));
+      }
     }
 
     @Test

--- a/test/net/sourceforge/kolmafia/request/RelayRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/RelayRequestTest.java
@@ -175,8 +175,8 @@ public class RelayRequestTest {
       var cleanups = withPasswordHash("xxxx");
       try (cleanups) {
         var rr = makeCommandRequest(endpoint, "echo hi", null);
-        assertThat(rr.statusLine, is("HTTP/1.1 403 Forbidden"));
-        assertThat(rr.responseCode, is(403));
+        assertThat(rr.statusLine, is("HTTP/1.1 401 Unauthorized"));
+        assertThat(rr.responseCode, is(401));
       }
     }
 
@@ -194,8 +194,8 @@ public class RelayRequestTest {
       var cleanups = withPasswordHash("xxxx");
       try (cleanups) {
         var rr = makeCommandRequest(endpoint, "echo hi", "yyy");
-        assertThat(rr.statusLine, is("HTTP/1.1 403 Forbidden"));
-        assertThat(rr.responseCode, is(403));
+        assertThat(rr.statusLine, is("HTTP/1.1 401 Unauthorized"));
+        assertThat(rr.responseCode, is(401));
       }
     }
 
@@ -259,8 +259,8 @@ public class RelayRequestTest {
       var cleanups = withPasswordHash("xxxx");
       try (cleanups) {
         var rr = makeApiRequest("{}", null);
-        assertThat(rr.statusLine, is("HTTP/1.1 403 Forbidden"));
-        assertThat(rr.responseCode, is(403));
+        assertThat(rr.statusLine, is("HTTP/1.1 401 Unauthorized"));
+        assertThat(rr.responseCode, is(401));
       }
     }
 
@@ -269,8 +269,8 @@ public class RelayRequestTest {
       var cleanups = withPasswordHash("xxxx");
       try (cleanups) {
         var rr = makeApiRequest("{}", "yyy");
-        assertThat(rr.statusLine, is("HTTP/1.1 403 Forbidden"));
-        assertThat(rr.responseCode, is(403));
+        assertThat(rr.statusLine, is("HTTP/1.1 401 Unauthorized"));
+        assertThat(rr.responseCode, is(401));
       }
     }
 


### PR DESCRIPTION
These APIs currently just reset the connection, which is difficult to handle from the script side. Instead, they should respond RESTfully, which means sending back a 401 Unauthorized status code.