### PR TITLE
Stop character sheet breaking Zootomist stats

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -3386,7 +3386,7 @@ public abstract class KoLCharacter {
   public static final boolean inElevenThingIHateAboutU() {
     return KoLCharacter.ascensionPath == Path.ELEVEN_THINGS;
   }
-  
+
   public static final boolean inZootomist() {
     return KoLCharacter.ascensionPath == Path.Z_IS_FOR_ZOOTOMIST;
   }

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -3386,6 +3386,10 @@ public abstract class KoLCharacter {
   public static final boolean inElevenThingIHateAboutU() {
     return KoLCharacter.ascensionPath == Path.ELEVEN_THINGS;
   }
+  
+  public static final boolean inZootomist() {
+    return KoLCharacter.ascensionPath == Path.Z_IS_FOR_ZOOTOMIST;
+  }
 
   public static final boolean isUnarmed() {
     AdventureResult weapon = EquipmentManager.getEquipment(Slot.WEAPON);

--- a/src/net/sourceforge/kolmafia/request/CharSheetRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CharSheetRequest.java
@@ -709,8 +709,8 @@ public class CharSheetRequest extends GenericRequest {
     long rawmuscle;
     long rawmysticality;
     long rawmoxie;
-    if (KoLCharacter.inGreyYou()) {
-      // Raw values are more precise, but they don't exist in Grey You
+    if (KoLCharacter.inGreyYou() || KoLCharacter.inZootomist()) {
+      // Raw values are more precise, but they don't exist in Grey You and are wrong in Zooto
       long basemuscle = JSON.getLong("basemuscle");
       rawmuscle = basemuscle * basemuscle;
 
@@ -724,7 +724,10 @@ public class CharSheetRequest extends GenericRequest {
       rawmysticality = JSON.getLong("rawmysticality");
       rawmoxie = JSON.getLong("rawmoxie");
     }
-
+    
+    //~ rawmuscle = 155*155;
+    //~ rawmysticality = 158*158;
+    //~ rawmoxie = 129*129;
     KoLCharacter.setStatPoints(muscle, rawmuscle, mysticality, rawmysticality, moxie, rawmoxie);
   }
 }

--- a/src/net/sourceforge/kolmafia/request/CharSheetRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CharSheetRequest.java
@@ -724,10 +724,10 @@ public class CharSheetRequest extends GenericRequest {
       rawmysticality = JSON.getLong("rawmysticality");
       rawmoxie = JSON.getLong("rawmoxie");
     }
-    
-    //~ rawmuscle = 155*155;
-    //~ rawmysticality = 158*158;
-    //~ rawmoxie = 129*129;
+
+    // ~ rawmuscle = 155*155;
+    // ~ rawmysticality = 158*158;
+    // ~ rawmoxie = 129*129;
     KoLCharacter.setStatPoints(muscle, rawmuscle, mysticality, rawmysticality, moxie, rawmoxie);
   }
 }

--- a/src/net/sourceforge/kolmafia/request/CharSheetRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CharSheetRequest.java
@@ -725,9 +725,6 @@ public class CharSheetRequest extends GenericRequest {
       rawmoxie = JSON.getLong("rawmoxie");
     }
 
-    // ~ rawmuscle = 155*155;
-    // ~ rawmysticality = 158*158;
-    // ~ rawmoxie = 129*129;
     KoLCharacter.setStatPoints(muscle, rawmuscle, mysticality, rawmysticality, moxie, rawmoxie);
   }
 }


### PR DESCRIPTION
At the moment, every time the char page request is hit for Zootomist, it gets the wrong stats and sets your character back to level 1. This uses the code from Grey You where a similar problem existed to fix the issue.