### PR TITLE
log Mall Purchase parsing error for another failure

### DIFF
--- a/src/net/sourceforge/kolmafia/request/MallPurchaseRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MallPurchaseRequest.java
@@ -553,6 +553,9 @@ public class MallPurchaseRequest extends PurchaseRequest {
 
     Matcher tableMatcher = MallPurchaseRequest.TABLE_PATTERN.matcher(responseText);
     if (!tableMatcher.find()) {
+      // Log and set ERROR state so we learn about the issue and the
+      // caller doesn't immediately go to the next PurchaseRequest.
+      logResultProcessingFailure(responseText);
       return;
     }
 
@@ -568,6 +571,8 @@ public class MallPurchaseRequest extends PurchaseRequest {
 
     Matcher meatMatcher = MallPurchaseRequest.MEAT_PATTERN.matcher(responseText);
     if (!meatMatcher.find()) {
+      // Considering that the item was successfully detected, hard to
+      // imagine we can't parse the Meat spent.
       return;
     }
 

--- a/src/net/sourceforge/kolmafia/request/MallPurchaseRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MallPurchaseRequest.java
@@ -565,7 +565,7 @@ public class MallPurchaseRequest extends PurchaseRequest {
       // This should not happen. But, apparently it (very rarely) does,
       // even though the mall purchase was actually successful.  Log the
       // failure, put the text into debug log, and leave in error state.
-      logResultProcessingFailure(tableText);
+      logResultProcessingFailure(responseText);
       return;
     }
 


### PR DESCRIPTION
We log (and set ERROR state) if we can't parse the item from the table in the responseText.
This PR also does so if it cannot find the table.
Chances are, KoL might be giving us an unexpected error message, or something.

I wonder if we should be logging the whole responseText for the other instance, as well?
I think so - we found a table, but perhaps it's a different table?

And what about if we could not find the Meat cost?
Considering we found - and processed - the purchased item, that seems extremely unlikely.

(What happens on salad day? I expect we'll find out on April 1.)