### PR TITLE
Grafted familiars can't be used in Zootomist.

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -13,6 +13,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import net.java.dev.spellcast.utilities.LockableListModel;
 import net.java.dev.spellcast.utilities.SortedListModel;
 import net.sourceforge.kolmafia.AscensionPath.Path;
@@ -4436,13 +4438,32 @@ public abstract class KoLCharacter {
         .orElse(null);
   }
 
+  private static Set<Integer> graftedFamiliars() {
+    return Stream.of(
+            "zootGraftedButtCheekLeftFamiliar",
+            "zootGraftedButtCheekRightFamiliar",
+            "zootGraftedFootLeftFamiliar",
+            "zootGraftedFootRightFamiliar",
+            "zootGraftedHandLeftFamiliar",
+            "zootGraftedHandRightFamiliar",
+            "zootGraftedHeadFamiliar",
+            "zootGraftedNippleLeftFamiliar",
+            "zootGraftedNippleRightFamiliar",
+            "zootGraftedShoulderLeftFamiliar",
+            "zootGraftedShoulderRightFamiliar")
+        .map(pref -> Preferences.getInteger(pref))
+        .filter(id -> id > 0)
+        .collect(Collectors.toUnmodifiableSet());
+  }
+
   private static boolean isUsable(FamiliarData f) {
     if (f == FamiliarData.NO_FAMILIAR) return !KoLCharacter.inQuantum();
 
     return StandardRequest.isAllowed(f)
         && (!KoLCharacter.inZombiecore() || f.isUndead())
         && (!KoLCharacter.inBeecore() || !KoLCharacter.hasBeeosity(f.getRace()))
-        && (!KoLCharacter.inGLover() || KoLCharacter.hasGs(f.getRace()));
+        && (!KoLCharacter.inGLover() || KoLCharacter.hasGs(f.getRace()))
+        && (!KoLCharacter.inZootomist() || !KoLCharacter.graftedFamiliars().contains(f.getId()));
   }
 
   /**

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -13,7 +13,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.java.dev.spellcast.utilities.LockableListModel;
 import net.java.dev.spellcast.utilities.SortedListModel;
@@ -4438,7 +4437,7 @@ public abstract class KoLCharacter {
         .orElse(null);
   }
 
-  private static Set<Integer> graftedFamiliars() {
+  private static Stream<Integer> graftedFamiliars() {
     return Stream.of(
             "zootGraftedButtCheekLeftFamiliar",
             "zootGraftedButtCheekRightFamiliar",
@@ -4452,8 +4451,7 @@ public abstract class KoLCharacter {
             "zootGraftedShoulderLeftFamiliar",
             "zootGraftedShoulderRightFamiliar")
         .map(pref -> Preferences.getInteger(pref))
-        .filter(id -> id > 0)
-        .collect(Collectors.toUnmodifiableSet());
+        .filter(id -> id > 0);
   }
 
   private static boolean isUsable(FamiliarData f) {
@@ -4463,7 +4461,8 @@ public abstract class KoLCharacter {
         && (!KoLCharacter.inZombiecore() || f.isUndead())
         && (!KoLCharacter.inBeecore() || !KoLCharacter.hasBeeosity(f.getRace()))
         && (!KoLCharacter.inGLover() || KoLCharacter.hasGs(f.getRace()))
-        && (!KoLCharacter.inZootomist() || !KoLCharacter.graftedFamiliars().contains(f.getId()));
+        && (!KoLCharacter.inZootomist()
+            || !KoLCharacter.graftedFamiliars().anyMatch(id -> id == f.getId()));
   }
 
   /**

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -299,6 +299,35 @@ public class KoLCharacterTest {
 
     try (cleanups) {
       var fam = KoLCharacter.ownedFamiliar("mosquito");
+      assertThat(fam.isPresent(), is(true));
+      assertThat(fam.get().getId(), is(FamiliarPool.MOSQUITO));
+    }
+  }
+
+  @Test
+  public void graftedFamiliarsArentUsableInZootomist() {
+    var cleanups =
+        new Cleanups(
+            withFamiliarInTerrarium(FamiliarPool.MOSQUITO),
+            withPath(Path.Z_IS_FOR_ZOOTOMIST),
+            withProperty("zootGraftedButtCheekLeftFamiliar", FamiliarPool.MOSQUITO));
+
+    try (cleanups) {
+      var fam = KoLCharacter.usableFamiliar("mosquito");
+      assertThat(fam, nullValue());
+    }
+  }
+
+  @Test
+  public void graftedFamiliarsAreOwnedInZootomist() {
+    var cleanups =
+        new Cleanups(
+            withFamiliarInTerrarium(FamiliarPool.MOSQUITO),
+            withPath(Path.Z_IS_FOR_ZOOTOMIST),
+            withProperty("zootGraftedButtCheekLeftFamiliar", FamiliarPool.MOSQUITO));
+
+    try (cleanups) {
+      var fam = KoLCharacter.ownedFamiliar("mosquito");
       assertTrue(fam.isPresent());
     }
   }

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -305,7 +305,7 @@ public class KoLCharacterTest {
   }
 
   @Test
-  public void graftedFamiliarsArentUsableInZootomist() {
+  public void graftedFamiliarsArentUsableAndAreOwnedInZootomist() {
     var cleanups =
         new Cleanups(
             withFamiliarInTerrarium(FamiliarPool.MOSQUITO),
@@ -313,22 +313,11 @@ public class KoLCharacterTest {
             withProperty("zootGraftedButtCheekLeftFamiliar", FamiliarPool.MOSQUITO));
 
     try (cleanups) {
-      var fam = KoLCharacter.usableFamiliar("mosquito");
-      assertThat(fam, nullValue());
-    }
-  }
-
-  @Test
-  public void graftedFamiliarsAreOwnedInZootomist() {
-    var cleanups =
-        new Cleanups(
-            withFamiliarInTerrarium(FamiliarPool.MOSQUITO),
-            withPath(Path.Z_IS_FOR_ZOOTOMIST),
-            withProperty("zootGraftedButtCheekLeftFamiliar", FamiliarPool.MOSQUITO));
-
-    try (cleanups) {
-      var fam = KoLCharacter.ownedFamiliar("mosquito");
-      assertTrue(fam.isPresent());
+      var famUsable = KoLCharacter.usableFamiliar("mosquito");
+      assertThat(famUsable, nullValue());
+      var famOwned = KoLCharacter.ownedFamiliar("mosquito");
+      assertTrue(famOwned.isPresent());
+      assertThat(famOwned.get().getId(), is(FamiliarPool.MOSQUITO));
     }
   }
 


### PR DESCRIPTION
This is causing various script failures. This PR designates them as not "usable", so `have_familiar` will return false in scripts. This works like QT or G-Lover.