### PR TITLE
fix: can adventure in mushroom garden when has campground and garden

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLAdventure.java
+++ b/src/net/sourceforge/kolmafia/KoLAdventure.java
@@ -983,10 +983,15 @@ public class KoLAdventure implements Comparable<KoLAdventure>, Runnable {
     }
 
     if (this.zone.equals("Campground")) {
-      return switch (this.adventureNumber) {
-        case AdventurePool.YOUR_MUSHROOM_GARDEN -> !KoLCharacter.isKingdomOfExploathing();
-        default -> true;
-      };
+      if (!KoLCharacter.hasCampground()) {
+        return false;
+      }
+      if (this.adventureNumber == AdventurePool.YOUR_MUSHROOM_GARDEN) {
+        AdventureResult crop = CampgroundRequest.getCrop();
+        return crop != null
+            && CampgroundRequest.getCropType(crop) == CampgroundRequest.CropType.MUSHROOM;
+      }
+      return true;
     }
 
     if (this.parentZone.equals("Manor")) {

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -5940,4 +5940,11 @@ public abstract class KoLCharacter {
     mods.addDouble(DoubleModifier.HOT_DAMAGE, 5 * level, ModifierType.OUTFIT, "McHugeLarge");
     mods.addDouble(DoubleModifier.INITIATIVE, 10 * level, ModifierType.OUTFIT, "McHugeLarge");
   }
+
+  public static boolean hasCampground() {
+    return switch (KoLCharacter.ascensionPath) {
+      case ACTUALLY_ED_THE_UNDYING, YOU_ROBOT, NUCLEAR_AUTUMN, SMALL, WEREPROFESSOR -> false;
+      default -> true;
+    };
+  }
 }

--- a/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
+++ b/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
@@ -6,6 +6,7 @@ import static internal.helpers.Networking.assertGetRequest;
 import static internal.helpers.Networking.assertPostRequest;
 import static internal.helpers.Networking.html;
 import static internal.helpers.Player.withAscensions;
+import static internal.helpers.Player.withCampgroundItem;
 import static internal.helpers.Player.withContinuationState;
 import static internal.helpers.Player.withDay;
 import static internal.helpers.Player.withEffect;
@@ -7630,6 +7631,19 @@ public class KoLAdventureValidationTest {
         assertThat("crimbo23CottageAtWar", isSetTo(true));
         assertThat("crimbo23FoundryAtWar", isSetTo(false));
       }
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void canOnlyAdventureInMushroomGardenWithGarden(boolean hasGarden) {
+    var cleanups =
+        new Cleanups(
+            withCampgroundItem(hasGarden ? ItemPool.MUSHROOM_SPORES : ItemPool.DRAGON_TEETH));
+
+    try (cleanups) {
+      var area = AdventureDatabase.getAdventureByName("Your Mushroom Garden");
+      assertThat(area.canAdventure(), is(hasGarden));
     }
   }
 }


### PR DESCRIPTION
Kingdom of Exploathing does seem to have Campground access by wiki, and I'm not sure why this wouldn't work, so I removed that part of the code.