### PR TITLE
feat: make zootomist effect mods show up correctly

### DIFF
--- a/src/data/classskills.txt
+++ b/src/data/classskills.txt
@@ -1122,12 +1122,12 @@
 7552	Leave nothing to the imagination	crepecamisole.gif	nc,self	0	20
 7553	Embrace polka	crepecharm.gif	nc,self	0	20
 7554	Thrust your geofencing rapier	cr_rapier.gif	combat	0	0
-7555	Drink The Milk of  Kindness	.gif	nc,self	10	20
-7556	Drink The Milk of  Cruelty	.gif	nc,self	20	20
-7557	Left  Punch	.gif	combat	5	0
-7558	Right  Punch	.gif	combat	10	0
-7559	Left  Kick	.gif	combat	15	0
-7560	Right  Kick	.gif	combat	20	0
+7555	Drink The Milk of %n Kindness	.gif	nc,self	10	20
+7556	Drink The Milk of %n Cruelty	.gif	nc,self	20	20
+7557	Left %n Punch	.gif	combat	5	0
+7558	Right %n Punch	.gif	combat	10	0
+7559	Left %n Kick	.gif	combat	15	0
+7560	Right %n Kick	.gif	combat	20	0
 
 # Skills granted by books on your Mystical Bookshelf
 # These skills were renumbered.  This section kept for historical purposes only.

--- a/src/data/consequences.txt
+++ b/src/data/consequences.txt
@@ -138,6 +138,9 @@ DESC_EFFECT	Blessing of the Bird		_birdOfTheDayMods=mods
 DESC_EFFECT	Blessing of your favorite Bird		yourFavoriteBirdMods=mods
 DESC_EFFECT	Citizen of a Zone	Citizen of ([^<]*)<	_citizenZone=$1
 DESC_EFFECT	Citizen of a Zone		_citizenZoneMods=mods
+DESC_EFFECT	Grafted		zootGraftedMods=mods
+DESC_EFFECT	Milk of Familiar Cruelty		zootMilkCrueltyMods=mods
+DESC_EFFECT	Milk of Familiar Kindness		zootMilkKindnessMods=mods
 DESC_EFFECT	Savage Beast		_savageBeastMods=mods
 
 DESC_EFFECT	Wine-Fortified	\+(\d+) .*? Damage	vintnerWineLevel=[$1/3]

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1751,6 +1751,10 @@ user	youRobotTop	0
 user	zeppelinProtestors	0
 user	zigguratLianas	0
 user	zombiePoints	0
+user	zootGraftedMods
+user	zootMilkCrueltyMods
+user	zootMilkKindnessMods
+user	zootomistPoints	0
 user	_2002MrStoreCreditsCollected	false
 user	_absintheDrops	0
 user	_abstractionDropsCrown	0

--- a/src/data/statuseffects.txt
+++ b/src/data/statuseffects.txt
@@ -2965,5 +2965,5 @@
 2962	Synthetic Buzz	coffeecup.gif	20528648bd6e3ac43c284af4efcd631f	neutral	none	use 1 synthetic coffee
 2963	Cybercrime Eyes	bigpupil.gif	94d178dfabaef344cc7591315e6bbb03	neutral	none	use 1 iDrops
 2964	Grafted	zootomist.gif	003e2e2d7de4a3fb2982c7615b1cbcdc	neutral	none
-2965	Milk of Familiar Kindness	noart.gif	49aaf365d871570cbdead2dc7e35ff26	neutral	none	cast 1 Drink The Milk of  Kindness
-2966	Milk of Familiar Cruelty	noart.gif	ddf36c8e65632ba327f2a6e756a963c0	neutral	none	cast 1 Drink The Milk of  Cruelty
+2965	Milk of Familiar Kindness	noart.gif	49aaf365d871570cbdead2dc7e35ff26	neutral	none	cast 1 Drink The Milk of %n Kindness
+2966	Milk of Familiar Cruelty	noart.gif	ddf36c8e65632ba327f2a6e756a963c0	neutral	none	cast 1 Drink The Milk of %n Cruelty

--- a/src/net/sourceforge/kolmafia/objectpool/EffectPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/EffectPool.java
@@ -382,6 +382,9 @@ public class EffectPool {
   public static final int SAVAGE_BEAST = 2898;
   public static final int EVERYTHING_LOOKS_PURPLE = 2922;
   public static final int CYBER_MEMORY_BOOST = 2953;
+  public static final int GRAFTED = 2964;
+  public static final int MILK_OF_FAMILIAR_KINDNESS = 2965;
+  public static final int MILK_OF_FAMILIAR_CRUELTY = 2966;
 
   public static final AdventureResult CURSE1_EFFECT = EffectPool.get(EffectPool.ONCE_CURSED);
   public static final AdventureResult CURSE2_EFFECT = EffectPool.get(EffectPool.TWICE_CURSED);

--- a/src/net/sourceforge/kolmafia/session/InventoryManager.java
+++ b/src/net/sourceforge/kolmafia/session/InventoryManager.java
@@ -35,6 +35,7 @@ import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.persistence.CoinmastersDatabase;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.persistence.DebugDatabase;
+import net.sourceforge.kolmafia.persistence.EffectDatabase;
 import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase.Attribute;
@@ -1578,6 +1579,12 @@ public abstract class InventoryManager {
     RequestThread.postRequest(req);
   }
 
+  public static final void checkEffectDescription(final int effectId) {
+    String descId = EffectDatabase.getDescriptionId(effectId);
+    GenericRequest req = new GenericRequest("desc_effect.php?whicheffect=" + descId);
+    RequestThread.postRequest(req);
+  }
+
   public static final void checkCrownOfThrones() {
     // If we are wearing the Crown of Thrones, we've already seen
     // which familiar is riding in it
@@ -1639,6 +1646,7 @@ public abstract class InventoryManager {
     checkCrimboTrainingManual();
     checkRing();
     checkFuturistic();
+    checkZootomistMods();
   }
 
   public static void checkNoHat() {
@@ -1806,6 +1814,16 @@ public abstract class InventoryManager {
     checkItem(ItemPool.FUTURISTIC_HAT, "_futuristicHatModifier");
     checkItem(ItemPool.FUTURISTIC_SHIRT, "_futuristicShirtModifier");
     checkItem(ItemPool.FUTURISTIC_COLLAR, "_futuristicCollarModifier");
+  }
+
+  public static void checkZootomistMods() {
+    if (!KoLCharacter.inZootomist()) {
+      // don't bother checking
+      return;
+    }
+    checkEffectDescription(EffectPool.GRAFTED);
+    checkEffectDescription(EffectPool.MILK_OF_FAMILIAR_KINDNESS);
+    checkEffectDescription(EffectPool.MILK_OF_FAMILIAR_CRUELTY);
   }
 
   private static void checkItem(int id, String preference) {

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -373,7 +373,10 @@ public class ResultProcessor {
             EffectPool.WINE_FRIENDLY,
             EffectPool.WINE_DARK,
             EffectPool.WINE_BEFOULED,
-            EffectPool.CITIZEN_OF_A_ZONE -> DebugDatabase.readEffectDescriptionText(effectId);
+            EffectPool.CITIZEN_OF_A_ZONE,
+            EffectPool.GRAFTED,
+            EffectPool.MILK_OF_FAMILIAR_CRUELTY,
+            EffectPool.MILK_OF_FAMILIAR_KINDNESS -> DebugDatabase.readEffectDescriptionText(effectId);
       }
 
       String acquisition = effectMatcher.group(2);

--- a/src/net/sourceforge/kolmafia/session/ResultProcessor.java
+++ b/src/net/sourceforge/kolmafia/session/ResultProcessor.java
@@ -376,7 +376,8 @@ public class ResultProcessor {
             EffectPool.CITIZEN_OF_A_ZONE,
             EffectPool.GRAFTED,
             EffectPool.MILK_OF_FAMILIAR_CRUELTY,
-            EffectPool.MILK_OF_FAMILIAR_KINDNESS -> DebugDatabase.readEffectDescriptionText(effectId);
+            EffectPool.MILK_OF_FAMILIAR_KINDNESS -> DebugDatabase.readEffectDescriptionText(
+            effectId);
       }
 
       String acquisition = effectMatcher.group(2);


### PR DESCRIPTION
Also avoid the double space in the skills by substituting the substituted familiar race. This appears in the milk skills when `/cast`ed, and probably in the others, but isn't visible without being replaced.

Add the effects to consequences and parse them when we see them.