### PR TITLE
feat: always read level from API, don't calculate it

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -185,8 +185,6 @@ public abstract class KoLCharacter {
   public static int AWOLtattoo = 0;
 
   private static int currentLevel = 1;
-  private static long decrementPrime = 0;
-  private static long incrementPrime = 25;
 
   private static long currentHP, maximumHP, baseMaxHP;
   private static long currentMP, maximumMP, baseMaxMP;
@@ -354,8 +352,6 @@ public abstract class KoLCharacter {
 
     KoLCharacter.gender = Gender.UNKNOWN;
     KoLCharacter.currentLevel = 1;
-    KoLCharacter.decrementPrime = 0L;
-    KoLCharacter.incrementPrime = 25L;
 
     KoLCharacter.fury = 0;
     KoLCharacter.soulsauce = 0;
@@ -826,28 +822,18 @@ public abstract class KoLCharacter {
    * @return The level of this character
    */
   public static final int getLevel() {
-    long totalPrime = KoLCharacter.getTotalPrime();
-
-    if (totalPrime < KoLCharacter.decrementPrime || totalPrime >= KoLCharacter.incrementPrime) {
-      int previousLevel = KoLCharacter.currentLevel;
-
-      KoLCharacter.currentLevel = KoLCharacter.calculateSubpointLevels(totalPrime);
-      KoLCharacter.decrementPrime = KoLCharacter.calculateLastLevel();
-      KoLCharacter.incrementPrime = KoLCharacter.calculateNextLevel();
-
-      if (KoLCharacter.incrementPrime < 0) {
-        // this will overflow at level 216
-        KoLCharacter.incrementPrime = Long.MAX_VALUE;
-      }
-
-      if (previousLevel != KoLCharacter.currentLevel) {
-        HPRestoreItemList.updateHealthRestored();
-        MPRestoreItemList.updateManaRestored();
-        ConsumablesDatabase.setLevelVariableConsumables();
-      }
-    }
-
     return KoLCharacter.currentLevel;
+  }
+
+  /** Set the level of this character. */
+  public static final void setLevel(int newLevel) {
+    int previousLevel = KoLCharacter.currentLevel;
+    if (previousLevel != newLevel) {
+      HPRestoreItemList.updateHealthRestored();
+      MPRestoreItemList.updateManaRestored();
+      ConsumablesDatabase.setLevelVariableConsumables();
+    }
+    KoLCharacter.currentLevel = newLevel;
   }
 
   public static final int getFury() {

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -828,12 +828,12 @@ public abstract class KoLCharacter {
   /** Set the level of this character. */
   public static final void setLevel(int newLevel) {
     int previousLevel = KoLCharacter.currentLevel;
+    KoLCharacter.currentLevel = newLevel;
     if (previousLevel != newLevel) {
       HPRestoreItemList.updateHealthRestored();
       MPRestoreItemList.updateManaRestored();
       ConsumablesDatabase.setLevelVariableConsumables();
     }
-    KoLCharacter.currentLevel = newLevel;
   }
 
   public static final int getFury() {

--- a/src/net/sourceforge/kolmafia/request/CharSheetRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CharSheetRequest.java
@@ -726,5 +726,7 @@ public class CharSheetRequest extends GenericRequest {
     }
 
     KoLCharacter.setStatPoints(muscle, rawmuscle, mysticality, rawmysticality, moxie, rawmoxie);
+    int level = JSON.getIntValue("level");
+    KoLCharacter.setLevel(level);
   }
 }

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -1242,19 +1242,15 @@ public class Player {
   }
 
   /**
-   * Sets the player's level to the given value. This also sets all stats to the minimum required
-   * for that level.
+   * Sets the player's level to the given value.
    *
    * @param level Required level
    * @return Resets level to zero
    */
   public static Cleanups withLevel(final int level) {
-    int substats = (int) Math.pow(level, 2) - level * 2 + 5;
     int previousLevel = KoLCharacter.getLevel();
     KoLCharacter.setLevel(level);
-    return new Cleanups(
-        withStats(substats, substats, substats),
-        new Cleanups(() -> KoLCharacter.setLevel(previousLevel)));
+    return new Cleanups(() -> KoLCharacter.setLevel(previousLevel));
   }
 
   /**

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -1251,6 +1251,7 @@ public class Player {
   public static Cleanups withLevel(final int level) {
     int substats = (int) Math.pow(level, 2) - level * 2 + 5;
     int previousLevel = KoLCharacter.getLevel();
+    KoLCharacter.setLevel(level);
     return new Cleanups(
         withStats(substats, substats, substats),
         new Cleanups(() -> KoLCharacter.setLevel(previousLevel)));

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -1242,15 +1242,18 @@ public class Player {
   }
 
   /**
-   * Sets the player's level to the given value. This is done by setting all stats to the minimum
-   * required for that level.
+   * Sets the player's level to the given value. This also sets all stats to the minimum required
+   * for that level.
    *
    * @param level Required level
    * @return Resets level to zero
    */
   public static Cleanups withLevel(final int level) {
     int substats = (int) Math.pow(level, 2) - level * 2 + 5;
-    return withStats(substats, substats, substats);
+    int previousLevel = KoLCharacter.getLevel();
+    return new Cleanups(
+        withStats(substats, substats, substats),
+        new Cleanups(() -> KoLCharacter.setLevel(previousLevel)));
   }
 
   /**

--- a/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
+++ b/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
@@ -10,6 +10,7 @@ import static internal.helpers.Player.withFullness;
 import static internal.helpers.Player.withInebriety;
 import static internal.helpers.Player.withInteractivity;
 import static internal.helpers.Player.withIntrinsicEffect;
+import static internal.helpers.Player.withLevel;
 import static internal.helpers.Player.withLocation;
 import static internal.helpers.Player.withMoxie;
 import static internal.helpers.Player.withMuscle;
@@ -419,7 +420,7 @@ public class ModifierExpressionTest {
 
   @Test
   public void canDetectLevel() {
-    var cleanups = new Cleanups(withMuscle(10, 100), withClass(AscensionClass.SEAL_CLUBBER));
+    var cleanups = new Cleanups(withLevel(3), withClass(AscensionClass.SEAL_CLUBBER));
     try (cleanups) {
       var exp = new ModifierExpression("L", "Level");
       assertThat(exp.eval(), is(3.0));

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -7,6 +7,7 @@ import static internal.helpers.Player.withEquipped;
 import static internal.helpers.Player.withFamiliar;
 import static internal.helpers.Player.withHP;
 import static internal.helpers.Player.withInteractivity;
+import static internal.helpers.Player.withLevel;
 import static internal.helpers.Player.withLocation;
 import static internal.helpers.Player.withMP;
 import static internal.helpers.Player.withOverrideModifiers;
@@ -134,8 +135,7 @@ public class ModifiersTest {
   @ParameterizedTest
   @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11})
   public void intrinsicSpicinessModifiers(int level) {
-    int myst = (level == 1) ? 0 : (level - 1) * (level - 1) + 4;
-    var cleanups = new Cleanups(withClass(AscensionClass.SAUCEROR), withStats(0, myst, 0));
+    var cleanups = new Cleanups(withClass(AscensionClass.SAUCEROR), withLevel(level));
 
     try (cleanups) {
       Modifiers mods = ModifierDatabase.getModifiers(ModifierType.SKILL, "Intrinsic Spiciness");

--- a/test/net/sourceforge/kolmafia/textui/command/AbsorbCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/AbsorbCommandTest.java
@@ -5,6 +5,7 @@ import static internal.helpers.Networking.html;
 import static internal.helpers.Player.withConcoctionRefresh;
 import static internal.helpers.Player.withHttpClientBuilder;
 import static internal.helpers.Player.withItem;
+import static internal.helpers.Player.withLevel;
 import static internal.helpers.Player.withPath;
 import static internal.helpers.Player.withRange;
 import static internal.helpers.Player.withUsedAbsorbs;
@@ -112,6 +113,7 @@ public class AbsorbCommandTest extends AbstractCommandTestBase {
             withPath(Path.GELATINOUS_NOOB),
             withHttpClientBuilder(builder),
             withItem("A Light that Never Goes Out", 15),
+            withLevel(15),
             withUsedAbsorbs(0));
     try (cleanups) {
       for (int i = 0; i < 15; i++) {


### PR DESCRIPTION
Zootomist uses grafts for levels, so easier to just always use the API.

This introduces a race on startup in Gelatinous Noob, which isn't great, but can be fixed
by refreshing the charpane as we'll definitely have the level by then.