### PR TITLE
correct wrong element in Spooky Gravy Fairy tags

### DIFF
--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -66,7 +66,7 @@
 34	Flaming Gravy Fairy	familiar34.gif	combat1,item0	pregnant flaming mushroom	flaming glowsticks	2	3	1	2	haseyes,haswings,hot,sentient,vegetable,hasbones,flies,cute,good
 35	Frozen Gravy Fairy	familiar35.gif	combat1,item0	pregnant frozen mushroom	iced-out bling	2	3	1	2	haseyes,haswings,flies,sentient,vegetable,hasbones,cute,cold,good
 36	Stinky Gravy Fairy	familiar36.gif	combat1,item0	pregnant stinky mushroom	limburger biker boots	2	3	1	2	haseyes,haswings,flies,sentient,vegetable,hasbones,cute,stench,good
-37	Spooky Gravy Fairy	sgfairy.gif	combat1,item0	pregnant gloomy black mushroom	miniature carton of clove cigarettes	3	3	1	2	haseyes,haswings,sentient,vegetable,hasbones,flies,cute,stench,good
+37	Spooky Gravy Fairy	sgfairy.gif	combat1,item0	pregnant gloomy black mushroom	miniature carton of clove cigarettes	3	3	1	2	haseyes,haswings,sentient,vegetable,hasbones,flies,cute,spooky,good
 38	Inflatable Dodecapede	familiar38.gif	combat0	deflated inflatable dodecapede	toy six-seater hovercraft	3	2	2	1
 39	Pygmy Bugbear Shaman	familiar39.gif	stat0,item0	pygmy bugbear shaman	tiny nose-bone fetish	1	3	1	2	hashands,haseyes,bite
 40	Doppelshifter	familiar40.gif	variable	doppelshifter egg	tiny makeup kit	3	3	3	3	haseyes


### PR DESCRIPTION
Spooky gravy fairy was listed as stench, it's actually spooky (shockingly).

![spooky](https://github.com/user-attachments/assets/bbac5054-e843-43ed-ba26-a3a6ee719a9d)
