### PR TITLE
Last Available modifier for items

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -3571,8 +3571,7 @@ Item	Pendant of Fire	Muscle: +3, Mysticality: +3, Moxie: +3, Hot Spell Damage: +
 Item	Pendant of Gargalesis	MP Regen Min: 6, MP Regen Max: 10
 Item	peppermint-scented socks	MP Regen Min: 8, MP Regen Max: 16, Last Available: "2021-12"
 Item	perfect Christmas scarf	Adventures: [+9*event(December)], Cold Resistance: [+7*event(December)], HP Regen Min: [4*event(December)], HP Regen Max: [6*event(December)], MP Regen Min: [4*event(December)], MP Regen Max: [6*event(December)], Single Equip, Last Available: "2024-12"
-Item	perfume-soaked bandana	Spooky Resistance: +2, Stench Resistance: 4, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2015-04"
-Item	perfume-soaked bandana	Stench Resistance: +4, Spooky Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip
+Item	perfume-soaked bandana	Spooky Resistance: +2, Stench Resistance: +4, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2015-04"
 # Personal Ventilation Unit: Allows Safe Access to Secret Government Lab
 Item	Personal Ventilation Unit	Muscle Limit: 100, Mysticality Limit: 100, Moxie Limit: 100, Single Equip, Last Available: "2014-10"
 Item	petrified wood waist protector	Experience (Muscle): +3, Adventures: +5, Avoid Attack: 1, Single Equip
@@ -3855,7 +3854,6 @@ Item	steel knuckles	Last Available: "2016-02"
 Item	stick-on eyebrow piercing	Muscle: +1, Last Available: "2008-04"
 Item	sticky gloves	Pickpocket Chance: +20, Single Equip, Last Available: "2011-05"
 Item	stinky cheese eye	Item Drop: [max(1,min(20,floor(pref(_stinkyCheeseCount)/5)))], Softcore Only, Last Available: "2010-01", Meat Drop: [max(1,min(20,floor(pref(_stinkyCheeseCount)/5)))]
-Item	stinky cheese eye	Softcore Only, Meat Drop: [max(1,min(20,floor(pref(_stinkyCheeseCount)/5)))], Item Drop: [max(1,min(20,floor(pref(_stinkyCheeseCount)/5)))]
 # stinky fannypack: +40% Item Drops while on Vacation
 # stinky fannypack: (in any Elemental Airport area)
 Item	stinky fannypack	Stench Damage: +25, Stench Spell Damage: +25, Last Available: "2015-04", Item Drop: [40*zone(Elemental International Airport)]
@@ -4420,8 +4418,7 @@ Item	spant backplate	Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent:
 Item	spiky back shell	Thorns: 1
 Item	stained glass serape	Experience (Moxie): +3, Sleaze Resistance: +3, Sleaze Damage: +5, Last Available: "2021-12"
 Item	super-absorbent tarp	Maximum Hooch: +2
-Item	T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	Combat Rate: 0, Last Available: "2010-04", Wiki Name: "Bugged baio"
-Item	T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	Wiki Name: "Bugged baio"
+Item	T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	Wiki Name: "Bugged baio", Last Available: "2010-04"
 Item	teddybear backpack	Meat Drop: +10, Raveosity: +1
 # terra cotta train: Lets you unleash a terra cotta army on your foes
 Item	terra cotta train	Mysticality Percent: +20, Item Drop: +10, Last Available: "2020-12"
@@ -5483,7 +5480,7 @@ Item	nicksilver spurs	Last Available: "2016-02", Item Drop: +20
 Item	quicksilver spurs	Initiative: +30, Last Available: "2016-02"
 # sicksilver spurs: Adds Stench Damage to kicks with your cowboy boots
 # slicksilver spurs: Adds Sleaze Damage to kicks with your cowboy boots
-Item	thicksilver spurs	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2
+Item	thicksilver spurs	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Last Available: "2016-02"
 Item	ticksilver spurs	Last Available: "2016-02", Adventures: +5
 # wicksilver spurs: Adds Hot Damage to kicks with your cowboy boots
 
@@ -9302,7 +9299,7 @@ Event	April Fool's Day	Alters Page Text
 # -100% is the most common penalty in The Sea; use it as the default
 
 Zone	The Sea	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
-Zone	Shadow Rift	Item Drop: [-0.8*mod(Item Drop))
+Zone	Shadow Rift	Item Drop: [-0.8*mod(Item Drop)]
 Zone	Suburbs	Alters Page Text
 
 # Location-specific section of modifiers.txt
@@ -9975,11 +9972,10 @@ Item	AutumnFest ale	Last Available: "2022-10"
 Item	Aye Aye	Effect: "Arresistible", Effect Duration: 5, Last Available: "2012-03"
 Item	Aye Aye, Captain	Effect: "Arresistible", Effect Duration: 10, Last Available: "2012-03"
 Item	Aye Aye, Tooth Tooth	Effect: "Arresistible", Effect Duration: 15, Last Available: "2012-03"
-Item	bad rum and good cola	Effect: "Faerie Fortune", Effect Duration: 30, Last Available: "2018-04"
 # *** KoL bug: bad rum and good cola grants Faerie Fortune, no item grants Fanatical Fortune.
 # *** Bug reported and acknowledged. bad rum and good cola DOES give Fanatical Fortune, but
 # *** the description is wrong for unknown reasons. Maybe the description will eventually be fixed..
-Item	bad rum and good cola	Effect: "Fanatical Fortune", Effect Duration: 30
+Item	bad rum and good cola	Effect: "Faerie Fortune", Effect Duration: 30, Last Available: "2018-04"
 Item	bark rootbeer	Effect: "Bark of the Dog", Effect Duration: 40, Last Available: "2015-12"
 Item	barrel-aged eggnog	Last Available: "2020-12"
 Item	barrel-aged martini	Effect: "Just Aged Enough", Effect Duration: 50, Last Available: "2015-09"
@@ -14986,7 +14982,6 @@ Item	They'll Love You In Rhinestones	Skill: "Acquire Rhinestones", Last Availabl
 # thick walrus blubber: Weakens foes
 # thick walrus blubber: (much more effective in the Canadian Wildlife Preserve)
 Item	thick walrus blubber	Last Available: "2018-12"
-Item	thicksilver spurs	Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
 Item	thin gold wire	Last Available: "2015-08"
 Item	Thinknerd T-shirt grab bag	Last Available: "2012-12"
 Item	Thinknerd's Grimoire of Geeky Gifts	Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -118,8 +118,8 @@ Item	black cowboy hat	Muscle: +8, Weapon Damage: +8, Familiar Effect: "1xBarrr, 
 Item	black helmet	Maximum HP: +30, Familiar Effect: "1xFairy, cap 40"
 Item	blue traffic cone	Moxie: +3, Hot Resistance: +2, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
 Item	bonedanna	Spooky Resistance: +3, Weapon Damage: +20, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
-Item	Boris's Helm	Initiative: +25, Weapon Damage Percent: +50, Familiar Weight: +5, Softcore Only: [1-path(Avatar of Boris)], Free Pull: [1-path(Avatar of Boris)], Last Available: "2012-04", MP Regen Min: [floor(L/2)+1], MP Regen Max: [floor(L/2)+3], Minstrel Level: +1, Familiar Effect: "atk, MP regen, cap 25"
-Item	Boris's Helm (askew)	Initiative: +25, Monster Level: +15, Weapon Damage Percent: +50, Familiar Weight: +5, Softcore Only: [1-path(Avatar of Boris)], Free Pull: [1-path(Avatar of Boris)], Last Available: "2012-04", MP Regen Min: [floor(L/2)+1], MP Regen Max: [floor(L/2)+3], Minstrel Level: +1, Familiar Effect: "atk, MP regen, cap 25"
+Item	Boris's Helm	Initiative: +25, Weapon Damage Percent: +50, Familiar Weight: +5, Softcore Only: [1-path(Avatar of Boris)], Free Pull: [path(Avatar of Boris)], Last Available: "2012-04", MP Regen Min: [floor(L/2)+1], MP Regen Max: [floor(L/2)+3], Minstrel Level: +1, Familiar Effect: "atk, MP regen, cap 25"
+Item	Boris's Helm (askew)	Initiative: +25, Monster Level: +15, Weapon Damage Percent: +50, Familiar Weight: +5, Softcore Only: [1-path(Avatar of Boris)], Free Pull: [path(Avatar of Boris)], Last Available: "2012-04", MP Regen Min: [floor(L/2)+1], MP Regen Max: [floor(L/2)+3], Minstrel Level: +1, Familiar Effect: "atk, MP regen, cap 25"
 Item	bounty-hunting helmet	Item Drop: +20, Familiar Effect: "1.5xFairy, cap 25"
 Item	bowler	Muscle: +5, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 # brainwave-controlled unicorn horn: Enables Friendship.  And Goring.
@@ -1105,9 +1105,9 @@ Item	smooth velvet shirt	Disco Style: +1, Last Available: "2015-08"
 Item	snailmail hauberk	Damage Absorption: +60, HP Regen Min: 6, HP Regen Max: 14, MP Regen Min: 6, MP Regen Max: 14
 Item	snakeskin jacket	Moxie: +15, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10, Last Available: "2018-11"
 # Sneaky Pete's leather jacket: The Audience Loves/Hates You Even More!
-Item	Sneaky Pete's leather jacket	Moxie: +10, Meat Drop: +20, Pickpocket Chance: +30, Adventures: +4, Softcore Only: [1-path(Avatar of Sneaky Pete)], Free Pull: [1-path(Avatar of Sneaky Pete)], Last Available: "2014-03"
+Item	Sneaky Pete's leather jacket	Moxie: +10, Meat Drop: +20, Pickpocket Chance: +30, Adventures: +4, Softcore Only: [1-path(Avatar of Sneaky Pete)], Free Pull: [path(Avatar of Sneaky Pete)], Last Available: "2014-03"
 # Sneaky Pete's leather jacket (collar popped): The Audience Loves/Hates You Even More!
-Item	Sneaky Pete's leather jacket (collar popped)	Moxie: +10, Initiative: +20, Monster Level: +30, PvP Fights: +4, Softcore Only: [1-path(Avatar of Sneaky Pete)], Free Pull: [1-path(Avatar of Sneaky Pete)], Last Available: "2014-03"
+Item	Sneaky Pete's leather jacket (collar popped)	Moxie: +10, Initiative: +20, Monster Level: +30, PvP Fights: +4, Softcore Only: [1-path(Avatar of Sneaky Pete)], Free Pull: [path(Avatar of Sneaky Pete)], Last Available: "2014-03"
 Item	soggy wofl t-shirt	Muscle: +3
 Item	souvenir ski t-shirt	Moxie: +5
 Item	spangly mariachi vest	Moxie Percent: +10, Initiative: -25
@@ -2448,10 +2448,10 @@ Item	iShield	Hot Resistance: +3, Damage Reduction: 16, Moxie Percent: +15
 Item	ivory cue ball	Item Drop: +5
 Item	jar of frostigkraut	Cold Damage: +10, Damage Aura: 1
 # Jarlsberg's pan: +1 Food Conjuration for Jarlsberg
-Item	Jarlsberg's pan	Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 10, Food Drop: +50, Experience (Mysticality): +2, Damage Reduction: 30, Softcore Only: [1-path(Avatar of Jarlsberg)], Free Pull: [1-path(Avatar of Jarlsberg)], Last Available: "2013-03"
+Item	Jarlsberg's pan	Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 10, Food Drop: +50, Experience (Mysticality): +2, Damage Reduction: 30, Softcore Only: [1-path(Avatar of Jarlsberg)], Free Pull: [path(Avatar of Jarlsberg)], Last Available: "2013-03"
 # Jarlsberg's pan (Cosmic portal mode): +1 Food Conjuration for Jarlsberg
 # Jarlsberg's pan (Cosmic portal mode): Converts dropped food and booze into Cosmic Calories
-Item	Jarlsberg's pan (Cosmic portal mode)	Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 10, Food Drop: +50, Experience (Mysticality): +2, Damage Reduction: 30, Softcore Only: [1-path(Avatar of Jarlsberg)], Free Pull: [1-path(Avatar of Jarlsberg)], Last Available: "2013-03"
+Item	Jarlsberg's pan (Cosmic portal mode)	Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 10, Food Drop: +50, Experience (Mysticality): +2, Damage Reduction: 30, Softcore Only: [1-path(Avatar of Jarlsberg)], Free Pull: [path(Avatar of Jarlsberg)], Last Available: "2013-03"
 Item	jet bennie marble	Spooky Spell Damage: +55
 # joybuzzer: Grants &quot;Shake Hands&quot; Combat Skill
 # joybuzzer: (31-50 damage per successful handshake)
@@ -3904,8 +3904,7 @@ Item	time halo	Adventures: +5, Unarmed, Single Equip, Last Available: "2011-09"
 Item	Time Lord Badge of Honor	Muscle Limit: 50, Mysticality Limit: 50, Moxie Limit: 50
 # time-twitching toolbelt: Reveals various Time-Forgotten Secrets
 # time-twitching toolbelt: (also in the Time-Twitching Tower)
-# time-twitching toolbelt	Muscle: +15, Mysticality: +15, Moxie: +15, Single Equip, Item Drop: [60*zone(Twitch)], Free Pull: [pref(timeTowerAvailable,true)]
-Item	time-twitching toolbelt	Muscle: +15, Mysticality: +15, Moxie: +15, Item Drop: [60*zone(Twitch)], Single Equip
+Item	time-twitching toolbelt	Muscle: +15, Mysticality: +15, Moxie: +15, Item Drop: [60*zone(Twitch)], Single Equip, Free Pull: [pref(timeTowerAvailable,true)]
 Item	tin star	Monster Level: +5, Moxie: +3, Last Available: "2007-05"
 Item	tiny die-cast arc-welding Elfborg	Meat Drop: +10, Last Available: "2013-12"
 Item	tiny die-cast Bashful the Reindeer	Sleaze Damage: +1, Last Available: "2013-12"

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -118,8 +118,8 @@ Item	black cowboy hat	Muscle: +8, Weapon Damage: +8, Familiar Effect: "1xBarrr, 
 Item	black helmet	Maximum HP: +30, Familiar Effect: "1xFairy, cap 40"
 Item	blue traffic cone	Moxie: +3, Hot Resistance: +2, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
 Item	bonedanna	Spooky Resistance: +3, Weapon Damage: +20, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
-Item	Boris's Helm	Initiative: +25, Weapon Damage Percent: +50, Familiar Weight: +5, MP Regen Min: [floor(L/2)+1], MP Regen Max: [floor(L/2)+3], Free Pull, Minstrel Level: +1, Familiar Effect: "atk, MP regen, cap 25"
-Item	Boris's Helm (askew)	Initiative: +25, Monster Level: +15, Weapon Damage Percent: +50, Familiar Weight: +5, MP Regen Min: [floor(L/2)+1], MP Regen Max: [floor(L/2)+3], Free Pull, Minstrel Level: +1, Familiar Effect: "atk, MP regen, cap 25"
+Item	Boris's Helm	Initiative: +25, Weapon Damage Percent: +50, Familiar Weight: +5, Softcore Only: [1-path(Avatar of Boris)], Free Pull: [1-path(Avatar of Boris)], Last Available: "2012-04", MP Regen Min: [floor(L/2)+1], MP Regen Max: [floor(L/2)+3], Minstrel Level: +1, Familiar Effect: "atk, MP regen, cap 25"
+Item	Boris's Helm (askew)	Initiative: +25, Monster Level: +15, Weapon Damage Percent: +50, Familiar Weight: +5, Softcore Only: [1-path(Avatar of Boris)], Free Pull: [1-path(Avatar of Boris)], Last Available: "2012-04", MP Regen Min: [floor(L/2)+1], MP Regen Max: [floor(L/2)+3], Minstrel Level: +1, Familiar Effect: "atk, MP regen, cap 25"
 Item	bounty-hunting helmet	Item Drop: +20, Familiar Effect: "1.5xFairy, cap 25"
 Item	bowler	Muscle: +5, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 # brainwave-controlled unicorn horn: Enables Friendship.  And Goring.
@@ -275,6 +275,7 @@ Item	government-issued eyeshade	Experience Percent (Moxie): +10, Damage vs. Ghos
 Item	governor's daughter's pearl hairpin	Moxie Percent: +20, Last Available: "2024-12"
 Item	grass hat	Maximum MP: +10, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 # gravy boat: Decreased Damage from Undead<br/>Improved Evil Suppression
+Item	gravy boat	Last Available: "2016-11"
 Item	gravyskin hat	Sleaze Damage: +11, Sleaze Spell Damage: +11, Last Available: "2024-12"
 Item	Great Wolf's headband	Muscle: +250, Maximum HP: +250, HP Regen Min: 50, HP Regen Max: 100, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 Item	green cloth cap	Stench Resistance: +1, Maximum HP: +15, Maximum MP: +15, Moxie: +3, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
@@ -285,6 +286,7 @@ Item	grubby wool hat	Stench Damage: +15, Sleaze Damage: +15, Muscle: +15, Mystic
 Item	grungy bandana	Stench Damage: +10, Sleaze Damage: +10, Familiar Effect: "1xVolley, 0.5xPotato, cap 37"
 Item	guard turtle shell	Maximum HP: +50, Familiar Effect: "atk, 1xFairy, cap 40"
 # Guzzlr hat: Earn 25% more stats from Guzzlr deliveries
+Item	Guzzlr hat	Last Available: "2020-05"
 Item	Hairpiece On Fire	Cold Resistance: +2, Adventures: +4, Smithsness: +5, Last Available: "2013-12", Maximum MP: [K], Familiar Effect: "atk, 1xPotato, cap 25"
 Item	hangman's hood	Muscle: +50, Weapon Damage: +50, Damage Reduction: 10
 Item	hardened slime hat	Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Damage Reduction: 10, Muscle Percent: +20, Familiar Effect: "1xFairy"
@@ -519,7 +521,7 @@ Item	Team Wrath cap	Monster Level: +30
 Item	ten-gallon hat	Muscle: +10, Mysticality: +10, Moxie: +10, Experience: +3
 # The Crown of Ed the Undying: Ed's servants will level up faster
 # The Crown of Ed the Undying: Allows you to read thoughts
-Item	The Crown of Ed the Undying	Maximum HP: +50, Maximum MP: +50, Initiative: +25, Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
+Item	The Crown of Ed the Undying	Maximum HP: +50, Maximum MP: +50, Initiative: +25, Softcore Only: [1-path(Actually Ed the Undying)], Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 Item	The Emperor's new hat	Mysticality: [L], Last Available: "2015-07"
 Item	The Jokester's wig	MP Regen Min: 6, MP Regen Max: 8, Monster Level: +10, Spooky Damage: +25, Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
 Item	The Necbromancer's Hat	Mysticality Percent: +20, Spooky Spell Damage: +30, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
@@ -542,6 +544,7 @@ Item	turtle wax helmet	Hot Resistance: +1, Familiar Effect: "0.5xPotato, 0.5xFai
 Item	turtlemail coif	Muscle: +5, Damage Reduction: 4, Familiar Effect: "1xPotato, cap 20"
 Item	two-gallon hat	Muscle: +2, Mysticality: +2, Moxie: +2, Experience: +3
 Item	Uncle Crimbo's hat	Adventures: +4, Rollover Effect: "The Spirit of Crimbo", Rollover Effect Duration: 100, Rollover Effect: "Crimbo Nostalgia", Rollover Effect Duration: 100
+Item	Uncle Crimbo's hat	Adventures: +4, Rollover Effect: "The Spirit of Crimbo", Rollover Effect Duration: 200, Last Available: "2016-12", Rollover Effect: "Crimbo Nostalgia", Rollover Effect Duration: 100
 Item	Uncle Hobo's stocking cap	Mysticality Percent: +20, Monster Level: +20, Last Available: "2010-12", Familiar Effect: "atk"
 Item	Unfortunato's foolscap	Spooky Damage: +10, Stench Damage: +10, Hot Damage: +10, Cold Damage: +10, Sleaze Damage: +10, Mysticality Percent: +10, Mana Cost (combat): -2, Last Available: "2016-08"
 Item	Unkillable Skeleton's skullcap	Muscle Percent: +50, Maximum HP: +500, HP Regen Min: 40, HP Regen Max: 80, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
@@ -655,9 +658,9 @@ Item	clockwork pants	Initiative: +10, Familiar Effect: "3xPotato, 1.5xGhuol, cap
 Item	cool iron greaves	Damage Reduction: 20, HP Regen Min: 20, HP Regen Max: 40, Familiar Effect: "atk, 1xBarrr"
 Item	corroded breeches	Damage Absorption: +50, Critical Hit Percent: +5, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 Item	crappy Mer-kin tailpiece	Initiative: -25, Mana Cost: +2, Familiar Effect: "1xBarrr, 1xFairy"
-Item	Crimbuccaneer breeches	Last Available: "2023-12"
 Item	Crimbo pants	Initiative: +30, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 Item	Crimbo stockings	PvP Fights: +5, Sleaze Damage: +75, Class: "Disco Bandit", Last Available: "2020-12"
+Item	Crimbuccaneer breeches	Last Available: "2023-12"
 Item	Crimbylow-rise jeans	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Adventures: +4, Last Available: "2019-12"
 Item	crotchety pants	Maximum HP: +40, Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 Item	cursed breeches	Moxie: +15, Familiar Effect: "stench atk, 1xPotato"
@@ -735,6 +738,7 @@ Item	Grimacite gaiters	Adventures: +3, Mysticality Percent: [10*G], Last Availab
 Item	Grimacite greaves	Initiative: +20, Moxie Percent: [10*G], Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 Item	grubby wool trousers	Initiative: +25, Damage Reduction: 5, Familiar Weight: +5
 # Guzzlr pants: Get more Guzzlrbucks for successful deliveries
+Item	Guzzlr pants	Last Available: "2020-05"
 Item	gym shorts	PvP Fights: +2, Initiative: +20, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 Item	hardened slime pants	Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Never Fumble, Moxie Percent: +20, Familiar Effect: "atk, 1xPotato"
 Item	hep waders	Maximum Hooch: +3, Familiar Effect: "1xPotato, 1xVolley, cap 12"
@@ -1087,6 +1091,7 @@ Item	Radio Free Jersey	Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Resista
 Item	red coat	Ranged Damage: +25, Initiative: -25
 Item	red shirt	Monster Level: +20, Muscle Percent: -50, Mysticality Percent: -50, Moxie Percent: -50
 # red-and-green sweater: Shocking!
+Item	red-and-green sweater	Last Available: "2009-12"
 Item	reflective vest	Combat Rate: +10
 Item	replica Jurassic Parka	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Spooky Resistance: 1, Stench Resistance: 1, Hot Resistance: 1, Cold Resistance: 1, Sleaze Resistance: 1, Avoid Attack: 1
 Item	rhinestone cowboy shirt	Muscle: +5
@@ -1101,9 +1106,9 @@ Item	smooth velvet shirt	Disco Style: +1, Last Available: "2015-08"
 Item	snailmail hauberk	Damage Absorption: +60, HP Regen Min: 6, HP Regen Max: 14, MP Regen Min: 6, MP Regen Max: 14
 Item	snakeskin jacket	Moxie: +15, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10, Last Available: "2018-11"
 # Sneaky Pete's leather jacket: The Audience Loves/Hates You Even More!
-Item	Sneaky Pete's leather jacket	Moxie: +10, Meat Drop: +20, Pickpocket Chance: +30, Adventures: +4, Free Pull
+Item	Sneaky Pete's leather jacket	Moxie: +10, Meat Drop: +20, Pickpocket Chance: +30, Adventures: +4, Softcore Only: [1-path(Avatar of Sneaky Pete)], Free Pull: [1-path(Avatar of Sneaky Pete)], Last Available: "2014-03"
 # Sneaky Pete's leather jacket (collar popped): The Audience Loves/Hates You Even More!
-Item	Sneaky Pete's leather jacket (collar popped)	Moxie: +10, Initiative: +20, Monster Level: +30, PvP Fights: +4, Free Pull
+Item	Sneaky Pete's leather jacket (collar popped)	Moxie: +10, Initiative: +20, Monster Level: +30, PvP Fights: +4, Softcore Only: [1-path(Avatar of Sneaky Pete)], Free Pull: [1-path(Avatar of Sneaky Pete)], Last Available: "2014-03"
 Item	soggy wofl t-shirt	Muscle: +3
 Item	souvenir ski t-shirt	Moxie: +5
 Item	spangly mariachi vest	Moxie Percent: +10, Initiative: -25
@@ -1116,6 +1121,7 @@ Item	surgical apron	Damage Reduction: 6, Surgeonosity: +1
 Item	tailored vest	Experience: +3, Lasts Until Rollover, Last Available: "2019-12"
 Item	The Emperor's new shirt	Muscle: [L], Last Available: "2015-07"
 # Thinknerd T-Shirt	enchantment varies per player?
+Item	Thinknerd T-Shirt	Last Available: "2012-12"
 Item	trench coat	Experience Percent (Muscle): +20, Muscle Percent: +20, Spooky Resistance: +4, Last Available: "2016-07"
 Item	tunac	Muscle Percent: +50, Monster Level: +25, Item Drop: +25, Combat Rate: +10, Lasts Until Rollover, Last Available: "2016-04"
 Item	turtlemail hauberk	Damage Absorption: +30, HP Regen Min: 6, HP Regen Max: 12
@@ -1156,6 +1162,7 @@ Item	adobe adze	Experience (Muscle): [3+3*min(1,effect(Adobe Adze Subscription))
 # aerogel accordion: Only takes up one hand!
 Item	aerogel accordion	Moxie: [10*(1+skill(Accordion Appreciation))], Maximum HP: [20*(1+skill(Accordion Appreciation))], Song Duration: 10, Last Available: "2017-12"
 # airblaster gun: Blasts Air (Duh.)
+Item	airblaster gun	Last Available: "2012-12"
 Item	alarm accordion	Adventures: [3*(1+skill(Accordion Appreciation))], Initiative: [20*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 20
 Item	amok putter	Hot Damage: +9, Cold Damage: +9, Initiative: +18
 Item	ancient Elf dessert spoon	Hot Spell Damage: +20, Cold Spell Damage: +20, Spooky Spell Damage: +20, Stench Spell Damage: +20, Sleaze Spell Damage: +20, Spell Damage Percent: +20, Last Available: "2023-12"
@@ -1170,6 +1177,7 @@ Item	Apriling band quad tom	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5
 Item	Apriling band saxophone	Sleaze Damage: +20, Sleaze Spell Damage: +20, Stench Resistance: +2, Hot Resistance: +2, Lasts Until Rollover
 Item	Apriling band tuba	Maximum HP: +30, Muscle: +10, Muscle Percent: +20, Cold Resistance: +2, Sleaze Resistance: +2, Lasts Until Rollover
 # archaeologing shovel
+Item	archaeologing shovel	Last Available: "2011-12"
 Item	armgun	Weapon Damage: +10, Critical Hit Percent: +5
 Item	arse-shooting crossbow	Muscle: +15, Mysticality: +15, Moxie: +15
 Item	asbestos crossbow	Moxie: +7, Muscle: +5
@@ -1183,6 +1191,7 @@ Item	astral pistol	Moxie Percent: +25, Ranged Damage: +20, PvP Fights: +4
 Item	autocalliope	Spooky Damage: [2*(1+skill(Accordion Appreciation))], Stench Damage: [2*(1+skill(Accordion Appreciation))], Hot Damage: [2*(1+skill(Accordion Appreciation))], Cold Damage: [2*(1+skill(Accordion Appreciation))], Sleaze Damage: [2*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 15
 # automatic catapult
 # Ax of L'rose
+Item	Ax of L'rose	Last Available: "2009-10"
 Item	backwoods banjo	Experience Percent (Moxie): +20, Ranged Damage: +40, Maximum HP: +200, Maximum MP: +200, Last Available: "2015-04"
 # bad vibroknife: Improves your ability to align chakras
 Item	bad vibroknife	Maximum HP: +25, Weapon Damage: +10, Last Available: "2016-12"
@@ -1281,6 +1290,7 @@ Item	can of fake snow	Cold Damage: +5, Last Available: "2005-12"
 Item	can of maces	Weapon Damage: +2, Sleaze Resistance: +1
 Item	can opener	Weakens Monster, Hat Drop: +50, Last Available: "2016-11"
 # can-you-dig-it?: + ???
+Item	can-you-dig-it?	Last Available: "2010-04"
 Item	candlestick	Experience (Mysticality): +2, Mysticality Percent: +100, Lasts Until Rollover, Last Available: "2015-07"
 Item	candy cane sword cane	Weapon Damage Percent: +50, Never Fumble, Rollover Effect: "Sugar Rush", Rollover Effect Duration: 250, Weapon Damage: [5+5*pref(_surprisinglySweetStabUsed)+5*pref(_surprisinglySweetSlashUsed)], Muscle: +10, Mysticality: +10, Moxie: +10
 Item	candy crowbar	Weapon Damage Percent: +100, Lasts Until Rollover, Last Available: "2016-12"
@@ -1309,6 +1319,7 @@ Item	charming flute	Moxie: +8
 Item	cheap plastic bottle opener	Sleaze Damage: +2
 Item	cheap plastic kazoo	Monster Level: +10, Last Available: "2010-06"
 # cheer extractor: Extract 1 additional crystalline cheer from mimes in the Silent Night
+Item	cheer extractor	Last Available: "2017-12"
 Item	Chelonian Morningstar	Muscle: +11, Never Fumble, Class: "Turtle Tamer"
 Item	Chester's bag of candy	Sleaze Damage: +30, Moxie Percent: +10, Class: "Disco Bandit"
 Item	chiffon chakram	Moxie: +10, Stench Damage: +10, Stench Spell Damage: +10, Last Available: "2023-12", Damage Aura: 1
@@ -1329,6 +1340,7 @@ Item	clockwork staff	Spell Damage: +10, Critical Hit Percent: +15
 # clockwork sword: Heals 3-24 HP on Critical Hit
 Item	clockwork sword	Weapon Damage: +10, Critical Hit Percent: +15
 # clown hammer: Squeaky!
+Item	clown hammer	Last Available: "2006-04"
 Item	clown whip	Sleaze Resistance: +2, Clowniness: 50
 Item	club of corruption	Weapon Damage: +3, Class: "Seal Clubber"
 Item	club of the five seasons	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Last Available: "2008-07"
@@ -1336,8 +1348,6 @@ Item	club of the five seasons	Spooky Damage: +5, Stench Damage: +5, Hot Damage: 
 Item	coal shovel	Hot Damage: +20
 Item	Coily&trade;	Moxie Percent: +15, Item Drop: +10, Meat Drop: +25
 Item	combat fan	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3
-Item	combat lover's locket	HP Regen Min: 8, HP Regen Max: 10, MP Regen Min: 8, MP Regen Max: 10, Single Equip, Critical Hit Percent: [pref(locketPhylum,beast)*10], Muscle: [pref(locketPhylum,beast)*20], Weapon Damage Percent: [pref(locketPhylum,bug)*25], Maximum MP Percent: [pref(locketPhylum,bug)*25], Spell Critical Percent: [pref(locketPhylum,constellation)*10], Mysticality: [pref(locketPhylum,constellation)*20], Experience (Moxie): [pref(locketPhylum,construct)*3], Spell Damage: [pref(locketPhylum,construct)*25], Hot Damage: [pref(locketPhylum,demon)*25], Gear Drop: [pref(locketPhylum,demon)*50], Cold Damage: [pref(locketPhylum,dude)*25], Moxie Percent: [pref(locketPhylum,dude)*50], Hot Resistance: [pref(locketPhylum,elemental)*3], Stench Spell Damage: [pref(locketPhylum,elemental)*25], Experience: [pref(locketPhylum,elf)*5], Candy Drop: [pref(locketPhylum,elf)*75], Meat Drop: [pref(locketPhylum,fish)*50], Spooky Spell Damage: [pref(locketPhylum,fish)*25], Stench Damage: [pref(locketPhylum,goblin)*25], Mysticality Percent: [pref(locketPhylum,goblin)*50], Stench Resistance: [pref(locketPhylum,hippy)*3], Damage Reduction: [pref(locketPhylum,hippy)*10], Experience (Mysticality): [pref(locketPhylum,hobo)*3], Hot Spell Damage: [pref(locketPhylum,hobo)*25], Spooky Resistance: [pref(locketPhylum,horror)*3], Maximum HP: [pref(locketPhylum,horror)*50], Spell Damage Percent: [pref(locketPhylum,humanoid)*25], Moxie: [pref(locketPhylum,humanoid)*20], Item Drop: [pref(locketPhylum,mer-kin)*25], Sleaze Spell Damage: [pref(locketPhylum,mer-kin)*25], Sleaze Resistance: [pref(locketPhylum,orc)*3], Maximum MP: [pref(locketPhylum,orc)*25], Experience (Muscle): [pref(locketPhylum,penguin)*3], Cold Spell Damage: [pref(locketPhylum,penguin)*25], Booze Drop: [pref(locketPhylum,pirate)*50], Sleaze Damage: [pref(locketPhylum,pirate)*25], Initiative: [pref(locketPhylum,plant)*50], Maximum HP Percent: [pref(locketPhylum,plant)*50], Cold Resistance: [pref(locketPhylum,slime)*3], Damage Absorption: [pref(locketPhylum,slime)*50], Spooky Damage: [pref(locketPhylum,undead)*25], Muscle Percent: [pref(locketPhylum,undead)*50], Food Drop: [pref(locketPhylum,weird)*50], Weapon Damage: [pref(locketPhylum,weird)*25]
-Item	combat lover's locket lockbox	Free Pull, Last Available: "2022-02"
 Item	contract enforcement stick	Critical Hit Percent: +4, Muscle Percent: +5
 # cool whip
 Item	corn holder	Spell Damage: +6
@@ -1353,6 +1363,7 @@ Item	creepy-ass club	Weapon Damage: +25, Monster Level: +15, Sleaze Damage: +15,
 Item	Crimbo sword	Weapon Damage: +5, Last Available: "2004-10"
 Item	Crimbo ukulele	Item Drop: +10, Last Available: "2006-12"
 # Crimbomination Contraption
+Item	Crimbomination Contraption	Last Available: "2009-12"
 # Crimbuccaneer squirtblunderbuss: 100% chance of poisoning opponent.
 Item	Crimbuccaneer squirtblunderbuss	Sleaze Damage: +30, Last Available: "2023-12"
 # Crimbuccaneer tavern swab: Helps clean up the Bar at War
@@ -1431,6 +1442,7 @@ Item	Elf Guard officer's sidearm	Elf Warfare Effectiveness: +3, Weapon Damage Pe
 Item	Elf Guard squirtgun	Weakens Monster, Stench Damage: +20, Last Available: "2023-12"
 Item	elven tambourine	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Last Available: "2015-12"
 # elven whittling knife: On Critical:  Whittles enemy down
+Item	elven whittling knife	Last Available: "2008-12"
 # encrypted shuriken: CyberRealm: Deal 20 damage for 2 RAM
 Item	encrypted shuriken	Last Available: "2025-12"
 Item	evil paper umbrella	Monster Level: +1
@@ -1513,6 +1525,7 @@ Item	giant shrimp fork	Mysticality Percent: +20, Spell Critical Percent: +10, Ma
 Item	giant spider leg	Spooky Damage: +10, Critical Hit Percent: +10
 Item	giant turkey leg	Weapon Damage Percent: +50, Combat Rate: +5
 # gift-a-pult: Allows hurling of Gift Items
+Item	gift-a-pult	Last Available: "2010-12"
 Item	gilded trumpet	Maximum HP: +5, Maximum MP: +5, Experience (Moxie): +3, Single Equip, Last Available: "2020-12"
 Item	gingerbread gavel	Critical Hit Percent: +5, Weapon Damage Percent: +25, Last Available: "2016-12"
 Item	gingerbread pistol	Ranged Damage Percent: +25, Sleaze Damage: +10, Last Available: "2016-12"
@@ -1579,6 +1592,7 @@ Item	heavy metal thunderrr guitarrr	Weapon Damage: +16
 # heteroerotic frat-paddle
 Item	high-energy mining laser	Fumble: 2, Hot Damage: +20, Last Available: "2014-12"
 # high-temperature mining drill: Allows Mining in the Velvet / Gold Mine
+Item	high-temperature mining drill	Last Available: "2015-08"
 Item	hilarious comedy prop	HP Regen Min: 4, HP Regen Max: 6, MP Regen Min: 4, MP Regen Max: 6
 Item	hippo whip	Monster Level: +10
 Item	hippy bongo	Stench Damage: +5
@@ -1608,7 +1622,7 @@ Item	ironic battle spoon	Spell Damage: +10
 Item	jack flapper	Spell Damage: +5
 Item	Jacob's rung	Maximum MP: +15, Spell Damage: +15
 # June cleaver: Grows stronger the more you use it
-Item	June cleaver	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, HP Regen Min: 6, HP Regen Max: 8, MP Regen Min: 6, MP Regen Max: 8, Adventures: +5, Hot Damage: [pref(_juneCleaverHot)], Spooky Damage: [pref(_juneCleaverSpooky)], Sleaze Damage: [pref(_juneCleaverSleaze)], Cold Damage: [pref(_juneCleaverCold)], Stench Damage: [pref(_juneCleaverStench)], Attacks Can't Miss
+Item	June cleaver	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, HP Regen Min: 6, HP Regen Max: 8, MP Regen Min: 6, MP Regen Max: 8, Adventures: +5, Hot Damage: [pref(_juneCleaverHot)], Spooky Damage: [pref(_juneCleaverSpooky)], Sleaze Damage: [pref(_juneCleaverSleaze)], Cold Damage: [pref(_juneCleaverCold)], Stench Damage: [pref(_juneCleaverStench)], Attacks Can't Miss, Last Available: "2022-06"
 Item	jungle drum	Spooky Damage: +10, Spooky Resistance: +2, Initiative: -20
 Item	keel-haulin' knife	Spell Damage: +17
 Item	kelp-holly gun	Moxie: +10, Ranged Damage Percent: +50, Pickpocket Chance: +25, Last Available: "2019-12"
@@ -1765,6 +1779,7 @@ Item	pixel whip	Muscle: +3, Mysticality: +3, Moxie: +3
 # plastic bazooka: Allows you to Super Blast your enemies
 # plastic bazooka: Quick Draw
 # plastic bazooka: (you will nearly always win Initiative)
+Item	plastic bazooka	Last Available: "2018-12"
 Item	plastic guitar	Moxie: +5, Initiative: +15
 Item	plastic nunchaku	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Initiative: +30, Last Available: "2014-08"
 Item	plastic replica blaster pistol	Initiative: +20, Ranged Damage: +20, Lasts Until Rollover
@@ -1772,6 +1787,7 @@ Item	plexiglass pikestaff	Weapon Damage: +25, PvP Fights: +9, Muscle Percent: +3
 Item	pocket theremin	Spooky Damage: +7
 Item	pointed stick	Critical Hit Percent: +5, Weapon Damage: +10
 # poison pen: 75% chance of poisoning opponent.
+Item	poison pen	Last Available: "2009-12"
 # polyester peeler: Increases the Damage of Stuffed Mortar Shell
 Item	polyester peeler	Spell Damage Percent: +20, MP Regen Min: 2, MP Regen Max: 4, Last Available: "2015-12"
 Item	pool cue	Moxie: +5, Pool Skill: +3
@@ -1816,6 +1832,7 @@ Item	red-hot sausage fork	Hot Damage: +8, Food Drop: +10, Last Available: "2019-
 Item	regret hose	Cold Damage: +10, Last Available: "2013-12"
 Item	reindeer hammer	Muscle: +10, Mysticality: +10, Moxie: +10, Last Available: "2015-12"
 # reindeer sickle: Successful hit causes bleeding.
+Item	reindeer sickle	Last Available: "2015-12"
 Item	remaindered axe	Muscle: +2, Weapon Damage: +2
 # remorseless knife: Successful hit causes bleeding.
 Item	repeating crossbow	Moxie: +2, Critical Hit Percent: +15
@@ -1830,7 +1847,7 @@ Item	rib of the Bonerdagon	Muscle: +5, Mysticality: +5, Spell Damage: +15
 Item	ridiculously huge sword	Weapon Damage: +12, Muscle: +4
 Item	ridiculously overelaborate ninja weapon	Critical Hit Percent: +15, Fumble: 3
 # right bear arm: Lets you act like a bear
-Item	right bear arm	Muscle Percent: +10, Weapon Damage Percent: +30
+Item	right bear arm	Muscle Percent: +10, Weapon Damage Percent: +30, Softcore Only: [1-path(Zombie Slayer)], Last Available: "2012-09"
 Item	roboduck-on-a-string	Weapon Damage: +5, Item Drop: +5, Last Available: "2007-12"
 Item	Rock and Roll Legend	Moxie: [7*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 10
 Item	rope	Experience (Muscle): +2, Familiar Weight: +10, Lasts Until Rollover, Last Available: "2015-07"
@@ -1838,6 +1855,7 @@ Item	rubber axe	Sleaze Damage: +2
 Item	rubber band gun	Moxie: +5, Last Available: "2011-05"
 Item	rubber spatula	Spell Damage: +2
 # Ruby Rod
+Item	Ruby Rod	Last Available: "2009-06"
 Item	runed taper candle	Item Drop: +25, Hot Spell Damage: +50, Lasts Until Rollover, Last Available: "2021-08"
 Item	rusted-out shootin' iron	Meat Drop: +10, Ranged Damage: +50, Combat Rate: -5
 Item	rusty grave robbing shovel	Spooky Damage: +5, Initiative: -10
@@ -1993,6 +2011,7 @@ Item	star sword	Muscle: +8
 Item	starchy crossbow	Moxie: +3
 Item	starchy staff	Mysticality: +3
 Item	starchy sword	Muscle: +3
+Item	status cymbal	Last Available: "2020-02"
 Item	steel drivin' hammer	Critical Hit Percent: +10, Muscle Percent: +15, Maximum HP: +25, PvP Fights: +3
 Item	steel sword	Weapon Damage: +15, HP Regen Min: 2, HP Regen Max: 4, Moxie: +5, Last Available: "2013-02"
 Item	Stick-Knife of Loathing	Weapon Damage Percent: +100, Spell Damage Percent: +200, Cold Resistance: +5, Cloathing
@@ -2044,7 +2063,7 @@ Item	third-hand nunchaku	Weapon Damage: +3
 # Thor's Pliers: Lets You Smith and Make Jewelry Faster
 # Thor's Pliers: Allows You to Ply Reality
 # Thor's Pliers: Regenerates Lightning Power (in Heavy Rains only)
-Item	Thor's Pliers	Experience: +4, MP Regen Min: 6, MP Regen Max: 9, Pickpocket Chance: +20, Attacks Can't Miss, Single Equip
+Item	Thor's Pliers	Experience: +4, MP Regen Min: 6, MP Regen Max: 9, Pickpocket Chance: +20, Attacks Can't Miss, Single Equip, Softcore Only: [1-path(Heavy Rains)], Last Available: "2014-09"
 Item	throwing wrench	Weakens Monster, Last Available: "2009-12"
 Item	time sword	Adventures: +3, Last Available: "2005-10"
 Item	tin drum	Moxie Percent: +10, Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Experience (Moxie): +1, Last Available: "2013-09"
@@ -2060,8 +2079,11 @@ Item	toy accordion	Song Duration: 5
 Item	toy Crimbot power glove	Weapon Damage: +15, Crimbot Outfit Power: +1, Last Available: "2014-12"
 Item	toy ray gun	Hot Damage: +5, Critical Hit Percent: +5, Last Available: "2006-12"
 # toy taijijian
+Item	toy taijijian	Last Available: "2013-12"
 # Toyleporter: Locates toys and then blasts them to the Crimbo Town Toy Factory
+Item	Toyleporter	Last Available: "2018-12"
 # trash net
+Item	trash net	Last Available: "2015-04"
 Item	triple barreled barrel gun	Weapon Damage Percent: +100, Critical Hit Percent: +10, Meat Drop: +25, Last Available: "2015-09"
 Item	Tropical Crimbo Sword	Weapon Damage: +5, Last Available: "2006-12"
 # trout fang: 25% chance of poisoning opponent.
@@ -2208,6 +2230,7 @@ Item	borg sock monkey	Moxie: +3, Last Available: "2007-12"
 # botanical sample kit: Increases the yield of Spacegate botany operations
 Item	botanical sample kit	Lasts Until Rollover, Last Available: "2017-04"
 Item	bottle of Goldschn&ouml;ckered	Hot Damage: +5, Cold Resistance: +2, Last Available: "2010-06"
+Item	bouquet of all-natural free-range flowers	Last Available: "2015-12"
 Item	bowl of petunias	Muscle: +4, Mysticality: +4, Moxie: +4, Experience: +4, PvP Fights: +4, HP Regen Min: 4, HP Regen Max: 8, MP Regen Min: 4, MP Regen Max: 8, Last Available: "2013-11"
 Item	box	Meat Drop: +1, Wiki Name: "box"
 Item	box turtle	Muscle: +1, Damage Reduction: 3
@@ -2227,6 +2250,7 @@ Item	C.H.U.M. lantern	Stench Damage: +17, Item Drop: [30*loc(Sewer Tunnels)]
 # can of mixed everything: There's a little bit of everything in there!
 Item	can of mixed everything	Muscle: +5, Mysticality: +5, Moxie: +5, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Last Available: "2021-12"
 # card sleeve: If you like it, you should put a card in it!
+Item	card sleeve	Last Available: "2011-03"
 Item	cardboard box turtle	Muscle: +3, Damage Reduction: 4
 Item	cardboard wine carrier	Booze Drop: +50, Lasts Until Rollover, Last Available: "2020-12"
 # carnivorous potted plant: Occasionally swallows your enemy whole
@@ -2274,6 +2298,7 @@ Item	cuddly teddy bear	Monster Level: +10, Last Available: "2014-10"
 Item	cup of infinite pencils	Meat Drop: +15, Damage Aura: 1
 Item	cursed arcane orb	Spooky Damage: +13, Stench Damage: +13, Hot Damage: +13, Cold Damage: +13, Sleaze Damage: +13, Item Drop: -50
 Item	cursed compass	Item Drop: [100*zone(PirateRealm)], Lasts Until Rollover
+Item	cursed compass	Lasts Until Rollover, Last Available: "2019-04", Item Drop: [100*zone(PirateRealm)]
 # cursed magnifying glass: Reveals things you weren't meant to see
 Item	cursed magnifying glass	Item Drop: +13, Spooky Damage: +13, Initiative: +13, Last Available: "2022-12"
 Item	cursed stats	Experience: +5, Muscle Limit: 69, Mysticality Limit: 69, Moxie Limit: 69
@@ -2284,6 +2309,7 @@ Item	deceased crimbo tree	Last Available: "2018-01", Lasts Until Rollover, Break
 Item	deck of lewd playing cards	Moxie Percent: +5, Sleaze Damage: +69, Sleaze Spell Damage: +69
 Item	deck of tropical cards	Experience: +1, Last Available: "2006-12", Stat Tuning: "Mysticality"
 # defective skull
+Item	defective skull	Last Available: "2011-12"
 # deft pirate hook: Occasionally snags on your opponent's stuff
 Item	deft pirate hook	Muscle: +20, Weapon Damage: +10, Lasts Until Rollover, Last Available: "2024-12"
 Item	demon buckler	Hot Damage: +3, Damage Reduction: 5
@@ -2317,14 +2343,17 @@ Item	enchanted brass knuckles	Critical Hit Percent: +5
 # enchanted fire extinguisher: All Spells Cast Are Cold
 Item	enchanted fire extinguisher	Spell Damage Percent: +100, Cold Spell Damage: +30, Last Available: "2012-07"
 # encrypted micro-cassette recorder: Optimized for Pun-Recording
+Item	encrypted micro-cassette recorder	Last Available: "2014-10"
 # Engorged Sausages and You: All Spells Cast Are Sleazy
 Item	Engorged Sausages and You	Spell Damage: +15, Food Drop: +20
 # enhanced signal receiver: Reveals and interprets electromagnetic noise
 Item	eye of the Tiger-lily	Spell Damage: +10, Item Drop: +5, Last Available: "2010-03"
+Item	faded green protest sign	Last Available: "2015-12"
+Item	faded red protest sign	Last Available: "2015-12"
 # fake hand: Gives Extra Offhand Equipment Slot
 Item	fake hand	Weapon Damage: -1, Last Available: "2006-04"
 Item	fake washboard	Experience Percent (Muscle): +25, Damage Absorption: +50, Accessory Drop: +75, Damage Reduction: 13, Last Available: "2015-04"
-Item	familiar scrapbook	HP Regen Min: [4+min(30,pref(scrapbookCharges)/10)], HP Regen Max: [6+min(30,pref(scrapbookCharges)/10)], MP Regen Min: [2+min(30,pref(scrapbookCharges)/10)], MP Regen Max: [3+min(30,pref(scrapbookCharges)/10)], Experience Percent (Muscle): [5+min(10,pref(scrapbookCharges)/10)], Experience Percent (Mysticality): [5+min(10,pref(scrapbookCharges)/10)], Experience Percent (Moxie): [5+min(10,pref(scrapbookCharges)/10)], Familiar Weight: +5, Experience (familiar): +1, Moxie: [min(1,floor(pref(scrapbookCharges)/1111))]
+Item	familiar scrapbook	HP Regen Min: [4+min(30,pref(scrapbookCharges)/10)], HP Regen Max: [6+min(30,pref(scrapbookCharges)/10)], MP Regen Min: [2+min(30,pref(scrapbookCharges)/10)], MP Regen Max: [3+min(30,pref(scrapbookCharges)/10)], Experience Percent (Muscle): [5+min(10,pref(scrapbookCharges)/10)], Experience Percent (Mysticality): [5+min(10,pref(scrapbookCharges)/10)], Experience Percent (Moxie): [5+min(10,pref(scrapbookCharges)/10)], Familiar Weight: +5, Experience (familiar): +1, Moxie: [min(1,floor(pref(scrapbookCharges)/1111))], Last Available: "2021-06"
 Item	fancy marzipan briefcase	MP Regen Min: 4, MP Regen Max: 8, Combat Rate: -10, Lasts Until Rollover, Last Available: "2016-12"
 Item	fancy opera glasses	Meat Drop: +5, Item Drop: +5
 # fiberglass fetish: A Seal Spirit will accompany you in combat
@@ -2370,7 +2399,9 @@ Item	gnauga hide buckler	Muscle: +3, Mysticality: +3, Moxie: +3, Damage Reductio
 # Golden HP-35 Calculator: Makes you look super altruistic
 # golden sausage
 # goo magnet: Automatically collects residual grey goo at Site Alpha locations
+Item	goo magnet	Last Available: "2021-12"
 # gore bucket
+Item	gore bucket	Last Available: "2014-10"
 Item	gravyskin buckler	Sleaze Damage: +11, Sleaze Spell Damage: +11, Damage Reduction: 7, Last Available: "2024-12"
 Item	Great Wolf's left paw	Critical Hit Percent: +10, Spooky Damage: +10, Stench Damage: +10, Hot Damage: +10, Cold Damage: +10, Sleaze Damage: +10, Never Fumble, Class: "Seal Clubber"
 # green balloon
@@ -2419,15 +2450,14 @@ Item	iShield	Hot Resistance: +3, Damage Reduction: 16, Moxie Percent: +15
 Item	ivory cue ball	Item Drop: +5
 Item	jar of frostigkraut	Cold Damage: +10, Damage Aura: 1
 # Jarlsberg's pan: +1 Food Conjuration for Jarlsberg
-# Jarlsberg's pan: Softcore Only (except for Avatar of Jarlsberg)
-Item	Jarlsberg's pan	Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 10, Food Drop: +50, Experience (Mysticality): +2, Damage Reduction: 30, Free Pull
+Item	Jarlsberg's pan	Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 10, Food Drop: +50, Experience (Mysticality): +2, Damage Reduction: 30, Softcore Only: [1-path(Avatar of Jarlsberg)], Free Pull: [1-path(Avatar of Jarlsberg)], Last Available: "2013-03"
 # Jarlsberg's pan (Cosmic portal mode): +1 Food Conjuration for Jarlsberg
 # Jarlsberg's pan (Cosmic portal mode): Converts dropped food and booze into Cosmic Calories
-# Jarlsberg's pan (Cosmic portal mode): Softcore Only (except for Avatar of Jarlsberg)
-Item	Jarlsberg's pan (Cosmic portal mode)	Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 10, Food Drop: +50, Experience (Mysticality): +2, Damage Reduction: 30, Free Pull
+Item	Jarlsberg's pan (Cosmic portal mode)	Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 10, Food Drop: +50, Experience (Mysticality): +2, Damage Reduction: 30, Softcore Only: [1-path(Avatar of Jarlsberg)], Free Pull: [1-path(Avatar of Jarlsberg)], Last Available: "2013-03"
 Item	jet bennie marble	Spooky Spell Damage: +55
 # joybuzzer: Grants &quot;Shake Hands&quot; Combat Skill
 # joybuzzer: (31-50 damage per successful handshake)
+Item	joybuzzer	Last Available: "2006-04"
 Item	keg shield	Damage Absorption: +50, Mysticality: +5, Damage Reduction: 11
 # Kevlar balloon
 Item	kickback cookbook	Spell Damage: +20
@@ -2441,7 +2471,7 @@ Item	KoL Con X Treasure Map	Item Drop: +5, Meat Drop: +10
 Item	Kramco Sausage-o-Matic&trade;	Item Drop: +10, Food Drop: +10, Maximum HP: +5, Maximum MP: +5, Critical Hit Percent: +20, Last Available: "2019-01"
 Item	LARP carp	Muscle: +10, Mysticality: +10, Moxie: +10
 # left bear arm: Lets you act like a bear
-Item	left bear arm	Muscle Percent: +10, Maximum HP: +30, Damage Reduction: 10
+Item	left bear arm	Muscle Percent: +10, Maximum HP: +30, Damage Reduction: 10, Softcore Only: [1-path(Zombie Slayer)], Last Available: "2012-09"
 Item	Left-Hand Man action figure	Familiar Weight: +7, Last Available: "2020-04"
 Item	left-handed melodica	Ranged Damage: +25, Class: "Accordion Thief"
 Item	lemonade marble	Cold Spell Damage: +45
@@ -2500,6 +2530,7 @@ Item	Microplushie: Raverdrine	Maximum HP: +8, Last Available: "2012-12"
 Item	Microplushie: Sororitrate	Sleaze Damage: +2, Last Available: "2012-12"
 # military orb: Detonate to destroy a monster
 Item	military orb	MP Regen Min: 10, MP Regen Max: 15, Mysticality: +15, Last Available: "2024-12"
+Item	mime pocket probe	Last Available: "2017-12"
 Item	mini kiwi whipping stick	Sleaze Damage: +5, Experience: +2
 # mini-zeppelin
 Item	miniature candle	Experience: +3, Item Drop: +20, Lasts Until Rollover, Last Available: "2017-01"
@@ -2531,7 +2562,7 @@ Item	Ol' Scratch's ash can	Spell Damage Percent: +100, Hot Spell Damage: +30, Cl
 Item	Ol' Scratch's stove door	Hot Damage: +20, Damage Reduction: 15, Thorns: 1
 Item	old pizza box	Damage Absorption: +50, Damage Reduction: 6, Last Available: "2020-04"
 Item	old school flying disc	Muscle Percent: +15, Damage Reduction: 24, Familiar Weight: +5
-Item	Operation Patriot Shield	Experience: +3, Maximum HP: +20, Maximum MP: +20, Softcore Only, Variable
+Item	Operation Patriot Shield	Experience: +3, Maximum HP: +20, Maximum MP: +20, Softcore Only, Last Available: "2011-07", Variable
 # * Seal Clubber:
 # * Operation Patriot Shield	HP Regen Min: 10, HP Regen Max: 12, Weapon Damage: +15, Damage Reduction: 1
 # * Turtle Tamer:
@@ -2550,6 +2581,7 @@ Item	Operation Patriot Shield	Experience: +3, Maximum HP: +20, Maximum MP: +20, 
 Item	optimal spreadsheet	Muscle: +10, Mysticality: +10, Moxie: +10, PvP Fights: +5, Monster Level: +20
 Item	orcish stud-finder	Weapon Damage: +5, Sleaze Damage: +5
 # ornate dowsing rod: Aids in desert exploration
+Item	ornate dowsing rod	Last Available: "2014-12"
 Item	Oscus's garbage can lid	Stench Damage: +20, Damage Reduction: 15, Thorns: 1
 # Ouija Board, Ouija Board: Gain the favor of the Turtle Spirits more quickly
 Item	Ouija Board, Ouija Board	Familiar Weight: +5, Smithsness: +5, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12", Muscle Percent: [2*K]
@@ -2563,6 +2595,7 @@ Item	padded tortoise	Damage Absorption: +20, HP Regen Min: 4, HP Regen Max: 8, D
 Item	paint palette	Spooky Damage: +8, Stench Damage: +8, Hot Damage: +8, Cold Damage: +8, Sleaze Damage: +8, Last Available: "2018-09"
 Item	painted shield	Muscle: +3, Mysticality: +3, Moxie: +3, Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2, Damage Reduction: 7
 # Paradaisical Cheeseburger recipe
+Item	Paradaisical Cheeseburger recipe	Last Available: "2014-05"
 Item	parasitic strangleworm	Damage Reduction: [min(L,15)], Last Available: "2008-12"
 # party crasher: Lets you crash into your foes, stunning them
 Item	party crasher	Initiative: +25, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 9, Last Available: "2018-09"
@@ -2682,7 +2715,9 @@ Item	spiky turtle shield	Weapon Damage: +8, Item Drop: +10, Damage Reduction: 8
 Item	spongy shield	Muscle Percent: +10, HP Regen Min: 20, HP Regen Max: 50, Damage Absorption: +50, Damage Reduction: 14
 Item	spooky little girl	Item Drop: [G], Last Available: "2011-06"
 # sprinkle shaker
+Item	sprinkle shaker	Last Available: "2014-05"
 Item	sprinkle-begging cup	Sprinkle Drop: +50, Last Available: "2016-12"
+Item	stack of communist leaflets	Last Available: "2015-12"
 Item	stained glass shield	Experience (Muscle): +3, Cold Resistance: +3, Cold Damage: +5, Damage Reduction: 7, Last Available: "2021-12"
 Item	standards and practices guide	Sleaze Resistance: +2, Last Available: "2016-08"
 Item	stapler bear	Muscle: +5, Last Available: "2010-12", Damage Aura: 1
@@ -2695,15 +2730,15 @@ Item	stress ball	Maximum HP: +100, Maximum MP: +100, Last Available: "2011-05"
 Item	studded sealhide shield	Muscle: +5, Maximum HP: +30, Damage Reduction: 7
 # stuffed astral badger
 # stuffed baby gravy fairy
-# stuffed bandersnatch
+Item	stuffed bandersnatch	Last Available: "2010-03"
 # stuffed Baron von Ratsworth
 # stuffed can of asparagus
-# stuffed caterpillar
+Item	stuffed caterpillar	Last Available: "2010-03"
 # stuffed Cheshire bitten
 # stuffed cocoabo
 Item	stuffed dinosaur	Muscle: +3, Mysticality: +3, Moxie: +3
 # stuffed dodecapede
-# stuffed dodo
+Item	stuffed dodo	Last Available: "2010-03"
 # stuffed flaming gravy fairy
 # stuffed frozen gravy fairy
 # stuffed ghuol whelp
@@ -2716,8 +2751,8 @@ Item	stuffed kraken	Last Available: "2023-12"
 # stuffed mind flayer
 # stuffed Mob Penguin
 # stuffed monocle
-# stuffed pocketwatch
-# stuffed porpoise
+Item	stuffed pocketwatch	Last Available: "2010-03"
+Item	stuffed porpoise	Last Available: "2010-03"
 # stuffed sabre-toothed lime
 # stuffed scary death orb
 # stuffed sleazy gravy fairy
@@ -2740,6 +2775,7 @@ Item	sucker bucket	Candy Drop: +50, Last Available: "2011-11"
 Item	surprisingly capacious handbag	Last Available: "2018-09", Item Drop: [50*loc(The Neverending Party)]
 Item	Sword of the Brouhaha Prince	Muscle Percent: +12, Last Available: "2011-10"
 # Taco Dan's Taco Stand Cocktail Sauce Bottle
+Item	Taco Dan's Taco Stand Cocktail Sauce Bottle	Last Available: "2014-05"
 Item	tailbone shield	Stench Damage: +40, Damage Reduction: 16, Thorns: 1
 Item	teflon shield	Muscle Percent: +10, Damage Reduction: 24, Damage Absorption: +50
 Item	Temporal Tempera Tube	Muscle Percent: [5*G], Mysticality Percent: [5*G], Moxie Percent: [5*G]
@@ -2791,6 +2827,7 @@ Item	visual packet sniffer	Last Available: "2025-12"
 Item	voodoo doll	Mysticality: +1
 Item	wad of Crovacite	Muscle: +5, Mysticality: +5, Moxie: +5, Spooky Damage: +5
 Item	Wal-Mart snowglobe	Muscle Percent: +40, Experience (Muscle): +4, Familiar Weight: +5, Last Available: "2015-11"
+Item	Walford's bucket	Last Available: "2015-11"
 # Wand of Oscus: All Spells Cast Are Stinky
 Item	Wand of Oscus	Spell Damage Percent: +100, Stench Spell Damage: +30, Class: "Pastamancer"
 Item	washboard shield	Damage Absorption: +50, Class: "Turtle Tamer", Damage Reduction: 10
@@ -2842,6 +2879,7 @@ Item	annealed drippy orb	Drippy Resistance: +5
 Item	anniversary balsa wood socks	Muscle: +1, Mysticality: +1, Moxie: +1
 Item	anniversary burlap belt	Muscle: +1, Mysticality: +1, Moxie: +1
 Item	Annual Ascot	Muscle Percent: +12, Mysticality Percent: +12, Moxie Percent: +12
+Item	anti-earplugs	Last Available: "2017-12"
 # antique Canadian lantern: +15% more Item Drops in the Canadian Wildlife Preserve
 Item	antique Canadian lantern	Item Drop: [15+15*loc(The Canadian Wildlife Preserve)], Cold Resistance: +3, Last Available: "2018-12"
 Item	antique nutcracker beard	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Mysticality Percent: +15, Single Equip, Last Available: "2019-12"
@@ -2867,7 +2905,7 @@ Item	attorney's badge	Single Equip
 # automatic wine thief: Fully restore your MP after Crimbo Train fights
 Item	automatic wine thief	Single Equip
 Item	autumn leaf pendant	Familiar Weight: +5, Familiar Damage: +10, Experience (familiar): +1, Lasts Until Rollover, Last Available: "2022-10"
-Item	backup camera	Maximum HP: +20, Maximum MP: +20, Single Equip
+Item	backup camera	Maximum HP: +20, Maximum MP: +20, Single Equip, Last Available: "2021-04"
 Item	baconstone bracelet	Mysticality: +2, Mana Cost: -1, Single Equip
 Item	baconstone earring	Mysticality: +2, Mana Cost: -1, Single Equip
 Item	baconstone pendant	Mysticality: +4, Spell Damage: +10
@@ -2879,7 +2917,7 @@ Item	bakelite badge	Familiar Weight: +5, Muscle Percent: +20, Single Equip, Last
 # bakelite belt: Makes Cavalcade of Fury consume less Fury
 Item	bakelite belt	Critical Hit Percent: +5, Damage Reduction: 10, Single Equip, Last Available: "2016-12"
 # bakelite brooch: Active Saucespheres increase your spell damage
-Item	bakelite brooch	Mana Cost (combat): -2, Mysticality Percent: +20, Spell Damage Percent: [20*(min(1,effect(Elemental Saucesphere))+min(1,effect(Jalape&ntilde;o Saucesphere))+min(1,effect(Antibiotic Saucesphere)))], Single Equip
+Item	bakelite brooch	Mana Cost (combat): -2, Mysticality Percent: +20, Spell Damage Percent: [20*(min(1,effect(Elemental Saucesphere))+min(1,effect(Jalape&ntilde;o Saucesphere))+min(1,effect(Antibiotic Saucesphere)))], Single Equip, Last Available: "2016-12"
 # bananarama bangle: (only in the Candy Diorama)
 Item	bananarama bangle	Damage Reduction: [30*zone(The Candy Diorama)], Single Equip, Last Available: "2011-11"
 Item	Bandolier of the Spaghetti Elemental	Mysticality: +11, MP Regen Min: 10, MP Regen Max: 12, Class: "Pastamancer", Single Equip
@@ -2969,9 +3007,9 @@ Item	cement sandals	Initiative: -10, Experience (Muscle): +1, Single Equip, Last
 Item	cement shoes	Mysticality: +20, Moxie: +20, Last Available: "2004-10"
 # ceramic celsiturometer: Deal 60 Hot Damage to a foe and briefly stun them,
 # ceramic celsiturometer: but also make them very angry
-Item	ceramic celsiturometer	Experience (Mysticality): +3, Maximum MP: +30, MP Regen Min: 6, MP Regen Max: 12
+Item	ceramic celsiturometer	Experience (Mysticality): +3, Maximum MP: +30, MP Regen Min: 6, MP Regen Max: 12, Single Equip, Last Available: "2023-12"
 # ceramic cerecloth belt: Deal 30 Spooky Damage to a target and weaken them
-Item	ceramic cerecloth belt	Moxie Percent: +20, Initiative: +40, Never Fumble
+Item	ceramic cerecloth belt	Moxie Percent: +20, Initiative: +40, Never Fumble, Single Equip, Last Available: "2023-12"
 # ceramic cestus: Punch a foe, dealing 30 damage and briefly stunning them
 Item	ceramic cestus	Muscle Percent: +20, Familiar Weight: +5, Single Equip, Last Available: "2023-12"
 # chalk chain: Weakens enemies who hit you
@@ -2983,7 +3021,7 @@ Item	cheap elven gloves	Mysticality: +1, Sleaze Resistance: +1, Last Available: 
 Item	cheap plastic pipe	Maximum MP: +40, MP Regen Min: 8, MP Regen Max: 12, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 Item	cheap studded belt	Damage Reduction: 1, Last Available: "2008-04"
 # cheap sunglasses: +60% Meat Drops from Tourists
-Item	cheap sunglasses	Meat Drop: [60*zone(Dinseylandfill)], Single Equip
+Item	cheap sunglasses	Meat Drop: [60*zone(Dinseylandfill)], Single Equip, Last Available: "2015-04"
 # Chester's Aquarius medallion: All Spells Cast Are Sleazy
 Item	Chester's Aquarius medallion	Sleaze Spell Damage: +30, Single Equip
 # Chester's moustache: Disco Bandit Combat Skills weaken enemies by an additional 50%
@@ -3014,6 +3052,7 @@ Item	coarse hemp socks	Adventures: [1+10*event(Crimbo2015)], Single Equip, Last 
 Item	codpiece	Mysticality Percent: +100, Maximum MP: +100, Spell Damage: +50, Combat Rate: -10, Lasts Until Rollover, Last Available: "2016-04"
 Item	Codpiece of the Goblin King	Moxie: +7, Single Equip
 Item	colored-light &quot;necklace&quot;	Maximum MP: +15, Last Available: "2005-12"
+Item	combat lover's locket	HP Regen Min: 8, HP Regen Max: 10, MP Regen Min: 8, MP Regen Max: 10, Single Equip, Critical Hit Percent: [pref(locketPhylum,beast)*10], Muscle: [pref(locketPhylum,beast)*20], Weapon Damage Percent: [pref(locketPhylum,bug)*25], Maximum MP Percent: [pref(locketPhylum,bug)*25], Spell Critical Percent: [pref(locketPhylum,constellation)*10], Mysticality: [pref(locketPhylum,constellation)*20], Experience (Moxie): [pref(locketPhylum,construct)*3], Spell Damage: [pref(locketPhylum,construct)*25], Hot Damage: [pref(locketPhylum,demon)*25], Gear Drop: [pref(locketPhylum,demon)*50], Cold Damage: [pref(locketPhylum,dude)*25], Moxie Percent: [pref(locketPhylum,dude)*50], Hot Resistance: [pref(locketPhylum,elemental)*3], Stench Spell Damage: [pref(locketPhylum,elemental)*25], Experience: [pref(locketPhylum,elf)*5], Candy Drop: [pref(locketPhylum,elf)*75], Meat Drop: [pref(locketPhylum,fish)*50], Spooky Spell Damage: [pref(locketPhylum,fish)*25], Stench Damage: [pref(locketPhylum,goblin)*25], Mysticality Percent: [pref(locketPhylum,goblin)*50], Stench Resistance: [pref(locketPhylum,hippy)*3], Damage Reduction: [pref(locketPhylum,hippy)*10], Experience (Mysticality): [pref(locketPhylum,hobo)*3], Hot Spell Damage: [pref(locketPhylum,hobo)*25], Spooky Resistance: [pref(locketPhylum,horror)*3], Maximum HP: [pref(locketPhylum,horror)*50], Spell Damage Percent: [pref(locketPhylum,humanoid)*25], Moxie: [pref(locketPhylum,humanoid)*20], Item Drop: [pref(locketPhylum,mer-kin)*25], Sleaze Spell Damage: [pref(locketPhylum,mer-kin)*25], Sleaze Resistance: [pref(locketPhylum,orc)*3], Maximum MP: [pref(locketPhylum,orc)*25], Experience (Muscle): [pref(locketPhylum,penguin)*3], Cold Spell Damage: [pref(locketPhylum,penguin)*25], Booze Drop: [pref(locketPhylum,pirate)*50], Sleaze Damage: [pref(locketPhylum,pirate)*25], Initiative: [pref(locketPhylum,plant)*50], Maximum HP Percent: [pref(locketPhylum,plant)*50], Cold Resistance: [pref(locketPhylum,slime)*3], Damage Absorption: [pref(locketPhylum,slime)*50], Spooky Damage: [pref(locketPhylum,undead)*25], Muscle Percent: [pref(locketPhylum,undead)*50], Food Drop: [pref(locketPhylum,weird)*50], Weapon Damage: [pref(locketPhylum,weird)*25], Last Available: "2022-02"
 Item	compression stocking	Maximum MP: +30, MP Regen Min: 3, MP Regen Max: 5
 Item	Congressional Medal of Insanity	Mysticality Percent: +25, Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 12, Last Available: "2024-12"
 Item	consolation ribbon	Muscle: +1, Mysticality: +1, Moxie: +1
@@ -3096,12 +3135,14 @@ Item	duonoculars	Combat Rate: -5, Monster Level: +5, Single Equip
 Item	Duskwalker fangs	Weapon Damage Percent: +5, Weakens Monster
 Item	Dyspepsi-Cola-issue canteen	Maximum MP: +5, Single Equip
 # E.M.U. Unit
+Item	E.M.U. Unit	Last Available: "2011-06"
 Item	Earring of Fire	Cold Resistance: +3, Spooky Resistance: +3, Single Equip
 Item	eerie fetish	Spooky Resistance: +4, Single Equip
 Item	Eight Days a Week Pill Keeper	Maximum HP: +20, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 10, MP Regen Max: 15, Muscle: +10, Mysticality: +10, Moxie: +10, Last Available: "2019-10", Avoid Attack: 1
 # El Vibrato translator
 Item	elevennis shoes	Muscle: +11, Mysticality: +11, Moxie: +11, Maximum HP: +11, Maximum MP: +11, Last Available: "2014-03"
 Item	Elf Guard commandeering gloves	Item Drop: +3, Piece of Twelve Drop: 0.5, Single Equip
+Item	Elf Guard commandeering gloves	Item Drop: +3, Single Equip, Last Available: "2023-12", Piece of Twelve Drop: 0.5
 Item	Elf Guard insignia (general)	Elf Warfare Effectiveness: +10, Adventures: +9, Single Equip, Last Available: "2023-12"
 Item	Elf Guard insignia (private)	Elf Warfare Effectiveness: +1, Last Available: "2023-12"
 Item	Elmley shades	Muscle: +12, Critical Hit Percent: +3, Single Equip
@@ -3118,6 +3159,7 @@ Item	enormous hoop earring	Moxie: +5
 # ert grey goo ring: Definitely Safe
 Item	ert grey goo ring	Maximum HP: +10, Maximum MP: +10
 # ESP suppression collar
+Item	ESP suppression collar	Last Available: "2014-10"
 # Everfull Dart Holster: Throw Darts in Battle
 Item	Everfull Dart Holster	Initiative: +50, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Single Equip, Last Available: "2024-03"
 Item	evil flaming eyeball pendant	Initiative: +15, Meat Drop: +15, Single Equip, Softcore Only, Last Available: "2007-01"
@@ -3204,6 +3246,7 @@ Item	ghost of a necklace	Sleaze Damage: +8, Sleaze Spell Damage: +8, Spooky Resi
 Item	giant bow tie	Muscle: +5, Mysticality: +5, Moxie: +5, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Clowniness: 25, Lasts Until Rollover, Last Available: "2024-10"
 Item	giant designer sunglasses	Moxie Percent: -10, Single Equip
 # giant diamond ring
+Item	giant diamond ring	Last Available: "2011-04"
 Item	giant motorcycle boots	Damage vs. Ghosts: +10, Muscle: +5, Single Equip
 Item	giant pinky ring	Negative Status Resist, Single Equip
 Item	gingerbeard	Single Equip, Last Available: "2016-12", Adventures: [6+(3*event(December))]
@@ -3227,6 +3270,7 @@ Item	government-issued necktie	Experience Percent (Mysticality): +10, Damage vs.
 Item	government-issued night-vision goggles	Item Drop: +5, Monster Level: +5, Single Equip, Last Available: "2014-05"
 Item	governor's daughter's lace collar	Mysticality Percent: +20, Last Available: "2024-12"
 # GPS-tracking wristwatch
+Item	GPS-tracking wristwatch	Last Available: "2014-10"
 Item	grandfather watch	Adventures: +6, Single Equip, Nonstackable Watch
 # Gravyskin Belt of the Sauceblob: 3 Additional Scrumptious Reagent Summons Per Day
 # Gravyskin Belt of the Sauceblob: This enchantment works even when this item is not equipped
@@ -3363,6 +3407,7 @@ Item	lube-shoes	Moxie: -10, Last Available: "2015-04"
 Item	lucky bottlecap	Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Single Equip
 Item	lucky cat collar	Meat Drop: +7, Single Equip, Last Available: "2013-12"
 # lucky Crimbo tiki necklace: Brings Good Luck!
+Item	lucky Crimbo tiki necklace	Last Available: "2006-12"
 # lucky gold ring: Find various valuable currencies after combat
 Item	lucky gold ring	Single Equip, Last Available: "2019-04"
 Item	lucky rabbit's foot	Item Drop: +7, Meat Drop: +7
@@ -3437,6 +3482,7 @@ Item	molten medallion	Hot Resistance: +1, Item Drop: +5, Last Available: "2009-0
 Item	monster bait	Combat Rate: +5, Single Equip
 Item	monstrous monocle	Spooky Resistance: +1, Item Drop: +5, Last Available: "2009-06", Synergetic
 # mood ring
+Item	mood ring	Last Available: "2007-02"
 Item	moon-amber necklace	Spell Damage Percent: +50, Maximum MP: +200, Mysticality Percent: [5*G], Single Equip
 Item	moss marlinspike	Moxie: +10, Negative Status Resist, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 # moss medal: Lets you impress your pasta thrall
@@ -3451,6 +3497,7 @@ Item	Mr. Accessory Jr.	Muscle: +5, Mysticality: +5, Moxie: +5, Item Drop: +25, S
 Item	Mr. Cheeng's spectacles	Item Drop: +15, Spell Critical Percent: +10, Spell Damage Percent: +30, Single Equip, Last Available: "2015-08", Drops Items
 Item	Mr. Eh?	Muscle: +12, Mysticality: +12, Moxie: +12, Softcore Only
 # Mr. Exploiter
+Item	Mr. Exploiter	Last Available: "2009-12"
 Item	Mr. Joe's bangles	Mysticality Percent: +10, Single Equip
 # Mr. Screege's spectacles: Lets you find valuables after fights
 Item	Mr. Screege's spectacles	Meat Drop: +20, Single Equip, Last Available: "2016-08", Drops Meat
@@ -3498,8 +3545,7 @@ Item	Oscus's pelt	Mysticality Percent: +20, Stench Spell Damage: +30, Class: "Pa
 Item	Othello's handkerchief	Othello Skill: +10, Single Equip
 Item	outlaw bandana	Moxie: +10, Initiative: +20, Weapon Drop: +40
 Item	oven mitts	Hot Resistance: +2, Single Equip
-# over-the-shoulder Folder Holder: Softcore Only (Except for High School Students)
-Item	over-the-shoulder Folder Holder	Single Equip
+Item	over-the-shoulder Folder Holder	Single Equip, Softcore Only: [1-path(KOLHS)], Last Available: "2013-08"
 Item	pacifier necklace	Sleaze Damage: +20, Single Equip, Raveosity: +2
 Item	pair of government shades	Maximum HP: +10, Single Equip, Last Available: "2014-05"
 # pair of pearidot earrings: (only in the Candy Diorama)
@@ -3520,15 +3566,17 @@ Item	pearl diver's necklace	Critical Hit Percent: +4, Monster Level: +20, Single
 Item	pearl diver's ring	Critical Hit Percent: +3, Monster Level: +15, Single Equip, Item Drop: [20*env(underwater)]
 Item	pearl necklace	Sleaze Damage: +23, Sleaze Spell Damage: +37, Moxie Percent: +69, Single Equip, Last Available: "2017-10"
 Item	peg key	Experience: +5, Last Available: "2020-08"
-Item	pegfinger	Spell Damage Percent: +25, MPC Drop: 0.5, Single Equip
+Item	pegfinger	Spell Damage Percent: +25, Single Equip, Last Available: "2023-12", MPC Drop: 0.5
 Item	Pendant of Fire	Muscle: +3, Mysticality: +3, Moxie: +3, Hot Spell Damage: +40, Single Equip
 Item	Pendant of Gargalesis	MP Regen Min: 6, MP Regen Max: 10
 Item	peppermint-scented socks	MP Regen Min: 8, MP Regen Max: 16, Last Available: "2021-12"
 Item	perfect Christmas scarf	Adventures: [+9*event(December)], Cold Resistance: [+7*event(December)], HP Regen Min: [4*event(December)], HP Regen Max: [6*event(December)], MP Regen Min: [4*event(December)], MP Regen Max: [6*event(December)], Single Equip, Last Available: "2024-12"
+Item	perfume-soaked bandana	Spooky Resistance: +2, Stench Resistance: 4, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2015-04"
 Item	perfume-soaked bandana	Stench Resistance: +4, Spooky Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip
 # Personal Ventilation Unit: Allows Safe Access to Secret Government Lab
 Item	Personal Ventilation Unit	Muscle Limit: 100, Mysticality Limit: 100, Moxie Limit: 100, Single Equip, Last Available: "2014-10"
 Item	petrified wood waist protector	Experience (Muscle): +3, Adventures: +5, Avoid Attack: 1, Single Equip
+Item	petrified wood waist protector	Experience (Muscle): +3, Adventures: +5, Single Equip, Last Available: "2025-12", Avoid Attack: 1
 # petrified wood wizard's pouch: Adds hot and physical damage to spells
 Item	petrified wood wizard's pouch	Mysticality Percent: +20, Item Drop: +10, Single Equip, Last Available: "2025-12"
 # phase-tuned shield generator belt: +10 Damage Reduction vs. Bugbears
@@ -3657,6 +3705,7 @@ Item	replica Powerful Glove	Maximum MP: +10, Maximum HP: +20, Weapon Damage Perc
 # replica V for Vivala mask: Critical Hits are extra-explosive
 Item	replica V for Vivala mask	Muscle Percent: +30, Critical Hit Percent: +10, Combat Item Damage Percent: 50, Single Equip
 # retro floppy disk: CyberRealm: Get one additional 1 after combat
+Item	retro floppy disk	Last Available: "2025-12"
 # Retrospecs: Gives you another chance on item drops you missed out on
 # Retrospecs: Reveals foes' weaknesses
 Item	Retrospecs	Muscle: +15, Mysticality: +15, Moxie: +15, Maximum HP: +25, Maximum MP: +25, HP Regen Min: 3, HP Regen Max: 5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Free Pull, Last Available: "2020-01"
@@ -3802,8 +3851,10 @@ Item	stainless steel solitaire	Mana Cost: -2, Adventures: +2, Mysticality Percen
 Item	stainless steel suspenders	Damage Absorption: +60, Maximum MP: +40, Moxie Percent: +15, Single Equip
 Item	Star of Bravery	Maximum HP: +25, Maximum MP: +25, Single Equip
 # steel knuckles: +30 Damage to Unarmed Attacks
+Item	steel knuckles	Last Available: "2016-02"
 Item	stick-on eyebrow piercing	Muscle: +1, Last Available: "2008-04"
 Item	sticky gloves	Pickpocket Chance: +20, Single Equip, Last Available: "2011-05"
+Item	stinky cheese eye	Item Drop: [max(1,min(20,floor(pref(_stinkyCheeseCount)/5)))], Softcore Only, Last Available: "2010-01", Meat Drop: [max(1,min(20,floor(pref(_stinkyCheeseCount)/5)))]
 Item	stinky cheese eye	Softcore Only, Meat Drop: [max(1,min(20,floor(pref(_stinkyCheeseCount)/5)))], Item Drop: [max(1,min(20,floor(pref(_stinkyCheeseCount)/5)))]
 # stinky fannypack: +40% Item Drops while on Vacation
 # stinky fannypack: (in any Elemental Airport area)
@@ -3848,7 +3899,7 @@ Item	The One Mood Ring	Muscle Percent: [5*G], Mysticality Percent: [5*G], Moxie 
 Item	The Ring	Muscle: +3, Mysticality: +3, Moxie: +3, Spooky Damage: +40, Single Equip
 # The Superconductor's CPU: (based on Crimbo 22 Elf Gratitude)
 Item	The Superconductor's CPU	Maximum HP: [floor(sqrt(pref(elfGratitude)))], Maximum MP: [floor(sqrt(pref(elfGratitude)))], Single Equip, Last Available: "2022-12"
-Item	thicksilver ring	Damage Absorption: +30, Damage Reduction: 60, Single Equip
+Item	thicksilver ring	Damage Absorption: +30, Damage Reduction: 60, Single Equip, Last Available: "2016-02"
 Item	third ear	Initiative: +50, Single Equip, Last Available: "2021-12"
 Item	ticksilver ring	Adventures: +6, PvP Fights: +4, Single Equip, Last Available: "2016-02"
 Item	tie-dyed fannypack	Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2, Item Drop: +10, Single Equip, Last Available: "2016-08"
@@ -4153,7 +4204,7 @@ Item	UV monocular	Item Drop: +5, Single Equip
 # V for Vivala mask: +1-3 Stat(s) per Fight
 # V for Vivala mask: Allows use of Creepy Grin (once per day)
 # V for Vivala mask: Critical Hits are extra-explosive
-Item	V for Vivala mask	Muscle Percent: +30, Critical Hit Percent: +10, Combat Item Damage Percent: 50, Single Equip, Softcore Only
+Item	V for Vivala mask	Muscle Percent: +30, Critical Hit Percent: +10, Combat Item Damage Percent: 50, Single Equip, Softcore Only, Last Available: "2007-11"
 # vampire collar: Makes You Act Like a Vampire.  Blah.
 Item	vampire collar	Single Equip
 Item	vampire pearl earring	MP Regen Min: 4, MP Regen Max: 14, Single Equip
@@ -4234,6 +4285,7 @@ Item	wrought-iron widget	Experience (Mysticality): +3, Maximum HP: +40, Single E
 # wrought-iron winch crank: Increases the damage of Spirit Snap
 Item	wrought-iron winch crank	Initiative: +40, MP Regen Min: 4, MP Regen Max: 6, Single Equip, Last Available: "2017-12"
 # x-ray specs
+Item	x-ray specs	Last Available: "2011-12"
 # Xiblaxian holo-wrist-puter: Detects Anomalous Materials of Xiblaxian Origin
 Item	Xiblaxian holo-wrist-puter	Item Drop: +10, Last Available: "2014-09", Drops Items
 # Xiblaxian xeno-detection goggles: They Really Open Your Eyes
@@ -4288,6 +4340,7 @@ Item	cod cape	Stench Damage: +25, Combat Rate: +5
 # crepe paper parachute cape: Parachute into a battle in a recent zone
 Item	crepe paper parachute cape	Experience (Muscle): +2, Cold Damage: +10, Cold Spell Damage: +10, Last Available: "2025-12"
 # cryptocloak: CyberRealm: Avoid damage from processes, once per combat
+Item	cryptocloak	Last Available: "2025-12"
 Item	cursed blanket	Hot Resistance: +3, Cold Resistance: +3, Spooky Resistance: +3, Stench Resistance: +3, Sleaze Resistance: +3, Familiar Weight: -20
 # cursed goblin cape: Cold Vulnerability (-6)
 # cursed goblin cape: Spooky Vulnerability (-6)
@@ -4367,6 +4420,7 @@ Item	spant backplate	Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent:
 Item	spiky back shell	Thorns: 1
 Item	stained glass serape	Experience (Moxie): +3, Sleaze Resistance: +3, Sleaze Damage: +5, Last Available: "2021-12"
 Item	super-absorbent tarp	Maximum Hooch: +2
+Item	T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	Combat Rate: 0, Last Available: "2010-04", Wiki Name: "Bugged baio"
 Item	T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	Wiki Name: "Bugged baio"
 Item	teddybear backpack	Meat Drop: +10, Raveosity: +1
 # terra cotta train: Lets you unleash a terra cotta army on your foes
@@ -4375,7 +4429,9 @@ Item	thermal blanket	Cold Resistance: +2, Spooky Resistance: +1, Combat Rate: +5
 Item	Time Bandit Time Towel	Muscle: +5, Mysticality: +5, Moxie: +5, Adventures: +1
 Item	Time Cape	Last Available: "2014-11", Item Drop: [25*zone(Twitch)]
 # Time Cloak: Sometimes Find an Extra Chroner in the Time-Twitching Tower
+Item	Time Cloak	Last Available: "2014-11"
 # toy jet pack: Jane!  Get Me Off This Crazy Thing!
+Item	toy jet pack	Last Available: "2006-12"
 # Trainbot harness: Lets you rescue elves from passenger-occupied Crimbo train cars
 Item	Trainbot harness	Initiative: -200
 Item	uncursed blanket	Hot Resistance: +1, Cold Resistance: +1, Spooky Resistance: +1, Stench Resistance: +1, Sleaze Resistance: +1
@@ -4407,12 +4463,15 @@ Item	aquaviolet jub-jub bird	Familiar Weight: +5, Familiar Tuning (Mysticality):
 Item	astral pet sweater	Familiar Weight: +10, Generic
 Item	attention spanner	Familiar Weight: +5
 # badger badge: Increases Astral Mushroom Drop Rate
+Item	badger badge	Last Available: "2006-06"
 # bag of many confections: Full of Candy!
+Item	bag of many confections	Last Available: "2009-12"
 Item	black gallstone	Familiar Weight: +5, Last Available: "2016-12"
 Item	blue canary nightlight	Familiar Weight: +5, Last Available: "2013-12"
-# blue pumps: Causes your Ms. Puck Man to sometimes drop extra yellow pixels
 # blue plate: Improves Cooking
 Item	blue plate	Familiar Weight: +5
+# blue pumps: Causes your Ms. Puck Man to sometimes drop extra yellow pixels
+Item	blue pumps	Last Available: "2015-06"
 Item	blue suede shoes	Familiar Weight: +5
 Item	blundarrrbus	Familiar Weight: +5
 Item	bone collar	Familiar Weight: +5
@@ -4429,6 +4488,7 @@ Item	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	Food Drop: +5, Pants Drop: +
 Item	bugged balaclava	Monster Level: +20, Last Available: "2010-04", Volleyball: 1.0, Equips On: "Baby Bugged Bugbear"
 Item	bugged beanie	Familiar Weight: +10, Last Available: "2010-04"
 # burglar/sleep mask: Helps your Cat Burglar take naps more efficiently
+Item	burglar/sleep mask	Last Available: "2018-07"
 Item	cactus monocle	Familiar Weight: +5
 # can of starch: Makes Origami Towel Crane More Resistant to Wear and Tear
 Item	candied yam pinky ring	Familiar Weight: +5, Last Available: "2011-12"
@@ -4478,6 +4538,7 @@ Item	futuristic collar	Lasts Until Rollover, Generic
 Item	fuzzy polar bear ears	Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12", Generic
 Item	gazing shoes	Familiar Weight: +5, Last Available: "2011-12"
 # giant book of ancient carols: Causes the Ancient Yuletide Troll to drop carol pages more frequently
+Item	giant book of ancient carols	Last Available: "2006-12"
 Item	gill rings	Familiar Weight: +5
 Item	gnomish athlete's foot	Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 Item	gnomish coal miner's lung	Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
@@ -4507,6 +4568,7 @@ Item	hardware upgrade	Familiar Weight: +5, Last Available: "2007-04"
 Item	heavy-duty Crimbot aerial	Familiar Weight: +5, Last Available: "2014-12"
 Item	high-speed upgrade	Familiar Weight: +5, Last Available: "2016-05"
 # homemade robot gear: +1 Gear
+Item	homemade robot gear	Last Available: "2012-12"
 Item	hot pink lipstick	Familiar Weight: +5
 Item	hypodermic needle	Familiar Weight: +5
 Item	iced-out bling	Familiar Weight: +5
@@ -4562,12 +4624,13 @@ Item	metallic foil radar dish	Familiar Weight: +5, Last Available: "2011-12", Vo
 Item	meteor shower cap	Familiar Weight: +5
 Item	metrognome	Familiar Weight: +5
 # microwave stogie: Helps your Organ Grinder Bake Pies Faster
+Item	microwave stogie	Last Available: "2011-12"
 Item	mini-Mr. Accessory	Familiar Weight: +5
 Item	miniature antlers	Familiar Weight: [1+ceil(M/2)], Last Available: "2008-12", Generic
 Item	miniature carton of clove cigarettes	Familiar Weight: +5
 Item	miniature castagnets	Familiar Weight: +5
 # miniature crystal ball: Randomly gives you either +50% Item Drops or +5 Stats After Combat
-Item	miniature crystal ball	Initiative: +50, Item Drop (sporadic): +25, Experience: +2.5, Generic
+Item	miniature crystal ball	Initiative: +50, Last Available: "2021-01", Generic, Item Drop (sporadic): +25, Experience: +2.5
 # miniature dormouse: Makes March Hare More Better
 Item	miniature espresso maker	Familiar Weight: +5
 Item	miniature goose mask	Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12", Generic
@@ -4578,6 +4641,7 @@ Item	miniature life preserver	Generic
 Item	miniature pruning shears	Familiar Weight: +5
 Item	miniature tophat	Familiar Weight: +5
 # MiniMechaElf Laser Punch Missile Launcher: More likely to use more powerful attacks
+Item	MiniMechaElf Laser Punch Missile Launcher	Last Available: "2012-12"
 Item	miniscule beatbox	Familiar Weight: +5, Last Available: "2012-12"
 Item	mint-condition magic wand	Last Available: "2011-12", Volleyball: 0.3334, Fairy: 0.3334
 Item	missing semicolon	Familiar Weight: +11
@@ -4586,9 +4650,11 @@ Item	moveable feast	Familiar Weight: +5, Softcore Only, Last Available: "2009-11
 # muscle band: Increases familiar damage
 Item	muscle band	Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03", Generic
 # nanorhino credit card: Helps your Nano-Rhino charge
+Item	nanorhino credit card	Last Available: "2012-11"
 Item	nosy nose ringy ring	Familiar Weight: +15
 # nutcracking pliers: Makes your Antique Nutcracker drop nuts more often
 # orange boxing gloves: Causes your Puck Man to sometimes drop extra yellow pixels
+Item	orange boxing gloves	Last Available: "2015-06"
 # origami &quot;gentlemen's&quot; magazine: +10 lbs. of Ghuol Whelp
 Item	origami &quot;gentlemen's&quot; magazine	Softcore Only, Last Available: "2008-02", Generic
 Item	overclocked avian microprocessor	Familiar Weight: +5, Last Available: "2007-12"
@@ -4606,6 +4672,7 @@ Item	Petite Paintbrush	Adventures: +1, Generic
 Item	pewter candlestick	Familiar Weight: +10
 Item	pile of dungeon junk	Familiar Weight: +5
 # plastic bib: Makes your ghost better at eating stuff
+Item	plastic bib	Last Available: "2011-12"
 Item	plastic piranha pot	Familiar Weight: +5
 Item	plastic pirate hat	Familiar Weight: +5
 Item	plastic pumpkin bucket	Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10", Generic, Sporadic Damage Aura: 0.35
@@ -4618,6 +4685,7 @@ Item	putty coat	Familiar Weight: +5
 # quadroculars: Helps Your He-Boulder See Better (x4)
 Item	quadroculars	Familiar Weight: +5, Last Available: "2009-09"
 # quake of arrows: Holds Heavier Arrows
+Item	quake of arrows	Last Available: "2011-12"
 Item	radioactive chew toy	Familiar Weight: +5, Last Available: "2008-12"
 Item	rainbow tie	Familiar Weight: +5, Last Available: "2011-12"
 Item	ramekin of space nuts	Familiar Weight: +5, Last Available: "2014-05"
@@ -4676,7 +4744,9 @@ Item	sugar shield	Familiar Weight: +10, Last Available: "2009-09", Generic, Brea
 # targeting chip: More likely to use more powerful attacks
 Item	tasteful black bow tie	Familiar Weight: +5
 # teddy bear sewing kit: Teddy Bear loses less stuffing when hit
+Item	teddy bear sewing kit	Last Available: "2006-01"
 # teddy borg sewing kit: Teddy Borg loses less stuffing when hit
+Item	teddy borg sewing kit	Last Available: "2007-12"
 Item	tinsel fin	Familiar Weight: +5
 Item	tiny baby scorpion	Familiar Weight: +10
 Item	tiny ballet slippers	Familiar Weight: +5, Last Available: "2008-12"
@@ -4685,13 +4755,13 @@ Item	tiny bindle	Familiar Weight: +5
 Item	tiny bowler	Generic, Damage Aura: 1
 Item	tiny bust of Pallas	Familiar Weight: +5
 Item	tiny cell phone	Familiar Weight: +10
+Item	tiny consolation ribbon	Familiar Weight: -10, Experience (familiar): -1, Generic
 # tiny costume wardrobe: Contains Many Adorable Costumes
 Item	tiny costume wardrobe	Softcore Only, Generic, Familiar Weight: [25*fam(doppelshifter)]
 Item	tiny do-rag	Familiar Weight: +5, Last Available: "2011-11"
 Item	tiny domino mask	Familiar Weight: +5
 Item	tiny fly glasses	Experience (familiar): +1, Last Available: "2010-04", Generic
 Item	tiny glowing red nose	Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12", Generic
-Item	tiny consolation ribbon	Familiar Weight: -10, Experience (familiar): -1, Generic
 # tiny gold medal: Doubles the chance that familiars act in combat
 Item	tiny gold medal	Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover, Generic
 Item	tiny knife and fork	Familiar Weight: +5
@@ -4699,6 +4769,7 @@ Item	tiny makeup kit	Familiar Weight: +15
 Item	tiny maracas	Familiar Weight: +5
 Item	tiny Mountie hat	Familiar Weight: +5
 # tiny nose-bone fetish: Reduces familiar's MP expenditure by 2-4
+Item	tiny nose-bone fetish	Last Available: "2011-12"
 Item	tiny prop sword	Familiar Weight: +5
 Item	tiny rake	Item Drop: +1, Generic, Leaves: +1.5
 Item	tiny shaker of salt	Familiar Weight: +5
@@ -4722,14 +4793,17 @@ Item	unspeakable lozenges	Familiar Weight: +5, Last Available: "2009-10"
 Item	velvet choker	Familiar Weight: +5, Last Available: "2011-12"
 Item	vicious spiked collar	Familiar Damage: +20, Generic
 # warbear drone codes: Makes the drone better, faster, stronger
+Item	warbear drone codes	Last Available: "2013-12"
 Item	wax lips	Experience: +3, Softcore Only, Last Available: "2005-07", Generic
 # weegee sqouija: Hobo's Booze Is More Effective
+Item	weegee sqouija	Last Available: "2011-12"
 # white arm towel: Your familiar will find extra food and booze on the Crimbo Train
 Item	white arm towel	Last Available: "2022-12", Generic
 Item	woimbook	Familiar Weight: +5
 Item	woolen cravat	Familiar Weight: +5, Last Available: "2007-03"
 Item	Xiblaxian holo-bowtie	Familiar Weight: +5, Last Available: "2014-09"
 # zen motorcycle: Makes Llama Lamas friendlier
+Item	zen motorcycle	Last Available: "2008-06"
 
 # Virtual Equipment
 
@@ -9321,52 +9395,77 @@ MaxCat	_smithsness	Meat Drop: +2, Item Drop: +1, Moxie Percent: +2, Mysticality 
 # Food section of modifiers.txt
 
 # &quot;caramel&quot; orange: Also gives 10 turns of a random beneficial effect
+Item	&quot;caramel&quot; orange	Last Available: "2021-12"
 Item	&quot;meat&quot; stick	Effect: "Empty Inside", Effect Duration: 50, Last Available: "2014-10"
 Item	3vi1 pr0n m4nic0tti	Effect: "[599]A Little Bit Evil", Effect Duration: 10
 Item	20-lb can of rice and beans	Effect: "Stuffed", Effect Duration: 100, Last Available: "2022-05"
+Item	a dance upon the palate	Last Available: "2010-04"
+Item	acceptable mayolus	Last Available: "2015-05"
+Item	Affirmation Cookie	Last Available: "2017-05"
 Item	Aldebaran sardines	Effect: "Fishy", Effect Duration: 60, Last Available: "2017-04"
+Item	alien meat	Last Available: "2017-04"
+Item	alien sandwich	Last Available: "2017-04"
 Item	amok pudding	Effect: "Puddingface", Effect Duration: 20
+Item	ancient unspeakable fruitcake	Last Available: "2006-12"
 Item	animal part cracker	Effect: "Sprinkle in Your Eye", Effect Duration: 30, Last Available: "2016-12"
 Item	autumn-spice donut	Effect: "Whet Appetite", Effect Duration: 30, Last Available: "2022-10"
 Item	bacteria bisque	Effect: "Infected with Chronerism", Effect Duration: 50
 Item	badass pie	Effect: "Pie in the Sky", Effect Duration: 20, Last Available: "2010-10"
 Item	bag of GORF	Effect: "Long Live GORF", Effect Duration: 3, Last Available: "2012-07"
+Item	bag of GORP	Last Available: "2012-07"
 Item	bag of QWOP	Effect: "QWOPped Up", Effect Duration: 10, Last Available: "2012-07"
 # Baja sopapilla: NOTE: This item will stop working when Crimbo 2019 is over.
 # Baja sopapilla: Effect: "Baja, Humbug", Effect Duration: 30
+Item	Baja sopapilla	Last Available: "2019-12"
 Item	baked stuffing	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
 Item	baked veggie ricotta casserole	Effect: "Pretty Delicious", Effect Duration: 50, Last Available: "2022-11"
+Item	banana milkshake	Last Available: "2009-06"
+Item	banana-frosted king cake	Last Available: "2008-08"
 Item	bar of freeze-dried water	Effect: "Ultrahydrated", Effect Duration: 10, Last Available: "2022-05"
 Item	barrel cracker	Effect: "Shortened", Effect Duration: 40, Last Available: "2015-09"
 Item	barrel pickle	Effect: "Briny Blood", Effect Duration: 50, Last Available: "2015-09"
 Item	Bash-&#332;s cereal	Wiki Name: "Bash-Os cereal"
 Item	bat-shaped Crimboween cookie	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 Item	bear claw	Effect: "Bear Clawed", Effect Duration: 30, Last Available: "2016-02"
+Item	beautiful soup	Last Available: "2010-03"
 Item	Beefy Crunch Pastaco	Effect: "Boletus Swoletus", Effect Duration: 40, Last Available: "2014-05"
 Item	beefy fish meat	Effect: "Fishy", Effect Duration: 5
 Item	bell-shaped Crimbo cookie	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
+Item	berries of suffering	Last Available: "2012-12"
 Item	bishop cookie	Effect: "Mitre Cut", Effect Duration: 30, Last Available: "2010-03"
 Item	Black Angus blackburger	Effect: "The Power of Negative Thinking", Effect Duration: 100, Last Available: "2016-12"
 Item	black forest cake	Effect: "Sugar Rush", Effect Duration: 5
 Item	black pudding	Wiki Name: "black pudding (food)"
 Item	blob-shaped Crimbo cookie	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 Item	blueberry muffin	Effect: "All Blued Up", Effect Duration: 25
+Item	blueberry-frosted king cake	Last Available: "2008-12"
 Item	blunt cat claw	Effect: "Feline Ferocity", Effect Duration: 30, Last Available: "2011-09"
+Item	bone broth	Last Available: "2021-12"
+Item	bone meal	Last Available: "2010-10"
 Item	Boris's bread	Effect: "Inspired Chef", Effect Duration: 30, Last Available: "2022-11"
 Item	bowl full of jelly	Effect: "Jowls Full, and Belly", Effect Duration: 30, Last Available: "2020-12"
 Item	bowl of Bounty-Os	Effect: "Broken Fast", Effect Duration: 20
 Item	bowl of eyeballs	Effect: "Your Eyes are Peeled!", Effect Duration: 30, Last Available: "2015-10"
+Item	bowl of maggots	Last Available: "2015-10"
 # bowl of mernudo: NOTE: This item will stop working when Crimbo 2019 is over.
 # bowl of mernudo: Effect: "Sea Guts", Effect Duration: 30
+Item	bowl of mernudo	Last Available: "2019-12"
 Item	bowl of mummy guts	Effect: "Guts Feeling", Effect Duration: 30, Last Available: "2015-10"
+Item	bowl of prescription candy	Last Available: "2021-12"
 Item	bowl of Tastee-Wheet&trade;	Effect: "Video... Games?", Effect Duration: 5
 Item	Brain Food Pastaco	Effect: "Omphalotus Omnipresence", Effect Duration: 40, Last Available: "2014-05"
 Item	bran muffin	Effect: "All Branned Up", Effect Duration: 25
 Item	bread line	Effect: "Bread-Lined", Effect Duration: 40, Last Available: "2015-12"
+Item	bread man	Last Available: "2021-12"
+Item	bread pie	Last Available: "2021-12"
 Item	bread roll	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
+Item	breakfast mess	Last Available: "2013-12"
+Item	breakfast miracle	Last Available: "2013-12"
 Item	brown sugar cane	Effect: "Sugar Rush", Effect Duration: 3
+Item	browser cookie	Last Available: "2016-06"
 # bu&ntilde;uelos Jaliscos: NOTE: This item will stop working when Crimbo 2019 is over.
 # bu&ntilde;uelos Jaliscos: Effect: "Fishy", Effect Duration: 30
+Item	bu&ntilde;uelos Jaliscos	Last Available: "2019-12"
 Item	bucket of honey	Effect: "Sugar Rush", Effect Duration: 50, Last Available: "2010-03"
 Item	C.H.U.M. chum	Effect: "Majorly Poisoned", Effect Duration: 20
 Item	Calzone of Legend	Effect: "In the 'zone zone!", Effect Duration: 100, Last Available: "2022-11"
@@ -9378,6 +9477,7 @@ Item	campfire s'more	Effect: "Gimme, Gimme", Effect Duration: 60, Last Available
 Item	campfire stew	Effect: "Just Like Me, They Want to Be", Effect Duration: 60, Last Available: "2019-08"
 Item	can of Adultwitch&trade;	Effect: "Greasy Visage", Effect Duration: 20, Last Available: "2014-12"
 Item	can of franks 'n' beans	Effect: "Crimbo Nostalgia", Effect Duration: 50, Last Available: "2010-12"
+Item	can of sardines	Last Available: "2013-11"
 Item	candied beef and cabbage	Effect: "Green-Blooded", Effect Duration: 20, Last Available: "2024-12"
 Item	candied lime	Effect: "Limed Up", Effect Duration: 50, Last Available: "2023-12"
 Item	candied pecan	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2014-12"
@@ -9388,6 +9488,7 @@ Item	candy carrot cake	Effect: "Improved Candy Vision", Effect Duration: 30, Las
 Item	candy kneecapping stick	Effect: "Sugar Rush", Effect Duration: 5, Last Available: "2009-12"
 Item	candy mountain oyster	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2014-12"
 Item	candy rations	Effect: "Toured of Duty", Effect Duration: 20, Last Available: "2024-12"
+Item	candy stake	Last Available: "2006-12"
 Item	carrot cake	Effect: "Pla-see-bo", Effect Duration: 10, Last Available: "2013-01"
 Item	carrot cake precipice bar	Effect: "On the Precipice of Carrots", Effect Duration: 30, Last Available: "2022-05"
 Item	centipede eggs	Effect: "Somewhat Poisoned", Effect Duration: 10
@@ -9397,19 +9498,32 @@ Item	chilly dog	Effect: "Chill Out, Dog", Effect Duration: 30
 Item	Choco-Mint patty	Effect: "Alpine Mintiness", Effect Duration: 25, Last Available: "2015-01"
 Item	chocolate chip muffin	Effect: "All Chipped Up", Effect Duration: 25
 Item	chocolate ostrich egg	Effect: "Resurrection of the Flesh", Effect Duration: 20, Last Available: "2024-12"
+Item	chocolate-covered scarab beetle	Last Available: "2009-10"
+Item	chocolate-frosted king cake	Last Available: "2009-06"
+Item	chocomotive	Last Available: "2022-12"
 Item	Christmas ham	Effect: "Eyesies on the Pressies", Effect Duration: 20, Last Available: "2024-12"
 Item	ciliophora chowder	Effect: "Twitching Senses", Effect Duration: 50
+Item	cinnamon cannoli	Last Available: "2014-12"
 Item	circular CRIMBCOOKIE	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 Item	cold hi mein	Effect: "Cold Breath", Effect Duration: 5
 # cold mashed potatoes: Selling Price: <b>1 Meat.</b><p><center><b><font color=blue>Deals <font color=blue>Cold Damage</font> based on your Mysticality when used as a combat item
+Item	cold mashed potatoes	Last Available: "2013-11"
+Item	coney haunch	Last Available: "2024-12"
 Item	cookie cookie	Effect: "Cookie Backup", Effect Duration: 10, Last Available: "2014-12"
 Item	Cool Brunch Pastaco	Effect: "Gyromitra Gymnastics", Effect Duration: 40, Last Available: "2014-05"
 Item	cool cat claw	Effect: "Feline Ferocity", Effect Duration: 30, Last Available: "2011-09"
 Item	cool jelly donut	Effect: "Filled with Magic", Effect Duration: 30, Last Available: "2011-09"
 Item	cool mint precipice bar	Effect: "On the Minty Precipice", Effect Duration: 30, Last Available: "2022-05"
+Item	corned beet	Last Available: "2023-12"
+Item	crabsicle	Last Available: "2019-04"
 Item	cranberry cylinder	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
 Item	cream of chloroplasts	Effect: "Chloroplasted", Effect Duration: 50
+Item	Crepes a la Lune	Last Available: "2011-06"
+Item	CRIMBCOIDS mints	Last Available: "2011-01"
+Item	CRIMBCOLOAF	Last Available: "2011-01"
+Item	Crimbo dinner	Last Available: "2022-12"
 Item	Crimbo salad	Effect: "Salad Days", Effect Duration: 40, Last Available: "2015-12"
+Item	Crimboysters Rockefeller	Last Available: "2018-12"
 Item	cup of lukewarm tea	Effect: "Jittery", Effect Duration: 20
 Item	cupcake-in-a-cup	Effect: "Cake Caked", Effect Duration: 10, Last Available: "2009-06"
 Item	cursed Aztec tamale	Effect: "Curse of the Tamale", Effect Duration: 20, Last Available: "2024-12"
@@ -9417,11 +9531,15 @@ Item	cursed black pearl onion	Effect: "Curse of the Black Pearl Onion", Effect D
 Item	cursed sea biscuit	Effect: "Curse Magnet", Effect Duration: 10
 Item	cyburger	Effect: "Connected", Effect Duration: 40, Last Available: "2025-12"
 Item	D roll	Effect: "On a Roll", Effect Duration: 20
+Item	dead lights pie	Last Available: "2010-10"
+Item	dead meat bun	Last Available: "2013-12"
 Item	Deep Dish of Legend	Effect: "In the Depths", Effect Duration: 100, Last Available: "2022-11"
 Item	denastified haunch	Effect: "Faerie Fortune", Effect Duration: 30, Last Available: "2018-04"
 Item	devil dog	Effect: "Devil Inside", Effect Duration: 30
+Item	deviled egg	Last Available: "2013-11"
 Item	diabolic pizza	Lasts Until Rollover
 # dinner roll: Selling Price: <b>1 Meat.</b><p><center><b><font color=blue>Deals Physical Damage based on your Muscle when used as a combat item
+Item	dinner roll	Last Available: "2013-11"
 Item	Dinsey food-cone	Effect: "The Dinsey Way", Effect Duration: 30, Last Available: "2015-04"
 Item	disco biscuit	Effect: "Buttermilk Boogie", Effect Duration: 100, Last Available: "2015-08"
 Item	double-candied yams	Effect: "Grateful, But Spelled With a Dollar Sign", Effect Duration: 20, Last Available: "2024-12"
@@ -9437,14 +9555,21 @@ Item	Dreadsylvanian stink pocket	Effect: "Dreadful Smell", Effect Duration: 200
 # drippy nugget: Puts 5 &micro;g of Drippy Juice into your blood
 # drippy plum(?): Puts 5 &micro;g of Drippy Juice into your blood
 Item	drive-thru burger	Effect: "It Went Through All Right", Effect Duration: 40, Last Available: "2020-12"
+Item	druidic s'more	Last Available: "2018-04"
 # dwarf bread: Deals 4-28 Physical Damage when used as a combat item
 Item	dwarf bread	Effect: "Dwarven Hardiness", Effect Duration: 5
+Item	edible alien plant bit	Last Available: "2017-04"
+Item	eggwater	Last Available: "2021-12"
 Item	eldritch distillate	Effect: "Eldritch Concentration", Effect Duration: 30, Last Available: "2016-11"
+Item	eldritch mushroom	Last Available: "2017-03"
 Item	eldritch mushroom pizza	Effect: "Eldritch Attunement", Effect Duration: 1, Last Available: "2017-03"
 Item	Eldritch snap	Effect: "Eldritch Attunement", Effect Duration: 3, Last Available: "2017-01"
 Item	electric Kool-Aid	Effect: "Electric, Kool", Effect Duration: 50
+Item	elf army field rations	Last Available: "2019-12"
 Item	elven <i>limbos</i> gingerbread	Effect: "Yuletide Industry", Effect Duration: 20, Last Available: "2008-12"
+Item	elven hardtack	Last Available: "2011-06"
 Item	Energy Buzz Pastaco	Effect: "Stemonitis Storm", Effect Duration: 40, Last Available: "2014-05"
+Item	enticing mayolus	Last Available: "2015-05"
 Item	escargotsicle	Effect: "Extremely Poor Taste", Effect Duration: 10, Last Available: "2007-06"
 Item	Every Day is Like This Sundae	Effect: "Smithsness Dinner", Effect Duration: 100, Last Available: "2013-12"
 Item	evil boring spaghetti	Effect: "[599]A Little Bit Evil", Effect Duration: 10
@@ -9455,21 +9580,31 @@ Item	evil ravioli della hippy	Effect: "[599]A Little Bit Evil", Effect Duration:
 Item	evil spicy noodles	Effect: "[599]A Little Bit Evil", Effect Duration: 10
 Item	exotic jungle fruit	Effect: "Full of Fruit, Yourself", Effect Duration: 25
 Item	expired can of franks 'n' beans	Effect: "Crimbo Nostalgia", Effect Duration: 30, Last Available: "2009-12"
+Item	expired MRE	Last Available: "2022-05"
 # expired MRE gives 3 random effects
 Item	extra-toasted half sandwich	Effect: "Stop the Presses!", Effect Duration: 20, Last Available: "2018-12"
+Item	FantasyRealm turkey leg	Last Available: "2018-04"
 Item	FDKOL hotcakes	Effect: "Hotcaked", Effect Duration: 50, Last Available: "2012-07"
 Item	festive sausage	Effect: "Sausage Festive", Effect Duration: 20, Last Available: "2011-01"
+Item	fiery wing	Last Available: "2012-07"
 Item	fire-roasted lake trout	Effect: "Fire-Roasted Feelings", Effect Duration: 50, Last Available: "2022-06"
 Item	fireman's lunch	Effect: "You're Not Cooking", Effect Duration: 20, Last Available: "2014-12"
+Item	fishcake	Last Available: "2021-12"
 # fishelada: NOTE: This item will stop working when Crimbo 2019 is over.
 # fishelada: Effect: "Fishy", Effect Duration: 30
 # flan del mar: NOTE: This item will stop working when Crimbo 2019 is over.
 # flan del mar: Effect: "Festively Brined", Effect Duration: 30
+Item	flan del mar	Last Available: "2019-12"
+Item	flask of peppermint oil	Last Available: "2006-12"
+Item	flour cookie	Last Available: "2021-12"
 Item	flower petal pie	Effect: "Flower Power", Effect Duration: 3
 Item	foie gras	Effect: "Beaten Up", Effect Duration: 1
 Item	forbidden danish	Effect: "Danish Cunning", Effect Duration: 30, Last Available: "2011-09"
+Item	freightcake	Last Available: "2022-12"
 Item	frozen danish	Effect: "Danish Cunning", Effect Duration: 30, Last Available: "2011-09"
+Item	frozen tofu pop	Last Available: "2021-12"
 Item	fruit-stuffed rumcake	Effect: "Fruit-Based Animosity", Effect Duration: 100, Last Available: "2023-12"
+Item	fudge bunny	Last Available: "2011-11"
 Item	fudgesicle	Effect: "Fudge Headache", Effect Duration: 30, Last Available: "2011-11"
 Item	gallon of milk	Effect: "Feeling Queasy", Effect Duration: 100, Last Available: "2016-05"
 Item	ghost dog	Effect: "Scaredy Dog", Effect Duration: 30
@@ -9477,23 +9612,37 @@ Item	ghostly ectoplasm	Effect: "Haunted Stomach", Effect Duration: 3, Last Avail
 Item	giant green gummi bear	Effect: "Gummibrain", Effect Duration: 40, Last Available: "2011-11"
 Item	giant red gummi bear	Effect: "Gummiheart", Effect Duration: 40, Last Available: "2011-11"
 Item	giant yellow gummi bear	Effect: "Gummiskin", Effect Duration: 40, Last Available: "2011-11"
+Item	gingerbread horror	Last Available: "2006-12"
+Item	gingerbread mug	Last Available: "2016-12"
 Item	gingerbread mutant bugbear	Effect: "Festive Radiation", Effect Duration: 10, Last Available: "2008-12"
 Item	gingerbread nylons	Effect: "Stocking Stuffer", Effect Duration: 50, Last Available: "2023-12"
 Item	gingerbread pirate	Effect: "Tiny Pirate Inside", Effect Duration: 50, Last Available: "2023-12"
 Item	gingerbread robot	Effect: "Gingerbread Robust", Effect Duration: 20, Last Available: "2013-12"
+Item	glass of baboon milk	Last Available: "2009-06"
 Item	glass of raw eggs	Effect: "Boxing Day Breakfast", Effect Duration: 50, Last Available: "2018-12"
 Item	glistening fish meat	Effect: "Fishy", Effect Duration: 5
+Item	gooey lava globs	Last Available: "2015-08"
+Item	government cheese	Last Available: "2014-05"
 Item	greedy ghostling	Free Pull, Last Available: "2020-12"
+Item	green and red bean	Last Available: "2019-12"
 Item	green bean casserole	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
 Item	green drunki-bear	Effect: "Gummibrain", Effect Duration: 80, Last Available: "2011-11"
 Item	green hamhock	Effect: "Just the Best Anapests", Effect Duration: 50, Last Available: "2012-12"
 Item	green-iced sweet roll	Effect: "Sprinkle Sense", Effect Duration: 40, Last Available: "2016-12"
 Item	gregarious ghostling	Free Pull, Last Available: "2020-12"
+Item	grilled cheese sandwich	Last Available: "2014-05"
+Item	grilled mooseflank	Last Available: "2018-12"
 Item	grinning ghostling	Free Pull, Last Available: "2020-12"
+Item	grog nuts	Last Available: "2023-12"
+Item	guffin	Last Available: "2019-12"
+Item	guilty sprout	Last Available: "2022-06"
 Item	gunky chicken	Effect: "Gunky Dory", Effect Duration: 20
 Item	haggis-wrapped haggis-stuffed haggis	Effect: "Highland Sheen", Effect Duration: 20, Last Available: "2012-12"
+Item	half double fruitcake	Last Available: "2017-12"
 Item	hambrosier	Effect: "The Power of Positive Thinking", Effect Duration: 50, Last Available: "2016-12"
+Item	hamburger	Last Available: "2013-02"
 Item	hamlet sandwich	Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 50
+Item	hand-crafted candy cane	Last Available: "2020-12"
 Item	hardboiled egg	Effect: "Too Noir For Snoir", Effect Duration: 50, Last Available: "2016-07"
 Item	haunted cherry pie	Effect: "Haunted Stomach", Effect Duration: 20, Last Available: "2018-11"
 Item	haunted Hell ramen	Effect: "Haunted Stomach", Effect Duration: 20, Last Available: "2018-11"
@@ -9501,39 +9650,58 @@ Item	haunted orange	Effect: "Haunted Stomach", Effect Duration: 20, Last Availab
 Item	haunted pizza	Effect: "Haunted Stomach", Effect Duration: 20, Last Available: "2018-11"
 Item	heart-shaped candy whetstone	Effect: "Sharpened Sweet Tooth", Effect Duration: 40, Last Available: "2018-02"
 Item	herb brownies	Effect: "Confused", Effect Duration: 5
+Item	hibiscus petal	Last Available: "2019-04"
 Item	Hide-rox&trade; cookie	Effect: "Broken Bone Nubs", Effect Duration: 30, Last Available: "2017-10"
+Item	high-calorie sugar substitute	Last Available: "2013-11"
 Item	hippy herbal tea	Effect: "Sleepy", Effect Duration: 5
 Item	holiday cheese log	Effect: "Stands Alone", Effect Duration: 20, Last Available: "2011-01"
+Item	holiday smorgasbord	Last Available: "2024-12"
 Item	honey bun of Boris	Effect: "Motherly Loved", Effect Duration: 30, Last Available: "2022-11"
 Item	honey-dew	Effect: "Mmmmmelon", Effect Duration: 10, Last Available: "2007-06"
 Item	hot hi mein	Effect: "Hot Breath", Effect Duration: 5
+Item	huge Crimbo cookie	Last Available: "2023-06"
+Item	humble pie	Last Available: "2014-12"
+Item	Humpty Dumplings	Last Available: "2010-03"
 Item	hushed puppy	Effect: "Noise Cancelled", Effect Duration: 100, Last Available: "2017-12"
 Item	ice cream sandwich	Effect: "Cold Throat", Effect Duration: 20, Last Available: "2014-12"
 Item	ice harvest	Effect: "Icy Demeanor", Effect Duration: 30, Last Available: "2014-01"
+Item	ice rice	Last Available: "2016-01"
 Item	iceberg lettuce	Effect: "Headstrong", Effect Duration: 50, Last Available: "2015-11"
+Item	igloo pie	Last Available: "2010-10"
 Item	initiative shawarma	Effect: "Shawarma Initiative", Effect Duration: 30, Last Available: "2014-10"
 Item	irradiated candy cane	Effect: "Festive Radiation", Effect Duration: 10, Last Available: "2008-12"
 Item	Jarlsberg's vegetable soup	Effect: "Souped Up", Effect Duration: 30, Last Available: "2022-11"
 Item	java cookie	Effect: "Updated", Effect Duration: 10, Last Available: "2014-12"
 Item	jawbruiser	Effect: "Sugar Rush", Effect Duration: 5, Last Available: "2010-12"
+Item	jerky coins	Last Available: "2011-11"
 Item	jive turkey leg	Effect: "Hollow Inside", Effect Duration: 50
 Item	jumping horseradish	Effect: "Kicked in the Sinuses", Effect Duration: 50, Last Available: "2016-03"
 Item	jungle floor wax	Effect: "Wax On Your Shoes", Effect Duration: 20
 Item	junkyard dog	Effect: "Dog Breath", Effect Duration: 30
+Item	karma shawarma	Last Available: "2014-10"
 Item	king cookie	Effect: "The Royal We", Effect Duration: 30, Last Available: "2010-03"
 Item	knight cookie	Effect: "Knightlife", Effect Duration: 30, Last Available: "2010-03"
 Item	knuckle sandwich	Effect: "Cruisin' for a Bruisin'", Effect Duration: 20, Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 # Kudzu salad
+Item	Kudzu salad	Last Available: "2016-12"
 Item	lab-grown meat	Effect: "Real Meat Craving", Effect Duration: 20, Last Available: "2021-12"
+Item	laser-broiled pear	Last Available: "2007-12"
 Item	lava cake	Effect: "Demonic Flavor", Effect Duration: 60, Last Available: "2015-08"
+Item	leftover canap&eacute;s	Last Available: "2014-12"
+Item	leftovers	Last Available: "2016-11"
+Item	leftovers sandwich	Last Available: "2016-11"
 # licorice garrote: Weakens enemies based on how sugared-up you are
 Item	licorice garrote	Effect: "Sugar Rush", Effect Duration: 5, Last Available: "2009-12"
 Item	lihc eye pie	Effect: "Eye of the Lihc", Effect Duration: 5
 Item	limp broccoli	Effect: "Nutrient-Rich", Effect Duration: 100, Last Available: "2014-10"
 Item	liquid bread	Effect: "Comprehensively Nourished", Effect Duration: 20, Last Available: "2013-09"
+Item	liver and let pie	Last Available: "2010-10"
+Item	loaf of alien bread	Last Available: "2014-05"
 Item	loaf of soda bread	Effect: "Bread Burps", Effect Duration: 15
+Item	Lobster <i>qua</i> Grill	Last Available: "2010-03"
 Item	Ludovico Pastaco	Effect: "Tremella Tremens", Effect Duration: 40, Last Available: "2014-05"
 # magical baguette: You can make stuff out of it
+Item	magical sausage	Last Available: "2019-01"
 Item	mana-basted tofurkey leg	Effect: "Mana-Blasted", Effect Duration: 20, Last Available: "2019-11"
 Item	mana-coated yams	Effect: "Mana-Blasted", Effect Duration: 20, Last Available: "2019-11"
 Item	mana-fortified cranberry sauce	Effect: "Mana-Blasted", Effect Duration: 20, Last Available: "2019-11"
@@ -9541,94 +9709,185 @@ Item	mana-stuffed herbal stuffing	Effect: "Mana-Blasted", Effect Duration: 20, L
 Item	maple syrup	Effect: "Antsy in your Pantsy", Effect Duration: 5
 Item	mashed potatoes	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
 Item	Mayam spinach	Effect: "Pop-eyed", Effect Duration: 50, Last Available: "2024-05"
+Item	meatball	Last Available: "2021-12"
 Item	Medical Pastaco	Effect: "Helvella Health", Effect Duration: 40, Last Available: "2014-05"
 Item	meteoreo	Effect: "Superioreo", Effect Duration: 40, Last Available: "2017-08"
+Item	mime army rations	Last Available: "2017-12"
 Item	mince pie	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
+Item	mineapple	Last Available: "2015-08"
+Item	mini kiwi	Last Available: "2024-06"
 Item	Miserable Pie	Effect: "Smithsness Dinner", Effect Duration: 50, Last Available: "2013-12"
+Item	mole mol&eacute;	Last Available: "2008-06"
+Item	Moon Pie	Last Available: "2011-06"
 Item	moosemeat pie	Effect: "Moose-Warmed Belly", Effect Duration: 50, Last Available: "2018-12"
+Item	mouth-watering mayolus	Last Available: "2015-05"
 # Mr. Burnsger: Reduces your Drunkenness by 2
+Item	Mr. Burnsger	Last Available: "2016-12"
 Item	muffled muffuletta	Effect: "Noise Cancelled", Effect Duration: 100, Last Available: "2017-12"
+Item	mulberry	Last Available: "2014-12"
+Item	mushroom filet	Last Available: "2020-03"
 Item	nachos of the night	Effect: "Night of the Nachos", Effect Duration: 20, Last Available: "2014-12"
 Item	nanite-infested candy cane	Effect: "Chock Full o' Nanites", Effect Duration: 20, Last Available: "2020-09"
 Item	nanite-infested fruitcake	Effect: "Chock Full o' Nanites", Effect Duration: 20, Last Available: "2007-12"
 Item	nanite-infested gingerbread bugbear	Effect: "Chock Full o' Nanites", Effect Duration: 20, Last Available: "2007-12"
 Item	natto pocky	Effect: "Ninja, Please", Effect Duration: 30, Last Available: "2011-03"
 Item	nega-mushroom	Effect: "Negavision", Effect Duration: 50, Last Available: "2017-12"
+Item	neutron lollipop	Last Available: "2014-12"
 Item	nut-shaped Crimbo cookie	Effect: "Nut-Rition", Effect Duration: 20, Last Available: "2023-06"
 Item	occult jelly donut	Effect: "Filled with Magic", Effect Duration: 30, Last Available: "2011-09"
 # ojo de pez burrito: NOTE: This item will stop working when Crimbo 2019 is over.
 # ojo de pez burrito: Effect: "Fish-Eye View", Effect Duration: 50
+Item	ojo de pez burrito	Last Available: "2019-12"
 Item	old chum	Effect: "Fishy", Effect Duration: 5, Last Available: "2013-12"
+Item	oldcake	Last Available: "2018-12"
 Item	one with everything	Effect: "Inner Dog", Effect Duration: 50
 Item	packet of beer nuts	Effect: "Salty Mouth", Effect Duration: 1
+Item	party platter for one	Last Available: "2018-09"
+Item	pat of butter	Last Available: "2013-11"
 Item	pawn cookie	Effect: "Pwnd", Effect Duration: 30, Last Available: "2010-06"
+Item	PB&J with the crusts cut off	Last Available: "2018-09"
+Item	peaza	Last Available: "2024-11"
 Item	pecan pie	Effect: "Pecan Pied Piper", Effect Duration: 30, Last Available: "2014-12"
+Item	penguin focaccia bread	Last Available: "2009-12"
 Item	peppermint donut	Effect: "Peppermint Rush", Effect Duration: 10
+Item	peppermint patty	Last Available: "2011-11"
+Item	peppermint tack	Last Available: "2023-12"
 Item	Pete's rich ricotta	Effect: "Rippin' Ricotta", Effect Duration: 30, Last Available: "2022-11"
 Item	Pete's wiley whey bar	Effect: "Awfully Wily", Effect Duration: 30, Last Available: "2022-11"
 Item	petit 4.1	Effect: "Petit Force", Effect Duration: 20, Last Available: "2013-12"
 Item	petit fortran	Effect: "Petit Forbearance", Effect Duration: 10, Last Available: "2014-12"
+Item	phish stick	Last Available: "2011-09"
+Item	pickled bread	Last Available: "2023-12"
+Item	piece of cake	Last Available: "2024-11"
+Item	pineapple slab	Last Available: "2019-04"
+Item	piping organ pie	Last Available: "2010-10"
 # pirate fork: Only one may be consumed per day<p><center><b><font color=blue>Usable once each day to steal some food!
+Item	pirate fork	Last Available: "2019-04"
 Item	pixel banana	Effect: "Going Ape", Effect Duration: 40, Last Available: "2015-06"
 Item	pixel bread	Effect: "Desandwiched", Effect Duration: 5
+Item	pixel lemon	Last Available: "2015-06"
 Item	Pizza of Legend	Effect: "Endless Drool", Effect Duration: 100, Last Available: "2022-11"
 Item	plain calzone	Effect: "Angering Pizza Purists", Effect Duration: 50, Last Available: "2022-11"
+Item	plain candy cane	Last Available: "2021-12"
+Item	plate of franks and beans	Last Available: "2011-12"
+Item	plate of Frigid Northern Beans	Last Available: "2016-02"
+Item	plate of Heimz Fortified Kidney Beans	Last Available: "2016-02"
+Item	plate of Hellfire Spicy Beans	Last Available: "2016-02"
+Item	plate of Mixed Garbanzos and Chickpeas	Last Available: "2016-02"
+Item	plate of Pork 'n' Pork 'n' Pork 'n' Beans	Last Available: "2016-02"
+Item	plate of Shrub's Premium Baked Beans	Last Available: "2016-02"
+Item	plate of Tesla's Electroplated Beans	Last Available: "2016-02"
+Item	plate of Trader Olaf's Exotic Stinkbeans	Last Available: "2016-02"
+Item	plate of Val-U Brand Every Bean Salad	Last Available: "2016-02"
+Item	plate of World's Blackest-Eyed Peas	Last Available: "2016-02"
 Item	plumber's lunch	Effect: "Egg Burps", Effect Duration: 20, Last Available: "2014-12"
 Item	poisonous caviar	Effect: "Majorly Poisoned", Effect Duration: 50, Last Available: "2010-09"
+Item	popcorn	Last Available: "2011-04"
 Item	powdered donut	Effect: "Powdered", Effect Duration: 5, Last Available: "2010-03"
+Item	primitive alien salad	Last Available: "2017-04"
+Item	primitive candy cane	Last Available: "2018-12"
 Item	protein paste	Effect: "Pasty", Effect Duration: 10, Last Available: "2009-06"
+Item	pumpkin pie	Last Available: "2010-11"
+Item	quantum taco	Last Available: "2010-10"
 Item	queen cookie	Effect: "Towering Strength", Last Available: "2010-03"
 Item	rack of dinosaur ribs	Effect: "Meat the Flintstones", Effect Duration: 30
+Item	raisin	Last Available: "2010-04"
 Item	ratatouille de Jarlsberg	Effect: "parfum d'herbes", Effect Duration: 30, Last Available: "2022-11"
+Item	raw bread	Last Available: "2016-11"
+Item	raw cranberry sauce	Last Available: "2016-11"
+Item	raw gravy	Last Available: "2016-11"
+Item	raw green beans	Last Available: "2016-11"
+Item	raw mincemeat	Last Available: "2016-11"
+Item	raw potato	Last Available: "2016-11"
+Item	raw stuffing	Last Available: "2016-11"
+Item	raw sweet potato	Last Available: "2016-11"
+Item	raw turkey	Last Available: "2016-11"
 Item	red drunki-bear	Effect: "Gummiheart", Effect Duration: 80, Last Available: "2011-11"
+Item	ridiculous sandwich	Last Available: "2011-11"
+Item	roasted duck	Last Available: "2013-12"
 Item	roasted marshmallow	Effect: "Mallowed Out", Effect Duration: 3
 Item	roasted vegetable focaccia	Effect: "Feeling Fancy", Effect Duration: 50, Last Available: "2022-11"
 Item	roasted vegetable of Jarlsberg	Effect: "Wizard Sight", Effect Duration: 30, Last Available: "2022-11"
+Item	robin flan	Last Available: "2016-12"
 Item	rocky road ice cream	Effect: "A Contender", Effect Duration: 40, Last Available: "2009-09"
 Item	rook cookie	Effect: "Towering Strength", Effect Duration: 30, Last Available: "2010-03"
+Item	room scale green bean casserole	Last Available: "2024-12"
 Item	rotting beefsteak	Effect: "Cowrruption", Effect Duration: 30, Last Available: "2016-02"
 Item	rum-soaked fruitcake	Effect: "Rum of Darkness", Effect Duration: 100, Last Available: "2023-12"
+Item	S.T.L.T.	Last Available: "2007-06"
+Item	s'more	Last Available: "2011-04"
+Item	salmagumdi	Last Available: "2024-12"
+Item	salt plum	Last Available: "2019-12"
+Item	salted mutton	Last Available: "2023-12"
 Item	sausage without a cause	Effect: "East of Eaten", Effect Duration: 1
 Item	savage macho dog	Effect: "Macho, Macho Dog", Effect Duration: 50
 Item	sea truffle	Effect: "Trufflin'", Effect Duration: 10, Last Available: "2017-01"
+Item	shadow bread	Last Available: "2023-03"
 Item	shadow candy	Effect: "Nothing Really Matters", Effect Duration: 10
 Item	shadow flame	Effect: "Inflamed With Shadows", Effect Duration: 100, Last Available: "2023-03"
+Item	shadow sausage	Last Available: "2023-03"
 Item	shadowy cat claw	Effect: "Feline Ferocity", Effect Duration: 30, Last Available: "2011-09"
 Item	shoo-fish pie	Effect: "Fishy", Effect Duration: 20, Last Available: "2010-10"
 Item	shrapnel jelly donut	Effect: "Filled with Magic", Effect Duration: 30, Last Available: "2011-09"
 Item	shushed potatoes	Effect: "Noise Cancelled", Effect Duration: 100, Last Available: "2017-12"
+Item	skeleton quiche	Last Available: "2012-10"
 Item	skull-shaped Crimboween cookie	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 Item	Skully's hot chocolate	Effect: "Skull Full of Hot Chocolate", Effect Duration: 10
 Item	sleazy hi mein	Effect: "Sleazy Breath", Effect Duration: 5
+Item	slice of pizza	Last Available: "2013-02"
 Item	slick fish meat	Effect: "Fishy", Effect Duration: 5
 Item	slimy sweetbreads	Effect: "Grimace", Effect Duration: 20
 Item	sly dog	Effect: "Top Dog", Effect Duration: 50
 Item	smashed danish	Effect: "Danish Cunning", Effect Duration: 30, Last Available: "2011-09"
 Item	smelted roe	Effect: "Sizzling with Fury", Effect Duration: 50, Last Available: "2015-08"
+Item	SMOOCH soda	Last Available: "2015-08"
 Item	snow berries	Effect: "Berry Berry Cold", Effect Duration: 30, Last Available: "2014-01"
+Item	snow crab	Last Available: "2014-01"
+Item	space jam toast	Last Available: "2011-01"
 Item	spaghetti con calaveras	Effect: "Eso S&iacute; Que Es", Effect Duration: 10, Last Available: "2011-04"
+Item	Spaghetti with Moonballs	Last Available: "2011-06"
+Item	spiritual candy cane	Last Available: "2016-12"
+Item	spiritual fruitcake	Last Available: "2016-12"
+Item	spiritual gingerbread	Last Available: "2016-12"
+Item	spooky frank	Last Available: "2011-12"
 Item	spooky hi mein	Effect: "Spooky Breath", Effect Duration: 5
 Item	square CRIMBCOOKIE	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 Item	squirmy violent party snack	Effect: "Broken Dancing", Effect Duration: 10, Last Available: "2010-04"
 Item	St. Pete's sneaky smoothie	Effect: "Gritty Soul", Effect Duration: 30, Last Available: "2022-11"
+Item	stale Cheer-E-Os	Last Available: "2017-12"
+Item	star pop	Last Available: "2021-12"
 Item	stinky hi mein	Effect: "Stinky Breath", Effect Duration: 5
+Item	stomach turnover	Last Available: "2010-10"
 Item	Strix stix	Effect: "Sugar-Frosted Pet Guts", Effect Duration: 40
+Item	stuffed red and green pepper (stale)	Last Available: "2020-12"
 Item	sugarplum ration	Effect: "Sugarplum Visions", Effect Duration: 50, Last Available: "2023-12"
 Item	sun-dried tofu	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+Item	sundae ration	Last Available: "2023-12"
+Item	super good fruit	Last Available: "2023-02"
 Item	Swedish massage fish	Effect: "Like a Fish to Walter", Effect Duration: 40, Last Available: "2018-02"
+Item	sweet party mix	Last Available: "2018-09"
 Item	sweet roll Alabama	Effect: "Helping Comes Second", Effect Duration: 30
+Item	Taco Dan's Basic Taco Dan Taco	Last Available: "2014-05"
+Item	Taco Dan's Taco Fish Fish Taco	Last Available: "2014-05"
 Item	Taco Dan's Taco Stand Taco	Effect: "Meaty and Cheesy", Effect Duration: 10, Last Available: "2012-12"
 Item	tainted milk	Effect: "Cowrruption", Effect Duration: 30, Last Available: "2016-02"
 Item	tea for one	Effect: "One For Tea", Effect Duration: 40
+Item	Tea, Earl Grey, Hot	Last Available: "2016-09"
 Item	temperance whiskey	Effect: "Old Time Hydration", Effect Duration: 100, Last Available: "2017-11"
 Item	tempura broccoli	Effect: "Down With Chow", Effect Duration: 20
 Item	tempura cauliflower	Effect: "Low on the Hog", Effect Duration: 20
+Item	tempura green and red bean	Last Available: "2019-12"
+Item	Thanksgiving ration	Last Available: "2024-12"
 Item	thanksgiving turkey	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
 # The Plumber's mushroom stew: Reduces your Drunkenness by 1
+Item	The Plumber's mushroom stew	Last Available: "2016-12"
 Item	They liver popsicle	Effect: "You Liver", Effect Duration: 100, Last Available: "2014-09"
+Item	This Charming Flan	Last Available: "2013-12"
+Item	throbbing organ pie	Last Available: "2010-10"
 Item	thyme jelly donut	Last Available: "2011-09", Effect Duration: 5
 Item	Tiger-lily's milk	Effect: "Grrrrrrreat!", Effect Duration: 5, Last Available: "2010-03"
 Item	tin of submardines	Effect: "Appeteyes", Effect Duration: 50, Last Available: "2015-11", Wiki Name: "tin of submardines"
+Item	tiny frozen prehistoric meteorite jawbreaker	Last Available: "2010-04"
 # toast with cold jelly: Freezes your liver
 Item	toast with cold jelly	Effect: "Cold Jellied", Effect Duration: 25, Last Available: "2017-01"
 # toast with hot jelly: Lets you breathe on a monster
@@ -9642,72 +9901,118 @@ Item	toast with spooky jelly	Effect: "Spooky Jellied", Effect Duration: 25, Last
 Item	toast with stench jelly	Effect: "Stench Jellied", Effect Duration: 25, Last Available: "2017-01"
 Item	toasted brie	Effect: "Refined Palate", Effect Duration: 20, Last Available: "2011-09"
 Item	tobiko pocky	Effect: "Pisces in the Skyces", Effect Duration: 30, Last Available: "2011-03"
+Item	toe jam toast	Last Available: "2011-01"
 Item	tombstone-shaped Crimboween cookie	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 Item	toxo	Effect: "Radiated and Grodiated", Effect Duration: 40, Last Available: "2015-04"
 Item	traditional Crimbo cookie	Effect: "Yeast-Hungry", Effect Duration: 75, Last Available: "2023-06"
+Item	traffic jam toast	Last Available: "2011-01"
 Item	transparent nog	Effect: "Holiday Disappointment", Effect Duration: 10, Last Available: "2017-12"
 Item	tree-shaped Crimbo cookie	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 Item	triangular CRIMBCOOKIE	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 Item	turtle soup	Effect: "[598]A Little Bit Evil", Effect Duration: 10
 Item	ultrafondue	Effect: "Fondid", Effect Duration: 30, Last Available: "2011-09"
+Item	unappetizing mayolus	Last Available: "2015-05"
 Item	unfortunate dumplings	Effect: "Really Quite Poisoned", Effect Duration: 20
 Item	unidentifiable dried fruit	Effect: "Fruited", Effect Duration: 50
+Item	uninteresting mayolus	Last Available: "2015-05"
 Item	Ur-Donut	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2011-09"
+Item	vanilla-frosted king cake	Last Available: "2008-03"
 Item	very hot lunch	Effect: "Inner Warmth", Effect Duration: 100, Last Available: "2015-08"
 Item	video games hot dog	Effect: "Video Game Hot Dog", Effect Duration: 50
+Item	void burger	Last Available: "2022-12"
+Item	VYKEA meatballs	Last Available: "2015-11"
+Item	walrus ice cream	Last Available: "2010-03"
 Item	warbear feasting bread	Effect: "Gift of the Warbear", Effect Duration: 40, Last Available: "2013-12"
+Item	warbear gyro	Last Available: "2013-12"
 Item	warbear thermoregulator bread	Effect: "Superheated Guts", Effect Duration: 40, Last Available: "2013-12"
 Item	warbear warrior bread	Effect: "Warriors, Come out to Playyyy", Effect Duration: 40, Last Available: "2013-12"
 Item	warm gravy	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
 Item	warm war shawarma	Effect: "Shawarma Warm War", Effect Duration: 30, Last Available: "2014-10"
 Item	wasabi pocky	Effect: "Wasabi With You", Effect Duration: 30, Last Available: "2011-03"
+Item	water log	Last Available: "2015-09"
 Item	wax pancake	Effect: "Waxing", Effect Duration: 30, Last Available: "2017-01"
+Item	wedge of gray cheese	Last Available: "2008-11"
 Item	weird gazelle steak	Effect: "Gaze of the Gazelle", Effect Duration: 1
 Item	wet dog	Effect: "Hangdog", Effect Duration: 30
+Item	wet tack	Last Available: "2023-12"
+Item	whalecake	Last Available: "2023-12"
+Item	whalesteak	Last Available: "2023-12"
 Item	wheel of camembert	Effect: "Burning Mouth", Effect Duration: 30, Last Available: "2024-09"
+Item	whirled peas	Last Available: "2024-11"
+Item	whole roasted chicken	Last Available: "2013-02"
 # whole turkey leg: Selling Price: <b>1 Meat.</b><p><center><b><font color=blue>Deals <font color=blueviolet>Sleaze Damage</font> based on your Moxie when used as a combat item
+Item	whole turkey leg	Last Available: "2013-11"
 Item	wild honey pie	Effect: "Sugar Rush", Effect Duration: 10
 Item	witch's bread	Effect: "Witch Breaded", Effect Duration: 20, Last Available: "2014-12"
 Item	wreath-shaped Crimbo cookie	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+Item	Xiblaxian ultraburrito	Last Available: "2014-09"
+Item	yam	Last Available: "2024-05"
+Item	yam and swiss	Last Available: "2024-05"
+Item	yam burrito	Last Available: "2024-05"
+Item	yam mayo	Last Available: "2024-05"
+Item	yam slider	Last Available: "2024-05"
+Item	Yeg's Motel pillow mint	Last Available: "2020-09"
 Item	yellow drunki-bear	Effect: "Gummiskin", Effect Duration: 80, Last Available: "2011-11"
+Item	yellow matter custard	Last Available: "2010-03"
+Item	yule gruel	Last Available: "2018-12"
 
 # Booze section of modifiers.txt
 
 Item	1950 Vampire Vintner wine	Effect Duration: 10
+Item	Acqua Del Piatto Merlot	Last Available: "2004-10"
+Item	Acque Luride Grezze Cabernet	Last Available: "2004-10"
+Item	Afternoon Delight	Last Available: "2015-04"
 Item	Agitated Turkey	Effect: "Turkey-Agitated", Effect Duration: 25, Last Available: "2014-11"
 Item	Alewife&trade; Ale	Effect: "Brined Liver", Effect Duration: 5
 Item	Ambitious Turkey	Effect: "Turkey-Ambitious", Effect Duration: 25, Last Available: "2014-11"
 Item	Amnesiac Ale	Effect: "All Is Forgiven", Effect Duration: 30, Last Available: "2014-10"
 Item	an evil little sump'm sump'm	Effect: "[601]A Little Bit Evil", Effect Duration: 10
+Item	antique beer	Last Available: "2018-12"
 Item	artisanal limoncello	Effect: "Sugar Rush", Effect Duration: 30
 Item	asbestos thermos	Effect: "Inner Warmth", Effect Duration: 100, Last Available: "2015-08"
 Item	Aura Libre	Effect: "Transcendental Wind", Effect Duration: 15, Last Available: "2012-03"
+Item	AutumnFest ale	Last Available: "2022-10"
 Item	Aye Aye	Effect: "Arresistible", Effect Duration: 5, Last Available: "2012-03"
 Item	Aye Aye, Captain	Effect: "Arresistible", Effect Duration: 10, Last Available: "2012-03"
 Item	Aye Aye, Tooth Tooth	Effect: "Arresistible", Effect Duration: 15, Last Available: "2012-03"
+Item	bad rum and good cola	Effect: "Faerie Fortune", Effect Duration: 30, Last Available: "2018-04"
 # *** KoL bug: bad rum and good cola grants Faerie Fortune, no item grants Fanatical Fortune.
 # *** Bug reported and acknowledged. bad rum and good cola DOES give Fanatical Fortune, but
 # *** the description is wrong for unknown reasons. Maybe the description will eventually be fixed..
 Item	bad rum and good cola	Effect: "Fanatical Fortune", Effect Duration: 30
 Item	bark rootbeer	Effect: "Bark of the Dog", Effect Duration: 40, Last Available: "2015-12"
+Item	barrel-aged eggnog	Last Available: "2020-12"
 Item	barrel-aged martini	Effect: "Just Aged Enough", Effect Duration: 50, Last Available: "2015-09"
 Item	Bartles and BRAAAINS wine cooler	Effect: "Braaaains Over Braaaawwn", Effect Duration: 30, Last Available: "2011-10"
+Item	Barulio's bottle	Last Available: "2012-12"
+Item	basic martini	Last Available: "2017-06"
+Item	beaver punch (cherry)	Last Available: "2018-12"
+Item	beaver punch (papaya)	Last Available: "2018-12"
+Item	beaver punch (peach)	Last Available: "2018-12"
+Item	beavermouth	Last Available: "2018-12"
 Item	Bee's Knees	Effect: "On the Trolley", Effect Duration: 25, Last Available: "2014-07"
 Item	Beignet Milgranet	Effect: "Sugar Rush", Effect Duration: 100, Last Available: "2011-09"
 Item	berry-infused sake	Effect: "Warm Belly", Effect Duration: 1
 Item	black brandy	Effect: "The Power of Negative Thinking", Effect Duration: 100, Last Available: "2016-12"
+Item	Black Hole	Last Available: "2012-03"
 Item	blood and blood	Effect: "Bloodthirsty", Effect Duration: 30, Last Available: "2015-10"
 Item	Blood Light	Effect: "Bloody-minded", Effect Duration: 30, Last Available: "2011-10"
 Item	blood-red mushroom wine	Effect: "Helvella Health", Effect Duration: 80, Last Available: "2014-05"
 Item	bloody kiwitini	Effect: "First Blood Kiwi", Effect Duration: 10
 Item	Bloody Nora	Effect: "Fishtacular Vernacular", Effect Duration: 40, Last Available: "2017-03"
+Item	bodyslam	Last Available: "2004-12"
+Item	bone aperitif	Last Available: "2010-10"
 Item	Bone's Farm &quot;wine&quot;	Effect: "Sticks and Stones", Effect Duration: 30, Last Available: "2011-10"
+Item	boot flask	Last Available: "2019-12"
 Item	Bordeaux Marteaux	Effect: "Hammered", Effect Duration: 20, Last Available: "2011-09"
 Item	Boris's beer	Effect: "Beery Cool", Effect Duration: 30, Last Available: "2022-11"
 Item	bottle of Amontillado	Effect: "Bricked-In", Effect Duration: 100, Last Available: "2015-09"
 Item	bottle of Bloodweiser	Effect: "Blood Porter", Effect Duration: 50
 Item	bottle of Cabernet Sauvignon	Effect: "Cabernet Hunter", Effect Duration: 30
+Item	bottle of Crimbognac	Last Available: "2018-12"
+Item	bottle of dark rhum	Last Available: "2019-04"
 Item	bottle of Evermore	Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 30
+Item	bottle of extra-dark rhum	Last Available: "2019-04"
 Item	bottle of Fishhead 900-Day IPA	Effect: "A Real Head for Fish", Effect Duration: 50, Last Available: "2016-04"
 Item	bottle of Greedy Dog	Effect: "Covetin' Drunk", Effect Duration: 20, Last Available: "2013-09"
 Item	bottle of Lambada Lambic	Effect: "Dancin' Drunk", Effect Duration: 20, Last Available: "2013-09"
@@ -9720,15 +10025,25 @@ Item	bottle of Professor Beer	Effect: "Thinkin' Drunk", Effect Duration: 20, Las
 Item	bottle of Race Car Red	Effect: "Flyin' Drunk", Effect Duration: 20, Last Available: "2013-09"
 Item	bottle of Rapier Witbier	Effect: "Jokin' Drunk", Effect Duration: 20, Last Available: "2013-09"
 Item	bottle of realpagne	Effect: "The Real Deal", Effect Duration: 10, Last Available: "2007-06"
+Item	bottle of sea wine	Last Available: "2019-07"
 Item	bottle of sewage schnapps	Effect: "Majorly Poisoned", Effect Duration: 20
+Item	bottle of super-extra-dark rhum	Last Available: "2019-04"
+Item	bottle of wine	Last Available: "2013-02"
 Item	Boulevardier cocktail	Effect: "Ready to Roll", Effect Duration: 40, Last Available: "2020-12"
+Item	breaded beer	Last Available: "2011-03"
 Item	broberry brogurt	Effect: "Broberry Brotality", Effect Duration: 40, Last Available: "2014-05"
 Item	brocolate brogurt	Effect: "Brocolate Brostidigitation", Effect Duration: 40, Last Available: "2014-05"
+Item	bucket of wine	Last Available: "2011-09"
 Item	Bustle Hustler	Effect: "Bustle Hustlin'", Effect Duration: 40, Last Available: "2018-02"
 Item	Buttery Boy	Effect: "Buttery, Boy", Effect Duration: 20, Last Available: "2020-05"
 Item	Buttery Knob	Effect: "Gutterminded", Effect Duration: 5, Last Available: "2012-03"
 Item	buzzing mushroom wine	Effect: "Stemonitis Storm", Effect Duration: 80, Last Available: "2014-05"
+Item	cabooze	Last Available: "2022-12"
 Item	Caipiranha	Effect: "Fishy", Effect Duration: 5, Last Available: "2012-03"
+Item	calle de miel with a fly in it	Last Available: "2006-04"
+Item	can of Br&uuml;talbr&auml;u	Last Available: "2013-09"
+Item	can of Drooling Monk	Last Available: "2013-09"
+Item	can of Impetuous Scofflaw	Last Available: "2013-09"
 Item	Candicaine	Effect: "Holiday Bliss", Effect Duration: 15, Last Available: "2012-03"
 Item	Candy Alexander	Effect: "Holiday Bliss", Effect Duration: 10, Last Available: "2012-03"
 Item	canteen of eggnog	Effect: "All Liquored Up For War", Effect Duration: 100, Last Available: "2023-12"
@@ -9740,24 +10055,40 @@ Item	Centauri fish wine	Effect: "Fishy", Effect Duration: 60, Last Available: "2
 Item	Chakra Libre	Effect: "Transcendental Wind", Effect Duration: 10, Last Available: "2012-03"
 Item	chakra-mental wine	Effect: "The Power of Positive Thinking", Effect Duration: 50, Last Available: "2016-12"
 Item	Charleston Choo-Choo	Effect: "Speakin' Easy", Effect Duration: 30
+Item	cheap Chinese beer	Last Available: "2013-12"
+Item	cherry bomb	Last Available: "2004-12"
 Item	chocotini	Effect: "High Blood Chocolate Content", Effect Duration: 30, Last Available: "2014-12"
 Item	Churchill	Effect: "Big Ol' Glass of Rum", Effect Duration: 40, Last Available: "2017-03"
 Item	Cinco Mayo Lager	Effect: "Cinco Elementos", Effect Duration: 5, Last Available: "2010-05"
 Item	citrus-infused sake	Effect: "Warm Belly", Effect Duration: 1
+Item	clear Russian	Last Available: "2021-12"
 Item	Cobra Bowl	Effect: "Tiki Temerity", Effect Duration: 40, Last Available: "2019-04"
 Item	complex mushroom wine	Effect: "Omphalotus Omnipresence", Effect Duration: 80, Last Available: "2014-05"
+Item	cranberry margarita (brackish)	Last Available: "2020-12"
 Item	cranberry schnapps	Effect: "Cranberry Cordiality", Effect Duration: 10, Last Available: "2011-03"
 Item	Crazymaker	Effect: "Void Between the Stars", Effect Duration: 15, Last Available: "2012-03"
+Item	CRIMBCO wine	Last Available: "2011-01"
+Item	Crimbojito	Last Available: "2011-12"
+Item	Crimbosmopolitan	Last Available: "2022-12"
+Item	Crimbow Rainbo	Last Available: "2023-12"
+Item	Crimbuccaneer mologrog cocktail	Last Available: "2023-12"
 Item	cruelty-free wine	Effect: "Compensatory Cruelness", Effect Duration: 5
 Item	crystal skeleton vodka	Effect: "Aykrophobia", Effect Duration: 20, Last Available: "2012-10"
+Item	CSA cheerfulness ration	Last Available: "2012-07"
+Item	CSA scoutmaster's &quot;water&quot;	Last Available: "2012-07"
+Item	cup of &quot;tea&quot;	Last Available: "2014-07"
 Item	cursed bottle of black-label rum	Effect: "Curse Magnet", Effect Duration: 10
 Item	cybeer	Effect: "Connected", Effect Duration: 40, Last Available: "2025-12"
+Item	Dad's brandy	Last Available: "2022-06"
+Item	Dark & Starry	Last Available: "2012-03"
 Item	dew yoana lei	Effect: "Brined Liver", Effect Duration: 20
 Item	dew yoana salacious lei	Effect: "Brined Liver", Effect Duration: 30
 Item	Dinsey Whinskey	Effect: "The Dinsey Spirit", Effect Duration: 30, Last Available: "2015-04"
 Item	dirt julep	Effect: "Here's Some More Mud in Your Eye", Effect Duration: 40, Last Available: "2017-03"
+Item	dirty martini	Last Available: "2004-12"
 Item	discocktail	Effect: "Disco Neuropathy", Effect Duration: 30
 # Doc Clock's thyme cocktail: Reduces your Fullness by 2
+Item	Doc Clock's thyme cocktail	Last Available: "2016-12"
 Item	Doc's Fortifying Wine	Effect: "Medically Fortified", Effect Duration: 40, Last Available: "2021-12"
 Item	Doc's Limbering Wine	Effect: "Medically Loosened", Effect Duration: 40, Last Available: "2021-12"
 Item	Doc's Medical-Grade Wine	Effect: "Fixed Up", Effect Duration: 40, Last Available: "2021-12"
@@ -9781,6 +10112,7 @@ Item	dusty bottle of Pinot Noir	Effect: "Kiss of the Black Fairy", Effect Durati
 Item	dusty bottle of Port	Effect: "Full of Vinegar", Effect Duration: 10
 Item	Earth and Firewater	Effect: "Elemental Mastery", Effect Duration: 10, Last Available: "2012-03"
 Item	Earth, Wind and Firewater	Effect: "Elemental Mastery", Effect Duration: 15, Last Available: "2012-03"
+Item	Easter eggnog	Last Available: "2024-12"
 Item	Easter grasshopper	Effect: "Resurrection of the Flesh", Effect Duration: 20, Last Available: "2024-12"
 Item	Ecto-Cooler	Effect: "Booing Radly", Effect Duration: 30, Last Available: "2011-10"
 Item	eighth plague	Effect: "Wings of the Dragonfly", Effect Duration: 40, Last Available: "2017-03"
@@ -9791,48 +10123,74 @@ Item	electric snakebite	Effect: "Once Bitten Twice Fried", Effect Duration: 20
 Item	elemental caipiroska	Effect: "Magically Delicious", Effect Duration: 40, Last Available: "2017-03"
 Item	elven cellocello	Effect: "Sugar Rush", Effect Duration: 20, Last Available: "2009-12"
 Item	elven moonshine	Effect: "Drunk With Power", Effect Duration: 20, Last Available: "2008-12"
+Item	elven squeeze	Last Available: "2011-06"
 Item	emergency margarita	Effect: "Margamergency", Effect Duration: 1
 Item	En Una Fila Tequila	Effect: "Mr. Skullhead's Birthday Happiness", Effect Duration: 20
+Item	Event Horizon	Last Available: "2012-03"
+Item	everfull glass	Last Available: "2018-09"
 Item	evil ducha de oro	Effect: "[601]A Little Bit Evil", Effect Duration: 10
 Item	evil horizontal tango	Effect: "[601]A Little Bit Evil", Effect Duration: 10
 Item	evil roll in the hay	Effect: "[601]A Little Bit Evil", Effect Duration: 10
 Item	executive mime flask	Effect: "Executive Greed", Effect Duration: 50, Last Available: "2017-12"
+Item	expensive champagne	Last Available: "2014-12"
 Item	expired bottle of peppermint schnapps	Effect: "Crimbo Nostalgia", Effect Duration: 30, Last Available: "2009-12"
 Item	Extra-slimy Slimosa	Effect: "In the Slimelight", Effect Duration: 10, Last Available: "2012-03"
 Item	extremely slippery nipple	Effect: "Slippery Tongue", Effect Duration: 40, Last Available: "2017-03"
 Item	Falcon&trade; Maltese Liquor	Effect: "Too Noir For Snoir", Effect Duration: 50, Last Available: "2016-07"
 Item	Fantasma en la M&aacute;quina	Effect: "Sangre Brillante", Effect Duration: 13
+Item	FantasyRealm mead	Last Available: "2018-04"
 Item	Fauna Libre	Effect: "Transcendental Wind", Effect Duration: 5, Last Available: "2012-03"
 Item	Feliz Navidad	Effect: "Wassailing You", Effect Duration: 40, Last Available: "2017-03"
+Item	Ferita Del Petto Zinfandel	Last Available: "2006-12"
 Item	firemilk	Effect: "Cowrruption", Effect Duration: 30, Last Available: "2016-02"
 Item	Firewater	Effect: "Elemental Mastery", Effect Duration: 5, Last Available: "2012-03"
+Item	fishelada	Last Available: "2019-12"
 Item	Flaming Caipiranha	Effect: "Fishy", Effect Duration: 15, Last Available: "2012-03"
 Item	Flaming Knob	Effect: "Gutterminded", Effect Duration: 15, Last Available: "2012-03"
 Item	Flaming Mohobo	Effect: "Mo' Hobo", Effect Duration: 15, Last Available: "2012-03"
 Item	Flaming Sazerorc	Effect: "Orc Chops", Effect Duration: 15, Last Available: "2012-03"
+Item	flask of Amontillado	Last Available: "2007-06"
 Item	flask of egggrog	Effect: "Grogged For Battle", Effect Duration: 100, Last Available: "2023-12"
+Item	flask of moonshine	Last Available: "2020-09"
+Item	flask of peppermint schnapps	Last Available: "2006-12"
 Item	flat cider	Effect: "Fruited", Effect Duration: 100
+Item	Flivver	Last Available: "2014-07"
 Item	Flying Caipiranha	Effect: "Fishy", Effect Duration: 10, Last Available: "2012-03"
 Item	French bronilla brogurt	Effect: "French Bronilla Brogueishness", Effect Duration: 40, Last Available: "2014-05"
 Item	Friendly Turkey	Effect: "Turkey-Friendly", Effect Duration: 25, Last Available: "2014-11"
 Item	Fromage Pinotage	Effect: "Some Cheese with Your Wine", Effect Duration: 20, Last Available: "2011-09"
 Item	Fuzzy Tentacle	Effect: "Void Between the Stars", Effect Duration: 10, Last Available: "2012-03"
+Item	gamma nog	Last Available: "2014-12"
 Item	Ghiaccio Colada	Effect: "On the Rocks", Effect Duration: 20, Last Available: "2020-05"
 Item	ghost beer	Damage Reduction: 11, Effect: "Booooooze", Effect Duration: 50
+Item	giant glass of brandy	Last Available: "2011-12"
+Item	Gin Mint	Last Available: "2011-12"
+Item	ginger beer	Last Available: "2016-12"
 Item	gingerbread wine	Effect: "Sprinkle in Your Eye", Effect Duration: 30, Last Available: "2016-12"
+Item	glass of &quot;milk&quot;	Last Available: "2014-07"
 # glass of drippy wine: Puts 5 &micro;g of Drippy Juice into your blood
 Item	glass of herbal tequila	Effect: "Herbal Pert", Effect Duration: 50
 Item	gloomy mushroom wine	Effect: "Gothy", Effect Duration: 20
 Item	Gnollish sangria	Effect: "Strength of the Gnoll", Effect Duration: 40, Last Available: "2017-03"
 Item	Gnomish sagngria	Effect: "Stregngth of the Gnome", Effect Duration: 40, Last Available: "2017-03"
+Item	Go-Wassail	Last Available: "2011-11"
+Item	Gold Velvet&trade; whiskey	Last Available: "2015-08"
 Item	Golden Mean	Effect: "World's Shortest Giant", Effect Duration: 10, Last Available: "2012-03"
 Item	Grasshopper	Effect: "Cockroach Scurry", Effect Duration: 5, Last Available: "2012-03"
+Item	Gratitude chocolate (bourbon-filled)	Last Available: "2016-02"
 Item	great old fashioned	Effect: "Creepin' Up on You", Effect Duration: 40, Last Available: "2017-03"
 Item	Great Older Fashioned	Effect: "Void Between the Stars", Effect Duration: 5, Last Available: "2012-03"
+Item	Green Burlap	Last Available: "2012-03"
 Item	green eggnog	Effect: "Just the Best Anapests", Effect Duration: 50, Last Available: "2012-12"
 Item	Green Giant	Effect: "World's Shortest Giant", Effect Duration: 15, Last Available: "2012-03"
 Item	Green Manalishi	Effect: "The Two-Prong Crown", Effect Duration: 30
+Item	Green Muslin	Last Available: "2012-03"
+Item	Green Velvet	Last Available: "2012-03"
+Item	Grimacite Bock	Last Available: "2008-11"
+Item	grogtini	Last Available: "2004-12"
 Item	gunner's daughter	Effect: "Kissed the Gunner's Daughter", Effect Duration: 40, Last Available: "2017-03"
+Item	hacked gibson	Last Available: "2016-06"
+Item	hard cocoa	Last Available: "2024-12"
 Item	haunted bottle of vodka	Effect: "Haunted Liver", Effect Duration: 20, Last Available: "2018-11"
 Item	haunted eggnog	Effect: "Haunted Liver", Effect Duration: 20, Last Available: "2018-11"
 Item	haunted gimlet	Effect: "Haunted Liver", Effect Duration: 20, Last Available: "2018-11"
@@ -9846,13 +10204,19 @@ Item	Herringtini	Effect: "Fishy", Effect Duration: 15, Last Available: "2012-03"
 Item	high-end ginger wine	Effect: "High-Falutin'", Effect Duration: 30, Last Available: "2016-12"
 Item	Highest Bitter	Effect: "Mercenary", Effect Duration: 60, Last Available: "2014-10"
 Item	hipster cocktail	Effect: "Artisanal Satiaton", Effect Duration: 10
+Item	holiday trip around the world	Last Available: "2024-12"
 Item	honey mead	Effect: "Sugar Rush", Effect Duration: 5
 Item	hot mint schnocolate	Effect: "Alpine Mintiness", Effect Duration: 25, Last Available: "2015-01"
 Item	Hot Socks	Effect: "[1701]Hip to the Jive", Effect Duration: 50, Last Available: "2014-07"
+Item	hot watered rum	Last Available: "2018-12"
 Item	hot wine	Effect: "In a Stealin' Mood", Effect Duration: 50, Last Available: "2023-12"
+Item	Humanitini	Last Available: "2012-03"
 Item	Hundred Headed IPA	Effect: "Hoppyness", Effect Duration: 20, Last Available: "2013-12"
+Item	Ice Island Long Tea	Last Available: "2014-01"
 Item	ice porter	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 Item	ice wine	Effect: "Brain Freeze", Effect Duration: 50, Last Available: "2015-11"
+Item	iced plum wine	Last Available: "2016-01"
+Item	improved martini	Last Available: "2017-06"
 Item	Irish Coffee, English Heart	Effect: "Smithsness Cheer", Effect Duration: 100, Last Available: "2013-12"
 Item	Irish eggnog	Effect: "Green-Blooded", Effect Duration: 20, Last Available: "2024-12"
 Item	Ish Kabibble	Effect: "Feeling No Pain", Effect Duration: 25, Last Available: "2014-07"
@@ -9862,9 +10226,11 @@ Item	Island Thunderstorm	Effect: "Tiki Thoughtfulness", Effect Duration: 20, Las
 Item	Jack-O-Lantern beer	Effect: "Toothy Grin", Effect Duration: 30, Last Available: "2015-10"
 Item	Jackhammer	Effect: "Mortarfied", Effect Duration: 10, Last Available: "2012-03"
 Item	Jamaican coffee	Effect: "Jamaican' Me Acquisitive", Effect Duration: 50, Last Available: "2023-12"
+Item	Jeppson's Malort	Last Available: "2011-06"
 Item	jug of booze	Effect: "Booze Goozles", Effect Duration: 30, Last Available: "2017-10"
 Item	Jungle Juice	Effect: "Jungle Juiced", Effect Duration: 30, Last Available: "2014-10"
 Item	La Fantasma y La Oscuridad	Effect: "La Oscuridad Adentro", Effect Duration: 13
+Item	large tankard of ale	Last Available: "2014-12"
 Item	lavawater	Effect: "Sizzling with Fury", Effect Duration: 50, Last Available: "2015-08"
 Item	Lemonade-235	Effect: "Radiated and Grodiated", Effect Duration: 40, Last Available: "2015-04"
 Item	literal grasshopper	Effect: "Wings of the Grasshopper", Effect Duration: 40, Last Available: "2017-03"
@@ -9872,29 +10238,47 @@ Item	Locust	Effect: "Cockroach Scurry", Effect Duration: 10, Last Available: "20
 Item	Lollipop Drop	Effect: "Holiday Bliss", Effect Duration: 5, Last Available: "2012-03"
 Item	London frog	Effect: "Slime Time", Effect Duration: 40, Last Available: "2017-03"
 Item	low tide martini	Effect: "Floundering", Effect Duration: 40, Last Available: "2017-03"
+Item	Lucky Lindy	Last Available: "2014-07"
 Item	Lumineux Limnio	Effect: "Bright!", Effect Duration: 50, Last Available: "2011-09"
 Item	lychee chuhai	Effect: "Brined Liver", Effect Duration: 20
+Item	magnum of fancy champagne	Last Available: "2014-12"
+Item	Maiali Sifilitici Pinot Noir	Last Available: "2004-10"
+Item	marshmallow bomb	Last Available: "2021-03"
 Item	marshmallow flamb&eacute;	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2011-03"
+Item	martiny	Last Available: "2019-12"
 Item	McLeod's Hard Haggis-Ade	Effect: "Hagg-ard", Effect Duration: 20, Last Available: "2012-12"
 Item	meadeorite	Effect: "Meadulla Oblongota", Effect Duration: 40, Last Available: "2017-08"
 Item	mechanically-mulled cider	Effect: "Eyesies on the Pressies", Effect Duration: 20, Last Available: "2024-12"
 Item	melon-infused sake	Effect: "Warm Belly", Effect Duration: 1
 Item	mentholated wine	Effect: "Christmessy", Effect Duration: 20, Last Available: "2017-03"
+Item	mid-level medieval mead	Last Available: "2014-12"
+Item	Middle of the Road&trade; brand whiskey	Last Available: "2018-09"
+Item	mime army wine	Last Available: "2017-12"
 Item	mini kiwitini	Effect: "Green Peace", Effect Duration: 15, Last Available: "2024-06"
 Item	mini-martini	Effect: "It's Not Even Funny", Effect Duration: 11
+Item	Mint Yulep	Last Available: "2011-12"
+Item	Miss Graves' vermouth	Last Available: "2016-12"
+Item	missing wine	Last Available: "2010-03"
 Item	Mohobo	Effect: "Mo' Hobo", Effect Duration: 5, Last Available: "2012-03"
 Item	Moonshine Mohobo	Effect: "Mo' Hobo", Effect Duration: 10, Last Available: "2012-03"
+Item	Moonthril Schnapps	Last Available: "2011-06"
+Item	More Humanitini than Humanitini	Last Available: "2012-03"
 Item	moreltini	Effect: "Truffle Tango", Effect Duration: 40, Last Available: "2017-03"
+Item	Morlock's Mark Bourbon	Last Available: "2008-06"
 Item	morning dew	Effect: "Granolarrrgh", Effect Duration: 40, Last Available: "2017-03"
 Item	Morto Moreto	Effect: "Majorly Poisoned", Effect Duration: 100, Last Available: "2011-09"
+Item	mourning wine	Last Available: "2018-04"
 Item	mulled berry wine	Effect: "Sweet Nostalgia", Effect Duration: 30, Last Available: "2014-12"
+Item	mulled cider	Last Available: "2009-10"
 Item	mulled hobo wine	Effect: "Burnt 'n' Turnt", Effect Duration: 20, Last Available: "2018-12"
 Item	mulled wine	Effect: "Mullin' for Bullion", Effect Duration: 50, Last Available: "2023-12"
 Item	Murderer's Punch	Effect: "Punchy, Murdery", Effect Duration: 40
 Item	Muschat	Effect: "L'instinct F&eacute;lin", Effect Duration: 20, Last Available: "2011-09"
+Item	mushroom whiskey	Last Available: "2020-03"
 Item	Mysterious Island iced tea	Effect: "Orcmouth", Effect Duration: 40, Last Available: "2017-03"
 Item	nanite-infested eggnog	Effect: "Chock Full o' Nanites", Effect Duration: 20, Last Available: "2007-12"
 Item	natto-infused sake	Effect: "Ninja, Please", Effect Duration: 30, Last Available: "2011-03"
+Item	neg grog	Last Available: "2017-12"
 Item	nega-mushroom wine	Effect: "Double Negavision", Effect Duration: 50, Last Available: "2017-12"
 Item	New Zealand iced tea	Effect: "New Zeal", Effect Duration: 20
 Item	Newark	Effect: "Hobo Powering Up!", Effect Duration: 40, Last Available: "2017-03"
@@ -9902,42 +10286,83 @@ Item	nice warm beer	Effect: "Cracked Open a Warm One", Effect Duration: 30
 Item	Nog-on-the-Cob	Effect: "Sulfurous Sinuses", Effect Duration: 20, Last Available: "2020-05"
 Item	non-aged vinegar	Effect: "Sour Grapes", Effect Duration: 40
 Item	nothingtini	Effect: "Nothing Happened", Effect Duration: 40, Last Available: "2017-03"
+Item	officer's nog	Last Available: "2023-12"
+Item	Oh, the Humanitini	Last Available: "2012-03"
+Item	old-school pirate grog	Last Available: "2023-12"
+Item	Oopsie IPA	Last Available: "2022-10"
 Item	oozenog	Effect: "Festive Radiation", Effect Duration: 10, Last Available: "2008-12"
 Item	Oreille Divis&eacute;e brandy	Effect: "Hoity Toity", Effect Duration: 20
 Item	overpowering mushroom wine	Effect: "Boletus Swoletus", Effect Duration: 80, Last Available: "2014-05"
+Item	Paint A Vulgar Pitcher	Last Available: "2013-12"
+Item	party beer bomb	Last Available: "2018-09"
+Item	peasco sour	Last Available: "2024-11"
+Item	pebblebr&auml;u	Last Available: "2009-09"
+Item	perfect cosmopolitan	Last Available: "2015-11"
+Item	perfect dark and stormy	Last Available: "2015-11"
+Item	perfect mimosa	Last Available: "2015-11"
+Item	perfect negroni	Last Available: "2015-11"
+Item	perfect old-fashioned	Last Available: "2015-11"
+Item	perfect paloma	Last Available: "2015-11"
+Item	perpendicular hula with a fly in it	Last Available: "2006-04"
 Item	Phil Collins	Effect: "Hello, I Must Be Going", Effect Duration: 40, Last Available: "2017-03"
 Item	Phlegethon	Effect: "Flambé-a-thon", Effect Duration: 40, Last Available: "2017-03"
+Item	Phonus Balonus	Last Available: "2014-07"
 Item	piscatini	Effect: "You Drank Fish Wine", Effect Duration: 40, Last Available: "2017-03"
 Item	pixel beer	Effect: "Analog Drunk", Effect Duration: 40, Last Available: "2015-06"
+Item	pixel daiquiri	Last Available: "2015-06"
 Item	pixel whiskey	Effect: "Wall Rage", Effect Duration: 5
 Item	Plague of Locusts	Effect: "Cockroach Scurry", Effect Duration: 15, Last Available: "2012-03"
 # plastic cup of beer: Deals 30-40 <font color=blueviolet>Sleaze Damage</font>
+Item	plastic cup of beer	Last Available: "2010-06"
 # primitive alien booze: Extends the duration of up to 10 of your effects by 5 Adventures
+Item	primitive alien booze	Last Available: "2017-04"
+Item	pumpkin beer	Last Available: "2010-11"
 Item	punch-drunk punch	Effect: "Boxing Day Drinking", Effect Duration: 50, Last Available: "2018-12"
 Item	Punchplanter	Effect: "Fishy", Effect Duration: 5, Last Available: "2012-03"
 Item	Quaatorade&trade;	Effect: "Quaaaaaaa", Effect Duration: 100, Last Available: "2015-08"
 Item	R'lyeh	Effect: "The Effect Man Was Not Meant to Have", Effect Duration: 40, Last Available: "2017-03"
+Item	Racisto Ruidoso	Last Available: "2017-11"
 Item	red ale	Effect: "Putting the Pro in Proletariat", Effect Duration: 40, Last Available: "2015-12"
+Item	red and white claret	Last Available: "2023-12"
 Item	Red Dwarf	Effect: "World's Shortest Giant", Effect Duration: 5, Last Available: "2012-03"
+Item	red white and blue claret	Last Available: "2023-12"
 Item	red-hot boilermaker	Effect: "Boilermade", Effect Duration: 50
+Item	regular-size brogurt	Last Available: "2014-05"
 Item	reverse Tantalus	Effect: "It Is So Hot In Your Guts, So So Hot", Effect Duration: 40, Last Available: "2017-03"
+Item	ridiculous cocktail	Last Available: "2011-11"
+Item	robin nog	Last Available: "2016-12"
+Item	rocket fuel	Last Available: "2014-05"
+Item	rockin' wagon with a fly in it	Last Available: "2006-04"
 Item	Rompedores de Fantasmas	Effect: "Desenfantasmada", Effect Duration: 13
+Item	runny fermented egg	Last Available: "2018-12"
 # Russian Ice: Weakens enemies somewhat when used as a combat item
+Item	Russian Ice	Last Available: "2011-04"
 Item	Sacramento wine	Effect: "Sacr&eacute; Mental", Effect Duration: 50
+Item	Sacramento wine	Effect: "Sacré Mental", Effect Duration: 50, Last Available: "2016-03"
+Item	Saison du Lune	Last Available: "2011-06"
 Item	salacious lychee chuhai	Effect: "Brined Liver", Effect Duration: 30
 Item	salacious screwdiver	Effect: "Brined Liver", Effect Duration: 30
 Item	salinated mint julep	Effect: "Brined Liver", Effect Duration: 10
 Item	salt plum sake	Effect: "Warm Belly", Effect Duration: 1, Last Available: "2019-12"
+Item	Sangria de Menthe	Last Available: "2011-12"
+Item	sangria del diablo	Last Available: "2004-12"
 Item	Sazerorc	Effect: "Orc Chops", Effect Duration: 5, Last Available: "2012-03"
 Item	Sazuruk-hai	Effect: "Orc Chops", Effect Duration: 10, Last Available: "2012-03"
+Item	Schr&ouml;dinger's thermos	Last Available: "2010-04"
 Item	Scorpion Bowl	Effect: "Tiki Toughness", Effect Duration: 40, Last Available: "2019-04"
 Item	scotch on the rocks	Effect: "Hair on Your Chest", Effect Duration: 30
 Item	screwdiver	Effect: "Brined Liver", Effect Duration: 20
+Item	Sexy Cosmo	Last Available: "2023-06"
+Item	shadow fluid	Last Available: "2023-03"
+Item	shadow venom	Last Available: "2023-03"
 Item	sham champagne	Effect: "Shamboozled", Effect Duration: 10, Last Available: "2009-06"
+Item	shining goblet	Last Available: "2013-02"
 Item	shot of flower schnapps	Effect: "Flower Power", Effect Duration: 3
+Item	Shot of Kardashian Gin	Last Available: "2016-09"
 Item	shot of mescal	Effect: "Brainworm", Effect Duration: 50
 Item	shot of nepenthe schnapps	Effect: "Memento Moir&eacute;", Effect Duration: 10, Last Available: "2007-06"
 Item	Shot of the Living Dead	Effect: "Creepypasted", Effect Duration: 15, Last Available: "2012-03"
+Item	shot of wasp venom	Last Available: "2023-02"
 Item	shroomtini	Effect: "Mushroom Samba", Effect Duration: 40, Last Available: "2017-03"
 Item	Siberian sunrise	Effect: "Sugar, Hello", Effect Duration: 40, Last Available: "2017-03"
 Item	Silver Bullet beer	Effect: "Wolf's Bane", Effect Duration: 30, Last Available: "2011-10"
@@ -9945,12 +10370,14 @@ Item	Simepore slime	Effect: "The Secret of the Ooze", Effect Duration: 40, Last 
 Item	single entendre	Effect: "Pounded by the Actual Stars", Effect Duration: 40, Last Available: "2017-03"
 Item	Sizzling Sinner	Effect: "Heart Aflame", Effect Duration: 15, Last Available: "2012-03"
 Item	Skull Punch	Effect: "Tiki Toughness", Effect Duration: 30, Last Available: "2019-04"
+Item	slap and tickle with a fly in it	Last Available: "2006-04"
 Item	Slimebite	Effect: "In the Slimelight", Effect Duration: 15, Last Available: "2012-03"
 Item	Slimosa	Effect: "In the Slimelight", Effect Duration: 5, Last Available: "2012-03"
 Item	slimy fermented bile bladder	Effect: "Bilious", Effect Duration: 20
 Item	Slippery Knob	Effect: "Gutterminded", Effect Duration: 10, Last Available: "2012-03"
 Item	Sloe Comfortable Zoo	Effect: "Rampage!", Effect Duration: 10, Last Available: "2012-03"
 Item	Sloe Comfortable Zoo on Fire	Effect: "Rampage!", Effect Duration: 15, Last Available: "2012-03"
+Item	Sloppy Jalopy	Last Available: "2014-07"
 Item	slug of rum	Effect: "Brined Liver", Effect Duration: 10
 Item	slug of shochu	Effect: "Brined Liver", Effect Duration: 10
 Item	slug of vodka	Effect: "Brined Liver", Effect Duration: 10
@@ -9960,43 +10387,73 @@ Item	snakebite	Effect: "Sweet Tooth", Effect Duration: 30, Last Available: "2014
 Item	Sockdollager	Effect: "In a Lather", Effect Duration: 25, Last Available: "2014-07"
 Item	soilzerac	Effect: "Here's Mud in Your Eye", Effect Duration: 40, Last Available: "2017-03"
 Item	Sourfinger	Effect: "Touched", Effect Duration: 20, Last Available: "2020-05"
+Item	Southern yam	Last Available: "2024-05"
 Item	soy cordial	Effect: "Electrolyte Fantastic", Effect Duration: 2, Last Available: "2011-03"
 Item	soyburger juice	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+Item	space port	Last Available: "2014-05"
+Item	Spasmi Dolorosi Del Rene Champagne	Last Available: "2004-10"
+Item	spiritual eggnog	Last Available: "2016-12"
+Item	splendid martini	Last Available: "2017-06"
+Item	spooky eggnog	Last Available: "2006-12"
+Item	stale cheer wine	Last Available: "2017-12"
+Item	stealth bomber	Last Available: "2014-05"
 Item	Steamboat	Effect: "Steamed", Effect Duration: 20, Last Available: "2020-05"
 Item	Strikes Again Bigmouth	Effect: "Smithsness Cheer", Effect Duration: 50, Last Available: "2013-12"
 Item	Strong, Silent Type	Effect: "Speakin' Even Easier", Effect Duration: 30
 Item	Suffering Sinner	Effect: "Heart Aflame", Effect Duration: 5, Last Available: "2012-03"
+Item	super-size brogurt	Last Available: "2014-05"
 Item	Suppurating Sinner	Effect: "Heart Aflame", Effect Duration: 10, Last Available: "2012-03"
 Item	Swedish coffee	Effect: "Swedish Courage", Effect Duration: 50, Last Available: "2023-12"
+Item	sweet potato o' mine	Last Available: "2024-05"
+Item	sweet potato punch	Last Available: "2024-05"
 Item	swirling mushroom wine	Effect: "Tremella Tremens", Effect Duration: 80, Last Available: "2014-05"
 Item	Taco Dan's Taco Stand Chimichangarita	Effect: "Margaritish", Effect Duration: 10, Last Available: "2012-12"
+Item	tankard of ale	Last Available: "2013-02"
+Item	tankard of spiced Goldschlepper	Last Available: "2024-12"
+Item	tankard of spiced rum	Last Available: "2024-12"
 Item	Temps Tempranillo	Last Available: "2011-09", Effect Duration: 5
+Item	Tequiz Navidad	Last Available: "2011-12"
 Item	The Cooler Out of Space	Effect: "You Can Taste the Darkness", Effect Duration: 30, Last Available: "2011-10"
 # The Mad Liquor: Reduces your Fullness by 1
+Item	The Mad Liquor	Last Available: "2016-12"
+Item	thermos of &quot;whiskey&quot;	Last Available: "2014-07"
 Item	Third Base	Effect: "Third Based", Effect Duration: 40, Last Available: "2018-02"
 Item	tobiko-infused sake	Effect: "Pisces in the Skyces", Effect Duration: 30, Last Available: "2011-03"
 Item	Transylvania Sling	Effect: "Creepypasted", Effect Duration: 10, Last Available: "2012-03"
+Item	TRIO cup of beer	Last Available: "2018-09"
 Item	turchucken	Effect: "Grateful, But Spelled With a Dollar Sign", Effect Duration: 20, Last Available: "2024-12"
 Item	Turtle Bowl	Effect: "Tiki Thoughtfulness", Effect Duration: 40, Last Available: "2019-04"
 Item	twice-haunted screwdriver	Effect: "Haunted Liver", Effect Duration: 40, Last Available: "2018-11"
 Item	unfinished fruitcake	Effect: "Holiday Disappointment", Effect Duration: 10, Last Available: "2017-12"
 Item	unquiet spirits	Effect: "Hollow Inside", Effect Duration: 50
+Item	Uovo Marcio Shiraz	Last Available: "2004-10"
+Item	vesper	Last Available: "2004-12"
 Item	vintage smart drink	Effect: "Smart Drunk", Effect Duration: 1
 Item	vodka barracuda	Effect: "Mer-kinkiness", Effect Duration: 40, Last Available: "2017-03"
+Item	Vodka Matryoshka	Last Available: "2011-12"
 Item	vodka stinger	Effect: "Mer-kindliness", Effect Duration: 40, Last Available: "2017-03"
+Item	void lager	Last Available: "2022-12"
+Item	VYKEA mead	Last Available: "2015-11"
 Item	warbear bearserker mead	Effect: "Warbear Warlust", Effect Duration: 40, Last Available: "2013-12"
 Item	warbear blizzard mead	Effect: "Warbear Blubber", Effect Duration: 40, Last Available: "2013-12"
 Item	warbear feasting mead	Effect: "Warbear Loot Lust", Effect Duration: 40, Last Available: "2013-12"
 Item	wasabi-infused sake	Effect: "Wasabi With You", Effect Duration: 30, Last Available: "2011-03"
+Item	water purification pills	Last Available: "2012-07"
 Item	wax booze	Effect: "Waxing", Effect Duration: 30, Last Available: "2017-01"
 Item	whiskey in a broken glass	Effect: "Bloody Grin", Effect Duration: 50
 Item	whiskey squeeze	Effect: "Hobo Powers Activate!", Effect Duration: 20, Last Available: "2017-03"
 Item	white Canadian	Effect: "Canadianity", Effect Duration: 3
 Item	white Dreadsylvanian	Effect: "Whitesloshed", Effect Duration: 50
+Item	White Hyborian	Last Available: "2009-06"
 Item	white lightning	Effect: "Temporary Blindness", Effect Duration: 3
 Item	white Xanadian	Effect: "Flashing Eyes", Effect Duration: 10, Last Available: "2007-06"
 Item	world's most unappetizing beverage	Effect: "Literally Insane", Effect Duration: 10, Last Available: "2010-04"
+Item	Wrecked Generator	Last Available: "2011-06"
+Item	Xiblaxian space-whiskey	Last Available: "2014-09"
+Item	yam martini	Last Available: "2024-05"
+Item	yule grog	Last Available: "2023-12"
 Item	zmobie	Wiki Name: "Zmobie (drink)"
+Item	zombie	Last Available: "2015-10"
 Item	Zoodriver	Effect: "Rampage!", Effect Duration: 5, Last Available: "2012-03"
 
 # Spleen Toxins section of modifiers.txt
@@ -10005,20 +10462,28 @@ Item	a bug's lymph	Effect: "A Bug's Life", Effect Duration: 60, Last Available: 
 Item	abstraction: action	Effect: "Action", Effect Duration: 50, Last Available: "2015-12"
 Item	abstraction: category	Effect: "Category", Effect Duration: 50, Last Available: "2015-12"
 Item	abstraction: certainty	Effect: "Certainty", Effect Duration: 50, Last Available: "2015-12"
+Item	abstraction: comprehension	Last Available: "2015-12"
 Item	abstraction: joy	Effect: "Joy", Effect Duration: 50, Last Available: "2015-12"
 Item	abstraction: motion	Effect: "Motion", Effect Duration: 50, Last Available: "2015-12"
 Item	abstraction: perception	Effect: "Perception", Effect Duration: 50, Last Available: "2015-12"
 Item	abstraction: purpose	Effect: "Purpose", Effect Duration: 50, Last Available: "2015-12"
 Item	abstraction: sensation	Effect: "Sensation", Effect Duration: 50, Last Available: "2015-12"
 Item	abstraction: thought	Effect: "Thought", Effect Duration: 50, Last Available: "2015-12"
+Item	adobe assortment	Last Available: "2024-12"
+Item	aerosolized aerogel	Last Available: "2017-12"
+Item	agua de vida	Last Available: "2009-06"
 Item	alien animal goo	Last Available: "2017-04", Effect: "Celestial Body", Effect Duration: 40
 Item	alien plant goo	Effect: "Celestial Mind", Effect Duration: 40, Last Available: "2017-04"
+Item	alien protein powder	Last Available: "2014-05"
 Item	ancient medicinal herbs	Effect: "Ancient Fortitude", Effect Duration: 50, Last Available: "2016-01"
 # ancient pills: Restore 30-40 MP
+Item	antimatter wad	Last Available: "2013-12"
 Item	antique bottle of cough syrup	Effect: "The Q Is Talking To You", Effect Duration: 10
 Item	armored prawn	Effect: "Rushtacean'", Effect Duration: 50, Last Available: "2016-03"
 # astral energy drink: Gives you good luck
+Item	astronaut ice-cream	Last Available: "2006-05"
 Item	autumn breeze	Effect: "Delighted by Autumn", Effect Duration: 50, Last Available: "2022-10"
+Item	bakelite bits	Last Available: "2016-12"
 Item	beastly paste	Effect: "Beastly Flavor", Effect Duration: 10, Last Available: "2011-08"
 Item	beefy pill	Effect: "Beefy", Effect Duration: 30
 Item	beggin' cologne	Effect: "Eau d' Clochard", Effect Duration: 60, Last Available: "2019-12"
@@ -10029,21 +10494,32 @@ Item	black striped oyster egg	Effect: "Egg-stortionary Tactics", Effect Duration
 # blue polka-dot oyster egg: Restores 30-35 MP
 # blue striped oyster egg: Restores 30-35 MP
 Item	body spradium	Effect: "Boxing Day Glow", Effect Duration: 100, Last Available: "2018-12"
+Item	boot plant	Last Available: "2009-06"
 Item	bottle of extra-strength melodramamine	Effect: "Emotion Sickness", Effect Duration: 50
 Item	bottle of melodramamine	Effect: "Emotion Sickness", Effect Duration: 5
 Item	bottle of ultravitamins	Effect: "Vitamin-Maxed", Effect Duration: 10
+Item	Breathitin&trade;	Last Available: "2021-12"
 Item	brilliant oyster egg	Effect: "Eggstraordinary Brilliance", Effect Duration: 20
 Item	bug paste	Effect: "Buggy Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	can-can-in-a-can	Last Available: "2007-06"
 Item	carrot juice	Effect: "Pla-see-bo", Effect Duration: 10, Last Available: "2013-01"
+Item	ceramic scree	Last Available: "2023-12"
+Item	chalk chunks	Last Available: "2019-12"
+Item	chiffon carbage	Last Available: "2023-12"
 Item	chlorophyll paste	Effect: "Chlorophyll Flavor", Effect Duration: 10, Last Available: "2011-08"
 # clovermint: Gives you good luck
+Item	clovermint	Last Available: "2024-12"
+Item	coffee pixie stick	Last Available: "2010-06"
 # cold jelly: Freezes your liver
 Item	cold jelly	Effect: "Cold Jellied", Effect Duration: 50, Last Available: "2017-01"
 Item	cold wad	Effect: "Cold Blooded", Effect Duration: 20
 Item	concentrated cooking	Effect: "Cooking Concentrate", Effect Duration: 10
 Item	cosmic paste	Effect: "Cosmic Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	crepe paper pared cuttings	Last Available: "2025-12"
 Item	Crimbeau de toilette	Effect: "Crimbeau'd", Effect Duration: 50, Last Available: "2018-12"
 Item	Crimbo paste	Effect: "Crimbo Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	cuppa Activi tea	Last Available: "2015-09"
+Item	cuppa Cruel tea	Last Available: "2015-09"
 Item	cute mushroom	Effect: "Cute Vision", Effect Duration: 50, Last Available: "2015-09"
 Item	demonic paste	Effect: "Demonic Flavor", Effect Duration: 10, Last Available: "2011-08"
 # dieting pill: Eat less, Enjoy it More!
@@ -10054,11 +10530,17 @@ Item	elemental paste	Effect: "Elemental Flavor", Effect Duration: 10, Last Avail
 Item	energized spores	Effect: "Energized", Effect Duration: 40, Last Available: "2023-02"
 # excitement pill: Get an exciting random effect!
 Item	eXpand	Effect: "Cyber Memory Boost", Effect Duration: 30, Last Available: "2025-12"
+Item	Extrovermectin&trade;	Last Available: "2021-12"
+Item	fiberglass fibers	Last Available: "2018-12"
 Item	fish sauce	Effect: "Fishy", Effect Duration: 30, Last Available: "2019-12"
 Item	fishy paste	Effect: "Fishy", Effect Duration: 10, Last Available: "2011-08"
+Item	Five Second Energy&trade;	Last Available: "2014-12"
+Item	flagstone flagments	Last Available: "2022-12"
+Item	Fleshazole&trade;	Last Available: "2021-12"
 Item	fried air	Effect: "Well-Ventilated", Effect Duration: 30, Last Available: "2021-12"
 Item	fruity pebble	Effect: "All Rainbow-y", Effect Duration: 30, Last Available: "2023-01"
 # furry pill: Removes a Negative Effect<br />Restores 40-50 HP
+Item	gabardine smithereens	Last Available: "2018-12"
 Item	gaseous gravy	Effect: "Gettin' the Goods", Effect Duration: 50
 Item	gleaming oyster egg	Effect: "Gleam-Inducing", Effect Duration: 50
 Item	glimmering buzzard feather	Effect: "Carrion' On", Effect Duration: 20, Last Available: "2008-06"
@@ -10066,15 +10548,19 @@ Item	glimmering great tit feather	Effect: "The Great Tit's Blessing", Effect Dur
 Item	glimmering penguin feather	Effect: "Antarctic Memories", Effect Duration: 20, Last Available: "2008-06"
 Item	glimmering phoenix feather	Effect: "Phoenix, Right?", Effect Duration: 20, Last Available: "2008-06"
 Item	glimmering raven feather	Effect: "Melancholy Burden", Effect Duration: 20, Last Available: "2008-06"
+Item	glimmering roc feather	Last Available: "2008-06"
 Item	glistening oyster egg	Effect: "Eggstraordinary Style", Effect Duration: 20
 Item	glyph of athleticism	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 50, Last Available: "2017-10"
 Item	goblin paste	Effect: "Gobliny Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	gooey paste	Last Available: "2011-08"
 Item	greasy paste	Effect: "Greasy Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	grim fairy tale	Last Available: "2014-12"
 Item	groose grease	Effect: "Just the Best Anapests", Effect Duration: 50, Last Available: "2012-12"
 Item	handful of Smithereens	Effect: "Smithsness Presence", Effect Duration: 100, Last Available: "2013-12"
 Item	hardening cream	Effect: "Really Hard", Effect Duration: 50
 Item	hippy paste	Effect: "Hippy Flavor", Effect Duration: 10, Last Available: "2011-08"
 Item	hobo paste	Effect: "Hobo Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	Homebodyl&trade;	Last Available: "2021-12"
 Item	homeopathic mint tea	Effect: "Alpine Mintiness", Effect Duration: 50, Last Available: "2015-01"
 # hot jelly: Lets you breathe on a monster
 Item	hot jelly	Effect: "Hot Jellied", Effect Duration: 50, Last Available: "2017-01"
@@ -10088,65 +10574,95 @@ Item	Knob Goblin nasal spray	Effect: "Wasabi Sinuses", Effect Duration: 30
 Item	Knob Goblin pet-buffing spray	Effect: "Heavy Petting", Effect Duration: 30
 Item	liquid shifting time weirdness	Effect: "Liquid Luck", Effect Duration: 10
 Item	livid energy	Effect: "Lividly Energized", Effect Duration: 60, Last Available: "2019-12"
+Item	loofah lumps	Last Available: "2022-12"
+Item	LOV Echinacea Bouquet	Last Available: "2017-02"
 # lucky-ish pill: Lucky!
 Item	lustrous oyster egg	Effect: "Lustre After Wealth", Effect Duration: 50
 Item	magnificent oyster egg	Effect: "Eggstraordinary Strength", Effect Duration: 20
 Item	Mansquito Serum	Effect: "More Mansquito Than Man", Effect Duration: 400, Last Available: "2016-12"
+Item	marble molecules	Last Available: "2019-12"
+Item	Mariner's Friend cough drops	Last Available: "2007-06"
 # Medicinal Herb's medicinal herbs: Restores all HP
 Item	Mer-kin paste	Effect: "Mer-kinny Flavor", Effect Duration: 10, Last Available: "2011-08"
 Item	mime army superserum	Effect: "I'll Have the Soup", Effect Duration: 50, Last Available: "2017-12"
 Item	moomy dust	Effect: "Cowrruption", Effect Duration: 30, Last Available: "2016-02"
+Item	moss mulch	Last Available: "2024-12"
 Item	mushroom tea	Effect: "Mush-Maw", Effect Duration: 50, Last Available: "2020-03"
+Item	nasty snuff	Last Available: "2015-04"
 # Nightmare Fuel: Lets you uneasily rest for free
+Item	Nightmare Fuel	Last Available: "2018-06"
 Item	non-Euclidean angle	Effect: "Different Way of Seeing Things", Effect Duration: 30, Last Available: "2019-12"
+Item	not-a-pipe	Last Available: "2007-06"
+Item	octolus oculus	Last Available: "2015-11"
 Item	off-white paisley oyster egg	Effect: "Eggs-tra Sensory Perception", Effect Duration: 20
 Item	off-white polka-dot oyster egg	Effect: "Eggs-tra Sensory Perception", Effect Duration: 20
 Item	off-white striped oyster egg	Effect: "Eggs-tra Sensory Perception", Effect Duration: 20
 Item	oily paste	Effect: "Oily Flavor", Effect Duration: 10, Last Available: "2011-08"
 Item	orc paste	Effect: "Fratty Flavor", Effect Duration: 10, Last Available: "2011-08"
 Item	oversized ice molecule	Effect: "Icy Composition", Effect Duration: 50, Last Available: "2019-04"
+Item	paraffin pieces	Last Available: "2020-12"
 Item	party balloon	Effect: "Lifted Spirits", Effect Duration: 50, Last Available: "2018-09"
 Item	Party-in-a-Can&trade;	Effect: "Party on Your Skin", Effect Duration: 50, Last Available: "2018-09"
+Item	patent antipsychotics	Last Available: "2007-06"
 Item	pearlescent oyster egg	Effect: "Pearly Vision", Effect Duration: 50
 Item	penguin paste	Effect: "Penguinny Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	petrified wood waste parts	Last Available: "2025-12"
 Item	pewter shavings	Effect: "Pewtershot", Effect Duration: 100, Last Available: "2019-04"
 Item	pirate paste	Effect: "Piratey Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	polyesterene powder	Last Available: "2015-12"
 Item	pool shark hair oil	Effect: "Sharky", Effect Duration: 20
+Item	porcelain powder	Last Available: "2015-12"
+Item	powdered gold	Last Available: "2015-12"
 Item	powdered oxygen	Effect: "Hyperoxygenated Blood", Effect Duration: 10, Last Available: "2017-04"
 Item	prismatic wad	Effect: "Rainbow Bright", Effect Duration: 10, Last Available: "2008-07"
-Item	psilocyber mushroom	Effect: "Connected", Effect Duration: 80, Last Available: "2025-12"
 Item	prototype stimulant	Effect: "Proto-Stimulated", Effect Duration: 50, Last Available: "2019-12"
+Item	psilocyber mushroom	Effect: "Connected", Effect Duration: 80, Last Available: "2025-12"
+Item	Purple Beast energy drink	Last Available: "2018-09"
 # red paisley oyster egg: Restores 30-35 HP
 # red polka-dot oyster egg: Restores 30-35 HP
 # red striped oyster egg: Restores 30-35 HP
+Item	residual zeal	Last Available: "2014-09"
 Item	sachet of strange powder	Effect: "Powder Power", Effect Duration: 40, Last Available: "2018-04"
 Item	scintillating oyster egg	Effect: "Eggscitingly Colorful", Effect Duration: 20
 Item	sea jelly	Effect: "Fishy", Effect Duration: 10, Last Available: "2017-01"
+Item	shadow nectar	Last Available: "2023-03"
 Item	shadow pill	Effect: "Shadow Medicine", Effect Duration: 30
 Item	Shantix&trade;	Effect: "Thou Shant Not Sing", Effect Duration: 30, Last Available: "2019-12"
+Item	single atom	Last Available: "2015-02"
 # sleaze jelly: Enables Sleazy Bickering
 Item	sleaze jelly	Effect: "Sleazy Jellied", Effect Duration: 50, Last Available: "2017-01"
 Item	sleaze wad	Effect: "Supafly", Effect Duration: 20
 Item	slimy alveolus	Effect: "Slimebreath", Effect Duration: 50
 Item	slimy paste	Effect: "Slimy Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	SMOOCH coffee cup	Last Available: "2015-08"
 Item	sparkling orb	Effect: "Latently Energized", Effect Duration: 30
 # spooky jelly: Makes you emanate Spookily
 Item	spooky jelly	Effect: "Spooky Jellied", Effect Duration: 50, Last Available: "2017-01"
 Item	spooky wad	Effect: "Spooky Demeanor", Effect Duration: 20
+Item	stained glass shards	Last Available: "2021-12"
 # stench jelly: Makes monsters avoid you
 Item	stench jelly	Effect: "Stench Jellied", Effect Duration: 50, Last Available: "2017-01"
 Item	stench wad	Effect: "Stenchtastic", Effect Duration: 20
 Item	strange paste	Effect: "Weird Flavor", Effect Duration: 10, Last Available: "2011-08"
 Item	super-sweet fish goo (spoiled)	Effect: "Fishy", Effect Duration: 15, Last Available: "2019-12"
+Item	sweat-ade	Last Available: "2022-07"
 Item	Synapse Blaster	Effect: "Cyber Resist x2000", Effect Duration: 30, Last Available: "2025-12"
+Item	terra cotta tidbits	Last Available: "2020-12"
 Item	The Author's ink	Effect: "It's a Good Life!", Effect Duration: 200, Last Available: "2016-02"
 Item	The Inquisitor's unidentifiable object	Effect: "The Inquisitor's Unknown Effect", Effect Duration: 100, Last Available: "2016-12"
+Item	thermos of brew	Last Available: "2011-12"
+Item	transdermal smoke patch	Last Available: "2014-10"
 Item	tube of hair oil	Effect: "Got Your Boots On", Effect Duration: 10
+Item	turkey blaster	Last Available: "2016-11"
 Item	twinkly wad	Effect: "Aspect of the Twinklefairy", Effect Duration: 20
+Item	Unconscious Collective Dream Jar	Last Available: "2013-12"
+Item	velour veneer	Last Available: "2021-12"
 Item	vial of humanoid growth hormone	Effect: "HGH-charged", Effect Duration: 30, Last Available: "2019-12"
 Item	vibrating mushroom	Effect: "Weird Vibrations", Effect Duration: 30, Last Available: "2015-09"
 Item	vitamin G pill	Effect: "Riboflavin'", Effect Duration: 5
 Item	watered-down Red Minotaur	Effect: "Water Wings", Effect Duration: 5
+Item	wickerbits	Last Available: "2016-12"
+Item	wrought-iron flakes	Last Available: "2017-12"
 Item	yellow paisley oyster egg	Effect: "Egg-headedness", Effect Duration: 20
 Item	yellow polka-dot oyster egg	Effect: "Egg-cellent Vocabulary", Effect Duration: 20
 Item	yellow striped oyster egg	Effect: "Egg-stra Arm", Effect Duration: 20
@@ -10312,7 +10828,9 @@ Item	chiffon lemon	Effect: "Bulging Jaw Muscles", Effect Duration: 20
 Item	children of the candy corn	Effect: "Sugar Rush", Effect Duration: 5
 Item	chitin powder	Effect: "Chitin Powderful", Effect Duration: 10
 Item	chitin powder paste	Effect: "Pastey Power", Effect Duration: 30
+Item	choco-Crimbot	Last Available: "2014-12"
 Item	chocolate bath ball	Effect: "[800]Chocolate Reign", Effect Duration: 10, Last Available: "2011-01"
+Item	chocolate cigar	Last Available: "2010-12"
 Item	chocolate filthy lucre	Effect: "Gelded", Effect Duration: 10
 Item	chocolate-covered caviar	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2020-09"
 Item	chocolate-covered loofah	Effect: "Aloofah", Effect Duration: 20
@@ -10394,6 +10912,7 @@ Item	cuppa Serendipi tea	Effect: "Serendipi Tea", Effect Duration: 30, Last Avai
 # cuppa Sobrie tea: Reduces your Drunkenness by 1
 Item	cuppa Toast tea	Effect: "Toast Tea", Effect Duration: 30, Last Available: "2015-09"
 Item	cuppa Twen tea	Effect: "Twen Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Uncertain tea	Last Available: "2015-09"
 Item	cuppa Vitali tea	Effect: "Vitali Tea", Effect Duration: 30, Last Available: "2015-09"
 # cuppa Voraci tea: Increase your stomach capacity by 1
 Item	cuppa Wit tea	Effect: "Wit Tea", Effect Duration: 30, Last Available: "2015-09"
@@ -10512,6 +11031,9 @@ Item	Fabiotion	Effect: "Faboooo", Effect Duration: 20, Last Available: "2018-02"
 Item	fabric hardener	Effect: "Hardened Fabric", Effect Duration: 20
 Item	fake blood	Effect: "Bloody Bloody Bloody!", Effect Duration: 10
 Item	fake cocktail	Effect: "Liquor-ish", Effect Duration: 10, Last Available: "2016-12"
+Item	fancy but probably evil chocolate	Last Available: "2006-12"
+Item	fancy chocolate	Last Available: "2015-11"
+Item	fancy chocolate car	Last Available: "2009-12"
 Item	Ferrigno's Elixir of Power	Effect: "Incredibly Hulking", Effect Duration: [R]
 Item	fiberglass insulation	Effect: "Insulated", Effect Duration: 25
 Item	filled mosquito	Effect: "Wisdom of Others", Effect Duration: 20, Last Available: "2023-02"
@@ -10710,6 +11232,7 @@ Item	jug of &quot;wine&quot;	Effect: "Grape Expectations", Effect Duration: 40, 
 Item	jug of baconstone juice	Effect: "Baconstoned", Effect Duration: 50
 Item	jug of hamethyst juice	Effect: "Ham-Fisted", Effect Duration: 50
 Item	jug of porquoise juice	Effect: "Je Ne Sais Porquoise", Effect Duration: 50
+Item	Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	Last Available: "2010-04"
 Item	Knob Goblin love potion	Effect: "Knob Goblin Lust Frenzy", Effect Duration: 5
 Item	Knob Goblin perfume	Effect: "Knob Goblin Perfume", Effect Duration: 1
 Item	Knob Goblin sharpening spray	Effect: "Sharp Weapon", Effect Duration: 5
@@ -10736,6 +11259,7 @@ Item	liquid smoke	Effect: "Liquidy Smoky", Effect Duration: 15, Last Available: 
 # liquid SONAR: NOTE: This item will stop working when Crimbo 2019 is over.
 Item	liquid SONAR	Effect: "PING...  PING...  PING...", Effect Duration: 50, Last Available: "2019-12"
 Item	little red jam	Effect: "Hood Ridin'", Effect Duration: 20
+Item	llama lama gong	Last Available: "2008-06"
 Item	Lobos Mints	Effect: "Lobos Fresh", Effect Duration: 20, Last Available: "2011-10"
 Item	lotion of coldness	Effect: "Cold Hands", Effect Duration: [R+5]
 Item	lotion of hotness	Effect: "Hot Hands", Effect Duration: [R+5]
@@ -11008,6 +11532,7 @@ Item	resolution: be feistier	Effect: "Destructive Resolve", Effect Duration: 20,
 Item	resolution: be happier	Effect: "Joyful Resolve", Effect Duration: 20, Last Available: "2012-01"
 Item	resolution: be kinder	Effect: "Kindly Resolve", Effect Duration: 20, Last Available: "2012-01"
 Item	resolution: be luckier	Effect: "Fortunate Resolve", Effect Duration: 20, Last Available: "2012-01"
+Item	resolution: be more adventurous	Last Available: "2012-01"
 Item	resolution: be sexier	Effect: "Irresistible Resolve", Effect Duration: 20, Last Available: "2012-01"
 Item	resolution: be smarter	Effect: "Brilliant Resolve", Effect Duration: 20, Last Available: "2012-01"
 Item	resolution: be stronger	Effect: "Strong Resolve", Effect Duration: 20, Last Available: "2012-01"
@@ -11118,6 +11643,7 @@ Item	sugar cherry	Effect: "Sweet and Red", Effect Duration: 10, Last Available: 
 Item	Sugar Cog	Effect: "Sugar Rush", Effect Duration: 5
 Item	sugar fairy	Effect: "Dance of the Sugar Fairy", Effect Duration: 20, Last Available: "2014-05"
 Item	sugar lime	Effect: "Sweet and Green", Effect Duration: 10, Last Available: "2008-12"
+Item	sugar plum	Last Available: "2008-12"
 Item	sugar sphere	Effect: "Influence of Sphere", Effect Duration: 10
 Item	sugar-coated pine cone	Effect: "Sugar Rush", Effect Duration: 5, Last Available: "2020-09"
 Item	Super Weight-Gain 9000	Effect: "Superveiny 9000", Effect Duration: 10
@@ -11126,6 +11652,7 @@ Item	Superdrifter holo-record	Effect: "Superdrifting", Effect Duration: 10
 Item	superwater	Effect: "Ultrahydrated", Effect Duration: 50
 Item	Swabbie&trade; swab	Effect: "Well-Swabbed Ear", Effect Duration: 10
 Item	swamp lolly	Effect: "Sugar Rush", Effect Duration: 10
+Item	sweet mochi ball	Last Available: "2012-12"
 Item	Sweet Sword	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2011-10"
 Item	sweet-corn-flavored Mr. Mediocrebar	Effect: "Kernel Panic!", Effect Duration: 30, Last Available: "2012-12"
 Item	sweetened reindeer fat	Effect: "Sweetened and Fattened", Effect Duration: 20
@@ -11200,6 +11727,7 @@ Item	vial of squid ink	Effect: "Inky Camouflage", Effect Duration: 20
 Item	vial of The Glistening	Effect: "The Glistening", Effect Duration: 15
 Item	violent pastilles	Effect: "Everything Must Go!", Effect Duration: 10
 Item	virgin jello shot	Effect: "Sugar Rush", Effect Duration: 100
+Item	vitachoconutriment capsule	Last Available: "2007-12"
 Item	votive of confidence	Effect: "Confidence of the Votive", Effect Duration: 80, Last Available: "2021-08"
 Item	VYKEA woadpaint	Effect: "This Is Where You're a Viking", Effect Duration: 30, Last Available: "2015-11"
 Item	wad of cotton	Effect: "Cotton Mouthed", Effect Duration: 50
@@ -11450,14 +11978,24 @@ Item	zombie hollandaise	Effect: "Chef Brains-are-dee", Effect Duration: 30
 
 # Everything Else section of modifiers.txt
 
+Item	'Smuggler Shot First' Button	Last Available: "2009-06"
+Item	&quot;DEBBIE&quot; tattoo kit	Last Available: "2015-08"
+Item	&quot;KICK ME&quot; sign	Last Available: "2014-08"
+Item	0	Last Available: "2025-12"
+Item	1	Last Available: "2025-12"
+Item	1,970 carat gold	Last Available: "2015-08"
+Item	3d printed server room key	Last Available: "2025-12"
 # 4:20 bomb: Deals 400-500 Physical Damage
 # 4:20 bomb: (super effective against hippies)
 # 4-d camera: Makes a copy of a monster to fight later
+Item	4:20 bomb	Last Available: "2011-09"
 # 8-ball: Weakens enemies very slightly
 # 11-leaf clover: Gives you good luck
 # 334 scroll: Mostly Just Confuses Enemies
 # 668 scroll: Mostly Just Confuses Enemies
 # 1952 Mickey Mantle card: Super valuable!
+Item	1952 Mickey Mantle card	Last Available: "2015-07"
+Item	2002 Mr. Store Catalog	Last Available: "2023-06"
 # 30669 scroll: Mostly Just Confuses Enemies
 # 31337 scroll: Mostly Just Confuses Enemies
 # 33398 scroll: Mostly Just Confuses Enemies
@@ -11481,33 +12019,67 @@ Item	a cute angel	Free Pull, Last Available: "2011-12"
 Item	A Guide to Burning Leaves	Free Pull, Leaves: +0.5
 Item	A Guide to Safari	Skill: "Experience Safari"
 # a ten-percent bonus: Gain 1,000 points in each stat
+Item	A. W. O. L. commendation	Last Available: "2011-05"
+Item	absentee voter ballot	Last Available: "2018-11"
 # adder: Poisons your opponent
 Item	adventurer clone egg	Free Pull, Last Available: "2013-06"
+Item	Agent Mauve	Last Available: "2014-10"
 Item	Aggressive Carrot	Free Pull
+Item	Aiolion	Last Available: "2018-03"
 Item	airplane charter: Conspiracy Island	Free Pull, Last Available: "2014-10"
 Item	airplane charter: Dinseylandfill	Free Pull, Last Available: "2015-04"
 Item	airplane charter: Spring Break Beach	Free Pull, Last Available: "2014-05"
 Item	airplane charter: That 70s Volcano	Free Pull, Last Available: "2015-08"
 Item	airplane charter: The Glaciest	Free Pull, Last Available: "2015-11"
+Item	airplane tattoo	Last Available: "2015-11"
+Item	alabaster bishop	Last Available: "2020-09"
+Item	alabaster king	Last Available: "2020-09"
+Item	alabaster knight	Last Available: "2020-09"
+Item	alabaster pawn	Last Available: "2020-09"
+Item	alabaster queen	Last Available: "2020-09"
+Item	alabaster rook	Last Available: "2020-09"
+Item	Alice's Army booster box	Last Available: "2011-03"
+Item	Alice's Army Dervish	Last Available: "2011-03"
+Item	Alice's Army Foil Dervish	Last Available: "2011-03"
+Item	Alice's Army Foil Mad Bomber	Last Available: "2011-03"
+Item	Alice's Army Foil tattoo	Last Available: "2011-03"
+Item	Alice's Army Mad Bomber	Last Available: "2011-03"
 # alien animal milk: Reduces your Fullness by 3
 # alien animal milk: (limit 1x / day)
+Item	alien animal milk	Last Available: "2017-04"
+Item	alien force field disruptor bean	Last Available: "2014-05"
 # alien gemstone: Worth 100 pages of Spacegate Research
+Item	alien gemstone	Last Available: "2017-04"
 # alien plant fibers: Worth 1 page of Spacegate Research
+Item	alien plant fibers	Last Available: "2017-04"
 # alien plant pod: Reduces your Drunkenness by 3
 # alien plant pod: (limit 1x / day)
+Item	alien plant pod	Last Available: "2017-04"
 # alien plant sample: Worth 3 pages of Spacegate Research
+Item	alien plant sample	Last Available: "2017-04"
 # alien rock sample: Worth 3 pages of Spacegate Research
+Item	alien rock sample	Last Available: "2017-04"
 Item	alien source code printout	Skill: "Alien Source Code", Last Available: "2014-05"
 Item	alien source code printout (used)	Skill: "Alien Source Code", Last Available: "2014-05"
 # alien toenails: Worth 1 page of Spacegate Research
+Item	alien toenails	Last Available: "2017-04"
 # alien zoological sample: Worth 3 pages of Spacegate Research
+Item	alien zoological sample	Last Available: "2017-04"
 Item	all-purpose cleaner	Effect: "Soul-Crushing Headache", Effect Duration: 10
 Item	all-year sucker	Last Available: "2011-11", Effect: "Gonna Get You, Sucker", Effect Duration: 10
+Item	almost-dead walkie-talkie	Last Available: "2016-08"
 # alpine watercolor set: Make a painting of a monster to hang on your wall
+Item	alpine watercolor set	Last Available: "2015-01"
+Item	Amanitee	Last Available: "2018-03"
+Item	ammonite candy mold	Last Available: "2011-11"
+Item	ammonite fossil	Last Available: "2011-11"
+Item	amorphous blob	Last Available: "2017-11"
 # anchor bomb: Banish a foe for 30 turns
+Item	anchor bomb	Last Available: "2024-12"
 # ancient cure-all: Allows you to remove an Effect
 # ancient Magi-Wipes: Restores 50-60 MP and HP and removes some negative effects
 # ancient poisoned dart: Poisons your opponent
+Item	ancient redwood	Last Available: "2020-08"
 # ancient skull key: Presumably unlocks things in PirateRealm
 Item	ancient skull key	Lasts Until Rollover, Last Available: "2019-04"
 # ancient spice: Deals 30-40 Physical Damage
@@ -11516,171 +12088,349 @@ Item	ancient skull key	Lasts Until Rollover, Last Available: "2019-04"
 # anemone nematocyst: (more effective underwater)
 # angry inch: Weakens enemies somewhat
 # anise-flavored venom: Poisons your opponent
+Item	anise-flavored venom	Last Available: "2014-12"
 Item	Antagonistic Snowman Kit	Skill: "Summon Carrot"
 # anti-anti-antidote: Doesn't not remove poison effects
+Item	antique 8-Bit Power magazine	Last Available: "2010-07"
+Item	antique bottle opener	Last Available: "2010-06"
 # antique hand mirror: Be Careful!
 Item	antique hand mirror	Effect: "Bad Luck", Effect Duration: 7
+Item	antique nutcracker figurine	Last Available: "2019-12"
+Item	antique painting of a landscape	Last Available: "2010-04"
+Item	antique pair of blue jeans	Last Available: "2010-09"
+Item	antique record album	Last Available: "2010-04"
+Item	antique souvenir drawing	Last Available: "2010-08"
 # antique tacklebox: (having more than one doesn't help)
 Item	antique tacklebox	Fishing Skill: +5, Last Available: "2016-04"
 Item	Apathargic Bandersnatch	Free Pull, Last Available: "2011-12"
 Item	Apriling band piccolo	Familiar Weight: +10, Lasts Until Rollover, Generic
+Item	Armory keycard	Last Available: "2014-10"
+Item	Arr, M80	Last Available: "2021-07"
 Item	arrest warrant	Lasts Until Rollover, Last Available: "2018-04"
+Item	Arrow (+1)	Last Available: "2023-06"
 Item	arrowgram	Free Pull, Last Available: "2011-12"
 # artificial skylight: +3 Adventures Per Day
 # Artist's Butterknife of Regret: Deals 10-20 Physical Damage
+Item	Artist's Butterknife of Regret	Last Available: "2013-12"
 # Artist's Cookie Cutter of Loneliness: Deals 10-20 Physical Damage
+Item	Artist's Cookie Cutter of Loneliness	Last Available: "2013-12"
 # Artist's Cr&egrave;me Brul&eacute;e Torch of Fury: Deals 10-20 Physical Damage
+Item	Artist's Cr&egrave;me Brul&eacute;e Torch of Fury	Last Available: "2013-12"
 # Artist's Spatula of Despair: Deals 10-20 Physical Damage
+Item	Artist's Spatula of Despair	Last Available: "2013-12"
 # Artist's Whisk of Misery: Deals 10-20 Physical Damage
+Item	Artist's Whisk of Misery	Last Available: "2013-12"
 # Asdon Martin keyfob
+Item	Asdon Martin keyfob (on ring)	Last Available: "2017-07"
 Item	Asleep in the Cemetery	Skill: "Creepy Lullaby"
+Item	aspirin	Last Available: "2005-12"
 Item	astral badger	Free Pull, Last Available: "2006-06"
+Item	atomic vector plotter	Last Available: "2011-12"
 Item	Autobiography Of Dynamite Superman Jones (used)	Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 Item	autumn dollar	Effect: "Bet Your Autumn Dollar", Effect Duration: 30, Last Available: "2022-10"
 Item	autumn leaf	Effect: "Crunching Leaves", Effect Duration: 20, Last Available: "2022-10"
 Item	autumn years wisdom	Effect: "Wisdom of the Autumn Years", Effect Duration: 30, Last Available: "2022-10"
+Item	autumn-aton	Last Available: "2022-10"
+Item	avarice stone	Last Available: "2012-12"
 Item	avatar of the Unconscious Collective	Free Pull, Last Available: "2013-12"
 # aviator goggles: Makes your mini kiwi lay mini kiwis more often
+Item	Azurite	Last Available: "2023-06"
 Item	baby camelCalf	Free Pull, Last Available: "2020-07"
 Item	baby chest mimic	Free Pull
+Item	baby oil shooter	Last Available: "2017-03"
+Item	baby rigging snake	Last Available: "2023-12"
+Item	BACON	Last Available: "2016-05"
 Item	bad penguin egg	Free Pull
 # bag of airline peanuts: Deals 6-10 Physical Damage
+Item	bag of airline peanuts	Last Available: "2006-04"
+Item	bag of bones	Last Available: "2010-10"
+Item	bag of foreign bribes	Last Available: "2015-11"
 # bag of gross foreign snacks: Deals <font color=green>Stench Damage</font> every round to every monster you fight today in the zone where you used it
+Item	bag of gross foreign snacks	Last Available: "2015-04"
 Item	bag of Iunion stones	Free Pull
 # bag of park garbage: Maybe there's something valuable inside?
+Item	bag of park garbage	Last Available: "2015-04"
+Item	bag of sausage links	Last Available: "2019-01"
 Item	bagged Cargo Cultist Shorts	Free Pull, Last Available: "2020-09"
 # ball: Lets You Escape From Combat
+Item	ball	Last Available: "2010-12"
 # ballpark hot daub: Deals 450-500 <font color=red>Hot Damage</font>, also briefly stuns enemies and weakens them a lot
+Item	ballpark hot daub	Last Available: "2012-07"
 # banana peel: Comedy!
 # banana spritzer: Restores 40-100 MP
+Item	bananagate	Last Available: "2011-11"
+Item	Banfoy's Boutique Order Form	Last Available: "2011-07"
 # barbed-wire fence: Weakens enemies a little bit
 # bargain flash powder: Lets you escape from combat
+Item	barnacled barrel	Last Available: "2015-09"
+Item	barrel beryl	Last Available: "2015-09"
 # baseball: Deals a 6-8 Physical Damage
 Item	Bash-&#332;s boxtop	Wiki Name: "Bash-Os boxtop"
 Item	basking robin	Free Pull, Last Available: "2016-12"
 # Bastille Battalion cheese wheel: Lets you specify your favorite kind of cheese on your profile
+Item	Bastille Battalion cheese wheel	Last Available: "2018-07"
 # Bastille Battalion control rig: Lets you control a mobile castle in Battle Royales for Cheese
 Item	Bastille Battalion control rig	Free Pull, Last Available: "2018-07"
 Item	Bastille Battalion control rig crate	Free Pull, Last Available: "2018-07"
+Item	Bastille Battalion control rig loaner voucher	Last Available: "2018-07"
+Item	Bastille Battalion Fondue Trophy	Last Available: "2018-07"
+Item	Bastille Battalion tattoo kit	Last Available: "2018-07"
 # Bat-Aid&trade; bandage: Quickly restores 20 Bat-Health
+Item	Bat-Aid&trade; bandage	Last Available: "2017-01"
 # bat-bearing: Deals 15 damage and briefly stuns foes
+Item	bat-bearing	Last Available: "2017-01"
 # bat-jute: Lets you tie up and interrogate a weakened foe
+Item	bat-jute	Last Available: "2017-01"
 # bat-o-mite: Defeats most foes in one shot
+Item	bat-o-mite	Last Available: "2017-01"
 # bat-oomerang: Deals 20 damage and disarms foes
+Item	bat-oomerang	Last Available: "2017-01"
 # Batfellow comic: Lets you have a fun adventure as a dark, brooding, bat-themed superhero.
 Item	Batfellow comic	Free Pull, Last Available: "2016-12"
+Item	bath ball gift set	Last Available: "2011-01"
+Item	battered Crimbo Crate	Last Available: "2008-12"
 # Battlie Light Saver: Deals 30-50 Physical Damage and briefly stuns your foe
 # battoo kit: Unlocks a sweet Batfellow tattoo
+Item	battoo kit	Last Available: "2016-12"
+Item	Beach Buck	Last Available: "2014-05"
 Item	Beach Comb Box	Free Pull, Last Available: "2019-07"
 Item	beautiful rainbow	Last Available: "2014-11", Skill: "Belch The Rainbow"
 # beehive: Full of bees!
 # beer bomb: Deals 55-75 Physical Damage
 # beer-scented teddy bear: Restores 15-20 MP
+Item	beet	Last Available: "2005-12"
+Item	belemnite candy mold	Last Available: "2011-11"
+Item	belemnite fossil	Last Available: "2011-11"
 Item	Benetton's Medley of Diversity	Skill: "Benetton's Medley of Diversity"
+Item	best joke ever	Last Available: "2011-04"
 Item	Better Shrooms and Gardens catalog	Free Pull, Last Available: "2020-03"
+Item	BGE merchandise order form	Last Available: "2010-12"
+Item	BGE shotglass	Last Available: "2010-12"
+Item	BGE temporary tattoo	Last Available: "2010-12"
+Item	bi-lateral logic compressor	Last Available: "2011-12"
+Item	Bicycle	Last Available: "2018-03"
 Item	Biddy Cracker's Old-Fashioned Cookbook	Skill: "Eggsplosion"
 # big boom: Deals 80-120 Physical Damage
 # big glob of skin: Restores half of your missing Hit Points
+Item	big leaf	Last Available: "2011-12"
 # big red button: Deals 2000-3000 Physical Damage
+Item	big tun	Last Available: "2015-09"
+Item	bike rental broupon	Last Available: "2014-05"
 # Bird-a-Day calendar: Receive a blessing from a different bird each day
+Item	Bird-a-Day calendar	Last Available: "2020-01"
 Item	birthday candle	Effect: "Light!", Effect Duration: 3
 # bitchin' meatcar: <b>Allows Travel to Desert Beach</b>
+Item	BittyCar HotCar	Last Available: "2012-12"
+Item	BittyCar MeatCar	Last Available: "2012-12"
+Item	BittyCar SoulCar	Last Available: "2012-12"
 Item	Black and White Apron Enrollment Form	Free Pull, Last Available: "2024-12"
+Item	Black and White Apron Meal Kit	Last Available: "2024-12"
 Item	Black Bart's Booty	Skill: "Pirate Bellow"
 # black BRICKO brick: Stuns your opponent for a few rounds
 # black BRICKO brick: (more effective against BRICKO monsters)
+Item	black BRICKO brick	Last Available: "2010-02"
+Item	black candygram	Last Available: "2008-04"
 # black cherry soda: Restores 9-11 MP
+Item	black Crimbo ball	Last Available: "2021-12"
 Item	black hymnal	Skill: "Canticle of Carboloading"
+Item	black mana	Last Available: "2015-07"
 # black pepper: Weakens enemies a little bit
 # black plastic oyster egg: Deals 300-400 Physical Damage and gives you matching Meat
+Item	black slime glob	Last Available: "2018-11"
 # black spot: Deals 30-40 Physical Damage per round for the rest of the fight
+Item	black-and-blue light	Last Available: "2008-04"
+Item	blank fudge mold	Last Available: "2011-11"
 # Blatantly Canadian: Restores 20-25 MP
+Item	blind-packed capsule toy	Last Available: "2012-12"
+Item	blind-packed die-cast metal toy	Last Available: "2013-12"
 Item	Blizzards I Have Died In	Skill: "Snowclone"
 # blob of wood glue: Weakens foes by 10% and briefly stuns them
 # blood bag: Restore all of your HP
 # blowdart: Poisons your opponent
+Item	blue lava globs	Last Available: "2015-08"
+Item	blue mana	Last Available: "2015-07"
+Item	Blue Milk Club Card	Last Available: "2009-06"
 # blue pixel potion: Restores 50-80 MP
+Item	blue plasma ball	Last Available: "2008-04"
 # blue plastic oyster egg: Restores 35-40 MP
 # blue potion: Restores 20-30 MP
 Item	blue potion	Last Available: "2013-02", Effect: "Healthy Blue Glow", Effect Duration: 20
 # blue raspberry troll doll: Deals 3-5 <font color=blue>Cold Damage</font>
 # blue raspberry troll doll: (doesn't go away when used)
+Item	blue raspberry troll doll	Last Available: "2011-11"
+Item	blue rocket	Last Available: "2021-07"
 # blue shell: Deals up to 25 Physical Damage to whoever is in the lead
+Item	Bluzzard	Last Available: "2018-03"
 # bobcat grenade: Deals 400-500 Physical Damage
 # bobcat grenade: (super effective against beasts)
+Item	bobcat grenade	Last Available: "2011-09"
+Item	Bodacious MechaElf Hunter Saga:Relay Wolf	Last Available: "2012-12"
 # bodyguard badge: Gives your bodyguard the authority to always stop one assault
 # Bohemian rhapsody: Deals Physical Damage based on your Level
+Item	Bohemian rhapsody	Last Available: "2007-06"
+Item	bolder boulder	Last Available: "2023-01"
+Item	bomb of unknown origin	Last Available: "2016-11"
+Item	bone chips	Last Available: "2011-12"
+Item	bonsai tree	Last Available: "2013-12"
 Item	book of facts	Skill: "Just the Facts", Last Available: "2023-09"
 Item	book of facts (dog-eared)	Skill: "Just the Facts", Last Available: "2023-09"
 # book of matches: Deals 40-60 <font color=red>Hot Damage</font>
 # Booke of Vampyric Knowledge: Grants one of several Vampyric skills
 # booze mailing list: Unlocks another row of houses for Crimbo activities
+Item	booze mailing list	Last Available: "2020-12"
 # boozebomb: Deals 400-500 Physical Damage
 # boozebomb: (super effective against orcs)
+Item	boozebomb	Last Available: "2011-09"
+Item	borrowed time	Last Available: "2011-09"
+Item	bottle of agitprop ink	Last Available: "2009-12"
 # bottle of alcohol: Deals 45-60 <font color=red>Hot Damage</font>
+Item	bottle of an&iacute;s	Last Available: "2017-03"
+Item	bottle of Blank-Out	Last Available: "2011-01"
+Item	bottle of clam juice	Last Available: "2017-03"
+Item	bottle of Cr&egrave;me de Fugu	Last Available: "2017-03"
 # bottle of G&uuml;-Gone: Dissolves Slimes
+Item	bottle of gregnadigne	Last Available: "2017-03"
 # bottle of lovebug pheromones: Unlocks lovebug abilities and encounters
 Item	bottle of lovebug pheromones	Free Pull
 # bottle of Monsieur Bubble: Restores 45-65 MP
+Item	bottle of novelty hot sauce	Last Available: "2017-03"
 # bottle of Vangoghbitussin: Restores 100 HP and MP and makes you feel weird
 Item	bottle of Vangoghbitussin	Effect: "The 'Tussin", Effect Duration: 5
+Item	bottle-opener keycard	Last Available: "2014-10"
 Item	bottled green pixie	Free Pull
 # bottled swamp gas: Deals 15-20 <font color=green>Stench Damage</font>
 # bottled swamp gas: Weakens Enemies Very Slightly
 Item	bottled Vampire Vintner	Free Pull, Last Available: "2021-10"
 # boulder: Deals 20-30 Physical Damage
+Item	bow	Last Available: "2004-12"
 # Bowl of Infinite Jelly: Improves the first thing you eat each day
+Item	Bowl of Infinite Jelly	Last Available: "2024-12"
 # bowl of potpourri: Gives some Moxie stats when you rest
+Item	bowl of potpourri	Last Available: "2015-01"
+Item	Bowlet	Last Available: "2018-03"
 # bowling ball: Weakens enemies somewhat and briefly stuns them
+Item	box of bear arms	Last Available: "2012-09"
+Item	box of Familiar Jacks	Last Available: "2011-09"
+Item	box of Gratitude chocolates	Last Available: "2016-02"
 # box of hammers: Deals 400-500 Physical Damage
 # box of hammers: (way more effective against constructs)
+Item	box of hammers	Last Available: "2011-09"
 # box of old Crimbo decorations: Lets you give your Crimbo Shrub new decorations each day
+Item	box of Pok&euml;mann band-aids	Last Available: "2011-05"
 Item	box of sunshine	Free Pull
 Item	boxed Apriling band helmet	Free Pull, Last Available: "2024-04"
 Item	boxed august scepter	Free Pull
 Item	boxed autumn-aton	Free Pull, Last Available: "2022-10"
 Item	boxed bat wings	Free Pull, Last Available: "2024-10"
+Item	boxed gumball machine	Last Available: "2021-12"
 Item	boxed Mayam Calendar	Free Pull, Last Available: "2024-05"
 Item	boxed Sept-Ember Censer	Free Pull, Last Available: "2024-09"
 Item	Boxing Day care package	Free Pull, Last Available: "2018-12"
+Item	Boxing Day Pass	Last Available: "2018-12"
+Item	boxing-glove-in-a-box	Last Available: "2011-04"
 # brain preservation fluid: Drink it for 5 Adventures!
+Item	brain preservation fluid	Last Available: "2015-04"
+Item	Braindeer	Last Available: "2018-12"
+Item	Brandonian footlocker key	Last Available: "2024-12"
 # brass abacus: Stuns your opponent for a few rounds
+Item	brass abacus	Last Available: "2013-12"
 Item	brass Dreadsylvanian flask	Effect: "Brass Loins", Effect Duration: 100
 # brass gear: Deals 20-30 Physical Damage and causes bleeding
+Item	bread mold	Last Available: "2016-11"
 Item	brick	Free Pull
 # brick of sand: Deals 60-80 Physical Damage
 # brick of sand: Weakens Enemies a Lot
+Item	BRICKO airship	Last Available: "2010-02"
+Item	BRICKO bat	Last Available: "2010-02"
+Item	BRICKO brick	Last Available: "2010-02"
+Item	BRICKO cathedral	Last Available: "2010-02"
+Item	BRICKO egg	Last Available: "2010-02"
+Item	BRICKO elephant	Last Available: "2010-02"
+Item	BRICKO eye brick	Last Available: "2010-02"
+Item	BRICKO gargantuchicken	Last Available: "2010-02"
 Item	BRICKO octopus	Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+Item	BRICKO ooze	Last Available: "2010-02"
+Item	BRICKO oyster	Last Available: "2010-02"
+Item	BRICKO pearl	Last Available: "2010-02"
+Item	BRICKO python	Last Available: "2010-02"
 # BRICKO reactor: Deals 200-1000 Physical Damage
 # BRICKO reactor: (more effective against BRICKO monsters)
+Item	BRICKO reactor	Last Available: "2010-02"
+Item	BRICKO trunk	Last Available: "2010-02"
+Item	BRICKO turtle	Last Available: "2010-02"
+Item	BRICKO vacuum cleaner	Last Available: "2010-02"
+Item	bridge truss	Last Available: "2017-10"
+Item	briefcase full of sprinkles	Last Available: "2016-12"
 # broken BRICKO brick: Deals Physical Damage every round for the rest of the fight
 # broken BRICKO brick: (deals more damage if you use additional ones)
+Item	broken BRICKO brick	Last Available: "2010-02"
+Item	broken cellular phone	Last Available: "2004-01"
+Item	broken chocolate pocketwatch	Last Available: "2016-12"
 # broken glass grenade: Deals 100-200 Physical Damage
 # broken glass grenade: Weakens enemies a lot
+Item	broken glass grenade	Last Available: "2011-09"
+Item	broken high-temperature mining drill	Last Available: "2015-08"
+Item	broken warbear gyrocopter	Last Available: "2013-12"
 # bronze: Give a Pokefamiliar Armor
 # bronze handcuffs: Handcuff yourself to your opponent
+Item	bronze handcuffs	Last Available: "2010-06"
 # bronzed locust: Weakens enemies a lot
+Item	bubble-wrap simulator	Last Available: "2012-12"
+Item	bubble-wrap simulator (half broken)	Last Available: "2012-12"
+Item	bubble-wrap simulator (one broken button)	Last Available: "2012-12"
+Item	bubble-wrap simulator (one button left)	Last Available: "2012-12"
 # bubblegum heart: Restores 80-100 Hit Points
+Item	bubblegum heart	Last Available: "2015-07"
 # buckyball: Lets you escape from combat
+Item	buckyball	Last Available: "2010-12"
+Item	buffalo dime	Last Available: "2016-02"
 # Build-a-City Gingerbread kit: Unlocks a Gingerbread City in the Big Mountains
 Item	Build-a-City Gingerbread kit	Free Pull, Last Available: "2016-12"
 Item	Bulky Buddy Box	Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+Item	bulky free-range mushroom	Last Available: "2020-03"
+Item	bunch of sea grapes	Last Available: "2019-07"
 # bundle of &quot;fragrant&quot; herbs: (up to 10 times per day)
 # bundle of &quot;fragrant&quot; herbs: (during the Crimbo 2015 event only)
 # bundle of &quot;fragrant&quot; herbs: Banish a monster for the rest of the day
+Item	bundle of &quot;fragrant&quot; herbs	Last Available: "2015-12"
+Item	bundle of firewood	Last Available: "2019-08"
+Item	burned government manual fragment	Last Available: "2014-05"
 # burning newspaper: Deal a bunch of <font color=red>Hot Damage</font> and briefly stun your enemy
+Item	burning newspaper	Last Available: "2018-12"
+Item	burnt stick	Last Available: "2019-08"
+Item	burrowgrub hive	Last Available: "2008-12"
 # bus pass: Deals 45-50 Physical Damage
 Item	calm attention-deficit demon	Free Pull, Last Available: "2006-10"
 # Camp Scout pup tent: Restores up to 1,000 HP
+Item	Camp Scout pup tent	Last Available: "2012-07"
+Item	can of cherry-flavored sterno	Last Available: "2017-03"
+Item	can of CRIMBCOLA	Last Available: "2010-12"
+Item	can of depilatory cream	Last Available: "2010-04"
 # can of Ghuol-B-Gone&trade;: Repels Ghuols
+Item	can of Minions-Be-Gone	Last Available: "2017-06"
+Item	can of Rain-Doh	Last Available: "2012-02"
 # can of sterno: Deals 15-20 <font color=red>Hot Damage</font> and 10-20 more each round for the rest of the fight
+Item	candy cane candygram	Last Available: "2011-12"
 Item	candy cornucopia	Free Pull, Last Available: "2011-12"
 # candy egg deviler: Convert any candy into a deviled candy egg (3x / day)
+Item	candy egg deviler	Last Available: "2024-12"
 # candy mailing list: Unlocks another row of houses for Crimbo activities
+Item	candy mailing list	Last Available: "2020-12"
 # candycaine powder: Poisons your opponent
+Item	candycaine powder	Last Available: "2011-12"
 # cannonbomb: Blow up a bunch of Elf Guard soldiers
+Item	cannonbomb	Last Available: "2023-12"
+Item	Cantelope	Last Available: "2018-03"
+Item	capacitor relay	Last Available: "2011-12"
+Item	capped blue lava bottle	Last Available: "2015-08"
+Item	capped green lava bottle	Last Available: "2015-08"
+Item	capped red lava bottle	Last Available: "2015-08"
+Item	Caramel	Last Available: "2018-03"
+Item	carbon nanotube frame	Last Available: "2011-12"
 # carbonated soy milk: Restores 70-80 MP
 # carbonated water lily: Restores 60-70 MP
+Item	carbonite visor	Last Available: "2007-12"
+Item	cardboard elf ear	Last Available: "2009-12"
 # caret: Guarantees that your next regular attack will Critically Hit
 Item	Carol of the Bulls	Skill: "Carol of the Bulls", Last Available: "2018-12"
 Item	Carol of the Bulls (used)	Skill: "Carol of the Bulls", Last Available: "2018-12"
@@ -11688,38 +12438,59 @@ Item	Carol of the Hells	Skill: "Carol of the Hells", Last Available: "2018-12"
 Item	Carol of the Hells (used)	Skill: "Carol of the Hells", Last Available: "2018-12"
 Item	Carol of the Thrills	Skill: "Carol of the Thrills", Last Available: "2018-12"
 Item	Carol of the Thrills (used)	Skill: "Carol of the Thrills", Last Available: "2018-12"
+Item	Carpricorn	Last Available: "2018-03"
+Item	carrot nose	Last Available: "2013-01"
 Item	carton of extra-sharp, rusty staples	Weapon Damage: +10, Spell Damage: +10
 # carton of rotten eggs: Deals 12-15 <font color=green>Stench Damage</font>
 # carton of rotten eggs: (can be used 8-10 times before the carton is empty)
+Item	cartoon harpoon	Last Available: "2019-06"
 # cartoon heart: Restores 40-60 HP
 Item	cartoon heart	Last Available: "2013-02", Effect: "Healthy Red Glow", Effect Duration: 10
+Item	cashew	Last Available: "2016-11"
 # cast: Restores 25-35 HP in combat, and 15-20 out of combat
 Item	Celsius 233	Skill: "Eternal Flame", Last Available: "2017-06"
 Item	Celsius 233 (singed)	Skill: "Eternal Flame", Last Available: "2017-06"
+Item	CEO office card	Last Available: "2013-12"
 # chainsaw chain: Deals 60-80 Physical Damage and weakens enemies a lot
+Item	chainsaw chain	Last Available: "2011-10"
 # chaos butterfly: Is Unpredictable
 Item	Charter: Nellyville	Last Available: "2023-06", Effect: "Hot in Herre", Effect Duration: 30
 # Chateau Mantegna room key: Permanently unlocks a new residence in the Big Mountains
 Item	Chateau Mantegna room key	Free Pull, Last Available: "2015-01"
+Item	Ched	Last Available: "2018-03"
 # cheer-o-gram: Send somebody a short but explosively cheerful message
+Item	cheer-o-gram	Last Available: "2017-12"
+Item	Chef Boy, R&D's business card	Last Available: "2013-11"
 # Cherry Cloaca Cola: Restores 7-9 MP
 Item	Cheshire Bitten	Free Pull, Last Available: "2005-10"
 # chest of &quot;pirate gold&quot;: Contains 20 Pieces of 12 (so, 240 in total)
+Item	chest of &quot;pirate gold&quot;	Last Available: "2023-12"
 Item	Cheswick Copperbottom's compass	Lasts Until Rollover, Last Available: "2018-04"
 Item	chewable paper	Free Pull, Last Available: "2014-08"
 Item	Chewsick Copperbottom's notes	Lasts Until Rollover, Last Available: "2018-04"
+Item	ChibiBuddy&trade; (off)	Last Available: "2012-12"
+Item	ChibiBuddy&trade; (on)	Last Available: "2012-12"
 # Chinese curse words: Stuns your opponent for a few rounds
+Item	Chinese curse words	Last Available: "2013-12"
 # chipotle wasabi cilantro aioli: Deals 30-40 Physical Damage and 8-10 Prismatic Damage
+Item	chitinous pod	Last Available: "2008-12"
 # chlorine crystal: Deals 20-40 <font color=green>Stench Damage</font>
 # chloroform rag: Stuns your opponent for a few rounds
 # chocolate frosted sugar bomb: Deals 200-300 Physical Damage
 # chocolate frosted sugar bomb: Weakens enemies somewhat
+Item	chocolate frosted sugar bomb	Last Available: "2011-09"
+Item	chocolate lump	Last Available: "2011-12"
+Item	chocolate puppy	Last Available: "2016-12"
 Item	Chorale of Companionship	Skill: "Chorale of Companionship"
+Item	chunk of cement	Last Available: "2009-12"
+Item	chunk of depleted Grimacite	Last Available: "2011-12"
 # chunk of hot iron: Deals 40-80 <font color=red>Hot Damage</font>
 # cigarette lighter: Deals 50-60 <font color=red>Hot Damage</font>
 # cinnamon troll doll: Deals 3-5 <font color=red>Hot Damage</font>
 # cinnamon troll doll: (doesn't go away when used)
+Item	cinnamon troll doll	Last Available: "2011-11"
 # circle drum: Lets you form and/or join a drum circle!  Yay!
+Item	circle drum	Last Available: "2015-12"
 Item	Clan Carnival Game	Free Pull, Last Available: "2018-02"
 Item	Clan Floundry	Free Pull, Last Available: "2016-04"
 Item	Clan hot dog stand	Free Pull, Last Available: "2013-07"
@@ -11727,66 +12498,113 @@ Item	Clan looking glass	Free Pull, Last Available: "2010-03"
 Item	Clan pool table	Free Pull, Last Available: "2009-05"
 Item	Clan shower	Free Pull, Last Available: "2011-04"
 Item	Clan speakeasy	Free Pull, Last Available: "2014-07"
+Item	clan underground fireworks shop	Last Available: "2021-07"
 Item	Clan VIP Lounge invitation	Free Pull
 # Clan VIP Lounge key: <b>Grants access to the Clan VIP Lounge</b>
 Item	Clan VIP Lounge key	Free Pull
+Item	Clancy's crumhorn	Last Available: "2012-12"
+Item	Clancy's lute	Last Available: "2012-12"
+Item	Clancy's sackbut	Last Available: "2012-12"
+Item	Clara's bell	Last Available: "2016-02"
 Item	class five ecto-larva	Free Pull, Last Available: "2011-12"
 # classy monkey: Lets you escape from combat without spending an Adventure
+Item	classy monkey	Last Available: "2012-12"
+Item	clay	Last Available: "2014-12"
 # clingfilm tangle: Stuns your opponent for a few rounds
 # Cloaca grenade: Deals 50-60 Physical Damage
 # Cloaca-Cola: Restores 10-14 MP
+Item	cloned monster	Last Available: "2021-12"
+Item	cloning kit	Last Available: "2021-12"
 # closed-circuit pay phone: Grants permanent access to Shadow Rift zones
 Item	closed-circuit phone system	Free Pull
 # clumsiness bark: Deals 10-20 Physical Damage and briefly stuns your foe
+Item	clumsiness bark	Last Available: "2012-12"
 # clutch of dodecapede eggs: Weakens enemies somewhat as it poisons them
+Item	coal paperweight	Last Available: "2010-12"
 # coal snakeskin: Adds Spooky Damage to kicks with your cowboy boots
+Item	coal snakeskin	Last Available: "2016-02"
+Item	cocktail mushroom	Last Available: "2017-03"
 # cocktail napkin: Deals 20-40 <font color=red>Hot Damage</font>
 Item	Cocktails of the Age of Sail	Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 Item	Cocktails of the Age of Sail (used)	Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 # cocoa of youth: Extend the duration of up to 10 of your effects by 5 Adventures
+Item	cocoa of youth	Last Available: "2019-04"
 Item	coffee sprite	Free Pull, Last Available: "2005-10"
+Item	Coinspiracy	Last Available: "2014-10"
 # cold clusterbomb: Deals <font color=blue>Cold Damage</font> based on your highest stat
 # cold clusterbomb: (more effective against groups)
 Item	Cold Fang	Skill: "Frost Bite", Last Available: "2015-11"
+Item	cold medicine cabinet	Last Available: "2021-12"
 Item	cold sore	Cold Damage: +10, Cold Spell Damage: +10
 # Colon Annihilation Hot Sauce: Deals 6-8 <font color=red>Hot Damage</font> per round for the rest of the fight
+Item	colorful plastic ball	Last Available: "2010-01"
+Item	colossal free-range mushroom	Last Available: "2020-03"
+Item	combat lover's locket lockbox	Free Pull, Last Available: "2022-02"
 # comfy pillow: Restores 20-30 HP
 Item	Comma Chameleon egg	Free Pull
 # communications windchimes: Summons Hippy Army Aid
 # complex alien plant sample: Worth 10 pages of Spacegate Research
+Item	complex alien plant sample	Last Available: "2017-04"
 # complex alien zoological sample: Worth 10 pages of Spacegate Research
+Item	complex alien zoological sample	Last Available: "2017-04"
 # complimentary Dinsey refreshments: Ya eat 'em.  Well, tourists do.
+Item	complimentary Dinsey refreshments	Last Available: "2015-04"
+Item	compounded experience	Last Available: "2016-09"
 # Comprehensive Cartographic Compendium: Imparts deep cartographic knowledge
 Item	Comprehensive Cartographic Compendium	Free Pull, Last Available: "2020-10"
 # Comprehensive Cartographic Compendium (well-read): Imparts deep cartographic knowledge
+Item	Comprehensive Cartographic Compendium (well-read)	Last Available: "2020-10"
+Item	computronic processing unit	Last Available: "2011-12"
 # confidence-building hug: Increases the damage of your bat-punches and bat-kicks
+Item	confidence-building hug	Last Available: "2017-01"
+Item	confusing LED clock	Last Available: "2012-12"
+Item	container of Spooky Putty	Last Available: "2009-01"
 # continental juice bar: Produces 3 random potions each day
+Item	continental juice bar	Last Available: "2015-01"
 Item	control crystal	Free Pull, Last Available: "2011-12"
 Item	Convincing People You Can See The Future	Skill: "Inscrutable Gaze", Last Available: "2018-02"
 # cool spore pod: Briefly enhances your Moxie
 # cop dollar
+Item	cop dollar	Last Available: "2016-07"
 Item	corked genie bottle	Free Pull, Last Available: "2017-09"
+Item	Cornbeefadon	Last Available: "2018-03"
+Item	cornucopia	Last Available: "2016-11"
 # cosmic bowling ball: Throw it in various ways
+Item	cosmic bowling ball	Last Available: "2022-01"
 Item	cosmic bucket	Free Pull
+Item	Cosmic Calorie	Last Available: "2013-03"
 # cotton bandages: Restores 20-40 HP
 # cotton candy bale: Restores 41-82 HP and MP
+Item	cotton candy bale	Last Available: "2008-08"
 Item	cotton candy cocoon	Free Pull, Last Available: "2008-08"
 # cotton candy cone: Restores 26-52 HP and MP
+Item	cotton candy cone	Last Available: "2008-08"
 # cotton candy pillow: Restores 34-68 HP and MP
+Item	cotton candy pillow	Last Available: "2008-08"
 # cotton candy pinch: Restores 7-15 HP and MP
+Item	cotton candy pinch	Last Available: "2008-08"
 # cotton candy plug: Restores 19-38 HP and MP
+Item	cotton candy plug	Last Available: "2008-08"
 # cotton candy skoshe: Restores 15-30 HP and MP
+Item	cotton candy skoshe	Last Available: "2008-08"
 # cotton candy smidgen: Restores 11-23 HP and MP
+Item	cotton candy smidgen	Last Available: "2008-08"
 # counterfeit city
+Item	counterfeit city	Last Available: "2016-12"
 Item	Covert Ops for Kids	Last Available: "2024-12", Skill: "Hide From Seekers"
 Item	Covert Ops for Kids (used)	Last Available: "2024-12", Skill: "Hide From Seekers"
+Item	cow poker	Last Available: "2016-02"
 # cracked stone sphere: Mysterious, Deprecated
 # crappy camera: Makes a copy of a monster to fight later
 # crappy camera: (when it works)
+Item	crappy camera	Last Available: "2014-12"
 # crayon shavings: Weakens enemies by 30%
+Item	crayon shavings	Last Available: "2012-06"
 # crazy hobo notebook: Deals <font color=gray>Spooky Damage</font> every round to every monster you fight today in the zone where you used it
+Item	Crazyleg's razor	Last Available: "2010-04"
 Item	cream pie	Free Pull
 # creepy ginger ale: Restores 35-45 MP
+Item	creepy voodoo doll	Last Available: "2011-04"
 Item	CRIMBCO Employee Handbook (chapter 1)	Skill: "Fashionably Late", Last Available: "2011-01"
 Item	CRIMBCO Employee Handbook (chapter 1) (used)	Skill: "Fashionably Late", Last Available: "2011-01"
 Item	CRIMBCO Employee Handbook (chapter 2)	Skill: "Executive Narcolepsy", Last Available: "2011-01"
@@ -11797,31 +12615,108 @@ Item	CRIMBCO Employee Handbook (chapter 4)	Skill: "Offensive Joke", Last Availab
 Item	CRIMBCO Employee Handbook (chapter 4) (used)	Skill: "Offensive Joke", Last Available: "2011-01"
 Item	CRIMBCO Employee Handbook (chapter 5)	Skill: "Managerial Manipulation", Last Available: "2011-01"
 Item	CRIMBCO Employee Handbook (chapter 5) (used)	Skill: "Managerial Manipulation", Last Available: "2011-01"
+Item	CRIMBCO mug	Last Available: "2011-01"
+Item	CRIMBCO scrip	Last Available: "2011-01"
 Item	Crimbo Candy Cookbook	Skill: "Summon Crimbo Candy", Last Available: "2009-12"
+Item	Crimbo Carol tattoo kit	Last Available: "2020-12"
+Item	Crimbo Cheer tattoo kit	Last Available: "2020-12"
+Item	Crimbo Commerce tattoo kit	Last Available: "2020-12"
+Item	Crimbo cookie sheet	Last Available: "2023-06"
 # Crimbo Credit: Use it to buy gifts in Crimbo Town!
 Item	crimbo elfling	Free Pull, Last Available: "2011-12"
 # Crimbo Factory surprise box: Full of Crimbo nostalgia!
+Item	Crimbo Factory surprise box	Last Available: "2019-12"
 Item	Crimbo P. R. E. S. S. I. E.	Free Pull, Last Available: "2011-12"
+Item	Crimbo pressie	Last Available: "2003-12"
 Item	Crimbo sapling	Free Pull, Last Available: "2014-12"
+Item	Crimbo stocking	Last Available: "2004-12"
+Item	Crimbo tattoo kit	Last Available: "2018-12"
+Item	Crimbo wreath	Last Available: "2009-12"
+Item	Crimbonium fuel rod	Last Available: "2014-12"
 Item	Crimbot ROM: Mathematical Precision	Skill: "Mathematical Precision", Last Available: "2014-12"
 Item	Crimbot ROM: Mathematical Precision (dirty)	Skill: "Mathematical Precision", Last Available: "2014-12"
 Item	Crimbot ROM: Rapid Prototyping	Skill: "Rapid Prototyping", Last Available: "2014-12"
 Item	Crimbot ROM: Rapid Prototyping (dirty)	Skill: "Rapid Prototyping", Last Available: "2014-12"
 Item	Crimbot ROM: Ruthless Efficiency	Skill: "Ruthless Efficiency", Last Available: "2014-12"
 Item	Crimbot ROM: Ruthless Efficiency (dirty)	Skill: "Ruthless Efficiency", Last Available: "2014-12"
+Item	Crimbot schematic: Big Head	Last Available: "2014-12"
+Item	Crimbot schematic: Big Wheel	Last Available: "2014-12"
+Item	Crimbot schematic: Bit Masher	Last Available: "2014-12"
+Item	Crimbot schematic: Bug Zapper	Last Available: "2014-12"
+Item	Crimbot schematic: Camera Claw	Last Available: "2014-12"
+Item	Crimbot schematic: Candle Lighter	Last Available: "2014-12"
+Item	Crimbot schematic: Cold Shoulder	Last Available: "2014-12"
+Item	Crimbot schematic: Crab Core	Last Available: "2014-12"
+Item	Crimbot schematic: Cyclopean Torso	Last Available: "2014-12"
+Item	Crimbot schematic: Data Analyzer	Last Available: "2014-12"
+Item	Crimbot schematic: Dynamo Head	Last Available: "2014-12"
+Item	Crimbot schematic: Grease / Regular Gun	Last Available: "2014-12"
+Item	Crimbot schematic: Grease Gun	Last Available: "2014-12"
+Item	Crimbot schematic: Gun Face	Last Available: "2014-12"
+Item	Crimbot schematic: Gun Legs	Last Available: "2014-12"
+Item	Crimbot schematic: Heavy Treads	Last Available: "2014-12"
+Item	Crimbot schematic: Heavy-Duty Legs	Last Available: "2014-12"
+Item	Crimbot schematic: High-Speed Fan	Last Available: "2014-12"
+Item	Crimbot schematic: Hoverjack	Last Available: "2014-12"
+Item	Crimbot schematic: Lamp Filler	Last Available: "2014-12"
+Item	Crimbot schematic: Maxi-Mag Lite	Last Available: "2014-12"
+Item	Crimbot schematic: Mega Vise	Last Available: "2014-12"
+Item	Crimbot schematic: Military Chassis	Last Available: "2014-12"
+Item	Crimbot schematic: Mobile Girder	Last Available: "2014-12"
+Item	Crimbot schematic: Nerding Module	Last Available: "2014-12"
+Item	Crimbot schematic: Power Arm	Last Available: "2014-12"
+Item	Crimbot schematic: Power Stapler	Last Available: "2014-12"
+Item	Crimbot schematic: Really Big Head	Last Available: "2014-12"
+Item	Crimbot schematic: Refrigerator Chassis	Last Available: "2014-12"
+Item	Crimbot schematic: Ribbon Manipulator	Last Available: "2014-12"
+Item	Crimbot schematic: Rivet Shocker	Last Available: "2014-12"
+Item	Crimbot schematic: Rocket Skirt	Last Available: "2014-12"
+Item	Crimbot schematic: Rodent Gun	Last Available: "2014-12"
+Item	Crimbot schematic: Rollerfeet	Last Available: "2014-12"
+Item	Crimbot schematic: Security Chassis	Last Available: "2014-12"
+Item	Crimbot schematic: Sim-Simian Feet	Last Available: "2014-12"
+Item	Crimbot schematic: Snow Blower	Last Available: "2014-12"
+Item	Crimbot schematic: Swiss Arm	Last Available: "2014-12"
+Item	Crimbot schematic: Tripod Legs	Last Available: "2014-12"
+Item	Crimbot schematic: Wrecking Ball	Last Available: "2014-12"
+Item	Crimbough	Last Available: "2009-12"
+Item	Crimboween memo	Last Available: "2006-10"
 # Crimbuccaneer captain's purse: Contains a bunch of Pieces of 12
+Item	Crimbuccaneer captain's purse	Last Available: "2023-12"
+Item	Crimbuccaneer flotsam	Last Available: "2023-12"
 # Crimbuccaneer invasion map: Globally increase MPC drops from Elf Guard enemies for an hour
+Item	Crimbuccaneer invasion map	Last Available: "2023-12"
+Item	Crimbuccaneer piece of 12	Last Available: "2023-12"
 # Crimbuccaneer premium booty sack: Contains a random rare Crimbuccaneer item
+Item	Crimbuccaneer premium booty sack	Last Available: "2023-12"
+Item	Crimbuccaneer rigging lasso	Last Available: "2023-12"
+Item	Crimbuccaneer tattoo gift certificate	Last Available: "2023-12"
+Item	Crimbuccaneer whale oil	Last Available: "2023-12"
+Item	Crimbuck	Last Available: "2009-12"
 # croquet hedgehog: Weakens enemies a little bit every round for the rest of the fight
+Item	croquet hedgehog	Last Available: "2010-03"
 # crude oil congealer: Converts 12 bubblin' crude into a jar of oil
 # crude voodoo doll: Makes an enemy smaller than you
 Item	crumbling rat skull	Class: "Pastamancer"
+Item	crushed steamer trunk	Last Available: "2017-01"
 # crystal skull: Banishes a monster for a while
+Item	crystal skull	Last Available: "2011-09"
+Item	crystalline cheer	Last Available: "2017-12"
+Item	crystalline light bulb	Last Available: "2015-08"
 # CSA all-purpose soap: Removes all harmful Effects
 # CSA all-purpose soap: Restores up to 1,000 MP
+Item	CSA all-purpose soap	Last Available: "2012-07"
+Item	CSA discount card	Last Available: "2020-09"
+Item	CSA fire-starting kit	Last Available: "2012-07"
 # CSA obedience grenade: Stuns your opponent for a few rounds and weakens them by 5%
+Item	CSA obedience grenade	Last Available: "2012-07"
 # cubic zirconia: Just sell it
+Item	cubic zirconia	Last Available: "2015-07"
 # cup of hickory chicory: Restores 30-50 MP
+Item	cup of hickory chicory	Last Available: "2012-12"
+Item	cuppa Royal tea	Last Available: "2015-09"
+Item	cuppa Sobrie tea	Last Available: "2015-09"
+Item	cuppa Voraci tea	Last Available: "2015-09"
 # curious anemometer: Increases the sailing speed of your PirateRealm ship
 Item	curious anemometer	Lasts Until Rollover, Last Available: "2019-04"
 # cursed cannonball: Deals <font color=gray>Spooky Damage</font> based on your Muscle
@@ -11831,42 +12726,88 @@ Item	cursed monkey glove	Free Pull, Last Available: "2023-04"
 Item	cursed pony keg	Free Pull
 # cursed voodoo skull: Deals <font color=red>Hot Damage</font> and <font color=gray>Spooky Damage</font> based on your Mysticality
 Item	custom avatar form	Free Pull
+Item	cute meteoroid	Last Available: "2017-08"
+Item	CyberRealm keycode	Free Pull, Last Available: "2025-12"
+Item	Cycloney	Last Available: "2018-03"
+Item	cylindrical mold	Last Available: "2014-12"
 # d4: Weakens enemies by 10-40%
+Item	d4	Last Available: "2011-09"
 # d6: Stuns your opponent for 1-6 rounds
+Item	d6	Last Available: "2011-09"
 # d8: Deals Prismatic Damage based on your Level
+Item	d8	Last Available: "2011-09"
 # d10: Weakens enemies somewhat
+Item	d10	Last Available: "2011-09"
 # d12: Deals a bunch of damage of a random element
 Item	d12	Last Available: "2011-09", Effect: "Bastard!", Effect Duration: 10
 # d20: Deals 1-20 <font color=red>Hot Damage</font> times your Level
 # d20	Effect: "20/20 Vision", Effect Duration: 20d20
 # d20	Effect: "Natural 1", Effect Duration: 1
 # d20	Effect: "Natural 20", Effect Duration: 1
+Item	d20	Last Available: "2011-09"
 # daily dungeon malware: Hacks a Daily Dungeon Monster
+Item	daily dungeon malware	Last Available: "2016-05"
 Item	dandy lion cub	Free Pull, Last Available: "2007-03"
 # dangerous chemicals: Take it to ChemiCorp's downtown office
+Item	dangerous chemicals	Last Available: "2017-01"
 # dangerous jerkcicle: Deals 20-40 <font color=blue>Cold Damage</font>
+Item	dangerous jerkcicle	Last Available: "2012-12"
 Item	Dark Jill-O-Lantern	Free Pull, Last Available: "2011-12"
 Item	Dark Jill-of-All-Trades	Free Pull, Last Available: "2023-10"
+Item	deactivated mini-Trainbot	Last Available: "2022-12"
+Item	Deactivated MiniMechaElf	Last Available: "2012-12"
 Item	deactivated nanobots	Free Pull, Last Available: "2012-11"
+Item	Deactivated O. A. F.	Last Available: "2007-04"
+Item	deactivated RoboGoose	Last Available: "2007-12"
 Item	deanimated reanimator's coffin	Free Pull
 Item	Dear Past Self Package	Free Pull, Last Available: "2016-09"
 # death blossom: Deals 20-25 Prismatic Damage
 # Deck of Every Card: Who knows what will happen when you draw from it!
+Item	Deck of Every Card	Last Available: "2015-07"
 Item	decoded cult documents	Skill: "Bind Spaghetti Elemental"
 Item	decorative fountain	Effect: "Sleepy", Effect Duration: 1
+Item	dedigitizer schematic: 3d printed server room key	Last Available: "2025-12"
+Item	dedigitizer schematic: brute force hammer	Last Available: "2025-12"
+Item	dedigitizer schematic: cryptocloak	Last Available: "2025-12"
 Item	dedigitizer schematic: cybeer	Last Available: "2025-12", Softcore Only
+Item	dedigitizer schematic: cybervisor	Last Available: "2025-12"
+Item	dedigitizer schematic: cyburger	Last Available: "2025-12"
+Item	dedigitizer schematic: digibritches	Last Available: "2025-12"
+Item	dedigitizer schematic: familiar-in-the-middle	Last Available: "2025-12"
+Item	dedigitizer schematic: geofencing rapier	Last Available: "2025-12"
+Item	dedigitizer schematic: geofencing shield	Last Available: "2025-12"
+Item	dedigitizer schematic: hashing vise	Last Available: "2025-12"
+Item	dedigitizer schematic: insignificant bit	Last Available: "2025-12"
+Item	dedigitizer schematic: malware injector	Last Available: "2025-12"
+Item	dedigitizer schematic: OVERCLOCK(10) rom chip	Last Available: "2025-12"
+Item	dedigitizer schematic: pocket GPU	Last Available: "2025-12"
+Item	dedigitizer schematic: psilocyber mushroom	Last Available: "2025-12"
+Item	dedigitizer schematic: retro floppy disk	Last Available: "2025-12"
+Item	dedigitizer schematic: SLEEP(5) rom chip	Last Available: "2025-12"
+Item	dedigitizer schematic: STATS+++ rom chip	Last Available: "2025-12"
+Item	dedigitizer schematic: trojan horseshoe	Last Available: "2025-12"
+Item	dedigitizer schematic: virtual cybertattoo	Last Available: "2025-12"
+Item	dedigitizer schematic: zero-trust tanktop	Last Available: "2025-12"
 Item	deed to Oliver's Place	Free Pull
 Item	defective Game Grid token	Effect: "Video... Games?", Effect Duration: 5
 Item	deflated inflatable dodecapede	Free Pull, Last Available: "2011-12"
+Item	delectable fire ant	Last Available: "2008-06"
 # delicious shimmering moth: Restore 30-40 MP if you are a bird
+Item	delicious shimmering moth	Last Available: "2008-06"
+Item	delicious stinkbug	Last Available: "2008-06"
+Item	deluxe fax machine	Last Available: "2011-01"
 # deluxe mushroom: Heals 30 HP
 # deluxe Neverending Party favor: Contains extra-fabulous prizes!
+Item	deluxe Neverending Party favor	Last Available: "2018-09"
 # depantsing bomb: Weakens enemies somewhat
 # Desert Bus pass: <b>Allows Travel to Desert Beach</b>
 Item	designer sweatpants (new old stock)	Free Pull, Last Available: "2022-07"
 Item	detective school application	Free Pull, Last Available: "2016-07"
 # detective tattoo
+Item	detective tattoo	Last Available: "2016-07"
+Item	diabolic pizza cube	Last Available: "2019-11"
 # diamondback skin: Adds +20 Monster Level to your cowboy boots
+Item	Dickory Farms Gift Basket	Last Available: "2011-01"
 # dictionary: Most Enemies Don't Care About It
 # Diet Cloaca Cola: Restores 7-9 MP
 # dinged-up triangle: Summons a Hobo buddy
@@ -11874,43 +12815,76 @@ Item	detective school application	Free Pull, Last Available: "2016-07"
 # dinosaur dart: Deal 500 damage to any non-Boss dinosaur
 Item	Dinsey Maintenance Manual	Skill: "Dinsey Operations Expert", Last Available: "2015-04"
 # Dinsey tattoo kit: Grants a cool Dinsey tattoo when used
+Item	Dinsey tattoo kit	Last Available: "2015-04"
 # dirty bottlecap: Absorb it for a useful skill!
 # dirty stinkbomb: Banishes a monster for a while
 # discarded button: Absorb it for a useful skill!
 Item	disconnected intergnat	Free Pull, Last Available: "2016-05"
 Item	Discontent&trade; Winter Garden Catalog	Free Pull, Last Available: "2014-01"
 # disease: Weakens enemies very slightly
+Item	Disgeist	Last Available: "2018-03"
+Item	Dish of Clarified Butter	Last Available: "2018-05"
+Item	disintegrating barrel	Last Available: "2015-09"
+Item	disintegrating sheet music	Last Available: "2006-12"
 # disposable instant camera: Weakens enemies somewhat
 # disposable instant camera: (more effective against undead)
 Item	Distant Woods Getaway Brochure	Free Pull, Last Available: "2019-08"
+Item	distention pill	Last Available: "2011-06"
 # divine blowout: Deals Physical Damage based on your Moxie
 # divine blowout: Makes you cooler when you use it
+Item	divine blowout	Last Available: "2008-01"
 # divine can of silly string: Deals Physical Damage based on your Mysticality
 # divine can of silly string: Makes you smarter when you use it
+Item	divine can of silly string	Last Available: "2008-01"
+Item	divine champagne flute	Last Available: "2008-01"
 # divine champagne popper: Banishes a monster for a while
+Item	divine champagne popper	Last Available: "2008-01"
 # divine cracker: Steals an item from your enemy
 # divine cracker: (Maybe)
+Item	divine cracker	Last Available: "2008-01"
 # divine noisemaker: Deals Physical Damage based on your Muscle
 # divine noisemaker: Makes you stronger when you use it
+Item	divine noisemaker	Last Available: "2008-01"
 Item	DIY protonic accelerator kit	Free Pull, Last Available: "2016-08"
 # DNA extraction syringe: Extracts DNA samples for analysis in your lab
 # DNA extraction syringe: (doesn't go away when used)
+Item	DNA extraction syringe	Last Available: "2014-04"
+Item	DNOTC Box	Last Available: "2017-12"
 Item	do-it-yourself laser eye surgery kit	Skill: "20/20 Vision"
+Item	Doc's Miracle Cure	Last Available: "2011-12"
+Item	doll house	Last Available: "2005-12"
+Item	dollar-sign bag	Last Available: "2013-02"
+Item	dollhive	Last Available: "2007-12"
 Item	Dolph Bossin's charity note	Free Pull, Last Available: "2019-12"
 Item	doppelshifter egg	Free Pull
 Item	dragon aluminum ore	Lasts Until Rollover, Last Available: "2018-04"
+Item	Dreadsylvanian hemlock	Last Available: "2020-08"
 # Dreadsylvanian seed pod: Fully restores your HP and removes negative status effects
 Item	dreaming Jung man	Free Pull, Last Available: "2013-12"
+Item	Dressage	Last Available: "2018-03"
 # drippy candy bar: It's too hard to chew
+Item	Dripwood slab	Last Available: "2020-08"
 # drone self-destruct chip: Deals 55-60 <font color=red>Hot Damage</font>
 # droopy doll eye: Deals 60-80 <font color=gray>Spooky Damage</font>
 # Drunkula's bell: Summons bats that deal <font color=blue>Cold Damage</font> based on your Mysticality
+Item	dry cleaning receipt	Last Available: "2013-11"
 # dumb mud: Deals 500 Physical Damage and weakens your enemy a lot
+Item	dungeon dragon chest	Last Available: "2011-09"
+Item	dungeoneering kit	Last Available: "2013-02"
 # Duskwalker syringe: Deals 25-40 <font color=gray>Spooky Damage</font>
+Item	dusty barrel	Last Available: "2015-09"
+Item	dusty Crimbo crate	Last Available: "2008-12"
 # Dyspepsi grenade: Deals 50-60 Physical Damage
 # Dyspepsi-Cola: Restores 10-14 MP
+Item	E.M.U. harness	Last Available: "2011-06"
+Item	E.M.U. helmet	Last Available: "2011-06"
+Item	E.M.U. joystick	Last Available: "2011-06"
+Item	E.M.U. rocket thrusters	Last Available: "2011-06"
 # ear poison: Briefly stuns and less briefly poisons your opponent
+Item	eaves droppers	Last Available: "2018-02"
+Item	eggman noodles	Last Available: "2010-03"
 # Egnaro berry: Restores MP and energizes you for a while
+Item	Egnaro berry	Last Available: "2018-03"
 Item	El Vibrato punchcard (ATTACK)	Wiki Name: "El Vibrato punchcard (115 holes)"
 Item	El Vibrato punchcard (BUFF)	Wiki Name: "El Vibrato punchcard (129 holes)"
 Item	El Vibrato punchcard (BUILD)	Wiki Name: "El Vibrato punchcard (165 holes)"
@@ -11922,15 +12896,21 @@ Item	El Vibrato punchcard (SELF)	Wiki Name: "El Vibrato punchcard (216 holes)"
 Item	El Vibrato punchcard (SPHERE)	Wiki Name: "El Vibrato punchcard (104 holes)"
 Item	El Vibrato punchcard (TARGET)	Wiki Name: "El Vibrato punchcard (142 holes)"
 Item	El Vibrato punchcard (WALL)	Wiki Name: "El Vibrato punchcard (176 holes)"
+Item	El Vibrato restraints	Last Available: "2016-02"
 # elbow soup: Add a pound and HP restore to your familiar
 Item	Eldritch Intellect: Journey into a Mind of Horror	Skill: "Eldritch Intellect"
 Item	eldritch tincture	Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 Item	eldritch tincture (depleted)	Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 # electric boning knife: Deals Physical Damage each round for the rest of the fight
 # electric muscle stimulator: Gives some Muscle stats when you rest
+Item	electric muscle stimulator	Last Available: "2015-01"
+Item	electrical thingamabob	Last Available: "2012-12"
 Item	electronic Brain Trainer game	Skill: "Brain Games"
 # electronics kit: Shocks your opponent, weakening and briefly stunning them.<p>Also restores 30-40 MP.
+Item	electronics kit	Last Available: "2018-09"
+Item	elemental sugarcube	Last Available: "2017-03"
 # eleven-foot pole: You know...  For traps.
+Item	Elf Army machine parts	Last Available: "2023-12"
 Item	Elf Guard Field Manual: Culinary Arts	Skill: "Elf Guard Cooking", Last Available: "2023-12"
 Item	Elf Guard Field Manual: Culinary Arts (used)	Skill: "Elf Guard Cooking", Last Available: "2023-12"
 Item	Elf Guard Field Manual: Extortion	Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
@@ -11939,56 +12919,112 @@ Item	Elf Guard Field Manual: Wilderness Sleeping	Skill: "Elf Guard Relaxation Te
 Item	Elf Guard Field Manual: Wilderness Sleeping (used)	Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 # Elf Guard hangover cure: Reduces your Drunkenness by 5 (1 after Crimbo)
 # Elf Guard hangover cure: (limit 1x / day)
+Item	Elf Guard hangover cure	Last Available: "2023-12"
 # Elf Guard honor present: Contains a random rare Elf Guard item
+Item	Elf Guard honor present	Last Available: "2023-12"
+Item	Elf Guard MPC	Last Available: "2023-12"
 # Elf Guard payroll bag: Contains a bunch of Elf Guard MPCs
+Item	Elf Guard payroll bag	Last Available: "2023-12"
 # Elf Guard strategic map: Globally increase Piece of 12 drops from Crimbuccaneer enemies for an hour
+Item	Elf Guard strategic map	Last Available: "2023-12"
+Item	Elf Guard temporary (permanent) tattoo	Last Available: "2023-12"
 # Elf Guard tinsel grenade: Blow up a bunch of Crimbuccaneers
+Item	Elf Guard tinsel grenade	Last Available: "2023-12"
+Item	elf resistance button	Last Available: "2009-12"
 Item	elf sleeper agent	Free Pull, Last Available: "2019-12"
 Item	Ellsbury's journal	Skill: "Unaccompanied Miner", Last Available: "2010-09"
 Item	Ellsbury's journal (used)	Skill: "Unaccompanied Miner", Last Available: "2010-09"
 Item	Elron's Explosive Etude	Skill: "Elron's Explosive Etude"
 # elven magi-pack: Restores 40-50 MP
+Item	elven magi-pack	Last Available: "2011-06"
 # elven medi-pack: Restores 80-100 HP
+Item	elven medi-pack	Last Available: "2011-06"
+Item	ember egg	Last Available: "2024-09"
+Item	embering hunk	Last Available: "2024-09"
 Item	emo roe	Free Pull, Last Available: "2005-04"
 Item	emotion chip	Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
+Item	empty agua de vida bottle	Last Available: "2009-06"
+Item	empty blowgun	Last Available: "2005-11"
+Item	empty hourglass	Last Available: "2019-07"
+Item	empty lava bottle	Last Available: "2015-08"
+Item	empty Rain-Doh can	Last Available: "2012-02"
+Item	envelope full of Meat	Last Available: "2019-12"
+Item	envyfish egg	Last Available: "2013-04"
 Item	Essence of Annoyance	Skill: "Summon Annoyance"
 Item	Essence of Bear	Skill: "Bear Essence"
+Item	essence of cold	Last Available: "2009-06"
+Item	essence of cute	Last Available: "2009-06"
+Item	essence of fright	Last Available: "2009-06"
+Item	essence of heat	Last Available: "2009-06"
+Item	essence of kink	Last Available: "2009-06"
+Item	essence of stench	Last Available: "2009-06"
+Item	essential tofu	Last Available: "2010-08"
+Item	etched hourglass	Last Available: "2019-07"
 # eternal car battery: Restores 45-55 MP
 # eternal car battery: (doesn't go away when used)
+Item	eternal knot tattoo	Last Available: "2016-12"
+Item	evil googly eye	Last Available: "2011-12"
+Item	evil teddy bear	Last Available: "2006-12"
 Item	experimental carbon fiber pasta additive	Class: "Pastamancer", Last Available: "2013-11"
 # experimental gene therapy: Increases your maximum Bat-Health
+Item	experimental gene therapy	Last Available: "2017-01"
+Item	exploding cigar	Last Available: "2017-06"
 # exploding hacky-sack: Deals 75-100 Physical Damage
 # exploding kickball: Instantly ends a fight
+Item	exploding kickball	Last Available: "2017-01"
 Item	extra DNA	Experience (familiar): +1
 # extra ooze: Increases sleaze damage
+Item	extra special Crimbo stocking	Last Available: "2004-12"
+Item	extra-grubby grub	Last Available: "2023-02"
 # extra-strength red potion: Restores 190-210 HP
 Item	extra-strength red potion	Last Available: "2013-02", Effect: "Healthy Red Glow", Effect Duration: 40
+Item	Eye Agate	Last Available: "2023-06"
 # fabric softener: Weakens enemies a lot
 # facehugging alien: Deals 100-300 Physical Damage after a few rounds have passed
+Item	facehugging alien	Last Available: "2009-06"
 # facsimile dictionary: Most Enemies Don't Care About It
 # facsimile dictionary: (doesn't go away when used)
 Item	faerie dust	Lasts Until Rollover, Last Available: "2018-04"
 Item	fairy-worn boots	Free Pull, Last Available: "2011-08"
+Item	fake fake vomit	Last Available: "2006-04"
+Item	fake plastic grass	Last Available: "2011-01"
 # familiar-in-the-middle wrapper: CyberRealm: Your familiar will find an extra 1 at the end of combat
 Item	familiar-in-the-middle wrapper	Last Available: "2025-12", Generic
 # fancy bath salts: Weakens enemies very slightly
 # fancy blue potion: Restores 90-110 MP
 Item	fancy blue potion	Last Available: "2013-02", Effect: "Healthy Blue Glow", Effect Duration: 40
 Item	fancy calligraphy pen	Free Pull, Last Available: "2015-01"
+Item	fancy chess set	Last Available: "2020-09"
+Item	fancy chocolate sculpture	Last Available: "2016-12"
 # fancy dress ball: Lets You Escape From Combat
+Item	fancy dress ball	Last Available: "2010-12"
+Item	fancy gourd potion	Last Available: "2013-12"
 # fancy oil painting: Useful for Bridge-Building
+Item	fancy oil painting	Last Available: "2014-12"
 # fancy stationery set: Produces 3 fancy calligraphy pens each day
+Item	fancy stationery set	Last Available: "2015-01"
 # FantasyRealm guest pass: Gives you access to FantasyRealm for the day
+Item	FantasyRealm guest pass	Last Available: "2018-04"
+Item	FantasyRealm key	Last Available: "2018-04"
 # FantasyRealm membership packet: Permanently unlocks access to FantasyRealm
 Item	FantasyRealm membership packet	Free Pull, Last Available: "2018-04"
+Item	FantasyRealm tattoo kit	Last Available: "2018-04"
 # fascinating alien plant sample: Worth 20 pages of Spacegate Research
+Item	fascinating alien plant sample	Last Available: "2017-04"
 # fascinating alien zoological sample: Worth 20 pages of Spacegate Research
+Item	fascinating alien zoological sample	Last Available: "2017-04"
 # fat bottom quark: Deals 25-40 <font color=green>Stench Damage</font>
+Item	fat bottom quark	Last Available: "2010-05"
 Item	fat loot token	No Pull
 # fat stacks of cash: Does Not Impress Most Monsters
+Item	Faux	Last Available: "2018-03"
+Item	FDKOL commendation	Last Available: "2012-07"
 # ferret bait: Deals 45-60 Physical Damage
+Item	festive egg sac	Last Available: "2021-12"
+Item	festive warbear bank	Last Available: "2013-12"
 # fetid feather: Deals 80-120 <font color=green>Stench Damage</font>
 Item	fettucini &eacute;pines Inconnu recipe	Recipe: "fettucini &eacute;pines Inconnu"
+Item	Feynman gate	Last Available: "2011-12"
 Item	Field Guide to Skeletal Anatomy	Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 Item	Field Guide to Skeletal Anatomy (shredded)	Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 Item	figurine of a charred seal	Class: "Seal Clubber"
@@ -12001,13 +13037,20 @@ Item	figurine of a stinking seal	Class: "Seal Clubber"
 Item	figurine of a wretched-looking seal	Class: "Seal Clubber"
 Item	figurine of an ancient seal	Class: "Seal Clubber"
 Item	figurine of an armored seal	Class: "Seal Clubber"
+Item	filling	Last Available: "2014-12"
 # filthy poultice: Restores 80-120 HP
 # finger cuffs: Stuns your opponent for a few rounds
+Item	finger cuffs	Last Available: "2010-06"
 # fingerprint dusting kit: Helps you find villains faster
+Item	fingerprint dusting kit	Last Available: "2017-01"
 # fire of unknown origin: Deals 35-45 <font color=red>Hot Damage</font> and 35-45 <font color=gray>Spooky Damage</font>
 # fireball: Deals 190-210 <font color=red>Hot Damage</font>
+Item	fireball	Last Available: "2013-02"
 # firebomb: Deals 40-50 <font color=red>Hot Damage</font>
+Item	First Post shirt package	Last Available: "2016-05"
+Item	fish head	Last Available: "2017-03"
 # fish-oil smoke bomb: Lets you escape from combat without spending an Adventure
+Item	fishin' pole	Last Available: "2016-04"
 Item	fishy pipe	Effect: "Fishy", Effect Duration: 10
 Item	fist turkey outline	Free Pull, Last Available: "2014-11"
 # fistful of wood shavings: Stops Enemy From Attacking and Weakens it Very Slightly
@@ -12015,152 +13058,313 @@ Item	fist turkey outline	Free Pull, Last Available: "2014-11"
 # flagellate flagon: Gain extra stats from your next drink
 # flagellate soup: Add a pound and increase the activation rate of your familiar
 # flame orb: Burn up an enemy and none of its items
+Item	flame orb	Last Available: "2020-09"
 # flaming feather: Deals 80-120 <font color=red>Hot Damage</font>
+Item	Flan	Last Available: "2018-03"
 # flaregun: Deals Various Kinds of Naval Damage
 Item	flask of holy water	Lasts Until Rollover, Last Available: "2018-04"
+Item	flavored foot massage oil	Last Available: "2008-04"
+Item	flickering pixel	Last Available: "2013-12"
+Item	flimsy hardwood scraps	Last Available: "2020-08"
 # flirtatious feather: Deals 80-120 <font color=blueviolet>Sleaze Damage</font>
+Item	floaty gravel	Last Available: "2009-09"
+Item	floaty pebbles	Last Available: "2009-09"
+Item	floaty rock	Last Available: "2009-09"
 Item	floaty stone sphere	Free Pull, Last Available: "2009-09"
 # floorboard cruft: Deals 100-120 <font color=green>Stench Damage</font>
 # floorboard cruft: Weakens Enemies Somewhat
 Item	Fly-By-Knight Heraldry form	Free Pull
+Item	foam dart	Last Available: "2008-04"
+Item	folder (barbarian)	Last Available: "2013-08"
+Item	folder (catfish)	Familiar Weight: +15, Last Available: "2013-08", Familiar Weight (hidden): [15*env(underwater)]
+Item	folder (holographic fractal)	Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
+Item	Folder Holder	Last Available: "2013-08"
 # food mailing list: Unlocks another row of houses for Crimbo activities
+Item	food mailing list	Last Available: "2020-12"
+Item	foreign language tapes	Last Available: "2015-01"
 # forest tears: Restores 5-10 HP
+Item	fossilized baboon skull	Last Available: "2010-09"
+Item	fossilized bat skull	Last Available: "2010-09"
+Item	fossilized demon skull	Last Available: "2010-09"
+Item	fossilized limb	Last Available: "2010-09"
+Item	fossilized serpent skull	Last Available: "2010-09"
+Item	fossilized spider skull	Last Available: "2010-09"
+Item	fossilized spike	Last Available: "2010-09"
+Item	fossilized spine	Last Available: "2010-09"
+Item	fossilized torso	Last Available: "2010-09"
+Item	fossilized wing	Last Available: "2010-09"
+Item	fossilized wyrm skull	Last Available: "2010-09"
 Item	foul cozy	Stench Damage: +10, Stench Spell Damage: +10
 Item	four-leaf potato sprout	Effect: "Luck of St. Patrick", Effect Duration: 30, Last Available: "2024-12"
 Item	Fourth of May Cosplay Saber kit	Free Pull
+Item	fragile Christmas ornament	Last Available: "2024-12"
 Item	fragment of Jarlsberg's soul	Free Pull, Last Available: "2013-06"
+Item	free-range mushroom	Last Available: "2020-03"
 Item	fresh can of paint	Free Pull, Last Available: "2021-12"
 # frightful feather: Deals 80-120 <font color=gray>Spooky Damage</font>
+Item	frigid fudgepuck	Last Available: "2011-11"
 # frigid ninja stars: Deals 20-25 <font color=blue>Cold Damage</font>
 # frontwinder skin: Adds +50% Mysticality to your cowboy boots
+Item	frost-rimed desk bell	Last Available: "2020-09"
 # Frosty's iceball: Deals 200-300 <font color=blue>Cold Damage</font>
 # Frosty's iceball: (you can use it 2 times a day without melting it)
 # frozen feather: Deals 80-120 <font color=blue>Cold Damage</font>
+Item	fruit-leather negatives	Last Available: "2016-12"
+Item	fudge cube	Last Available: "2011-11"
+Item	fudge spork	Last Available: "2011-11"
+Item	fudgecule	Last Available: "2011-11"
+Item	full lava bottle	Last Available: "2015-08"
 Item	fumble formula	Recipe: "concoction of clumsiness"
+Item	FunFunds&trade;	Last Available: "2015-04"
+Item	funhouse mirror	Last Available: "2011-10"
+Item	furious stone	Last Available: "2012-12"
+Item	furry brown pillow	Last Available: "2013-12"
+Item	furry pink pillow	Last Available: "2013-12"
+Item	fused fuse	Last Available: "2015-08"
 Item	Fuzzby	Free Pull, Last Available: "2011-11"
+Item	Game Grid ticket	Last Available: "2010-06"
+Item	Game Grid token	Last Available: "2010-06"
+Item	Game Grid valued membership card	Last Available: "2010-06"
+Item	GameInformPowerDailyPro magazine	Last Available: "2013-02"
 Item	GameInformPowerDailyPro subscription card	Free Pull, Last Available: "2013-02"
+Item	GameInformPowerDailyPro walkthru	Last Available: "2013-02"
 # gas balloon: Stuns your opponent for a few rounds
+Item	gas can	Last Available: "2018-09"
 # Gathered Meat-Clip: Unclip some meat
+Item	Gathered Meat-Clip	Last Available: "2020-09"
 # gauze garter: Restores 80-120 HP
+Item	Gazelleton	Last Available: "2018-03"
+Item	General Assembly Module	Last Available: "2007-12"
 # generic healing potion: Restores HP based on your level
+Item	generic healing potion	Last Available: "2011-09"
 # generic mana potion: Restores MP based on your level
+Item	generic mana potion	Last Available: "2011-09"
 # generic restorative potion: Restores 4-5 HP and 2-3 MP
+Item	generic restorative potion	Last Available: "2011-09"
+Item	genie bottle	Last Available: "2017-09"
+Item	Ghosprey	Last Available: "2018-03"
 # Ghost Dog Chow: Grants 20 Familiar XP
+Item	Ghost Dog Chow	Last Available: "2015-10"
 Item	Ghost Pinching Quarterly	Skill: "Pinch Ghost", Last Available: "2012-12"
 # ghost protocol: Makes you nearly impervious to damage for the duration of the fight
+Item	ghost protocol	Last Available: "2011-10"
 # ghost trap: Traps ghosts
+Item	ghost trap	Last Available: "2011-10"
+Item	giant amorphous blob	Last Available: "2017-11"
+Item	Giant black monolith	Last Available: "2023-06"
 # giant eraser: Lets you escape from combat without spending an Adventure
+Item	giant free-range mushroom	Last Available: "2020-03"
+Item	giant green gummi ingot	Last Available: "2011-11"
+Item	giant O	Last Available: "2017-11"
+Item	giant red gummi ingot	Last Available: "2011-11"
+Item	giant X	Last Available: "2017-11"
+Item	giant yellow gummi ingot	Last Available: "2011-11"
 # gift card: Allows you to draw one card from the Deck of Every Card
+Item	gift card	Last Available: "2015-07"
+Item	gilded BRICKO brick	Last Available: "2010-02"
+Item	gilded BRICKO chalice	Last Available: "2010-02"
+Item	gingerbread blackmail photos	Last Available: "2016-12"
 # gingerbread cigarette: Placate a gingerbread man
+Item	gingerbread cigarette	Last Available: "2016-12"
 # gingerbread dog treat: Grants 20 Familiar XP
+Item	gingerbread dog treat	Last Available: "2016-12"
 # gingerbread restraining order: Banish a gingerbread man for the rest of the day
+Item	gingerbread restraining order	Last Available: "2016-12"
 # gingerbread smartphone
+Item	gingerbread smartphone	Last Available: "2016-12"
 # gingernade: Deals 200-250 damage
+Item	gingernade	Last Available: "2019-12"
 # ginseng: Gives a Pokefamiliar Regeneration
+Item	Glamare	Last Available: "2018-03"
 # glark cable: Instantly defeats most monsters on the Red Zeppelin
+Item	glass	Last Available: "2014-12"
+Item	glass ceiling fragments	Last Available: "2015-08"
 # Glass Jack's spyglass: Reveals the distant secrets of PirateRealm
 Item	Glass Jack's spyglass	Lasts Until Rollover, Last Available: "2019-04"
 Item	glass of warm water	Free Pull
 # Glenn's golden dice: Grants you some random beneficial effects
+Item	Glenn's golden dice	Last Available: "2016-02"
 # glitched malware: CyberRealm:  Banish a process for the rest of the day
+Item	glitched malware	Last Available: "2025-12"
 # glob of Bat-Glue: Stuns foes for a few rounds
+Item	glob of Bat-Glue	Last Available: "2017-01"
 # glob of Blank-Out: Lets you escape from combat without spending an Adventure
 # glob of Blank-Out: (usable a few times before it goes away)
+Item	glob of Blank-Out	Last Available: "2011-01"
 # glob of melted wax: Can be fashioned into various wax objects
 # glob of melted wax: Stuns enemies for a few rounds, dealing <font color=red>Hot Damage</font> all the while
+Item	glob of melted wax	Last Available: "2017-01"
 # glob of undifferentiated tissue: You have no idea what will happen!
+Item	glob of undifferentiated tissue	Last Available: "2018-11"
+Item	Globmule	Last Available: "2018-03"
 Item	glover liners	Pickpocket Chance: +10
 Item	glowing frisbee	Free Pull, Last Available: "2011-12"
 # glowing New Age crystal: Restores 500 MP
 # glowing New Age crystal: (and briefly stuns your opponent)
+Item	glowing New Age crystal	Last Available: "2015-08"
 # glowing spore pod: Briefly enhances your Mysticality
 # Glum berry: Removes negative effects and energizes you for a while
+Item	Glum berry	Last Available: "2018-03"
+Item	gluttonous stone	Last Available: "2012-12"
+Item	gnashing teeth	Last Available: "2008-12"
 # Gnomitronic Hyperspatial Demodulizer: Science!
 # gob of wet hair: Stops Enemy From Attacking and Weakens it Very Slightly
 Item	God Lobster Egg	Free Pull, Last Available: "2018-05"
+Item	gold piece	Last Available: "2013-12"
 # gold star: Restores 20-30 MP
 Item	gold star	Last Available: "2013-02", Effect: "Healthy Blue Glow", Effect Duration: 10
 Item	golden gum	Free Pull, Last Available: "2017-06"
 Item	golden gun	Free Pull, Last Available: "2017-06"
 # Golden Kokomo Resort Chip: Shiny!
+Item	Golden Kokomo Resort Chip	Last Available: "2015-04"
 # Golden Light: Vaporizes an enemy and causes all of its items to drop
+Item	Golden Light	Last Available: "2013-12"
 Item	golden monkey statuette	Free Pull, Last Available: "2015-12"
+Item	golden pet rock	Last Available: "2024-12"
 # golden plastic oyster egg: Lets you escape from combat without spending an Adventure
 # golden plastic oyster egg: (Maybe)
 # golden ring: Weakens enemies a lot
+Item	golden ring	Last Available: "2007-12"
+Item	golden tattoo gun	Last Available: "2017-06"
 # goodberry: Restores all of your HP
+Item	goodberry	Last Available: "2019-12"
 # Goodfella contract: Make your Goodfella an offer he can't refuse
+Item	Goodfella contract	Last Available: "2011-12"
 Item	googly chest eyes	Familiar Weight: +5
+Item	gooified animal matter	Last Available: "2021-12"
+Item	gooified mineral matter	Last Available: "2021-12"
+Item	gooified vegetable matter	Last Available: "2021-12"
+Item	Gordon Beer's Beer Garden Catalog	Last Available: "2013-09"
+Item	Gorillape	Last Available: "2018-03"
 # GOTO: Lets you escape from combat without spending an Adventure
 # GOTO: (Maybe)
 # government booze shipment: Send 50 donated booze to another player (limit 1 per recipient per day)
+Item	government booze shipment	Last Available: "2020-12"
 # government candy shipment: Send 50 donated candy to another player (limit 1 per recipient per day)
+Item	government candy shipment	Last Available: "2020-12"
 # government food shipment: Send 50 donated food to another player (limit 1 per recipient per day)
+Item	government food shipment	Last Available: "2020-12"
+Item	government requisition form	Last Available: "2018-11"
+Item	grain of sand	Last Available: "2019-07"
 Item	Granny Tood's Thanksgarden Catalog	Free Pull, Last Available: "2016-11"
 # grape troll doll: Deals 3-5 <font color=blueviolet>Sleaze Damage</font>
 # grape troll doll: (doesn't go away when used)
+Item	grape troll doll	Last Available: "2011-11"
+Item	grappling hook	Last Available: "2009-12"
 # grass clippings: Weakens enemies very slightly
+Item	grass clippings	Last Available: "2023-12"
 # Gratitude chocolate (Meat-filled): Contains 10,000 Meat
+Item	Gratitude chocolate (Meat-filled)	Last Available: "2016-02"
+Item	Gratitude chocolate (octopus-filled)	Last Available: "2016-02"
 # Gratitude chocolate (thyme-filled): Grants 10 Adventures
+Item	Gratitude chocolate (thyme-filled)	Last Available: "2016-02"
+Item	gravy skin	Last Available: "2024-12"
+Item	greasy desk bell	Last Available: "2020-09"
+Item	Great Ball of Frozen Fire	Last Available: "2007-01"
 # great big capacitor: Deals 25-35 Physical Damage and briefly stuns your foe
+Item	great big capacitor	Last Available: "2013-12"
 # Great Wolf's lice: (by 30% if they are beasts)
 # Great Wolf's lice: (doesn't go away when used)
 # Great Wolf's lice: Weakens enemies a lot
 # green BRICKO brick: Deals a percentage of a monster's current Hit Points in Physical Damage
 # green BRICKO brick: (more effective against BRICKO monsters)
+Item	green BRICKO brick	Last Available: "2010-02"
+Item	green candygram	Last Available: "2007-02"
 # green face paint: Does not go away when used.
 # green face paint: Makes you green with holiday cheer!
 Item	green face paint	Free Pull, Last Available: "2015-12"
+Item	green gummi ingot	Last Available: "2011-11"
+Item	green lava globs	Last Available: "2015-08"
+Item	green mana	Last Available: "2015-07"
 # green pill: It unlocks a tattoo.  That's what it does.
+Item	green pill	Last Available: "2016-06"
 # green pixel potion: Restores 40-60 HP and 30-40 MP
+Item	green slime glob	Last Available: "2018-11"
 # green smoke bomb: Lets you escape from combat without spending an Adventure
 # green smoke bomb: (Probably)
 Item	grey gosling	Free Pull, Last Available: "2022-03"
 Item	grim cellophane	Combat Rate: -5
+Item	grimstone mask	Last Available: "2014-12"
 # grizzled bearskin Adds +50% Muscle to your cowboy boots
 # grody jug: Deals a Buttload of <font color=green>Stench Damage</font>
+Item	grody jug	Last Available: "2015-04"
 # grogpagne: Restores 30-50 MP
+Item	grogpagne	Last Available: "2021-07"
 Item	grolblin rum	Lasts Until Rollover, Last Available: "2018-04"
 # grouchy restless spirit: Deals 40-45 <font color=gray>Spooky Damage</font>
 # groupie lipstick: Deals 150-250 <font color=blueviolet>Sleaze Damage</font>
 # groveling gravel: &quot;Defeat&quot; your opponent for meat and stats, but no items.
+Item	groveling gravel	Last Available: "2023-01"
+Item	Grumpy Bumpkin's Pumpkin Seed Catalog	Last Available: "2010-11"
 # Gummi-Memory: Your future Gelatinous Noob runs will start with 5 extra skills (up to 20)
 # gun parts: Maybe you can make a gun out of them?
+Item	gun parts	Last Available: "2016-02"
 Item	Guzzlr application	Free Pull
+Item	Guzzlr cocktail set	Last Available: "2020-05"
+Item	Guzzlr tattoo kit	Last Available: "2020-05"
+Item	Guzzlrbuck	Last Available: "2020-05"
 Item	Gygaxian Libram	Last Available: "2011-09", Skill: "Summon Dice"
+Item	gym membership card	Last Available: "2013-11"
 # gyroscope: Briefly distracts enemies
+Item	gyroscope	Last Available: "2010-12"
+Item	hair of the calf	Last Available: "2010-04"
 # half of a gold tooth: It's gross.  Just sell it.
+Item	half-digested rat	Last Available: "2024-12"
 # half-empty carton of milk: Deals 50-100 <font color=green>Stench Damage</font>
+Item	half-empty carton of milk	Last Available: "2012-12"
+Item	half-melted hula girl	Last Available: "2015-08"
 # half-rotten brain: Disappoints Zombies
 # hand grenegg: Deals 6-8 <font color=green>Stench Damage</font> per round for the rest of the fight
 Item	hand turkey outline	Free Pull, Last Available: "2004-11"
 # handful of bees: Deals 80-100 Physical Damage per round for the rest of the fight
+Item	handful of headless bolts	Last Available: "2009-12"
 # handful of napalm: Deals 100 <font color=red>Hot Damage</font> and sets your opponent on fire
+Item	handful of numbers	Last Available: "2020-09"
 # handful of sand: Make stuff out of it!
 # handful of sand: Weakens Enemies a Little Bit
 # handful of sawdust: Weakens enemies somewhat
 # handful of split pea soup: Banish a foe
+Item	handful of split pea soup	Last Available: "2024-11"
+Item	handful of wires	Last Available: "2009-12"
 # Handsome Devil: Instantly defeats most monsters
+Item	Handsome Devil	Last Available: "2013-12"
+Item	Hanukkimbo dreidl	Last Available: "2004-12"
+Item	hard rock	Last Available: "2023-01"
 # hard spore pod: Briefly enhances your defense
 # Harold's bell: Banishes a monster for a while
+Item	harpoon	Last Available: "2024-12"
+Item	hashing vise	Last Available: "2025-12"
+Item	Haunted Sorority House staff guide	Last Available: "2011-10"
 # head of emberg lettuce: Wrap your next food in lettuce!
+Item	head of emberg lettuce	Last Available: "2024-09"
+Item	heart cozy	Last Available: "2018-02"
 Item	heart necklace	Free Pull
 # heart of dark chocolate: Restores 40-50 HP
 # heart of dark chocolate: (doesn't go away when used)
+Item	heart of dark chocolate	Last Available: "2011-11"
 Item	heart-shaped crate	Free Pull, Last Available: "2017-02"
 Item	heat particle	Hot Damage: +10, Hot Spell Damage: +10
+Item	heat-resistant sheet metal	Last Available: "2015-08"
 # hedgeturtle: Causes Bleeding
 # hedgeturtle: Deals 30-60 Physical Damage
 Item	Hell and How I Bent It	Skill: "Bend Hell", Last Available: "2016-02"
 # hemp net: Deals 90-100 Physical Damage
 # hemp net: Weakens Enemies Somewhat
+Item	hermit factoid	Last Available: "2015-07"
 Item	hero's skull	Lasts Until Rollover, Last Available: "2018-04"
+Item	hi-density nylocite leg armor	Last Available: "2007-12"
 Item	hibernating Grimstone Golem	Free Pull, Last Available: "2014-12"
 Item	hibernating robot reindeer	Free Pull, Last Available: "2010-12"
+Item	hideous egg	Last Available: "2011-05"
 # high-grade explosives: Can be used in the Bat-Cavern's Bat-Fab to make Bat-o-mite
+Item	high-grade explosives	Last Available: "2017-01"
 # high-grade metal: Can be used in the Bat-Cavern's Bat-Fab to make Bat-oomerangs
+Item	high-grade metal	Last Available: "2017-01"
 # high-pressure seltzer bottle: Restores 150-200 MP
+Item	high-resistance ultrapolymer plating	Last Available: "2011-12"
 # high-tensile-strength fibers: Can be used in the Bat-Cavern's Bat-Fab to make Bat-jute
+Item	high-tensile-strength fibers	Last Available: "2017-01"
+Item	hippo tutu	Last Available: "2011-09"
 Item	History's Most Offensive Jokes, Vol. IX	Skill: "Unoffendable", Last Available: "2014-05"
 Item	Hjodor's Guide to Arctic Dalmatians	Skill: "Frigidalmatian", Last Available: "2012-07"
 Item	Hjodor's Guide to Arctic Dalmatians (used)	Skill: "Frigidalmatian", Last Available: "2012-07"
@@ -12173,25 +13377,39 @@ Item	Hodgman's journal #3: Pumping Tin	Skill: "Abs of Tin"
 Item	Hodgman's journal #4: View From The Big Top	Skill: "Marginally Insane"
 Item	Holiday Fun!	Free Pull, Last Available: "2014-12"
 Item	Holiday Hal's Happy-Time Fun Book!	Skill: "Summon Holiday Fun!"
+Item	holiday log	Last Available: "2011-01"
 Item	Holiday Multitasking	Last Available: "2024-12", Skill: "Holiday Multitasking"
 Item	Holiday Multitasking (used)	Last Available: "2024-12", Skill: "Holiday Multitasking"
+Item	hollow rock	Last Available: "2023-02"
 # holo-bomber: Deals 5,000 Physical Damage
+Item	holo-bomber	Last Available: "2014-09"
 # holo-platoon: Deals 5,000 Physical Damage
+Item	holo-platoon	Last Available: "2014-09"
 # holo-tank: Deals 5,000 Physical Damage
+Item	holo-tank	Last Available: "2014-09"
 # holy bomb, batman: Deals 400-500 Physical Damage
 # holy bomb, batman: (way more effective against undead foes)
+Item	holy bomb, batman	Last Available: "2011-09"
 # holy spring water: Restores 20-25 MP
 Item	holy spring water	Effect: "Spiritually Awake", Effect Duration: 10
+Item	home robotics kit	Last Available: "2012-12"
 Item	homeless hobo spirit	Free Pull, Last Available: "2006-05"
+Item	homemade robot	Last Available: "2012-12"
+Item	homeopathic healing powder	Last Available: "2006-06"
 # honey-dipped locust: Restores 30-40 HP and MP
 Item	hopeful candle	Free Pull, Last Available: "2017-01"
 # Horsery contract: Installs a Horsery in Seaside Town
 # Horsery contract: (and unlocks Horse Armor DLC for West of Loathing)
 Item	Horsery contract	Free Pull, Last Available: "2018-08"
 # hot ashes: Deals <font color=red>Hot Damage</font> based on your highest stat
+Item	hot ashes	Last Available: "2014-06"
 # hot clusterbomb: Deals <font color=red>Hot Damage</font> based on your highest stat
 # hot clusterbomb: (more effective against groups)
+Item	hot daub	Last Available: "2012-07"
+Item	hot egg	Last Available: "2012-07"
 # hot spore pod: Briefly improves your <font color = red>Hot</font> spells
+Item	hotel minibar key	Last Available: "2015-11"
+Item	hourglass	Last Available: "2019-07"
 Item	How To Get Bigger Without Really Trying	Skill: "Get Big", Last Available: "2018-02"
 Item	How to Hold a Grudge	Skill: "Chip on your Shoulder"
 Item	How to Lose Friends and Attract Snakes	Last Available: "2024-12", Skill: "Attract Snakes"
@@ -12200,77 +13418,161 @@ Item	How to Lose Friends and Attract Snakes (used)	Last Available: "2024-12", Sk
 Item	How to Tolerate Jerks	Skill: "Thick-Skinned"
 Item	Hoyle's Guide to Reindeer Games	Last Available: "2024-12", Skill: "Reindeer Games"
 Item	Hoyle's Guide to Reindeer Games (used)	Last Available: "2024-12", Skill: "Reindeer Games"
+Item	huge gold coin	Last Available: "2013-02"
+Item	huge pumpkin	Last Available: "2010-11"
 Item	Huggler Radio	Free Pull
 # human musk: Banish an enemy for the rest of the day
+Item	human musk	Last Available: "2019-12"
 Item	hungover chauvinist pig	Free Pull, Last Available: "2010-10"
+Item	hyperbolic plasma focuser	Last Available: "2011-12"
 # ice hotel bell: Deals 250-300 Cold Damage
+Item	ice hotel bell	Last Available: "2015-11"
 # ice house: Banishes a monster more or less permanently
+Item	ice house	Last Available: "2014-01"
+Item	ice sculpture	Last Available: "2014-01"
 # ice skate decoy: Put it down, and monsters will attack it instead of you
+Item	ice stein	Last Available: "2006-06"
 # ice-cold Cloaca Zero: Deals 100-200 <font color=blue>Cold Damage</font> and restores up to 2,000 MP
+Item	ice-cold Cloaca Zero	Last Available: "2014-10"
+Item	iceberglet	Last Available: "2006-02"
+Item	ICEbox	Last Available: "2025-12"
+Item	iGoogly	Last Available: "2007-12"
 # illegal firecracker: Deals 15-20 Physical Damage and 15-20 <font color=red>Hot Damage</font>
 Item	Illustrated Mating Rituals of the Gallapagos	Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
+Item	imaginary lemon	Last Available: "2017-03"
 Item	imbued seal-blubber candle	Class: "Seal Clubber"
 # imitation crab meat: Deals 150-250 Physical Damage
 # imitation crab meat: (will backfire if used on land)
+Item	immense free-range mushroom	Last Available: "2020-03"
 # imp air: Deals 35-40 <font color=red>Hot Damage</font>
 Item	in-the-box spring shoes	Free Pull, Last Available: "2024-02"
 # incriminating evidence: Take it downtown to Gotpork P. D.
+Item	incriminating evidence	Last Available: "2017-01"
+Item	Indigo Party Invitation	Last Available: "2009-06"
+Item	industrial strength anti-fungal spray	Last Available: "2014-05"
+Item	industrially-crushed ice	Last Available: "2022-12"
+Item	inert sludgepuppy	Last Available: "2015-04"
 Item	infant sandworm	Free Pull, Last Available: "2011-12"
 # infinite BACON machine: Generate 100 BACON per day
+Item	infinite BACON machine	Last Available: "2016-05"
+Item	inflatable LT&T telegraph office	Last Available: "2016-02"
 # ingot turtle: Deals 90-110 <font color=red>Hot Damage</font> and changes your opponent's element to Hot
 Item	Inigo's Incantation of Inspiration	Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 Item	Inigo's Incantation of Inspiration (crumpled)	Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 # ink bladder: Lets you escape from combat without spending an Adventure (underwater)
 # ink bladder: Weakens enemies significantly (on land)
 # inkwell: Weakens enemies a little bit
+Item	innuendo	Last Available: "2011-04"
+Item	insignificant bit	Last Available: "2025-12"
+Item	insulated gold wire	Last Available: "2015-08"
 # intact anemone spike: Deal 100 damage (Underwater only)
+Item	intact anemone spike	Last Available: "2019-12"
 # interesting clod of dirt: Absorb it for a useful skill!
+Item	interesting-looking twig	Last Available: "2008-06"
 # internet point: Give yourself +1
+Item	internet point	Last Available: "2016-05"
+Item	Interview With You (a Vampire)	Last Available: "2011-10"
+Item	intriguing puzzle box	Last Available: "2011-04"
+Item	ion grid	Last Available: "2011-12"
+Item	ion-pulse modulation stabilizer	Last Available: "2011-12"
+Item	iron chain	Last Available: "2015-12"
 Item	Island Drinkin', a Tiki Mixology Odyssey	Skill: "Tiki Mixology", Last Available: "2019-04"
+Item	Jack-in-the-box	Last Available: "2009-12"
 Item	Jackass Plumber home game	Last Available: "2011-11", Effect: "Gamer Rage", Effect Duration: 10
 # jagged scrap metal: Deals 20-30 Physical Damage and causes bleeding
+Item	jam band bootleg	Last Available: "2018-09"
 # jam band flyers: Advertise!
 # Jamocha berry: Grants passive physical damage and energizes you for a while
 Item	Jamocha berry	Last Available: "2018-03", Effect: "Berry Thorny", Effect Duration: 20
+Item	jangly spurs	Last Available: "2016-02"
 # janitor sponge: Deals 20-30 <font color=green>Stench Damage</font> and briefly stuns your opponent
 # January's Garbage Tote: Allows you to rummage up Holiday Detritus
+Item	January's Garbage Tote	Last Available: "2018-01"
 # January's Garbage Tote (unopened): Allows you to rummage up Holiday Detritus
 Item	January's Garbage Tote (unopened)	Free Pull, Last Available: "2018-01"
 # jar full of wind: Weakens enemies somewhat and briefly stuns them
+Item	jar full of wind	Last Available: "2012-12"
+Item	jar of psychoses (Jick)	Last Available: "2013-12"
+Item	jar of psychoses (The Captain of the Gourd)	Last Available: "2013-12"
+Item	jar of psychoses (The Crackpot Mystic)	Last Available: "2013-12"
+Item	jar of psychoses (The Meatsmith)	Last Available: "2013-12"
+Item	jar of psychoses (The Old Man)	Last Available: "2013-12"
+Item	jar of psychoses (The Pretentious Artist)	Last Available: "2013-12"
+Item	jar of psychoses (The Suspicious-Looking Guy)	Last Available: "2013-12"
 # jar of swamp gas: Deals 20-30 <font color=green>Stench Damage</font>
 # jar of swamp gas: Stuns enemies for a few rounds
+Item	jar of swamp gas	Last Available: "2007-05"
 # jar of swamp honey: You can dip food in it
+Item	jar of swamp honey	Last Available: "2015-04"
+Item	jealousy stone	Last Available: "2012-12"
+Item	Jerks' Health&trade; Magazine	Last Available: "2014-12"
 # Jick's autograph: Cool!
 # jigsaw blade: Deals 10-20 Physical Damage, causes a brief stun and less brief bleeding
+Item	jingle bell	Last Available: "2010-12"
 # jingling spore pod: Briefly improves your Ranged damage
 Item	jitterbug larva	Free Pull, Last Available: "2007-10"
+Item	jolly roger tattoo kit	Last Available: "2024-12"
 Item	jug of Sneaky Pete's Mojo	Free Pull
+Item	juggling ball	Last Available: "2014-12"
 # Junk-Bond: Weakens enemies somewhat and briefly stuns them
 # Keese berry: Improves your defenses and energizes you for a while
 Item	Keese berry	Last Available: "2018-03", Effect: "Berry Defensive", Effect Duration: 20
 Item	kerosene-soaked skip	Free Pull, Last Available: "2018-12"
+Item	kevlateflocite helmet	Last Available: "2007-12"
+Item	keycard &alpha;	Last Available: "2015-04"
+Item	keycard &beta;	Last Available: "2015-04"
+Item	keycard &delta;	Last Available: "2015-04"
+Item	keycard &gamma;	Last Available: "2015-04"
+Item	khaki duffel bag	Last Available: "2014-10"
 # kidnapped orphan: Take it downtown to Gotpork Orphanage
+Item	kidnapped orphan	Last Available: "2017-01"
 # killing feather: Deals 100-120 Physical Damage
+Item	killing feather	Last Available: "2007-12"
 # killing jar: Weakens enemies somewhat and briefly stuns them
 Item	Kissin' Cousins	Skill: "Awesome Balls of Fire"
 # kite: Weakens enemies somewhat and briefly stuns them
+Item	kite	Last Available: "2005-12"
 Item	kitten burglar	Free Pull, Last Available: "2018-07"
 # Knob Goblin firecracker: Deals 2-4 Physical Damage
 Item	Knob Goblin firecracker	Effect: "Missing Fingers", Effect Duration: 3
 # Knob Goblin seltzer: Restores 8-12 MP
 # Knob Goblin stink bomb: Weakens enemies slightly
 # Knob Goblin superseltzer: Restores 25-29 MP
+Item	kobold treasure hoard	Last Available: "2011-09"
+Item	Kokomo Resort Chip	Last Available: "2015-04"
 # Kokomo Resort Order Pad: Boring!
+Item	Kokomo Resort Order Pad	Last Available: "2015-04"
 Item	KoLHS Pep Squad Box	Free Pull, Last Available: "2013-09"
 Item	Kramco Industries packing carton	Free Pull, Last Available: "2019-01"
+Item	kumquartz	Last Available: "2011-11"
+Item	Lapis Lazuli	Last Available: "2023-06"
+Item	large pile of sand	Last Available: "2019-07"
+Item	LARP membership card	Last Available: "2008-10"
+Item	Lars the Cyberian	Last Available: "2011-04"
+Item	laser cannon	Last Available: "2007-12"
+Item	laser targeting chip	Last Available: "2007-12"
 Item	latte lovers club card	Free Pull, Last Available: "2018-10"
 Item	Lava Miner's Daughter	Skill: "Asbestos Heart", Last Available: "2015-08"
+Item	LavaCo&trade; Lamp housing	Last Available: "2015-08"
+Item	Lavalos core	Last Available: "2015-08"
+Item	lavender candygram	Last Available: "2007-02"
 # lavender plastic oyster egg: Deals 40-50 Physical Damage
 # Law of Averages: Averages you out
 # Lazenby's Life Lesson: Increase your Social Capital in License to Adventure Runs
 Item	Lazenby's Life Lesson	Free Pull
+Item	LCD game: Burger Belt	Last Available: "2014-08"
+Item	LCD game: Food Eater	Last Available: "2014-08"
+Item	LCD game: Garbage River	Last Available: "2014-08"
+Item	leaf tube	Last Available: "2006-12"
+Item	leather	Last Available: "2014-12"
+Item	lecherous stone	Last Available: "2012-12"
+Item	LED block	Last Available: "2007-12"
+Item	leftover Crimbo rations	Last Available: "2009-12"
 # leftovers of indeterminate origin: Deals 8-10 <font color=green>Stench Damage</font>
+Item	lemony scales	Last Available: "2014-12"
+Item	Lepardner	Last Available: "2018-03"
 Item	Let Me Be!	Skill: "Raise Backup Dancer"
+Item	Letter from Carrie Bradshaw	Last Available: "2023-06"
 # lewd playing card: Deals 100-150 Physical Damage and 100-150 <font color=blueviolet>Sleaze Damage</font>
 Item	LI-11 Motor Pool voucher	Free Pull, Last Available: "2017-07"
 # li'l orphan tot: Does a multitude of things depending on outfit
@@ -12281,54 +13583,127 @@ Item	Libram of Divine Favors	Free Pull, Last Available: "2011-12", Skill: "Summo
 Item	Libram of Love Songs	Last Available: "2009-02", Skill: "Summon Love Song"
 Item	Libram of Pulled Taffy	Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
 Item	Libram of Resolutions	Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
+Item	library card	Last Available: "2007-06"
+Item	License to Chill	Last Available: "2017-07"
 # License To Kill: ???
 # Lil' Snowball Factory: Makes 3 perfect snowballs, every day!
+Item	Lil' Snowball Factory	Last Available: "2023-12"
+Item	limepatch	Last Available: "2017-03"
 # linen bandages: Restores 10-20 HP
+Item	lint	Last Available: "2011-12"
 # lip soup: Add a pound and volleyball behavior to your familiar
+Item	lit cigar	Last Available: "2011-12"
+Item	little firkin	Last Available: "2015-09"
+Item	Little Geneticist DNA-Splicing Lab	Last Available: "2014-04"
 # little parachute guy: Eventually restores 10-20 HP and MP
+Item	little parachute guy	Last Available: "2010-06"
 # little piece of steel: Deals <font color=red>Hot</font> and Physical Damage based on your Muscle
 # little red book: Doesn't go away when used.
 # little red book: Weakens enemies by 5% and briefly stuns them.
+Item	little red book	Last Available: "2015-12"
+Item	live lobster	Last Available: "2011-12"
 # live nautical mine: Deals a bunch of Physical Damage
 # live nautical mine: Is unsafe on land
 Item	Living to Drink, Drinking to Live	Last Available: "2018-09", Skill: "Drinking to Drink"
 Item	llama lama cria	Free Pull, Last Available: "2008-06"
+Item	loaded serum blowgun	Last Available: "2005-11"
+Item	Loathing Idol Microphone	Last Available: "2023-06"
+Item	Loathing Idol Microphone (25% charged)	Last Available: "2023-06"
+Item	Loathing Idol Microphone (50% charged)	Last Available: "2023-06"
+Item	Loathing Idol Microphone (75% charged)	Last Available: "2023-06"
 # Loathing Legion jackhammer: Allows Meatsmithing without the Adventure cost (3 times a day)
 Item	Loathing Legion jackhammer	Softcore Only, Last Available: "2011-01"
+Item	Loathing Legion knife	Last Available: "2011-01"
+Item	Loathing Legion tattoo needle	Last Available: "2011-01"
+Item	Loathing Legion universal screwdriver	Last Available: "2011-01"
 # locked mumming trunk: Dress your familiars up like weird old dramatic archetypes!
 Item	locked mumming trunk	Free Pull, Last Available: "2017-12"
 Item	lodestone	Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 # logic grenade: Instantly kill a CyberRealm process
+Item	logic grenade	Last Available: "2025-12"
+Item	logic synthesizer	Last Available: "2011-12"
+Item	lollipop stick	Last Available: "2011-11"
 # LOLmec statuette: Sells for 1 Million Meat
+Item	LOLmec statuette	Last Available: "2015-12"
+Item	Lolsipop	Last Available: "2018-02"
+Item	lost key	Last Available: "2012-05"
 # Louder Than Bomb: Banishes a monster for a while
+Item	Louder Than Bomb	Last Available: "2013-12"
+Item	Loudmouth Larry Lamprey	Last Available: "2008-04"
+Item	LOV Emotionizer	Last Available: "2017-02"
+Item	LOV Enamorang	Last Available: "2017-02"
+Item	LOV Entrance Pass	Last Available: "2017-02"
+Item	LOV Extraterrestrial Chocolate	Last Available: "2017-02"
 Item	Love Potions and the Wizards who Mix Them	Skill: "Love Mixology", Last Available: "2018-02"
+Item	LT&T tattoo kit	Last Available: "2016-02"
 # LT&T telegraph office deed: Opens a LT&T telegraph office in Seaside Town
 Item	LT&T telegraph office deed	Free Pull, Last Available: "2016-02"
+Item	lucky cat statue	Last Available: "2013-12"
 # lucky moai statuette: Contains three 11-leaf clovers
+Item	lucky moai statuette	Last Available: "2024-12"
+Item	lucky napkin	Last Available: "2024-12"
+Item	lump of bauxite	Last Available: "2018-12"
+Item	lump of black ichor	Last Available: "2017-03"
+Item	lump of Brituminous coal	Last Available: "2013-12"
 # lump of frequently wriggling eldritch matter: Makes you feel Vaguely Uneasy
 # lump of not really wriggling eldritch matter: Makes you feel Vaguely Uneasy
 Item	Lump-Stacking for Beginners	Skill: "Stack Lumps", Last Available: "2016-12"
+Item	lunar isotope	Last Available: "2011-06"
+Item	lupine appetite hormones	Last Available: "2014-12"
 Item	luxury fly-tying workbench	Fishing Skill: +10, Last Available: "2016-04"
 Item	LyleCo Contractor's Manual	Skill: "Expert Corner-Cutter", Last Available: "2018-04"
+Item	LyleCo premium pickaxe	Last Available: "2018-04"
+Item	LyleCo premium rope	Last Available: "2018-04"
 Item	machine elf capsule	Free Pull, Last Available: "2015-12"
 # mafia filofax: Organize some quiet moments in an area
+Item	magical battery	Last Available: "2013-12"
+Item	magical ice cube with a fly in it	Last Available: "2006-04"
 # magical mystery juice: Restores an amount of MP that increases as you level up
+Item	magical pony: Dusk Shiny	Last Available: "2017-09"
+Item	magical pony: Pearjack	Last Available: "2017-09"
+Item	magical pony: Rosey Cake	Last Available: "2017-09"
+Item	magical pony: Shutterfly	Last Available: "2017-09"
+Item	magical pony: Spectrum Dash	Last Available: "2017-09"
+Item	magical pony: Uniquity	Last Available: "2017-09"
+Item	magical sausage casing	Last Available: "2019-01"
+Item	magnetic sculpture kit	Last Available: "2012-12"
 # magnolia blossom: Restores 15-30 HP and MP
+Item	magnolia blossom	Last Available: "2012-12"
+Item	Make-Your-Own-Vampire-Fangs kit	Last Available: "2011-10"
 Item	Manual of Lock Picking	Skill: "Lock Picking", Last Available: "2020-08"
 Item	Manual of Numberology	Skill: "Calculate the Universe"
 Item	Manual of Secret Door Detection	Last Available: "2023-06", Skill: "Secret Door Awareness"
 Item	Manual of Transcendent Olfaction	Skill: "Transcendent Olfaction"
+Item	map to a candy-rich block	Last Available: "2023-10"
 Item	map to Dolph Bossin's hideout	Free Pull, Last Available: "2019-12"
+Item	map to Ellsbury's Claim	Last Available: "2010-09"
 Item	Map to Kokomo	Free Pull, Skill: "Summon Kokomo Resort Pass"
+Item	map to Professor Jacking's laboratory	Last Available: "2010-04"
+Item	Map to Safety Shelter Grimace Prime	Last Available: "2011-06"
+Item	Map to Safety Shelter Ronald Prime	Last Available: "2011-06"
+Item	map to the Biggest Barrel	Last Available: "2015-09"
 # map to the Cursed Village: Gives permanent access to the Cursed Village in FantasyRealm
+Item	map to the Cursed Village	Last Available: "2018-04"
+Item	map to the Kegger in the Woods	Last Available: "2010-06"
+Item	map to The Landscaper's Lair	Last Available: "2010-04"
+Item	map to the Magic Commune	Last Available: "2010-08"
 # map to the Mystic Wood: Gives permanent access to the Forest in FantasyRealm
+Item	map to the Mystic Wood	Last Available: "2018-04"
 # map to the Putrid Swamp: Gives permanent access to the Swamp in FantasyRealm
+Item	map to the Putrid Swamp	Last Available: "2018-04"
 # map to the Sprawling Cemetery: Gives permanent access to the Cemetery in FantasyRealm
+Item	map to the Sprawling Cemetery	Last Available: "2018-04"
 # map to the Towering Mountains: Gives permanent access to the Mountains in FantasyRealm
+Item	map to the Towering Mountains	Last Available: "2018-04"
+Item	map to Vanya's Castle	Last Available: "2010-07"
 Item	March hat	Free Pull
 # mariachi G-string: Deals 10-15 Physical Damage
 # Marquis de Poivre soda: Restores 30-40 MP
+Item	Martialest Arts trophy	Last Available: "2016-01"
+Item	mass of wriggling tentacles	Last Available: "2008-12"
+Item	massive gemstone	Last Available: "2013-02"
 # Massive Manual of Marauder Mockery: Makes marauder mockery mossible
+Item	Massive Manual of Marauder Mockery	Last Available: "2011-05"
 # mauve plastic oyster egg: Deals 40-50 Physical Damage
 Item	Maxing, Relaxing	Skill: "Maximum Chill"
 Item	Mayam Calendar	Free Pull, Last Available: "2024-05"
@@ -12338,20 +13713,33 @@ Item	MayDay&trade; supply package	Last Available: "2022-05", Effect: "Ready to S
 # mayo lance: Unleash a torrent of inner mayonnaise.  The torrent will be yellow and ray-like.
 Item	mayo lance	Lasts Until Rollover, Last Available: "2015-05"
 # Mayo Minder&trade;: Makes it so packets of prescription mayonnaise are automatically consumed as you eat
+Item	Mayo Minder&trade;	Last Available: "2015-05"
 # Mayodiol: One Fullness of the next thing you eat will be converted into Drunkenness
+Item	Mayodiol	Last Available: "2015-05"
 # Mayoflex: The next thing you eat will grant an additional Adventure
+Item	Mayoflex	Last Available: "2015-05"
 # Mayonex: Instead of giving Adventures, the next thing you eat will increase your blood-mayonnaise level.
+Item	Mayonex	Last Available: "2015-05"
 # Mayor Ghost's scissors: Weakens enemies a lot
 # Mayor Ghost's scissors: (by 30% if they are undead)
 # Mayor Ghost's scissors: (doesn't go away when used)
 # Mayostat: Recover a portion of the next substantial thing you eat for later use
+Item	Mayostat	Last Available: "2015-05"
 # Mayozapine: Increases the stat gains from the next thing you eat
+Item	Mayozapine	Last Available: "2015-05"
 Item	McHugeLarge deluxe ski set	Free Pull, Last Available: "2025-01"
 Item	McPhee's Grimoire of Hilarious Object Summoning	Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+Item	meat st&permil;&iquest;bing club	Last Available: "2010-04"
 # meat vortex: Steals Some Meat From an Enemy
+Item	meatball machine	Last Available: "2021-12"
+Item	Mecha Mayhem Club Card	Last Available: "2009-06"
+Item	Mechamelion	Last Available: "2018-03"
+Item	megacopia	Last Available: "2016-11"
 # melty plastic grenade: Deals <font color=green>Stench Damage</font> based on your highest stat
 # melty plastic grenade: (and leaves the monster permanently stinky)
+Item	melty plastic grenade	Last Available: "2019-04"
 # meme generator: Generate a Meme!
+Item	meme generator	Last Available: "2016-05"
 # Memories of Beanslinging: Grants one AWOL "skill point" as a Beanslinger (In future ascensions)
 Item	Memories of Beanslinging	Free Pull
 # Memories of Cow Punching: Grants one AWOL "skill point" as a Cow Puncher (In future ascensions)
@@ -12359,12 +13747,32 @@ Item	Memories of Cow Punching	Free Pull
 # Memories of Snake Oiling: Grants one AWOL "skill point" as a Snake Oiler (In future ascensions)
 Item	Memories of Snake Oiling	Free Pull
 # Memory Disk, Alpha: Lets you experience the future
+Item	Memory Disk, Alpha	Last Available: "2016-09"
+Item	memory of a C	Last Available: "2009-06"
 # memory of a CA base pair: Causes a memory of evolution
+Item	memory of a CA base pair	Last Available: "2009-06"
 # memory of a CG base pair: Causes a memory of evolution
+Item	memory of a CG base pair	Last Available: "2009-06"
 # memory of a CT base pair: Causes a memory of evolution
+Item	memory of a CT base pair	Last Available: "2009-06"
+Item	memory of a G	Last Available: "2009-06"
+Item	memory of a glowing crystal	Last Available: "2009-06"
+Item	memory of a grappling hook	Last Available: "2009-06"
 # memory of a GT base pair: Causes a memory of evolution
+Item	memory of a GT base pair	Last Available: "2009-06"
+Item	memory of a little stone block	Last Available: "2009-06"
+Item	memory of a small stone block	Last Available: "2009-06"
+Item	memory of a stone half-circle	Last Available: "2009-06"
+Item	memory of a T	Last Available: "2009-06"
+Item	memory of an A	Last Available: "2009-06"
 # memory of an AG base pair: Causes a memory of evolution
+Item	memory of an AG base pair	Last Available: "2009-06"
 # memory of an AT base pair: Causes a memory of evolution
+Item	memory of an AT base pair	Last Available: "2009-06"
+Item	memory of an iron key	Last Available: "2009-06"
+Item	memory of half a stone circle	Last Available: "2009-06"
+Item	memory of some delicious amino acids	Last Available: "2009-06"
+Item	Mer-kin cookiestove	Last Available: "2019-12"
 Item	Mer-kin darkbook	Skill: "Deep Dark Visions"
 # Mer-kin fitbrine: Restores 300-400 HP and MP
 # Mer-kin healscroll: Restores up to 300 Hit Points
@@ -12374,133 +13782,254 @@ Item	Mer-kin darkbook	Skill: "Deep Dark Visions"
 # Mer-kin sawdust: Deals 450-500 Physical Damage underwater
 # Mer-kin sawdust: Weakens enemies a lot on land
 # Merc Core challenge coin: Grants a new tattoo when used
+Item	Merc Core challenge coin	Last Available: "2014-10"
 # Merc Core deployment orders: Contains a one-day ticket to Conspiracy Island
+Item	Merc Core deployment orders	Last Available: "2014-10"
 Item	Merc Core Field Manual: Intimidation Techniques	Skill: "Intimidating Mien", Last Available: "2014-10"
 Item	Merc Core Field Manual: Sanity Maintenance	Skill: "Hypersane", Last Available: "2014-10"
 # metal meteoroid: Can be shaped into various pieces of equipment
+Item	metal meteoroid	Last Available: "2017-08"
 # metandienone: Increase a Pokefamiliar's power by 1
+Item	meteorite fragment	Last Available: "2019-07"
 # Meteorite-Ade: Gives 5 PvP fights
+Item	Meteorite-Ade	Last Available: "2017-08"
 # micronova: Vaporizes an enemy and causes all of its items to drop
+Item	micronova	Last Available: "2019-12"
 # milestone: Explores the Desert
+Item	milestone	Last Available: "2023-01"
 # military-grade fingernail clippers: Clips fingernails
+Item	military-grade fingernail clippers	Last Available: "2014-10"
+Item	military-grade peppermint oil	Last Available: "2023-12"
 # milk of magnesium: The next food item you eat will give 5 extra Adventures (usable once per day)
 # mime army challenge coin: Flip it.  I'm sure it's safe.
+Item	mime army challenge coin	Last Available: "2017-12"
 # mime army shotglass: Your first 1-drunkenness booze item of the day doesn't count
+Item	mime army shotglass	Last Available: "2017-12"
 # mime eraser: Instantly destroy a mime in the Cheerless Spire
+Item	mime eraser	Last Available: "2017-12"
+Item	mime soul fragment	Last Available: "2012-04"
 Item	mini kiwi egg	Free Pull, Last Available: "2024-06"
 Item	mini kiwi invisible dirigible	Familiar Weight: -20, Last Available: "2024-06", Generic
+Item	Mini-Crimbot crate	Last Available: "2014-12"
 # miniature boiler: Deals 20-40 Physical Damage
 # miniature Embering Hulk: Fight an Embering Hulk
+Item	miniature Embering Hulk	Last Available: "2024-09"
 # Miniborg beeper: Deals 20-25 Physical Damage and hurts you a little bit
 # Miniborg beeper: (doesn't go away when used)
+Item	Miniborg beeper	Last Available: "2007-12"
 # Miniborg Destroy-O-Bot: Deals 10-15 Physical Damage
 # Miniborg Destroy-O-Bot: Deals 10-15 <font color=red>Hot Damage</font>
 # Miniborg Destroy-O-Bot: Weakens Enemies Slightly
 # Miniborg Destroy-O-Bot: (doesn't go away when used)
+Item	Miniborg Destroy-O-Bot	Last Available: "2007-12"
 # Miniborg hiveminder: Weakens enemies somewhat
 # Miniborg hiveminder: (doesn't go away when used)
+Item	Miniborg hiveminder	Last Available: "2007-12"
 # Miniborg laser: Deals 15-20 <font color=red>Hot Damage</font>
 # Miniborg laser: (doesn't go away when used)
+Item	Miniborg laser	Last Available: "2007-12"
 # Miniborg stomper: Deals 15-20 Physical Damage
 # Miniborg stomper: (doesn't go away when used)
+Item	Miniborg stomper	Last Available: "2007-12"
 # Miniborg strangler: Weakens enemies slightly
 # Miniborg strangler: (doesn't go away when used)
+Item	Miniborg strangler	Last Available: "2007-12"
 Item	miniscule temporal rip	Free Pull, Last Available: "2005-11"
 Item	mint condition Lil' Doctor&trade; bag	Free Pull, Last Available: "2019-02"
 # mint condition magnifying glass: Helps you solve mysteries and is totally safe
+Item	mint condition magnifying glass	Last Available: "2022-12"
+Item	Mint Salton Pepper's Peppermint Seed Catalog	Last Available: "2011-11"
+Item	Mint-in-box Moonthril Circlet	Last Available: "2011-06"
+Item	Mint-in-box Moonthril Cuirass	Last Available: "2011-06"
+Item	Mint-in-box Moonthril Flamberge	Last Available: "2011-06"
+Item	Mint-in-box Moonthril Greaves	Last Available: "2011-06"
+Item	Mint-in-box Moonthril Longbow	Last Available: "2011-06"
 Item	mint-in-box Powerful Glove	Free Pull, Last Available: "2020-02"
 # Mmm-brr! brand mouthwash: Gain stats based on your cold protection
+Item	Mmm-brr! brand mouthwash	Last Available: "2024-09"
 # Mob Penguin cellular phone: Lets You Talk to Penguins
+Item	model train set	Last Available: "2022-12"
 # modern picture frame: Put abstractions in it to create abstract art!
+Item	modern picture frame	Last Available: "2015-12"
+Item	moist barrel	Last Available: "2015-09"
+Item	moist Crimbo spices	Last Available: "2019-12"
+Item	molehill mountain	Last Available: "2023-01"
 # molotov cocktail cocktail: Deals 65-80 <font color=red>Hot Damage</font>
+Item	molten brick	Last Available: "2012-07"
 # molten scrap metal: Deals 20-30 <font color=red>Hot Damage</font> and sets your opponent on fire
 # molybdenum magnet: Attracts Molybdenum
 # monomolecular yo-yo: Deals 35-45 Physical Damage
+Item	monomolecular yo-yo	Last Available: "2010-12"
 # Monstar energy beverage: Restores 70-80 MP
 Item	Monster Manuel	Free Pull
+Item	moon unit	Last Available: "2011-06"
+Item	mooseflank	Last Available: "2018-12"
 Item	Moping Artistic Goth Kid	Free Pull, Last Available: "2012-06"
+Item	Morphan	Last Available: "2018-03"
 Item	mosquito speakers	Monster Level: +5
 # mossy stone sphere: Mysterious, Deprecated
 Item	mother's secret recipe	Recipe: "white chocolate chip brownies"
+Item	mouldering barrel	Last Available: "2015-09"
 # mountain lion skin: Adds +50% Moxie to your cowboy boots
 # Mountain Stream Code Black Alert: Restores 15-20 MP
 # Mountain Stream soda: Restores 30-40 MP
+Item	Mr. Big's Wallet	Last Available: "2023-06"
+Item	Mr. Cheeng's 'stache	Last Available: "2015-08"
+Item	Mr. Choch's bone	Last Available: "2015-08"
+Item	Mu	Last Available: "2018-03"
+Item	multi-pass	Last Available: "2009-06"
 Item	mummified entombed cookbookbat	Free Pull, Last Available: "2022-11"
 # mumming trunk: Dress your familiars up like weird old dramatic archetypes!
+Item	mumming trunk	Last Available: "2017-12"
+Item	munchies pill	Last Available: "2006-06"
+Item	murderbot component casing	Last Available: "2017-04"
+Item	murderbot data core	Last Available: "2017-04"
 # murderbot live wire: Deals <font color=red>Hot Damage</font> every round to every monster you fight today in the zone where you used it
+Item	murderbot live wire	Last Available: "2017-04"
 # murderbot memory chip: Worth 15 pages of Spacegate Research
+Item	murderbot memory chip	Last Available: "2017-04"
+Item	murderbot monofilament	Last Available: "2017-04"
+Item	murderbot power cell	Last Available: "2017-04"
 # muscular soup: Add a pound and increase the combat damage of your familiar
 # mushroom: Heals 10 HP
+Item	mushroom slab	Last Available: "2020-03"
+Item	Mustardigrade	Last Available: "2018-03"
 Item	My First Art of War	Skill: "Army of Toddlers", Last Available: "2018-12"
 # My First Paycheck envelope: Contains 50 Elf Guard MPCs
+Item	My First Paycheck envelope	Last Available: "2023-12"
 Item	My Life of Crime, a Memoir	Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
 Item	My Own Pen Pal kit	Free Pull, Last Available: "2011-12"
 # mylar scout drone: Weakens enemies somewhat
+Item	mylar scout drone	Last Available: "2007-12"
 # Mysterious Black Box: Can only be opened on February 29
+Item	Mysterious Black Box	Last Available: "2018-02"
 # Mysterious Blue Box: Can only be opened on February 29
+Item	Mysterious Blue Box	Last Available: "2018-02"
 Item	mysterious chest	Free Pull, Last Available: "2011-06"
 # Mysterious Green Box: Can only be opened on February 29
+Item	Mysterious Green Box	Last Available: "2018-02"
+Item	mysterious present	Last Available: "2011-04"
 # Mysterious Red Box: Can only be opened on February 29
+Item	Mysterious Red Box	Last Available: "2018-02"
 # Nadsat berry: Improves critical hit chance and energizes you for a while (also gives Berry Experiential)
 Item	Nadsat berry	Last Available: "2018-03", Effect: "Berry Critical", Effect Duration: 20
+Item	nanofiber cloth	Last Available: "2007-12"
 # Nardz energy beverage: Restores 50-70 MP
+Item	nasty desk bell	Last Available: "2020-09"
 Item	nasty haunch	Lasts Until Rollover, Last Available: "2018-04"
 # nasty-smelling moss: Restores 20-30 HP and briefly stuns opponents.
 # nasty-smelling moss: Doesn't go away when used.
+Item	nasty-smelling moss	Last Available: "2015-12"
 # nastygeist: Deals <font color=blueviolet>Sleaze Damage</font> each round for the rest of the fight
 # natural fennel soda: Restores 80-120 MP
+Item	naughty origami kit	Last Available: "2008-02"
 # naughty paper shuriken: Removes a monster's pants and stuns it for a few rounds
 # naughty paper shuriken: (if the monster is wearing pants)
+Item	naughty paper shuriken	Last Available: "2008-02"
 Item	nervous tick egg	Free Pull, Last Available: "2007-10"
 Item	Never Don't Stop Not Striving	Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 # Neverending Party favor: Contains fabulous prizes!
+Item	Neverending Party favor	Last Available: "2018-09"
+Item	Neverending Party guest pass	Last Available: "2018-09"
 Item	Neverending Party invitation envelope	Free Pull, Last Available: "2018-09"
 # New Age healing crystal: Restores 500 HP
 # New Age healing crystal: (and briefly stuns your opponent)
+Item	New Age healing crystal	Last Available: "2015-08"
 # New Age hurting crystal: Deals 500 Physical Damage and briefly stuns them
+Item	New Age hurting crystal	Last Available: "2015-08"
 # New Cloaca-Cola: Restores 140-160 MP
 Item	new-in-box toy Cupid bow	Free Pull, Last Available: "2025-02"
 Item	New-You Club Membership Form	Free Pull, Last Available: "2017-05"
+Item	newborn kobold	Last Available: "2011-09"
+Item	newly-hatched mayonnaise wasp	Last Available: "2015-05"
 # NG: Deals 40-70 Physical Damage
+Item	ninja pirate zombie robot head	Last Available: "2005-11"
 Item	No Hats as Art	Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
 Item	Non-Euclidean Finance	Skill: "5-D Earning Potential", Last Available: "2017-04"
+Item	normal barrel	Last Available: "2015-09"
 # notarized arrest warrant: Now it actually counts
 Item	notarized arrest warrant	Lasts Until Rollover, Last Available: "2018-04"
 Item	note from Clancy	Skill: "Request Sandwich"
 # Notes from the Elfpocalypse, Chapter I: Restores 30-40 HP and MP
+Item	Notes from the Elfpocalypse, Chapter I	Last Available: "2011-06"
 # Notes from the Elfpocalypse, Chapter II: Restores 30-40 HP and MP
+Item	Notes from the Elfpocalypse, Chapter II	Last Available: "2011-06"
 # Notes from the Elfpocalypse, Chapter III: Restores 30-40 HP and MP
+Item	Notes from the Elfpocalypse, Chapter III	Last Available: "2011-06"
 # Notes from the Elfpocalypse, Chapter IV: Restores 30-40 HP and MP
+Item	Notes from the Elfpocalypse, Chapter IV	Last Available: "2011-06"
 # Notes from the Elfpocalypse, Chapter V: Restores 30-40 HP and MP
+Item	Notes from the Elfpocalypse, Chapter V	Last Available: "2011-06"
 # Notes from the Elfpocalypse, Chapter VI: Restores 30-40 HP and MP
+Item	Notes from the Elfpocalypse, Chapter VI	Last Available: "2011-06"
 Item	Now You're Cooking With Grease	Skill: "Grease Up", Last Available: "2014-05"
 # noxious gas grenade: Deals 200-300 <font color=green>Stench Damage</font> and lingering Poison Damage
+Item	noxious gas grenade	Last Available: "2011-09"
+Item	NPZR chemistry set	Last Available: "2011-08"
 # nuclear stockpile: Instantly destroy an enemy
 # nuclear stockpile: (up to 10 times per day)
 # nuclear stockpile: (during the Crimbo 2015 event only)
+Item	nuclear stockpile	Last Available: "2015-12"
+Item	nugget of Crimbonium	Last Available: "2014-12"
+Item	nugget of nicksilver	Last Available: "2016-02"
+Item	nugget of quicksilver	Last Available: "2016-02"
+Item	nugget of sicksilver	Last Available: "2016-02"
+Item	nugget of slicksilver	Last Available: "2016-02"
 # nugget of sodium: Deals 10-20 <font color=red>Hot Damage</font> and 10-20 <font color=green>Stench Damage</font>
+Item	nugget of thicksilver	Last Available: "2016-02"
+Item	nugget of ticksilver	Last Available: "2016-02"
+Item	nugget of wicksilver	Last Available: "2016-02"
+Item	Nursine	Last Available: "2018-03"
+Item	O	Last Available: "2017-10"
+Item	obnoxious riddle	Last Available: "2011-04"
+Item	odd silver coin	Last Available: "2014-12"
 # odor extractor: Capture a monster's smell so you can track down similar monsters
+Item	odor extractor	Last Available: "2019-12"
 # off-white plastic oyster egg: Weakens enemies a little bit
 # oily boid: Weakens enemies a little bit as it briefly stuns them
 # old school beer pull tab: Causes a significant amount of bleeding
+Item	old school beer pull tab	Last Available: "2013-11"
+Item	old-fashioned Crimbo Pressie	Last Available: "2007-12"
 Item	Olympic-sized Clan crate	Free Pull, Last Available: "2012-05"
+Item	one-day ticket to Conspiracy Island	Last Available: "2014-10"
+Item	one-day ticket to Dinseylandfill	Last Available: "2015-04"
+Item	one-day ticket to Spring Break Beach	Last Available: "2014-05"
+Item	one-day ticket to That 70s Volcano	Last Available: "2015-08"
+Item	one-day ticket to The Glaciest	Last Available: "2015-11"
 # onion shurikens: Deals 10-15 <font color=blueviolet>Sleaze Damage</font>
+Item	onyx bishop	Last Available: "2020-09"
+Item	onyx king	Last Available: "2020-09"
+Item	onyx knight	Last Available: "2020-09"
+Item	onyx pawn	Last Available: "2020-09"
+Item	onyx queen	Last Available: "2020-09"
+Item	onyx rook	Last Available: "2020-09"
 # opium grenade: Stuns your opponent for a few rounds
 # opium grenade: (extra effective against hippies)
+Item	Oppossum	Last Available: "2018-03"
+Item	orange candygram	Last Available: "2007-02"
+Item	orange slime glob	Last Available: "2018-11"
 Item	Order of the Green Thumb Order Form	Free Pull
 Item	organ grinder	Free Pull, Last Available: "2011-12"
 # ornate picture frame: Weakens enemies somewhat and briefly stuns them
 Item	orphan baby yeti	Free Pull, Last Available: "2011-12"
+Item	orquette's phone number	Last Available: "2010-06"
 # Oscus's neverending soda: Restores 200-300 MP
 # Oscus's neverending soda: (doesn't go away when used)
 Item	Our Daily Candles&trade; order form	Free Pull, Last Available: "2021-08"
 Item	OVERCLOCK(10) rom chip	Skill: "OVERCLOCK(10)", Last Available: "2025-12"
 # overflowing gift basket: Produces a random food item (1x/day)
+Item	overflowing gift basket	Last Available: "2020-12"
 # overloaded micro-reactor: Deals 300 Physical Damage
+Item	overloaded micro-reactor	Last Available: "2015-12"
 # oversized snowflake: Stuns your opponent for a few rounds
+Item	oversized snowflake	Last Available: "2011-09"
 # ovoid leather thing: Deals 80-100 Physical Damage
 # pacification grenade: Weakens enemies somewhat
+Item	Pack of Alice's Army Cards	Last Available: "2011-03"
+Item	Pack of Alice's Army Foil Cards	Last Available: "2011-03"
 Item	Pack of Every Card	Free Pull, Last Available: "2015-07"
+Item	pack of pogs	Last Available: "2011-11"
+Item	pack of smokes	Last Available: "2014-10"
 Item	packaged backup camera	Free Pull, Last Available: "2021-04"
 Item	packaged cold medicine cabinet	Free Pull, Last Available: "2021-12"
 Item	packaged Daylight Shavings Helmet	Free Pull, Last Available: "2021-11"
@@ -12510,63 +14039,151 @@ Item	packaged industrial fire extinguisher	Free Pull, Last Available: "2021-09"
 Item	packaged June cleaver	Free Pull, Last Available: "2022-06"
 Item	packaged Jurassic Parka	Free Pull, Last Available: "2022-09"
 Item	packaged knock-off retro superhero cape	Free Pull, Last Available: "2020-11"
+Item	packaged luxury garment	Last Available: "2024-12"
 Item	packaged miniature crystal ball	Free Pull, Last Available: "2021-01"
 Item	packaged model train set	Free Pull, Last Available: "2022-12"
 Item	packaged Pocket Professor	Free Pull, Last Available: "2019-09"
 Item	packaged Roman Candelabra	Free Pull
 Item	packaged SpinMaster&trade; lathe	Free Pull, Last Available: "2020-08"
+Item	packet of beer seeds	Last Available: "2013-09"
+Item	packet of dragon's teeth	Last Available: "2012-10"
+Item	packet of mayfly bait	Last Available: "2008-05"
+Item	packet of mushroom spores	Last Available: "2020-03"
+Item	packet of pumpkin seeds	Last Available: "2010-11"
+Item	packet of rock seeds	Last Available: "2023-01"
+Item	packet of tall grass seeds	Last Available: "2018-03"
+Item	packet of thanksgarden seeds	Last Available: "2016-11"
+Item	packet of winter seeds	Last Available: "2014-01"
 # PADL Phone: Summons Frat Army Aid
 # paint bomb: Deals 5-10 Prismatic Damage
 # paint bomb: (keeps dealing damage every round)
+Item	paint bomb	Last Available: "2011-05"
 # painted turtle: Deals 10-20 Prismatic Damage
+Item	pair of ragged claws	Last Available: "2008-12"
+Item	pair of rhinoceros horns	Last Available: "2013-12"
+Item	pair of scissors	Last Available: "2017-10"
+Item	pair of twitching claws	Last Available: "2008-12"
 # paisley spore pod: Stuns your opponent for a couple of rounds.
 # palm-frond fan: Restores 35-45 HP and MP
 # palm-frond net: Weakens enemies somewhat
 Item	panicked kernel	Free Pull, Last Available: "2010-04"
 Item	pantogram	Free Pull, Last Available: "2017-11"
+Item	paperclip	Last Available: "2011-01"
 # paperclip sproinger: Stuns your opponent for a couple of rounds and deals 10-15 Physical Damage
+Item	paperclip sproinger	Last Available: "2011-01"
+Item	papier-m&acirc;ch&eacute; base	Last Available: "2012-09"
+Item	papier-m&acirc;ch&eacute; bowl	Last Available: "2012-09"
+Item	papier-m&acirc;ch&eacute; glob	Last Available: "2012-09"
+Item	papier-m&acirc;ch&eacute; handle	Last Available: "2012-09"
+Item	papier-m&acirc;ch&eacute; plaque	Last Available: "2012-09"
+Item	papier-m&acirc;ch&eacute; trophy pi&ntilde;ata	Last Available: "2012-09"
 Item	paranormal ricotta	Class: "Pastamancer"
+Item	parchment	Last Available: "2014-12"
 Item	parity bit	Familiar Weight: +5
 Item	Party Planning on a Budget	Skill: "Budget Conscious", Last Available: "2018-09"
+Item	party pup	Last Available: "2018-09"
+Item	Party Tattoo&trade; gift certificate	Last Available: "2018-09"
 Item	passed-out psychedelic bear	Free Pull, Last Available: "2009-10"
+Item	Pastaco shell	Last Available: "2014-05"
 # patchouli incense stick: Weakens enemies a little bit
 Item	patchouli incense stick	Effect: "Far Out", Effect: "Embarrassed", Effect Duration: 5
 # patchouli oil bomb: Deals 65-80 <font color=green>Stench Damage</font>
 # peace shooter: Makes an opponent peaceful for 3 rounds
+Item	peace shooter	Last Available: "2024-11"
 Item	peace turkey outline	Free Pull, Last Available: "2024-11"
+Item	Peaclock	Last Available: "2018-03"
+Item	pearidot	Last Available: "2011-11"
 Item	Peek-a-Boo!	Skill: "Object Quasi-Permanence", Last Available: "2017-04"
 # pencil kunai: Deals 20-30 Physical Damage
+Item	pencil kunai	Last Available: "2013-12"
 # pencil stub: Does any number of crazy things
+Item	pencil thin mushroom	Last Available: "2014-05"
+Item	Pener's crisps	Last Available: "2015-08"
+Item	peppermint bomb	Last Available: "2023-12"
 # peppermint crook: Steals an item from your enemy
 # peppermint crook: (Maybe)
+Item	peppermint crook	Last Available: "2011-11"
+Item	peppermint eel sauce	Last Available: "2019-12"
 # peppermint parasol: Lets you escape from combat without spending an Adventure
 # peppermint parasol: (Maybe)
+Item	peppermint parasol	Last Available: "2011-11"
+Item	Peppermint Pip Packet	Last Available: "2011-11"
+Item	peppermint rhino baby	Last Available: "2011-11"
+Item	peppermint sprig	Last Available: "2017-03"
+Item	peppermint sprout	Last Available: "2011-11"
+Item	peppermint tailings	Last Available: "2014-12"
+Item	perfect ice cube	Last Available: "2015-11"
+Item	perfectly fair coin	Last Available: "2017-11"
 Item	perfectly ordinary frog	Free Pull, Last Available: "2010-10"
+Item	personal graffiti kit	Last Available: "2018-02"
+Item	personal massager	Last Available: "2008-04"
 Item	personal raindrop	Free Pull, Last Available: "2005-04"
+Item	personalizable gingerbread cookie	Last Available: "2019-12"
 Item	personalized coffee mug	Free Pull, Last Available: "2008-04"
 # personalized wassail stein: Produces a random booze item (1x/day)
+Item	personalized wassail stein	Last Available: "2020-12"
+Item	pet anchor	Last Available: "2023-12"
+Item	pet bad vibe	Last Available: "2016-12"
+Item	pet rock	Last Available: "2005-12"
+Item	Pete & Jackie's Dragon Tooth Emporium Catalog	Last Available: "2012-10"
+Item	petrified time	Last Available: "2005-10"
 # petrified wood: Deals 50-60 Physical Damage and 50-60 <font color=gray>Spooky Damage</font>
+Item	petrified wood	Last Available: "2009-10"
 Item	phantom brace	Spooky Damage: +10, Spooky Spell Damage: +10
 # phonics down: Restores 46-50 HP and MP and also does other weird stuff
 Item	photo booth sized crate	Free Pull, Last Available: "2024-10"
+Item	photocopied monster	Last Available: "2011-01"
 # photoprotoneutron torpedo: Deals 30-40 Physical Damage
+Item	pickled grasshopper	Last Available: "2017-03"
+Item	picky tweezers	Last Available: "2015-02"
+Item	piece of coral	Last Available: "2019-07"
+Item	piece of driftwood	Last Available: "2019-07"
+Item	pile of dirt	Last Available: "2017-03"
+Item	pile of loose snow	Last Available: "2009-12"
+Item	pile of sand	Last Available: "2019-07"
+Item	pile of useless robot parts	Last Available: "2012-12"
+Item	Pillowbug	Last Available: "2018-03"
+Item	Pimpsqueak	Last Available: "2018-03"
+Item	pine cone	Last Available: "2015-12"
+Item	pink candygram	Last Available: "2007-02"
 # pink-belly slapper: Weakens enemies a little bit, brieftly stuns them, and restores 8-16 of your Hit Points
+Item	pink-belly slapper	Last Available: "2012-12"
 # pint of sweat: Deals 25-30 <font color=green>Stench Damage</font> and 25-30 <font color=blueviolet>Sleaze Damage</font>
 # pint of sweat: (and additional Stench and Sleaze damage in subsequent rounds)
+Item	pint of sweat	Last Available: "2014-12"
 # piracetam: Make a Pokefamiliar Smart
 # pirate dinghy: Take a relaxing sail or visit the Mysterious Island of Mystery
+Item	pirate dinghy	Last Available: "2024-12"
+Item	pirate encryption key (complete)	Last Available: "2023-12"
+Item	pirate encryption key alpha	Last Available: "2023-12"
+Item	pirate encryption key bravo	Last Available: "2023-12"
+Item	pirate encryption key charlie	Last Available: "2023-12"
+Item	pirate encryption key delta	Last Available: "2023-12"
+Item	pirate zombie head	Last Available: "2005-11"
+Item	pirate zombie robot head	Last Available: "2005-11"
 # PirateRealm fun-a-log: Purchase gifts using PirateRealm FunPoints
+Item	PirateRealm fun-a-log	Last Available: "2019-04"
 # PirateRealm guest pass: Gives you access to PirateRealm for the day
+Item	PirateRealm guest pass	Last Available: "2019-04"
 # PirateRealm membership packet: Permanently unlocks access to PirateRealm
 Item	PirateRealm membership packet	Free Pull, Last Available: "2019-04"
+Item	pirrrate's currrse	Last Available: "2024-12"
 # pixel coin: Sell it for 2,000 Meat
+Item	pixel coin	Last Available: "2015-06"
 # pixel cross: Deals 80-100 Physical Damage
 # pixel cross: (does it again the next round)
 # pixel energy tank: Restores up to 1,000 HP and MP
 # pixel holy water: Deals 50-60 Physical Damage per round for the rest of the fight
+Item	pixel holy water	Last Available: "2010-07"
+Item	pixel orb	Last Available: "2010-07"
+Item	pixel power cell	Last Available: "2013-12"
 # pixel stopwatch: Stuns your opponent for a few rounds
+Item	pixel stopwatch	Last Available: "2010-07"
+Item	pixellated moneybag	Last Available: "2010-07"
 # pixie axie: Helps witches find more candy
+Item	pixie axie	Last Available: "2014-12"
 # plaid bandage: Restores 120-150 HP
+Item	plaintive telegram	Last Available: "2016-02"
 Item	plans for depleted Grimacite astrolabe	Recipe: "depleted Grimacite astrolabe"
 Item	plans for depleted Grimacite grappling hook	Recipe: "depleted Grimacite grappling hook"
 Item	plans for depleted Grimacite gravy boat	Recipe: "depleted Grimacite gravy boat"
@@ -12574,86 +14191,161 @@ Item	plans for depleted Grimacite hammer	Recipe: "depleted Grimacite hammer"
 Item	plans for depleted Grimacite ninja mask	Recipe: "depleted Grimacite ninja mask"
 Item	plans for depleted Grimacite shinguards	Recipe: "depleted Grimacite shinguards"
 Item	plans for depleted Grimacite weightlifting belt	Recipe: "depleted Grimacite weightlifting belt"
+Item	plastic Crimbo reindeer	Last Available: "2009-12"
 # plastic cup of flat beer: Deals 30-40 <font color=blueviolet>Sleaze Damage</font> and increases Item Drops by 15% if you win
+Item	plastic ingot	Last Available: "2012-12"
+Item	plastic nightmare troll	Last Available: "2015-10"
+Item	plexifoam chin strap	Last Available: "2007-12"
 # plot hole: Deals 20-25 Physical Damage
+Item	plump free-range mushroom	Last Available: "2020-03"
 # plump juicy grub: Restores 90-100 HP
+Item	plump juicy grub	Last Available: "2008-06"
 Item	plump purple mushroom	Lasts Until Rollover, Last Available: "2018-04"
 # plus one: Give a pal +1
+Item	plus one	Last Available: "2016-05"
 # plus-sized phylactery: Contains the soul of a specific lihc
 Item	Pocket Guide to Mild Evil	Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
 Item	Pocket Guide to Mild Evil (used)	Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+Item	pocket lint (blue)	Last Available: "2013-11"
+Item	pocket lint (green)	Last Available: "2013-11"
+Item	pocket lint (orange)	Last Available: "2013-11"
+Item	pocket lint (white)	Last Available: "2013-11"
 # Pocket Meteor Guide: Teaches you everything about meteors
+Item	Pocket Meteor Guide	Last Available: "2017-08"
 # Pocket Meteor Guide (well-thumbed): Teaches you everything about meteors
+Item	Pocket Meteor Guide (well-thumbed)	Last Available: "2017-08"
+Item	pocket wish	Last Available: "2023-09"
 # pog #01 (spider): Does all sorts of crazy things
+Item	pog #01 (spider)	Last Available: "2011-11"
 # pog #02 (Knob goblin): Does all sorts of crazy things
+Item	pog #02 (Knob goblin)	Last Available: "2011-11"
 # pog #03 (warwelf): Does all sorts of crazy things
+Item	pog #03 (warwelf)	Last Available: "2011-11"
 # pog #04 (skleleton): Does all sorts of crazy things
+Item	pog #04 (skleleton)	Last Available: "2011-11"
 # pog #05 (ninja snowman): Does all sorts of crazy things
+Item	pog #05 (ninja snowman)	Last Available: "2011-11"
 # pog #06 (filthy hippy): Does all sorts of crazy things
+Item	pog #06 (filthy hippy)	Last Available: "2011-11"
 # pog #07 (orcish frat boy): Does all sorts of crazy things
+Item	pog #07 (orcish frat boy)	Last Available: "2011-11"
 # pog #08 (hellion): Does all sorts of crazy things
+Item	pog #08 (hellion)	Last Available: "2011-11"
 # pog #09 (pirate): Does all sorts of crazy things
+Item	pog #09 (pirate)	Last Available: "2011-11"
 # pog #10 (hobo): Does all sorts of crazy things
+Item	pog #10 (hobo)	Last Available: "2011-11"
 # pog #11 (Naughty Sorceress): Does all sorts of crazy things
+Item	pog #11 (Naughty Sorceress)	Last Available: "2011-11"
 Item	poisoned druidic s'more	Lasts Until Rollover, Last Available: "2018-04"
 # poisonsettia: Poisons an enemy for 25 and then doubles the amount of poison
+Item	poisonsettia	Last Available: "2021-12"
+Item	Pok&eacute;-Gro fertilizer	Last Available: "2018-03"
 Item	Pok&eacute;fam Guide to Capturing All of Them	Free Pull, Last Available: "2018-03"
 # poltergeist-in-the-jar-o: Deals 200-250 Physical Damage
+Item	polymorphic fastening apparatus	Last Available: "2007-12"
 # pool of liquid metal: Does various things
+Item	pool of liquid metal	Last Available: "2009-06"
 # pool torpedo: Deals 250-250 Physical Damage
 # pool torpedo: (underwater only)
 # pool torpedo: (has a chance to not go away when used)
+Item	pool torpedo	Last Available: "2012-05"
 Item	Pop Art: a Guide	Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
 # portable Mayo Clinic: Installs a mayonnaise-centered medical clinic in your workshed
+Item	portable Mayo Clinic	Last Available: "2015-05"
+Item	portable pantogram	Last Available: "2017-11"
 # portable photocopier: Makes a photocopy of an enemy
+Item	portable photocopier	Last Available: "2011-01"
 # portable Spacegate: Provides one day's access to a random Spacegate planet
+Item	portable Spacegate	Last Available: "2017-04"
 # portable steam unit: Clears Your Sinuses (once per day)
+Item	portable steam unit	Last Available: "2022-12"
 # portable table: You can hide behind it
+Item	possessed sugar cube	Last Available: "2014-05"
 # possessed tomato: Deals 6-8 <font color=gray>Spooky Damage</font> per round for the rest of the fight
 # possessed top: Weakens enemies a little bit
+Item	possessed top	Last Available: "2010-12"
 # potato alarm clock: Gives you 5 additional Adventures when you log in
+Item	potato alarm clock	Last Available: "2021-12"
+Item	potted power plant	Last Available: "2021-03"
 # potted tea tree: 1) Plant it in your campsite
 # potted tea tree: 2) Get tea every day
+Item	potted tea tree	Last Available: "2015-09"
+Item	pottery barn owl figurine	Last Available: "2010-09"
 # powdered madness: Instantly dispatch a foe (limit 5/day)
+Item	powdered madness	Last Available: "2019-12"
 # powdered organs: Weakens enemies somewhat
 Item	power seed	Free Pull, Last Available: "2021-03"
+Item	prank Crimbo card	Last Available: "2023-12"
 Item	praying Grim Brother	Free Pull, Last Available: "2014-12"
 # precision snowball: Deal 100 Cold Damage to an enemy (or toss in your campground.)
+Item	precision snowball	Last Available: "2023-12"
 Item	Prelude of Precision	Skill: "Prelude of Precision"
+Item	present	Last Available: "2004-11"
 # print screen button: Copies a Monster
+Item	print screen button	Last Available: "2016-05"
+Item	pristine piranha seed	Last Available: "2020-03"
 # procrastination potion: Causes Enemy to Put Off Attacking You
+Item	Procrastinator locker key	Last Available: "2017-04"
 Item	profane eye patch	Sleaze Damage: +3
 Item	Professor of Spelunkology	Free Pull, Last Available: "2015-12"
+Item	Project T. L. B.	Last Available: "2014-10"
+Item	projectile chemistry set	Last Available: "2021-12"
 Item	Psycho From The Heat	Skill: "Pyromania", Last Available: "2015-08"
+Item	psychoanalytic jar	Last Available: "2013-12"
 # psychokinetic energy blob: Restores 20-30 MP
+Item	psychokinetic energy blob	Last Available: "2016-08"
 # puce plastic oyster egg: Deals 40-50 Physical Damage
+Item	puff of smoke	Last Available: "2010-03"
 # pufferfish spine: Poisons your opponent, and using additional ones makes the poison way worse
+Item	pulsing flesh	Last Available: "2008-12"
+Item	pumpkin	Last Available: "2010-11"
 # pumpkin bomb: Vaporizes an enemy and causes all of its items to drop
+Item	pumpkin bomb	Last Available: "2010-11"
 # pumpkin carriage: <b>Allows Travel to Desert Beach</b>
+Item	pumpkin carriage	Last Available: "2010-11"
 # pumpkin spice whorl: Permanent +3 Level for Pastamancer Spice Ghost
+Item	pumpkin spice whorl	Last Available: "2024-12"
 # punching mirror: Punch it for 5 PvP fights per day
+Item	punching mirror	Last Available: "2023-12"
 Item	puppet strings	Free Pull
+Item	purple prose pen	Last Available: "2012-12"
+Item	purpleheart logs	Last Available: "2020-08"
 # pygmy blowgun: Poisons enemies, dealing damage over multiple rounds
 Item	pygmy bugbear shaman	Free Pull, Last Available: "2011-12"
 # quantum nanopolymer spider web: Weakens enemies somewhat and briefly stuns them
+Item	quantum polarity inducer	Last Available: "2011-12"
 Item	quantum watch	Adventures: +2
 Item	quasi-ethereal macaroni fragments	Class: "Pastamancer"
+Item	Rad Lib	Last Available: "2012-09"
 # Rad-B-Gone (1 lb.): Cures Radiation Sickness
+Item	ragged wool yarn	Last Available: "2024-12"
 # Rain-Doh black box: Makes a copy of a monster to fight later
+Item	Rain-Doh black box	Last Available: "2012-02"
 # Rain-Doh blue balls: Deals 10-20 <font color=blue>Cold Damage</font> and stuns opponent for a couple of rounds
 # Rain-Doh blue balls: (doesn't go away when used)
+Item	Rain-Doh blue balls	Last Available: "2012-02"
+Item	Rain-Doh box full of monster	Last Available: "2012-02"
 # Rain-Doh indigo cup: Heals 20% of your Maximum Hit Points
 # Rain-Doh indigo cup: (doesn't go away when used)
+Item	Rain-Doh indigo cup	Last Available: "2012-02"
 # Rain-Doh orange agent: Deals Physical Damage for Meat
 # Rain-Doh orange agent: (doesn't go away when used)
+Item	Rain-Doh orange agent	Last Available: "2012-02"
 # rainbow bomb: Deals 20-30 Physical Damage and 20-30 Prismatic Damage
+Item	rainbow bomb	Last Available: "2008-07"
+Item	rainbow pearl	Last Available: "2007-12"
 Item	Rainbow's Gravity	Skill: "Rainbow Gravitation", Last Available: "2008-07"
 # rattler rattle: Weakens enemies by 25%
 # rattler rattle: (75% for beasts)
+Item	Raul's guitar pick	Last Available: "2015-08"
 # razor-sharp can lid: Deals 2-3 Physical Damage
 # razor-tipped yo-yo: Deals 30-40 Physical Damage
+Item	razor-tipped yo-yo	Last Available: "2010-12"
+Item	realistic cap gun	Last Available: "2016-02"
 Item	Really Expensive Jewelry and You	Skill: "Really Expensive Jewelrycrafting"
 # really nice net: Weakens your foe and stuns them for a few rounds
+Item	really nice net	Last Available: "2019-12"
 # really really sticky spider web: Weakens enemies a little bit
 # really sticky spider web: Weakens enemies slightly
 # really thick bandage: Restores 100-120 HP
@@ -12672,6 +14364,7 @@ Item	Recipe of Before Yore: ratatouille de Jarlsberg	Last Available: "2022-11", 
 Item	Recipe of Before Yore: roasted vegetable focaccia	Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
 Item	Recipe of Before Yore: roasted vegetable of J.	Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
 Item	Recipe of Before Yore: St. Pete's sneaky smoothie	Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+Item	reconstituted crow	Last Available: "2011-05"
 Item	record of infuriating silence	Skill: "Silent Slam", Last Available: "2012-10"
 Item	record of infuriating silence (used)	Skill: "Silent Slam", Last Available: "2012-10"
 Item	record of menacing silence	Skill: "Silent Slice", Last Available: "2012-10"
@@ -12679,184 +14372,386 @@ Item	record of menacing silence (used)	Skill: "Silent Slice", Last Available: "2
 Item	record of tranquil silence	Skill: "Silent Squirt", Last Available: "2012-10"
 Item	record of tranquil silence (used)	Skill: "Silent Squirt", Last Available: "2012-10"
 # recovered elf magazine: Turn it in at the E. R. F. camp for 1 Crimbo Credit
+Item	recovered elf magazine	Last Available: "2014-12"
 # recovered elf photo album: Turn it in at the E. R. F. camp for 4 Crimbo Credits
+Item	recovered elf photo album	Last Available: "2014-12"
 # recovered elf pocketwatch: Turn it in at the E. R. F. camp for 3 Crimbo Credits
+Item	recovered elf pocketwatch	Last Available: "2014-12"
 # recovered elf sleeping pills: Turn it in at the E. R. F. camp for 2 Crimbo Credits
+Item	recovered elf sleeping pills	Last Available: "2014-12"
 # recovered elf smartphone: Turn it in at the E. R. F. camp for 5 Crimbo Credits
+Item	recovered elf smartphone	Last Available: "2014-12"
 # recovered elf toothbrush: Turn it in at the E. R. F. camp for 1 Crimbo Credit
+Item	recovered elf toothbrush	Last Available: "2014-12"
 # recovered elf underpants: Turn it in at the E. R. F. camp for 2 Crimbo Credits
+Item	recovered elf underpants	Last Available: "2014-12"
 # recovered elf wallet: Turn it in at the E. R. F. camp for 3 Crimbo Credits
+Item	recovered elf wallet	Last Available: "2014-12"
+Item	recursive spline reticulator	Last Available: "2011-12"
 Item	red and green rain stick	Effect: "Peaceful, Easy Feeling", Effect Duration: 30
 # red button: Deals Physical Damage based on how many of them you have
 # red coin: Try using 11 of them!
 # red face paint: Makes you red with holiday cheer!
 # red face paint: Does not go away when used.
 Item	red face paint	Free Pull, Last Available: "2015-12"
+Item	red gummi ingot	Last Available: "2011-11"
+Item	red lava globs	Last Available: "2015-08"
+Item	red mana	Last Available: "2015-07"
 # red pixel potion: Heals 100-120 Hit Points
 # red plastic oyster egg: Restores 35-40 Hit Points
 # red potion: Restores 90-110 HP
 Item	red potion	Last Available: "2013-02", Effect: "Healthy Red Glow", Effect Duration: 20
+Item	red rocket	Last Available: "2021-07"
+Item	Red Roger tattoo kit	Last Available: "2019-04"
 # Red Roger's flag: Increases the likelihood of sea battles in PirateRealm
 Item	Red Roger's flag	Lasts Until Rollover, Last Available: "2019-04"
 Item	Red Roger's map	Lasts Until Rollover, Last Available: "2019-04"
+Item	Red Roger's reliquary	Last Available: "2019-04"
+Item	Red Roger's skull	Last Available: "2019-04"
+Item	red-hot knucklebone	Last Available: "2016-02"
 Item	red-spotted snapper roe	Free Pull, Last Available: "2019-12"
 Item	redwood rain stick	Effect: "You Have Ever Seen The Rain", Effect Duration: 20, Last Available: "2020-08"
+Item	reflection of a map	Last Available: "2010-03"
+Item	refurbished air fryer	Last Available: "2021-12"
 # Regular Cloaca Cola: Restores 7-9 MP
 Item	rehearsing dramatic hedgehog	Free Pull, Last Available: "2011-12"
+Item	Replica 2002 Mr. Store Catalog	Last Available: "2023-06"
 # replica bat-oomerang: Instantly kill a foe (up to 3x per day)
 # replica bat-oomerang: (does not go away when used)
+Item	replica bat-oomerang	Last Available: "2016-12"
 Item	replica emotion chip	Skill: "Replica Emotionally Chipped"
 Item	residual chitin paste	Skill: "Chitinous Soul"
+Item	respected companion biscuit	Last Available: "2010-08"
 Item	Rethinking Candy	Skill: "Sweet Synthesis", Last Available: "2016-12"
 Item	Retrospecs try-at-home kit	Free Pull, Last Available: "2020-01"
+Item	reverse-oscillating klystron	Last Available: "2011-12"
+Item	rhinoceros horn	Last Available: "2013-12"
 # riboflavin: Increase a Pokefamiliar's maximum HP by 1
 Item	rift oculus	Combat Rate: +5
 Item	rigging knot	Familiar Weight: +5
+Item	rigid carapace	Last Available: "2008-12"
 # Riker's Search History: Deals 900-1000 Sleaze Damage
+Item	Riker's Search History	Last Available: "2016-09"
+Item	robot reindeer protocol B.L.I.T.Z.E.N.	Last Available: "2010-12"
+Item	robot reindeer protocol C.O.M.E.T.	Last Available: "2010-12"
+Item	robot reindeer protocol C.U.P.I.D.	Last Available: "2010-12"
+Item	robot reindeer protocol D.A.N.C.E.R.	Last Available: "2010-12"
+Item	robot reindeer protocol D.A.S.H.E.R.	Last Available: "2010-12"
+Item	robot reindeer protocol D.O.N.N.E.R.	Last Available: "2010-12"
+Item	robot reindeer protocol O.L.I.V.E.	Last Available: "2010-12"
+Item	robot reindeer protocol P.R.A.N.C.E.R.	Last Available: "2010-12"
+Item	robot reindeer protocol R.U.D.O.L.P.H.	Last Available: "2010-12"
+Item	robot reindeer protocol V.I.X.E.N.	Last Available: "2010-12"
 # robotronic egg: Crazy robotronic action!
+Item	robotronic egg	Last Available: "2007-12"
 # rock band flyers: Advertise!
 Item	Rock Garden Guide	Free Pull, Last Available: "2023-01"
+Item	rock lobster	Last Available: "2009-09"
+Item	rockfish stomach	Last Available: "2009-09"
 # rocky raccoon: Deals 50-60 Physical Damage
 # rogue swarmer: Deals Physical Damage based on how many swarmers you have
+Item	rogue swarmer	Last Available: "2007-12"
 Item	roll of toilet paper	Free Pull
 # roller skate decoy: Put it down, and monsters will attack it instead of you
 Item	ROM of Optimality	Skill: "Toggle Optimality"
 # rotten tomato: Throw it at somebody to grant extra PvP fights
+Item	rotting barrel	Last Available: "2015-09"
 # rotting cowskin: Adds Demonic Bovine Taint to your cowboy boots
+Item	rotting cowskin	Last Available: "2016-02"
 # rough stone sphere: Mysterious, Deprecated
 # round blue bomb: Deals 90-110 <font color=red>Hot Damage</font>
+Item	round blue bomb	Last Available: "2013-02"
+Item	rubber emo roe	Last Available: "2006-04"
+Item	rubber spider	Last Available: "2014-08"
+Item	Rubee&trade;	Last Available: "2018-04"
+Item	Ruffalo	Last Available: "2018-03"
 # Rufus's shadow lodestone: Reveals hidden things in Shadow Rifts
 Item	rune-strewn spoon cocoon	Free Pull, Last Available: "2019-06"
+Item	runny icing	Last Available: "2019-12"
 # rusty bonesaw: Saws bones
+Item	S.I.T. Course Completion Certificate	Last Available: "2023-02"
 Item	S.I.T. Course Voucher	Free Pull, Last Available: "2023-02"
 # S.O.C.K.: Allows access to the Castle in the Clouds in the Sky
+Item	s'more gun	Last Available: "2011-04"
+Item	sack lunch	Last Available: "2011-01"
 # sacramental wine: Restores 80-100 MP
 Item	sacramental wine	Effect: "Spiritually Awash", Effect Duration: 10
 # sake bomb: Deals 45-60 Physical Damage
 # sake bomb: Weakens Enemies a Little Bit
+Item	Salsa de las Epocas	Last Available: "2011-04"
+Item	salty sailor salt	Last Available: "2014-05"
 # samurai turtle: Does various ninja things
 # sanctified cola: Restores 400-500 MP
 Item	sanctified cola	Lasts Until Rollover, Last Available: "2018-04"
 Item	sane hatrack	Free Pull, Last Available: "2011-12"
+Item	Saturday Night thermometer	Last Available: "2015-08"
 # sausage bomb: Deals 100-120 <font color=blueviolet>Sleaze Damage</font>
 # sausage bomb: Weakens Enemies Somewhat
+Item	sausage golem	Last Available: "2019-01"
 # sawblade fragment: Deals 100-150 Physical Damage and causes additional Bleeding over time
+Item	sawblade fragment	Last Available: "2007-12"
 # scented massage oil: Restores all HP
 Item	Schmalz's First Prize Beer	Free Pull, Last Available: "2011-12"
 # School of Hard Knocks Diploma: Brings up Enraging Memories
 Item	scintillating powder	Class: "Pastamancer"
 Item	Scratch 'n' Sniff Sticker Tome	Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
 Item	Scratch-and-Sniff Guide to Dinseylandfill	Skill: "Olfactory Burnout", Last Available: "2015-04"
+Item	screencapped monster	Last Available: "2016-05"
 # scroll of ancient forbidden unspeakable evil: Invokes Dangerous and Unpredictable Magic
 # scroll of drastic healing: Restores all HP
+Item	scrumptious ice ant	Last Available: "2008-06"
 Item	Scurvy and Sobriety Prevention	Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 # sea cowbell: Gives you a fever
 # sea lasso: Allows underwater rooting and tooting
 # seal tooth: Deals 1 Physical Damage
 Item	seal tooth	Effect: "Bloody Hand", Effect Duration: 3
 Item	seal-blubber candle	Class: "Seal Clubber"
+Item	Sealed TakerSpace letter of Marque	Free Pull, Last Available: "2024-12"
 # sealhide snare: Stuns your opponent for a few rounds
+Item	secret from the future	Last Available: "2009-06"
 Item	Secrets of the Master Egg Hunters	Last Available: "2024-12", Skill: "Master Egg Hunter"
 Item	Secrets of the Master Egg Hunters (used)	Last Available: "2024-12", Skill: "Master Egg Hunter"
 # self-defense training: Increases your Bat-Armor
+Item	self-defense training	Last Available: "2017-01"
 Item	Sensual Massage for Creeps	Skill: "Inappropriate Backrub"
 # Sept-Ember Censer: Generate 7 embers each day to magically consume
+Item	Sept-Ember Censer	Last Available: "2024-09"
+Item	Septapus summoning charm	Last Available: "2024-09"
+Item	Sequestrian	Last Available: "2018-03"
+Item	server room key	Last Available: "2025-12"
+Item	servomechanical torsion facilitator	Last Available: "2011-12"
+Item	set of Unobtainium straps	Last Available: "2007-12"
 # sew-on bandage: Restores up to 300 HP
+Item	sew-on bandage	Last Available: "2019-12"
 # sewing kit: Restores up to 1,000 HP
 # sewing kit: (doesn't go away when used)
 # shadow brick: Instantly destroy an enemy
+Item	shadow brick	Last Available: "2023-03"
 # shadow glass: Refracts prismatic damage at your foes again and again
+Item	shadow glass	Last Available: "2023-03"
 # shadow ice: Stun an opponent for a very long time
+Item	shadow ice	Last Available: "2023-03"
 # shadow needle: Gives you a shadow tattoo
 # shadow sinew: Weakens and briefly stuns an opponent
+Item	shadow sinew	Last Available: "2023-03"
 # shadowy cheat sheet: Grants one "skill point" for each Shadows Over Loathing Class (In future ascensions)
 Item	shadowy cheat sheet	Free Pull
+Item	shaker of dry rub	Last Available: "2014-06"
+Item	shaking crappy camera	Last Available: "2014-12"
 Item	shaking skull	No Pull
 # shard of double-ice: Deals <font color=blue>Cold Damage</font> based on your highest stat
 # shard of double-ice: (and leaves the monster permanently cold)
+Item	shard of double-ice	Last Available: "2011-04"
 # sharpened hubcap: Deals 400-500 Physical Damage
 # shaving cream: Stops Enemy From Attacking
 Item	shaving cream	Effect: "Clean-Shaven", Effect Duration: 5
+Item	SHAWARMA Initiative Keycard	Last Available: "2014-10"
 Item	shimmering tendrils	Class: "Pastamancer"
 # shingle: Stops Enemy From Attacking and Weakens it Slightly
 Item	shingle	Effect: "Confused", Effect: "Amorous", Effect Duration: 10
 # short calculator: ???
 # short writ of habeas corpus: Lets you get away from pygmies without spending an Adventure
 Item	shortest-order cook	Free Pull, Last Available: "2021-05"
+Item	shot of granola liqueur	Last Available: "2017-03"
 Item	shot of Sneaky Pete's Mojo	Free Pull
 Item	shrine to the Barrel god	Free Pull, Last Available: "2015-09"
 Item	shrink-wrapped 2002 Mr. Store Catalog	Free Pull, Last Available: "2023-06"
 Item	shrink-wrapped Cincho de Mayo	Free Pull, Last Available: "2023-05"
 # shrinking powder: Reduce an enemy's size (Hit Points) by 35-50%
+Item	Shudder	Last Available: "2018-03"
+Item	shuddering cow skull	Last Available: "2016-02"
 # shuriken salad: Deals 25-35 Physical Damage, 25-35 <font color=blue>Cold Damage</font> and 25-35 <font color=green>Stench Damage</font>
+Item	sicksilver spurs	Last Available: "2016-02"
 Item	siesta-ing Casagnova gnome	Free Pull, Last Available: "2008-10"
+Item	signal fragment	Last Available: "2019-04"
+Item	signed deuce	Last Available: "2015-08"
+Item	silent A	Last Available: "2017-12"
+Item	silent B	Last Available: "2017-12"
+Item	silent C	Last Available: "2017-12"
+Item	silent D	Last Available: "2017-12"
+Item	silent E	Last Available: "2017-12"
+Item	silent F	Last Available: "2017-12"
+Item	silent G	Last Available: "2017-12"
+Item	silent H	Last Available: "2017-12"
+Item	silent I	Last Available: "2017-12"
+Item	silent J	Last Available: "2017-12"
+Item	silent K	Last Available: "2017-12"
+Item	silent L	Last Available: "2017-12"
+Item	silent M	Last Available: "2017-12"
+Item	silent N	Last Available: "2017-12"
+Item	silent O	Last Available: "2017-12"
+Item	silent P	Last Available: "2017-12"
+Item	silent Q	Last Available: "2017-12"
+Item	silent R	Last Available: "2017-12"
+Item	silent S	Last Available: "2017-12"
+Item	silent T	Last Available: "2017-12"
+Item	silent U	Last Available: "2017-12"
+Item	silent V	Last Available: "2017-12"
+Item	silent W	Last Available: "2017-12"
+Item	silent X	Last Available: "2017-12"
+Item	silent Y	Last Available: "2017-12"
+Item	silent Z	Last Available: "2017-12"
+Item	silicon-infused gluteal shield	Last Available: "2007-12"
 # silk bandages: Restores 40-80 HP
 Item	silk garter snake	Free Pull, Last Available: "2011-12"
 Item	Silly Little Love Song	Skill: "Paul's Passionate Pop Song", Last Available: "2018-02"
 # silver cow skull: Sells for a pretty penny!
+Item	silver cow skull	Last Available: "2016-02"
 Item	silver Dreadsylvanian flask	Effect: "Silver Age Secrets", Effect Duration: 100
+Item	silver keg	Last Available: "2010-06"
+Item	silver shotgun shell	Last Available: "2011-10"
+Item	Single Alice's Army Foil	Last Available: "2011-03"
 Item	sinistral homunculus	Free Pull, Last Available: "2020-04"
 # Sitrep berry: Restores HP and energizes you for a while
+Item	Sitrep berry	Last Available: "2018-03"
+Item	sizzling desk bell	Last Available: "2020-09"
 # skate skates: Deals 150-300 Physical Damage and briefly stuns your opponent
 # skeletal skiff: <b>Allows Travel to The Mysterious Island of Mystery</b>
+Item	skeletal skiff	Last Available: "2012-10"
+Item	skeleton	Last Available: "2012-10"
+Item	skewered cherry	Last Available: "2004-12"
+Item	skewered jumbo olive	Last Available: "2004-12"
+Item	skewered lime	Last Available: "2004-12"
 # skull with a fuse in it: Deals 400-500 Physical Damage
+Item	skull with a fuse in it	Last Available: "2011-09"
+Item	skulldozer egg	Last Available: "2012-10"
 # Skullhead's Screw: Deals 10-20 <font color=blueviolet>Sleaze Damage</font>
+Item	Skullhead's Screw	Last Available: "2011-04"
 Item	slap and slap again recipe	Recipe: "slap and slap again"
 # sleaze clusterbomb: Deals <font color=blueviolet>Sleaze Damage</font> based on your highest stat
 # sleaze clusterbomb: (more effective against groups)
+Item	Sledgehamster	Last Available: "2018-03"
 Item	SLEEP(5) rom chip	Skill: "SLEEP(5)", Last Available: "2025-12"
 Item	sleeping patriotic eagle	Free Pull
 Item	sleeping piano cat	Free Pull, Last Available: "2011-12"
+Item	sleeping profane parrot	Last Available: "2024-12"
+Item	sleeping snowy owl	Last Available: "2005-12"
+Item	sleeping stocking	Last Available: "2010-12"
+Item	slicksilver spurs	Last Available: "2016-02"
+Item	slime shooter	Last Available: "2017-03"
 # slime stack: Deals 10-20% of a monster's current Hit Points in Physical Damage
 # slime stack: Weakens the monster by 10%
 Item	slime-soaked brain	Skill: "Slimy Synapses"
 Item	slime-soaked hypophysis	Skill: "Slimy Sinews"
 Item	slime-soaked sweat gland	Skill: "Slimy Shoulders"
 Item	Sloppy Seconds Diner Employee Handbook	Skill: "Sloppy Secrets", Last Available: "2014-05"
+Item	Slotter	Last Available: "2018-03"
+Item	slow jam collection	Last Available: "2011-01"
+Item	small Crimbo Pressie	Last Available: "2004-12"
 # small golem: Deals Physical Damage each round for the rest of the fight
+Item	small golem	Last Available: "2014-12"
 Item	Small Medium	Free Pull, Last Available: "2012-03"
+Item	small pile of sand	Last Available: "2019-07"
+Item	Smashmoth	Last Available: "2018-03"
 # smoke grenade: Banishes a monster for a while
 # smoking grass: Deals 250-300 <font color=red>Hot Damage</font> and also, like, weakens enemies a bunch and briefly makes them forget what they were doing
+Item	smoking grass	Last Available: "2012-07"
 Item	smoking talon	Class: "Pastamancer"
 # SMOOCH bottlecap: It's a collector's item!
+Item	SMOOCH bottlecap	Last Available: "2020-09"
 # smooth stone sphere: Mysterious, Deprecated
 # snake oil: Increase the venom and medicine level of your briefcase full of snakes
+Item	snake skin	Last Available: "2018-11"
 # Snarf berry: Increases your stats and energizes you for a while
 Item	Snarf berry	Last Available: "2018-03", Effect: "Berry Statistical", Effect Duration: 20
 # sneaky wrapping paper: Hide gifts for other players in various locations
+Item	sneaky wrapping paper	Last Available: "2014-12"
+Item	Snoutlet	Last Available: "2018-03"
 # snow boards: Useful for Bridge-Building
+Item	snow boards	Last Available: "2014-01"
+Item	snow machine	Last Available: "2014-01"
 # soda water: Restores 3-5 MP
 # soft green echo eyedrop antidote: Allows you to remove an Effect
+Item	software bug	Last Available: "2016-06"
 # software glitch: <b>Fatal Error:</b> Unexpected } in line 17
+Item	soggy gingerbread chunk	Last Available: "2019-12"
 # soggy used band-aid: Heals all of your Hit Points and stuns your opponent for a few rounds
+Item	soggy used band-aid	Last Available: "2012-05"
 # solid gold jewel: Can be sold for 100,000 Meat
+Item	solid gold rosary	Last Available: "2014-12"
 # sonar-in-a-biscuit: Freaks Bats Out
 # SongBoom&trade; BoomBox: Plays a Soundtrack for your Life<br />Lets you <i>Sing Along</i> during Fights
+Item	SongBoom&trade; BoomBox	Last Available: "2018-06"
 Item	SongBoom&trade; BoomBox Box	Free Pull, Last Available: "2018-06"
 Item	Sorcerers of the Shore Grimoire	Free Pull, Skill: "Summon Alice's Army Cards"
+Item	sorority girl's box	Last Available: "2011-10"
 # soup turtle: Deals 5-10 <font color=red>Hot Damage</font>
+Item	Source essence	Last Available: "2016-06"
 Item	Source terminal	Free Pull, Last Available: "2016-06"
+Item	Source terminal ASHRAM chip	Last Available: "2016-06"
+Item	Source terminal CRAM chip	Last Available: "2016-06"
+Item	Source terminal DIAGRAM chip	Last Available: "2016-06"
+Item	Source terminal DRAM chip	Last Available: "2016-06"
+Item	Source terminal file: compress.edu	Last Available: "2016-06"
+Item	Source terminal file: cram.ext	Last Available: "2016-06"
+Item	Source terminal file: critical.enh	Last Available: "2016-06"
+Item	Source terminal file: damage.enh	Last Available: "2016-06"
+Item	Source terminal file: dram.ext	Last Available: "2016-06"
+Item	Source terminal file: duplicate.edu	Last Available: "2016-06"
+Item	Source terminal file: familiar.ext	Last Available: "2016-06"
+Item	Source terminal file: gram.ext	Last Available: "2016-06"
+Item	Source terminal file: portscan.edu	Last Available: "2016-06"
+Item	Source terminal file: pram.ext	Last Available: "2016-06"
+Item	Source terminal file: protect.enq	Last Available: "2016-06"
+Item	Source terminal file: spam.ext	Last Available: "2016-06"
+Item	Source terminal file: stats.enq	Last Available: "2016-06"
+Item	Source terminal file: substats.enh	Last Available: "2016-06"
+Item	Source terminal file: tram.ext	Last Available: "2016-06"
+Item	Source terminal file: turbo.edu	Last Available: "2016-06"
+Item	Source terminal GRAM chip	Last Available: "2016-06"
+Item	Source terminal INGRAM chip	Last Available: "2016-06"
+Item	Source terminal PRAM chip	Last Available: "2016-06"
+Item	Source terminal SCRAM chip	Last Available: "2016-06"
+Item	Source terminal SPAM chip	Last Available: "2016-06"
+Item	Source terminal TRAM chip	Last Available: "2016-06"
+Item	Source terminal TRIGRAM chip	Last Available: "2016-06"
+Item	Souvenir Chopsticks	Last Available: "2023-06"
 Item	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	Last Available: "2008-04", Skill: "Summon Tasteful Items"
+Item	Space Baby bawbaw	Last Available: "2017-04"
+Item	Space Baby children's book	Last Available: "2017-04"
+Item	space bar	Last Available: "2014-05"
+Item	space beast fur	Last Available: "2014-05"
+Item	space blanket	Last Available: "2022-05"
 # space invader: Deals 300-400 Physical Damage
+Item	space invader	Last Available: "2014-05"
+Item	space jam	Last Available: "2011-01"
+Item	space junk	Last Available: "2014-05"
 Item	Space Pirate Astrogation Handbook	Skill: "Quantum Movement", Last Available: "2017-04"
+Item	space pirate treasure map	Last Available: "2017-04"
 Item	space planula	Free Pull, Last Available: "2017-01"
 # Space Tours Tripple: Weakens enemies a little bit
+Item	Spacefleet Communicator Badge	Last Available: "2009-06"
 # Spacegate access badge: Unlocks billions of strange alien worlds
 Item	Spacegate access badge	Free Pull, Last Available: "2017-04"
 Item	Spacegate emergency disintegrator	Skill: "Disintegrate", Last Available: "2017-04"
+Item	Spacegate Initiative tattoo unit	Last Available: "2017-04"
+Item	Spacegate Research	Last Available: "2017-04"
 # spangly unitard: Deals 100-250 Physical Damage and weakens your opponent somewhat
+Item	spant chitin	Last Available: "2017-04"
 # spant egg casing: Worth 25 pages of Spacegate Research
+Item	spant egg casing	Last Available: "2017-04"
+Item	spant tendon	Last Available: "2017-04"
+Item	spare chocolate parts	Last Available: "2016-12"
 # sparking El Vibrato drone: Deals 250-300 Physical Damage
 # sparking robo-battery: Restores 80-100 MP
+Item	sparking robo-battery	Last Available: "2015-12"
 # special clip: boneburners: Deals <font color=gray>Spooky Damage</font> and <font color=red>Hot Damage</font> based on your Moxie
 # special clip: graveburpers: Deals <font color=green>Stench Damage</font> and <font color=gray>Spooky Damage</font> based on your Moxie
 # special clip: splatterers: Deals <font color=blueviolet>Sleaze Damage</font> and <font color=gray>Spooky Damage</font> based on your Moxie
 # special clip: squelchers: Deals <font color=blueviolet>Sleaze Damage</font> based on your Moxie
 # special clip: tracers: Deals <font color=red>Hot Damage</font> based on your Moxie
 # special clip: wailers: Deals <font color=gray>Spooky Damage</font> based on your Moxie
+Item	special clip: boneburners	Last Available: "2014-10"
+Item	special clip: graveburpers	Last Available: "2014-10"
+Item	special clip: splatterers	Last Available: "2014-10"
+Item	special clip: squelchers	Last Available: "2014-10"
+Item	special clip: tracers	Last Available: "2014-10"
+Item	special clip: wailers	Last Available: "2014-10"
 # special edition Batfellow comic: Lets you have a fun adventure (once a week) as a dark, brooding, bat-themed superhero.
 Item	special edition Batfellow comic	Free Pull, Last Available: "2016-12"
 # Special Seasoning: Kicks Food Up a Notch
+Item	Special Seasoning	Last Available: "2018-06"
+Item	specialty ammo bandolier	Last Available: "2014-10"
 # spectral jelly: Makes you nearly impervious to damage for the duration of the fight
 # spectre scepter: Invoke the Ancient Gods!
 Item	Spellbook: Drescher's Annoying Noise	Skill: "Drescher's Annoying Noise"
@@ -12864,64 +14759,130 @@ Item	Spellbook: Singer's Faithful Ocelot	Skill: "Singer's Faithful Ocelot"
 Item	Spellbook: Walberg's Dim Bulb	Skill: "Walberg's Dim Bulb"
 Item	Spelunker of Fortune	Skill: "Speluck", Last Available: "2015-12"
 Item	Spelunker of Fortune (used)	Skill: "Speluck"
+Item	Spelunker's Guild prize sack	Last Available: "2015-12"
 # spice melange: Makes you less full and more sober
 # spices: Deals 1 Physical Damage
 # spider web: Weakens enemies very slightly
 Item	spinal-fluid-covered emotion chip	Last Available: "2021-02", Skill: "Emotionally Chipped"
+Item	SpinMaster&trade; lathe	Last Available: "2020-08"
 # spinning wheel: Turns air into Meat (once per day)
+Item	spinning wheel	Last Available: "2014-12"
+Item	spiraling shape	Last Available: "2009-12"
 # spirit beer: Restores 40-50 MP
 Item	spirit beer	Effect: "Spiritually Aware", Effect Duration: 10
+Item	Spirit of Christmas	Last Available: "2024-12"
+Item	Spirit of Easter	Last Available: "2024-12"
+Item	Spirit of St. Patrick's Day	Last Available: "2024-12"
+Item	Spirit of Thanksgiving	Last Available: "2024-12"
+Item	Spirit of Veteran's Day	Last Available: "2024-12"
 # spooky alphabet block: Mysterious and spooky
+Item	spooky bark	Last Available: "2009-10"
 # spooky clusterbomb: Deals <font color=gray>Spooky Damage</font> based on your highest stat
 # spooky clusterbomb: (more effective against groups)
+Item	spooky felt	Last Available: "2011-12"
 # spooky lasso: Deals <font color=gray>Spooky Damage</font> based on your Moxie and briefly stuns your opponent
+Item	spooky length of string	Last Available: "2011-12"
 # spooky music box mechanism: Deals 100-120 <font color=gray>Spooky Damage</font>
 # spooky music box mechanism: (unless you're in Spookyraven Manor, in which case it banishes a monster for a while)
+Item	Spooky Putty monster	Last Available: "2009-01"
 # Spooky Putty sheet: Makes a copy of a monster to fight later
+Item	Spooky Putty sheet	Last Available: "2009-01"
 Item	spooky rattling cigar box	Free Pull, Last Available: "2011-12"
+Item	spooky stuffing	Last Available: "2011-12"
+Item	spooky toy wheel	Last Available: "2011-12"
+Item	Spooky VHS Tape	Last Available: "2023-06"
+Item	spooky wooden block	Last Available: "2011-12"
 Item	spray paint	Effect: "Tagged", Effect Duration: 10
+Item	Spring Break Beach tattoo coupon	Last Available: "2014-05"
+Item	sprinkles	Last Available: "2016-12"
 Item	squamous polyp	Free Pull, Last Available: "2011-12"
+Item	Squib	Last Available: "2018-03"
+Item	squirming egg sac	Last Available: "2011-06"
+Item	St. Sneaky Pete's Day goodies basket	Last Available: "2006-04"
+Item	St. Sneaky Pete's Whey	Last Available: "2022-11"
 Item	Stabonic scroll	Last Available: "2010-10", Effect: "Bone Homie", Effect Duration: 20
 # star throwing star: Deals 50-75 Physical Damage
 Item	STATS+++ rom chip	Skill: "STATS+++", Last Available: "2025-12"
 # steam-powered model rocketship: Allows access to the Hole in the Sky
 # stench clusterbomb: Deals <font color=green>Stench Damage</font> based on your highest stat
 # stench clusterbomb: (more effective against groups)
+Item	stick	Last Available: "2011-12"
 # stick of dynamite: Deals 15-20 Physical Damage
+Item	stick of firewood	Last Available: "2019-08"
 # stick-on-a-string: Either Slightly Damages or Slight Weakens Foes
+Item	stick-on-a-string	Last Available: "2006-12"
 # sticky clay homunculus: Makes a copy of a monster to fight later
 Item	still grill	Free Pull, Last Available: "2014-06"
+Item	stinky cheese ball	Last Available: "2010-01"
 Item	stomach churner	Sleaze Damage: +10, Sleaze Spell Damage: +10
 # stone frisbee: Deals 80-100 Physical Damage
+Item	Stooper	Last Available: "2018-03"
+Item	strange cube	Last Available: "2011-02"
 # strange goggles: ???
+Item	strange goggles	Last Available: "2013-12"
+Item	strange shiny disc	Last Available: "2008-01"
+Item	strange stalagmite	Last Available: "2023-01"
+Item	straw	Last Available: "2014-12"
+Item	strawberyl	Last Available: "2011-11"
+Item	Straypler	Last Available: "2018-03"
+Item	string of Crimbo lights	Last Available: "2009-12"
+Item	stringy sinew	Last Available: "2011-12"
+Item	structural ember	Last Available: "2024-09"
 # stuffed alien blob: Randomly Becomes a Different Combat Item When Used
+Item	stuffed alien blob	Last Available: "2006-12"
 # stuffed doppelshifter: Randomly Becomes a Different Combat Item When Used
+Item	stuffed doppelshifter	Last Available: "2005-12"
 # stuffed gray blob: Randomly becomes a different combat item when used
+Item	stuffed gray blob	Last Available: "2007-12"
 # stuffed yam stinkbomb: Banish a monster for 15 turns
+Item	stuffed yam stinkbomb	Last Available: "2024-05"
 Item	stuffed-shirt scarecrow	Free Pull, Last Available: "2011-11"
+Item	stuffing fluffer	Last Available: "2016-11"
+Item	sturdy Crimbo crate	Last Available: "2008-12"
+Item	sub-molecular interocitor	Last Available: "2011-12"
+Item	subscription cocoa dispenser	Last Available: "2020-12"
+Item	sucker scaffold	Last Available: "2011-11"
 # sugar shard: Restores 10-20 HP and 5-10 MP
+Item	sugar shard	Last Available: "2009-09"
+Item	sugar sheet	Last Available: "2009-09"
 Item	Summer Nights	Skill: "Grease Lightning"
 # super deluxe mushroom: Heals 100 HP
 # superamplified boom box: Deals 90-100 Physical Damage
 # superamplified boom box: Weakens enemies somewhat
 # superamplified boom box: Briefly stuns your opponent
+Item	superduperball	Last Available: "2010-06"
 # superduperheated metal: Vaporizes foes
+Item	superduperheated metal	Last Available: "2015-08"
+Item	superheated fudge	Last Available: "2011-11"
+Item	superheated metal	Last Available: "2015-08"
+Item	Supreme Being Glossary	Last Available: "2009-06"
 # surgical tape: Weakens enemies a little bit and restores 20-30 Hit Points
 Item	suspicious package	Free Pull, Last Available: "2017-06"
 Item	suspicious stocking	Free Pull, Last Available: "2009-12"
+Item	sweaty balsam	Last Available: "2020-08"
 Item	sweaty egg	HP Regen Min: 4, HP Regen Max: 8
 Item	sweet nutcracker	Free Pull, Last Available: "2005-12"
 Item	sweet tooth	Last Available: "2014-05", Wiki Name: "sweet tooth"
+Item	Swiss piggy bank	Last Available: "2015-01"
 # synaptic soup: Add a pound and MP restore to your familiar
+Item	synthetic dog hair pill	Last Available: "2011-06"
+Item	synthetic rock	Last Available: "2021-12"
+Item	synthetic stuffing	Last Available: "2007-12"
 # T.U.R.D.S. Key: Lets you escape from combat without spending an Adventure
 # T.U.R.D.S. Key: (Maybe)
 # tabletop candy dispenser: Produces some random candy items (1x/day, costs 10 Meat)
+Item	tabletop candy dispenser	Last Available: "2020-12"
+Item	Taco Dan's Super Taco-Riffic Taco Sauce!	Last Available: "2014-05"
+Item	Taco Dan's Taco Stand Flier	Last Available: "2012-12"
+Item	Taco Dan's Taco Stand's Taco Receipt	Last Available: "2014-05"
 Item	tainted marshmallow	Lasts Until Rollover, Last Available: "2018-04"
+Item	TakerSpace letter of Marque	Last Available: "2024-12"
 Item	Tales from the Fireside	Skill: "Conjure Relaxing Campfire"
 Item	Tales of a Kansas Toymaker	Skill: "Toynado", Last Available: "2010-12"
 Item	Tales of a Kansas Toymaker (used)	Skill: "Toynado", Last Available: "2010-12"
 Item	Tales of Dread	Free Pull
 # Tales of Spelunking: Begins a Spelunking Adventure!
+Item	Tales of Spelunking	Last Available: "2015-12"
 # Tales of the West: Beanslinging: Teaches you Beanslinger skills
 # Tales of the West: Cow Punching: Teaches you Cow Puncher skills
 # Tales of the West: Snake Oiling: Teaches you Snake Oiler skills
@@ -12934,13 +14895,23 @@ Item	talking spade	Free Pull
 # tangle of rat tails: Deals 50-70 <font color=blueviolet>Sleaze Damage</font> and 100-120 <font color=green>Stench Damage</font>
 # Tapioc berry: Grants elemental resistance and energizes you for a while
 Item	Tapioc berry	Last Available: "2018-03", Effect: "Berry Elemental", Effect Duration: 20
+Item	tarnished luggage key	Last Available: "2017-01"
+Item	tasty louse	Last Available: "2008-06"
 # tattered scrap of paper: Lets you escape from combat without spending an Adventure
 # tattered scrap of paper: (Maybe)
 # tattoo of two turkeys: Grants a tattoo when used
+Item	tattoo of two turkeys	Last Available: "2024-12"
+Item	teddy bear	Last Available: "2005-12"
+Item	teddy borg	Last Available: "2007-12"
+Item	teethpick	Last Available: "2016-12"
+Item	Telltale&trade; rubber heart	Last Available: "2015-10"
 # tennis ball: Banish an enemy for 30 Adventures
+Item	tennis ball	Last Available: "2015-10"
 # tequila grenade: Deals 75-100 Physical Damage
 # terrible poem: Deals 5-6 Physical Damage
+Item	test site key	Last Available: "2013-12"
 # thanksgiving bomb: Deals 750-1000 Physical and Hot Damage
+Item	thanksgiving bomb	Last Available: "2024-05"
 Item	The Art of Slapfighting	Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 Item	The Art of Slapfighting (used)	Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 Item	The Autobiography Of Dynamite Superman Jones	Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
@@ -12949,13 +14920,17 @@ Item	The Big Book of Communism	Last Available: "2015-12", Skill: "Communism!"
 Item	The Big Book of Communism (used)	Skill: "Communism!", Last Available: "2015-12"
 # The Big Book of Pirate Insults: Use it to insult Pirates
 # The Bomb: Deals 400-500 Physical Damage
+Item	The Bomb	Last Available: "2011-09"
 Item	The Chill of the Wild	Skill: "Beardfreeze", Last Available: "2015-11"
+Item	The Cocktail Shaker	Last Available: "2015-04"
 Item	The Confiscator's Grimoire	Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 Item	the Crymbich Manuscript	Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 Item	the Crymbich Manuscript (used)	Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
+Item	The Emperor's dry cleaning	Last Available: "2015-07"
 # The Emperor's new cookie: So delicious!
 Item	The Encyclopedia of Fruit	Skill: "Fruit Recognition", Last Available: "2023-12"
 Item	The Encyclopedia of Fruit (used)	Skill: "Fruit Recognition", Last Available: "2023-12"
+Item	the finger	Last Available: "2011-04"
 # The Fingernail of the Thing in the Basement: Jeremy Science will be interested in this
 Item	The Firegate Tapes	Skill: "Firegate", Last Available: "2015-08"
 Item	The Fun-Guy Cold Weather Bartender's Guide	Skill: "Perfect Freeze", Last Available: "2015-11"
@@ -12979,6 +14954,7 @@ Item	The Joy of Wassailing (used)	Skill: "Wassail", Last Available: "2010-12"
 Item	The Kloop in the Coop	Free Pull, Last Available: "2012-12"
 Item	The Legendary Beat	Last Available: "2010-04", Effect: "Clyde's Blessing", Effect Duration: 20
 # The Lost Comb: Stuns your opponent for a few rounds
+Item	The Lost Pill Bottle	Last Available: "2012-05"
 Item	The Necbronomicon	Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 Item	The Necbronomicon (used)	Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 Item	The Night Before Crimbo, Ch. 1	Skill: "Long Winter's Nap", Last Available: "2020-12"
@@ -13003,32 +14979,49 @@ Item	The Spirit of Giving	Skill: "The Spirit of Taking", Last Available: "2019-1
 Item	The Spirit of Giving (used)	Skill: "The Spirit of Taking", Last Available: "2019-12"
 Item	The Sword in the Steak	Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
 Item	The Thorax's Codex of Tormenting Plants	Skill: "Torment Plant", Last Available: "2012-12"
+Item	the tongue of Smimmons	Last Available: "2015-08"
 Item	The Western Look	Skill: "Steely-Eyed Squint", Last Available: "2016-02"
+Item	theoretical string	Last Available: "2007-12"
 Item	They'll Love You In Rhinestones	Skill: "Acquire Rhinestones", Last Available: "2018-02"
 # thick walrus blubber: Weakens foes
 # thick walrus blubber: (much more effective in the Canadian Wildlife Preserve)
+Item	thick walrus blubber	Last Available: "2018-12"
+Item	thicksilver spurs	Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
+Item	thin gold wire	Last Available: "2015-08"
+Item	Thinknerd T-shirt grab bag	Last Available: "2012-12"
 Item	Thinknerd's Grimoire of Geeky Gifts	Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
 Item	throbbing rage gland	Skill: "Vent Rage Gland"
+Item	throwin' ember	Last Available: "2024-09"
+Item	throwing bone	Last Available: "2011-10"
 # throwing candy: Deals 25-50 Physical Damage and weakens enemies somewhat
 # throwing fork: Deals 20-30 Physical Damage with each of its three tines
 # throwing knife: Causes bleeding
 # throwing spoon: Deals 50-60 Physical Damage and weakens enemies somewhat
+Item	Tickle-Me Emilio	Last Available: "2011-11"
 # tie-dye headband: Makes your peace turkey outline block delevel more often
+Item	Time Juice	Last Available: "2004-01"
+Item	time residue	Last Available: "2016-09"
 # time shuriken: (does not go away when used)
 Item	time sleigh	Free Pull, Last Available: "2006-12"
 # Time-Spinner: Allows you to travel through time
 # Time-Spinner: Weakens opponents in combat
+Item	Time-Spinner	Last Available: "2016-09"
 Item	time's arrow	Free Pull, Last Available: "2011-12"
 # tin lizzie: <b>Allows Travel to Desert Beach</b>
+Item	tin lizzie	Last Available: "2013-09"
 # tin snips: Deals 8-10 Physical Damage and causes bleeding
+Item	tin snips	Last Available: "2013-09"
+Item	tiny barrel	Last Available: "2015-09"
 # tiny bomb: Deals moderate damage to enemies
 # tiny bomb: (much more effective in the Canadian Wildlife Preserve)
+Item	tiny bomb	Last Available: "2018-12"
 Item	tiny ember	Cold Resistance: +1
 # tiny goth giant: Makes combat all Gothy
 # tiny goth giant: (doesn't go away when used)
 # tiny house: Restores 20-24 HP and MP and removes negative effects
 Item	To Build an Igloo	Skill: "Refusal to Freeze", Last Available: "2015-11"
 Item	to-go brew	Lasts Until Rollover, Last Available: "2018-04"
+Item	toe jam	Last Available: "2011-01"
 # Tom's of the Spanish Main Toothpaste: Weakens enemies a little bit
 # tomayohawk-style reflex hammer: Stops enemy from attacking and deals <font color=blueviolet>Sleaze Damage</font> based on your blood-mayonnaise concentration.
 Item	tomayohawk-style reflex hammer	Lasts Until Rollover, Last Available: "2015-05"
@@ -13044,38 +15037,77 @@ Item	Too Cold to Hold: How to Be Cool - A Memoir	Skill: "Too Cool"
 Item	Too Cold to Hold: How to Be Cool - A Memoir (read)	Skill: "Too Cool"
 Item	toothbrush	Effect: "Very Clean Teeth", Effect Duration: 10
 # top: Weakens enemies a little bit
+Item	top	Last Available: "2010-12"
+Item	tourmalime	Last Available: "2011-11"
 # toxic globule: Can be scienced into various objects
+Item	toxic globule	Last Available: "2015-04"
 # toy Cupid bow: Occasionally snag a missed item drop
 # toy Cupid bow: Distract foes with a plunger to the face
 # toy Cupid bow: Lets your familiar fetch their own equipment after a while
 Item	toy Cupid bow	Experience (familiar): +2, Last Available: "2025-02", Generic
 # toy deathbot: Deals damage in exchange for some of your blood
+Item	toy deathbot	Last Available: "2007-12"
+Item	toy hoverpad	Last Available: "2007-12"
 # toy mercenary: Charges Meat to Attack Foes
+Item	toy mercenary	Last Available: "2006-12"
 # toy sixgun: Bang!
 # toy soldier: Deals 30-35 Damage (Requires Tequila)
 # toy soldier: (Not consumed when used)
+Item	toy soldier	Last Available: "2005-12"
+Item	traffic jam	Last Available: "2011-01"
+Item	Trafikoan	Last Available: "2018-03"
 # train whistle: Blow it to weaken your foes
+Item	train whistle	Last Available: "2022-12"
 # Trainbot autoassembly module: Gives you a piece of the Trainbot outfit
 Item	training scroll:  Shattering Punch	Skill: "Shattering Punch", Last Available: "2016-01"
 Item	training scroll:  Shivering Monkey Technique	Skill: "Shivering Monkey Technique", Last Available: "2016-01"
 Item	training scroll:  Snokebomb	Skill: "Snokebomb", Last Available: "2016-01"
+Item	transmission from planet Xi	Last Available: "2014-09"
 Item	Trash, a Memoir	Skill: "Garbage Nova", Last Available: "2015-04"
+Item	traumatic holiday memory	Last Available: "2024-12"
 Item	Travels with Jerry	Skill: "Mudbath"
 # tree-eating kite: Deals 20-25 Physical Damage
+Item	tree-eating kite	Last Available: "2006-12"
+Item	triad summoning scroll	Last Available: "2013-12"
+Item	trick coin	Last Available: "2023-12"
+Item	trilobite candy mold	Last Available: "2011-11"
+Item	trilobite fossil	Last Available: "2011-11"
+Item	Trivial Avocations board game	Last Available: "2011-11"
+Item	Trivial Avocations Card: What?	Last Available: "2011-11"
+Item	Trivial Avocations Card: When?	Last Available: "2011-11"
+Item	Trivial Avocations Card: Where?	Last Available: "2011-11"
+Item	Trivial Avocations Card: Who?	Last Available: "2011-11"
+Item	tropical Crimbo pressie	Last Available: "2006-12"
 # tropical orchid: Weakens enemies a little bit
+Item	tropical wrapping paper	Last Available: "2006-12"
 Item	Trout Fishing in Loathing	Skill: "Astute Angler", Last Available: "2016-04"
 # tryptophan dart: Knocks an enemy out.  You won't see them for the rest of the day.
+Item	tryptophan dart	Last Available: "2019-12"
 # tube of herbal ointment: Restores 14-16 HP
+Item	tube of herbal ointment	Last Available: "2013-12"
+Item	Turpin	Last Available: "2018-03"
+Item	Turtive	Last Available: "2018-03"
 # turtle-shaped rock: Deals 45-50 Physical Damage
 # Twelve Night Energy: Grants 12 Adventures
 # Twelve Night Energy: (You can only use one of these per day)
 # twisted piece of wire: Stuns your opponent for a couple of rounds
+Item	twitching claw	Last Available: "2008-12"
+Item	twitching space egg	Last Available: "2014-05"
 Item	twitching trigger finger	Class: "Pastamancer"
+Item	Ultimate Mind Destroyer	Last Available: "2014-05"
 # Ultra Mega Sour Ball: Makes you less full and more sober
 # ultracalcium: Give a Pokefamiliar Thorns: 1
 # ultracoagulator: Restores all of your Bat-Health during a fight
+Item	ultracoagulator	Last Available: "2017-01"
 Item	Unagnimated Gnome	Free Pull, Last Available: "2012-08"
 # unbearable light: Vaporizes an enemy and causes all of its items to drop
+Item	unbearable light	Last Available: "2011-09"
+Item	uncanny desk bell	Last Available: "2020-09"
+Item	uncapped blue lava bottle	Last Available: "2015-08"
+Item	uncapped green lava bottle	Last Available: "2015-08"
+Item	uncapped red lava bottle	Last Available: "2015-08"
+Item	Uncle Crimbo's Rations	Last Available: "2010-12"
+Item	Uncle Crimbo's Sack	Last Available: "2011-01"
 Item	Uncle Romulus	Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 Item	Uncle Romulus (used)	Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 Item	undamaged Unbreakable Umbrella	Free Pull, Last Available: "2022-04"
@@ -13083,13 +15115,18 @@ Item	undamaged Unbreakable Umbrella	Free Pull, Last Available: "2022-04"
 # underwater slingshot: (sometimes more)
 # underwater slingshot: (and only works underwater)
 Item	Underworld acorn	Free Pull, Last Available: "2009-10"
+Item	Underworld sapling	Last Available: "2009-10"
+Item	Underworld trunk	Last Available: "2009-10"
 Item	undrilled cosmic bowling ball	Free Pull, Last Available: "2022-01"
 Item	unearthed volcanic meteoroid	Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 Item	unemployed hunchbacked minion	Free Pull, Last Available: "2008-10"
 Item	unevolved organism	Free Pull
 # unfinished ice sculpture: Makes a copy of a monster to fight later
+Item	unfinished ice sculpture	Last Available: "2014-01"
+Item	Ungulant	Last Available: "2018-03"
 Item	uniclops egg	Free Pull, Last Available: "2009-10"
 # universal biscuit: Gives your familiar 10 XP
+Item	universal biscuit	Last Available: "2021-12"
 Item	Unmotivator: Crashed Meat Car	Free Pull
 Item	Unmotivator: Crashed Orca	Free Pull
 Item	Unmotivator: Success Warrior	Free Pull
@@ -13101,82 +15138,218 @@ Item	Unopened Eight Days a Week Pill Keeper	Free Pull, Last Available: "2019-10"
 Item	unopened tiny stillsuit	Free Pull, Last Available: "2022-08"
 Item	unpowered Robortender	Free Pull, Last Available: "2017-03"
 # unrefined Mountain Stream syrup: Restores 50-60 MP
+Item	unremarkable duffel bag	Last Available: "2018-09"
+Item	unsmoothed velvet	Last Available: "2015-08"
+Item	Unspeakachu	Last Available: "2018-03"
 # unstable laser battery: Deals 200-250 <font color=red>Hot Damage</font>
 # unstable laser battery: Briefly stuns enemies
+Item	unstable laser battery	Last Available: "2007-12"
 Item	untorn tearaway pants package	Free Pull
 Item	unused walkie-talkie	Free Pull
 Item	unwound cymbal-playing monkey	Free Pull, Last Available: "2006-10"
 # unwrapped knock-off retro superhero cape
 Item	Valentine	Free Pull
 # valuable coin: Worth a lot!
+Item	valuable coin	Last Available: "2015-07"
 Item	vampire glitter	Class: "Pastamancer"
+Item	Vamprey	Last Available: "2018-03"
 Item	vampyric cloake pattern	Free Pull
+Item	van key	Last Available: "2018-09"
+Item	vanity stone	Last Available: "2012-12"
+Item	Vaporpoise	Last Available: "2018-03"
+Item	Vegetable of Jarlsberg	Last Available: "2022-11"
 # veiny spore pod: Briefly enhances your muscle
 # very large caltrop: Deals 150-200 Physical Damage
 # very large caltrop: Stuns an enemy for a few rounds
 # very small red dress: Angers enemies (making them harder but worth 50 additional substats)
+Item	very small red dress	Last Available: "2018-09"
+Item	Vial of <i>jus de larmes</i>	Last Available: "2010-03"
 # vial of holy water: Deals 40-60 <font color=red>Hot Damage</font>
+Item	vial of holy water	Last Available: "2013-02"
 # vial of patchouli oil: Weakens enemies a little bit
+Item	Violet Hunt Invitation	Last Available: "2009-06"
 # viral video: Brainlock an enemy and causes all of its items to drop
+Item	viral video	Last Available: "2016-05"
+Item	virtual cybertattoo	Last Available: "2025-12"
+Item	viscous lava globs	Last Available: "2015-08"
+Item	Vivian's Vitamin	Last Available: "2012-12"
 # void stone: I'm sure it's safe to just sell it
+Item	void stone	Last Available: "2022-12"
 # Volcoino: Spend it at the Towering Inferno Discotheque's Gift Shop
+Item	Volcoino	Last Available: "2015-08"
 Item	voter registration form	Free Pull, Last Available: "2018-11"
+Item	Vulgure	Last Available: "2018-03"
+Item	VYKEA blood rune	Last Available: "2015-11"
+Item	VYKEA bracket	Last Available: "2015-11"
+Item	VYKEA dowel	Last Available: "2015-11"
+Item	VYKEA frenzy rune	Last Available: "2015-11"
+Item	VYKEA instructions	Last Available: "2015-11"
+Item	VYKEA lightning rune	Last Available: "2015-11"
+Item	VYKEA plank	Last Available: "2015-11"
+Item	VYKEA rail	Last Available: "2015-11"
+Item	Waifuton	Last Available: "2018-03"
+Item	Wal-Mart gift certificate	Last Available: "2015-11"
+Item	Wal-Mart tattoo kit	Last Available: "2015-11"
 Item	walkie-talkie	Free Pull
+Item	wand of fudge control	Last Available: "2011-11"
 # wand of pigification: Turns your foe into a pig
+Item	warbear accoutrements chunk	Last Available: "2013-12"
 # warbear auto-anvil: Allows Meatsmithing without using an Adventure
 # warbear auto-anvil: (5x / day)
+Item	warbear auto-anvil	Last Available: "2013-12"
+Item	warbear badge	Last Available: "2013-12"
+Item	warbear battery	Last Available: "2013-12"
+Item	warbear beeping telegram	Last Available: "2013-12"
+Item	warbear black box	Last Available: "2013-12"
+Item	warbear breakfast machine	Last Available: "2013-12"
+Item	warbear breakfast machine assembler	Last Available: "2013-12"
 # warbear chemistry lab: Lets you occasionally cook extra Potions
+Item	warbear chemistry lab	Last Available: "2013-12"
+Item	warbear drone assembler	Last Available: "2013-12"
 Item	warbear empathy chip	Skill: "Psychokinetic Hug", Last Available: "2013-12"
 Item	warbear empathy chip (used)	Skill: "Psychokinetic Hug", Last Available: "2013-12"
+Item	warbear gyrocopter	Last Available: "2013-12"
+Item	warbear helm fragment	Last Available: "2013-12"
 # warbear high-efficiency still: Sometimes recovers ingredients when you craft cocktails
+Item	warbear high-efficiency still	Last Available: "2013-12"
+Item	warbear hoverbelt piecepart	Last Available: "2013-12"
+Item	warbear induction oven	Last Available: "2013-12"
 # warbear jackhammer drill press: Increases the effectiveness of Pulverize
+Item	warbear jackhammer drill press	Last Available: "2013-12"
 # warbear LP-ROM burner: Lets you make recordings of your Accordion Thief buffs
+Item	warbear LP-ROM burner	Last Available: "2013-12"
 Item	warbear metalworking primer	Skill: "Shrap", Last Available: "2013-12"
 Item	warbear metalworking primer (used)	Skill: "Shrap", Last Available: "2013-12"
+Item	warbear officer requisition box	Last Available: "2013-12"
 Item	warbear procedural hilarity drone	Free Pull, Last Available: "2013-12"
+Item	warbear requisition box	Last Available: "2013-12"
+Item	warbear sequential gaiety distribution system	Last Available: "2013-12"
+Item	warbear soda machine	Last Available: "2013-12"
+Item	warbear soda machine assembler	Last Available: "2013-12"
+Item	warbear trouser fragment	Last Available: "2013-12"
+Item	warbear whosit	Last Available: "2013-12"
+Item	warehouse key	Last Available: "2017-12"
 Item	Wart Dinsey: An Afterlife	Skill: "Rotten Memories"
 # water pipe bomb: Deals 55-75 Physical Damage
 Item	water wings	Wiki Name: "water wings"
+Item	waterlogged cloth	Last Available: "2019-12"
+Item	waterlogged crate	Last Available: "2011-12"
+Item	waterlogged leather	Last Available: "2019-12"
+Item	waterlogged metal	Last Available: "2019-12"
+Item	waterlogged stuffing	Last Available: "2019-12"
+Item	waterlogged wood	Last Available: "2019-12"
+Item	wax bugbear	Last Available: "2012-06"
 # Way More Tears&trade; pepper spray: Deals 12-15 <font color=red>Hot Damage</font> and weakens enemies somewhat
 # Way More Tears&trade; pepper spray: (can be used 8-10 times before the can is empty)
+Item	weathered barrel	Last Available: "2015-09"
+Item	weird space book	Last Available: "2014-05"
+Item	Wendtigo	Last Available: "2018-03"
 # Western Slang Vol. 1: Violence: Unlocks advanced Cow Puncher skills in the Avatar of West of Loathing Challenge Path
 Item	Western Slang Vol. 1: Violence	Free Pull, Last Available: "2016-02"
 # Western Slang Vol. 2: Cooking: Unlocks advanced Beanslinger skills in the Avatar of West of Loathing Challenge Path
 Item	Western Slang Vol. 2: Cooking	Free Pull, Last Available: "2016-02"
 # Western Slang Vol. 3: Fraud: Unlocks advanced Snake Oiler skills in the Avatar of West of Loathing Challenge Path
 Item	Western Slang Vol. 3: Fraud	Free Pull, Last Available: "2016-02"
+Item	whet stone	Last Available: "2023-01"
 # whimpering willow bark: Restores up to 25% of your Maximum HP
+Item	whimpering willow bark	Last Available: "2012-12"
+Item	white candygram	Last Available: "2007-02"
+Item	white Crimbo ball	Last Available: "2021-12"
+Item	white mana	Last Available: "2015-07"
 # white picket fence: Stops Enemy From Attacking and Restores 14-15 Hit Points
+Item	whoopie cushion	Last Available: "2006-04"
+Item	wicksilver spurs	Last Available: "2016-02"
+Item	wind-up chattering teeth	Last Available: "2006-04"
+Item	wind-up spider	Last Available: "2015-10"
+Item	windicle	Last Available: "2019-04"
 Item	wine-soaked bone chips	Class: "Pastamancer"
 # Winifred's whistle: Banishes a monster for a while
+Item	Winifred's whistle	Last Available: "2012-12"
 Item	Witchess Set	Free Pull, Last Available: "2016-03"
 Item	wizard action figure	Free Pull, Last Available: "2011-12"
+Item	wok lobster	Last Available: "2011-12"
 # Wolfman Nardz: Restores 200-300 MP
+Item	Wolfman Nardz	Last Available: "2009-10"
 # wood screw: Deals 20-30 Physical Damage and briefly stuns your opponent
+Item	Workytime Tea	Last Available: "2011-01"
 # world's most dangerous birdhouse: Instantly defeats most monsters
+Item	wormwood stick	Last Available: "2020-08"
 Item	wrapped candy cane sword cane	Free Pull
+Item	wrapping paper	Last Available: "2003-12"
+Item	wrench handle	Last Available: "2009-12"
+Item	wriggling tentacle	Last Available: "2008-12"
+Item	Wullabye	Last Available: "2018-03"
+Item	wumpus hair	Last Available: "2009-06"
 # wumpus-hair bolo: Lets you escape from combat without spending an Adventure
 # wumpus-hair bolo: (Maybe)
+Item	wumpus-hair bolo	Last Available: "2009-06"
 # wumpus-hair net: Weakens enemies somewhat
+Item	wumpus-hair net	Last Available: "2009-06"
 # wussiness potion: Weakens enemies a little bit
 Item	wussiness potion	Effect: "Wussiness", Effect Duration: 3
+Item	X	Last Available: "2017-10"
 # X-32-F snowman crate: Installs a Combat Training Snowman in the Big Mountains
 Item	X-32-F snowman crate	Free Pull, Last Available: "2016-01"
+Item	Xi Receiver Unit	Last Available: "2014-09"
+Item	Xiblaxian 5D printer	Last Available: "2014-09"
+Item	Xiblaxian alloy	Last Available: "2014-09"
+Item	Xiblaxian cache locator simcode	Last Available: "2014-09"
+Item	Xiblaxian circuitry	Last Available: "2014-09"
+Item	Xiblaxian crystal	Last Available: "2014-09"
+Item	Xiblaxian direct marketing simcode	Last Available: "2014-09"
+Item	Xiblaxian encrypted political prisoner	Last Available: "2014-09"
+Item	Xiblaxian holo-buddy simcode	Last Available: "2014-09"
+Item	Xiblaxian holo-schematic: residence cube	Last Available: "2014-09"
+Item	Xiblaxian holo-schematic: space whiskey	Last Available: "2014-09"
+Item	Xiblaxian holo-schematic: stealth cowl	Last Available: "2014-09"
+Item	Xiblaxian holo-schematic: stealth trousers	Last Available: "2014-09"
+Item	Xiblaxian holo-schematic: stealth vest	Last Available: "2014-09"
+Item	Xiblaxian holo-schematic: ultraburrito	Last Available: "2014-09"
+Item	Xiblaxian holo-schematic: xeno-goggles	Last Available: "2014-09"
+Item	Xiblaxian holo-training simcode	Last Available: "2014-09"
+Item	Xiblaxian holo-wrist-puter simcode	Last Available: "2014-09"
+Item	Xiblaxian polymer	Last Available: "2014-09"
 Item	xo-skeleton-in-a-box	Free Pull, Last Available: "2017-10"
 # yam battery: Restore up to 1,000 MP
 # yam battery: Gain 3 Random Good Effects
+Item	yam battery	Last Available: "2024-05"
 # Ye Olde Medieval Insult: Weakens enemies somewhat and briefly stuns them
+Item	Ye Wizard's Shack snack voucher	Last Available: "2011-03"
+Item	Yeast of Boris	Last Available: "2022-11"
+Item	Yeg's Motel alarm clock	Last Available: "2020-09"
+Item	Yeg's Motel ashtray	Last Available: "2020-09"
 # Yeg's Motel disposable razor: Deals 50% of a monster's current Hit Points in Physical Damage
+Item	Yeg's Motel disposable razor	Last Available: "2020-09"
+Item	Yeg's Motel minibar key	Last Available: "2020-09"
 # Yeg's Motel sewing kit: Restores all HP
+Item	Yeg's Motel sewing kit	Last Available: "2020-09"
+Item	Yeg's Motel stationery	Last Available: "2020-09"
+Item	yellow candygram	Last Available: "2007-02"
+Item	yellow gummi ingot	Last Available: "2011-11"
+Item	yellow pixel	Last Available: "2015-06"
 # yellow plastic oyster egg: Grants a Random Beneficial Effect
 Item	yellow puck	Free Pull, Last Available: "2015-06"
 Item	yellow puck with a bow on it	Free Pull, Last Available: "2015-06"
+Item	yellow rocket	Last Available: "2021-07"
 # yellow submarine: Allows Travel to The Mysterious Island of Mystery
+Item	yellow submarine	Last Available: "2015-06"
 # yellowcake bomb: Vaporizes an enemy and causes all of its items to drop
 # yo: Deals 15-20 Physical Damage
+Item	yo	Last Available: "2006-12"
 # yo-yo: Deals 30-40 Physical Damage
+Item	yo-yo	Last Available: "2010-12"
+Item	Young Man's Cargo Load	Last Available: "2013-12"
+Item	Young Man's Crew Sequester	Last Available: "2013-12"
 # your own black heart: Restores all HP and MP
+Item	your own black heart	Last Available: "2011-10"
+Item	yule pup	Last Available: "2018-12"
 Item	yuletide troll chrysalis	Free Pull, Last Available: "2006-12"
+Item	yummy death watch beetle	Last Available: "2008-06"
+Item	zaibatsu level 1 card	Last Available: "2013-12"
+Item	zaibatsu level 2 card	Last Available: "2013-12"
+Item	zaibatsu level 3 card	Last Available: "2013-12"
+Item	zaibatsu lobby card	Last Available: "2013-12"
+Item	zombie pineal gland	Last Available: "2005-11"
 # Zombo's empty eye: Deals 150-200 <font color=gray>Spooky Damage</font>
 # Zombo's empty eye: Weakens Enemies a Lot
 # Zombo's empty eye: (doesn't go away when used)

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -396,7 +396,7 @@ Item	nasty rat mask	Moxie: +9, Monster Level: -5, Familiar Effect: "sleaze atk, 
 Item	neoprene skullcap	Moxie: +7, Familiar Effect: "atk, 1xFairy, cap 16"
 Item	nine-gallon hat	Muscle: +9, Mysticality: +9, Moxie: +9, Experience: +3
 # no hat: (May or May Not Truly Exist)
-Item	no hat	Lasts Until Rollover
+Item	no hat	Lasts Until Rollover, Last Available: "2016-12"
 Item	noir fedora	Experience Percent (Moxie): +20, Moxie Percent: +20, HP Regen Min: 8, HP Regen Max: 10, MP Regen Min: 8, MP Regen Max: 10, Last Available: "2016-07"
 Item	norwhal helmet	Experience (Mysticality): +2, Spell Damage Percent: +60, Booze Drop: +60, Last Available: "2015-11", Familiar Effect: "atk"
 Item	nurse's hat	Maximum HP: +300, HP Regen Min: 30, HP Regen Max: 60, MP Regen Min: 10, MP Regen Max: 15, Familiar Effect: "atk"
@@ -1597,7 +1597,7 @@ Item	icy-hot katana	Hot Damage: +3, Cold Damage: +3
 Item	iFlail	Monster Level: +11, Familiar Weight: +5, Combat Rate: -5
 Item	immense cyborg hand	Weapon Damage: +5, Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2007-12"
 Item	impromptu torch	Hot Damage: +10, Experience (Muscle): +2, Lasts Until Rollover
-Item	industrial fire extinguisher	Hot Resistance: +3, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Cold Damage: +15, Cold Spell Damage: +15, Maximum HP: +20, Maximum MP: +20, Adventures: +3
+Item	industrial fire extinguisher	Hot Resistance: +3, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Cold Damage: +15, Cold Spell Damage: +15, Maximum HP: +20, Maximum MP: +20, Adventures: +3, Last Available: "2021-09"
 Item	infernal fife	Hot Damage: +7
 Item	infernal toilet brush	Stench Damage: +20, Maximum HP: +20, Maximum MP: +20, Class: "Seal Clubber"
 Item	inflatable baseball bat	Weapon Damage: +30, Last Available: "2010-06"
@@ -2158,7 +2158,7 @@ Item	Abracandalabra	Spell Damage Percent: +100, MP Regen Min: 5, MP Regen Max: 1
 Item	Abyssal ember	Hot Damage: +20, Weapon Drop: +25, Class: "Seal Clubber"
 Item	adhesive tape dolly	Moxie: +5, Last Available: "2010-12"
 Item	adobe abacus	Mysticality Percent: [20+20*min(1,effect(Adobe Abacus Subscription))], Spell Damage: [20+20*min(1,effect(Adobe Abacus Subscription))], Last Available: "2024-12"
-Item	Adventurer bobblehead	Muscle Percent: [pref(nuclearAutumnPoints)], Mysticality Percent: [pref(nuclearAutumnPoints)], Moxie Percent: [pref(nuclearAutumnPoints)]
+Item	Adventurer bobblehead	Muscle Percent: [pref(nuclearAutumnPoints)], Mysticality Percent: [pref(nuclearAutumnPoints)], Moxie Percent: [pref(nuclearAutumnPoints)], Last Available: "2016-11"
 # aerogel attache case: Produce random cocktailcrafting ingredients as you adventure
 Item	aerogel attache case	Pickpocket Chance: +10, Stench Damage: +10, Last Available: "2017-12", Drops Items
 Item	ancient calendar	Adventures: +3, Damage Reduction: 4
@@ -3000,7 +3000,7 @@ Item	chintzy turtle brooch	Muscle: +12, Mysticality: +6, Class: "Turtle Tamer", 
 Item	chocolate pocketwatch	Maximum MP: +20, Spell Damage: +15, Spell Critical Percent: +10, Single Equip, Last Available: "2016-12"
 Item	chocolate rabbit's foot	Item Drop: +5, Meat Drop: +5, Candy Drop: +20, Last Available: "2014-12"
 Item	Choker of the Ultragoth	Muscle: +3, Mysticality: +3, Moxie: +3, Spooky Spell Damage: +40, Single Equip
-Item	Cincho de Mayo	Moxie Percent: +25, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Booze Drop: +30, Item Drop: +15
+Item	Cincho de Mayo	Moxie Percent: +25, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Booze Drop: +30, Item Drop: +15, Last Available: "2023-05"
 # Claw of the Infernal Seal: 5 Additional Seal Summons Per Day
 # Claw of the Infernal Seal: This enchantment works even when this item is not equipped
 Item	Claw of the Infernal Seal	Muscle: +11, HP Regen Min: 20, HP Regen Max: 25, Class: "Seal Clubber", Single Equip
@@ -3339,7 +3339,7 @@ Item	Lead Zeta of Chastity	Muscle: +6, Mysticality: +6, Moxie: +6, Item Drop: +1
 # left half of a heart necklace
 # Lil' Doctor&trade; bag: Lets you perform various medical procedures on enemies
 # Lil' Doctor&trade; bag: Regenerate 4-7 HP per Adventure</font>
-Item	Lil' Doctor&trade; bag	Maximum HP: [15+5*pref(doctorBagUpgrades)], HP Regen Min: [4+pref(doctorBagUpgrades)], HP Regen Max: [7+pref(doctorBagUpgrades)], Single Equip
+Item	Lil' Doctor&trade; bag	Maximum HP: [15+5*pref(doctorBagUpgrades)], HP Regen Min: [4+pref(doctorBagUpgrades)], HP Regen Max: [7+pref(doctorBagUpgrades)], Single Equip, Last Available: "2019-02"
 Item	loafers	Initiative: +10, Single Equip
 Item	Loathing Legion necktie	Experience: +4, Single Equip, Softcore Only, Last Available: "2011-01"
 Item	Loathing Legion rollerblades	Initiative: +50, Single Equip, Softcore Only, Last Available: "2011-01"
@@ -3596,7 +3596,7 @@ Item	psychic's amulet	Spell Damage: +10, Spooky Resistance: +1, Stench Resistanc
 Item	pulled porquoise earring	Moxie: +9, Never Fumble
 Item	pulled porquoise pendant	Moxie: +10, Meat Drop: +15, Single Equip
 Item	pulled porquoise ring	Moxie: +11, Maximum HP: +15, Maximum MP: +15, HP Regen Min: 1, HP Regen Max: 2, MP Regen Min: 1, MP Regen Max: 2, Single Equip
-Item	pump-up high-tops	Moxie: +15, Initiative: [+10+5*pref(highTopPumped)], Single Equip
+Item	pump-up high-tops	Moxie: +15, Initiative: [+10+5*pref(highTopPumped)], Single Equip, Last Available: "2018-09"
 Item	purple glowstick	Maximum MP: +5, Moxie: -3, Last Available: "2008-02", Raveosity: +1
 Item	Purple Horseshoe of Honor	Muscle: +6, Mysticality: +6, Moxie: +6, Item Drop: +10, Single Equip
 Item	Putrid Pendant	Muscle: +3, Mysticality: +3, Moxie: +3, Stench Spell Damage: +40, Single Equip
@@ -9345,7 +9345,7 @@ Item	bear claw	Effect: "Bear Clawed", Effect Duration: 30, Last Available: "2016
 Item	Beefy Crunch Pastaco	Effect: "Boletus Swoletus", Effect Duration: 40, Last Available: "2014-05"
 Item	beefy fish meat	Effect: "Fishy", Effect Duration: 5
 Item	bell-shaped Crimbo cookie	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
-Item	bishop cookie	Effect: "Mitre Cut", Effect Duration: 30
+Item	bishop cookie	Effect: "Mitre Cut", Effect Duration: 30, Last Available: "2010-03"
 Item	Black Angus blackburger	Effect: "The Power of Negative Thinking", Effect Duration: 100, Last Available: "2016-12"
 Item	black forest cake	Effect: "Sugar Rush", Effect Duration: 5
 Item	black pudding	Wiki Name: "black pudding (food)"
@@ -9521,7 +9521,7 @@ Item	jumping horseradish	Effect: "Kicked in the Sinuses", Effect Duration: 50, L
 Item	jungle floor wax	Effect: "Wax On Your Shoes", Effect Duration: 20
 Item	junkyard dog	Effect: "Dog Breath", Effect Duration: 30
 Item	king cookie	Effect: "The Royal We", Effect Duration: 30, Last Available: "2010-03"
-Item	knight cookie	Effect: "Knightlife", Effect Duration: 30
+Item	knight cookie	Effect: "Knightlife", Effect Duration: 30, Last Available: "2010-03"
 Item	knuckle sandwich	Effect: "Cruisin' for a Bruisin'", Effect Duration: 20, Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 # Kudzu salad
 Item	lab-grown meat	Effect: "Real Meat Craving", Effect Duration: 20, Last Available: "2021-12"
@@ -9577,7 +9577,7 @@ Item	plumber's lunch	Effect: "Egg Burps", Effect Duration: 20, Last Available: "
 Item	poisonous caviar	Effect: "Majorly Poisoned", Effect Duration: 50, Last Available: "2010-09"
 Item	powdered donut	Effect: "Powdered", Effect Duration: 5, Last Available: "2010-03"
 Item	protein paste	Effect: "Pasty", Effect Duration: 10, Last Available: "2009-06"
-Item	queen cookie	Effect: "Towering Strength"
+Item	queen cookie	Effect: "Towering Strength", Last Available: "2010-03"
 Item	rack of dinosaur ribs	Effect: "Meat the Flintstones", Effect Duration: 30
 Item	ratatouille de Jarlsberg	Effect: "parfum d'herbes", Effect Duration: 30, Last Available: "2022-11"
 Item	red drunki-bear	Effect: "Gummiheart", Effect Duration: 80, Last Available: "2011-11"
@@ -9585,7 +9585,7 @@ Item	roasted marshmallow	Effect: "Mallowed Out", Effect Duration: 3
 Item	roasted vegetable focaccia	Effect: "Feeling Fancy", Effect Duration: 50, Last Available: "2022-11"
 Item	roasted vegetable of Jarlsberg	Effect: "Wizard Sight", Effect Duration: 30, Last Available: "2022-11"
 Item	rocky road ice cream	Effect: "A Contender", Effect Duration: 40, Last Available: "2009-09"
-Item	rook cookie	Effect: "Towering Strength", Effect Duration: 30
+Item	rook cookie	Effect: "Towering Strength", Effect Duration: 30, Last Available: "2010-03"
 Item	rotting beefsteak	Effect: "Cowrruption", Effect Duration: 30, Last Available: "2016-02"
 Item	rum-soaked fruitcake	Effect: "Rum of Darkness", Effect Duration: 100, Last Available: "2023-12"
 Item	sausage without a cause	Effect: "East of Eaten", Effect Duration: 1
@@ -10498,7 +10498,7 @@ Item	evil serum of sarcasm	Effect: "Superhuman Sarcasm", Effect Duration: [R+5]
 Item	evil tomato juice of powerful power	Effect: "Tomato Power", Effect Duration: [R+5]
 Item	evil vihuela	Effect: "El Tango de la Maldita Suegra", Effect Duration: 10
 Item	exotic travel brochure	Effect: "Expert Vacationer", Effect Duration: 20, Last Available: "2015-11"
-Item	experimental serum G-9	Effect: "Experimental Effect G-9", Effect Duration: 40
+Item	experimental serum G-9	Effect: "Experimental Effect G-9", Effect Duration: 40, Last Available: "2014-10"
 Item	experimental serum P-00	Effect: "Schroedinger's Butt", Effect Duration: 20, Last Available: "2014-10"
 Item	explosion-flavored chewing gum	Effect: "Beaten Up", Effect Duration: 10, Last Available: "2006-04"
 Item	extra-hard jawbreaker	Effect: "Delayed Gratification", Effect Duration: 20

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -543,8 +543,7 @@ Item	Tropical Crimbo Hat	Spooky Resistance: +1, Last Available: "2006-12", Famil
 Item	turtle wax helmet	Hot Resistance: +1, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
 Item	turtlemail coif	Muscle: +5, Damage Reduction: 4, Familiar Effect: "1xPotato, cap 20"
 Item	two-gallon hat	Muscle: +2, Mysticality: +2, Moxie: +2, Experience: +3
-Item	Uncle Crimbo's hat	Adventures: +4, Rollover Effect: "The Spirit of Crimbo", Rollover Effect Duration: 100, Rollover Effect: "Crimbo Nostalgia", Rollover Effect Duration: 100
-Item	Uncle Crimbo's hat	Adventures: +4, Rollover Effect: "The Spirit of Crimbo", Rollover Effect Duration: 200, Last Available: "2016-12", Rollover Effect: "Crimbo Nostalgia", Rollover Effect Duration: 100
+Item	Uncle Crimbo's hat	Adventures: +4, Rollover Effect: "The Spirit of Crimbo", Rollover Effect Duration: 100, Rollover Effect: "Crimbo Nostalgia", Rollover Effect Duration: 100, Last Available: "2016-12"
 Item	Uncle Hobo's stocking cap	Mysticality Percent: +20, Monster Level: +20, Last Available: "2010-12", Familiar Effect: "atk"
 Item	Unfortunato's foolscap	Spooky Damage: +10, Stench Damage: +10, Hot Damage: +10, Cold Damage: +10, Sleaze Damage: +10, Mysticality Percent: +10, Mana Cost (combat): -2, Last Available: "2016-08"
 Item	Unkillable Skeleton's skullcap	Muscle Percent: +50, Maximum HP: +500, HP Regen Min: 40, HP Regen Max: 80, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
@@ -2297,7 +2296,6 @@ Item	crumbling rabbit's foot	Meat Drop: +30, Last Available: "2020-04"
 Item	cuddly teddy bear	Monster Level: +10, Last Available: "2014-10"
 Item	cup of infinite pencils	Meat Drop: +15, Damage Aura: 1
 Item	cursed arcane orb	Spooky Damage: +13, Stench Damage: +13, Hot Damage: +13, Cold Damage: +13, Sleaze Damage: +13, Item Drop: -50
-Item	cursed compass	Item Drop: [100*zone(PirateRealm)], Lasts Until Rollover
 Item	cursed compass	Lasts Until Rollover, Last Available: "2019-04", Item Drop: [100*zone(PirateRealm)]
 # cursed magnifying glass: Reveals things you weren't meant to see
 Item	cursed magnifying glass	Item Drop: +13, Spooky Damage: +13, Initiative: +13, Last Available: "2022-12"
@@ -3141,7 +3139,6 @@ Item	eerie fetish	Spooky Resistance: +4, Single Equip
 Item	Eight Days a Week Pill Keeper	Maximum HP: +20, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 10, MP Regen Max: 15, Muscle: +10, Mysticality: +10, Moxie: +10, Last Available: "2019-10", Avoid Attack: 1
 # El Vibrato translator
 Item	elevennis shoes	Muscle: +11, Mysticality: +11, Moxie: +11, Maximum HP: +11, Maximum MP: +11, Last Available: "2014-03"
-Item	Elf Guard commandeering gloves	Item Drop: +3, Piece of Twelve Drop: 0.5, Single Equip
 Item	Elf Guard commandeering gloves	Item Drop: +3, Single Equip, Last Available: "2023-12", Piece of Twelve Drop: 0.5
 Item	Elf Guard insignia (general)	Elf Warfare Effectiveness: +10, Adventures: +9, Single Equip, Last Available: "2023-12"
 Item	Elf Guard insignia (private)	Elf Warfare Effectiveness: +1, Last Available: "2023-12"
@@ -3574,7 +3571,6 @@ Item	perfect Christmas scarf	Adventures: [+9*event(December)], Cold Resistance: 
 Item	perfume-soaked bandana	Spooky Resistance: +2, Stench Resistance: +4, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2015-04"
 # Personal Ventilation Unit: Allows Safe Access to Secret Government Lab
 Item	Personal Ventilation Unit	Muscle Limit: 100, Mysticality Limit: 100, Moxie Limit: 100, Single Equip, Last Available: "2014-10"
-Item	petrified wood waist protector	Experience (Muscle): +3, Adventures: +5, Avoid Attack: 1, Single Equip
 Item	petrified wood waist protector	Experience (Muscle): +3, Adventures: +5, Single Equip, Last Available: "2025-12", Avoid Attack: 1
 # petrified wood wizard's pouch: Adds hot and physical damage to spells
 Item	petrified wood wizard's pouch	Mysticality Percent: +20, Item Drop: +10, Single Equip, Last Available: "2025-12"
@@ -5439,15 +5435,16 @@ Item	Alice's Army Foil Wallman	Last Available: "2011-03", Damage Reduction: 9
 # Folder section of modifiers.txt
 
 # folder (barbarian): Increased physical damage as you take damage
+Item	folder (barbarian)	Last Available: "2013-08"
 Item	folder (blue)	Mysticality: +20, Last Available: "2013-08"
-Item	folder (catfish)	Familiar Weight (hidden): [15*env(underwater)]
+Item	folder (catfish)	Last Available: "2013-08", Familiar Weight (hidden): [15*env(underwater)]
 Item	folder (cyan)	Mysticality: +15, Moxie: +15, Last Available: "2013-08"
 Item	folder (D-Team)	Last Available: "2013-08", Experience (Muscle): +1, Experience (Mysticality): +1, Experience (Moxie): +1
 Item	folder (dancing dolphins)	Last Available: "2013-08", Item Drop: [50*env(underwater)]
 Item	folder (Ex-Files)	Combat Rate: +5, Last Available: "2013-08"
 Item	folder (green)	Moxie: +20, Last Available: "2013-08"
 Item	folder (heavy metal)	Familiar Weight: +5, Last Available: "2013-08"
-Item	folder (holographic fractal)	Cold Resistance: +4, Hot Resistance: +4, Sleaze Resistance: +4, Spooky Resistance: +4, Stench Resistance: +4
+Item	folder (holographic fractal)	Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
 Item	folder (Jackass Plumber)	Monster Level: +25, Last Available: "2013-08"
 Item	folder (Knight Writer)	Initiative: +40, Last Available: "2013-08"
 Item	folder (KOLHS)	Last Available: "2013-08", Item Drop: [50*zone(KOL High School)]
@@ -10333,8 +10330,7 @@ Item	Rompedores de Fantasmas	Effect: "Desenfantasmada", Effect Duration: 13
 Item	runny fermented egg	Last Available: "2018-12"
 # Russian Ice: Weakens enemies somewhat when used as a combat item
 Item	Russian Ice	Last Available: "2011-04"
-Item	Sacramento wine	Effect: "Sacr&eacute; Mental", Effect Duration: 50
-Item	Sacramento wine	Effect: "Sacré Mental", Effect Duration: 50, Last Available: "2016-03"
+Item	Sacramento wine	Effect: "Sacr&eacute; Mental", Effect Duration: 50, Last Available: "2016-03"
 Item	Saison du Lune	Last Available: "2011-06"
 Item	salacious lychee chuhai	Effect: "Brined Liver", Effect Duration: 30
 Item	salacious screwdiver	Effect: "Brined Liver", Effect Duration: 30
@@ -13071,9 +13067,6 @@ Item	floaty stone sphere	Free Pull, Last Available: "2009-09"
 # floorboard cruft: Weakens Enemies Somewhat
 Item	Fly-By-Knight Heraldry form	Free Pull
 Item	foam dart	Last Available: "2008-04"
-Item	folder (barbarian)	Last Available: "2013-08"
-Item	folder (catfish)	Familiar Weight: +15, Last Available: "2013-08", Familiar Weight (hidden): [15*env(underwater)]
-Item	folder (holographic fractal)	Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
 Item	Folder Holder	Last Available: "2013-08"
 # food mailing list: Unlocks another row of houses for Crimbo activities
 Item	food mailing list	Last Available: "2020-12"

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -76,7 +76,7 @@ Item	4-dimensional fez	Maximum Hooch: +4, Familiar Effect: "atk, 1xLep, cap 12"
 Item	8-billed baseball cap	Muscle Percent: +15, Initiative: +30, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 # Admiral's hat: +50 Skeleton Anger
 Item	Admiral's hat	Adventures: +5, Moxie Percent: +30, Familiar Effect: "atk"
-Item	adobe ayam	Experience (Mysticality): [3+3*min(1,effect(Adobe Ayam Subscription))], Meat Drop: [20+20*min(1,effect(Adobe Ayam Subscription))]
+Item	adobe ayam	Experience (Mysticality): [3+3*min(1,effect(Adobe Ayam Subscription))], Meat Drop: [20+20*min(1,effect(Adobe Ayam Subscription))], Last Available: "2024-12"
 Item	aerated diving helmet	Stench Resistance: +3, Item Drop: -25, Initiative: -50, Adventure Underwater, Familiar Effect: "0.5xPotato"
 # aerogel akubra: Lets you use Spirit Snap multiple times per fight
 Item	aerogel akubra	Muscle: +10, Meat Drop: +10
@@ -92,7 +92,7 @@ Item	Apriling band helmet	Maximum HP: +25, Maximum MP: +25, Never Fumble, Negati
 Item	asbestos helmet turtle	Hot Resistance: +2, Familiar Effect: "hot atk, 1xFairy, cap 20"
 Item	asshat	Stench Resistance: +1, Sleaze Damage: +1, Familiar Effect: "stench atk, 1xVolley, cap 7"
 Item	astral chapeau	Mysticality Percent: +25, Spell Damage: +20, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xVolley, 1xLep, cap 12"
-Item	astronaut helmet	Cold Resistance: +3, Stench Resistance: +3, Lasts Until Rollover
+Item	astronaut helmet	Cold Resistance: +3, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2024-10"
 Item	balaclava	Cold Resistance: +1, Familiar Effect: "cold atk, 1.5xLep, cap 12"
 Item	balloon helmet	Damage Absorption: +20, Clowniness: 25, Familiar Effect: "3xFairy, cap 12"
 Item	bark beret	Damage Reduction: 4, Familiar Effect: "2xPotato, 2.5xLep, cap 10"
@@ -141,7 +141,7 @@ Item	Cerebral Cloche	Maximum HP: +15, Familiar Effect: "1.5xLep, cap 22"
 Item	chalk chapeau	PvP Fights: +3, HP Regen Min: 3, HP Regen Max: 6, MP Regen Min: 3, MP Regen Max: 6
 Item	cheerful antler hat	Cold Resistance: +2, Moxie: -15
 Item	chef's hat	Mysticality: +2, MP Regen Min: 1, MP Regen Max: 1, Familiar Effect: "atk, 3xLep, cap 7"
-Item	chiffon chapeau	Experience (Muscle): +2, Spooky Damage: +10, Spooky Spell Damage: +10, Damage Aura: 1
+Item	chiffon chapeau	Experience (Muscle): +2, Spooky Damage: +10, Spooky Spell Damage: +10, Last Available: "2023-12", Damage Aura: 1
 Item	chrome helmet turtle	Muscle: +5, Mysticality: +5, Moxie: +5, Familiar Effect: "cold atk, 1xFairy, cap 30"
 Item	clingfilm cap	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, MP Regen Min: 2, MP Regen Max: 3, Familiar Effect: "1xVolley, cap 37"
 Item	Cloaca-Cola helmet	Damage Absorption: +10, Familiar Effect: "3xFairy, cap 7"
@@ -158,8 +158,9 @@ Item	Covers-Your-Head	Moxie: +250, Maximum HP: +100, Maximum MP: +100, Initiativ
 Item	cr&ecirc;epy mask	Mysticality: +2, Maximum MP: +5, Familiar Effect: "spooky atk, cap 5"
 Item	crappy Mer-kin mask	Stench Resistance: +3, Item Drop: -25, Initiative: -50, Adventure Underwater, Familiar Effect: "hot atk, 1xBarrr"
 # crepe paper phrygian cap: Pull down to avoid monsters
-Item	crepe paper phrygian cap	Muscle: +10, Stench Damage: +10, Stench Spell Damage: +10
+Item	crepe paper phrygian cap	Muscle: +10, Stench Damage: +10, Stench Spell Damage: +10, Last Available: "2025-12"
 Item	Crimbo hat	Spooky Resistance: +1, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+Item	Crimbuccaneer tricorn	Last Available: "2023-12"
 Item	Crown of the Goblin King	Muscle: +10, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 # Crown of Thrones: Put a Familiar In It!
 # Crown of Thrones: That Familiar gains 1 Experience per Fight
@@ -168,7 +169,7 @@ Item	crown-shaped beanie	Slime Resistance: +1, Food Drop: +20, Initiative: +20, 
 Item	crumpled felt fedora	Familiar Weight: +10, Muscle Percent: +5, Familiar Effect: "0.75xVolley, 0.75xLep"
 Item	cursed eyepatch	Mysticality: +15, Familiar Effect: "spooky atk, 1xBarrr"
 Item	cursed tricorn hat	Mysticality: +25, Experience: +10, PvP Fights: +5
-Item	cybervisor	RAM: +3
+Item	cybervisor	RAM: +3, Last Available: "2025-12"
 # Daylight Shavings Helmet: Keeps your facial hair stylish at all times
 Item	Daylight Shavings Helmet	Experience: +3, Adventures: +5, Familiar Weight: +5
 Item	demon-horned hat	Moxie: +4, Familiar Effect: "hot atk, 1xLep, cap 17"
@@ -206,6 +207,7 @@ Item	eldritch hat	Spooky Damage: +40, Spooky Spell Damage: +40, Spooky Resistanc
 Item	eldritch scanner	Mysticality Limit: 100
 Item	electrician's hardhat	Muscle Percent: +40, Weapon Damage: +40, HP Regen Min: 20, HP Regen Max: 40, Familiar Effect: "atk"
 Item	eleven-gallon hat	Muscle: +11, Mysticality: +11, Moxie: +11, Experience: +3
+Item	Elf Guard patrol cap	Last Available: "2023-12"
 Item	Elf Guard red and white beret	PvP Fights: [+5*event(December)]
 Item	elf ploughshare	Maximum HP: +30, Maximum MP: +30
 Item	enchanted eyepatch	Mysticality: +5, Familiar Effect: "4xBarrr, cap 8"
@@ -215,7 +217,7 @@ Item	extra-wide head candle	Weapon Damage Percent: +100, HP Regen Min: 10, HP Re
 Item	eXtreme scarf	Mysticality: +5, Familiar Effect: "atk, 1xBarrr, cap 25"
 Item	eyepatch	Moxie: +2, Familiar Effect: "3xBarrr, cap 6"
 Item	f3d0r4	Moxie: +6, Familiar Effect: "atk, 1xLep, cap 27"
-Item	fake arrow-through-the-head	Moxie Percent: +25, Combat Rate: -5, Lasts Until Rollover
+Item	fake arrow-through-the-head	Moxie Percent: +25, Combat Rate: -5, Lasts Until Rollover, Last Available: "2024-10"
 Item	fancy ball mask	Moxie Percent: +10, Familiar Effect: "1xBarrr, 1xFairy, cap 22"
 Item	fancy tophat	Mysticality Percent: +15, Familiar Effect: "1xBarrr, cap 25"
 Item	FantasyRealm Mage's Hat	Mysticality: +15
@@ -270,10 +272,10 @@ Item	googly-ball hat	Mysticality: +10, Experience (Mysticality): +3
 Item	googly-heart hat	Moxie: +10, Experience (Moxie): +3
 Item	googly-star hat	Muscle: +10, Experience (Muscle): +3, Familiar Effect: "atk"
 Item	government-issued eyeshade	Experience Percent (Moxie): +10, Damage vs. Ghosts: +25, Pool Skill: +5
-Item	governor's daughter's pearl hairpin	Moxie Percent: +20
+Item	governor's daughter's pearl hairpin	Moxie Percent: +20, Last Available: "2024-12"
 Item	grass hat	Maximum MP: +10, Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 # gravy boat: Decreased Damage from Undead<br/>Improved Evil Suppression
-Item	gravyskin hat	Sleaze Damage: +11, Sleaze Spell Damage: +11
+Item	gravyskin hat	Sleaze Damage: +11, Sleaze Spell Damage: +11, Last Available: "2024-12"
 Item	Great Wolf's headband	Muscle: +250, Maximum HP: +250, HP Regen Min: 50, HP Regen Max: 100, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 Item	green cloth cap	Stench Resistance: +1, Maximum HP: +15, Maximum MP: +15, Moxie: +3, Familiar Effect: "atk, 1xVolley, cap 12"
 Item	green traffic cone	Moxie: +3, Stench Resistance: +2, Familiar Effect: "2xLep, 2xFairy, cap 15"
@@ -287,10 +289,10 @@ Item	Hairpiece On Fire	Cold Resistance: +2, Adventures: +4, Smithsness: +5, Maxi
 Item	hangman's hood	Muscle: +50, Weapon Damage: +50, Damage Reduction: 10
 Item	hardened slime hat	Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Damage Reduction: 10, Muscle Percent: +20, Familiar Effect: "1xFairy"
 Item	Hat O' Nine Tails	Moxie Percent: +9
-Item	hat of remembering	Maximum MP: +50, MP Regen Min: 8, MP Regen Max: 12, Mana Cost: -1, Lasts Until Rollover
+Item	hat of remembering	Maximum MP: +50, MP Regen Min: 8, MP Regen Max: 12, Mana Cost: -1, Lasts Until Rollover, Last Available: "2024-09"
 # hazmat helmet: Changes Your Avatar
 Item	hazmat helmet	Damage Absorption: +50, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 40, HP Regen Max: 60, Negative Status Resist
-Item	head-mounted Trainbot	Item Drop: +5, Maximum MP: +5, Moxie: +5
+Item	head-mounted Trainbot	Item Drop: +5, Maximum MP: +5, Moxie: +5, Last Available: "2022-12"
 Item	headlamp	Item Drop: +15, Lasts Until Rollover
 Item	heavy crown	Muscle: +5, Mysticality: +5, Moxie: +5, Familiar Damage: +5, Initiative: +15, Familiar Effect: "atk, 1xGhuol, cap 27"
 Item	Helm of the Scream Emperor	MP Regen Min: 1, MP Regen Max: 3, Experience: +2, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Familiar Effect: "spooky atk, 1xFairy, cap 30"
@@ -313,7 +315,7 @@ Item	invisible bag	Familiar Effect: "8xVolley, 8xLep, cap 2"
 Item	irate sombrero	Weapon Damage: +3, Familiar Effect: "1xPotato, 3xLep, cap 11"
 Item	iron helmet	Cold Resistance: +2, MP Regen Min: 1, MP Regen Max: 2, Initiative: +10, Familiar Effect: "atk, 1xFairy, cap 25"
 # iron tricorn hat: Allows you to headbutt your foes
-Item	iron tricorn hat	Maximum HP: +40, Damage Reduction: 10, Lasts Until Rollover
+Item	iron tricorn hat	Maximum HP: +40, Damage Reduction: 10, Lasts Until Rollover, Last Available: "2024-12"
 Item	ironic knit cap	Maximum MP: +20, Mysticality: +1, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 Item	isotophat	Stench Damage: +10, Stench Spell Damage: +20, Familiar Effect: "stench atk, cap 25"
 # Iunion Crown: Becomes more powerful as you adventure each day
@@ -344,7 +346,7 @@ Item	literal bucket hat	Water: +5
 Item	longhaired hippy wig	Stench Damage: +20, Mysticality Percent: +5, Familiar Effect: "1xPotato, 1xGhuol"
 # loofah lumberjack's hat: Feels good on your head
 Item	loofah lumberjack's hat	Muscle: +10, HP Regen Min: 15, HP Regen Max: 25
-Item	lucky army helmet	Damage Absorption: +10, Maximum HP: +100, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Never Fumble
+Item	lucky army helmet	Damage Absorption: +10, Maximum HP: +100, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Never Fumble, Last Available: "2024-12"
 Item	lynyrdskin cap	Initiative: +25, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 Item	MAHI fez	Moxie: +30, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 Item	maiden wig	Familiar Effect: "2xPotato, cap 8"
@@ -379,7 +381,7 @@ Item	moist sailor's cap	Muscle Percent: +10, Stench Damage: +20, Hot Resistance:
 Item	Moonthril Circlet	Mysticality Percent: [15*G], Familiar Effect: "2xVolley, cap 25"
 Item	moose antlers	Critical Hit Percent: +5, Familiar Effect: "atk, 1xLep, cap 27"
 # moss mitre: Lets you spend Soulsauce to heal
-Item	moss mitre	Mysticality: +10, Stench Resistance: +2
+Item	moss mitre	Mysticality: +10, Stench Resistance: +2, Last Available: "2024-12"
 Item	Mu cap	Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4
 Item	muddy pirate hat	Item Drop: +5, Initiative: +20, Familiar Effect: "1xFairy, cap 31"
 Item	mullet wig	Sleaze Damage: +2, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
@@ -421,7 +423,7 @@ Item	party hat	MP Regen Min: [3*J], MP Regen Max: [5*J], Mysticality: +3, Famili
 Item	passable elf mask	Familiar Effect: "atk, cap 2"
 Item	pentacorn hat	Familiar Effect: "atk, cap 10"
 Item	pentagram bandana	Mysticality: +15, Maximum MP: +15
-Item	petrified wood whoopie panama	Moxie Percent: +20, Critical Hit Percent: +10, Thorns: 1
+Item	petrified wood whoopie panama	Moxie Percent: +20, Critical Hit Percent: +10, Last Available: "2025-12", Thorns: 1
 Item	pickelhaube	Weapon Damage: +5, Weapon Damage Percent: +10, Familiar Effect: "atk, 1xFairy, cap 18"
 Item	pig-iron helm	Muscle: +7, Weapon Damage: +10, Familiar Effect: "1xFairy, cap 22"
 Item	pimpin' meat hat	Muscle: +2, Moxie: +2, Familiar Effect: "sleaze atk, 1xVolley, cap 13"
@@ -487,7 +489,7 @@ Item	snorkel	Familiar Effect: "atk, cap 2"
 Item	snow hat	Damage Reduction: 3, Familiar Effect: "cold atk, cap 12"
 Item	Snow Queen Crown	Cold Damage: +5, Cold Resistance: +3, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 # snowman-enchanting tophat: Can turn enemies into snowmen
-Item	snowman-enchanting tophat	Moxie Percent: +25, Spell Damage Percent: +50
+Item	snowman-enchanting tophat	Moxie Percent: +25, Spell Damage Percent: +50, Last Available: "2024-12"
 Item	soft cap of diminishing returns	Experience (Muscle): [-1*floor(basemus/100)], Experience (Mysticality): [-1*floor(basemys/100)], Experience (Moxie): [-1*floor(basemox/100)]
 Item	Sombrero De Vida	Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 Item	sombrero-mounted sparkler	Combat Rate: +5, Hot Damage: +10, Hot Spell Damage: +20, Lasts Until Rollover
@@ -596,7 +598,7 @@ Item	Zombo's skullcap	Muscle Percent: +20, Familiar Weight: +10, Class: "Turtle 
 # Pants section of modifiers.txt
 
 Item	1337 7r0uZ0RZ	Muscle: +6, Moxie: -3, Familiar Effect: "2xPotato, cap 27"
-Item	adobe arsecover	Muscle Percent: [20+20*min(1,effect(Adobe Arsecover Subscription))], Item Drop: [10+10*min(1,effect(Adobe Arsecover Subscription))]
+Item	adobe arsecover	Muscle Percent: [20+20*min(1,effect(Adobe Arsecover Subscription))], Item Drop: [10+10*min(1,effect(Adobe Arsecover Subscription))], Last Available: "2024-12"
 Item	alpha-mail pants	Familiar Effect: "atk, 1xBarrr, cap 35"
 Item	Angelhair Culottes	Mysticality: +11, Spell Damage: +15, Class: "Pastamancer", Familiar Effect: "1.5xPotato, 2xGhoul, cap 31"
 Item	antique greaves	Initiative: -10, Breakable, Familiar Effect: "1xBarrr"
@@ -630,7 +632,7 @@ Item	BRICKO pants	Damage Absorption: +9, Familiar Effect: "1.5xVolley, 2xLep, 1x
 Item	Brimstone Boxers	Moxie Percent: +50, Mysticality Percent: -20, Initiative: +50, Brimstone, Familiar Effect: "1xVolley, 1xLep"
 Item	Brogre brorts	Monster Level: +10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 Item	brown paper pants	Moxie: +2, Initiative: +10
-Item	brown pirate pants	Spooky Resistance: +4, Monster Level: +15
+Item	brown pirate pants	Spooky Resistance: +4, Monster Level: +15, Last Available: "2023-12"
 Item	bugbear bungguard	Familiar Effect: "5xBarrr, cap 7"
 Item	bullet-proof corduroys	Maximum MP: +40, Damage Reduction: 2, Familiar Effect: "stench atk, 1xBarrr, cap 42"
 Item	buoybottoms	Moxie: +11, Monster Level: +7, Initiative: -30, Familiar Effect: "1xPotato, 1xLep, cap 37"
@@ -646,13 +648,14 @@ Item	chain-mail monokini	Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
 Item	chalk chinos	Experience (Mysticality): +2, Initiative: +20
 Item	cheerful pajama pants	Cold Resistance: +2, Moxie: -15
 Item	Chester's cutoffs	Hot Resistance: +3, Stench Resistance: +3, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-Item	chiffon chaps	Experience (Moxie): +2, Hot Damage: +10, Hot Spell Damage: +10, Damage Aura: 1
+Item	chiffon chaps	Experience (Moxie): +2, Hot Damage: +10, Hot Spell Damage: +10, Last Available: "2023-12", Damage Aura: 1
 Item	clingfilm trousers	Mysticality: +9, Familiar Effect: "sleaze atk, 1xPotato, cap 37"
 Item	Cloaca-Cola fatigues	Mysticality: +3, Familiar Effect: "4xPotato, 1.5x Ghoul, cap 7"
 Item	clockwork pants	Initiative: +10, Familiar Effect: "3xPotato, 1.5xGhuol, cap 20"
 Item	cool iron greaves	Damage Reduction: 20, HP Regen Min: 20, HP Regen Max: 40, Familiar Effect: "atk, 1xBarrr"
 Item	corroded breeches	Damage Absorption: +50, Critical Hit Percent: +5, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 Item	crappy Mer-kin tailpiece	Initiative: -25, Mana Cost: +2, Familiar Effect: "1xBarrr, 1xFairy"
+Item	Crimbuccaneer breeches	Last Available: "2023-12"
 Item	Crimbo pants	Initiative: +30, Familiar Effect: "atk, cap 25"
 Item	Crimbo stockings	PvP Fights: +5, Sleaze Damage: +75, Class: "Disco Bandit"
 Item	Crimbylow-rise jeans	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Adventures: +4
@@ -666,6 +669,7 @@ Item	depleted Grimacite shinguards	Muscle Percent: [5*G], PvP Fights: [G], Famil
 Item	designer sweatpants	Muscle: [5+(2*floor(sqrt(pref(sweat))))], Mysticality: [5+(2*floor(sqrt(pref(sweat))))], Moxie: [5+(2*floor(sqrt(pref(sweat))))], Damage Reduction: [5+(1*floor(sqrt(pref(sweat))))], Hot Resistance: [1+(0.5*floor(sqrt(pref(sweat))))], Sleaze Damage: [10+(5*floor(sqrt(pref(sweat))))], Sleaze Spell Damage: [10+(5*floor(sqrt(pref(sweat))))]
 Item	dice-print pajama pants	Random Monster Modifiers: +1
 # digibritches: CyberRealm: Take less damage from processes
+Item	digibritches	Last Available: "2025-12"
 # Dinsey's pants: Disco Bandit Combat Skills weaken enemies by an additional 50%
 Item	Dinsey's pants	DB Combat Damage: +15
 Item	discarded swimming trunks	Experience Percent (Muscle): +5, Sleaze Damage: +10, Sleaze Spell Damage: +10
@@ -687,6 +691,7 @@ Item	El Vibrato leg guards	Familiar Effect: "1xBarrr, 1xGhuol"
 Item	eldritch pants	Mysticality Percent: +20, Maximum MP: +40, MP Regen Min: 6, MP Regen Max: 10
 Item	electric pants	Spooky Damage: +10, Stench Damage: +10, Hot Damage: +10, Cold Damage: +10, Sleaze Damage: +10
 Item	electronic dulcimer pants	Adventures: +2, Initiative: +25, Familiar Effect: "8xPotato, cap 2"
+Item	Elf Guard hotpants	Last Available: "2023-12"
 # exo-servo leg braces: Allows you to move normally in high gravity environments (Spacegate)
 Item	exo-servo leg braces	Lasts Until Rollover
 Item	extremely skinny jeans	Muscle Percent: -10, Mysticality Percent: -10, Moxie Percent: -10, Critical Hit Percent: +5, Familiar Effect: "1xPotato, 1xFairy"
@@ -717,10 +722,10 @@ Item	gnauga hide kilt	Damage Absorption: +30, Familiar Effect: "2.5xFairy, cap 2
 Item	gnauga hide skirt	Damage Absorption: +30, Familiar Effect: "2.5xFairy, cap 20"
 Item	gold lam&eacute; pants	Moxie: -8, Familiar Effect: "2xPotato, 1xLep, cap 25"
 Item	government-issued slacks	Experience Percent (Muscle): +10, Damage vs. Skeletons: +25, Fishing Skill: +5
-Item	governor's daughter's petticoats	Muscle Percent: +20
+Item	governor's daughter's petticoats	Muscle Percent: +20, Last Available: "2024-12"
 Item	grass skirt	Moxie: +5, Familiar Effect: "atk, 1.5xFairy, cap 20"
-Item	gravyskin pants	Sleaze Damage: +11, Sleaze Spell Damage: +11
-Item	gravyskin skirt	Sleaze Damage: +11, Sleaze Spell Damage: +11
+Item	gravyskin pants	Sleaze Damage: +11, Sleaze Spell Damage: +11, Last Available: "2024-12"
+Item	gravyskin skirt	Sleaze Damage: +11, Sleaze Spell Damage: +11, Last Available: "2024-12"
 # Great Wolf's beastly trousers: Troubling Vulnerability to All Elements (-5)
 Item	Great Wolf's beastly trousers	Weapon Damage Percent: +50, Familiar Weight: +10, Hot Resistance: -5, Cold Resistance: -5, Spooky Resistance: -5, Stench Resistance: -5, Sleaze Resistance: -5, Familiar Effect: "1xPotato, 1.5xWhelp"
 # Greatest American Pants: Amazing Super Powers
@@ -756,7 +761,7 @@ Item	lava-proof pants	Hot Resistance: +5, Muscle Percent: -50, Mysticality Perce
 Item	Leapin' Trousers	Adventures: +1, Muscle: +4, Mysticality: +4, Moxie: +4
 Item	leather chaps	Moxie: +8, Muscle: -4, Familiar Effect: "sleaze atk, 1xBarrr, cap 40"
 Item	Lederhosen of the Night	Moxie: +11, Initiative: +15, Class: "Accordion Thief", Familiar Effect: "atk, 2xGhuol, cap 31"
-Item	leg-mounted Trainbots	Maximum HP: +5, Damage Reduction: 5, Muscle: +5
+Item	leg-mounted Trainbots	Maximum HP: +5, Damage Reduction: 5, Muscle: +5, Last Available: "2022-12"
 Item	leggings of the Spider Queen	Moxie: +15, Moxie Percent: +25, Maximum HP: +50, Maximum MP: +50
 Item	lemon drop trousers	Candy Drop: +50, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12"
 Item	leotarrrd	Initiative: +15, Familiar Effect: "2xVolley, 2xPotato, cap 22"
@@ -812,11 +817,11 @@ Item	penguin shorts	Initiative: +20, Familiar Effect: "cold atk, 1xGhuol, cap 30
 Item	penguinskin mini-kilt	Initiative: +20, Familiar Effect: "cold atk, 1xFairy, cap 30"
 Item	penguinskin mini-skirt	Initiative: +20, Familiar Effect: "cold atk, 1xFairy, cap 30"
 # petrified wood walking pants: Make you dodge some attacks
-Item	petrified wood walking pants	Experience (Moxie): +3, Spell Critical Percent: +10
+Item	petrified wood walking pants	Experience (Moxie): +3, Spell Critical Percent: +10, Last Available: "2025-12"
 Item	pig-iron shinguards	Moxie: +6, Initiative: +10, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 Item	pin-stripe slacks	Initiative: +15, Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 Item	pink pinkslip slip	Initiative: +35, Damage Reduction: 4, Familiar Effect: "1xVolley, 1xBarrr"
-Item	pirate pantaloons	Experience (Moxie): +2, Weapon Damage Percent: +15
+Item	pirate pantaloons	Experience (Moxie): +2, Weapon Damage Percent: +15, Last Available: "2019-04"
 Item	pixel pants	Maximum HP: +10, Maximum MP: +10, Familiar Effect: "atk, 4xPotato, cap 12"
 Item	plaid skirt	Initiative: +25, MP Regen Min: 6, MP Regen Max: 10, Familiar Effect: "1xPotato, 1xFairy, cap 38"
 Item	plexiglass pants	Initiative: +25, Item Drop: +20, Moxie Percent: +30, Familiar Effect: "1xVolley, 1xLep, cap 45"
@@ -851,7 +856,7 @@ Item	sea chaps	Muscle Percent: +15, HP Regen Min: 6, HP Regen Max: 10, Familiar 
 Item	sealhide leggings	HP Regen Min: 5, HP Regen Max: 10, Familiar Effect: "1xVolley, cap 40"
 Item	servo-assisted exo-pants	Initiative: -30, Familiar Effect: "cold atk, 1xPotato, cap 12"
 Item	shadow trousers	Monster Level: +13, Meat Drop: +13, Maximum HP: +13
-Item	silky pirate drawers	Combat Rate: -5, Initiative: +50
+Item	silky pirate drawers	Combat Rate: -5, Initiative: +50, Last Available: "2024-12"
 Item	slime waders	Mysticality Percent: +25, Experience (Mysticality): +3, Sleaze Resistance: +3
 Item	slime-covered greaves	Slime Resistance: +2, HP Regen Min: 20, HP Regen Max: 40, Initiative: -10, Familiar Effect: "sleaze atk, 0.5xBarrr"
 Item	SMOOCH codpiece	Damage Reduction: 5, Damage Absorption: +20, Familiar Effect: "atk, 1xBarrr, cap 20", Thorns: 1
@@ -947,6 +952,7 @@ Item	Whoompa Fur Pants	Stench Damage: +10, Stench Resistance: +2, Familiar Effec
 # wicker knickers: Increases the effectiveness of Shield of the Pastalord
 Item	wicker knickers	Experience (Mysticality): +2, Adventures: +2
 # wired underwear: CyberRealm: Restore your HP (Hacker Physiology) by 50% for 1 RAM
+Item	wired underwear	Last Available: "2025-12"
 Item	wooly loincloth	Pickpocket Chance: +25, MP Regen Min: 4, MP Regen Max: 8, Familiar Effect: "atk, 1xVolley, cap 27"
 # wrought-iron waders: Adds an extra source of damage to Concerto de los Muertos
 Item	wrought-iron waders	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Meat Drop: +20
@@ -962,7 +968,7 @@ Item	Zombo's grievous greaves	Cold Resistance: +3, Sleaze Resistance: +3, Class:
 
 Item	&quot;Humorous&quot; T-shirt	Muscle: +4, Mysticality: +4, Moxie: +4, Fumble: 2
 Item	&quot;Remember the Trees&quot; Shirt	Monster Level: +10, Stench Damage: +10, Combat Rate: +5
-Item	adobe abaya	Experience (Moxie): [3+3*min(1,effect(Adobe Abaya Subscription))], Weapon Damage: [20+20*min(1,effect(Adobe Abaya Subscription))]
+Item	adobe abaya	Experience (Moxie): [3+3*min(1,effect(Adobe Abaya Subscription))], Weapon Damage: [20+20*min(1,effect(Adobe Abaya Subscription))], Last Available: "2024-12"
 Item	anniversary safety glass vest	Muscle: +1, Mysticality: +1, Moxie: +1
 Item	antique nutcracker waistcoat	PvP Fights: +3, Muscle Percent: +15
 Item	asbestos apron	Hot Resistance: +3
@@ -971,7 +977,7 @@ Item	ASCII shirt	Mysticality: +7
 Item	astral shirt	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Experience: +3, Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3
 Item	autumn sweater-weather sweater	Cold Resistance: +3, Maximum HP: +50, HP Regen Min: 8, HP Regen Max: 12, MP Regen Min: 8, MP Regen Max: 12, Lasts Until Rollover
 # barnacle-encrusted sweater: Weakens foes at the start of combat
-Item	barnacle-encrusted sweater	Muscle: +5, Mysticality: +5, Moxie: +5, Familiar Damage: +5, Fishing Skill: +5
+Item	barnacle-encrusted sweater	Muscle: +5, Mysticality: +5, Moxie: +5, Familiar Damage: +5, Fishing Skill: +5, Last Available: "2023-12"
 Item	bat-ass leather jacket	Mysticality: +10, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1
 Item	BGE 'cuddly critter' shirt	Item Drop: +7, Meat Drop: +7
 Item	BGE 'ferocious fruit' shirt	Moxie: +10, Maximum HP: +10
@@ -984,12 +990,12 @@ Item	camouflage T-shirt	Mana Cost (combat): -3, Combat Rate: -5, Muscle Percent:
 Item	camouflage vest	Combat Rate: -10
 Item	cane-mail shirt	Candy Drop: +25, Monster Level: +20, Meat Drop: +15
 # ceramic cenobite's robe: Deal 30 damage and heal 30 HP
-Item	ceramic cenobite's robe	Experience (Moxie): +3, Maximum HP: +20, Maximum MP: +20, HP Regen Min: 4, HP Regen Max: 8, MP Regen Min: 4, MP Regen Max: 8
+Item	ceramic cenobite's robe	Experience (Moxie): +3, Maximum HP: +20, Maximum MP: +20, HP Regen Min: 4, HP Regen Max: 8, MP Regen Min: 4, MP Regen Max: 8, Last Available: "2023-12"
 Item	chamoisole	Slime Resistance: +3
 Item	cheerful Crimbo sweater	Cold Resistance: +2, Moxie: -15
 Item	chest barrel	Damage Reduction: 5, Damage Absorption: +50
 Item	Chester's muscle shirt	Muscle Percent: +20, Damage Reduction: 10
-Item	chiffon chemise	Experience (Mysticality): +2, Cold Damage: +10, Cold Spell Damage: +10, Damage Aura: 1
+Item	chiffon chemise	Experience (Mysticality): +2, Cold Damage: +10, Cold Spell Damage: +10, Last Available: "2023-12", Damage Aura: 1
 Item	clockwork trench coat	Damage Absorption: +15
 Item	clownskin harness	Spooky Damage: +2, Sleaze Damage: +2, Clowniness: 50
 Item	coconut bikini top	Mysticality: +5
@@ -998,15 +1004,15 @@ Item	conquistador's breastplate	Spooky Resistance: +2, Stench Resistance: +2, Ho
 Item	cool iron breastplate	Damage Reduction: 20, Maximum HP: +200
 Item	Corporal Fennel's Lonely Clubs Club Jacket	PvP Fights: +2
 # crepe paper plunge camisole: Leave nothing to the imagination and distract your foes
-Item	crepe paper plunge camisole	Moxie: +10, Sleaze Damage: +10, Sleaze Spell Damage: +10
+Item	crepe paper plunge camisole	Moxie: +10, Sleaze Damage: +10, Sleaze Spell Damage: +10, Last Available: "2025-12"
 Item	Crimbuccaneer bombjacket	Moxie Percent: +25, Ranged Damage: +25, Combat Item Damage Percent: 100
-Item	Crimbuccaneer shirt	Familiar Weight: [+10*event(December)]
+Item	Crimbuccaneer shirt	Familiar Weight: [+10*event(December)], Last Available: "2023-12"
 Item	demonskin jacket	Mysticality: +5, Hot Spell Damage: +5
 Item	denim jacket	Mysticality: +10, MP Regen Min: 4, MP Regen Max: 8
 Item	Dragonscale breastplate	Muscle: +15, Muscle Percent: +25, Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3
 Item	dreadful sweater	HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Kruegerand Drop: 5
 Item	duct tape shirt	Moxie: +9, Meat Drop: +20
-Item	embers-only jacket	Hot Damage: +10, Hot Resistance: +3, Hot Spell Damage: +20, Lasts Until Rollover
+Item	embers-only jacket	Hot Damage: +10, Hot Resistance: +3, Hot Spell Damage: +20, Lasts Until Rollover, Last Available: "2024-09"
 Item	extra-see-thru nightie	Moxie Percent: +15
 Item	eXtreme Bi-Polar Fleece Vest	Cold Resistance: +2
 Item	extremely wet T-shirt	Moxie Percent: +10, Sleaze Damage: +25, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10
@@ -1045,9 +1051,9 @@ Item	hipposkin poncho	Monster Level: +10
 Item	Hodgman's disgusting technicolor overcoat	Spooky Damage: +15, Stench Damage: +15, Hot Damage: +15, Cold Damage: +15, Sleaze Damage: +15, Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5
 Item	icing poncho	Cold Damage: +25, Cold Spell Damage: +25, Food Drop: +50
 Item	junk-mail shirt	Muscle: +4, Mysticality: +4, Moxie: +4
-Item	Jurassic Parka	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Spooky Resistance: 1, Stench Resistance: 1, Hot Resistance: 1, Cold Resistance: 1, Sleaze Resistance: 1, Avoid Attack: 1
+Item	Jurassic Parka	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Last Available: "2022-09", Avoid Attack: 1
 Item	Kashmir sweater	Hot Damage: +10, Hot Spell Damage: +10
-Item	Kelflar vest	Elf Warfare Effectiveness: +3, Damage Reduction: 5, Negative Status Resist
+Item	Kelflar vest	Elf Warfare Effectiveness: +3, Damage Reduction: 5, Negative Status Resist, Last Available: "2023-12"
 Item	Kiss the Knob apron	Maximum MP: +5
 Item	Knob Goblin elite shirt	Muscle: +3
 Item	KoL Con 13 T-shirt	Sleaze Resistance: +2, Experience Percent (Moxie): +5
@@ -1071,7 +1077,7 @@ Item	Othello's military jacket	Othello Skill: +10
 Item	PARTY HARD T-shirt	Muscle Limit: 100, Mysticality Limit: 100, Moxie Limit: 100
 Item	pirate shirt	Moxie: +3
 Item	poncho de azucar	Adventures: +5, Stench Damage: +30, Class: "Accordion Thief"
-Item	potato jacket	Hot Damage: +20, Cold Resistance: +3, Meat Drop: +15
+Item	potato jacket	Hot Damage: +20, Cold Resistance: +3, Meat Drop: +15, Last Available: "2024-12"
 # Private Pepper's Lonely Hearts Club Jacket: 50% Discount on Gift Packages
 Item	Professor What T-Shirt	MP Regen Min: 1, MP Regen Max: 2
 Item	psycho sweater	Weapon Damage Percent: +20, Spell Damage Percent: +20
@@ -1086,7 +1092,7 @@ Item	replica Jurassic Parka	Muscle Percent: +10, Mysticality Percent: +10, Moxie
 Item	rhinestone cowboy shirt	Muscle: +5
 Item	safety vest	Damage Reduction: 3, Moxie: +5
 Item	sea salt scrubs	Maximum HP: +400, Maximum MP: +400, Mysticality Percent: +15
-Item	sequin-encrusted sweater	Spooky Damage: +9, Stench Damage: +9, Hot Damage: +9, Cold Damage: +9, Sleaze Damage: +9
+Item	sequin-encrusted sweater	Spooky Damage: +9, Stench Damage: +9, Hot Damage: +9, Cold Damage: +9, Sleaze Damage: +9, Last Available: "2023-12"
 Item	shark jumper	Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, HP Regen Min: 20, HP Regen Max: 40
 Item	shoe ad T-shirt	Muscle: +5, Mysticality: +5, Moxie: +5, Adventures: +3
 Item	SMOOCH breastplate	Damage Absorption: +40, Thorns: 1
@@ -1128,6 +1134,7 @@ Item	Ye Olde Navy Fleece	Meat Drop: +10
 # Yeg's Motel bathrobe: Extremely fragile (will be destroyed if you are hit in combat)
 Item	Yeg's Motel bathrobe	Spooky Damage: +50, Muscle Percent: +66, Lasts Until Rollover
 # zero-trust tanktop: CyberRealm: Regenerate some of your HP (Hacker Physiology) each round
+Item	zero-trust tanktop	Last Available: "2025-12"
 
 # Weapons section of modifiers.txt
 
@@ -1145,13 +1152,13 @@ Item	accordion file	MP Regen Min: [2*(1+skill(Accordion Appreciation))], MP Rege
 Item	Accordion of Jordion	Item Drop: [5*(1+skill(Accordion Appreciation))], Meat Drop: [10*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 14
 Item	accordionoid rocca	Damage Reduction: [10*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 18
 Item	acoustic guitarrr	Meat Drop: +8
-Item	adobe adze	Experience (Muscle): [3+3*min(1,effect(Adobe Adze Subscription))], Familiar Weight: [5+5*min(1,effect(Adobe Adze Subscription))], Single Equip
+Item	adobe adze	Experience (Muscle): [3+3*min(1,effect(Adobe Adze Subscription))], Familiar Weight: [5+5*min(1,effect(Adobe Adze Subscription))], Single Equip, Last Available: "2024-12"
 # aerogel accordion: Only takes up one hand!
 Item	aerogel accordion	Moxie: [10*(1+skill(Accordion Appreciation))], Maximum HP: [20*(1+skill(Accordion Appreciation))], Song Duration: 10
 # airblaster gun: Blasts Air (Duh.)
 Item	alarm accordion	Adventures: [3*(1+skill(Accordion Appreciation))], Initiative: [20*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 20
 Item	amok putter	Hot Damage: +9, Cold Damage: +9, Initiative: +18
-Item	ancient Elf dessert spoon	Hot Spell Damage: +20, Cold Spell Damage: +20, Spooky Spell Damage: +20, Stench Spell Damage: +20, Sleaze Spell Damage: +20, Spell Damage Percent: +20
+Item	ancient Elf dessert spoon	Hot Spell Damage: +20, Cold Spell Damage: +20, Spooky Spell Damage: +20, Stench Spell Damage: +20, Sleaze Spell Damage: +20, Spell Damage Percent: +20, Last Available: "2023-12"
 Item	ancient ice cream scoop	Spell Damage: +20
 Item	ancient stone fist	Damage Reduction: 2, Maximum HP: +20
 Item	anger blaster	Hot Damage: +10
@@ -1219,7 +1226,7 @@ Item	black blade	Spooky Damage: +10
 Item	black kettle drum	Moxie: +5, Maximum HP: +30, Maximum MP: +30
 Item	black sword	Critical Hit Percent: +7, Weapon Damage: +7
 # blade of dismemberment: Does more damage to armed or legged foes
-Item	blade of dismemberment	Weakens Monster, Lasts Until Rollover
+Item	blade of dismemberment	Weakens Monster, Lasts Until Rollover, Last Available: "2024-09"
 Item	blammer	Critical Hit Percent: +7, Weakens Monster
 # blood knife: Gross!
 Item	blood knife	Lasts Until Rollover
@@ -1254,6 +1261,7 @@ Item	Brimstone Bludgeon	Muscle Percent: +50, Mysticality Percent: -20, Weapon Da
 Item	broken champagne bottle	MP Regen Min: 4, MP Regen Max: 8, Weapon Damage Percent: +50, Lasts Until Rollover, Breakable
 Item	broken sword	Spooky Resistance: +1
 # brute force hammer: CyberRealm: Deal 40 damage for 3 RAM
+Item	brute force hammer	Last Available: "2025-12"
 Item	bubble bauble bow	Moxie: +3, Mysticality: +2, Item Drop: +5
 Item	bubblewrap crossbow	Moxie: +3, Mysticality: +2
 Item	bubblewrap staff	Mysticality: +3, Muscle: +2
@@ -1293,7 +1301,7 @@ Item	carrot-on-a-stick	Moxie: +7, Candy Drop: +50
 Item	cast-iron legacy paddle	Muscle: +15, Weapon Damage: +10
 Item	cat o' nine teeth	Sleaze Damage: +10, Monster Level: +10
 # ceramic celery grater: Deal 30 damage and cause bleeding
-Item	ceramic celery grater	Mysticality Percent: +20, Spell Critical Percent: +20
+Item	ceramic celery grater	Mysticality Percent: +20, Spell Critical Percent: +20, Last Available: "2023-12"
 Item	Cerebral Crossbow	Cold Damage: +3, Spooky Damage: +3, Sleaze Damage: +3
 # charming flute: +20 Damage vs. Snakes
 Item	charming flute	Moxie: +8
@@ -1303,8 +1311,8 @@ Item	cheap plastic kazoo	Monster Level: +10
 # cheer extractor: Extract 1 additional crystalline cheer from mimes in the Silent Night
 Item	Chelonian Morningstar	Muscle: +11, Never Fumble, Class: "Turtle Tamer"
 Item	Chester's bag of candy	Sleaze Damage: +30, Moxie Percent: +10, Class: "Disco Bandit"
-Item	chiffon chakram	Moxie: +10, Stench Damage: +10, Stench Spell Damage: +10, Damage Aura: 1
-Item	chili powder cutlass	Hot Damage: +20
+Item	chiffon chakram	Moxie: +10, Stench Damage: +10, Stench Spell Damage: +10, Last Available: "2023-12", Damage Aura: 1
+Item	chili powder cutlass	Hot Damage: +20, Last Available: "2024-12"
 # chisel
 # chocolate cow bone: Candilicious Smacks!
 Item	chocolate cow bone	Candy Drop: +30
@@ -1346,9 +1354,9 @@ Item	Crimbo sword	Weapon Damage: +5
 Item	Crimbo ukulele	Item Drop: +10
 # Crimbomination Contraption
 # Crimbuccaneer squirtblunderbuss: 100% chance of poisoning opponent.
-Item	Crimbuccaneer squirtblunderbuss	Sleaze Damage: +30
+Item	Crimbuccaneer squirtblunderbuss	Sleaze Damage: +30, Last Available: "2023-12"
 # Crimbuccaneer tavern swab: Helps clean up the Bar at War
-Item	Crimbuccaneer tavern swab	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Sleaze Damage: +20, Stench Damage: +20
+Item	Crimbuccaneer tavern swab	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Sleaze Damage: +20, Stench Damage: +20, Last Available: "2023-12"
 Item	crowbar	Initiative: +25
 Item	crowbarrr	Initiative: +15
 Item	crystalline reamer	Spell Damage: +10
@@ -1407,7 +1415,7 @@ Item	dueling banjo	Moxie: +4, Monster Level: +5
 # dwarvish war mattock: Magical Blue Glow
 # ebony epee: Lets you disarm your foes
 Item	ebony epee	Weapon Damage Percent: +100, Muscle: +25, Experience (Muscle): +5, Lasts Until Rollover
-Item	egg gun	Stench Damage: +25, Familiar Weight: +5, Food Drop: +75, HP Regen Min: 15, HP Regen Max: 20
+Item	egg gun	Stench Damage: +25, Familiar Weight: +5, Food Drop: +75, HP Regen Min: 15, HP Regen Max: 20, Last Available: "2024-12"
 Item	eggbeater	Spell Damage: +7
 # El Vibrato energy spear
 Item	eldritch hammer	Maximum MP: +40, Monster Level: +10, Weapon Damage Percent: +50
@@ -1417,13 +1425,14 @@ Item	elegant nightstick	Maximum HP: +30, Maximum MP: +15
 Item	elephant stinger	Muscle: +3
 Item	elevenderizing hammer	Muscle: +11, Mysticality: +11, Moxie: +11, Weapon Damage: +11
 # Elf Guard broom: Helps clean up the Bar at War
-Item	Elf Guard broom	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Weakens Monster
-Item	Elf Guard mouthknife	Elf Warfare Effectiveness: +3, Moxie Percent: +20
-Item	Elf Guard officer's sidearm	Elf Warfare Effectiveness: +3, Weapon Damage Percent: +10
-Item	Elf Guard squirtgun	Weakens Monster, Stench Damage: +20
+Item	Elf Guard broom	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Weakens Monster, Last Available: "2023-12"
+Item	Elf Guard mouthknife	Elf Warfare Effectiveness: +3, Moxie Percent: +20, Last Available: "2023-12"
+Item	Elf Guard officer's sidearm	Elf Warfare Effectiveness: +3, Weapon Damage Percent: +10, Last Available: "2023-12"
+Item	Elf Guard squirtgun	Weakens Monster, Stench Damage: +20, Last Available: "2023-12"
 Item	elven tambourine	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2
 # elven whittling knife: On Critical:  Whittles enemy down
 # encrypted shuriken: CyberRealm: Deal 20 damage for 2 RAM
+Item	encrypted shuriken	Last Available: "2025-12"
 Item	evil paper umbrella	Monster Level: +1
 Item	evil-ass club	Weapon Damage: +25, Monster Level: +15, Spooky Damage: +15, Class: "Seal Clubber"
 Item	extra-large utility candle	Item Drop: +25, Hot Damage: +50, Lasts Until Rollover
@@ -1486,7 +1495,7 @@ Item	garbage sticker	Food Drop: +20, Booze Drop: +20, Accessory Drop: +20, Weapo
 Item	gatorskin umbrella	Stench Resistance: +3, Weapon Damage: +15
 Item	genie's scimitar	Muscle: +5, Weapon Damage: +5
 # geofencing rapier: CyberRealm:  Deal 150-200 damage for 7 RAM
-Item	geofencing rapier	Single Equip
+Item	geofencing rapier	Single Equip, Last Available: "2025-12"
 Item	ghast iron cleaver	Spooky Damage: +15, Hot Damage: +15
 Item	ghost accordion	Spooky Damage: [5*(1+skill(Accordion Appreciation))], Booze Drop: [15*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 16
 Item	ghostly dagger	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Damage Reduction: 11, Weapon Damage: -10
@@ -1541,7 +1550,7 @@ Item	Grimacite glaive	Weapon Damage: +15, Muscle Percent: [10*G]
 Item	groping claw	Weakens Monster, Sleaze Damage: +30
 Item	guancertina	Stench Damage: [4*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 9
 Item	gummi sword	Muscle: +7, Candy Drop: +50
-Item	gunwale whalegun	Damage Absorption: +100, Weapon Damage Percent: +100, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1
+Item	gunwale whalegun	Damage Absorption: +100, Weapon Damage Percent: +100, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Last Available: "2023-12"
 # haiku katana: Allows use of seasonal attacks
 Item	haiku katana	Muscle Percent: +15, Critical Hit Percent: +5, Weapon Damage Percent: +50, Softcore Only
 Item	hairy staff	Mysticality: +7, Spell Damage: +7, MP Regen Min: 5, MP Regen Max: 7
@@ -1655,13 +1664,13 @@ Item	magilaser blastercannon	Ranged Damage: +15, Hot Damage: +5
 Item	mama's squeezebox	Moxie: [3*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 8
 Item	mannequin leg	Sleaze Damage: +20, Moxie: +5, Class: "Seal Clubber"
 Item	massive sitar	Mysticality: +12, Spell Damage: +20
-Item	massive wrench	Elf Warfare Effectiveness: +10, Critical Hit Percent: +20, Weapon Damage Percent: +50
+Item	massive wrench	Elf Warfare Effectiveness: +10, Critical Hit Percent: +20, Weapon Damage Percent: +50, Last Available: "2023-12"
 Item	Maxwell's Silver Hammer	Mysticality: +10, Weapon Damage: +10
 # Mayor Ghost's gavel: Lets you hit ghosts with a gavel.
 # Mayor Ghost's gavel: This gavel, specifically.
 Item	Mayor Ghost's gavel	Critical Hit Percent: +10, Weapon Damage: +30, Damage vs. Ghosts: +50
 # McHugeLarge right pole: Stab your foe to hurt them
-Item	McHugeLarge right pole	Critical Hit Percent: +10, Weapon Damage: +10, Weapon Damage Percent: +25, Single Equip, McHugeLarge
+Item	McHugeLarge right pole	Critical Hit Percent: +10, Weapon Damage: +10, Weapon Damage Percent: +25, Single Equip, Last Available: "2025-01", McHugeLarge
 # Meat Tenderizer is Murder: 25% chance to gain an extra gallon of Fury when you gain a gallon of Fury.
 Item	Meat Tenderizer is Murder	Weapon Damage Percent: +20, Smithsness: +5, Class: "Seal Clubber", Muscle Percent: [2*K]
 Item	Meatcleaver	Meat Drop: +35, Weapon Damage Percent: +100
@@ -1687,7 +1696,7 @@ Item	miracle whip	Initiative: +50, Weapon Damage: +50, Item Drop: +50, Meat Drop
 Item	Moonthril Flamberge	Muscle Percent: [15*G]
 Item	Moonthril Longbow	Moxie Percent: [15*G]
 # moss mace: Lets you mug a foe
-Item	moss mace	Experience (Muscle): +2, Hot Resistance: +2
+Item	moss mace	Experience (Muscle): +2, Hot Resistance: +2, Last Available: "2024-12"
 Item	muculent machete	Muscle: +2, Meat Drop: +5
 # murderbot plasma rifle: Can be used to instantly kill Spants
 Item	murderbot plasma rifle	Hot Damage: +25, Reduce Enemy Defense: 10
@@ -1740,7 +1749,7 @@ Item	Periodical Paintbrush	Muscle Percent: [+5*G], Mysticality Percent: [+5*G], 
 Item	pernicious cudgel	Sleaze Damage: +30, Critical Hit Percent: +10, Slime Hates It: +1
 Item	pestoblade	Muscle: +3, Stench Damage: +3
 # petrified wood war pike: Attack a second time when you attack
-Item	petrified wood war pike	Muscle Percent: +20, PvP Fights: +5
+Item	petrified wood war pike	Muscle Percent: +20, PvP Fights: +5, Last Available: "2025-12"
 Item	pewter claymore	HP Regen Min: 6, HP Regen Max: 12, MP Regen Min: 6, MP Regen Max: 12
 # Pigsticker of Violence: Lets you stab opponents as they fail to attack you
 Item	Pigsticker of Violence	HP Regen Min: 20, HP Regen Max: 30, Critical Hit Percent: +10, Weapon Damage Percent: +60
@@ -1845,7 +1854,7 @@ Item	Saucepanic	Experience (Mysticality): +2, Smithsness: +5, Class: "Sauceror",
 Item	savory crossbow	Moxie: +4
 Item	savory staff	Mysticality: +4
 Item	savory sword	Muscle: +4
-Item	sawed-off blunderbuss	Pirate Warfare Effectiveness: +3, Muscle: +3, Mysticality: +3, Moxie: +3, Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3
+Item	sawed-off blunderbuss	Pirate Warfare Effectiveness: +3, Muscle: +3, Mysticality: +3, Moxie: +3, Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2023-12"
 Item	scepter of the Skeleton Lord	Moxie Percent: +50, Adventures: +3, PvP Fights: +3, Single Equip
 # scorpion whip: 50% chance of poisoning opponent.
 Item	scorpion whip	Weapon Damage: +13
@@ -1861,16 +1870,16 @@ Item	severed flipper	Muscle: +5, Weapon Damage: +5, Class: "Seal Clubber"
 Item	sewage-clogged pistol	Monster Level: +10, Stench Damage: +20
 Item	sewer snake	Stench Damage: +3
 Item	shadow hammer	Combat Rate: +5, Experience: +3
-Item	shadow stick	Spooky Damage: +13, Cold Damage: +13, Weakens Monster
+Item	shadow stick	Spooky Damage: +13, Cold Damage: +13, Weakens Monster, Last Available: "2023-03"
 Item	Shagadelic Disco Banjo	Moxie: +11, Meat Drop: +10, DB Combat Damage: +7, Class: "Disco Bandit"
 # Shakespeare's Sister's Accordion: Has a cool Cadenza
 Item	Shakespeare's Sister's Accordion	Mana Cost: [-1*(1+skill(Accordion Appreciation))], Smithsness: [5*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 15, Moxie Percent: [2*K]
 # sharpened spoon
 Item	Sheila Take a Crossbow	HP Regen Min: 1, HP Regen Max: 2, MP Regen Min: 1, MP Regen Max: 2, Pickpocket Chance: +5, Smithsness: +5, Initiative: [K]
 # Sheriff pistol: Provides 1/3 Authority
-Item	Sheriff pistol	Muscle Percent: +50, Hot Damage: +15, Lasts Until Rollover
+Item	Sheriff pistol	Muscle Percent: +50, Hot Damage: +15, Lasts Until Rollover, Last Available: "2024-10"
 Item	shiny butcherknife	Spell Damage: +8
-Item	shipwright's hammer	Pirate Warfare Effectiveness: +3, Weapon Damage Percent: +30, Damage vs. Skeletons: +30
+Item	shipwright's hammer	Pirate Warfare Effectiveness: +3, Weapon Damage Percent: +30, Damage vs. Skeletons: +30, Last Available: "2023-12"
 Item	shooting morning star	Muscle Percent: +15, Hot Damage: +15, Weakens Monster, Single Equip
 Item	short-handled mop	Stench Damage: +10, Sleaze Damage: +10
 Item	shotgun	Ranged Damage: +10
@@ -2092,7 +2101,7 @@ Item	warbear oil pan	Hot Spell Damage: +10, Sleaze Spell Damage: +10, Class: "Sa
 Item	weeping willow wand	Spell Damage Percent: +100, Mysticality: +25, Experience (Mysticality): +5, Lasts Until Rollover
 Item	weighted paperclip chain	Weapon Damage: +12
 Item	western-style skinning knife	Weapon Damage: +5, Hat Drop: +10
-Item	whalegun	Pirate Warfare Effectiveness: +10, Monster Level: +10, Weapon Damage: +100
+Item	whalegun	Pirate Warfare Effectiveness: +10, Monster Level: +10, Weapon Damage: +100, Last Available: "2023-12"
 Item	White Dragon Fang	Muscle Percent: +9, Mysticality Percent: +9, Moxie Percent: +9, Spooky Damage: +9, Stench Damage: +9, Hot Damage: +9, Cold Damage: +9, Sleaze Damage: +9, MP Regen Min: 9, MP Regen Max: 9
 Item	white sword	Muscle: +2
 Item	white whip	Experience: +1
@@ -2123,7 +2132,7 @@ Item	wumpus-hair whip	Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold
 # X-37 gun: Shoots Elemental Blasts
 Item	X-37 gun	Breakable
 Item	yak whip	Weakens Monster
-Item	yam cannon	Hot Damage: +50, Ranged Damage Percent: +25, Food Drop: +30, Lasts Until Rollover
+Item	yam cannon	Hot Damage: +50, Ranged Damage Percent: +25, Food Drop: +30, Lasts Until Rollover, Last Available: "2024-05"
 Item	yohohoyo	Critical Hit Percent: +5, Spooky Damage: +1, Stench Damage: +1, Hot Damage: +1, Cold Damage: +1, Sleaze Damage: +1
 Item	yule hatchet	Experience (familiar): +2
 Item	Zim Merman's guitar	Ranged Damage: +20
@@ -2148,7 +2157,7 @@ Item	Abracandalabra	Spell Damage Percent: +100, MP Regen Min: 5, MP Regen Max: 1
 # Abuela Crimbo's special magnet: Get more items from Trainbots
 Item	Abyssal ember	Hot Damage: +20, Weapon Drop: +25, Class: "Seal Clubber"
 Item	adhesive tape dolly	Moxie: +5
-Item	adobe abacus	Mysticality Percent: [20+20*min(1,effect(Adobe Abacus Subscription))], Spell Damage: [20+20*min(1,effect(Adobe Abacus Subscription))]
+Item	adobe abacus	Mysticality Percent: [20+20*min(1,effect(Adobe Abacus Subscription))], Spell Damage: [20+20*min(1,effect(Adobe Abacus Subscription))], Last Available: "2024-12"
 Item	Adventurer bobblehead	Muscle Percent: [pref(nuclearAutumnPoints)], Mysticality Percent: [pref(nuclearAutumnPoints)], Moxie Percent: [pref(nuclearAutumnPoints)]
 # aerogel attache case: Produce random cocktailcrafting ingredients as you adventure
 Item	aerogel attache case	Pickpocket Chance: +10, Stench Damage: +10, Drops Items
@@ -2187,7 +2196,7 @@ Item	beach ball marble	Spell Damage: +35, Hot Spell Damage: +35, Cold Spell Dama
 Item	beetle antenna	Maximum MP: +30, Mysticality: [5*L]
 Item	beige clambroth marble	Spell Damage: +30, Hot Spell Damage: +30
 Item	big bumboozer marble	Spell Damage: +80
-Item	big hot pepper	Spell Damage: +10, Hot Damage: +10
+Item	big hot pepper	Spell Damage: +10, Hot Damage: +10, Last Available: "2023-02"
 Item	birdybug antenna	Maximum MP: +20, Mysticality: [4*L]
 Item	black catseye marble	Spooky Spell Damage: +75
 Item	black shield	Muscle: +5, Maximum HP: +20, Damage Reduction: 10
@@ -2224,14 +2233,14 @@ Item	cardboard wine carrier	Booze Drop: +50, Lasts Until Rollover
 Item	carnivorous potted plant	Monster Level: +25
 Item	catskin buckler	Muscle: +10, Damage Absorption: +50, Damage Reduction: 11
 # ceramic centurion shield: Bash a foe, dealing 30 damage and weakening them
-Item	ceramic centurion shield	Experience (Muscle): +3, Maximum HP: +40, HP Regen Min: 8, HP Regen Max: 16, Damage Reduction: 9
+Item	ceramic centurion shield	Experience (Muscle): +3, Maximum HP: +40, HP Regen Min: 8, HP Regen Max: 16, Damage Reduction: 9, Last Available: "2023-12"
 Item	Chalice of the Malkovich Prince	Muscle Percent: +4, Mysticality Percent: +4, Moxie Percent: +4
 # chalk chalice: Weakens enemies who hit you
 Item	chalk chalice	Maximum MP: +15, Hot Spell Damage: +20
 Item	charged druidic orb	Lasts Until Rollover
 # charged magnet: Radiates a Strange Energy
 Item	charged magnet	Maximum MP: +5, MP Regen Min: 1, MP Regen Max: 2
-Item	chiffon chamberpot	Mysticality: +10, Sleaze Damage: +10, Sleaze Spell Damage: +10, Damage Aura: 1
+Item	chiffon chamberpot	Mysticality: +10, Sleaze Damage: +10, Sleaze Spell Damage: +10, Last Available: "2023-12", Damage Aura: 1
 Item	chipped coffee mug	Maximum HP: +30, Maximum MP: +15
 Item	Cloaca-Cola shield	Mysticality: +1, Damage Reduction: 4
 # clockwork detective skull
@@ -2250,7 +2259,7 @@ Item	creepy doll head	Spooky Damage: +15
 # creepy voice box: Pull the String!  I Dare You!
 Item	creme brulee torch	Hot Damage: +30, Lasts Until Rollover
 # crepe paper puzzle cube: Play with it to get more stats after combat
-Item	crepe paper puzzle cube	Experience (Mysticality): +2, Spooky Damage: +10, Spooky Spell Damage: +10
+Item	crepe paper puzzle cube	Experience (Mysticality): +2, Spooky Damage: +10, Spooky Spell Damage: +10, Last Available: "2025-12"
 Item	Crimbo bottomless hot cocoa mug	Hot Spell Damage: +10
 Item	Crimbo Elf creepy bobble-head	Spooky Damage: +10
 Item	Crimbo light-up Rudolph doll	Sleaze Damage: +10
@@ -2258,8 +2267,8 @@ Item	Crimbo smile	Experience: [5*event(December)]
 Item	Crimbo stogie-scented room odorizer	Stench Spell Damage: +10
 Item	Crimbo tree flocker	Cold Damage: +10
 # Crimbuccaneer lantern: Increases Item Drops on Crimbo Battlefields
-Item	Crimbuccaneer lantern	Hat Drop: +50, Weapon Drop: +50, Accessory Drop: +50
-Item	Crimbuccaneer war standard	Pirate Warfare Effectiveness: +50, Initiative: +25
+Item	Crimbuccaneer lantern	Hat Drop: +50, Weapon Drop: +50, Accessory Drop: +50, Last Available: "2023-12"
+Item	Crimbuccaneer war standard	Pirate Warfare Effectiveness: +50, Initiative: +25, Last Available: "2023-12"
 Item	crumbling rabbit's foot	Meat Drop: +30
 Item	cuddly teddy bear	Monster Level: +10
 Item	cup of infinite pencils	Meat Drop: +15, Damage Aura: 1
@@ -2276,7 +2285,7 @@ Item	deck of lewd playing cards	Moxie Percent: +5, Sleaze Damage: +69, Sleaze Sp
 Item	deck of tropical cards	Experience: +1, Stat Tuning: "Mysticality"
 # defective skull
 # deft pirate hook: Occasionally snags on your opponent's stuff
-Item	deft pirate hook	Muscle: +20, Weapon Damage: +10, Lasts Until Rollover
+Item	deft pirate hook	Muscle: +20, Weapon Damage: +10, Lasts Until Rollover, Last Available: "2024-12"
 Item	demon buckler	Hot Damage: +3, Damage Reduction: 5
 Item	depleted Grimacite gravy boat	Mysticality Percent: [5*G], Adventures: [G]
 # detective skull
@@ -2299,8 +2308,9 @@ Item	Dyspepsi-Cola shield	Mysticality: +1, Damage Reduction: 4
 Item	easter egg balloon	Muscle: +5, Mysticality: +5, Moxie: +5
 Item	eelskin shield	Maximum HP: +55, Maximum MP: +55, Damage Reduction: 13, Thorns: [env(underwater)]
 # Elf Guard clipboard: Increases Item Drops on Crimbo Battlefields
-Item	Elf Guard clipboard	Food Drop: +25, Booze Drop: +25, Meat Drop: +25
-Item	Elf Guard war standard	Elf Warfare Effectiveness: +50, MP Regen Min: 4, MP Regen Max: 8
+Item	Elf Guard clipboard	Food Drop: +25, Booze Drop: +25, Meat Drop: +25, Last Available: "2023-12"
+Item	Elf Guard safety bear	Last Available: "2023-12"
+Item	Elf Guard war standard	Elf Warfare Effectiveness: +50, MP Regen Min: 4, MP Regen Max: 8, Last Available: "2023-12"
 Item	Elizabeth's Dollie	Cold Resistance: +4, Spooky Spell Damage: +25
 Item	Ellsbury's skull	Meat Drop: +10, Item Drop: +10
 Item	enchanted brass knuckles	Critical Hit Percent: +5
@@ -2335,10 +2345,11 @@ Item	foon of foulness	Mysticality: +3, Stench Spell Damage: +8
 Item	foon of frigidity	Mysticality: +3, Cold Spell Damage: +8
 Item	foon of fulmination	Mysticality: +3, Hot Spell Damage: +8
 Item	frankincenser	Maximum MP: +10, Experience (Mysticality): +3
-Item	furry yam buckler	Cold Resistance: +4, Damage Reduction: 14, Negative Status Resist, Lasts Until Rollover
+Item	furry yam buckler	Cold Resistance: +4, Damage Reduction: 14, Negative Status Resist, Lasts Until Rollover, Last Available: "2024-05"
 # Gazpacho's Glacial Grimoire: All Spells Cast Are Cold
 Item	Gazpacho's Glacial Grimoire	Spell Damage: +10
 # geofencing shield: CyberRealm: Prevent most damage from processes
+Item	geofencing shield	Last Available: "2025-12"
 # geological sample kit: Increases the yield of Spacegate geology operations
 Item	geological sample kit	Lasts Until Rollover
 Item	ghast iron heater shield	Spooky Damage: +10, Hot Damage: +10, Damage Reduction: 11
@@ -2360,14 +2371,14 @@ Item	gnauga hide buckler	Muscle: +3, Mysticality: +3, Moxie: +3, Damage Reductio
 # golden sausage
 # goo magnet: Automatically collects residual grey goo at Site Alpha locations
 # gore bucket
-Item	gravyskin buckler	Sleaze Damage: +11, Sleaze Spell Damage: +11, Damage Reduction: 7
+Item	gravyskin buckler	Sleaze Damage: +11, Sleaze Spell Damage: +11, Damage Reduction: 7, Last Available: "2024-12"
 Item	Great Wolf's left paw	Critical Hit Percent: +10, Spooky Damage: +10, Stench Damage: +10, Hot Damage: +10, Cold Damage: +10, Sleaze Damage: +10, Never Fumble, Class: "Seal Clubber"
 # green balloon
 Item	green LavaCo Lamp&trade;	Adventures: +5, Rollover Effect: "Green Peace", Rollover Effect Duration: 50
 Item	green peawee marble	Stench Spell Damage: +30
 Item	Grey Guanon	Stench Damage: +5, Damage Aura: 1
 Item	grisly shield	Weapon Damage: +50, PvP Fights: +5, Slime Hates It: +1, Damage Reduction: 13
-Item	gunwale	Muscle Percent: +25, Maximum HP: +50, Damage Absorption: +75, Damage Reduction: 9
+Item	gunwale	Muscle Percent: +25, Maximum HP: +50, Damage Absorption: +75, Damage Reduction: 9, Last Available: "2023-12"
 Item	Guzzlr souvenir stein	Booze Drop: +50
 Item	Half a Purse	Experience: +1, Damage Reduction: 3, Smithsness: +5, Meat Drop: [2*K]
 # hand of Mr. Cards: Can be thrown
@@ -2456,6 +2467,7 @@ Item	magic lamp	Mysticality: +5
 Item	magical ice cubes	Cold Damage: +1
 Item	makeshift castanets	DB Combat Damage: +10, Class: "Disco Bandit"
 # malware injector: CyberRealm: Infect a process (1 RAM, 30 damage per round)
+Item	malware injector	Last Available: "2025-12"
 Item	maple magnet	Maximum HP: +100, Weapon Drop: +50, Accessory Drop: +50, Lasts Until Rollover
 Item	marble mignonette bowl	MP Regen Min: 4, MP Regen Max: 8, Cold Spell Damage: +40, Thorns: 1
 Item	marinara jug	Spell Damage: +30, Class: "Sauceror"
@@ -2463,7 +2475,7 @@ Item	marionette	Mysticality: +3
 Item	marionette collective	Mysticality: +3
 Item	martini dregs	Moxie Percent: +50
 # McHugeLarge left pole: Slash an enemy to make them easier to track
-Item	McHugeLarge left pole	Mysticality: +10, Spell Damage: +10, Spell Damage Percent: +25, McHugeLarge
+Item	McHugeLarge left pole	Mysticality: +10, Spell Damage: +10, Spell Damage Percent: +25, Last Available: "2025-01", McHugeLarge
 Item	meat shield	Meat Drop: +3, Damage Reduction: 3
 Item	Medallion of the Ventrilo Prince	Moxie Percent: +12
 Item	Mer-kin begsign	Weakens Monster, Meat Drop: [40*env(underwater)]
@@ -2487,7 +2499,7 @@ Item	Microplushie: Otakulone	Maximum MP: +4
 Item	Microplushie: Raverdrine	Maximum HP: +8
 Item	Microplushie: Sororitrate	Sleaze Damage: +2
 # military orb: Detonate to destroy a monster
-Item	military orb	MP Regen Min: 10, MP Regen Max: 15, Mysticality: +15
+Item	military orb	MP Regen Min: 10, MP Regen Max: 15, Mysticality: +15, Last Available: "2024-12"
 Item	mini kiwi whipping stick	Sleaze Damage: +5, Experience: +2
 # mini-zeppelin
 Item	miniature candle	Experience: +3, Item Drop: +20, Lasts Until Rollover
@@ -2496,10 +2508,10 @@ Item	misfit dolly	Moxie: +5, Spooky Damage: +5
 Item	misfit hobby horse	Muscle: +5, Stench Damage: +5
 Item	misfit teddy bear	Mysticality: +5, Hot Damage: +5
 Item	Mixed Garbanzos and Chickpeas	Maximum HP: [5*(1+skill(Beanweaver))], Maximum MP: [5*(1+skill(Beanweaver))], Spell Damage: [10*(1+skill(Beanweaver))], HP Regen Min: [(1+skill(Beanweaver))], HP Regen Max: [3*(1+skill(Beanweaver))], MP Regen Min: [(1+skill(Beanweaver))], MP Regen Max: [3*(1+skill(Beanweaver))]
-Item	moaiball	Muscle Percent: +25, Item Drop: +10, Initiative: +50
+Item	moaiball	Muscle Percent: +25, Item Drop: +10, Initiative: +50, Last Available: "2024-12"
 Item	mole skin notebook	Moxie: +1
 # moss megaphone: Whisper with the voice of the Great Turtle Spirits
-Item	moss megaphone	Muscle: +10, Cold Resistance: +2
+Item	moss megaphone	Muscle: +10, Cold Resistance: +2, Last Available: "2024-12"
 Item	moxie magnet	Moxie Controls MP
 Item	Mr. Balloon	Muscle: +3, Mysticality: +3, Moxie: +3
 # Mr. Haggis: Haggis!
@@ -2542,7 +2554,7 @@ Item	Oscus's garbage can lid	Stench Damage: +20, Damage Reduction: 15, Thorns: 1
 # Ouija Board, Ouija Board: Gain the favor of the Turtle Spirits more quickly
 Item	Ouija Board, Ouija Board	Familiar Weight: +5, Smithsness: +5, Class: "Turtle Tamer", Damage Reduction: 7, Muscle Percent: [2*K]
 Item	outmoded fidget toy	Experience: +2
-Item	oversized monocle on a stick	Mysticality Percent: +25, Item Drop: +25, Lasts Until Rollover
+Item	oversized monocle on a stick	Mysticality Percent: +25, Item Drop: +25, Lasts Until Rollover, Last Available: "2024-10"
 Item	ox-head shield	Maximum HP: +100, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 26, PvP Fights: +8, Never Fumble, Lasts Until Rollover
 # oyster basket
 Item	oyster egg balloon	Muscle: +5, Mysticality: +5, Moxie: +5
@@ -2558,9 +2570,9 @@ Item	peanut brittle shield	Candy Drop: +100, Damage Reduction: 3
 Item	penguin skin buckler	Moxie: +5, Damage Reduction: 5
 Item	penguin thesaurus	Mysticality: +1, Maximum HP: +5, Maximum MP: +5
 # petrified wood water purifier: Adds cold and sleaze damage to spells
-Item	petrified wood water purifier	Experience (Mysticality): +3, Meat Drop: +20
+Item	petrified wood water purifier	Experience (Mysticality): +3, Meat Drop: +20, Last Available: "2025-12"
 # photo booth supply list: Lets you find photo booth supplies
-Item	photo booth supply list	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Damage Reduction: 20, Lasts Until Rollover
+Item	photo booth supply list	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Damage Reduction: 20, Lasts Until Rollover, Last Available: "2024-10"
 Item	pilgrim shield	Maximum HP: +30, Weapon Damage: +15, Experience: +3, HP Regen Min: 10, HP Regen Max: 12, Weapon Drop: +50, Damage Reduction: [L], Softcore Only
 Item	pirate hook	Weapon Damage: +3
 Item	pixel grappling hook	Initiative: +40, Item Drop: +10
@@ -2697,6 +2709,7 @@ Item	stuffed dinosaur	Muscle: +3, Mysticality: +3, Moxie: +3
 # stuffed ghuol whelp
 # stuffed hand turkey
 # stuffed key
+Item	stuffed kraken	Last Available: "2023-12"
 # stuffed MagiMechTech MicroMechaMech
 # stuffed martini
 # stuffed Meat
@@ -2752,6 +2765,7 @@ Item	toy Crimbot super fist	Damage Reduction: 10, Crimbot Outfit Power: +1
 Item	Trader Olaf's Exotic Stinkbeans	Stench Spell Damage: [15*(1+skill(Beanweaver))]
 Item	trench lighter	Experience Percent (Muscle): +10, Experience Percent (Mysticality): +10, Experience Percent (Moxie): +10
 # trojan horseshoe: CyberRealm: Occasionally find 0s after combat
+Item	trojan horseshoe	Last Available: "2025-12"
 Item	tropical paperweight	Experience: +1, Stat Tuning: "Muscle"
 # Tuesday's ruby: Has day-dependent effects which are hard-coded
 Item	Tuesday's ruby	Variable
@@ -2764,7 +2778,7 @@ Item	uncursed arcane orb	Spooky Damage: +1, Stench Damage: +1, Hot Damage: +1, C
 Item	uncursed stats	Experience: +1
 Item	Unkillable Skeleton's shield	Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Maximum MP: -300, Damage Reduction: 23, Thorns: 1
 # UV-resistant compass: Aids in desert exploration
-Item	Val-U Brand Every Bean Salad	Hot Spell Damage: +5, Cold Spell Damage: +5, Spooky Spell Damage: +5, Stench Spell Damage: +5, Sleaze Spell Damage: +5
+Item	Val-U Brand Every Bean Salad	Hot Spell Damage: +5, Cold Spell Damage: +5, Spooky Spell Damage: +5, Stench Spell Damage: +5, Sleaze Spell Damage: +5, Last Available: "2016-02"
 Item	vampire pellet	MP Regen Min: 4, MP Regen Max: 8, Spooky Damage: +10, Spooky Spell Damage: +20
 Item	velcro shield	Mysticality Percent: +10, Damage Reduction: 24, Weapon Drop: +25
 # velour valise: Triples the damage and deleveling of Tango of Terror
@@ -2773,6 +2787,7 @@ Item	vengeful spirit	Hot Spell Damage: +80
 Item	Victor, the Insult Comic Hellhound Puppet	Monster Level: +5
 Item	vinyl shield	Moxie Percent: +10, Damage Reduction: 24, Monster Level: +25
 # visual packet sniffer: CyberRealm:  Gives a chance for additional 1s to drop after combat
+Item	visual packet sniffer	Last Available: "2025-12"
 Item	voodoo doll	Mysticality: +1
 Item	wad of Crovacite	Muscle: +5, Mysticality: +5, Moxie: +5, Spooky Damage: +5
 Item	Wal-Mart snowglobe	Muscle Percent: +40, Experience (Muscle): +4, Familiar Weight: +5
@@ -2798,7 +2813,7 @@ Item	zoological sample kit	Lasts Until Rollover
 
 # Accessories section of modifiers.txt
 
-Item	&quot;I survived Y2K&quot; T-Shirt	Maximum HP: +2, Maximum MP: +2, Adventures: +2, Experience (Muscle): +2, Experience (Mysticality): +2, Experience (Moxie): +2, Single Equip
+Item	&quot;I survived Y2K&quot; T-Shirt	Maximum HP: +2, Maximum MP: +2, Adventures: +2, Experience (Muscle): +2, Experience (Mysticality): +2, Experience (Moxie): +2, Single Equip, Last Available: "2023-06"
 Item	&quot;I Voted!&quot; sticker	Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Lasts Until Rollover
 Item	acid-squirting flower	Single Equip, Thorns: 1
 # actual reality goggles: Reveals peoples' true nature

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -73,20 +73,20 @@
 # Hats section of modifiers.txt
 
 Item	4-dimensional fez	Maximum Hooch: +4, Familiar Effect: "atk, 1xLep, cap 12"
-Item	8-billed baseball cap	Muscle Percent: +15, Initiative: +30, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 12"
+Item	8-billed baseball cap	Muscle Percent: +15, Initiative: +30, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 # Admiral's hat: +50 Skeleton Anger
-Item	Admiral's hat	Adventures: +5, Moxie Percent: +30, Familiar Effect: "atk"
+Item	Admiral's hat	Adventures: +5, Moxie Percent: +30, Last Available: "2011-05", Familiar Effect: "atk"
 Item	adobe ayam	Experience (Mysticality): [3+3*min(1,effect(Adobe Ayam Subscription))], Meat Drop: [20+20*min(1,effect(Adobe Ayam Subscription))], Last Available: "2024-12"
 Item	aerated diving helmet	Stench Resistance: +3, Item Drop: -25, Initiative: -50, Adventure Underwater, Familiar Effect: "0.5xPotato"
 # aerogel akubra: Lets you use Spirit Snap multiple times per fight
-Item	aerogel akubra	Muscle: +10, Meat Drop: +10
+Item	aerogel akubra	Muscle: +10, Meat Drop: +10, Last Available: "2017-12"
 Item	All-Hallow's Steve's fright wig	Sleaze Damage: +20, Spooky Resistance: +2, Candy Drop: +20, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
-Item	Amoon-Ra Cowtep's nemes	Mysticality Percent: +35, Spell Damage: +25, Spell Critical Percent: +15, Familiar Effect: "atk, 1xVolley"
+Item	Amoon-Ra Cowtep's nemes	Mysticality Percent: +35, Spell Damage: +25, Spell Critical Percent: +15, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 Item	Ancient Saucehelm	Mysticality: +11, Spell Damage: +11, Class: "Sauceror", Familiar Effect: "3xGhuol, cap 25"
 Item	ancient turtle shell helmet	Meat Drop: +10, Familiar Effect: "hot atk, cap 8"
 Item	anniversary concrete fedora	Muscle: +1, Mysticality: +1, Moxie: +1, Familiar Effect: "5xVolley, 5xLep, cap 2"
 Item	antique helmet	Initiative: -10, Spooky Resistance: +2, Breakable, Familiar Effect: "0.5xPotato, 0.5xFairy"
-Item	antique nutcracker hat	Initiative: +15, Moxie Percent: +15
+Item	antique nutcracker hat	Initiative: +15, Moxie Percent: +15, Last Available: "2019-12"
 # Apriling band helmet: Conduct the Band!
 Item	Apriling band helmet	Maximum HP: +25, Maximum MP: +25, Never Fumble, Negative Status Resist, Meat Drop: +40, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10
 Item	asbestos helmet turtle	Hot Resistance: +2, Familiar Effect: "hot atk, 1xFairy, cap 20"
@@ -95,51 +95,51 @@ Item	astral chapeau	Mysticality Percent: +25, Spell Damage: +20, MP Regen Min: 3
 Item	astronaut helmet	Cold Resistance: +3, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2024-10"
 Item	balaclava	Cold Resistance: +1, Familiar Effect: "cold atk, 1.5xLep, cap 12"
 Item	balloon helmet	Damage Absorption: +20, Clowniness: 25, Familiar Effect: "3xFairy, cap 12"
-Item	bark beret	Damage Reduction: 4, Familiar Effect: "2xPotato, 2.5xLep, cap 10"
+Item	bark beret	Damage Reduction: 4, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 Item	Baron von Ratsworth's tophat	Muscle: +5, Mysticality: +5, Moxie: +5, Familiar Effect: "1xPotato, 3xGhuol, cap 18"
-Item	barrelhead	Maximum MP: +25, MP Regen Min: 3, MP Regen Max: 5
+Item	barrelhead	Maximum MP: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-09"
 Item	barskin hat	Muscle: +1, Familiar Effect: "atk, 1xVolley, cap 13"
 Item	basic meat fez	Moxie: +2, Mysticality: +1, Familiar Effect: "3xLep, cap 11"
 Item	basic meat helmet	Muscle: +1, Familiar Effect: "sleaze atk, 2xFairy, cap 10"
 Item	bat hat	Mysticality: +9, Item Drop: +5, Familiar Effect: "spooky atk, 1xVolley, cap 45"
 Item	battered old top-hat	Maximum HP: +500, Muscle Percent: +5, Familiar Effect: "0.5xVolley, 0.75xFairy"
-Item	bauxite beret	Muscle: +11, Maximum HP: [23+floor(pref(daycareToddlers)^0.35)], Weapon Damage: [37+floor(pref(daycareToddlers)^0.35)]
+Item	bauxite beret	Muscle: +11, Maximum HP: [23+floor(pref(daycareToddlers)^0.35)], Weapon Damage: [37+floor(pref(daycareToddlers)^0.35)], Last Available: "2018-12"
 Item	beer helmet	Maximum MP: +40, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 Item	beholed bedsheet	Familiar Effect: "8xVolley, 8xLep, cap 2"
 # bellhop's hat: Helps you blend in at the Ice Hotel
-Item	bellhop's hat	Muscle: +10, Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
+Item	bellhop's hat	Muscle: +10, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
 Item	big bad voodoo mask	Mysticality: +7, Spell Damage: +15, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
-Item	Big Candy's tophat	Candy Drop: +25, Damage Reduction: 5, Familiar Effect: "1xGhoul, 1xFairy, cap 25"
-Item	biker's hat	Moxie Percent: +40, Booze Drop: +40, Pickpocket Chance: +20, Familiar Effect: "atk"
-Item	biomechanical crimborg helmet	Hot Damage: +5, Stench Damage: +5, Familiar Effect: "atk, 1xFairy, cap 37"
+Item	Big Candy's tophat	Candy Drop: +25, Damage Reduction: 5, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
+Item	biker's hat	Moxie Percent: +40, Booze Drop: +40, Pickpocket Chance: +20, Last Available: "2015-08", Familiar Effect: "atk"
+Item	biomechanical crimborg helmet	Hot Damage: +5, Stench Damage: +5, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 # biphasic molecular oculus: Allows advanced monster research
 # birdseed hat: Attracts chickens
 Item	black cowboy hat	Muscle: +8, Weapon Damage: +8, Familiar Effect: "1xBarrr, 1xLep, cap 41"
 Item	black helmet	Maximum HP: +30, Familiar Effect: "1xFairy, cap 40"
-Item	blue traffic cone	Moxie: +3, Hot Resistance: +2, Familiar Effect: "2xLep, 2xFairy, cap 15"
-Item	bonedanna	Spooky Resistance: +3, Weapon Damage: +20, Familiar Effect: "atk, cap 30"
+Item	blue traffic cone	Moxie: +3, Hot Resistance: +2, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
+Item	bonedanna	Spooky Resistance: +3, Weapon Damage: +20, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
 Item	Boris's Helm	Initiative: +25, Weapon Damage Percent: +50, Familiar Weight: +5, MP Regen Min: [floor(L/2)+1], MP Regen Max: [floor(L/2)+3], Free Pull, Minstrel Level: +1, Familiar Effect: "atk, MP regen, cap 25"
 Item	Boris's Helm (askew)	Initiative: +25, Monster Level: +15, Weapon Damage Percent: +50, Familiar Weight: +5, MP Regen Min: [floor(L/2)+1], MP Regen Max: [floor(L/2)+3], Free Pull, Minstrel Level: +1, Familiar Effect: "atk, MP regen, cap 25"
 Item	bounty-hunting helmet	Item Drop: +20, Familiar Effect: "1.5xFairy, cap 25"
-Item	bowler	Muscle: +5, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
+Item	bowler	Muscle: +5, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 # brainwave-controlled unicorn horn: Enables Friendship.  And Goring.
-Item	brainwave-controlled unicorn horn	Maximum HP: +20, Maximum MP: +20, Familiar Effect: "atk, 5xVolley, cap 2"
-Item	BRICKO hat	Maximum MP: +3, Familiar Effect: "atk, cap 7"
+Item	brainwave-controlled unicorn horn	Maximum HP: +20, Maximum MP: +20, Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
+Item	BRICKO hat	Maximum MP: +3, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
 Item	Brimstone Beret	Moxie Percent: +50, Muscle Percent: -20, Four Songs, Brimstone, Familiar Effect: "1xVolley, 1xLep"
-Item	Brogre bucket hat	Combat Rate: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 14"
+Item	Brogre bucket hat	Combat Rate: +5, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 Item	brown felt tophat	Mysticality: +5, Familiar Effect: "1xLep, cap 37"
 Item	brown paper bag mask	Moxie: +2, Maximum HP: +3, Maximum MP: +3
 Item	bubblewrap bottlecap turtleban	Mysticality: +3, Maximum MP: +5, MP Regen Min: 2, MP Regen Max: 3, Familiar Effect: "1xPotato, 2xLep, cap 17"
 Item	bugbear beanie	Familiar Effect: "atk, cap 7"
 Item	bum cheek	Stench Resistance: +1, Familiar Effect: "stench atk, 1xVolley, cap 5"
-Item	burning paper hat	Stench Resistance: +3, Maximum HP: +25, Maximum MP: +25, HP Regen Min: 6, HP Regen Max: 10, MP Regen Min: 6, MP Regen Max: 10, Lasts Until Rollover
+Item	burning paper hat	Stench Resistance: +3, Maximum HP: +25, Maximum MP: +25, HP Regen Min: 6, HP Regen Max: 10, MP Regen Min: 6, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2018-12"
 Item	catskin cap	Muscle: +9, Maximum HP: +40, Familiar Effect: "1xVolley, 1xBarrr, cap 45"
 Item	centurion helmet	Muscle: +7, Mysticality: +7, Moxie: +7, Familiar Effect: "1xFairy, atk, cap 25"
 # Cerebral Cloche: Jellyfish Vision
-Item	Cerebral Cloche	Maximum HP: +15, Familiar Effect: "1.5xLep, cap 22"
+Item	Cerebral Cloche	Maximum HP: +15, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
 # chalk chapeau: Weakens enemies who hit you
-Item	chalk chapeau	PvP Fights: +3, HP Regen Min: 3, HP Regen Max: 6, MP Regen Min: 3, MP Regen Max: 6
-Item	cheerful antler hat	Cold Resistance: +2, Moxie: -15
+Item	chalk chapeau	PvP Fights: +3, HP Regen Min: 3, HP Regen Max: 6, MP Regen Min: 3, MP Regen Max: 6, Last Available: "2019-12"
+Item	cheerful antler hat	Cold Resistance: +2, Moxie: -15, Last Available: "2017-12"
 Item	chef's hat	Mysticality: +2, MP Regen Min: 1, MP Regen Max: 1, Familiar Effect: "atk, 3xLep, cap 7"
 Item	chiffon chapeau	Experience (Muscle): +2, Spooky Damage: +10, Spooky Spell Damage: +10, Last Available: "2023-12", Damage Aura: 1
 Item	chrome helmet turtle	Muscle: +5, Mysticality: +5, Moxie: +5, Familiar Effect: "cold atk, 1xFairy, cap 30"
@@ -159,38 +159,38 @@ Item	cr&ecirc;epy mask	Mysticality: +2, Maximum MP: +5, Familiar Effect: "spooky
 Item	crappy Mer-kin mask	Stench Resistance: +3, Item Drop: -25, Initiative: -50, Adventure Underwater, Familiar Effect: "hot atk, 1xBarrr"
 # crepe paper phrygian cap: Pull down to avoid monsters
 Item	crepe paper phrygian cap	Muscle: +10, Stench Damage: +10, Stench Spell Damage: +10, Last Available: "2025-12"
-Item	Crimbo hat	Spooky Resistance: +1, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+Item	Crimbo hat	Spooky Resistance: +1, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
 Item	Crimbuccaneer tricorn	Last Available: "2023-12"
 Item	Crown of the Goblin King	Muscle: +10, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 # Crown of Thrones: Put a Familiar In It!
 # Crown of Thrones: That Familiar gains 1 Experience per Fight
-Item	Crown of Thrones	Softcore Only
+Item	Crown of Thrones	Softcore Only, Last Available: "2010-05"
 Item	crown-shaped beanie	Slime Resistance: +1, Food Drop: +20, Initiative: +20, Familiar Effect: "1xBarrr, 1xGhuol"
 Item	crumpled felt fedora	Familiar Weight: +10, Muscle Percent: +5, Familiar Effect: "0.75xVolley, 0.75xLep"
 Item	cursed eyepatch	Mysticality: +15, Familiar Effect: "spooky atk, 1xBarrr"
-Item	cursed tricorn hat	Mysticality: +25, Experience: +10, PvP Fights: +5
+Item	cursed tricorn hat	Mysticality: +25, Experience: +10, PvP Fights: +5, Last Available: "2019-07"
 Item	cybervisor	RAM: +3, Last Available: "2025-12"
 # Daylight Shavings Helmet: Keeps your facial hair stylish at all times
-Item	Daylight Shavings Helmet	Experience: +3, Adventures: +5, Familiar Weight: +5
+Item	Daylight Shavings Helmet	Experience: +3, Adventures: +5, Familiar Weight: +5, Last Available: "2021-11"
 Item	demon-horned hat	Moxie: +4, Familiar Effect: "hot atk, 1xLep, cap 17"
 # depleted Crimbonium football helmet: Reduce all damage taken from monster attacks by 50%
-Item	depleted Crimbonium football helmet	Initiative: -50
-Item	depleted Grimacite ninja mask	Moxie Percent: [5*G], PvP Fights: [G], Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+Item	depleted Crimbonium football helmet	Initiative: -50, Last Available: "2021-12"
+Item	depleted Grimacite ninja mask	Moxie Percent: [5*G], PvP Fights: [G], Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
 Item	dice-print do-rag	Random Monster Modifiers: +1
 Item	dilapidated wizard hat	Hot Damage: +10, Hot Spell Damage: +15, Familiar Effect: "cap 31"
 # Dinsey mascot mask: Changes Your Avatar
-Item	Dinsey mascot mask	Item Drop: -50, Initiative: -100
-Item	Dinsey's brain	Stench Spell Damage: +30, Mysticality Percent: +30
+Item	Dinsey mascot mask	Item Drop: -50, Initiative: -100, Last Available: "2015-04"
+Item	Dinsey's brain	Stench Spell Damage: +30, Mysticality Percent: +30, Last Available: "2015-04"
 Item	Disco 'Fro Pick	Moxie: +11, Initiative: +11, Class: "Disco Bandit", Familiar Effect: "3xGhuol, cap 25"
 Item	disco mask	Moxie: +1, Familiar Effect: "atk, cap 2"
 # Dolph Bossin's Crimbo hat: Dolphins will occasionally return items they've stolen from you
-Item	Dolph Bossin's Crimbo hat	Cold Damage: +25, Hot Resistance: +3, PvP Fights: +4
+Item	Dolph Bossin's Crimbo hat	Cold Damage: +25, Hot Resistance: +3, PvP Fights: +4, Last Available: "2019-12"
 Item	Dolphin King's crown	Muscle: +2, Mysticality: +2, Moxie: +2, Familiar Effect: "atk, 2xGhuol, cap 8"
 # double-ice cap: Stuns opponents who hit you
-Item	double-ice cap	MP Regen Min: 5, MP Regen Max: 9, Cold Damage: +10, Familiar Effect: "1xPotato, 1xFairy, cap 17"
+Item	double-ice cap	MP Regen Min: 5, MP Regen Max: 9, Cold Damage: +10, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 Item	draggin' ball hat	Moxie: +6, Muscle: -3, Familiar Effect: "atk, 1xVolley, cap 25"
 Item	dreadful fedora	Spooky Damage: +25, Spooky Spell Damage: +25, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
-Item	driftwood hat	Moxie: +5, Moxie Percent: +1, Damage Absorption: +1, Damage Reduction: 1, Ranged Damage: +1, Ranged Damage Percent: +1, Initiative: +1, Experience (Moxie): +2, Experience Percent (Moxie): +1, Lasts Until Rollover
+Item	driftwood hat	Moxie: +5, Moxie Percent: +1, Damage Absorption: +1, Damage Reduction: 1, Ranged Damage: +1, Ranged Damage Percent: +1, Initiative: +1, Experience (Moxie): +2, Experience Percent (Moxie): +1, Lasts Until Rollover, Last Available: "2019-07"
 # drippy diadem: Significant protection from damage in The Drip
 Item	drippy diadem	Drippy Resistance: +15
 Item	duct tape fedora	Mysticality: +12, Maximum MP: +40, Familiar Effect: "1xBarrr, 1xLep, cap 48"
@@ -202,47 +202,47 @@ Item	eight-gallon hat	Muscle: +8, Mysticality: +8, Moxie: +8, Experience: +3
 Item	El Sombrero De Lopez	Moxie: +11, Ranged Damage: +7, Class: "Accordion Thief", Familiar Effect: "3xGhuol, cap 25"
 Item	El Vibrato helmet	Familiar Effect: "0.5xPotato, 1xFairy"
 Item	Elder Turtle Shell	Muscle: +11, Familiar Weight: +3, Class: "Turtle Tamer", Familiar Effect: "3xGhuol, cap 25"
-Item	eldritch hat	Spooky Damage: +40, Spooky Spell Damage: +40, Spooky Resistance: +3
+Item	eldritch hat	Spooky Damage: +40, Spooky Spell Damage: +40, Spooky Resistance: +3, Last Available: "2016-11"
 # eldritch scanner: Helps with Science
-Item	eldritch scanner	Mysticality Limit: 100
-Item	electrician's hardhat	Muscle Percent: +40, Weapon Damage: +40, HP Regen Min: 20, HP Regen Max: 40, Familiar Effect: "atk"
+Item	eldritch scanner	Mysticality Limit: 100, Last Available: "2017-02"
+Item	electrician's hardhat	Muscle Percent: +40, Weapon Damage: +40, HP Regen Min: 20, HP Regen Max: 40, Last Available: "2015-08", Familiar Effect: "atk"
 Item	eleven-gallon hat	Muscle: +11, Mysticality: +11, Moxie: +11, Experience: +3
 Item	Elf Guard patrol cap	Last Available: "2023-12"
-Item	Elf Guard red and white beret	PvP Fights: [+5*event(December)]
-Item	elf ploughshare	Maximum HP: +30, Maximum MP: +30
+Item	Elf Guard red and white beret	PvP Fights: [+5*event(December)], Last Available: "2023-12"
+Item	elf ploughshare	Maximum HP: +30, Maximum MP: +30, Last Available: "2015-12"
 Item	enchanted eyepatch	Mysticality: +5, Familiar Effect: "4xBarrr, cap 8"
 Item	enchantlers	Hot Spell Damage: +10, Familiar Effect: "hot atk, 1xLep, cap 28"
 Item	extra-large palm-frond toupee	Experience: +2, Familiar Effect: "1xVolley, 1xPotato, cap 37"
-Item	extra-wide head candle	Weapon Damage Percent: +100, HP Regen Min: 10, HP Regen Max: 20, Maximum HP Percent: +100, Lasts Until Rollover
+Item	extra-wide head candle	Weapon Damage Percent: +100, HP Regen Min: 10, HP Regen Max: 20, Maximum HP Percent: +100, Lasts Until Rollover, Last Available: "2021-08"
 Item	eXtreme scarf	Mysticality: +5, Familiar Effect: "atk, 1xBarrr, cap 25"
 Item	eyepatch	Moxie: +2, Familiar Effect: "3xBarrr, cap 6"
 Item	f3d0r4	Moxie: +6, Familiar Effect: "atk, 1xLep, cap 27"
 Item	fake arrow-through-the-head	Moxie Percent: +25, Combat Rate: -5, Lasts Until Rollover, Last Available: "2024-10"
-Item	fancy ball mask	Moxie Percent: +10, Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+Item	fancy ball mask	Moxie Percent: +10, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
 Item	fancy tophat	Mysticality Percent: +15, Familiar Effect: "1xBarrr, cap 25"
-Item	FantasyRealm Mage's Hat	Mysticality: +15
-Item	FantasyRealm Rogue's Mask	Moxie: +15
-Item	FantasyRealm Warrior's Helm	Muscle: +15
-Item	feathered headdress	Mysticality Percent: +40, Food Drop: +40, MP Regen Min: 10, MP Regen Max: 20, Familiar Effect: "atk, 1xVolley"
-Item	fedora-mounted fountain	Monster Level: +20, Hot Damage: +20, Hot Spell Damage: +10, Lasts Until Rollover
-Item	festive holiday hat	Moxie: +1, Cold Resistance: +1, Familiar Effect: "1xFairy, cap 7"
+Item	FantasyRealm Mage's Hat	Mysticality: +15, Last Available: "2018-04"
+Item	FantasyRealm Rogue's Mask	Moxie: +15, Last Available: "2018-04"
+Item	FantasyRealm Warrior's Helm	Muscle: +15, Last Available: "2018-04"
+Item	feathered headdress	Mysticality Percent: +40, Food Drop: +40, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+Item	fedora-mounted fountain	Monster Level: +20, Hot Damage: +20, Hot Spell Damage: +10, Lasts Until Rollover, Last Available: "2021-07"
+Item	festive holiday hat	Moxie: +1, Cold Resistance: +1, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 Item	fez of etymology	Moxie: +7, Familiar Effect: "1xLep, cap 30"
 # fiberglass fedora: Doubles the effectiveness of The Sonata of Sneakiness and Carlweathers Cantata of Confrontation
-Item	fiberglass fedora	Experience (Moxie): +3, Familiar Weight: +5
+Item	fiberglass fedora	Experience (Moxie): +3, Familiar Weight: +5, Last Available: "2018-12"
 # filter helmet: Provides protection against toxic alien atmospheres
-Item	filter helmet	Lasts Until Rollover
+Item	filter helmet	Lasts Until Rollover, Last Available: "2017-04"
 Item	filthy knitted dread sack	Stench Damage: +3, Familiar Effect: "1xVolley, 1xPotato, cap 15"
-Item	fire	Initiative: +10, Hot Damage: +7, Familiar Effect: "hot atk, 1xVolley, cap 2"
+Item	fire	Initiative: +10, Hot Damage: +7, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 # fireman's helmet: +1 FDKOL Commendation per Fire
-Item	fireman's helmet	Hot Resistance: +3, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Familiar Effect: "cold atk"
-Item	fishin' hat	Fishing Skill: +5
+Item	fireman's helmet	Hot Resistance: +3, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2012-07", Familiar Effect: "cold atk"
+Item	fishin' hat	Fishing Skill: +5, Last Available: "2016-04"
 Item	five-gallon hat	Muscle: +5, Mysticality: +5, Moxie: +5, Experience: +3
 # flagstone fez: Unleash dark rituals on your unsuspecting foes
-Item	flagstone fez	Mysticality Percent: +20, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5
+Item	flagstone fez	Mysticality Percent: +20, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Last Available: "2022-12"
 Item	flaming leaf crown	Cold Resistance: +5, Hot Damage: +10, Hot Spell Damage: +10, Experience: +3, PvP Fights: +3, Adventures: +3
 # flatusaur gasmask: Protects against flatusaurus emissions
 Item	floaty rock helmet	Spell Critical Percent: +10, Familiar Effect: "1xGhuol, cap 25"
-Item	foam commodore's hat	Weapon Damage Percent: +25, Spell Damage Percent: +25, Familiar Effect: "atk, 1xVolley"
+Item	foam commodore's hat	Weapon Damage Percent: +25, Spell Damage Percent: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
 Item	foolscap fool's cap	Moxie: +2, Mysticality: -2, Clowniness: 25, Familiar Effect: "3xVolley, cap 10"
 Item	football helmet	Familiar Effect: "atk, cap 37"
 Item	four-gallon hat	Muscle: +4, Mysticality: +4, Moxie: +4, Experience: +3
@@ -254,58 +254,58 @@ Item	fuzzy busby	Muscle: +11, Weapon Damage: +10, Familiar Effect: "1.5xVolley, 
 Item	fuzzy earmuffs	Mysticality: +11, MP Regen Min: 2, MP Regen Max: 3, Familiar Effect: "1.5xVolley, cap 32"
 Item	fuzzy montera	Moxie: +7, Initiative: +7, Ranged Damage: +7, Familiar Effect: "1.5xVolley, cap 32"
 # gabardine garibaldi: Increases the damage of Saucegeyser
-Item	gabardine garibaldi	Spell Damage: +10, Maximum MP: +20
+Item	gabardine garibaldi	Spell Damage: +10, Maximum MP: +20, Last Available: "2018-12"
 Item	ganger bandana	Muscle Percent: +5, Weapon Damage Percent: +15, Familiar Effect: "atk"
 Item	gasmask	Stench Resistance: +3, Familiar Effect: "1xBarrr, cap 12"
-Item	genie's turbane	Adventures: +2, Maximum HP: +10
+Item	genie's turbane	Adventures: +2, Maximum HP: +10, Last Available: "2018-02"
 Item	ghast iron Garibaldi	Spooky Damage: +10, Hot Damage: +10, Familiar Effect: "atk, 1xFairy, cap 14"
 Item	giant discarded bottlecap	Damage Reduction: 3, Mysticality: -10, Familiar Effect: "atk, 1xFairy, cap 38"
-Item	giant yellow hat	Familiar Damage: +10, Experience (familiar): +1, HP Regen Min: 4, HP Regen Max: 8, MP Regen Min: 4, MP Regen Max: 8, Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
-Item	gingerbread mask	Hat Drop: +25
-Item	gingerbread tophat	Mysticality: +10
+Item	giant yellow hat	Familiar Damage: +10, Experience (familiar): +1, HP Regen Min: 4, HP Regen Max: 8, MP Regen Min: 4, MP Regen Max: 8, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
+Item	gingerbread mask	Hat Drop: +25, Last Available: "2016-12"
+Item	gingerbread tophat	Mysticality: +10, Last Available: "2016-12"
 Item	goat beard	Mysticality: +3, Familiar Effect: "atk, 1xPotato, cap 15"
 # Goggles of Loathing: Makes you a better diver
 Item	Goggles of Loathing	Initiative: +50, Hot Resistance: +5, Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)], Cloathing, Familiar Effect: "1.5xVolley, 1.5xBarrr"
-Item	gold crown	Sleaze Resistance: +3, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4, Meat Drop: +10, Familiar Effect: "3xGhoul, cap 37"
+Item	gold crown	Sleaze Resistance: +3, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4, Meat Drop: +10, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 Item	goofily-plumed helmet	Familiar Effect: "atk, cap 17"
-Item	googly-ball hat	Mysticality: +10, Experience (Mysticality): +3
-Item	googly-heart hat	Moxie: +10, Experience (Moxie): +3
-Item	googly-star hat	Muscle: +10, Experience (Muscle): +3, Familiar Effect: "atk"
-Item	government-issued eyeshade	Experience Percent (Moxie): +10, Damage vs. Ghosts: +25, Pool Skill: +5
+Item	googly-ball hat	Mysticality: +10, Experience (Mysticality): +3, Last Available: "2010-06"
+Item	googly-heart hat	Moxie: +10, Experience (Moxie): +3, Last Available: "2010-06"
+Item	googly-star hat	Muscle: +10, Experience (Muscle): +3, Last Available: "2010-06", Familiar Effect: "atk"
+Item	government-issued eyeshade	Experience Percent (Moxie): +10, Damage vs. Ghosts: +25, Pool Skill: +5, Last Available: "2018-11"
 Item	governor's daughter's pearl hairpin	Moxie Percent: +20, Last Available: "2024-12"
-Item	grass hat	Maximum MP: +10, Familiar Effect: "2xVolley, 1xBarrr, cap 20"
+Item	grass hat	Maximum MP: +10, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 # gravy boat: Decreased Damage from Undead<br/>Improved Evil Suppression
 Item	gravyskin hat	Sleaze Damage: +11, Sleaze Spell Damage: +11, Last Available: "2024-12"
 Item	Great Wolf's headband	Muscle: +250, Maximum HP: +250, HP Regen Min: 50, HP Regen Max: 100, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
-Item	green cloth cap	Stench Resistance: +1, Maximum HP: +15, Maximum MP: +15, Moxie: +3, Familiar Effect: "atk, 1xVolley, cap 12"
-Item	green traffic cone	Moxie: +3, Stench Resistance: +2, Familiar Effect: "2xLep, 2xFairy, cap 15"
-Item	Grimacite gasmask	Weapon Damage: +15, Muscle Percent: [10*G], Familiar Effect: "1xLep, 1.5xFairy, cap 37"
-Item	Grimacite goggles	Adventures: +3, Mysticality Percent: [10*G], Familiar Effect: "1xVolley, 1xLep, cap 31"
+Item	green cloth cap	Stench Resistance: +1, Maximum HP: +15, Maximum MP: +15, Moxie: +3, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
+Item	green traffic cone	Moxie: +3, Stench Resistance: +2, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
+Item	Grimacite gasmask	Weapon Damage: +15, Muscle Percent: [10*G], Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
+Item	Grimacite goggles	Adventures: +3, Mysticality Percent: [10*G], Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 Item	grubby wool hat	Stench Damage: +15, Sleaze Damage: +15, Muscle: +15, Mysticality: +15, Moxie: +15
 Item	grungy bandana	Stench Damage: +10, Sleaze Damage: +10, Familiar Effect: "1xVolley, 0.5xPotato, cap 37"
 Item	guard turtle shell	Maximum HP: +50, Familiar Effect: "atk, 1xFairy, cap 40"
 # Guzzlr hat: Earn 25% more stats from Guzzlr deliveries
-Item	Hairpiece On Fire	Cold Resistance: +2, Adventures: +4, Smithsness: +5, Maximum MP: [K], Familiar Effect: "atk, 1xPotato, cap 25"
+Item	Hairpiece On Fire	Cold Resistance: +2, Adventures: +4, Smithsness: +5, Last Available: "2013-12", Maximum MP: [K], Familiar Effect: "atk, 1xPotato, cap 25"
 Item	hangman's hood	Muscle: +50, Weapon Damage: +50, Damage Reduction: 10
 Item	hardened slime hat	Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Damage Reduction: 10, Muscle Percent: +20, Familiar Effect: "1xFairy"
 Item	Hat O' Nine Tails	Moxie Percent: +9
 Item	hat of remembering	Maximum MP: +50, MP Regen Min: 8, MP Regen Max: 12, Mana Cost: -1, Lasts Until Rollover, Last Available: "2024-09"
 # hazmat helmet: Changes Your Avatar
-Item	hazmat helmet	Damage Absorption: +50, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 40, HP Regen Max: 60, Negative Status Resist
+Item	hazmat helmet	Damage Absorption: +50, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 40, HP Regen Max: 60, Negative Status Resist, Last Available: "2015-04"
 Item	head-mounted Trainbot	Item Drop: +5, Maximum MP: +5, Moxie: +5, Last Available: "2022-12"
-Item	headlamp	Item Drop: +15, Lasts Until Rollover
+Item	headlamp	Item Drop: +15, Lasts Until Rollover, Last Available: "2022-05"
 Item	heavy crown	Muscle: +5, Mysticality: +5, Moxie: +5, Familiar Damage: +5, Initiative: +15, Familiar Effect: "atk, 1xGhuol, cap 27"
-Item	Helm of the Scream Emperor	MP Regen Min: 1, MP Regen Max: 3, Experience: +2, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Familiar Effect: "spooky atk, 1xFairy, cap 30"
-Item	helm of the white knight	HP Regen Min: 2, HP Regen Max: 5, MP Regen Min: 2, MP Regen Max: 5, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Familiar Effect: "atk, 1xVolley, cap 15"
+Item	Helm of the Scream Emperor	MP Regen Min: 1, MP Regen Max: 3, Experience: +2, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
+Item	helm of the white knight	HP Regen Min: 2, HP Regen Max: 5, MP Regen Min: 2, MP Regen Max: 5, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 Item	helmet turtle	Muscle: +1, Familiar Effect: "atk, cap 2"
-Item	hemlock helm	Muscle Percent: +100, Monster Level: +30, PvP Fights: +5
-Item	high-temperature mining mask	Hot Resistance: +4, Item Drop: -100, Familiar Effect: "atk, cap 25"
+Item	hemlock helm	Muscle Percent: +100, Monster Level: +30, PvP Fights: +5, Last Available: "2020-08"
+Item	high-temperature mining mask	Hot Resistance: +4, Item Drop: -100, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 Item	Hodgman's porkpie hat	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, Hobo Power: +25, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 Item	Hollandaise helmet	Spell Damage: +1, Familiar Effect: "atk, cap 2"
 Item	honeycap	Moxie Percent: +5, Item Drop: +10, Ranged Damage: +15, Familiar Effect: "1xPotato, cap 43"
-Item	hot daub bun	Hot Damage: +9, Hot Spell Damage: +9, Familiar Effect: "hot atk, cap 21"
-Item	ice crown	Maximum HP: +30, Maximum MP: +30, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Lasts Until Rollover
-Item	ice pick	Item Drop: +15, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+Item	hot daub bun	Hot Damage: +9, Hot Spell Damage: +9, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+Item	ice crown	Maximum HP: +30, Maximum MP: +30, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2021-12"
+Item	ice pick	Item Drop: +15, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 Item	indie comic hipster glasses	Muscle: +5, Mysticality: +5, Moxie: +5, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 # insane tophat: We're All Mad Here!
 Item	insane tophat	Familiar Effect: "1xVolley, 1xLep, cap 7"
@@ -313,18 +313,18 @@ Item	insulting hat	PvP Fights: +3, Familiar Effect: "cap 2"
 Item	intimidating coiffure	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Familiar Effect: "hot afk, 1xPotato"
 Item	invisible bag	Familiar Effect: "8xVolley, 8xLep, cap 2"
 Item	irate sombrero	Weapon Damage: +3, Familiar Effect: "1xPotato, 3xLep, cap 11"
-Item	iron helmet	Cold Resistance: +2, MP Regen Min: 1, MP Regen Max: 2, Initiative: +10, Familiar Effect: "atk, 1xFairy, cap 25"
+Item	iron helmet	Cold Resistance: +2, MP Regen Min: 1, MP Regen Max: 2, Initiative: +10, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 # iron tricorn hat: Allows you to headbutt your foes
 Item	iron tricorn hat	Maximum HP: +40, Damage Reduction: 10, Lasts Until Rollover, Last Available: "2024-12"
 Item	ironic knit cap	Maximum MP: +20, Mysticality: +1, Familiar Effect: "1xVolley, 2xPotato, cap 10"
-Item	isotophat	Stench Damage: +10, Stench Spell Damage: +20, Familiar Effect: "stench atk, cap 25"
+Item	isotophat	Stench Damage: +10, Stench Spell Damage: +20, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 # Iunion Crown: Becomes more powerful as you adventure each day
-Item	Iunion Crown	Muscle: +10, Mysticality: +10, Moxie: +10, Item Drop: +10, Initiative: +10
+Item	Iunion Crown	Muscle: +10, Mysticality: +10, Moxie: +10, Item Drop: +10, Initiative: +10, Last Available: "2020-06"
 Item	Jarlsberg's hat	Mysticality: +5, MP Regen Min: 4, MP Regen Max: 5, Experience (Mysticality): +1
 # jewel-eyed wizard hat: Regenerate MP Based on Level
 # jewel-eyed wizard hat: +5 Duration to Buffs You Cast
 # jewel-eyed wizard hat: Allows casting of Magic Missile
-Item	jewel-eyed wizard hat	Maximum MP: +30, Mana Cost: -1, Softcore Only, MP Regen Min: [floor(L/2)+1], MP Regen Max: [floor(L/2)+3], Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
+Item	jewel-eyed wizard hat	Maximum MP: +30, Mana Cost: -1, Softcore Only, Last Available: "2006-07", MP Regen Min: [floor(L/2)+1], MP Regen Max: [floor(L/2)+3], Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 Item	Kentucky-style derby	Familiar Effect: "atk, cap 5"
 Item	kilopede skull	Ranged Damage: +10, Moxie: [4*L]
 Item	Knob Goblin elite helm	Muscle: +3, Familiar Effect: "2xFairy, cap 15"
@@ -332,11 +332,11 @@ Item	Knob Goblin harem veil	Stench Resistance: +1, Familiar Effect: "5xLep, cap 
 Item	Knob Goblin visor	Moxie: +3, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 Item	knobby helmet turtle	Weapon Damage: +1, Familiar Effect: "atk, 2xFairy, cap 5"
 Item	KoL Con 3-D Glasses	Familiar Effect: "8xLep, 1xFairy, cap 2"
-Item	lava balaclava	Hot Spell Damage: +50, MP Regen Min: 10, MP Regen Max: 12, Weapon Drop: +50
+Item	lava balaclava	Hot Spell Damage: +50, MP Regen Min: 10, MP Regen Max: 12, Weapon Drop: +50, Last Available: "2015-08"
 # leather aviator's cap: Kill 5% More Skeletons
-Item	leather aviator's cap	Adventures: +5, Damage Reduction: 1, Familiar Effect: "atk, cap 12"
+Item	leather aviator's cap	Adventures: +5, Damage Reduction: 1, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 Item	leather mask	Muscle: +3, Moxie: -3, Familiar Effect: "sleaze atk, 1xBarrr, cap 15"
-Item	lemon party hat	Candy Drop: +50, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12"
+Item	lemon party hat	Candy Drop: +50, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 Item	Lens of Hatred	Meat Drop: +15, Reduce Enemy Defense: 10, Spell Damage Percent: +60, Familiar Effect: "hot atk, 1xBarrr"
 # Lens of Violence: Allows you to discover your opponents' magical weaknesses
 Item	Lens of Violence	Item Drop: +15, Critical Hit Percent: +5, Weapon Damage Percent: +30, Familiar Effect: "atk, 1xBarrr"
@@ -345,15 +345,15 @@ Item	linoleum helmet turtle	Maximum HP: +10, Maximum MP: +10, Familiar Effect: "
 Item	literal bucket hat	Water: +5
 Item	longhaired hippy wig	Stench Damage: +20, Mysticality Percent: +5, Familiar Effect: "1xPotato, 1xGhuol"
 # loofah lumberjack's hat: Feels good on your head
-Item	loofah lumberjack's hat	Muscle: +10, HP Regen Min: 15, HP Regen Max: 25
+Item	loofah lumberjack's hat	Muscle: +10, HP Regen Min: 15, HP Regen Max: 25, Last Available: "2022-12"
 Item	lucky army helmet	Damage Absorption: +10, Maximum HP: +100, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Never Fumble, Last Available: "2024-12"
 Item	lynyrdskin cap	Initiative: +25, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 Item	MAHI fez	Moxie: +30, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 Item	maiden wig	Familiar Effect: "2xPotato, cap 8"
 Item	makeshift turban	Spooky Resistance: +2, Familiar Effect: "1.5xBarrr, 1xLep, cap 25", Blind
-Item	makeshift yakuza mask	Moxie: -10
+Item	makeshift yakuza mask	Moxie: -10, Last Available: "2013-12"
 Item	mantis skull	Ranged Damage: +15, Moxie: [5*L]
-Item	marble mariachi hat	Monster Level: +10, Ranged Damage Percent: +30, Thorns: 1
+Item	marble mariachi hat	Monster Level: +10, Ranged Damage Percent: +30, Last Available: "2019-12", Thorns: 1
 Item	mariachi hat	Moxie: +1, Familiar Effect: "atk, cap 2"
 Item	Mark I Steam-Hat	Mysticality: +5, Maximum HP: +20, Familiar Effect: "1xLep, cap 37"
 Item	Mark II Steam-Hat	Mysticality: +5, Maximum HP: +20, Initiative: +15, Familiar Effect: "1xLep, cap 37"
@@ -373,12 +373,12 @@ Item	Mer-kin scholar mask	Stench Resistance: +3, Item Drop: -25, Initiative: -50
 Item	Mer-kin sneakmask	Moxie Percent: +5, Initiative: +30, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
 Item	mesh cap	Muscle: +15, Moxie: -5, Familiar Effect: "atk, 1xVolley, cap 41"
 Item	metallic foil cat ears	Familiar Effect: "atk, cap 7", Alters Page Text
-Item	meteortarboard	MP Regen Min: 4, MP Regen Max: 8, Mysticality Percent: +15, Spell Critical Percent: +10
-Item	miming beret	Damage Reduction: 10, Stench Resistance: +3
+Item	meteortarboard	MP Regen Min: 4, MP Regen Max: 8, Mysticality Percent: +15, Spell Critical Percent: +10, Last Available: "2017-08"
+Item	miming beret	Damage Reduction: 10, Stench Resistance: +3, Last Available: "2017-12"
 Item	miner's helmet	Item Drop: +5, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 Item	Mohawk wig	Weapon Damage: +10, Familiar Effect: "1xPotato, 1xGhuol, cap 35"
 Item	moist sailor's cap	Muscle Percent: +10, Stench Damage: +20, Hot Resistance: +4, Familiar Effect: "stench atk"
-Item	Moonthril Circlet	Mysticality Percent: [15*G], Familiar Effect: "2xVolley, cap 25"
+Item	Moonthril Circlet	Mysticality Percent: [15*G], Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
 Item	moose antlers	Critical Hit Percent: +5, Familiar Effect: "atk, 1xLep, cap 27"
 # moss mitre: Lets you spend Soulsauce to heal
 Item	moss mitre	Mysticality: +10, Stench Resistance: +2, Last Available: "2024-12"
@@ -387,74 +387,74 @@ Item	muddy pirate hat	Item Drop: +5, Initiative: +20, Familiar Effect: "1xFairy,
 Item	mullet wig	Sleaze Damage: +2, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 Item	mummy costume	Familiar Effect: "1xVolley, 8xLep, cap 2"
 Item	mummy mask	Spooky Damage: +12, Familiar Effect: "1xBarrr, 1xFairy, cap 42"
-Item	murderbot mask	Muscle: +10, Maximum HP: +20, PvP Fights: +2, Avatar: "Murderbot"
-Item	mushroom cap	Monster Level: +25, Adventures: +5, PvP Fights: +5
+Item	murderbot mask	Muscle: +10, Maximum HP: +20, PvP Fights: +2, Avatar: "Murderbot", Last Available: "2017-04"
+Item	mushroom cap	Monster Level: +25, Adventures: +5, PvP Fights: +5, Last Available: "2020-03"
 # muskox-skin cap: +100% Meat Drops in the Canadian Wildlife Preserve
-Item	muskox-skin cap	Cold Resistance: +3, Meat Drop: [100*loc(The Canadian Wildlife Preserve)]
-Item	mutant crown	Monster Level: +15, Muscle Percent: +25, HP Regen Min: 25, HP Regen Max: 50, MP Regen Min: 25, MP Regen Max: 50
+Item	muskox-skin cap	Cold Resistance: +3, Last Available: "2018-12", Meat Drop: [100*loc(The Canadian Wildlife Preserve)]
+Item	mutant crown	Monster Level: +15, Muscle Percent: +25, HP Regen Min: 25, HP Regen Max: 50, MP Regen Min: 25, MP Regen Max: 50, Last Available: "2018-11"
 Item	nasty rat mask	Moxie: +9, Monster Level: -5, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 Item	neoprene skullcap	Moxie: +7, Familiar Effect: "atk, 1xFairy, cap 16"
 Item	nine-gallon hat	Muscle: +9, Mysticality: +9, Moxie: +9, Experience: +3
 # no hat: (May or May Not Truly Exist)
 Item	no hat	Lasts Until Rollover
-Item	noir fedora	Experience Percent (Moxie): +20, Moxie Percent: +20, HP Regen Min: 8, HP Regen Max: 10, MP Regen Min: 8, MP Regen Max: 10
-Item	norwhal helmet	Experience (Mysticality): +2, Spell Damage Percent: +60, Booze Drop: +60, Familiar Effect: "atk"
+Item	noir fedora	Experience Percent (Moxie): +20, Moxie Percent: +20, HP Regen Min: 8, HP Regen Max: 10, MP Regen Min: 8, MP Regen Max: 10, Last Available: "2016-07"
+Item	norwhal helmet	Experience (Mysticality): +2, Spell Damage Percent: +60, Booze Drop: +60, Last Available: "2015-11", Familiar Effect: "atk"
 Item	nurse's hat	Maximum HP: +300, HP Regen Min: 30, HP Regen Max: 60, MP Regen Min: 10, MP Regen Max: 15, Familiar Effect: "atk"
 Item	oil cap	MP Regen Min: 2, MP Regen Max: 4, Sleaze Resistance: +2, Familiar Effect: "cap 28"
 Item	Ol' Scratch's stovepipe hat	Mysticality Percent: +20, Hot Spell Damage: +30, Class: "Sauceror", Familiar Effect: "hot atk"
 Item	one-gallon hat	Muscle: +1, Mysticality: +1, Moxie: +1, Experience: +1
 Item	opera mask	Moxie: -5, Familiar Effect: "spooky atk, 1xBarrr, cap 2"
 Item	orange peel hat	Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Familiar Effect: "atk, 1xVolley"
-Item	orange traffic cone	Moxie: +3, Spooky Resistance: +2, Familiar Effect: "cap 15"
+Item	orange traffic cone	Moxie: +3, Spooky Resistance: +2, Last Available: "2005-03", Familiar Effect: "cap 15"
 Item	Orcish baseball cap	Muscle: +3, Mysticality: -3, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 Item	oriole-feather headdress	Maximum HP: +1, Maximum MP: +1, Familiar Effect: "atk, 3xVolley, cap 3"
-Item	outrageous sombrero	Muscle: +5, Mysticality: +5, Moxie: +5, Initiative: -20, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+Item	outrageous sombrero	Muscle: +5, Mysticality: +5, Moxie: +5, Initiative: -20, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 Item	oversized skullcap	Muscle: +2, Damage Reduction: 3, Familiar Effect: "1xVolley,cap 5"
-Item	oxygenated eggnog helmet	Item Drop: -100, Initiative: -100, Adventure Underwater
+Item	oxygenated eggnog helmet	Item Drop: -100, Initiative: -100, Adventure Underwater, Last Available: "2019-12"
 Item	pail	Damage Absorption: +10, Familiar Effect: "2xFairy, cap 7"
 Item	panhandle panhandling hat	Food Drop: +30, Familiar Effect: "1xLep, cap 37"
-Item	paperclip turban	Muscle: +5, Mysticality: +5, Moxie: +5, Maximum HP: +5, Maximum MP: +5, Damage Reduction: 5, Familiar Effect: "atk, cap 12"
-Item	papier-mitre	Familiar Weight: +5, PvP Fights: +2, Familiar Effect: "1xVolley, cap 25", Alters Page Text
+Item	paperclip turban	Muscle: +5, Mysticality: +5, Moxie: +5, Maximum HP: +5, Maximum MP: +5, Damage Reduction: 5, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
+Item	papier-mitre	Familiar Weight: +5, PvP Fights: +2, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25", Alters Page Text
 # paraffin pith helmet: Lets you unleash a prismatic attack
-Item	paraffin pith helmet	Experience (Muscle): +2, Cold Damage: +10
+Item	paraffin pith helmet	Experience (Muscle): +2, Cold Damage: +10, Last Available: "2020-12"
 Item	parasitic headgnawer	Familiar Effect: "atk, cap 7", Thorns: 1
 # party hat: (On the Festival of Jarlsberg only)
 Item	party hat	MP Regen Min: [3*J], MP Regen Max: [5*J], Mysticality: +3, Familiar Effect: "4xLep, cap 7"
 Item	passable elf mask	Familiar Effect: "atk, cap 2"
 Item	pentacorn hat	Familiar Effect: "atk, cap 10"
-Item	pentagram bandana	Mysticality: +15, Maximum MP: +15
+Item	pentagram bandana	Mysticality: +15, Maximum MP: +15, Last Available: "2018-09"
 Item	petrified wood whoopie panama	Moxie Percent: +20, Critical Hit Percent: +10, Last Available: "2025-12", Thorns: 1
 Item	pickelhaube	Weapon Damage: +5, Weapon Damage Percent: +10, Familiar Effect: "atk, 1xFairy, cap 18"
-Item	pig-iron helm	Muscle: +7, Weapon Damage: +10, Familiar Effect: "1xFairy, cap 22"
+Item	pig-iron helm	Muscle: +7, Weapon Damage: +10, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
 Item	pimpin' meat hat	Muscle: +2, Moxie: +2, Familiar Effect: "sleaze atk, 1xVolley, cap 13"
 # PirateRealm party hat: Gain more FunPoints during PirateRealm adventures
-Item	PirateRealm party hat	Muscle: +10, Mysticality: +10, Moxie: +10
+Item	PirateRealm party hat	Muscle: +10, Mysticality: +10, Moxie: +10, Last Available: "2019-04"
 Item	pixel hat	Muscle: +2, Mysticality: +2, Moxie: +2, Familiar Effect: "atk, 2xVolley, cap 12"
 Item	plaid cowboy hat	Weapon Damage: +20, Hot Resistance: +2, Familiar Effect: "2xLep, 1xBarrr, cap 25"
-Item	plain paper hat	Cold Damage: +20, Cold Spell Damage: +25, Spell Damage Percent: +30, Familiar Effect: "cold atk, cap 37"
+Item	plain paper hat	Cold Damage: +20, Cold Spell Damage: +25, Spell Damage Percent: +30, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 Item	plexiglass pith helmet	Familiar Weight: +5, HP Regen Min: 10, HP Regen Max: 12, MP Regen Min: 10, MP Regen Max: 12, Muscle Percent: +30, Familiar Effect: "1xVolley, 1xLep, cap 45"
-Item	pointy red hat	Damage Reduction: 5, Familiar Effect: "1xVolley, 1xLep, cap 27"
+Item	pointy red hat	Damage Reduction: 5, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 # polyester panama hat: Adds Damage to Disco Dances
-Item	polyester panama hat	Experience (Moxie): +2, Meat Drop: +10
+Item	polyester panama hat	Experience (Moxie): +2, Meat Drop: +10, Last Available: "2015-12"
 # porcelain porkpie: Adds <font color=purple>Sleaze Damage</font> to all Pastamancer Spells
-Item	porcelain porkpie	Food Drop: +20, Mysticality Percent: +20
+Item	porcelain porkpie	Food Drop: +20, Mysticality Percent: +20, Last Available: "2015-12"
 Item	portable Spacegate (open)	Lasts Until Rollover
-Item	pottery hat	Cold Resistance: +1, Hot Damage: +5, Familiar Effect: "hot atk, cap 11"
-Item	powdered wig	Moxie: +3, MP Regen Min: 2, MP Regen Max: 4, Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+Item	pottery hat	Cold Resistance: +1, Hot Damage: +5, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+Item	powdered wig	Moxie: +3, MP Regen Min: 2, MP Regen Max: 4, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
 # primitive alien mask: Reveals your inner alien
-Item	primitive alien mask	Mysticality: +10, Maximum MP: +20, Adventures: +2
+Item	primitive alien mask	Mysticality: +10, Maximum MP: +20, Adventures: +2, Last Available: "2017-04"
 Item	prohie's hat	Booze Drop: +100
 Item	propeller beanie	Initiative: +10, Familiar Effect: "atk, cap 7"
-Item	psychic's circlet	Adventures: +3, MP Regen Min: 3, MP Regen Max: 6
+Item	psychic's circlet	Adventures: +3, MP Regen Min: 3, MP Regen Max: 6, Last Available: "2018-02"
 Item	pumpkinhead mask	Familiar Effect: "1xVolley, 8xLep, cap 2"
-Item	radiation-resistant helmet	Item Drop: -10, Familiar Effect: "1xFairy, cap 12"
-Item	Radio Free Baseball Cap	Moxie: +20, Familiar Effect: "1xLep, 1xFairy, cap 37"
+Item	radiation-resistant helmet	Item Drop: -10, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+Item	Radio Free Baseball Cap	Moxie: +20, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
 Item	raspberry beret	Hot Resistance: +2, Familiar Effect: "2xPotato, 2xLep, cap 12"
-Item	ratty knitted cap	Sleaze Damage: +15, Sleaze Spell Damage: +15
+Item	ratty knitted cap	Sleaze Damage: +15, Sleaze Spell Damage: +15, Last Available: "2018-09"
 Item	rave visor	Maximum MP: +20, Raveosity: +2, Familiar Effect: "1xVolley, 1.5xPotato, cap 37"
 Item	ravioli hat	Spell Damage: +1, Familiar Effect: "atk, cap 2"
 Item	real cowboy hat	PvP Fights: +3
-Item	red traffic cone	Moxie: +3, Cold Resistance: +2, Familiar Effect: "2xVolley, 2xLep, cap 15"
+Item	red traffic cone	Moxie: +3, Cold Resistance: +2, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 Item	reinforced beaded headband	Maximum HP: +40, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 # replica jewel-eyed wizard hat: Regenerate MP Based on Level
 # replica jewel-eyed wizard hat: +5 Duration to Buffs You Cast
@@ -464,7 +464,7 @@ Item	rusty diving helmet	Stench Resistance: +1, Item Drop: -50, Initiative: -50,
 # safarrri hat: +10 Damage vs. Lions
 Item	safarrri hat	Maximum HP: +15, Familiar Effect: "2xVolley, cap 22"
 Item	samurai turtle helmet	Muscle: +1, Weapon Damage: +2, Familiar Effect: "atk, 1xPotato, cap 6"
-Item	Satan hat	Hat Drop: +50, Hot Damage: +30, Class: "Sauceror"
+Item	Satan hat	Hat Drop: +50, Hot Damage: +30, Class: "Sauceror", Last Available: "2020-12"
 Item	Scalp of Gorgolok	Muscle: +11, Weapon Damage: +7, Class: "Seal Clubber", Familiar Effect: "3xGhuol, cap 25"
 Item	sea cowboy hat	Adventures: +3, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Maximum HP: +50, Familiar Effect: "1xLep"
 Item	seal-skull helmet	Weapon Damage: +1, Familiar Effect: "atk, cap 2"
@@ -474,44 +474,44 @@ Item	sequined fez	Moxie: +3, Familiar Effect: "1.75xLep, cap 20"
 Item	seven-gallon hat	Muscle: +7, Mysticality: +7, Moxie: +7, Experience: +3
 Item	shadow chef's hat	Spooky Damage: +13, Muscle: +13, Mysticality: +13, Moxie: +13, Maximum MP: +13
 Item	shapeless wide-brimmed hat	HP Regen Min: 15, HP Regen Max: 20, MP Regen Min: 15, MP Regen Max: 20, Mysticality Percent: +5, Familiar Effect: "0.75xLep, 0.75xFairy"
-Item	shining star cap	Familiar Weight: [+10*event(December)]
+Item	shining star cap	Familiar Weight: [+10*event(December)], Last Available: "2020-12"
 Item	silent beret	Muscle Percent: -30, Mysticality Percent: -30, Moxie Percent: -30, Initiative: -50, Combat Rate: -5, Familiar Effect: "1xVolley, cap 3"
-Item	sinister demon mask	Spooky Damage: +25, HP Regen Min: 10, HP Regen Max: 25, Food Drop: +25, Familiar Effect: "atk, cap 25"
+Item	sinister demon mask	Spooky Damage: +25, HP Regen Min: 10, HP Regen Max: 25, Food Drop: +25, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 Item	six-gallon hat	Muscle: +6, Mysticality: +6, Moxie: +6, Experience: +3
 Item	skeletortoise	Mysticality: +2, Familiar Effect: "spooky atk, 2xFairy, cap 7"
 Item	sleep mask	Familiar Effect: "atk, 1xBarrr, cap 37", Blind
-Item	slime fedora	Mysticality Percent: +25, Spell Critical Percent: +10, MP Regen Min: 10, MP Regen Max: 15
+Item	slime fedora	Mysticality Percent: +25, Spell Critical Percent: +10, MP Regen Min: 10, MP Regen Max: 15, Last Available: "2018-11"
 Item	slime-covered helmet	Slime Resistance: +2, Stench Resistance: +2, Cold Resistance: +2, Familiar Effect: "1xPotato, 1xFairy"
-Item	smooth velvet hat	Disco Style: +1
+Item	smooth velvet hat	Disco Style: +1, Last Available: "2015-08"
 Item	snailmail coif	Muscle: +10, Damage Reduction: 8, Familiar Effect: "1xPotato, 1xFairy, cap 41"
-Item	snakeskin cowboy hat	Moxie: +5, Ranged Damage Percent: +50
+Item	snakeskin cowboy hat	Moxie: +5, Ranged Damage Percent: +50, Last Available: "2018-11"
 Item	snorkel	Familiar Effect: "atk, cap 2"
-Item	snow hat	Damage Reduction: 3, Familiar Effect: "cold atk, cap 12"
+Item	snow hat	Damage Reduction: 3, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
 Item	Snow Queen Crown	Cold Damage: +5, Cold Resistance: +3, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 # snowman-enchanting tophat: Can turn enemies into snowmen
 Item	snowman-enchanting tophat	Moxie Percent: +25, Spell Damage Percent: +50, Last Available: "2024-12"
 Item	soft cap of diminishing returns	Experience (Muscle): [-1*floor(basemus/100)], Experience (Mysticality): [-1*floor(basemys/100)], Experience (Moxie): [-1*floor(basemox/100)]
 Item	Sombrero De Vida	Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
-Item	sombrero-mounted sparkler	Combat Rate: +5, Hot Damage: +10, Hot Spell Damage: +20, Lasts Until Rollover
-Item	space beast fur hat	Damage Reduction: 5, Familiar Effect: "1xVolley"
+Item	sombrero-mounted sparkler	Combat Rate: +5, Hot Damage: +10, Hot Spell Damage: +20, Lasts Until Rollover, Last Available: "2021-07"
+Item	space beast fur hat	Damage Reduction: 5, Last Available: "2014-05", Familiar Effect: "1xVolley"
 Item	space trooper helmet	Muscle: +5, Mysticality: +5, Moxie: +5, Softcore Only, Familiar Effect: "1xVolley, 1xLep, cap 2"
 Item	spaghetti cult mask	Spell Damage Percent: +15, Familiar Effect: "1xBarrr, 1xGhuol, cap 38"
 Item	spangly sombrero	Experience (Moxie): +3, Familiar Effect: "2xFairy, 2xPotato, cap 37"
-Item	Spelunker's fedora	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Adventures: +4, Experience: +2, Familiar Effect: "atk, 1xLep, cap 25"
+Item	Spelunker's fedora	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Adventures: +4, Experience: +2, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 Item	spiky turtle helmet	Weapon Damage: +8, Monster Level: +8, Familiar Effect: "atk, 1xFairy, cap 32"
 Item	sponge helmet	Mysticality Percent: +10, MP Regen Min: 15, MP Regen Max: 20, Damage Absorption: +40, Familiar Effect: "atk, 1xFairy"
 Item	spooky hockey mask	Spooky Resistance: +2, Spooky Damage: +3, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
-Item	Spooky Putty mitre	Experience: +3, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
-Item	stained glass stetson	Mysticality Percent: +20, Familiar Weight: +5, Hot Spell Damage: +5, Cold Spell Damage: +5, Stench Spell Damage: +5, Spooky Spell Damage: +5, Sleaze Spell Damage: +5
+Item	Spooky Putty mitre	Experience: +3, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+Item	stained glass stetson	Mysticality Percent: +20, Familiar Weight: +5, Hot Spell Damage: +5, Cold Spell Damage: +5, Stench Spell Damage: +5, Spooky Spell Damage: +5, Sleaze Spell Damage: +5, Last Available: "2021-12"
 Item	stainless steel skullcap	Maximum HP: +30, Damage Absorption: +60, Muscle Percent: +15, Familiar Effect: "1xLep, 1xFairy, cap 22"
 Item	star hat	Maximum MP: +30, Familiar Effect: "0.5xVolley, 0.5xPotato, cap 41"
 Item	stone baseball cap	Damage Reduction: 10, Weapon Damage: +15, Muscle: -10, Familiar Effect: "1xVolley, cap 48"
 Item	straw hat	Item Drop: +10, Food Drop: +15, Booze Drop: +15, Familiar Effect: "1xFairy"
-Item	sucker kabuto	Damage Reduction: 5, Familiar Effect: "Atk, cap 12"
-Item	sugar chapeau	Spell Damage Percent: +50, Spell Critical Percent: +10, MP Regen Min: 3, MP Regen Max: 5, Breakable, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+Item	sucker kabuto	Damage Reduction: 5, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
+Item	sugar chapeau	Spell Damage Percent: +50, Spell Critical Percent: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2009-09", Breakable, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
 Item	superhero mask	Muscle: +5, Mysticality: +5, Moxie: +5, Softcore Only, Familiar Effect: "1xLep, 1xFairy, cap 2"
-Item	suspicious-looking fedora	Moxie: +6, Weapon Damage: +6, Familiar Effect: "atk, 1xFairy, cap 15"
-Item	sweatband	PvP Fights: +2, Damage Reduction: 5, Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+Item	suspicious-looking fedora	Moxie: +6, Weapon Damage: +6, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
+Item	sweatband	PvP Fights: +2, Damage Reduction: 5, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
 Item	tattered paper crown	Muscle: +3, Familiar Effect: "1xSombrero, cap 15"
 Item	Team Avarice cap	Item Drop: +100
 Item	Team Sloth cap	Combat Rate: -15
@@ -520,57 +520,57 @@ Item	ten-gallon hat	Muscle: +10, Mysticality: +10, Moxie: +10, Experience: +3
 # The Crown of Ed the Undying: Ed's servants will level up faster
 # The Crown of Ed the Undying: Allows you to read thoughts
 Item	The Crown of Ed the Undying	Maximum HP: +50, Maximum MP: +50, Initiative: +25, Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
-Item	The Emperor's new hat	Mysticality: [L]
-Item	The Jokester's wig	MP Regen Min: 6, MP Regen Max: 8, Monster Level: +10, Spooky Damage: +25, Familiar Effect: "1xPotato, 1xGhuol"
-Item	The Necbromancer's Hat	Mysticality Percent: +20, Spooky Spell Damage: +30, Familiar Effect: "1xVolley, 1xBarrr"
+Item	The Emperor's new hat	Mysticality: [L], Last Available: "2015-07"
+Item	The Jokester's wig	MP Regen Min: 6, MP Regen Max: 8, Monster Level: +10, Spooky Damage: +25, Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
+Item	The Necbromancer's Hat	Mysticality Percent: +20, Spooky Spell Damage: +30, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 # Third Eye: Improves chances of finding lumps and sludge
-Item	Third Eye	Initiative: +20, Muscle Percent: +15, Mysticality Percent: +15, Moxie Percent: +15
+Item	Third Eye	Initiative: +20, Muscle Percent: +15, Mysticality Percent: +15, Moxie Percent: +15, Last Available: "2016-12"
 Item	three-gallon hat	Muscle: +3, Mysticality: +3, Moxie: +3, Experience: +3
 Item	Thunkula's drinking cap	Mysticality Percent: +50, Maximum MP: +250, MP Regen Min: 20, MP Regen Max: 40, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
-Item	time helmet	Adventures: +3, Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
-Item	tin tam	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 5, Experience (Mysticality): +1, Familiar Effect: "MP regen, cap 25"
+Item	time helmet	Adventures: +3, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+Item	tin tam	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 5, Experience (Mysticality): +1, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 Item	tooth cap	Candy Drop: +25, Spell Damage: +5
 Item	tope&eacute;	Stench Resistance: +3, Hot Resistance: +3, Familiar Effect: "3xBarrr, cap 12"
 # toy Crimbot mega face: Allows use of LIGHT in combat
-Item	toy Crimbot mega face	Item Drop: +10, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12"
+Item	toy Crimbot mega face	Item Drop: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
 # toy space helmet: Provides Mostly Accurate Battle Statistics During Fights
-Item	toy space helmet	Stench Resistance: +3, Spooky Resistance: +3, Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
-Item	training helmet	Initiative: -50, Item Drop: +25, Moxie Percent: +25, Familiar Effect: "atk, cap 25"
+Item	toy space helmet	Stench Resistance: +3, Spooky Resistance: +3, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
+Item	training helmet	Initiative: -50, Item Drop: +25, Moxie Percent: +25, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 # triphasic molecular oculus: Allows improved advanced monster research
-Item	Tropical Crimbo Hat	Spooky Resistance: +1, Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+Item	Tropical Crimbo Hat	Spooky Resistance: +1, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
 Item	turtle wax helmet	Hot Resistance: +1, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
 Item	turtlemail coif	Muscle: +5, Damage Reduction: 4, Familiar Effect: "1xPotato, cap 20"
 Item	two-gallon hat	Muscle: +2, Mysticality: +2, Moxie: +2, Experience: +3
 Item	Uncle Crimbo's hat	Adventures: +4, Rollover Effect: "The Spirit of Crimbo", Rollover Effect Duration: 100, Rollover Effect: "Crimbo Nostalgia", Rollover Effect Duration: 100
-Item	Uncle Hobo's stocking cap	Mysticality Percent: +20, Monster Level: +20, Familiar Effect: "atk"
-Item	Unfortunato's foolscap	Spooky Damage: +10, Stench Damage: +10, Hot Damage: +10, Cold Damage: +10, Sleaze Damage: +10, Mysticality Percent: +10, Mana Cost (combat): -2
+Item	Uncle Hobo's stocking cap	Mysticality Percent: +20, Monster Level: +20, Last Available: "2010-12", Familiar Effect: "atk"
+Item	Unfortunato's foolscap	Spooky Damage: +10, Stench Damage: +10, Hot Damage: +10, Cold Damage: +10, Sleaze Damage: +10, Mysticality Percent: +10, Mana Cost (combat): -2, Last Available: "2016-08"
 Item	Unkillable Skeleton's skullcap	Muscle Percent: +50, Maximum HP: +500, HP Regen Min: 40, HP Regen Max: 80, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
-Item	Van der Graaf helmet	Maximum MP: +15, MP Regen Min: 1, MP Regen Max: 3, Familiar Effect: "3xPotato, cap 7"
+Item	Van der Graaf helmet	Maximum MP: +15, MP Regen Min: 1, MP Regen Max: 3, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 # very pointy crown: Weakens Monster on Critical Hit
-Item	very pointy crown	Experience (Moxie): +5, Adventures: +5, Moxie Percent: +50, Combat Rate: -5, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol"
+Item	very pointy crown	Experience (Moxie): +5, Adventures: +5, Moxie Percent: +50, Combat Rate: -5, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 Item	viking helmet	Muscle: +1, Familiar Effect: "atk, cap 5"
 Item	Voluminous Radio Hat	MP Regen Min: 5, MP Regen Max: 6, Familiar Effect: "1xPotato, 1xGhoul, cap 37"
-Item	wad of used tape	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Item Drop: +15, Meat Drop: +30, Lasts Until Rollover
-Item	warbear dress helmet	Moxie: +10, Booze Drop: +25, Familiar Effect: "cold atk, 1xVolley, cap 25"
+Item	wad of used tape	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Item Drop: +15, Meat Drop: +30, Last Available: "2018-01", Lasts Until Rollover
+Item	warbear dress helmet	Moxie: +10, Booze Drop: +25, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 # warbear electro-spiked helm: Troubling Vulnerability to All Elements (-5)
-Item	warbear electro-spiked helm	WarBear Armor Penetration: +60, Muscle Percent: -25, Mysticality Percent: -25, Moxie Percent: -25, Hot Resistance: -5, Cold Resistance: -5, Spooky Resistance: -5, Stench Resistance: -5, Sleaze Resistance: -5, Familiar Effect: "atk, 1xFairy"
+Item	warbear electro-spiked helm	WarBear Armor Penetration: +60, Muscle Percent: -25, Mysticality Percent: -25, Moxie Percent: -25, Last Available: "2013-12", Hot Resistance: -5, Cold Resistance: -5, Spooky Resistance: -5, Stench Resistance: -5, Sleaze Resistance: -5, Familiar Effect: "atk, 1xFairy"
 # warbear fancy fedora: +15% Item Drops from WarBears
-Item	warbear fancy fedora	Initiative: -25, Maximum HP: -50, Maximum MP: -50, Familiar Effect: "atk, 1xLep"
+Item	warbear fancy fedora	Initiative: -25, Maximum HP: -50, Maximum MP: -50, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
 # warbear feathered fedora: +10% Item Drops from WarBears
 Item	warbear feathered fedora	Familiar Effect: "atk, 1xLep, cap 37"
 # warbear foil hat: (additional +10 lbs. to Robotic Familiars)
-Item	warbear foil hat	Familiar Weight: [5+10*famattr(robot)], Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25"
-Item	warbear heated ushanka	Supercold Resistance: +3, Weapon Damage Percent: -25, Spell Damage Percent: -50, Familiar Effect: "1xatk, 1xLep"
-Item	warbear lined ushanka	Supercold Resistance: +2, Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+Item	warbear foil hat	Familiar Weight: [5+10*famattr(robot)], Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
+Item	warbear heated ushanka	Supercold Resistance: +3, Weapon Damage Percent: -25, Spell Damage Percent: -50, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
+Item	warbear lined ushanka	Supercold Resistance: +2, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
 # warbear plain fedora: +5% Item Drops from WarBears
-Item	warbear plain fedora	Initiative: +25, Maximum HP: +50, Maximum MP: +50, Familiar Effect: "atk, 1xLep, cap 12"
-Item	warbear plain helm	WarBear Armor Penetration: +20, Weapon Damage Percent: +25, Spell Damage Percent: +50, Familiar Effect: "atk, 1xFairy, cap 12"
-Item	warbear plain ushanka	Supercold Resistance: +1, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 10, MP Regen Max: 15, Familiar Effect: "1xBarrr, 1xLep, cap 12"
-Item	warbear spiked helm	WarBear Armor Penetration: +40, Familiar Effect: "atk, 1xFairy, cap 37"
+Item	warbear plain fedora	Initiative: +25, Maximum HP: +50, Maximum MP: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+Item	warbear plain helm	WarBear Armor Penetration: +20, Weapon Damage Percent: +25, Spell Damage Percent: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+Item	warbear plain ushanka	Supercold Resistance: +1, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 10, MP Regen Max: 15, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+Item	warbear spiked helm	WarBear Armor Penetration: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
 Item	water-polo cap	Weapon Damage: +30, Familiar Effect: "1xVolley, 1xBarrr"
-Item	wax hat	Moxie: +7, Maximum HP: +10, Familiar Effect: "1xPotato, 1xFairy"
+Item	wax hat	Moxie: +7, Maximum HP: +10, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
 Item	webbed comic mask	Muscle: +5, Mysticality: +5, Moxie: +5, Softcore Only, Familiar Effect: "1xVolley, 1xLep, cap 2"
-Item	whittled tiara	Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Experience: +3
+Item	whittled tiara	Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Experience: +3, Last Available: "2019-08"
 Item	willowy bonnet	Maximum MP: +40, Familiar Effect: "1xFairy, cap 18"
 Item	witch hat	Familiar Effect: "8xVolley, 8xLep, cap 2"
 Item	wolf mask	Muscle: +4, Moxie: -5, Familiar Effect: "1xBarrr, HP regen, cap 37"
@@ -581,15 +581,15 @@ Item	wool hat	Damage Absorption: +20, Cold Resistance: +2, Familiar Effect: "1xL
 Item	worn tophat	Moxie: +5, Initiative: +15, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 Item	wreath of laurels	Muscle: +25, Maximum HP: +25, Maximum MP: +25, Familiar Effect: "0.5xLep, 0.5xFairy"
 # wrought-iron wig: Makes Northern Explosion deal additional damage over time
-Item	wrought-iron wig	Experience (Muscle): +3, Cold Damage: +15
-Item	wumpus-hair wig	Moxie: -5, Stench Damage: +20, Stench Spell Damage: +20, Familiar Effect: "1xPotato, 1xGhuol, cap 25"
-Item	Xiblaxian stealth cowl	Combat Rate: -5, Mysticality Percent: +20, Familiar Effect: "spooky atk, cap 25"
+Item	wrought-iron wig	Experience (Muscle): +3, Cold Damage: +15, Last Available: "2017-12"
+Item	wumpus-hair wig	Moxie: -5, Stench Damage: +20, Stench Spell Damage: +20, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+Item	Xiblaxian stealth cowl	Combat Rate: -5, Mysticality Percent: +20, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 Item	yabba dabba doo rag	Stench Resistance: +4, HP Regen Min: 5, HP Regen Max: 10, Familiar Effect: "atk, 1xVolley, cap 27"
 Item	yak toupee	MP Regen Min: 3, MP Regen Max: 4, Familiar Effect: "atk, 1xPotato, cap 25"
 # Yeg's Motel shower cap: Extremely fragile (will be destroyed if you are hit in combat)
-Item	Yeg's Motel shower cap	Spooky Resistance: +5, Moxie Percent: +66, Lasts Until Rollover
+Item	Yeg's Motel shower cap	Spooky Resistance: +5, Moxie Percent: +66, Lasts Until Rollover, Last Available: "2020-09"
 Item	yellow plastic hard hat	Familiar Effect: "atk, cap 22"
-Item	yellow traffic cone	Moxie: +3, Sleaze Resistance: +2, Familiar Effect: "1xVolley, 1xLep, cap 15"
+Item	yellow traffic cone	Moxie: +3, Sleaze Resistance: +2, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 # Ze&trade; goggles: +25% Item Drops from Monsters (Underwater only)
 Item	Ze&trade; goggles	Item Drop: [25*env(underwater)], Familiar Effect: "Atk, cap 7"
 Item	zombie mariachi hat	Moxie Percent: +50, Maximum HP: +150, Maximum MP: +150, Initiative: +40, Class: "Accordion Thief", Familiar Effect: "atk, 1xLep"
@@ -602,51 +602,51 @@ Item	adobe arsecover	Muscle Percent: [20+20*min(1,effect(Adobe Arsecover Subscri
 Item	alpha-mail pants	Familiar Effect: "atk, 1xBarrr, cap 35"
 Item	Angelhair Culottes	Mysticality: +11, Spell Damage: +15, Class: "Pastamancer", Familiar Effect: "1.5xPotato, 2xGhoul, cap 31"
 Item	antique greaves	Initiative: -10, Breakable, Familiar Effect: "1xBarrr"
-Item	antique nutcracker pants	Meat Drop: +15, Moxie Percent: +15
+Item	antique nutcracker pants	Meat Drop: +15, Moxie Percent: +15, Last Available: "2019-12"
 Item	astral shorts	Moxie Percent: +25, Initiative: +20, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4, Familiar Effect: "1xGhoul, cap 12"
 Item	astral trousers	Muscle Percent: +25, Weapon Damage Percent: +50, Meat Drop: +20, Familiar Effect: "1xPotato, cap 12"
-Item	astronaut pants	Maximum HP: +30, Maximum MP: +30, Muscle: +5, Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
+Item	astronaut pants	Maximum HP: +30, Maximum MP: +30, Muscle: +5, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 Item	baggy rave pants	Damage Absorption: +20, Raveosity: +2, Familiar Effect: "1xVolley, 1xPotato, cap 37"
 # bakelite breeches: Doubles the damage of Disco Inferno
-Item	bakelite breeches	Hot Resistance: +5, Moxie Percent: +20
-Item	bankruptcy barrel	Moxie Percent: +25, Initiative: +50, HP Regen Min: 10, HP Regen Max: 20, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25"
-Item	bark boxers	Damage Reduction: 5, Familiar Effect: "atk, 3xVolley, cap 10"
+Item	bakelite breeches	Hot Resistance: +5, Moxie Percent: +20, Last Available: "2016-12"
+Item	bankruptcy barrel	Moxie Percent: +25, Initiative: +50, HP Regen Min: 10, HP Regen Max: 20, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
+Item	bark boxers	Damage Reduction: 5, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
 Item	barskin loincloth	Muscle: +1, Familiar Effect: "sleaze atk, 4xVolley, cap 6"
 Item	basic meat kilt	Moxie: +1, Familiar Effect: "3xPotato, 3xFairy, cap 10"
 Item	basic meat pants	Moxie: +1, Familiar Effect: "atk, 2xPotato, cap 10"
 Item	basic meat skirt	Moxie: +1, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
-Item	bauxite boxers	Moxie: +11, Initiative: [23+floor(pref(daycareToddlers)^0.35)], Ranged Damage: [37+floor(pref(daycareToddlers)^0.35)]
+Item	bauxite boxers	Moxie: +11, Initiative: [23+floor(pref(daycareToddlers)^0.35)], Ranged Damage: [37+floor(pref(daycareToddlers)^0.35)], Last Available: "2018-12"
 Item	big pants	Weapon Damage: +25, Spell Damage: +25, Familiar Effect: "atk"
-Item	biomechanical crimborg leg armor	Hot Damage: +5, Stench Damage: +5, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
+Item	biomechanical crimborg leg armor	Hot Damage: +5, Stench Damage: +5, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 Item	black greaves	Muscle: +10, Damage Absorption: +30, Familiar Effect: "atk, 1xBarrr, cap 40"
 # bloodied surgical dungarees: Makes you look like a gross doctor
 Item	bloodied surgical dungarees	MP Regen Min: 3, MP Regen Max: 5, Surgeonosity: +1, Familiar Effect: "1xPotato, 1xFairy, cap 38"
 Item	bloody clown pants	Spooky Damage: +3, Clowniness: 25, Familiar Effect: "3xPotato, 2xFairy, cap 12"
-Item	boneana hammock	Sleaze Spell Damage: +20, Sleaze Damage: +20, Familiar Effect: "sleaze atk, 1xVolley, cap 30"
+Item	boneana hammock	Sleaze Spell Damage: +20, Sleaze Damage: +20, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 Item	Boss Bat britches	Moxie: +5, Familiar Effect: "atk, 3xGhuol, cap 16"
-Item	bottoms of the barrel	Maximum HP: +50, HP Regen Min: 5, HP Regen Max: 10
+Item	bottoms of the barrel	Maximum HP: +50, HP Regen Min: 5, HP Regen Max: 10, Last Available: "2015-09"
 Item	bounty-hunting pants	Item Drop: +20, Familiar Effect: "1xPotato, 2xFairy, cap 25"
-Item	bowlegged pants	Moxie: +5, Familiar Effect: "1xGhoul, cap 25"
-Item	BRAINS shorts	Sleaze Damage: +40, Sleaze Spell Damage: +40, Familiar Effect: "sleaze atk, 1.5xGhuol"
-Item	BRICKO pants	Damage Absorption: +9, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
+Item	bowlegged pants	Moxie: +5, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
+Item	BRAINS shorts	Sleaze Damage: +40, Sleaze Spell Damage: +40, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
+Item	BRICKO pants	Damage Absorption: +9, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 Item	Brimstone Boxers	Moxie Percent: +50, Mysticality Percent: -20, Initiative: +50, Brimstone, Familiar Effect: "1xVolley, 1xLep"
-Item	Brogre brorts	Monster Level: +10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+Item	Brogre brorts	Monster Level: +10, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 Item	brown paper pants	Moxie: +2, Initiative: +10
 Item	brown pirate pants	Spooky Resistance: +4, Monster Level: +15, Last Available: "2023-12"
 Item	bugbear bungguard	Familiar Effect: "5xBarrr, cap 7"
 Item	bullet-proof corduroys	Maximum MP: +40, Damage Reduction: 2, Familiar Effect: "stench atk, 1xBarrr, cap 42"
 Item	buoybottoms	Moxie: +11, Monster Level: +7, Initiative: -30, Familiar Effect: "1xPotato, 1xLep, cap 37"
-Item	burning paper jorts	Sleaze Resistance: +3, Maximum HP: +25, Maximum MP: +25, Spell Damage: +25, Lasts Until Rollover
-Item	burnt snowpants	Cold Resistance: +2, Hot Damage: +10, Familiar Effect: "1.5xPotato, cap 25"
-Item	Can-Can skirt	Muscle Percent: +10, Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
-Item	cane-mail pants	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, HP Regen Min: 1, HP Regen Max: 4, MP Regen Min: 1, MP Regen Max: 4, PvP Fights: +3, Familiar Effect: "atk, 2xBarrr, cap 25"
+Item	burning paper jorts	Sleaze Resistance: +3, Maximum HP: +25, Maximum MP: +25, Spell Damage: +25, Lasts Until Rollover, Last Available: "2018-12"
+Item	burnt snowpants	Cold Resistance: +2, Hot Damage: +10, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
+Item	Can-Can skirt	Muscle Percent: +10, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
+Item	cane-mail pants	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, HP Regen Min: 1, HP Regen Max: 4, MP Regen Min: 1, MP Regen Max: 4, PvP Fights: +3, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 # Cargo Cultist Shorts: 666 Pockets to Explore
-Item	Cargo Cultist Shorts	Muscle: +6, Mysticality: +6, Moxie: +6, Monster Level: +6, Initiative: +66, Food Drop: +66, Maximum HP Percent: +66, Maximum MP Percent: +66
-Item	Cerebral Culottes	Mysticality: +10, Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
+Item	Cargo Cultist Shorts	Muscle: +6, Mysticality: +6, Moxie: +6, Monster Level: +6, Initiative: +66, Food Drop: +66, Maximum HP Percent: +66, Maximum MP Percent: +66, Last Available: "2020-09"
+Item	Cerebral Culottes	Mysticality: +10, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 Item	chain-mail monokini	Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
 # chalk chinos: Weakens enemies who hit you
-Item	chalk chinos	Experience (Mysticality): +2, Initiative: +20
-Item	cheerful pajama pants	Cold Resistance: +2, Moxie: -15
+Item	chalk chinos	Experience (Mysticality): +2, Initiative: +20, Last Available: "2019-12"
+Item	cheerful pajama pants	Cold Resistance: +2, Moxie: -15, Last Available: "2017-12"
 Item	Chester's cutoffs	Hot Resistance: +3, Stench Resistance: +3, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
 Item	chiffon chaps	Experience (Moxie): +2, Hot Damage: +10, Hot Spell Damage: +10, Last Available: "2023-12", Damage Aura: 1
 Item	clingfilm trousers	Mysticality: +9, Familiar Effect: "sleaze atk, 1xPotato, cap 37"
@@ -656,28 +656,28 @@ Item	cool iron greaves	Damage Reduction: 20, HP Regen Min: 20, HP Regen Max: 40,
 Item	corroded breeches	Damage Absorption: +50, Critical Hit Percent: +5, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 Item	crappy Mer-kin tailpiece	Initiative: -25, Mana Cost: +2, Familiar Effect: "1xBarrr, 1xFairy"
 Item	Crimbuccaneer breeches	Last Available: "2023-12"
-Item	Crimbo pants	Initiative: +30, Familiar Effect: "atk, cap 25"
-Item	Crimbo stockings	PvP Fights: +5, Sleaze Damage: +75, Class: "Disco Bandit"
-Item	Crimbylow-rise jeans	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Adventures: +4
+Item	Crimbo pants	Initiative: +30, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
+Item	Crimbo stockings	PvP Fights: +5, Sleaze Damage: +75, Class: "Disco Bandit", Last Available: "2020-12"
+Item	Crimbylow-rise jeans	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Adventures: +4, Last Available: "2019-12"
 Item	crotchety pants	Maximum HP: +40, Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 Item	cursed breeches	Moxie: +15, Familiar Effect: "stench atk, 1xPotato"
-Item	Daisy's unclean bloomers	Stench Damage: +30, Stench Spell Damage: +30, Monster Level: +15, Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
+Item	Daisy's unclean bloomers	Stench Damage: +30, Stench Spell Damage: +30, Monster Level: +15, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 Item	Danglin' Chad's loincloth	Sleaze Damage: +25, Moxie: -10, Familiar Effect: "stench atk, 0.5xVolley"
 Item	demonskin trousers	Hot Resistance: +2, Familiar Effect: "hot atk, 3xPotato, cap 17"
-Item	depleted Grimacite shinguards	Muscle Percent: [5*G], PvP Fights: [G], Familiar Effect: "atk, 3xBarrr, cap 25"
+Item	depleted Grimacite shinguards	Muscle Percent: [5*G], PvP Fights: [G], Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 # designer sweatpants: oh, and also a 5% discount at NPC stores
-Item	designer sweatpants	Muscle: [5+(2*floor(sqrt(pref(sweat))))], Mysticality: [5+(2*floor(sqrt(pref(sweat))))], Moxie: [5+(2*floor(sqrt(pref(sweat))))], Damage Reduction: [5+(1*floor(sqrt(pref(sweat))))], Hot Resistance: [1+(0.5*floor(sqrt(pref(sweat))))], Sleaze Damage: [10+(5*floor(sqrt(pref(sweat))))], Sleaze Spell Damage: [10+(5*floor(sqrt(pref(sweat))))]
+Item	designer sweatpants	Muscle: [5+(2*floor(sqrt(pref(sweat))))], Mysticality: [5+(2*floor(sqrt(pref(sweat))))], Moxie: [5+(2*floor(sqrt(pref(sweat))))], Damage Reduction: [5+(1*floor(sqrt(pref(sweat))))], Hot Resistance: [1+(0.5*floor(sqrt(pref(sweat))))], Sleaze Damage: [10+(5*floor(sqrt(pref(sweat))))], Sleaze Spell Damage: [10+(5*floor(sqrt(pref(sweat))))], Last Available: "2022-07"
 Item	dice-print pajama pants	Random Monster Modifiers: +1
 # digibritches: CyberRealm: Take less damage from processes
 Item	digibritches	Last Available: "2025-12"
 # Dinsey's pants: Disco Bandit Combat Skills weaken enemies by an additional 50%
-Item	Dinsey's pants	DB Combat Damage: +15
+Item	Dinsey's pants	DB Combat Damage: +15, Last Available: "2015-04"
 Item	discarded swimming trunks	Experience Percent (Muscle): +5, Sleaze Damage: +10, Sleaze Spell Damage: +10
 Item	distressed denim pants	Stench Resistance: +1, Damage Reduction: 2, Familiar Effect: "sleaze atk, 1xPotato, cap 42"
-Item	double-ice britches	Hot Resistance: +4, Damage Reduction: 4, Maximum HP: +40, Maximum MP: +40, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
+Item	double-ice britches	Hot Resistance: +4, Damage Reduction: 4, Maximum HP: +40, Maximum MP: +40, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 Item	drafty drawers	Maximum MP: +200, MP Regen Min: 15, MP Regen Max: 20, Familiar Effect: "1.5xVolley"
 Item	dress pants	Moxie: +5, Familiar Effect: "2xFairy, cap 28"
-Item	driftwood pants	Muscle: +5, Muscle Percent: +1, Maximum HP: +1, Maximum HP Percent: +1, Weapon Damage: +1, Weapon Damage Percent: +1, Critical Hit Percent: +1, Experience (Muscle): +2, Experience Percent (Muscle): +1, Lasts Until Rollover
+Item	driftwood pants	Muscle: +5, Muscle Percent: +1, Maximum HP: +1, Maximum HP Percent: +1, Weapon Damage: +1, Weapon Damage Percent: +1, Critical Hit Percent: +1, Experience (Muscle): +2, Experience Percent (Muscle): +1, Lasts Until Rollover, Last Available: "2019-07"
 Item	drippy khakis	Drippy Resistance: +5
 Item	Drunkula's silky pants	Cold Spell Damage: +100, Stench Resistance: +5, Sleaze Resistance: +1, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
 Item	dubious loincloth	Familiar Effect: "atk, 1.5xVolley", Damage Aura: 1
@@ -688,54 +688,54 @@ Item	dwarvish war kilt	Familiar Effect: "1xBarrr, 1xFairy, cap 41"
 Item	Dyspepsi-Cola fatigues	Mysticality: +3, Familiar Effect: "3.5xPotato, 3xVolley, cap 7"
 Item	eelskin pants	Mysticality Percent: +5, Familiar Effect: "1xPotato, MP regen", Thorns: [env(underwater)]
 Item	El Vibrato leg guards	Familiar Effect: "1xBarrr, 1xGhuol"
-Item	eldritch pants	Mysticality Percent: +20, Maximum MP: +40, MP Regen Min: 6, MP Regen Max: 10
-Item	electric pants	Spooky Damage: +10, Stench Damage: +10, Hot Damage: +10, Cold Damage: +10, Sleaze Damage: +10
-Item	electronic dulcimer pants	Adventures: +2, Initiative: +25, Familiar Effect: "8xPotato, cap 2"
+Item	eldritch pants	Mysticality Percent: +20, Maximum MP: +40, MP Regen Min: 6, MP Regen Max: 10, Last Available: "2016-11"
+Item	electric pants	Spooky Damage: +10, Stench Damage: +10, Hot Damage: +10, Cold Damage: +10, Sleaze Damage: +10, Last Available: "2021-12"
+Item	electronic dulcimer pants	Adventures: +2, Initiative: +25, Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
 Item	Elf Guard hotpants	Last Available: "2023-12"
 # exo-servo leg braces: Allows you to move normally in high gravity environments (Spacegate)
-Item	exo-servo leg braces	Lasts Until Rollover
-Item	extremely skinny jeans	Muscle Percent: -10, Mysticality Percent: -10, Moxie Percent: -10, Critical Hit Percent: +5, Familiar Effect: "1xPotato, 1xFairy"
-Item	fancy party pants	Moxie Percent: +10, Booze Drop: +40
+Item	exo-servo leg braces	Lasts Until Rollover, Last Available: "2017-04"
+Item	extremely skinny jeans	Muscle Percent: -10, Mysticality Percent: -10, Moxie Percent: -10, Critical Hit Percent: +5, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+Item	fancy party pants	Moxie Percent: +10, Booze Drop: +40, Last Available: "2018-09"
 Item	fancy tuxedo pants	Moxie Percent: +15, Familiar Effect: "2xVolley, 1xPotato, cap 25"
 Item	filthy corduroys	Mysticality: +3, Moxie: -3, Familiar Effect: "stench atk, 2xPotato, cap 15"
-Item	fire hose	Hot Damage: +20, Hot Spell Damage: +25, Spell Damage Percent: +30, Familiar Effect: "hot atk, 1xVolley, cap 37"
+Item	fire hose	Hot Damage: +20, Hot Spell Damage: +25, Spell Damage Percent: +30, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 Item	flaming fig leaf	Cold Resistance: +3, Experience (Moxie): +2, Lasts Until Rollover
 Item	floaty rock pants	Spell Critical Percent: +10, Familiar Effect: "1.5xBarrr, 1xGhuol, cap 25"
 Item	floral-print skirt	Stench Damage: +20, Monster Level: +5, Familiar Effect: "stench atk, 2xPotato, cap 15"
 Item	flowing hippy skirt	Mysticality: +9, Stench Spell Damage: +15, Familiar Effect: "stench atk, 1xFairy, cap 45"
-Item	foam naval trousers	Initiative: +50, Familiar Effect: "sleaze atk, 1xPotato"
+Item	foam naval trousers	Initiative: +50, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 Item	frilly skirt	Familiar Effect: "4xFairy, cap 8"
-Item	frozen jeans	Cold Damage: +20, Cold Spell Damage: +20, Item Drop: +15, Lasts Until Rollover
+Item	frozen jeans	Cold Damage: +20, Cold Spell Damage: +20, Item Drop: +15, Lasts Until Rollover, Last Available: "2021-12"
 Item	furry kilt	Sleaze Damage: +5, Familiar Effect: "sleaze atk, 1xFairy, cap 37"
 Item	furry pants	Sleaze Damage: +5, Familiar Effect: "1xPotato, 1xGhuol, MP regen, cap 37"
 Item	furry skirt	Sleaze Damage: +5, Familiar Effect: "sleaze atk, 1xFairy, cap 37"
 # gabardine gaiters: Makes Smacks hit automatically even without a club equipped
-Item	gabardine gaiters	Muscle: +10, Weapon Damage: +15
+Item	gabardine gaiters	Muscle: +10, Weapon Damage: +15, Last Available: "2018-12"
 Item	Galapagosian Cuisses	Muscle: +11, Familiar Weight: +10, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
 Item	gauze shorts	Damage Reduction: 3, HP Regen Min: 6, HP Regen Max: 10, Familiar Effect: "1xBarrr, 1xGhuol, cap 42"
-Item	genie's pants	PvP Fights: +2, Maximum MP: +10
+Item	genie's pants	PvP Fights: +2, Maximum MP: +10, Last Available: "2018-02"
 Item	ghast iron codpiece	Spooky Damage: +10, Hot Damage: +10, Familiar Effect: "atk, 1xBarrr, cap 42"
 Item	giant discarded torn-up glove	Stench Damage: +5, Moxie: -10, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
-Item	gingerbread trousers	Moxie: +10
+Item	gingerbread trousers	Moxie: +10, Last Available: "2016-12"
 Item	gnauga hide chaps	Damage Absorption: +30, Familiar Effect: "atk, 4xBarrr, cap 20"
 Item	gnauga hide kilt	Damage Absorption: +30, Familiar Effect: "2.5xFairy, cap 20"
 Item	gnauga hide skirt	Damage Absorption: +30, Familiar Effect: "2.5xFairy, cap 20"
 Item	gold lam&eacute; pants	Moxie: -8, Familiar Effect: "2xPotato, 1xLep, cap 25"
-Item	government-issued slacks	Experience Percent (Muscle): +10, Damage vs. Skeletons: +25, Fishing Skill: +5
+Item	government-issued slacks	Experience Percent (Muscle): +10, Damage vs. Skeletons: +25, Fishing Skill: +5, Last Available: "2018-11"
 Item	governor's daughter's petticoats	Muscle Percent: +20, Last Available: "2024-12"
-Item	grass skirt	Moxie: +5, Familiar Effect: "atk, 1.5xFairy, cap 20"
+Item	grass skirt	Moxie: +5, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
 Item	gravyskin pants	Sleaze Damage: +11, Sleaze Spell Damage: +11, Last Available: "2024-12"
 Item	gravyskin skirt	Sleaze Damage: +11, Sleaze Spell Damage: +11, Last Available: "2024-12"
 # Great Wolf's beastly trousers: Troubling Vulnerability to All Elements (-5)
 Item	Great Wolf's beastly trousers	Weapon Damage Percent: +50, Familiar Weight: +10, Hot Resistance: -5, Cold Resistance: -5, Spooky Resistance: -5, Stench Resistance: -5, Sleaze Resistance: -5, Familiar Effect: "1xPotato, 1.5xWhelp"
 # Greatest American Pants: Amazing Super Powers
-Item	Greatest American Pants	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Weapon Damage Percent: +50, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
-Item	Greaves of the Murk Lord	HP Regen Min: 2, HP Regen Max: 5, Familiar Weight: +5, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Familiar Effect: "1xBarrr, cap 30"
-Item	Grimacite gaiters	Adventures: +3, Mysticality Percent: [10*G], Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
-Item	Grimacite greaves	Initiative: +20, Moxie Percent: [10*G], Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
+Item	Greatest American Pants	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Weapon Damage Percent: +50, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
+Item	Greaves of the Murk Lord	HP Regen Min: 2, HP Regen Max: 5, Familiar Weight: +5, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
+Item	Grimacite gaiters	Adventures: +3, Mysticality Percent: [10*G], Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
+Item	Grimacite greaves	Initiative: +20, Moxie Percent: [10*G], Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 Item	grubby wool trousers	Initiative: +25, Damage Reduction: 5, Familiar Weight: +5
 # Guzzlr pants: Get more Guzzlrbucks for successful deliveries
-Item	gym shorts	PvP Fights: +2, Initiative: +20, Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+Item	gym shorts	PvP Fights: +2, Initiative: +20, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 Item	hardened slime pants	Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Never Fumble, Moxie Percent: +20, Familiar Effect: "atk, 1xPotato"
 Item	hep waders	Maximum Hooch: +3, Familiar Effect: "1xPotato, 1xVolley, cap 12"
 Item	high-tension exoskeleton	Avoid Attack: 1
@@ -745,7 +745,7 @@ Item	hippopotamus skirt	Maximum HP: +25, Familiar Effect: "1xBarrr, 1xFairy, cap
 Item	hobo dungarees	Maximum MP: +500, Mysticality Percent: +5, Familiar Effect: "0.5xVolley, 1xPotato"
 Item	Hodgman's lobsterskin pants	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, Hobo Power: +25, Familiar Effect: "atk, 1xPotato"
 Item	honeybritches	Muscle Percent: +5, Critical Hit Percent: +5, Weapon Damage: +15, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
-Item	hot daub stand	Hot Damage: +9, Hot Spell Damage: +9, Familiar Effect: "hot atk, cap 21"
+Item	hot daub stand	Hot Damage: +9, Hot Spell Damage: +9, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 Item	ironic jogging shorts	Initiative: +10, Damage Absorption: +20, Moxie: -5, Familiar Effect: "1xBarrr, 6xGhuol, cap 10"
 Item	irresponsible-tension exoskeleton	Avoid Attack: 3
 Item	Jeans of Loathing	HP Regen Min: 20, HP Regen Max: 30, MP Regen Min: 20, MP Regen Max: 30, Maximum HP: +500, Maximum MP: +500, Stench Resistance: +5, Cloathing, Familiar Effect: "stench atk, 1xPotato"
@@ -757,48 +757,48 @@ Item	Knob Goblin harem pants	Moxie: +1, Familiar Effect: "sleaze atk, 8xPotato, 
 Item	Knob Goblin pants	Muscle: +1, Familiar Effect: "atk, 5xPotato, cap 6"
 Item	Knob Goblin Uberpants	Muscle: +2, Mysticality: +2, Moxie: +2, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 Item	Krakrox's Loincloth	Muscle: +11, Initiative: +15, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
-Item	lava-proof pants	Hot Resistance: +5, Muscle Percent: -50, Mysticality Percent: -50, Moxie Percent: -50
+Item	lava-proof pants	Hot Resistance: +5, Muscle Percent: -50, Mysticality Percent: -50, Moxie Percent: -50, Last Available: "2015-08"
 Item	Leapin' Trousers	Adventures: +1, Muscle: +4, Mysticality: +4, Moxie: +4
 Item	leather chaps	Moxie: +8, Muscle: -4, Familiar Effect: "sleaze atk, 1xBarrr, cap 40"
 Item	Lederhosen of the Night	Moxie: +11, Initiative: +15, Class: "Accordion Thief", Familiar Effect: "atk, 2xGhuol, cap 31"
 Item	leg-mounted Trainbots	Maximum HP: +5, Damage Reduction: 5, Muscle: +5, Last Available: "2022-12"
-Item	leggings of the Spider Queen	Moxie: +15, Moxie Percent: +25, Maximum HP: +50, Maximum MP: +50
-Item	lemon drop trousers	Candy Drop: +50, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12"
+Item	leggings of the Spider Queen	Moxie: +15, Moxie Percent: +25, Maximum HP: +50, Maximum MP: +50, Last Available: "2018-04"
+Item	lemon drop trousers	Candy Drop: +50, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 Item	leotarrrd	Initiative: +15, Familiar Effect: "2xVolley, 2xPotato, cap 22"
 # liar's pants: +30 to All Attributes.  Yeah, +30.  That's the ticket.
-Item	liar's pants	Hot Damage: +10, Softcore Only, Muscle: +5, Mysticality: +5, Moxie: +5, Familiar Effect: "hot atk, cold atk, cap 25"
+Item	liar's pants	Hot Damage: +10, Softcore Only, Last Available: "2007-01", Muscle: +5, Mysticality: +5, Moxie: +5, Familiar Effect: "hot atk, cold atk, cap 25"
 # loofah lederhosen: You often find loose Meat in them
-Item	loofah lederhosen	Mysticality: +10, MP Regen Min: 10, MP Regen Max: 20
+Item	loofah lederhosen	Mysticality: +10, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2022-12"
 Item	los chinos	Damage Absorption: +20, Familiar Effect: "2xPotato, HP regen, cap 13"
 Item	lynyrdskin breeches	Initiative: +25, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 Item	makeshift skirt	Initiative: +15, Familiar Effect: "2xBarrr, 1xFairy, cap 25"
 Item	manly bloomers	Muscle: +6, Moxie: -3, Familiar Effect: "3xBarrr, 1xGhuol, cap 13"
-Item	marble maebari	Muscle Percent: +20, Sleaze Damage: +20, Thorns: 1
+Item	marble maebari	Muscle Percent: +20, Sleaze Damage: +20, Last Available: "2019-12", Thorns: 1
 Item	mariachi pants	Familiar Effect: "8xPotato, cap 2"
 Item	Mayor Ghost's khakis	Spooky Spell Damage: +100, Sleaze Resistance: +5, Cold Resistance: +1, Class: "Pastamancer", Familiar Effect: "1xPotato, HP regen"
 Item	Mer-kin gladiator tailpiece	Initiative: -25, Damage Reduction: 10, Mana Cost: +2, Familiar Effect: "1xBarrr, 1xFairy"
 Item	Mer-kin scholar tailpiece	Initiative: -25, Mysticality Percent: +10, Mana Cost: +2, Familiar Effect: "1.5xBarrr, 1xFairy"
-Item	miming corduroys	Damage Reduction: 10, Hot Resistance: +3
+Item	miming corduroys	Damage Reduction: 10, Hot Resistance: +3, Last Available: "2017-12"
 Item	miner's pants	Damage Absorption: +20, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
-Item	monster pants	Critical Hit Percent: +5, Familiar Effect: "3xVolley, 3xPotato, cap 17"
-Item	Moonthril Greaves	Muscle Percent: [10*G], Mysticality Percent: [10*G], Moxie Percent: [10*G], Familiar Effect: "cap 25"
+Item	monster pants	Critical Hit Percent: +5, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
+Item	Moonthril Greaves	Muscle Percent: [10*G], Mysticality Percent: [10*G], Moxie Percent: [10*G], Last Available: "2011-06", Familiar Effect: "cap 25"
 Item	mostly rat-hide leggings	Initiative: +40, Moxie Percent: +5, Familiar Effect: "stench atk, 1xPotato"
 Item	muddy skirt	Familiar Effect: "sleaze atk, 1xFairy", Damage Aura: 1
-Item	mushroom pants	Moxie: +40, Muscle: -20, Mysticality: -20, Combat Rate: -10
-Item	mutant legs	Monster Level: +10, Muscle: +10, Critical Hit Percent: +10
-Item	nativity shorts	Initiative: [+100*event(December)]
+Item	mushroom pants	Moxie: +40, Muscle: -20, Mysticality: -20, Combat Rate: -10, Last Available: "2020-03"
+Item	mutant legs	Monster Level: +10, Muscle: +10, Critical Hit Percent: +10, Last Available: "2018-11"
+Item	nativity shorts	Initiative: [+100*event(December)], Last Available: "2020-12"
 Item	Newman's Own Trousers	Mysticality: +11, MP Regen Min: 3, MP Regen Max: 7, Class: "Sauceror", Familiar Effect: "hot atk, 1xPotato, cap 31"
 Item	ninja hot pants	Hot Damage: +4, Familiar Effect: "hot atk, 3xPotato, cap 17"
 Item	ninjammies	Adventures: +2, PvP Fights: +2, Rollover Effect: "Morninja", Rollover Effect Duration: 50, Familiar Effect: "atk, 0.5xPotato, cap 25"
 Item	oil slacks	Initiative: +20, Familiar Effect: "1xPotato, cap 30"
 Item	Ol' Scratch's ol' britches	Cold Resistance: +3, Spooky Resistance: +3, Class: "Sauceror", Familiar Effect: "hot atk, 1xPotato"
 Item	old patched suit-pants	Monster Level: +40, Moxie Percent: +5, Familiar Effect: "1xPotato, 0.5xFairy"
-Item	old school Mafia knickerbockers	Muscle: +25, Mysticality: +25, Moxie: +25, Familiar Effect: "5xGhoul, cap 25"
+Item	old school Mafia knickerbockers	Muscle: +25, Mysticality: +25, Moxie: +25, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 Item	old sweatpants	Familiar Effect: "8xPotato, cap 2"
 Item	Orcish cargo shorts	Muscle: +3, Mysticality: -3, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 Item	Oscus's dumpster waders	Hot Resistance: +3, Spooky Resistance: +3, Class: "Pastamancer", Familiar Effect: "stench atk, 1xBarrr"
 Item	Oscus's flypaper pants	Moxie Percent: +20, Damage Absorption: +50, Familiar Effect: "stench atk, 1xPotato"
-Item	pair of plants	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Meat Drop: +20, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10
+Item	pair of plants	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Meat Drop: +20, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10, Last Available: "2014-10"
 Item	palm-frond capris	Moxie: +4, Maximum HP: +30, Maximum MP: +30, Familiar Effect: "1.5xGhuol, cap 35"
 # Pantaloons of Hatred: Generates a lot of static electricity
 Item	Pantaloons of Hatred	Adventures: +4, Reduce Enemy Defense: 10, Spell Damage Percent: +60, Familiar Effect: "hot atk, 2xVolley"
@@ -806,40 +806,40 @@ Item	pantogram pants	Lasts Until Rollover
 Item	pants of the Slug Lord	Stench Resistance: +2, Familiar Effect: "stench atk, 3xPotato, cap 8"
 # Pantsgiving: Improves resting
 # Pantsgiving: Lets you use various Thanksgivingy skills
-Item	Pantsgiving	Experience: +2, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Item Drop: +15, Meat Drop: +30, Softcore Only, Bonus Resting HP: [5*F], Bonus Resting MP: [5*F], Familiar Effect: "1xPotato, cap 25", Drops Items, Variable
+Item	Pantsgiving	Experience: +2, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Item Drop: +15, Meat Drop: +30, Softcore Only, Last Available: "2013-11", Bonus Resting HP: [5*F], Bonus Resting MP: [5*F], Familiar Effect: "1xPotato, cap 25", Drops Items, Variable
 Item	paper-plate-mail pants	Familiar Effect: "hot atk, 2xBarrr, cap 20"
-Item	paperclip pants	Adventures: +2, Initiative: +15, Familiar Effect: "atk, 3xBarrr, cap 12"
-Item	papier-m&acirc;churidars	Initiative: +25, Never Fumble, Familiar Effect: "1xFairy, cap 25", Alters Page Text
+Item	paperclip pants	Adventures: +2, Initiative: +15, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+Item	papier-m&acirc;churidars	Initiative: +25, Never Fumble, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25", Alters Page Text
 # paraffin palazzos: Lets you unleash a prismatic attack
-Item	paraffin palazzos	Moxie: +10, Stench Damage: +10
-Item	parasitic tentacles	Initiative: [min(2*L,30)], Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+Item	paraffin palazzos	Moxie: +10, Stench Damage: +10, Last Available: "2020-12"
+Item	parasitic tentacles	Initiative: [min(2*L,30)], Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
 Item	penguin shorts	Initiative: +20, Familiar Effect: "cold atk, 1xGhuol, cap 30"
 Item	penguinskin mini-kilt	Initiative: +20, Familiar Effect: "cold atk, 1xFairy, cap 30"
 Item	penguinskin mini-skirt	Initiative: +20, Familiar Effect: "cold atk, 1xFairy, cap 30"
 # petrified wood walking pants: Make you dodge some attacks
 Item	petrified wood walking pants	Experience (Moxie): +3, Spell Critical Percent: +10, Last Available: "2025-12"
-Item	pig-iron shinguards	Moxie: +6, Initiative: +10, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
-Item	pin-stripe slacks	Initiative: +15, Familiar Effect: "6xSombrero, 2xPotato, cap 7"
+Item	pig-iron shinguards	Moxie: +6, Initiative: +10, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
+Item	pin-stripe slacks	Initiative: +15, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 Item	pink pinkslip slip	Initiative: +35, Damage Reduction: 4, Familiar Effect: "1xVolley, 1xBarrr"
 Item	pirate pantaloons	Experience (Moxie): +2, Weapon Damage Percent: +15, Last Available: "2019-04"
 Item	pixel pants	Maximum HP: +10, Maximum MP: +10, Familiar Effect: "atk, 4xPotato, cap 12"
 Item	plaid skirt	Initiative: +25, MP Regen Min: 6, MP Regen Max: 10, Familiar Effect: "1xPotato, 1xFairy, cap 38"
 Item	plexiglass pants	Initiative: +25, Item Drop: +20, Moxie Percent: +30, Familiar Effect: "1xVolley, 1xLep, cap 45"
 # polyester pettipants: Makes Curse of Vichyssoise Way Better
-Item	polyester pettipants	Experience (Mysticality): +2, Cold Resistance: +3
+Item	polyester pettipants	Experience (Mysticality): +2, Cold Resistance: +3, Last Available: "2015-12"
 Item	poodle skirt	Slime Resistance: +1, Meat Drop: +25, Hot Damage: +25, Familiar Effect: "atk, 1xFairy"
 # porcelain plus-fours: Increase Duration of Turtle Tamer Buffs by 4
-Item	porcelain plus-fours	Muscle: +4, Mysticality: +4, Moxie: +4, Maximum HP: +4, Maximum MP: +4, Spooky Damage: +4, Stench Damage: +4, Hot Damage: +4, Cold Damage: +4, Sleaze Damage: +4, Critical Hit Percent: +4, Damage Reduction: 4, Familiar Weight: +4
-Item	porkpie-mounted popper	Combat Rate: -5, Hot Damage: +20, Hot Spell Damage: +20, Lasts Until Rollover
-Item	pottery training pants	Muscle: +3, Mysticality: +3, Moxie: +3, Hot Damage: +5, Familiar Effect: "hot atk, 2xGhuol, cap 12"
+Item	porcelain plus-fours	Muscle: +4, Mysticality: +4, Moxie: +4, Maximum HP: +4, Maximum MP: +4, Spooky Damage: +4, Stench Damage: +4, Hot Damage: +4, Cold Damage: +4, Sleaze Damage: +4, Critical Hit Percent: +4, Damage Reduction: 4, Familiar Weight: +4, Last Available: "2015-12"
+Item	porkpie-mounted popper	Combat Rate: -5, Hot Damage: +20, Hot Spell Damage: +20, Lasts Until Rollover, Last Available: "2021-07"
+Item	pottery training pants	Muscle: +3, Mysticality: +3, Moxie: +3, Hot Damage: +5, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 Item	power pants	Maximum PP: +1
-Item	primitive alien loincloth	Initiative: +50, Stench Damage: +25, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4
-Item	psychic's pslacks	PvP Fights: +3, HP Regen Min: 5, HP Regen Max: 10
+Item	primitive alien loincloth	Initiative: +50, Stench Damage: +25, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4, Last Available: "2017-04"
+Item	psychic's pslacks	PvP Fights: +3, HP Regen Min: 5, HP Regen Max: 10, Last Available: "2018-02"
 Item	pteruges	Weapon Damage: +10, Familiar Effect: "1xFairy, atk, cap 25"
-Item	purpleheart &quot;pants&quot;	Moxie Percent: +100, Initiative: +50, Adventures: +5
+Item	purpleheart &quot;pants&quot;	Moxie Percent: +100, Initiative: +50, Adventures: +5, Last Available: "2020-08"
 Item	pygmy briefs	Stench Damage: +5, Sleaze Damage: +5, Familiar Effect: "atk, 1xVolley, cap 41"
-Item	Radio Free Pants	Mysticality: +20, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
-Item	ratskin pajama pants	PvP Fights: +2, Adventures: +4, Rollover Effect: "Pajama Party", Rollover Effect Duration: 40
+Item	Radio Free Pants	Mysticality: +20, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
+Item	ratskin pajama pants	PvP Fights: +2, Adventures: +4, Rollover Effect: "Pajama Party", Rollover Effect Duration: 40, Last Available: "2015-04"
 Item	red silk skirt	Experience (Moxie): +1, Hat Drop: +30, Familiar Effect: "atk, 1xFairy, cap 38"
 Item	repaid diaper	Familiar Weight: +15
 # replica Cargo Cultist Shorts: 666 Pockets to Explore
@@ -850,114 +850,114 @@ Item	replica designer sweatpants	Muscle: [5+(2*floor(sqrt(pref(sweat))))], Mysti
 Item	replica Greatest American Pants	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Weapon Damage Percent: +50
 Item	rusty metal greaves	Initiative: -10, Familiar Effect: "1xBarrr, cap 37"
 # saffron antaravasaka: Improves chances of finding lumps and sludge
-Item	saffron antaravasaka	MP Regen Min: 4, MP Regen Max: 6, Spell Critical Percent: +5
+Item	saffron antaravasaka	MP Regen Min: 4, MP Regen Max: 6, Spell Critical Percent: +5, Last Available: "2016-12"
 Item	scale-mail underwear	MP Regen Min: 8, MP Regen Max: 12, Spooky Resistance: +3, Familiar Effect: "2xVolley"
 Item	sea chaps	Muscle Percent: +15, HP Regen Min: 6, HP Regen Max: 10, Familiar Effect: "atk, 2xBarrr"
 Item	sealhide leggings	HP Regen Min: 5, HP Regen Max: 10, Familiar Effect: "1xVolley, cap 40"
-Item	servo-assisted exo-pants	Initiative: -30, Familiar Effect: "cold atk, 1xPotato, cap 12"
+Item	servo-assisted exo-pants	Initiative: -30, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 Item	shadow trousers	Monster Level: +13, Meat Drop: +13, Maximum HP: +13
 Item	silky pirate drawers	Combat Rate: -5, Initiative: +50, Last Available: "2024-12"
-Item	slime waders	Mysticality Percent: +25, Experience (Mysticality): +3, Sleaze Resistance: +3
+Item	slime waders	Mysticality Percent: +25, Experience (Mysticality): +3, Sleaze Resistance: +3, Last Available: "2018-11"
 Item	slime-covered greaves	Slime Resistance: +2, HP Regen Min: 20, HP Regen Max: 40, Initiative: -10, Familiar Effect: "sleaze atk, 0.5xBarrr"
-Item	SMOOCH codpiece	Damage Reduction: 5, Damage Absorption: +20, Familiar Effect: "atk, 1xBarrr, cap 20", Thorns: 1
-Item	smooth velvet pants	Disco Style: +1, Familiar Effect: "2xVolley, 2xPotato, cap 12"
+Item	SMOOCH codpiece	Damage Reduction: 5, Damage Absorption: +20, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20", Thorns: 1
+Item	smooth velvet pants	Disco Style: +1, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 Item	snailmail breeches	Maximum HP: +20, Maximum MP: +20, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Familiar Effect: "1xBarrr, 0.5xFairy, cap 41"
-Item	snakeskin thighboots	Moxie: +10, Initiative: +50
-Item	snow pants	Hot Resistance: +2, Familiar Effect: "cold atk, 1xPotato, cap 12"
+Item	snakeskin thighboots	Moxie: +10, Initiative: +50, Last Available: "2018-11"
+Item	snow pants	Hot Resistance: +2, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 Item	snowboarder pants	Damage Absorption: +20, Familiar Effect: "1xPotato, cap 25"
-Item	space beast fur pants	Damage Reduction: 5, Familiar Effect: "1xVolley"
+Item	space beast fur pants	Damage Reduction: 5, Last Available: "2014-05", Familiar Effect: "1xVolley"
 Item	spandex anniversary shorts	Muscle: +1, Mysticality: +1, Moxie: +1, Familiar Effect: "5xVolley, 10xLep, cap 2"
 Item	spangly mariachi pants	MP Regen Min: 5, MP Regen Max: 10, Familiar Effect: "2xFairy, 2xPotato, cap 37"
-Item	spants	Moxie Percent: +15, Damage Absorption: +100
-Item	Spelunker's khakis	Initiative: +25, HP Regen Min: 4, HP Regen Max: 8, MP Regen Min: 4, MP Regen Max: 8, Combat Rate: +5, Familiar Effect: "1.5xVolley, cap 25"
-Item	Spooky Putty leotard	Initiative: +15, Meat Drop: +15, Softcore Only, Familiar Effect: "1.5xVolley, cap 25"
+Item	spants	Moxie Percent: +15, Damage Absorption: +100, Last Available: "2017-04"
+Item	Spelunker's khakis	Initiative: +25, HP Regen Min: 4, HP Regen Max: 8, MP Regen Min: 4, MP Regen Max: 8, Combat Rate: +5, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
+Item	Spooky Putty leotard	Initiative: +15, Meat Drop: +15, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 Item	square sponge pants	Moxie Percent: +10, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 10, MP Regen Max: 15, Damage Absorption: +30, Familiar Effect: "hot atk, 1xPotato"
 Item	stainless steel slacks	Initiative: +15, Meat Drop: +20, Moxie Percent: +15, Familiar Effect: "prismatic atk, 4xBarrr, cap 22"
 Item	star pants	Initiative: +20, Familiar Effect: "1xPotato, 2xGhuol, cap 41"
 Item	sticky meat kilt	Moxie: +3, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 Item	sticky meat pants	Moxie: +3, Familiar Effect: "2xPotato, cap 11"
 Item	sticky meat skirt	Moxie: +3, Familiar Effect: "3xPotato, 3xFairy, cap 11"
-Item	stinky cheese diaper	Adventures: [max(1,min(10,floor(pref(_stinkyCheeseCount)/10)))], Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25"
+Item	stinky cheese diaper	Adventures: [max(1,min(10,floor(pref(_stinkyCheeseCount)/10)))], Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 Item	studded leather boxer shorts	Familiar Effect: "atk, 4xVolley, cap 5"
-Item	stylish swimsuit	Moxie: +5, Sleaze Damage: [5-5*X], Familiar Effect: "1xPotato, cap 10"
-Item	sucker hakama	Damage Reduction: 5, Familiar Effect: "afk, cap 12"
-Item	sugar shorts	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Breakable, Familiar Effect: "2xVolley, 1xLep, cap 25"
+Item	stylish swimsuit	Moxie: +5, Last Available: "2012-05", Sleaze Damage: [5-5*X], Familiar Effect: "1xPotato, cap 10"
+Item	sucker hakama	Damage Reduction: 5, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+Item	sugar shorts	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Last Available: "2009-09", Breakable, Familiar Effect: "2xVolley, 1xLep, cap 25"
 Item	swashbuckling pants	Moxie: +4, Familiar Effect: "3xPotato, 1.5xFairy, cap 20"
 # tearaway pants: Tear them away in combat!
 Item	tearaway pants	Sleaze Damage: [5*L], Damage Reduction: 10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Initiative: +50, Maximum HP: +50
 # terra cotta trousers: Lets you unleash a terra cotta army on your foes
-Item	terra cotta trousers	Muscle Percent: +20, Familiar Weight: +5
-Item	the Archwizard's briefs	Mysticality: +15, Mysticality Percent: +25, Maximum MP: +100
-Item	The Emperor's new pants	Moxie: [L]
-Item	The Ghoul King's ghoulottes	Muscle: +15, Muscle Percent: +25, Maximum HP: +100
-Item	The Jokester's pants	HP Regen Min: 6, HP Regen Max: 8, Moxie Percent: +20, Never Fumble
-Item	The Necbromancer's Shorts	Cold Resistance: +3, Sleaze Resistance: +3, Booze Drop: +30, Familiar Effect: "atk, 2xGhuol"
+Item	terra cotta trousers	Muscle Percent: +20, Familiar Weight: +5, Last Available: "2020-12"
+Item	the Archwizard's briefs	Mysticality: +15, Mysticality Percent: +25, Maximum MP: +100, Last Available: "2018-04"
+Item	The Emperor's new pants	Moxie: [L], Last Available: "2015-07"
+Item	The Ghoul King's ghoulottes	Muscle: +15, Muscle Percent: +25, Maximum HP: +100, Last Available: "2018-04"
+Item	The Jokester's pants	HP Regen Min: 6, HP Regen Max: 8, Moxie Percent: +20, Never Fumble, Last Available: "2016-12"
+Item	The Necbromancer's Shorts	Cold Resistance: +3, Sleaze Resistance: +3, Booze Drop: +30, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 # The Sagittarian's leisure pants: Disco Bandit Combat Skills weaken enemies by an additional 20%
 Item	The Sagittarian's leisure pants	DB Combat Damage: +13, Familiar Effect: "atk, cap 18"
-Item	Three Mile Island shorts	Stench Damage: +20, Stench Spell Damage: +10
+Item	Three Mile Island shorts	Stench Damage: +20, Stench Spell Damage: +10, Last Available: "2015-04"
 Item	three-legged pants	Muscle: +2, Maximum HP: +5, Familiar Effect: "hot atk, cap 25"
 Item	thunder down underwear	Damage Absorption: +100, Maximum HP: +100, HP Regen Min: 10, HP Regen Max: 20, Lasts Until Rollover
 Item	tighty whiteys	Spooky Resistance: +2, Familiar Effect: "sleaze atk, 3xVolley, cap 10"
-Item	time trousers	Adventures: +3, Familiar Effect: "1xPotato, cap 25"
-Item	tinsel tights	Monster Level: +25, Sleaze Damage: +10, Lasts Until Rollover
+Item	time trousers	Adventures: +3, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
+Item	tinsel tights	Monster Level: +25, Sleaze Damage: +10, Last Available: "2018-01", Lasts Until Rollover
 Item	toothy trousers	PvP Fights: +2, Weapon Damage: +10
 Item	topiary tights	Cold Resistance: +3, Spooky Resistance: +3
 # toy Crimbot rocket legs: Allows use of BURN in combat
-Item	toy Crimbot rocket legs	Initiative: +30, Crimbot Outfit Power: +1
+Item	toy Crimbot rocket legs	Initiative: +30, Crimbot Outfit Power: +1, Last Available: "2014-12"
 Item	transparent pants	Sleaze Damage: +60, Sleaze Spell Damage: +60, Familiar Effect: "sleaze atk, 1xPotato"
 # Travoltan trousers: 5-Finger Discount
 # Travoltan trousers: Moxie used to determine Maximum MP
 # Travoltan trousers: (unless Mysticality is higher)
-Item	Travoltan trousers	Moxie: +15, Initiative: +30, Ranged Damage: +10, Softcore Only, Moxie May Control MP, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
-Item	tree skirt	Moxie: +5, Familiar Effect: "hot atk, 2xFairy, cap 25"
+Item	Travoltan trousers	Moxie: +15, Initiative: +30, Ranged Damage: +10, Softcore Only, Last Available: "2006-09", Moxie May Control MP, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
+Item	tree skirt	Moxie: +5, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 Item	troll britches	Monster Level: +5, Experience: +1, Familiar Effect: "1.5xPotato, cap 28"
-Item	Tropical Crimbo Shorts	Initiative: +30, Familiar Effect: "1xPotato, 1xGhoul"
-Item	trousers of the white knight	Muscle: +3, Mysticality: +3, Moxie: +3, Maximum HP: +15, Maximum MP: +15, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
+Item	Tropical Crimbo Shorts	Initiative: +30, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
+Item	trousers of the white knight	Muscle: +3, Mysticality: +3, Moxie: +3, Maximum HP: +15, Maximum MP: +15, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 Item	troutpiece	Familiar Effect: "1xVolley, 1xBarrr, cap 27"
-Item	troutsers	Moxie Percent: +50, Pickpocket Chance: +50, Spooky Damage: +11, Stench Damage: +11, Hot Damage: +11, Cold Damage: +11, Sleaze Damage: +11, Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato"
+Item	troutsers	Moxie Percent: +50, Pickpocket Chance: +50, Spooky Damage: +11, Stench Damage: +11, Hot Damage: +11, Cold Damage: +11, Sleaze Damage: +11, Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 Item	turtle wax greaves	Muscle: +2, Familiar Effect: "atk, 3xBarrr, cap 10"
 Item	turtlemail breeches	Maximum HP: +30, Sleaze Resistance: +2, Familiar Effect: "3xBarrr, 1.5xFairy, cap 20"
 Item	ultra-high-tension exoskeleton	Avoid Attack: 2
-Item	Uncle Hobo's gift baggy pants	Moxie Percent: +20, Critical Hit Percent: +5, Familiar Effect: "1xPotato, 1xGhuol"
+Item	Uncle Hobo's gift baggy pants	Moxie Percent: +20, Critical Hit Percent: +5, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 Item	union scalemail pants	Familiar Effect: "2xBarrr, cap 12"
 Item	Unkillable Skeleton's shinguards	Sleaze Damage: +50, Hot Resistance: +5, Stench Resistance: +1, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
 # velour vaqueros: Triples the effectiveness of the Dirge of Dreadfulness
-Item	velour vaqueros	Moxie: +10, Pants Drop: +30
-Item	Vicar's Tutu	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, PvP Fights: +3, Smithsness: +5, Maximum HP: [2*K], Familiar Effect: "1.2xFairy, cap 25"
+Item	velour vaqueros	Moxie: +10, Pants Drop: +30, Last Available: "2021-12"
+Item	Vicar's Tutu	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, PvP Fights: +3, Smithsness: +5, Last Available: "2013-12", Maximum HP: [2*K], Familiar Effect: "1.2xFairy, cap 25"
 Item	Volartta's bellbottoms	Moxie: +11, Ranged Damage: +11, Class: "Disco Bandit", Familiar Effect: "1xPotato, 1.5xFairy, cap 31"
 Item	Voluminous Radio Pants	HP Regen Min: 5, HP Regen Max: 10, Familiar Effect: "2xGhoul, cap 37"
-Item	waders	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Experience: +5, Fishing Skill: +5
-Item	Wal-Mart overalls	Moxie Percent: +40, Experience (Moxie): +4, Initiative: +30
-Item	warbear battle greaves	WarBear Armor Penetration: +20, Weapon Damage Percent: +25, Spell Damage Percent: +50, Familiar Effect: "atk, 1xBarrr, cap 25"
+Item	waders	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Experience: +5, Fishing Skill: +5, Last Available: "2019-07"
+Item	Wal-Mart overalls	Moxie Percent: +40, Experience (Moxie): +4, Initiative: +30, Last Available: "2015-11"
+Item	warbear battle greaves	WarBear Armor Penetration: +20, Weapon Damage Percent: +25, Spell Damage Percent: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
 # warbear bearserker greaves: Troubling Vulnerability to All Elements (-5)
-Item	warbear bearserker greaves	WarBear Armor Penetration: +60, Muscle Percent: -25, Mysticality Percent: -25, Moxie Percent: -25, Hot Resistance: -5, Cold Resistance: -5, Spooky Resistance: -5, Stench Resistance: -5, Sleaze Resistance: -5, Familiar Effect: "atk, 1xBarrr"
+Item	warbear bearserker greaves	WarBear Armor Penetration: +60, Muscle Percent: -25, Mysticality Percent: -25, Moxie Percent: -25, Last Available: "2013-12", Hot Resistance: -5, Cold Resistance: -5, Spooky Resistance: -5, Stench Resistance: -5, Sleaze Resistance: -5, Familiar Effect: "atk, 1xBarrr"
 # warbear ceremonial party pants: +10% Item Drops from WarBears
 Item	warbear ceremonial party pants	Familiar Effect: "1xPotato, 1xGhuol, cap 37"
-Item	warbear dress greaves	Muscle: +10, Food Drop: +25, Familiar Effect: "2xBarrr, cap 25"
-Item	warbear electric long johns	Supercold Resistance: +3, Weapon Damage Percent: -25, Spell Damage Percent: -50, Familiar Effect: "hot atk, 1xVolley"
-Item	warbear fleece-lined long johns	Supercold Resistance: +2, Familiar Effect: "hot atk, 1xVolley, cap 37"
+Item	warbear dress greaves	Muscle: +10, Food Drop: +25, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+Item	warbear electric long johns	Supercold Resistance: +3, Weapon Damage Percent: -25, Spell Damage Percent: -50, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
+Item	warbear fleece-lined long johns	Supercold Resistance: +2, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 # warbear high festival pants: +15% Item Drops from WarBears
-Item	warbear high festival pants	Initiative: -25, Maximum HP: -50, Maximum MP: -50, Familiar Effect: "1xPotato, 1xGhoul"
-Item	warbear long johns	Supercold Resistance: +1, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 10, MP Regen Max: 15, Familiar Effect: "hot atk, 1xVolley, cap 12"
-Item	warbear officer greaves	WarBear Armor Penetration: +40, Familiar Effect: "atk, 1xBarrr, cap 37"
+Item	warbear high festival pants	Initiative: -25, Maximum HP: -50, Maximum MP: -50, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+Item	warbear long johns	Supercold Resistance: +1, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 10, MP Regen Max: 15, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+Item	warbear officer greaves	WarBear Armor Penetration: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
 # warbear party pants: +5% Item Drops from WarBears
-Item	warbear party pants	Initiative: +25, Maximum HP: +50, Maximum MP: +50, Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+Item	warbear party pants	Initiative: +25, Maximum HP: +50, Maximum MP: +50, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
 Item	Warms-Your-Tush	Hot Damage: +50, Cold Resistance: +5, Spooky Resistance: +1, Class: "Disco Bandit", Familiar Effect: "1xVolley, 1xPotato"
-Item	wax pants	Moxie: +7, Initiative: +10, Familiar Effect: "atk, 3xBarrr, cap 12"
-Item	weasel stomping pants	Initiative: +25, Candy Drop: +25, Familiar Effect: "1xGhoul, cap 20"
+Item	wax pants	Moxie: +7, Initiative: +10, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
+Item	weasel stomping pants	Initiative: +25, Candy Drop: +25, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 Item	weedy skirt	Maximum HP: +400, HP Regen Min: 25, HP Regen Max: 50, Initiative: +25, Familiar Effect: "atk, 1xFairy"
 Item	white satin pants	Sleaze Resistance: +2, Familiar Effect: "atk, 2xPotato, cap 10"
-Item	whittled shorts	Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 10
+Item	whittled shorts	Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 10, Last Available: "2019-08"
 Item	Whoompa Fur Pants	Stench Damage: +10, Stench Resistance: +2, Familiar Effect: "atk, cap 27"
 # wicker knickers: Increases the effectiveness of Shield of the Pastalord
-Item	wicker knickers	Experience (Mysticality): +2, Adventures: +2
+Item	wicker knickers	Experience (Mysticality): +2, Adventures: +2, Last Available: "2016-12"
 # wired underwear: CyberRealm: Restore your HP (Hacker Physiology) by 50% for 1 RAM
 Item	wired underwear	Last Available: "2025-12"
 Item	wooly loincloth	Pickpocket Chance: +25, MP Regen Min: 4, MP Regen Max: 8, Familiar Effect: "atk, 1xVolley, cap 27"
 # wrought-iron waders: Adds an extra source of damage to Concerto de los Muertos
-Item	wrought-iron waders	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Meat Drop: +20
-Item	wumpus-hair loincloth	Initiative: -10, HP Regen Min: 2, HP Regen Max: 8, MP Regen Min: 2, MP Regen Max: 8, Cold Resistance: +2, Familiar Effect: "1xVolley, 1xPotato, cap 5"
-Item	Xiblaxian stealth trousers	Combat Rate: -5, Moxie Percent: +20
+Item	wrought-iron waders	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Meat Drop: +20, Last Available: "2017-12"
+Item	wumpus-hair loincloth	Initiative: -10, HP Regen Min: 2, HP Regen Max: 8, MP Regen Min: 2, MP Regen Max: 8, Cold Resistance: +2, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
+Item	Xiblaxian stealth trousers	Combat Rate: -5, Moxie Percent: +20, Last Available: "2014-09"
 Item	yakskin kilt	Maximum MP: +25, Familiar Effect: "1xFairy, cap 35"
 Item	yakskin pants	Maximum MP: +25, Familiar Effect: "stench atk, 1xPotato, cap 35"
 Item	yakskin skirt	Maximum MP: +25, Familiar Effect: "1xFairy, cap 35"
@@ -966,90 +966,90 @@ Item	Zombo's grievous greaves	Cold Resistance: +3, Sleaze Resistance: +3, Class:
 
 # Shirts section of modifiers.txt
 
-Item	&quot;Humorous&quot; T-shirt	Muscle: +4, Mysticality: +4, Moxie: +4, Fumble: 2
+Item	&quot;Humorous&quot; T-shirt	Muscle: +4, Mysticality: +4, Moxie: +4, Fumble: 2, Last Available: "2007-05"
 Item	&quot;Remember the Trees&quot; Shirt	Monster Level: +10, Stench Damage: +10, Combat Rate: +5
 Item	adobe abaya	Experience (Moxie): [3+3*min(1,effect(Adobe Abaya Subscription))], Weapon Damage: [20+20*min(1,effect(Adobe Abaya Subscription))], Last Available: "2024-12"
 Item	anniversary safety glass vest	Muscle: +1, Mysticality: +1, Moxie: +1
-Item	antique nutcracker waistcoat	PvP Fights: +3, Muscle Percent: +15
+Item	antique nutcracker waistcoat	PvP Fights: +3, Muscle Percent: +15, Last Available: "2019-12"
 Item	asbestos apron	Hot Resistance: +3
 # Ascension Souvenir T-Shirt
 Item	ASCII shirt	Mysticality: +7
 Item	astral shirt	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Experience: +3, Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3
-Item	autumn sweater-weather sweater	Cold Resistance: +3, Maximum HP: +50, HP Regen Min: 8, HP Regen Max: 12, MP Regen Min: 8, MP Regen Max: 12, Lasts Until Rollover
+Item	autumn sweater-weather sweater	Cold Resistance: +3, Maximum HP: +50, HP Regen Min: 8, HP Regen Max: 12, MP Regen Min: 8, MP Regen Max: 12, Lasts Until Rollover, Last Available: "2022-10"
 # barnacle-encrusted sweater: Weakens foes at the start of combat
 Item	barnacle-encrusted sweater	Muscle: +5, Mysticality: +5, Moxie: +5, Familiar Damage: +5, Fishing Skill: +5, Last Available: "2023-12"
 Item	bat-ass leather jacket	Mysticality: +10, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1
-Item	BGE 'cuddly critter' shirt	Item Drop: +7, Meat Drop: +7
-Item	BGE 'ferocious fruit' shirt	Moxie: +10, Maximum HP: +10
+Item	BGE 'cuddly critter' shirt	Item Drop: +7, Meat Drop: +7, Last Available: "2010-12"
+Item	BGE 'ferocious fruit' shirt	Moxie: +10, Maximum HP: +10, Last Available: "2010-12"
 Item	birdbone corset	Maximum Hooch: +2
-Item	blessed rustproof +2 gray dragon scale mail	Muscle: +2, Mysticality: +2, Moxie: +2, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 2, HP Regen Max: 22, MP Regen Min: 2, MP Regen Max: 22
-Item	bod-ice	Monster Level: +25, Sleaze Damage: +25, Sleaze Spell Damage: +25, Lasts Until Rollover
-Item	Brogre brolo shirt	PvP Fights: +3
+Item	blessed rustproof +2 gray dragon scale mail	Muscle: +2, Mysticality: +2, Moxie: +2, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 2, HP Regen Max: 22, MP Regen Min: 2, MP Regen Max: 22, Last Available: "2023-09"
+Item	bod-ice	Monster Level: +25, Sleaze Damage: +25, Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2014-01"
+Item	Brogre brolo shirt	PvP Fights: +3, Last Available: "2014-05"
 Item	bronze breastplate	Damage Absorption: +20, Damage Reduction: 4
-Item	camouflage T-shirt	Mana Cost (combat): -3, Combat Rate: -5, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Weapon Damage: +15
+Item	camouflage T-shirt	Mana Cost (combat): -3, Combat Rate: -5, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Weapon Damage: +15, Last Available: "2014-10"
 Item	camouflage vest	Combat Rate: -10
-Item	cane-mail shirt	Candy Drop: +25, Monster Level: +20, Meat Drop: +15
+Item	cane-mail shirt	Candy Drop: +25, Monster Level: +20, Meat Drop: +15, Last Available: "2011-12"
 # ceramic cenobite's robe: Deal 30 damage and heal 30 HP
 Item	ceramic cenobite's robe	Experience (Moxie): +3, Maximum HP: +20, Maximum MP: +20, HP Regen Min: 4, HP Regen Max: 8, MP Regen Min: 4, MP Regen Max: 8, Last Available: "2023-12"
 Item	chamoisole	Slime Resistance: +3
-Item	cheerful Crimbo sweater	Cold Resistance: +2, Moxie: -15
-Item	chest barrel	Damage Reduction: 5, Damage Absorption: +50
+Item	cheerful Crimbo sweater	Cold Resistance: +2, Moxie: -15, Last Available: "2017-12"
+Item	chest barrel	Damage Reduction: 5, Damage Absorption: +50, Last Available: "2015-09"
 Item	Chester's muscle shirt	Muscle Percent: +20, Damage Reduction: 10
 Item	chiffon chemise	Experience (Mysticality): +2, Cold Damage: +10, Cold Spell Damage: +10, Last Available: "2023-12", Damage Aura: 1
 Item	clockwork trench coat	Damage Absorption: +15
 Item	clownskin harness	Spooky Damage: +2, Sleaze Damage: +2, Clowniness: 50
 Item	coconut bikini top	Mysticality: +5
 # Colonel Mustard's Lonely Spades Club Jacket: + ???
-Item	conquistador's breastplate	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Meat Drop: +15
+Item	conquistador's breastplate	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Meat Drop: +15, Last Available: "2019-04"
 Item	cool iron breastplate	Damage Reduction: 20, Maximum HP: +200
 Item	Corporal Fennel's Lonely Clubs Club Jacket	PvP Fights: +2
 # crepe paper plunge camisole: Leave nothing to the imagination and distract your foes
 Item	crepe paper plunge camisole	Moxie: +10, Sleaze Damage: +10, Sleaze Spell Damage: +10, Last Available: "2025-12"
-Item	Crimbuccaneer bombjacket	Moxie Percent: +25, Ranged Damage: +25, Combat Item Damage Percent: 100
+Item	Crimbuccaneer bombjacket	Moxie Percent: +25, Ranged Damage: +25, Last Available: "2023-12", Combat Item Damage Percent: 100
 Item	Crimbuccaneer shirt	Familiar Weight: [+10*event(December)], Last Available: "2023-12"
 Item	demonskin jacket	Mysticality: +5, Hot Spell Damage: +5
-Item	denim jacket	Mysticality: +10, MP Regen Min: 4, MP Regen Max: 8
-Item	Dragonscale breastplate	Muscle: +15, Muscle Percent: +25, Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3
+Item	denim jacket	Mysticality: +10, MP Regen Min: 4, MP Regen Max: 8, Last Available: "2018-09"
+Item	Dragonscale breastplate	Muscle: +15, Muscle Percent: +25, Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Last Available: "2018-04"
 Item	dreadful sweater	HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Kruegerand Drop: 5
 Item	duct tape shirt	Moxie: +9, Meat Drop: +20
 Item	embers-only jacket	Hot Damage: +10, Hot Resistance: +3, Hot Spell Damage: +20, Lasts Until Rollover, Last Available: "2024-09"
-Item	extra-see-thru nightie	Moxie Percent: +15
+Item	extra-see-thru nightie	Moxie Percent: +15, Last Available: "2011-10"
 Item	eXtreme Bi-Polar Fleece Vest	Cold Resistance: +2
-Item	extremely wet T-shirt	Moxie Percent: +10, Sleaze Damage: +25, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10
+Item	extremely wet T-shirt	Moxie Percent: +10, Sleaze Damage: +25, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10, Last Available: "2014-05"
 Item	famous blue raincoat	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Item Drop: +10, Initiative: +40, Lasts Until Rollover
 Item	filthy hippy poncho	Mysticality: +3
-Item	First Post shirt - Cir Senam	Spooky Damage: +1, Stench Damage: +1, Hot Damage: +1, Cold Damage: +1, Sleaze Damage: +1, Monster Level: +15, PvP Fights: +5
+Item	First Post shirt - Cir Senam	Spooky Damage: +1, Stench Damage: +1, Hot Damage: +1, Cold Damage: +1, Sleaze Damage: +1, Monster Level: +15, PvP Fights: +5, Last Available: "2016-05"
 # fishbone corset: Reduces the level of nearby water
 # flagstone fleece: Lets you flex your muscles
-Item	flagstone fleece	Experience (Moxie): +3, Adventures: +3
-Item	flaming pink shirt	Item Drop: +15, Softcore Only
+Item	flagstone fleece	Experience (Moxie): +3, Adventures: +3, Last Available: "2022-12"
+Item	flaming pink shirt	Item Drop: +15, Softcore Only, Last Available: "2007-01"
 # flatusaur gasmask: Protects against flatusaurus emissions
 Item	floral print shirt	Mysticality: +5
-Item	flyest of shirts	Moxie: +5, Spell Damage: +5
+Item	flyest of shirts	Moxie: +5, Spell Damage: +5, Last Available: "2010-04"
 # fresh coat of paint: Enchantments are different every day
 Item	frilly shirt	Mysticality: +3
 Item	futuristic shirt	Lasts Until Rollover
 Item	General Sage's Lonely Diamonds Club Jacket	Adventures: +3
 Item	ghost toga	Damage Reduction: 5, Spooky Damage: +10
-Item	gingerbread hoodie	Experience: +2, Spell Damage: +10, Sprinkle Drop: +15
-Item	gingerbread waistcoat	Muscle: +10
+Item	gingerbread hoodie	Experience: +2, Spell Damage: +10, Sprinkle Drop: +15, Last Available: "2016-12"
+Item	gingerbread waistcoat	Muscle: +10, Last Available: "2016-12"
 Item	gingham blouse	Muscle: +5
 Item	gladiator tunica	HP Regen Min: 5, HP Regen Max: 15
 # glass casserole dish: Minor Radiation Sickness Protection
-Item	glass casserole dish	PvP Fights: +3, Sleaze Damage: +30, Damage Reduction: 10
+Item	glass casserole dish	PvP Fights: +3, Sleaze Damage: +30, Damage Reduction: 10, Last Available: "2016-11"
 Item	gnauga hide vest	Damage Reduction: 6, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1
-Item	golden fleece	Meat Drop: +20
+Item	golden fleece	Meat Drop: +20, Last Available: "2021-12"
 Item	goth kid t-shirt	Monster Level: +5
 Item	Grateful Undead T-shirt	Item Drop: +5
 Item	Gregarious Gregorian Smock	Muscle Percent: [5+G], Mysticality Percent: [5+G], Moxie Percent: [5+G]
-Item	Grimacite gown	Monster Level: [10*G]
-Item	Grimacite guayabera	Monster Level: [10*G]
+Item	Grimacite gown	Monster Level: [10*G], Last Available: "2008-11"
+Item	Grimacite guayabera	Monster Level: [10*G], Last Available: "2008-10"
 Item	grungy flannel shirt	Moxie: +11
 Item	hairshirt	Monster Level: [50-10*G]
 Item	harem girl t-shirt	Moxie: +3
 Item	hipposkin poncho	Monster Level: +10
 Item	Hodgman's disgusting technicolor overcoat	Spooky Damage: +15, Stench Damage: +15, Hot Damage: +15, Cold Damage: +15, Sleaze Damage: +15, Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5
-Item	icing poncho	Cold Damage: +25, Cold Spell Damage: +25, Food Drop: +50
+Item	icing poncho	Cold Damage: +25, Cold Spell Damage: +25, Food Drop: +50, Last Available: "2019-12"
 Item	junk-mail shirt	Muscle: +4, Mysticality: +4, Moxie: +4
 Item	Jurassic Parka	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Last Available: "2022-09", Avoid Attack: 1
 Item	Kashmir sweater	Hot Damage: +10, Hot Spell Damage: +10
@@ -1057,32 +1057,32 @@ Item	Kelflar vest	Elf Warfare Effectiveness: +3, Damage Reduction: 5, Negative S
 Item	Kiss the Knob apron	Maximum MP: +5
 Item	Knob Goblin elite shirt	Muscle: +3
 Item	KoL Con 13 T-shirt	Sleaze Resistance: +2, Experience Percent (Moxie): +5
-Item	lemon shirt	Candy Drop: +50, Lasts Until Rollover
+Item	lemon shirt	Candy Drop: +50, Lasts Until Rollover, Last Available: "2014-12"
 Item	letterman's jacket	Slime Resistance: +1, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, HP Regen Min: 10, HP Regen Max: 20
-Item	Liam's mail	Damage Absorption: +50, Muscle Percent: +10, Experience: +2
+Item	Liam's mail	Damage Absorption: +50, Muscle Percent: +10, Experience: +2, Last Available: "2016-08"
 Item	loathing eagle baby-doll shirt	Moxie: +3
-Item	LOV Eardigan	Experience Percent (Muscle): +25, HP Regen Min: 8, HP Regen Max: 12, Monster Level: +25, Lasts Until Rollover
+Item	LOV Eardigan	Experience Percent (Muscle): +25, HP Regen Min: 8, HP Regen Max: 12, Monster Level: +25, Lasts Until Rollover, Last Available: "2017-02"
 Item	lynyrdskin tunic	Initiative: +25
 # makeshift garbage shirt: Doubles stat gains from monsters while it's readable
-Item	makeshift garbage shirt	Experience: +3, PvP Fights: +3, Stench Damage: +10, Lasts Until Rollover, Breakable
+Item	makeshift garbage shirt	Experience: +3, PvP Fights: +3, Stench Damage: +10, Last Available: "2018-01", Lasts Until Rollover, Breakable
 Item	Mer-kin breastplate	Damage Absorption: +40, HP Regen Min: 10, HP Regen Max: 20
 Item	metal band T-shirt	Monster Level: +15
 Item	midriff scrubs	Sleaze Damage: +10, Sleaze Spell Damage: +20
-Item	miming shirt	Damage Reduction: 10, Cold Resistance: +3
-Item	Moonthril Cuirass	Monster Level: [10*G], Softcore Only
+Item	miming shirt	Damage Reduction: 10, Cold Resistance: +3, Last Available: "2017-12"
+Item	Moonthril Cuirass	Monster Level: [10*G], Softcore Only, Last Available: "2011-06"
 Item	Mr. Shirt	Muscle: +1, Mysticality: +1, Moxie: +1
-Item	origami pasties	Meat Drop: +30, Softcore Only
+Item	origami pasties	Meat Drop: +30, Softcore Only, Last Available: "2008-02"
 Item	Othello's military jacket	Othello Skill: +10
 # PARTY HARD T-shirt: Makes the Neverending Party harder
-Item	PARTY HARD T-shirt	Muscle Limit: 100, Mysticality Limit: 100, Moxie Limit: 100
+Item	PARTY HARD T-shirt	Muscle Limit: 100, Mysticality Limit: 100, Moxie Limit: 100, Last Available: "2018-09"
 Item	pirate shirt	Moxie: +3
-Item	poncho de azucar	Adventures: +5, Stench Damage: +30, Class: "Accordion Thief"
+Item	poncho de azucar	Adventures: +5, Stench Damage: +30, Class: "Accordion Thief", Last Available: "2020-12"
 Item	potato jacket	Hot Damage: +20, Cold Resistance: +3, Meat Drop: +15, Last Available: "2024-12"
 # Private Pepper's Lonely Hearts Club Jacket: 50% Discount on Gift Packages
 Item	Professor What T-Shirt	MP Regen Min: 1, MP Regen Max: 2
-Item	psycho sweater	Weapon Damage Percent: +20, Spell Damage Percent: +20
+Item	psycho sweater	Weapon Damage Percent: +20, Spell Damage Percent: +20, Last Available: "2008-12"
 Item	punk rock jacket	Moxie: +8, Damage Reduction: 5
-Item	Quartet of Flare Masters Jacket	PvP Fights: +2, Rollover Effect: "Eldritch Concentration", Rollover Effect Duration: 1
+Item	Quartet of Flare Masters Jacket	PvP Fights: +2, Rollover Effect: "Eldritch Concentration", Rollover Effect Duration: 1, Last Available: "2016-11"
 Item	Radio Free Jersey	Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3
 Item	red coat	Ranged Damage: +25, Initiative: -25
 Item	red shirt	Monster Level: +20, Muscle Percent: -50, Mysticality Percent: -50, Moxie Percent: -50
@@ -1094,12 +1094,12 @@ Item	safety vest	Damage Reduction: 3, Moxie: +5
 Item	sea salt scrubs	Maximum HP: +400, Maximum MP: +400, Mysticality Percent: +15
 Item	sequin-encrusted sweater	Spooky Damage: +9, Stench Damage: +9, Hot Damage: +9, Cold Damage: +9, Sleaze Damage: +9, Last Available: "2023-12"
 Item	shark jumper	Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, HP Regen Min: 20, HP Regen Max: 40
-Item	shoe ad T-shirt	Muscle: +5, Mysticality: +5, Moxie: +5, Adventures: +3
-Item	SMOOCH breastplate	Damage Absorption: +40, Thorns: 1
-Item	smooth velvet bra	Maximum HP: +20, HP Regen Min: 5, HP Regen Max: 10
-Item	smooth velvet shirt	Disco Style: +1
+Item	shoe ad T-shirt	Muscle: +5, Mysticality: +5, Moxie: +5, Adventures: +3, Last Available: "2018-09"
+Item	SMOOCH breastplate	Damage Absorption: +40, Last Available: "2015-08", Thorns: 1
+Item	smooth velvet bra	Maximum HP: +20, HP Regen Min: 5, HP Regen Max: 10, Last Available: "2015-08"
+Item	smooth velvet shirt	Disco Style: +1, Last Available: "2015-08"
 Item	snailmail hauberk	Damage Absorption: +60, HP Regen Min: 6, HP Regen Max: 14, MP Regen Min: 6, MP Regen Max: 14
-Item	snakeskin jacket	Moxie: +15, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10
+Item	snakeskin jacket	Moxie: +15, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10, Last Available: "2018-11"
 # Sneaky Pete's leather jacket: The Audience Loves/Hates You Even More!
 Item	Sneaky Pete's leather jacket	Moxie: +10, Meat Drop: +20, Pickpocket Chance: +30, Adventures: +4, Free Pull
 # Sneaky Pete's leather jacket (collar popped): The Audience Loves/Hates You Even More!
@@ -1109,36 +1109,36 @@ Item	souvenir ski t-shirt	Moxie: +5
 Item	spangly mariachi vest	Moxie Percent: +10, Initiative: -25
 Item	star shirt	Muscle: +5, Mysticality: +5, Moxie: +5
 Item	Stephen's lab coat	Monster Level: +10, Familiar Weight: +5
-Item	sugar shirt	Experience: +3, Breakable
+Item	sugar shirt	Experience: +3, Last Available: "2009-09", Breakable
 Item	supportive bra	Moxie: +3
 # surgical apron: Makes you look like a gross doctor
 Item	surgical apron	Damage Reduction: 6, Surgeonosity: +1
-Item	tailored vest	Experience: +3, Lasts Until Rollover
-Item	The Emperor's new shirt	Muscle: [L]
+Item	tailored vest	Experience: +3, Lasts Until Rollover, Last Available: "2019-12"
+Item	The Emperor's new shirt	Muscle: [L], Last Available: "2015-07"
 # Thinknerd T-Shirt	enchantment varies per player?
-Item	trench coat	Experience Percent (Muscle): +20, Muscle Percent: +20, Spooky Resistance: +4
-Item	tunac	Muscle Percent: +50, Monster Level: +25, Item Drop: +25, Combat Rate: +10, Lasts Until Rollover
+Item	trench coat	Experience Percent (Muscle): +20, Muscle Percent: +20, Spooky Resistance: +4, Last Available: "2016-07"
+Item	tunac	Muscle Percent: +50, Monster Level: +25, Item Drop: +25, Combat Rate: +10, Lasts Until Rollover, Last Available: "2016-04"
 Item	turtlemail hauberk	Damage Absorption: +30, HP Regen Min: 6, HP Regen Max: 12
 Item	tuxedo shirt	Moxie: +7
-Item	Ultracolor&trade; shirt	Spooky Damage: [E], Stench Damage: [E], Hot Damage: [E], Cold Damage: [E], Sleaze Damage: [E]
+Item	Ultracolor&trade; shirt	Spooky Damage: [E], Stench Damage: [E], Hot Damage: [E], Cold Damage: [E], Sleaze Damage: [E], Last Available: "2011-05"
 Item	Unkillable Skeleton's breastplate	Experience (familiar): +1, Familiar Weight: +5, Familiar Damage: +10, Class: "Turtle Tamer"
 Item	unrequired jacket	Initiative: +20
 Item	white hat hacker T-shirt	Critical Hit Percent: +3, Muscle: +2, Mysticality: +2, Moxie: +2
 Item	white snakeskin duster	Muscle: +2, Maximum HP: +10
 # witch's bra: All Spells Cast Are Cold
-Item	witch's bra	Spell Damage Percent: +50, Cold Spell Damage: +50
-Item	wumpus-hair sweater	Muscle: +3, Mysticality: +3, Moxie: +3, Maximum HP: +30, Maximum MP: +30
-Item	Xiblaxian stealth vest	Combat Rate: -5, Muscle Percent: +20
+Item	witch's bra	Spell Damage Percent: +50, Cold Spell Damage: +50, Last Available: "2014-12"
+Item	wumpus-hair sweater	Muscle: +3, Mysticality: +3, Moxie: +3, Maximum HP: +30, Maximum MP: +30, Last Available: "2009-06"
+Item	Xiblaxian stealth vest	Combat Rate: -5, Muscle Percent: +20, Last Available: "2014-09"
 Item	yak anorak	MP Regen Min: 3, MP Regen Max: 4
 Item	Ye Olde Navy Fleece	Meat Drop: +10
 # Yeg's Motel bathrobe: Extremely fragile (will be destroyed if you are hit in combat)
-Item	Yeg's Motel bathrobe	Spooky Damage: +50, Muscle Percent: +66, Lasts Until Rollover
+Item	Yeg's Motel bathrobe	Spooky Damage: +50, Muscle Percent: +66, Lasts Until Rollover, Last Available: "2020-09"
 # zero-trust tanktop: CyberRealm: Regenerate some of your HP (Hacker Physiology) each round
 Item	zero-trust tanktop	Last Available: "2025-12"
 
 # Weapons section of modifiers.txt
 
-Item	&quot;honey&quot; dipper	Stench Damage: +20, Stench Spell Damage: +25, Spell Damage Percent: +30
+Item	&quot;honey&quot; dipper	Stench Damage: +20, Stench Spell Damage: +25, Spell Damage Percent: +30, Last Available: "2014-12"
 Item	4-dimensional guitar	Ranged Damage: +5, Critical Hit Percent: +10
 Item	5-Alarm Saucepan	Mysticality: +7, Class: "Sauceror"
 Item	7-Foot Dwarven mattock	Weakens Monster
@@ -1154,17 +1154,17 @@ Item	accordionoid rocca	Damage Reduction: [10*(1+skill(Accordion Appreciation))]
 Item	acoustic guitarrr	Meat Drop: +8
 Item	adobe adze	Experience (Muscle): [3+3*min(1,effect(Adobe Adze Subscription))], Familiar Weight: [5+5*min(1,effect(Adobe Adze Subscription))], Single Equip, Last Available: "2024-12"
 # aerogel accordion: Only takes up one hand!
-Item	aerogel accordion	Moxie: [10*(1+skill(Accordion Appreciation))], Maximum HP: [20*(1+skill(Accordion Appreciation))], Song Duration: 10
+Item	aerogel accordion	Moxie: [10*(1+skill(Accordion Appreciation))], Maximum HP: [20*(1+skill(Accordion Appreciation))], Song Duration: 10, Last Available: "2017-12"
 # airblaster gun: Blasts Air (Duh.)
 Item	alarm accordion	Adventures: [3*(1+skill(Accordion Appreciation))], Initiative: [20*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 20
 Item	amok putter	Hot Damage: +9, Cold Damage: +9, Initiative: +18
 Item	ancient Elf dessert spoon	Hot Spell Damage: +20, Cold Spell Damage: +20, Spooky Spell Damage: +20, Stench Spell Damage: +20, Sleaze Spell Damage: +20, Spell Damage Percent: +20, Last Available: "2023-12"
 Item	ancient ice cream scoop	Spell Damage: +20
-Item	ancient stone fist	Damage Reduction: 2, Maximum HP: +20
-Item	anger blaster	Hot Damage: +10
+Item	ancient stone fist	Damage Reduction: 2, Maximum HP: +20, Last Available: "2009-06"
+Item	anger blaster	Hot Damage: +10, Last Available: "2013-12"
 Item	antique accordion	Song Duration: 10
 Item	antique machete	Muscle Percent: +5
-Item	antique nutcracker sword	Weapon Damage Percent: +30, Muscle Percent: +15, Single Equip
+Item	antique nutcracker sword	Weapon Damage Percent: +30, Muscle Percent: +15, Single Equip, Last Available: "2019-12"
 Item	antique spear	Initiative: -30, Weakens Monster, Breakable
 Item	Apriling band quad tom	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, Muscle: +5, Mysticality: +5, Moxie: +5, Damage Reduction: 10, Lasts Until Rollover
 Item	Apriling band saxophone	Sleaze Damage: +20, Sleaze Spell Damage: +20, Stench Resistance: +2, Hot Resistance: +2, Lasts Until Rollover
@@ -1183,32 +1183,32 @@ Item	astral pistol	Moxie Percent: +25, Ranged Damage: +20, PvP Fights: +4
 Item	autocalliope	Spooky Damage: [2*(1+skill(Accordion Appreciation))], Stench Damage: [2*(1+skill(Accordion Appreciation))], Hot Damage: [2*(1+skill(Accordion Appreciation))], Cold Damage: [2*(1+skill(Accordion Appreciation))], Sleaze Damage: [2*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 15
 # automatic catapult
 # Ax of L'rose
-Item	backwoods banjo	Experience Percent (Moxie): +20, Ranged Damage: +40, Maximum HP: +200, Maximum MP: +200
+Item	backwoods banjo	Experience Percent (Moxie): +20, Ranged Damage: +40, Maximum HP: +200, Maximum MP: +200, Last Available: "2015-04"
 # bad vibroknife: Improves your ability to align chakras
-Item	bad vibroknife	Maximum HP: +25, Weapon Damage: +10
+Item	bad vibroknife	Maximum HP: +25, Weapon Damage: +10, Last Available: "2016-12"
 Item	bad-ass club	Weapon Damage: +15, Monster Level: +10, Class: "Seal Clubber"
 Item	bag of unfinished business	Stench Damage: +40, Familiar Weight: +5
-Item	Bal-musette accordion	PvP Fights: [4*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 10
+Item	Bal-musette accordion	PvP Fights: [4*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 # balanced antler: Keeps beasts away
-Item	balanced antler	Monster Level: +15
+Item	balanced antler	Monster Level: +15, Last Available: "2018-12"
 Item	balloon sword	Never Fumble, Weapon Damage: -2, Clowniness: 50
 # bamboo bokuto
 Item	bar whip	Familiar Weight: +2
 Item	baritone accordion	HP Regen Min: [2*(1+skill(Accordion Appreciation))], HP Regen Max: [4*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 7
 Item	Barney's rake	Spooky Damage: +3, Muscle: +3
-Item	barrel gun	Weapon Damage Percent: +25
+Item	barrel gun	Weapon Damage Percent: +25, Last Available: "2015-09"
 Item	basic meat crossbow	Moxie: +1
 Item	basic meat spork	Muscle: +3, Weapon Damage: +3
 Item	basic meat staff	Mysticality: +1
 Item	basic meat sword	Muscle: +1
-Item	bass clarinet	Moxie Percent: +100, Ranged Damage: +50, Mana Cost: -3, Combat Rate: -10, Lasts Until Rollover
+Item	bass clarinet	Moxie Percent: +100, Ranged Damage: +50, Mana Cost: -3, Combat Rate: -10, Lasts Until Rollover, Last Available: "2016-04"
 Item	bastard baster	Spell Damage Percent: +20
 Item	bat whip	Spell Damage: +10, Monster Level: +5
 Item	batblade	Weapon Damage: +15
-Item	battery-powered drill	Spell Damage Percent: +100, Maximum HP: +50, Maximum MP: +50, Monster Level: +10, Meat Drop: +10
+Item	battery-powered drill	Spell Damage Percent: +100, Maximum HP: +50, Maximum MP: +50, Monster Level: +10, Meat Drop: +10, Last Available: "2014-10"
 Item	beaver spear	Muscle: +5, Weapon Damage: +10
 # beechwood blowgun: Lets you fire poison darts at your foes
-Item	beechwood blowgun	Ranged Damage Percent: +100, Moxie: +25, Experience (Moxie): +5, Lasts Until Rollover
+Item	beechwood blowgun	Ranged Damage Percent: +100, Moxie: +25, Experience (Moxie): +5, Lasts Until Rollover, Last Available: "2020-08"
 Item	beer bong	Stench Damage: +15, Monster Level: +5
 Item	beer-a-pult	Stench Damage: +10, Sleaze Damage: +10
 Item	beer-battered accordion	Sleaze Damage: [2*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 6
@@ -1219,7 +1219,7 @@ Item	big stirring stick	Mysticality: +5, Spell Damage: +5
 Item	Bigger Bugfinder Blade	Muscle: +11, Mysticality: +11, Moxie: +11, Adventures: +3
 # bill bec-de-bardiche glaive-guisarme
 # bindlestocking: On Critical:  Merry Crimbo!
-Item	bindlestocking	Item Drop: +10, Weapon Damage: +25, Drops Items
+Item	bindlestocking	Item Drop: +10, Weapon Damage: +25, Last Available: "2010-12", Drops Items
 Item	Bjorn's Hammer	Muscle: +10, Class: "Seal Clubber"
 # black blade: Successful attacks restore some HP
 Item	black blade	Spooky Damage: +10
@@ -1227,38 +1227,38 @@ Item	black kettle drum	Moxie: +5, Maximum HP: +30, Maximum MP: +30
 Item	black sword	Critical Hit Percent: +7, Weapon Damage: +7
 # blade of dismemberment: Does more damage to armed or legged foes
 Item	blade of dismemberment	Weakens Monster, Lasts Until Rollover, Last Available: "2024-09"
-Item	blammer	Critical Hit Percent: +7, Weakens Monster
+Item	blammer	Critical Hit Percent: +7, Weakens Monster, Last Available: "2011-09"
 # blood knife: Gross!
 Item	blood knife	Lasts Until Rollover
-Item	Bloodbath	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 25, HP Regen Max: 30, MP Regen Min: 25, MP Regen Max: 30
+Item	Bloodbath	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 25, HP Regen Max: 30, MP Regen Min: 25, MP Regen Max: 30, Last Available: "2013-12"
 # bloody harpoon: +100% Physical Damage (in PirateRealm only)
-Item	bloody harpoon	Weapon Damage Percent: [100*zone(PirateRealm)], Lasts Until Rollover
-Item	blunt icepick	Cold Damage: +15
+Item	bloody harpoon	Weapon Damage Percent: [100*zone(PirateRealm)], Lasts Until Rollover, Last Available: "2019-04"
+Item	blunt icepick	Cold Damage: +15, Last Available: "2011-09"
 Item	boilgun	Hot Damage: +8, Maximum MP: +10
-Item	bone and arrows	Damage vs. Skeletons: +30
+Item	bone and arrows	Damage vs. Skeletons: +30, Last Available: "2010-10"
 Item	bone bandoneon	Spooky Damage: [7*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 11
-Item	bone crusher	Damage vs. Skeletons: +30
+Item	bone crusher	Damage vs. Skeletons: +30, Last Available: "2010-10"
 Item	bone flute	Spooky Damage: +11
 Item	bone rattle	Spooky Damage: +4
-Item	bonerang	Damage vs. Skeletons: +10
-Item	Bonestabber	Spooky Resistance: +3, Spooky Damage: +10, Monster Level: +5, Damage vs. Skeletons: +30
+Item	bonerang	Damage vs. Skeletons: +10, Last Available: "2010-10"
+Item	Bonestabber	Spooky Resistance: +3, Spooky Damage: +10, Monster Level: +5, Damage vs. Skeletons: +30, Last Available: "2012-10"
 Item	bonfire flower	Plumber Stat: "Mysticality", Plumber Power: 2
-Item	boning knife	Damage vs. Skeletons: +10
+Item	boning knife	Damage vs. Skeletons: +10, Last Available: "2010-10"
 # boot knife
 # bottle-rocket crossbow: Shoots Bottle-Rockets!
-Item	bottle-rocket crossbow	Moxie Percent: +15, Meat Drop: +15, Item Drop: +10, Softcore Only
+Item	bottle-rocket crossbow	Moxie Percent: +15, Meat Drop: +15, Item Drop: +10, Softcore Only, Last Available: "2007-07"
 Item	bounty-hunting rifle	Item Drop: +15
-Item	bow staff	Mysticality: +5, Weapon Damage: +3
+Item	bow staff	Mysticality: +5, Weapon Damage: +3, Last Available: "2004-12"
 Item	boxing glove on a spring	Moxie: +3, Weapon Damage: +4, Initiative: +10
 Item	brand new key	Muscle Percent: +5, Weapon Damage: +20
 # breadchucks: Deals 45-50 Physical Damage and 45-50 <font color=red>Hot Damage</font> when used as a combat item
 Item	breadchucks	Weapon Damage: +10, Hot Damage: +10
 Item	breadwand	Spell Damage: +3
-Item	BRICKO sword	Weapon Damage: +6
+Item	BRICKO sword	Weapon Damage: +6, Last Available: "2010-02"
 Item	Brimstone Bludgeon	Muscle Percent: +50, Mysticality Percent: -20, Weapon Damage: +30, Brimstone
 # broken beer bottle
 # broken champagne bottle: Doubles item drop bonus while the champagne flows
-Item	broken champagne bottle	MP Regen Min: 4, MP Regen Max: 8, Weapon Damage Percent: +50, Lasts Until Rollover, Breakable
+Item	broken champagne bottle	MP Regen Min: 4, MP Regen Max: 8, Weapon Damage Percent: +50, Last Available: "2018-01", Lasts Until Rollover, Breakable
 Item	broken sword	Spooky Resistance: +1
 # brute force hammer: CyberRealm: Deal 40 damage for 3 RAM
 Item	brute force hammer	Last Available: "2025-12"
@@ -1270,44 +1270,44 @@ Item	bucket of anniversary lard	Muscle: +1, Mysticality: +1, Moxie: +1
 Item	buffalo blade	Muscle: +5, Hot Damage: +3, Sleaze Damage: +2
 Item	bugbear-smiting sword	Weapon Damage: +10, Muscle: +10, Damage vs. Bugbears: +100
 Item	Bugfinder Blade	Muscle: +7, Mysticality: +7, Moxie: +7, Adventures: +3
-Item	butterfly knife	Moxie: +6
-Item	Byte	Spell Damage Percent: +100, Spell Critical Percent: +15
-Item	C.B.F.G.	Hot Damage: +10, Stench Damage: +10
+Item	butterfly knife	Moxie: +6, Last Available: "2013-12"
+Item	Byte	Spell Damage Percent: +100, Spell Critical Percent: +15, Last Available: "2013-12"
+Item	C.B.F.G.	Hot Damage: +10, Stench Damage: +10, Last Available: "2007-12"
 Item	C.H.U.M. knife	Stench Damage: +30
-Item	Cajun accordion	Maximum HP: [15*(1+skill(Accordion Appreciation))], Maximum MP: [15*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 10
+Item	Cajun accordion	Maximum HP: [15*(1+skill(Accordion Appreciation))], Maximum MP: [15*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 Item	calavera concertina	Moxie: [3*(1+skill(Accordion Appreciation))], Song Duration: 7
 Item	can cannon	Moxie: +3, Monster Level: +3, Weapon Damage: +3
-Item	can of fake snow	Cold Damage: +5
+Item	can of fake snow	Cold Damage: +5, Last Available: "2005-12"
 Item	can of maces	Weapon Damage: +2, Sleaze Resistance: +1
-Item	can opener	Weakens Monster, Hat Drop: +50
+Item	can opener	Weakens Monster, Hat Drop: +50, Last Available: "2016-11"
 # can-you-dig-it?: + ???
-Item	candlestick	Experience (Mysticality): +2, Mysticality Percent: +100, Lasts Until Rollover
+Item	candlestick	Experience (Mysticality): +2, Mysticality Percent: +100, Lasts Until Rollover, Last Available: "2015-07"
 Item	candy cane sword cane	Weapon Damage Percent: +50, Never Fumble, Rollover Effect: "Sugar Rush", Rollover Effect Duration: 250, Weapon Damage: [5+5*pref(_surprisinglySweetStabUsed)+5*pref(_surprisinglySweetSlashUsed)], Muscle: +10, Mysticality: +10, Moxie: +10
-Item	candy crowbar	Weapon Damage Percent: +100, Lasts Until Rollover
+Item	candy crowbar	Weapon Damage Percent: +100, Lasts Until Rollover, Last Available: "2016-12"
 # candy knife
-Item	candy knuckles	Weapon Damage: +25
-Item	candy screwdriver	Monster Level: +10, Candy Drop: +25
-Item	candy stick	Spell Damage Percent: +50, Candy Drop: +40
+Item	candy knuckles	Weapon Damage: +25, Last Available: "2009-12"
+Item	candy screwdriver	Monster Level: +10, Candy Drop: +25, Last Available: "2016-12"
+Item	candy stick	Spell Damage Percent: +50, Candy Drop: +40, Last Available: "2014-12"
 # cap gun: Bang Bang!
-Item	cap gun	Muscle Limit: 200, Mysticality Limit: 200, Moxie Limit: 200
+Item	cap gun	Muscle Limit: 200, Mysticality Limit: 200, Moxie Limit: 200, Last Available: "2014-08"
 Item	cardboard crossbow	Moxie: +3, Weapon Damage: +3
 Item	cardboard katana	Weapon Damage: +7, Synergetic
 Item	cardboard staff	Mysticality: +3, Weapon Damage: +3
 Item	cardboard sword	Muscle: +3, Weapon Damage: +3
 Item	cardboard wakizashi	Damage Reduction: 4, Synergetic
 Item	carob cannon	Moxie: +7, Adventures: +3, Stench Damage: +5
-Item	Carpathian longsword	Hot Damage: +20, Hot Spell Damage: +20, Monster Level: +10
-Item	carrot-on-a-stick	Moxie: +7, Candy Drop: +50
+Item	Carpathian longsword	Hot Damage: +20, Hot Spell Damage: +20, Monster Level: +10, Last Available: "2016-08"
+Item	carrot-on-a-stick	Moxie: +7, Candy Drop: +50, Last Available: "2014-12"
 Item	cast-iron legacy paddle	Muscle: +15, Weapon Damage: +10
 Item	cat o' nine teeth	Sleaze Damage: +10, Monster Level: +10
 # ceramic celery grater: Deal 30 damage and cause bleeding
 Item	ceramic celery grater	Mysticality Percent: +20, Spell Critical Percent: +20, Last Available: "2023-12"
-Item	Cerebral Crossbow	Cold Damage: +3, Spooky Damage: +3, Sleaze Damage: +3
+Item	Cerebral Crossbow	Cold Damage: +3, Spooky Damage: +3, Sleaze Damage: +3, Last Available: "2006-06"
 # charming flute: +20 Damage vs. Snakes
 Item	charming flute	Moxie: +8
 # cheap plastic blowgun: 50% chance of poisoning opponent.
 Item	cheap plastic bottle opener	Sleaze Damage: +2
-Item	cheap plastic kazoo	Monster Level: +10
+Item	cheap plastic kazoo	Monster Level: +10, Last Available: "2010-06"
 # cheer extractor: Extract 1 additional crystalline cheer from mimes in the Silent Night
 Item	Chelonian Morningstar	Muscle: +11, Never Fumble, Class: "Turtle Tamer"
 Item	Chester's bag of candy	Sleaze Damage: +30, Moxie Percent: +10, Class: "Disco Bandit"
@@ -1315,13 +1315,13 @@ Item	chiffon chakram	Moxie: +10, Stench Damage: +10, Stench Spell Damage: +10, L
 Item	chili powder cutlass	Hot Damage: +20, Last Available: "2024-12"
 # chisel
 # chocolate cow bone: Candilicious Smacks!
-Item	chocolate cow bone	Candy Drop: +30
+Item	chocolate cow bone	Candy Drop: +30, Last Available: "2014-12"
 Item	chopsticks	Initiative: +20, Spell Damage: +12
 Item	chrome crossbow	Moxie: +7, Adventures: +3
 Item	chrome staff	Mysticality: +7, Adventures: +3
 Item	chrome sword	Muscle: +7, Adventures: +3
 # Cloaca-Cola-issue combat knife: Drains MP on Successful Hit
-Item	clock-cleaning hammer	Weapon Damage: +20
+Item	clock-cleaning hammer	Weapon Damage: +20, Last Available: "2011-09"
 # clockwork crossbow: Weakens Monster on Critical Hit
 Item	clockwork crossbow	Ranged Damage: +10, Critical Hit Percent: +7
 # clockwork staff: Restores 3-24 MP on Critical Hit
@@ -1331,13 +1331,13 @@ Item	clockwork sword	Weapon Damage: +10, Critical Hit Percent: +15
 # clown hammer: Squeaky!
 Item	clown whip	Sleaze Resistance: +2, Clowniness: 50
 Item	club of corruption	Weapon Damage: +3, Class: "Seal Clubber"
-Item	club of the five seasons	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5
+Item	club of the five seasons	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Last Available: "2008-07"
 # coal shovel: Lets you hurl hot coals at your foes
 Item	coal shovel	Hot Damage: +20
 Item	Coily&trade;	Moxie Percent: +15, Item Drop: +10, Meat Drop: +25
 Item	combat fan	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3
 Item	combat lover's locket	HP Regen Min: 8, HP Regen Max: 10, MP Regen Min: 8, MP Regen Max: 10, Single Equip, Critical Hit Percent: [pref(locketPhylum,beast)*10], Muscle: [pref(locketPhylum,beast)*20], Weapon Damage Percent: [pref(locketPhylum,bug)*25], Maximum MP Percent: [pref(locketPhylum,bug)*25], Spell Critical Percent: [pref(locketPhylum,constellation)*10], Mysticality: [pref(locketPhylum,constellation)*20], Experience (Moxie): [pref(locketPhylum,construct)*3], Spell Damage: [pref(locketPhylum,construct)*25], Hot Damage: [pref(locketPhylum,demon)*25], Gear Drop: [pref(locketPhylum,demon)*50], Cold Damage: [pref(locketPhylum,dude)*25], Moxie Percent: [pref(locketPhylum,dude)*50], Hot Resistance: [pref(locketPhylum,elemental)*3], Stench Spell Damage: [pref(locketPhylum,elemental)*25], Experience: [pref(locketPhylum,elf)*5], Candy Drop: [pref(locketPhylum,elf)*75], Meat Drop: [pref(locketPhylum,fish)*50], Spooky Spell Damage: [pref(locketPhylum,fish)*25], Stench Damage: [pref(locketPhylum,goblin)*25], Mysticality Percent: [pref(locketPhylum,goblin)*50], Stench Resistance: [pref(locketPhylum,hippy)*3], Damage Reduction: [pref(locketPhylum,hippy)*10], Experience (Mysticality): [pref(locketPhylum,hobo)*3], Hot Spell Damage: [pref(locketPhylum,hobo)*25], Spooky Resistance: [pref(locketPhylum,horror)*3], Maximum HP: [pref(locketPhylum,horror)*50], Spell Damage Percent: [pref(locketPhylum,humanoid)*25], Moxie: [pref(locketPhylum,humanoid)*20], Item Drop: [pref(locketPhylum,mer-kin)*25], Sleaze Spell Damage: [pref(locketPhylum,mer-kin)*25], Sleaze Resistance: [pref(locketPhylum,orc)*3], Maximum MP: [pref(locketPhylum,orc)*25], Experience (Muscle): [pref(locketPhylum,penguin)*3], Cold Spell Damage: [pref(locketPhylum,penguin)*25], Booze Drop: [pref(locketPhylum,pirate)*50], Sleaze Damage: [pref(locketPhylum,pirate)*25], Initiative: [pref(locketPhylum,plant)*50], Maximum HP Percent: [pref(locketPhylum,plant)*50], Cold Resistance: [pref(locketPhylum,slime)*3], Damage Absorption: [pref(locketPhylum,slime)*50], Spooky Damage: [pref(locketPhylum,undead)*25], Muscle Percent: [pref(locketPhylum,undead)*50], Food Drop: [pref(locketPhylum,weird)*50], Weapon Damage: [pref(locketPhylum,weird)*25]
-Item	combat lover's locket lockbox	Free Pull
+Item	combat lover's locket lockbox	Free Pull, Last Available: "2022-02"
 Item	contract enforcement stick	Critical Hit Percent: +4, Muscle Percent: +5
 # cool whip
 Item	corn holder	Spell Damage: +6
@@ -1350,8 +1350,8 @@ Item	cozy bazooka	Moxie Percent: +15, Meat Drop: +20, Initiative Penalty: [30*en
 Item	cozy scimitar	Muscle Percent: +15, Weapon Damage Percent: +50, Initiative Penalty: [30*env(underwater)], Item Drop Penalty: [30*env(underwater)], Meat Drop Penalty: [30*env(underwater)], Breakable
 Item	crazy bastard sword	Weapon Damage: +30, Critical Hit Percent: +10, PvP Fights: +6
 Item	creepy-ass club	Weapon Damage: +25, Monster Level: +15, Sleaze Damage: +15, Class: "Seal Clubber"
-Item	Crimbo sword	Weapon Damage: +5
-Item	Crimbo ukulele	Item Drop: +10
+Item	Crimbo sword	Weapon Damage: +5, Last Available: "2004-10"
+Item	Crimbo ukulele	Item Drop: +10, Last Available: "2006-12"
 # Crimbomination Contraption
 # Crimbuccaneer squirtblunderbuss: 100% chance of poisoning opponent.
 Item	Crimbuccaneer squirtblunderbuss	Sleaze Damage: +30, Last Available: "2023-12"
@@ -1365,8 +1365,8 @@ Item	curmudgel	Monster Level: +8, Weapon Damage: +10
 Item	cursed cutlass	Muscle: +15
 # cursed machete: You will constantly cut yourself with it
 Item	cursed machete	Meat Drop: +50
-Item	cursed pirate cutlass	Muscle: +25, Familiar Weight: +10, Adventures: +5, Single Equip
-Item	cyber-mattock	Item Drop: +5, Meat Drop: +10
+Item	cursed pirate cutlass	Muscle: +25, Familiar Weight: +10, Adventures: +5, Single Equip, Last Available: "2019-07"
+Item	cyber-mattock	Item Drop: +5, Meat Drop: +10, Last Available: "2009-06"
 Item	daddy shortlegs leg	Weapon Damage: +10, Muscle: [4*L]
 Item	deadfall branch	Mysticality Percent: +10, Weapon Damage Percent: +10, Adventures: +1, PvP Fights: +1
 Item	deathchucks	Weapon Damage Percent: +75, Monster Level: +15
@@ -1379,25 +1379,25 @@ Item	dense meat crossbow	Moxie: +3
 Item	dense meat staff	Mysticality: +3
 Item	dense meat sword	Muscle: +3
 Item	dented harmonica	Mysticality: +1
-Item	dented scepter	Experience (Muscle): +5, HP Regen Min: 5, HP Regen Max: 10, Muscle Percent: +50, Weapon Damage Percent: +50, Critical Hit Percent: +10, Single Equip, Lasts Until Rollover
+Item	dented scepter	Experience (Muscle): +5, HP Regen Min: 5, HP Regen Max: 10, Muscle Percent: +50, Weapon Damage Percent: +50, Critical Hit Percent: +10, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 # depleted Grimacite hammer: Needed for depleted Grimacite smithing
-Item	depleted Grimacite hammer	Monster Level: [5*G]
-Item	depleted Grimacite kneecapping stick	Critical Hit Percent: [ceil(G/2)]
-Item	detective roscoe	Ranged Damage: +10, Weakens Monster, Booze Drop: +20
+Item	depleted Grimacite hammer	Monster Level: [5*G], Last Available: "2011-12"
+Item	depleted Grimacite kneecapping stick	Critical Hit Percent: [ceil(G/2)], Last Available: "2007-06"
+Item	detective roscoe	Ranged Damage: +10, Weakens Monster, Booze Drop: +20, Last Available: "2016-07"
 Item	diabolical crossbow	Spooky Damage: +30, Critical Hit Percent: +10, Slime Hates It: +1
 Item	diamond-studded cane	Moxie: +5, Class: "Disco Bandit"
 Item	didgeridooka	Moxie: +9
 # Dinsey's pizza cutter: Motorized Blade is Good for Twisting
-Item	Dinsey's pizza cutter	Spell Damage Percent: +50, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2
+Item	Dinsey's pizza cutter	Spell Damage Percent: +50, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Last Available: "2015-04"
 # disco ball
 Item	Disco Banjo	Moxie: +7, DB Combat Damage: +3, Class: "Disco Bandit"
 Item	dishrag	Stench Damage: +5
-Item	double barreled barrel gun	Weapon Damage Percent: +50, Critical Hit Percent: +5
+Item	double barreled barrel gun	Weapon Damage Percent: +50, Critical Hit Percent: +5, Last Available: "2015-09"
 Item	double-barreled sling	Sleaze Damage: +5, Cold Resistance: +1
-Item	doubt cannon	Weakens Monster
+Item	doubt cannon	Weakens Monster, Last Available: "2013-12"
 Item	Dr. Hobo's scalpel	Weapon Damage: +3, Stench Damage: +1
 # dragon slaying sword: Kills dragons, probably
-Item	dragon slaying sword	Lasts Until Rollover
+Item	dragon slaying sword	Lasts Until Rollover, Last Available: "2018-04"
 Item	dreadful glove	Critical Hit Percent: +5, Kruegerand Drop: 5
 Item	dreadlock whip	Sleaze Damage: +5, Stench Damage: +5, Monster Level: +10
 Item	dripping meat crossbow	Moxie: +2
@@ -1409,53 +1409,53 @@ Item	drippy stake	Single Equip, Drippy Damage: +40
 Item	drippy truncheon	Single Equip, Drippy Damage: +30
 Item	Drowsy Sword	Weakens Monster, Monster Level: -10
 Item	drywall axe	Muscle: +2, Mysticality: +2, Moxie: +2, Muscle Percent: +3, Mysticality Percent: +3, Moxie Percent: +3
-Item	duck-on-a-string	Weapon Damage: +5, Item Drop: +5
+Item	duck-on-a-string	Weapon Damage: +5, Item Drop: +5, Last Available: "2005-12"
 Item	duct tape sword	Damage Absorption: +40, Item Drop: +5
 Item	dueling banjo	Moxie: +4, Monster Level: +5
 # dwarvish war mattock: Magical Blue Glow
 # ebony epee: Lets you disarm your foes
-Item	ebony epee	Weapon Damage Percent: +100, Muscle: +25, Experience (Muscle): +5, Lasts Until Rollover
+Item	ebony epee	Weapon Damage Percent: +100, Muscle: +25, Experience (Muscle): +5, Lasts Until Rollover, Last Available: "2020-08"
 Item	egg gun	Stench Damage: +25, Familiar Weight: +5, Food Drop: +75, HP Regen Min: 15, HP Regen Max: 20, Last Available: "2024-12"
 Item	eggbeater	Spell Damage: +7
 # El Vibrato energy spear
-Item	eldritch hammer	Maximum MP: +40, Monster Level: +10, Weapon Damage Percent: +50
-Item	electric crutch	Spell Damage: +20
+Item	eldritch hammer	Maximum MP: +40, Monster Level: +10, Weapon Damage Percent: +50, Last Available: "2017-01"
+Item	electric crutch	Spell Damage: +20, Last Available: "2011-05"
 Item	elegant nightstick	Maximum HP: +30, Maximum MP: +15
 # elephant stinger: 50% chance of poisoning opponent.
-Item	elephant stinger	Muscle: +3
-Item	elevenderizing hammer	Muscle: +11, Mysticality: +11, Moxie: +11, Weapon Damage: +11
+Item	elephant stinger	Muscle: +3, Last Available: "2010-03"
+Item	elevenderizing hammer	Muscle: +11, Mysticality: +11, Moxie: +11, Weapon Damage: +11, Last Available: "2014-03"
 # Elf Guard broom: Helps clean up the Bar at War
 Item	Elf Guard broom	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Weakens Monster, Last Available: "2023-12"
 Item	Elf Guard mouthknife	Elf Warfare Effectiveness: +3, Moxie Percent: +20, Last Available: "2023-12"
 Item	Elf Guard officer's sidearm	Elf Warfare Effectiveness: +3, Weapon Damage Percent: +10, Last Available: "2023-12"
 Item	Elf Guard squirtgun	Weakens Monster, Stench Damage: +20, Last Available: "2023-12"
-Item	elven tambourine	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2
+Item	elven tambourine	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Last Available: "2015-12"
 # elven whittling knife: On Critical:  Whittles enemy down
 # encrypted shuriken: CyberRealm: Deal 20 damage for 2 RAM
 Item	encrypted shuriken	Last Available: "2025-12"
 Item	evil paper umbrella	Monster Level: +1
 Item	evil-ass club	Weapon Damage: +25, Monster Level: +15, Spooky Damage: +15, Class: "Seal Clubber"
-Item	extra-large utility candle	Item Drop: +25, Hot Damage: +50, Lasts Until Rollover
+Item	extra-large utility candle	Item Drop: +25, Hot Damage: +50, Lasts Until Rollover, Last Available: "2021-08"
 Item	eXtreme meat crossbow	Moxie: +7
 Item	eXtreme meat staff	Mysticality: +7
 Item	eXtreme meat sword	Muscle: +7
-Item	FDKOL fire hose	Cold Damage: +200
-Item	fear condenser	Spooky Damage: +10
+Item	FDKOL fire hose	Cold Damage: +200, Last Available: "2012-07"
+Item	fear condenser	Spooky Damage: +10, Last Available: "2013-12"
 Item	fetus-smashing club	Adventures: +3
 # fiberglass foil: Deals damage and restores some MP at the beginning of each fight
-Item	fiberglass foil	Experience (Muscle): +3, Monster Level: +10, MP Regen Min: [class(Turtle Tamer)*ceil(mus/6)], MP Regen Max: [class(Turtle Tamer)*ceil(mus/4)]
+Item	fiberglass foil	Experience (Muscle): +3, Monster Level: +10, Last Available: "2018-12", MP Regen Min: [class(Turtle Tamer)*ceil(mus/6)], MP Regen Max: [class(Turtle Tamer)*ceil(mus/4)]
 Item	filthy pestle	Spell Damage: +7
 Item	finger cymbals	Maximum MP: +20
-Item	fire axe	Cold Damage: +200
-Item	fire crackers	Effect: "Fire cracked", Effect Duration: 20
+Item	fire axe	Cold Damage: +200, Last Available: "2012-07"
+Item	fire crackers	Effect: "Fire cracked", Effect Duration: 20, Last Available: "2021-07"
 Item	[10462]fire flower	Plumber Stat: "Mysticality", Plumber Power: 1
 Item	fire poi	Hot Damage: +15, Moxie: +3
 Item	fish bazooka	Moxie Percent: +5, Meat Drop: +10
-Item	fish hatchet	Muscle Percent: +100, Weapon Damage: +50, Familiar Weight: +5, Combat Rate: -10, Lasts Until Rollover
+Item	fish hatchet	Muscle Percent: +100, Weapon Damage: +50, Familiar Weight: +5, Combat Rate: -10, Lasts Until Rollover, Last Available: "2016-04"
 Item	fish scimitar	Muscle Percent: +5, Weapon Damage Percent: +10
 Item	fish stick	Mysticality Percent: +5, Spell Damage Percent: +15
 # flagstone flail: Lets you clobber your enemies
-Item	flagstone flail	Muscle Percent: +20, Meat Drop: +20
+Item	flagstone flail	Muscle Percent: +20, Meat Drop: +20, Last Available: "2022-12"
 # Flail of the Seven Aspects: Handle Doubles as a Turtling Rod
 # Flail of the Seven Aspects: Special Attack:  Turtle of Seven Tails
 Item	Flail of the Seven Aspects	Muscle: +15, Never Fumble, Class: "Turtle Tamer"
@@ -1463,23 +1463,23 @@ Item	Flail of the Seven Aspects	Muscle: +15, Never Fumble, Class: "Turtle Tamer"
 Item	flamin' bindle	Item Drop: +10, Hot Damage: +25
 Item	flaming cardboard sword	Muscle: +3, Weapon Damage: +3, Hot Damage: +3
 Item	flaming crutch	Hot Damage: +3
-Item	flaming juggler's balls	Hot Damage: +10, Experience: +2, Softcore Only
-Item	flaming sword	Hot Damage: +20, Spell Critical Percent: +10, Never Fumble
-Item	flamingo mallet	Monster Level: +4, Meat Drop: +5
+Item	flaming juggler's balls	Hot Damage: +10, Experience: +2, Softcore Only, Last Available: "2007-01"
+Item	flaming sword	Hot Damage: +20, Spell Critical Percent: +10, Never Fumble, Last Available: "2013-02"
+Item	flamingo mallet	Monster Level: +4, Meat Drop: +5, Last Available: "2010-03"
 Item	fleetwood chain	Weapon Damage: +5
-Item	fluorescent lightbulb	Maximum MP: +30
+Item	fluorescent lightbulb	Maximum MP: +30, Last Available: "2011-09"
 Item	flypaper staff	Mysticality: +3, Weapon Damage: +3, Spooky Damage: +3
 Item	foam pistol	Critical Hit Percent: +5, Experience Percent (Mysticality): +5
 # focused magnetron pistol: Lets you attempt to steal an item from an enemy
 Item	focused magnetron pistol	Single Equip
-Item	foot-long hot daub	Hot Damage: +9, Hot Spell Damage: +9
+Item	foot-long hot daub	Hot Damage: +9, Hot Spell Damage: +9, Last Available: "2012-07"
 Item	fouet de tortue-dressage	Familiar Weight: +10, Familiar Damage: +10
-Item	Fourth of May Cosplay Saber	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, Spooky Damage: +4, Stench Damage: +4, Hot Damage: +4, Cold Damage: +4, Sleaze Damage: +4, Spooky Resistance: [1+3*pref(_saberMod,3)], Stench Resistance: [1+3*pref(_saberMod,3)], Hot Resistance: [1+3*pref(_saberMod,3)], Cold Resistance: [1+3*pref(_saberMod,3)], Sleaze Resistance: [1+3*pref(_saberMod,3)], MP Regen Min: [10*pref(_saberMod,1)], MP Regen Max: [15*pref(_saberMod,1)], Monster Level: [20*pref(_saberMod,2)], Familiar Weight: [10*pref(_saberMod,4)]
+Item	Fourth of May Cosplay Saber	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, Spooky Damage: +4, Stench Damage: +4, Hot Damage: +4, Cold Damage: +4, Sleaze Damage: +4, Spooky Resistance: [1+3*pref(_saberMod,3)], Stench Resistance: [1+3*pref(_saberMod,3)], Hot Resistance: [1+3*pref(_saberMod,3)], Cold Resistance: [1+3*pref(_saberMod,3)], Sleaze Resistance: [1+3*pref(_saberMod,3)], Last Available: "2019-05", MP Regen Min: [10*pref(_saberMod,1)], MP Regen Max: [15*pref(_saberMod,1)], Monster Level: [20*pref(_saberMod,2)], Familiar Weight: [10*pref(_saberMod,4)]
 # Frankly Mr. Shank: Disco Bandit Combat Skills weaken enemies by an additional 25%
-Item	Frankly Mr. Shank	Smithsness: +5, Class: "Disco Bandit", Moxie Percent: [2*K]
+Item	Frankly Mr. Shank	Smithsness: +5, Class: "Disco Bandit", Last Available: "2013-12", Moxie Percent: [2*K]
 # freezin' bindle: On Critical: Deals 70-100 <font color=blue>Cold Damage</font>
 Item	freezin' bindle	Item Drop: +10, Cold Damage: +25
-Item	frigid derringer	Cold Damage: +20
+Item	frigid derringer	Cold Damage: +20, Last Available: "2016-08"
 Item	frigid hanky&#363;	Cold Damage: +6, Moxie: +2, Wiki Name: "frigid hankyu"
 Item	frigid-ass club	Weapon Damage: +25, Monster Level: +15, Cold Damage: +15, Class: "Seal Clubber"
 Item	Frost&trade; brand sword	Muscle: +3, Monster Level: +3, Cold Damage: +3
@@ -1488,12 +1488,12 @@ Item	Frosty's nailbat	Muscle Percent: +30, Critical Hit Percent: +15, Cold Damag
 Item	Frosty's snowball sack	Cold Damage: +50
 Item	frozen nunchaku	Weapon Damage: +3, Cold Damage: +3
 Item	frozen seal spine	Cold Damage: +20, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10, Class: "Seal Clubber"
-Item	fruit bat	Weapon Drop: +50, Weapon Damage: +75, Class: "Seal Clubber", Single Equip
+Item	fruit bat	Weapon Drop: +50, Weapon Damage: +75, Class: "Seal Clubber", Single Equip, Last Available: "2020-12"
 Item	frying brainpan	Hot Spell Damage: +40, Maximum MP: +200
 Item	ga-ga radio	Experience: +1, Weapon Damage: +5, Maximum MP: +20
-Item	garbage sticker	Food Drop: +20, Booze Drop: +20, Accessory Drop: +20, Weapon Drop: +20, Hat Drop: +20, Meat Drop: +30, Drops Meat
+Item	garbage sticker	Food Drop: +20, Booze Drop: +20, Accessory Drop: +20, Weapon Drop: +20, Hat Drop: +20, Meat Drop: +30, Last Available: "2015-04", Drops Meat
 Item	gatorskin umbrella	Stench Resistance: +3, Weapon Damage: +15
-Item	genie's scimitar	Muscle: +5, Weapon Damage: +5
+Item	genie's scimitar	Muscle: +5, Weapon Damage: +5, Last Available: "2018-02"
 # geofencing rapier: CyberRealm:  Deal 150-200 damage for 7 RAM
 Item	geofencing rapier	Single Equip, Last Available: "2025-12"
 Item	ghast iron cleaver	Spooky Damage: +15, Hot Damage: +15
@@ -1501,7 +1501,7 @@ Item	ghost accordion	Spooky Damage: [5*(1+skill(Accordion Appreciation))], Booze
 Item	ghostly dagger	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Damage Reduction: 11, Weapon Damage: -10
 Item	giant artisanal rice peeler	Spell Damage: +15
 Item	giant cactus quill	Critical Hit Percent: +7, Maximum HP: +30
-Item	giant candy cane	Candy Drop: +40
+Item	giant candy cane	Candy Drop: +40, Last Available: "2011-12"
 Item	giant cheesestick	Mysticality: +5, Sleaze Spell Damage: +11
 Item	giant discarded plastic fork	Critical Hit Percent: +10, Initiative: -10
 Item	giant driftwood sculpture	Moxie: +8, Weapon Damage: +15
@@ -1509,17 +1509,17 @@ Item	giant driftwood sculpture	Moxie: +8, Weapon Damage: +15
 Item	giant foam finger	Damage Reduction: 3
 Item	giant needle	Monster Level: +5
 Item	giant safety pin	Weapon Damage: +10, Weakens Monster
-Item	giant shrimp fork	Mysticality Percent: +20, Spell Critical Percent: +10, Maximum MP: +100
+Item	giant shrimp fork	Mysticality Percent: +20, Spell Critical Percent: +10, Maximum MP: +100, Last Available: "2014-05"
 Item	giant spider leg	Spooky Damage: +10, Critical Hit Percent: +10
 Item	giant turkey leg	Weapon Damage Percent: +50, Combat Rate: +5
 # gift-a-pult: Allows hurling of Gift Items
-Item	gilded trumpet	Maximum HP: +5, Maximum MP: +5, Experience (Moxie): +3, Single Equip
-Item	gingerbread gavel	Critical Hit Percent: +5, Weapon Damage Percent: +25
-Item	gingerbread pistol	Ranged Damage Percent: +25, Sleaze Damage: +10
-Item	Ginsu&trade;	Food Drop: +100, Weapon Damage Percent: +100
+Item	gilded trumpet	Maximum HP: +5, Maximum MP: +5, Experience (Moxie): +3, Single Equip, Last Available: "2020-12"
+Item	gingerbread gavel	Critical Hit Percent: +5, Weapon Damage Percent: +25, Last Available: "2016-12"
+Item	gingerbread pistol	Ranged Damage Percent: +25, Sleaze Damage: +10, Last Available: "2016-12"
+Item	Ginsu&trade;	Food Drop: +100, Weapon Damage Percent: +100, Last Available: "2013-12"
 Item	glistening staff	Mysticality: +2, Sleaze Damage: +3
 # glow-in-the-dark dart gun: Super Accurate!
-Item	glow-in-the-dark dart gun	Moxie: [9-M], Ranged Damage: [2*(9-M)]
+Item	glow-in-the-dark dart gun	Moxie: [9-M], Ranged Damage: [2*(9-M)], Last Available: "2009-01"
 Item	gnauga hide whip	Item Drop: +3
 Item	gnawed-up dog bone	Familiar Weight: +5, Experience (familiar): +1
 Item	Gnollish autoplunger	Mysticality: +3
@@ -1529,30 +1529,30 @@ Item	Gnollish pie server	Spell Damage: +3
 Item	Gnollish slotted spoon	Spell Damage: +3
 Item	goatskin umbrella	Stench Damage: +15
 # goblin autoblowgun: 50% chance of poisoning opponent.
-Item	goblin autoblowgun	Ranged Damage: +5
+Item	goblin autoblowgun	Ranged Damage: +5, Last Available: "2009-06"
 # goblin hunting spear: +15 Damage vs. Jungle Beasts
-Item	goblin hunting spear	Weapon Damage: [5+15*loc(jungle)]
+Item	goblin hunting spear	Weapon Damage: [5+15*loc(jungle)], Last Available: "2009-06"
 Item	goulauncher	Moxie: +4, Spooky Damage: +5
-Item	Granny Hackleton's Gatling gun	Moxie Percent: +25, Critical Hit Percent: +10, Ranged Damage Percent: +200
-Item	grass blade	Weapon Damage: +5
+Item	Granny Hackleton's Gatling gun	Moxie Percent: +25, Critical Hit Percent: +10, Ranged Damage Percent: +200, Last Available: "2016-02"
+Item	grass blade	Weapon Damage: +5, Last Available: "2011-01"
 Item	grass whistle	Moxie: +6, MP Regen Min: 4, MP Regen Max: 6
 Item	grassy cutlass	Weapon Damage: +11
 Item	grave robbing shovel	Spooky Damage: +3, Initiative: -10
 # grease cannon: Sets opponents on fire
-Item	grease cannon	Hot Damage: +20, Sleaze Damage: +20
+Item	grease cannon	Hot Damage: +20, Sleaze Damage: +20, Last Available: "2015-08"
 Item	grease gun	Moxie: +3, Weapon Damage: +3, Sleaze Damage: +3
 Item	Great Wolf's right paw	Weapon Damage: +50, Weapon Damage Percent: +50, Critical Hit Percent: +10, Class: "Seal Clubber", Single Equip
 # Great Wolf's rocket launcher: Lets you fire rockets <font color=white>Duh</font>
 Item	Great Wolf's rocket launcher	Ranged Damage: +50, Critical Hit Percent: +20, Single Equip
 Item	Greek Pasta Spoon of Peril	Mysticality: +11, Food Drop: +10, Initiative: +25, Class: "Pastamancer"
-Item	Grimacite gat	Initiative: +20, Moxie Percent: [10*G]
-Item	Grimacite glaive	Weapon Damage: +15, Muscle Percent: [10*G]
+Item	Grimacite gat	Initiative: +20, Moxie Percent: [10*G], Last Available: "2008-11"
+Item	Grimacite glaive	Weapon Damage: +15, Muscle Percent: [10*G], Last Available: "2008-10"
 Item	groping claw	Weakens Monster, Sleaze Damage: +30
 Item	guancertina	Stench Damage: [4*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 9
-Item	gummi sword	Muscle: +7, Candy Drop: +50
+Item	gummi sword	Muscle: +7, Candy Drop: +50, Last Available: "2014-12"
 Item	gunwale whalegun	Damage Absorption: +100, Weapon Damage Percent: +100, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Last Available: "2023-12"
 # haiku katana: Allows use of seasonal attacks
-Item	haiku katana	Muscle Percent: +15, Critical Hit Percent: +5, Weapon Damage Percent: +50, Softcore Only
+Item	haiku katana	Muscle Percent: +15, Critical Hit Percent: +5, Weapon Damage Percent: +50, Softcore Only, Last Available: "2008-09"
 Item	hairy staff	Mysticality: +7, Spell Damage: +7, MP Regen Min: 5, MP Regen Max: 7
 Item	half-melted spoon	Spell Damage: +10, Hot Spell Damage: +10
 # half-size scalpel: Makes you look like a doctor
@@ -1562,14 +1562,14 @@ Item	halfberd	Weapon Damage: +2
 Item	halibut	Stench Damage: +100, Sleaze Damage: +100, Moxie Percent: -10
 Item	hammer	Plumber Stat: "Muscle", Plumber Power: 1
 Item	Hammer of Smiting	Muscle: +16, Critical Hit Percent: +7, Class: "Seal Clubber"
-Item	hammerus	Spooky Damage: +15
+Item	hammerus	Spooky Damage: +15, Last Available: "2011-09"
 # Hand that Rocks the Ladle: Eminently Twistable
-Item	Hand that Rocks the Ladle	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Smithsness: +5, Class: "Pastamancer", Mysticality Percent: [2*K]
+Item	Hand that Rocks the Ladle	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Smithsness: +5, Class: "Pastamancer", Last Available: "2013-12", Mysticality Percent: [2*K]
 Item	hand-carved bokken	Muscle Percent: +5, Weapon Damage: +15, Critical Hit Percent: +5
 Item	hand-carved bow	Moxie Percent: +10, Ranged Damage: +10, Initiative: +20
 Item	hand-carved staff	Mysticality Percent: +10, Spell Damage: +10, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1
 Item	happiness	Hot Damage: +12
-Item	haunted bindle	Spooky Damage: +10, Spooky Spell Damage: +10
+Item	haunted bindle	Spooky Damage: +10, Spooky Spell Damage: +10, Last Available: "2016-08"
 Item	haunted paddle-ball	Monster Level: +5, Spooky Damage: +10
 Item	hawk	Critical Hit Percent: +5, Weapon Damage: +11, Damage vs. Skeletons: +22
 # heavy hammer: +2 to Hammer attacks
@@ -1577,7 +1577,7 @@ Item	heavy hammer	Plumber Stat: "Muscle", Plumber Power: 2
 Item	heavy leather-bound tome	Weakens Monster
 Item	heavy metal thunderrr guitarrr	Weapon Damage: +16
 # heteroerotic frat-paddle
-Item	high-energy mining laser	Fumble: 2, Hot Damage: +20
+Item	high-energy mining laser	Fumble: 2, Hot Damage: +20, Last Available: "2014-12"
 # high-temperature mining drill: Allows Mining in the Velvet / Gold Mine
 Item	hilarious comedy prop	HP Regen Min: 4, HP Regen Max: 6, MP Regen Min: 4, MP Regen Max: 6
 Item	hippo whip	Monster Level: +10
@@ -1591,18 +1591,18 @@ Item	hothammer	Hot Damage: +50
 Item	huge mirror shard	Weapon Damage: +5
 Item	huge mosquito proboscis	HP Regen Min: 8, HP Regen Max: 12, Maximum HP: +20
 Item	huge spoon	Spell Damage: +10
-Item	ice nine	Critical Hit Percent: +10, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Meat Drop: +30, PvP Fights: +5, Lasts Until Rollover
-Item	ice sickle	Monster Level: +15, Cold Damage: +5, Softcore Only
+Item	ice nine	Critical Hit Percent: +10, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Meat Drop: +30, PvP Fights: +5, Lasts Until Rollover, Last Available: "2014-01"
+Item	ice sickle	Monster Level: +15, Cold Damage: +5, Softcore Only, Last Available: "2006-02"
 Item	icy-hot katana	Hot Damage: +3, Cold Damage: +3
 Item	iFlail	Monster Level: +11, Familiar Weight: +5, Combat Rate: -5
-Item	immense cyborg hand	Weapon Damage: +5, Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3
+Item	immense cyborg hand	Weapon Damage: +5, Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2007-12"
 Item	impromptu torch	Hot Damage: +10, Experience (Muscle): +2, Lasts Until Rollover
 Item	industrial fire extinguisher	Hot Resistance: +3, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Cold Damage: +15, Cold Spell Damage: +15, Maximum HP: +20, Maximum MP: +20, Adventures: +3
 Item	infernal fife	Hot Damage: +7
 Item	infernal toilet brush	Stench Damage: +20, Maximum HP: +20, Maximum MP: +20, Class: "Seal Clubber"
-Item	inflatable baseball bat	Weapon Damage: +30
-Item	intimidating chainsaw	Weapon Damage Percent: +100, Reduce Enemy Defense: 10, Lasts Until Rollover
-Item	iron dagger	Muscle: +3, Spell Damage: +10, Item Drop: +5
+Item	inflatable baseball bat	Weapon Damage: +30, Last Available: "2010-06"
+Item	intimidating chainsaw	Weapon Damage Percent: +100, Reduce Enemy Defense: 10, Lasts Until Rollover, Last Available: "2018-09"
+Item	iron dagger	Muscle: +3, Spell Damage: +10, Item Drop: +5, Last Available: "2013-02"
 Item	iron pasta spoon	Spell Damage: +10
 Item	ironic battle spoon	Spell Damage: +10
 Item	jack flapper	Spell Damage: +5
@@ -1611,13 +1611,13 @@ Item	Jacob's rung	Maximum MP: +15, Spell Damage: +15
 Item	June cleaver	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, HP Regen Min: 6, HP Regen Max: 8, MP Regen Min: 6, MP Regen Max: 8, Adventures: +5, Hot Damage: [pref(_juneCleaverHot)], Spooky Damage: [pref(_juneCleaverSpooky)], Sleaze Damage: [pref(_juneCleaverSleaze)], Cold Damage: [pref(_juneCleaverCold)], Stench Damage: [pref(_juneCleaverStench)], Attacks Can't Miss
 Item	jungle drum	Spooky Damage: +10, Spooky Resistance: +2, Initiative: -20
 Item	keel-haulin' knife	Spell Damage: +17
-Item	kelp-holly gun	Moxie: +10, Ranged Damage Percent: +50, Pickpocket Chance: +25
+Item	kelp-holly gun	Moxie: +10, Ranged Damage Percent: +50, Pickpocket Chance: +25, Last Available: "2019-12"
 Item	Kentucky-fried meat crossbow	Moxie: +5
 Item	Kentucky-fried meat staff	Mysticality: +5
 Item	Kentucky-fried meat sword	Muscle: +5
 Item	kiwi beak	Food Drop: +25, Booze Drop: +25
 Item	kneecapping stick	Critical Hit Percent: +8
-Item	knife	Meat Drop: +50, Moxie Percent: +100, Lasts Until Rollover
+Item	knife	Meat Drop: +50, Moxie Percent: +100, Lasts Until Rollover, Last Available: "2015-07"
 Item	knob bugle	Weakens Monster
 Item	Knob Goblin deluxe scimitar	Muscle: +5
 Item	Knob Goblin elite polearm	Weapon Damage: +3
@@ -1625,40 +1625,40 @@ Item	Knob Goblin melon baller	Spell Damage: +8
 Item	Knob Goblin scimitar	Muscle: +1
 Item	Knob Goblin spatula	Spell Damage: +4
 Item	Knob Goblin tongs	Spell Damage: +2
-Item	KoL Con 12-gauge	Maximum HP: +12, Maximum MP: +12
-Item	KoL Con Cinco Pi&ntilde;ata Bat	Maximum HP: +10, Maximum MP: +10, HP Regen Min: 1, HP Regen Max: 3, MP Regen Min: 1, MP Regen Max: 3, Softcore Only
-Item	lavalarva	Hot Damage: +30, Cold Resistance: +4, Monster Level: +10
+Item	KoL Con 12-gauge	Maximum HP: +12, Maximum MP: +12, Last Available: "2015-09"
+Item	KoL Con Cinco Pi&ntilde;ata Bat	Maximum HP: +10, Maximum MP: +10, HP Regen Min: 1, HP Regen Max: 3, MP Regen Min: 1, MP Regen Max: 3, Softcore Only, Last Available: "2008-09"
+Item	lavalarva	Hot Damage: +30, Cold Resistance: +4, Monster Level: +10, Last Available: "2015-08"
 Item	law-abiding citizen cane	Maximum Hooch: +5, Single Equip
 Item	lawn dart	Muscle Percent: +15, Weapon Damage Percent: +20, Maximum HP: +300
-Item	lawnmower blade	Weapon Damage: +15
-Item	lead pipe	Maximum HP: +50, Muscle Percent: +100, Lasts Until Rollover
+Item	lawnmower blade	Weapon Damage: +15, Last Available: "2010-04"
+Item	lead pipe	Maximum HP: +50, Muscle Percent: +100, Lasts Until Rollover, Last Available: "2015-07"
 # lead yo-yo
 Item	leechknife	Maximum HP: +10, Maximum MP: +5, HP Regen Min: 4, HP Regen Max: 6, MP Regen Min: 4, MP Regen Max: 6
 # licorice whip: Candiful Crits
-Item	licorice whip	Critical Hit Percent: +5
+Item	licorice whip	Critical Hit Percent: +5, Last Available: "2014-12"
 Item	lightning rod	Spell Damage Percent: +200, Maximum MP: +50, MP Regen Min: 5, MP Regen Max: 10, Lasts Until Rollover
 Item	linoleum crossbow	Moxie: +7, Spell Damage: +7
 Item	linoleum staff	Mysticality: +7, Spell Damage: +7
 Item	linoleum sword	Muscle: +7, Spell Damage: +7
 Item	little paper umbrella	Spell Damage: +1
-Item	live wire	Weapon Damage: +3, MP Regen Min: 2, MP Regen Max: 3
-Item	Loathing Legion chainsaw	Weapon Damage Percent: +100, Weakens Monster, Softcore Only
-Item	Loathing Legion double prism	Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2, Softcore Only
-Item	Loathing Legion flamethrower	Hot Damage: +20, Softcore Only
+Item	live wire	Weapon Damage: +3, MP Regen Min: 2, MP Regen Max: 3, Last Available: "2009-12"
+Item	Loathing Legion chainsaw	Weapon Damage Percent: +100, Weakens Monster, Softcore Only, Last Available: "2011-01"
+Item	Loathing Legion double prism	Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2, Softcore Only, Last Available: "2011-01"
+Item	Loathing Legion flamethrower	Hot Damage: +20, Softcore Only, Last Available: "2011-01"
 # Loathing Legion hammer: Gets the job done
-Item	Loathing Legion hammer	Softcore Only
+Item	Loathing Legion hammer	Softcore Only, Last Available: "2011-01"
 Item	logging hatchet	Weapon Damage: +5
 # loofah ladle: Lets you sling cold stew at your enemies
-Item	loofah ladle	Experience (Mysticality): +2, Maximum MP: +30
-Item	love	Pants Drop: +50, HP Regen Min: 8, HP Regen Max: 16, MP Regen Min: 8, MP Regen Max: 16, Familiar Weight: +5
+Item	loofah ladle	Experience (Mysticality): +2, Maximum MP: +30, Last Available: "2022-12"
+Item	love	Pants Drop: +50, HP Regen Min: 8, HP Regen Max: 16, MP Regen Min: 8, MP Regen Max: 16, Familiar Weight: +5, Last Available: "2015-08"
 # lucky ball-and-chain
 Item	lupine sword	Spooky Damage: +9, Synergetic
-Item	LyleCo premium magnifying glass	Rubee Drop: 1, Single Equip
+Item	LyleCo premium magnifying glass	Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 Item	Mace of the Tortoise	Muscle: +7, Class: "Turtle Tamer"
-Item	machetito	Weapon Damage: +9
+Item	machetito	Weapon Damage: +9, Last Available: "2010-04"
 Item	macroplane grater	Spell Damage Percent: +10
 Item	madius	Monster Level: +7
-Item	Mafia violin case	Muscle: +20, Weapon Damage: +30
+Item	Mafia violin case	Muscle: +20, Weapon Damage: +30, Last Available: "2004-10"
 Item	magic whistle	Monster Level: +4, Familiar Weight: +1
 Item	magilaser blastercannon	Ranged Damage: +15, Hot Damage: +5
 Item	mama's squeezebox	Moxie: [3*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 8
@@ -1672,8 +1672,8 @@ Item	Mayor Ghost's gavel	Critical Hit Percent: +10, Weapon Damage: +30, Damage v
 # McHugeLarge right pole: Stab your foe to hurt them
 Item	McHugeLarge right pole	Critical Hit Percent: +10, Weapon Damage: +10, Weapon Damage Percent: +25, Single Equip, Last Available: "2025-01", McHugeLarge
 # Meat Tenderizer is Murder: 25% chance to gain an extra gallon of Fury when you gain a gallon of Fury.
-Item	Meat Tenderizer is Murder	Weapon Damage Percent: +20, Smithsness: +5, Class: "Seal Clubber", Muscle Percent: [2*K]
-Item	Meatcleaver	Meat Drop: +35, Weapon Damage Percent: +100
+Item	Meat Tenderizer is Murder	Weapon Damage Percent: +20, Smithsness: +5, Class: "Seal Clubber", Last Available: "2013-12", Muscle Percent: [2*K]
+Item	Meatcleaver	Meat Drop: +35, Weapon Damage Percent: +100, Last Available: "2013-12"
 Item	meatspout staff	Mysticality: +7, Adventures: +3, Meat Drop: +15
 Item	Mer-kin digpick	Weapon Damage: +30
 Item	Mer-kin dodgeball	PvP Fights: +7, Muscle Percent: +10, Moxie Percent: +10
@@ -1681,28 +1681,28 @@ Item	Mer-kin dragnet	PvP Fights: +7, Muscle Percent: +10, Moxie Percent: +10
 # Mer-kin finpaddle: +100% Damage vs. Mer-kin
 # Mer-kin hookspear: Extracts Meat on Critical Hits
 Item	Mer-kin hookspear	Initiative: +20, Weapon Damage: +40, Drops Meat
-Item	Mer-kin rollpin	Mysticality Percent: +25, Food Drop: +75
+Item	Mer-kin rollpin	Mysticality Percent: +25, Food Drop: +75, Last Available: "2019-12"
 Item	Mer-kin switchblade	PvP Fights: +7, Muscle Percent: [10*G], Moxie Percent: +10
 # mercenary pistol: Allows the Use of Specialty Ammunition
-Item	mercenary pistol	Muscle: +10, Mysticality: +10, Moxie: +10, Never Fumble
+Item	mercenary pistol	Muscle: +10, Mysticality: +10, Moxie: +10, Never Fumble, Last Available: "2014-10"
 # mercenary rifle: Allows the Use of Specialty Ammunition
-Item	mercenary rifle	Ranged Damage: +20, Initiative: +50
+Item	mercenary rifle	Ranged Damage: +20, Initiative: +50, Last Available: "2014-10"
 # Meteoid ice beam: On Critical:  Freeze Opponent
-Item	Meteoid ice beam	Cold Damage: +20, Critical Hit Percent: +10
+Item	Meteoid ice beam	Cold Damage: +20, Critical Hit Percent: +10, Last Available: "2011-12"
 Item	mini kiwi icepick	Booze Drop: +30
-Item	miniature deck cannon	Ranged Damage: +25, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20
-Item	miracle whip	Initiative: +50, Weapon Damage: +50, Item Drop: +50, Meat Drop: +100, Lasts Until Rollover
+Item	miniature deck cannon	Ranged Damage: +25, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-12"
+Item	miracle whip	Initiative: +50, Weapon Damage: +50, Item Drop: +50, Meat Drop: +100, Lasts Until Rollover, Last Available: "2015-05"
 # Mjolnir Jr.
-Item	Moonthril Flamberge	Muscle Percent: [15*G]
-Item	Moonthril Longbow	Moxie Percent: [15*G]
+Item	Moonthril Flamberge	Muscle Percent: [15*G], Last Available: "2011-06"
+Item	Moonthril Longbow	Moxie Percent: [15*G], Last Available: "2011-06"
 # moss mace: Lets you mug a foe
 Item	moss mace	Experience (Muscle): +2, Hot Resistance: +2, Last Available: "2024-12"
 Item	muculent machete	Muscle: +2, Meat Drop: +5
 # murderbot plasma rifle: Can be used to instantly kill Spants
-Item	murderbot plasma rifle	Hot Damage: +25, Reduce Enemy Defense: 10
+Item	murderbot plasma rifle	Hot Damage: +25, Reduce Enemy Defense: 10, Last Available: "2017-04"
 # murderbot whip: Deals 1,000 extra damage on Critical Hit
-Item	murderbot whip	Weapon Damage: +10, Critical Hit Percent: +10
-Item	mutant arm	Monster Level: +5, Maximum HP: +25, Weapon Damage Percent: +50
+Item	murderbot whip	Weapon Damage: +10, Critical Hit Percent: +10, Last Available: "2017-04"
+Item	mutant arm	Monster Level: +5, Maximum HP: +25, Weapon Damage Percent: +50, Last Available: "2018-11"
 Item	nasty-ass club	Weapon Damage: +25, Monster Level: +15, Stench Damage: +15, Class: "Seal Clubber"
 Item	ncle leg	Weapon Damage: +5, Muscle: [3*L]
 Item	negotiatin' hammer	Critical Hit Percent: +12, Muscle Percent: +15, Maximum HP: +30, PvP Fights: +5
@@ -1710,7 +1710,7 @@ Item	ninja mop	Weapon Damage: +5
 Item	non-Euclidean non-accordion	Initiative: [15*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 15
 # non-stick pugil stick: On Critical:  Stuns Opponent
 Item	non-stick pugil stick	Muscle Percent: +10, Weapon Damage Percent: +10
-Item	novelty sparkling candle	Item Drop: +25, Hot Damage: +25, Hot Spell Damage: +25, Lasts Until Rollover
+Item	novelty sparkling candle	Item Drop: +25, Hot Damage: +25, Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2021-08"
 Item	obsidian dagger	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3
 Item	obsidian nutcracker	Spell Damage Percent: +30
 Item	ocarina of space	Muscle: +4, Mysticality: +4, Moxie: +4, Ranged Damage: +5, Experience: +2
@@ -1719,31 +1719,31 @@ Item	office-supply crossbow	Moxie: +3, Ranged Damage: +3
 Item	oil pan	Mysticality Percent: +10
 Item	Ol' Scratch's infernal pitchfork	Hot Damage: +40, Critical Hit Percent: +10
 Item	old dry bone	Spooky Damage: +50
-Item	old school Mafi<i>a kni</i>cke&frac12;&aelig;	Ranged Damage: +27
+Item	old school Mafi<i>a kni</i>cke&frac12;&aelig;	Ranged Damage: +27, Last Available: "2010-04"
 Item	Orcish frat-paddle	Sleaze Damage: +4
 # origami riding crop: Makes you prone to innuendo (heh heh)
-Item	origami riding crop	Sleaze Damage: +10, Initiative: +15, Softcore Only
+Item	origami riding crop	Sleaze Damage: +10, Initiative: +15, Softcore Only, Last Available: "2008-02"
 Item	Othello's dagger	Othello Skill: +10, Single Equip
 Item	out-of-tune biwa	Ranged Damage: +2
 Item	oversized pipe	Muscle: +6, Mysticality: +6
 Item	oversized pizza cutter	Spell Damage: +13
-Item	pair of bolt cutters	Weakens Monster
+Item	pair of bolt cutters	Weakens Monster, Last Available: "2009-12"
 Item	palm-frond whip	Weapon Damage: +30
-Item	papier-m&acirc;ch&eacute;te	Weapon Damage: +10, Muscle Percent: +15, Mysticality Percent: +15, Moxie Percent: +15, Alters Page Text
-Item	papier-m&acirc;chine gun	Ranged Damage: +10, Muscle Percent: +15, Mysticality Percent: +15, Moxie Percent: +15, Alters Page Text
+Item	papier-m&acirc;ch&eacute;te	Weapon Damage: +10, Muscle Percent: +15, Mysticality Percent: +15, Moxie Percent: +15, Last Available: "2012-09", Alters Page Text
+Item	papier-m&acirc;chine gun	Ranged Damage: +10, Muscle Percent: +15, Mysticality Percent: +15, Moxie Percent: +15, Last Available: "2012-09", Alters Page Text
 # paraffin pseudoaccordion: Lets you unleash a prismatic attack
-Item	paraffin pseudoaccordion	Experience (Moxie): +2, Spooky Damage: +10, Song Duration: 5
-Item	parasitic claw	Weapon Damage: [min(L,15)]
-Item	party whip	Monster Level: +15, Item Drop: +10, Familiar Weight: +5
+Item	paraffin pseudoaccordion	Experience (Moxie): +2, Spooky Damage: +10, Song Duration: 5, Last Available: "2020-12"
+Item	parasitic claw	Weapon Damage: [min(L,15)], Last Available: "2008-12"
+Item	party whip	Monster Level: +15, Item Drop: +10, Familiar Weight: +5, Last Available: "2018-09"
 # pasta spoon
 Item	Pasta Spoon of Peril	Mysticality: +7, Initiative: +15, Class: "Pastamancer"
 Item	peace accordion	Stench Damage: [12*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 19
 # Pener's drumstick: Sets opponents on fire
-Item	Pener's drumstick	Hot Damage: +20, Initiative: +20, Critical Hit Percent: +5
+Item	Pener's drumstick	Hot Damage: +20, Initiative: +20, Critical Hit Percent: +5, Last Available: "2015-08"
 Item	penguin whip	Meat Drop: +3
 Item	pentatonic accordion	Cold Damage: [9*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 12
 Item	peppermint harpoon gun	Weapon Damage: [100*env(underwater)]
-Item	peppermint spine	Mysticality: +10, Spell Critical Percent: +10
+Item	peppermint spine	Mysticality: +10, Spell Critical Percent: +10, Last Available: "2019-12"
 Item	perforated battle paddle	Weapon Damage: +10
 Item	Periodical Paintbrush	Muscle Percent: [+5*G], Mysticality Percent: [+5*G], Moxie Percent: [+5*G], Softcore Only
 Item	pernicious cudgel	Sleaze Damage: +30, Critical Hit Percent: +10, Slime Hates It: +1
@@ -1755,38 +1755,38 @@ Item	pewter claymore	HP Regen Min: 6, HP Regen Max: 12, MP Regen Min: 6, MP Rege
 Item	Pigsticker of Violence	HP Regen Min: 20, HP Regen Max: 30, Critical Hit Percent: +10, Weapon Damage Percent: +60
 Item	ping-pong paddle	Single Equip
 Item	pipe wrench	Weapon Damage: +8
-Item	piratical blunderbuss	Familiar Weight: +5, Booze Drop: +30
+Item	piratical blunderbuss	Familiar Weight: +5, Booze Drop: +30, Last Available: "2019-04"
 Item	pitchfork	Weapon Damage: +7
 Item	pixel boomerang	Item Drop: +5
-Item	pixel chain whip	Muscle: +4, Mysticality: +4, Moxie: +4
-Item	pixel morning star	Muscle: +5, Mysticality: +5, Moxie: +5
+Item	pixel chain whip	Muscle: +4, Mysticality: +4, Moxie: +4, Last Available: "2010-07"
+Item	pixel morning star	Muscle: +5, Mysticality: +5, Moxie: +5, Last Available: "2010-07"
 Item	pixel sword	Initiative: +15
 Item	pixel whip	Muscle: +3, Mysticality: +3, Moxie: +3
 # plastic bazooka: Allows you to Super Blast your enemies
 # plastic bazooka: Quick Draw
 # plastic bazooka: (you will nearly always win Initiative)
 Item	plastic guitar	Moxie: +5, Initiative: +15
-Item	plastic nunchaku	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Initiative: +30
+Item	plastic nunchaku	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Initiative: +30, Last Available: "2014-08"
 Item	plastic replica blaster pistol	Initiative: +20, Ranged Damage: +20, Lasts Until Rollover
 Item	plexiglass pikestaff	Weapon Damage: +25, PvP Fights: +9, Muscle Percent: +30
 Item	pocket theremin	Spooky Damage: +7
 Item	pointed stick	Critical Hit Percent: +5, Weapon Damage: +10
 # poison pen: 75% chance of poisoning opponent.
 # polyester peeler: Increases the Damage of Stuffed Mortar Shell
-Item	polyester peeler	Spell Damage Percent: +20, MP Regen Min: 2, MP Regen Max: 4
+Item	polyester peeler	Spell Damage Percent: +20, MP Regen Min: 2, MP Regen Max: 4, Last Available: "2015-12"
 Item	pool cue	Moxie: +5, Pool Skill: +3
 # porcelain police baton: Your Smacks Restore MP
-Item	porcelain police baton	Maximum MP: +20, Muscle Percent: +20
-Item	portable corkscrew	Weapon Damage: +3, Spell Damage: +3
-Item	potato masher	Spell Damage: +15, Spell Critical Percent: +10
+Item	porcelain police baton	Maximum MP: +20, Muscle Percent: +20, Last Available: "2015-12"
+Item	portable corkscrew	Weapon Damage: +3, Spell Damage: +3, Last Available: "2006-04"
+Item	potato masher	Spell Damage: +15, Spell Critical Percent: +10, Last Available: "2016-11"
 Item	potato pistol	Moxie: +5, Sleaze Damage: +5
-Item	pottery club	Hot Damage: +5
-Item	pottery yo-yo	Hot Damage: +5
+Item	pottery club	Hot Damage: +5, Last Available: "2010-09"
+Item	pottery yo-yo	Hot Damage: +5, Last Available: "2010-09"
 Item	poutine pole	Mysticality: +3, Sleaze Damage: +3
-Item	prehistoric spear	Critical Hit Percent: +5
-Item	primitive alien blowgun	Moxie: +20, Sleaze Damage: +25, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4
-Item	primitive alien spear	Muscle: +20, Hot Damage: +25, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4
-Item	pristine walrus tusk	Cold Damage: +50, Muscle: +15
+Item	prehistoric spear	Critical Hit Percent: +5, Last Available: "2006-12"
+Item	primitive alien blowgun	Moxie: +20, Sleaze Damage: +25, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4, Last Available: "2017-04"
+Item	primitive alien spear	Muscle: +20, Hot Damage: +25, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4, Last Available: "2017-04"
+Item	pristine walrus tusk	Cold Damage: +50, Muscle: +15, Last Available: "2018-12"
 Item	projectile icemaker	Moxie: +7, Spell Damage: +7, Cold Damage: +5
 Item	protection stick	Critical Hit Percent: +4, Muscle Percent: +6, Maximum HP: +10, PvP Fights: +1
 # pterodactyl rifle: Lets you snipe pterodactyls from a great distance
@@ -1795,12 +1795,12 @@ Item	PVC staff	Mysticality Percent: +15, Item Drop: +10, Cold Spell Damage: +60
 Item	pygmy concertinette	Weapon Damage: [10*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 17
 Item	pygmy spear	Muscle: +7
 Item	quantum disintegrator pistol	Damage vs. Bugbears: +15
-Item	quirky accordion	Monster Level: [5*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 10
-Item	Radio Free Foil	Muscle: +20
-Item	Rain-Doh violet bo	Sleaze Damage: +11, Moxie: +11, Softcore Only
+Item	quirky accordion	Monster Level: [5*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
+Item	Radio Free Foil	Muscle: +20, Last Available: "2006-07"
+Item	Rain-Doh violet bo	Sleaze Damage: +11, Moxie: +11, Softcore Only, Last Available: "2012-02"
 # Rain-Doh yellow laser gun: Super Accurate!
-Item	Rain-Doh yellow laser gun	Weakens Monster, Softcore Only
-Item	rainbow crossbow	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5
+Item	Rain-Doh yellow laser gun	Weakens Monster, Softcore Only, Last Available: "2012-02"
+Item	rainbow crossbow	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Last Available: "2008-07"
 Item	ram stick	Moxie: +5
 Item	ram-battering staff	Hot Spell Damage: +10, Moxie: +5
 Item	rare oboe	Spooky Damage: +10, Stench Damage: +10, Hot Damage: +10, Cold Damage: +10, Sleaze Damage: +10, Experience: +3
@@ -1810,11 +1810,11 @@ Item	rave whistle	Maximum HP: +10, Monster Level: +10, Raveosity: +1
 # Red Roger's red right hand: +50 Physical Damage (in PirateRealm only)
 Item	Red Roger's red right hand	Weapon Damage: [50*zone(PirateRealm)]
 # Red Rover BB gun: You'll Put Your Eye Out!
-Item	Red Rover BB gun	Critical Hit Percent: +15
+Item	Red Rover BB gun	Critical Hit Percent: +15, Last Available: "2009-12"
 Item	red-hot poker	Hot Damage: +15
-Item	red-hot sausage fork	Hot Damage: +8, Food Drop: +10
-Item	regret hose	Cold Damage: +10
-Item	reindeer hammer	Muscle: +10, Mysticality: +10, Moxie: +10
+Item	red-hot sausage fork	Hot Damage: +8, Food Drop: +10, Last Available: "2019-01"
+Item	regret hose	Cold Damage: +10, Last Available: "2013-12"
+Item	reindeer hammer	Muscle: +10, Mysticality: +10, Moxie: +10, Last Available: "2015-12"
 # reindeer sickle: Successful hit causes bleeding.
 Item	remaindered axe	Muscle: +2, Weapon Damage: +2
 # remorseless knife: Successful hit causes bleeding.
@@ -1825,20 +1825,20 @@ Item	replica Fourth of May Cosplay Saber	Muscle Percent: +20, Mysticality Percen
 # replica haiku katana: Allows use of seasonal attacks
 Item	replica haiku katana	Muscle Percent: +15, Critical Hit Percent: +5, Weapon Damage Percent: +50
 Item	replica industrial fire extinguisher	Hot Resistance: +3, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Cold Damage: +15, Cold Spell Damage: +15, Maximum HP: +20, Maximum MP: +20, Adventures: +3
-Item	revolver	Experience (Moxie): +2, Initiative: +50, Lasts Until Rollover
+Item	revolver	Experience (Moxie): +2, Initiative: +50, Lasts Until Rollover, Last Available: "2015-07"
 Item	rib of the Bonerdagon	Muscle: +5, Mysticality: +5, Spell Damage: +15
 Item	ridiculously huge sword	Weapon Damage: +12, Muscle: +4
 Item	ridiculously overelaborate ninja weapon	Critical Hit Percent: +15, Fumble: 3
 # right bear arm: Lets you act like a bear
 Item	right bear arm	Muscle Percent: +10, Weapon Damage Percent: +30
-Item	roboduck-on-a-string	Weapon Damage: +5, Item Drop: +5
+Item	roboduck-on-a-string	Weapon Damage: +5, Item Drop: +5, Last Available: "2007-12"
 Item	Rock and Roll Legend	Moxie: [7*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 10
-Item	rope	Experience (Muscle): +2, Familiar Weight: +10, Lasts Until Rollover
+Item	rope	Experience (Muscle): +2, Familiar Weight: +10, Lasts Until Rollover, Last Available: "2015-07"
 Item	rubber axe	Sleaze Damage: +2
-Item	rubber band gun	Moxie: +5
+Item	rubber band gun	Moxie: +5, Last Available: "2011-05"
 Item	rubber spatula	Spell Damage: +2
 # Ruby Rod
-Item	runed taper candle	Item Drop: +25, Hot Spell Damage: +50, Lasts Until Rollover
+Item	runed taper candle	Item Drop: +25, Hot Spell Damage: +50, Lasts Until Rollover, Last Available: "2021-08"
 Item	rusted-out shootin' iron	Meat Drop: +10, Ranged Damage: +50, Combat Rate: -5
 Item	rusty grave robbing shovel	Spooky Damage: +5, Initiative: -10
 Item	rusty piece of rebar	Weapon Damage: +25, Critical Hit Percent: +7
@@ -1850,37 +1850,37 @@ Item	sabre teeth	Weapon Damage: +4
 Item	Saturday Night Special	Hot Resistance: +2
 # saucepan
 # Saucepanic: Lets you gather more Soulsauce
-Item	Saucepanic	Experience (Mysticality): +2, Smithsness: +5, Class: "Sauceror", Mysticality Percent: [2*K]
+Item	Saucepanic	Experience (Mysticality): +2, Smithsness: +5, Class: "Sauceror", Last Available: "2013-12", Mysticality Percent: [2*K]
 Item	savory crossbow	Moxie: +4
 Item	savory staff	Mysticality: +4
 Item	savory sword	Muscle: +4
 Item	sawed-off blunderbuss	Pirate Warfare Effectiveness: +3, Muscle: +3, Mysticality: +3, Moxie: +3, Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2023-12"
-Item	scepter of the Skeleton Lord	Moxie Percent: +50, Adventures: +3, PvP Fights: +3, Single Equip
+Item	scepter of the Skeleton Lord	Moxie Percent: +50, Adventures: +3, PvP Fights: +3, Single Equip, Last Available: "2018-04"
 # scorpion whip: 50% chance of poisoning opponent.
 Item	scorpion whip	Weapon Damage: +13
 Item	scratch 'n' sniff crossbow	none, Breakable
 Item	scratch 'n' sniff sword	none, Breakable
-Item	sea-worn candlestick	PvP Fights: +5, Meat Drop: +25, Sleaze Resistance: +3
+Item	sea-worn candlestick	PvP Fights: +5, Meat Drop: +25, Sleaze Resistance: +3, Last Available: "2020-09"
 # seal-clubbing club
 Item	sealhide whip	Cold Damage: +25
 # Seeger's Unstoppable Banjo: Special Attack:  Funk Bluegrass Fusion
 Item	Seeger's Unstoppable Banjo	Moxie: +15, Meat Drop: +23, DB Combat Damage: +15, Class: "Disco Bandit"
 Item	serpentine sword	Monster Level: +10, Synergetic
 Item	severed flipper	Muscle: +5, Weapon Damage: +5, Class: "Seal Clubber"
-Item	sewage-clogged pistol	Monster Level: +10, Stench Damage: +20
+Item	sewage-clogged pistol	Monster Level: +10, Stench Damage: +20, Last Available: "2015-04"
 Item	sewer snake	Stench Damage: +3
 Item	shadow hammer	Combat Rate: +5, Experience: +3
 Item	shadow stick	Spooky Damage: +13, Cold Damage: +13, Weakens Monster, Last Available: "2023-03"
 Item	Shagadelic Disco Banjo	Moxie: +11, Meat Drop: +10, DB Combat Damage: +7, Class: "Disco Bandit"
 # Shakespeare's Sister's Accordion: Has a cool Cadenza
-Item	Shakespeare's Sister's Accordion	Mana Cost: [-1*(1+skill(Accordion Appreciation))], Smithsness: [5*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 15, Moxie Percent: [2*K]
+Item	Shakespeare's Sister's Accordion	Mana Cost: [-1*(1+skill(Accordion Appreciation))], Smithsness: [5*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12", Moxie Percent: [2*K]
 # sharpened spoon
-Item	Sheila Take a Crossbow	HP Regen Min: 1, HP Regen Max: 2, MP Regen Min: 1, MP Regen Max: 2, Pickpocket Chance: +5, Smithsness: +5, Initiative: [K]
+Item	Sheila Take a Crossbow	HP Regen Min: 1, HP Regen Max: 2, MP Regen Min: 1, MP Regen Max: 2, Pickpocket Chance: +5, Smithsness: +5, Last Available: "2013-12", Initiative: [K]
 # Sheriff pistol: Provides 1/3 Authority
 Item	Sheriff pistol	Muscle Percent: +50, Hot Damage: +15, Lasts Until Rollover, Last Available: "2024-10"
 Item	shiny butcherknife	Spell Damage: +8
 Item	shipwright's hammer	Pirate Warfare Effectiveness: +3, Weapon Damage Percent: +30, Damage vs. Skeletons: +30, Last Available: "2023-12"
-Item	shooting morning star	Muscle Percent: +15, Hot Damage: +15, Weakens Monster, Single Equip
+Item	shooting morning star	Muscle Percent: +15, Hot Damage: +15, Weakens Monster, Single Equip, Last Available: "2017-08"
 Item	short-handled mop	Stench Damage: +10, Sleaze Damage: +10
 Item	shotgun	Ranged Damage: +10
 Item	shuddersword	Muscle: +7, Spell Damage: +7, Spooky Damage: +5
@@ -1891,7 +1891,7 @@ Item	silver shrimp fork	Spell Damage: +14, Weapon Damage: +5
 Item	skate blade	Moxie Percent: +5, Weakens Monster
 Item	skate board	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Damage Reduction: 10
 Item	skeleton bone	Spooky Damage: +1
-Item	Skipper's accordion	Pickpocket Chance: [10*(1+skill(Accordion Appreciation))], Moxie Percent: [15*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 10
+Item	Skipper's accordion	Pickpocket Chance: [10*(1+skill(Accordion Appreciation))], Moxie Percent: [15*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 # sleazy bindle: On Critical: Deals 70-100 <font color=blueviolet>Sleaze Damage</font>
 Item	sleazy bindle	Item Drop: +10, Sleaze Damage: +25
 # Sledgehammer of the V&aelig;lkyr: +20% Physical Damage (currently approximated with Weapon Damage)
@@ -1899,7 +1899,7 @@ Item	sleazy bindle	Item Drop: +10, Sleaze Damage: +25
 Item	Sledgehammer of the V&aelig;lkyr	Muscle: +23, Critical Hit Percent: +10, Class: "Seal Clubber", Weapon Damage Percent: +20
 Item	slide rule	Mysticality Percent: +5, Initiative: +10
 # slightly peevedbow
-Item	slime knuckles	Mysticality Percent: +25, Sleaze Spell Damage: +25, Spell Damage Percent: +50
+Item	slime knuckles	Mysticality Percent: +25, Sleaze Spell Damage: +25, Spell Damage Percent: +50, Last Available: "2018-11"
 # slime-covered club: +50 Damage against Slimes
 Item	slime-covered club	Weapon Damage: [50*loc(The Slime Tube)+25], Critical Hit Percent: +7
 # slime-covered shovel: +100 Damage against Slimes
@@ -1909,30 +1909,30 @@ Item	slime-covered speargun	Weapon Damage: [50*loc(The Slime Tube)+25], Critical
 # slime-covered staff: All Spells Cast Are Sleazy
 Item	slime-covered staff	Spell Damage: +60, Initiative: -10
 # slingshot
-Item	smoldering bagel punch	Hot Spell Damage: +10, Spell Damage: +5
+Item	smoldering bagel punch	Hot Spell Damage: +10, Spell Damage: +5, Last Available: "2016-08"
 Item	smoldering staff	Mysticality: +7, Moxie: +5, Stench Spell Damage: +11
 Item	Sneaky Pete's basket	Moxie: +5, Initiative: +10, Item Drop: +10
-Item	snow shovel	Muscle: +10, Mysticality: +10, Moxie: +10, Weapon Damage Percent: +100, Lasts Until Rollover
+Item	snow shovel	Muscle: +10, Mysticality: +10, Moxie: +10, Weapon Damage Percent: +100, Lasts Until Rollover, Last Available: "2014-01"
 # soap knife
 # soul knife: Can harm True Mimes
 Item	soup-chucks	Hot Damage: +2
 Item	soylent staff	Mysticality: +4, Spell Damage: +10
-Item	space beast fur whip	Damage Reduction: 5
-Item	space heater	Hot Damage: +12, Cold Resistance: +2
-Item	space needle	Weapon Damage: +10, Spooky Resistance: +2
+Item	space beast fur whip	Damage Reduction: 5, Last Available: "2014-05"
+Item	space heater	Hot Damage: +12, Cold Resistance: +2, Last Available: "2014-05"
+Item	space needle	Weapon Damage: +10, Spooky Resistance: +2, Last Available: "2014-05"
 # Space Tourist Phaser: This Phaser is set to Fun
-Item	spant spear	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Weapon Damage Percent: +25
-Item	spearfish fishing spear	Weapon Damage Percent: +50, Monster Level: +10, Fishing Skill: +5
+Item	spant spear	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Weapon Damage Percent: +25, Last Available: "2017-04"
+Item	spearfish fishing spear	Weapon Damage Percent: +50, Monster Level: +10, Fishing Skill: +5, Last Available: "2019-07"
 Item	spectral axe	Cold Damage: +15, Damage vs. Ghosts: +30
-Item	Spelunker's whip	Weapon Damage Percent: +25, Item Drop: +10, Familiar Weight: +5
+Item	Spelunker's whip	Weapon Damage Percent: +25, Item Drop: +10, Familiar Weight: +5, Last Available: "2015-12"
 Item	spider leg	Weapon Damage: +15, Muscle: [5*L]
 Item	spiked femur	Spooky Damage: +6
 Item	Spirit Precipice	Muscle: +7, Mysticality: +5, Critical Hit Percent: +20
 Item	spooky bicycle chain	Spooky Damage: +5, Critical Hit Percent: +5
 # spooky bindle: On Critical: Deals 70-100 <font color=gray>Spooky Damage</font>
 Item	spooky bindle	Item Drop: +10, Spooky Damage: +25
-Item	Spooky Putty ball	Spooky Damage: +10, Softcore Only
-Item	Spooky Putty snake	Spell Damage Percent: +50, Spooky Spell Damage: +20, MP Regen Min: 6, MP Regen Max: 8, Softcore Only
+Item	Spooky Putty ball	Spooky Damage: +10, Softcore Only, Last Available: "2009-01"
+Item	Spooky Putty snake	Spell Damage Percent: +50, Spooky Spell Damage: +20, MP Regen Min: 6, MP Regen Max: 8, Softcore Only, Last Available: "2009-01"
 Item	spooky staff	Mysticality: +2, Spooky Damage: +2
 Item	spooky stick	Spooky Damage: +2
 Item	spork	Muscle: +2
@@ -1942,11 +1942,11 @@ Item	Staff of Blood and Pudding	Spell Damage Percent: +25, Maximum HP: +15, MP R
 Item	[7961]Staff of Ed	Mysticality Percent: +25, Spell Damage Percent: +25, MP Regen Min: 2, MP Regen Max: 6, Pool Skill: +5
 Item	[2268]Staff of Fats	Pool Skill: +5
 Item	[7964]Staff of Fats	Pool Skill: +5
-Item	Staff of Frozen Lard	Spell Damage Percent: +200, Cold Spell Damage: +20, Sleaze Spell Damage: +20, MP Regen Min: 15, MP Regen Max: 20
+Item	Staff of Frozen Lard	Spell Damage Percent: +200, Cold Spell Damage: +20, Sleaze Spell Damage: +20, MP Regen Min: 15, MP Regen Max: 20, Last Available: "2018-12"
 Item	Staff of Fruit Salad	Spell Damage: +10, Moxie: +10, MP Regen Min: 2, MP Regen Max: 3, Jiggle: "Deal Some Prismatic Damage"
-Item	Staff of Holiday Sensations	Spell Damage Percent: +75, Cold Spell Damage: +15, MP Regen Min: 5, MP Regen Max: 6
-Item	Staff of Kitchen Royalty	Spell Damage Percent: +200, MP Regen Min: 30, MP Regen Max: 40, Moxie Percent: +50, Adventures: +4, PvP Fights: +4
-Item	Staff of Queso Escusado	Spell Damage Percent: +50, Stench Spell Damage: +20, MP Regen Min: 6, MP Regen Max: 8, Softcore Only
+Item	Staff of Holiday Sensations	Spell Damage Percent: +75, Cold Spell Damage: +15, MP Regen Min: 5, MP Regen Max: 6, Last Available: "2011-11"
+Item	Staff of Kitchen Royalty	Spell Damage Percent: +200, MP Regen Min: 30, MP Regen Max: 40, Moxie Percent: +50, Adventures: +4, PvP Fights: +4, Last Available: "2018-04"
+Item	Staff of Queso Escusado	Spell Damage Percent: +50, Stench Spell Damage: +20, MP Regen Min: 6, MP Regen Max: 8, Softcore Only, Last Available: "2010-01"
 Item	Staff of Simmering Hatred	MP Regen Min: 20, MP Regen Max: 30, Reduce Enemy Defense: 10, Spell Damage Percent: +200
 # Staff of the All-Steak: (5 charges left today)
 Item	Staff of the All-Steak	Spell Damage Percent: +50, Damage Reduction: 15, MP Regen Min: 5, MP Regen Max: 6, Jiggle: "Massive Bonus to Item Drops"
@@ -1960,15 +1960,15 @@ Item	Staff of the Electric Range	Spell Damage Percent: +50, Spooky Spell Damage:
 Item	Staff of the Grand Flamb&eacute;	Spell Damage Percent: +150, Cold Resistance: +5, MP Regen Min: 8, MP Regen Max: 10
 Item	Staff of the Grease Trap	Spell Damage Percent: +150, Sleaze Spell Damage: +20, MP Regen Min: 8, MP Regen Max: 10
 Item	Staff of the Greasefire	Spell Damage Percent: +35, Hot Spell Damage: +10, Sleaze Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 4
-Item	Staff of the Headmaster's Victuals	MP Regen Min: 2, MP Regen Max: 3, Sleaze Spell Damage: +5, Smithsness: +5, Spell Damage: [2*K]
+Item	Staff of the Headmaster's Victuals	MP Regen Min: 2, MP Regen Max: 3, Sleaze Spell Damage: +5, Smithsness: +5, Last Available: "2013-12", Spell Damage: [2*K]
 Item	Staff of the Healthy Breakfast	Spell Damage: +10, Maximum HP: +15, Item Drop: +10, MP Regen Min: 2, MP Regen Max: 4, Jiggle: "Recover Some HP"
 Item	Staff of the Hearty Dinner	Spell Damage: +10, Damage Reduction: 5, MP Regen Min: 2, MP Regen Max: 3, Jiggle: "Weaken Bad Guy"
 Item	Staff of the Kitchen Floor	Spell Damage Percent: +150, Stench Spell Damage: +20, MP Regen Min: 8, MP Regen Max: 10
 Item	Staff of the Light Lunch	Spell Damage: +10, Initiative: +15, MP Regen Min: 2, MP Regen Max: 3, Jiggle: "Deal Some Cold Damage"
 Item	Staff of the Lunch Lady	Spell Damage Percent: +75, Maximum HP: +15, Maximum MP: +15, MP Regen Min: 5, MP Regen Max: 6, Food Drop: +25
 Item	Staff of the Midnight Snack	Spell Damage Percent: +20, Spooky Spell Damage: +10, MP Regen Min: 2, MP Regen Max: 3
-Item	Staff of the November Jack-O-Lantern	Spell Damage Percent: +20, Stench Spell Damage: +10, MP Regen Min: 2, MP Regen Max: 3
-Item	Staff of the Peppermint Twist	Spell Damage Percent: +200, Hot Spell Damage: +20, Cold Spell Damage: +20, MP Regen Min: 15, MP Regen Max: 20
+Item	Staff of the November Jack-O-Lantern	Spell Damage Percent: +20, Stench Spell Damage: +10, MP Regen Min: 2, MP Regen Max: 3, Last Available: "2010-11"
+Item	Staff of the Peppermint Twist	Spell Damage Percent: +200, Hot Spell Damage: +20, Cold Spell Damage: +20, MP Regen Min: 15, MP Regen Max: 20, Last Available: "2019-12"
 Item	Staff of the Roaring Hearth	Spell Damage Percent: +250, Hot Spell Damage: +40, MP Regen Min: 30, MP Regen Max: 35
 Item	Staff of the Scummy Sink	Spell Damage Percent: +150, Sleaze Spell Damage: +20, MP Regen Min: 8, MP Regen Max: 10, Slime Hates It: +1
 Item	Staff of the Short Order Cook	Spell Damage Percent: +20, Mysticality: +5, MP Regen Min: 2, MP Regen Max: 3
@@ -1980,8 +1980,8 @@ Item	Staff of the Standalone Cheese	Spell Damage Percent: +50, Initiative: +30, 
 Item	Staff of the Teapot Tempest	Spell Damage Percent: +25, Mysticality: +5, MP Regen Min: 3, MP Regen Max: 4
 Item	Staff of the Walk-In Freezer	Spell Damage Percent: +150, Cold Spell Damage: +20, MP Regen Min: 8, MP Regen Max: 10
 Item	Staff of the Well-Tempered Cauldron	Spell Damage Percent: +125, Mysticality: +15, MP Regen Min: 7, MP Regen Max: 8
-Item	Staff of the Woodfire	Experience (Mysticality): +10, Spell Damage Percent: +100, MP Regen Min: 5, MP Regen Max: 15
-Item	stained glass shiv	Moxie Percent: +20, Stench Resistance: +3, Stench Damage: +5
+Item	Staff of the Woodfire	Experience (Mysticality): +10, Spell Damage Percent: +100, MP Regen Min: 5, MP Regen Max: 15, Last Available: "2009-10"
+Item	stained glass shiv	Moxie Percent: +20, Stench Resistance: +3, Stench Damage: +5, Last Available: "2021-12"
 Item	stainless steel shillelagh	Weapon Damage: +20, Critical Hit Percent: +10, Muscle Percent: +15
 Item	staph of homophones	Mysticality: +7, Adventures: +5, Alters Page Text
 Item	star boomerang	Moxie: +5
@@ -1994,12 +1994,12 @@ Item	starchy crossbow	Moxie: +3
 Item	starchy staff	Mysticality: +3
 Item	starchy sword	Muscle: +3
 Item	steel drivin' hammer	Critical Hit Percent: +10, Muscle Percent: +15, Maximum HP: +25, PvP Fights: +3
-Item	steel sword	Weapon Damage: +15, HP Regen Min: 2, HP Regen Max: 4, Moxie: +5
+Item	steel sword	Weapon Damage: +15, HP Regen Min: 2, HP Regen Max: 4, Moxie: +5, Last Available: "2013-02"
 Item	Stick-Knife of Loathing	Weapon Damage Percent: +100, Spell Damage Percent: +200, Cold Resistance: +5, Cloathing
-Item	sticky hand whip	Item Drop: +5, Pickpocket Chance: +10, Meat Drop: +15
+Item	sticky hand whip	Item Drop: +5, Pickpocket Chance: +10, Meat Drop: +15, Last Available: "2014-08"
 # stinkin' bindle: On Critical: Deals 70-100 <font color=green>Stench Damage</font>
 Item	stinkin' bindle	Item Drop: +10, Stench Damage: +25
-Item	stinky cheese sword	Stench Damage: [max(1,min(33,floor(pref(_stinkyCheeseCount)/3)))], Softcore Only
+Item	stinky cheese sword	Stench Damage: [max(1,min(33,floor(pref(_stinkyCheeseCount)/3)))], Softcore Only, Last Available: "2010-01"
 Item	stolen accordion	Song Duration: 5
 Item	stone banjo	Moxie: +1
 # stuffed club
@@ -2007,36 +2007,36 @@ Item	stone banjo	Moxie: +1
 Item	styrofoam crossbow	Moxie: +3, Monster Level: +3
 Item	styrofoam staff	Mysticality: +3, Monster Level: +3
 Item	styrofoam sword	Muscle: +3, Monster Level: +3
-Item	sucker tachi	Weapon Damage: +10
+Item	sucker tachi	Weapon Damage: +10, Last Available: "2011-11"
 # suede shortsword
-Item	sugar raygun	Sprinkle Drop: +50
+Item	sugar raygun	Sprinkle Drop: +50, Last Available: "2016-12"
 # sugar shank: On Critical:  Cause Opponent to Bleed
-Item	sugar shank	Weapon Damage Percent: +50, Breakable
-Item	sugar shillelagh	Weapon Damage Percent: +50, Breakable
+Item	sugar shank	Weapon Damage Percent: +50, Last Available: "2009-09", Breakable
+Item	sugar shillelagh	Weapon Damage Percent: +50, Last Available: "2009-09", Breakable
 # sugar shotgun: On Critical:  Stuns Opponent
-Item	sugar shotgun	Weapon Damage Percent: +50, Breakable
-Item	Super Crimboman Ultra Mega Hypersword	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5
+Item	sugar shotgun	Weapon Damage Percent: +50, Last Available: "2009-09", Breakable
+Item	Super Crimboman Ultra Mega Hypersword	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Last Available: "2012-12"
 Item	Super Magic Power Sword X	Muscle: +4, Initiative: +20, Critical Hit Percent: +5
-Item	super-sweet boom box	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10, Four Songs
+Item	super-sweet boom box	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10, Four Songs, Last Available: "2010-06"
 # survival knife: Aids in desert exploration
-Item	survival knife	Muscle: +5, Mysticality: +5, Moxie: +5, Lasts Until Rollover
+Item	survival knife	Muscle: +5, Mysticality: +5, Moxie: +5, Lasts Until Rollover, Last Available: "2022-05"
 # sweet ninja sword
 Item	sword behind inappropriate prepositions	Muscle: +7, Adventures: +5, Alters Page Text
-Item	Sword of Dark Omens	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Spell Damage Percent: +50, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5
+Item	Sword of Dark Omens	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Spell Damage Percent: +50, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Last Available: "2013-02"
 # Sword of Procedural Generation: Randomized per player
 Item	sword of static	Muscle: +3, Moxie: +2, MP Regen Min: 2, MP Regen Max: 3
 Item	swordzall	Weapon Damage: +8, Maximum MP: +10
 Item	tail o' nine cats	Initiative: +15, Monster Level: +5
 # Tales of the Word Realms: Lends Power to Your Words
 Item	tambourine	Maximum HP: +20, Maximum MP: +20
-Item	teacher's pen	Experience: +3, Experience (familiar): +2
+Item	teacher's pen	Experience: +3, Experience (familiar): +2, Last Available: "2022-06"
 Item	teflon spatula	Mysticality Percent: +10, Sleaze Resistance: +3, Spell Damage: +40
 # terra cotta tongs: Lets you unleash a terra cotta army on your foes
-Item	terra cotta tongs	Experience (Mysticality): +3, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5
+Item	terra cotta tongs	Experience (Mysticality): +3, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Last Available: "2020-12"
 # The Jokester's gun: Can be fired in a weird way once per day to instantly defeat an opponent
-Item	The Jokester's gun	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Initiative: +25, Pants Drop: +50
+Item	The Jokester's gun	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Initiative: +25, Pants Drop: +50, Last Available: "2016-12"
 Item	The Landscaper's leafblower	Monster Level: [pref(_leafblowerML)]
-Item	The Necbromancer's Wizard Staff	Spell Damage Percent: +200, Sleaze Spell Damage: +30, MP Regen Min: 20, MP Regen Max: 30
+Item	The Necbromancer's Wizard Staff	Spell Damage Percent: +200, Sleaze Spell Damage: +30, MP Regen Min: 20, MP Regen Max: 30, Last Available: "2011-10"
 Item	The Nuge's favorite crossbow	Ranged Damage: +30, Initiative: +100, Adventures: +5
 # The Trickster's Trikitixa: Special Attack:  Extreme High Note
 Item	The Trickster's Trikitixa	Moxie: [15*(1+skill(Accordion Appreciation))], Ranged Damage: [23*(1+skill(Accordion Appreciation))], Item Drop: [11*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 20
@@ -2045,96 +2045,96 @@ Item	third-hand nunchaku	Weapon Damage: +3
 # Thor's Pliers: Allows You to Ply Reality
 # Thor's Pliers: Regenerates Lightning Power (in Heavy Rains only)
 Item	Thor's Pliers	Experience: +4, MP Regen Min: 6, MP Regen Max: 9, Pickpocket Chance: +20, Attacks Can't Miss, Single Equip
-Item	throwing wrench	Weakens Monster
-Item	time sword	Adventures: +3
-Item	tin drum	Moxie Percent: +10, Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Experience (Moxie): +1
-Item	tin foil	Muscle Percent: +10, Weapon Damage Percent: +10, Experience (Muscle): +1
+Item	throwing wrench	Weakens Monster, Last Available: "2009-12"
+Item	time sword	Adventures: +3, Last Available: "2005-10"
+Item	tin drum	Moxie Percent: +10, Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Experience (Moxie): +1, Last Available: "2013-09"
+Item	tin foil	Muscle Percent: +10, Weapon Damage Percent: +10, Experience (Muscle): +1, Last Available: "2013-09"
 Item	tiny ninja sword	Moxie: +1
-Item	tiny plastic sword	Moxie: +1
+Item	tiny plastic sword	Moxie: +1, Last Available: "2004-12"
 Item	titanium assault umbrella	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1
 Item	tommy gun	Weapon Damage: +5
 # Totally Gay Claymore
-Item	toxic mop	Stench Damage: +20, Stench Spell Damage: +20
+Item	toxic mop	Stench Damage: +20, Stench Spell Damage: +20, Last Available: "2015-04"
 Item	toy accordion	Song Duration: 5
 # toy Crimbot power glove: Allows use of ZAP in combat
-Item	toy Crimbot power glove	Weapon Damage: +15, Crimbot Outfit Power: +1
-Item	toy ray gun	Hot Damage: +5, Critical Hit Percent: +5
+Item	toy Crimbot power glove	Weapon Damage: +15, Crimbot Outfit Power: +1, Last Available: "2014-12"
+Item	toy ray gun	Hot Damage: +5, Critical Hit Percent: +5, Last Available: "2006-12"
 # toy taijijian
 # Toyleporter: Locates toys and then blasts them to the Crimbo Town Toy Factory
 # trash net
-Item	triple barreled barrel gun	Weapon Damage Percent: +100, Critical Hit Percent: +10, Meat Drop: +25
-Item	Tropical Crimbo Sword	Weapon Damage: +5
+Item	triple barreled barrel gun	Weapon Damage Percent: +100, Critical Hit Percent: +10, Meat Drop: +25, Last Available: "2015-09"
+Item	Tropical Crimbo Sword	Weapon Damage: +5, Last Available: "2006-12"
 # trout fang: 25% chance of poisoning opponent.
-Item	trout fang	Weapon Damage: +15
+Item	trout fang	Weapon Damage: +15, Last Available: "2010-09"
 Item	Trusty	Muscle: +5
-Item	trusty torch	Hot Damage: +3
-Item	Truthsayer	Monster Level: +12, Weapon Damage Percent: +40
+Item	trusty torch	Hot Damage: +3, Last Available: "2011-12"
+Item	Truthsayer	Monster Level: +12, Weapon Damage Percent: +40, Last Available: "2013-12"
 # turtle totem
 # twisted-up wet towel: +25% Item Drops from Monsters (KoL High School zones only)
 Item	twisted-up wet towel	Item Drop: [+25*zone(KOL High School)]
 # two-handed depthsword
 Item	ultimate ultimate frisbee	Moxie: +2, Ranged Damage: +4
-Item	Uncle Hobo's highest bough	Muscle Percent: +15, HP Regen Min: 15, HP Regen Max: 30, MP Regen Min: 15, MP Regen Max: 30
+Item	Uncle Hobo's highest bough	Muscle Percent: +15, HP Regen Min: 15, HP Regen Max: 30, MP Regen Min: 15, MP Regen Max: 30, Last Available: "2010-12"
 Item	uncursed machete	Meat Drop: +20
-Item	Underworld flail	Experience (Moxie): +10, Ranged Damage: +30, Moxie Percent: +10
-Item	Underworld truncheon	Experience (Muscle): +10, Weapon Damage Percent: +20, Muscle Percent: +10
-Item	Unionize The Elves sign	Weakens Monster
+Item	Underworld flail	Experience (Moxie): +10, Ranged Damage: +30, Moxie Percent: +10, Last Available: "2009-10"
+Item	Underworld truncheon	Experience (Muscle): +10, Weapon Damage Percent: +20, Muscle Percent: +10, Last Available: "2009-10"
+Item	Unionize The Elves sign	Weakens Monster, Last Available: "2005-12"
 Item	Unkillable Skeleton's restless leg	Weapon Damage: +40, MP Regen Min: 20, MP Regen Max: 30
 Item	Unkillable Skeleton's sawsword	Damage vs. Skeletons: +100, Damage vs. Zombies: +50, Damage vs. Vampires: +50, Damage vs. Werewolves: +50, Damage vs. Ghosts: +50, Damage vs. Bugbears: +50
 Item	unsanitized scalpel	Sleaze Damage: +25
-Item	vampire duck-on-a-string	Weapon Damage: +5, Item Drop: +5
+Item	vampire duck-on-a-string	Weapon Damage: +5, Item Drop: +5, Last Available: "2006-12"
 Item	velcro broadsword	Muscle Percent: +5, MP Regen Min: 6, MP Regen Max: 12, Hat Drop: +20, Pants Drop: +20
 Item	velcro paddle ball	Moxie Percent: +5, MP Regen Min: 6, MP Regen Max: 12, Accessory Drop: +20
 # velour voulge: Triples the effect of Snarl of the Timberwolf
-Item	velour voulge	Experience (Muscle): +2, Weapon Drop: +30
-Item	vibrating cyborg knife	Weapon Damage: +20, Fumble: 3
+Item	velour voulge	Experience (Muscle): +2, Weapon Drop: +30, Last Available: "2021-12"
+Item	vibrating cyborg knife	Weapon Damage: +20, Fumble: 3, Last Available: "2007-12"
 Item	villainous scythe	Weapon Damage Percent: +30, Critical Hit Percent: +20, Slime Hates It: +2
-Item	void shard	Muscle Percent: +13, Mysticality Percent: +13, Moxie Percent: +13, Item Drop: +13, Monster Level: +13, Spooky Damage: +13
+Item	void shard	Muscle Percent: +13, Mysticality Percent: +13, Moxie Percent: +13, Item Drop: +13, Monster Level: +13, Spooky Damage: +13, Last Available: "2022-12"
 Item	vorpal blade	Critical Hit Percent: +8
-Item	VYKEA hex key	Muscle: +6, Mysticality: +6, Moxie: +6, HP Regen Min: 6, HP Regen Max: 6, MP Regen Min: 6, MP Regen Max: 6, Weapon Damage: +6
+Item	VYKEA hex key	Muscle: +6, Mysticality: +6, Moxie: +6, HP Regen Min: 6, HP Regen Max: 6, MP Regen Min: 6, MP Regen Max: 6, Weapon Damage: +6, Last Available: "2015-11"
 # Wand of Nagamar
 Item	war tongs	Hot Damage: +10, Hot Spell Damage: +10
-Item	warbear exhaust manifold	Stench Damage: [10*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 10
+Item	warbear exhaust manifold	Stench Damage: [10*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 # warbear oil pan: Lets you sling hot grease!
-Item	warbear oil pan	Hot Spell Damage: +10, Sleaze Spell Damage: +10, Class: "Sauceror"
+Item	warbear oil pan	Hot Spell Damage: +10, Sleaze Spell Damage: +10, Class: "Sauceror", Last Available: "2013-12"
 # weeping willow wand: Lets you blast your foes with tears
-Item	weeping willow wand	Spell Damage Percent: +100, Mysticality: +25, Experience (Mysticality): +5, Lasts Until Rollover
-Item	weighted paperclip chain	Weapon Damage: +12
-Item	western-style skinning knife	Weapon Damage: +5, Hat Drop: +10
+Item	weeping willow wand	Spell Damage Percent: +100, Mysticality: +25, Experience (Mysticality): +5, Lasts Until Rollover, Last Available: "2020-08"
+Item	weighted paperclip chain	Weapon Damage: +12, Last Available: "2013-12"
+Item	western-style skinning knife	Weapon Damage: +5, Hat Drop: +10, Last Available: "2016-02"
 Item	whalegun	Pirate Warfare Effectiveness: +10, Monster Level: +10, Weapon Damage: +100, Last Available: "2023-12"
-Item	White Dragon Fang	Muscle Percent: +9, Mysticality Percent: +9, Moxie Percent: +9, Spooky Damage: +9, Stench Damage: +9, Hot Damage: +9, Cold Damage: +9, Sleaze Damage: +9, MP Regen Min: 9, MP Regen Max: 9
+Item	White Dragon Fang	Muscle Percent: +9, Mysticality Percent: +9, Moxie Percent: +9, Spooky Damage: +9, Stench Damage: +9, Hot Damage: +9, Cold Damage: +9, Sleaze Damage: +9, MP Regen Min: 9, MP Regen Max: 9, Last Available: "2013-12"
 Item	white sword	Muscle: +2
 Item	white whip	Experience: +1
-Item	whittled flail	Muscle: +20, Weapon Damage Percent: +50, Critical Hit Percent: +10
-Item	whittled flute	Moxie: +20, Ranged Damage Percent: +50, Meat Drop: +25
-Item	whittled wand	Mysticality: +20, Spell Damage Percent: +50, Spell Critical Percent: +10
+Item	whittled flail	Muscle: +20, Weapon Damage Percent: +50, Critical Hit Percent: +10, Last Available: "2019-08"
+Item	whittled flute	Moxie: +20, Ranged Damage Percent: +50, Meat Drop: +25, Last Available: "2019-08"
+Item	whittled wand	Mysticality: +20, Spell Damage Percent: +50, Spell Critical Percent: +10, Last Available: "2019-08"
 Item	wholeberd	Weapon Damage: +6
 # wicker sticker: Is a sweet, sweet knife
-Item	wicker sticker	Weapon Damage Percent: +20, PvP Fights: +4
+Item	wicker sticker	Weapon Damage Percent: +20, PvP Fights: +4, Last Available: "2016-12"
 Item	wiffle-flail	Mysticality: +3, Muscle: +2, Initiative: +20
 # Windsor Pan of the Source: Special Attack:  Saucemageddon
 Item	Windsor Pan of the Source	Mysticality: +15, Spell Damage: +23, Spell Critical Percent: +11, Class: "Sauceror"
 Item	witty rapier	Experience (Mysticality): +2
 # wolf whistle: Blowable for massive <font color=blueviolet>Sleaze Damage</font>
-Item	wolf whistle	HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Sleaze Damage: +100
+Item	wolf whistle	HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Sleaze Damage: +100, Last Available: "2014-12"
 Item	wooden axe	Muscle: +3
 Item	wooden spoon	Spell Damage: +5
 Item	wooden stakes	Weapon Damage: +1
-Item	Work is a Four Letter Sword	HP Regen Min: 4, HP Regen Max: 6, Critical Hit Percent: +5, Smithsness: +5, Weapon Damage: [K]
+Item	Work is a Four Letter Sword	HP Regen Min: 4, HP Regen Max: 6, Critical Hit Percent: +5, Smithsness: +5, Last Available: "2013-12", Weapon Damage: [K]
 Item	world's smallest violin	Ranged Damage: +5, Meat Drop: +5, Monster Level: +5
 # worm-riding hooks
 # Wrath of the Capsaician Pastalords: Special Attack:  Noodles of Fire
 Item	Wrath of the Capsaician Pastalords	Mysticality: +15, Food Drop: +50, Initiative: +40, Class: "Pastamancer"
-Item	wrench	Maximum MP: +50, Spell Damage Percent: +100, Lasts Until Rollover
+Item	wrench	Maximum MP: +50, Spell Damage Percent: +100, Lasts Until Rollover, Last Available: "2015-07"
 # wrought-iron whisk: Adds many additional balls to Salsaball
-Item	wrought-iron whisk	Spooky Damage: +10, Monster Level: +10
-Item	wumpus-hair whip	Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2
+Item	wrought-iron whisk	Spooky Damage: +10, Monster Level: +10, Last Available: "2017-12"
+Item	wumpus-hair whip	Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2, Last Available: "2009-06"
 # X-37 gun: Shoots Elemental Blasts
 Item	X-37 gun	Breakable
 Item	yak whip	Weakens Monster
 Item	yam cannon	Hot Damage: +50, Ranged Damage Percent: +25, Food Drop: +30, Lasts Until Rollover, Last Available: "2024-05"
 Item	yohohoyo	Critical Hit Percent: +5, Spooky Damage: +1, Stench Damage: +1, Hot Damage: +1, Cold Damage: +1, Sleaze Damage: +1
-Item	yule hatchet	Experience (familiar): +2
+Item	yule hatchet	Experience (familiar): +2, Last Available: "2021-12"
 Item	Zim Merman's guitar	Ranged Damage: +20
 Item	zombie accordion	Ranged Damage: [50*(1+skill(Accordion Appreciation))], Item Drop: [5*(1+skill(Accordion Appreciation))], Additional Song: 1, Class: "Accordion Thief", Single Equip, Song Duration: 20
 Item	Zombo's shoulder blade	Muscle Percent: +30, Weapon Damage Percent: +30
@@ -2142,7 +2142,7 @@ Item	Zombo's shoulder blade	Muscle Percent: +30, Weapon Damage Percent: +30
 # Off-hand Items section of modifiers.txt
 
 Item	'WILL WORK FOR BOOZE' sign	Booze Drop: +30
-Item	&quot;reusable&quot; grocery bag	Food Drop: +50, Lasts Until Rollover
+Item	&quot;reusable&quot; grocery bag	Food Drop: +50, Lasts Until Rollover, Last Available: "2020-12"
 Item	1-ball	Initiative: +10
 Item	2-ball	Cold Damage: +8, Cold Spell Damage: +8
 Item	3-ball	Spooky Damage: +8, Spooky Spell Damage: +8
@@ -2152,22 +2152,22 @@ Item	6-ball	Stench Damage: +8, Stench Spell Damage: +8
 Item	7-ball	Meat Drop: +5
 Item	9-ball	Weapon Damage: +8, Ranged Damage: +8, Spell Damage: +8
 Item	17-ball	Spooky Damage: +20, Stench Damage: +20, Hot Damage: +20, Cold Damage: +20, Sleaze Damage: +20
-Item	A Light that Never Goes Out	Mysticality: +5, Hot Damage: +5, Smithsness: +5, Item Drop: [K]
-Item	Abracandalabra	Spell Damage Percent: +100, MP Regen Min: 5, MP Regen Max: 10, Maximum MP Percent: +100, Lasts Until Rollover
+Item	A Light that Never Goes Out	Mysticality: +5, Hot Damage: +5, Smithsness: +5, Last Available: "2013-12", Item Drop: [K]
+Item	Abracandalabra	Spell Damage Percent: +100, MP Regen Min: 5, MP Regen Max: 10, Maximum MP Percent: +100, Lasts Until Rollover, Last Available: "2021-08"
 # Abuela Crimbo's special magnet: Get more items from Trainbots
 Item	Abyssal ember	Hot Damage: +20, Weapon Drop: +25, Class: "Seal Clubber"
-Item	adhesive tape dolly	Moxie: +5
+Item	adhesive tape dolly	Moxie: +5, Last Available: "2010-12"
 Item	adobe abacus	Mysticality Percent: [20+20*min(1,effect(Adobe Abacus Subscription))], Spell Damage: [20+20*min(1,effect(Adobe Abacus Subscription))], Last Available: "2024-12"
 Item	Adventurer bobblehead	Muscle Percent: [pref(nuclearAutumnPoints)], Mysticality Percent: [pref(nuclearAutumnPoints)], Moxie Percent: [pref(nuclearAutumnPoints)]
 # aerogel attache case: Produce random cocktailcrafting ingredients as you adventure
-Item	aerogel attache case	Pickpocket Chance: +10, Stench Damage: +10, Drops Items
+Item	aerogel attache case	Pickpocket Chance: +10, Stench Damage: +10, Last Available: "2017-12", Drops Items
 Item	ancient calendar	Adventures: +3, Damage Reduction: 4
 Item	ancient hot dog wrapper	HP Regen Min: 25, HP Regen Max: 30, MP Regen Min: 25, MP Regen Max: 30
-Item	ancient stone head	Negative Status Resist, Damage Reduction: 5
+Item	ancient stone head	Negative Status Resist, Damage Reduction: 5, Last Available: "2009-06"
 # anniversary balloon
 Item	anniversary chutney sculpture	Muscle: +1, Mysticality: +1, Moxie: +1
-Item	antique candy bucket	Candy Drop: +50, Lasts Until Rollover
-Item	antique nutcracker drumstick	MP Regen Min: 4, MP Regen Max: 8, Mysticality Percent: +15
+Item	antique candy bucket	Candy Drop: +50, Lasts Until Rollover, Last Available: "2020-12"
+Item	antique nutcracker drumstick	MP Regen Min: 4, MP Regen Max: 8, Mysticality Percent: +15, Last Available: "2019-12"
 Item	antique shield	Initiative: -10, Damage Reduction: 11, Breakable
 Item	antique spyglass	Reduce Enemy Defense: 15, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10
 Item	Apriling band staff	Mysticality: +10, Mysticality Percent: +10, Spell Damage: +20, Spooky Resistance: +2, Sleaze Resistance: +2, Spell Damage Percent: +10, Lasts Until Rollover
@@ -2176,20 +2176,20 @@ Item	arm buzzer	Maximum MP: +25, Damage Reduction: 6
 Item	astral shield	Muscle Percent: +25, HP Regen Min: 5, HP Regen Max: 10, Damage Reduction: 15
 Item	astral statuette	Mysticality Percent: +25, Spell Damage Percent: +50, Adventures: +4
 Item	august scepter	Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50
-Item	autumn debris shield	Damage Reduction: 19, Initiative: +30, Hot Damage: +20, Hot Spell Damage: +20, Lasts Until Rollover
+Item	autumn debris shield	Damage Reduction: 19, Initiative: +30, Hot Damage: +20, Hot Spell Damage: +20, Lasts Until Rollover, Last Available: "2022-10"
 Item	autumnal aegis	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Absorption: +250, Damage Reduction: 9
 # Bag o' Tricks: Summons Animals During Combat
-Item	Bag o' Tricks	Item Drop: +10, Meat Drop: +15, MP Regen Min: 10, MP Regen Max: 12, Spell Damage Percent: +50, Softcore Only
+Item	Bag o' Tricks	Item Drop: +10, Meat Drop: +15, MP Regen Min: 10, MP Regen Max: 12, Spell Damage Percent: +50, Softcore Only, Last Available: "2009-07"
 # bag of Crotchety Pine saplings
 # bag of Laughing Willow saplings
 # bag of Saccharine Maple saplings
 # bakelite bowl: Increase the number of Ravioli Shurikens you can conjure
-Item	bakelite bowl	Maximum MP: +20, Spell Damage: +20
-Item	ball-in-a-cup	Experience (Mysticality): +2
+Item	bakelite bowl	Maximum MP: +20, Spell Damage: +20, Last Available: "2016-12"
+Item	ball-in-a-cup	Experience (Mysticality): +2, Last Available: "2007-12"
 Item	balloon shield	Damage Reduction: 3, Thorns: 1
-Item	barrel lid	Muscle Percent: +25, Monster Level: +50, Maximum HP: +100, Damage Reduction: 9, Lasts Until Rollover
+Item	barrel lid	Muscle Percent: +25, Monster Level: +50, Maximum HP: +100, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 Item	barskin buckler	Muscle: +2, Damage Reduction: 1
-Item	basaltamander buckler	Experience Percent (Mysticality): +25, Damage Absorption: +50, Hat Drop: +75, Damage Reduction: 15
+Item	basaltamander buckler	Experience Percent (Mysticality): +25, Damage Absorption: +50, Hat Drop: +75, Damage Reduction: 15, Last Available: "2015-08"
 Item	basic meat foon	Mysticality: +3, Spell Damage: +3
 Item	battered hubcap	Muscle: +15, Maximum HP: +100, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 14
 Item	beach ball marble	Spell Damage: +35, Hot Spell Damage: +35, Cold Spell Damage: +35
@@ -2200,15 +2200,15 @@ Item	big hot pepper	Spell Damage: +10, Hot Damage: +10, Last Available: "2023-02
 Item	birdybug antenna	Maximum MP: +20, Mysticality: [4*L]
 Item	black catseye marble	Spooky Spell Damage: +75
 Item	black shield	Muscle: +5, Maximum HP: +20, Damage Reduction: 10
-Item	blue LavaCo Lamp&trade;	Adventures: +5, Rollover Effect: "Blue Eyed Devil", Rollover Effect Duration: 50
-Item	bobble-hip hula elf doll	Muscle: +5, Mysticality: +5, Moxie: +5, Meat Drop: +15
+Item	blue LavaCo Lamp&trade;	Adventures: +5, Rollover Effect: "Blue Eyed Devil", Rollover Effect Duration: 50, Last Available: "2015-08"
+Item	bobble-hip hula elf doll	Muscle: +5, Mysticality: +5, Moxie: +5, Meat Drop: +15, Last Available: "2006-12"
 # bone abacus: Helps you track your progress
-Item	Book of Old-Timey Carols	Item Drop: [15*event(December)]
-Item	borg sock monkey	Moxie: +3
+Item	Book of Old-Timey Carols	Item Drop: [15*event(December)], Last Available: "2020-12"
+Item	borg sock monkey	Moxie: +3, Last Available: "2007-12"
 # botanical sample kit: Increases the yield of Spacegate botany operations
-Item	botanical sample kit	Lasts Until Rollover
-Item	bottle of Goldschn&ouml;ckered	Hot Damage: +5, Cold Resistance: +2
-Item	bowl of petunias	Muscle: +4, Mysticality: +4, Moxie: +4, Experience: +4, PvP Fights: +4, HP Regen Min: 4, HP Regen Max: 8, MP Regen Min: 4, MP Regen Max: 8
+Item	botanical sample kit	Lasts Until Rollover, Last Available: "2017-04"
+Item	bottle of Goldschn&ouml;ckered	Hot Damage: +5, Cold Resistance: +2, Last Available: "2010-06"
+Item	bowl of petunias	Muscle: +4, Mysticality: +4, Moxie: +4, Experience: +4, PvP Fights: +4, HP Regen Min: 4, HP Regen Max: 8, MP Regen Min: 4, MP Regen Max: 8, Last Available: "2013-11"
 Item	box	Meat Drop: +1, Wiki Name: "box"
 Item	box turtle	Muscle: +1, Damage Reduction: 3
 Item	box-in-the-box	Meat Drop: +2
@@ -2217,93 +2217,93 @@ Item	box-in-the-box-in-the-box	Meat Drop: +3
 Item	Brand of Violence	Moxie Percent: +20, Critical Hit Percent: +5, Weapon Damage Percent: +30
 Item	brass dorsal fin	Weapon Damage Percent: +20, Damage Reduction: 13
 Item	bread basket	Food Drop: +20
-Item	BRICKO bulwark	Maximum HP: +6, Damage Reduction: 3
+Item	BRICKO bulwark	Maximum HP: +6, Damage Reduction: 3, Last Available: "2010-02"
 Item	Brimstone Bunker	Muscle Percent: +50, Moxie Percent: -20, Damage Reduction: 25, Brimstone
 Item	brown crock marble	Stench Spell Damage: +35
-Item	Brutal brogues	Muscle Percent: +50, Weapon Damage Percent: +50, Familiar Weight: +8, Experience (Muscle): +4, Lasts Until Rollover
+Item	Brutal brogues	Muscle Percent: +50, Weapon Damage Percent: +50, Familiar Weight: +8, Experience (Muscle): +4, Lasts Until Rollover, Last Available: "2018-07"
 Item	bumblebee marble	Spell Damage: +50
-Item	burning paper crane	Spooky Resistance: +3, Maximum HP: +25, Maximum MP: +25, Familiar Weight: +10, Lasts Until Rollover
+Item	burning paper crane	Spooky Resistance: +3, Maximum HP: +25, Maximum MP: +25, Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-12"
 Item	C.H.U.M. lantern	Stench Damage: +17, Item Drop: [30*loc(Sewer Tunnels)]
 # can of mixed everything: There's a little bit of everything in there!
-Item	can of mixed everything	Muscle: +5, Mysticality: +5, Moxie: +5, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1
+Item	can of mixed everything	Muscle: +5, Mysticality: +5, Moxie: +5, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Last Available: "2021-12"
 # card sleeve: If you like it, you should put a card in it!
 Item	cardboard box turtle	Muscle: +3, Damage Reduction: 4
-Item	cardboard wine carrier	Booze Drop: +50, Lasts Until Rollover
+Item	cardboard wine carrier	Booze Drop: +50, Lasts Until Rollover, Last Available: "2020-12"
 # carnivorous potted plant: Occasionally swallows your enemy whole
-Item	carnivorous potted plant	Monster Level: +25
+Item	carnivorous potted plant	Monster Level: +25, Last Available: "2021-12"
 Item	catskin buckler	Muscle: +10, Damage Absorption: +50, Damage Reduction: 11
 # ceramic centurion shield: Bash a foe, dealing 30 damage and weakening them
 Item	ceramic centurion shield	Experience (Muscle): +3, Maximum HP: +40, HP Regen Min: 8, HP Regen Max: 16, Damage Reduction: 9, Last Available: "2023-12"
-Item	Chalice of the Malkovich Prince	Muscle Percent: +4, Mysticality Percent: +4, Moxie Percent: +4
+Item	Chalice of the Malkovich Prince	Muscle Percent: +4, Mysticality Percent: +4, Moxie Percent: +4, Last Available: "2011-10"
 # chalk chalice: Weakens enemies who hit you
-Item	chalk chalice	Maximum MP: +15, Hot Spell Damage: +20
-Item	charged druidic orb	Lasts Until Rollover
+Item	chalk chalice	Maximum MP: +15, Hot Spell Damage: +20, Last Available: "2019-12"
+Item	charged druidic orb	Lasts Until Rollover, Last Available: "2018-04"
 # charged magnet: Radiates a Strange Energy
-Item	charged magnet	Maximum MP: +5, MP Regen Min: 1, MP Regen Max: 2
+Item	charged magnet	Maximum MP: +5, MP Regen Min: 1, MP Regen Max: 2, Last Available: "2009-09"
 Item	chiffon chamberpot	Mysticality: +10, Sleaze Damage: +10, Sleaze Spell Damage: +10, Last Available: "2023-12", Damage Aura: 1
-Item	chipped coffee mug	Maximum HP: +30, Maximum MP: +15
+Item	chipped coffee mug	Maximum HP: +30, Maximum MP: +15, Last Available: "2020-04"
 Item	Cloaca-Cola shield	Mysticality: +1, Damage Reduction: 4
 # clockwork detective skull
 Item	clownskin buckler	Spooky Damage: +3, Damage Reduction: 3, Clowniness: 50
-Item	cobbled-together Meat detector	Meat Drop: +15, Lasts Until Rollover
+Item	cobbled-together Meat detector	Meat Drop: +15, Lasts Until Rollover, Last Available: "2019-12"
 # Codex of Capsaicin Conjuration: All Spells Cast Are Hot
 Item	Codex of Capsaicin Conjuration	Spell Damage: +10
 Item	coffin lid	Spooky Resistance: +1, Damage Reduction: 3
 Item	Cold Stone of Hatred	Mysticality Percent: +20, Reduce Enemy Defense: 10, Spell Damage Percent: +60
 Item	collapsible baton	Mysticality Percent: +10, Spell Critical Percent: +5
-Item	complicated device	Experience: +1, Hot Damage: +1, Cold Damage: +1, Stench Damage: +1, Spooky Damage: +1, Sleaze Damage: +1, Hot Spell Damage: +11, Cold Spell Damage: +11, Stench Spell Damage: +11, Spooky Spell Damage: +11, Sleaze Spell Damage: +11, Monster Level: +11, Initiative: +11, Damage Reduction: 11, Damage Absorption: +11, Meat Drop: +11, Item Drop: +11, Muscle: +11, Mysticality: +11, Moxie: +11, Muscle Percent: +11, Mysticality Percent: +11, Moxie Percent: +11, Maximum HP: +111, Maximum MP: +111, Maximum HP Percent: +111, Maximum MP Percent: +111
+Item	complicated device	Experience: +1, Hot Damage: +1, Cold Damage: +1, Stench Damage: +1, Spooky Damage: +1, Sleaze Damage: +1, Hot Spell Damage: +11, Cold Spell Damage: +11, Stench Spell Damage: +11, Spooky Spell Damage: +11, Sleaze Spell Damage: +11, Monster Level: +11, Initiative: +11, Damage Reduction: 11, Damage Absorption: +11, Meat Drop: +11, Item Drop: +11, Muscle: +11, Mysticality: +11, Moxie: +11, Muscle Percent: +11, Mysticality Percent: +11, Moxie Percent: +11, Maximum HP: +111, Maximum MP: +111, Maximum HP Percent: +111, Maximum MP Percent: +111, Last Available: "2020-09"
 # Cookbook of the Damned: All Spells Cast Are Stinky
 Item	Cookbook of the Damned	Spell Damage: +10
-Item	cosmetic football	Muscle: +10
+Item	cosmetic football	Muscle: +10, Last Available: "2018-09"
 Item	creepy doll head	Spooky Damage: +15
 # creepy voice box: Pull the String!  I Dare You!
-Item	creme brulee torch	Hot Damage: +30, Lasts Until Rollover
+Item	creme brulee torch	Hot Damage: +30, Lasts Until Rollover, Last Available: "2016-12"
 # crepe paper puzzle cube: Play with it to get more stats after combat
 Item	crepe paper puzzle cube	Experience (Mysticality): +2, Spooky Damage: +10, Spooky Spell Damage: +10, Last Available: "2025-12"
-Item	Crimbo bottomless hot cocoa mug	Hot Spell Damage: +10
-Item	Crimbo Elf creepy bobble-head	Spooky Damage: +10
-Item	Crimbo light-up Rudolph doll	Sleaze Damage: +10
-Item	Crimbo smile	Experience: [5*event(December)]
-Item	Crimbo stogie-scented room odorizer	Stench Spell Damage: +10
-Item	Crimbo tree flocker	Cold Damage: +10
+Item	Crimbo bottomless hot cocoa mug	Hot Spell Damage: +10, Last Available: "2012-12"
+Item	Crimbo Elf creepy bobble-head	Spooky Damage: +10, Last Available: "2012-12"
+Item	Crimbo light-up Rudolph doll	Sleaze Damage: +10, Last Available: "2012-12"
+Item	Crimbo smile	Experience: [5*event(December)], Last Available: "2020-12"
+Item	Crimbo stogie-scented room odorizer	Stench Spell Damage: +10, Last Available: "2012-12"
+Item	Crimbo tree flocker	Cold Damage: +10, Last Available: "2012-12"
 # Crimbuccaneer lantern: Increases Item Drops on Crimbo Battlefields
 Item	Crimbuccaneer lantern	Hat Drop: +50, Weapon Drop: +50, Accessory Drop: +50, Last Available: "2023-12"
 Item	Crimbuccaneer war standard	Pirate Warfare Effectiveness: +50, Initiative: +25, Last Available: "2023-12"
-Item	crumbling rabbit's foot	Meat Drop: +30
-Item	cuddly teddy bear	Monster Level: +10
+Item	crumbling rabbit's foot	Meat Drop: +30, Last Available: "2020-04"
+Item	cuddly teddy bear	Monster Level: +10, Last Available: "2014-10"
 Item	cup of infinite pencils	Meat Drop: +15, Damage Aura: 1
 Item	cursed arcane orb	Spooky Damage: +13, Stench Damage: +13, Hot Damage: +13, Cold Damage: +13, Sleaze Damage: +13, Item Drop: -50
 Item	cursed compass	Item Drop: [100*zone(PirateRealm)], Lasts Until Rollover
 # cursed magnifying glass: Reveals things you weren't meant to see
-Item	cursed magnifying glass	Item Drop: +13, Spooky Damage: +13, Initiative: +13
+Item	cursed magnifying glass	Item Drop: +13, Spooky Damage: +13, Initiative: +13, Last Available: "2022-12"
 Item	cursed stats	Experience: +5, Muscle Limit: 69, Mysticality Limit: 69, Moxie Limit: 69
-Item	cyborg doll	Muscle: +3
+Item	cyborg doll	Muscle: +3, Last Available: "2007-12"
 Item	Dallas Dynasty Falcon Crest shield	Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Damage Reduction: 15
 # deceased crimbo tree: Blocks damage while needles remain
 Item	deceased crimbo tree	Lasts Until Rollover, Breakable
 Item	deck of lewd playing cards	Moxie Percent: +5, Sleaze Damage: +69, Sleaze Spell Damage: +69
-Item	deck of tropical cards	Experience: +1, Stat Tuning: "Mysticality"
+Item	deck of tropical cards	Experience: +1, Last Available: "2006-12", Stat Tuning: "Mysticality"
 # defective skull
 # deft pirate hook: Occasionally snags on your opponent's stuff
 Item	deft pirate hook	Muscle: +20, Weapon Damage: +10, Lasts Until Rollover, Last Available: "2024-12"
 Item	demon buckler	Hot Damage: +3, Damage Reduction: 5
-Item	depleted Grimacite gravy boat	Mysticality Percent: [5*G], Adventures: [G]
+Item	depleted Grimacite gravy boat	Mysticality Percent: [5*G], Adventures: [G], Last Available: "2011-12"
 # detective skull
-Item	detour shield	Damage Absorption: +10, Damage Reduction: 6
+Item	detour shield	Damage Absorption: +10, Damage Reduction: 6, Last Available: "2010-03"
 # Diamond HP-35 Calculator: Makes you look the most altruisticest
-Item	Dinsey's radar dish	MP Regen Min: 8, MP Regen Max: 10, Damage Reduction: 15, Damage Aura: 1
-Item	dirty rigging rope	Initiative: +30, Stench Damage: +15
-Item	discarded finger painting	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2
+Item	Dinsey's radar dish	MP Regen Min: 8, MP Regen Max: 10, Damage Reduction: 15, Last Available: "2015-04", Damage Aura: 1
+Item	dirty rigging rope	Initiative: +30, Stench Damage: +15, Last Available: "2015-04"
+Item	discarded finger painting	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Last Available: "2020-04"
 Item	disturbing fanfic	Sleaze Spell Damage: +30
 # double-ice box: All Spells Cast Are Cold
-Item	double-ice box	Spell Damage Percent: +10, Damage Aura: 1
+Item	double-ice box	Spell Damage Percent: +10, Last Available: "2011-04", Damage Aura: 1
 Item	drippy shield	Drippy Resistance: +10
-Item	druidic orb	Lasts Until Rollover
+Item	druidic orb	Lasts Until Rollover, Last Available: "2018-04"
 # Drunkula's wineglass: Allows adventuring while falling-down drunk
 # Drunkula's wineglass: Prevents you from using skills and spells and combat items
 Item	Drunkula's wineglass	Familiar Weight: -30
 Item	duct tape buckler	Maximum HP: +65, Maximum MP: +65, Damage Reduction: 12
-Item	Dungeon Fist gauntlet	Weapon Damage: +25, Combat Rate: +5, Food Drop: -100
+Item	Dungeon Fist gauntlet	Weapon Damage: +25, Combat Rate: +5, Food Drop: -100, Last Available: "2011-06"
 Item	Dyspepsi-Cola shield	Mysticality: +1, Damage Reduction: 4
 Item	easter egg balloon	Muscle: +5, Mysticality: +5, Moxie: +5
 Item	eelskin shield	Maximum HP: +55, Maximum MP: +55, Damage Reduction: 13, Thorns: [env(underwater)]
@@ -2312,60 +2312,60 @@ Item	Elf Guard clipboard	Food Drop: +25, Booze Drop: +25, Meat Drop: +25, Last A
 Item	Elf Guard safety bear	Last Available: "2023-12"
 Item	Elf Guard war standard	Elf Warfare Effectiveness: +50, MP Regen Min: 4, MP Regen Max: 8, Last Available: "2023-12"
 Item	Elizabeth's Dollie	Cold Resistance: +4, Spooky Spell Damage: +25
-Item	Ellsbury's skull	Meat Drop: +10, Item Drop: +10
+Item	Ellsbury's skull	Meat Drop: +10, Item Drop: +10, Last Available: "2010-09"
 Item	enchanted brass knuckles	Critical Hit Percent: +5
 # enchanted fire extinguisher: All Spells Cast Are Cold
-Item	enchanted fire extinguisher	Spell Damage Percent: +100, Cold Spell Damage: +30
+Item	enchanted fire extinguisher	Spell Damage Percent: +100, Cold Spell Damage: +30, Last Available: "2012-07"
 # encrypted micro-cassette recorder: Optimized for Pun-Recording
 # Engorged Sausages and You: All Spells Cast Are Sleazy
 Item	Engorged Sausages and You	Spell Damage: +15, Food Drop: +20
 # enhanced signal receiver: Reveals and interprets electromagnetic noise
-Item	eye of the Tiger-lily	Spell Damage: +10, Item Drop: +5
+Item	eye of the Tiger-lily	Spell Damage: +10, Item Drop: +5, Last Available: "2010-03"
 # fake hand: Gives Extra Offhand Equipment Slot
-Item	fake hand	Weapon Damage: -1
-Item	fake washboard	Experience Percent (Muscle): +25, Damage Absorption: +50, Accessory Drop: +75, Damage Reduction: 13
+Item	fake hand	Weapon Damage: -1, Last Available: "2006-04"
+Item	fake washboard	Experience Percent (Muscle): +25, Damage Absorption: +50, Accessory Drop: +75, Damage Reduction: 13, Last Available: "2015-04"
 Item	familiar scrapbook	HP Regen Min: [4+min(30,pref(scrapbookCharges)/10)], HP Regen Max: [6+min(30,pref(scrapbookCharges)/10)], MP Regen Min: [2+min(30,pref(scrapbookCharges)/10)], MP Regen Max: [3+min(30,pref(scrapbookCharges)/10)], Experience Percent (Muscle): [5+min(10,pref(scrapbookCharges)/10)], Experience Percent (Mysticality): [5+min(10,pref(scrapbookCharges)/10)], Experience Percent (Moxie): [5+min(10,pref(scrapbookCharges)/10)], Familiar Weight: +5, Experience (familiar): +1, Moxie: [min(1,floor(pref(scrapbookCharges)/1111))]
-Item	fancy marzipan briefcase	MP Regen Min: 4, MP Regen Max: 8, Combat Rate: -10, Lasts Until Rollover
+Item	fancy marzipan briefcase	MP Regen Min: 4, MP Regen Max: 8, Combat Rate: -10, Lasts Until Rollover, Last Available: "2016-12"
 Item	fancy opera glasses	Meat Drop: +5, Item Drop: +5
 # fiberglass fetish: A Seal Spirit will accompany you in combat
-Item	fiberglass fetish	HP Regen Min: 6, HP Regen Max: 10, Stench Resistance: +5
-Item	fireproof megaphone	Monster Level: +10, Hot Resistance: +2
+Item	fiberglass fetish	HP Regen Min: 6, HP Regen Max: 10, Stench Resistance: +5, Last Available: "2018-12"
+Item	fireproof megaphone	Monster Level: +10, Hot Resistance: +2, Last Available: "2015-08"
 # fishbone catcher's mitt: Prevents some items from washing away in the Heavy Rains
 # flagstone flag: Lets you hit your enemies with a big heavy flag
-Item	flagstone flag	Experience (Muscle): +3, Item Drop: +10
+Item	flagstone flag	Experience (Muscle): +3, Item Drop: +10, Last Available: "2022-12"
 Item	flaming talons	Weapon Damage: +5, Hot Damage: +5
-Item	fleshy lump	Maximum HP: +20, HP Regen Min: 2, HP Regen Max: 4, Damage Reduction: 3
-Item	flickering flashlight	Item Drop: +15
+Item	fleshy lump	Maximum HP: +20, HP Regen Min: 2, HP Regen Max: 4, Damage Reduction: 3, Last Available: "2016-08"
+Item	flickering flashlight	Item Drop: +15, Last Available: "2020-04"
 Item	flimsy clipboard	Meat Drop: +5, Damage Reduction: 3
-Item	flimsy ski pole	Initiative: +30
+Item	flimsy ski pole	Initiative: +30, Last Available: "2020-04"
 Item	foon	Mysticality: +2
 Item	foon of fearfulness	Mysticality: +3, Spooky Spell Damage: +8
 Item	foon of fleshiness	Mysticality: +3, Sleaze Spell Damage: +8
 Item	foon of foulness	Mysticality: +3, Stench Spell Damage: +8
 Item	foon of frigidity	Mysticality: +3, Cold Spell Damage: +8
 Item	foon of fulmination	Mysticality: +3, Hot Spell Damage: +8
-Item	frankincenser	Maximum MP: +10, Experience (Mysticality): +3
+Item	frankincenser	Maximum MP: +10, Experience (Mysticality): +3, Last Available: "2020-12"
 Item	furry yam buckler	Cold Resistance: +4, Damage Reduction: 14, Negative Status Resist, Lasts Until Rollover, Last Available: "2024-05"
 # Gazpacho's Glacial Grimoire: All Spells Cast Are Cold
 Item	Gazpacho's Glacial Grimoire	Spell Damage: +10
 # geofencing shield: CyberRealm: Prevent most damage from processes
 Item	geofencing shield	Last Available: "2025-12"
 # geological sample kit: Increases the yield of Spacegate geology operations
-Item	geological sample kit	Lasts Until Rollover
+Item	geological sample kit	Lasts Until Rollover, Last Available: "2017-04"
 Item	ghast iron heater shield	Spooky Damage: +10, Hot Damage: +10, Damage Reduction: 11
-Item	ghostly reins	Familiar Weight: +10, Experience (familiar): +2, Lasts Until Rollover
-Item	giant clay ashtray	Muscle: +5, Damage Reduction: 3
+Item	ghostly reins	Familiar Weight: +10, Experience (familiar): +2, Lasts Until Rollover, Last Available: "2016-08"
+Item	giant clay ashtray	Muscle: +5, Damage Reduction: 3, Last Available: "2011-05"
 Item	giant penguin keychain	HP Regen Min: 12, HP Regen Max: 16, Moxie: -5, Damage Reduction: 10
 # giant stuffed bugbear
-Item	gingerbread moneybag	Sprinkle Drop: +25
+Item	gingerbread moneybag	Sprinkle Drop: +25, Last Available: "2016-12"
 Item	Glass Balls of the Goblin King	Mysticality: +14
 Item	glass gnoll eye	Mysticality: +3
 # glass pie plate: Half Damage from Ghosts
-Item	glass pie plate	Hot Resistance: +3, Damage vs. Ghosts: +25, Damage Reduction: 7
-Item	glow-in-the-dark stuffed burrowgrub	Muscle: [9-M], Weapon Damage: [9-M]
+Item	glass pie plate	Hot Resistance: +3, Damage vs. Ghosts: +25, Damage Reduction: 7, Last Available: "2016-11"
+Item	glow-in-the-dark stuffed burrowgrub	Muscle: [9-M], Weapon Damage: [9-M], Last Available: "2009-01"
 Item	glowing esca	Item Drop: [20*env(underwater)]
 Item	glowstick on a string	Weapon Damage: +10, Raveosity: +1
-Item	glued-together crystal ball	Mysticality Percent: +50
+Item	glued-together crystal ball	Mysticality Percent: +50, Last Available: "2020-04"
 Item	gnauga hide buckler	Muscle: +3, Mysticality: +3, Moxie: +3, Damage Reduction: 5
 # Golden HP-35 Calculator: Makes you look super altruistic
 # golden sausage
@@ -2374,22 +2374,22 @@ Item	gnauga hide buckler	Muscle: +3, Mysticality: +3, Moxie: +3, Damage Reductio
 Item	gravyskin buckler	Sleaze Damage: +11, Sleaze Spell Damage: +11, Damage Reduction: 7, Last Available: "2024-12"
 Item	Great Wolf's left paw	Critical Hit Percent: +10, Spooky Damage: +10, Stench Damage: +10, Hot Damage: +10, Cold Damage: +10, Sleaze Damage: +10, Never Fumble, Class: "Seal Clubber"
 # green balloon
-Item	green LavaCo Lamp&trade;	Adventures: +5, Rollover Effect: "Green Peace", Rollover Effect Duration: 50
+Item	green LavaCo Lamp&trade;	Adventures: +5, Rollover Effect: "Green Peace", Rollover Effect Duration: 50, Last Available: "2015-08"
 Item	green peawee marble	Stench Spell Damage: +30
 Item	Grey Guanon	Stench Damage: +5, Damage Aura: 1
 Item	grisly shield	Weapon Damage: +50, PvP Fights: +5, Slime Hates It: +1, Damage Reduction: 13
 Item	gunwale	Muscle Percent: +25, Maximum HP: +50, Damage Absorption: +75, Damage Reduction: 9, Last Available: "2023-12"
-Item	Guzzlr souvenir stein	Booze Drop: +50
-Item	Half a Purse	Experience: +1, Damage Reduction: 3, Smithsness: +5, Meat Drop: [2*K]
+Item	Guzzlr souvenir stein	Booze Drop: +50, Last Available: "2020-05"
+Item	Half a Purse	Experience: +1, Damage Reduction: 3, Smithsness: +5, Last Available: "2013-12", Meat Drop: [2*K]
 # hand of Mr. Cards: Can be thrown
 Item	hand of Mr. Cards	Muscle: +5, Mysticality: +5, Moxie: +5
-Item	handmade hobby horse	Experience (Muscle): +2
+Item	handmade hobby horse	Experience (Muscle): +2, Last Available: "2007-12"
 # heart-shaped balloon
 # heavy duty umbrella: Reduces the level of nearby water.  Somehow.
 Item	heavy duty umbrella	Water Level: -2
-Item	heavy-duty clipboard	Mysticality: +10, Spell Critical Percent: +10, Spooky Resistance: +5, Damage Reduction: 8
-Item	Heimz Fortified Kidney Beans	Maximum HP: [15*(1+skill(Beanweaver))], Spell Damage: [10*(1+skill(Beanweaver))], HP Regen Min: [4*(1+skill(Beanweaver))], HP Regen Max: [5*(1+skill(Beanweaver))]
-Item	Hellfire Spicy Beans	Hot Spell Damage: [15*(1+skill(Beanweaver))]
+Item	heavy-duty clipboard	Mysticality: +10, Spell Critical Percent: +10, Spooky Resistance: +5, Damage Reduction: 8, Last Available: "2014-10"
+Item	Heimz Fortified Kidney Beans	Maximum HP: [15*(1+skill(Beanweaver))], Spell Damage: [10*(1+skill(Beanweaver))], HP Regen Min: [4*(1+skill(Beanweaver))], HP Regen Max: [5*(1+skill(Beanweaver))], Last Available: "2016-02"
+Item	Hellfire Spicy Beans	Hot Spell Damage: [15*(1+skill(Beanweaver))], Last Available: "2016-02"
 Item	hippo skin buckler	Muscle: +5, Damage Reduction: 5
 Item	HOA regulation book	Reduce Enemy Defense: 20, Monster Level: -100, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 23
 Item	hobo code binder	Free Pull
@@ -2411,10 +2411,10 @@ Item	hors d'oeuvre tray	Initiative: +15, Damage Reduction: 5
 Item	hot plate	Hot Damage: +3, Damage Reduction: 3, Thorns: 1
 # HP-35 Calculator: Makes you look altruistic
 Item	hypnodisk	Item Drop: +30
-Item	ice baby	Experience: +3, Softcore Only
-Item	ice bucket	Item Drop: +20, Lasts Until Rollover
+Item	ice baby	Experience: +3, Softcore Only, Last Available: "2006-02"
+Item	ice bucket	Item Drop: +20, Lasts Until Rollover, Last Available: "2014-01"
 Item	Idol of Ak'gyxoth	Moxie: +43, Mana Cost: -1
-Item	incredibly creepy marionette	Mysticality: +3
+Item	incredibly creepy marionette	Mysticality: +3, Last Available: "2006-12"
 Item	iShield	Hot Resistance: +3, Damage Reduction: 16, Moxie Percent: +15
 Item	ivory cue ball	Item Drop: +5
 Item	jar of frostigkraut	Cold Damage: +10, Damage Aura: 1
@@ -2431,53 +2431,53 @@ Item	jet bennie marble	Spooky Spell Damage: +55
 Item	keg shield	Damage Absorption: +50, Mysticality: +5, Damage Reduction: 11
 # Kevlar balloon
 Item	kickback cookbook	Spell Damage: +20
-Item	killer rag doll	Muscle: +3
+Item	killer rag doll	Muscle: +3, Last Available: "2006-12"
 # KoL Con 13 snowglobe: Lets you recall precious memories at the end of every fight
 Item	KoL Con 13 snowglobe	Drops Items
-Item	KoL Con IV Pole	Maximum HP: +4, Maximum MP: +4, Muscle: +4, Mysticality: +4, Moxie: +4, Hot Damage: +4
+Item	KoL Con IV Pole	Maximum HP: +4, Maximum MP: +4, Muscle: +4, Mysticality: +4, Moxie: +4, Hot Damage: +4, Last Available: "2007-09"
 Item	KoL Con Six Pack	Muscle: +5, Mysticality: +5, Moxie: +5, Booze Drop: +25
 Item	KoL Con X Treasure Map	Item Drop: +5, Meat Drop: +10
 # Kramco Sausage-o-Matic&trade;: Shows you how the sausage is made
-Item	Kramco Sausage-o-Matic&trade;	Item Drop: +10, Food Drop: +10, Maximum HP: +5, Maximum MP: +5, Critical Hit Percent: +20
+Item	Kramco Sausage-o-Matic&trade;	Item Drop: +10, Food Drop: +10, Maximum HP: +5, Maximum MP: +5, Critical Hit Percent: +20, Last Available: "2019-01"
 Item	LARP carp	Muscle: +10, Mysticality: +10, Moxie: +10
 # left bear arm: Lets you act like a bear
 Item	left bear arm	Muscle Percent: +10, Maximum HP: +30, Damage Reduction: 10
-Item	Left-Hand Man action figure	Familiar Weight: +7
+Item	Left-Hand Man action figure	Familiar Weight: +7, Last Available: "2020-04"
 Item	left-handed melodica	Ranged Damage: +25, Class: "Accordion Thief"
 Item	lemonade marble	Cold Spell Damage: +45
 Item	little black book	Spell Damage: +15, MP Regen Min: 5, MP Regen Max: 6
 Item	little round pebble	Initiative: +50
 Item	loadstone	Meat Drop: +10
-Item	Loathing Legion abacus	Mana Cost (combat): -5, Softcore Only
-Item	Loathing Legion can opener	Food Drop: +25, Softcore Only
-Item	Loathing Legion corkscrew	Booze Drop: +25, Softcore Only
-Item	Loathing Legion defibrillator	MP Regen Min: 5, MP Regen Max: 6, Softcore Only
-Item	Loathing Legion electric knife	Meat Drop: +20, Softcore Only
-Item	Loathing Legion kitchen sink	Spell Damage Percent: +25, Softcore Only
-Item	Loathing Legion many-purpose hook	Item Drop: +10, Softcore Only
-Item	Loathing Legion moondial	Adventures: +4, Softcore Only
-Item	Loathing Legion pizza stone	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Damage Reduction: 6, Softcore Only
-Item	Loathing Legion tape measure	Critical Hit Percent: +10, Softcore Only
+Item	Loathing Legion abacus	Mana Cost (combat): -5, Softcore Only, Last Available: "2011-01"
+Item	Loathing Legion can opener	Food Drop: +25, Softcore Only, Last Available: "2011-01"
+Item	Loathing Legion corkscrew	Booze Drop: +25, Softcore Only, Last Available: "2011-01"
+Item	Loathing Legion defibrillator	MP Regen Min: 5, MP Regen Max: 6, Softcore Only, Last Available: "2011-01"
+Item	Loathing Legion electric knife	Meat Drop: +20, Softcore Only, Last Available: "2011-01"
+Item	Loathing Legion kitchen sink	Spell Damage Percent: +25, Softcore Only, Last Available: "2011-01"
+Item	Loathing Legion many-purpose hook	Item Drop: +10, Softcore Only, Last Available: "2011-01"
+Item	Loathing Legion moondial	Adventures: +4, Softcore Only, Last Available: "2011-01"
+Item	Loathing Legion pizza stone	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Damage Reduction: 6, Softcore Only, Last Available: "2011-01"
+Item	Loathing Legion tape measure	Critical Hit Percent: +10, Softcore Only, Last Available: "2011-01"
 # loose purse strings: Monsters Will Drop Additional Meat
-Item	LOV Elephant	Damage Reduction: 16
+Item	LOV Elephant	Damage Reduction: 16, Last Available: "2017-02"
 Item	low-budget shield	Damage Reduction: 3
 Item	lucky lighter	Hot Damage: +6, Critical Hit Percent: +5
-Item	mad scientist's sock monkey	Moxie: +3
+Item	mad scientist's sock monkey	Moxie: +3, Last Available: "2006-12"
 Item	magic lamp	Mysticality: +5
 Item	magical ice cubes	Cold Damage: +1
 Item	makeshift castanets	DB Combat Damage: +10, Class: "Disco Bandit"
 # malware injector: CyberRealm: Infect a process (1 RAM, 30 damage per round)
 Item	malware injector	Last Available: "2025-12"
-Item	maple magnet	Maximum HP: +100, Weapon Drop: +50, Accessory Drop: +50, Lasts Until Rollover
-Item	marble mignonette bowl	MP Regen Min: 4, MP Regen Max: 8, Cold Spell Damage: +40, Thorns: 1
+Item	maple magnet	Maximum HP: +100, Weapon Drop: +50, Accessory Drop: +50, Lasts Until Rollover, Last Available: "2020-08"
+Item	marble mignonette bowl	MP Regen Min: 4, MP Regen Max: 8, Cold Spell Damage: +40, Last Available: "2019-12", Thorns: 1
 Item	marinara jug	Spell Damage: +30, Class: "Sauceror"
-Item	marionette	Mysticality: +3
-Item	marionette collective	Mysticality: +3
-Item	martini dregs	Moxie Percent: +50
+Item	marionette	Mysticality: +3, Last Available: "2005-12"
+Item	marionette collective	Mysticality: +3, Last Available: "2007-12"
+Item	martini dregs	Moxie Percent: +50, Last Available: "2020-04"
 # McHugeLarge left pole: Slash an enemy to make them easier to track
 Item	McHugeLarge left pole	Mysticality: +10, Spell Damage: +10, Spell Damage Percent: +25, Last Available: "2025-01", McHugeLarge
 Item	meat shield	Meat Drop: +3, Damage Reduction: 3
-Item	Medallion of the Ventrilo Prince	Moxie Percent: +12
+Item	Medallion of the Ventrilo Prince	Moxie Percent: +12, Last Available: "2011-10"
 Item	Mer-kin begsign	Weakens Monster, Meat Drop: [40*env(underwater)]
 Item	Mer-kin roundshield	Damage Reduction: 19, Damage Absorption: +40, HP Regen Min: 10, HP Regen Max: 20
 Item	Mer-kin stopwatch	Adventures: +3, Initiative: [50*env(underwater)]
@@ -2485,29 +2485,29 @@ Item	Mer-kin stopwatch	Adventures: +3, Initiative: [50*env(underwater)]
 Item	Mer-kin takebag	Item Drop: [5+10*env(underwater)]
 Item	mesquito proboscis	Maximum MP: +5, Mysticality: [3*L]
 # meteorb: Contributes Hot Damage to your spells
-Item	meteorb	Mysticality: +5, Maximum MP: +10
-Item	meteorite guard	Stench Resistance: +3, Hot Resistance: +3, Negative Status Resist, Damage Reduction: 9
-Item	Microplushie: Bropane	Weapon Damage: +3
-Item	Microplushie: Dorkonide	Muscle: +1, Mysticality: +1, Moxie: +1
-Item	Microplushie: Ermahgerdic Acid	Hot Damage: +2
-Item	Microplushie: Fauxnerditide	Moxie: +2
-Item	Microplushie: Gothochondria	Spooky Damage: +2
-Item	Microplushie: Hippylase	Stench Damage: +2
-Item	Microplushie: Hipsterine	Monster Level: +1
-Item	Microplushie: Hobomosome	Stench Resistance: +1
-Item	Microplushie: Otakulone	Maximum MP: +4
-Item	Microplushie: Raverdrine	Maximum HP: +8
-Item	Microplushie: Sororitrate	Sleaze Damage: +2
+Item	meteorb	Mysticality: +5, Maximum MP: +10, Last Available: "2017-08"
+Item	meteorite guard	Stench Resistance: +3, Hot Resistance: +3, Negative Status Resist, Damage Reduction: 9, Last Available: "2017-08"
+Item	Microplushie: Bropane	Weapon Damage: +3, Last Available: "2012-12"
+Item	Microplushie: Dorkonide	Muscle: +1, Mysticality: +1, Moxie: +1, Last Available: "2012-12"
+Item	Microplushie: Ermahgerdic Acid	Hot Damage: +2, Last Available: "2012-12"
+Item	Microplushie: Fauxnerditide	Moxie: +2, Last Available: "2012-12"
+Item	Microplushie: Gothochondria	Spooky Damage: +2, Last Available: "2012-12"
+Item	Microplushie: Hippylase	Stench Damage: +2, Last Available: "2012-12"
+Item	Microplushie: Hipsterine	Monster Level: +1, Last Available: "2012-12"
+Item	Microplushie: Hobomosome	Stench Resistance: +1, Last Available: "2012-12"
+Item	Microplushie: Otakulone	Maximum MP: +4, Last Available: "2012-12"
+Item	Microplushie: Raverdrine	Maximum HP: +8, Last Available: "2012-12"
+Item	Microplushie: Sororitrate	Sleaze Damage: +2, Last Available: "2012-12"
 # military orb: Detonate to destroy a monster
 Item	military orb	MP Regen Min: 10, MP Regen Max: 15, Mysticality: +15, Last Available: "2024-12"
 Item	mini kiwi whipping stick	Sleaze Damage: +5, Experience: +2
 # mini-zeppelin
-Item	miniature candle	Experience: +3, Item Drop: +20, Lasts Until Rollover
+Item	miniature candle	Experience: +3, Item Drop: +20, Lasts Until Rollover, Last Available: "2017-01"
 # miniature stuffed Goth Giant
-Item	misfit dolly	Moxie: +5, Spooky Damage: +5
-Item	misfit hobby horse	Muscle: +5, Stench Damage: +5
-Item	misfit teddy bear	Mysticality: +5, Hot Damage: +5
-Item	Mixed Garbanzos and Chickpeas	Maximum HP: [5*(1+skill(Beanweaver))], Maximum MP: [5*(1+skill(Beanweaver))], Spell Damage: [10*(1+skill(Beanweaver))], HP Regen Min: [(1+skill(Beanweaver))], HP Regen Max: [3*(1+skill(Beanweaver))], MP Regen Min: [(1+skill(Beanweaver))], MP Regen Max: [3*(1+skill(Beanweaver))]
+Item	misfit dolly	Moxie: +5, Spooky Damage: +5, Last Available: "2009-12"
+Item	misfit hobby horse	Muscle: +5, Stench Damage: +5, Last Available: "2009-12"
+Item	misfit teddy bear	Mysticality: +5, Hot Damage: +5, Last Available: "2009-12"
+Item	Mixed Garbanzos and Chickpeas	Maximum HP: [5*(1+skill(Beanweaver))], Maximum MP: [5*(1+skill(Beanweaver))], Spell Damage: [10*(1+skill(Beanweaver))], HP Regen Min: [(1+skill(Beanweaver))], HP Regen Max: [3*(1+skill(Beanweaver))], MP Regen Min: [(1+skill(Beanweaver))], MP Regen Max: [3*(1+skill(Beanweaver))], Last Available: "2016-02"
 Item	moaiball	Muscle Percent: +25, Item Drop: +10, Initiative: +50, Last Available: "2024-12"
 Item	mole skin notebook	Moxie: +1
 # moss megaphone: Whisper with the voice of the Great Turtle Spirits
@@ -2516,20 +2516,20 @@ Item	moxie magnet	Moxie Controls MP
 Item	Mr. Balloon	Muscle: +3, Mysticality: +3, Moxie: +3
 # Mr. Haggis: Haggis!
 Item	Mr. Haggis	Damage Aura: 1
-Item	mushroom shield	Muscle: +40, Mysticality: -20, Moxie: -20, Combat Rate: +10, Damage Reduction: 6
+Item	mushroom shield	Muscle: +40, Mysticality: -20, Moxie: -20, Combat Rate: +10, Damage Reduction: 6, Last Available: "2020-03"
 # Mylar balloon
 # naughty fortune teller: + Some Stats Per Fight
-Item	naughty fortune teller	Softcore Only
+Item	naughty fortune teller	Softcore Only, Last Available: "2008-02"
 # Necrotelicomnicon: All Spells Cast Are Spooky
 Item	Necrotelicomnicon	Spell Damage: +10
 Item	novelty monorail ticket	Adventures: +3, Rollover Effect: "Favored by Lyle", Rollover Effect Duration: 100
-Item	nozzle of the Phoenix	Mysticality: +15, Mysticality Percent: +25, Hot Spell Damage: +50
+Item	nozzle of the Phoenix	Mysticality: +15, Mysticality Percent: +25, Hot Spell Damage: +50, Last Available: "2018-04"
 Item	off-hand balloon	Muscle: +1, Mysticality: +1, Moxie: +1
 Item	oil lamp	Sleaze Damage: +5, Hot Damage: +5
 # Ol' Scratch's ash can: All Spells Cast Are Hot
 Item	Ol' Scratch's ash can	Spell Damage Percent: +100, Hot Spell Damage: +30, Class: "Sauceror"
 Item	Ol' Scratch's stove door	Hot Damage: +20, Damage Reduction: 15, Thorns: 1
-Item	old pizza box	Damage Absorption: +50, Damage Reduction: 6
+Item	old pizza box	Damage Absorption: +50, Damage Reduction: 6, Last Available: "2020-04"
 Item	old school flying disc	Muscle Percent: +15, Damage Reduction: 24, Familiar Weight: +5
 Item	Operation Patriot Shield	Experience: +3, Maximum HP: +20, Maximum MP: +20, Softcore Only, Variable
 # * Seal Clubber:
@@ -2552,146 +2552,146 @@ Item	orcish stud-finder	Weapon Damage: +5, Sleaze Damage: +5
 # ornate dowsing rod: Aids in desert exploration
 Item	Oscus's garbage can lid	Stench Damage: +20, Damage Reduction: 15, Thorns: 1
 # Ouija Board, Ouija Board: Gain the favor of the Turtle Spirits more quickly
-Item	Ouija Board, Ouija Board	Familiar Weight: +5, Smithsness: +5, Class: "Turtle Tamer", Damage Reduction: 7, Muscle Percent: [2*K]
-Item	outmoded fidget toy	Experience: +2
+Item	Ouija Board, Ouija Board	Familiar Weight: +5, Smithsness: +5, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12", Muscle Percent: [2*K]
+Item	outmoded fidget toy	Experience: +2, Last Available: "2020-04"
 Item	oversized monocle on a stick	Mysticality Percent: +25, Item Drop: +25, Lasts Until Rollover, Last Available: "2024-10"
-Item	ox-head shield	Maximum HP: +100, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 26, PvP Fights: +8, Never Fumble, Lasts Until Rollover
+Item	ox-head shield	Maximum HP: +100, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 26, PvP Fights: +8, Never Fumble, Lasts Until Rollover, Last Available: "2016-03"
 # oyster basket
 Item	oyster egg balloon	Muscle: +5, Mysticality: +5, Moxie: +5
 Item	padded tortoise	Damage Absorption: +20, HP Regen Min: 4, HP Regen Max: 8, Damage Reduction: 6
 # paint palette: Lets you paint your foes
-Item	paint palette	Spooky Damage: +8, Stench Damage: +8, Hot Damage: +8, Cold Damage: +8, Sleaze Damage: +8
+Item	paint palette	Spooky Damage: +8, Stench Damage: +8, Hot Damage: +8, Cold Damage: +8, Sleaze Damage: +8, Last Available: "2018-09"
 Item	painted shield	Muscle: +3, Mysticality: +3, Moxie: +3, Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2, Damage Reduction: 7
 # Paradaisical Cheeseburger recipe
-Item	parasitic strangleworm	Damage Reduction: [min(L,15)]
+Item	parasitic strangleworm	Damage Reduction: [min(L,15)], Last Available: "2008-12"
 # party crasher: Lets you crash into your foes, stunning them
-Item	party crasher	Initiative: +25, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 9
-Item	peanut brittle shield	Candy Drop: +100, Damage Reduction: 3
+Item	party crasher	Initiative: +25, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 9, Last Available: "2018-09"
+Item	peanut brittle shield	Candy Drop: +100, Damage Reduction: 3, Last Available: "2009-12"
 Item	penguin skin buckler	Moxie: +5, Damage Reduction: 5
-Item	penguin thesaurus	Mysticality: +1, Maximum HP: +5, Maximum MP: +5
+Item	penguin thesaurus	Mysticality: +1, Maximum HP: +5, Maximum MP: +5, Last Available: "2008-12"
 # petrified wood water purifier: Adds cold and sleaze damage to spells
 Item	petrified wood water purifier	Experience (Mysticality): +3, Meat Drop: +20, Last Available: "2025-12"
 # photo booth supply list: Lets you find photo booth supplies
 Item	photo booth supply list	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Damage Reduction: 20, Lasts Until Rollover, Last Available: "2024-10"
-Item	pilgrim shield	Maximum HP: +30, Weapon Damage: +15, Experience: +3, HP Regen Min: 10, HP Regen Max: 12, Weapon Drop: +50, Damage Reduction: [L], Softcore Only
+Item	pilgrim shield	Maximum HP: +30, Weapon Damage: +15, Experience: +3, HP Regen Min: 10, HP Regen Max: 12, Weapon Drop: +50, Damage Reduction: [L], Softcore Only, Last Available: "2006-11"
 Item	pirate hook	Weapon Damage: +3
 Item	pixel grappling hook	Initiative: +40, Item Drop: +10
 Item	pixel shield	Muscle: +5, Damage Reduction: 3
 # Platinum HP-35 Calculator: Makes you look incredibly altruistic
-Item	plush alielf	Maximum HP: +30
-Item	plush alien hamsterpus	Muscle Percent: [2*G], Mysticality Percent: [2*G], Moxie Percent: [2*G]
-Item	plush dogcat	Maximum MP: +30
-Item	plush ferrelf	Muscle: +5, Mysticality: +5, Moxie: +5
-Item	plush hamsterpus	Maximum HP: +50, Maximum MP: +50
-Item	plush mutated alielephant	Muscle Percent: [3*G], Mysticality Percent: [3*G], Moxie Percent: [3*G], Critical Hit Percent: +5
-Item	plush mutated alielf	Muscle Percent: [G], Mysticality Percent: [G], Moxie Percent: [G]
-Item	pocketwatch on a chain	Monster Level: -10, Experience (Mysticality): +1
-Item	polyalloy shield	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Muscle: +10, Damage Reduction: 9
+Item	plush alielf	Maximum HP: +30, Last Available: "2011-06"
+Item	plush alien hamsterpus	Muscle Percent: [2*G], Mysticality Percent: [2*G], Moxie Percent: [2*G], Last Available: "2011-06"
+Item	plush dogcat	Maximum MP: +30, Last Available: "2011-06"
+Item	plush ferrelf	Muscle: +5, Mysticality: +5, Moxie: +5, Last Available: "2011-06"
+Item	plush hamsterpus	Maximum HP: +50, Maximum MP: +50, Last Available: "2011-06"
+Item	plush mutated alielephant	Muscle Percent: [3*G], Mysticality Percent: [3*G], Moxie Percent: [3*G], Critical Hit Percent: +5, Last Available: "2011-06"
+Item	plush mutated alielf	Muscle Percent: [G], Mysticality Percent: [G], Moxie Percent: [G], Last Available: "2011-06"
+Item	pocketwatch on a chain	Monster Level: -10, Experience (Mysticality): +1, Last Available: "2009-12"
+Item	polyalloy shield	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Muscle: +10, Damage Reduction: 9, Last Available: "2007-12"
 # polyester pad: Shieldbutting Always Causes Bad Guys to Stagger
-Item	polyester pad	Damage Reduction: 13, HP Regen Min: 4, HP Regen Max: 8
+Item	polyester pad	Damage Reduction: 13, HP Regen Min: 4, HP Regen Max: 8, Last Available: "2015-12"
 # pool skimmer: Catches other people's washed-away items
 # porcelain pepper mill: Adds Physical Damage to Saucestorm
-Item	porcelain pepper mill	Spell Critical Percent: +10, Weakens Monster
-Item	Pork 'n' Pork 'n' Pork 'n' Beans	Sleaze Spell Damage: [15*(1+skill(Beanweaver))]
-Item	portable dam	Damage Reduction: 109
+Item	porcelain pepper mill	Spell Critical Percent: +10, Weakens Monster, Last Available: "2015-12"
+Item	Pork 'n' Pork 'n' Pork 'n' Beans	Sleaze Spell Damage: [15*(1+skill(Beanweaver))], Last Available: "2016-02"
+Item	portable dam	Damage Reduction: 109, Last Available: "2018-12"
 Item	portable Othello set	Othello Skill: +10
-Item	pottery shield	Hot Damage: +5, Damage Reduction: 3
+Item	pottery shield	Hot Damage: +5, Damage Reduction: 3, Last Available: "2010-09"
 Item	pretty bouquet	Moxie: +3
-Item	primitive alien totem	Damage Reduction: 25, Spooky Damage: +25, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4
-Item	psychic's crystal ball	Muscle: +5, Mysticality: +5, Moxie: +5, Initiative: +20
-Item	pumpkin spice candle	Item Drop: +40, Lasts Until Rollover
+Item	primitive alien totem	Damage Reduction: 25, Spooky Damage: +25, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4, Last Available: "2017-04"
+Item	psychic's crystal ball	Muscle: +5, Mysticality: +5, Moxie: +5, Initiative: +20, Last Available: "2018-02"
+Item	pumpkin spice candle	Item Drop: +40, Lasts Until Rollover, Last Available: "2016-12"
 Item	radiator heater shield	Cold Resistance: +3, Damage Reduction: 6
-Item	rag doll	Muscle: +3
+Item	rag doll	Muscle: +3, Last Available: "2005-12"
 # Raggedy Hippy doll
 # Rain-Doh green lantern: Makes Spells Smell Worse
-Item	Rain-Doh green lantern	Maximum MP: +20, Softcore Only
+Item	Rain-Doh green lantern	Maximum MP: +20, Softcore Only, Last Available: "2012-02"
 Item	Rainbow Jello Mould	Moxie Percent: +25
 Item	rake	Meat Drop: +3, Leaves: +1.5
 # recursed compass: Now it's even more cursed
-Item	recursed compass	Lasts Until Rollover
+Item	recursed compass	Lasts Until Rollover, Last Available: "2019-04"
 # red balloon
 Item	red book	Spell Damage: +20, HP Regen Min: 5, HP Regen Max: 10
 Item	red China marble	Hot Spell Damage: +40
-Item	red LavaCo Lamp&trade;	Adventures: +5, Rollover Effect: "Red Menace", Rollover Effect Duration: 50
+Item	red LavaCo Lamp&trade;	Adventures: +5, Rollover Effect: "Red Menace", Rollover Effect Duration: 50, Last Available: "2015-08"
 Item	Red Roger's red left hand	Item Drop: [100*zone(PirateRealm)]
 Item	red wagon	Mysticality Percent: +15, Spell Damage Percent: +50, Maximum MP: +300
 Item	Red X Shield	Maximum HP: +20, Maximum MP: +20, Damage Reduction: 11
 Item	replica august scepter	Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50
 Item	replica Operation Patriot Shield	Experience: +3, Maximum HP: +20, Maximum MP: +20, Variable
-Item	reusable shopping bag	Food Drop: +20, Booze Drop: +20, Candy Drop: +20
+Item	reusable shopping bag	Food Drop: +20, Booze Drop: +20, Candy Drop: +20, Last Available: "2015-12"
 Item	rice bowl	Food Drop: +20
 Item	Roman Candelabra	Maximum HP: [10*(pref(romanCandelabraRedCasts)+2)], Maximum MP: [10*(pref(romanCandelabraYellowCasts)+2)], Muscle: [5*(pref(romanCandelabraBlueCasts)+2)], Mysticality: [5*(pref(romanCandelabraGreenCasts)+2)], Moxie: [5*(pref(romanCandelabraPurpleCasts)+2)], Spooky Damage: [10*(1-min(1,effect(Everything Looks Yellow)))], Cold Damage: [10*(1-min(1,effect(Everything Looks Blue)))], Hot Damage: [10*(1-min(1,effect(Everything Looks Red)))], Stench Damage: [10*(1-min(1,effect(Everything Looks Green)))], Sleaze Damage: [10*(1-min(1,effect(Everything Looks Purple)))]
-Item	Royal scepter	Adventures: +4, PvP Fights: +8, Rollover Effect: "It's Good To Be Royal!", Rollover Effect Duration: 5
+Item	Royal scepter	Adventures: +4, PvP Fights: +8, Rollover Effect: "It's Good To Be Royal!", Rollover Effect Duration: 5, Last Available: "2015-09"
 Item	rubber baby doll	Damage Aura: 1
 Item	rubber ribcage	Spooky Resistance: +3, Damage Reduction: 12
 Item	rusty compass	Initiative: +30
 Item	rusty empty nacho cheese can	Water: +1
-Item	rusty kettle bell	Muscle Percent: +50
+Item	rusty kettle bell	Muscle Percent: +50, Last Available: "2020-04"
 # rusty old lantern
-Item	rxr shield	Damage Absorption: +10, Damage Reduction: 6
-Item	SalesCo sample kit	Meat Drop: [30*event(December)]
+Item	rxr shield	Damage Absorption: +10, Damage Reduction: 6, Last Available: "2010-06"
+Item	SalesCo sample kit	Meat Drop: [30*event(December)], Last Available: "2020-12"
 Item	sawblade shield	Weapon Damage: +11, Damage Reduction: 11
 Item	Scepter of Loathing	Critical Hit Percent: +15, Spell Critical Percent: +15, Spooky Resistance: +5, Cloathing
-Item	Sceptre of the Torremolinos Prince	Mysticality Percent: +12
+Item	Sceptre of the Torremolinos Prince	Mysticality Percent: +12, Last Available: "2011-10"
 # Science Notebook: Allows you to collect data about Tentacles
 Item	Science Notebook	Monster Level: +10
-Item	scissor duck	Mysticality: +5
+Item	scissor duck	Mysticality: +5, Last Available: "2010-12"
 Item	sealhide buckler	Damage Reduction: 17
 Item	sealskin drum	Weapon Damage: +20, Class: "Seal Clubber"
 Item	sebaceous shield	Stench Damage: +1, Sleaze Damage: +1, Damage Reduction: 2
 Item	security flashlight	Monster Level: -10
-Item	set of jacks	Experience (Moxie): +2
-Item	Seven Loco	Booze Drop: +5, Candy Drop: +5
+Item	set of jacks	Experience (Moxie): +2, Last Available: "2007-12"
+Item	Seven Loco	Booze Drop: +5, Candy Drop: +5, Last Available: "2010-09"
 Item	sewer turtle	Stench Damage: +1, Damage Reduction: 1
 # shadow candle: Bathe your foes in cleansing flame
 Item	shadowy seal eye	Spooky Damage: +20, Monster Level: +15, Class: "Seal Clubber"
-Item	Shield of Icy Fate	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Weapon Damage Percent: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Damage Reduction: 7
-Item	shield of the Skeleton Lord	Muscle Percent: +50, Monster Level: +50, Familiar Weight: +5, Damage Reduction: 19
-Item	Shrub's Premium Baked Beans	Maximum MP: [25*(1+skill(Beanweaver))], Spell Damage Percent: [25*(1+skill(Beanweaver))], Spell Critical Percent: [5*(1+skill(Beanweaver))]
+Item	Shield of Icy Fate	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Weapon Damage Percent: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Damage Reduction: 7, Last Available: "2013-02"
+Item	shield of the Skeleton Lord	Muscle Percent: +50, Monster Level: +50, Familiar Weight: +5, Damage Reduction: 19, Last Available: "2018-04"
+Item	Shrub's Premium Baked Beans	Maximum MP: [25*(1+skill(Beanweaver))], Spell Damage Percent: [25*(1+skill(Beanweaver))], Spell Critical Percent: [5*(1+skill(Beanweaver))], Last Available: "2016-02"
 # signal receiver: Receives signals, presumably
-Item	silver cow creamer	Adventures: +3, PvP Fights: +3, Meat Drop: +30
+Item	silver cow creamer	Adventures: +3, PvP Fights: +3, Meat Drop: +30, Last Available: "2014-12"
 # silver sausage
 # Sinful Desires: All Spells Cast Are Sleazy
 Item	Sinful Desires	Spell Damage: +10
-Item	six-rainbow shield	Maximum HP: +50, Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Damage Reduction: 12
-Item	skull gearshift knob	Spooky Damage: +20, Spooky Spell Damage: +25, Spell Damage Percent: +30
+Item	six-rainbow shield	Maximum HP: +50, Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Damage Reduction: 12, Last Available: "2008-07"
+Item	skull gearshift knob	Spooky Damage: +20, Spooky Spell Damage: +25, Spell Damage Percent: +30, Last Available: "2014-12"
 Item	skull of the Bonerdagon	Spooky Damage: +5
 Item	slime-covered compass	Slime Resistance: +2, Initiative: +40
 Item	slime-covered lantern	Slime Resistance: +2, Maximum HP: +50, Maximum MP: +50, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 10, MP Regen Max: 15
-Item	slippery when wet shield	Damage Absorption: +10, Damage Reduction: 6
+Item	slippery when wet shield	Damage Absorption: +10, Damage Reduction: 6, Last Available: "2010-04"
 Item	smirking shrunken head	Damage Aura: 1
 Item	snake shield	Muscle: +6, Damage Reduction: 7, Synergetic
 # snapdragon pistil: All Spells Cast Are Hot
-Item	snapdragon pistil	Spell Critical Percent: +5
+Item	snapdragon pistil	Spell Critical Percent: +5, Last Available: "2010-03"
 Item	snarling wolf shield	Maximum HP: +40, Damage Reduction: 7, Synergetic
 # snow mobile: Makes Spells Way Cooler
-Item	snow mobile	Maximum MP: +20, Lasts Until Rollover
+Item	snow mobile	Maximum MP: +20, Lasts Until Rollover, Last Available: "2014-01"
 Item	snowstick	Cold Spell Damage: +80
-Item	sock monkey	Moxie: +3
+Item	sock monkey	Moxie: +3, Last Available: "2005-12"
 Item	Solstice Shield	Muscle Percent: [5*G], Mysticality Percent: [5*G], Moxie Percent: [5*G], Damage Absorption: +20
 Item	sommelier's towel	Booze Drop: +30
-Item	sonar fishfinder	Fishing Skill: +5
+Item	sonar fishfinder	Fishing Skill: +5, Last Available: "2016-04"
 # space shield: Deflects Invader Bullets
 Item	space shield	Damage Reduction: 9
 Item	Space Tourist palmdoctor	Maximum HP: +25, Maximum MP: +25, HP Regen Min: 4, HP Regen Max: 6, MP Regen Min: 4, MP Regen Max: 6, Lasts Until Rollover
 Item	spaghetti-box banjo	MP Regen Min: 5, MP Regen Max: 10, Class: "Pastamancer"
 # Spanish fly trap
-Item	spant shield	Muscle Percent: +15, Damage Absorption: +100, Damage Reduction: 6
-Item	speed limit shield	Damage Absorption: +10, Damage Reduction: 6
+Item	spant shield	Muscle Percent: +15, Damage Absorption: +100, Damage Reduction: 6, Last Available: "2017-04"
+Item	speed limit shield	Damage Absorption: +10, Damage Reduction: 6, Last Available: "2009-12"
 Item	spiky turtle shield	Weapon Damage: +8, Item Drop: +10, Damage Reduction: 8
 Item	spongy shield	Muscle Percent: +10, HP Regen Min: 20, HP Regen Max: 50, Damage Absorption: +50, Damage Reduction: 14
-Item	spooky little girl	Item Drop: [G]
+Item	spooky little girl	Item Drop: [G], Last Available: "2011-06"
 # sprinkle shaker
-Item	sprinkle-begging cup	Sprinkle Drop: +50
-Item	stained glass shield	Experience (Muscle): +3, Cold Resistance: +3, Cold Damage: +5, Damage Reduction: 7
-Item	standards and practices guide	Sleaze Resistance: +2
-Item	stapler bear	Muscle: +5, Damage Aura: 1
+Item	sprinkle-begging cup	Sprinkle Drop: +50, Last Available: "2016-12"
+Item	stained glass shield	Experience (Muscle): +3, Cold Resistance: +3, Cold Damage: +5, Damage Reduction: 7, Last Available: "2021-12"
+Item	standards and practices guide	Sleaze Resistance: +2, Last Available: "2016-08"
+Item	stapler bear	Muscle: +5, Last Available: "2010-12", Damage Aura: 1
 Item	star buckler	Muscle: +2, Mysticality: +2, Moxie: +2, Damage Reduction: 10
 Item	steaming evil	Hot Damage: +6, Sleaze Damage: +6, Spooky Damage: +6
 Item	steely marble	Sleaze Spell Damage: +65
-Item	stinky cheese wheel	Damage Reduction: 6, Softcore Only, Damage Absorption: [max(1,min(50,floor(pref(_stinkyCheeseCount)/2)))]
-Item	stop shield	Damage Absorption: +10, Damage Reduction: 6
-Item	stress ball	Maximum HP: +100, Maximum MP: +100
+Item	stinky cheese wheel	Damage Reduction: 6, Softcore Only, Last Available: "2010-01", Damage Absorption: [max(1,min(50,floor(pref(_stinkyCheeseCount)/2)))]
+Item	stop shield	Damage Absorption: +10, Damage Reduction: 6, Last Available: "2009-12"
+Item	stress ball	Maximum HP: +100, Maximum MP: +100, Last Available: "2011-05"
 Item	studded sealhide shield	Muscle: +5, Maximum HP: +30, Damage Reduction: 7
 # stuffed astral badger
 # stuffed baby gravy fairy
@@ -2735,38 +2735,38 @@ Item	stuffed kraken	Last Available: "2023-12"
 Item	Stupid University Diploma	Maximum HP: +3, Maximum MP: +3, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5
 Item	sturdy cane	PvP Fights: +4, Fumble: 2, Initiative: -25
 # sucker bucket: May Attract Walruses
-Item	sucker bucket	Candy Drop: +50
+Item	sucker bucket	Candy Drop: +50, Last Available: "2011-11"
 # surprisingly capacious handbag: +50% Item Drops at the Neverending Party
 Item	surprisingly capacious handbag	Item Drop: [50*loc(The Neverending Party)]
-Item	Sword of the Brouhaha Prince	Muscle Percent: +12
+Item	Sword of the Brouhaha Prince	Muscle Percent: +12, Last Available: "2011-10"
 # Taco Dan's Taco Stand Cocktail Sauce Bottle
 Item	tailbone shield	Stench Damage: +40, Damage Reduction: 16, Thorns: 1
 Item	teflon shield	Muscle Percent: +10, Damage Reduction: 24, Damage Absorption: +50
 Item	Temporal Tempera Tube	Muscle Percent: [5*G], Mysticality Percent: [5*G], Moxie Percent: [5*G]
 # terra cotta tambourine: Lets you unleash a terra cotta army on your foes
-Item	terra cotta tambourine	Moxie Percent: +20, Monster Level: +10
-Item	Tesla's Electroplated Beans	Maximum MP: [15*(1+skill(Beanweaver))], Spell Damage: [10*(1+skill(Beanweaver))], MP Regen Min: [4*(1+skill(Beanweaver))], MP Regen Max: [5*(1+skill(Beanweaver))]
+Item	terra cotta tambourine	Moxie Percent: +20, Monster Level: +10, Last Available: "2020-12"
+Item	Tesla's Electroplated Beans	Maximum MP: [15*(1+skill(Beanweaver))], Spell Damage: [10*(1+skill(Beanweaver))], MP Regen Min: [4*(1+skill(Beanweaver))], MP Regen Max: [5*(1+skill(Beanweaver))], Last Available: "2016-02"
 # The Lot's engagement ring: Allows Noxious Proposals
 Item	The Lot's engagement ring	Stench Damage: +3
 # The Necbromancer's Stein: All Spells Cast Are Spooky
-Item	The Necbromancer's Stein	Spell Damage Percent: +100, Spooky Spell Damage: +30
-Item	The Spirit of Crimbo	Free Pull
+Item	The Necbromancer's Stein	Spell Damage Percent: +100, Spooky Spell Damage: +30, Last Available: "2011-10"
+Item	The Spirit of Crimbo	Free Pull, Last Available: "2008-12"
 Item	third-hand lantern	Initiative: +5
 # thought balloon
-Item	Tiki lighter	Experience: +1, Stat Tuning: "Moxie"
+Item	Tiki lighter	Experience: +1, Last Available: "2006-12", Stat Tuning: "Moxie"
 Item	Time Lord Participation Mug	Maximum Hooch: +3
-Item	tinsel orb	Accessory Drop: +100, Spooky Damage: +60, Class: "Turtle Tamer"
+Item	tinsel orb	Accessory Drop: +100, Spooky Damage: +60, Class: "Turtle Tamer", Last Available: "2020-12"
 # tiny black hole: Allows Pickpocketing
-Item	tiny black hole	Pickpocket Chance: +25, Initiative: -200
+Item	tiny black hole	Pickpocket Chance: +25, Initiative: -200, Last Available: "2011-04"
 Item	tip jar	Meat Drop: +5
 Item	tortoboggan shield	Initiative: +30, Cold Resistance: +2, Damage Reduction: 6
 # toy Crimbot super fist: Allows use of POW in combat
-Item	toy Crimbot super fist	Damage Reduction: 10, Crimbot Outfit Power: +1
-Item	Trader Olaf's Exotic Stinkbeans	Stench Spell Damage: [15*(1+skill(Beanweaver))]
-Item	trench lighter	Experience Percent (Muscle): +10, Experience Percent (Mysticality): +10, Experience Percent (Moxie): +10
+Item	toy Crimbot super fist	Damage Reduction: 10, Crimbot Outfit Power: +1, Last Available: "2014-12"
+Item	Trader Olaf's Exotic Stinkbeans	Stench Spell Damage: [15*(1+skill(Beanweaver))], Last Available: "2016-02"
+Item	trench lighter	Experience Percent (Muscle): +10, Experience Percent (Mysticality): +10, Experience Percent (Moxie): +10, Last Available: "2014-10"
 # trojan horseshoe: CyberRealm: Occasionally find 0s after combat
 Item	trojan horseshoe	Last Available: "2025-12"
-Item	tropical paperweight	Experience: +1, Stat Tuning: "Muscle"
+Item	tropical paperweight	Experience: +1, Last Available: "2006-12", Stat Tuning: "Muscle"
 # Tuesday's ruby: Has day-dependent effects which are hard-coded
 Item	Tuesday's ruby	Variable
 Item	turtle wax shield	Maximum HP: +10, Damage Reduction: 2
@@ -2782,7 +2782,7 @@ Item	Val-U Brand Every Bean Salad	Hot Spell Damage: +5, Cold Spell Damage: +5, S
 Item	vampire pellet	MP Regen Min: 4, MP Regen Max: 8, Spooky Damage: +10, Spooky Spell Damage: +20
 Item	velcro shield	Mysticality Percent: +10, Damage Reduction: 24, Weapon Drop: +25
 # velour valise: Triples the damage and deleveling of Tango of Terror
-Item	velour valise	Experience (Moxie): +2, Booze Drop: +30
+Item	velour valise	Experience (Moxie): +2, Booze Drop: +30, Last Available: "2021-12"
 Item	vengeful spirit	Hot Spell Damage: +80
 Item	Victor, the Insult Comic Hellhound Puppet	Monster Level: +5
 Item	vinyl shield	Moxie Percent: +10, Damage Reduction: 24, Monster Level: +25
@@ -2790,7 +2790,7 @@ Item	vinyl shield	Moxie Percent: +10, Damage Reduction: 24, Monster Level: +25
 Item	visual packet sniffer	Last Available: "2025-12"
 Item	voodoo doll	Mysticality: +1
 Item	wad of Crovacite	Muscle: +5, Mysticality: +5, Moxie: +5, Spooky Damage: +5
-Item	Wal-Mart snowglobe	Muscle Percent: +40, Experience (Muscle): +4, Familiar Weight: +5
+Item	Wal-Mart snowglobe	Muscle Percent: +40, Experience (Muscle): +4, Familiar Weight: +5, Last Available: "2015-11"
 # Wand of Oscus: All Spells Cast Are Stinky
 Item	Wand of Oscus	Spell Damage Percent: +100, Stench Spell Damage: +30, Class: "Pastamancer"
 Item	washboard shield	Damage Absorption: +50, Class: "Turtle Tamer", Damage Reduction: 10
@@ -2798,56 +2798,56 @@ Item	water candle	Hot Resistance: +3, Lasts Until Rollover, Water: +3
 Item	Whatsian Ionic Pliers	HP Regen Min: 3, HP Regen Max: 5, MP Regen Min: 3, MP Regen Max: 5
 # white balloon
 Item	white satin shield	Moxie: +2, Damage Reduction: 5
-Item	whittled walking stick	Adventures: +3, PvP Fights: +6, Combat Rate: +10, Item Drop: +20
+Item	whittled walking stick	Adventures: +3, PvP Fights: +6, Combat Rate: +10, Item Drop: +20, Last Available: "2019-08"
 # wicker clicker: Cadenza will briefly stun opponents
-Item	wicker clicker	Experience (Moxie): +2, MP Regen Min: 2, MP Regen Max: 4
+Item	wicker clicker	Experience (Moxie): +2, MP Regen Min: 2, MP Regen Max: 4, Last Available: "2016-12"
 Item	wicker shield	Moxie: +6, Damage Reduction: 11
 Item	wonderwall shield	Maximum HP: +50, Damage Reduction: 12
-Item	World's Blackest-Eyed Peas	Spooky Spell Damage: [15*(1+skill(Beanweaver))]
+Item	World's Blackest-Eyed Peas	Spooky Spell Damage: [15*(1+skill(Beanweaver))], Last Available: "2016-02"
 Item	yakskin buckler	Mysticality: +5, Damage Reduction: 5
-Item	yield shield	Damage Absorption: +10, Damage Reduction: 6
+Item	yield shield	Damage Absorption: +10, Damage Reduction: 6, Last Available: "2009-09"
 Item	Yorick	Experience: +2, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10, Item Drop: +15
 Item	Zombo's shield	Damage Absorption: +50, Spooky Damage: +30, Muscle Percent: +20, Class: "Turtle Tamer", Damage Reduction: 15
 # zoological sample kit: Increases the yield of Spacegate zoology operations
-Item	zoological sample kit	Lasts Until Rollover
+Item	zoological sample kit	Lasts Until Rollover, Last Available: "2017-04"
 
 # Accessories section of modifiers.txt
 
 Item	&quot;I survived Y2K&quot; T-Shirt	Maximum HP: +2, Maximum MP: +2, Adventures: +2, Experience (Muscle): +2, Experience (Mysticality): +2, Experience (Moxie): +2, Single Equip, Last Available: "2023-06"
-Item	&quot;I Voted!&quot; sticker	Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Lasts Until Rollover
+Item	&quot;I Voted!&quot; sticker	Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Lasts Until Rollover, Last Available: "2018-11"
 Item	acid-squirting flower	Single Equip, Thorns: 1
 # actual reality goggles: Reveals peoples' true nature
-Item	actual reality goggles	Single Equip, Free Pull
-Item	actual skeleton key	Damage Absorption: +100, Damage Reduction: 10
-Item	adobe ascot	Moxie Percent: [20+20*min(1,effect(Adobe Ascot Subscription))], Initiative: [30+30*min(1,effect(Adobe Ascot Subscription))], Single Equip
+Item	actual reality goggles	Single Equip, Free Pull, Last Available: "2012-12"
+Item	actual skeleton key	Damage Absorption: +100, Damage Reduction: 10, Last Available: "2020-08"
+Item	adobe ascot	Moxie Percent: [20+20*min(1,effect(Adobe Ascot Subscription))], Initiative: [30+30*min(1,effect(Adobe Ascot Subscription))], Single Equip, Last Available: "2024-12"
 # aerogel anvil: Gives a chance of generating extra Fury
-Item	aerogel anvil	Weapon Damage Percent: +25, Never Fumble, Single Equip
+Item	aerogel anvil	Weapon Damage Percent: +25, Never Fumble, Single Equip, Last Available: "2017-12"
 # aerogel apron: Weapon of the Pastalord can be even messier
-Item	aerogel apron	Spell Critical Percent: +5, Hot Resistance: +3, Single Equip
+Item	aerogel apron	Spell Critical Percent: +5, Hot Resistance: +3, Single Equip, Last Available: "2017-12"
 # aerogel ascot: Dramatically improves Saucecicle
-Item	aerogel ascot	Mysticality: +10, Adventures: +3, Single Equip
-Item	albatross necklace	Mysticality Percent: +10, Single Equip
+Item	aerogel ascot	Mysticality: +10, Adventures: +3, Single Equip, Last Available: "2017-12"
+Item	albatross necklace	Mysticality Percent: +10, Single Equip, Last Available: "2007-06"
 Item	Aluminum Epsilon of Humility	Muscle: +7, Mysticality: +7, Moxie: +7, Item Drop: +9, Single Equip
 Item	amber aviator shades	Mysticality Percent: +5, Moxie Percent: +5, Sleaze Damage: +30, Single Equip
 Item	amulet of extreme plot significance	Maximum MP: +30
-Item	Amulet of Perpetual Darkness	Monster Level: +15, Spooky Damage: +10, Spooky Spell Damage: +10, Weakens Monster, Blind
+Item	Amulet of Perpetual Darkness	Monster Level: +15, Spooky Damage: +10, Spooky Spell Damage: +10, Weakens Monster, Last Available: "2023-06", Blind
 # Amulet of Yendor: Prevents Level Teleporting
-Item	Amulet of Yendor	Mana Cost: +3, Initiative: -10, Single Equip
-Item	anchovy can key	Food Drop: +100
+Item	Amulet of Yendor	Mana Cost: +3, Initiative: -10, Single Equip, Last Available: "2011-12"
+Item	anchovy can key	Food Drop: +100, Last Available: "2020-08"
 # anemoney clip: +50% Meat Drops (Underwater only)
-Item	anemoney clip	Meat Drop: [25+50*env(underwater)], Single Equip
+Item	anemoney clip	Meat Drop: [25+50*env(underwater)], Single Equip, Last Available: "2019-12"
 Item	Ankh of Badahnkadh	Spell Damage Percent: +25, Single Equip
-Item	ankleweights	PvP Fights: +4, Experience: +1, Single Equip
+Item	ankleweights	PvP Fights: +4, Experience: +1, Single Equip, Last Available: "2014-12"
 Item	annealed drippy orb	Drippy Resistance: +5
 Item	anniversary balsa wood socks	Muscle: +1, Mysticality: +1, Moxie: +1
 Item	anniversary burlap belt	Muscle: +1, Mysticality: +1, Moxie: +1
 Item	Annual Ascot	Muscle Percent: +12, Mysticality Percent: +12, Moxie Percent: +12
 # antique Canadian lantern: +15% more Item Drops in the Canadian Wildlife Preserve
-Item	antique Canadian lantern	Item Drop: [15+15*loc(The Canadian Wildlife Preserve)], Cold Resistance: +3
-Item	antique nutcracker beard	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Mysticality Percent: +15, Single Equip
-Item	antique nutcracker boots	Weapon Damage: +15, Muscle Percent: +15, Single Equip
-Item	antique nutcracker epaulets	HP Regen Min: 6, HP Regen Max: 12, Moxie Percent: +15, Single Equip
-Item	aqu&iacute;	Hot Resistance: +3, Hot Damage: +15, Hot Spell Damage: +30
+Item	antique Canadian lantern	Item Drop: [15+15*loc(The Canadian Wildlife Preserve)], Cold Resistance: +3, Last Available: "2018-12"
+Item	antique nutcracker beard	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Mysticality Percent: +15, Single Equip, Last Available: "2019-12"
+Item	antique nutcracker boots	Weapon Damage: +15, Muscle Percent: +15, Single Equip, Last Available: "2019-12"
+Item	antique nutcracker epaulets	HP Regen Min: 6, HP Regen Max: 12, Moxie Percent: +15, Single Equip, Last Available: "2019-12"
+Item	aqu&iacute;	Hot Resistance: +3, Hot Damage: +15, Hot Spell Damage: +30, Last Available: "2020-08"
 # aquamariner's necklace: Makes you a better diver
 Item	aquamariner's necklace	MP Regen Min: 10, MP Regen Max: 15, Meat Drop: +15, Single Equip, Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)]
 # aquamariner's ring: Makes you a better diver
@@ -2856,17 +2856,17 @@ Item	arrrgyle socks	Mysticality: +6
 # Ass-Stompers of Violence: Allows you to stomp asses
 Item	Ass-Stompers of Violence	Combat Rate: +5, Critical Hit Percent: +5, Weapon Damage Percent: +30, Single Equip
 # asteroid belt: Deflects 25% of enemy attacks
-Item	asteroid belt	Monster Level: +10, Ranged Damage Percent: +50, Single Equip
+Item	asteroid belt	Monster Level: +10, Ranged Damage Percent: +50, Single Equip, Last Available: "2017-08"
 Item	astral belt	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Monster Level: +20
 Item	astral bracer	Mysticality Percent: +25, Mana Cost (combat): -3, Adventures: +3
 Item	astral mask	Moxie Percent: +25, Item Drop: +20
 Item	astral ring	Mysticality Percent: +25, Spell Damage: +20, MP Regen Min: 4, MP Regen Max: 6
-Item	atlas of local maps	Combat Rate: -5, Lasts Until Rollover
+Item	atlas of local maps	Combat Rate: -5, Lasts Until Rollover, Last Available: "2022-05"
 # attorney's badge: OBJECTION!
 Item	attorney's badge	Single Equip
 # automatic wine thief: Fully restore your MP after Crimbo Train fights
 Item	automatic wine thief	Single Equip
-Item	autumn leaf pendant	Familiar Weight: +5, Familiar Damage: +10, Experience (familiar): +1, Lasts Until Rollover
+Item	autumn leaf pendant	Familiar Weight: +5, Familiar Damage: +10, Experience (familiar): +1, Lasts Until Rollover, Last Available: "2022-10"
 Item	backup camera	Maximum HP: +20, Maximum MP: +20, Single Equip
 Item	baconstone bracelet	Mysticality: +2, Mana Cost: -1, Single Equip
 Item	baconstone earring	Mysticality: +2, Mana Cost: -1, Single Equip
@@ -2875,113 +2875,113 @@ Item	baconstone ring	Mysticality: +5, Maximum MP: +10, MP Regen Min: 2, MP Regen
 Item	badass belt	Muscle: +5, Mysticality: +5, Moxie: +5
 Item	badge of authority	Monster Level: +10, Single Equip
 # bakelite badge: Gain the favor of the Great Turtle Spirits more quickly
-Item	bakelite badge	Familiar Weight: +5, Muscle Percent: +20, Single Equip
+Item	bakelite badge	Familiar Weight: +5, Muscle Percent: +20, Single Equip, Last Available: "2016-12"
 # bakelite belt: Makes Cavalcade of Fury consume less Fury
-Item	bakelite belt	Critical Hit Percent: +5, Damage Reduction: 10, Single Equip
+Item	bakelite belt	Critical Hit Percent: +5, Damage Reduction: 10, Single Equip, Last Available: "2016-12"
 # bakelite brooch: Active Saucespheres increase your spell damage
 Item	bakelite brooch	Mana Cost (combat): -2, Mysticality Percent: +20, Spell Damage Percent: [20*(min(1,effect(Elemental Saucesphere))+min(1,effect(Jalape&ntilde;o Saucesphere))+min(1,effect(Antibiotic Saucesphere)))], Single Equip
 # bananarama bangle: (only in the Candy Diorama)
-Item	bananarama bangle	Damage Reduction: [30*zone(The Candy Diorama)], Single Equip
+Item	bananarama bangle	Damage Reduction: [30*zone(The Candy Diorama)], Single Equip, Last Available: "2011-11"
 Item	Bandolier of the Spaghetti Elemental	Mysticality: +11, MP Regen Min: 10, MP Regen Max: 12, Class: "Pastamancer", Single Equip
 Item	baneful bandolier	Ranged Damage: +30, Hat Drop: +30, Slime Hates It: +1, Pants Drop: +30
 Item	banjo kazoo mount	Maximum Hooch: +2, Single Equip
 Item	bark bracelet	Damage Reduction: 2, Single Equip
 Item	Baron von Ratsworth's money clip	Meat Drop: +15, Single Equip
 Item	Baron von Ratsworth's monocle	Item Drop: +10, Single Equip
-Item	barrel beryl choker	Muscle: +10, Weapon Damage: +10
-Item	barrel beryl nose ring	Mysticality: +10, Spell Damage: +20
-Item	barrel beryl ring	Moxie: +10, Initiative: +20
-Item	barrel hoop earring	Mysticality Percent: +25, Item Drop: +50, MP Regen Min: 5, MP Regen Max: 10, Lasts Until Rollover
+Item	barrel beryl choker	Muscle: +10, Weapon Damage: +10, Last Available: "2015-09"
+Item	barrel beryl nose ring	Mysticality: +10, Spell Damage: +20, Last Available: "2015-09"
+Item	barrel beryl ring	Moxie: +10, Initiative: +20, Last Available: "2015-09"
+Item	barrel hoop earring	Mysticality Percent: +25, Item Drop: +50, MP Regen Min: 5, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2015-09"
 Item	batskin belt	Muscle: +3, Mysticality: +3, Moxie: +3
-Item	batting cage key	Stench Resistance: +3, Stench Damage: +15, Stench Spell Damage: +30
-Item	battle broom	Experience (Mysticality): +5, MP Regen Min: 5, MP Regen Max: 10, Mysticality Percent: +50, Spell Damage Percent: +100, Spell Critical Percent: +10, Single Equip, Lasts Until Rollover
-Item	bauxite bow-tie	Mysticality: +11, Maximum MP: [23+floor(pref(daycareToddlers)^0.35)], Spell Damage: [37+floor(pref(daycareToddlers)^0.35)], Single Equip
+Item	batting cage key	Stench Resistance: +3, Stench Damage: +15, Stench Spell Damage: +30, Last Available: "2020-08"
+Item	battle broom	Experience (Mysticality): +5, MP Regen Min: 5, MP Regen Max: 10, Mysticality Percent: +50, Spell Damage Percent: +100, Spell Critical Percent: +10, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
+Item	bauxite bow-tie	Mysticality: +11, Maximum MP: [23+floor(pref(daycareToddlers)^0.35)], Spell Damage: [37+floor(pref(daycareToddlers)^0.35)], Single Equip, Last Available: "2018-12"
 Item	baywatch	Adventures: +7, PvP Fights: +2, Mana Cost: -2, Lasts Until Rollover, Nonstackable Watch
-Item	Beach Comb	Moxie Percent: +20, MP Regen Min: 8, MP Regen Max: 12, Familiar Weight: +5, Single Equip
+Item	Beach Comb	Moxie Percent: +20, MP Regen Min: 8, MP Regen Max: 12, Familiar Weight: +5, Single Equip, Last Available: "2019-07"
 Item	beach glass necklace	Muscle: +5
 Item	beaten-up Chucks	Initiative: +40
 # beer goggles: They Do Nothing!
-Item	bejazzled eyepatch	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3
+Item	bejazzled eyepatch	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2024-12"
 Item	bejeweled accordion strap	Maximum HP: +25, Maximum MP: +25, Class: "Accordion Thief"
 Item	bejeweled cufflinks	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Single Equip
 Item	bejeweled pledge pin	Maximum HP: +40, Single Equip
-Item	Belt of Howling Anger	PvP Fights: +3, Critical Hit Percent: +3, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Single Equip
+Item	Belt of Howling Anger	PvP Fights: +3, Critical Hit Percent: +3, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Single Equip, Last Available: "2013-02"
 Item	Belt of Loathing	Damage Reduction: 20, Familiar Weight: +10, Negative Status Resist, Single Equip, Cloathing
-Item	belt of Ogrekind	Muscle: +15, Muscle Percent: +25, Experience (Muscle): +5, Single Equip
-Item	bembershoot	Cold Resistance: +5, Lasts Until Rollover
+Item	belt of Ogrekind	Muscle: +15, Muscle Percent: +25, Experience (Muscle): +5, Single Equip, Last Available: "2018-04"
+Item	bembershoot	Cold Resistance: +5, Lasts Until Rollover, Last Available: "2024-09"
 # bewitching boots: Slight Cute Resistance
-Item	bewitching boots	Meat Drop: +10, Synergetic
+Item	bewitching boots	Meat Drop: +10, Last Available: "2009-06", Synergetic
 # bezoar ring: Protects the wearer from poison
-Item	BGE pocket calendar	Adventures: +3, Single Equip
-Item	BGE tiny plastic toy	Familiar Weight: +3, Single Equip
+Item	BGE pocket calendar	Adventures: +3, Single Equip, Last Available: "2010-12"
+Item	BGE tiny plastic toy	Familiar Weight: +3, Single Equip, Last Available: "2010-12"
 Item	big red clown nose	Maximum HP: +7, Clowniness: 25
-Item	birch battery	Maximum MP: +100, MP Regen Min: 15, MP Regen Max: 20, Lasts Until Rollover
-Item	bitter bowtie	Cold Resistance: +1, Meat Drop: +10, Synergetic
+Item	birch battery	Maximum MP: +100, MP Regen Min: 15, MP Regen Max: 20, Lasts Until Rollover, Last Available: "2020-08"
+Item	bitter bowtie	Cold Resistance: +1, Meat Drop: +10, Last Available: "2009-06", Synergetic
 Item	black belt	Muscle: +7, Weapon Damage: +7, Single Equip
 # black glass
-Item	black rose key	Familiar Weight: +5, Experience (familiar): +2
+Item	black rose key	Familiar Weight: +5, Experience (familiar): +2, Last Available: "2020-08"
 Item	blackberry combat boots	Muscle: +10, Maximum HP: +45, Weapon Damage: +5, Single Equip
 Item	blackberry galoshes	Muscle: +7, Mysticality: +7, Moxie: +7, Single Equip
 Item	blackberry moccasins	Moxie: +8, Initiative: +25, Damage Reduction: 3, Single Equip
 Item	blackberry slippers	Mysticality: +10, Spell Damage: +10, Spell Damage Percent: +5, Single Equip
 Item	Bling of the New Wave	Moxie: +11, HP Regen Min: 5, HP Regen Max: 9, MP Regen Min: 5, MP Regen Max: 9, Extra Pickpocket, Class: "Disco Bandit", Single Equip
 Item	Blue Diamond of Honesty	Muscle: +7, Mysticality: +7, Moxie: +7, Item Drop: +9, Single Equip
-Item	blue glowstick	Maximum MP: +5, Moxie: -3, Raveosity: +1
-Item	blue plastic baby	Maximum HP: +5, Maximum MP: +5, Single Equip
-Item	blue ribbon	Maximum HP: +5
-Item	bone spurs	Monster Level: +20, Single Equip
+Item	blue glowstick	Maximum MP: +5, Moxie: -3, Last Available: "2007-11", Raveosity: +1
+Item	blue plastic baby	Maximum HP: +5, Maximum MP: +5, Single Equip, Last Available: "2008-12"
+Item	blue ribbon	Maximum HP: +5, Last Available: "2006-07"
+Item	bone spurs	Monster Level: +20, Single Equip, Last Available: "2010-10"
 Item	Bonerdagon necklace	Muscle: +5, Moxie: +5, Initiative: +30
 Item	BOOtonniere	Cold Resistance: +4, Single Equip
-Item	Boots of Twilight Whispers	Adventures: +3, Initiative: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Single Equip
+Item	Boots of Twilight Whispers	Adventures: +3, Initiative: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Single Equip, Last Available: "2013-02"
 Item	booty chest charrrm bracelet	Meat Drop: +10, Single Equip
 # booze drive button: Lets you collect booze donations as you adventure
-Item	booze drive button	Single Equip
+Item	booze drive button	Single Equip, Last Available: "2020-12"
 Item	Boris's ring	Muscle: +10
 Item	Boss Bat bling	Muscle: +3, Moxie: +3
 Item	bottle opener belt buckle	Single Equip, Damage Aura: 1
 Item	bottlecap turtle	Mysticality: +1, Maximum MP: +3
 Item	boxing glove	Weapon Damage: +4
 Item	Bram's choker	Moxie Percent: +10, Combat Rate: -5, PvP Fights: +3, Single Equip
-Item	brazen bracelet	Sleaze Resistance: +1, Meat Drop: +10, Synergetic
+Item	brazen bracelet	Sleaze Resistance: +1, Meat Drop: +10, Last Available: "2009-06", Synergetic
 Item	Brimstone Bracelet	Mysticality Percent: +50, Muscle Percent: -20, Mana Cost: -3, Single Equip, Brimstone
 Item	Brimstone Brooch	Mysticality Percent: +50, Moxie Percent: -20, Spell Damage: +40, Single Equip, Brimstone
-Item	broken clock	Monster Level: +5
-Item	bronze detective badge	Maximum HP: +20, Maximum MP: +20, Item Drop: +10, Meat Drop: +20
-Item	brown plastic baby	Maximum HP: +5, Maximum MP: +5, Single Equip
+Item	broken clock	Monster Level: +5, Last Available: "2011-09"
+Item	bronze detective badge	Maximum HP: +20, Maximum MP: +20, Item Drop: +10, Meat Drop: +20, Last Available: "2016-07"
+Item	brown plastic baby	Maximum HP: +5, Maximum MP: +5, Single Equip, Last Available: "2008-08"
 # bugbear communicator badge
 # bugbear detector: Detects Bugbears (Duh)
 Item	bugbear detector	Single Equip
 Item	bullet necklace	Mysticality: +30, Maximum MP: +30, Single Equip
-Item	burning paper slippers	Cold Resistance: +3, Maximum HP: +25, Maximum MP: +25, Initiative: +50, Single Equip, Lasts Until Rollover
+Item	burning paper slippers	Cold Resistance: +3, Maximum HP: +25, Maximum MP: +25, Initiative: +50, Single Equip, Lasts Until Rollover, Last Available: "2018-12"
 Item	C.A.R.N.I.V.O.R.E. button	Monster Level: +15
-Item	cactus key	Maximum HP: +20, HP Regen Min: 9, HP Regen Max: 10
-Item	candy dress shoes	Maximum HP: +20, Weapon Damage: +15, Critical Hit Percent: +10, Single Equip
+Item	cactus key	Maximum HP: +20, HP Regen Min: 9, HP Regen Max: 10, Last Available: "2020-08"
+Item	candy dress shoes	Maximum HP: +20, Weapon Damage: +15, Critical Hit Percent: +10, Single Equip, Last Available: "2016-12"
 # candy drive button: Lets you collect candy donations as you adventure
-Item	candy drive button	Single Equip
+Item	candy drive button	Single Equip, Last Available: "2020-12"
 Item	candy necklace	Candy Drop: +10, Single Equip, Raveosity: +1
-Item	candy necktie	Initiative: +20, Ranged Damage: +15, Pickpocket Chance: +10, Single Equip
+Item	candy necktie	Initiative: +20, Ranged Damage: +15, Pickpocket Chance: +10, Single Equip, Last Available: "2016-12"
 Item	cannonball charrrm bracelet	Single Equip, Sporadic Thorns: 0.25
 # Cat-Herding Prod: +10 Damage vs. Lions
 Item	Cat-Herding Prod	Muscle: +15, Mysticality: +15, Moxie: +15
 Item	Caveman Dan's favorite rock	Maximum HP: +60, Food Drop: +30, Experience (Muscle): +3, Single Equip
-Item	cement sandals	Initiative: -10, Experience (Muscle): +1, Single Equip
+Item	cement sandals	Initiative: -10, Experience (Muscle): +1, Single Equip, Last Available: "2009-12"
 # cement shoes: Makes you sleep like the dead
-Item	cement shoes	Mysticality: +20, Moxie: +20
+Item	cement shoes	Mysticality: +20, Moxie: +20, Last Available: "2004-10"
 # ceramic celsiturometer: Deal 60 Hot Damage to a foe and briefly stun them,
 # ceramic celsiturometer: but also make them very angry
 Item	ceramic celsiturometer	Experience (Mysticality): +3, Maximum MP: +30, MP Regen Min: 6, MP Regen Max: 12
 # ceramic cerecloth belt: Deal 30 Spooky Damage to a target and weaken them
 Item	ceramic cerecloth belt	Moxie Percent: +20, Initiative: +40, Never Fumble
 # ceramic cestus: Punch a foe, dealing 30 damage and briefly stunning them
-Item	ceramic cestus	Muscle Percent: +20, Familiar Weight: +5, Single Equip
+Item	ceramic cestus	Muscle Percent: +20, Familiar Weight: +5, Single Equip, Last Available: "2023-12"
 # chalk chain: Weakens enemies who hit you
-Item	chalk chain	Experience (Muscle): +2, Experience (familiar): +1, Single Equip
+Item	chalk chain	Experience (Muscle): +2, Experience (familiar): +1, Single Equip, Last Available: "2019-12"
 # chalk choker: Weakens enemies who hit you
-Item	chalk choker	Experience (Moxie): +2, Pants Drop: +20, Single Equip
+Item	chalk choker	Experience (Moxie): +2, Pants Drop: +20, Single Equip, Last Available: "2019-12"
 Item	Charleston shoes	Moxie: +30, Item Drop: +10, Single Equip
-Item	cheap elven gloves	Mysticality: +1, Sleaze Resistance: +1
-Item	cheap plastic pipe	Maximum MP: +40, MP Regen Min: 8, MP Regen Max: 12, Single Equip, Lasts Until Rollover
-Item	cheap studded belt	Damage Reduction: 1
+Item	cheap elven gloves	Mysticality: +1, Sleaze Resistance: +1, Last Available: "2008-12"
+Item	cheap plastic pipe	Maximum MP: +40, MP Regen Min: 8, MP Regen Max: 12, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
+Item	cheap studded belt	Damage Reduction: 1, Last Available: "2008-04"
 # cheap sunglasses: +60% Meat Drops from Tourists
 Item	cheap sunglasses	Meat Drop: [60*zone(Dinseylandfill)], Single Equip
 # Chester's Aquarius medallion: All Spells Cast Are Sleazy
@@ -2990,15 +2990,15 @@ Item	Chester's Aquarius medallion	Sleaze Spell Damage: +30, Single Equip
 Item	Chester's moustache	DB Combat Damage: +20, Sleaze Damage: +20, Class: "Disco Bandit", Single Equip
 Item	Chester's sunglasses	Moxie Percent: +15, Sleaze Damage: +20, Reduce Enemy Defense: 15, Single Equip
 # chiffon chevrons: Delevels your foe each round
-Item	chiffon chevrons	Muscle: +10, Weapon Damage: +10, Spell Damage: +10, Single Equip
+Item	chiffon chevrons	Muscle: +10, Weapon Damage: +10, Spell Damage: +10, Single Equip, Last Available: "2023-12"
 Item	chintzy accordion pin	Moxie: +12, Mysticality: +6, Class: "Accordion Thief", Single Equip
 Item	chintzy disco ball pendant	Moxie: +12, Muscle: +6, Class: "Disco Bandit", Single Equip
 Item	chintzy noodle ring	Mysticality: +12, Muscle: +6, Class: "Pastamancer", Single Equip
 Item	chintzy saucepan earring	Mysticality: +12, Moxie: +6, Class: "Sauceror", Single Equip
 Item	chintzy seal pendant	Muscle: +12, Moxie: +6, Class: "Seal Clubber", Single Equip
 Item	chintzy turtle brooch	Muscle: +12, Mysticality: +6, Class: "Turtle Tamer", Single Equip
-Item	chocolate pocketwatch	Maximum MP: +20, Spell Damage: +15, Spell Critical Percent: +10, Single Equip
-Item	chocolate rabbit's foot	Item Drop: +5, Meat Drop: +5, Candy Drop: +20
+Item	chocolate pocketwatch	Maximum MP: +20, Spell Damage: +15, Spell Critical Percent: +10, Single Equip, Last Available: "2016-12"
+Item	chocolate rabbit's foot	Item Drop: +5, Meat Drop: +5, Candy Drop: +20, Last Available: "2014-12"
 Item	Choker of the Ultragoth	Muscle: +3, Mysticality: +3, Moxie: +3, Spooky Spell Damage: +40, Single Equip
 Item	Cincho de Mayo	Moxie Percent: +25, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Booze Drop: +30, Item Drop: +15
 # Claw of the Infernal Seal: 5 Additional Seal Summons Per Day
@@ -3006,90 +3006,90 @@ Item	Cincho de Mayo	Moxie Percent: +25, HP Regen Min: 10, HP Regen Max: 20, MP R
 Item	Claw of the Infernal Seal	Muscle: +11, HP Regen Min: 20, HP Regen Max: 25, Class: "Seal Clubber", Single Equip
 Item	Claybender glasses	Item Drop: +4, Damage vs. Ghosts: +15, Single Equip
 Item	clingfilm slippers	Spell Damage: +15, Single Equip
-Item	clown car key	Spooky Damage: +10, Stench Damage: +10, Hot Damage: +10, Cold Damage: +10, Sleaze Damage: +10, Monster Level: +10
+Item	clown car key	Spooky Damage: +10, Stench Damage: +10, Hot Damage: +10, Cold Damage: +10, Sleaze Damage: +10, Monster Level: +10, Last Available: "2020-08"
 Item	clown shoes	Maximum MP: +7, Clowniness: 25
 Item	clownskin belt	Maximum MP: +15, Clowniness: 50
 # club necklace
-Item	coarse hemp socks	Adventures: [1+10*event(Crimbo2015)], Single Equip
-Item	codpiece	Mysticality Percent: +100, Maximum MP: +100, Spell Damage: +50, Combat Rate: -10, Lasts Until Rollover
+Item	coarse hemp socks	Adventures: [1+10*event(Crimbo2015)], Single Equip, Last Available: "2015-12"
+Item	codpiece	Mysticality Percent: +100, Maximum MP: +100, Spell Damage: +50, Combat Rate: -10, Lasts Until Rollover, Last Available: "2016-04"
 Item	Codpiece of the Goblin King	Moxie: +7, Single Equip
-Item	colored-light &quot;necklace&quot;	Maximum MP: +15
+Item	colored-light &quot;necklace&quot;	Maximum MP: +15, Last Available: "2005-12"
 Item	compression stocking	Maximum MP: +30, MP Regen Min: 3, MP Regen Max: 5
-Item	Congressional Medal of Insanity	Mysticality Percent: +25, Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 12
+Item	Congressional Medal of Insanity	Mysticality Percent: +25, Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 12, Last Available: "2024-12"
 Item	consolation ribbon	Muscle: +1, Mysticality: +1, Moxie: +1
 # continuum transfunctioner
 Item	Copper Alpha of Sincerity	Muscle: +11, Mysticality: +11, Moxie: +11, Item Drop: +5, Single Equip
 Item	copper ha'penny charrrm bracelet	Maximum HP: +20, Maximum MP: +20
 Item	corncob pipe	Muscle Percent: +10, Single Equip
 Item	Counterclockwise Watch	Adventures: +10, Single Equip, Nonstackable Watch
-Item	cozy scarf	Cold Resistance: +5
-Item	crank-powered radio on a lanyard	Monster Level: +15, Lasts Until Rollover
+Item	cozy scarf	Cold Resistance: +5, Last Available: "2021-12"
+Item	crank-powered radio on a lanyard	Monster Level: +15, Lasts Until Rollover, Last Available: "2022-05"
 # crepe paper pie clip: Look through it to enhance your spells
-Item	crepe paper pie clip	Mysticality: +10, Hot Damage: +10, Hot Spell Damage: +10
+Item	crepe paper pie clip	Mysticality: +10, Hot Damage: +10, Hot Spell Damage: +10, Last Available: "2025-12"
 # crepe paper polka charm: Embrace polka and dance for more items
-Item	crepe paper polka charm	Experience (Moxie): +2, Weapon Damage: +10, Spell Damage: +10
+Item	crepe paper polka charm	Experience (Moxie): +2, Weapon Damage: +10, Spell Damage: +10, Last Available: "2025-12"
 # CRIMBCO lanyard: Lets you work harder!
-Item	CRIMBCO lanyard	Single Equip
-Item	Crimbolex watch	Adventures: +5, PvP Fights: +5, Rollover Effect: "Watched Over", Rollover Effect Duration: 100, Single Equip, Nonstackable Watch
+Item	CRIMBCO lanyard	Single Equip, Last Available: "2011-01"
+Item	Crimbolex watch	Adventures: +5, PvP Fights: +5, Rollover Effect: "Watched Over", Rollover Effect Duration: 100, Single Equip, Last Available: "2018-12", Nonstackable Watch
 # Crimbomega drive chain: Allows use of LUBE in combat
-Item	Crimbomega drive chain	Moxie: +5, Sleaze Damage: +20, Sleaze Spell Damage: +20, Crimbot Outfit Power: +1, Single Equip
-Item	Crimbuccaneer fledges (disintegrating)	Pirate Warfare Effectiveness: +10, PvP Fights: +9, Single Equip
-Item	Crimbuccaneer fledges (mint)	Pirate Warfare Effectiveness: +1
-Item	Crimbuccaneer nose ring	Pirate Warfare Effectiveness: +5, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Potion Drop: +25
-Item	Crimbuccaneer runebone	Mysticality Percent: +25, Spell Damage: +50, Single Equip
+Item	Crimbomega drive chain	Moxie: +5, Sleaze Damage: +20, Sleaze Spell Damage: +20, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12"
+Item	Crimbuccaneer fledges (disintegrating)	Pirate Warfare Effectiveness: +10, PvP Fights: +9, Single Equip, Last Available: "2023-12"
+Item	Crimbuccaneer fledges (mint)	Pirate Warfare Effectiveness: +1, Last Available: "2023-12"
+Item	Crimbuccaneer nose ring	Pirate Warfare Effectiveness: +5, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Potion Drop: +25, Last Available: "2023-12"
+Item	Crimbuccaneer runebone	Mysticality Percent: +25, Spell Damage: +50, Single Equip, Last Available: "2023-12"
 Item	crusty hula hoop	Mysticality Percent: +15, Spell Damage: +50, Negative Status Resist, Single Equip
 Item	crying statue earrings	Muscle: +5, Maximum HP: +100, Single Equip, Lasts Until Rollover
 # crystal belt buckle: Improves your ability to align chakras
-Item	crystal belt buckle	Maximum MP: +25, Spell Damage: +10
+Item	crystal belt buckle	Maximum MP: +25, Spell Damage: +10, Last Available: "2016-12"
 # crystalline seal eye: +200% Item Drops from Seals
 Item	crystalline seal eye	Single Equip
 Item	cursed bat paw	Monster Level: +25, Muscle Percent: -25, Mysticality Percent: -25, Moxie Percent: -25
 Item	cursed dragon wishbone	Item Drop: +50, Meat Drop: -50
 Item	cursed medallion	Initiative: +100, Weapon Damage Percent: -50, Spell Damage Percent: -50
 # cursed monkey's paw: Grants Wishes!
-Item	cursed monkey's paw	Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip
+Item	cursed monkey's paw	Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04"
 Item	cursed ring finger ring	Spell Damage Percent: +50, Spooky Spell Damage: +30, Spell Critical Percent: +10, Single Equip
-Item	cursed scrunchie	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Single Equip
-Item	cursed swash buckle	Moxie: +25, Meat Drop: +50, Item Drop: +25, Single Equip
-Item	cyborg stompin' boot	Damage Reduction: 8, Weapon Damage: +20, Initiative: +30, Single Equip
+Item	cursed scrunchie	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Single Equip, Last Available: "2011-10"
+Item	cursed swash buckle	Moxie: +25, Meat Drop: +50, Item Drop: +25, Single Equip, Last Available: "2019-07"
+Item	cyborg stompin' boot	Damage Reduction: 8, Weapon Damage: +20, Initiative: +30, Single Equip, Last Available: "2007-12"
 # dark baconstone ring: Spell Criticals Deal Extra Damage
 Item	dark baconstone ring	Mysticality: +15
 # dark hamethyst ring: Critical Hits Deal Extra Damage
 Item	dark hamethyst ring	Muscle: +15
 # dark porquoise ring: Makes Deleveling More Effective
 Item	dark porquoise ring	Moxie: +15
-Item	datastick	RAM: +1
+Item	datastick	RAM: +1, Last Available: "2025-12"
 Item	dead guy's memento	Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Adventures: +5, Single Equip, Nonstackable Watch
 Item	dead guy's watch	Adventures: +1, Single Equip, Nonstackable Watch
-Item	deep-fried key	Sleaze Resistance: +3, Sleaze Damage: +15, Sleaze Spell Damage: +30
+Item	deep-fried key	Sleaze Resistance: +3, Sleaze Damage: +15, Sleaze Spell Damage: +30, Last Available: "2020-08"
 Item	defective Golden Mr. Accessory	Muscle: +15, Mysticality: +15, Moxie: +14
-Item	demonic key	Experience Percent (Mysticality): +20, Mysticality: +5, Mana Cost: -1
-Item	depleted Grimacite astrolabe	Mysticality Percent: [5*G], PvP Fights: [G], Single Equip
-Item	depleted Grimacite grappling hook	Moxie Percent: [5*G], Adventures: [G], Single Equip
-Item	depleted Grimacite weightlifting belt	Muscle Percent: [5*G], Adventures: [G], Single Equip
-Item	dethklok	Spooky Damage: +15
+Item	demonic key	Experience Percent (Mysticality): +20, Mysticality: +5, Mana Cost: -1, Last Available: "2020-08"
+Item	depleted Grimacite astrolabe	Mysticality Percent: [5*G], PvP Fights: [G], Single Equip, Last Available: "2011-12"
+Item	depleted Grimacite grappling hook	Moxie Percent: [5*G], Adventures: [G], Single Equip, Last Available: "2011-12"
+Item	depleted Grimacite weightlifting belt	Muscle Percent: [5*G], Adventures: [G], Single Equip, Last Available: "2011-12"
+Item	dethklok	Spooky Damage: +15, Last Available: "2011-09"
 # diamond necklace
 Item	dice belt buckle	Random Monster Modifiers: +1, Single Equip
 Item	dice ring	Random Monster Modifiers: +1, Single Equip
 Item	dice sunglasses	Random Monster Modifiers: +1, Single Equip
 # Dinsey's glove: +30 damage to Accordion Thief Combat Skills
-Item	Dinsey's glove	Moxie Percent: +30, Single Equip
-Item	Dinsey's oculus	Initiative: +40, Muscle Percent: +30, Single Equip
+Item	Dinsey's glove	Moxie Percent: +30, Single Equip, Last Available: "2015-04"
+Item	Dinsey's oculus	Initiative: +40, Muscle Percent: +30, Single Equip, Last Available: "2015-04"
 Item	dirty hobo gloves	Stench Damage: +2, Single Equip
 Item	disbelief suspenders	Sleaze Resistance: +1
-Item	discarded bike lock key	Maximum MP: +10, MP Regen Min: 4, MP Regen Max: 5
-Item	discarded bowtie	Combat Rate: -5, Monster Level: -10, Lasts Until Rollover
+Item	discarded bike lock key	Maximum MP: +10, MP Regen Min: 4, MP Regen Max: 5, Last Available: "2020-08"
+Item	discarded bowtie	Combat Rate: -5, Monster Level: -10, Lasts Until Rollover, Last Available: "2019-12"
 Item	disembodied smile	Spooky Damage: +2, Single Equip
 # diving muff: Makes you a better diver
 Item	diving muff	Single Equip, Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)]
 # doll-eye amulet: +40% Item Drops in Spookyraven Manor
 Item	doll-eye amulet	Single Equip, Item Drop: [40*zone(Manor)]
 Item	dope gangsta bling-bling	Moxie: +1
-Item	dorky glasses	Moxie: -30, Mysticality: +30, Single Equip
-Item	Draftsman's driving gloves	Mysticality Percent: +50, Spell Damage Percent: +50, Adventures: +8, Experience (Mysticality): +4, Lasts Until Rollover
+Item	dorky glasses	Moxie: -30, Mysticality: +30, Single Equip, Last Available: "2018-09"
+Item	Draftsman's driving gloves	Mysticality Percent: +50, Spell Damage Percent: +50, Adventures: +8, Experience (Mysticality): +4, Lasts Until Rollover, Last Available: "2018-07"
 Item	Dreadsylvania Auditor's badge	Item Drop: +10, Kruegerand Drop: 5, Single Equip
-Item	driftwood beach comb	Moxie Percent: +5, MP Regen Min: 4, MP Regen Max: 5, Familiar Weight: +2, Single Equip, Lasts Until Rollover
-Item	driftwood bracelet	Mysticality: +5, Mysticality Percent: +1, Maximum MP: +1, Maximum MP Percent: +1, Spell Damage: +1, Spell Damage Percent: +1, Spell Critical Percent: +1, Experience (Mysticality): +2, Experience Percent (Mysticality): +1, Single Equip, Lasts Until Rollover
+Item	driftwood beach comb	Moxie Percent: +5, MP Regen Min: 4, MP Regen Max: 5, Familiar Weight: +2, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
+Item	driftwood bracelet	Mysticality: +5, Mysticality Percent: +1, Maximum MP: +1, Maximum MP Percent: +1, Spell Damage: +1, Spell Damage Percent: +1, Spell Critical Percent: +1, Experience (Mysticality): +2, Experience Percent (Mysticality): +1, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
 Item	droll monocle	MP Regen Min: 2, MP Regen Max: 4, Meat Drop: +20, Single Equip
 Item	Drunkula's ring of haze	Weapon Damage Percent: -100, Maximum HP: -200, Maximum MP: +300, Single Equip, Avoid Attack: 1
 Item	duonoculars	Combat Rate: -5, Monster Level: +5, Single Equip
@@ -3098,17 +3098,17 @@ Item	Dyspepsi-Cola-issue canteen	Maximum MP: +5, Single Equip
 # E.M.U. Unit
 Item	Earring of Fire	Cold Resistance: +3, Spooky Resistance: +3, Single Equip
 Item	eerie fetish	Spooky Resistance: +4, Single Equip
-Item	Eight Days a Week Pill Keeper	Maximum HP: +20, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 10, MP Regen Max: 15, Muscle: +10, Mysticality: +10, Moxie: +10, Avoid Attack: 1
+Item	Eight Days a Week Pill Keeper	Maximum HP: +20, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 10, MP Regen Max: 15, Muscle: +10, Mysticality: +10, Moxie: +10, Last Available: "2019-10", Avoid Attack: 1
 # El Vibrato translator
-Item	elevennis shoes	Muscle: +11, Mysticality: +11, Moxie: +11, Maximum HP: +11, Maximum MP: +11
+Item	elevennis shoes	Muscle: +11, Mysticality: +11, Moxie: +11, Maximum HP: +11, Maximum MP: +11, Last Available: "2014-03"
 Item	Elf Guard commandeering gloves	Item Drop: +3, Piece of Twelve Drop: 0.5, Single Equip
-Item	Elf Guard insignia (general)	Elf Warfare Effectiveness: +10, Adventures: +9, Single Equip
-Item	Elf Guard insignia (private)	Elf Warfare Effectiveness: +1
+Item	Elf Guard insignia (general)	Elf Warfare Effectiveness: +10, Adventures: +9, Single Equip, Last Available: "2023-12"
+Item	Elf Guard insignia (private)	Elf Warfare Effectiveness: +1, Last Available: "2023-12"
 Item	Elmley shades	Muscle: +12, Critical Hit Percent: +3, Single Equip
-Item	elven socks	Muscle: +1, Cold Resistance: +1
+Item	elven socks	Muscle: +1, Cold Resistance: +1, Last Available: "2008-12"
 # Elvish sunglasses: Lets you Rock Out
-Item	Elvish sunglasses	Moxie: +10, Moxie Percent: +10, Ranged Damage: +15, Pickpocket Chance: +25, Single Equip, Softcore Only
-Item	Elvish underarmor	Damage Absorption: +200, Maximum HP: +50, HP Regen Min: 10, HP Regen Max: 20, Single Equip
+Item	Elvish sunglasses	Moxie: +10, Moxie Percent: +10, Ranged Damage: +15, Pickpocket Chance: +25, Single Equip, Softcore Only, Last Available: "2009-04"
+Item	Elvish underarmor	Damage Absorption: +200, Maximum HP: +50, HP Regen Min: 10, HP Regen Max: 20, Single Equip, Last Available: "2023-12"
 Item	Emblem of Ak'gyxoth	Moxie: +43, Mana Cost: -1
 Item	enchanted handwarmer	Cold Resistance: +2, Hot Damage: +4, Single Equip
 Item	enchanted toothpick	Spell Damage: +12, Single Equip
@@ -3119,27 +3119,27 @@ Item	enormous hoop earring	Moxie: +5
 Item	ert grey goo ring	Maximum HP: +10, Maximum MP: +10
 # ESP suppression collar
 # Everfull Dart Holster: Throw Darts in Battle
-Item	Everfull Dart Holster	Initiative: +50, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Single Equip
-Item	evil flaming eyeball pendant	Initiative: +15, Meat Drop: +15, Single Equip, Softcore Only
+Item	Everfull Dart Holster	Initiative: +50, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Single Equip, Last Available: "2024-03"
+Item	evil flaming eyeball pendant	Initiative: +15, Meat Drop: +15, Single Equip, Softcore Only, Last Available: "2007-01"
 Item	exclusive ultra-rare item	Muscle: +15, Mysticality: +15, Moxie: +15
-Item	expensive camera	Initiative: +20, Reduce Enemy Defense: 10, Single Equip
+Item	expensive camera	Initiative: +20, Reduce Enemy Defense: 10, Single Equip, Last Available: "2015-04"
 Item	eXtreme mittens	Weapon Damage: +6
 Item	eXtreme nose ring	Muscle: +4, Mysticality: +4, Moxie: +4
-Item	f'c'le sh'c'le k'y	Monster Level: +20, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5
-Item	fake huge beard	Muscle Percent: +25, Food Drop: +40, Lasts Until Rollover
+Item	f'c'le sh'c'le k'y	Monster Level: +20, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Last Available: "2020-08"
+Item	fake huge beard	Muscle Percent: +25, Food Drop: +40, Lasts Until Rollover, Last Available: "2024-10"
 Item	fancy black tie	Muscle Percent: +15, Single Equip
 Item	fancy boots	Plumber Stat: "Moxie", Plumber Power: 2, Single Equip
-Item	Fancy Jeff's fancy pocket square	Moxie Percent: +25, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10
-Item	FantasyRealm G. E. M.	Muscle Limit: 100, Mysticality Limit: 100, Moxie Limit: 100, Lasts Until Rollover
-Item	feather boa	Sleaze Damage: +15, Meat Drop: +50, Single Equip, Lasts Until Rollover
+Item	Fancy Jeff's fancy pocket square	Moxie Percent: +25, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10, Last Available: "2016-02"
+Item	FantasyRealm G. E. M.	Muscle Limit: 100, Mysticality Limit: 100, Moxie Limit: 100, Lasts Until Rollover, Last Available: "2018-04"
+Item	feather boa	Sleaze Damage: +15, Meat Drop: +50, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 # fiberglass fannypack: Filled with a never-ending supply of deadly pasta
-Item	fiberglass fannypack	Mana Cost (combat): -2, Sleaze Damage: +15, Single Equip
+Item	fiberglass fannypack	Mana Cost (combat): -2, Sleaze Damage: +15, Single Equip, Last Available: "2018-12"
 # fiberglass fingerguard: Dramatically increases the effectiveness of Disco Eye Poke
-Item	fiberglass fingerguard	Initiative: +40, Item Drop: +10, Single Equip
+Item	fiberglass fingerguard	Initiative: +40, Item Drop: +10, Single Equip, Last Available: "2018-12"
 Item	filigreed hamethyst earring	Muscle: +8, Critical Hit Percent: +5
 Item	filigreed hamethyst necklace	Muscle: +10, Weapon Damage: +8, PvP Fights: +2, Single Equip
 Item	filigreed hamethyst ring	Muscle: +12, Maximum HP: +25, HP Regen Min: 2, HP Regen Max: 4, Single Equip
-Item	first-aid pouch	Maximum HP: +40, HP Regen Min: 5, HP Regen Max: 10
+Item	first-aid pouch	Maximum HP: +40, HP Regen Min: 5, HP Regen Max: 10, Last Available: "2014-10"
 # fishbone belt: (Heavy Rains only)
 Item	fishbone belt	Critical Hit Percent: [25*path(Heavy Rains)], Weapon Damage: [25*path(Heavy Rains)], Single Equip
 # fishbone bracers: (Heavy Rains only)
@@ -3151,43 +3151,43 @@ Item	fishbone fins	Single Equip
 # fishbone kneepads: (Heavy Rains only)
 Item	fishbone kneepads	Initiative: [60*path(Heavy Rains)], Single Equip
 # flagstone flip-flops: Lets you kick your enemies
-Item	flagstone flip-flops	Experience (Mysticality): +3, Initiative: +40, Single Equip
-Item	flagstone fringe	Moxie Percent: +20, PvP Fights: +4, Single Equip
+Item	flagstone flip-flops	Experience (Mysticality): +3, Initiative: +40, Single Equip, Last Available: "2022-12"
+Item	flagstone fringe	Moxie Percent: +20, PvP Fights: +4, Single Equip, Last Available: "2022-12"
 Item	flapper floppers	Mysticality Percent: +25, Experience (Mysticality): +2, Single Equip
-Item	Flash Liquidizer Ultra Dousing Accessory	Item Drop: +20
+Item	Flash Liquidizer Ultra Dousing Accessory	Item Drop: +20, Last Available: "2023-06"
 Item	flashing novelty button	Maximum HP: +5, Moxie: -2
 Item	flask flops	Booze Drop: +20, Maximum Hooch: +3, Single Equip
 Item	floaty rock necklace	Spell Critical Percent: +10, Single Equip
 # foam noodle
 # food drive button: Lets you collect food donations as you adventure
-Item	food drive button	Single Equip
-Item	Former Sheriff Dan's tin star	Muscle Percent: +25, Maximum HP: +50, HP Regen Min: 5, HP Regen Max: 10, Weapon Damage Percent: +25, Critical Hit Percent: +5
+Item	food drive button	Single Equip, Last Available: "2020-12"
+Item	Former Sheriff Dan's tin star	Muscle Percent: +25, Maximum HP: +50, HP Regen Min: 5, HP Regen Max: 10, Weapon Damage Percent: +25, Critical Hit Percent: +5, Last Available: "2016-02"
 Item	fossilized necklace	Muscle: [2*pref(fossilB)], Mysticality: [2*pref(fossilB)], Moxie: [2*pref(fossilB)], Spell Damage: [2*pref(fossilS)], Weapon Damage: [3*pref(fossilN)], Muscle Percent: [3*pref(fossilW)], Mysticality Percent: [3*pref(fossilW)], Moxie Percent: [3*pref(fossilW)], Hot Damage: [3*pref(fossilD)], Spooky Damage: [3*pref(fossilP)]
 Item	frayed rope belt	Moxie Percent: +10, Single Equip
 # free boots: Give your opponents the old one-two (kick)
-Item	free boots	Sleaze Resistance: +3, HP Regen Min: 8, HP Regen Max: 12, MP Regen Min: 8, MP Regen Max: 12, Single Equip
+Item	free boots	Sleaze Resistance: +3, HP Regen Min: 8, HP Regen Max: 12, MP Regen Min: 8, MP Regen Max: 12, Single Equip, Last Available: "2023-12"
 # French slippers
 Item	freshwater pearl necklace	Spell Critical Percent: +5
-Item	Frigid Northern Beans	Cold Spell Damage: [15*(1+skill(Beanweaver))]
+Item	Frigid Northern Beans	Cold Spell Damage: [15*(1+skill(Beanweaver))], Last Available: "2016-02"
 # frosty button: Makes your fireball attacks deal Cold damage
 Item	frosty button	Single Equip
-Item	frosty halo	Item Drop: +25, Unarmed, Single Equip
+Item	frosty halo	Item Drop: +25, Unarmed, Single Equip, Last Available: "2011-09"
 Item	Frosty's carrot	Stench Resistance: +3, Sleaze Resistance: +3, Class: "Seal Clubber", Single Equip
-Item	Frown Exerciser	Monster Level: [5*G], Moxie: -5, Single Equip
-Item	fudge pocket square	Muscle: +5
-Item	fudgecycle	Adventures: +7, Candy Drop: +100, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Single Equip
+Item	Frown Exerciser	Monster Level: [5*G], Moxie: -5, Single Equip, Last Available: "2012-12"
+Item	fudge pocket square	Muscle: +5, Last Available: "2011-11"
+Item	fudgecycle	Adventures: +7, Candy Drop: +100, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Single Equip, Last Available: "2011-11"
 Item	furniture dolly	Initiative: +30, Single Equip
 Item	furry green earmuffs	Cold Resistance: +1
-Item	furry halo	Familiar Weight: +5, Unarmed, Single Equip
+Item	furry halo	Familiar Weight: +5, Unarmed, Single Equip, Last Available: "2011-09"
 Item	fuzzy bracelets	Muscle: +15, Mysticality: +15, Moxie: +15
 # Fuzzy Slippers of Hatred: Makes running more comfortable
 Item	Fuzzy Slippers of Hatred	Combat Rate: -5, Reduce Enemy Defense: 10, Spell Damage Percent: +60, Single Equip
 # gabardine garland: Makes your Headbutts restore HP
-Item	gabardine garland	Maximum MP: +10, Hot Damage: +10, Single Equip
+Item	gabardine garland	Maximum MP: +10, Hot Damage: +10, Single Equip, Last Available: "2018-12"
 # gabardine girdle: Allows you to unleash your Disco Pudge
-Item	gabardine girdle	Moxie: +10, Booze Drop: +20, Single Equip
+Item	gabardine girdle	Moxie: +10, Booze Drop: +20, Single Equip, Last Available: "2018-12"
 # gabardine gloves: Increases the duration of Accordion Bash stuns
-Item	gabardine gloves	HP Regen Min: 4, HP Regen Max: 8, Spooky Resistance: +3, Single Equip
+Item	gabardine gloves	HP Regen Min: 4, HP Regen Max: 8, Spooky Resistance: +3, Single Equip, Last Available: "2018-12"
 Item	Gaia beads	Stench Damage: +10, Stench Spell Damage: +10
 Item	garish pinky ring	Maximum HP: +10, Maximum MP: +10
 Item	Garland of Greatness	Maximum HP Percent: [pref(garlandUpgrades)*20], Maximum MP Percent: [pref(garlandUpgrades)*20]
@@ -3195,89 +3195,89 @@ Item	Garland of Greatness	Maximum HP Percent: [pref(garlandUpgrades)*20], Maximu
 Item	Garter of the Turtle Poacher	Muscle: +11, HP Regen Min: 20, HP Regen Max: 25, Class: "Turtle Tamer", Single Equip
 Item	Gary Claybender's Time Screwer	Mysticality: +5, MP Regen Min: 8, MP Regen Max: 10, Single Equip, Lasts Until Rollover
 # gate transceiver: Allows you to negotiate magnetic storms without losing your way
-Item	gate transceiver	Single Equip, Lasts Until Rollover
+Item	gate transceiver	Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 Item	gator shades	Muscle: +3, Spooky Damage: +3, Single Equip
-Item	Gauntlets of the Blood Moon	Maximum HP: +75, Item Drop: +5, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Single Equip
+Item	Gauntlets of the Blood Moon	Maximum HP: +75, Item Drop: +5, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Single Equip, Last Available: "2013-02"
 Item	gearbox necklace	Mysticality: +11, Maximum MP: +50
-Item	genie's bracers	Mysticality: +5, Moxie: +5
+Item	genie's bracers	Mysticality: +5, Moxie: +5, Last Available: "2018-02"
 Item	ghost of a necklace	Sleaze Damage: +8, Sleaze Spell Damage: +8, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1
-Item	giant bow tie	Muscle: +5, Mysticality: +5, Moxie: +5, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Clowniness: 25, Lasts Until Rollover
+Item	giant bow tie	Muscle: +5, Mysticality: +5, Moxie: +5, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Clowniness: 25, Lasts Until Rollover, Last Available: "2024-10"
 Item	giant designer sunglasses	Moxie Percent: -10, Single Equip
 # giant diamond ring
 Item	giant motorcycle boots	Damage vs. Ghosts: +10, Muscle: +5, Single Equip
 Item	giant pinky ring	Negative Status Resist, Single Equip
-Item	gingerbeard	Single Equip, Adventures: [6+(3*event(December))]
-Item	gingerservo	Muscle Percent: +25, HP Regen Min: 6, HP Regen Max: 12, PvP Fights: +6, Single Equip
+Item	gingerbeard	Single Equip, Last Available: "2016-12", Adventures: [6+(3*event(December))]
+Item	gingerservo	Muscle Percent: +25, HP Regen Min: 6, HP Regen Max: 12, PvP Fights: +6, Single Equip, Last Available: "2016-12"
 # Girdle of Hatred: Tightenable
 Item	Girdle of Hatred	Initiative: +45, Reduce Enemy Defense: 10, Spell Damage Percent: +60, Single Equip
-Item	glacial clock	Cold Damage: +15
+Item	glacial clock	Cold Damage: +15, Last Available: "2011-09"
 Item	glass eye	Initiative: +20, Weapon Damage: +20, Item Drop: [40*zone(Twitch)], Single Equip
-Item	glow-in-the-dark necklace	Mysticality Percent: +10, Spell Damage: +10, MP Regen Min: 2, MP Regen Max: 10
-Item	glow-in-the-dark wristwatch	Mysticality: [9-M], Spell Damage: [9-M], Adventures: +3, Single Equip, Nonstackable Watch
+Item	glow-in-the-dark necklace	Mysticality Percent: +10, Spell Damage: +10, MP Regen Min: 2, MP Regen Max: 10, Last Available: "2014-08"
+Item	glow-in-the-dark wristwatch	Mysticality: [9-M], Spell Damage: [9-M], Adventures: +3, Single Equip, Last Available: "2009-01", Nonstackable Watch
 Item	glowing red eye	Spooky Resistance: +2
 Item	gnatwing earring	Initiative: +15, Mysticality: +6
 Item	gnoll-tooth necklace	Muscle: +5
-Item	gold detective badge	Maximum HP: +40, Maximum MP: +40, Item Drop: +20, Meat Drop: +30
-Item	gold skull ring	PvP Fights: +7, Single Equip
+Item	gold detective badge	Maximum HP: +40, Maximum MP: +40, Item Drop: +20, Meat Drop: +30, Last Available: "2016-07"
+Item	gold skull ring	PvP Fights: +7, Single Equip, Last Available: "2018-09"
 Item	gold wedding ring	Adventures: +1, Negative Status Resist, Single Equip
 Item	Golden Mr. Accessory	Muscle: +15, Mysticality: +15, Moxie: +15, Softcore Only
-Item	Golden Mr. Eh?	Muscle: +12, Mysticality: +12, Moxie: +12
+Item	Golden Mr. Eh?	Muscle: +12, Mysticality: +12, Moxie: +12, Last Available: "2015-09"
 Item	gory drippy orb	Drippy Damage: +5
-Item	government-issued necktie	Experience Percent (Mysticality): +10, Damage vs. Zombies: +25, Meat Drop: [5*G], Single Equip
-Item	government-issued night-vision goggles	Item Drop: +5, Monster Level: +5, Single Equip
-Item	governor's daughter's lace collar	Mysticality Percent: +20
+Item	government-issued necktie	Experience Percent (Mysticality): +10, Damage vs. Zombies: +25, Meat Drop: [5*G], Single Equip, Last Available: "2018-11"
+Item	government-issued night-vision goggles	Item Drop: +5, Monster Level: +5, Single Equip, Last Available: "2014-05"
+Item	governor's daughter's lace collar	Mysticality Percent: +20, Last Available: "2024-12"
 # GPS-tracking wristwatch
 Item	grandfather watch	Adventures: +6, Single Equip, Nonstackable Watch
 # Gravyskin Belt of the Sauceblob: 3 Additional Scrumptious Reagent Summons Per Day
 # Gravyskin Belt of the Sauceblob: This enchantment works even when this item is not equipped
 Item	Gravyskin Belt of the Sauceblob	Mysticality: +11, MP Regen Min: 10, MP Regen Max: 12, Class: "Sauceror", Single Equip
-Item	gray bow tie	Moxie: +1, Spooky Resistance: +1
+Item	gray bow tie	Moxie: +1, Spooky Resistance: +1, Last Available: "2008-12"
 Item	Green Clover of Justice	Muscle: +8, Mysticality: +8, Moxie: +8, Item Drop: +8, Single Equip
-Item	green glowstick	Maximum MP: +5, Moxie: -3, Raveosity: +1
-Item	Grimacite galoshes	Meat Drop: +25, Moxie Percent: [10*G]
-Item	Grimacite garter	Spell Damage: +15, Mysticality Percent: [10*G]
-Item	Grimacite gauntlets	Meat Drop: +30, Muscle Percent: [10*G], Single Equip
-Item	Grimacite girdle	Spell Damage: +20, Mysticality Percent: [10*G], Single Equip
-Item	Grimacite go-go boots	Item Drop: +30, Moxie Percent: [10*G], Single Equip
-Item	Grimacite gorget	Item Drop: +25, Muscle Percent: [10*G]
-Item	groggles	Booze Drop: +50
+Item	green glowstick	Maximum MP: +5, Moxie: -3, Last Available: "2007-01", Raveosity: +1
+Item	Grimacite galoshes	Meat Drop: +25, Moxie Percent: [10*G], Last Available: "2008-10"
+Item	Grimacite garter	Spell Damage: +15, Mysticality Percent: [10*G], Last Available: "2008-10"
+Item	Grimacite gauntlets	Meat Drop: +30, Muscle Percent: [10*G], Single Equip, Last Available: "2008-11"
+Item	Grimacite girdle	Spell Damage: +20, Mysticality Percent: [10*G], Single Equip, Last Available: "2008-11"
+Item	Grimacite go-go boots	Item Drop: +30, Moxie Percent: [10*G], Single Equip, Last Available: "2008-11"
+Item	Grimacite gorget	Item Drop: +25, Muscle Percent: [10*G], Last Available: "2008-10"
+Item	groggles	Booze Drop: +50, Last Available: "2024-12"
 # Groll doll: Is The Best The Best The Best The Best The Best The Best The Best
-Item	Groll doll	Single Equip, Sporadic Damage Aura: 0.6
+Item	Groll doll	Single Equip, Last Available: "2014-08", Sporadic Damage Aura: 0.6
 Item	groovy prism necklace	Single Equip, Sporadic Thorns: 2.5
 Item	grubby wool gloves	Sleaze Resistance: +2, Item Drop: +10, Maximum HP: +20, Maximum MP: +20, HP Regen Min: 3, HP Regen Max: 5, MP Regen Min: 3, MP Regen Max: 5, Single Equip
 Item	grubby wool scarf	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Adventures: +5, Single Equip
 Item	grumpy old man charrrm bracelet	Monster Level: +7, Single Equip
-Item	gummi bowtie	Moxie: +5
+Item	gummi bowtie	Moxie: +5, Last Available: "2011-11"
 Item	gumshoes	Muscle Percent: +25, Experience (Muscle): +2, Single Equip
 Item	guts necklace	Stench Resistance: +4, Single Equip
 # Guzzlr shoes: Make Guzzlr deliveries in less time
-Item	Guzzlr shoes	Single Equip
+Item	Guzzlr shoes	Single Equip, Last Available: "2020-05"
 # Guzzlr tablet: Dispatches you to deliver booze to clients
-Item	Guzzlr tablet	Item Drop: +10, Maximum HP: +10, Maximum MP: +10, Booze Drop: [min(50,1+floor(pref(guzzlrBronzeDeliveries)/4))], MP Regen Min: [min(7,1+floor((sqrt(pref(guzzlrPlatinumDeliveries))))+floor(pref(guzzlrPlatinumDeliveries)/30))], MP Regen Max: [min(8,2+floor((sqrt(pref(guzzlrPlatinumDeliveries))))+floor(pref(guzzlrPlatinumDeliveries)/30))], HP Regen Min: [min(9,3+floor(pref(guzzlrGoldDeliveries)^0.35)+floor(pref(guzzlrGoldDeliveries)/150))], HP Regen Max: [min(12,3+floor(pref(guzzlrGoldDeliveries)^0.35)+floor(pref(guzzlrGoldDeliveries)/150))]
+Item	Guzzlr tablet	Item Drop: +10, Maximum HP: +10, Maximum MP: +10, Booze Drop: [min(50,1+floor(pref(guzzlrBronzeDeliveries)/4))], MP Regen Min: [min(7,1+floor((sqrt(pref(guzzlrPlatinumDeliveries))))+floor(pref(guzzlrPlatinumDeliveries)/30))], MP Regen Max: [min(8,2+floor((sqrt(pref(guzzlrPlatinumDeliveries))))+floor(pref(guzzlrPlatinumDeliveries)/30))], HP Regen Min: [min(9,3+floor(pref(guzzlrGoldDeliveries)^0.35)+floor(pref(guzzlrGoldDeliveries)/150))], HP Regen Max: [min(12,3+floor(pref(guzzlrGoldDeliveries)^0.35)+floor(pref(guzzlrGoldDeliveries)/150))], Last Available: "2020-05"
 # haggis socks: Allows you to deliver disgusting kicks
-Item	haggis socks	Initiative: +5, Single Equip
+Item	haggis socks	Initiative: +5, Single Equip, Last Available: "2012-12"
 Item	hamethyst bracelet	Muscle: +3, Critical Hit Percent: +5, Single Equip
 Item	hamethyst earring	Muscle: +3, Critical Hit Percent: +5
 Item	hamethyst necklace	Muscle: +4, Weapon Damage: +5, PvP Fights: +2, Single Equip
 Item	hamethyst ring	Muscle: +5, Maximum HP: +10, HP Regen Min: 2, HP Regen Max: 4, Single Equip
-Item	Hand in Glove	Muscle: +5, Smithsness: +5, Single Equip, Monster Level: [K], Damage Aura: 1
+Item	Hand in Glove	Muscle: +5, Smithsness: +5, Single Equip, Last Available: "2013-12", Monster Level: [K], Damage Aura: 1
 Item	hand-knitted Crimbo socks	Maximum HP: +10, HP Regen Min: 3, HP Regen Max: 5, Cold Resistance: +1
 Item	hand-knitted diving booties	Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)]
 Item	hardened slime belt	Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, HP Regen Min: 10, HP Regen Max: 30, MP Regen Min: 10, MP Regen Max: 30, Mysticality Percent: +20, Single Equip
-Item	hare pin	Moxie Percent: +20, Initiative: +40, Single Equip
+Item	hare pin	Moxie Percent: +20, Initiative: +40, Single Equip, Last Available: "2014-12"
 # hazardous sauce dosimeter: Lets you gather more Soulsauce
-Item	hazardous sauce dosimeter	Class: "Sauceror"
+Item	hazardous sauce dosimeter	Class: "Sauceror", Last Available: "2013-11"
 # head mirror: Makes you look like a doctor
 Item	head mirror	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Surgeonosity: +1
 Item	headhunter necktie	Muscle: +15, Moxie: -3, Single Equip
 Item	heart of the volcano	HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 2, MP Regen Max: 5
-Item	heat-resistant gloves	Hot Resistance: +4, Weapon Damage Percent: -50, Fumble: 2, Single Equip
-Item	heat-resistant necktie	Hot Resistance: +4, Spell Damage: -50, Single Equip
+Item	heat-resistant gloves	Hot Resistance: +4, Weapon Damage Percent: -50, Fumble: 2, Single Equip, Last Available: "2015-08"
+Item	heat-resistant necktie	Hot Resistance: +4, Spell Damage: -50, Single Equip, Last Available: "2015-08"
 Item	Helps-You-Sleep	Initiative: +75, Critical Hit Percent: +10, Single Equip, Blind
 # hemp string
-Item	hewn moon-rune spoon	Experience: +3, Familiar Weight: +5, Critical Hit Percent: +10, Spell Damage: +10, Initiative: +25, Rollover Effect: "Spoon Boon", Rollover Effect Duration: 50, Muscle: +5, Mysticality: +5, Moxie: +5, Maximum HP: +25, Maximum MP: +25, Single Equip, Alters Page Text
+Item	hewn moon-rune spoon	Experience: +3, Familiar Weight: +5, Critical Hit Percent: +10, Spell Damage: +10, Initiative: +25, Rollover Effect: "Spoon Boon", Rollover Effect Duration: 50, Muscle: +5, Mysticality: +5, Moxie: +5, Maximum HP: +25, Maximum MP: +25, Single Equip, Last Available: "2019-06", Alters Page Text
 # high-friction boots: Allows you to move normally on extremely windy planets
-Item	high-friction boots	Single Equip, Lasts Until Rollover
+Item	high-friction boots	Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 Item	hippy medical kit	Mysticality: +10, HP Regen Min: 6, HP Regen Max: 10, Single Equip
 Item	hippy protest button	Single Equip, Thorns: 1
 Item	HOA zombie eyes	Combat Rate: +5, Muscle Percent: -100, Mysticality Percent: -100, Moxie Percent: -100, Experience: +10, Single Equip
@@ -3287,14 +3287,14 @@ Item	hockey stick of furious angry rage	Monster Level: +30, Muscle Percent: +5
 Item	Hodgman's bow tie	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, Hobo Power: +25, Single Equip
 Item	Hodgman's lucky sock	Hobo Power: +50, Single Equip
 Item	hopping socks	Slime Resistance: +1, Accessory Drop: +20, Maximum HP: +200, Maximum MP: +200, Single Equip
-Item	ice key	Cold Resistance: +3, Cold Damage: +15, Cold Spell Damage: +30
-Item	ice skates	Initiative: +15, Meat Drop: +15, Single Equip, Softcore Only
-Item	ice wrap	Muscle: +10, Mysticality: +10, Moxie: +10, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Experience: +3, Single Equip, Lasts Until Rollover
+Item	ice key	Cold Resistance: +3, Cold Damage: +15, Cold Spell Damage: +30, Last Available: "2020-08"
+Item	ice skates	Initiative: +15, Meat Drop: +15, Single Equip, Softcore Only, Last Available: "2006-02"
+Item	ice wrap	Muscle: +10, Mysticality: +10, Moxie: +10, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Experience: +3, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
 Item	Ice-Cold Aluminum Necklace	Muscle: +3, Mysticality: +3, Moxie: +3, Cold Spell Damage: +40, Single Equip
 Item	Ice-Cold Beer Ring	Muscle: +3, Mysticality: +3, Moxie: +3, Cold Damage: +40, Single Equip
 Item	Ice-Cold Beerring	Sleaze Resistance: +3, Stench Resistance: +3, Single Equip
 Item	Iiti Kitty phone charm	Spooky Damage: +15, Single Equip
-Item	imitation nice watch	Adventures: +3, Single Equip, Nonstackable Watch
+Item	imitation nice watch	Adventures: +3, Single Equip, Last Available: "2004-12", Nonstackable Watch
 Item	imp unity ring	Hot Damage: +5, Hot Spell Damage: +5
 Item	incredibly dense meat gem	Meat Drop: +60, Moxie: +5, Maximum MP: +10
 Item	infernal insoles	Hot Resistance: +1, Initiative: +10
@@ -3303,36 +3303,36 @@ Item	intergalactic pom poms	Moxie: +20, Initiative: +30
 Item	Iron Beta of Industry	Muscle: +10, Mysticality: +10, Moxie: +10, Item Drop: +6, Single Equip
 Item	ironic oversized sunglasses	Single Equip, Thorns: 1
 Item	jam band	Item Drop: +5, Booze Drop: +20, Food Drop: +35
-Item	jangly bracelet	Spooky Damage: +30, Spooky Spell Damage: +30, Spooky Resistance: +1
+Item	jangly bracelet	Spooky Damage: +30, Spooky Spell Damage: +30, Spooky Resistance: +1, Last Available: "2014-10"
 Item	jar of anniversary jam	Muscle: +1, Mysticality: +1, Moxie: +1
 Item	Jarlsberg's earring	Mysticality: +10
 Item	jaunty feather	Muscle: +1, Mysticality: +1, Moxie: +1, Maximum HP: +3, Maximum MP: +3
 Item	Jefferson wings	Sleaze Damage: +20
-Item	Jekyllin hide belt	Muscle: [9-M], Mysticality: [9-M], Moxie: [9-M], Item Drop: [15+5*M], Softcore Only
+Item	Jekyllin hide belt	Muscle: [9-M], Mysticality: [9-M], Moxie: [9-M], Item Drop: [15+5*M], Softcore Only, Last Available: "2005-09"
 Item	Jolly Roger charrrm bracelet	Moxie: +5
 # jolly roger flag: Scares away rich monsters
-Item	jolly roger flag	Meat Drop: +25, Lasts Until Rollover
+Item	jolly roger flag	Meat Drop: +25, Lasts Until Rollover, Last Available: "2024-12"
 # Juju Mojo Mask: Big Mojo
-Item	Juju Mojo Mask	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Experience: +2, Single Equip, Softcore Only
+Item	Juju Mojo Mask	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Experience: +2, Single Equip, Softcore Only, Last Available: "2010-07"
 Item	Junior Adventurer's merit badge	Muscle: +3, Mysticality: +3, Moxie: +3, Single Equip
-Item	Junior LAAAAME merit badge	Muscle: +1, Mysticality: +1, Moxie: +1
+Item	Junior LAAAAME merit badge	Muscle: +1, Mysticality: +1, Moxie: +1, Last Available: "2006-05"
 Item	junk band	Spell Damage: +11
-Item	kekekey	Meat Drop: +50
-Item	key sausage	Combat Rate: -10
+Item	kekekey	Meat Drop: +50, Last Available: "2020-08"
+Item	key sausage	Combat Rate: -10, Last Available: "2020-08"
 Item	kick-ass kicks	Sleaze Damage: +10, Moxie: +3, Single Equip
-Item	knob labinet key	Experience Percent (Muscle): +20, Muscle: +5, Mana Cost: -1
-Item	knob shaft skate key	HP Regen Min: 9, HP Regen Max: 12, MP Regen Min: 9, MP Regen Max: 12, Adventures: +3
-Item	knob treasury key	Pickpocket Chance: +20, Meat Drop: +50
+Item	knob labinet key	Experience Percent (Muscle): +20, Muscle: +5, Mana Cost: -1, Last Available: "2020-08"
+Item	knob shaft skate key	HP Regen Min: 9, HP Regen Max: 12, MP Regen Min: 9, MP Regen Max: 12, Adventures: +3, Last Available: "2020-08"
+Item	knob treasury key	Pickpocket Chance: +20, Meat Drop: +50, Last Available: "2020-08"
 Item	knobby kneepads	Weapon Damage: +3
-Item	KoL Con 8-Bit power bracelet	Muscle: +8
+Item	KoL Con 8-Bit power bracelet	Muscle: +8, Last Available: "2011-09"
 Item	KoL Con X Bingo Card	HP Regen Min: 3, HP Regen Max: 5, MP Regen Min: 3, MP Regen Max: 5
 # Krampus Horn: Doubles your damage against Bad Vibes
 # Krampus Horn: Greatly improves chances of finding lumps and sludge
-Item	Krampus Horn	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Experience: +2, Single Equip
+Item	Krampus Horn	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Experience: +2, Single Equip, Last Available: "2016-12"
 Item	Kremlin's Greatest Briefcase	Muscle: +10, Mysticality: +10, Moxie: +10, Maximum HP: +25, Maximum MP: +25, Weapon Damage Percent: +25, Initiative: +25, MP Regen Min: 5, MP Regen Max: 10, HP Regen Min: 5, HP Regen Max: 10, Single Equip
 # kumquartz ring: +200% Physical Damage (currently approximated with Weapon Damage)
 # kumquartz ring: (only in the Candy Diorama)
-Item	kumquartz ring	Single Equip, Weapon Damage Percent: [200*zone(The Candy Diorama)]
+Item	kumquartz ring	Single Equip, Last Available: "2011-11", Weapon Damage Percent: [200*zone(The Candy Diorama)]
 Item	La Hebilla del Cintur&oacute;n de Lopez	Moxie: +11, HP Regen Min: 5, HP Regen Max: 9, MP Regen Min: 5, MP Regen Max: 9, Additional Song: 1, Class: "Accordion Thief", Single Equip
 Item	ladle of mystery	Maximum HP: +20, Maximum MP: +20, Class: "Sauceror"
 Item	Lead Zeta of Chastity	Muscle: +6, Mysticality: +6, Moxie: +6, Item Drop: +10, Single Equip
@@ -3341,146 +3341,146 @@ Item	Lead Zeta of Chastity	Muscle: +6, Mysticality: +6, Moxie: +6, Item Drop: +1
 # Lil' Doctor&trade; bag: Regenerate 4-7 HP per Adventure</font>
 Item	Lil' Doctor&trade; bag	Maximum HP: [15+5*pref(doctorBagUpgrades)], HP Regen Min: [4+pref(doctorBagUpgrades)], HP Regen Max: [7+pref(doctorBagUpgrades)], Single Equip
 Item	loafers	Initiative: +10, Single Equip
-Item	Loathing Legion necktie	Experience: +4, Single Equip, Softcore Only
-Item	Loathing Legion rollerblades	Initiative: +50, Single Equip, Softcore Only
+Item	Loathing Legion necktie	Experience: +4, Single Equip, Softcore Only, Last Available: "2011-01"
+Item	Loathing Legion rollerblades	Initiative: +50, Single Equip, Softcore Only, Last Available: "2011-01"
 Item	Lockenstock&trade; sandals	Mysticality: +7, Stench Damage: +7, Single Equip
-Item	lollipop cufflinks	Mysticality: +5
+Item	lollipop cufflinks	Mysticality: +5, Last Available: "2011-11"
 Item	long-forgotten necklace	Meat Drop: +15
 # loofah lavalier: Lets you unleash lava on your foes
-Item	loofah lavalier	Experience (Moxie): +2, Maximum HP: +20, Maximum MP: +20, Single Equip
+Item	loofah lavalier	Experience (Moxie): +2, Maximum HP: +20, Maximum MP: +20, Single Equip, Last Available: "2022-12"
 # loofah legwarmers: They keep your legs warm
-Item	loofah legwarmers	Moxie: +10, HP Regen Min: 5, HP Regen Max: 15, MP Regen Min: 5, MP Regen Max: 15, Single Equip
+Item	loofah legwarmers	Moxie: +10, HP Regen Min: 5, HP Regen Max: 15, MP Regen Min: 5, MP Regen Max: 15, Single Equip, Last Available: "2022-12"
 # loofah lei: Lets you lasso your foes
-Item	loofah lei	Experience (Muscle): +2, Maximum HP: +40, Single Equip
+Item	loofah lei	Experience (Muscle): +2, Maximum HP: +40, Single Equip, Last Available: "2022-12"
 Item	Lord Soggyraven's Slippers	Initiative: +20, Pickpocket Chance: +20, Maximum HP: +20, Maximum MP: +20, Single Equip
 Item	Lord Spookyraven's ear trumpet	Initiative: +25, Single Equip
 # Lord Spookyraven's spectacles
-Item	LOV Earrings	Experience Percent (Moxie): +25, Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Meat Drop: +50, Single Equip, Lasts Until Rollover
+Item	LOV Earrings	Experience Percent (Moxie): +25, Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Meat Drop: +50, Single Equip, Lasts Until Rollover, Last Available: "2017-02"
 # low-pressure oxygen tank: Prevents oxygen deprivation in the event of a planetary explosion
 Item	low-pressure oxygen tank	Single Equip
 # lube-shoes: Good for lubricating rollercoaster tracks
-Item	lube-shoes	Moxie: -10
+Item	lube-shoes	Moxie: -10, Last Available: "2015-04"
 Item	lucky bottlecap	Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Single Equip
-Item	lucky cat collar	Meat Drop: +7, Single Equip
+Item	lucky cat collar	Meat Drop: +7, Single Equip, Last Available: "2013-12"
 # lucky Crimbo tiki necklace: Brings Good Luck!
 # lucky gold ring: Find various valuable currencies after combat
-Item	lucky gold ring	Single Equip
+Item	lucky gold ring	Single Equip, Last Available: "2019-04"
 Item	lucky rabbit's foot	Item Drop: +7, Meat Drop: +7
-Item	lucky rabbitfish fin	HP Regen Min: 10, HP Regen Max: 12, MP Regen Min: 10, MP Regen Max: 12, Familiar Weight: +5, Fishing Skill: +5, Single Equip
+Item	lucky rabbitfish fin	HP Regen Min: 10, HP Regen Max: 12, MP Regen Min: 10, MP Regen Max: 12, Familiar Weight: +5, Fishing Skill: +5, Single Equip, Last Available: "2019-07"
 # lustrous drippy orb: Increases Driplet drops from monsters
 Item	LWA ring	MP Regen Min: 2, MP Regen Max: 3
-Item	LyleCo premium monocle	Rubee Drop: 1, Single Equip
-Item	Mafia bow tie	Muscle: +20, Moxie: +20
+Item	LyleCo premium monocle	Rubee Drop: 1, Single Equip, Last Available: "2018-04"
+Item	Mafia bow tie	Muscle: +20, Moxie: +20, Last Available: "2004-10"
 # mafia middle finger ring: Show enemies your ring once a day!
 Item	mafia middle finger ring	Weapon Damage Percent: +13, Muscle Percent: +13, Single Equip
 Item	mafia organizer badge	Adventures: +2, Single Equip
 Item	mafia pinky ring	Weapon Damage Percent: +10, Muscle Percent: +10, Single Equip
 # mafia pointer finger ring: Take advantage of critical moments.
 Item	mafia pointer finger ring	Critical Hit Percent: +15, Muscle Percent: +15, Single Equip, Drops Meat
-Item	Mafia stogie	Muscle: +20, Mysticality: +20
+Item	Mafia stogie	Muscle: +20, Mysticality: +20, Last Available: "2004-10"
 # mafia thumb ring: Occasionally knock your opponent into last week
 Item	mafia thumb ring	Weapon Damage Percent: +11, Muscle Percent: +11, Single Equip
 Item	mafia wedding ring	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Adventures: +3, Single Equip
-Item	MagiMechTech NanoMechaMech	Single Equip, Sporadic Damage Aura: 0.3
+Item	MagiMechTech NanoMechaMech	Single Equip, Last Available: "2006-12", Sporadic Damage Aura: 0.3
 Item	makeshift SCUBA gear	Stench Resistance: +2, Item Drop: -50, Initiative: -100, Adventure Underwater
 Item	malevolent medallion	Spooky Damage: +10, Stench Damage: +10, Hot Damage: +10, Cold Damage: +10, Sleaze Damage: +10, MP Regen Min: 10, MP Regen Max: 30, Slime Hates It: +1, Single Equip
-Item	marble magnet	Mysticality Percent: +20, Spell Damage Percent: +30, Single Equip, Thorns: 1
-Item	marble medallion	Moxie Percent: +20, Spooky Resistance: +5, Single Equip, Thorns: 1
-Item	Marvelous Unitard	Muscle: +5, Mysticality: +5, Moxie: +5, Softcore Only
-Item	Master Thief's utility belt	Moxie: +15, Moxie Percent: +25, Experience (Moxie): +5, Single Equip
+Item	marble magnet	Mysticality Percent: +20, Spell Damage Percent: +30, Single Equip, Last Available: "2019-12", Thorns: 1
+Item	marble medallion	Moxie Percent: +20, Spooky Resistance: +5, Single Equip, Last Available: "2019-12", Thorns: 1
+Item	Marvelous Unitard	Muscle: +5, Mysticality: +5, Moxie: +5, Softcore Only, Last Available: "2011-07"
+Item	Master Thief's utility belt	Moxie: +15, Moxie Percent: +25, Experience (Moxie): +5, Single Equip, Last Available: "2018-04"
 # mayfly bait necklace: Allows Summoning of Mayflies in Combat
-Item	mayfly bait necklace	Meat Drop: +10, Item Drop: +10, Single Equip, Softcore Only
+Item	mayfly bait necklace	Meat Drop: +10, Item Drop: +10, Single Equip, Softcore Only, Last Available: "2008-05"
 Item	Mayor Ghost's sash	Item Drop: +30, Meat Drop: -30, Experience: -10, Single Equip
 # McHugeLarge left ski: Clear the area of monsters
-Item	McHugeLarge left ski	Combat Rate: -5, Muscle: +10, McHugeLarge
+Item	McHugeLarge left ski	Combat Rate: -5, Muscle: +10, Last Available: "2025-01", McHugeLarge
 # McHugeLarge right ski: Cover your foe in snow and embarass them
-Item	McHugeLarge right ski	Combat Rate: +5, Moxie: +10, McHugeLarge
+Item	McHugeLarge right ski	Combat Rate: +5, Moxie: +10, Last Available: "2025-01", McHugeLarge
 # Mega Gem
-Item	memory of a cultist's robe	Single Equip
+Item	memory of a cultist's robe	Single Equip, Last Available: "2009-06"
 Item	Mer-kin dragbelt	Initiative: -25, Experience (Muscle): [20*env(underwater)], Single Equip
 Item	Mer-kin eyeglasses	Maximum MP: -300, Experience (Mysticality): [20*env(underwater)], Single Equip
 Item	Mer-kin gutgirdle	Maximum HP: -300, Experience (Moxie): [20*env(underwater)], Single Equip
 # Mer-kin prayerbeads: Makes you feel uneasy...
 Item	Mer-kin thighguard	Damage Reduction: 10
 Item	Mer-kin waistrope	Mysticality Percent: +10
-Item	Mesmereyes&trade; contact lenses	Mysticality Percent: +15, Single Equip
+Item	Mesmereyes&trade; contact lenses	Mysticality Percent: +15, Single Equip, Last Available: "2011-10"
 Item	messenger bag RNA	Experience: +2, Experience (familiar): +2, HP Regen Min: 4, HP Regen Max: 8, MP Regen Min: 4, MP Regen Max: 8
-Item	meteorite earring	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience Percent (Moxie): +25, Initiative: +200, Single Equip
-Item	meteorite necklace	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience Percent (Mysticality): +25, Spell Damage Percent: +200, Single Equip
-Item	meteorite ring	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience Percent (Muscle): +25, Weapon Damage Percent: +200, Single Equip
-Item	meteorthopedic shoes	Initiative: +30, Moxie Percent: +15, Adventures: +5, Single Equip
+Item	meteorite earring	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience Percent (Moxie): +25, Initiative: +200, Single Equip, Last Available: "2019-07"
+Item	meteorite necklace	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience Percent (Mysticality): +25, Spell Damage Percent: +200, Single Equip, Last Available: "2019-07"
+Item	meteorite ring	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience Percent (Muscle): +25, Weapon Damage Percent: +200, Single Equip, Last Available: "2019-07"
+Item	meteorthopedic shoes	Initiative: +30, Moxie Percent: +15, Adventures: +5, Single Equip, Last Available: "2017-08"
 # mime army infiltration glove: Allows pickpocketing
-Item	mime army infiltration glove	Pickpocket Chance: +25, Initiative: -200, Single Equip
+Item	mime army infiltration glove	Pickpocket Chance: +25, Initiative: -200, Single Equip, Last Available: "2017-12"
 # mime army insignia (cryonics): Convert all your elemental bonus damage to <font color=blue>Cold Damage</font>
-Item	mime army insignia (cryonics)	Single Equip
-Item	mime army insignia (espionage)	Moxie: +5, Single Equip, Stat Tuning: "Moxie (all)"
-Item	mime army insignia (infantry)	Muscle: +5, Single Equip, Stat Tuning: "Muscle (all)"
-Item	mime army insignia (intelligence)	Mysticality: +5, Single Equip, Stat Tuning: "Mysticality (all)"
+Item	mime army insignia (cryonics)	Single Equip, Last Available: "2017-12"
+Item	mime army insignia (espionage)	Moxie: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
+Item	mime army insignia (infantry)	Muscle: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+Item	mime army insignia (intelligence)	Mysticality: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
 # mime army insignia (morale): Convert all your elemental bonus damage to <font color=purple>Sleaze Damage</font>
-Item	mime army insignia (morale)	Single Equip
+Item	mime army insignia (morale)	Single Equip, Last Available: "2017-12"
 # mime army insignia (psychological warfare): Convert all your elemental bonus damage to <font color=gray>Spooky Damage</font>
-Item	mime army insignia (psychological warfare)	Single Equip
+Item	mime army insignia (psychological warfare)	Single Equip, Last Available: "2017-12"
 # mime army insignia (pyrotechnics): Convert all your elemental bonus damage to <font color=red>Hot Damage</font>
-Item	mime army insignia (pyrotechnics)	Single Equip
+Item	mime army insignia (pyrotechnics)	Single Equip, Last Available: "2017-12"
 # mime army insignia (sanitation): Convert all your elemental bonus damage to <font color=green>Stench Damage</font>
-Item	mime army insignia (sanitation)	Single Equip
+Item	mime army insignia (sanitation)	Single Equip, Last Available: "2017-12"
 # mime-proof sunglasses: Damage from mimes is reduced by 50
-Item	mime-proof sunglasses	Single Equip
-Item	miming boots	Damage Reduction: 10, Spooky Resistance: +3, Single Equip
-Item	miming gloves	Damage Reduction: 10, Sleaze Resistance: +3, Single Equip
-Item	mini kiwi bikini	Moxie: +11, Sleaze Damage: +20, Sleaze Spell Damage: +40
+Item	mime-proof sunglasses	Single Equip, Last Available: "2017-12"
+Item	miming boots	Damage Reduction: 10, Spooky Resistance: +3, Single Equip, Last Available: "2017-12"
+Item	miming gloves	Damage Reduction: 10, Sleaze Resistance: +3, Single Equip, Last Available: "2017-12"
+Item	mini kiwi bikini	Moxie: +11, Sleaze Damage: +20, Sleaze Spell Damage: +40, Last Available: "2024-06"
 Item	mini kiwi silicon tiepin	Initiative: +30, Mysticality: +3, Moxie: +3
-Item	mini-marshmallow dispenser	Maximum HP: +30, Maximum MP: +30, HP Regen Min: 6, HP Regen Max: 8, MP Regen Min: 6, MP Regen Max: 8
+Item	mini-marshmallow dispenser	Maximum HP: +30, Maximum MP: +30, HP Regen Min: 6, HP Regen Max: 8, MP Regen Min: 6, MP Regen Max: 8, Last Available: "2016-11"
 # mirrored aviator shades: Kill 10% More Skeletons
-Item	mirrored aviator shades	Moxie: +15, Single Equip
-Item	molten medallion	Hot Resistance: +1, Item Drop: +5, Synergetic
+Item	mirrored aviator shades	Moxie: +15, Single Equip, Last Available: "2011-05"
+Item	molten medallion	Hot Resistance: +1, Item Drop: +5, Last Available: "2009-06", Synergetic
 Item	monster bait	Combat Rate: +5, Single Equip
-Item	monstrous monocle	Spooky Resistance: +1, Item Drop: +5, Synergetic
+Item	monstrous monocle	Spooky Resistance: +1, Item Drop: +5, Last Available: "2009-06", Synergetic
 # mood ring
 Item	moon-amber necklace	Spell Damage Percent: +50, Maximum MP: +200, Mysticality Percent: [5*G], Single Equip
-Item	moss marlinspike	Moxie: +10, Negative Status Resist, Extra Pickpocket, Single Equip
+Item	moss marlinspike	Moxie: +10, Negative Status Resist, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 # moss medal: Lets you impress your pasta thrall
-Item	moss medal	Experience (Mysticality): +2, Spooky Resistance: +2, Single Equip
-Item	mother's necklace	Adventures: +3, Never Fumble
+Item	moss medal	Experience (Mysticality): +2, Spooky Resistance: +2, Single Equip, Last Available: "2024-12"
+Item	mother's necklace	Adventures: +3, Never Fumble, Last Available: "2022-06"
 Item	motion sensor	Initiative: +100, Single Equip
-Item	moustache sock	Moxie: +20, Muscle: -5, Mysticality: -5, Initiative: +20, Single Equip
-Item	Mr. Accessaturday	Muscle: [1+104*event(Saturday)], Mysticality: [1+104*event(Saturday)], Moxie: [1+104*event(Saturday)]
+Item	moustache sock	Moxie: +20, Muscle: -5, Mysticality: -5, Initiative: +20, Single Equip, Last Available: "2013-11"
+Item	Mr. Accessaturday	Muscle: [1+104*event(Saturday)], Mysticality: [1+104*event(Saturday)], Moxie: [1+104*event(Saturday)], Last Available: "2023-06"
 Item	Mr. Accessory	Muscle: +15, Mysticality: +15, Moxie: +15, Softcore Only
 Item	Mr. Accessory Jr.	Muscle: +5, Mysticality: +5, Moxie: +5, Item Drop: +25, Softcore Only
 # Mr. Cheeng's spectacles: Find... like...  far out stuff, like everywhere... man...
-Item	Mr. Cheeng's spectacles	Item Drop: +15, Spell Critical Percent: +10, Spell Damage Percent: +30, Single Equip, Drops Items
+Item	Mr. Cheeng's spectacles	Item Drop: +15, Spell Critical Percent: +10, Spell Damage Percent: +30, Single Equip, Last Available: "2015-08", Drops Items
 Item	Mr. Eh?	Muscle: +12, Mysticality: +12, Moxie: +12, Softcore Only
 # Mr. Exploiter
 Item	Mr. Joe's bangles	Mysticality Percent: +10, Single Equip
 # Mr. Screege's spectacles: Lets you find valuables after fights
-Item	Mr. Screege's spectacles	Meat Drop: +20, Single Equip, Drops Meat
+Item	Mr. Screege's spectacles	Meat Drop: +20, Single Equip, Last Available: "2016-08", Drops Meat
 Item	Ms. Accessory	Muscle: +15, Mysticality: +15, Moxie: +15, Softcore Only
 Item	Mudflap-Girl Earring	Stench Resistance: +3, Hot Resistance: +3, Single Equip
 Item	Mudflap-Girl Necklace	Muscle: +3, Mysticality: +3, Moxie: +3, Sleaze Spell Damage: +40, Single Equip
 Item	Mudflap-Girl Ring	Muscle: +3, Mysticality: +3, Moxie: +3, Sleaze Damage: +40, Single Equip
-Item	mushroom badge	Mysticality: +40, Muscle: -20, Moxie: -20, Monster Level: -25, Single Equip
-Item	music box key	Combat Rate: +10
-Item	musty moccasins	Stench Resistance: +1, Item Drop: +5, Synergetic
-Item	myrrh pouch	Maximum HP: +10, Experience (Muscle): +3, Single Equip
+Item	mushroom badge	Mysticality: +40, Muscle: -20, Moxie: -20, Monster Level: -25, Single Equip, Last Available: "2020-03"
+Item	music box key	Combat Rate: +10, Last Available: "2020-08"
+Item	musty moccasins	Stench Resistance: +1, Item Drop: +5, Last Available: "2009-06", Synergetic
+Item	myrrh pouch	Maximum HP: +10, Experience (Muscle): +3, Single Equip, Last Available: "2020-12"
 Item	mysterious silver lapel pin	HP Regen Min: 5, HP Regen Max: 9, Meat Drop: +5, Single Equip
 Item	natty blue ascot	Meat Drop: +20
-Item	navel ring of navel gazing	Damage Reduction: [L], Mysticality Percent: +25, Spell Damage Percent: +100, Mana Cost: -1, Single Equip, Softcore Only, Item Drop (sporadic): 4.25, Meat Drop (sporadic): 4.25, Experience: 0.6375, MP Regen Min: 2.125, MP Regen Max: 4.25
-Item	neck wreath	Spooky Resistance: [+5*event(December)], Stench Resistance: [+5*event(December)], Hot Resistance: [+5*event(December)], Cold Resistance: [+5*event(December)], Sleaze Resistance: [+5*event(December)], Single Equip
+Item	navel ring of navel gazing	Damage Reduction: [L], Mysticality Percent: +25, Spell Damage Percent: +100, Mana Cost: -1, Single Equip, Softcore Only, Last Available: "2007-09", Item Drop (sporadic): 4.25, Meat Drop (sporadic): 4.25, Experience: 0.6375, MP Regen Min: 2.125, MP Regen Max: 4.25
+Item	neck wreath	Spooky Resistance: [+5*event(December)], Stench Resistance: [+5*event(December)], Hot Resistance: [+5*event(December)], Cold Resistance: [+5*event(December)], Sleaze Resistance: [+5*event(December)], Single Equip, Last Available: "2020-12"
 Item	neverending wallet chain	Meat Drop: [30*loc(The Neverending Party)]
 Item	Nickel Gamma of Frugality	Muscle: +9, Mysticality: +9, Moxie: +9, Item Drop: +7, Single Equip
-Item	nicksilver ring	Pickpocket Chance: +15, Item Drop: +15, Weapon Drop: +30, Single Equip
-Item	night-vision goggles	Moxie Percent: -10, Experience (Moxie): +1, Single Equip
+Item	nicksilver ring	Pickpocket Chance: +15, Item Drop: +15, Weapon Drop: +30, Single Equip, Last Available: "2016-02"
+Item	night-vision goggles	Moxie Percent: -10, Experience (Moxie): +1, Single Equip, Last Available: "2009-12"
 Item	Nose Ring of Putrescence	Hot Resistance: +3, Spooky Resistance: +3, Single Equip
-Item	noticeable pumps	Moxie: +10, Experience: +1, Single Equip
-Item	Nouveau nosering	Moxie Percent: +50, Item Drop: +25, Maximum HP: +25, Maximum MP: +25, Experience (Moxie): +4, Lasts Until Rollover
+Item	noticeable pumps	Moxie: +10, Experience: +1, Single Equip, Last Available: "2018-09"
+Item	Nouveau nosering	Moxie Percent: +50, Item Drop: +25, Maximum HP: +25, Maximum MP: +25, Experience (Moxie): +4, Lasts Until Rollover, Last Available: "2018-07"
 # Novelty Belt Buckle of Violence: Casts reflections of your spells
 Item	Novelty Belt Buckle of Violence	Muscle Percent: +20, Critical Hit Percent: +5, Weapon Damage Percent: +30, Single Equip
-Item	novelty tattoo sleeves	Muscle: +6, PvP Fights: +1, Single Equip
+Item	novelty tattoo sleeves	Muscle: +6, PvP Fights: +1, Single Equip, Last Available: "2013-12"
 Item	numberwang	PvP Fights: +5, Adventures: +5, Monster Level: +11, Initiative: +23, Maximum HP: +37, Maximum MP: +37, HP Regen Min: 6, HP Regen Max: 9, MP Regen Min: 6, MP Regen Max: 9, Single Equip
-Item	nylon Christmas stockings	Initiative: +75, Spell Damage Percent: +50, Experience: +3, Mana Cost: -1, Single Equip
+Item	nylon Christmas stockings	Initiative: +75, Spell Damage Percent: +50, Experience: +3, Mana Cost: -1, Single Equip, Last Available: "2024-12"
 Item	observational glasses	Item Drop: +5
 Item	offensive moustache	PvP Fights: +7, Single Equip
-Item	Official Council Aide Pin	Adventures: +4, PvP Fights: +2
+Item	Official Council Aide Pin	Adventures: +4, PvP Fights: +2, Last Available: "2016-11"
 # Ol' Scratch's manacles: All Spells Cast Are Hot
 Item	Ol' Scratch's manacles	Hot Spell Damage: +30, Moxie Percent: +15, Single Equip
 Item	old ball and chain	Initiative: -50, Cold Damage: +100, Single Equip
@@ -3488,12 +3488,12 @@ Item	old ball and chain	Initiative: -50, Cold Damage: +100, Single Equip
 Item	old school calculator watch	Sporadic Damage Aura: 0.25
 # old soft shoes: +30% Item Drops from Hobos
 Item	old soft shoes	Single Equip, Item Drop: [30*zone(Hobopolis)*(1-loc(Sewer Tunnels))]
-Item	orange glowstick	Maximum MP: +5, Moxie: -3, Raveosity: +1
-Item	orange leather lanyard	Weapon Damage: +15, Single Equip
+Item	orange glowstick	Maximum MP: +5, Moxie: -3, Last Available: "2006-10", Raveosity: +1
+Item	orange leather lanyard	Weapon Damage: +15, Single Equip, Last Available: "2011-05"
 Item	Orange Star of Sacrifice	Muscle: +10, Mysticality: +10, Moxie: +10, Item Drop: +6, Single Equip
 # orc wrist: +15 Damage vs. Orcs
 Item	Order of the Silver Wossname	Muscle: +11, Mysticality: +11, Moxie: +11, Item Drop: +11, Meat Drop: +11, Single Equip
-Item	ornamental sextant	Muscle Percent: +15, Mysticality Percent: +15, Moxie Percent: +15
+Item	ornamental sextant	Muscle Percent: +15, Mysticality Percent: +15, Moxie Percent: +15, Last Available: "2013-12"
 Item	Oscus's pelt	Mysticality Percent: +20, Stench Spell Damage: +30, Class: "Pastamancer", Single Equip
 Item	Othello's handkerchief	Othello Skill: +10, Single Equip
 Item	outlaw bandana	Moxie: +10, Initiative: +20, Weapon Drop: +40
@@ -3501,103 +3501,103 @@ Item	oven mitts	Hot Resistance: +2, Single Equip
 # over-the-shoulder Folder Holder: Softcore Only (Except for High School Students)
 Item	over-the-shoulder Folder Holder	Single Equip
 Item	pacifier necklace	Sleaze Damage: +20, Single Equip, Raveosity: +2
-Item	pair of government shades	Maximum HP: +10, Single Equip
+Item	pair of government shades	Maximum HP: +10, Single Equip, Last Available: "2014-05"
 # pair of pearidot earrings: (only in the Candy Diorama)
-Item	pair of pearidot earrings	Item Drop: [100*zone(The Candy Diorama)], Single Equip
-Item	paperclip-on tie	Weapon Damage: +5, Spell Damage: +5, Experience: +1, Single Equip
-Item	papier-masque	Spell Damage: +10, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4, Single Equip, Alters Page Text
+Item	pair of pearidot earrings	Item Drop: [100*zone(The Candy Diorama)], Single Equip, Last Available: "2011-11"
+Item	paperclip-on tie	Weapon Damage: +5, Spell Damage: +5, Experience: +1, Single Equip, Last Available: "2011-01"
+Item	papier-masque	Spell Damage: +10, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4, Single Equip, Last Available: "2012-09", Alters Page Text
 # paraffin pendant: Lets you unleash a prismatic attack
-Item	paraffin pendant	Experience (Mysticality): +2, Maximum MP: +10, Single Equip
+Item	paraffin pendant	Experience (Mysticality): +2, Maximum MP: +10, Single Equip, Last Available: "2020-12"
 # paraffin punching bag: Lets you unleash a prismatic attack
-Item	paraffin punching bag	Muscle: +10, Hot Damage: +10, Single Equip
+Item	paraffin punching bag	Muscle: +10, Hot Damage: +10, Single Equip, Last Available: "2020-12"
 # pat-a-cake pendant: Regenerate 1 MP per adventure (sometimes)
 Item	pat-a-cake pendant	Mysticality: +1, MP Regen Min: 0, MP Regen Max: 1
-Item	patent leather shoes	Muscle: +1, Hot Resistance: +1
+Item	patent leather shoes	Muscle: +1, Hot Resistance: +1, Last Available: "2008-12"
 Item	peace-sign necklace	Damage Reduction: 3
 # pearl diver's necklace: +30% Item Drops from Monsters (Underwater only)
 Item	pearl diver's necklace	Critical Hit Percent: +4, Monster Level: +20, Single Equip, Item Drop: [30*env(underwater)]
 # pearl diver's ring: +20% Item Drops from Monsters (Underwater only)
 Item	pearl diver's ring	Critical Hit Percent: +3, Monster Level: +15, Single Equip, Item Drop: [20*env(underwater)]
-Item	pearl necklace	Sleaze Damage: +23, Sleaze Spell Damage: +37, Moxie Percent: +69, Single Equip
-Item	peg key	Experience: +5
+Item	pearl necklace	Sleaze Damage: +23, Sleaze Spell Damage: +37, Moxie Percent: +69, Single Equip, Last Available: "2017-10"
+Item	peg key	Experience: +5, Last Available: "2020-08"
 Item	pegfinger	Spell Damage Percent: +25, MPC Drop: 0.5, Single Equip
 Item	Pendant of Fire	Muscle: +3, Mysticality: +3, Moxie: +3, Hot Spell Damage: +40, Single Equip
 Item	Pendant of Gargalesis	MP Regen Min: 6, MP Regen Max: 10
-Item	peppermint-scented socks	MP Regen Min: 8, MP Regen Max: 16
-Item	perfect Christmas scarf	Adventures: [+9*event(December)], Cold Resistance: [+7*event(December)], HP Regen Min: [4*event(December)], HP Regen Max: [6*event(December)], MP Regen Min: [4*event(December)], MP Regen Max: [6*event(December)], Single Equip
+Item	peppermint-scented socks	MP Regen Min: 8, MP Regen Max: 16, Last Available: "2021-12"
+Item	perfect Christmas scarf	Adventures: [+9*event(December)], Cold Resistance: [+7*event(December)], HP Regen Min: [4*event(December)], HP Regen Max: [6*event(December)], MP Regen Min: [4*event(December)], MP Regen Max: [6*event(December)], Single Equip, Last Available: "2024-12"
 Item	perfume-soaked bandana	Stench Resistance: +4, Spooky Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip
 # Personal Ventilation Unit: Allows Safe Access to Secret Government Lab
-Item	Personal Ventilation Unit	Muscle Limit: 100, Mysticality Limit: 100, Moxie Limit: 100, Single Equip
+Item	Personal Ventilation Unit	Muscle Limit: 100, Mysticality Limit: 100, Moxie Limit: 100, Single Equip, Last Available: "2014-10"
 Item	petrified wood waist protector	Experience (Muscle): +3, Adventures: +5, Avoid Attack: 1, Single Equip
 # petrified wood wizard's pouch: Adds hot and physical damage to spells
-Item	petrified wood wizard's pouch	Mysticality Percent: +20, Item Drop: +10, Single Equip
+Item	petrified wood wizard's pouch	Mysticality Percent: +20, Item Drop: +10, Single Equip, Last Available: "2025-12"
 # phase-tuned shield generator belt: +10 Damage Reduction vs. Bugbears
 Item	phase-tuned shield generator belt	Single Equip
 Item	phat turquoise bracelet	Mysticality: +5
-Item	pig-iron bracers	Mysticality: +8, Spell Damage: +10, Single Equip
-Item	pine cone necklace	Monster Level: -50
+Item	pig-iron bracers	Mysticality: +8, Spell Damage: +10, Single Equip, Last Available: "2009-06"
+Item	pine cone necklace	Monster Level: -50, Last Available: "2015-12"
 Item	Pine-Fresh air freshener	Stench Resistance: +1
-Item	pink glowstick	Maximum MP: +5, Moxie: -3, Raveosity: +1
+Item	pink glowstick	Maximum MP: +5, Moxie: -3, Last Available: "2007-03", Raveosity: +1
 Item	Pink Heart of Spirit	Muscle: +11, Mysticality: +11, Moxie: +11, Item Drop: +5, Single Equip
-Item	pink plastic baby	Maximum HP: +5, Maximum MP: +5, Single Equip
+Item	pink plastic baby	Maximum HP: +5, Maximum MP: +5, Single Equip, Last Available: "2008-03"
 Item	pirate fledges	Muscle: +7, Mysticality: +7, Moxie: +7, Look like a Pirate
-Item	pirate radio ring	Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2, Spell Damage Percent: +15, Single Equip
-Item	PirateRealm eyepatch	Muscle Limit: 20, Mysticality Limit: 20, Moxie Limit: 20, Lasts Until Rollover
+Item	pirate radio ring	Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2, Spell Damage Percent: +15, Single Equip, Last Available: "2019-04"
+Item	PirateRealm eyepatch	Muscle Limit: 20, Mysticality Limit: 20, Moxie Limit: 20, Lasts Until Rollover, Last Available: "2019-04"
 Item	plaid pocket square	Meat Drop: +15
-Item	plastic detective badge	Maximum HP: +10, Maximum MP: +10, Item Drop: +5, Meat Drop: +15
+Item	plastic detective badge	Maximum HP: +10, Maximum MP: +10, Item Drop: +5, Meat Drop: +15, Last Available: "2016-07"
 Item	plastic Duskwalker necklace	Moxie: +5, Familiar Weight: +3, Single Equip, Lasts Until Rollover
-Item	plastic spider ring	Mysticality: +3, Single Equip
+Item	plastic spider ring	Mysticality: +3, Single Equip, Last Available: "2010-06"
 # plastic vampire fangs: Makes You Thirst For Blood
-Item	plastic vampire fangs	Maximum HP: +30, Maximum MP: +30, Muscle: +15, Mysticality: +15, Moxie: +15, Single Equip, Softcore Only
+Item	plastic vampire fangs	Maximum HP: +30, Maximum MP: +30, Muscle: +15, Mysticality: +15, Moxie: +15, Single Equip, Softcore Only, Last Available: "2011-10"
 Item	plexiglass pendant	Never Fumble, Moxie Percent: +30, Four Songs, Single Equip
 Item	plexiglass pinky ring	Spell Damage: +30, Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Mysticality Percent: +30, Single Equip
 Item	plexiglass pocketwatch	Mana Cost: -3, Adventures: +3, Mysticality Percent: +30, Single Equip
-Item	plush sea serpent	Damage Reduction: 10, Monster Level: [-100*env(underwater)], Single Equip
+Item	plush sea serpent	Damage Reduction: 10, Monster Level: [-100*env(underwater)], Single Equip, Last Available: "2019-04"
 # pocket GPU: CyberRealm:  Allows you to run one command faster than a process can respond
-Item	pocket GPU	Single Equip
+Item	pocket GPU	Single Equip, Last Available: "2025-12"
 Item	Pocket Square of Loathing	Never Fumble, Mana Cost: -3, Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Single Equip, Cloathing
 Item	pogo stick	Initiative: +30, Moxie Percent: +10, Single Equip
-Item	Pok&euml;mann figurine: Bloodkip	Familiar Weight: +3, Single Equip
-Item	Pok&euml;mann figurine: Duck	Cold Resistance: +2, Single Equip
-Item	Pok&euml;mann figurine: Frank	Muscle Percent: +10, Single Equip
-Item	Pok&euml;mann figurine: Galumpagump	Hot Resistance: +2, Single Equip
-Item	Pok&euml;mann figurine: Hoboking	Stench Resistance: +2, Single Equip
-Item	Pok&euml;mann figurine: Kagosan	Sleaze Resistance: +2, Single Equip
-Item	Pok&euml;mann figurine: Magikrap	Familiar Weight: +3, Single Equip
-Item	Pok&euml;mann figurine: Moog	Moxie Percent: +10, Single Equip
-Item	Pok&euml;mann figurine: Nothing	Spooky Resistance: +2, Single Equip
-Item	Pok&euml;mann figurine: Porkachu	Familiar Weight: +3, Single Equip
-Item	Pok&euml;mann figurine: Shoggoth	Mysticality Percent: +10, Single Equip
-Item	Pok&euml;mann figurine: Smugleaf	Familiar Weight: +3, Single Equip
-Item	Pok&euml;mann figurine: Twitter	Familiar Weight: +3, Single Equip
-Item	Pok&euml;mann figurine: Vegemite	Familiar Weight: +3, Single Equip
-Item	Pok&euml;mann figurine: Vermouth	Familiar Weight: +3, Single Equip
+Item	Pok&euml;mann figurine: Bloodkip	Familiar Weight: +3, Single Equip, Last Available: "2011-05"
+Item	Pok&euml;mann figurine: Duck	Cold Resistance: +2, Single Equip, Last Available: "2011-05"
+Item	Pok&euml;mann figurine: Frank	Muscle Percent: +10, Single Equip, Last Available: "2011-05"
+Item	Pok&euml;mann figurine: Galumpagump	Hot Resistance: +2, Single Equip, Last Available: "2011-05"
+Item	Pok&euml;mann figurine: Hoboking	Stench Resistance: +2, Single Equip, Last Available: "2011-05"
+Item	Pok&euml;mann figurine: Kagosan	Sleaze Resistance: +2, Single Equip, Last Available: "2011-05"
+Item	Pok&euml;mann figurine: Magikrap	Familiar Weight: +3, Single Equip, Last Available: "2011-05"
+Item	Pok&euml;mann figurine: Moog	Moxie Percent: +10, Single Equip, Last Available: "2011-05"
+Item	Pok&euml;mann figurine: Nothing	Spooky Resistance: +2, Single Equip, Last Available: "2011-05"
+Item	Pok&euml;mann figurine: Porkachu	Familiar Weight: +3, Single Equip, Last Available: "2011-05"
+Item	Pok&euml;mann figurine: Shoggoth	Mysticality Percent: +10, Single Equip, Last Available: "2011-05"
+Item	Pok&euml;mann figurine: Smugleaf	Familiar Weight: +3, Single Equip, Last Available: "2011-05"
+Item	Pok&euml;mann figurine: Twitter	Familiar Weight: +3, Single Equip, Last Available: "2011-05"
+Item	Pok&euml;mann figurine: Vegemite	Familiar Weight: +3, Single Equip, Last Available: "2011-05"
+Item	Pok&euml;mann figurine: Vermouth	Familiar Weight: +3, Single Equip, Last Available: "2011-05"
 Item	polka-dot bow tie	Moxie: +3, Clowniness: 75
 # polyester pulsera: Causes Songs in your Head to Restore HP
-Item	polyester pulsera	Pickpocket Chance: +10, Initiative: +20, Single Equip
-Item	ponytail clip	Moxie: -30, Initiative: +30
+Item	polyester pulsera	Pickpocket Chance: +10, Initiative: +20, Single Equip, Last Available: "2015-12"
+Item	ponytail clip	Moxie: -30, Initiative: +30, Last Available: "2018-09"
 # porcelain phantom mask: Adds <font color=gray>Spooky Damage</font> to Bawdy Refrain
-Item	porcelain phantom mask	Accessory Drop: +20, Moxie Percent: +20, Single Equip
+Item	porcelain phantom mask	Accessory Drop: +20, Moxie Percent: +20, Single Equip, Last Available: "2015-12"
 Item	porquoise bracelet	Moxie: +4, Never Fumble
 Item	porquoise eyebrow ring	Moxie: +4, Never Fumble
 Item	porquoise necklace	Moxie: +4, Meat Drop: +10, Single Equip
 Item	porquoise ring	Moxie: +5, Maximum HP: +5, Maximum MP: +5, HP Regen Min: 1, HP Regen Max: 2, MP Regen Min: 1, MP Regen Max: 2, Single Equip
 # portable cassette player: Has An Obnoxious Mix Tape Stuck In It
-Item	portable cassette player	Combat Rate: +5, Monster Level: +5, Single Equip
-Item	power sock	Muscle: +20, Mysticality: -5, Moxie: -5, Weapon Damage Percent: +20, Single Equip
+Item	portable cassette player	Combat Rate: +5, Monster Level: +5, Single Equip, Last Available: "2014-08"
+Item	power sock	Muscle: +20, Mysticality: -5, Moxie: -5, Weapon Damage Percent: +20, Single Equip, Last Available: "2013-11"
 # Powerful Glove: Lets you use various glitchy cheat codes
-Item	Powerful Glove	Maximum MP: +10, Maximum HP: +20, Weapon Damage Percent: +25, Spell Damage Percent: +50, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10, Single Equip
-Item	primitive alien necklace	Experience: +5, Cold Damage: +25, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4
+Item	Powerful Glove	Maximum MP: +10, Maximum HP: +20, Weapon Damage Percent: +25, Spell Damage Percent: +50, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10, Single Equip, Last Available: "2020-02"
+Item	primitive alien necklace	Experience: +5, Cold Damage: +25, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4, Last Available: "2017-04"
 # pro skateboard: Do some awesome moves in combat!
-Item	pro skateboard	Weapon Damage: +10, Moxie Percent: +10
+Item	pro skateboard	Weapon Damage: +10, Moxie Percent: +10, Last Available: "2023-06"
 # Protects-Your-Junk: Grants Protection from Dreadsylvanian Curses
 Item	Protects-Your-Junk	Negative Status Resist, Damage Reduction: 20, Single Equip
-Item	psychic's amulet	Spell Damage: +10, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1
+Item	psychic's amulet	Spell Damage: +10, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Last Available: "2018-02"
 Item	pulled porquoise earring	Moxie: +9, Never Fumble
 Item	pulled porquoise pendant	Moxie: +10, Meat Drop: +15, Single Equip
 Item	pulled porquoise ring	Moxie: +11, Maximum HP: +15, Maximum MP: +15, HP Regen Min: 1, HP Regen Max: 2, MP Regen Min: 1, MP Regen Max: 2, Single Equip
 Item	pump-up high-tops	Moxie: +15, Initiative: [+10+5*pref(highTopPumped)], Single Equip
-Item	purple glowstick	Maximum MP: +5, Moxie: -3, Raveosity: +1
+Item	purple glowstick	Maximum MP: +5, Moxie: -3, Last Available: "2008-02", Raveosity: +1
 Item	Purple Horseshoe of Honor	Muscle: +6, Mysticality: +6, Moxie: +6, Item Drop: +10, Single Equip
 Item	Putrid Pendant	Muscle: +3, Mysticality: +3, Moxie: +3, Stench Spell Damage: +40, Single Equip
 Item	pygmy nose-bone	Moxie: +7, Single Equip
@@ -3607,9 +3607,9 @@ Item	quick-release belt pouch	Single Equip
 Item	quick-release fannypack	Single Equip
 # quick-release utility belt: The first three combat items you use each fight are Quick Actions
 Item	quick-release utility belt	Single Equip
-Item	quicksilver ring	Initiative: +40, Single Equip
+Item	quicksilver ring	Initiative: +40, Single Equip, Last Available: "2016-02"
 Item	Quiets-Your-Steps	Combat Rate: -5, Pickpocket Chance: +50, Initiative: -50, Single Equip
-Item	rabbit's foot key	Muscle: +10, Mysticality: +10, Moxie: +10
+Item	rabbit's foot key	Muscle: +10, Mysticality: +10, Moxie: +10, Last Available: "2020-08"
 Item	Radio KoL Antenna Ball	Experience: +1
 Item	Radio KoL Bottle Opener	Meat Drop: +15
 Item	Radio KoL Coffee Mug	Muscle: +10, Mysticality: +10, Moxie: +10, Hot Damage: +10
@@ -3617,29 +3617,29 @@ Item	Radio KoL Flashlight	Mysticality: +15
 Item	Radio KoL Keychain	Muscle: +15
 Item	Radio KoL Maracas	Item Drop: +15
 Item	Radio KoL Patch	Moxie: +15
-Item	rainbow pearl earring	Muscle: +15, Mysticality: +15, Moxie: +15, Spooky Resistance: +9, Stench Resistance: +9, Hot Resistance: +9, Cold Resistance: +9, Sleaze Resistance: +9, Single Equip
-Item	rainbow pearl necklace	Muscle: +15, Mysticality: +15, Moxie: +15, Spell Damage: +200, Single Equip
-Item	rainbow pearl ring	Muscle: +15, Mysticality: +15, Moxie: +15, Spooky Damage: +40, Stench Damage: +40, Hot Damage: +40, Cold Damage: +40, Sleaze Damage: +40, Single Equip
+Item	rainbow pearl earring	Muscle: +15, Mysticality: +15, Moxie: +15, Spooky Resistance: +9, Stench Resistance: +9, Hot Resistance: +9, Cold Resistance: +9, Sleaze Resistance: +9, Single Equip, Last Available: "2007-12"
+Item	rainbow pearl necklace	Muscle: +15, Mysticality: +15, Moxie: +15, Spell Damage: +200, Single Equip, Last Available: "2007-12"
+Item	rainbow pearl ring	Muscle: +15, Mysticality: +15, Moxie: +15, Spooky Damage: +40, Stench Damage: +40, Hot Damage: +40, Cold Damage: +40, Sleaze Damage: +40, Single Equip, Last Available: "2007-12"
 Item	ratskin belt	Moxie: +8, Meat Drop: +10, Single Equip
-Item	recovered cufflinks	Familiar Weight: +6, Single Equip
-Item	red armband	Adventures: [1+10*event(Crimbo2015)], Single Equip
+Item	recovered cufflinks	Familiar Weight: +6, Single Equip, Last Available: "2017-01"
+Item	red armband	Adventures: [1+10*event(Crimbo2015)], Single Equip, Last Available: "2015-12"
 Item	red badge	Damage Reduction: 5, Monster Level: -25, Single Equip
 Item	Red Balloon of Valor	Muscle: +5, Mysticality: +5, Moxie: +5, Item Drop: +11, Single Equip
 Item	Red Fox glove	Critical Hit Percent: +5, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10, Attacks Can't Miss, Single Equip
 Item	red masque	Spooky Damage: +15, Maximum HP: +30, Single Equip
-Item	red plastic baby	Maximum HP: +5, Maximum MP: +5, Single Equip
+Item	red plastic baby	Maximum HP: +5, Maximum MP: +5, Single Equip, Last Available: "2009-06"
 # red plumber's boots: Lets you unleash powerful jump attacks
 Item	red plumber's boots	Single Equip
 # Red Roger's red left foot: Gain more FunPoints during PirateRealm island adventures
-Item	Red Roger's red left foot	Single Equip
+Item	Red Roger's red left foot	Single Equip, Last Available: "2019-04"
 # Red Roger's red right foot: Gain more FunPoints during PirateRealm sailing adventures
-Item	Red Roger's red right foot	Single Equip
+Item	Red Roger's red right foot	Single Equip, Last Available: "2019-04"
 Item	red shoe	Hot Resistance: +2, Combat Rate: -5, Single Equip
-Item	red-hot medallion	Hot Damage: +30, Single Equip
-Item	red-soled high heels	Moxie Percent: +10, Experience (Moxie): +3, Booze Drop: +50
+Item	red-hot medallion	Hot Damage: +30, Single Equip, Last Available: "2010-09"
+Item	red-soled high heels	Moxie Percent: +10, Experience (Moxie): +3, Booze Drop: +50, Last Available: "2023-06"
 Item	reinforced furry underpants	Mysticality: +2, Sleaze Damage: +2
 Item	replica Cincho de Mayo	Moxie Percent: +25, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Booze Drop: +30, Item Drop: +15
-Item	replica Elf Guard medal	Elf Warfare Effectiveness: +5, Experience: +2, Maximum HP: +20, Maximum MP: +20
+Item	replica Elf Guard medal	Elf Warfare Effectiveness: +5, Experience: +2, Maximum HP: +20, Maximum MP: +20, Last Available: "2023-12"
 # replica Elvish sunglasses: Lets you Rock Out
 Item	replica Elvish sunglasses	Moxie: +10, Moxie Percent: +10, Ranged Damage: +15, Pickpocket Chance: +25, Single Equip
 Item	replica hewn moon-rune spoon	Experience: +3, Familiar Weight: +5, Critical Hit Percent: +10, Spell Damage: +10, Initiative: +25, Rollover Effect: "Spoon Boon", Rollover Effect Duration: 50, Muscle: +5, Mysticality: +5, Moxie: +5, Maximum HP: +25, Maximum MP: +25, Single Equip, Alters Page Text
@@ -3659,12 +3659,12 @@ Item	replica V for Vivala mask	Muscle Percent: +30, Critical Hit Percent: +10, C
 # retro floppy disk: CyberRealm: Get one additional 1 after combat
 # Retrospecs: Gives you another chance on item drops you missed out on
 # Retrospecs: Reveals foes' weaknesses
-Item	Retrospecs	Muscle: +15, Mysticality: +15, Moxie: +15, Maximum HP: +25, Maximum MP: +25, HP Regen Min: 3, HP Regen Max: 5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Free Pull
-Item	ribbon candy ascot	Candy Drop: +100, HP Regen Min: 6, HP Regen Max: 10, MP Regen Min: 6, MP Regen Max: 10, Single Equip
+Item	Retrospecs	Muscle: +15, Mysticality: +15, Moxie: +15, Maximum HP: +25, Maximum MP: +25, HP Regen Min: 3, HP Regen Max: 5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Free Pull, Last Available: "2020-01"
+Item	ribbon candy ascot	Candy Drop: +100, HP Regen Min: 6, HP Regen Max: 10, MP Regen Min: 6, MP Regen Max: 10, Single Equip, Last Available: "2019-12"
 Item	rickety old unicycle	Moxie Percent: +15, Initiative: +50, MP Regen Min: 10, MP Regen Max: 25, Single Equip
-Item	ridiculous belt	Muscle: +11
-Item	ridiculous earring	Mysticality: +11
-Item	ridiculous sunglasses	Moxie: +11
+Item	ridiculous belt	Muscle: +11, Last Available: "2011-11"
+Item	ridiculous earring	Mysticality: +11, Last Available: "2011-11"
+Item	ridiculous sunglasses	Moxie: +11, Last Available: "2011-11"
 # right half of a heart necklace
 Item	ring	Single Equip
 Item	ring of adornment	Moxie: +10
@@ -3683,14 +3683,14 @@ Item	ring of teleportation	Single Equip, Adventure Randomly
 # ring of telling skeletons what to do: Lets you tell skeletons what to do
 Item	ring of telling skeletons what to do	Muscle: +2, Mysticality: +2, Moxie: +2
 Item	Ring of the Sewer Snake	Muscle: +3, Mysticality: +3, Moxie: +3, Stench Damage: +40, Single Equip
-Item	ring of the Skeleton Lord	Mysticality Percent: +50, Meat Drop: +50, Item Drop: +25, Single Equip
-Item	rocket boots	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, Initiative: +100, Single Equip, Lasts Until Rollover
+Item	ring of the Skeleton Lord	Mysticality Percent: +50, Meat Drop: +50, Item Drop: +25, Single Equip, Last Available: "2018-04"
+Item	rocket boots	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, Initiative: +100, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
 Item	Roman sadnals	Experience: +2, Single Equip
 Item	rope with some soap on it	Spell Damage Percent: [100*zone(Hobopolis)*(1-loc(Sewer Tunnels))], Single Equip
 Item	rose-colored glasses	Maximum HP: +5, Maximum MP: +5
 Item	round green sunglasses	Moxie: +9, Sleaze Resistance: +2, Single Equip
 Item	round purple sunglasses	Sleaze Resistance: +1, Single Equip
-Item	rubber gloves	Sleaze Resistance: +2
+Item	rubber gloves	Sleaze Resistance: +2, Last Available: "2013-12"
 # rubber WWBBDD? bracelet
 # rubber WWBD? bracelet
 # rubber WWJD? bracelet
@@ -3699,11 +3699,11 @@ Item	rubber gloves	Sleaze Resistance: +2
 Item	rum barrel charrrm bracelet	Booze Drop: +5
 Item	rusty chain necklace	Muscle: +9, Maximum HP: +25
 Item	Saccharine Maple pendant	Maximum HP: +20, Maximum MP: +20
-Item	sardine can key	Cold Damage: +40, Hot Resistance: +4, Food Drop: +60
-Item	Sasq&trade; watch	PvP Fights: +3, Adventures: +6, Rollover Effect: "The Rich Get Richer", Rollover Effect Duration: 30, Single Equip, Nonstackable Watch
+Item	sardine can key	Cold Damage: +40, Hot Resistance: +4, Food Drop: +60, Last Available: "2015-11"
+Item	Sasq&trade; watch	PvP Fights: +3, Adventures: +6, Rollover Effect: "The Rich Get Richer", Rollover Effect Duration: 30, Single Equip, Last Available: "2014-10", Nonstackable Watch
 Item	scabrous seal epaulets	Maximum HP: +20, HP Regen Min: 8, HP Regen Max: 10, Single Equip
 Item	Scandalously Skimpy Bikini	Four Songs, Single Equip
-Item	scrap metal key	Experience Percent (Moxie): +20, Moxie: +5, Mana Cost: -1
+Item	scrap metal key	Experience Percent (Moxie): +20, Moxie: +5, Mana Cost: -1, Last Available: "2020-08"
 Item	screwing pooch	Item Drop: +3
 Item	sea holster	Ranged Damage: +20, Critical Hit Percent: +4, Never Fumble, Single Equip
 # seal medal: 25% chance to gain an extra gallon of Fury when you gain a gallon of Fury.
@@ -3712,30 +3712,30 @@ Item	sealhide belt	Maximum HP: +25, Maximum MP: +25
 Item	sealhide gloves	Weapon Damage: +10
 Item	sealhide moccasins	Muscle: +5, Mysticality: +5, Moxie: +5, Single Equip
 Item	second-hand knockoff engagement ring	Muscle: +1, Mysticality: +1, Moxie: +1, Single Equip
-Item	self-repairing earmuffs	HP Regen Min: 10, HP Regen Max: 20
+Item	self-repairing earmuffs	HP Regen Min: 10, HP Regen Max: 20, Last Available: "2021-12"
 Item	senate fly thorax	Ranged Damage: +5, Moxie: [3*L]
-Item	Senior LAAAAME merit badge	Muscle: +3, Mysticality: +3, Moxie: +3
+Item	Senior LAAAAME merit badge	Muscle: +3, Mysticality: +3, Moxie: +3, Last Available: "2006-05"
 Item	severed rocking horse head	Muscle: +3, Mysticality: +3, Moxie: +3
 Item	shadow monocle	Spell Damage: +13, Item Drop: +13, Initiative: +13, Single Equip
 Item	shamanic beads	Spooky Damage: +1, Stench Damage: +1, Hot Damage: +1, Cold Damage: +1, Sleaze Damage: +1, Spell Damage: +10
 Item	shark tooth necklace	Moxie Percent: +5, Initiative: +35, Single Equip
 # Sheriff badge: Provides 1/3 Authority
-Item	Sheriff badge	Mysticality Percent: +50, Spooky Resistance: +3, Single Equip, Lasts Until Rollover
+Item	Sheriff badge	Mysticality Percent: +50, Spooky Resistance: +3, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 # Sheriff moustache: Provides 1/3 Authority
-Item	Sheriff moustache	Moxie Percent: +50, Initiative: +25, Single Equip, Lasts Until Rollover
-Item	shin gourds	Damage Reduction: 5, Weapon Damage: +10, Single Equip
-Item	shining halo	Experience: +3, Unarmed, Single Equip
+Item	Sheriff moustache	Moxie Percent: +50, Initiative: +25, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
+Item	shin gourds	Damage Reduction: 5, Weapon Damage: +10, Single Equip, Last Available: "2010-11"
+Item	shining halo	Experience: +3, Unarmed, Single Equip, Last Available: "2011-09"
 Item	shiny hood ornament	Muscle: +5, Mysticality: +5, Moxie: +5, Maximum HP: +30, Maximum MP: +30, Initiative: +10
 Item	shiny ring	Muscle: +3, Mysticality: +3, Moxie: +3
-Item	shiny tribal beads	Mysticality: +6
+Item	shiny tribal beads	Mysticality: +6, Last Available: "2009-06"
 # shock belt: Shocks enemies that hit you
-Item	shock belt	Single Equip
-Item	shoulder-mounted Trainbot	Meat Drop: +5, Monster Level: -5, Mysticality: +5, Single Equip
-Item	sicksilver ring	Stench Damage: +20, Stench Spell Damage: +40, Muscle: +10, Single Equip
+Item	shock belt	Single Equip, Last Available: "2011-05"
+Item	shoulder-mounted Trainbot	Meat Drop: +5, Monster Level: -5, Mysticality: +5, Single Equip, Last Available: "2022-12"
+Item	sicksilver ring	Stench Damage: +20, Stench Spell Damage: +40, Muscle: +10, Single Equip, Last Available: "2016-02"
 # signal jammer: Repels Skeleton Astronauts
 Item	signal jammer	Single Equip
 Item	silent nightlight	Muscle: +5, Mysticality: +5, Moxie: +5, Rollover Effect: "Nightlit", Rollover Effect Duration: 50
-Item	silver detective badge	Maximum HP: +30, Maximum MP: +30, Item Drop: +15, Meat Drop: +25
+Item	silver detective badge	Maximum HP: +30, Maximum MP: +30, Item Drop: +15, Meat Drop: +25, Last Available: "2016-07"
 # silver table-scraper: Fully restore your HP after Crimbo Train fights
 Item	silver table-scraper	Single Equip
 Item	silver tongue charrrm bracelet	Moxie: +5, Spell Damage: +10, Single Equip
@@ -3743,26 +3743,26 @@ Item	silver tongue charrrm bracelet	Moxie: +5, Spell Damage: +10, Single Equip
 Item	Sister Accessory	Muscle: +5, Mysticality: +5, Moxie: +5, Meat Drop: +25, Softcore Only
 Item	sk8board	Initiative: +15
 # skeletal scabbard: Doubles the damage dealt by swords
-Item	skeletal scabbard	Single Equip
-Item	skeleton skis	Initiative: +25, Cold Damage: +5, Spooky Damage: +5, Single Equip
-Item	Sketcherz&trade;	Sleaze Damage: +20, Sleaze Spell Damage: +25, Spell Damage Percent: +30
-Item	slicksilver ring	Sleaze Damage: +20, Sleaze Spell Damage: +40, Moxie: +10, Single Equip
+Item	skeletal scabbard	Single Equip, Last Available: "2012-10"
+Item	skeleton skis	Initiative: +25, Cold Damage: +5, Spooky Damage: +5, Single Equip, Last Available: "2012-10"
+Item	Sketcherz&trade;	Sleaze Damage: +20, Sleaze Spell Damage: +25, Spell Damage Percent: +30, Last Available: "2014-12"
+Item	slicksilver ring	Sleaze Damage: +20, Sleaze Spell Damage: +40, Moxie: +10, Single Equip, Last Available: "2016-02"
 Item	slime convention pin	Moxie: -1
 # slime-covered necklace: +50 Damage against Slimes
 Item	slime-covered necklace	Muscle: +6, Mysticality: +6, Moxie: +6, Maximum HP: +200, Weapon Damage: [50*loc(The Slime Tube)]
 Item	Slow Talkin' Elliot's dogtags	Muscle: +30, Initiative: -30
-Item	SMOOCH bracers	Damage Reduction: 5, Damage Absorption: +15, Single Equip, Thorns: 1
-Item	SMOOCH kneepads	Damage Reduction: 10, Single Equip, Thorns: 1
-Item	SMOOCH spaulders	Damage Absorption: +25, Single Equip, Thorns: 1
-Item	smooth velvet hanky	Disco Style: +1, Single Equip
-Item	smooth velvet pocket square	Disco Style: +1, Single Equip
-Item	smooth velvet socks	Disco Style: +1, Single Equip
+Item	SMOOCH bracers	Damage Reduction: 5, Damage Absorption: +15, Single Equip, Last Available: "2015-08", Thorns: 1
+Item	SMOOCH kneepads	Damage Reduction: 10, Single Equip, Last Available: "2015-08", Thorns: 1
+Item	SMOOCH spaulders	Damage Absorption: +25, Single Equip, Last Available: "2015-08", Thorns: 1
+Item	smooth velvet hanky	Disco Style: +1, Single Equip, Last Available: "2015-08"
+Item	smooth velvet pocket square	Disco Style: +1, Single Equip, Last Available: "2015-08"
+Item	smooth velvet socks	Disco Style: +1, Single Equip, Last Available: "2015-08"
 Item	sneakeasies	Moxie Percent: +25, Experience (Moxie): +2, Single Equip
 Item	Sneaky Pete's breath spray	Moxie: +10
-Item	snow belly	Cold Damage: +6, Single Equip
-Item	snow belt	Experience (Muscle): +5, Experience (Mysticality): +5, Experience (Moxie): +5, Adventures: +8, Single Equip, Lasts Until Rollover
+Item	snow belly	Cold Damage: +6, Single Equip, Last Available: "2009-12"
+Item	snow belt	Experience (Muscle): +5, Experience (Mysticality): +5, Experience (Moxie): +5, Adventures: +8, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 Item	sock garters	Cold Resistance: +2, Single Equip
-Item	soggy elf shoes	Initiative: +40, Sleaze Damage: +40, Single Equip
+Item	soggy elf shoes	Initiative: +40, Sleaze Damage: +40, Single Equip, Last Available: "2019-12"
 Item	solid baconstone earring	Mysticality: +8, Maximum MP: +15, Mana Cost: -1, Single Equip
 Item	solid baconstone necklace	Mysticality: +10, Spell Damage: +15, Single Equip
 Item	solid baconstone ring	Mysticality: +12, Maximum MP: +30, MP Regen Min: 2, MP Regen Max: 4, Single Equip
@@ -3771,50 +3771,50 @@ Item	solid gold pegleg	Initiative: -50, Single Equip
 Item	soul mask	Single Equip
 # soul monocle: Reveals secrets
 Item	soul monocle	Single Equip
-Item	sour ball and chain	Initiative: -300, Sprinkle Drop: +50, Single Equip
+Item	sour ball and chain	Initiative: -300, Sprinkle Drop: +50, Single Equip, Last Available: "2016-12"
 # Source shades: Improves yields of the Extraction skill.
-Item	Source shades	Item Drop: +10
-Item	Space Trip safety headphones	Monster Level: -100, Damage Reduction: 10, Combat Rate: -5, Single Equip
-Item	Spacegate diplomat's insignia	Moxie Percent: +25, Initiative: +25, Meat Drop: +25, Single Equip
-Item	Spacegate military insignia	PvP Fights: +6, Rollover Effect: "Spirit of Galactic Unity", Rollover Effect Duration: 30, Single Equip
-Item	Spacegate scientist's insignia	Adventures: +6, Rollover Effect: "Spirit of Galactic Unity", Rollover Effect Duration: 30, Single Equip
+Item	Source shades	Item Drop: +10, Last Available: "2016-06"
+Item	Space Trip safety headphones	Monster Level: -100, Damage Reduction: 10, Combat Rate: -5, Single Equip, Last Available: "2010-06"
+Item	Spacegate diplomat's insignia	Moxie Percent: +25, Initiative: +25, Meat Drop: +25, Single Equip, Last Available: "2017-04"
+Item	Spacegate military insignia	PvP Fights: +6, Rollover Effect: "Spirit of Galactic Unity", Rollover Effect Duration: 30, Single Equip, Last Available: "2017-04"
+Item	Spacegate scientist's insignia	Adventures: +6, Rollover Effect: "Spirit of Galactic Unity", Rollover Effect Duration: 30, Single Equip, Last Available: "2017-04"
 # spade necklace
 # spaghetti cult robe
 Item	spaghetti cult rosary	Maximum MP: +50
-Item	spant shoulderpads	Mysticality Percent: +15, Damage Absorption: +100, Single Equip
+Item	spant shoulderpads	Mysticality Percent: +15, Damage Absorption: +100, Single Equip, Last Available: "2017-04"
 Item	spark plug earring	MP Regen Min: 3, MP Regen Max: 4, Spooky Resistance: +2
 Item	sparkly engagement ring	Muscle: +15, Mysticality: +15, Moxie: +15, Single Equip
 # special sauce glove: Allows you to equip Chefstaves
 Item	special sauce glove	Class: "Sauceror", Single Equip
-Item	sphygmayomanometer	Muscle Percent: [pref(mayoLevel)+20], Mysticality Percent: [pref(mayoLevel)+20], Moxie Percent: [pref(mayoLevel)+20], Lasts Until Rollover
+Item	sphygmayomanometer	Muscle Percent: [pref(mayoLevel)+20], Mysticality Percent: [pref(mayoLevel)+20], Moxie Percent: [pref(mayoLevel)+20], Lasts Until Rollover, Last Available: "2015-05"
 Item	sphygmomanometer	Maximum HP: +60, HP Regen Min: 5, HP Regen Max: 10
 Item	spiky turtle shoulderpads	Damage Absorption: +75, Single Equip, Thorns: 2
 # spirit bell: Gain the favor of the Turtle Spirits more quickly
 Item	spirit bell	Muscle: +5, Mysticality: +5, Maximum HP: +10, Maximum MP: +10, Class: "Turtle Tamer"
 Item	spooky glove	Never Fumble, Moxie: +5, Spooky Damage: +5
-Item	Spookyraven signet	Spooky Resistance: +2, Stench Damage: +15, Stench Spell Damage: +15, Single Equip
+Item	Spookyraven signet	Spooky Resistance: +2, Stench Damage: +15, Stench Spell Damage: +15, Single Equip, Last Available: "2016-08"
 # spring shoes: Nature springs up after each step
-Item	spring shoes	Initiative: +100, Moxie Percent: +20, Critical Hit Percent: +50, Drops Items
-Item	stained glass spectacles	Experience (Mysticality): +3, Spooky Resistance: +3, Spooky Damage: +5, Single Equip
-Item	stained glass suspenders	Muscle Percent: +20, Hot Resistance: +3, Hot Damage: +5, Single Equip
+Item	spring shoes	Initiative: +100, Moxie Percent: +20, Critical Hit Percent: +50, Last Available: "2024-02", Drops Items
+Item	stained glass spectacles	Experience (Mysticality): +3, Spooky Resistance: +3, Spooky Damage: +5, Single Equip, Last Available: "2021-12"
+Item	stained glass suspenders	Muscle Percent: +20, Hot Resistance: +3, Hot Damage: +5, Single Equip, Last Available: "2021-12"
 Item	stainless steel scarf	Spell Damage: +20, Monster Level: +20, Mysticality Percent: +15, Single Equip
 Item	stainless steel solitaire	Mana Cost: -2, Adventures: +2, Mysticality Percent: +15, Single Equip
 Item	stainless steel suspenders	Damage Absorption: +60, Maximum MP: +40, Moxie Percent: +15, Single Equip
 Item	Star of Bravery	Maximum HP: +25, Maximum MP: +25, Single Equip
 # steel knuckles: +30 Damage to Unarmed Attacks
-Item	stick-on eyebrow piercing	Muscle: +1
-Item	sticky gloves	Pickpocket Chance: +20, Single Equip
+Item	stick-on eyebrow piercing	Muscle: +1, Last Available: "2008-04"
+Item	sticky gloves	Pickpocket Chance: +20, Single Equip, Last Available: "2011-05"
 Item	stinky cheese eye	Softcore Only, Meat Drop: [max(1,min(20,floor(pref(_stinkyCheeseCount)/5)))], Item Drop: [max(1,min(20,floor(pref(_stinkyCheeseCount)/5)))]
 # stinky fannypack: +40% Item Drops while on Vacation
 # stinky fannypack: (in any Elemental Airport area)
-Item	stinky fannypack	Stench Damage: +25, Stench Spell Damage: +25, Item Drop: [40*zone(Elemental International Airport)]
+Item	stinky fannypack	Stench Damage: +25, Stench Spell Damage: +25, Last Available: "2015-04", Item Drop: [40*zone(Elemental International Airport)]
 Item	stolen necklace	PvP Fights: +1, Spooky Damage: +5
 # strawberyl necklace: (only in the Candy Diorama)
-Item	strawberyl necklace	Spell Damage Percent: [200*zone(The Candy Diorama)], Single Equip
-Item	streetfighting champion's belt	Maximum HP: +40, Maximum MP: +40, HP Regen Min: 6, HP Regen Max: 8, MP Regen Min: 6, MP Regen Max: 8, Critical Hit Percent: +5, Single Equip
+Item	strawberyl necklace	Spell Damage Percent: [200*zone(The Candy Diorama)], Single Equip, Last Available: "2011-11"
+Item	streetfighting champion's belt	Maximum HP: +40, Maximum MP: +40, HP Regen Min: 6, HP Regen Max: 8, MP Regen Min: 6, MP Regen Max: 8, Critical Hit Percent: +5, Single Equip, Last Available: "2010-06"
 Item	string of blue beads	Mysticality: +1
 Item	string of green beads	Moxie: +1
-Item	string of moist beads	Pants Drop: +10
+Item	string of moist beads	Pants Drop: +10, Last Available: "2014-05"
 Item	string of red beads	Muscle: +1
 Item	stuffed carpenter	Synergetic
 # stuffed mink
@@ -3826,7 +3826,7 @@ Item	Superhero Reboots	Muscle: +5, Mysticality: +5, Moxie: +5, Initiative: +10
 Item	support cummerbund	Maximum HP: +20
 # surgical mask: Makes you look like a doctor
 Item	surgical mask	Maximum MP: +40, Surgeonosity: +1
-Item	sweat socks	Stench Damage: +5, Stench Spell Damage: +5, Sleaze Damage: +5, Sleaze Spell Damage: +5, Drops Items
+Item	sweat socks	Stench Damage: +5, Stench Spell Damage: +5, Sleaze Damage: +5, Sleaze Spell Damage: +5, Last Available: "2014-12", Drops Items
 Item	Talisman o' Namsilat	Muscle: +3, Mysticality: +3, Moxie: +3, Single Equip
 # Talisman of Baio: All Attributes Increase with Moonlight
 Item	Talisman of Baio	Muscle Percent: [+10*M], Mysticality Percent: [+10*M], Moxie Percent: [+10*M]
@@ -3839,98 +3839,98 @@ Item	tarrrnished charrrm bracelet	Stench Damage: +10, Stench Spell Damage: +10, 
 # teflon swim fins: Makes you a better diver
 Item	teflon swim fins	Moxie Percent: -5, Initiative: +25, Single Equip, Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)]
 # terra cotta tie tack: Lets you unleash a terra cotta army on your foes
-Item	terra cotta tie tack	Experience (Moxie): +3, Meat Drop: +20, Single Equip
+Item	terra cotta tie tack	Experience (Moxie): +3, Meat Drop: +20, Single Equip, Last Available: "2020-12"
 # terra cotta truss: Lets you unleash a terra cotta army on your foes
-Item	terra cotta truss	Experience (Muscle): +3, Initiative: +40, Single Equip
-Item	the Ley Incursion's waist	Mysticality: +15, Mysticality Percent: +25, Experience (Mysticality): +5, Single Equip
+Item	terra cotta truss	Experience (Muscle): +3, Initiative: +40, Single Equip, Last Available: "2020-12"
+Item	the Ley Incursion's waist	Mysticality: +15, Mysticality Percent: +25, Experience (Mysticality): +5, Single Equip, Last Available: "2018-04"
 Item	The Lost Glasses	Reduce Enemy Defense: 15, Hot Resistance: +2, Single Equip
-Item	The One Mood Ring	Muscle Percent: [5*G], Mysticality Percent: [5*G], Moxie Percent: [5*G], Monster Level: [25-5*G], Single Equip
+Item	The One Mood Ring	Muscle Percent: [5*G], Mysticality Percent: [5*G], Moxie Percent: [5*G], Monster Level: [25-5*G], Single Equip, Last Available: "2015-08"
 Item	The Ring	Muscle: +3, Mysticality: +3, Moxie: +3, Spooky Damage: +40, Single Equip
 # The Superconductor's CPU: (based on Crimbo 22 Elf Gratitude)
-Item	The Superconductor's CPU	Maximum HP: [floor(sqrt(pref(elfGratitude)))], Maximum MP: [floor(sqrt(pref(elfGratitude)))], Single Equip
+Item	The Superconductor's CPU	Maximum HP: [floor(sqrt(pref(elfGratitude)))], Maximum MP: [floor(sqrt(pref(elfGratitude)))], Single Equip, Last Available: "2022-12"
 Item	thicksilver ring	Damage Absorption: +30, Damage Reduction: 60, Single Equip
-Item	third ear	Initiative: +50, Single Equip
-Item	ticksilver ring	Adventures: +6, PvP Fights: +4, Single Equip
-Item	tie-dyed fannypack	Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2, Item Drop: +10, Single Equip
+Item	third ear	Initiative: +50, Single Equip, Last Available: "2021-12"
+Item	ticksilver ring	Adventures: +6, PvP Fights: +4, Single Equip, Last Available: "2016-02"
+Item	tie-dyed fannypack	Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2, Item Drop: +10, Single Equip, Last Available: "2016-08"
 # Time Bandit Badge of Courage: Proves your worth to the Time Bandits
 Item	Time Bandit Badge of Courage	Muscle Limit: 50, Mysticality Limit: 50, Moxie Limit: 50
-Item	time halo	Adventures: +5, Unarmed, Single Equip
+Item	time halo	Adventures: +5, Unarmed, Single Equip, Last Available: "2011-09"
 # Time Lord Badge of Honor: Proves your worth to the Time Lords
 Item	Time Lord Badge of Honor	Muscle Limit: 50, Mysticality Limit: 50, Moxie Limit: 50
 # time-twitching toolbelt: Reveals various Time-Forgotten Secrets
 # time-twitching toolbelt: (also in the Time-Twitching Tower)
 # time-twitching toolbelt	Muscle: +15, Mysticality: +15, Moxie: +15, Single Equip, Item Drop: [60*zone(Twitch)], Free Pull: [pref(timeTowerAvailable,true)]
 Item	time-twitching toolbelt	Muscle: +15, Mysticality: +15, Moxie: +15, Item Drop: [60*zone(Twitch)], Single Equip
-Item	tin star	Monster Level: +5, Moxie: +3
-Item	tiny die-cast arc-welding Elfborg	Meat Drop: +10
-Item	tiny die-cast Bashful the Reindeer	Sleaze Damage: +1
-Item	tiny die-cast blade a-spinning	Spooky Damage: +1, Stench Damage: +1, Hot Damage: +1, Cold Damage: +1, Sleaze Damage: +1
-Item	tiny die-cast CrimboTown Toy Factory	Hot Damage: +1
-Item	tiny die-cast death ray in a pear tree	Hot Damage: +2, Ranged Damage: +2
-Item	tiny die-cast Doc the Reindeer	HP Regen Min: 1, HP Regen Max: 2
-Item	tiny die-cast Don Crimbo	Moxie Percent: +5, Accessory Drop: +10
-Item	tiny die-cast Dopey the Reindeer	Weapon Damage: +2
-Item	tiny die-cast factory worker elf	Spell Damage Percent: +5
-Item	tiny die-cast Father Crimbo	Muscle: +5, Mysticality: +5, Moxie: +5, Food Drop: +10
-Item	tiny die-cast Father Crimborg	Mysticality Percent: +5, Hat Drop: +10
-Item	tiny die-cast gift-wrapping elf	Maximum HP: +5
-Item	tiny die-cast golden ring	Adventures: +2
-Item	tiny die-cast goose a-laying	Item Drop: +5
-Item	tiny die-cast Grumpy the Reindeer	Muscle: +1
-Item	tiny die-cast Happy the Reindeer	Cold Damage: +1
-Item	tiny die-cast killing bird	PvP Fights: +2
-Item	tiny die-cast middle-management elf	Booze Drop: +5
-Item	tiny die-cast pencil-pusher elf	Ranged Damage: +2
-Item	tiny die-cast ribbon-cutting Elfborg	Critical Hit Percent: +5
-Item	tiny die-cast Rudolphus of Crimborg	Muscle Percent: +5, Weapon Drop: +10
-Item	tiny die-cast Sleepy the Reindeer	Maximum MP: +3
-Item	tiny die-cast Sneezy the Reindeer	Stench Damage: +1
-Item	tiny die-cast stocking-stuffer elf	Mysticality: +1
-Item	tiny die-cast swarm a-swarming	Initiative: +20
-Item	tiny die-cast Swiss hen	Weapon Damage Percent: +10
-Item	tiny die-cast turtle mech	Familiar Weight: +2
-Item	tiny die-cast Uncle Hobo	HP Regen Min: 3, HP Regen Max: 5, MP Regen Min: 3, MP Regen Max: 5, Booze Drop: +10
-Item	tiny die-cast Unionize the Elves Sign	Monster Level: +1
-Item	tiny die-cast Zeppo the Reindeer	Spooky Damage: +1
-Item	tiny plastic &quot;Santa Claus&quot;	Muscle: +3, Mysticality: +3, Moxie: +3
+Item	tin star	Monster Level: +5, Moxie: +3, Last Available: "2007-05"
+Item	tiny die-cast arc-welding Elfborg	Meat Drop: +10, Last Available: "2013-12"
+Item	tiny die-cast Bashful the Reindeer	Sleaze Damage: +1, Last Available: "2013-12"
+Item	tiny die-cast blade a-spinning	Spooky Damage: +1, Stench Damage: +1, Hot Damage: +1, Cold Damage: +1, Sleaze Damage: +1, Last Available: "2013-12"
+Item	tiny die-cast CrimboTown Toy Factory	Hot Damage: +1, Last Available: "2013-12"
+Item	tiny die-cast death ray in a pear tree	Hot Damage: +2, Ranged Damage: +2, Last Available: "2013-12"
+Item	tiny die-cast Doc the Reindeer	HP Regen Min: 1, HP Regen Max: 2, Last Available: "2013-12"
+Item	tiny die-cast Don Crimbo	Moxie Percent: +5, Accessory Drop: +10, Last Available: "2013-12"
+Item	tiny die-cast Dopey the Reindeer	Weapon Damage: +2, Last Available: "2013-12"
+Item	tiny die-cast factory worker elf	Spell Damage Percent: +5, Last Available: "2013-12"
+Item	tiny die-cast Father Crimbo	Muscle: +5, Mysticality: +5, Moxie: +5, Food Drop: +10, Last Available: "2013-12"
+Item	tiny die-cast Father Crimborg	Mysticality Percent: +5, Hat Drop: +10, Last Available: "2013-12"
+Item	tiny die-cast gift-wrapping elf	Maximum HP: +5, Last Available: "2013-12"
+Item	tiny die-cast golden ring	Adventures: +2, Last Available: "2013-12"
+Item	tiny die-cast goose a-laying	Item Drop: +5, Last Available: "2013-12"
+Item	tiny die-cast Grumpy the Reindeer	Muscle: +1, Last Available: "2013-12"
+Item	tiny die-cast Happy the Reindeer	Cold Damage: +1, Last Available: "2013-12"
+Item	tiny die-cast killing bird	PvP Fights: +2, Last Available: "2013-12"
+Item	tiny die-cast middle-management elf	Booze Drop: +5, Last Available: "2013-12"
+Item	tiny die-cast pencil-pusher elf	Ranged Damage: +2, Last Available: "2013-12"
+Item	tiny die-cast ribbon-cutting Elfborg	Critical Hit Percent: +5, Last Available: "2013-12"
+Item	tiny die-cast Rudolphus of Crimborg	Muscle Percent: +5, Weapon Drop: +10, Last Available: "2013-12"
+Item	tiny die-cast Sleepy the Reindeer	Maximum MP: +3, Last Available: "2013-12"
+Item	tiny die-cast Sneezy the Reindeer	Stench Damage: +1, Last Available: "2013-12"
+Item	tiny die-cast stocking-stuffer elf	Mysticality: +1, Last Available: "2013-12"
+Item	tiny die-cast swarm a-swarming	Initiative: +20, Last Available: "2013-12"
+Item	tiny die-cast Swiss hen	Weapon Damage Percent: +10, Last Available: "2013-12"
+Item	tiny die-cast turtle mech	Familiar Weight: +2, Last Available: "2013-12"
+Item	tiny die-cast Uncle Hobo	HP Regen Min: 3, HP Regen Max: 5, MP Regen Min: 3, MP Regen Max: 5, Booze Drop: +10, Last Available: "2013-12"
+Item	tiny die-cast Unionize the Elves Sign	Monster Level: +1, Last Available: "2013-12"
+Item	tiny die-cast Zeppo the Reindeer	Spooky Damage: +1, Last Available: "2013-12"
+Item	tiny plastic &quot;Santa Claus&quot;	Muscle: +3, Mysticality: +3, Moxie: +3, Last Available: "2024-12"
 Item	tiny plastic 7-foot dwarf	Monster Level: +1
-Item	tiny plastic 11 Dealer	Meat Drop: +4
-Item	tiny plastic abominable fudgeman	Weapon Damage: +10
-Item	tiny plastic Abuela Crimbo	Spooky Resistance: +1
+Item	tiny plastic 11 Dealer	Meat Drop: +4, Last Available: "2009-12"
+Item	tiny plastic abominable fudgeman	Weapon Damage: +10, Last Available: "2011-12"
+Item	tiny plastic Abuela Crimbo	Spooky Resistance: +1, Last Available: "2018-12"
 Item	tiny plastic Abuela's cottage	Muscle: +3, Mysticality: +3, Moxie: +3
 Item	tiny plastic accordion thief	Moxie: +2, Mysticality: +1
-Item	tiny plastic ambulatory robo-minecart	Moxie: +1
-Item	tiny plastic Ancient Unspeakable Bugbear	Monster Level: +1
-Item	tiny plastic ancient yuletide troll	Familiar Weight: +1
+Item	tiny plastic ambulatory robo-minecart	Moxie: +1, Last Available: "2014-12"
+Item	tiny plastic Ancient Unspeakable Bugbear	Monster Level: +1, Last Available: "2012-12"
+Item	tiny plastic ancient yuletide troll	Familiar Weight: +1, Last Available: "2006-12"
 Item	tiny plastic angry bugbear	Monster Level: +1
 Item	tiny plastic angry goat	Familiar Weight: +1
-Item	tiny plastic angry space marine	Monster Level: +1
-Item	tiny plastic angry vikings	Weapon Damage: +10
+Item	tiny plastic angry space marine	Monster Level: +1, Last Available: "2012-12"
+Item	tiny plastic angry vikings	Weapon Damage: +10, Last Available: "2016-12"
 Item	tiny plastic anime smiley	Monster Level: +1
-Item	tiny plastic animelf	Initiative: +5
+Item	tiny plastic animelf	Initiative: +5, Last Available: "2012-12"
 Item	tiny plastic apathetic lizardman	Monster Level: +1
 Item	tiny plastic Armory	Weapon Damage: +3
 Item	tiny plastic astronomer	Monster Level: +1
 Item	tiny plastic Axe Wound	Monster Level: +1
 Item	tiny plastic baby gravy fairy	Familiar Weight: +1
-Item	tiny plastic bad vibe	Monster Level: +2
+Item	tiny plastic bad vibe	Monster Level: +2, Last Available: "2016-12"
 Item	tiny plastic Bar	Booze Drop: +3
 Item	tiny plastic Baron von Ratsworth	Meat Drop: +3
 Item	tiny plastic barrrnacle	Familiar Weight: +1
-Item	tiny plastic batbugbear	Monster Level: +1
-Item	tiny plastic Battlesuit Bugbear Type	Muscle: +3
+Item	tiny plastic batbugbear	Monster Level: +1, Last Available: "2012-12"
+Item	tiny plastic Battlesuit Bugbear Type	Muscle: +3, Last Available: "2012-12"
 Item	tiny plastic beanbat	Monster Level: +1
-Item	tiny plastic bee swarm	Monster Level: +1
-Item	tiny plastic beebee gunners	Monster Level: +1
-Item	tiny plastic Beebee King	Initiative: +5
-Item	tiny plastic beebee queue	Monster Level: +1
+Item	tiny plastic bee swarm	Monster Level: +1, Last Available: "2012-12"
+Item	tiny plastic beebee gunners	Monster Level: +1, Last Available: "2012-12"
+Item	tiny plastic Beebee King	Initiative: +5, Last Available: "2012-12"
+Item	tiny plastic beebee queue	Monster Level: +1, Last Available: "2012-12"
 Item	tiny plastic Beelzebozo	Sleaze Damage: +5
-Item	tiny plastic Best Game Ever	Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5
-Item	tiny plastic Big Candy	Muscle: +3, Mysticality: +3, Moxie: +3, Maximum HP: +3, Maximum MP: +3
+Item	tiny plastic Best Game Ever	Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Last Available: "2010-12"
+Item	tiny plastic Big Candy	Muscle: +3, Mysticality: +3, Moxie: +3, Maximum HP: +3, Maximum MP: +3, Last Available: "2011-12"
 Item	tiny plastic bitchin' meatcar	Adventures: +1, Single Equip
 Item	tiny plastic Black Knight	Monster Level: +1
-Item	tiny plastic black ops bugbear	Monster Level: +1
-Item	tiny plastic blazing bat	Monster Level: +1
+Item	tiny plastic black ops bugbear	Monster Level: +1, Last Available: "2012-12"
+Item	tiny plastic blazing bat	Monster Level: +1, Last Available: "2012-12"
 Item	tiny plastic blood-faced volleyball	Familiar Weight: +1
 Item	tiny plastic blooper	Monster Level: +1
 Item	tiny plastic Bonerdagon	Mysticality: +3
@@ -3938,216 +3938,216 @@ Item	tiny plastic Boris	Muscle: +5, Mysticality: +3, Moxie: +3
 Item	tiny plastic Boss Bat	Maximum HP: +5
 Item	tiny plastic brainsweeper	Monster Level: +1
 Item	tiny plastic briefcase bat	Monster Level: +1
-Item	tiny plastic bugaboo	Monster Level: +1
-Item	tiny plastic Bugbear Captain	Maximum HP: +20, Maximum MP: +20, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4, Single Equip
-Item	tiny plastic buzzerker	Monster Level: +1
+Item	tiny plastic bugaboo	Monster Level: +1, Last Available: "2012-12"
+Item	tiny plastic Bugbear Captain	Maximum HP: +20, Maximum MP: +20, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4, Single Equip, Last Available: "2012-12"
+Item	tiny plastic buzzerker	Monster Level: +1, Last Available: "2012-12"
 Item	tiny plastic caboose	Damage Reduction: 3
-Item	tiny plastic Caf&eacute; Elf	Hot Resistance: +1
+Item	tiny plastic Caf&eacute; Elf	Hot Resistance: +1, Last Available: "2018-12"
 Item	tiny plastic Cafe	Food Drop: +3
 Item	tiny plastic Captain Kerkard	Monster Level: +1
-Item	tiny plastic cavebugbear	Monster Level: +1
-Item	tiny plastic Charity the Zombie Hunter	Monster Level: +1
-Item	tiny plastic Cheer Core	Experience: +1, Single Equip
-Item	tiny plastic chem lab	Spleen Drop: +20, Single Equip
+Item	tiny plastic cavebugbear	Monster Level: +1, Last Available: "2012-12"
+Item	tiny plastic Charity the Zombie Hunter	Monster Level: +1, Last Available: "2012-12"
+Item	tiny plastic Cheer Core	Experience: +1, Single Equip, Last Available: "2021-12"
+Item	tiny plastic chem lab	Spleen Drop: +20, Single Equip, Last Available: "2021-12"
 Item	tiny plastic Cheshire bat	Familiar Weight: +1
-Item	tiny plastic ChibiBuddy&trade;	Familiar Weight: +2
-Item	tiny plastic chunk of depleted Grimacite	HP Regen Min: 1, HP Regen Max: 2, MP Regen Min: 1, MP Regen Max: 2
-Item	tiny plastic Clancy the Minstrel	HP Regen Min: 1, HP Regen Max: 2, MP Regen Min: 1, MP Regen Max: 2
-Item	tiny plastic coal car	Hot Damage: +5, Hot Spell Damage: +5
+Item	tiny plastic ChibiBuddy&trade;	Familiar Weight: +2, Last Available: "2012-12"
+Item	tiny plastic chunk of depleted Grimacite	HP Regen Min: 1, HP Regen Max: 2, MP Regen Min: 1, MP Regen Max: 2, Last Available: "2008-12"
+Item	tiny plastic Clancy the Minstrel	HP Regen Min: 1, HP Regen Max: 2, MP Regen Min: 1, MP Regen Max: 2, Last Available: "2012-12"
+Item	tiny plastic coal car	Hot Damage: +5, Hot Spell Damage: +5, Last Available: "2022-12"
 Item	tiny plastic cocoabo	Familiar Weight: +1
 Item	tiny plastic coffee pixie	Familiar Weight: +1
-Item	tiny plastic colollilossus	HP Regen Min: 3, HP Regen Max: 5
-Item	tiny plastic Colonel Brando	Spooky Damage: +3, Spooky Spell Damage: +3
+Item	tiny plastic colollilossus	HP Regen Min: 3, HP Regen Max: 5, Last Available: "2011-12"
+Item	tiny plastic Colonel Brando	Spooky Damage: +3, Spooky Spell Damage: +3, Last Available: "2024-12"
 Item	tiny plastic conservationist hippy	Stench Damage: +5
-Item	tiny plastic CRIMBCO HQ	Item Drop: +4
-Item	tiny plastic Crimbo caroler	Familiar Weight: +3
-Item	tiny plastic Crimbo Casino	Meat Drop: +4
-Item	tiny plastic Crimbo cheer	Familiar Weight: +3
-Item	tiny plastic Crimbo elf	Familiar Weight: +1
-Item	tiny plastic Crimbo reindeer	Adventures: +1, Single Equip
-Item	tiny plastic Crimbo wreath	MP Regen Min: 1, MP Regen Max: 2, Single Equip
-Item	tiny plastic Crimbodhisattva	Stench Resistance: +2
-Item	tiny plastic Crimbomega	Muscle: +1, Mysticality: +1, Moxie: +1
-Item	tiny plastic Crimbomination	Spooky Damage: +1, Stench Damage: +1, Hot Damage: +1, Cold Damage: +1, Sleaze Damage: +1
-Item	tiny plastic Crimborgatron	Sleaze Resistance: +2
-Item	tiny plastic Crimbot	Monster Level: +1
-Item	tiny plastic Crimboween pentagram	MP Regen Min: 1, MP Regen Max: 2, Single Equip
+Item	tiny plastic CRIMBCO HQ	Item Drop: +4, Last Available: "2010-12"
+Item	tiny plastic Crimbo caroler	Familiar Weight: +3, Last Available: "2020-12"
+Item	tiny plastic Crimbo Casino	Meat Drop: +4, Last Available: "2009-12"
+Item	tiny plastic Crimbo cheer	Familiar Weight: +3, Last Available: "2020-12"
+Item	tiny plastic Crimbo elf	Familiar Weight: +1, Last Available: "2005-12"
+Item	tiny plastic Crimbo reindeer	Adventures: +1, Single Equip, Last Available: "2005-12"
+Item	tiny plastic Crimbo wreath	MP Regen Min: 1, MP Regen Max: 2, Single Equip, Last Available: "2005-12"
+Item	tiny plastic Crimbodhisattva	Stench Resistance: +2, Last Available: "2015-12"
+Item	tiny plastic Crimbomega	Muscle: +1, Mysticality: +1, Moxie: +1, Last Available: "2014-12"
+Item	tiny plastic Crimbomination	Spooky Damage: +1, Stench Damage: +1, Hot Damage: +1, Cold Damage: +1, Sleaze Damage: +1, Last Available: "2009-12"
+Item	tiny plastic Crimborgatron	Sleaze Resistance: +2, Last Available: "2015-12"
+Item	tiny plastic Crimbot	Monster Level: +1, Last Available: "2014-12"
+Item	tiny plastic Crimboween pentagram	MP Regen Min: 1, MP Regen Max: 2, Single Equip, Last Available: "2006-12"
 Item	tiny plastic cubist bull	Monster Level: +1
 Item	tiny plastic demoninja	Monster Level: +1
-Item	tiny plastic dining car	Food Drop: +10
+Item	tiny plastic dining car	Food Drop: +10, Last Available: "2022-12"
 Item	tiny plastic disco bandit	Moxie: +2, Muscle: +1
-Item	tiny plastic Dolph Bossin	Experience (familiar): +1
-Item	tiny plastic dolphin &quot;orphan&quot;	Familiar Weight: +3, Single Equip
-Item	tiny plastic Don Crimbo	Weapon Damage Percent: +5
+Item	tiny plastic Dolph Bossin	Experience (familiar): +1, Last Available: "2019-12"
+Item	tiny plastic dolphin &quot;orphan&quot;	Familiar Weight: +3, Single Equip, Last Available: "2019-12"
+Item	tiny plastic Don Crimbo	Weapon Damage Percent: +5, Last Available: "2009-12"
 Item	tiny plastic Dr. Awkward	Never Fumble
 Item	tiny plastic drunk goat	Monster Level: +1
 Item	tiny plastic Duke Starkiller	Monster Level: +1
-Item	tiny plastic Easter Island Bunny	Damage Reduction: 3
+Item	tiny plastic Easter Island Bunny	Damage Reduction: 3, Last Available: "2024-12"
 Item	tiny plastic Ed the Undying	Maximum HP: +30, Damage Absorption: +30
-Item	tiny plastic exo-suited miner	Muscle: +1
+Item	tiny plastic exo-suited miner	Muscle: +1, Last Available: "2014-12"
 Item	tiny plastic Factory	Initiative: +3
-Item	tiny plastic fat stack of cash	Meat Drop: +3
-Item	tiny plastic Father McGruber	Monster Level: +1
-Item	tiny plastic fax machine	Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2
+Item	tiny plastic fat stack of cash	Meat Drop: +3, Last Available: "2008-12"
+Item	tiny plastic Father McGruber	Monster Level: +1, Last Available: "2012-12"
+Item	tiny plastic fax machine	Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2, Last Available: "2010-12"
 Item	tiny plastic Felonia	Spooky Damage: +5
 Item	tiny plastic fiendish can of asparagus	Monster Level: +1
 Item	tiny plastic filthy hippy jewelry maker	Monster Level: +1
-Item	tiny plastic fire servant	Hot Spell Damage: +5
+Item	tiny plastic fire servant	Hot Spell Damage: +5, Last Available: "2012-12"
 Item	tiny plastic fluffy bunny	Monster Level: +1
-Item	tiny plastic food lab	Food Drop: +20, Single Equip
-Item	tiny plastic four-shadowed mime	Monster Level: +20, Spooky Damage: +50, Spooky Spell Damage: +50, Single Equip
+Item	tiny plastic food lab	Food Drop: +20, Single Equip, Last Available: "2021-12"
+Item	tiny plastic four-shadowed mime	Monster Level: +20, Spooky Damage: +50, Spooky Spell Damage: +50, Single Equip, Last Available: "2012-12"
 Item	tiny plastic fruit golem	Monster Level: +1
-Item	tiny plastic Fudge Wizard	Spell Damage: +10
+Item	tiny plastic Fudge Wizard	Spell Damage: +10, Last Available: "2011-12"
 Item	tiny plastic fuzzy dice	Familiar Weight: +1
 Item	tiny plastic G Imp	Monster Level: +1
-Item	tiny plastic Gaia'ajh-dsli Ak'lwej	Spooky Resistance: +2
+Item	tiny plastic Gaia'ajh-dsli Ak'lwej	Spooky Resistance: +2, Last Available: "2015-12"
 Item	tiny plastic Gary Claybender	Monster Level: +1
 Item	tiny plastic ghost pickle on a stick	Familiar Weight: +1
 Item	tiny plastic ghuol whelp	Familiar Weight: +1
 Item	tiny plastic giant pair of tweezers	Monster Level: +1
-Item	tiny plastic gift-wrapping vampire	Familiar Weight: +1
+Item	tiny plastic gift-wrapping vampire	Familiar Weight: +1, Last Available: "2006-12"
 Item	tiny plastic Gnollish crossdresser	Monster Level: +1
 Item	tiny plastic Gnomester Blomester	Monster Level: +1
-Item	tiny plastic golden gundam	Adventures: +1, PvP Fights: +1, Muscle: +1, Mysticality: +1, Moxie: +1
-Item	tiny plastic GORM-8	Food Drop: +10
+Item	tiny plastic golden gundam	Adventures: +1, PvP Fights: +1, Muscle: +1, Mysticality: +1, Moxie: +1, Last Available: "2017-06"
+Item	tiny plastic GORM-8	Food Drop: +10, Last Available: "2013-12"
 Item	tiny plastic goth giant	Monster Level: +1
 Item	tiny plastic grue	Familiar Weight: +1
 Item	tiny plastic handsome mariachi	Monster Level: +1
-Item	tiny plastic Hank North, Photojournalist	Monster Level: +1
+Item	tiny plastic Hank North, Photojournalist	Monster Level: +1, Last Available: "2012-12"
 Item	tiny plastic Hellion	Monster Level: +1
 Item	tiny plastic hermit	Meat Drop: +6
-Item	tiny plastic hobo elf	Meat Drop: +4
+Item	tiny plastic hobo elf	Meat Drop: +4, Last Available: "2010-12"
 Item	tiny plastic howling balloon monkey	Familiar Weight: +1
-Item	tiny plastic hypodermic bugbear	Monster Level: +1
+Item	tiny plastic hypodermic bugbear	Monster Level: +1, Last Available: "2012-12"
 Item	tiny plastic Iiti Kitty	Monster Level: +1
 Item	tiny plastic Jared the Duskwalker	Monster Level: +1
 Item	tiny plastic Jarlsberg	Mysticality: +5, Muscle: +3, Moxie: +3
-Item	tiny plastic Jedediah and Boiling Cloud	Weapon Damage: +3
-Item	tiny plastic K.R.A.M.P.U.S.	Weapon Damage: +5, Spooky Damage: +1, Stench Damage: +1, Hot Damage: +1, Cold Damage: +1, Sleaze Damage: +1
+Item	tiny plastic Jedediah and Boiling Cloud	Weapon Damage: +3, Last Available: "2024-12"
+Item	tiny plastic K.R.A.M.P.U.S.	Weapon Damage: +5, Spooky Damage: +1, Stench Damage: +1, Hot Damage: +1, Cold Damage: +1, Sleaze Damage: +1, Last Available: "2013-12"
 Item	tiny plastic killer bee	Familiar Weight: +1
 Item	tiny plastic Knob Goblin bean counter	Monster Level: +1
 Item	tiny plastic Knob Goblin harem girl	Monster Level: +1
 Item	tiny plastic Knob Goblin King	Muscle: +3
 Item	tiny plastic Knob Goblin mad scientist	Monster Level: +1
 Item	tiny plastic Knott Yeti	Monster Level: +1
-Item	tiny plastic Knows About Chakras	Spell Damage: +10
-Item	tiny plastic Krampus	PvP Fights: +1
+Item	tiny plastic Knows About Chakras	Spell Damage: +10, Last Available: "2016-12"
+Item	tiny plastic Krampus	PvP Fights: +1, Last Available: "2016-12"
 Item	tiny plastic lemon-in-the-box	Monster Level: +1
 Item	tiny plastic leprechaun	Familiar Weight: +1
 Item	tiny plastic levitating potato	Familiar Weight: +1
 Item	tiny plastic lobsterfrogman	Monster Level: +1
-Item	tiny plastic locomotive	Initiative: +10
-Item	tiny plastic Lord Flameface	Hot Damage: +20, Cold Resistance: +1, Single Equip
+Item	tiny plastic locomotive	Initiative: +10, Last Available: "2022-12"
+Item	tiny plastic Lord Flameface	Hot Damage: +20, Cold Resistance: +1, Single Equip, Last Available: "2012-12"
 Item	tiny plastic Lord Spookyraven	Maximum MP: +30, Spell Damage: +10
-Item	tiny plastic MechaElf	Monster Level: +4
-Item	tiny plastic Mer-kin baker	Familiar Weight: +1
-Item	tiny plastic mime executive	Meat Drop: +4
-Item	tiny plastic mime functionary	Moxie: +2
-Item	tiny plastic mime scientist	Mysticality: +2
-Item	tiny plastic mime soldier	Muscle: +2
-Item	tiny plastic Mirth	Adventures: +3
-Item	tiny plastic Mob Penguin	Weapon Damage: +3
-Item	tiny plastic moneybee	Monster Level: +1
+Item	tiny plastic MechaElf	Monster Level: +4, Last Available: "2012-12"
+Item	tiny plastic Mer-kin baker	Familiar Weight: +1, Last Available: "2019-12"
+Item	tiny plastic mime executive	Meat Drop: +4, Last Available: "2017-12"
+Item	tiny plastic mime functionary	Moxie: +2, Last Available: "2017-12"
+Item	tiny plastic mime scientist	Mysticality: +2, Last Available: "2017-12"
+Item	tiny plastic mime soldier	Muscle: +2, Last Available: "2017-12"
+Item	tiny plastic Mirth	Adventures: +3, Last Available: "2020-12"
+Item	tiny plastic Mob Penguin	Weapon Damage: +3, Last Available: "2008-12"
+Item	tiny plastic moneybee	Monster Level: +1, Last Available: "2012-12"
 Item	tiny plastic mosquito	Familiar Weight: +1
-Item	tiny plastic Mr. Mination	Monster Level: +4
-Item	tiny plastic multi-level marketer	Familiar Weight: +3
-Item	tiny plastic mumblebee	Monster Level: +1
-Item	tiny plastic mutant elf	Maximum HP: +3, Maximum MP: +3
+Item	tiny plastic Mr. Mination	Monster Level: +4, Last Available: "2010-12"
+Item	tiny plastic multi-level marketer	Familiar Weight: +3, Last Available: "2020-12"
+Item	tiny plastic mumblebee	Monster Level: +1, Last Available: "2012-12"
+Item	tiny plastic mutant elf	Maximum HP: +3, Maximum MP: +3, Last Available: "2008-12"
 Item	tiny plastic Naughty Sorceress	Spell Damage Percent: +100, Maximum MP: +100
 Item	tiny plastic ninja snowman	Monster Level: +1
-Item	tiny plastic nog lab	Booze Drop: +20, Single Equip
-Item	tiny plastic Norville Rogers	Monster Level: +1
+Item	tiny plastic nog lab	Booze Drop: +20, Single Equip, Last Available: "2021-12"
+Item	tiny plastic Norville Rogers	Monster Level: +1, Last Available: "2012-12"
 Item	tiny plastic Orcish Frat Boy	Monster Level: +1
-Item	tiny plastic orphan	Stench Resistance: +1
-Item	tiny plastic passenger car	Familiar Weight: +3
+Item	tiny plastic orphan	Stench Resistance: +1, Last Available: "2018-12"
+Item	tiny plastic passenger car	Familiar Weight: +3, Last Available: "2022-12"
 Item	tiny plastic pastamancer	Mysticality: +2, Muscle: +1
-Item	tiny plastic peacannon	Ranged Damage: +5
-Item	tiny plastic Penny	Meat Drop: +10
-Item	tiny plastic primary lab	Potion Drop: +20, Single Equip
+Item	tiny plastic peacannon	Ranged Damage: +5, Last Available: "2012-12"
+Item	tiny plastic Penny	Meat Drop: +10, Last Available: "2020-12"
+Item	tiny plastic primary lab	Potion Drop: +20, Single Equip, Last Available: "2021-12"
 Item	tiny plastic Professor What	Monster Level: +1
 Item	tiny plastic Protagonist	Monster Level: +1
 Item	tiny plastic protector spectre	Spooky Damage: +10
-Item	tiny plastic Queen Bee	Maximum HP: +10
-Item	tiny plastic reindeer	Cold Resistance: +1
-Item	tiny plastic Rene C. Corman	Mysticality Percent: +5, Spell Damage Percent: +25, Single Equip
-Item	tiny plastic Rudolph the Red	Hot Resistance: +2
+Item	tiny plastic Queen Bee	Maximum HP: +10, Last Available: "2012-12"
+Item	tiny plastic reindeer	Cold Resistance: +1, Last Available: "2018-12"
+Item	tiny plastic Rene C. Corman	Mysticality Percent: +5, Spell Damage Percent: +25, Single Equip, Last Available: "2012-12"
+Item	tiny plastic Rudolph the Red	Hot Resistance: +2, Last Available: "2015-12"
 Item	tiny plastic sabre-toothed lime	Familiar Weight: +1
 Item	tiny plastic sauceror	Mysticality: +2, Moxie: +1
 Item	tiny plastic scary clown	Monster Level: +1
-Item	tiny plastic Scott the Miner	Monster Level: +1
-Item	tiny plastic Scream Queen	Muscle: +1, Mysticality: +1, Moxie: +1
-Item	tiny plastic sea elf	Familiar Weight: +2
+Item	tiny plastic Scott the Miner	Monster Level: +1, Last Available: "2012-12"
+Item	tiny plastic Scream Queen	Muscle: +1, Mysticality: +1, Moxie: +1, Last Available: "2006-12"
+Item	tiny plastic sea elf	Familiar Weight: +2, Last Available: "2019-12"
 Item	tiny plastic seal clubber	Muscle: +2, Moxie: +1
-Item	tiny plastic semi-autonomous drill unit	Mysticality: +1
+Item	tiny plastic semi-autonomous drill unit	Mysticality: +1, Last Available: "2014-12"
 Item	tiny plastic senile lihc	Monster Level: +1
-Item	tiny plastic skeletal reindeer	Adventures: +1, Single Equip
+Item	tiny plastic skeletal reindeer	Adventures: +1, Single Equip, Last Available: "2006-12"
 Item	tiny plastic smarmy pirate	Monster Level: +1
 Item	tiny plastic Sneaky Pete	Moxie: +5, Muscle: +3, Mysticality: +3
 Item	tiny plastic Spam Witch	Monster Level: +1
-Item	tiny plastic spiderbugbear	Spooky Damage: +5
+Item	tiny plastic spiderbugbear	Spooky Damage: +5, Last Available: "2012-12"
 Item	tiny plastic spiny skelelton	Monster Level: +1
 Item	tiny plastic spooky pirate skeleton	Familiar Weight: +1
 Item	tiny plastic spooky vampire	Monster Level: +1
 Item	tiny plastic Spunky Princess	Monster Level: +1
-Item	tiny plastic St. Patrick	Familiar Weight: +1
+Item	tiny plastic St. Patrick	Familiar Weight: +1, Last Available: "2024-12"
 Item	tiny plastic stab bat	Familiar Weight: +1
 Item	tiny plastic star starfish	Familiar Weight: +1
-Item	tiny plastic stocking mimic	Candy Drop: +10
-Item	tiny plastic strand of DNA	Muscle: +3, Mysticality: +3, Moxie: +3
+Item	tiny plastic stocking mimic	Candy Drop: +10, Last Available: "2009-12"
+Item	tiny plastic strand of DNA	Muscle: +3, Mysticality: +3, Moxie: +3, Last Available: "2008-12"
 Item	tiny plastic Susie	Muscle: +5, Mysticality: +5, Moxie: +5
-Item	tiny plastic sweet nutcracker	Familiar Weight: +1
+Item	tiny plastic sweet nutcracker	Familiar Weight: +1, Last Available: "2005-12"
 Item	tiny plastic taco cat	Monster Level: +1
-Item	tiny plastic taco-clad Crimbo elf	Muscle: +1, Mysticality: +1, Moxie: +1
-Item	tiny plastic Tammy the Tambourine Elf	Cold Resistance: +2
+Item	tiny plastic taco-clad Crimbo elf	Muscle: +1, Mysticality: +1, Moxie: +1, Last Available: "2012-12"
+Item	tiny plastic Tammy the Tambourine Elf	Cold Resistance: +2, Last Available: "2015-12"
 Item	tiny plastic The Big Wisniewski	Food Drop: +3
-Item	tiny plastic the Free Man	Mysticality: +5
+Item	tiny plastic the Free Man	Mysticality: +5, Last Available: "2012-12"
 Item	tiny plastic The Man	Meat Drop: +3
-Item	tiny plastic The Silent Nightmare	Muscle Percent: +4, Mysticality Percent: +4, Moxie Percent: +4
+Item	tiny plastic The Silent Nightmare	Muscle Percent: +4, Mysticality Percent: +4, Moxie Percent: +4, Last Available: "2017-12"
 Item	tiny plastic topiary golem	Monster Level: +1
-Item	tiny plastic Toybot	Accessory Drop: +10
-Item	tiny plastic trollipop	Monster Level: +5
+Item	tiny plastic Toybot	Accessory Drop: +10, Last Available: "2013-12"
+Item	tiny plastic trollipop	Monster Level: +5, Last Available: "2011-12"
 Item	tiny plastic Trouser Snake	Monster Level: +1
 Item	tiny plastic turtle tamer	Muscle: +2, Mysticality: +1
-Item	tiny plastic Uncle Crimbo	Muscle: +1, Mysticality: +1, Moxie: +1
-Item	tiny plastic Uncle Crimboku	Meat Drop: +5
+Item	tiny plastic Uncle Crimbo	Muscle: +1, Mysticality: +1, Moxie: +1, Last Available: "2005-12"
+Item	tiny plastic Uncle Crimboku	Meat Drop: +5, Last Available: "2012-12"
 Item	tiny plastic undead elbow macaroni	Monster Level: +1
-Item	tiny plastic warbear	Weapon Damage: +5
-Item	tiny plastic warbear fortress	Muscle: +3, Mysticality: +3, Moxie: +3
+Item	tiny plastic warbear	Weapon Damage: +5, Last Available: "2013-12"
+Item	tiny plastic warbear fortress	Muscle: +3, Mysticality: +3, Moxie: +3, Last Available: "2013-12"
 Item	tiny plastic warwelf	Monster Level: +1
 Item	tiny plastic whitesnake	Monster Level: +1
-Item	tiny plastic wild beaver	Sleaze Resistance: +1
-Item	tiny plastic Wu Tang the Betrayer	Weapon Damage: +5
+Item	tiny plastic wild beaver	Sleaze Resistance: +1, Last Available: "2018-12"
+Item	tiny plastic Wu Tang the Betrayer	Weapon Damage: +5, Last Available: "2012-12"
 Item	tiny plastic XXX pr0n	Monster Level: +1
-Item	tiny plastic Your Brain	MP Regen Min: 3, MP Regen Max: 4
-Item	tiny plastic yuleviathan	Familiar Damage: +5
+Item	tiny plastic Your Brain	MP Regen Min: 3, MP Regen Max: 4, Last Available: "2016-12"
+Item	tiny plastic yuleviathan	Familiar Damage: +5, Last Available: "2019-12"
 Item	tiny plastic zmobie	Monster Level: +1
 Item	tonguebone	Sleaze Resistance: +4, Single Equip
 Item	topiary necktie	Sleaze Resistance: +3
 Item	torquoise ring	Moxie: +3, MP Regen Min: 2, MP Regen Max: 3, Single Equip
 Item	tortoboggan	Moxie: +4, Initiative: +20, Single Equip
 # tourmalime tourniquet: Makes Candy Diorama Fights Harder
-Item	tourmalime tourniquet	Single Equip
-Item	toy crazy train	Meat Drop: +10, Single Equip
-Item	toy maglev monorail	Meat Drop: +10, Single Equip
-Item	toy train	Meat Drop: +10, Single Equip
+Item	tourmalime tourniquet	Single Equip, Last Available: "2011-11"
+Item	toy crazy train	Meat Drop: +10, Single Equip, Last Available: "2006-12"
+Item	toy maglev monorail	Meat Drop: +10, Single Equip, Last Available: "2007-12"
+Item	toy train	Meat Drop: +10, Single Equip, Last Available: "2005-12"
 # Trainbot luggage hook: Find extra elf luggage in the Crimbo Train Passenger Car
 Item	Trainbot luggage hook	Single Equip
 # Trainbot radar monocle: Get more items from Trainbots
 Item	Trainbot radar monocle	Single Equip
-Item	training belt	Weapon Damage Percent: -50, Monster Level: +25, Muscle Percent: +25, Single Equip
-Item	training legwarmers	Spell Damage Percent: -50, Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Mysticality Percent: +25, Single Equip
+Item	training belt	Weapon Damage Percent: -50, Monster Level: +25, Muscle Percent: +25, Single Equip, Last Available: "2016-01"
+Item	training legwarmers	Spell Damage Percent: -50, Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Mysticality Percent: +25, Single Equip, Last Available: "2016-01"
 Item	Treads of Loathing	Adventures: +6, PvP Fights: +6, Sleaze Resistance: +5, Single Equip, Cloathing
-Item	treasure chest key	Item Drop: +30, Meat Drop: +30
+Item	treasure chest key	Item Drop: +30, Meat Drop: +30, Last Available: "2020-08"
 Item	tube sock	Moxie: +20, Single Equip
 Item	Uncle Buck	Maximum HP: +15, Softcore Only
-Item	Uncle Hobo's belt	Mysticality Percent: +15, Meat Drop: +25, Single Equip
-Item	Uncle Hobo's epic beard	Muscle Percent: +20, Single Equip, Adventures: [6+(3*event(December))]
-Item	Uncle Hobo's fingerless tinsel gloves	Moxie Percent: +15, PvP Fights: +5, Single Equip
+Item	Uncle Hobo's belt	Mysticality Percent: +15, Meat Drop: +25, Single Equip, Last Available: "2010-12"
+Item	Uncle Hobo's epic beard	Muscle Percent: +20, Single Equip, Last Available: "2010-12", Adventures: [6+(3*event(December))]
+Item	Uncle Hobo's fingerless tinsel gloves	Moxie Percent: +15, PvP Fights: +5, Single Equip, Last Available: "2010-12"
 Item	uncursed bat paw	Monster Level: -25
 Item	uncursed dragon wishbone	Item Drop: +25
 Item	uncursed medallion	Initiative: +25
 Item	Unspeakable Earring	Cold Resistance: +3, Sleaze Resistance: +3, Single Equip
-Item	Unstable Pointy Ears	Experience: +3, Lasts Until Rollover
+Item	Unstable Pointy Ears	Experience: +3, Lasts Until Rollover, Last Available: "2016-09"
 Item	Uranium Omega of Temperance	Muscle: +5, Mysticality: +5, Moxie: +5, Item Drop: +11, Single Equip
 Item	UV monocular	Item Drop: +5, Single Equip
 # V for Vivala mask: +1-3 Stat(s) per Fight
@@ -4161,94 +4161,94 @@ Item	vampire pearl necklace	HP Regen Min: 6, HP Regen Max: 18, Single Equip
 Item	vampire pearl ring	HP Regen Min: 2, HP Regen Max: 10, MP Regen Min: 2, MP Regen Max: 10, Single Equip
 Item	velcro boots	Mysticality Percent: +10, MP Regen Min: 12, MP Regen Max: 24, Initiative: -50, Single Equip
 # velour vambraces: Triples the damage of Spectral Snapper
-Item	velour vambraces	Muscle: +10, Candy Drop: +30, Single Equip
+Item	velour vambraces	Muscle: +10, Candy Drop: +30, Single Equip, Last Available: "2021-12"
 # velour veil: Triples the damage of Fearful Fettucini
-Item	velour veil	Experience (Mysticality): +2, Accessory Drop: +30, Single Equip
+Item	velour veil	Experience (Mysticality): +2, Accessory Drop: +30, Single Equip, Last Available: "2021-12"
 # velour viscometer: Triples the effectiveness of Scarysauce
-Item	velour viscometer	Mysticality: +10, Food Drop: +30, Single Equip
+Item	velour viscometer	Mysticality: +10, Food Drop: +30, Single Equip, Last Available: "2021-12"
 Item	vial of hot blood	Hot Resistance: +4, Single Equip
 Item	vinyl boots	Moxie Percent: [15*X], HP Regen Min: 15, HP Regen Max: 30, Weapon Damage Percent: +10, Single Equip
 Item	Voluminous Radio Sneakers	Muscle: +10, Mysticality: +10, Moxie: +10, Single Equip
-Item	Wal-Mart nametag	Mysticality Percent: +40, Experience (Mysticality): +4, Spell Critical Percent: +10
+Item	Wal-Mart nametag	Mysticality Percent: +40, Experience (Mysticality): +4, Spell Critical Percent: +10, Last Available: "2015-11"
 Item	walrus-tusk earring	Maximum HP: +10
-Item	warbear dress bracers	Mysticality: +10, Candy Drop: +25, Single Equip
-Item	warbear electric warscarf	Supercold Resistance: +3, Weapon Damage Percent: -25, Spell Damage Percent: -50, Single Equip
+Item	warbear dress bracers	Mysticality: +10, Candy Drop: +25, Single Equip, Last Available: "2013-12"
+Item	warbear electric warscarf	Supercold Resistance: +3, Weapon Damage Percent: -25, Spell Damage Percent: -50, Single Equip, Last Available: "2013-12"
 # warbear energy bracers: Monster attacks reduce MP instead of HP
-Item	warbear energy bracers	Class: "Pastamancer", Single Equip
+Item	warbear energy bracers	Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 # warbear exo-arm: Increases the magnitude of your Smacks
-Item	warbear exo-arm	Class: "Seal Clubber", Single Equip
-Item	warbear fleece-lined warscarf	Supercold Resistance: +2, Single Equip
+Item	warbear exo-arm	Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
+Item	warbear fleece-lined warscarf	Supercold Resistance: +2, Single Equip, Last Available: "2013-12"
 # warbear goggles: +5% Item Drops from WarBears
-Item	warbear goggles	Initiative: +25, Maximum HP: +50, Maximum MP: +50, Single Equip
+Item	warbear goggles	Initiative: +25, Maximum HP: +50, Maximum MP: +50, Single Equip, Last Available: "2013-12"
 # warbear hoverbelt: Grants access to the upper floors of the Warbear fortress
-Item	warbear hoverbelt	Muscle Limit: 100, Mysticality Limit: 100, Moxie Limit: 100, Single Equip
+Item	warbear hoverbelt	Muscle Limit: 100, Mysticality Limit: 100, Moxie Limit: 100, Single Equip, Last Available: "2013-12"
 # warbear laser beacon: Attracts Cool Lasers
 # warbear laser beacon: (Lasers respond to Disco Momentum)
-Item	warbear laser beacon	Class: "Disco Bandit", Single Equip
-Item	warbear laser bowtie	WarBear Armor Penetration: +20, Weapon Damage Percent: +25, Spell Damage Percent: +50, Single Equip
+Item	warbear laser beacon	Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
+Item	warbear laser bowtie	WarBear Armor Penetration: +20, Weapon Damage Percent: +25, Spell Damage Percent: +50, Single Equip, Last Available: "2013-12"
 # warbear nuclear bowtie: Troubling Vulnerability to All Elements (-5)
-Item	warbear nuclear bowtie	WarBear Armor Penetration: +60, Muscle Percent: -25, Mysticality Percent: -25, Moxie Percent: -25, Single Equip, Cold Resistance: -5, Hot Resistance: -5, Sleaze Resistance: -5, Spooky Resistance: -5, Stench Resistance: -5
-Item	warbear plasma bowtie	WarBear Armor Penetration: +40, Single Equip
+Item	warbear nuclear bowtie	WarBear Armor Penetration: +60, Muscle Percent: -25, Mysticality Percent: -25, Moxie Percent: -25, Single Equip, Last Available: "2013-12", Cold Resistance: -5, Hot Resistance: -5, Sleaze Resistance: -5, Spooky Resistance: -5, Stench Resistance: -5
+Item	warbear plasma bowtie	WarBear Armor Penetration: +40, Single Equip, Last Available: "2013-12"
 # warbear polarized goggles: +15% Item Drops from WarBears
-Item	warbear polarized goggles	Initiative: -25, Maximum HP: -50, Maximum MP: -50, Single Equip
+Item	warbear polarized goggles	Initiative: -25, Maximum HP: -50, Maximum MP: -50, Single Equip, Last Available: "2013-12"
 # warbear snowblindness goggles: +10% Item Drops from WarBears
-Item	warbear snowblindness goggles	Single Equip
-Item	warbear warscarf	Supercold Resistance: +1, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 10, MP Regen Max: 15, Single Equip
+Item	warbear snowblindness goggles	Single Equip, Last Available: "2013-12"
+Item	warbear warscarf	Supercold Resistance: +1, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 10, MP Regen Max: 15, Single Equip, Last Available: "2013-12"
 Item	Warehouse 23 bling	Maximum MP: +23
 Item	warm fur	Hot Damage: +60
 # water wings
 Item	water wings for babies	Maximum HP: +10, Monster Level: -15
 Item	water-polo mitt	Weapon Damage: +30, Single Equip
-Item	wax face	Maximum MP: +20, Spell Damage Percent: +25
-Item	wax hand	Maximum HP: +40, Weapon Damage Percent: +25
-Item	weremoose key	Spooky Resistance: +3, Spooky Damage: +15, Spooky Spell Damage: +30
+Item	wax face	Maximum MP: +20, Spell Damage Percent: +25, Last Available: "2017-01"
+Item	wax hand	Maximum HP: +40, Weapon Damage Percent: +25, Last Available: "2017-01"
+Item	weremoose key	Spooky Resistance: +3, Spooky Damage: +15, Spooky Spell Damage: +30, Last Available: "2020-08"
 Item	whalebone corset	Maximum HP: -10, Damage Reduction: 5, Single Equip
-Item	wheel	Initiative: +10
+Item	wheel	Initiative: +10, Last Available: "2006-12"
 Item	white belt	Muscle: +3, Weapon Damage: +3, Single Equip
 Item	white collar	Meat Drop: +3, Moxie: +1
 Item	white earbuds	Spooky Resistance: +4, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10, Monster Level: -11, Single Equip
-Item	whittled bear figurine	Muscle Percent: +25, HP Regen Min: 8, HP Regen Max: 10, Familiar Weight: +5, Single Equip
-Item	whittled fox figurine	Moxie Percent: +25, HP Regen Min: 4, HP Regen Max: 6, MP Regen Min: 4, MP Regen Max: 6, Initiative: +50, Single Equip
-Item	whittled owl figurine	Mysticality Percent: +25, MP Regen Min: 6, MP Regen Max: 8, Monster Level: +20, Single Equip
+Item	whittled bear figurine	Muscle Percent: +25, HP Regen Min: 8, HP Regen Max: 10, Familiar Weight: +5, Single Equip, Last Available: "2019-08"
+Item	whittled fox figurine	Moxie Percent: +25, HP Regen Min: 4, HP Regen Max: 6, MP Regen Min: 4, MP Regen Max: 6, Initiative: +50, Single Equip, Last Available: "2019-08"
+Item	whittled owl figurine	Mysticality Percent: +25, MP Regen Min: 6, MP Regen Max: 8, Monster Level: +20, Single Equip, Last Available: "2019-08"
 # wicker kickers: Add a stomp attack to every Smack
-Item	wicker kickers	Initiative: +20, Maximum HP: +20, Single Equip
+Item	wicker kickers	Initiative: +20, Maximum HP: +20, Single Equip, Last Available: "2016-12"
 # wicker ticker: Collecting Soul Sauce restores HP
-Item	wicker ticker	HP Regen Min: 4, HP Regen Max: 8, Spell Damage Percent: +20, Single Equip
-Item	wicksilver ring	Hot Damage: +20, Hot Spell Damage: +40, Mysticality: +10, Single Equip
+Item	wicker ticker	HP Regen Min: 4, HP Regen Max: 8, Spell Damage Percent: +20, Single Equip, Last Available: "2016-12"
+Item	wicksilver ring	Hot Damage: +20, Hot Spell Damage: +40, Mysticality: +10, Single Equip, Last Available: "2016-02"
 Item	witch wart	Mysticality: +5, MP Regen Min: 6, MP Regen Max: 8
-Item	wool sock	Mysticality: +20, Muscle: -5, Moxie: -5, Spell Damage Percent: +40, Single Equip
+Item	wool sock	Mysticality: +20, Muscle: -5, Moxie: -5, Spell Damage Percent: +40, Single Equip, Last Available: "2013-11"
 Item	work boots	Plumber Stat: "Moxie", Plumber Power: 1, Single Equip
 # worksite credentials: Grants access to worksites
 Item	worksite credentials	Adventures: +1, Single Equip
 Item	World's Best Adventurer sash	Muscle: [min(100,A+1)], Mysticality: [min(100,A+1)], Moxie: [min(100,A+1)]
-Item	wormwood wedding ring	Mysticality Percent: +100, Meat Drop: +50, Spooky Damage: +30, Spooky Spell Damage: +30, Spooky Resistance: +3, Single Equip
+Item	wormwood wedding ring	Mysticality Percent: +100, Meat Drop: +50, Spooky Damage: +30, Spooky Spell Damage: +30, Spooky Resistance: +3, Single Equip, Last Available: "2020-08"
 Item	woven baling wire bracelets	Spell Damage: +15, Mana Cost: -1
 Item	wrench bracelet	Muscle: +5, Weapon Damage: +9
 # Wrist-Boy: Allows use of holo-records
 Item	Wrist-Boy	Damage Reduction: 10
-Item	wristwatch of the white knight	Initiative: +10, Adventures: +3, Single Equip, Nonstackable Watch
+Item	wristwatch of the white knight	Initiative: +10, Adventures: +3, Single Equip, Last Available: "2010-03", Nonstackable Watch
 # wrought-iron walker: Makes Disco Momentum cause passive damage over time
-Item	wrought-iron walker	Experience (Moxie): +3, HP Regen Min: 6, HP Regen Max: 10, Single Equip
+Item	wrought-iron walker	Experience (Moxie): +3, HP Regen Min: 6, HP Regen Max: 10, Single Equip, Last Available: "2017-12"
 # wrought-iron widget: Adds extra sources of damage to Cannelloni Cannon
-Item	wrought-iron widget	Experience (Mysticality): +3, Maximum HP: +40, Single Equip
+Item	wrought-iron widget	Experience (Mysticality): +3, Maximum HP: +40, Single Equip, Last Available: "2017-12"
 # wrought-iron winch crank: Increases the damage of Spirit Snap
-Item	wrought-iron winch crank	Initiative: +40, MP Regen Min: 4, MP Regen Max: 6, Single Equip
+Item	wrought-iron winch crank	Initiative: +40, MP Regen Min: 4, MP Regen Max: 6, Single Equip, Last Available: "2017-12"
 # x-ray specs
 # Xiblaxian holo-wrist-puter: Detects Anomalous Materials of Xiblaxian Origin
-Item	Xiblaxian holo-wrist-puter	Item Drop: +10, Drops Items
+Item	Xiblaxian holo-wrist-puter	Item Drop: +10, Last Available: "2014-09", Drops Items
 # Xiblaxian xeno-detection goggles: They Really Open Your Eyes
-Item	Xiblaxian xeno-detection goggles	Meat Drop: +15, Single Equip
+Item	Xiblaxian xeno-detection goggles	Meat Drop: +15, Single Equip, Last Available: "2014-09"
 Item	Xlyinia's notebook	Muscle: +15, Mysticality: +15, Moxie: +15
-Item	yamtility belt	Meat Drop: +55, Initiative: +15, Moxie Percent: +5, Lasts Until Rollover
+Item	yamtility belt	Meat Drop: +55, Initiative: +15, Moxie Percent: +5, Lasts Until Rollover, Last Available: "2024-05"
 Item	ye olde golde frontes	Muscle: +15, Class: "Disco Bandit", Single Equip
 Item	Yearbook Club Camera	Muscle: [5*min(pref(yearbookCameraUpgrades),1)+5*max(min(pref(yearbookCameraUpgrades)-3,1),0)+5*max(min(pref(yearbookCameraUpgrades)-6,1),0)], Mysticality: [5*max(min(pref(yearbookCameraUpgrades)-1,1),0)+5*max(min(pref(yearbookCameraUpgrades)-4,1),0)+5*max(min(pref(yearbookCameraUpgrades)-7,1),0)], Moxie: [5*max(min(pref(yearbookCameraUpgrades)-2,1),0)+5*max(min(pref(yearbookCameraUpgrades)-5,1),0)+5*max(min(pref(yearbookCameraUpgrades)-8,1),0)], Maximum HP: [20*max(min(pref(yearbookCameraUpgrades)-9,1),0)], Maximum MP: [10*max(min(pref(yearbookCameraUpgrades)-10,1),0)], HP Regen Min: [4*max(min(pref(yearbookCameraUpgrades)-11,1),0)], HP Regen Max: [5*max(min(pref(yearbookCameraUpgrades)-11,1),0)], MP Regen Min: [2*max(min(pref(yearbookCameraUpgrades)-12,1),0)], MP Regen Max: [3*max(min(pref(yearbookCameraUpgrades)-12,1),0)], Adventures: [5*max(min(pref(yearbookCameraUpgrades)-13,1),0)], PvP Fights: [5*max(min(pref(yearbookCameraUpgrades)-14,1),0)], Damage Reduction: [5*max(min(pref(yearbookCameraUpgrades)-15,1),0)], Hot Damage: [max(min(pref(yearbookCameraUpgrades)-16,1),0)], Cold Damage: [max(min(pref(yearbookCameraUpgrades)-16,1),0)], Spooky Damage: [max(min(pref(yearbookCameraUpgrades)-16,1),0)], Stench Damage: [max(min(pref(yearbookCameraUpgrades)-16,1),0)], Sleaze Damage: [max(min(pref(yearbookCameraUpgrades)-16,1),0)], Initiative: [10*max(min(pref(yearbookCameraUpgrades)-17,1),0)], Meat Drop: [20*max(min(pref(yearbookCameraUpgrades)-18,1),0)], Item Drop: [10*max(min(pref(yearbookCameraUpgrades)-19,1),0)]
 # Yeg's Motel slippers: Extremely fragile (will be destroyed if you are hit in combat)
-Item	Yeg's Motel slippers	Spooky Spell Damage: +100, Mysticality Percent: +66, Single Equip, Lasts Until Rollover
-Item	yellow glowstick	Maximum MP: +5, Moxie: -3, Raveosity: +1
+Item	Yeg's Motel slippers	Spooky Spell Damage: +100, Mysticality Percent: +66, Single Equip, Lasts Until Rollover, Last Available: "2020-09"
+Item	yellow glowstick	Maximum MP: +5, Moxie: -3, Last Available: "2007-08", Raveosity: +1
 Item	Yellow Moon of Compassion	Muscle: +9, Mysticality: +9, Moxie: +9, Item Drop: +7, Single Equip
 # your cowboy boots: Lets you engage in Cowboy Kicking, can be further upgraded with skins and spurs
-Item	your cowboy boots	Maximum HP: +25, Maximum MP: +25
-Item	Yuleviathan necklace	Spooky Damage: +15, Stench Damage: +15, Hot Damage: +15, Cold Damage: +15, Sleaze Damage: +15, MP Regen Min: 20, MP Regen Max: 30, Single Equip
+Item	your cowboy boots	Maximum HP: +25, Maximum MP: +25, Last Available: "2016-02"
+Item	Yuleviathan necklace	Spooky Damage: +15, Stench Damage: +15, Hot Damage: +15, Cold Damage: +15, Sleaze Damage: +15, MP Regen Min: 20, MP Regen Max: 30, Single Equip, Last Available: "2019-12"
 Item	Zinc Delta of Tranquility	Muscle: +8, Mysticality: +8, Moxie: +8, Item Drop: +8, Single Equip
 Item	zombie monkey necklace	Spooky Damage: +11, Stench Damage: +11
 Item	Zombo's skull ring	Moxie Percent: +15, PvP Fights: +4, Single Equip
@@ -4256,37 +4256,37 @@ Item	Zombo's skull ring	Moxie Percent: +15, PvP Fights: +4, Single Equip
 # Containers section of modifiers.txt
 
 Item	anniversary pewter cape	Muscle: +1, Mysticality: +1, Moxie: +1
-Item	antique nutcracker cape	Spell Damage Percent: +30, Mysticality Percent: +15
-Item	auxiliary backbone	PvP Fights: +3
+Item	antique nutcracker cape	Spell Damage Percent: +30, Mysticality Percent: +15, Last Available: "2019-12"
+Item	auxiliary backbone	PvP Fights: +3, Last Available: "2012-10"
 Item	awkward dinosaur research harness	Muscle Percent: -30, Mysticality Percent: -30, Moxie Percent: -30, Monster Level: +10, Initiative: -100
 # B. L. A. R. T.: Spray water at your foes in various stream configurations
 Item	B. L. A. R. T.	Hot Resistance: +3
 Item	back shell	Damage Absorption: +200, Damage Reduction: 20
 # bakelite backpack: Makes Accordion Bash knock loose some Meat
-Item	bakelite backpack	Monster Level: +10, Candy Drop: +20
-Item	balsam barrel	Muscle Percent: +50, Mysticality Percent: +50, Moxie Percent: +50, Item Drop: +15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20
+Item	bakelite backpack	Monster Level: +10, Candy Drop: +20, Last Available: "2016-12"
+Item	balsam barrel	Muscle Percent: +50, Mysticality Percent: +50, Moxie Percent: +50, Item Drop: +15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2020-08"
 Item	barskin cloak	Muscle: +7
 # bat wings: Find Fruit
 # bat wings: Random bonuses underground
 # bat wings: Use some bat skills
-Item	bat wings	Muscle: +5, Mysticality: +5, Moxie: +5, Initiative: +100, Food Drop: +50
+Item	bat wings	Muscle: +5, Mysticality: +5, Moxie: +5, Initiative: +100, Food Drop: +50, Last Available: "2024-10"
 Item	black cloak	Spell Damage: +10
 Item	bony back shell	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2
 # Buddy Bjorn: Put a Familiar In It!
 # Buddy Bjorn: That Familiar gains 1 Experience per Fight
-Item	Buddy Bjorn	Softcore Only
-Item	burning cape	Hot Resistance: +3, Maximum HP: +25, Maximum MP: +25, Adventures: +5, Lasts Until Rollover
+Item	Buddy Bjorn	Softcore Only, Last Available: "2014-02"
+Item	burning cape	Hot Resistance: +3, Maximum HP: +25, Maximum MP: +25, Adventures: +5, Lasts Until Rollover, Last Available: "2018-12"
 # Camp Scout backpack: Helps You Be Prepared
-Item	Camp Scout backpack	Item Drop: +15, Softcore Only, Drops Items
+Item	Camp Scout backpack	Item Drop: +15, Softcore Only, Last Available: "2012-07", Drops Items
 Item	cape	Initiative: +100
-Item	carpe	Mysticality Percent: +50, MP Regen Min: 5, MP Regen Max: 10, Meat Drop: +50, Combat Rate: +10, Lasts Until Rollover
-Item	Catherine Wheel	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, Experience: +3, Lasts Until Rollover
+Item	carpe	Mysticality Percent: +50, MP Regen Min: 5, MP Regen Max: 10, Meat Drop: +50, Combat Rate: +10, Lasts Until Rollover, Last Available: "2016-04"
+Item	Catherine Wheel	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, Experience: +3, Lasts Until Rollover, Last Available: "2021-07"
 # chalk chlamys: Weakens enemies who hit you
-Item	chalk chlamys	Adventures: +2, Combat Rate: -5
-Item	Cloak of Dire Shadows	Maximum MP: +40, Meat Drop: +10, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5
+Item	chalk chlamys	Adventures: +2, Combat Rate: -5, Last Available: "2019-12"
+Item	Cloak of Dire Shadows	Maximum MP: +40, Meat Drop: +10, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Last Available: "2013-02"
 Item	cod cape	Stench Damage: +25, Combat Rate: +5
 # crepe paper parachute cape: Parachute into a battle in a recent zone
-Item	crepe paper parachute cape	Experience (Muscle): +2, Cold Damage: +10, Cold Spell Damage: +10
+Item	crepe paper parachute cape	Experience (Muscle): +2, Cold Damage: +10, Cold Spell Damage: +10, Last Available: "2025-12"
 # cryptocloak: CyberRealm: Avoid damage from processes, once per combat
 Item	cursed blanket	Hot Resistance: +3, Cold Resistance: +3, Spooky Resistance: +3, Stench Resistance: +3, Sleaze Resistance: +3, Familiar Weight: -20
 # cursed goblin cape: Cold Vulnerability (-6)
@@ -4297,81 +4297,81 @@ Item	Drapes-You-Regally	Meat Drop: +20, Booze Drop: +20, Hat Drop: +20, Class: "
 # Drip harness: Allows you to enter The Drip
 Item	Drip harness	Muscle Limit: 100, Mysticality Limit: 100, Moxie Limit: 100
 Item	Drunkula's cape	Adventures: +3, Candy Drop: +20, Accessory Drop: +20, Class: "Sauceror"
-Item	Duke Vampire's regal cloak	Moxie: +15, Moxie Percent: +25, Initiative: +50
-Item	elf army poncho	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Lasts Until Rollover
-Item	Elf Guard fuel tank	Adventures: +4
-Item	Elf Guard SCUBA tank	Muscle Percent: -25, Mysticality Percent: -25, Moxie Percent: -25, Maximum HP: -100, Maximum MP: -100, Adventure Underwater
+Item	Duke Vampire's regal cloak	Moxie: +15, Moxie Percent: +25, Initiative: +50, Last Available: "2018-04"
+Item	elf army poncho	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Lasts Until Rollover, Last Available: "2019-12"
+Item	Elf Guard fuel tank	Adventures: +4, Last Available: "2023-12"
+Item	Elf Guard SCUBA tank	Muscle Percent: -25, Mysticality Percent: -25, Moxie Percent: -25, Maximum HP: -100, Maximum MP: -100, Adventure Underwater, Last Available: "2023-12"
 # fiberglass frock: Makes it so dealing Cold damage causes ongoing additional Cold damage
-Item	fiberglass frock	Experience (Mysticality): +3, Maximum MP: +20
+Item	fiberglass frock	Experience (Mysticality): +3, Maximum MP: +20, Last Available: "2018-12"
 Item	frozen turtle shell	Cold Damage: +15, Stench Resistance: +2, Sleaze Resistance: +2, Class: "Turtle Tamer"
 # gabardine gunnysack: Increases the effectiveness of Vermincelli
-Item	gabardine gunnysack	Mysticality: +10, PvP Fights: +3
+Item	gabardine gunnysack	Mysticality: +10, PvP Fights: +3, Last Available: "2018-12"
 Item	ghost shawl	Spell Damage: +50, Spell Critical Percent: +5
 Item	giant gym membership card	Weapon Damage: +15
-Item	Great S-Cape	Muscle: +5, Mysticality: +5, Moxie: +5, Softcore Only
-Item	hemp backpack	Item Drop: +2
-Item	kelp-holly drape	Monster Level: +15, HP Regen Min: 6, HP Regen Max: 10, MP Regen Min: 6, MP Regen Max: 10
-Item	Lavalos's shell	Damage Absorption: +40, Hot Damage: +20, Hot Resistance: +2
-Item	little deuce cape	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Weapon Damage Percent: +25
+Item	Great S-Cape	Muscle: +5, Mysticality: +5, Moxie: +5, Softcore Only, Last Available: "2011-07"
+Item	hemp backpack	Item Drop: +2, Last Available: "2004-12"
+Item	kelp-holly drape	Monster Level: +15, HP Regen Min: 6, HP Regen Max: 10, MP Regen Min: 6, MP Regen Max: 10, Last Available: "2019-12"
+Item	Lavalos's shell	Damage Absorption: +40, Hot Damage: +20, Hot Resistance: +2, Last Available: "2015-08"
+Item	little deuce cape	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Weapon Damage Percent: +25, Last Available: "2015-08"
 # Lord Flameface's cloak: Has Cool Swirling Flames
-Item	Lord Flameface's cloak	Cold Resistance: +2
-Item	LOV Epaulettes	Experience Percent (Mysticality): +25, MP Regen Min: 4, MP Regen Max: 6, Mana Cost (combat): -3, Lasts Until Rollover
+Item	Lord Flameface's cloak	Cold Resistance: +2, Last Available: "2012-07"
+Item	LOV Epaulettes	Experience Percent (Mysticality): +25, MP Regen Min: 4, MP Regen Max: 6, Mana Cost (combat): -3, Lasts Until Rollover, Last Available: "2017-02"
 Item	makeshift cape	Item Drop: +5
-Item	marble mantle	Damage Reduction: 10, Weapon Damage Percent: +30, Thorns: 1
+Item	marble mantle	Damage Reduction: 10, Weapon Damage Percent: +30, Last Available: "2019-12", Thorns: 1
 Item	Mayor Ghost's cloak	PvP Fights: +5, Weapon Drop: +20, Food Drop: +20, Class: "Pastamancer"
 # McHugeLarge duffel bag: Lets you hit the slopes when equipped with all your McHugeLarge ski gear
-Item	McHugeLarge duffel bag	Item Drop: +15, Maximum HP: +20, McHugeLarge
+Item	McHugeLarge duffel bag	Item Drop: +15, Maximum HP: +20, Last Available: "2025-01", McHugeLarge
 Item	Misty Cape	Moxie: +5, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 1, MP Regen Max: 2
 Item	Misty Cloak	Muscle: +5, HP Regen Min: 4, HP Regen Max: 8
 Item	Misty Robe	Mysticality: +5, MP Regen Min: 2, MP Regen Max: 4
 # moss mantle: Lets you delevel and stun a foe
-Item	moss mantle	Experience (Moxie): +2, Sleaze Resistance: +2
-Item	Mr. Container	Item Drop: +3
-Item	Newbiesport&trade; backpack	Item Drop: +1
-Item	octolus-skin cloak	Adventures: +2, PvP Fights: +4, Rollover Effect: "Octolus Gift", Rollover Effect Duration: 30
+Item	moss mantle	Experience (Moxie): +2, Sleaze Resistance: +2, Last Available: "2024-12"
+Item	Mr. Container	Item Drop: +3, Last Available: "2004-12"
+Item	Newbiesport&trade; backpack	Item Drop: +1, Last Available: "2004-12"
+Item	octolus-skin cloak	Adventures: +2, PvP Fights: +4, Rollover Effect: "Octolus Gift", Rollover Effect Duration: 30, Last Available: "2015-11"
 Item	oil shell	Sleaze Damage: +15, Class: "Turtle Tamer"
 Item	old SCUBA tank	Item Drop: -50, Initiative: -100, Adventure Underwater
 Item	palm-frond cloak	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1
-Item	paperclip cape	HP Regen Min: 5, HP Regen Max: 7, MP Regen Min: 5, MP Regen Max: 7
+Item	paperclip cape	HP Regen Min: 5, HP Regen Max: 7, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-01"
 # paraffin poncho: Lets you unleash a prismatic attack
-Item	paraffin poncho	Mysticality: +10, Sleaze Damage: +10
+Item	paraffin poncho	Mysticality: +10, Sleaze Damage: +10, Last Available: "2020-12"
 Item	pillow shell	Damage Reduction: 3, Class: "Turtle Tamer"
 # polyester parachute: Fury Increases Your Initiative
-Item	polyester parachute	Experience (Muscle): +2, Weapon Drop: +10, Initiative: [10*Y]
+Item	polyester parachute	Experience (Muscle): +2, Weapon Drop: +10, Last Available: "2015-12", Initiative: [10*Y]
 # porcelain pelerine: Begin Fights with 1 Disco Momentum
-Item	porcelain pelerine	Hat Drop: +20, Monster Level: +10
+Item	porcelain pelerine	Hat Drop: +20, Monster Level: +10, Last Available: "2015-12"
 Item	portable housekeeping robot	Adventures: +10
-Item	protonic accelerator pack	Damage vs. Ghosts: +25, MP Regen Min: 2, MP Regen Max: 20, Item Drop: +15, Muscle: +10, Mysticality: +10, Moxie: +10, Critical Hit Percent: +5, Combat Rate: -5
+Item	protonic accelerator pack	Damage vs. Ghosts: +25, MP Regen Min: 2, MP Regen Max: 20, Item Drop: +15, Muscle: +10, Mysticality: +10, Moxie: +10, Critical Hit Percent: +5, Combat Rate: -5, Last Available: "2016-08"
 # rad cloak: Protects against harmful radiation on alien worlds
-Item	rad cloak	Lasts Until Rollover
-Item	Rain-Doh red wings	Hot Damage: +11, Initiative: +20, Softcore Only
+Item	rad cloak	Lasts Until Rollover, Last Available: "2017-04"
+Item	Rain-Doh red wings	Hot Damage: +11, Initiative: +20, Softcore Only, Last Available: "2012-02"
 # replica Camp Scout backpack: Helps You Be Prepared
 Item	replica Camp Scout backpack	Item Drop: +15, Drops Items
-Item	rubber cape	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 10
+Item	rubber cape	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 10, Last Available: "2014-08"
 Item	rutabuga bag	Maximum HP: +10, Damage Reduction: 5
 # saffron uttarasanga: Improves chances of finding lumps and sludge
-Item	saffron uttarasanga	HP Regen Min: 4, HP Regen Max: 6, Critical Hit Percent: +5
+Item	saffron uttarasanga	HP Regen Min: 4, HP Regen Max: 6, Critical Hit Percent: +5, Last Available: "2016-12"
 Item	sea cape	Moxie Percent: +5, Maximum HP: +30, Maximum MP: +30, Initiative: [50*env(underwater)], Critical Hit Percent: [15*env(underwater)]
 # sea mantle: +150% Physical Damage (Underwater Only)
 Item	sea mantle	Muscle Percent: +10, Maximum MP: +50, Weapon Damage Percent: [150*env(underwater)]
 Item	sea shawl	Mysticality Percent: +15, Maximum HP: +100, Spell Damage Percent: [150*env(underwater)]
 Item	sealhide cloak	Cold Resistance: +2
-Item	shadow skin	Spooky Resistance: +3, Cold Resistance: +3
+Item	shadow skin	Spooky Resistance: +3, Cold Resistance: +3, Last Available: "2023-03"
 Item	shellacked shell	Maximum HP: +5, HP Regen Min: 2, HP Regen Max: 3, Class: "Turtle Tamer"
 Item	shocked shell	Class: "Turtle Tamer", Damage Aura: 1
-Item	Size XI Wizard's Robe	Booze Drop: +11, Food Drop: +11, Candy Drop: +11
-Item	smoker's cloak	Monster Level: +10, Initiative: +20, Stench Damage: +30
+Item	Size XI Wizard's Robe	Booze Drop: +11, Food Drop: +11, Candy Drop: +11, Last Available: "2014-09"
+Item	smoker's cloak	Monster Level: +10, Initiative: +20, Stench Damage: +30, Last Available: "2014-10"
 Item	smoldering drape	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, Experience (Mysticality): +2, Lasts Until Rollover
-Item	snowpack	Familiar Weight: +5, Cold Damage: +30, Class: "Pastamancer"
-Item	spant backplate	Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Damage Absorption: +100
+Item	snowpack	Familiar Weight: +5, Cold Damage: +30, Class: "Pastamancer", Last Available: "2020-12"
+Item	spant backplate	Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Damage Absorption: +100, Last Available: "2017-04"
 Item	spiky back shell	Thorns: 1
-Item	stained glass serape	Experience (Moxie): +3, Sleaze Resistance: +3, Sleaze Damage: +5
+Item	stained glass serape	Experience (Moxie): +3, Sleaze Resistance: +3, Sleaze Damage: +5, Last Available: "2021-12"
 Item	super-absorbent tarp	Maximum Hooch: +2
 Item	T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	Wiki Name: "Bugged baio"
 Item	teddybear backpack	Meat Drop: +10, Raveosity: +1
 # terra cotta train: Lets you unleash a terra cotta army on your foes
-Item	terra cotta train	Mysticality Percent: +20, Item Drop: +10
-Item	thermal blanket	Cold Resistance: +2, Spooky Resistance: +1, Combat Rate: +5, Lasts Until Rollover
+Item	terra cotta train	Mysticality Percent: +20, Item Drop: +10, Last Available: "2020-12"
+Item	thermal blanket	Cold Resistance: +2, Spooky Resistance: +1, Combat Rate: +5, Lasts Until Rollover, Last Available: "2022-05"
 Item	Time Bandit Time Towel	Muscle: +5, Mysticality: +5, Moxie: +5, Adventures: +1
 Item	Time Cape	Item Drop: [25*zone(Twitch)]
 # Time Cloak: Sometimes Find an Extra Chroner in the Time-Twitching Tower
@@ -4381,20 +4381,20 @@ Item	Trainbot harness	Initiative: -200
 Item	uncursed blanket	Hot Resistance: +1, Cold Resistance: +1, Spooky Resistance: +1, Stench Resistance: +1, Sleaze Resistance: +1
 Item	uncursed goblin cape	Combat Rate: -5
 # vampyric cloake: Improves the effectiveness of various Dark Gyffte skills
-Item	vampyric cloake	Item Drop: +15, Maximum HP: [min(10*L,1300)], Initiative: +25, Adventures: +4, Experience: +3
+Item	vampyric cloake	Item Drop: +15, Maximum HP: [min(10*L,1300)], Initiative: +25, Adventures: +4, Experience: +3, Last Available: "2019-03"
 Item	whatsit-covered turtle shell	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Class: "Turtle Tamer"
 # wicker slicker: Lets you use Shell Up multiple times per fight
-Item	wicker slicker	Experience (Muscle): +2, Sleaze Resistance: +3
-Item	wings of fire	Hot Damage: +25, Hot Spell Damage: +25
+Item	wicker slicker	Experience (Muscle): +2, Sleaze Resistance: +3, Last Available: "2016-12"
+Item	wings of fire	Hot Damage: +25, Hot Spell Damage: +25, Last Available: "2012-07"
 
 # Familiar Items section of modifiers.txt
 
-Item	1.21 jigawatts	Familiar Weight: +5
-Item	100-Watt bulb	Familiar Weight: +5
-Item	affordable teak perch	Familiar Weight: +5
+Item	1.21 jigawatts	Familiar Weight: +5, Last Available: "2005-11"
+Item	100-Watt bulb	Familiar Weight: +5, Last Available: "2011-12"
+Item	affordable teak perch	Familiar Weight: +5, Last Available: "2010-09"
 # amphibious tophat: Lets your Frog Breathe Underwater
 Item	amphibious tophat	Underwater Familiar, Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
-Item	amulet coin	Familiar Weight: +10, Meat Drop: +50, Lasts Until Rollover, Generic
+Item	amulet coin	Familiar Weight: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2018-03", Generic
 Item	anniversary tiny latex mask	Familiar Weight: +1, Generic
 Item	annoying pitchfork	Monster Level: +5, Generic
 Item	ant antidepressant	Familiar Weight: +5
@@ -4408,8 +4408,8 @@ Item	astral pet sweater	Familiar Weight: +10, Generic
 Item	attention spanner	Familiar Weight: +5
 # badger badge: Increases Astral Mushroom Drop Rate
 # bag of many confections: Full of Candy!
-Item	black gallstone	Familiar Weight: +5
-Item	blue canary nightlight	Familiar Weight: +5
+Item	black gallstone	Familiar Weight: +5, Last Available: "2016-12"
+Item	blue canary nightlight	Familiar Weight: +5, Last Available: "2013-12"
 # blue pumps: Causes your Ms. Puck Man to sometimes drop extra yellow pixels
 # blue plate: Improves Cooking
 Item	blue plate	Familiar Weight: +5
@@ -4422,52 +4422,52 @@ Item	bottle of perfume	Familiar Weight: +5
 Item	box of hickory chips	Familiar Weight: +5
 # brass bung spigot: Lets your Barrel Mimic restore HP and MP after combat.
 Item	brass bung spigot	Equips On: "Lil' Barrel Mimic"
-Item	brass crank handle	Familiar Weight: +5
+Item	brass crank handle	Familiar Weight: +5, Last Available: "2009-12"
 Item	brass stinger	Familiar Weight: +5
-Item	brass turkey knuckles	Familiar Weight: +10
-Item	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Fairy: 1.0, Equips On: "Baby Bugged Bugbear"
-Item	bugged balaclava	Monster Level: +20, Volleyball: 1.0, Equips On: "Baby Bugged Bugbear"
-Item	bugged beanie	Familiar Weight: +10
+Item	brass turkey knuckles	Familiar Weight: +10, Last Available: "2014-11"
+Item	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Fairy: 1.0, Equips On: "Baby Bugged Bugbear"
+Item	bugged balaclava	Monster Level: +20, Last Available: "2010-04", Volleyball: 1.0, Equips On: "Baby Bugged Bugbear"
+Item	bugged beanie	Familiar Weight: +10, Last Available: "2010-04"
 # burglar/sleep mask: Helps your Cat Burglar take naps more efficiently
 Item	cactus monocle	Familiar Weight: +5
 # can of starch: Makes Origami Towel Crane More Resistant to Wear and Tear
-Item	candied yam pinky ring	Familiar Weight: +5
-Item	candy dog collar	Sprinkle Drop: +25, Generic
+Item	candied yam pinky ring	Familiar Weight: +5, Last Available: "2011-12"
+Item	candy dog collar	Sprinkle Drop: +25, Last Available: "2016-12", Generic
 Item	charpuce jub-jub bird	Familiar Weight: +5, Familiar Tuning (Moxie): 100, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
 Item	chiptune guitar	Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
 Item	chocolate bowtie	Familiar Weight: +5
-Item	chocolate leash	Familiar Weight: +10
+Item	chocolate leash	Familiar Weight: +10, Last Available: "2016-12"
 Item	chocolate spurs	Familiar Weight: +5
-Item	chocolate-stained collar	Candy Drop: +25, Generic
+Item	chocolate-stained collar	Candy Drop: +25, Last Available: "2014-12", Generic
 Item	claw-held flag	Familiar Weight: +5
 Item	cookbookbat book	Familiar Weight: +5
-Item	cotton candy cordial	Familiar Weight: +5
+Item	cotton candy cordial	Familiar Weight: +5, Last Available: "2008-08"
 Item	cracker	Familiar Weight: +15
 Item	Crimbo dog sweater	Familiar Weight: +5
 Item	crimsilion jub-jub bird	Familiar Weight: +5, Familiar Tuning (Muscle): 100, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-Item	crystal decanter	Familiar Weight: +5
+Item	crystal decanter	Familiar Weight: +5, Last Available: "2012-03"
 Item	cute bow from beyond the stars	Familiar Weight: +5
 Item	das boot	Familiar Weight: -10, Underwater Familiar, Generic, Familiar Effect: "adventure underwater"
-Item	dental pliers	Familiar Weight: +5
-Item	diamond-studded fronts	Familiar Weight: +5
+Item	dental pliers	Familiar Weight: +5, Last Available: "2011-12"
+Item	diamond-studded fronts	Familiar Weight: +5, Last Available: "2006-04"
 # dromedary drinking helmet: Improves the efficiency of your Melodramedary's drinking
 Item	even more tinsel	Familiar Weight: +5
 # evil teddy bear sewing kit: Teddy Bear loses less stuffing when hit
 Item	exo-xo-skeleton-skeleton	Familiar Weight: +5
-Item	extra-heavy BRICKO brick	Familiar Weight: +5
+Item	extra-heavy BRICKO brick	Familiar Weight: +5, Last Available: "2010-02"
 Item	extra-strength rubber bands	Familiar Weight: +5
 Item	eye 'n' horn shampoo	Familiar Weight: +5
 Item	eye-pod	Familiar Weight: +5
 Item	false eyelashes	Familiar Weight: +5
 # farfalle bow tie: +10 lbs. of Barnacle
-Item	filthy child leash	Familiar Weight: +5, Generic, Damage Aura: 1
+Item	filthy child leash	Familiar Weight: +5, Last Available: "2015-04", Generic, Damage Aura: 1
 Item	fin-bit wax	Familiar Weight: +5
 Item	fireproof skip lid	Familiar Weight: +5
 # fishy wand: Lets your familiar cast fishy spells
 Item	fishy wand	Generic, Familiar Effect: "fishy spells", Sporadic Damage Aura: [0.2475*env(underwater)]
 Item	fixed-gear bicycle	Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
 # flaming familiar doppelg&auml;nger: Familiar gains 1-2 extra experience per Adventure
-Item	flaming familiar doppelg&auml;nger	Monster Level: +5, Softcore Only, Generic, Experience (familiar): +1.5
+Item	flaming familiar doppelg&auml;nger	Monster Level: +5, Softcore Only, Last Available: "2007-01", Generic, Experience (familiar): +1.5
 Item	flaming glowsticks	Familiar Weight: +5
 # flaming nose: Makes Flaming Face More Complete
 # flask of embalming fluid: Helps your Reanimated Reanimator collect body parts
@@ -4475,8 +4475,8 @@ Item	french-fry grabber	Familiar Weight: +5
 Item	French-Transylvanian Dictionary	Familiar Weight: +5
 Item	funky brass fez	Familiar Weight: +5
 Item	futuristic collar	Lasts Until Rollover, Generic
-Item	fuzzy polar bear ears	Familiar Weight: +5, Experience (Muscle): +3, Generic
-Item	gazing shoes	Familiar Weight: +5
+Item	fuzzy polar bear ears	Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12", Generic
+Item	gazing shoes	Familiar Weight: +5, Last Available: "2011-12"
 # giant book of ancient carols: Causes the Ancient Yuletide Troll to drop carol pages more frequently
 Item	gill rings	Familiar Weight: +5
 Item	gnomish athlete's foot	Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
@@ -4495,7 +4495,7 @@ Item	God Lobster's Rod	Equips On: "God Lobster", Familiar Effect: "whelp"
 # God Lobster's Scepter: Makes your God Lobster slightly increase Item and Meat Drops
 Item	God Lobster's Scepter	Leprechaun: 0.5, Fairy: 0.5, Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
 Item	golden banana	Familiar Weight: +5
-Item	green pixie spog	Familiar Weight: +5
+Item	green pixie spog	Familiar Weight: +5, Last Available: "2007-06"
 Item	grey down vest	Experience (familiar): +2
 Item	Grim Brothers' story book	Familiar Weight: +5
 Item	grimstone galoshes	Familiar Weight: +5
@@ -4503,9 +4503,9 @@ Item	guard turtle collar	Familiar Damage: +10, Generic
 # half-height cigar: Increase the rate at which wool is gathered
 Item	half-height cigar	Familiar Weight: +5
 Item	half-height unicycle	Familiar Weight: +5
-Item	hardware upgrade	Familiar Weight: +5
-Item	heavy-duty Crimbot aerial	Familiar Weight: +5
-Item	high-speed upgrade	Familiar Weight: +5
+Item	hardware upgrade	Familiar Weight: +5, Last Available: "2007-04"
+Item	heavy-duty Crimbot aerial	Familiar Weight: +5, Last Available: "2014-12"
+Item	high-speed upgrade	Familiar Weight: +5, Last Available: "2016-05"
 # homemade robot gear: +1 Gear
 Item	hot pink lipstick	Familiar Weight: +5
 Item	hypodermic needle	Familiar Weight: +5
@@ -4515,117 +4515,117 @@ Item	icicle katana	Familiar Weight: +5
 Item	immense ballet shoes	Familiar Weight: +5
 Item	ironic moustache	Familiar Weight: +10, Familiar Effect: "+10 lbs"
 # ittah bittah hookah: Magical Smoke!
-Item	ittah bittah hookah	Familiar Weight: +5, Generic
+Item	ittah bittah hookah	Familiar Weight: +5, Last Available: "2010-03", Generic
 # jalape&ntilde;o slices: +10 lbs. of Leprechaun
 Item	jalape&ntilde;o slices	Meat Drop: +60.9
 Item	jar of magical relish	Familiar Weight: +5
 Item	Jawmaster 2000&trade;	Familiar Weight: +5
-Item	kill screen	Random Monster Modifiers: +1, Generic
+Item	kill screen	Random Monster Modifiers: +1, Last Available: "2015-06", Generic
 Item	kitty sheet music	Familiar Weight: +5
-Item	lead collar	Familiar Weight: +5
+Item	lead collar	Familiar Weight: +5, Last Available: "2015-04"
 Item	lead necklace	Familiar Weight: +3, Generic
-Item	LED candle	Familiar Weight: +5
+Item	LED candle	Familiar Weight: +5, Last Available: "2023-10"
 # Li'l Businessman Kit: Lets your familiar make deals
-Item	Li'l Businessman Kit	Meat Drop: +5, Item Drop: +5, Generic
-Item	li'l candy corn costume	Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot"
-Item	li'l clown costume	Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot"
-Item	li'l eyeball costume	Combat Rate: -10, Equips On: "Trick-or-Treating Tot"
-Item	li'l ghost costume	Initiative: +100, Equips On: "Trick-or-Treating Tot"
-Item	li'l knight costume	Muscle: +15, Mysticality: +15, Moxie: +15
-Item	li'l liberty costume	Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot"
-Item	li'l ninja costume	Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot"
-Item	li'l pirate costume	Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot"
+Item	Li'l Businessman Kit	Meat Drop: +5, Item Drop: +5, Last Available: "2011-05", Generic
+Item	li'l candy corn costume	Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+Item	li'l clown costume	Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+Item	li'l eyeball costume	Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+Item	li'l ghost costume	Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+Item	li'l knight costume	Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
+Item	li'l liberty costume	Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+Item	li'l ninja costume	Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+Item	li'l pirate costume	Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 # li'l robot costume: Reduces radiation sickness levels
-Item	li'l robot costume	Experience: +10, Equips On: "Trick-or-Treating Tot"
-Item	li'l unicorn costume	Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot"
-Item	licorice boa	Familiar Weight: +5
+Item	li'l robot costume	Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+Item	li'l unicorn costume	Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+Item	licorice boa	Familiar Weight: +5, Last Available: "2011-12"
 Item	limburger biker boots	Familiar Weight: +5
 Item	little bitty bathysphere	Familiar Weight: -20, Underwater Familiar, Generic, Familiar Effect: "adventure underwater"
-Item	little box of fireworks	Familiar Weight: +5, Softcore Only, Generic, Experience: +1.5, Item Drop (sporadic): +12.5
-Item	Little Crimson Book	Familiar Weight: +5
+Item	little box of fireworks	Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Generic, Experience: +1.5, Item Drop (sporadic): +12.5
+Item	Little Crimson Book	Familiar Weight: +5, Last Available: "2013-12"
 # little wooden mannequin: Makes Kid Better at Drawing Other Players
 Item	little wooden mannequin	Familiar Weight: +5
-Item	Loathing Legion helicopter	Familiar Weight: +5, Softcore Only, Generic, Familiar Action Bonus: +25
-Item	luck incense	Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Generic
-Item	lucky Tam O'Shanter	Meat Drop: +50, Softcore Only, Generic
-Item	lucky Tam O'Shatner	Meat Drop: +50, Softcore Only, Generic
+Item	Loathing Legion helicopter	Familiar Weight: +5, Softcore Only, Last Available: "2011-01", Generic, Familiar Action Bonus: +25
+Item	luck incense	Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03", Generic
+Item	lucky Tam O'Shanter	Meat Drop: +50, Softcore Only, Last Available: "2005-03", Generic
+Item	lucky Tam O'Shatner	Meat Drop: +50, Softcore Only, Last Available: "2005-03", Generic
 Item	magnifying glass	Familiar Weight: +5
 Item	many-eyed glasses	Familiar Weight: +5
-Item	Mayflower bouquet	Familiar Weight: +5, Softcore Only, Generic, Experience: +0.625, Meat Drop (sporadic): +5, Item Drop (sporadic): +2.5, Experience (familiar): +0.375, Drops Items
+Item	Mayflower bouquet	Familiar Weight: +5, Softcore Only, Last Available: "2007-05", Generic, Experience: +0.625, Meat Drop (sporadic): +5, Item Drop (sporadic): +2.5, Experience (familiar): +0.375, Drops Items
 Item	mayo pump	Familiar Weight: +5
 Item	Meat detector	Familiar Weight: +5
 Item	meatcar model	Familiar Weight: +5
-Item	menorette	Familiar Weight: +5
-Item	metal mandible	Familiar Weight: +5
-Item	metallic foil bow	Familiar Weight: +5
-Item	metallic foil radar dish	Familiar Weight: +5, Volleyball: -1, Sombrero: +1, Equips On: "Crimbo P. R. E. S. S. I. E."
+Item	menorette	Familiar Weight: +5, Last Available: "2004-12"
+Item	metal mandible	Familiar Weight: +5, Last Available: "2005-12"
+Item	metallic foil bow	Familiar Weight: +5, Last Available: "2011-12"
+Item	metallic foil radar dish	Familiar Weight: +5, Last Available: "2011-12", Volleyball: -1, Sombrero: +1, Equips On: "Crimbo P. R. E. S. S. I. E."
 Item	meteor shower cap	Familiar Weight: +5
 Item	metrognome	Familiar Weight: +5
 # microwave stogie: Helps your Organ Grinder Bake Pies Faster
 Item	mini-Mr. Accessory	Familiar Weight: +5
-Item	miniature antlers	Familiar Weight: [1+ceil(M/2)], Generic
+Item	miniature antlers	Familiar Weight: [1+ceil(M/2)], Last Available: "2008-12", Generic
 Item	miniature carton of clove cigarettes	Familiar Weight: +5
 Item	miniature castagnets	Familiar Weight: +5
 # miniature crystal ball: Randomly gives you either +50% Item Drops or +5 Stats After Combat
 Item	miniature crystal ball	Initiative: +50, Item Drop (sporadic): +25, Experience: +2.5, Generic
 # miniature dormouse: Makes March Hare More Better
 Item	miniature espresso maker	Familiar Weight: +5
-Item	miniature goose mask	Familiar Weight: +5, Experience (Moxie): +3, Generic
-Item	miniature gravy-covered maypole	Item Drop: +25, Softcore Only, Generic
+Item	miniature goose mask	Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12", Generic
+Item	miniature gravy-covered maypole	Item Drop: +25, Softcore Only, Last Available: "2005-05", Generic
 Item	miniature Jacob's ladder	Familiar Weight: +5
 # miniature life preserver: Helps your familiar deal with all this rain
 Item	miniature life preserver	Generic
 Item	miniature pruning shears	Familiar Weight: +5
 Item	miniature tophat	Familiar Weight: +5
 # MiniMechaElf Laser Punch Missile Launcher: More likely to use more powerful attacks
-Item	miniscule beatbox	Familiar Weight: +5
+Item	miniscule beatbox	Familiar Weight: +5, Last Available: "2012-12"
 Item	mint-condition magic wand	Volleyball: 0.3334, Fairy: 0.3334
 Item	missing semicolon	Familiar Weight: +11
 # moonglasses: Makes Familiar Less Sensitive to Light
-Item	moveable feast	Familiar Weight: +5, Softcore Only, Generic, Experience (familiar): +1, Sporadic Damage Aura: 0.35
+Item	moveable feast	Familiar Weight: +5, Softcore Only, Last Available: "2009-11", Generic, Experience (familiar): +1, Sporadic Damage Aura: 0.35
 # muscle band: Increases familiar damage
-Item	muscle band	Familiar Weight: +10, Lasts Until Rollover, Generic
+Item	muscle band	Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03", Generic
 # nanorhino credit card: Helps your Nano-Rhino charge
 Item	nosy nose ringy ring	Familiar Weight: +15
 # nutcracking pliers: Makes your Antique Nutcracker drop nuts more often
 # orange boxing gloves: Causes your Puck Man to sometimes drop extra yellow pixels
 # origami &quot;gentlemen's&quot; magazine: +10 lbs. of Ghuol Whelp
-Item	origami &quot;gentlemen's&quot; magazine	Softcore Only, Generic
-Item	overclocked avian microprocessor	Familiar Weight: +5
-Item	overloaded Yule battery	Familiar Weight: +25
+Item	origami &quot;gentlemen's&quot; magazine	Softcore Only, Last Available: "2008-02", Generic
+Item	overclocked avian microprocessor	Familiar Weight: +5, Last Available: "2007-12"
+Item	overloaded Yule battery	Familiar Weight: +25, Last Available: "2022-12"
 Item	oversized fish scaler	Generic, Sporadic Damage Aura: 0.33
-Item	oversized sparkler	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, Item Drop: +20, Lasts Until Rollover
+Item	oversized sparkler	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, Item Drop: +20, Lasts Until Rollover, Last Available: "2021-07"
 Item	palm-frond toupee	Familiar Weight: +5
 Item	Panda outfit	Familiar Weight: +5, Item Drop: +5, Generic
 Item	party mouse hat	Familiar Weight: +5
 Item	penguin-smacking club	Familiar Damage: +15
 Item	pet anemone	Familiar Weight: +5
-Item	pet rock &quot;Groucho&quot; disguise	Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
-Item	pet rock &quot;Snooty&quot; disguise	Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+Item	pet rock &quot;Groucho&quot; disguise	Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+Item	pet rock &quot;Snooty&quot; disguise	Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 Item	Petite Paintbrush	Adventures: +1, Generic
 Item	pewter candlestick	Familiar Weight: +10
 Item	pile of dungeon junk	Familiar Weight: +5
 # plastic bib: Makes your ghost better at eating stuff
 Item	plastic piranha pot	Familiar Weight: +5
 Item	plastic pirate hat	Familiar Weight: +5
-Item	plastic pumpkin bucket	Familiar Weight: +5, Item Drop: +13, Softcore Only, Generic, Sporadic Damage Aura: 0.35
-Item	portable motorcycle	Familiar Weight: +5
+Item	plastic pumpkin bucket	Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10", Generic, Sporadic Damage Aura: 0.35
+Item	portable motorcycle	Familiar Weight: +5, Last Available: "2010-06"
 # pretty pink bow: +10 lbs. of Ghoul Whelp
-Item	Pretty Predator Clawicure Kit	Familiar Weight: +5
+Item	Pretty Predator Clawicure Kit	Familiar Weight: +5, Last Available: "2006-01"
 Item	prosthetic forehead	Familiar Weight: +5
 Item	psychedelic bubble wand	Familiar Weight: +5
 Item	putty coat	Familiar Weight: +5
 # quadroculars: Helps Your He-Boulder See Better (x4)
-Item	quadroculars	Familiar Weight: +5
+Item	quadroculars	Familiar Weight: +5, Last Available: "2009-09"
 # quake of arrows: Holds Heavier Arrows
-Item	radioactive chew toy	Familiar Weight: +5
-Item	rainbow tie	Familiar Weight: +5
-Item	ramekin of space nuts	Familiar Weight: +5
+Item	radioactive chew toy	Familiar Weight: +5, Last Available: "2008-12"
+Item	rainbow tie	Familiar Weight: +5, Last Available: "2011-12"
+Item	ramekin of space nuts	Familiar Weight: +5, Last Available: "2014-05"
 Item	rat head balloon	Familiar Weight: -3, Generic
 Item	rat tooth polish	Familiar Weight: +5
 Item	rattlesnake enrager	Familiar Weight: +5
 # razor fang: Your familiar will sometimes interrupt enemy attacks
-Item	razor fang	Familiar Weight: +10, Lasts Until Rollover, Generic
+Item	razor fang	Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03", Generic
 Item	really tiny cocktail shaker	Familiar Weight: +5
 # red-and-green microcamera: Increases operational effectiveness
 Item	red-and-green microcamera	Familiar Weight: +5
@@ -4637,49 +4637,49 @@ Item	replica plastic pumpkin bucket	Familiar Weight: +5, Item Drop: +13, Generic
 Item	replica wax lips	Experience: +3, Generic
 Item	rhesus monkey	Familiar Weight: +5
 Item	rhinestone cowhorn	Familiar Weight: +5
-Item	ribcage rollcage	Familiar Weight: +5
-Item	S.L.E.I.G.H.B.E.L.L.S.	Familiar Weight: +5
+Item	ribcage rollcage	Familiar Weight: +5, Last Available: "2012-10"
+Item	S.L.E.I.G.H.B.E.L.L.S.	Familiar Weight: +5, Last Available: "2010-12"
 Item	S.S. Ticket	Familiar Weight: +5
 # school spirit socket set: Keeps more steam in
 Item	security blankie	Familiar Weight: +5
-Item	self-dribbling basketball	Familiar Weight: +10
+Item	self-dribbling basketball	Familiar Weight: +10, Last Available: "2015-12"
 Item	serrated proboscis extension	Familiar Weight: +20
 # shell bell: Heals you when your familiar deals damage
-Item	shell bell	Familiar Weight: +10, Lasts Until Rollover, Generic
+Item	shell bell	Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03", Generic
 Item	shiny brass tailfeathers	Familiar Weight: +5
 Item	shiny gold fronts	Familiar Weight: +5
 # shock collar: Familiar Will Attack You Less Often
 Item	Site Alpha ID badge	Familiar Weight: +5
 Item	six-armed sweater	Familiar Weight: +5
 Item	skewer-mounted razor blade	Familiar Weight: +5
-Item	slightly thicker filthy rags	Familiar Weight: +5
+Item	slightly thicker filthy rags	Familiar Weight: +5, Last Available: "2011-09"
 Item	smile-sharpening stone	Familiar Weight: +5
 # smiley-face sticker: +10 lbs. of Volleyball
 Item	smiley-face sticker	Experience: +3.16
 # smoke ball: Running away is always successful, and gives stats based on the enemy
-Item	smoke ball	Familiar Weight: +10, Lasts Until Rollover, Generic
-Item	snow halo	Familiar Weight: +5
+Item	smoke ball	Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03", Generic
+Item	snow halo	Familiar Weight: +5, Last Available: "2009-12"
 # Snow Suit: Lets Your Familiar Do Various Tricks
-Item	Snow Suit	Familiar Weight: [max(5,20-floor(pref(_snowSuitCount)/5))], Softcore Only, Generic
+Item	Snow Suit	Familiar Weight: [max(5,20-floor(pref(_snowSuitCount)/5))], Softcore Only, Last Available: "2013-01", Generic
 Item	solid shifting time weirdness	Adventures: +4, PvP Fights: +4, Generic
 Item	solid state loom	Familiar Weight: +10
 Item	space jellybicycle	Familiar Weight: +5
 Item	spoon!	Familiar Weight: +5
-Item	spruce juice	Familiar Weight: +5
+Item	spruce juice	Familiar Weight: +5, Last Available: "2012-12"
 # Stembridge sidearm: Decisively ends fights, but only occasionally
 Item	Stembridge sidearm	Familiar Weight: +5
 # stick-on mini solar panels: +10 lbs. of Starfish
-Item	stomp box	Familiar Weight: +5
-Item	string of dingle balls	Familiar Weight: +5
+Item	stomp box	Familiar Weight: +5, Last Available: "2011-12"
+Item	string of dingle balls	Familiar Weight: +5, Last Available: "2011-12"
 Item	sucky decal	Familiar Weight: +5
-Item	sugar shield	Familiar Weight: +10, Generic, Breakable
+Item	sugar shield	Familiar Weight: +10, Last Available: "2009-09", Generic, Breakable
 # targeting chip: More likely to use more powerful attacks
 Item	tasteful black bow tie	Familiar Weight: +5
 # teddy bear sewing kit: Teddy Bear loses less stuffing when hit
 # teddy borg sewing kit: Teddy Borg loses less stuffing when hit
 Item	tinsel fin	Familiar Weight: +5
 Item	tiny baby scorpion	Familiar Weight: +10
-Item	tiny ballet slippers	Familiar Weight: +5
+Item	tiny ballet slippers	Familiar Weight: +5, Last Available: "2008-12"
 Item	tiny balloon knife	Familiar Weight: +5
 Item	tiny bindle	Familiar Weight: +5
 Item	tiny bowler	Generic, Damage Aura: 1
@@ -4687,10 +4687,10 @@ Item	tiny bust of Pallas	Familiar Weight: +5
 Item	tiny cell phone	Familiar Weight: +10
 # tiny costume wardrobe: Contains Many Adorable Costumes
 Item	tiny costume wardrobe	Softcore Only, Generic, Familiar Weight: [25*fam(doppelshifter)]
-Item	tiny do-rag	Familiar Weight: +5
+Item	tiny do-rag	Familiar Weight: +5, Last Available: "2011-11"
 Item	tiny domino mask	Familiar Weight: +5
-Item	tiny fly glasses	Experience (familiar): +1, Generic
-Item	tiny glowing red nose	Familiar Weight: +5, Experience (Mysticality): +3, Generic
+Item	tiny fly glasses	Experience (familiar): +1, Last Available: "2010-04", Generic
+Item	tiny glowing red nose	Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12", Generic
 Item	tiny consolation ribbon	Familiar Weight: -10, Experience (familiar): -1, Generic
 # tiny gold medal: Doubles the chance that familiars act in combat
 Item	tiny gold medal	Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover, Generic
@@ -4703,32 +4703,32 @@ Item	tiny prop sword	Familiar Weight: +5
 Item	tiny rake	Item Drop: +1, Generic, Leaves: +1.5
 Item	tiny shaker of salt	Familiar Weight: +5
 Item	tiny sombrero	Sombrero Bonus: +10
-Item	tiny stillsuit	Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Generic
+Item	tiny stillsuit	Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08", Generic
 # tiny Tina gun: Your Moll Doll will deal a lot more damage in combat
 Item	tiny Tina gun	Familiar Weight: +5
 # tiny top hat and cane: Lets your Li'l Xenomorph dance!
 # tiny top hat and cane: (adds item0 to familiar abilities)
 Item	tiny top hat and cane	Fairy: 1.0
 # tiny yam cannon: Gives your familiar an extra attack.
-Item	tiny yam cannon	Initiative: +50, Lasts Until Rollover, Generic
+Item	tiny yam cannon	Initiative: +50, Lasts Until Rollover, Last Available: "2024-05", Generic
 Item	Toddler-sized Dragon Costume	Familiar Weight: +5, Item Drop: +5, Softcore Only, Generic
 Item	toggle switch (Bartend)	Familiar Weight: +5
 Item	toggle switch (Bounce)	Familiar Weight: +5, Equips On: "Robortender"
 Item	topiary noseplugs	Familiar Weight: +5
-Item	toy six-seater hovercraft	Familiar Weight: -5
+Item	toy six-seater hovercraft	Familiar Weight: -5, Last Available: "2011-12"
 # tuning fork: Familiar Will Attack You Less Often
 # undissolvable contact lenses: Helps your Slimeling See Better
-Item	unspeakable lozenges	Familiar Weight: +5
-Item	velvet choker	Familiar Weight: +5
+Item	unspeakable lozenges	Familiar Weight: +5, Last Available: "2009-10"
+Item	velvet choker	Familiar Weight: +5, Last Available: "2011-12"
 Item	vicious spiked collar	Familiar Damage: +20, Generic
 # warbear drone codes: Makes the drone better, faster, stronger
-Item	wax lips	Experience: +3, Softcore Only, Generic
+Item	wax lips	Experience: +3, Softcore Only, Last Available: "2005-07", Generic
 # weegee sqouija: Hobo's Booze Is More Effective
 # white arm towel: Your familiar will find extra food and booze on the Crimbo Train
 Item	white arm towel	Generic
 Item	woimbook	Familiar Weight: +5
-Item	woolen cravat	Familiar Weight: +5
-Item	Xiblaxian holo-bowtie	Familiar Weight: +5
+Item	woolen cravat	Familiar Weight: +5, Last Available: "2007-03"
+Item	Xiblaxian holo-bowtie	Familiar Weight: +5, Last Available: "2014-09"
 # zen motorcycle: Makes Llama Lamas friendlier
 
 # Virtual Equipment
@@ -5314,12 +5314,12 @@ Edpiece	fish	Adventure Underwater
 
 # Bedazzlements section of modifiers.txt
 
-Item	scratch 'n' sniff apple sticker	Experience: +2
-Item	scratch 'n' sniff dragon sticker	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3
-Item	scratch 'n' sniff rock band sticker	Weapon Damage: +20, Spell Damage: +20
-Item	scratch 'n' sniff unicorn sticker	Item Drop: +25
-Item	scratch 'n' sniff UPC sticker	Meat Drop: +25
-Item	scratch 'n' sniff wrestler sticker	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10
+Item	scratch 'n' sniff apple sticker	Experience: +2, Last Available: "2008-11"
+Item	scratch 'n' sniff dragon sticker	Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2008-11"
+Item	scratch 'n' sniff rock band sticker	Weapon Damage: +20, Spell Damage: +20, Last Available: "2008-11"
+Item	scratch 'n' sniff unicorn sticker	Item Drop: +25, Last Available: "2008-11"
+Item	scratch 'n' sniff UPC sticker	Meat Drop: +25, Last Available: "2008-11"
+Item	scratch 'n' sniff wrestler sticker	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2008-11"
 
 # Alice's Army section of modifiers.txt
 
@@ -5368,45 +5368,45 @@ Item	Alice's Army Foil Wallman	Damage Reduction: 9
 # Folder section of modifiers.txt
 
 # folder (barbarian): Increased physical damage as you take damage
-Item	folder (blue)	Mysticality: +20
+Item	folder (blue)	Mysticality: +20, Last Available: "2013-08"
 Item	folder (catfish)	Familiar Weight (hidden): [15*env(underwater)]
-Item	folder (cyan)	Mysticality: +15, Moxie: +15
+Item	folder (cyan)	Mysticality: +15, Moxie: +15, Last Available: "2013-08"
 Item	folder (D-Team)	Experience (Muscle): +1, Experience (Mysticality): +1, Experience (Moxie): +1
 Item	folder (dancing dolphins)	Item Drop: [50*env(underwater)]
-Item	folder (Ex-Files)	Combat Rate: +5
-Item	folder (green)	Moxie: +20
-Item	folder (heavy metal)	Familiar Weight: +5
+Item	folder (Ex-Files)	Combat Rate: +5, Last Available: "2013-08"
+Item	folder (green)	Moxie: +20, Last Available: "2013-08"
+Item	folder (heavy metal)	Familiar Weight: +5, Last Available: "2013-08"
 Item	folder (holographic fractal)	Cold Resistance: +4, Hot Resistance: +4, Sleaze Resistance: +4, Spooky Resistance: +4, Stench Resistance: +4
-Item	folder (Jackass Plumber)	Monster Level: +25
-Item	folder (Knight Writer)	Initiative: +40
+Item	folder (Jackass Plumber)	Monster Level: +25, Last Available: "2013-08"
+Item	folder (Knight Writer)	Initiative: +40, Last Available: "2013-08"
 Item	folder (KOLHS)	Item Drop: [50*zone(KOL High School)]
-Item	folder (magenta)	Muscle: +15, Mysticality: +15
+Item	folder (magenta)	Muscle: +15, Mysticality: +15, Last Available: "2013-08"
 Item	folder (owl)	Item Drop: [500*zone(Dreadsylvania)]
 Item	folder (rainbow unicorn)	Thorns: 5
-Item	folder (red)	Muscle: +20
+Item	folder (red)	Muscle: +20, Last Available: "2013-08"
 Item	folder (Seawolf)	Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)]
-Item	folder (skull and crossbones)	Combat Rate: -5
-Item	folder (smiley face)	Experience (Muscle): +2
-Item	folder (space skeleton)	Experience (Moxie): +2
-Item	folder (sports car)	Adventures: +5
-Item	folder (sportsballs)	PvP Fights: +5
+Item	folder (skull and crossbones)	Combat Rate: -5, Last Available: "2013-08"
+Item	folder (smiley face)	Experience (Muscle): +2, Last Available: "2013-08"
+Item	folder (space skeleton)	Experience (Moxie): +2, Last Available: "2013-08"
+Item	folder (sports car)	Adventures: +5, Last Available: "2013-08"
+Item	folder (sportsballs)	PvP Fights: +5, Last Available: "2013-08"
 Item	folder (Stinky Trash Kid)	Damage Aura: 1
-Item	folder (tranquil landscape)	Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20
-Item	folder (wizard)	Experience (Mysticality): +2
-Item	folder (Yedi)	Spell Damage Percent: +50
-Item	folder (yellow)	Muscle: +15, Moxie: +15
+Item	folder (tranquil landscape)	Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
+Item	folder (wizard)	Experience (Mysticality): +2, Last Available: "2013-08"
+Item	folder (Yedi)	Spell Damage Percent: +50, Last Available: "2013-08"
+Item	folder (yellow)	Muscle: +15, Moxie: +15, Last Available: "2013-08"
 
 # Cowboy boot decorations section of modifiers.txt
 
 # coal snakeskin: Adds Spooky Damage to kicks with your cowboy boots
 Item	diamondback skin	Monster Level: +20
-Item	frontwinder skin	Mysticality Percent: +50
-Item	grizzled bearskin	Muscle Percent: +50
-Item	mountain lion skin	Moxie Percent: +50
+Item	frontwinder skin	Mysticality Percent: +50, Last Available: "2016-02"
+Item	grizzled bearskin	Muscle Percent: +50, Last Available: "2016-02"
+Item	mountain lion skin	Moxie Percent: +50, Last Available: "2016-02"
 # rotting cowskin: Adds Demonic Bovine Taint to your cowboy boots
 
 Item	nicksilver spurs	Item Drop: +20
-Item	quicksilver spurs	Initiative: +30
+Item	quicksilver spurs	Initiative: +30, Last Available: "2016-02"
 # sicksilver spurs: Adds Stench Damage to kicks with your cowboy boots
 # slicksilver spurs: Adds Sleaze Damage to kicks with your cowboy boots
 Item	thicksilver spurs	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2
@@ -5446,7 +5446,7 @@ Item	giant pilgrim hat	Base Resting HP: +39, Base Resting MP: +40
 Item	house-sized mushroom	Base Resting HP: +69, Base Resting MP: +70
 Item	ginormous pumpkin	Base Resting HP: +49, Base Resting MP: +50
 # haunted doghouse: Houses your very own Hallowiener Dog!
-Item	haunted doghouse	Free Pull
+Item	haunted doghouse	Free Pull, Last Available: "2015-10"
 Item	hobo fortress blueprints	Base Resting HP: +84, Base Resting MP: +85
 Item	house of twigs and spit	Base Resting HP: +59, Base Resting MP: +60
 Item	Lazybones&trade; recliner	Spooky Resistance: +2
@@ -9321,111 +9321,111 @@ MaxCat	_smithsness	Meat Drop: +2, Item Drop: +1, Moxie Percent: +2, Mysticality 
 # Food section of modifiers.txt
 
 # &quot;caramel&quot; orange: Also gives 10 turns of a random beneficial effect
-Item	&quot;meat&quot; stick	Effect: "Empty Inside", Effect Duration: 50
+Item	&quot;meat&quot; stick	Effect: "Empty Inside", Effect Duration: 50, Last Available: "2014-10"
 Item	3vi1 pr0n m4nic0tti	Effect: "[599]A Little Bit Evil", Effect Duration: 10
-Item	20-lb can of rice and beans	Effect: "Stuffed", Effect Duration: 100
-Item	Aldebaran sardines	Effect: "Fishy", Effect Duration: 60
+Item	20-lb can of rice and beans	Effect: "Stuffed", Effect Duration: 100, Last Available: "2022-05"
+Item	Aldebaran sardines	Effect: "Fishy", Effect Duration: 60, Last Available: "2017-04"
 Item	amok pudding	Effect: "Puddingface", Effect Duration: 20
-Item	animal part cracker	Effect: "Sprinkle in Your Eye", Effect Duration: 30
-Item	autumn-spice donut	Effect: "Whet Appetite", Effect Duration: 30
+Item	animal part cracker	Effect: "Sprinkle in Your Eye", Effect Duration: 30, Last Available: "2016-12"
+Item	autumn-spice donut	Effect: "Whet Appetite", Effect Duration: 30, Last Available: "2022-10"
 Item	bacteria bisque	Effect: "Infected with Chronerism", Effect Duration: 50
-Item	badass pie	Effect: "Pie in the Sky", Effect Duration: 20
-Item	bag of GORF	Effect: "Long Live GORF", Effect Duration: 3
-Item	bag of QWOP	Effect: "QWOPped Up", Effect Duration: 10
+Item	badass pie	Effect: "Pie in the Sky", Effect Duration: 20, Last Available: "2010-10"
+Item	bag of GORF	Effect: "Long Live GORF", Effect Duration: 3, Last Available: "2012-07"
+Item	bag of QWOP	Effect: "QWOPped Up", Effect Duration: 10, Last Available: "2012-07"
 # Baja sopapilla: NOTE: This item will stop working when Crimbo 2019 is over.
 # Baja sopapilla: Effect: "Baja, Humbug", Effect Duration: 30
-Item	baked stuffing	Effect: "Thanksgetting", Effect Duration: 20
-Item	baked veggie ricotta casserole	Effect: "Pretty Delicious", Effect Duration: 50
-Item	bar of freeze-dried water	Effect: "Ultrahydrated", Effect Duration: 10
-Item	barrel cracker	Effect: "Shortened", Effect Duration: 40
-Item	barrel pickle	Effect: "Briny Blood", Effect Duration: 50
+Item	baked stuffing	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
+Item	baked veggie ricotta casserole	Effect: "Pretty Delicious", Effect Duration: 50, Last Available: "2022-11"
+Item	bar of freeze-dried water	Effect: "Ultrahydrated", Effect Duration: 10, Last Available: "2022-05"
+Item	barrel cracker	Effect: "Shortened", Effect Duration: 40, Last Available: "2015-09"
+Item	barrel pickle	Effect: "Briny Blood", Effect Duration: 50, Last Available: "2015-09"
 Item	Bash-&#332;s cereal	Wiki Name: "Bash-Os cereal"
-Item	bat-shaped Crimboween cookie	Effect: "Bells in the Batfry", Effect Duration: 5
-Item	bear claw	Effect: "Bear Clawed", Effect Duration: 30
-Item	Beefy Crunch Pastaco	Effect: "Boletus Swoletus", Effect Duration: 40
+Item	bat-shaped Crimboween cookie	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+Item	bear claw	Effect: "Bear Clawed", Effect Duration: 30, Last Available: "2016-02"
+Item	Beefy Crunch Pastaco	Effect: "Boletus Swoletus", Effect Duration: 40, Last Available: "2014-05"
 Item	beefy fish meat	Effect: "Fishy", Effect Duration: 5
-Item	bell-shaped Crimbo cookie	Effect: "Fury of the Bells", Effect Duration: 10
+Item	bell-shaped Crimbo cookie	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 Item	bishop cookie	Effect: "Mitre Cut", Effect Duration: 30
-Item	Black Angus blackburger	Effect: "The Power of Negative Thinking", Effect Duration: 100
+Item	Black Angus blackburger	Effect: "The Power of Negative Thinking", Effect Duration: 100, Last Available: "2016-12"
 Item	black forest cake	Effect: "Sugar Rush", Effect Duration: 5
 Item	black pudding	Wiki Name: "black pudding (food)"
-Item	blob-shaped Crimbo cookie	Effect: "Amorphous Cheer", Effect Duration: 10
+Item	blob-shaped Crimbo cookie	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 Item	blueberry muffin	Effect: "All Blued Up", Effect Duration: 25
-Item	blunt cat claw	Effect: "Feline Ferocity", Effect Duration: 30
-Item	Boris's bread	Effect: "Inspired Chef", Effect Duration: 30
-Item	bowl full of jelly	Effect: "Jowls Full, and Belly", Effect Duration: 30
+Item	blunt cat claw	Effect: "Feline Ferocity", Effect Duration: 30, Last Available: "2011-09"
+Item	Boris's bread	Effect: "Inspired Chef", Effect Duration: 30, Last Available: "2022-11"
+Item	bowl full of jelly	Effect: "Jowls Full, and Belly", Effect Duration: 30, Last Available: "2020-12"
 Item	bowl of Bounty-Os	Effect: "Broken Fast", Effect Duration: 20
-Item	bowl of eyeballs	Effect: "Your Eyes are Peeled!", Effect Duration: 30
+Item	bowl of eyeballs	Effect: "Your Eyes are Peeled!", Effect Duration: 30, Last Available: "2015-10"
 # bowl of mernudo: NOTE: This item will stop working when Crimbo 2019 is over.
 # bowl of mernudo: Effect: "Sea Guts", Effect Duration: 30
-Item	bowl of mummy guts	Effect: "Guts Feeling", Effect Duration: 30
+Item	bowl of mummy guts	Effect: "Guts Feeling", Effect Duration: 30, Last Available: "2015-10"
 Item	bowl of Tastee-Wheet&trade;	Effect: "Video... Games?", Effect Duration: 5
-Item	Brain Food Pastaco	Effect: "Omphalotus Omnipresence", Effect Duration: 40
+Item	Brain Food Pastaco	Effect: "Omphalotus Omnipresence", Effect Duration: 40, Last Available: "2014-05"
 Item	bran muffin	Effect: "All Branned Up", Effect Duration: 25
-Item	bread line	Effect: "Bread-Lined", Effect Duration: 40
-Item	bread roll	Effect: "Thanksgetting", Effect Duration: 20
+Item	bread line	Effect: "Bread-Lined", Effect Duration: 40, Last Available: "2015-12"
+Item	bread roll	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
 Item	brown sugar cane	Effect: "Sugar Rush", Effect Duration: 3
 # bu&ntilde;uelos Jaliscos: NOTE: This item will stop working when Crimbo 2019 is over.
 # bu&ntilde;uelos Jaliscos: Effect: "Fishy", Effect Duration: 30
-Item	bucket of honey	Effect: "Sugar Rush", Effect Duration: 50
+Item	bucket of honey	Effect: "Sugar Rush", Effect Duration: 50, Last Available: "2010-03"
 Item	C.H.U.M. chum	Effect: "Majorly Poisoned", Effect Duration: 20
-Item	Calzone of Legend	Effect: "In the 'zone zone!", Effect Duration: 100
-Item	campfire baked potato	Effect: "Trial by Campfire", Effect Duration: 60
-Item	campfire beans	Effect: "The More You Eat", Effect Duration: 40
-Item	campfire coffee	Effect: "Coffee Achiever", Effect Duration: 40
-Item	campfire hot dog	Effect: "Traditional Eating", Effect Duration: 40
-Item	campfire s'more	Effect: "Gimme, Gimme", Effect Duration: 60
-Item	campfire stew	Effect: "Just Like Me, They Want to Be", Effect Duration: 60
-Item	can of Adultwitch&trade;	Effect: "Greasy Visage", Effect Duration: 20
-Item	can of franks 'n' beans	Effect: "Crimbo Nostalgia", Effect Duration: 50
-Item	candied beef and cabbage	Effect: "Green-Blooded", Effect Duration: 20
-Item	candied lime	Effect: "Limed Up", Effect Duration: 50
-Item	candied pecan	Effect: "Sugar Rush", Effect Duration: 10
-Item	candied sweet potatoes	Effect: "Thanksgetting", Effect Duration: 20
-Item	candy carrot	Effect: "Improved Candy Vision", Effect Duration: 10
-Item	candy carrot cake	Effect: "Improved Candy Vision", Effect Duration: 30
+Item	Calzone of Legend	Effect: "In the 'zone zone!", Effect Duration: 100, Last Available: "2022-11"
+Item	campfire baked potato	Effect: "Trial by Campfire", Effect Duration: 60, Last Available: "2019-08"
+Item	campfire beans	Effect: "The More You Eat", Effect Duration: 40, Last Available: "2019-08"
+Item	campfire coffee	Effect: "Coffee Achiever", Effect Duration: 40, Last Available: "2019-08"
+Item	campfire hot dog	Effect: "Traditional Eating", Effect Duration: 40, Last Available: "2019-08"
+Item	campfire s'more	Effect: "Gimme, Gimme", Effect Duration: 60, Last Available: "2019-08"
+Item	campfire stew	Effect: "Just Like Me, They Want to Be", Effect Duration: 60, Last Available: "2019-08"
+Item	can of Adultwitch&trade;	Effect: "Greasy Visage", Effect Duration: 20, Last Available: "2014-12"
+Item	can of franks 'n' beans	Effect: "Crimbo Nostalgia", Effect Duration: 50, Last Available: "2010-12"
+Item	candied beef and cabbage	Effect: "Green-Blooded", Effect Duration: 20, Last Available: "2024-12"
+Item	candied lime	Effect: "Limed Up", Effect Duration: 50, Last Available: "2023-12"
+Item	candied pecan	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2014-12"
+Item	candied sweet potatoes	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
+Item	candy carrot	Effect: "Improved Candy Vision", Effect Duration: 10, Last Available: "2014-12"
+Item	candy carrot cake	Effect: "Improved Candy Vision", Effect Duration: 30, Last Available: "2014-12"
 # candy kneecapping stick: Deals 10-20 Physical Damage when used as a combat item
-Item	candy kneecapping stick	Effect: "Sugar Rush", Effect Duration: 5
-Item	candy mountain oyster	Effect: "Sugar Rush", Effect Duration: 10
-Item	candy rations	Effect: "Toured of Duty", Effect Duration: 20
-Item	carrot cake	Effect: "Pla-see-bo", Effect Duration: 10
-Item	carrot cake precipice bar	Effect: "On the Precipice of Carrots", Effect Duration: 30
+Item	candy kneecapping stick	Effect: "Sugar Rush", Effect Duration: 5, Last Available: "2009-12"
+Item	candy mountain oyster	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2014-12"
+Item	candy rations	Effect: "Toured of Duty", Effect Duration: 20, Last Available: "2024-12"
+Item	carrot cake	Effect: "Pla-see-bo", Effect Duration: 10, Last Available: "2013-01"
+Item	carrot cake precipice bar	Effect: "On the Precipice of Carrots", Effect Duration: 30, Last Available: "2022-05"
 Item	centipede eggs	Effect: "Somewhat Poisoned", Effect Duration: 10
 Item	chaos popcorn	Effect Duration: 5
-Item	cheezburger	Effect: "Yes, Can Haz", Effect Duration: 50
+Item	cheezburger	Effect: "Yes, Can Haz", Effect Duration: 50, Last Available: "2011-09"
 Item	chilly dog	Effect: "Chill Out, Dog", Effect Duration: 30
-Item	Choco-Mint patty	Effect: "Alpine Mintiness", Effect Duration: 25
+Item	Choco-Mint patty	Effect: "Alpine Mintiness", Effect Duration: 25, Last Available: "2015-01"
 Item	chocolate chip muffin	Effect: "All Chipped Up", Effect Duration: 25
-Item	chocolate ostrich egg	Effect: "Resurrection of the Flesh", Effect Duration: 20
-Item	Christmas ham	Effect: "Eyesies on the Pressies", Effect Duration: 20
+Item	chocolate ostrich egg	Effect: "Resurrection of the Flesh", Effect Duration: 20, Last Available: "2024-12"
+Item	Christmas ham	Effect: "Eyesies on the Pressies", Effect Duration: 20, Last Available: "2024-12"
 Item	ciliophora chowder	Effect: "Twitching Senses", Effect Duration: 50
-Item	circular CRIMBCOOKIE	Effect: "Mystic Circle", Effect Duration: 10
+Item	circular CRIMBCOOKIE	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 Item	cold hi mein	Effect: "Cold Breath", Effect Duration: 5
 # cold mashed potatoes: Selling Price: <b>1 Meat.</b><p><center><b><font color=blue>Deals <font color=blue>Cold Damage</font> based on your Mysticality when used as a combat item
-Item	cookie cookie	Effect: "Cookie Backup", Effect Duration: 10
-Item	Cool Brunch Pastaco	Effect: "Gyromitra Gymnastics", Effect Duration: 40
-Item	cool cat claw	Effect: "Feline Ferocity", Effect Duration: 30
-Item	cool jelly donut	Effect: "Filled with Magic", Effect Duration: 30
-Item	cool mint precipice bar	Effect: "On the Minty Precipice", Effect Duration: 30
-Item	cranberry cylinder	Effect: "Thanksgetting", Effect Duration: 20
+Item	cookie cookie	Effect: "Cookie Backup", Effect Duration: 10, Last Available: "2014-12"
+Item	Cool Brunch Pastaco	Effect: "Gyromitra Gymnastics", Effect Duration: 40, Last Available: "2014-05"
+Item	cool cat claw	Effect: "Feline Ferocity", Effect Duration: 30, Last Available: "2011-09"
+Item	cool jelly donut	Effect: "Filled with Magic", Effect Duration: 30, Last Available: "2011-09"
+Item	cool mint precipice bar	Effect: "On the Minty Precipice", Effect Duration: 30, Last Available: "2022-05"
+Item	cranberry cylinder	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
 Item	cream of chloroplasts	Effect: "Chloroplasted", Effect Duration: 50
-Item	Crimbo salad	Effect: "Salad Days", Effect Duration: 40
+Item	Crimbo salad	Effect: "Salad Days", Effect Duration: 40, Last Available: "2015-12"
 Item	cup of lukewarm tea	Effect: "Jittery", Effect Duration: 20
-Item	cupcake-in-a-cup	Effect: "Cake Caked", Effect Duration: 10
-Item	cursed Aztec tamale	Effect: "Curse of the Tamale", Effect Duration: 20
+Item	cupcake-in-a-cup	Effect: "Cake Caked", Effect Duration: 10, Last Available: "2009-06"
+Item	cursed Aztec tamale	Effect: "Curse of the Tamale", Effect Duration: 20, Last Available: "2024-12"
 Item	cursed black pearl onion	Effect: "Curse of the Black Pearl Onion", Effect Duration: 1
 Item	cursed sea biscuit	Effect: "Curse Magnet", Effect Duration: 10
-Item	cyburger	Effect: "Connected", Effect Duration: 40
+Item	cyburger	Effect: "Connected", Effect Duration: 40, Last Available: "2025-12"
 Item	D roll	Effect: "On a Roll", Effect Duration: 20
-Item	Deep Dish of Legend	Effect: "In the Depths", Effect Duration: 100
-Item	denastified haunch	Effect: "Faerie Fortune", Effect Duration: 30
+Item	Deep Dish of Legend	Effect: "In the Depths", Effect Duration: 100, Last Available: "2022-11"
+Item	denastified haunch	Effect: "Faerie Fortune", Effect Duration: 30, Last Available: "2018-04"
 Item	devil dog	Effect: "Devil Inside", Effect Duration: 30
 Item	diabolic pizza	Lasts Until Rollover
 # dinner roll: Selling Price: <b>1 Meat.</b><p><center><b><font color=blue>Deals Physical Damage based on your Muscle when used as a combat item
-Item	Dinsey food-cone	Effect: "The Dinsey Way", Effect Duration: 30
-Item	disco biscuit	Effect: "Buttermilk Boogie", Effect Duration: 100
-Item	double-candied yams	Effect: "Grateful, But Spelled With a Dollar Sign", Effect Duration: 20
-Item	dragon snaps	Effect: "Oh Snap", Effect Duration: 5
+Item	Dinsey food-cone	Effect: "The Dinsey Way", Effect Duration: 30, Last Available: "2015-04"
+Item	disco biscuit	Effect: "Buttermilk Boogie", Effect Duration: 100, Last Available: "2015-08"
+Item	double-candied yams	Effect: "Grateful, But Spelled With a Dollar Sign", Effect Duration: 20, Last Available: "2024-12"
+Item	dragon snaps	Effect: "Oh Snap", Effect Duration: 5, Last Available: "2010-03"
 Item	Dreadsylvanian cold pocket	Effect: "Dreadful Chill", Effect Duration: 200
 Item	Dreadsylvanian hot pocket	Effect: "Dreadful Heat", Effect Duration: 200
 Item	Dreadsylvanian shepherd's pie	Effect: "Shepherd's Breath", Effect Duration: 10
@@ -9436,17 +9436,17 @@ Item	Dreadsylvanian stink pocket	Effect: "Dreadful Smell", Effect Duration: 200
 # drippy caviar: Puts 5 &micro;g of Drippy Juice into your blood
 # drippy nugget: Puts 5 &micro;g of Drippy Juice into your blood
 # drippy plum(?): Puts 5 &micro;g of Drippy Juice into your blood
-Item	drive-thru burger	Effect: "It Went Through All Right", Effect Duration: 40
+Item	drive-thru burger	Effect: "It Went Through All Right", Effect Duration: 40, Last Available: "2020-12"
 # dwarf bread: Deals 4-28 Physical Damage when used as a combat item
 Item	dwarf bread	Effect: "Dwarven Hardiness", Effect Duration: 5
-Item	eldritch distillate	Effect: "Eldritch Concentration", Effect Duration: 30
-Item	eldritch mushroom pizza	Effect: "Eldritch Attunement", Effect Duration: 1
-Item	Eldritch snap	Effect: "Eldritch Attunement", Effect Duration: 3
+Item	eldritch distillate	Effect: "Eldritch Concentration", Effect Duration: 30, Last Available: "2016-11"
+Item	eldritch mushroom pizza	Effect: "Eldritch Attunement", Effect Duration: 1, Last Available: "2017-03"
+Item	Eldritch snap	Effect: "Eldritch Attunement", Effect Duration: 3, Last Available: "2017-01"
 Item	electric Kool-Aid	Effect: "Electric, Kool", Effect Duration: 50
-Item	elven <i>limbos</i> gingerbread	Effect: "Yuletide Industry", Effect Duration: 20
-Item	Energy Buzz Pastaco	Effect: "Stemonitis Storm", Effect Duration: 40
-Item	escargotsicle	Effect: "Extremely Poor Taste", Effect Duration: 10
-Item	Every Day is Like This Sundae	Effect: "Smithsness Dinner", Effect Duration: 100
+Item	elven <i>limbos</i> gingerbread	Effect: "Yuletide Industry", Effect Duration: 20, Last Available: "2008-12"
+Item	Energy Buzz Pastaco	Effect: "Stemonitis Storm", Effect Duration: 40, Last Available: "2014-05"
+Item	escargotsicle	Effect: "Extremely Poor Taste", Effect Duration: 10, Last Available: "2007-06"
+Item	Every Day is Like This Sundae	Effect: "Smithsness Dinner", Effect Duration: 100, Last Available: "2013-12"
 Item	evil boring spaghetti	Effect: "[599]A Little Bit Evil", Effect Duration: 10
 Item	evil delicious noodles	Effect: "[599]A Little Bit Evil", Effect Duration: 10
 Item	evil delicious spicy noodles	Effect: "[599]A Little Bit Evil", Effect Duration: 10
@@ -9454,697 +9454,697 @@ Item	evil painful penne pasta	Effect: "[599]A Little Bit Evil", Effect Duration:
 Item	evil ravioli della hippy	Effect: "[599]A Little Bit Evil", Effect Duration: 10
 Item	evil spicy noodles	Effect: "[599]A Little Bit Evil", Effect Duration: 10
 Item	exotic jungle fruit	Effect: "Full of Fruit, Yourself", Effect Duration: 25
-Item	expired can of franks 'n' beans	Effect: "Crimbo Nostalgia", Effect Duration: 30
+Item	expired can of franks 'n' beans	Effect: "Crimbo Nostalgia", Effect Duration: 30, Last Available: "2009-12"
 # expired MRE gives 3 random effects
-Item	extra-toasted half sandwich	Effect: "Stop the Presses!", Effect Duration: 20
-Item	FDKOL hotcakes	Effect: "Hotcaked", Effect Duration: 50
-Item	festive sausage	Effect: "Sausage Festive", Effect Duration: 20
-Item	fire-roasted lake trout	Effect: "Fire-Roasted Feelings", Effect Duration: 50
-Item	fireman's lunch	Effect: "You're Not Cooking", Effect Duration: 20
+Item	extra-toasted half sandwich	Effect: "Stop the Presses!", Effect Duration: 20, Last Available: "2018-12"
+Item	FDKOL hotcakes	Effect: "Hotcaked", Effect Duration: 50, Last Available: "2012-07"
+Item	festive sausage	Effect: "Sausage Festive", Effect Duration: 20, Last Available: "2011-01"
+Item	fire-roasted lake trout	Effect: "Fire-Roasted Feelings", Effect Duration: 50, Last Available: "2022-06"
+Item	fireman's lunch	Effect: "You're Not Cooking", Effect Duration: 20, Last Available: "2014-12"
 # fishelada: NOTE: This item will stop working when Crimbo 2019 is over.
 # fishelada: Effect: "Fishy", Effect Duration: 30
 # flan del mar: NOTE: This item will stop working when Crimbo 2019 is over.
 # flan del mar: Effect: "Festively Brined", Effect Duration: 30
 Item	flower petal pie	Effect: "Flower Power", Effect Duration: 3
 Item	foie gras	Effect: "Beaten Up", Effect Duration: 1
-Item	forbidden danish	Effect: "Danish Cunning", Effect Duration: 30
-Item	frozen danish	Effect: "Danish Cunning", Effect Duration: 30
-Item	fruit-stuffed rumcake	Effect: "Fruit-Based Animosity", Effect Duration: 100
-Item	fudgesicle	Effect: "Fudge Headache", Effect Duration: 30
-Item	gallon of milk	Effect: "Feeling Queasy", Effect Duration: 100
+Item	forbidden danish	Effect: "Danish Cunning", Effect Duration: 30, Last Available: "2011-09"
+Item	frozen danish	Effect: "Danish Cunning", Effect Duration: 30, Last Available: "2011-09"
+Item	fruit-stuffed rumcake	Effect: "Fruit-Based Animosity", Effect Duration: 100, Last Available: "2023-12"
+Item	fudgesicle	Effect: "Fudge Headache", Effect Duration: 30, Last Available: "2011-11"
+Item	gallon of milk	Effect: "Feeling Queasy", Effect Duration: 100, Last Available: "2016-05"
 Item	ghost dog	Effect: "Scaredy Dog", Effect Duration: 30
-Item	ghostly ectoplasm	Effect: "Haunted Stomach", Effect Duration: 3
-Item	giant green gummi bear	Effect: "Gummibrain", Effect Duration: 40
-Item	giant red gummi bear	Effect: "Gummiheart", Effect Duration: 40
-Item	giant yellow gummi bear	Effect: "Gummiskin", Effect Duration: 40
-Item	gingerbread mutant bugbear	Effect: "Festive Radiation", Effect Duration: 10
-Item	gingerbread nylons	Effect: "Stocking Stuffer", Effect Duration: 50
-Item	gingerbread pirate	Effect: "Tiny Pirate Inside", Effect Duration: 50
-Item	gingerbread robot	Effect: "Gingerbread Robust", Effect Duration: 20
-Item	glass of raw eggs	Effect: "Boxing Day Breakfast", Effect Duration: 50
+Item	ghostly ectoplasm	Effect: "Haunted Stomach", Effect Duration: 3, Last Available: "2018-11"
+Item	giant green gummi bear	Effect: "Gummibrain", Effect Duration: 40, Last Available: "2011-11"
+Item	giant red gummi bear	Effect: "Gummiheart", Effect Duration: 40, Last Available: "2011-11"
+Item	giant yellow gummi bear	Effect: "Gummiskin", Effect Duration: 40, Last Available: "2011-11"
+Item	gingerbread mutant bugbear	Effect: "Festive Radiation", Effect Duration: 10, Last Available: "2008-12"
+Item	gingerbread nylons	Effect: "Stocking Stuffer", Effect Duration: 50, Last Available: "2023-12"
+Item	gingerbread pirate	Effect: "Tiny Pirate Inside", Effect Duration: 50, Last Available: "2023-12"
+Item	gingerbread robot	Effect: "Gingerbread Robust", Effect Duration: 20, Last Available: "2013-12"
+Item	glass of raw eggs	Effect: "Boxing Day Breakfast", Effect Duration: 50, Last Available: "2018-12"
 Item	glistening fish meat	Effect: "Fishy", Effect Duration: 5
-Item	greedy ghostling	Free Pull
-Item	green bean casserole	Effect: "Thanksgetting", Effect Duration: 20
-Item	green drunki-bear	Effect: "Gummibrain", Effect Duration: 80
-Item	green hamhock	Effect: "Just the Best Anapests", Effect Duration: 50
-Item	green-iced sweet roll	Effect: "Sprinkle Sense", Effect Duration: 40
-Item	gregarious ghostling	Free Pull
-Item	grinning ghostling	Free Pull
+Item	greedy ghostling	Free Pull, Last Available: "2020-12"
+Item	green bean casserole	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
+Item	green drunki-bear	Effect: "Gummibrain", Effect Duration: 80, Last Available: "2011-11"
+Item	green hamhock	Effect: "Just the Best Anapests", Effect Duration: 50, Last Available: "2012-12"
+Item	green-iced sweet roll	Effect: "Sprinkle Sense", Effect Duration: 40, Last Available: "2016-12"
+Item	gregarious ghostling	Free Pull, Last Available: "2020-12"
+Item	grinning ghostling	Free Pull, Last Available: "2020-12"
 Item	gunky chicken	Effect: "Gunky Dory", Effect Duration: 20
-Item	haggis-wrapped haggis-stuffed haggis	Effect: "Highland Sheen", Effect Duration: 20
-Item	hambrosier	Effect: "The Power of Positive Thinking", Effect Duration: 50
+Item	haggis-wrapped haggis-stuffed haggis	Effect: "Highland Sheen", Effect Duration: 20, Last Available: "2012-12"
+Item	hambrosier	Effect: "The Power of Positive Thinking", Effect Duration: 50, Last Available: "2016-12"
 Item	hamlet sandwich	Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 50
-Item	hardboiled egg	Effect: "Too Noir For Snoir", Effect Duration: 50
-Item	haunted cherry pie	Effect: "Haunted Stomach", Effect Duration: 20
-Item	haunted Hell ramen	Effect: "Haunted Stomach", Effect Duration: 20
-Item	haunted orange	Effect: "Haunted Stomach", Effect Duration: 20
-Item	haunted pizza	Effect: "Haunted Stomach", Effect Duration: 20
-Item	heart-shaped candy whetstone	Effect: "Sharpened Sweet Tooth", Effect Duration: 40
+Item	hardboiled egg	Effect: "Too Noir For Snoir", Effect Duration: 50, Last Available: "2016-07"
+Item	haunted cherry pie	Effect: "Haunted Stomach", Effect Duration: 20, Last Available: "2018-11"
+Item	haunted Hell ramen	Effect: "Haunted Stomach", Effect Duration: 20, Last Available: "2018-11"
+Item	haunted orange	Effect: "Haunted Stomach", Effect Duration: 20, Last Available: "2018-11"
+Item	haunted pizza	Effect: "Haunted Stomach", Effect Duration: 20, Last Available: "2018-11"
+Item	heart-shaped candy whetstone	Effect: "Sharpened Sweet Tooth", Effect Duration: 40, Last Available: "2018-02"
 Item	herb brownies	Effect: "Confused", Effect Duration: 5
-Item	Hide-rox&trade; cookie	Effect: "Broken Bone Nubs", Effect Duration: 30
+Item	Hide-rox&trade; cookie	Effect: "Broken Bone Nubs", Effect Duration: 30, Last Available: "2017-10"
 Item	hippy herbal tea	Effect: "Sleepy", Effect Duration: 5
-Item	holiday cheese log	Effect: "Stands Alone", Effect Duration: 20
-Item	honey bun of Boris	Effect: "Motherly Loved", Effect Duration: 30
-Item	honey-dew	Effect: "Mmmmmelon", Effect Duration: 10
+Item	holiday cheese log	Effect: "Stands Alone", Effect Duration: 20, Last Available: "2011-01"
+Item	honey bun of Boris	Effect: "Motherly Loved", Effect Duration: 30, Last Available: "2022-11"
+Item	honey-dew	Effect: "Mmmmmelon", Effect Duration: 10, Last Available: "2007-06"
 Item	hot hi mein	Effect: "Hot Breath", Effect Duration: 5
-Item	hushed puppy	Effect: "Noise Cancelled", Effect Duration: 100
-Item	ice cream sandwich	Effect: "Cold Throat", Effect Duration: 20
-Item	ice harvest	Effect: "Icy Demeanor", Effect Duration: 30
-Item	iceberg lettuce	Effect: "Headstrong", Effect Duration: 50
-Item	initiative shawarma	Effect: "Shawarma Initiative", Effect Duration: 30
-Item	irradiated candy cane	Effect: "Festive Radiation", Effect Duration: 10
-Item	Jarlsberg's vegetable soup	Effect: "Souped Up", Effect Duration: 30
-Item	java cookie	Effect: "Updated", Effect Duration: 10
-Item	jawbruiser	Effect: "Sugar Rush", Effect Duration: 5
+Item	hushed puppy	Effect: "Noise Cancelled", Effect Duration: 100, Last Available: "2017-12"
+Item	ice cream sandwich	Effect: "Cold Throat", Effect Duration: 20, Last Available: "2014-12"
+Item	ice harvest	Effect: "Icy Demeanor", Effect Duration: 30, Last Available: "2014-01"
+Item	iceberg lettuce	Effect: "Headstrong", Effect Duration: 50, Last Available: "2015-11"
+Item	initiative shawarma	Effect: "Shawarma Initiative", Effect Duration: 30, Last Available: "2014-10"
+Item	irradiated candy cane	Effect: "Festive Radiation", Effect Duration: 10, Last Available: "2008-12"
+Item	Jarlsberg's vegetable soup	Effect: "Souped Up", Effect Duration: 30, Last Available: "2022-11"
+Item	java cookie	Effect: "Updated", Effect Duration: 10, Last Available: "2014-12"
+Item	jawbruiser	Effect: "Sugar Rush", Effect Duration: 5, Last Available: "2010-12"
 Item	jive turkey leg	Effect: "Hollow Inside", Effect Duration: 50
-Item	jumping horseradish	Effect: "Kicked in the Sinuses", Effect Duration: 50
+Item	jumping horseradish	Effect: "Kicked in the Sinuses", Effect Duration: 50, Last Available: "2016-03"
 Item	jungle floor wax	Effect: "Wax On Your Shoes", Effect Duration: 20
 Item	junkyard dog	Effect: "Dog Breath", Effect Duration: 30
-Item	king cookie	Effect: "The Royal We", Effect Duration: 30
+Item	king cookie	Effect: "The Royal We", Effect Duration: 30, Last Available: "2010-03"
 Item	knight cookie	Effect: "Knightlife", Effect Duration: 30
-Item	knuckle sandwich	Effect: "Cruisin' for a Bruisin'", Effect Duration: 20, Wiki Name: "knuckle sandwich"
+Item	knuckle sandwich	Effect: "Cruisin' for a Bruisin'", Effect Duration: 20, Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 # Kudzu salad
-Item	lab-grown meat	Effect: "Real Meat Craving", Effect Duration: 20
-Item	lava cake	Effect: "Demonic Flavor", Effect Duration: 60
+Item	lab-grown meat	Effect: "Real Meat Craving", Effect Duration: 20, Last Available: "2021-12"
+Item	lava cake	Effect: "Demonic Flavor", Effect Duration: 60, Last Available: "2015-08"
 # licorice garrote: Weakens enemies based on how sugared-up you are
-Item	licorice garrote	Effect: "Sugar Rush", Effect Duration: 5
+Item	licorice garrote	Effect: "Sugar Rush", Effect Duration: 5, Last Available: "2009-12"
 Item	lihc eye pie	Effect: "Eye of the Lihc", Effect Duration: 5
-Item	limp broccoli	Effect: "Nutrient-Rich", Effect Duration: 100
-Item	liquid bread	Effect: "Comprehensively Nourished", Effect Duration: 20
+Item	limp broccoli	Effect: "Nutrient-Rich", Effect Duration: 100, Last Available: "2014-10"
+Item	liquid bread	Effect: "Comprehensively Nourished", Effect Duration: 20, Last Available: "2013-09"
 Item	loaf of soda bread	Effect: "Bread Burps", Effect Duration: 15
-Item	Ludovico Pastaco	Effect: "Tremella Tremens", Effect Duration: 40
+Item	Ludovico Pastaco	Effect: "Tremella Tremens", Effect Duration: 40, Last Available: "2014-05"
 # magical baguette: You can make stuff out of it
-Item	mana-basted tofurkey leg	Effect: "Mana-Blasted", Effect Duration: 20
-Item	mana-coated yams	Effect: "Mana-Blasted", Effect Duration: 20
-Item	mana-fortified cranberry sauce	Effect: "Mana-Blasted", Effect Duration: 20
-Item	mana-stuffed herbal stuffing	Effect: "Mana-Blasted", Effect Duration: 20
+Item	mana-basted tofurkey leg	Effect: "Mana-Blasted", Effect Duration: 20, Last Available: "2019-11"
+Item	mana-coated yams	Effect: "Mana-Blasted", Effect Duration: 20, Last Available: "2019-11"
+Item	mana-fortified cranberry sauce	Effect: "Mana-Blasted", Effect Duration: 20, Last Available: "2019-11"
+Item	mana-stuffed herbal stuffing	Effect: "Mana-Blasted", Effect Duration: 20, Last Available: "2019-11"
 Item	maple syrup	Effect: "Antsy in your Pantsy", Effect Duration: 5
-Item	mashed potatoes	Effect: "Thanksgetting", Effect Duration: 20
-Item	Mayam spinach	Effect: "Pop-eyed", Effect Duration: 50
-Item	Medical Pastaco	Effect: "Helvella Health", Effect Duration: 40
-Item	meteoreo	Effect: "Superioreo", Effect Duration: 40
-Item	mince pie	Effect: "Thanksgetting", Effect Duration: 20
-Item	Miserable Pie	Effect: "Smithsness Dinner", Effect Duration: 50
-Item	moosemeat pie	Effect: "Moose-Warmed Belly", Effect Duration: 50
+Item	mashed potatoes	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
+Item	Mayam spinach	Effect: "Pop-eyed", Effect Duration: 50, Last Available: "2024-05"
+Item	Medical Pastaco	Effect: "Helvella Health", Effect Duration: 40, Last Available: "2014-05"
+Item	meteoreo	Effect: "Superioreo", Effect Duration: 40, Last Available: "2017-08"
+Item	mince pie	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
+Item	Miserable Pie	Effect: "Smithsness Dinner", Effect Duration: 50, Last Available: "2013-12"
+Item	moosemeat pie	Effect: "Moose-Warmed Belly", Effect Duration: 50, Last Available: "2018-12"
 # Mr. Burnsger: Reduces your Drunkenness by 2
-Item	muffled muffuletta	Effect: "Noise Cancelled", Effect Duration: 100
-Item	nachos of the night	Effect: "Night of the Nachos", Effect Duration: 20
-Item	nanite-infested candy cane	Effect: "Chock Full o' Nanites", Effect Duration: 20
-Item	nanite-infested fruitcake	Effect: "Chock Full o' Nanites", Effect Duration: 20
-Item	nanite-infested gingerbread bugbear	Effect: "Chock Full o' Nanites", Effect Duration: 20
-Item	natto pocky	Effect: "Ninja, Please", Effect Duration: 30
-Item	nega-mushroom	Effect: "Negavision", Effect Duration: 50
-Item	nut-shaped Crimbo cookie	Effect: "Nut-Rition", Effect Duration: 20
-Item	occult jelly donut	Effect: "Filled with Magic", Effect Duration: 30
+Item	muffled muffuletta	Effect: "Noise Cancelled", Effect Duration: 100, Last Available: "2017-12"
+Item	nachos of the night	Effect: "Night of the Nachos", Effect Duration: 20, Last Available: "2014-12"
+Item	nanite-infested candy cane	Effect: "Chock Full o' Nanites", Effect Duration: 20, Last Available: "2020-09"
+Item	nanite-infested fruitcake	Effect: "Chock Full o' Nanites", Effect Duration: 20, Last Available: "2007-12"
+Item	nanite-infested gingerbread bugbear	Effect: "Chock Full o' Nanites", Effect Duration: 20, Last Available: "2007-12"
+Item	natto pocky	Effect: "Ninja, Please", Effect Duration: 30, Last Available: "2011-03"
+Item	nega-mushroom	Effect: "Negavision", Effect Duration: 50, Last Available: "2017-12"
+Item	nut-shaped Crimbo cookie	Effect: "Nut-Rition", Effect Duration: 20, Last Available: "2023-06"
+Item	occult jelly donut	Effect: "Filled with Magic", Effect Duration: 30, Last Available: "2011-09"
 # ojo de pez burrito: NOTE: This item will stop working when Crimbo 2019 is over.
 # ojo de pez burrito: Effect: "Fish-Eye View", Effect Duration: 50
-Item	old chum	Effect: "Fishy", Effect Duration: 5
+Item	old chum	Effect: "Fishy", Effect Duration: 5, Last Available: "2013-12"
 Item	one with everything	Effect: "Inner Dog", Effect Duration: 50
 Item	packet of beer nuts	Effect: "Salty Mouth", Effect Duration: 1
-Item	pawn cookie	Effect: "Pwnd", Effect Duration: 30
-Item	pecan pie	Effect: "Pecan Pied Piper", Effect Duration: 30
+Item	pawn cookie	Effect: "Pwnd", Effect Duration: 30, Last Available: "2010-06"
+Item	pecan pie	Effect: "Pecan Pied Piper", Effect Duration: 30, Last Available: "2014-12"
 Item	peppermint donut	Effect: "Peppermint Rush", Effect Duration: 10
-Item	Pete's rich ricotta	Effect: "Rippin' Ricotta", Effect Duration: 30
-Item	Pete's wiley whey bar	Effect: "Awfully Wily", Effect Duration: 30
-Item	petit 4.1	Effect: "Petit Force", Effect Duration: 20
-Item	petit fortran	Effect: "Petit Forbearance", Effect Duration: 10
+Item	Pete's rich ricotta	Effect: "Rippin' Ricotta", Effect Duration: 30, Last Available: "2022-11"
+Item	Pete's wiley whey bar	Effect: "Awfully Wily", Effect Duration: 30, Last Available: "2022-11"
+Item	petit 4.1	Effect: "Petit Force", Effect Duration: 20, Last Available: "2013-12"
+Item	petit fortran	Effect: "Petit Forbearance", Effect Duration: 10, Last Available: "2014-12"
 # pirate fork: Only one may be consumed per day<p><center><b><font color=blue>Usable once each day to steal some food!
-Item	pixel banana	Effect: "Going Ape", Effect Duration: 40
+Item	pixel banana	Effect: "Going Ape", Effect Duration: 40, Last Available: "2015-06"
 Item	pixel bread	Effect: "Desandwiched", Effect Duration: 5
-Item	Pizza of Legend	Effect: "Endless Drool", Effect Duration: 100
-Item	plain calzone	Effect: "Angering Pizza Purists", Effect Duration: 50
-Item	plumber's lunch	Effect: "Egg Burps", Effect Duration: 20
-Item	poisonous caviar	Effect: "Majorly Poisoned", Effect Duration: 50
-Item	powdered donut	Effect: "Powdered", Effect Duration: 5
-Item	protein paste	Effect: "Pasty", Effect Duration: 10
+Item	Pizza of Legend	Effect: "Endless Drool", Effect Duration: 100, Last Available: "2022-11"
+Item	plain calzone	Effect: "Angering Pizza Purists", Effect Duration: 50, Last Available: "2022-11"
+Item	plumber's lunch	Effect: "Egg Burps", Effect Duration: 20, Last Available: "2014-12"
+Item	poisonous caviar	Effect: "Majorly Poisoned", Effect Duration: 50, Last Available: "2010-09"
+Item	powdered donut	Effect: "Powdered", Effect Duration: 5, Last Available: "2010-03"
+Item	protein paste	Effect: "Pasty", Effect Duration: 10, Last Available: "2009-06"
 Item	queen cookie	Effect: "Towering Strength"
 Item	rack of dinosaur ribs	Effect: "Meat the Flintstones", Effect Duration: 30
-Item	ratatouille de Jarlsberg	Effect: "parfum d'herbes", Effect Duration: 30
-Item	red drunki-bear	Effect: "Gummiheart", Effect Duration: 80
+Item	ratatouille de Jarlsberg	Effect: "parfum d'herbes", Effect Duration: 30, Last Available: "2022-11"
+Item	red drunki-bear	Effect: "Gummiheart", Effect Duration: 80, Last Available: "2011-11"
 Item	roasted marshmallow	Effect: "Mallowed Out", Effect Duration: 3
-Item	roasted vegetable focaccia	Effect: "Feeling Fancy", Effect Duration: 50
-Item	roasted vegetable of Jarlsberg	Effect: "Wizard Sight", Effect Duration: 30
-Item	rocky road ice cream	Effect: "A Contender", Effect Duration: 40
+Item	roasted vegetable focaccia	Effect: "Feeling Fancy", Effect Duration: 50, Last Available: "2022-11"
+Item	roasted vegetable of Jarlsberg	Effect: "Wizard Sight", Effect Duration: 30, Last Available: "2022-11"
+Item	rocky road ice cream	Effect: "A Contender", Effect Duration: 40, Last Available: "2009-09"
 Item	rook cookie	Effect: "Towering Strength", Effect Duration: 30
-Item	rotting beefsteak	Effect: "Cowrruption", Effect Duration: 30
-Item	rum-soaked fruitcake	Effect: "Rum of Darkness", Effect Duration: 100
+Item	rotting beefsteak	Effect: "Cowrruption", Effect Duration: 30, Last Available: "2016-02"
+Item	rum-soaked fruitcake	Effect: "Rum of Darkness", Effect Duration: 100, Last Available: "2023-12"
 Item	sausage without a cause	Effect: "East of Eaten", Effect Duration: 1
 Item	savage macho dog	Effect: "Macho, Macho Dog", Effect Duration: 50
-Item	sea truffle	Effect: "Trufflin'", Effect Duration: 10
+Item	sea truffle	Effect: "Trufflin'", Effect Duration: 10, Last Available: "2017-01"
 Item	shadow candy	Effect: "Nothing Really Matters", Effect Duration: 10
-Item	shadow flame	Effect: "Inflamed With Shadows", Effect Duration: 100
-Item	shadowy cat claw	Effect: "Feline Ferocity", Effect Duration: 30
-Item	shoo-fish pie	Effect: "Fishy", Effect Duration: 20
-Item	shrapnel jelly donut	Effect: "Filled with Magic", Effect Duration: 30
-Item	shushed potatoes	Effect: "Noise Cancelled", Effect Duration: 100
-Item	skull-shaped Crimboween cookie	Effect: "Bells in the Batfry", Effect Duration: 10
+Item	shadow flame	Effect: "Inflamed With Shadows", Effect Duration: 100, Last Available: "2023-03"
+Item	shadowy cat claw	Effect: "Feline Ferocity", Effect Duration: 30, Last Available: "2011-09"
+Item	shoo-fish pie	Effect: "Fishy", Effect Duration: 20, Last Available: "2010-10"
+Item	shrapnel jelly donut	Effect: "Filled with Magic", Effect Duration: 30, Last Available: "2011-09"
+Item	shushed potatoes	Effect: "Noise Cancelled", Effect Duration: 100, Last Available: "2017-12"
+Item	skull-shaped Crimboween cookie	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 Item	Skully's hot chocolate	Effect: "Skull Full of Hot Chocolate", Effect Duration: 10
 Item	sleazy hi mein	Effect: "Sleazy Breath", Effect Duration: 5
 Item	slick fish meat	Effect: "Fishy", Effect Duration: 5
 Item	slimy sweetbreads	Effect: "Grimace", Effect Duration: 20
 Item	sly dog	Effect: "Top Dog", Effect Duration: 50
-Item	smashed danish	Effect: "Danish Cunning", Effect Duration: 30
-Item	smelted roe	Effect: "Sizzling with Fury", Effect Duration: 50
-Item	snow berries	Effect: "Berry Berry Cold", Effect Duration: 30
-Item	spaghetti con calaveras	Effect: "Eso S&iacute; Que Es", Effect Duration: 10
+Item	smashed danish	Effect: "Danish Cunning", Effect Duration: 30, Last Available: "2011-09"
+Item	smelted roe	Effect: "Sizzling with Fury", Effect Duration: 50, Last Available: "2015-08"
+Item	snow berries	Effect: "Berry Berry Cold", Effect Duration: 30, Last Available: "2014-01"
+Item	spaghetti con calaveras	Effect: "Eso S&iacute; Que Es", Effect Duration: 10, Last Available: "2011-04"
 Item	spooky hi mein	Effect: "Spooky Breath", Effect Duration: 5
-Item	square CRIMBCOOKIE	Effect: "Square to be Hip", Effect Duration: 10
-Item	squirmy violent party snack	Effect: "Broken Dancing", Effect Duration: 10
-Item	St. Pete's sneaky smoothie	Effect: "Gritty Soul", Effect Duration: 30
+Item	square CRIMBCOOKIE	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+Item	squirmy violent party snack	Effect: "Broken Dancing", Effect Duration: 10, Last Available: "2010-04"
+Item	St. Pete's sneaky smoothie	Effect: "Gritty Soul", Effect Duration: 30, Last Available: "2022-11"
 Item	stinky hi mein	Effect: "Stinky Breath", Effect Duration: 5
 Item	Strix stix	Effect: "Sugar-Frosted Pet Guts", Effect Duration: 40
-Item	sugarplum ration	Effect: "Sugarplum Visions", Effect Duration: 50
-Item	sun-dried tofu	Effect: "Oversaturated Palate", Effect Duration: 1
-Item	Swedish massage fish	Effect: "Like a Fish to Walter", Effect Duration: 40
+Item	sugarplum ration	Effect: "Sugarplum Visions", Effect Duration: 50, Last Available: "2023-12"
+Item	sun-dried tofu	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+Item	Swedish massage fish	Effect: "Like a Fish to Walter", Effect Duration: 40, Last Available: "2018-02"
 Item	sweet roll Alabama	Effect: "Helping Comes Second", Effect Duration: 30
-Item	Taco Dan's Taco Stand Taco	Effect: "Meaty and Cheesy", Effect Duration: 10
-Item	tainted milk	Effect: "Cowrruption", Effect Duration: 30
+Item	Taco Dan's Taco Stand Taco	Effect: "Meaty and Cheesy", Effect Duration: 10, Last Available: "2012-12"
+Item	tainted milk	Effect: "Cowrruption", Effect Duration: 30, Last Available: "2016-02"
 Item	tea for one	Effect: "One For Tea", Effect Duration: 40
-Item	temperance whiskey	Effect: "Old Time Hydration", Effect Duration: 100
+Item	temperance whiskey	Effect: "Old Time Hydration", Effect Duration: 100, Last Available: "2017-11"
 Item	tempura broccoli	Effect: "Down With Chow", Effect Duration: 20
 Item	tempura cauliflower	Effect: "Low on the Hog", Effect Duration: 20
-Item	thanksgiving turkey	Effect: "Thanksgetting", Effect Duration: 20
+Item	thanksgiving turkey	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
 # The Plumber's mushroom stew: Reduces your Drunkenness by 1
-Item	They liver popsicle	Effect: "You Liver", Effect Duration: 100
+Item	They liver popsicle	Effect: "You Liver", Effect Duration: 100, Last Available: "2014-09"
 Item	thyme jelly donut	Effect Duration: 5
-Item	Tiger-lily's milk	Effect: "Grrrrrrreat!", Effect Duration: 5
-Item	tin of submardines	Effect: "Appeteyes", Effect Duration: 50, Wiki Name: "tin of submardines"
+Item	Tiger-lily's milk	Effect: "Grrrrrrreat!", Effect Duration: 5, Last Available: "2010-03"
+Item	tin of submardines	Effect: "Appeteyes", Effect Duration: 50, Last Available: "2015-11", Wiki Name: "tin of submardines"
 # toast with cold jelly: Freezes your liver
-Item	toast with cold jelly	Effect: "Cold Jellied", Effect Duration: 25
+Item	toast with cold jelly	Effect: "Cold Jellied", Effect Duration: 25, Last Available: "2017-01"
 # toast with hot jelly: Lets you breathe on a monster
-Item	toast with hot jelly	Effect: "Hot Jellied", Effect Duration: 25
-Item	toast with jam	Effect: "Jammin'", Effect Duration: 5
+Item	toast with hot jelly	Effect: "Hot Jellied", Effect Duration: 25, Last Available: "2017-01"
+Item	toast with jam	Effect: "Jammin'", Effect Duration: 5, Last Available: "2008-12"
 # toast with sleaze jelly: Enables Sleazy Bickering
-Item	toast with sleaze jelly	Effect: "Sleazy Jellied", Effect Duration: 25
+Item	toast with sleaze jelly	Effect: "Sleazy Jellied", Effect Duration: 25, Last Available: "2017-01"
 # toast with spooky jelly: Makes you emanate Spookily
-Item	toast with spooky jelly	Effect: "Spooky Jellied", Effect Duration: 25
+Item	toast with spooky jelly	Effect: "Spooky Jellied", Effect Duration: 25, Last Available: "2017-01"
 # toast with stench jelly: Makes monsters avoid you
-Item	toast with stench jelly	Effect: "Stench Jellied", Effect Duration: 25
-Item	toasted brie	Effect: "Refined Palate", Effect Duration: 20
-Item	tobiko pocky	Effect: "Pisces in the Skyces", Effect Duration: 30
-Item	tombstone-shaped Crimboween cookie	Effect: "Crimbo Epiphany", Effect Duration: 10
-Item	toxo	Effect: "Radiated and Grodiated", Effect Duration: 40
-Item	traditional Crimbo cookie	Effect: "Yeast-Hungry", Effect Duration: 75
-Item	transparent nog	Effect: "Holiday Disappointment", Effect Duration: 10
-Item	tree-shaped Crimbo cookie	Effect: "Yuletide Sappiness", Effect Duration: 10
-Item	triangular CRIMBCOOKIE	Effect: "Triangle, Man", Effect Duration: 10
+Item	toast with stench jelly	Effect: "Stench Jellied", Effect Duration: 25, Last Available: "2017-01"
+Item	toasted brie	Effect: "Refined Palate", Effect Duration: 20, Last Available: "2011-09"
+Item	tobiko pocky	Effect: "Pisces in the Skyces", Effect Duration: 30, Last Available: "2011-03"
+Item	tombstone-shaped Crimboween cookie	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
+Item	toxo	Effect: "Radiated and Grodiated", Effect Duration: 40, Last Available: "2015-04"
+Item	traditional Crimbo cookie	Effect: "Yeast-Hungry", Effect Duration: 75, Last Available: "2023-06"
+Item	transparent nog	Effect: "Holiday Disappointment", Effect Duration: 10, Last Available: "2017-12"
+Item	tree-shaped Crimbo cookie	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
+Item	triangular CRIMBCOOKIE	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 Item	turtle soup	Effect: "[598]A Little Bit Evil", Effect Duration: 10
-Item	ultrafondue	Effect: "Fondid", Effect Duration: 30
+Item	ultrafondue	Effect: "Fondid", Effect Duration: 30, Last Available: "2011-09"
 Item	unfortunate dumplings	Effect: "Really Quite Poisoned", Effect Duration: 20
 Item	unidentifiable dried fruit	Effect: "Fruited", Effect Duration: 50
-Item	Ur-Donut	Effect: "Sugar Rush", Effect Duration: 10
-Item	very hot lunch	Effect: "Inner Warmth", Effect Duration: 100
+Item	Ur-Donut	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2011-09"
+Item	very hot lunch	Effect: "Inner Warmth", Effect Duration: 100, Last Available: "2015-08"
 Item	video games hot dog	Effect: "Video Game Hot Dog", Effect Duration: 50
-Item	warbear feasting bread	Effect: "Gift of the Warbear", Effect Duration: 40
-Item	warbear thermoregulator bread	Effect: "Superheated Guts", Effect Duration: 40
-Item	warbear warrior bread	Effect: "Warriors, Come out to Playyyy", Effect Duration: 40
-Item	warm gravy	Effect: "Thanksgetting", Effect Duration: 20
-Item	warm war shawarma	Effect: "Shawarma Warm War", Effect Duration: 30
-Item	wasabi pocky	Effect: "Wasabi With You", Effect Duration: 30
-Item	wax pancake	Effect: "Waxing", Effect Duration: 30
+Item	warbear feasting bread	Effect: "Gift of the Warbear", Effect Duration: 40, Last Available: "2013-12"
+Item	warbear thermoregulator bread	Effect: "Superheated Guts", Effect Duration: 40, Last Available: "2013-12"
+Item	warbear warrior bread	Effect: "Warriors, Come out to Playyyy", Effect Duration: 40, Last Available: "2013-12"
+Item	warm gravy	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
+Item	warm war shawarma	Effect: "Shawarma Warm War", Effect Duration: 30, Last Available: "2014-10"
+Item	wasabi pocky	Effect: "Wasabi With You", Effect Duration: 30, Last Available: "2011-03"
+Item	wax pancake	Effect: "Waxing", Effect Duration: 30, Last Available: "2017-01"
 Item	weird gazelle steak	Effect: "Gaze of the Gazelle", Effect Duration: 1
 Item	wet dog	Effect: "Hangdog", Effect Duration: 30
-Item	wheel of camembert	Effect: "Burning Mouth", Effect Duration: 30
+Item	wheel of camembert	Effect: "Burning Mouth", Effect Duration: 30, Last Available: "2024-09"
 # whole turkey leg: Selling Price: <b>1 Meat.</b><p><center><b><font color=blue>Deals <font color=blueviolet>Sleaze Damage</font> based on your Moxie when used as a combat item
 Item	wild honey pie	Effect: "Sugar Rush", Effect Duration: 10
-Item	witch's bread	Effect: "Witch Breaded", Effect Duration: 20
-Item	wreath-shaped Crimbo cookie	Effect: "Wreathed in Merriment", Effect Duration: 10
-Item	yellow drunki-bear	Effect: "Gummiskin", Effect Duration: 80
+Item	witch's bread	Effect: "Witch Breaded", Effect Duration: 20, Last Available: "2014-12"
+Item	wreath-shaped Crimbo cookie	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+Item	yellow drunki-bear	Effect: "Gummiskin", Effect Duration: 80, Last Available: "2011-11"
 
 # Booze section of modifiers.txt
 
 Item	1950 Vampire Vintner wine	Effect Duration: 10
-Item	Agitated Turkey	Effect: "Turkey-Agitated", Effect Duration: 25
+Item	Agitated Turkey	Effect: "Turkey-Agitated", Effect Duration: 25, Last Available: "2014-11"
 Item	Alewife&trade; Ale	Effect: "Brined Liver", Effect Duration: 5
-Item	Ambitious Turkey	Effect: "Turkey-Ambitious", Effect Duration: 25
-Item	Amnesiac Ale	Effect: "All Is Forgiven", Effect Duration: 30
+Item	Ambitious Turkey	Effect: "Turkey-Ambitious", Effect Duration: 25, Last Available: "2014-11"
+Item	Amnesiac Ale	Effect: "All Is Forgiven", Effect Duration: 30, Last Available: "2014-10"
 Item	an evil little sump'm sump'm	Effect: "[601]A Little Bit Evil", Effect Duration: 10
 Item	artisanal limoncello	Effect: "Sugar Rush", Effect Duration: 30
-Item	asbestos thermos	Effect: "Inner Warmth", Effect Duration: 100
-Item	Aura Libre	Effect: "Transcendental Wind", Effect Duration: 15
-Item	Aye Aye	Effect: "Arresistible", Effect Duration: 5
-Item	Aye Aye, Captain	Effect: "Arresistible", Effect Duration: 10
-Item	Aye Aye, Tooth Tooth	Effect: "Arresistible", Effect Duration: 15
+Item	asbestos thermos	Effect: "Inner Warmth", Effect Duration: 100, Last Available: "2015-08"
+Item	Aura Libre	Effect: "Transcendental Wind", Effect Duration: 15, Last Available: "2012-03"
+Item	Aye Aye	Effect: "Arresistible", Effect Duration: 5, Last Available: "2012-03"
+Item	Aye Aye, Captain	Effect: "Arresistible", Effect Duration: 10, Last Available: "2012-03"
+Item	Aye Aye, Tooth Tooth	Effect: "Arresistible", Effect Duration: 15, Last Available: "2012-03"
 # *** KoL bug: bad rum and good cola grants Faerie Fortune, no item grants Fanatical Fortune.
 # *** Bug reported and acknowledged. bad rum and good cola DOES give Fanatical Fortune, but
 # *** the description is wrong for unknown reasons. Maybe the description will eventually be fixed..
 Item	bad rum and good cola	Effect: "Fanatical Fortune", Effect Duration: 30
-Item	bark rootbeer	Effect: "Bark of the Dog", Effect Duration: 40
-Item	barrel-aged martini	Effect: "Just Aged Enough", Effect Duration: 50
-Item	Bartles and BRAAAINS wine cooler	Effect: "Braaaains Over Braaaawwn", Effect Duration: 30
-Item	Bee's Knees	Effect: "On the Trolley", Effect Duration: 25
-Item	Beignet Milgranet	Effect: "Sugar Rush", Effect Duration: 100
+Item	bark rootbeer	Effect: "Bark of the Dog", Effect Duration: 40, Last Available: "2015-12"
+Item	barrel-aged martini	Effect: "Just Aged Enough", Effect Duration: 50, Last Available: "2015-09"
+Item	Bartles and BRAAAINS wine cooler	Effect: "Braaaains Over Braaaawwn", Effect Duration: 30, Last Available: "2011-10"
+Item	Bee's Knees	Effect: "On the Trolley", Effect Duration: 25, Last Available: "2014-07"
+Item	Beignet Milgranet	Effect: "Sugar Rush", Effect Duration: 100, Last Available: "2011-09"
 Item	berry-infused sake	Effect: "Warm Belly", Effect Duration: 1
-Item	black brandy	Effect: "The Power of Negative Thinking", Effect Duration: 100
-Item	blood and blood	Effect: "Bloodthirsty", Effect Duration: 30
-Item	Blood Light	Effect: "Bloody-minded", Effect Duration: 30
-Item	blood-red mushroom wine	Effect: "Helvella Health", Effect Duration: 80
+Item	black brandy	Effect: "The Power of Negative Thinking", Effect Duration: 100, Last Available: "2016-12"
+Item	blood and blood	Effect: "Bloodthirsty", Effect Duration: 30, Last Available: "2015-10"
+Item	Blood Light	Effect: "Bloody-minded", Effect Duration: 30, Last Available: "2011-10"
+Item	blood-red mushroom wine	Effect: "Helvella Health", Effect Duration: 80, Last Available: "2014-05"
 Item	bloody kiwitini	Effect: "First Blood Kiwi", Effect Duration: 10
-Item	Bloody Nora	Effect: "Fishtacular Vernacular", Effect Duration: 40
-Item	Bone's Farm &quot;wine&quot;	Effect: "Sticks and Stones", Effect Duration: 30
-Item	Bordeaux Marteaux	Effect: "Hammered", Effect Duration: 20
-Item	Boris's beer	Effect: "Beery Cool", Effect Duration: 30
-Item	bottle of Amontillado	Effect: "Bricked-In", Effect Duration: 100
+Item	Bloody Nora	Effect: "Fishtacular Vernacular", Effect Duration: 40, Last Available: "2017-03"
+Item	Bone's Farm &quot;wine&quot;	Effect: "Sticks and Stones", Effect Duration: 30, Last Available: "2011-10"
+Item	Bordeaux Marteaux	Effect: "Hammered", Effect Duration: 20, Last Available: "2011-09"
+Item	Boris's beer	Effect: "Beery Cool", Effect Duration: 30, Last Available: "2022-11"
+Item	bottle of Amontillado	Effect: "Bricked-In", Effect Duration: 100, Last Available: "2015-09"
 Item	bottle of Bloodweiser	Effect: "Blood Porter", Effect Duration: 50
 Item	bottle of Cabernet Sauvignon	Effect: "Cabernet Hunter", Effect Duration: 30
 Item	bottle of Evermore	Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 30
-Item	bottle of Fishhead 900-Day IPA	Effect: "A Real Head for Fish", Effect Duration: 50
-Item	bottle of Greedy Dog	Effect: "Covetin' Drunk", Effect Duration: 20
-Item	bottle of Lambada Lambic	Effect: "Dancin' Drunk", Effect Duration: 20
-Item	bottle of norwhiskey	Effect: "Norwhalloped", Effect Duration: 50
-Item	bottle of Old Pugilist	Effect: "Fightin' Drunk", Effect Duration: 20
+Item	bottle of Fishhead 900-Day IPA	Effect: "A Real Head for Fish", Effect Duration: 50, Last Available: "2016-04"
+Item	bottle of Greedy Dog	Effect: "Covetin' Drunk", Effect Duration: 20, Last Available: "2013-09"
+Item	bottle of Lambada Lambic	Effect: "Dancin' Drunk", Effect Duration: 20, Last Available: "2013-09"
+Item	bottle of norwhiskey	Effect: "Norwhalloped", Effect Duration: 50, Last Available: "2015-11"
+Item	bottle of Old Pugilist	Effect: "Fightin' Drunk", Effect Duration: 20, Last Available: "2013-09"
 Item	bottle of Ooze-O	Effect: "Really Quite Poisoned", Effect Duration: 20
-Item	bottle of peppermint schnapps	Effect: "Crimbo Nostalgia", Effect Duration: 50
+Item	bottle of peppermint schnapps	Effect: "Crimbo Nostalgia", Effect Duration: 50, Last Available: "2010-12"
 Item	bottle of Pete's Sake	Effect: "Warm Belly", Effect Duration: 1
-Item	bottle of Professor Beer	Effect: "Thinkin' Drunk", Effect Duration: 20
-Item	bottle of Race Car Red	Effect: "Flyin' Drunk", Effect Duration: 20
-Item	bottle of Rapier Witbier	Effect: "Jokin' Drunk", Effect Duration: 20
-Item	bottle of realpagne	Effect: "The Real Deal", Effect Duration: 10
+Item	bottle of Professor Beer	Effect: "Thinkin' Drunk", Effect Duration: 20, Last Available: "2013-09"
+Item	bottle of Race Car Red	Effect: "Flyin' Drunk", Effect Duration: 20, Last Available: "2013-09"
+Item	bottle of Rapier Witbier	Effect: "Jokin' Drunk", Effect Duration: 20, Last Available: "2013-09"
+Item	bottle of realpagne	Effect: "The Real Deal", Effect Duration: 10, Last Available: "2007-06"
 Item	bottle of sewage schnapps	Effect: "Majorly Poisoned", Effect Duration: 20
-Item	Boulevardier cocktail	Effect: "Ready to Roll", Effect Duration: 40
-Item	broberry brogurt	Effect: "Broberry Brotality", Effect Duration: 40
-Item	brocolate brogurt	Effect: "Brocolate Brostidigitation", Effect Duration: 40
-Item	Bustle Hustler	Effect: "Bustle Hustlin'", Effect Duration: 40
-Item	Buttery Boy	Effect: "Buttery, Boy", Effect Duration: 20
-Item	Buttery Knob	Effect: "Gutterminded", Effect Duration: 5
-Item	buzzing mushroom wine	Effect: "Stemonitis Storm", Effect Duration: 80
-Item	Caipiranha	Effect: "Fishy", Effect Duration: 5
-Item	Candicaine	Effect: "Holiday Bliss", Effect Duration: 15
-Item	Candy Alexander	Effect: "Holiday Bliss", Effect Duration: 10
-Item	canteen of eggnog	Effect: "All Liquored Up For War", Effect Duration: 100
-Item	canteen of jungle juice	Effect: "Toured of Duty", Effect Duration: 20
-Item	canteen of wine	Effect: "In Vino Vires", Effect Duration: 20
-Item	carrot claret	Effect: "Pla-see-bo", Effect Duration: 10
-Item	Cement Mixer	Effect: "Mortarfied", Effect Duration: 5
-Item	Centauri fish wine	Effect: "Fishy", Effect Duration: 60
-Item	Chakra Libre	Effect: "Transcendental Wind", Effect Duration: 10
-Item	chakra-mental wine	Effect: "The Power of Positive Thinking", Effect Duration: 50
+Item	Boulevardier cocktail	Effect: "Ready to Roll", Effect Duration: 40, Last Available: "2020-12"
+Item	broberry brogurt	Effect: "Broberry Brotality", Effect Duration: 40, Last Available: "2014-05"
+Item	brocolate brogurt	Effect: "Brocolate Brostidigitation", Effect Duration: 40, Last Available: "2014-05"
+Item	Bustle Hustler	Effect: "Bustle Hustlin'", Effect Duration: 40, Last Available: "2018-02"
+Item	Buttery Boy	Effect: "Buttery, Boy", Effect Duration: 20, Last Available: "2020-05"
+Item	Buttery Knob	Effect: "Gutterminded", Effect Duration: 5, Last Available: "2012-03"
+Item	buzzing mushroom wine	Effect: "Stemonitis Storm", Effect Duration: 80, Last Available: "2014-05"
+Item	Caipiranha	Effect: "Fishy", Effect Duration: 5, Last Available: "2012-03"
+Item	Candicaine	Effect: "Holiday Bliss", Effect Duration: 15, Last Available: "2012-03"
+Item	Candy Alexander	Effect: "Holiday Bliss", Effect Duration: 10, Last Available: "2012-03"
+Item	canteen of eggnog	Effect: "All Liquored Up For War", Effect Duration: 100, Last Available: "2023-12"
+Item	canteen of jungle juice	Effect: "Toured of Duty", Effect Duration: 20, Last Available: "2024-12"
+Item	canteen of wine	Effect: "In Vino Vires", Effect Duration: 20, Last Available: "2008-12"
+Item	carrot claret	Effect: "Pla-see-bo", Effect Duration: 10, Last Available: "2013-01"
+Item	Cement Mixer	Effect: "Mortarfied", Effect Duration: 5, Last Available: "2012-03"
+Item	Centauri fish wine	Effect: "Fishy", Effect Duration: 60, Last Available: "2017-04"
+Item	Chakra Libre	Effect: "Transcendental Wind", Effect Duration: 10, Last Available: "2012-03"
+Item	chakra-mental wine	Effect: "The Power of Positive Thinking", Effect Duration: 50, Last Available: "2016-12"
 Item	Charleston Choo-Choo	Effect: "Speakin' Easy", Effect Duration: 30
-Item	chocotini	Effect: "High Blood Chocolate Content", Effect Duration: 30
-Item	Churchill	Effect: "Big Ol' Glass of Rum", Effect Duration: 40
-Item	Cinco Mayo Lager	Effect: "Cinco Elementos", Effect Duration: 5
+Item	chocotini	Effect: "High Blood Chocolate Content", Effect Duration: 30, Last Available: "2014-12"
+Item	Churchill	Effect: "Big Ol' Glass of Rum", Effect Duration: 40, Last Available: "2017-03"
+Item	Cinco Mayo Lager	Effect: "Cinco Elementos", Effect Duration: 5, Last Available: "2010-05"
 Item	citrus-infused sake	Effect: "Warm Belly", Effect Duration: 1
-Item	Cobra Bowl	Effect: "Tiki Temerity", Effect Duration: 40
-Item	complex mushroom wine	Effect: "Omphalotus Omnipresence", Effect Duration: 80
-Item	cranberry schnapps	Effect: "Cranberry Cordiality", Effect Duration: 10
-Item	Crazymaker	Effect: "Void Between the Stars", Effect Duration: 15
+Item	Cobra Bowl	Effect: "Tiki Temerity", Effect Duration: 40, Last Available: "2019-04"
+Item	complex mushroom wine	Effect: "Omphalotus Omnipresence", Effect Duration: 80, Last Available: "2014-05"
+Item	cranberry schnapps	Effect: "Cranberry Cordiality", Effect Duration: 10, Last Available: "2011-03"
+Item	Crazymaker	Effect: "Void Between the Stars", Effect Duration: 15, Last Available: "2012-03"
 Item	cruelty-free wine	Effect: "Compensatory Cruelness", Effect Duration: 5
-Item	crystal skeleton vodka	Effect: "Aykrophobia", Effect Duration: 20
+Item	crystal skeleton vodka	Effect: "Aykrophobia", Effect Duration: 20, Last Available: "2012-10"
 Item	cursed bottle of black-label rum	Effect: "Curse Magnet", Effect Duration: 10
-Item	cybeer	Effect: "Connected", Effect Duration: 40
+Item	cybeer	Effect: "Connected", Effect Duration: 40, Last Available: "2025-12"
 Item	dew yoana lei	Effect: "Brined Liver", Effect Duration: 20
 Item	dew yoana salacious lei	Effect: "Brined Liver", Effect Duration: 30
-Item	Dinsey Whinskey	Effect: "The Dinsey Spirit", Effect Duration: 30
-Item	dirt julep	Effect: "Here's Some More Mud in Your Eye", Effect Duration: 40
+Item	Dinsey Whinskey	Effect: "The Dinsey Spirit", Effect Duration: 30, Last Available: "2015-04"
+Item	dirt julep	Effect: "Here's Some More Mud in Your Eye", Effect Duration: 40, Last Available: "2017-03"
 Item	discocktail	Effect: "Disco Neuropathy", Effect Duration: 30
 # Doc Clock's thyme cocktail: Reduces your Fullness by 2
-Item	Doc's Fortifying Wine	Effect: "Medically Fortified", Effect Duration: 40
-Item	Doc's Limbering Wine	Effect: "Medically Loosened", Effect Duration: 40
-Item	Doc's Medical-Grade Wine	Effect: "Fixed Up", Effect Duration: 40
-Item	Doc's Smartifying Wine	Effect: "Medically Smartified", Effect Duration: 40
-Item	Doc's Special Reserve Wine	Effect: "Fixed Right Up", Effect Duration: 40
-Item	double entendre	Effect: "Space Cadet", Effect Duration: 40
-Item	Doublepunchplanter	Effect: "Fishy", Effect Duration: 10
-Item	Drac & Tan	Effect: "Creepypasted", Effect Duration: 5
+Item	Doc's Fortifying Wine	Effect: "Medically Fortified", Effect Duration: 40, Last Available: "2021-12"
+Item	Doc's Limbering Wine	Effect: "Medically Loosened", Effect Duration: 40, Last Available: "2021-12"
+Item	Doc's Medical-Grade Wine	Effect: "Fixed Up", Effect Duration: 40, Last Available: "2021-12"
+Item	Doc's Smartifying Wine	Effect: "Medically Smartified", Effect Duration: 40, Last Available: "2021-12"
+Item	Doc's Special Reserve Wine	Effect: "Fixed Right Up", Effect Duration: 40, Last Available: "2021-12"
+Item	double entendre	Effect: "Space Cadet", Effect Duration: 40, Last Available: "2017-03"
+Item	Doublepunchplanter	Effect: "Fishy", Effect Duration: 10, Last Available: "2012-03"
+Item	Drac & Tan	Effect: "Creepypasted", Effect Duration: 5, Last Available: "2012-03"
 Item	Dreadsylvanian cold-fashioned	Effect: "Dreadful Chill", Effect Duration: 200
 Item	Dreadsylvanian dank and stormy	Effect: "Dreadful Smell", Effect Duration: 200
 Item	Dreadsylvanian grimlet	Effect: "Dreadful Fear", Effect Duration: 200
 Item	Dreadsylvanian hot toddy	Effect: "Dreadful Heat", Effect Duration: 200
 Item	Dreadsylvanian slithery nipple	Effect: "Dreadful Sheen", Effect Duration: 200
-Item	drive-by shooting	Effect: "Drive-By Shot", Effect Duration: 40
-Item	Drunken Astrophysicist	Effect: "Heisenberglary", Effect Duration: 15
-Item	Drunken Neurologist	Effect: "Heisenberglary", Effect Duration: 10
-Item	Drunken Philosopher	Effect: "Heisenberglary", Effect Duration: 5
-Item	DUFRESNE Suds	Effect: "Favored by Lyle", Effect Duration: 10
-Item	Dump Truck	Effect: "Mortarfied", Effect Duration: 15
+Item	drive-by shooting	Effect: "Drive-By Shot", Effect Duration: 40, Last Available: "2017-03"
+Item	Drunken Astrophysicist	Effect: "Heisenberglary", Effect Duration: 15, Last Available: "2012-03"
+Item	Drunken Neurologist	Effect: "Heisenberglary", Effect Duration: 10, Last Available: "2012-03"
+Item	Drunken Philosopher	Effect: "Heisenberglary", Effect Duration: 5, Last Available: "2012-03"
+Item	DUFRESNE Suds	Effect: "Favored by Lyle", Effect Duration: 10, Last Available: "2017-09"
+Item	Dump Truck	Effect: "Mortarfied", Effect Duration: 15, Last Available: "2012-03"
 Item	dusty bottle of Pinot Noir	Effect: "Kiss of the Black Fairy", Effect Duration: 10
 Item	dusty bottle of Port	Effect: "Full of Vinegar", Effect Duration: 10
-Item	Earth and Firewater	Effect: "Elemental Mastery", Effect Duration: 10
-Item	Earth, Wind and Firewater	Effect: "Elemental Mastery", Effect Duration: 15
-Item	Easter grasshopper	Effect: "Resurrection of the Flesh", Effect Duration: 20
-Item	Ecto-Cooler	Effect: "Booing Radly", Effect Duration: 30
-Item	eighth plague	Effect: "Wings of the Dragonfly", Effect Duration: 40
-Item	eldritch elixir	Effect: "Eldritch Attunement", Effect Duration: 5
-Item	eldritch extract	Effect: "Eldritch Concentration", Effect Duration: 10
-Item	Electric Punch	Effect: "Tiki Thoughtfulness", Effect Duration: 30
+Item	Earth and Firewater	Effect: "Elemental Mastery", Effect Duration: 10, Last Available: "2012-03"
+Item	Earth, Wind and Firewater	Effect: "Elemental Mastery", Effect Duration: 15, Last Available: "2012-03"
+Item	Easter grasshopper	Effect: "Resurrection of the Flesh", Effect Duration: 20, Last Available: "2024-12"
+Item	Ecto-Cooler	Effect: "Booing Radly", Effect Duration: 30, Last Available: "2011-10"
+Item	eighth plague	Effect: "Wings of the Dragonfly", Effect Duration: 40, Last Available: "2017-03"
+Item	eldritch elixir	Effect: "Eldritch Attunement", Effect Duration: 5, Last Available: "2016-11"
+Item	eldritch extract	Effect: "Eldritch Concentration", Effect Duration: 10, Last Available: "2016-11"
+Item	Electric Punch	Effect: "Tiki Thoughtfulness", Effect Duration: 30, Last Available: "2019-04"
 Item	electric snakebite	Effect: "Once Bitten Twice Fried", Effect Duration: 20
-Item	elemental caipiroska	Effect: "Magically Delicious", Effect Duration: 40
-Item	elven cellocello	Effect: "Sugar Rush", Effect Duration: 20
-Item	elven moonshine	Effect: "Drunk With Power", Effect Duration: 20
+Item	elemental caipiroska	Effect: "Magically Delicious", Effect Duration: 40, Last Available: "2017-03"
+Item	elven cellocello	Effect: "Sugar Rush", Effect Duration: 20, Last Available: "2009-12"
+Item	elven moonshine	Effect: "Drunk With Power", Effect Duration: 20, Last Available: "2008-12"
 Item	emergency margarita	Effect: "Margamergency", Effect Duration: 1
 Item	En Una Fila Tequila	Effect: "Mr. Skullhead's Birthday Happiness", Effect Duration: 20
 Item	evil ducha de oro	Effect: "[601]A Little Bit Evil", Effect Duration: 10
 Item	evil horizontal tango	Effect: "[601]A Little Bit Evil", Effect Duration: 10
 Item	evil roll in the hay	Effect: "[601]A Little Bit Evil", Effect Duration: 10
-Item	executive mime flask	Effect: "Executive Greed", Effect Duration: 50
-Item	expired bottle of peppermint schnapps	Effect: "Crimbo Nostalgia", Effect Duration: 30
-Item	Extra-slimy Slimosa	Effect: "In the Slimelight", Effect Duration: 10
-Item	extremely slippery nipple	Effect: "Slippery Tongue", Effect Duration: 40
-Item	Falcon&trade; Maltese Liquor	Effect: "Too Noir For Snoir", Effect Duration: 50
+Item	executive mime flask	Effect: "Executive Greed", Effect Duration: 50, Last Available: "2017-12"
+Item	expired bottle of peppermint schnapps	Effect: "Crimbo Nostalgia", Effect Duration: 30, Last Available: "2009-12"
+Item	Extra-slimy Slimosa	Effect: "In the Slimelight", Effect Duration: 10, Last Available: "2012-03"
+Item	extremely slippery nipple	Effect: "Slippery Tongue", Effect Duration: 40, Last Available: "2017-03"
+Item	Falcon&trade; Maltese Liquor	Effect: "Too Noir For Snoir", Effect Duration: 50, Last Available: "2016-07"
 Item	Fantasma en la M&aacute;quina	Effect: "Sangre Brillante", Effect Duration: 13
-Item	Fauna Libre	Effect: "Transcendental Wind", Effect Duration: 5
-Item	Feliz Navidad	Effect: "Wassailing You", Effect Duration: 40
-Item	firemilk	Effect: "Cowrruption", Effect Duration: 30
-Item	Firewater	Effect: "Elemental Mastery", Effect Duration: 5
-Item	Flaming Caipiranha	Effect: "Fishy", Effect Duration: 15
-Item	Flaming Knob	Effect: "Gutterminded", Effect Duration: 15
-Item	Flaming Mohobo	Effect: "Mo' Hobo", Effect Duration: 15
-Item	Flaming Sazerorc	Effect: "Orc Chops", Effect Duration: 15
-Item	flask of egggrog	Effect: "Grogged For Battle", Effect Duration: 100
+Item	Fauna Libre	Effect: "Transcendental Wind", Effect Duration: 5, Last Available: "2012-03"
+Item	Feliz Navidad	Effect: "Wassailing You", Effect Duration: 40, Last Available: "2017-03"
+Item	firemilk	Effect: "Cowrruption", Effect Duration: 30, Last Available: "2016-02"
+Item	Firewater	Effect: "Elemental Mastery", Effect Duration: 5, Last Available: "2012-03"
+Item	Flaming Caipiranha	Effect: "Fishy", Effect Duration: 15, Last Available: "2012-03"
+Item	Flaming Knob	Effect: "Gutterminded", Effect Duration: 15, Last Available: "2012-03"
+Item	Flaming Mohobo	Effect: "Mo' Hobo", Effect Duration: 15, Last Available: "2012-03"
+Item	Flaming Sazerorc	Effect: "Orc Chops", Effect Duration: 15, Last Available: "2012-03"
+Item	flask of egggrog	Effect: "Grogged For Battle", Effect Duration: 100, Last Available: "2023-12"
 Item	flat cider	Effect: "Fruited", Effect Duration: 100
-Item	Flying Caipiranha	Effect: "Fishy", Effect Duration: 10
-Item	French bronilla brogurt	Effect: "French Bronilla Brogueishness", Effect Duration: 40
-Item	Friendly Turkey	Effect: "Turkey-Friendly", Effect Duration: 25
-Item	Fromage Pinotage	Effect: "Some Cheese with Your Wine", Effect Duration: 20
-Item	Fuzzy Tentacle	Effect: "Void Between the Stars", Effect Duration: 10
-Item	Ghiaccio Colada	Effect: "On the Rocks", Effect Duration: 20
+Item	Flying Caipiranha	Effect: "Fishy", Effect Duration: 10, Last Available: "2012-03"
+Item	French bronilla brogurt	Effect: "French Bronilla Brogueishness", Effect Duration: 40, Last Available: "2014-05"
+Item	Friendly Turkey	Effect: "Turkey-Friendly", Effect Duration: 25, Last Available: "2014-11"
+Item	Fromage Pinotage	Effect: "Some Cheese with Your Wine", Effect Duration: 20, Last Available: "2011-09"
+Item	Fuzzy Tentacle	Effect: "Void Between the Stars", Effect Duration: 10, Last Available: "2012-03"
+Item	Ghiaccio Colada	Effect: "On the Rocks", Effect Duration: 20, Last Available: "2020-05"
 Item	ghost beer	Damage Reduction: 11, Effect: "Booooooze", Effect Duration: 50
-Item	gingerbread wine	Effect: "Sprinkle in Your Eye", Effect Duration: 30
+Item	gingerbread wine	Effect: "Sprinkle in Your Eye", Effect Duration: 30, Last Available: "2016-12"
 # glass of drippy wine: Puts 5 &micro;g of Drippy Juice into your blood
 Item	glass of herbal tequila	Effect: "Herbal Pert", Effect Duration: 50
 Item	gloomy mushroom wine	Effect: "Gothy", Effect Duration: 20
-Item	Gnollish sangria	Effect: "Strength of the Gnoll", Effect Duration: 40
-Item	Gnomish sagngria	Effect: "Stregngth of the Gnome", Effect Duration: 40
-Item	Golden Mean	Effect: "World's Shortest Giant", Effect Duration: 10
-Item	Grasshopper	Effect: "Cockroach Scurry", Effect Duration: 5
-Item	great old fashioned	Effect: "Creepin' Up on You", Effect Duration: 40
-Item	Great Older Fashioned	Effect: "Void Between the Stars", Effect Duration: 5
-Item	green eggnog	Effect: "Just the Best Anapests", Effect Duration: 50
-Item	Green Giant	Effect: "World's Shortest Giant", Effect Duration: 15
+Item	Gnollish sangria	Effect: "Strength of the Gnoll", Effect Duration: 40, Last Available: "2017-03"
+Item	Gnomish sagngria	Effect: "Stregngth of the Gnome", Effect Duration: 40, Last Available: "2017-03"
+Item	Golden Mean	Effect: "World's Shortest Giant", Effect Duration: 10, Last Available: "2012-03"
+Item	Grasshopper	Effect: "Cockroach Scurry", Effect Duration: 5, Last Available: "2012-03"
+Item	great old fashioned	Effect: "Creepin' Up on You", Effect Duration: 40, Last Available: "2017-03"
+Item	Great Older Fashioned	Effect: "Void Between the Stars", Effect Duration: 5, Last Available: "2012-03"
+Item	green eggnog	Effect: "Just the Best Anapests", Effect Duration: 50, Last Available: "2012-12"
+Item	Green Giant	Effect: "World's Shortest Giant", Effect Duration: 15, Last Available: "2012-03"
 Item	Green Manalishi	Effect: "The Two-Prong Crown", Effect Duration: 30
-Item	gunner's daughter	Effect: "Kissed the Gunner's Daughter", Effect Duration: 40
-Item	haunted bottle of vodka	Effect: "Haunted Liver", Effect Duration: 20
-Item	haunted eggnog	Effect: "Haunted Liver", Effect Duration: 20
-Item	haunted gimlet	Effect: "Haunted Liver", Effect Duration: 20
-Item	haunted martini	Effect: "Haunted Liver", Effect Duration: 20
-Item	Haymaker	Effect: "Fishy", Effect Duration: 15
-Item	hell in a bucket	Effect: "Hell ib a Hambasked", Effect Duration: 40
-Item	Herring Daiquiri	Effect: "Fishy", Effect Duration: 5
-Item	Herring Wallbanger	Effect: "Fishy", Effect Duration: 10
-Item	herringcello	Effect: "Sugar Rush", Effect Duration: 20
-Item	Herringtini	Effect: "Fishy", Effect Duration: 15
-Item	high-end ginger wine	Effect: "High-Falutin'", Effect Duration: 30
-Item	Highest Bitter	Effect: "Mercenary", Effect Duration: 60
+Item	gunner's daughter	Effect: "Kissed the Gunner's Daughter", Effect Duration: 40, Last Available: "2017-03"
+Item	haunted bottle of vodka	Effect: "Haunted Liver", Effect Duration: 20, Last Available: "2018-11"
+Item	haunted eggnog	Effect: "Haunted Liver", Effect Duration: 20, Last Available: "2018-11"
+Item	haunted gimlet	Effect: "Haunted Liver", Effect Duration: 20, Last Available: "2018-11"
+Item	haunted martini	Effect: "Haunted Liver", Effect Duration: 20, Last Available: "2018-11"
+Item	Haymaker	Effect: "Fishy", Effect Duration: 15, Last Available: "2012-03"
+Item	hell in a bucket	Effect: "Hell ib a Hambasked", Effect Duration: 40, Last Available: "2017-03"
+Item	Herring Daiquiri	Effect: "Fishy", Effect Duration: 5, Last Available: "2012-03"
+Item	Herring Wallbanger	Effect: "Fishy", Effect Duration: 10, Last Available: "2012-03"
+Item	herringcello	Effect: "Sugar Rush", Effect Duration: 20, Last Available: "2009-12"
+Item	Herringtini	Effect: "Fishy", Effect Duration: 15, Last Available: "2012-03"
+Item	high-end ginger wine	Effect: "High-Falutin'", Effect Duration: 30, Last Available: "2016-12"
+Item	Highest Bitter	Effect: "Mercenary", Effect Duration: 60, Last Available: "2014-10"
 Item	hipster cocktail	Effect: "Artisanal Satiaton", Effect Duration: 10
 Item	honey mead	Effect: "Sugar Rush", Effect Duration: 5
-Item	hot mint schnocolate	Effect: "Alpine Mintiness", Effect Duration: 25
-Item	Hot Socks	Effect: "[1701]Hip to the Jive", Effect Duration: 50
-Item	hot wine	Effect: "In a Stealin' Mood", Effect Duration: 50
-Item	Hundred Headed IPA	Effect: "Hoppyness", Effect Duration: 20
+Item	hot mint schnocolate	Effect: "Alpine Mintiness", Effect Duration: 25, Last Available: "2015-01"
+Item	Hot Socks	Effect: "[1701]Hip to the Jive", Effect Duration: 50, Last Available: "2014-07"
+Item	hot wine	Effect: "In a Stealin' Mood", Effect Duration: 50, Last Available: "2023-12"
+Item	Hundred Headed IPA	Effect: "Hoppyness", Effect Duration: 20, Last Available: "2013-12"
 Item	ice porter	Wiki Name: "ice porter (drink)"
-Item	ice wine	Effect: "Brain Freeze", Effect Duration: 50
-Item	Irish Coffee, English Heart	Effect: "Smithsness Cheer", Effect Duration: 100
-Item	Irish eggnog	Effect: "Green-Blooded", Effect Duration: 20
-Item	Ish Kabibble	Effect: "Feeling No Pain", Effect Duration: 25
-Item	Island Hurricane	Effect: "Tiki Temerity", Effect Duration: 20
-Item	Island Landslide	Effect: "Tiki Toughness", Effect Duration: 20
-Item	Island Thunderstorm	Effect: "Tiki Thoughtfulness", Effect Duration: 20
-Item	Jack-O-Lantern beer	Effect: "Toothy Grin", Effect Duration: 30
-Item	Jackhammer	Effect: "Mortarfied", Effect Duration: 10
-Item	Jamaican coffee	Effect: "Jamaican' Me Acquisitive", Effect Duration: 50
-Item	jug of booze	Effect: "Booze Goozles", Effect Duration: 30
-Item	Jungle Juice	Effect: "Jungle Juiced", Effect Duration: 30
+Item	ice wine	Effect: "Brain Freeze", Effect Duration: 50, Last Available: "2015-11"
+Item	Irish Coffee, English Heart	Effect: "Smithsness Cheer", Effect Duration: 100, Last Available: "2013-12"
+Item	Irish eggnog	Effect: "Green-Blooded", Effect Duration: 20, Last Available: "2024-12"
+Item	Ish Kabibble	Effect: "Feeling No Pain", Effect Duration: 25, Last Available: "2014-07"
+Item	Island Hurricane	Effect: "Tiki Temerity", Effect Duration: 20, Last Available: "2019-04"
+Item	Island Landslide	Effect: "Tiki Toughness", Effect Duration: 20, Last Available: "2019-04"
+Item	Island Thunderstorm	Effect: "Tiki Thoughtfulness", Effect Duration: 20, Last Available: "2019-04"
+Item	Jack-O-Lantern beer	Effect: "Toothy Grin", Effect Duration: 30, Last Available: "2015-10"
+Item	Jackhammer	Effect: "Mortarfied", Effect Duration: 10, Last Available: "2012-03"
+Item	Jamaican coffee	Effect: "Jamaican' Me Acquisitive", Effect Duration: 50, Last Available: "2023-12"
+Item	jug of booze	Effect: "Booze Goozles", Effect Duration: 30, Last Available: "2017-10"
+Item	Jungle Juice	Effect: "Jungle Juiced", Effect Duration: 30, Last Available: "2014-10"
 Item	La Fantasma y La Oscuridad	Effect: "La Oscuridad Adentro", Effect Duration: 13
-Item	lavawater	Effect: "Sizzling with Fury", Effect Duration: 50
-Item	Lemonade-235	Effect: "Radiated and Grodiated", Effect Duration: 40
-Item	literal grasshopper	Effect: "Wings of the Grasshopper", Effect Duration: 40
-Item	Locust	Effect: "Cockroach Scurry", Effect Duration: 10
-Item	Lollipop Drop	Effect: "Holiday Bliss", Effect Duration: 5
-Item	London frog	Effect: "Slime Time", Effect Duration: 40
-Item	low tide martini	Effect: "Floundering", Effect Duration: 40
-Item	Lumineux Limnio	Effect: "Bright!", Effect Duration: 50
+Item	lavawater	Effect: "Sizzling with Fury", Effect Duration: 50, Last Available: "2015-08"
+Item	Lemonade-235	Effect: "Radiated and Grodiated", Effect Duration: 40, Last Available: "2015-04"
+Item	literal grasshopper	Effect: "Wings of the Grasshopper", Effect Duration: 40, Last Available: "2017-03"
+Item	Locust	Effect: "Cockroach Scurry", Effect Duration: 10, Last Available: "2012-03"
+Item	Lollipop Drop	Effect: "Holiday Bliss", Effect Duration: 5, Last Available: "2012-03"
+Item	London frog	Effect: "Slime Time", Effect Duration: 40, Last Available: "2017-03"
+Item	low tide martini	Effect: "Floundering", Effect Duration: 40, Last Available: "2017-03"
+Item	Lumineux Limnio	Effect: "Bright!", Effect Duration: 50, Last Available: "2011-09"
 Item	lychee chuhai	Effect: "Brined Liver", Effect Duration: 20
-Item	marshmallow flamb&eacute;	Effect: "Sugar Rush", Effect Duration: 10
-Item	McLeod's Hard Haggis-Ade	Effect: "Hagg-ard", Effect Duration: 20
-Item	meadeorite	Effect: "Meadulla Oblongota", Effect Duration: 40
-Item	mechanically-mulled cider	Effect: "Eyesies on the Pressies", Effect Duration: 20
+Item	marshmallow flamb&eacute;	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2011-03"
+Item	McLeod's Hard Haggis-Ade	Effect: "Hagg-ard", Effect Duration: 20, Last Available: "2012-12"
+Item	meadeorite	Effect: "Meadulla Oblongota", Effect Duration: 40, Last Available: "2017-08"
+Item	mechanically-mulled cider	Effect: "Eyesies on the Pressies", Effect Duration: 20, Last Available: "2024-12"
 Item	melon-infused sake	Effect: "Warm Belly", Effect Duration: 1
-Item	mentholated wine	Effect: "Christmessy", Effect Duration: 20
-Item	mini kiwitini	Effect: "Green Peace", Effect Duration: 15
+Item	mentholated wine	Effect: "Christmessy", Effect Duration: 20, Last Available: "2017-03"
+Item	mini kiwitini	Effect: "Green Peace", Effect Duration: 15, Last Available: "2024-06"
 Item	mini-martini	Effect: "It's Not Even Funny", Effect Duration: 11
-Item	Mohobo	Effect: "Mo' Hobo", Effect Duration: 5
-Item	Moonshine Mohobo	Effect: "Mo' Hobo", Effect Duration: 10
-Item	moreltini	Effect: "Truffle Tango", Effect Duration: 40
-Item	morning dew	Effect: "Granolarrrgh", Effect Duration: 40
-Item	Morto Moreto	Effect: "Majorly Poisoned", Effect Duration: 100
-Item	mulled berry wine	Effect: "Sweet Nostalgia", Effect Duration: 30
-Item	mulled hobo wine	Effect: "Burnt 'n' Turnt", Effect Duration: 20
-Item	mulled wine	Effect: "Mullin' for Bullion", Effect Duration: 50
+Item	Mohobo	Effect: "Mo' Hobo", Effect Duration: 5, Last Available: "2012-03"
+Item	Moonshine Mohobo	Effect: "Mo' Hobo", Effect Duration: 10, Last Available: "2012-03"
+Item	moreltini	Effect: "Truffle Tango", Effect Duration: 40, Last Available: "2017-03"
+Item	morning dew	Effect: "Granolarrrgh", Effect Duration: 40, Last Available: "2017-03"
+Item	Morto Moreto	Effect: "Majorly Poisoned", Effect Duration: 100, Last Available: "2011-09"
+Item	mulled berry wine	Effect: "Sweet Nostalgia", Effect Duration: 30, Last Available: "2014-12"
+Item	mulled hobo wine	Effect: "Burnt 'n' Turnt", Effect Duration: 20, Last Available: "2018-12"
+Item	mulled wine	Effect: "Mullin' for Bullion", Effect Duration: 50, Last Available: "2023-12"
 Item	Murderer's Punch	Effect: "Punchy, Murdery", Effect Duration: 40
-Item	Muschat	Effect: "L'instinct F&eacute;lin", Effect Duration: 20
-Item	Mysterious Island iced tea	Effect: "Orcmouth", Effect Duration: 40
-Item	nanite-infested eggnog	Effect: "Chock Full o' Nanites", Effect Duration: 20
-Item	natto-infused sake	Effect: "Ninja, Please", Effect Duration: 30
-Item	nega-mushroom wine	Effect: "Double Negavision", Effect Duration: 50
+Item	Muschat	Effect: "L'instinct F&eacute;lin", Effect Duration: 20, Last Available: "2011-09"
+Item	Mysterious Island iced tea	Effect: "Orcmouth", Effect Duration: 40, Last Available: "2017-03"
+Item	nanite-infested eggnog	Effect: "Chock Full o' Nanites", Effect Duration: 20, Last Available: "2007-12"
+Item	natto-infused sake	Effect: "Ninja, Please", Effect Duration: 30, Last Available: "2011-03"
+Item	nega-mushroom wine	Effect: "Double Negavision", Effect Duration: 50, Last Available: "2017-12"
 Item	New Zealand iced tea	Effect: "New Zeal", Effect Duration: 20
-Item	Newark	Effect: "Hobo Powering Up!", Effect Duration: 40
+Item	Newark	Effect: "Hobo Powering Up!", Effect Duration: 40, Last Available: "2017-03"
 Item	nice warm beer	Effect: "Cracked Open a Warm One", Effect Duration: 30
-Item	Nog-on-the-Cob	Effect: "Sulfurous Sinuses", Effect Duration: 20
+Item	Nog-on-the-Cob	Effect: "Sulfurous Sinuses", Effect Duration: 20, Last Available: "2020-05"
 Item	non-aged vinegar	Effect: "Sour Grapes", Effect Duration: 40
-Item	nothingtini	Effect: "Nothing Happened", Effect Duration: 40
-Item	oozenog	Effect: "Festive Radiation", Effect Duration: 10
+Item	nothingtini	Effect: "Nothing Happened", Effect Duration: 40, Last Available: "2017-03"
+Item	oozenog	Effect: "Festive Radiation", Effect Duration: 10, Last Available: "2008-12"
 Item	Oreille Divis&eacute;e brandy	Effect: "Hoity Toity", Effect Duration: 20
-Item	overpowering mushroom wine	Effect: "Boletus Swoletus", Effect Duration: 80
-Item	Phil Collins	Effect: "Hello, I Must Be Going", Effect Duration: 40
-Item	Phlegethon	Effect: "Flambé-a-thon", Effect Duration: 40
-Item	piscatini	Effect: "You Drank Fish Wine", Effect Duration: 40
-Item	pixel beer	Effect: "Analog Drunk", Effect Duration: 40
+Item	overpowering mushroom wine	Effect: "Boletus Swoletus", Effect Duration: 80, Last Available: "2014-05"
+Item	Phil Collins	Effect: "Hello, I Must Be Going", Effect Duration: 40, Last Available: "2017-03"
+Item	Phlegethon	Effect: "Flambé-a-thon", Effect Duration: 40, Last Available: "2017-03"
+Item	piscatini	Effect: "You Drank Fish Wine", Effect Duration: 40, Last Available: "2017-03"
+Item	pixel beer	Effect: "Analog Drunk", Effect Duration: 40, Last Available: "2015-06"
 Item	pixel whiskey	Effect: "Wall Rage", Effect Duration: 5
-Item	Plague of Locusts	Effect: "Cockroach Scurry", Effect Duration: 15
+Item	Plague of Locusts	Effect: "Cockroach Scurry", Effect Duration: 15, Last Available: "2012-03"
 # plastic cup of beer: Deals 30-40 <font color=blueviolet>Sleaze Damage</font>
 # primitive alien booze: Extends the duration of up to 10 of your effects by 5 Adventures
-Item	punch-drunk punch	Effect: "Boxing Day Drinking", Effect Duration: 50
-Item	Punchplanter	Effect: "Fishy", Effect Duration: 5
-Item	Quaatorade&trade;	Effect: "Quaaaaaaa", Effect Duration: 100
-Item	R'lyeh	Effect: "The Effect Man Was Not Meant to Have", Effect Duration: 40
-Item	red ale	Effect: "Putting the Pro in Proletariat", Effect Duration: 40
-Item	Red Dwarf	Effect: "World's Shortest Giant", Effect Duration: 5
+Item	punch-drunk punch	Effect: "Boxing Day Drinking", Effect Duration: 50, Last Available: "2018-12"
+Item	Punchplanter	Effect: "Fishy", Effect Duration: 5, Last Available: "2012-03"
+Item	Quaatorade&trade;	Effect: "Quaaaaaaa", Effect Duration: 100, Last Available: "2015-08"
+Item	R'lyeh	Effect: "The Effect Man Was Not Meant to Have", Effect Duration: 40, Last Available: "2017-03"
+Item	red ale	Effect: "Putting the Pro in Proletariat", Effect Duration: 40, Last Available: "2015-12"
+Item	Red Dwarf	Effect: "World's Shortest Giant", Effect Duration: 5, Last Available: "2012-03"
 Item	red-hot boilermaker	Effect: "Boilermade", Effect Duration: 50
-Item	reverse Tantalus	Effect: "It Is So Hot In Your Guts, So So Hot", Effect Duration: 40
+Item	reverse Tantalus	Effect: "It Is So Hot In Your Guts, So So Hot", Effect Duration: 40, Last Available: "2017-03"
 Item	Rompedores de Fantasmas	Effect: "Desenfantasmada", Effect Duration: 13
 # Russian Ice: Weakens enemies somewhat when used as a combat item
 Item	Sacramento wine	Effect: "Sacr&eacute; Mental", Effect Duration: 50
 Item	salacious lychee chuhai	Effect: "Brined Liver", Effect Duration: 30
 Item	salacious screwdiver	Effect: "Brined Liver", Effect Duration: 30
 Item	salinated mint julep	Effect: "Brined Liver", Effect Duration: 10
-Item	salt plum sake	Effect: "Warm Belly", Effect Duration: 1
-Item	Sazerorc	Effect: "Orc Chops", Effect Duration: 5
-Item	Sazuruk-hai	Effect: "Orc Chops", Effect Duration: 10
-Item	Scorpion Bowl	Effect: "Tiki Toughness", Effect Duration: 40
+Item	salt plum sake	Effect: "Warm Belly", Effect Duration: 1, Last Available: "2019-12"
+Item	Sazerorc	Effect: "Orc Chops", Effect Duration: 5, Last Available: "2012-03"
+Item	Sazuruk-hai	Effect: "Orc Chops", Effect Duration: 10, Last Available: "2012-03"
+Item	Scorpion Bowl	Effect: "Tiki Toughness", Effect Duration: 40, Last Available: "2019-04"
 Item	scotch on the rocks	Effect: "Hair on Your Chest", Effect Duration: 30
 Item	screwdiver	Effect: "Brined Liver", Effect Duration: 20
-Item	sham champagne	Effect: "Shamboozled", Effect Duration: 10
+Item	sham champagne	Effect: "Shamboozled", Effect Duration: 10, Last Available: "2009-06"
 Item	shot of flower schnapps	Effect: "Flower Power", Effect Duration: 3
 Item	shot of mescal	Effect: "Brainworm", Effect Duration: 50
-Item	shot of nepenthe schnapps	Effect: "Memento Moir&eacute;", Effect Duration: 10
-Item	Shot of the Living Dead	Effect: "Creepypasted", Effect Duration: 15
-Item	shroomtini	Effect: "Mushroom Samba", Effect Duration: 40
-Item	Siberian sunrise	Effect: "Sugar, Hello", Effect Duration: 40
-Item	Silver Bullet beer	Effect: "Wolf's Bane", Effect Duration: 30
-Item	Simepore slime	Effect: "The Secret of the Ooze", Effect Duration: 40
-Item	single entendre	Effect: "Pounded by the Actual Stars", Effect Duration: 40
-Item	Sizzling Sinner	Effect: "Heart Aflame", Effect Duration: 15
-Item	Skull Punch	Effect: "Tiki Toughness", Effect Duration: 30
-Item	Slimebite	Effect: "In the Slimelight", Effect Duration: 15
-Item	Slimosa	Effect: "In the Slimelight", Effect Duration: 5
+Item	shot of nepenthe schnapps	Effect: "Memento Moir&eacute;", Effect Duration: 10, Last Available: "2007-06"
+Item	Shot of the Living Dead	Effect: "Creepypasted", Effect Duration: 15, Last Available: "2012-03"
+Item	shroomtini	Effect: "Mushroom Samba", Effect Duration: 40, Last Available: "2017-03"
+Item	Siberian sunrise	Effect: "Sugar, Hello", Effect Duration: 40, Last Available: "2017-03"
+Item	Silver Bullet beer	Effect: "Wolf's Bane", Effect Duration: 30, Last Available: "2011-10"
+Item	Simepore slime	Effect: "The Secret of the Ooze", Effect Duration: 40, Last Available: "2017-03"
+Item	single entendre	Effect: "Pounded by the Actual Stars", Effect Duration: 40, Last Available: "2017-03"
+Item	Sizzling Sinner	Effect: "Heart Aflame", Effect Duration: 15, Last Available: "2012-03"
+Item	Skull Punch	Effect: "Tiki Toughness", Effect Duration: 30, Last Available: "2019-04"
+Item	Slimebite	Effect: "In the Slimelight", Effect Duration: 15, Last Available: "2012-03"
+Item	Slimosa	Effect: "In the Slimelight", Effect Duration: 5, Last Available: "2012-03"
 Item	slimy fermented bile bladder	Effect: "Bilious", Effect Duration: 20
-Item	Slippery Knob	Effect: "Gutterminded", Effect Duration: 10
-Item	Sloe Comfortable Zoo	Effect: "Rampage!", Effect Duration: 10
-Item	Sloe Comfortable Zoo on Fire	Effect: "Rampage!", Effect Duration: 15
+Item	Slippery Knob	Effect: "Gutterminded", Effect Duration: 10, Last Available: "2012-03"
+Item	Sloe Comfortable Zoo	Effect: "Rampage!", Effect Duration: 10, Last Available: "2012-03"
+Item	Sloe Comfortable Zoo on Fire	Effect: "Rampage!", Effect Duration: 15, Last Available: "2012-03"
 Item	slug of rum	Effect: "Brined Liver", Effect Duration: 10
 Item	slug of shochu	Effect: "Brined Liver", Effect Duration: 10
 Item	slug of vodka	Effect: "Brined Liver", Effect Duration: 10
-Item	smooth mushroom wine	Effect: "Gyromitra Gymnastics", Effect Duration: 80
-Item	Smuggler's Punch	Effect: "Tiki Temerity", Effect Duration: 30
-Item	snakebite	Effect: "Sweet Tooth", Effect Duration: 30
-Item	Sockdollager	Effect: "In a Lather", Effect Duration: 25
-Item	soilzerac	Effect: "Here's Mud in Your Eye", Effect Duration: 40
-Item	Sourfinger	Effect: "Touched", Effect Duration: 20
-Item	soy cordial	Effect: "Electrolyte Fantastic", Effect Duration: 2
-Item	soyburger juice	Effect: "Oversaturated Palate", Effect Duration: 1
-Item	Steamboat	Effect: "Steamed", Effect Duration: 20
-Item	Strikes Again Bigmouth	Effect: "Smithsness Cheer", Effect Duration: 50
+Item	smooth mushroom wine	Effect: "Gyromitra Gymnastics", Effect Duration: 80, Last Available: "2014-05"
+Item	Smuggler's Punch	Effect: "Tiki Temerity", Effect Duration: 30, Last Available: "2019-04"
+Item	snakebite	Effect: "Sweet Tooth", Effect Duration: 30, Last Available: "2014-12"
+Item	Sockdollager	Effect: "In a Lather", Effect Duration: 25, Last Available: "2014-07"
+Item	soilzerac	Effect: "Here's Mud in Your Eye", Effect Duration: 40, Last Available: "2017-03"
+Item	Sourfinger	Effect: "Touched", Effect Duration: 20, Last Available: "2020-05"
+Item	soy cordial	Effect: "Electrolyte Fantastic", Effect Duration: 2, Last Available: "2011-03"
+Item	soyburger juice	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+Item	Steamboat	Effect: "Steamed", Effect Duration: 20, Last Available: "2020-05"
+Item	Strikes Again Bigmouth	Effect: "Smithsness Cheer", Effect Duration: 50, Last Available: "2013-12"
 Item	Strong, Silent Type	Effect: "Speakin' Even Easier", Effect Duration: 30
-Item	Suffering Sinner	Effect: "Heart Aflame", Effect Duration: 5
-Item	Suppurating Sinner	Effect: "Heart Aflame", Effect Duration: 10
-Item	Swedish coffee	Effect: "Swedish Courage", Effect Duration: 50
-Item	swirling mushroom wine	Effect: "Tremella Tremens", Effect Duration: 80
-Item	Taco Dan's Taco Stand Chimichangarita	Effect: "Margaritish", Effect Duration: 10
+Item	Suffering Sinner	Effect: "Heart Aflame", Effect Duration: 5, Last Available: "2012-03"
+Item	Suppurating Sinner	Effect: "Heart Aflame", Effect Duration: 10, Last Available: "2012-03"
+Item	Swedish coffee	Effect: "Swedish Courage", Effect Duration: 50, Last Available: "2023-12"
+Item	swirling mushroom wine	Effect: "Tremella Tremens", Effect Duration: 80, Last Available: "2014-05"
+Item	Taco Dan's Taco Stand Chimichangarita	Effect: "Margaritish", Effect Duration: 10, Last Available: "2012-12"
 Item	Temps Tempranillo	Effect Duration: 5
-Item	The Cooler Out of Space	Effect: "You Can Taste the Darkness", Effect Duration: 30
+Item	The Cooler Out of Space	Effect: "You Can Taste the Darkness", Effect Duration: 30, Last Available: "2011-10"
 # The Mad Liquor: Reduces your Fullness by 1
-Item	Third Base	Effect: "Third Based", Effect Duration: 40
-Item	tobiko-infused sake	Effect: "Pisces in the Skyces", Effect Duration: 30
-Item	Transylvania Sling	Effect: "Creepypasted", Effect Duration: 10
-Item	turchucken	Effect: "Grateful, But Spelled With a Dollar Sign", Effect Duration: 20
-Item	Turtle Bowl	Effect: "Tiki Thoughtfulness", Effect Duration: 40
-Item	twice-haunted screwdriver	Effect: "Haunted Liver", Effect Duration: 40
-Item	unfinished fruitcake	Effect: "Holiday Disappointment", Effect Duration: 10
+Item	Third Base	Effect: "Third Based", Effect Duration: 40, Last Available: "2018-02"
+Item	tobiko-infused sake	Effect: "Pisces in the Skyces", Effect Duration: 30, Last Available: "2011-03"
+Item	Transylvania Sling	Effect: "Creepypasted", Effect Duration: 10, Last Available: "2012-03"
+Item	turchucken	Effect: "Grateful, But Spelled With a Dollar Sign", Effect Duration: 20, Last Available: "2024-12"
+Item	Turtle Bowl	Effect: "Tiki Thoughtfulness", Effect Duration: 40, Last Available: "2019-04"
+Item	twice-haunted screwdriver	Effect: "Haunted Liver", Effect Duration: 40, Last Available: "2018-11"
+Item	unfinished fruitcake	Effect: "Holiday Disappointment", Effect Duration: 10, Last Available: "2017-12"
 Item	unquiet spirits	Effect: "Hollow Inside", Effect Duration: 50
 Item	vintage smart drink	Effect: "Smart Drunk", Effect Duration: 1
-Item	vodka barracuda	Effect: "Mer-kinkiness", Effect Duration: 40
-Item	vodka stinger	Effect: "Mer-kindliness", Effect Duration: 40
-Item	warbear bearserker mead	Effect: "Warbear Warlust", Effect Duration: 40
-Item	warbear blizzard mead	Effect: "Warbear Blubber", Effect Duration: 40
-Item	warbear feasting mead	Effect: "Warbear Loot Lust", Effect Duration: 40
-Item	wasabi-infused sake	Effect: "Wasabi With You", Effect Duration: 30
-Item	wax booze	Effect: "Waxing", Effect Duration: 30
+Item	vodka barracuda	Effect: "Mer-kinkiness", Effect Duration: 40, Last Available: "2017-03"
+Item	vodka stinger	Effect: "Mer-kindliness", Effect Duration: 40, Last Available: "2017-03"
+Item	warbear bearserker mead	Effect: "Warbear Warlust", Effect Duration: 40, Last Available: "2013-12"
+Item	warbear blizzard mead	Effect: "Warbear Blubber", Effect Duration: 40, Last Available: "2013-12"
+Item	warbear feasting mead	Effect: "Warbear Loot Lust", Effect Duration: 40, Last Available: "2013-12"
+Item	wasabi-infused sake	Effect: "Wasabi With You", Effect Duration: 30, Last Available: "2011-03"
+Item	wax booze	Effect: "Waxing", Effect Duration: 30, Last Available: "2017-01"
 Item	whiskey in a broken glass	Effect: "Bloody Grin", Effect Duration: 50
-Item	whiskey squeeze	Effect: "Hobo Powers Activate!", Effect Duration: 20
+Item	whiskey squeeze	Effect: "Hobo Powers Activate!", Effect Duration: 20, Last Available: "2017-03"
 Item	white Canadian	Effect: "Canadianity", Effect Duration: 3
 Item	white Dreadsylvanian	Effect: "Whitesloshed", Effect Duration: 50
 Item	white lightning	Effect: "Temporary Blindness", Effect Duration: 3
-Item	white Xanadian	Effect: "Flashing Eyes", Effect Duration: 10
-Item	world's most unappetizing beverage	Effect: "Literally Insane", Effect Duration: 10
+Item	white Xanadian	Effect: "Flashing Eyes", Effect Duration: 10, Last Available: "2007-06"
+Item	world's most unappetizing beverage	Effect: "Literally Insane", Effect Duration: 10, Last Available: "2010-04"
 Item	zmobie	Wiki Name: "Zmobie (drink)"
-Item	Zoodriver	Effect: "Rampage!", Effect Duration: 5
+Item	Zoodriver	Effect: "Rampage!", Effect Duration: 5, Last Available: "2012-03"
 
 # Spleen Toxins section of modifiers.txt
 
-Item	a bug's lymph	Effect: "A Bug's Life", Effect Duration: 60
-Item	abstraction: action	Effect: "Action", Effect Duration: 50
-Item	abstraction: category	Effect: "Category", Effect Duration: 50
-Item	abstraction: certainty	Effect: "Certainty", Effect Duration: 50
-Item	abstraction: joy	Effect: "Joy", Effect Duration: 50
-Item	abstraction: motion	Effect: "Motion", Effect Duration: 50
-Item	abstraction: perception	Effect: "Perception", Effect Duration: 50
-Item	abstraction: purpose	Effect: "Purpose", Effect Duration: 50
-Item	abstraction: sensation	Effect: "Sensation", Effect Duration: 50
-Item	abstraction: thought	Effect: "Thought", Effect Duration: 50
+Item	a bug's lymph	Effect: "A Bug's Life", Effect Duration: 60, Last Available: "2019-12"
+Item	abstraction: action	Effect: "Action", Effect Duration: 50, Last Available: "2015-12"
+Item	abstraction: category	Effect: "Category", Effect Duration: 50, Last Available: "2015-12"
+Item	abstraction: certainty	Effect: "Certainty", Effect Duration: 50, Last Available: "2015-12"
+Item	abstraction: joy	Effect: "Joy", Effect Duration: 50, Last Available: "2015-12"
+Item	abstraction: motion	Effect: "Motion", Effect Duration: 50, Last Available: "2015-12"
+Item	abstraction: perception	Effect: "Perception", Effect Duration: 50, Last Available: "2015-12"
+Item	abstraction: purpose	Effect: "Purpose", Effect Duration: 50, Last Available: "2015-12"
+Item	abstraction: sensation	Effect: "Sensation", Effect Duration: 50, Last Available: "2015-12"
+Item	abstraction: thought	Effect: "Thought", Effect Duration: 50, Last Available: "2015-12"
 Item	alien animal goo	Effect: "Celestial Body", Effect Duration: 40
-Item	alien plant goo	Effect: "Celestial Mind", Effect Duration: 40
-Item	ancient medicinal herbs	Effect: "Ancient Fortitude", Effect Duration: 50
+Item	alien plant goo	Effect: "Celestial Mind", Effect Duration: 40, Last Available: "2017-04"
+Item	ancient medicinal herbs	Effect: "Ancient Fortitude", Effect Duration: 50, Last Available: "2016-01"
 # ancient pills: Restore 30-40 MP
 Item	antique bottle of cough syrup	Effect: "The Q Is Talking To You", Effect Duration: 10
-Item	armored prawn	Effect: "Rushtacean'", Effect Duration: 50
+Item	armored prawn	Effect: "Rushtacean'", Effect Duration: 50, Last Available: "2016-03"
 # astral energy drink: Gives you good luck
-Item	autumn breeze	Effect: "Delighted by Autumn", Effect Duration: 50
-Item	beastly paste	Effect: "Beastly Flavor", Effect Duration: 10
+Item	autumn breeze	Effect: "Delighted by Autumn", Effect Duration: 50, Last Available: "2022-10"
+Item	beastly paste	Effect: "Beastly Flavor", Effect Duration: 10, Last Available: "2011-08"
 Item	beefy pill	Effect: "Beefy", Effect Duration: 30
-Item	beggin' cologne	Effect: "Eau d' Clochard", Effect Duration: 60
+Item	beggin' cologne	Effect: "Eau d' Clochard", Effect Duration: 60, Last Available: "2019-12"
 Item	black paisley oyster egg	Effect: "Egg-stortionary Tactics", Effect Duration: 20
 Item	black polka-dot oyster egg	Effect: "Egg-stortionary Tactics", Effect Duration: 20
 Item	black striped oyster egg	Effect: "Egg-stortionary Tactics", Effect Duration: 20
 # blue paisley oyster egg: Restores 30-35 MP
 # blue polka-dot oyster egg: Restores 30-35 MP
 # blue striped oyster egg: Restores 30-35 MP
-Item	body spradium	Effect: "Boxing Day Glow", Effect Duration: 100
+Item	body spradium	Effect: "Boxing Day Glow", Effect Duration: 100, Last Available: "2018-12"
 Item	bottle of extra-strength melodramamine	Effect: "Emotion Sickness", Effect Duration: 50
 Item	bottle of melodramamine	Effect: "Emotion Sickness", Effect Duration: 5
 Item	bottle of ultravitamins	Effect: "Vitamin-Maxed", Effect Duration: 10
 Item	brilliant oyster egg	Effect: "Eggstraordinary Brilliance", Effect Duration: 20
-Item	bug paste	Effect: "Buggy Flavor", Effect Duration: 10
-Item	carrot juice	Effect: "Pla-see-bo", Effect Duration: 10
-Item	chlorophyll paste	Effect: "Chlorophyll Flavor", Effect Duration: 10
+Item	bug paste	Effect: "Buggy Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	carrot juice	Effect: "Pla-see-bo", Effect Duration: 10, Last Available: "2013-01"
+Item	chlorophyll paste	Effect: "Chlorophyll Flavor", Effect Duration: 10, Last Available: "2011-08"
 # clovermint: Gives you good luck
 # cold jelly: Freezes your liver
-Item	cold jelly	Effect: "Cold Jellied", Effect Duration: 50
+Item	cold jelly	Effect: "Cold Jellied", Effect Duration: 50, Last Available: "2017-01"
 Item	cold wad	Effect: "Cold Blooded", Effect Duration: 20
 Item	concentrated cooking	Effect: "Cooking Concentrate", Effect Duration: 10
-Item	cosmic paste	Effect: "Cosmic Flavor", Effect Duration: 10
-Item	Crimbeau de toilette	Effect: "Crimbeau'd", Effect Duration: 50
-Item	Crimbo paste	Effect: "Crimbo Flavor", Effect Duration: 10
-Item	cute mushroom	Effect: "Cute Vision", Effect Duration: 50
-Item	demonic paste	Effect: "Demonic Flavor", Effect Duration: 10
+Item	cosmic paste	Effect: "Cosmic Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	Crimbeau de toilette	Effect: "Crimbeau'd", Effect Duration: 50, Last Available: "2018-12"
+Item	Crimbo paste	Effect: "Crimbo Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	cute mushroom	Effect: "Cute Vision", Effect Duration: 50, Last Available: "2015-09"
+Item	demonic paste	Effect: "Demonic Flavor", Effect Duration: 10, Last Available: "2011-08"
 # dieting pill: Eat less, Enjoy it More!
-Item	drenchrome 2.0	Effect: "Cyber Slicer", Effect Duration: 30
-Item	ectoplasmic paste	Effect: "Spooky Flavor", Effect Duration: 10
-Item	eldritch essence	Effect: "Eldritch Concentration", Effect Duration: 50
-Item	elemental paste	Effect: "Elemental Flavor", Effect Duration: 10
-Item	energized spores	Effect: "Energized", Effect Duration: 40
+Item	drenchrome 2.0	Effect: "Cyber Slicer", Effect Duration: 30, Last Available: "2025-12"
+Item	ectoplasmic paste	Effect: "Spooky Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	eldritch essence	Effect: "Eldritch Concentration", Effect Duration: 50, Last Available: "2016-11"
+Item	elemental paste	Effect: "Elemental Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	energized spores	Effect: "Energized", Effect Duration: 40, Last Available: "2023-02"
 # excitement pill: Get an exciting random effect!
-Item	eXpand	Effect: "Cyber Memory Boost", Effect Duration: 30
-Item	fish sauce	Effect: "Fishy", Effect Duration: 30
-Item	fishy paste	Effect: "Fishy", Effect Duration: 10
-Item	fried air	Effect: "Well-Ventilated", Effect Duration: 30
-Item	fruity pebble	Effect: "All Rainbow-y", Effect Duration: 30
+Item	eXpand	Effect: "Cyber Memory Boost", Effect Duration: 30, Last Available: "2025-12"
+Item	fish sauce	Effect: "Fishy", Effect Duration: 30, Last Available: "2019-12"
+Item	fishy paste	Effect: "Fishy", Effect Duration: 10, Last Available: "2011-08"
+Item	fried air	Effect: "Well-Ventilated", Effect Duration: 30, Last Available: "2021-12"
+Item	fruity pebble	Effect: "All Rainbow-y", Effect Duration: 30, Last Available: "2023-01"
 # furry pill: Removes a Negative Effect<br />Restores 40-50 HP
 Item	gaseous gravy	Effect: "Gettin' the Goods", Effect Duration: 50
 Item	gleaming oyster egg	Effect: "Gleam-Inducing", Effect Duration: 50
-Item	glimmering buzzard feather	Effect: "Carrion' On", Effect Duration: 20
-Item	glimmering great tit feather	Effect: "The Great Tit's Blessing", Effect Duration: 20
-Item	glimmering penguin feather	Effect: "Antarctic Memories", Effect Duration: 20
-Item	glimmering phoenix feather	Effect: "Phoenix, Right?", Effect Duration: 20
-Item	glimmering raven feather	Effect: "Melancholy Burden", Effect Duration: 20
+Item	glimmering buzzard feather	Effect: "Carrion' On", Effect Duration: 20, Last Available: "2008-06"
+Item	glimmering great tit feather	Effect: "The Great Tit's Blessing", Effect Duration: 20, Last Available: "2008-06"
+Item	glimmering penguin feather	Effect: "Antarctic Memories", Effect Duration: 20, Last Available: "2008-06"
+Item	glimmering phoenix feather	Effect: "Phoenix, Right?", Effect Duration: 20, Last Available: "2008-06"
+Item	glimmering raven feather	Effect: "Melancholy Burden", Effect Duration: 20, Last Available: "2008-06"
 Item	glistening oyster egg	Effect: "Eggstraordinary Style", Effect Duration: 20
-Item	glyph of athleticism	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 50
-Item	goblin paste	Effect: "Gobliny Flavor", Effect Duration: 10
-Item	greasy paste	Effect: "Greasy Flavor", Effect Duration: 10
-Item	groose grease	Effect: "Just the Best Anapests", Effect Duration: 50
-Item	handful of Smithereens	Effect: "Smithsness Presence", Effect Duration: 100
+Item	glyph of athleticism	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 50, Last Available: "2017-10"
+Item	goblin paste	Effect: "Gobliny Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	greasy paste	Effect: "Greasy Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	groose grease	Effect: "Just the Best Anapests", Effect Duration: 50, Last Available: "2012-12"
+Item	handful of Smithereens	Effect: "Smithsness Presence", Effect Duration: 100, Last Available: "2013-12"
 Item	hardening cream	Effect: "Really Hard", Effect Duration: 50
-Item	hippy paste	Effect: "Hippy Flavor", Effect Duration: 10
-Item	hobo paste	Effect: "Hobo Flavor", Effect Duration: 10
-Item	homeopathic mint tea	Effect: "Alpine Mintiness", Effect Duration: 50
+Item	hippy paste	Effect: "Hippy Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	hobo paste	Effect: "Hobo Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	homeopathic mint tea	Effect: "Alpine Mintiness", Effect Duration: 50, Last Available: "2015-01"
 # hot jelly: Lets you breathe on a monster
-Item	hot jelly	Effect: "Hot Jellied", Effect Duration: 50
+Item	hot jelly	Effect: "Hot Jellied", Effect Duration: 50, Last Available: "2017-01"
 Item	hot wad	Effect: "Hot Blooded", Effect Duration: 20
-Item	indescribably horrible paste	Effect: "Indescribable Flavor", Effect Duration: 10
-Item	industrial lubricant	Effect: "Industrially Lubricated", Effect Duration: 30
-Item	kelp	Effect: "Does a Body Good", Effect Duration: 50
+Item	indescribably horrible paste	Effect: "Indescribable Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	industrial lubricant	Effect: "Industrially Lubricated", Effect Duration: 30, Last Available: "2019-12"
+Item	kelp	Effect: "Does a Body Good", Effect Duration: 50, Last Available: "2019-07"
 Item	Knob Goblin eyedrops	Effect: "Peeled Eyeballs", Effect Duration: 30
 Item	Knob Goblin learning pill	Effect: "Big Veiny Brain", Effect Duration: 30
 Item	Knob Goblin nasal spray	Effect: "Wasabi Sinuses", Effect Duration: 30
 Item	Knob Goblin pet-buffing spray	Effect: "Heavy Petting", Effect Duration: 30
 Item	liquid shifting time weirdness	Effect: "Liquid Luck", Effect Duration: 10
-Item	livid energy	Effect: "Lividly Energized", Effect Duration: 60
+Item	livid energy	Effect: "Lividly Energized", Effect Duration: 60, Last Available: "2019-12"
 # lucky-ish pill: Lucky!
 Item	lustrous oyster egg	Effect: "Lustre After Wealth", Effect Duration: 50
 Item	magnificent oyster egg	Effect: "Eggstraordinary Strength", Effect Duration: 20
-Item	Mansquito Serum	Effect: "More Mansquito Than Man", Effect Duration: 400
+Item	Mansquito Serum	Effect: "More Mansquito Than Man", Effect Duration: 400, Last Available: "2016-12"
 # Medicinal Herb's medicinal herbs: Restores all HP
-Item	Mer-kin paste	Effect: "Mer-kinny Flavor", Effect Duration: 10
-Item	mime army superserum	Effect: "I'll Have the Soup", Effect Duration: 50
-Item	moomy dust	Effect: "Cowrruption", Effect Duration: 30
-Item	mushroom tea	Effect: "Mush-Maw", Effect Duration: 50
+Item	Mer-kin paste	Effect: "Mer-kinny Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	mime army superserum	Effect: "I'll Have the Soup", Effect Duration: 50, Last Available: "2017-12"
+Item	moomy dust	Effect: "Cowrruption", Effect Duration: 30, Last Available: "2016-02"
+Item	mushroom tea	Effect: "Mush-Maw", Effect Duration: 50, Last Available: "2020-03"
 # Nightmare Fuel: Lets you uneasily rest for free
-Item	non-Euclidean angle	Effect: "Different Way of Seeing Things", Effect Duration: 30
+Item	non-Euclidean angle	Effect: "Different Way of Seeing Things", Effect Duration: 30, Last Available: "2019-12"
 Item	off-white paisley oyster egg	Effect: "Eggs-tra Sensory Perception", Effect Duration: 20
 Item	off-white polka-dot oyster egg	Effect: "Eggs-tra Sensory Perception", Effect Duration: 20
 Item	off-white striped oyster egg	Effect: "Eggs-tra Sensory Perception", Effect Duration: 20
-Item	oily paste	Effect: "Oily Flavor", Effect Duration: 10
-Item	orc paste	Effect: "Fratty Flavor", Effect Duration: 10
-Item	oversized ice molecule	Effect: "Icy Composition", Effect Duration: 50
-Item	party balloon	Effect: "Lifted Spirits", Effect Duration: 50
-Item	Party-in-a-Can&trade;	Effect: "Party on Your Skin", Effect Duration: 50
+Item	oily paste	Effect: "Oily Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	orc paste	Effect: "Fratty Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	oversized ice molecule	Effect: "Icy Composition", Effect Duration: 50, Last Available: "2019-04"
+Item	party balloon	Effect: "Lifted Spirits", Effect Duration: 50, Last Available: "2018-09"
+Item	Party-in-a-Can&trade;	Effect: "Party on Your Skin", Effect Duration: 50, Last Available: "2018-09"
 Item	pearlescent oyster egg	Effect: "Pearly Vision", Effect Duration: 50
-Item	penguin paste	Effect: "Penguinny Flavor", Effect Duration: 10
-Item	pewter shavings	Effect: "Pewtershot", Effect Duration: 100
-Item	pirate paste	Effect: "Piratey Flavor", Effect Duration: 10
+Item	penguin paste	Effect: "Penguinny Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	pewter shavings	Effect: "Pewtershot", Effect Duration: 100, Last Available: "2019-04"
+Item	pirate paste	Effect: "Piratey Flavor", Effect Duration: 10, Last Available: "2011-08"
 Item	pool shark hair oil	Effect: "Sharky", Effect Duration: 20
-Item	powdered oxygen	Effect: "Hyperoxygenated Blood", Effect Duration: 10
-Item	prismatic wad	Effect: "Rainbow Bright", Effect Duration: 10
-Item	psilocyber mushroom	Effect: "Connected", Effect Duration: 80
-Item	prototype stimulant	Effect: "Proto-Stimulated", Effect Duration: 50
+Item	powdered oxygen	Effect: "Hyperoxygenated Blood", Effect Duration: 10, Last Available: "2017-04"
+Item	prismatic wad	Effect: "Rainbow Bright", Effect Duration: 10, Last Available: "2008-07"
+Item	psilocyber mushroom	Effect: "Connected", Effect Duration: 80, Last Available: "2025-12"
+Item	prototype stimulant	Effect: "Proto-Stimulated", Effect Duration: 50, Last Available: "2019-12"
 # red paisley oyster egg: Restores 30-35 HP
 # red polka-dot oyster egg: Restores 30-35 HP
 # red striped oyster egg: Restores 30-35 HP
-Item	sachet of strange powder	Effect: "Powder Power", Effect Duration: 40
+Item	sachet of strange powder	Effect: "Powder Power", Effect Duration: 40, Last Available: "2018-04"
 Item	scintillating oyster egg	Effect: "Eggscitingly Colorful", Effect Duration: 20
-Item	sea jelly	Effect: "Fishy", Effect Duration: 10
+Item	sea jelly	Effect: "Fishy", Effect Duration: 10, Last Available: "2017-01"
 Item	shadow pill	Effect: "Shadow Medicine", Effect Duration: 30
-Item	Shantix&trade;	Effect: "Thou Shant Not Sing", Effect Duration: 30
+Item	Shantix&trade;	Effect: "Thou Shant Not Sing", Effect Duration: 30, Last Available: "2019-12"
 # sleaze jelly: Enables Sleazy Bickering
-Item	sleaze jelly	Effect: "Sleazy Jellied", Effect Duration: 50
+Item	sleaze jelly	Effect: "Sleazy Jellied", Effect Duration: 50, Last Available: "2017-01"
 Item	sleaze wad	Effect: "Supafly", Effect Duration: 20
 Item	slimy alveolus	Effect: "Slimebreath", Effect Duration: 50
-Item	slimy paste	Effect: "Slimy Flavor", Effect Duration: 10
+Item	slimy paste	Effect: "Slimy Flavor", Effect Duration: 10, Last Available: "2011-08"
 Item	sparkling orb	Effect: "Latently Energized", Effect Duration: 30
 # spooky jelly: Makes you emanate Spookily
-Item	spooky jelly	Effect: "Spooky Jellied", Effect Duration: 50
+Item	spooky jelly	Effect: "Spooky Jellied", Effect Duration: 50, Last Available: "2017-01"
 Item	spooky wad	Effect: "Spooky Demeanor", Effect Duration: 20
 # stench jelly: Makes monsters avoid you
-Item	stench jelly	Effect: "Stench Jellied", Effect Duration: 50
+Item	stench jelly	Effect: "Stench Jellied", Effect Duration: 50, Last Available: "2017-01"
 Item	stench wad	Effect: "Stenchtastic", Effect Duration: 20
-Item	strange paste	Effect: "Weird Flavor", Effect Duration: 10
-Item	super-sweet fish goo (spoiled)	Effect: "Fishy", Effect Duration: 15
-Item	Synapse Blaster	Effect: "Cyber Resist x2000", Effect Duration: 30
-Item	The Author's ink	Effect: "It's a Good Life!", Effect Duration: 200
-Item	The Inquisitor's unidentifiable object	Effect: "The Inquisitor's Unknown Effect", Effect Duration: 100
+Item	strange paste	Effect: "Weird Flavor", Effect Duration: 10, Last Available: "2011-08"
+Item	super-sweet fish goo (spoiled)	Effect: "Fishy", Effect Duration: 15, Last Available: "2019-12"
+Item	Synapse Blaster	Effect: "Cyber Resist x2000", Effect Duration: 30, Last Available: "2025-12"
+Item	The Author's ink	Effect: "It's a Good Life!", Effect Duration: 200, Last Available: "2016-02"
+Item	The Inquisitor's unidentifiable object	Effect: "The Inquisitor's Unknown Effect", Effect Duration: 100, Last Available: "2016-12"
 Item	tube of hair oil	Effect: "Got Your Boots On", Effect Duration: 10
 Item	twinkly wad	Effect: "Aspect of the Twinklefairy", Effect Duration: 20
-Item	vial of humanoid growth hormone	Effect: "HGH-charged", Effect Duration: 30
-Item	vibrating mushroom	Effect: "Weird Vibrations", Effect Duration: 30
+Item	vial of humanoid growth hormone	Effect: "HGH-charged", Effect Duration: 30, Last Available: "2019-12"
+Item	vibrating mushroom	Effect: "Weird Vibrations", Effect Duration: 30, Last Available: "2015-09"
 Item	vitamin G pill	Effect: "Riboflavin'", Effect Duration: 5
 Item	watered-down Red Minotaur	Effect: "Water Wings", Effect Duration: 5
 Item	yellow paisley oyster egg	Effect: "Egg-headedness", Effect Duration: 20
@@ -10165,36 +10165,36 @@ Item	toy sixgun	Sixgun Damage: [5*(1+skill(Well-Oiled Guns))]
 
 # Potions section of modifiers.txt
 
-Item	&quot;DRINK ME&quot; potion	Effect: "Down the Rabbit Hole", Effect Duration: 20
-Item	1/6th Pound Cake	Effect: "Heal Thy Nanoself", Effect Duration: 100
+Item	&quot;DRINK ME&quot; potion	Effect: "Down the Rabbit Hole", Effect Duration: 20, Last Available: "2010-03"
+Item	1/6th Pound Cake	Effect: "Heal Thy Nanoself", Effect Duration: 100, Last Available: "2011-06"
 Item	8-bit banana	Effect: "Banono", Effect Duration: 20
-Item	37x37x37 puzzle cube	Effect: "Puzzle Fury", Effect Duration: 10
+Item	37x37x37 puzzle cube	Effect: "Puzzle Fury", Effect Duration: 10, Last Available: "2012-12"
 Item	abominable blubber	Effect: "Abominably Slippery", Effect Duration: 10
 Item	adder bladder	Effect: "Deadly Flashing Blade", Effect Duration: 10
 Item	adobe brittle	Effect: "Clay-Coated Teeth", Effect Duration: 20
 Item	Aerheads	Effect: "Aerated", Effect Duration: 20
-Item	airborne mutagen	Effect: "Heightened Senses", Effect Duration: 20
-Item	alien drugs	Effect: "Space Cowboy", Effect Duration: 15
+Item	airborne mutagen	Effect: "Heightened Senses", Effect Duration: 20, Last Available: "2014-10"
+Item	alien drugs	Effect: "Space Cowboy", Effect Duration: 15, Last Available: "2023-09"
 Item	alphabet gum	Effect: "Bubble, Bubble", Effect Duration: 5
 Item	Ancient Protector Soda	Effect: "Ancient Protected", Effect Duration: 50
-Item	angry agate	Effect: "Misplaced Rage", Effect Duration: 20
+Item	angry agate	Effect: "Misplaced Rage", Effect Duration: 20, Last Available: "2023-02"
 Item	Angry Farmer candy	Effect: "Sugar Rush", Effect Duration: 10
 Item	Angry Farmer's Wife Candy	Effect: "Sugar Rush", Effect Duration: 10
 Item	ant agonist	Effect: "All Fired Up", Effect Duration: 10
-Item	anti-burn cream	Effect: "Anti-Burning", Effect Duration: 20
-Item	anti-creep cream	Effect: "Anti-Creeped", Effect Duration: 20
-Item	anti-freeze cream	Effect: "Anti-Freezing", Effect Duration: 20
-Item	anti-goosebump cream	Effect: "Anti-Goosebumped", Effect Duration: 20
-Item	anti-odor cream	Effect: "Anti-Odored", Effect Duration: 20
-Item	anti-pain cream	Effect: "Anti-Hurt", Effect Duration: 20
-Item	arse-a'fire elixir	Effect: "Arse-a'fire", Effect Duration: 10
-Item	ash soda	Effect: "Ashen Burps", Effect Duration: 15
-Item	astral mushroom	Effect: "Half-Astral", Effect Duration: 5
-Item	Atomic Comic	Effect: "Single-Eyed Vision", Effect Duration: 20
-Item	Atomic Pop	Effect: "Cinnamouth", Effect Duration: 10
-Item	augmented-reality shades	Effect: "Glasshole", Effect Duration: 50
+Item	anti-burn cream	Effect: "Anti-Burning", Effect Duration: 20, Last Available: "2021-12"
+Item	anti-creep cream	Effect: "Anti-Creeped", Effect Duration: 20, Last Available: "2021-12"
+Item	anti-freeze cream	Effect: "Anti-Freezing", Effect Duration: 20, Last Available: "2021-12"
+Item	anti-goosebump cream	Effect: "Anti-Goosebumped", Effect Duration: 20, Last Available: "2021-12"
+Item	anti-odor cream	Effect: "Anti-Odored", Effect Duration: 20, Last Available: "2021-12"
+Item	anti-pain cream	Effect: "Anti-Hurt", Effect Duration: 20, Last Available: "2021-12"
+Item	arse-a'fire elixir	Effect: "Arse-a'fire", Effect Duration: 10, Last Available: "2007-01"
+Item	ash soda	Effect: "Ashen Burps", Effect Duration: 15, Last Available: "2014-06"
+Item	astral mushroom	Effect: "Half-Astral", Effect Duration: 5, Last Available: "2006-06"
+Item	Atomic Comic	Effect: "Single-Eyed Vision", Effect Duration: 20, Last Available: "2011-04"
+Item	Atomic Pop	Effect: "Cinnamouth", Effect Duration: 10, Last Available: "2020-09"
+Item	augmented-reality shades	Effect: "Glasshole", Effect Duration: 50, Last Available: "2014-12"
 Item	autumnic balm	Effect: "Autumnically Balmy", Effect Duration: 30
-Item	bacon bath ball	Effect: "Pork Power", Effect Duration: 10
+Item	bacon bath ball	Effect: "Pork Power", Effect Duration: 10, Last Available: "2011-01"
 Item	bag of Cheat-Os	Effect: "Sticky Fingers", Effect Duration: 10
 Item	bag of grain	Effect: "Nearly All-Natural", Effect Duration: 1
 Item	bag of lard	Effect: "Cuts Like a Buttered Knife", Effect Duration: 10
@@ -10204,239 +10204,239 @@ Item	bag of W&Ws	Effect: "Just the Brown Ones", Effect Duration: 15
 Item	baggie of powdered sugar	Effect: "So You Can Work More...", Effect Duration: 10
 Item	bakelite-covered bacon	Effect: "Litely Baked", Effect Duration: 10
 Item	ballast turtle	Effect: "Oxygenated Blood", Effect Duration: 20
-Item	banana candle	Effect: "Everything Is Bananas", Effect Duration: 80
+Item	banana candle	Effect: "Everything Is Bananas", Effect Duration: 80, Last Available: "2021-08"
 Item	banana smoothie	Effect: "Bananas!", Effect Duration: [R]
-Item	banana supersucker	Effect: "Bananas!", Effect Duration: 30
-Item	baobab sap	Effect: "Buff as a Baobab", Effect Duration: 10
-Item	basaltamander tongue	Effect: "Burning Tongue", Effect Duration: 10
-Item	battery (9-Volt)	Effect: "9-Volt-Charged", Effect Duration: 30
-Item	battery (AA)	Effect: "AA-Charged", Effect Duration: 30
-Item	battery (AAA)	Effect: "AAA-Charged", Effect Duration: 30
-Item	battery (car)	Effect: "Car-Charged", Effect Duration: 30
-Item	battery (D)	Effect: "D-Charged", Effect Duration: 30
-Item	battery (lantern)	Effect: "Lantern-Charged", Effect Duration: 30
+Item	banana supersucker	Effect: "Bananas!", Effect Duration: 30, Last Available: "2011-11"
+Item	baobab sap	Effect: "Buff as a Baobab", Effect Duration: 10, Last Available: "2012-12"
+Item	basaltamander tongue	Effect: "Burning Tongue", Effect Duration: 10, Last Available: "2015-08"
+Item	battery (9-Volt)	Effect: "9-Volt-Charged", Effect Duration: 30, Last Available: "2021-03"
+Item	battery (AA)	Effect: "AA-Charged", Effect Duration: 30, Last Available: "2021-03"
+Item	battery (AAA)	Effect: "AAA-Charged", Effect Duration: 30, Last Available: "2021-03"
+Item	battery (car)	Effect: "Car-Charged", Effect Duration: 30, Last Available: "2021-03"
+Item	battery (D)	Effect: "D-Charged", Effect Duration: 30, Last Available: "2021-03"
+Item	battery (lantern)	Effect: "Lantern-Charged", Effect Duration: 30, Last Available: "2021-03"
 Item	bazookafish bubble gum	Effect: "Fishbreath", Effect Duration: 5
-Item	beard incense	Effect: "Stinkybeard", Effect Duration: 20
-Item	beet-flavored Mr. Mediocrebar	Effect: "Block-Rockin' Beet", Effect Duration: 30
-Item	begpwnia	Effect: "Can't Be a Chooser", Effect Duration: 10
-Item	bellhop bell	Effect: "Ringing Ears", Effect Duration: 10
+Item	beard incense	Effect: "Stinkybeard", Effect Duration: 20, Last Available: "2015-04"
+Item	beet-flavored Mr. Mediocrebar	Effect: "Block-Rockin' Beet", Effect Duration: 30, Last Available: "2012-12"
+Item	begpwnia	Effect: "Can't Be a Chooser", Effect Duration: 10, Last Available: "2007-05"
+Item	bellhop bell	Effect: "Ringing Ears", Effect Duration: 10, Last Available: "2007-06"
 Item	Ben-Gal&trade; Balm	Effect: "Go Get 'Em, Tiger!", Effect Duration: 3
 Item	bent scrap metal	Effect: "Armor-Plated", Effect Duration: 10
-Item	Bettie page	Effect: "Paging Betty", Effect Duration: 20
+Item	Bettie page	Effect: "Paging Betty", Effect Duration: 20, Last Available: "2018-02"
 Item	big dribbly candle	Effect: "Waxing Mystical", Effect Duration: 10
 Item	Big Punk	Effect: "Big Punkin'", Effect Duration: 50
 Item	Bit O' Ectoplasm	Effect: "Sugar Rush", Effect Duration: 5
 Item	Bit O' Quail Spleen	Effect: "Vented Spleen", Effect Duration: 10
 Item	bitter pill	Effect: "Bitterskin", Effect Duration: 100
-Item	BitterSweetTarts	Effect: "Full of Wist", Effect Duration: 10
-Item	black and white cracker	Effect: "Holiday Disappointment", Effect Duration: 30
+Item	BitterSweetTarts	Effect: "Full of Wist", Effect Duration: 10, Last Available: "2009-12"
+Item	black and white cracker	Effect: "Holiday Disappointment", Effect Duration: 30, Last Available: "2017-12"
 Item	Black Body&trade; spray	Effect: "Radiating Black Body&trade;", Effect Duration: 10
-Item	black candy heart	Effect: "Heart of Black", Effect Duration: 10
+Item	black candy heart	Effect: "Heart of Black", Effect Duration: 10, Last Available: "2007-02"
 Item	black eye shadow	Effect: "Black Eyes", Effect Duration: 10
 Item	black eyedrops	Effect: "Hyphemariffic", Effect Duration: 10
 Item	black facepaint	Effect: "Football Eyes", Effect Duration: 10
 Item	Black No. 2	Effect: "Locks Like the Raven", Effect Duration: 10
 Item	black sheepskin diploma	Effect: "Erudite", Effect Duration: 10
-Item	black snowcone	Effect: "Black Tongue", Effect Duration: 20
+Item	black snowcone	Effect: "Black Tongue", Effect Duration: 20, Last Available: "2006-01"
 Item	black tear	Effect: "Weepy, Creepy", Effect Duration: 1
 Item	blackberry polite	Effect: "Blackberry Politeness", Effect Duration: [R]
-Item	blob of Alphredo&trade;	Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 10
-Item	Blood 'n' Plenty	Effect: "Sugar Rush", Effect Duration: 10
+Item	blob of Alphredo&trade;	Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 10, Last Available: "2013-11"
+Item	Blood 'n' Plenty	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2011-10"
 Item	blood of the Wereseal	Effect: "Temporary Lycanthropy", Effect Duration: 10
 Item	bloodstain stick	Effect: "Bloodstain-Resistant", Effect Duration: 20
 Item	blooper ink	Effect: "Blooper Inked", Effect Duration: 10
 Item	blue grass	Effect: "The Grass...  Is Blue...", Effect Duration: 20
-Item	blue snowcone	Effect: "Blue Tongue", Effect Duration: 20
+Item	blue snowcone	Effect: "Blue Tongue", Effect Duration: 20, Last Available: "2006-01"
 Item	blue-frosted astral cupcake	Effect: "Cupcake of Choice", Effect Duration: 20
-Item	boiling broth	Effect: "Boiling Determination", Effect Duration: 1
-Item	boiling hot cocoa	Effect: "Cocoa-Crispy", Effect Duration: 20
+Item	boiling broth	Effect: "Boiling Determination", Effect Duration: 1, Last Available: "2018-07"
+Item	boiling hot cocoa	Effect: "Cocoa-Crispy", Effect Duration: 20, Last Available: "2020-12"
 Item	boiling seal blood	Effect: "Abyssal Blood", Effect Duration: 20
-Item	Boletus Broletus mushroom	Effect: "Boletus Swoletus", Effect Duration: 10
+Item	Boletus Broletus mushroom	Effect: "Boletus Swoletus", Effect Duration: 10, Last Available: "2014-05"
 Item	bone bons	Effect: "Bone Chilling", Effect Duration: 20
 Item	Boosty Juice	Effect: "Juicy Boost", Effect Duration: 300
 Item	BOOterfinger	Effect: "BOOsted", Effect Duration: 50
 Item	Boss Drops	Effect: "Chief Executive Optimism", Effect Duration: 5
 Item	bottle of antifreeze	Effect: "Fever From the Flavor", Effect Duration: 10
-Item	bottle of black cat tonic	Effect: "Contagious Bad Luck", Effect Duration: 10
-Item	bottle of bubbles	Effect: "Bubble Vision", Effect Duration: 100
-Item	bottle of fire	Effect: "The Fire Inside", Effect Duration: 10
+Item	bottle of black cat tonic	Effect: "Contagious Bad Luck", Effect Duration: 10, Last Available: "2007-06"
+Item	bottle of bubbles	Effect: "Bubble Vision", Effect Duration: 100, Last Available: "2011-11"
+Item	bottle of fire	Effect: "The Fire Inside", Effect Duration: 10, Last Available: "2012-07"
 Item	bottle of goofballs	Effect: "Hopped Up on Goofballs", Effect Duration: 10
-Item	bottle of lighter fluid	Effect: "Lit Up", Effect Duration: 10
-Item	bottle of limeade	Effect: "Sugar Rush", Effect Duration: 20
+Item	bottle of lighter fluid	Effect: "Lit Up", Effect Duration: 10, Last Available: "2014-06"
+Item	bottle of limeade	Effect: "Sugar Rush", Effect Duration: 20, Last Available: "2013-12"
 Item	bottle of Mystic Shell	Effect: "Impregnably Delicious", Effect Duration: 10
 Item	bottle of pirate juice	Effect: "Piratastic", Effect Duration: 10
 Item	bottle of rhinoceros hormones	Effect: "'Roids of the Rhinoceros", Effect Duration: 10
-Item	bottled inspiration	Effect: "Inspired!", Effect Duration: 10
+Item	bottled inspiration	Effect: "Inspired!", Effect Duration: 10, Last Available: "2007-06"
 Item	bowl of Jeal-O	Effect: "Oth-Jeal-O", Effect Duration: 30
-Item	bowl of marinade	Effect: "Marinated", Effect Duration: 15
-Item	box o' ghosts	Free Pull
+Item	bowl of marinade	Effect: "Marinated", Effect Duration: 15, Last Available: "2014-06"
+Item	box o' ghosts	Free Pull, Last Available: "2020-12"
 Item	box of Dweebs	Effect: "Dweeby", Effect Duration: 15
 Item	breath mint	Effect: "Sugar Rush", Effect Duration: 3
-Item	Bright Water	Effect: "Bright!", Effect Duration: 10
-Item	BROS Energy Drink	Effect: "Tapped In", Effect Duration: 20
+Item	Bright Water	Effect: "Bright!", Effect Duration: 10, Last Available: "2011-09"
+Item	BROS Energy Drink	Effect: "Tapped In", Effect Duration: 20, Last Available: "2014-05"
 Item	Bruno's blessing of Mars	Effect: "The Smeezingtons", Effect Duration: 50
-Item	buffed alien drugs	Effect: "Space Tripping", Effect Duration: 10
+Item	buffed alien drugs	Effect: "Space Tripping", Effect Duration: 10, Last Available: "2014-05"
 Item	bug juice	Effect: "Insectudinal Fortitude", Effect Duration: 10
 Item	Bugbearclaw Donut	Effect: "Bugbear in Tooth and Claw", Effect Duration: 20
 Item	Burt's blessing of Bacchus	Effect: "Smoking like a Bandit", Effect Duration: 50
-Item	buzzard feather	Effect: "Buzzard Breath", Effect Duration: 30
-Item	cabbage-flavored Mr. Mediocrebar	Effect: "I Am the Slaw!", Effect Duration: 30
+Item	buzzard feather	Effect: "Buzzard Breath", Effect Duration: 30, Last Available: "2016-02"
+Item	cabbage-flavored Mr. Mediocrebar	Effect: "I Am the Slaw!", Effect Duration: 30, Last Available: "2012-12"
 Item	can of Binarrrca	Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
 Item	can of black paint	Effect: "Red Door Syndrome", Effect Duration: 10
-Item	Can of Spaghetto	Effect: "Blessing of the Spaghetto", Effect Duration: 20
+Item	Can of Spaghetto	Effect: "Blessing of the Spaghetto", Effect Duration: 20, Last Available: "2013-11"
 Item	can of spinach	Effect: "Pop-eyed", Effect Duration: 10
-Item	can of V-11	Effect: "It's Ridiculous", Effect Duration: 111
+Item	can of V-11	Effect: "It's Ridiculous", Effect Duration: 111, Last Available: "2014-03"
 Item	candied almond	Effect: "Almond Allemande", Effect Duration: 10
-Item	candied bolts	Effect: "Bolts about Candy", Effect Duration: 20
+Item	candied bolts	Effect: "Bolts about Candy", Effect Duration: 20, Last Available: "2013-12"
 Item	candied kobold	Effect: "Sugar Rush", Effect Duration: 3
-Item	candied nuts	Effect: "Nuts about Candy", Effect Duration: 20
-Item	candy brain	Effect: "Sugar Rush", Effect Duration: 15
+Item	candied nuts	Effect: "Nuts about Candy", Effect Duration: 20, Last Available: "2013-12"
+Item	candy brain	Effect: "Sugar Rush", Effect Duration: 15, Last Available: "2020-09"
 Item	candy chalk	Effect: "Chalked-Up Teeth", Effect Duration: 20
 Item	candy cigarette	Effect: "Hollow Inside", Effect Duration: 20
-Item	candy crayons	Effect: "A Taste of Rainbow", Effect Duration: 5
-Item	candy harmonica	Effect: "Self-Harmonizing", Effect Duration: 100
-Item	candy skeleton	Effect: "Candied Skeleton", Effect Duration: 10
+Item	candy crayons	Effect: "A Taste of Rainbow", Effect Duration: 5, Last Available: "2020-09"
+Item	candy harmonica	Effect: "Self-Harmonizing", Effect Duration: 100, Last Available: "2020-12"
+Item	candy skeleton	Effect: "Candied Skeleton", Effect Duration: 10, Last Available: "2020-09"
 Item	candy UFOs	Effect: "Fizzier Than Light", Effect Duration: 10
 Item	catfish whiskers	Effect: "Fishy Whiskers", Effect Duration: 40
-Item	celestial au jus	Effect: "Celestial Saltiness", Effect Duration: 10
-Item	celestial carrot juice	Effect: "Celestial Vision", Effect Duration: 10
-Item	celestial olive oil	Effect: "Celestial Sheen", Effect Duration: 10
-Item	celestial squid ink	Effect: "Celestial Camouflage", Effect Duration: 10
-Item	chakra malt	Effect: "The Power of Positive Thinking", Effect Duration: 10
+Item	celestial au jus	Effect: "Celestial Saltiness", Effect Duration: 10, Last Available: "2013-03"
+Item	celestial carrot juice	Effect: "Celestial Vision", Effect Duration: 10, Last Available: "2013-03"
+Item	celestial olive oil	Effect: "Celestial Sheen", Effect Duration: 10, Last Available: "2013-03"
+Item	celestial squid ink	Effect: "Celestial Camouflage", Effect Duration: 10, Last Available: "2013-03"
+Item	chakra malt	Effect: "The Power of Positive Thinking", Effect Duration: 10, Last Available: "2016-12"
 Item	charisma potion	Effect: "Amplified Fabulousness", Effect Duration: 10
 Item	cheap cigar butt	Effect: "Smokin'", Effect Duration: 10
 Item	cheap wind-up clock	Effect: "Ticking Clock", Effect Duration: 10
-Item	Cheer-Up soda	Effect: "Cheered Up", Effect Duration: 20
+Item	Cheer-Up soda	Effect: "Cheered Up", Effect Duration: 20, Last Available: "2017-12"
 Item	chicle de salchicha	Effect: "Here to Kick Ass", Effect Duration: 20
 Item	chiffon lemon	Effect: "Bulging Jaw Muscles", Effect Duration: 20
 Item	children of the candy corn	Effect: "Sugar Rush", Effect Duration: 5
 Item	chitin powder	Effect: "Chitin Powderful", Effect Duration: 10
 Item	chitin powder paste	Effect: "Pastey Power", Effect Duration: 30
-Item	chocolate bath ball	Effect: "[800]Chocolate Reign", Effect Duration: 10
+Item	chocolate bath ball	Effect: "[800]Chocolate Reign", Effect Duration: 10, Last Available: "2011-01"
 Item	chocolate filthy lucre	Effect: "Gelded", Effect Duration: 10
-Item	chocolate-covered caviar	Effect: "Sugar Rush", Effect Duration: 10
+Item	chocolate-covered caviar	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2020-09"
 Item	chocolate-covered loofah	Effect: "Aloofah", Effect Duration: 20
-Item	Chubby and Plump bar	Effect: "Plump and Chubby", Effect Duration: 60
+Item	Chubby and Plump bar	Effect: "Plump and Chubby", Effect Duration: 60, Last Available: "2020-12"
 Item	chunk of rock salt	Effect: "Fresh Scent", Effect Duration: 10
 Item	cigar box turtle	Effect: "Colorful Gratitude", Effect Duration: 15
-Item	Climate Colada	Effect: "Weather, Man", Effect Duration: 20
+Item	Climate Colada	Effect: "Weather, Man", Effect Duration: 20, Last Available: "2008-06"
 # Cloaca Cola Polar: Restores 100-200 MP
-Item	Cloaca Cola Polar	Effect: "Polar Express", Effect Duration: 50
+Item	Cloaca Cola Polar	Effect: "Polar Express", Effect Duration: 50, Last Available: "2013-12"
 Item	coal dust	Effect: "Funky Coal Patina", Effect Duration: 15
-Item	cocoa chondrule	Effect: "Chondruling", Effect Duration: 10
+Item	cocoa chondrule	Effect: "Chondruling", Effect Duration: 10, Last Available: "2020-09"
 Item	Cold Hots candy	Effect: "Sugar Rush", Effect Duration: 1
 Item	cold nuggets	Effect: "Frigid Weapon", Effect Duration: 5
 Item	cold powder	Effect: "Insulated Trousers", Effect Duration: 5
 Item	cold seal sweat	Effect: "Abyssal Sweat", Effect Duration: 20
-Item	cold-filtered water	Effect: "Purity of Spirit", Effect Duration: 10
+Item	cold-filtered water	Effect: "Purity of Spirit", Effect Duration: 10, Last Available: "2011-09"
 Item	cologne of contempt	Effect: "Contemptible Emanations", Effect Duration: [R]
 Item	colorful toad	Effect: "All Glory To the Toad", Effect Duration: 10
 Item	comb jelly	Effect: "Jelly Combed", Effect Duration: 20
-Item	Comet Drop	Effect: "Heal Thy Nanoself", Effect Duration: 1
-Item	Comet Pop	Effect: "Heal Thy Nanoself", Effect Duration: 10
-Item	communal gobstopper	Effect: "The Magic of Sharing", Effect Duration: 20
+Item	Comet Drop	Effect: "Heal Thy Nanoself", Effect Duration: 1, Last Available: "2020-09"
+Item	Comet Pop	Effect: "Heal Thy Nanoself", Effect Duration: 10, Last Available: "2011-06"
+Item	communal gobstopper	Effect: "The Magic of Sharing", Effect Duration: 20, Last Available: "2015-12"
 Item	concentrated cordial of concentration	Effect: "Concentrated Concentration", Effect Duration: [R]
-Item	concentrated fish broth	Effect: "Fishy", Effect Duration: 30
+Item	concentrated fish broth	Effect: "Fishy", Effect Duration: 30, Last Available: "2019-12"
 Item	concentrated garbage juice	Effect: "Drenched With Filth", Effect Duration: 20
 Item	concoction of clumsiness	Effect: "Clumsy", Effect Duration: [R]
-Item	confiscated cell phone	Effect: "OMG WTF", Effect Duration: 20
-Item	confiscated comic book	Effect: "Superheroic", Effect Duration: 20
-Item	confiscated love note	Effect: "Notably Lovely", Effect Duration: 20
+Item	confiscated cell phone	Effect: "OMG WTF", Effect Duration: 20, Last Available: "2014-08"
+Item	confiscated comic book	Effect: "Superheroic", Effect Duration: 20, Last Available: "2014-08"
+Item	confiscated love note	Effect: "Notably Lovely", Effect Duration: 20, Last Available: "2014-08"
 Item	Connery's Elixir of Audacity	Effect: "Cock of the Walk", Effect Duration: [R]
-Item	Conspiracy&trade; mascara	Effect: "Conspiratory Eyes", Effect Duration: 50
-Item	cool cat elixir	Effect: "Cool, Catlike", Effect Duration: 20
-Item	cool hot cocoa	Effect: "Cocoa-Chanel", Effect Duration: 20
+Item	Conspiracy&trade; mascara	Effect: "Conspiratory Eyes", Effect Duration: 50, Last Available: "2015-11"
+Item	cool cat elixir	Effect: "Cool, Catlike", Effect Duration: 20, Last Available: "2011-09"
+Item	cool hot cocoa	Effect: "Cocoa-Chanel", Effect Duration: 20, Last Available: "2020-12"
 Item	coping juice	Effect: "This is Fine", Effect Duration: 50
 Item	cordial of concentration	Effect: "Concentration", Effect Duration: [R]
-Item	correction fluid	Effect: "The Solution", Effect Duration: 30
-Item	corrupted data	Effect: "Corrupted", Effect Duration: 30
+Item	correction fluid	Effect: "The Solution", Effect Duration: 30, Last Available: "2011-05"
+Item	corrupted data	Effect: "Corrupted", Effect Duration: 30, Last Available: "2011-06"
 Item	corrupted marrow	Effect: "Cowrruption", Effect Duration: 30
-Item	cosmic lemonade	Effect: "Lemon Enlightenment", Effect Duration: 10
+Item	cosmic lemonade	Effect: "Lemon Enlightenment", Effect Duration: 10, Last Available: "2007-01"
 Item	cranberry cordial	Effect: "Cranberry Cordiality", Effect Duration: [R]
 Item	crappy waiter disguise	Effect: "Crappily Disguised as a Waiter", Effect Duration: 5
 Item	crepe paper peanut candy	Effect: "Crepe Paper Pedestrian Cacophony", Effect Duration: 20
-Item	Crimbo candied pecan	Effect: "Sweet, Nuts", Effect Duration: 5
-Item	Crimbo fudge	Effect: "Busy Bein' Delicious", Effect Duration: 5
-Item	Crimbo peppermint bark	Effect: "Peppermint Bite", Effect Duration: 5
-Item	Crimbot battery	Effect: "Batteries Included", Effect Duration: 50
+Item	Crimbo candied pecan	Effect: "Sweet, Nuts", Effect Duration: 5, Last Available: "2009-12"
+Item	Crimbo fudge	Effect: "Busy Bein' Delicious", Effect Duration: 5, Last Available: "2009-12"
+Item	Crimbo peppermint bark	Effect: "Peppermint Bite", Effect Duration: 5, Last Available: "2009-12"
+Item	Crimbot battery	Effect: "Batteries Included", Effect Duration: 50, Last Available: "2014-12"
 Item	crude crudit&eacute;s	Effect: "Crud&eacute;", Effect Duration: 10
-Item	crunchy brush	Effect: "Crunchy Steps", Effect Duration: 5
-Item	crystallized pumpkin spice	Effect: "Spiced Out", Effect Duration: 50
-Item	CSA bravery badge	Effect: "Standard Issue Bravery", Effect Duration: 20
+Item	crunchy brush	Effect: "Crunchy Steps", Effect Duration: 5, Last Available: "2024-02"
+Item	crystallized pumpkin spice	Effect: "Spiced Out", Effect Duration: 50, Last Available: "2024-12"
+Item	CSA bravery badge	Effect: "Standard Issue Bravery", Effect Duration: 20, Last Available: "2012-07"
 Item	cube of billiard chalk	Effect: "Chalked Weapon", Effect Duration: 10
-Item	cuppa Alacri tea	Effect: "Alacri Tea", Effect Duration: 30
-Item	cuppa Boo tea	Effect: "Boo Tea", Effect Duration: 30
-Item	cuppa Chari tea	Effect: "Chari Tea", Effect Duration: 30
-Item	cuppa Craft tea	Effect: "Craft Tea", Effect Duration: 30
-Item	cuppa Dexteri tea	Effect: "Dexteri Tea", Effect Duration: 30
-Item	cuppa Feroci tea	Effect: "Feroci Tea", Effect Duration: 30
-Item	cuppa Flamibili tea	Effect: "Flamibili Tea", Effect Duration: 30
-Item	cuppa Flexibili tea	Effect: "Flexibili Tea", Effect Duration: 30
-Item	cuppa Frost tea	Effect: "Frost Tea", Effect Duration: 30
-Item	cuppa Gill tea	Effect: "Fishy", Effect Duration: 30
-Item	cuppa Impregnabili tea	Effect: "Impregnabili Tea", Effect Duration: 30
-Item	cuppa Improprie tea	Effect: "Improprie Tea", Effect Duration: 30
-Item	cuppa Insani tea	Effect: "Insani Tea", Effect Duration: 30
-Item	cuppa Irritabili tea	Effect: "Irritabili Tea", Effect Duration: 30
-Item	cuppa Loyal tea	Effect: "Loyal Tea", Effect Duration: 30
-Item	cuppa Mana tea	Effect: "Mana Tea", Effect Duration: 30
-Item	cuppa Mediocri tea	Effect: "Mediocri Tea", Effect Duration: 30
-Item	cuppa Monstrosi tea	Effect: "Monstrosi Tea", Effect Duration: 30
-Item	cuppa Morbidi tea	Effect: "Morbidi Tea", Effect Duration: 30
-Item	cuppa Nas tea	Effect: "Nas Tea", Effect Duration: 30
-Item	cuppa Net tea	Effect: "Net Tea", Effect Duration: 30
-Item	cuppa Neuroplastici tea	Effect: "Neuroplastici Tea", Effect Duration: 30
-Item	cuppa Obscuri tea	Effect: "Obscuri Tea", Effect Duration: 30
-Item	cuppa Physicali tea	Effect: "Physicali Tea", Effect Duration: 30
-Item	cuppa Proprie tea	Effect: "Proprie Tea", Effect Duration: 30
+Item	cuppa Alacri tea	Effect: "Alacri Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Boo tea	Effect: "Boo Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Chari tea	Effect: "Chari Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Craft tea	Effect: "Craft Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Dexteri tea	Effect: "Dexteri Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Feroci tea	Effect: "Feroci Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Flamibili tea	Effect: "Flamibili Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Flexibili tea	Effect: "Flexibili Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Frost tea	Effect: "Frost Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Gill tea	Effect: "Fishy", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Impregnabili tea	Effect: "Impregnabili Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Improprie tea	Effect: "Improprie Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Insani tea	Effect: "Insani Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Irritabili tea	Effect: "Irritabili Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Loyal tea	Effect: "Loyal Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Mana tea	Effect: "Mana Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Mediocri tea	Effect: "Mediocri Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Monstrosi tea	Effect: "Monstrosi Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Morbidi tea	Effect: "Morbidi Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Nas tea	Effect: "Nas Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Net tea	Effect: "Net Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Neuroplastici tea	Effect: "Neuroplastici Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Obscuri tea	Effect: "Obscuri Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Physicali tea	Effect: "Physicali Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Proprie tea	Effect: "Proprie Tea", Effect Duration: 30, Last Available: "2015-09"
 # cuppa Royal tea: Makes you more royal
-Item	cuppa Serendipi tea	Effect: "Serendipi Tea", Effect Duration: 30
+Item	cuppa Serendipi tea	Effect: "Serendipi Tea", Effect Duration: 30, Last Available: "2015-09"
 # cuppa Sobrie tea: Reduces your Drunkenness by 1
-Item	cuppa Toast tea	Effect: "Toast Tea", Effect Duration: 30
-Item	cuppa Twen tea	Effect: "Twen Tea", Effect Duration: 30
-Item	cuppa Vitali tea	Effect: "Vitali Tea", Effect Duration: 30
+Item	cuppa Toast tea	Effect: "Toast Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Twen tea	Effect: "Twen Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Vitali tea	Effect: "Vitali Tea", Effect Duration: 30, Last Available: "2015-09"
 # cuppa Voraci tea: Increase your stomach capacity by 1
-Item	cuppa Wit tea	Effect: "Wit Tea", Effect Duration: 30
-Item	cuppa Yet tea	Effect: "Yet tea", Effect Duration: 30
+Item	cuppa Wit tea	Effect: "Wit Tea", Effect Duration: 30, Last Available: "2015-09"
+Item	cuppa Yet tea	Effect: "Yet tea", Effect Duration: 30, Last Available: "2015-09"
 Item	cursed chocolate doubloon	Effect: "Sweet Pirate Curse", Effect Duration: 20
-Item	cursed wishbone	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 30
-Item	cyan seashell	Effect: "Shells of the Damned", Effect Duration: 20
+Item	cursed wishbone	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 30, Last Available: "2017-11"
+Item	cyan seashell	Effect: "Shells of the Damned", Effect Duration: 20, Last Available: "2019-07"
 Item	cyclops eyedrops	Effect: "One Very Clear Eye", Effect Duration: 10
-Item	cymbal syrup	Free Pull, Effect: "Tinnitus", Effect Duration: 20
+Item	cymbal syrup	Free Pull, Effect: "Tinnitus", Effect Duration: 20, Last Available: "2007-02"
 Item	Daffy Taffy	Effect: "Sugar Rush", Effect Duration: 3
 # Daily Affirmation: Adapt to Change Eventually: In Combat: Enact Immediate Change!
-Item	Daily Affirmation: Adapt to Change Eventually	Effect: "Adapt to Change Eventually", Effect Duration: 100
+Item	Daily Affirmation: Adapt to Change Eventually	Effect: "Adapt to Change Eventually", Effect Duration: 100, Last Available: "2017-05"
 # Daily Affirmation: Always be Collecting: In Combat: Collect more stuff after a fight!
-Item	Daily Affirmation: Always be Collecting	Effect: "Always be Collecting", Effect Duration: 100
+Item	Daily Affirmation: Always be Collecting	Effect: "Always be Collecting", Effect Duration: 100, Last Available: "2017-05"
 # Daily Affirmation: Be a Mind Master: In Combat: Banish Terrible Encounters!
-Item	Daily Affirmation: Be a Mind Master	Effect: "Be a Mind Master", Effect Duration: 100
+Item	Daily Affirmation: Be a Mind Master	Effect: "Be a Mind Master", Effect Duration: 100, Last Available: "2017-05"
 # Daily Affirmation: Be Superficially interested: In Combat: Superficially track a monster!
-Item	Daily Affirmation: Be Superficially interested	Effect: "Become Superficially interested", Effect Duration: 100
+Item	Daily Affirmation: Be Superficially interested	Effect: "Become Superficially interested", Effect Duration: 100, Last Available: "2017-05"
 # Daily Affirmation: Keep Free Hate in your Heart: In Combat: Demean Foes and Increase Your Belligerence
-Item	Daily Affirmation: Keep Free Hate in your Heart	Effect: "Keep Free Hate in your Heart", Effect Duration: 100
+Item	Daily Affirmation: Keep Free Hate in your Heart	Effect: "Keep Free Hate in your Heart", Effect Duration: 100, Last Available: "2017-05"
 # Daily Affirmation: Think Win-Lose: In Combat: Force a win!
-Item	Daily Affirmation: Think Win-Lose	Effect: "Think Win-Lose", Effect Duration: 100
+Item	Daily Affirmation: Think Win-Lose	Effect: "Think Win-Lose", Effect Duration: 100, Last Available: "2017-05"
 # Daily Affirmation: Work For Hours a Week: In Combat: Earn Active Income!
-Item	Daily Affirmation: Work For Hours a Week	Effect: "Work For Hours a Week", Effect Duration: 100
-Item	dark chocolate egg	Effect: "Herder, Bitter, Fester, Stranger", Effect Duration: 10
-Item	daub-breaker	Effect: "Hot Breath", Effect Duration: 1
+Item	Daily Affirmation: Work For Hours a Week	Effect: "Work For Hours a Week", Effect Duration: 100, Last Available: "2017-05"
+Item	dark chocolate egg	Effect: "Herder, Bitter, Fester, Stranger", Effect Duration: 10, Last Available: "2024-12"
+Item	daub-breaker	Effect: "Hot Breath", Effect Duration: 1, Last Available: "2020-09"
 Item	deadly lampshade	Effect: "Deadly Lampblade", Effect Duration: 20
-Item	Deep Machine Tunnels snowglobe	Effect: "Inside The Snowglobe", Effect Duration: 57
-Item	delicious candy	Effect: "Eyes All Black", Effect Duration: 15
-Item	delicious comfit?	Effect: "Discomfited", Effect Duration: 10
-Item	demon makeup kit	Effect: "Demonicity", Effect Duration: 40
-Item	demonic cow's blood	Effect: "Cowrruption", Effect Duration: 20
+Item	Deep Machine Tunnels snowglobe	Effect: "Inside The Snowglobe", Effect Duration: 57, Last Available: "2015-12"
+Item	delicious candy	Effect: "Eyes All Black", Effect Duration: 15, Last Available: "2014-10"
+Item	delicious comfit?	Effect: "Discomfited", Effect Duration: 10, Last Available: "2010-03"
+Item	demon makeup kit	Effect: "Demonicity", Effect Duration: 40, Last Available: "2015-08"
+Item	demonic cow's blood	Effect: "Cowrruption", Effect Duration: 20, Last Available: "2016-02"
 Item	Dennis's blessing of Minerva	Effect: "Minerva's Zen", Effect Duration: 50
-Item	dented spoon	Effect: "There Is A Spoon", Effect Duration: 20
+Item	dented spoon	Effect: "There Is A Spoon", Effect Duration: 20, Last Available: "2013-11"
 Item	deodorant	Effect: "Fresh Scent", Effect Duration: [10+skill(Dead Nostrils)]
-Item	desktop zen garden	Effect: "Everything's Zen", Effect Duration: 10
-Item	deviled candy egg	Effect: "Candied Devil", Effect Duration: 10
-Item	devilish folio	Effect: "Dis Abled", Effect Duration: 30
-Item	digital honeypot	Effect: "Honeypotted", Effect Duration: 90
-Item	digital underground potion	Effect: "Digitally Converted", Effect Duration: 20
+Item	desktop zen garden	Effect: "Everything's Zen", Effect Duration: 10, Last Available: "2012-12"
+Item	deviled candy egg	Effect: "Candied Devil", Effect Duration: 10, Last Available: "2024-12"
+Item	devilish folio	Effect: "Dis Abled", Effect Duration: 30, Last Available: "2012-12"
+Item	digital honeypot	Effect: "Honeypotted", Effect Duration: 90, Last Available: "2025-12"
+Item	digital underground potion	Effect: "Digitally Converted", Effect Duration: 20, Last Available: "2008-06"
 Item	diluted makeup	Effect: "Made Up, Watered Down", Effect Duration: 10
 Item	Dino DNAde&trade;	Effect: "Prehistoric Potential", Effect Duration: 30
-Item	Dinsey face paint	Effect: "The Dinsey Look", Effect Duration: 20
+Item	Dinsey face paint	Effect: "The Dinsey Look", Effect Duration: 20, Last Available: "2015-04"
 Item	disco horoscope (Aquarius)	Effect: "Aquarius Rising", Effect Duration: 10
 Item	disco horoscope (Aries)	Effect: "Aries Rising", Effect Duration: 10
 Item	disco horoscope (Cancer)	Effect: "Cancer Rising", Effect Duration: 10
@@ -10449,7 +10449,7 @@ Item	disco horoscope (Sagittarius)	Effect: "Sagittarius Rising", Effect Duration
 Item	disco horoscope (Scorpio)	Effect: "Scorpio Rising", Effect Duration: 10
 Item	disco horoscope (Taurus)	Effect: "Taurus Rising", Effect Duration: 10
 Item	disco horoscope (Virgo)	Effect: "Virgo Rising", Effect Duration: 10
-Item	disintegrating spiky collar	Effect: "Man's Worst Enemy", Effect Duration: 10
+Item	disintegrating spiky collar	Effect: "Man's Worst Enemy", Effect Duration: 10, Last Available: "2007-06"
 Item	distilled resin	Effect: "Resined", Effect Duration: 100
 # Doc Galaktik's Ailment Ointment: Heals 35-45 Hit Points
 # Doc Galaktik's Homeopathic Elixir: Heals 18-20 Hit Points
@@ -10459,35 +10459,35 @@ Item	distilled resin	Effect: "Resined", Effect Duration: 100
 Item	Doc Galaktik's Vitality Serum	Effect: "Vital", Effect Duration: 20
 Item	dog ointment	Effect: "Unbarking Dogs", Effect Duration: 20
 Item	Dogsgotnonoz pills	Effect: "Can't Smell Nothin'", Effect Duration: 10
-Item	dollop of barbecue sauce	Effect: "Barbecue Saucy", Effect Duration: 15
+Item	dollop of barbecue sauce	Effect: "Barbecue Saucy", Effect Duration: 15, Last Available: "2014-06"
 Item	donkey flipbook	Effect: "Hyperoffended", Effect Duration: 10
-Item	double-ice gum	Effect: "Wintry Breath", Effect Duration: 10
+Item	double-ice gum	Effect: "Wintry Breath", Effect Duration: 10, Last Available: "2011-04"
 Item	Drizzlers&trade; Black Licorice	Effect: "Rainy Soul Miasma", Effect Duration: 1
-Item	drop of water-37	Effect: "Extra-Wet", Effect Duration: 30
-Item	drum of pomade	Effect: "Perfect Hair", Effect Duration: 10
+Item	drop of water-37	Effect: "Extra-Wet", Effect Duration: 30, Last Available: "2012-07"
+Item	drum of pomade	Effect: "Perfect Hair", Effect Duration: 10, Last Available: "2011-10"
 Item	Drunk Uncles holo-record	Effect: "Drunk and Avuncular", Effect Duration: 10
-Item	dubious peppermint	Effect: "Minty Freshness", Effect Duration: 5
+Item	dubious peppermint	Effect: "Minty Freshness", Effect Duration: 5, Last Available: "2020-09"
 Item	eagle feather	Effect: "Eagle Eyes", Effect Duration: 20
-Item	ear candle	Effect: "Clear Ears, Can't Lose", Effect Duration: 80
+Item	ear candle	Effect: "Clear Ears, Can't Lose", Effect Duration: 80, Last Available: "2021-08"
 Item	Eau de Guaneau	Effect: "Chauve-Souris Merde Fou", Effect Duration: 10
 Item	ectoplasmic orbs	Effect: "Balls of Ectoplasm", Effect Duration: 10
 Item	eel battery	Effect: "It's Electric!", Effect Duration: 15
 Item	Effermint&trade; tablets	Effect: "Winning Smile", Effect Duration: 10
-Item	elderly jawbreaker	Effect: "Sugar Rush", Effect Duration: 10
-Item	eldritch alignment spray	Effect: "Eldritch Alignment", Effect Duration: 10
-Item	eldritch concentrate	Effect: "Eldritch Concentration", Effect Duration: 50
+Item	elderly jawbreaker	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2020-09"
+Item	eldritch alignment spray	Effect: "Eldritch Alignment", Effect Duration: 10, Last Available: "2017-02"
+Item	eldritch concentrate	Effect: "Eldritch Concentration", Effect Duration: 50, Last Available: "2016-11"
 Item	eldritch oil	Effect: "Uncanny Shot", Effect Duration: 30
-Item	eldritch rub	Effect: "Infused with Sssshhsssblllrrggghsssssggggrrgglssss", Effect Duration: 10
-Item	electric mushroom	Effect: "Tingling Insides", Effect Duration: 20
-Item	Elf Guard eyedrops	Effect: "Elf Watch", Effect Duration: 30
+Item	eldritch rub	Effect: "Infused with Sssshhsssblllrrggghsssssggggrrgglssss", Effect Duration: 10, Last Available: "2017-02"
+Item	electric mushroom	Effect: "Tingling Insides", Effect Duration: 20, Last Available: "2023-02"
+Item	Elf Guard eyedrops	Effect: "Elf Watch", Effect Duration: 30, Last Available: "2023-12"
 Item	Elizabeth's paintbrush	Effect: "Boschface", Effect Duration: 25
-Item	elven suicide capsule	Effect: "Sugar Rush", Effect Duration: 10
+Item	elven suicide capsule	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2009-12"
 Item	Elvish delight	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 3
 Item	EMD holo-record	Effect: "Ministrations in the Dark", Effect Duration: 10
-Item	emergency glowstick	Effect: "Glowing Hands", Effect Duration: 20
+Item	emergency glowstick	Effect: "Glowing Hands", Effect Duration: 20, Last Available: "2022-05"
 Item	ennui-flavored potato chips	Effect: "Also Schmeckt Zarathustra", Effect Duration: 10
-Item	essential cameraderie	Effect: "2 Hearts, 1 Mind", Effect Duration: 50
-Item	essential soy	Effect: "Electrolyte Fantastic", Effect Duration: 50
+Item	essential cameraderie	Effect: "2 Hearts, 1 Mind", Effect Duration: 50, Last Available: "2010-08"
+Item	essential soy	Effect: "Electrolyte Fantastic", Effect Duration: 50, Last Available: "2010-08"
 Item	Everlasting Deckswabber	Effect: "Sugar Rush", Effect Duration: 10
 Item	evil eyedrops of the ermine	Effect: "Ermine Eyes", Effect Duration: [R+5]
 Item	evil libation of liveliness	Effect: "Provocative Perkiness", Effect Duration: [R+5]
@@ -10497,65 +10497,65 @@ Item	evil potion of potency	Effect: "Pronounced Potency", Effect Duration: [R+5]
 Item	evil serum of sarcasm	Effect: "Superhuman Sarcasm", Effect Duration: [R+5]
 Item	evil tomato juice of powerful power	Effect: "Tomato Power", Effect Duration: [R+5]
 Item	evil vihuela	Effect: "El Tango de la Maldita Suegra", Effect Duration: 10
-Item	exotic travel brochure	Effect: "Expert Vacationer", Effect Duration: 20
+Item	exotic travel brochure	Effect: "Expert Vacationer", Effect Duration: 20, Last Available: "2015-11"
 Item	experimental serum G-9	Effect: "Experimental Effect G-9", Effect Duration: 40
-Item	experimental serum P-00	Effect: "Schroedinger's Butt", Effect Duration: 20
-Item	explosion-flavored chewing gum	Effect: "Beaten Up", Effect Duration: 10
+Item	experimental serum P-00	Effect: "Schroedinger's Butt", Effect Duration: 20, Last Available: "2014-10"
+Item	explosion-flavored chewing gum	Effect: "Beaten Up", Effect Duration: 10, Last Available: "2006-04"
 Item	extra-hard jawbreaker	Effect: "Delayed Gratification", Effect Duration: 20
 Item	extra-potent gremlin mutagen	Effect: "Seriously Mutated", Effect Duration: 1
-Item	extra-strength goo	Effect: "Gooed Enough For Government Work", Effect Duration: 20
-Item	Eye and a Twist	Effect: "Twist and an Eye", Effect Duration: 30
+Item	extra-strength goo	Effect: "Gooed Enough For Government Work", Effect Duration: 20, Last Available: "2019-12"
+Item	Eye and a Twist	Effect: "Twist and an Eye", Effect Duration: 30, Last Available: "2020-12"
 Item	eyedrops of newt	Effect: "Newt Gets In Your Eyes", Effect Duration: [R]
 Item	eyedrops of the ermine	Effect: "Ermine Eyes", Effect Duration: [R]
 Item	eyedrops of the ocelot	Effect: "Ocelot Eyes", Effect Duration: [R]
-Item	Fabiotion	Effect: "Faboooo", Effect Duration: 20
+Item	Fabiotion	Effect: "Faboooo", Effect Duration: 20, Last Available: "2018-02"
 Item	fabric hardener	Effect: "Hardened Fabric", Effect Duration: 20
 Item	fake blood	Effect: "Bloody Bloody Bloody!", Effect Duration: 10
-Item	fake cocktail	Effect: "Liquor-ish", Effect Duration: 10
+Item	fake cocktail	Effect: "Liquor-ish", Effect Duration: 10, Last Available: "2016-12"
 Item	Ferrigno's Elixir of Power	Effect: "Incredibly Hulking", Effect Duration: [R]
 Item	fiberglass insulation	Effect: "Insulated", Effect Duration: 25
-Item	filled mosquito	Effect: "Wisdom of Others", Effect Duration: 20
+Item	filled mosquito	Effect: "Wisdom of Others", Effect Duration: 20, Last Available: "2023-02"
 Item	filthworm drone scent gland	Effect: "Filthworm Drone Stench", Effect Duration: 10
 Item	filthworm hatchling scent gland	Effect: "Filthworm Larva Stench", Effect Duration: 10
 Item	filthworm royal guard scent gland	Effect: "Filthworm Guard Stench", Effect Duration: 10
-Item	finger exerciser	Effect: "Strong Grip", Effect Duration: 20
+Item	finger exerciser	Effect: "Strong Grip", Effect Duration: 20, Last Available: "2013-11"
 Item	Finnish Fish	Effect: "Fishing For Knowledge", Effect Duration: 20
-Item	fire ant pheromones	Effect: "Attractive to Fire Ants", Effect Duration: 20
+Item	fire ant pheromones	Effect: "Attractive to Fire Ants", Effect Duration: 20, Last Available: "2023-02"
 Item	[2426]fire flower	Effect: "Flamingly Floral", Effect Duration: 10
-Item	fish juice box	Effect: "Fishy", Effect Duration: 20
+Item	fish juice box	Effect: "Fishy", Effect Duration: 20, Last Available: "2011-05"
 Item	fish-liver oil	Effect: "Fishy Fortification", Effect Duration: 5
-Item	fitness wristband	Effect: "Fitter, Bitter", Effect Duration: 50
-Item	five-fingered fern resin	Effect: "Five Sticky Fingers", Effect Duration: 20
+Item	fitness wristband	Effect: "Fitter, Bitter", Effect Duration: 50, Last Available: "2014-12"
+Item	five-fingered fern resin	Effect: "Five Sticky Fingers", Effect Duration: 20, Last Available: "2023-02"
 Item	fizzy soda	Effect: "Fizzy Fizzy", Effect Duration: 20
 Item	Flag by the Foot&trade;	Effect: "One Foot Heavier", Effect Duration: 20
-Item	Flan in the Moon	Effect: "Heal Thy Nanoself", Effect Duration: 50
-Item	flapper fly	Effect: "Flapper Dancin'", Effect Duration: 20
+Item	Flan in the Moon	Effect: "Heal Thy Nanoself", Effect Duration: 50, Last Available: "2011-06"
+Item	flapper fly	Effect: "Flapper Dancin'", Effect Duration: 20, Last Available: "2023-02"
 Item	flask of baconstone juice	Effect: "Baconstoned", Effect Duration: 10
 Item	flask of hamethyst juice	Effect: "Ham-Fisted", Effect Duration: 10
 Item	flask of mining oil	Effect Duration: 10
 Item	flask of porquoise juice	Effect: "Je Ne Sais Porquoise", Effect Duration: 10
 Item	flask of tainted mining oil	Effect Duration: 0
-Item	Flaskfull of Hollow	Effect: "Merry Smithsness", Effect Duration: 150
-Item	fleshy putty	Effect: "Puttied, Fleshly", Effect Duration: 30
+Item	Flaskfull of Hollow	Effect: "Merry Smithsness", Effect Duration: 150, Last Available: "2013-12"
+Item	fleshy putty	Effect: "Puttied, Fleshly", Effect Duration: 30, Last Available: "2021-12"
 Item	floaty sand	Effect: "5 Pounds Lighter", Effect Duration: 10
-Item	fluid of fudge-finding	Effect: "Fudgehound", Effect Duration: 5
+Item	fluid of fudge-finding	Effect: "Fudgehound", Effect Duration: 5, Last Available: "2011-11"
 Item	foetid seal tear	Effect: "Abyssal Tears", Effect Duration: 20
-Item	fortifying hot cocoa	Effect: "Cocoa-Fortified", Effect Duration: 20
+Item	fortifying hot cocoa	Effect: "Cocoa-Fortified", Effect Duration: 20, Last Available: "2020-12"
 Item	Freddie's blessing of Mercury	Effect: "You're High as a Crow, Marty", Effect Duration: 50
-Item	freezer-burned frost-bitten tortellini	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 10
+Item	freezer-burned frost-bitten tortellini	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 10, Last Available: "2013-11"
 Item	freezerburned ice cube	Effect: "Permafrosty", Effect Duration: 10
 Item	Friendliness Beverage	Effect: "Over-Familiar With Dactyls", Effect Duration: 20
 Item	Frogade	Effect: "Frog In Your Throat", Effect Duration: [R]
-Item	frost flower	Effect: "Frosty", Effect Duration: 50
+Item	frost flower	Effect: "Frosty", Effect Duration: 50, Last Available: "2014-01"
 Item	frost-rimed seal hide	Effect: "Cold Hard Skin", Effect Duration: 10
 Item	frostbite-flavored Hob-O	Effect: "Tundra Mouth", Effect Duration: 1
-Item	frozen shampoo-conditioner	Effect: "Spiky Frozen Hair", Effect Duration: 20
+Item	frozen shampoo-conditioner	Effect: "Spiky Frozen Hair", Effect Duration: 20, Last Available: "2015-11"
 Item	fry-oil-flavored Hob-O	Effect: "Cholestoriffic", Effect Duration: 1
-Item	Fudge Fiber Armor Plating	Effect: "Armored Innards", Effect Duration: 20
-Item	fudge lily	Effect: "Stop and Smell the Fudge", Effect Duration: 20
+Item	Fudge Fiber Armor Plating	Effect: "Armored Innards", Effect Duration: 20, Last Available: "2014-12"
+Item	fudge lily	Effect: "Stop and Smell the Fudge", Effect Duration: 20, Last Available: "2011-11"
 Item	fudge-shaped hole in space-time	Effect: "Things Man Was Not Meant to Eat", Effect Duration: 10
-Item	Fudgie Roll	Effect: "Sugar Rush", Effect Duration: 20
-Item	Fun-Guy spore	Effect: "Mush-Mouth", Effect Duration: 11
+Item	Fudgie Roll	Effect: "Sugar Rush", Effect Duration: 20, Last Available: "2011-11"
+Item	Fun-Guy spore	Effect: "Mush-Mouth", Effect Duration: 11, Last Available: "2014-05"
 Item	funky dried mushroom	Effect: "Seeing Colors", Effect Duration: 10
 Item	funny bone	Effect: "Angry Bone", Effect Duration: 30
 Item	fustulent seal grulch	Effect: "Grulched", Effect Duration: 10
@@ -10563,150 +10563,150 @@ Item	future drug: Coolscaline	Effect: "The Style... of the Future", Effect Durat
 Item	future drug: Muscularactum	Effect: "The Strength...  of the Future", Effect Duration: 25
 Item	future drug: Smartinex	Effect: "The Wisdom... of the Future", Effect Duration: 25
 Item	Gabarbar	Effect: "Gabarding", Effect Duration: 25
-Item	gaffer's tape	Effect: "Gaffe Free", Effect Duration: 20
+Item	gaffer's tape	Effect: "Gaffe Free", Effect Duration: 20, Last Available: "2022-05"
 Item	garbage-juice-flavored Hob-O	Effect: "Refuse Reflux", Effect Duration: 1
 Item	gazely stare	Effect: "The Eyes Have It", Effect Duration: 100
-Item	Gene Tonic: Beast	Effect: "Human-Beast Hybrid", Effect Duration: 30
-Item	Gene Tonic: Constellation	Effect: "Human-Constellation Hybrid", Effect Duration: 30
-Item	Gene Tonic: Construct	Effect: "Human-Machine Hybrid", Effect Duration: 30
-Item	Gene Tonic: Demon	Effect: "Human-Demon Hybrid", Effect Duration: 30
-Item	Gene Tonic: Dude	Effect: "Human-Human Hybrid", Effect Duration: 30
-Item	Gene Tonic: Elemental	Effect: "Human-Elemental Hybrid", Effect Duration: 30
-Item	Gene Tonic: Elf	Effect: "Human-Elf Hybrid", Effect Duration: 30
-Item	Gene Tonic: Fish	Effect: "Human-Fish Hybrid", Effect Duration: 30
-Item	Gene Tonic: Goblin	Effect: "Human-Goblin Hybrid", Effect Duration: 30
-Item	Gene Tonic: Hippy	Effect: "Human-Hippy Hybrid", Effect Duration: 30
-Item	Gene Tonic: Hobo	Effect: "Human-Hobo Hybrid", Effect Duration: 30
-Item	Gene Tonic: Horror	Effect: "Human-Horror Hybrid", Effect Duration: 30
-Item	Gene Tonic: Humanoid	Effect: "Human-Humanoid Hybrid", Effect Duration: 30
-Item	Gene Tonic: Insect	Effect: "Human-Insect Hybrid", Effect Duration: 30
-Item	Gene Tonic: Mer-kin	Effect: "Human-Mer-kin Hybrid", Effect Duration: 30
-Item	Gene Tonic: Orc	Effect: "Human-Orc Hybrid", Effect Duration: 30
-Item	Gene Tonic: Penguin	Effect: "Human-Penguin Hybrid", Effect Duration: 30
-Item	Gene Tonic: Pirate	Effect: "Human-Pirate Hybrid", Effect Duration: 30
-Item	Gene Tonic: Plant	Effect: "Human-Plant Hybrid", Effect Duration: 30
-Item	Gene Tonic: Slime	Effect: "Human-Slime Hybrid", Effect Duration: 30
-Item	Gene Tonic: Undead	Effect: "Human-Undead Hybrid", Effect Duration: 30
-Item	Gene Tonic: Weird	Effect: "Human-Weird Thing Hybrid", Effect Duration: 30
-Item	ghost bit	Effect: "Partially Ghosted", Effect Duration: 30
+Item	Gene Tonic: Beast	Effect: "Human-Beast Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Constellation	Effect: "Human-Constellation Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Construct	Effect: "Human-Machine Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Demon	Effect: "Human-Demon Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Dude	Effect: "Human-Human Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Elemental	Effect: "Human-Elemental Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Elf	Effect: "Human-Elf Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Fish	Effect: "Human-Fish Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Goblin	Effect: "Human-Goblin Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Hippy	Effect: "Human-Hippy Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Hobo	Effect: "Human-Hobo Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Horror	Effect: "Human-Horror Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Humanoid	Effect: "Human-Humanoid Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Insect	Effect: "Human-Insect Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Mer-kin	Effect: "Human-Mer-kin Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Orc	Effect: "Human-Orc Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Penguin	Effect: "Human-Penguin Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Pirate	Effect: "Human-Pirate Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Plant	Effect: "Human-Plant Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Slime	Effect: "Human-Slime Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Undead	Effect: "Human-Undead Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	Gene Tonic: Weird	Effect: "Human-Weird Thing Hybrid", Effect Duration: 30, Last Available: "2014-04"
+Item	ghost bit	Effect: "Partially Ghosted", Effect Duration: 30, Last Available: "2016-02"
 Item	ghost thread	Effect: "Ghost Finger", Effect Duration: 40
 Item	giant giant moth dust	Effect: "Slightly Larger Than Usual", Effect Duration: 50
 Item	ginger snaps	Effect: "Ready to Snap", Effect Duration: 15
-Item	gingerbread spice latte	Effect: "Whole Latte Love", Effect Duration: 30
+Item	gingerbread spice latte	Effect: "Whole Latte Love", Effect Duration: 30, Last Available: "2016-12"
 Item	giraffe-necked turtle	Effect: "Adorable Lookout", Effect Duration: 15
-Item	glass slipper	Effect: "Don't Step to Your Stepmother", Effect Duration: 10
+Item	glass slipper	Effect: "Don't Step to Your Stepmother", Effect Duration: 10, Last Available: "2014-12"
 Item	glittery mascara	Effect: "Glittering Eyelashes", Effect Duration: 3
 Item	Glo-Pop	Effect: "Glo-Face", Effect Duration: 10
-Item	glob of extra-green chlorophyll	Effect: "Extra-Green", Effect Duration: 20
-Item	glob of salty molasses	Effect: "Molasses Flooded", Effect Duration: 1
+Item	glob of extra-green chlorophyll	Effect: "Extra-Green", Effect Duration: 20, Last Available: "2023-02"
+Item	glob of salty molasses	Effect: "Molasses Flooded", Effect Duration: 1, Last Available: "2019-12"
 Item	glob of spoiled mayo	Effect: "Mayeaugh", Effect Duration: 10
 Item	glowing El Vibrato drone	Effect: "Inscrutable exoskeleton", Effect Duration: 10
 Item	glowing syringe	Effect: "Biologically Shocked", Effect Duration: 20
-Item	go-go potion	Effect: "Go-Gone", Effect Duration: 20
+Item	go-go potion	Effect: "Go-Gone", Effect Duration: 20, Last Available: "2014-05"
 Item	goblin water	Effect: "Wet and Greedy", Effect Duration: 100
 Item	Good 'n' Quiet	Effect: "Quiet 'n' Good", Effect Duration: 10
 Item	Good 'n' Slimy	Effect: "Sugar Rush", Effect Duration: 5
 Item	gooey drippy candy bar	Effect: "Snichors", Effect Duration: 10
 Item	gourmet gourami oil	Effect: "Fishy, Oily", Effect Duration: 40
-Item	government	Effect: "I See Everything Thrice!", Effect Duration: 10
+Item	government	Effect: "I See Everything Thrice!", Effect Duration: 10, Last Available: "2014-05"
 Item	government-issued candy	Effect: "Standard Cheer", Effect Duration: 20
-Item	graveyard snowglobe	Effect: "Cold, Dead Hands", Effect Duration: 20
-Item	gray seashell	Effect: "Worst Willy", Effect Duration: 20
-Item	Greek fire	Effect: "Sweetbreads Flambé", Effect Duration: 25
-Item	green candy heart	Effect: "Heart of Green", Effect Duration: 10
-Item	green rock candy	Effect: "Sprinkle Sense", Effect Duration: 10
-Item	green seashell	Effect: "On Smellier Tides", Effect Duration: 20
-Item	green snowcone	Effect: "Green Tongue", Effect Duration: 20
+Item	graveyard snowglobe	Effect: "Cold, Dead Hands", Effect Duration: 20, Last Available: "2011-09"
+Item	gray seashell	Effect: "Worst Willy", Effect Duration: 20, Last Available: "2019-07"
+Item	Greek fire	Effect: "Sweetbreads Flambé", Effect Duration: 25, Last Available: "2016-03"
+Item	green candy heart	Effect: "Heart of Green", Effect Duration: 10, Last Available: "2007-02"
+Item	green rock candy	Effect: "Sprinkle Sense", Effect Duration: 10, Last Available: "2016-12"
+Item	green seashell	Effect: "On Smellier Tides", Effect Duration: 20, Last Available: "2019-07"
+Item	green snowcone	Effect: "Green Tongue", Effect Duration: 20, Last Available: "2006-01"
 Item	green-frosted astral cupcake	Effect: "The Cupcake of Wrath", Effect Duration: 20
 Item	gremlin juice	Effect: "Comic Violence", Effect Duration: 5
 Item	gremlin mutagen	Effect: "Mutated", Effect Duration: 1
 Item	grisly shell fragment	Effect: "Thick, Sick", Effect Duration: 1
 Item	groggipop	Effect: "Groggipopped", Effect Duration: 10
 Item	groupie spangles	Effect: "Spangled Star", Effect Duration: 5
-Item	gummi ammonite	Effect: "Sugar Rush", Effect Duration: 100
-Item	gummi belemnite	Effect: "Sugar Rush", Effect Duration: 100
-Item	gummi canary	Effect: "Gummiskin", Effect Duration: 1
-Item	gummi fang	Effect: "Gummi Badass", Effect Duration: 5
-Item	gummi salamander	Effect: "Gummiheart", Effect Duration: 1
-Item	gummi snake	Effect: "Gummibrain", Effect Duration: 1
-Item	gummi trilobite	Effect: "Sugar Rush", Effect Duration: 100
+Item	gummi ammonite	Effect: "Sugar Rush", Effect Duration: 100, Last Available: "2011-11"
+Item	gummi belemnite	Effect: "Sugar Rush", Effect Duration: 100, Last Available: "2011-11"
+Item	gummi canary	Effect: "Gummiskin", Effect Duration: 1, Last Available: "2011-11"
+Item	gummi fang	Effect: "Gummi Badass", Effect Duration: 5, Last Available: "2014-12"
+Item	gummi salamander	Effect: "Gummiheart", Effect Duration: 1, Last Available: "2011-11"
+Item	gummi snake	Effect: "Gummibrain", Effect Duration: 1, Last Available: "2011-11"
+Item	gummi trilobite	Effect: "Sugar Rush", Effect Duration: 100, Last Available: "2011-11"
 Item	gummi turtle	Effect: "Gummi-Grin", Effect Duration: 15
-Item	Gummi-DNA	Effect: "Sugar Rush", Effect Duration: 3
+Item	Gummi-DNA	Effect: "Sugar Rush", Effect Duration: 3, Last Available: "2020-09"
 Item	Gummi-Gnauga	Effect: "Sugar Rush", Effect Duration: 10
-Item	Gummy Brains	Effect: "Sugar Rush", Effect Duration: 10
+Item	Gummy Brains	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2011-10"
 Item	gun cleaning kit	Effect: "Very Clean Guns", Effect Duration: 20
-Item	Gyromitra Dynomita mushroom	Effect: "Gyromitra Gymnastics", Effect Duration: 10
+Item	Gyromitra Dynomita mushroom	Effect: "Gyromitra Gymnastics", Effect Duration: 10, Last Available: "2014-05"
 Item	haemolymphnode	Effect: "Haemolymphatic", Effect Duration: 10
-Item	haggis-infused soap	Effect: "Sheepskinned", Effect Duration: 20
+Item	haggis-infused soap	Effect: "Sheepskinned", Effect Duration: 20, Last Available: "2012-12"
 Item	hair of the fish	Effect: "Antihangover", Effect Duration: 10
 Item	hair oil	Effect: "[1342]Slicked-Back Do", Effect Duration: 10
 # hair spray: Deals 3-4 <font color=red>Hot Damage</font>
 Item	hair spray	Effect: "Butt-Rock Hair", Effect Duration: 3
 Item	half-baked potion	Effect Duration: 5
-Item	half-digested coal	Effect: "Coal-Powered", Effect Duration: 20
-Item	half-orchid	Effect: "Bestial Sympathy", Effect Duration: 10
-Item	handful of crafty noodles	Effect: "Blessing of the Pervy Noodles", Effect Duration: 10
+Item	half-digested coal	Effect: "Coal-Powered", Effect Duration: 20, Last Available: "2016-02"
+Item	half-orchid	Effect: "Bestial Sympathy", Effect Duration: 10, Last Available: "2007-05"
+Item	handful of crafty noodles	Effect: "Blessing of the Pervy Noodles", Effect Duration: 10, Last Available: "2013-11"
 Item	handful of Crotchety Pine needles	Effect: "Crotchety, Pining", Effect Duration: 100
 Item	handful of hand chalk	Effect: "Chalky Hand", Effect Duration: 5
 Item	handful of Laughing Willow bark	Effect: "Barking Mad", Effect Duration: 100
 Item	handful of pine needles	Effect: "Hippy Stench", Effect Duration: 10
 Item	handsomeness potion	Effect: "Mysteriously Handsome", Effect Duration: 5
-Item	hare brush	Effect: "Hare-o-dynamic", Effect Duration: 10
+Item	hare brush	Effect: "Hare-o-dynamic", Effect Duration: 10, Last Available: "2014-12"
 Item	Hawking's Elixir of Brilliance	Effect: "On the Shoulders of Giants", Effect Duration: [R]
 Item	healthy juice	Effect: "Juicy Health", Effect Duration: 20
-Item	heather graham cracker	Effect: "Graham Crackling", Effect Duration: 20
-Item	Helvella Haemophilia mushroom	Effect: "Helvella Health", Effect Duration: 10
-Item	hemp candy necklace	Effect: "You Ate Some Hemp Candy", Effect Duration: 20
+Item	heather graham cracker	Effect: "Graham Crackling", Effect Duration: 20, Last Available: "2018-02"
+Item	Helvella Haemophilia mushroom	Effect: "Helvella Health", Effect Duration: 10, Last Available: "2014-05"
+Item	hemp candy necklace	Effect: "You Ate Some Hemp Candy", Effect Duration: 20, Last Available: "2015-12"
 Item	henna face paint	Effect: "Florid Cheeks", Effect Duration: 10
 Item	henna tattoo	Effect: "Hennaliciousness", Effect Duration: 5
-Item	hermedisiac cologne	Effect: "The Odor of Money", Effect Duration: 15
+Item	hermedisiac cologne	Effect: "The Odor of Money", Effect Duration: 15, Last Available: "2020-12"
 Item	Hersey&trade; SMOOCH	Effect: "Kissed By Fire", Effect Duration: 20
-Item	hi-octane carrot juice	Effect: "Beta Carotene Overdose", Effect Duration: 30
-Item	high-test fishing line	Effect: "High-Test Fishing Line", Effect Duration: 20
-Item	hoarded candy wad	Effect: "Not Sharing", Effect Duration: 10
-Item	holly-flavored Hob-O	Effect: "Holiday Bliss", Effect Duration: 1
+Item	hi-octane carrot juice	Effect: "Beta Carotene Overdose", Effect Duration: 30, Last Available: "2014-12"
+Item	high-test fishing line	Effect: "High-Test Fishing Line", Effect Duration: 20, Last Available: "2016-04"
+Item	hoarded candy wad	Effect: "Not Sharing", Effect Duration: 10, Last Available: "2016-10"
+Item	holly-flavored Hob-O	Effect: "Holiday Bliss", Effect Duration: 1, Last Available: "2020-09"
 Item	honey stick	Effect: "Stuck That Way", Effect Duration: 10
 Item	honeypot	Effect: "Float Like a Butterfly, Smell Like a Bee", Effect Duration: 100
 Item	Hot 'n' Scarys	Effect: "Sugar Rush", Effect Duration: 3, Effect: "Hot Breath", Effect: "Spooky Breath"
 Item	hot button candy	Effect: "Hot Buttoned", Effect Duration: 10
 Item	hot coal	Effect: "Fire Inside", Effect Duration: 15
-Item	hot cocoa au beurre	Effect: "Cocoa-Buttery", Effect Duration: 20
-Item	hot cocoa with rainbow marshmallows	Effect: "Cocoa-Nuts", Effect Duration: 20
+Item	hot cocoa au beurre	Effect: "Cocoa-Buttery", Effect Duration: 20, Last Available: "2020-12"
+Item	hot cocoa with rainbow marshmallows	Effect: "Cocoa-Nuts", Effect Duration: 20, Last Available: "2020-12"
 Item	hot nuggets	Effect: "Flaming Weapon", Effect Duration: 5
 Item	hot powder	Effect: "Flame-Retardant Trousers", Effect Duration: 5
-Item	Hotwire&trade; brand candy rope	Effect: "Grand Theft Candy", Effect Duration: 20
-Item	How to Avoid Scams	Effect: "How to Scam Tourists", Effect Duration: 20
-Item	huge mint leaf	Effect: "Mint-Condition Breath", Effect Duration: 20
+Item	Hotwire&trade; brand candy rope	Effect: "Grand Theft Candy", Effect Duration: 20, Last Available: "2020-12"
+Item	How to Avoid Scams	Effect: "How to Scam Tourists", Effect Duration: 20, Last Available: "2015-04"
+Item	huge mint leaf	Effect: "Mint-Condition Breath", Effect Duration: 20, Last Available: "2019-04"
 Item	humming El Vibrato drone	Effect: "El Vibrations", Effect Duration: 10
 Item	Hunger&trade; Sauce	Effect: "The Tunger&trade;", Effect Duration: 1
 Item	hyperinflated seal lung	Effect: "Really Deep Breath", Effect Duration: 20
 Item	iDrops	Effect: "Cybercrime Eyes", Effect Duration: 10
-Item	imported lemon lozenge	Effect: "Hypersoothed Throat", Effect Duration: 15
+Item	imported lemon lozenge	Effect: "Hypersoothed Throat", Effect Duration: 15, Last Available: "2020-12"
 Item	imported taffy	Effect: "Imported Strength", Effect Duration: 30
-Item	incense bath ball	Effect: "Incensed", Effect Duration: 10
-Item	industrial frosting	Effect: "Industrially Frosted", Effect Duration: 5
+Item	incense bath ball	Effect: "Incensed", Effect Duration: 10, Last Available: "2011-01"
+Item	industrial frosting	Effect: "Industrially Frosted", Effect Duration: 5, Last Available: "2016-12"
 Item	industrial strength starch	Effect: "Industrial Strength Starch", Effect Duration: 20, Wiki Name: "industrial strength starch"
-Item	infernal snowball	Effect: "Good Chance of Surviving Hell", Effect Duration: 20
-Item	Inner Strength	Effect: "Innately Strong", Effect Duration: 20
-Item	Inner Truth	Effect: "Innately Truthy", Effect Duration: 20
-Item	Inner Wisdom	Effect: "Innately Wise", Effect Duration: 20
-Item	interrogative elixir	Effect: "Enhanced Interrogation", Effect Duration: 1
-Item	invisibility potion	Effect: "Simply Invisible", Effect Duration: 20
+Item	infernal snowball	Effect: "Good Chance of Surviving Hell", Effect Duration: 20, Last Available: "2019-12"
+Item	Inner Strength	Effect: "Innately Strong", Effect Duration: 20, Last Available: "2016-12"
+Item	Inner Truth	Effect: "Innately Truthy", Effect Duration: 20, Last Available: "2016-12"
+Item	Inner Wisdom	Effect: "Innately Wise", Effect Duration: 20, Last Available: "2016-12"
+Item	interrogative elixir	Effect: "Enhanced Interrogation", Effect Duration: 1, Last Available: "2018-07"
+Item	invisibility potion	Effect: "Simply Invisible", Effect Duration: 20, Last Available: "2011-08"
 Item	invisible potion	Effect: "Invisible (20 Minutes Ago)", Effect Duration: 20
-Item	invisible seam ripper	Lasts Until Rollover, Effect: "Invisibly Ripped", Effect Duration: 5
-Item	invisible string	Lasts Until Rollover, Effect: "Invisible Ties", Effect Duration: 5
+Item	invisible seam ripper	Lasts Until Rollover, Effect: "Invisibly Ripped", Effect Duration: 5, Last Available: "2016-10"
+Item	invisible string	Lasts Until Rollover, Effect: "Invisible Ties", Effect Duration: 5, Last Available: "2016-10"
 Item	ironic mint	Effect: "Deeply Ironic", Effect Duration: 20
 Item	irradiated pet snacks	Effect: "Healthy Green Glow", Effect Duration: 10
 Item	irradiated turtle	Effect: "Turtle Power", Effect Duration: 15
-Item	irresistibility potion	Effect: "Simply Irresistible", Effect Duration: 20
-Item	irritability potion	Effect: "Simply Irritable", Effect Duration: 20
+Item	irresistibility potion	Effect: "Simply Irresistible", Effect Duration: 20, Last Available: "2011-08"
+Item	irritability potion	Effect: "Simply Irritable", Effect Duration: 20, Last Available: "2011-08"
 Item	jaba&ntilde;ero-flavored chewing gum	Effect: "Spicy Mouth", Effect Duration: 5
 Item	jagged tooth	Effect: "Horrid, Torrid", Effect Duration: 1
 Item	jar of &quot;Creole Lady&quot; marrrmalade	Effect: "Savage Beast Inside", Effect Duration: 10
 Item	jazz soap	Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 Item	jellyfish gel	Effect: "Old School Pompadour", Effect Duration: 10
-Item	Jokester makeup	Effect: "Why So Serious?", Effect Duration: 25
-Item	jug of &quot;wine&quot;	Effect: "Grape Expectations", Effect Duration: 40
+Item	Jokester makeup	Effect: "Why So Serious?", Effect Duration: 25, Last Available: "2016-12"
+Item	jug of &quot;wine&quot;	Effect: "Grape Expectations", Effect Duration: 40, Last Available: "2014-12"
 Item	jug of baconstone juice	Effect: "Baconstoned", Effect Duration: 50
 Item	jug of hamethyst juice	Effect: "Ham-Fisted", Effect Duration: 50
 Item	jug of porquoise juice	Effect: "Je Ne Sais Porquoise", Effect Duration: 50
@@ -10714,69 +10714,69 @@ Item	Knob Goblin love potion	Effect: "Knob Goblin Lust Frenzy", Effect Duration:
 Item	Knob Goblin perfume	Effect: "Knob Goblin Perfume", Effect Duration: 1
 Item	Knob Goblin sharpening spray	Effect: "Sharp Weapon", Effect Duration: 5
 Item	Knob Goblin steroids	Effect: "Steroid Boost", Effect Duration: 5
-Item	Kokomo Resort Brand Suntan Oil	Effect: "Tropical Contact High", Effect Duration: 3
-Item	Kokomo Resort Pass	Effect: "Tropical Contact High", Effect Duration: 10
-Item	kumquat supersucker	Effect: "Koyaaniskumquatsi", Effect Duration: 30
-Item	labrador cookie	Effect: "Insatiable Hunger", Effect Duration: 40
-Item	lavender candy heart	Effect: "Heart of Lavender", Effect Duration: 10
+Item	Kokomo Resort Brand Suntan Oil	Effect: "Tropical Contact High", Effect Duration: 3, Last Available: "2015-04"
+Item	Kokomo Resort Pass	Effect: "Tropical Contact High", Effect Duration: 10, Last Available: "2023-08"
+Item	kumquat supersucker	Effect: "Koyaaniskumquatsi", Effect Duration: 30, Last Available: "2011-11"
+Item	labrador cookie	Effect: "Insatiable Hunger", Effect Duration: 40, Last Available: "2015-08"
+Item	lavender candy heart	Effect: "Heart of Lavender", Effect Duration: 10, Last Available: "2007-02"
 Item	leftover chocolate bar	Effect: "Sugar Rush", Effect Duration: 50
-Item	lemonhead caviar	Effect: "Sourpuss", Effect Duration: 30
-Item	lesser grodulated violet	Effect: "Fustulent", Effect Duration: 10
+Item	lemonhead caviar	Effect: "Sourpuss", Effect Duration: 30, Last Available: "2014-12"
+Item	lesser grodulated violet	Effect: "Fustulent", Effect Duration: 10, Last Available: "2007-05"
 Item	libation of liveliness	Effect: "Provocative Perkiness", Effect Duration: [R]
-Item	licorice root	Effect: "Rootin' Around", Effect Duration: 20
+Item	licorice root	Effect: "Rootin' Around", Effect Duration: 20, Last Available: "2011-12"
 Item	licorice snake	Effect: "Whippin' It Good", Effect Duration: 20
-Item	LIDAR candle	Effect: "LIDARed", Effect Duration: 30
-Item	lime supersucker	Effect: "In the Limelight", Effect Duration: 30
+Item	LIDAR candle	Effect: "LIDARed", Effect Duration: 30, Last Available: "2024-12"
+Item	lime supersucker	Effect: "In the Limelight", Effect Duration: 30, Last Available: "2011-11"
 Item	lime-and-chile-flavored chewing gum	Effect: "Spicy Limeness", Effect Duration: 5
-Item	lion musk	Effect: "Lion in Ambush", Effect Duration: 20
+Item	lion musk	Effect: "Lion in Ambush", Effect Duration: 20, Last Available: "2016-02"
 Item	liquid ice	Effect: "Cold as Ice", Effect Duration: 50
-Item	liquid ice pack	Effect: "Ice Packed", Effect Duration: 30
-Item	liquid rhinestones	Effect: "Sparkly!", Effect Duration: 40
-Item	liquid smoke	Effect: "Liquidy Smoky", Effect Duration: 15
+Item	liquid ice pack	Effect: "Ice Packed", Effect Duration: 30, Last Available: "2014-01"
+Item	liquid rhinestones	Effect: "Sparkly!", Effect Duration: 40, Last Available: "2015-08"
+Item	liquid smoke	Effect: "Liquidy Smoky", Effect Duration: 15, Last Available: "2014-06"
 # liquid SONAR: NOTE: This item will stop working when Crimbo 2019 is over.
-Item	liquid SONAR	Effect: "PING...  PING...  PING...", Effect Duration: 50
+Item	liquid SONAR	Effect: "PING...  PING...  PING...", Effect Duration: 50, Last Available: "2019-12"
 Item	little red jam	Effect: "Hood Ridin'", Effect Duration: 20
-Item	Lobos Mints	Effect: "Lobos Fresh", Effect Duration: 20
+Item	Lobos Mints	Effect: "Lobos Fresh", Effect Duration: 20, Last Available: "2011-10"
 Item	lotion of coldness	Effect: "Cold Hands", Effect Duration: [R+5]
 Item	lotion of hotness	Effect: "Hot Hands", Effect Duration: [R+5]
 Item	lotion of sleaziness	Effect: "Sleazy Hands", Effect Duration: [R+5]
 Item	lotion of spookiness	Effect: "Spooky Hands", Effect Duration: [R+5]
 Item	lotion of stench	Effect: "Stinky Hands", Effect Duration: [R+5]
-Item	LOV Elixir #3	Effect: "The Power of LOV", Effect Duration: 40
-Item	LOV Elixir #6	Effect: "The Magic of LOV", Effect Duration: 40
-Item	LOV Elixir #9	Effect: "The Moxie of LOV", Effect Duration: 40
+Item	LOV Elixir #3	Effect: "The Power of LOV", Effect Duration: 40, Last Available: "2017-02"
+Item	LOV Elixir #6	Effect: "The Magic of LOV", Effect Duration: 40, Last Available: "2017-02"
+Item	LOV Elixir #9	Effect: "The Moxie of LOV", Effect Duration: 40, Last Available: "2017-02"
 Item	Love Potion #0	Effect: "Tainted Love Potion", Effect Duration: 20
 # love song of disturbing obsession: Deals <font color=gray>Spooky Damage</font> based on your Mysticality
-Item	love song of disturbing obsession	Effect: "Withered Heart", Effect Duration: 5
+Item	love song of disturbing obsession	Effect: "Withered Heart", Effect Duration: 5, Last Available: "2009-02"
 # love song of icy revenge: Deals <font color=blue>Cold Damage</font> based on your Moxie
-Item	love song of icy revenge	Effect: "Cold Hearted", Effect Duration: 5
+Item	love song of icy revenge	Effect: "Cold Hearted", Effect Duration: 5, Last Available: "2009-02"
 # love song of naughty innuendo: Deals <font color=blueviolet>Sleaze Damage</font> based on your Moxie
-Item	love song of naughty innuendo	Effect: "Lustful Heart", Effect Duration: 5
+Item	love song of naughty innuendo	Effect: "Lustful Heart", Effect Duration: 5, Last Available: "2009-02"
 # love song of smoldering passion: Deals <font color=red>Hot Damage</font> based on your Mysticality
-Item	love song of smoldering passion	Effect: "Fiery Heart", Effect Duration: 5
+Item	love song of smoldering passion	Effect: "Fiery Heart", Effect Duration: 5, Last Available: "2009-02"
 # love song of sugary cuteness: Deals <font color=green>Stench Damage</font> based on your Muscle
-Item	love song of sugary cuteness	Effect: "Sweet Heart", Effect Duration: 5
+Item	love song of sugary cuteness	Effect: "Sweet Heart", Effect Duration: 5, Last Available: "2009-02"
 # love song of vague ambiguity: Deals Physical Damage based on your Muscle
-Item	love song of vague ambiguity	Effect: "Broken Heart", Effect Duration: 5
+Item	love song of vague ambiguity	Effect: "Broken Heart", Effect Duration: 5, Last Available: "2009-02"
 Item	Lucky Strikes holo-record	Effect: "Lucky Struck", Effect Duration: 10
-Item	lump of loyal latite	Effect: "Loyal as a Rock", Effect Duration: 20
+Item	lump of loyal latite	Effect: "Loyal as a Rock", Effect Duration: 20, Last Available: "2023-02"
 Item	lump of Saccharine Maple sap	Effect: "Artificially Sweet", Effect Duration: 100
 Item	lynyrd musk	Effect: "Musky", Effect Duration: 30
 Item	M-242	Effect: "Adrenaline Rush", Effect Duration: 50
 Item	mafia aria	Effect: "Macho Profundo", Effect Duration: 5
-Item	magenta seashell	Effect: "Too Cool for (Fish) School", Effect Duration: 20
-Item	magicberry tablets	Effect: "Magic Tongue", Effect Duration: 1
+Item	magenta seashell	Effect: "Too Cool for (Fish) School", Effect Duration: 20, Last Available: "2019-07"
+Item	magicberry tablets	Effect: "Magic Tongue", Effect Duration: 1, Last Available: "2012-12"
 Item	Mallomarbles	Effect: "Marbles in Your Mouth", Effect Duration: 20
 Item	mangled finger	Effect: "It Tickles!  It Tickles!", Effect Duration: 20
 Item	mariachi toothpaste	Effect: "Gleaming White Teeth", Effect Duration: 20
 Item	marshroom	Effect: "Extra Spongy", Effect Duration: 5
-Item	Marvin's marvelous pill	Effect: "Pharmaceutically Cool", Effect Duration: 10
+Item	Marvin's marvelous pill	Effect: "Pharmaceutically Cool", Effect Duration: 10, Last Available: "2012-12"
 Item	marzipan skull	Effect: "Sugar Rush", Effect Duration: 5, Effect: "Hardly Poisoned at All", Effect Duration: 5, Effect: "Hombre Muerto Caminando", Effect Duration: 5
 Item	Mayo de Mayo&trade; mayo	Effect: "Force of Mayo Be With You", Effect Duration: 5
-Item	Meat-inflating powder	Effect: "Big Meat Big Prizes", Effect Duration: 20
+Item	Meat-inflating powder	Effect: "Big Meat Big Prizes", Effect Duration: 20, Last Available: "2014-05"
 Item	Meleegra&trade; pills	Effect: "Engorged Weapon", Effect Duration: 5
 Item	Mer-kin cooljuice	Effect: "Juiced", Effect Duration: 30
-Item	Mer-kin eyedrops	Effect: "Sea Seeing", Effect Duration: 20
+Item	Mer-kin eyedrops	Effect: "Sea Seeing", Effect Duration: 20, Last Available: "2019-12"
 Item	Mer-kin fastjuice	Effect: "Juiced Up", Effect Duration: 10
 Item	Mer-kin hidepaint	Effect: "Colorfully Concealed", Effect Duration: 10
 Item	Mer-kin lipstick	Effect: "Red Around the Gills", Effect Duration: 25
@@ -10790,43 +10790,43 @@ Item	Mick's IcyVapoHotness Inhaler	Effect: "Sinuses For Miles", Effect Duration:
 Item	Mick's IcyVapoHotness Rub	Effect: "Extreme Muscle Relaxation", Effect Duration: 10
 Item	military candy cane	Effect: "Militarily Minted", Effect Duration: 10
 Item	Milk Studs	Effect: "Milk Studly", Effect Duration: 15
-Item	mime army camouflage kit	Effect: "Mimeoflage", Effect Duration: 30
+Item	mime army camouflage kit	Effect: "Mimeoflage", Effect Duration: 30, Last Available: "2017-12"
 Item	mini kiwi antimilitaristic hippy petition	Effect: "Hippy Antimilitarism", Effect Duration: 5
 Item	mini kiwi illicit antibiotic	Effect: "Incredibly Healthy", Effect Duration: 5
 Item	mini kiwi-flavored aspirin-injecting lipstick	Effect: "Aspirinated Lips", Effect Duration: 5
-Item	miniature power pill	Effect: "Pill Power", Effect Duration: 30
+Item	miniature power pill	Effect: "Pill Power", Effect Duration: 30, Last Available: "2015-06"
 Item	mocking turtle	Effect: "Tortious", Effect Duration: 15
-Item	monkey barf	Effect: "Barfpits", Effect Duration: 1
+Item	monkey barf	Effect: "Barfpits", Effect Duration: 1, Last Available: "2014-10"
 Item	Moonds	Effect: "Moon-Eyed", Effect Duration: 50
 Item	moose thought	Effect: "Moose Wisdom", Effect Duration: 10
-Item	Mortimer's nostrum	Effect: "Limber as Mortimer", Effect Duration: 10
+Item	Mortimer's nostrum	Effect: "Limber as Mortimer", Effect Duration: 10, Last Available: "2012-12"
 Item	moss floss	Effect: "Flossed Blood", Effect Duration: 20
 Item	mostly-broken sunglasses	Effect: "Almost Cool", Effect Duration: 15
 Item	mother's little helper	Effect: "Tranquilized Mind", Effect Duration: 10
-Item	motivational poster	Effect: "Loco Motives", Effect Duration: 10
+Item	motivational poster	Effect: "Loco Motives", Effect Duration: 10, Last Available: "2011-01"
 Item	mouse skull	Effect: "Little Mouse Skull Buddy", Effect Duration: 20
 Item	Mr. Mediocrebar	Effect: "Apathy", Effect Duration: 10
-Item	multi-level marzipan	Effect: "Multi-Level Mindset", Effect Duration: 100
-Item	murderbot shield unit	Effect: "Shielded Unit", Effect Duration: 20
-Item	murderbot spring injector	Effect: "Spring Training", Effect Duration: 20
+Item	multi-level marzipan	Effect: "Multi-Level Mindset", Effect Duration: 100, Last Available: "2020-12"
+Item	murderbot shield unit	Effect: "Shielded Unit", Effect Duration: 20, Last Available: "2017-04"
+Item	murderbot spring injector	Effect: "Spring Training", Effect Duration: 20, Last Available: "2017-04"
 Item	musk turtle	Effect: "High Colognic", Effect Duration: 15
 Item	mutated candy lump	Effect: "Slightly Mutated", Effect Duration: 20
-Item	myrrh-soaked, chocolate-covered bacon bath ball	Effect: "Incensed", Effect Duration: 10
+Item	myrrh-soaked, chocolate-covered bacon bath ball	Effect: "Incensed", Effect Duration: 10, Last Available: "2011-01"
 Item	mysterious chemical residue	Effect Duration: 5
 Item	mystery lollipop	Effect: "Your Favorite Flavor", Effect Duration: 5
-Item	nail file	Effect: "Extra-Sharp Weapon", Effect Duration: 20
-Item	Napalm In The Morning&trade; candle	Effect: "Scorched Earth", Effect Duration: 40
+Item	nail file	Effect: "Extra-Sharp Weapon", Effect Duration: 20, Last Available: "2013-11"
+Item	Napalm In The Morning&trade; candle	Effect: "Scorched Earth", Effect Duration: 40, Last Available: "2021-08"
 Item	nasty gum	Effect: "Nasty, Nasty Breath", Effect Duration: 5
-Item	natto marble soda	Effect: "Ninja, Please", Effect Duration: 15
-Item	natural magick candle	Effect: "The Odour of Magick", Effect Duration: 80
-Item	Necbro wafers	Effect: "Chalk Outline", Effect Duration: 5
-Item	neurostim pill	Effect: "Stimulated Brain", Effect Duration: 10
-Item	new habit	Effect: "Habituated", Effect Duration: 365
-Item	Nightstalker perfume	Effect: "Nightstalkin'", Effect Duration: 30
+Item	natto marble soda	Effect: "Ninja, Please", Effect Duration: 15, Last Available: "2011-03"
+Item	natural magick candle	Effect: "The Odour of Magick", Effect Duration: 80, Last Available: "2021-08"
+Item	Necbro wafers	Effect: "Chalk Outline", Effect Duration: 5, Last Available: "2020-09"
+Item	neurostim pill	Effect: "Stimulated Brain", Effect Duration: 10, Last Available: "2009-06"
+Item	new habit	Effect: "Habituated", Effect Duration: 365, Last Available: "2017-10"
+Item	Nightstalker perfume	Effect: "Nightstalkin'", Effect Duration: 30, Last Available: "2011-10"
 Item	Northern pemmican	Effect: "Pemmican't", Effect Duration: 20
-Item	Now and Earlier	Effect: "Sugar Rush", Effect Duration: 5
-Item	Nuclear Blastball	Effect: "Taste the Inferno", Effect Duration: 50
-Item	null-day exploit	Effect: "Null Afternoon", Effect Duration: 30
+Item	Now and Earlier	Effect: "Sugar Rush", Effect Duration: 5, Last Available: "2020-09"
+Item	Nuclear Blastball	Effect: "Taste the Inferno", Effect Duration: 50, Last Available: "2011-05"
+Item	null-day exploit	Effect: "Null Afternoon", Effect Duration: 30, Last Available: "2025-12"
 Item	O'RLY manual	Effect: "You Read The Manual", Effect Duration: 20
 Item	Ogres and Oubliettes&trade; module	Effect: "Ogred and Oublietted", Effect Duration: 10
 Item	oil of expertise	Effect: "Expert Oiliness", Effect Duration: [R]
@@ -10834,52 +10834,52 @@ Item	Oil of Parrrlay	Effect: "Well-Oiled", Effect Duration: 5
 Item	oil of slipperiness	Effect: "Slippery Oiliness", Effect Duration: [R]
 Item	oil of stability	Effect: "Stabilizing Oiliness", Effect Duration: [R]
 Item	ointment of the occult	Effect: "Mystically Oiled", Effect Duration: [R]
-Item	Okee-Dokee soda	Effect: "Sugar Rush", Effect Duration: 20
+Item	Okee-Dokee soda	Effect: "Sugar Rush", Effect Duration: 20, Last Available: "2011-05"
 Item	old bronzer	Effect: "Sepia Tan", Effect Duration: 25
-Item	old candy wrapper	Effect: "Litterbug", Effect Duration: 5
+Item	old candy wrapper	Effect: "Litterbug", Effect Duration: 5, Last Available: "2013-11"
 Item	old eyebrow pencil	Effect: "Browbeaten", Effect Duration: 25
-Item	old love note	Effect: "Memories of Puppy Love", Effect Duration: 20
+Item	old love note	Effect: "Memories of Puppy Love", Effect Duration: 20, Last Available: "2013-11"
 Item	old rosewater cream	Effect: "Rosewater Mark", Effect Duration: 25
-Item	Omphalotus Omphaloskepsis mushroom	Effect: "Omphalotus Omnipresence", Effect Duration: 10
+Item	Omphalotus Omphaloskepsis mushroom	Effect: "Omphalotus Omnipresence", Effect Duration: 10, Last Available: "2014-05"
 Item	one piece of bubble gum	Effect: "Sugar Rush", Effect Duration: 10
 Item	one pill	Effect Duration: 0
-Item	orange and black Crimboween candy	Effect: "Sugar Rush", Effect Duration: 5
-Item	orange candy heart	Effect: "Heart of Orange", Effect Duration: 10
-Item	orange snowcone	Effect: "Orange Tongue", Effect Duration: 20
+Item	orange and black Crimboween candy	Effect: "Sugar Rush", Effect Duration: 5, Last Available: "2020-09"
+Item	orange candy heart	Effect: "Heart of Orange", Effect Duration: 10, Last Available: "2007-02"
+Item	orange snowcone	Effect: "Orange Tongue", Effect Duration: 20, Last Available: "2006-01"
 Item	orange-frosted astral cupcake	Effect: "Shiny Happy Cupcake", Effect Duration: 20
 Item	orcish hand lotion	Effect: "Hairy Palms", Effect Duration: 10
 Item	orcish nailing lube	Effect: "Well-Lubed", Effect Duration: 10
 Item	orcish rubber	Effect: "Using Protection", Effect Duration: 10
-Item	organic potpourri	Effect: "Potpourri Committed", Effect Duration: 20
-Item	out-of-work circus flea	Effect: "They've Got Fleas", Effect Duration: 20
-Item	Outer Wolf&trade; cologne	Effect: "Outer Wolf&trade;", Effect Duration: 20
-Item	overly-fancy hot cocoa	Effect: "Smug of Cocoa", Effect Duration: 20
+Item	organic potpourri	Effect: "Potpourri Committed", Effect Duration: 20, Last Available: "2019-12"
+Item	out-of-work circus flea	Effect: "They've Got Fleas", Effect Duration: 20, Last Available: "2023-02"
+Item	Outer Wolf&trade; cologne	Effect: "Outer Wolf&trade;", Effect Duration: 20, Last Available: "2014-12"
+Item	overly-fancy hot cocoa	Effect: "Smug of Cocoa", Effect Duration: 20, Last Available: "2020-12"
 Item	Pain Dip	Effect: "The HeyDezebound Heart", Effect Duration: 1
-Item	pair of candy glasses	Effect: "Sucrose-Colored Glasses", Effect Duration: 10
+Item	pair of candy glasses	Effect: "Sucrose-Colored Glasses", Effect Duration: 10, Last Available: "2017-10"
 Item	panty raider camouflage	Effect: "Hiding in Plain Sight", Effect Duration: 10
-Item	papier-m&acirc;ch&eacute; toothpicks	Effect: "Eyes Wide Propped", Effect Duration: 40
-Item	papier-m&acirc;chaeranthera	Effect: "Stopping to Smell the Flowers", Effect Duration: 40
-Item	papier-mochi	Effect: "Altered Wavelengths", Effect Duration: 40
+Item	papier-m&acirc;ch&eacute; toothpicks	Effect: "Eyes Wide Propped", Effect Duration: 40, Last Available: "2012-09"
+Item	papier-m&acirc;chaeranthera	Effect: "Stopping to Smell the Flowers", Effect Duration: 40, Last Available: "2012-09"
+Item	papier-mochi	Effect: "Altered Wavelengths", Effect Duration: 40, Last Available: "2012-09"
 Item	papotion of papower	Effect: "Papowerful", Effect Duration: [R]
 Item	Para-Pop	Effect: "Para-lyzed Jaw", Effect Duration: 20
-Item	patch of extra-warm fur	Effect: "Furrier Than Thou", Effect Duration: 20
+Item	patch of extra-warm fur	Effect: "Furrier Than Thou", Effect Duration: 20, Last Available: "2019-12"
 Item	patent aggression tonic	Effect: "Patent Aggression", Effect Duration: 30
 Item	patent alacrity tonic	Effect: "Patent Alacrity", Effect Duration: 20
 Item	patent avarice tonic	Effect: "Patent Avarice", Effect Duration: 30
 Item	patent invisibility tonic	Effect: "Patent Invisibility", Effect Duration: 30
 Item	patent preventative tonic	Effect: "Patent Prevention", Effect Duration: 30
 Item	patent sallowness tonic	Effect: "Patent Sallowness", Effect Duration: 50
-Item	pea brittle	Effect: "Brittled", Effect Duration: 20
+Item	pea brittle	Effect: "Brittled", Effect Duration: 20, Last Available: "2024-11"
 Item	peach lozenge	Effect: "The Halls of Moxiousness", Effect Duration: [R]
 Item	pear lozenge	Effect: "The Halls of Mysticality", Effect Duration: [R]
-Item	pear supersucker	Effect: "Dirty Pear", Effect Duration: 30
+Item	pear supersucker	Effect: "Dirty Pear", Effect Duration: 30, Last Available: "2011-11"
 Item	pec oil	Effect: "Oiled-Up", Effect Duration: 20
 Item	PEEZ dispenser	Effect: "Sugar Rush", Effect Duration: 5
-Item	peppermint pegleg	Effect: "Peppermint Endoskeleton", Effect Duration: 30
-Item	peppermint syrup	Effect: "Candied Teeth", Effect Duration: 20
-Item	peppermint twist	Effect: "Peppermint Twisted", Effect Duration: 10
+Item	peppermint pegleg	Effect: "Peppermint Endoskeleton", Effect Duration: 30, Last Available: "2024-12"
+Item	peppermint syrup	Effect: "Candied Teeth", Effect Duration: 20, Last Available: "2019-12"
+Item	peppermint twist	Effect: "Peppermint Twisted", Effect Duration: 10, Last Available: "2011-11"
 Item	perfume of prejudice	Effect: "Eau D'enmity", Effect Duration: [R]
-Item	perl necklace	Effect: "PERL of Great Price", Effect Duration: 20
+Item	perl necklace	Effect: "PERL of Great Price", Effect Duration: 20, Last Available: "2014-12"
 Item	petrified wood wafer praline	Effect: "Petrified Wood Wound Prevention", Effect Duration: 20
 Item	ph balancer	Effect: "Phairly Balanced", Effect Duration: 5
 Item	phial of coldness	Effect: "Coldform", Effect Duration: 5
@@ -10888,22 +10888,22 @@ Item	phial of sleaziness	Effect: "Sleazeform", Effect Duration: 5
 Item	phial of spookiness	Effect: "Spookyform", Effect Duration: 5
 Item	phial of stench	Effect: "Stenchform", Effect Duration: 5
 Item	philter of phorce	Effect: "Phorcefullness", Effect Duration: [R]
-Item	physiostim pill	Effect: "Stimulated Body", Effect Duration: 10
+Item	physiostim pill	Effect: "Stimulated Body", Effect Duration: 10, Last Available: "2009-06"
 Item	pickle-flavored chewing gum	Effect: "Mystic Pickleness", Effect Duration: 5
-Item	Piddles	Effect: "Belch the Rainbow&trade;", Effect Duration: 10
+Item	Piddles	Effect: "Belch the Rainbow&trade;", Effect Duration: 10, Last Available: "2009-12"
 Item	piece of after eight	Effect: "Sugar Rush", Effect Duration: 5
 Item	pile of ashes	Effect: "Ashen", Effect Duration: 20
 Item	pill cup	Effect: "Pill Party!", Effect Duration: 30
 Item	pine tar	Effect: "Sticky Hands", Effect Duration: 30
-Item	pink candy heart	Effect: "Heart of Pink", Effect Duration: 10
+Item	pink candy heart	Effect: "Heart of Pink", Effect Duration: 10, Last Available: "2007-02"
 Item	pink-frosted astral cupcake	Effect: "Your Cupcake Senses Are Tingling", Effect Duration: 20
-Item	piranha pollen	Effect: "Piranha Power", Effect Duration: 20
+Item	piranha pollen	Effect: "Piranha Power", Effect Duration: 20, Last Available: "2020-03"
 Item	pirate brochure	Effect: "Muscularrr", Effect Duration: 10
 Item	pirate pamphlet	Effect: "Charrrming", Effect Duration: 10
-Item	pirate shaving cream	Effect: "The Best a Pirate Can Get", Effect Duration: 40
+Item	pirate shaving cream	Effect: "The Best a Pirate Can Get", Effect Duration: 40, Last Available: "2019-04"
 Item	pirate tract	Effect: "Carrrsmic", Effect Duration: 10
-Item	pitted sheet metal	Effect: "Ironclad", Effect Duration: 20
-Item	pixel star	Effect: "Nigh-Invincible", Effect Duration: 30
+Item	pitted sheet metal	Effect: "Ironclad", Effect Duration: 20, Last Available: "2015-12"
+Item	pixel star	Effect: "Nigh-Invincible", Effect Duration: 30, Last Available: "2015-06"
 # pixellated candy heart: Restores 4-5 HP
 Item	pixellated candy heart	Effect: "Sugar Rush", Effect Duration: 3
 Item	PlexiPips	Effect: "Sole Soul", Effect Duration: 1
@@ -10911,132 +10911,132 @@ Item	plum lozenge	Effect: "The Halls of Muscularity", Effect Duration: [R]
 Item	Pneumo bar	Effect: "Bubblin' Rage", Effect Duration: 20
 Item	pocket maze	Effect: "Amazing", Effect Duration: 1
 # Pok&euml;mann band-aid: Restores 100 HP
-Item	Pok&euml;mann band-aid	Effect: "Aided and Abetted", Effect Duration: 10
-Item	poker face paint	Effect: "Poker Faced", Effect Duration: 10
-Item	Polka Pop	Effect: "Polka Face", Effect Duration: 10
-Item	polo trophy	Effect: "Polonoia", Effect Duration: 15
+Item	Pok&euml;mann band-aid	Effect: "Aided and Abetted", Effect Duration: 10, Last Available: "2011-05"
+Item	poker face paint	Effect: "Poker Faced", Effect Duration: 10, Last Available: "2016-02"
+Item	Polka Pop	Effect: "Polka Face", Effect Duration: 10, Last Available: "2009-12"
+Item	polo trophy	Effect: "Polonoia", Effect Duration: 15, Last Available: "2014-12"
 Item	polyeaster egg	Effect: "Roly Poly", Effect Duration: 5
 Item	Polysniff Perfume	Effect: "Neutered Nostrils", Effect Duration: 10
 Item	poppy	Effect: "It's Soporiffic!", Effect Duration: 10
 Item	porcelain candy dish	Effect: "Red in Tooth", Effect Duration: 5
-Item	portable wall	Effect: "Wallflowering", Effect Duration: 20
+Item	portable wall	Effect: "Wallflowering", Effect Duration: 20, Last Available: "2014-12"
 Item	possibility potion	Effect: "Always In Motion", Effect Duration: 10
-Item	post-holiday sale coupon	Effect: "Black Day", Effect Duration: 1
+Item	post-holiday sale coupon	Effect: "Black Day", Effect Duration: 1, Last Available: "2013-11"
 Item	potent potion of potency	Effect: "Ponderous Potency", Effect Duration: [R]
-Item	potion of animal rage	Effect: "Raging Animal", Effect Duration: 30
+Item	potion of animal rage	Effect: "Raging Animal", Effect Duration: 30, Last Available: "2011-09"
 Item	potion of fishy speed	Effect: "Fishily Speeding", Effect Duration: 20
-Item	Potion of Heroism	Effect: "Heroic Fortune", Effect Duration: 10
+Item	Potion of Heroism	Effect: "Heroic Fortune", Effect Duration: 10, Last Available: "2018-04"
 Item	potion of potency	Effect: "Pronounced Potency", Effect Duration: [R]
-Item	potion of punctual companionship	Effect: "Stickler for Promptness", Effect Duration: 30
-Item	potion of spiritual gunkifying	Effect: "The Power of Negative Thinking", Effect Duration: 20
+Item	potion of punctual companionship	Effect: "Stickler for Promptness", Effect Duration: 30, Last Available: "2011-09"
+Item	potion of spiritual gunkifying	Effect: "The Power of Negative Thinking", Effect Duration: 20, Last Available: "2016-12"
 Item	potion of temporary gr8ness	Effect: "Gr8ness", Effect Duration: [R]
-Item	potion of the captain's hammer	Effect: "The Captain's Hammer", Effect Duration: 20
-Item	potion of the field gar	Effect: "Gar-ish", Effect Duration: 10
-Item	potion of the litterbox	Effect: "Litterboxing", Effect Duration: 20
-Item	potion of X-ray vision	Effect: "X-Ray Vision", Effect Duration: 30
-Item	powdered candy sushi set	Effect: "Fishy", Effect Duration: 30
+Item	potion of the captain's hammer	Effect: "The Captain's Hammer", Effect Duration: 20, Last Available: "2011-09"
+Item	potion of the field gar	Effect: "Gar-ish", Effect Duration: 10, Last Available: "2011-09"
+Item	potion of the litterbox	Effect: "Litterboxing", Effect Duration: 20, Last Available: "2011-09"
+Item	potion of X-ray vision	Effect: "X-Ray Vision", Effect Duration: 30, Last Available: "2011-09"
+Item	powdered candy sushi set	Effect: "Fishy", Effect Duration: 30, Last Available: "2012-12"
 Item	powdered dice	Effect: "Curse of Randomness", Effect Duration: 100
-Item	powdered powdered sugar	Effect: "Festively-Dusted", Effect Duration: 100
-Item	powdered toad horn	Effect: "Squirming Like a Toad", Effect Duration: 10
+Item	powdered powdered sugar	Effect: "Festively-Dusted", Effect Duration: 100, Last Available: "2020-12"
+Item	powdered toad horn	Effect: "Squirming Like a Toad", Effect Duration: 10, Last Available: "2007-01"
 # power pill: Can also be fed to Puck Mans in combat
-Item	power pill	Effect: "Pill Power", Effect Duration: 30
+Item	power pill	Effect: "Pill Power", Effect Duration: 30, Last Available: "2015-06"
 Item	Power-Guy 2000 holo-record	Effect: "Power, Man", Effect Duration: 10
-Item	prescription teeth whitener	Effect: "Dazzling Smile", Effect Duration: 15
+Item	prescription teeth whitener	Effect: "Dazzling Smile", Effect Duration: 15, Last Available: "2020-12"
 Item	pressurized potion of perception	Effect: "Perceptive Pressure", Effect Duration: [R]
 Item	pressurized potion of perspicacity	Effect: "Perspicacious Pressure", Effect Duration: [R]
 Item	pressurized potion of pneumaticity	Effect: "Pneumatic", Effect Duration: 20
-Item	pressurized potion of possessiveness	Effect: "Possessive Pressure", Effect Duration: 5
+Item	pressurized potion of possessiveness	Effect: "Possessive Pressure", Effect Duration: 5, Last Available: "2019-12"
 Item	pressurized potion of proficiency	Effect: "Proficient Pressure", Effect Duration: [R]
 Item	pressurized potion of puissance	Effect: "Puissant Pressure", Effect Duration: [R]
 Item	pressurized potion of pulchritude	Effect: "Pulchritudinous Pressure", Effect Duration: [R]
-Item	primitive alien medicine	Effect: "Preemptive Medicine", Effect Duration: 20
+Item	primitive alien medicine	Effect: "Preemptive Medicine", Effect Duration: 20, Last Available: "2017-04"
 Item	probability potion	Effect: "Uncertain", Effect Duration: 10
 Item	programmable turtle	Effect: "Spiro Gyro", Effect Duration: 15
 Item	Prunets	Effect: "She Ate Too Much Candy", Effect Duration: 5
-Item	Puffstone cigar	Effect: "Stogied", Effect Duration: 50
+Item	Puffstone cigar	Effect: "Stogied", Effect Duration: 50, Last Available: "2015-11"
 # pulled blue taffy: Summons a helpful fish
 # pulled blue taffy: (underwater only)
-Item	pulled blue taffy	Effect: "Blue Swayed", Effect Duration: 10
+Item	pulled blue taffy	Effect: "Blue Swayed", Effect Duration: 10, Last Available: "2013-04"
 # pulled green taffy: Makes a copy of a monster to fight later
 # pulled green taffy: (underwater only)
-Item	pulled green taffy	Effect: "Soda Jerked", Effect Duration: 10
+Item	pulled green taffy	Effect: "Soda Jerked", Effect Duration: 10, Last Available: "2013-04"
 # pulled indigo taffy: Lets you escape from combat without spending an Adventure
 # pulled indigo taffy: (underwater only)
-Item	pulled indigo taffy	Effect: "Closer to Fine", Effect Duration: 10
+Item	pulled indigo taffy	Effect: "Closer to Fine", Effect Duration: 10, Last Available: "2013-04"
 # pulled orange taffy: Summons a helpful fish
 # pulled orange taffy: (underwater only)
-Item	pulled orange taffy	Effect: "Orange Crusher", Effect Duration: 10
+Item	pulled orange taffy	Effect: "Orange Crusher", Effect Duration: 10, Last Available: "2013-04"
 # pulled red taffy: Summons a helpful fish
 # pulled red taffy: (underwater only)
-Item	pulled red taffy	Effect: "Cinnamon Challenger", Effect Duration: 10
+Item	pulled red taffy	Effect: "Cinnamon Challenger", Effect Duration: 10, Last Available: "2013-04"
 # pulled violet taffy: Summons a helpful fish
 # pulled violet taffy: (underwater only)
-Item	pulled violet taffy	Effect: "Purple Reign", Effect Duration: 10
+Item	pulled violet taffy	Effect: "Purple Reign", Effect Duration: 10, Last Available: "2013-04"
 # pulled yellow taffy: Vaporizes an enemy and causes all of its items to drop
 # pulled yellow taffy: (underwater only)
-Item	pulled yellow taffy	Effect: "Sour Softshoe", Effect Duration: 10
-Item	pumpkin juice	Effect: "Juiced and Jacked", Effect Duration: 10
-Item	Punching Potion	Effect: "Feeling Punchy", Effect Duration: 10
-Item	purple snowcone	Effect: "Purple Tongue", Effect Duration: 20
+Item	pulled yellow taffy	Effect: "Sour Softshoe", Effect Duration: 10, Last Available: "2013-04"
+Item	pumpkin juice	Effect: "Juiced and Jacked", Effect Duration: 10, Last Available: "2010-11"
+Item	Punching Potion	Effect: "Feeling Punchy", Effect Duration: 10, Last Available: "2018-06"
+Item	purple snowcone	Effect: "Purple Tongue", Effect Duration: 20, Last Available: "2006-01"
 Item	purple-frosted astral cupcake	Effect: "Tiny Bubbles in the Cupcake", Effect Duration: 20
 Item	pygmy phone number	Effect: "Pygmy Drinking Buddy", Effect Duration: 15
 Item	pygmy pygment	Effect: "Woad Warrior", Effect Duration: 10
-Item	R&uuml;mpelstiltz	Effect: "Rumpel-pumped", Effect Duration: 5
+Item	R&uuml;mpelstiltz	Effect: "Rumpel-pumped", Effect Duration: 5, Last Available: "2014-12"
 Item	Rad-Pro (1 oz.)	Effect: "Rad-Pro Tected", Effect Duration: 20
 Item	radium-flavored potato chips	Effect: "Radium Radicality", Effect Duration: 10
-Item	rainbow glitter candle	Effect: "Covered in the Rainbow", Effect Duration: 80
+Item	rainbow glitter candle	Effect: "Covered in the Rainbow", Effect Duration: 80, Last Available: "2021-08"
 Item	rainbow jellybean	Effect: "Tasting the Rainbow", Effect Duration: 5
-Item	rattler gland	Effect: "Venomous Weapon", Effect Duration: 20
-Item	Rattlin' Chains	Effect: "The Chains Down In The Belly-O", Effect Duration: 20
+Item	rattler gland	Effect: "Venomous Weapon", Effect Duration: 20, Last Available: "2016-02"
+Item	Rattlin' Chains	Effect: "The Chains Down In The Belly-O", Effect Duration: 20, Last Available: "2011-10"
 Item	really thick spine	Effect: "Extra Backbone", Effect Duration: 15
 Item	recording of Benetton's Medley of Diversity	Effect: "Benetton's Medley of Diversity", Effect Duration: 20
 Item	recording of Chorale of Companionship	Effect: "Chorale of Companionship", Effect Duration: 20
 Item	recording of Donho's Bubbly Ballad	Effect: "Donho's Bubbly Ballad", Effect Duration: 20
 Item	recording of Elron's Explosive Etude	Effect: "Elron's Explosive Etude", Effect Duration: 20
-Item	recording of Inigo's Incantation of Inspiration	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 20
+Item	recording of Inigo's Incantation of Inspiration	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 20, Last Available: "2010-02"
 Item	recording of Prelude of Precision	Effect: "Prelude of Precision", Effect Duration: 20
-Item	recording of Rolando's Rondo of Resisto	Effect: "Rolando's Rondo of Resisto", Effect Duration: 20
+Item	recording of Rolando's Rondo of Resisto	Effect: "Rolando's Rondo of Resisto", Effect Duration: 20, Last Available: "2013-12"
 Item	recording of The Ballad of Richie Thingfinder	Effect: "The Ballad of Richie Thingfinder", Effect Duration: 20
 Item	red blood cells	Effect: "Extra-Thick Blood", Effect Duration: 100
 Item	red eye	Effect: "Seeing Red", Effect Duration: 20
 Item	red foxglove	Effect: "Digitalis, Dig It", Effect Duration: 10
 Item	red letter	Effect: "Red Lettered", Effect Duration: 20
-Item	Red Pill	Effect: "There is No Spoon", Effect Duration: 5
-Item	red snowcone	Effect: "Red Tongue", Effect Duration: 20
+Item	Red Pill	Effect: "There is No Spoon", Effect Duration: 5, Last Available: "2011-04"
+Item	red snowcone	Effect: "Red Tongue", Effect Duration: 20, Last Available: "2006-01"
 Item	reodorant	Effect: "Hippy Stench", Effect Duration: 10
-Item	resolution: be feistier	Effect: "Destructive Resolve", Effect Duration: 20
-Item	resolution: be happier	Effect: "Joyful Resolve", Effect Duration: 20
-Item	resolution: be kinder	Effect: "Kindly Resolve", Effect Duration: 20
-Item	resolution: be luckier	Effect: "Fortunate Resolve", Effect Duration: 20
-Item	resolution: be sexier	Effect: "Irresistible Resolve", Effect Duration: 20
-Item	resolution: be smarter	Effect: "Brilliant Resolve", Effect Duration: 20
-Item	resolution: be stronger	Effect: "Strong Resolve", Effect Duration: 20
-Item	resolution: be wealthier	Effect: "Greedy Resolve", Effect Duration: 20
+Item	resolution: be feistier	Effect: "Destructive Resolve", Effect Duration: 20, Last Available: "2012-01"
+Item	resolution: be happier	Effect: "Joyful Resolve", Effect Duration: 20, Last Available: "2012-01"
+Item	resolution: be kinder	Effect: "Kindly Resolve", Effect Duration: 20, Last Available: "2012-01"
+Item	resolution: be luckier	Effect: "Fortunate Resolve", Effect Duration: 20, Last Available: "2012-01"
+Item	resolution: be sexier	Effect: "Irresistible Resolve", Effect Duration: 20, Last Available: "2012-01"
+Item	resolution: be smarter	Effect: "Brilliant Resolve", Effect Duration: 20, Last Available: "2012-01"
+Item	resolution: be stronger	Effect: "Strong Resolve", Effect Duration: 20, Last Available: "2012-01"
+Item	resolution: be wealthier	Effect: "Greedy Resolve", Effect Duration: 20, Last Available: "2012-01"
 Item	rhinestone	Effect: "Rhinestoned", Effect Duration: 1
-Item	ribbon candy	Effect: "Sugar Rush", Effect Duration: 10
+Item	ribbon candy	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2020-09"
 # robin's egg: When used in combat: weakens enemies by 50% and briefly stuns them
-Item	robin's egg	Effect: "Egged On", Effect Duration: 10
+Item	robin's egg	Effect: "Egged On", Effect Duration: 10, Last Available: "2016-12"
 Item	robot grease	Effect: "Greasy Peasy", Effect Duration: 30
 Item	Rock Pops	Effect: "Sugar Rush", Effect Duration: 3
 Item	roll of meat	Effect: "Stick Emporium Membership", Effect Duration: 50
-Item	rubber nubbin	Effect: "You're Rubber", Effect Duration: 20
-Item	ruby on canes	Effect: "Ruby-ous", Effect Duration: 20
+Item	rubber nubbin	Effect: "You're Rubber", Effect Duration: 20, Last Available: "2014-08"
+Item	ruby on canes	Effect: "Ruby-ous", Effect Duration: 20, Last Available: "2014-12"
 Item	rum ball	Effect: "Rummy", Effect Duration: 20
-Item	runproof mascara	Effect: "Unrunnable Face", Effect Duration: 20
+Item	runproof mascara	Effect: "Unrunnable Face", Effect Duration: 20, Last Available: "2018-09"
 Item	salamander slurry	Effect: "Salamander In Your Stomach", Effect Duration: [R]
-Item	Salsa Caliente&trade; candle	Effect: "El Aroma de Salsa", Effect Duration: 40
+Item	Salsa Caliente&trade; candle	Effect: "El Aroma de Salsa", Effect Duration: 40, Last Available: "2021-08"
 Item	salt wages	Effect: "Worth Your Salt", Effect Duration: 30
 Item	salty drippy candy bar	Effect: "Bit-o-Salt", Effect Duration: 10
-Item	salty gumdrop	Effect: "Salt Rush", Effect Duration: 1
+Item	salty gumdrop	Effect: "Salt Rush", Effect Duration: 1, Last Available: "2019-12"
 Item	sampler size toothpaste	Effect: "Very Clean Teeth", Effect Duration: 10
-Item	Scent of a Human&trade; candle	Effect: "Ew, The Humanity", Effect Duration: 40
+Item	Scent of a Human&trade; candle	Effect: "Ew, The Humanity", Effect Duration: 40, Last Available: "2021-08"
 Item	scrap metal	Effect: "Armor-Plated", Effect Duration: 20
 Item	scrap of shadow	Effect: "Scrappy, Shadowy", Effect Duration: 10
-Item	scroll case	Effect: "Medieval Mage Mayhem", Effect Duration: 30
-Item	scroll of minor invulnerability	Effect: "Minor Invulnerability", Effect Duration: 20
-Item	scroll of Protection from Bad Stuff	Effect: "Protection from Bad Stuff", Effect Duration: 20
-Item	scroll of protection from lycanthropes	Effect: "Protection from Lycanthropes", Effect Duration: 50
-Item	scroll of Puddingskin	Effect: "Puddingskin", Effect Duration: 80
+Item	scroll case	Effect: "Medieval Mage Mayhem", Effect Duration: 30, Last Available: "2014-12"
+Item	scroll of minor invulnerability	Effect: "Minor Invulnerability", Effect Duration: 20, Last Available: "2023-06"
+Item	scroll of Protection from Bad Stuff	Effect: "Protection from Bad Stuff", Effect Duration: 20, Last Available: "2013-02"
+Item	scroll of protection from lycanthropes	Effect: "Protection from Lycanthropes", Effect Duration: 50, Last Available: "2023-06"
+Item	scroll of Puddingskin	Effect: "Puddingskin", Effect Duration: 80, Last Available: "2013-02"
 Item	sea grease	Effect: "Greased-Up Familiar", Effect Duration: 40
 Item	sea salt crystal	Effect: "Salty Dogs", Effect Duration: 5
 Item	seal eyeball	Effect: "Eye of the Seal", Effect Duration: 10
@@ -11045,151 +11045,151 @@ Item	seal-brain elixir	Effect: "Sealed Brain", Effect Duration: 20
 Item	sealhide seal doll	Effect: "Red Misty-Eyed", Effect Duration: 10
 Item	seegar butt	Effect: "Stinking Cloud", Effect Duration: 10
 Item	Senior Mints	Effect: "Sugar Rush", Effect Duration: 3
-Item	sensitive poetry journal	Effect: "Moon June Spooned", Effect Duration: 10
+Item	sensitive poetry journal	Effect: "Moon June Spooned", Effect Duration: 10, Last Available: "2007-06"
 Item	serum of sarcasm	Effect: "Superhuman Sarcasm", Effect Duration: [R]
 Item	shady shades	Effect: "Throwing Some Shade", Effect Duration: 1
 Item	shark cartilage	Effect: "Swimming with Sharks", Effect Duration: 15
-Item	sharkfin gumbo	Effect: "Shark-Tooth Grin", Effect Duration: 1
+Item	sharkfin gumbo	Effect: "Shark-Tooth Grin", Effect Duration: 1, Last Available: "2018-07"
 Item	shavin' razor	Effect: "Hairless and Airless", Effect Duration: 30
-Item	Shielding Potion	Effect: "Remaining Alive", Effect Duration: 10
-Item	shim of shame shale	Effect: "Too Shamed", Effect Duration: 20
-Item	shoe gum	Effect: "Gummed Shoes", Effect Duration: 50
-Item	short beer	Effect: "Shortly Drunk", Effect Duration: 11
-Item	short glass of water	Effect: "Shortly Hydrated", Effect Duration: 11
-Item	short stack of pancakes	Effect: "Shortly Stacked", Effect Duration: 11
-Item	short stick of butter	Effect: "Shortly Buttered", Effect Duration: 11
-Item	short white	Effect: "Shortly Wired", Effect Duration: 11
-Item	shoulder-warming lotion	Effect: "Warm Shoulders", Effect Duration: 20
+Item	Shielding Potion	Effect: "Remaining Alive", Effect Duration: 10, Last Available: "2018-06"
+Item	shim of shame shale	Effect: "Too Shamed", Effect Duration: 20, Last Available: "2023-02"
+Item	shoe gum	Effect: "Gummed Shoes", Effect Duration: 50, Last Available: "2016-07"
+Item	short beer	Effect: "Shortly Drunk", Effect Duration: 11, Last Available: "2021-05"
+Item	short glass of water	Effect: "Shortly Hydrated", Effect Duration: 11, Last Available: "2021-05"
+Item	short stack of pancakes	Effect: "Shortly Stacked", Effect Duration: 11, Last Available: "2021-05"
+Item	short stick of butter	Effect: "Shortly Buttered", Effect Duration: 11, Last Available: "2021-05"
+Item	short white	Effect: "Shortly Wired", Effect Duration: 11, Last Available: "2021-05"
+Item	shoulder-warming lotion	Effect: "Warm Shoulders", Effect Duration: 20, Last Available: "2015-11"
 Item	Shrieking Weasel holo-record	Effect: "Shrieking Weasel", Effect Duration: 10
-Item	shrimp cocktail	Effect: "Shrimpin' Ain't Easy", Effect Duration: 20
+Item	shrimp cocktail	Effect: "Shrimpin' Ain't Easy", Effect Duration: 20, Last Available: "2014-05"
 Item	Shrubble Bubble	Effect: "Jawin'", Effect Duration: 10
 Item	silver face paint	Effect: "Robot Friends", Effect Duration: 1
 Item	single of Donho's Bubbly Ballad	Effect: "Donho's Bubbly Ballad", Effect Duration: 10
-Item	single of Inigo's Incantation of Inspiration	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 10
-Item	single-use dust mask	Effect: "Temporarily Filtered", Effect Duration: 20
+Item	single of Inigo's Incantation of Inspiration	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 10, Last Available: "2010-02"
+Item	single-use dust mask	Effect: "Temporarily Filtered", Effect Duration: 20, Last Available: "2022-05"
 Item	sizzling seal fat	Effect: "Sizzling with Fury", Effect Duration: 10
 Item	skin oil	Effect: "Oiled Skin", Effect Duration: 20
 Item	sleaze nuggets	Effect: "Sleazy Weapon", Effect Duration: 5
 Item	sleaze powder	Effect: "Sleaze-Resistant Trousers", Effect Duration: 5
-Item	sleight-of-hand mushroom	Effect: "Sleight of Mind", Effect Duration: 3
+Item	sleight-of-hand mushroom	Effect: "Sleight of Mind", Effect Duration: 3, Last Available: "2014-05"
 Item	sludgesicle	Effect: "Sludgesick", Effect Duration: 10
-Item	small gummi fin	Effect: "Sweet Taste", Effect Duration: 10
-Item	smart watch	Effect: "Watch Out!", Effect Duration: 50
-Item	Smoldering Clover&trade; candle	Effect: "Good Things Are Coming, You Can Smell It", Effect Duration: 40
-Item	smudge stick	Effect: "Wreathed in Smoke", Effect Duration: 10
+Item	small gummi fin	Effect: "Sweet Taste", Effect Duration: 10, Last Available: "2014-12"
+Item	smart watch	Effect: "Watch Out!", Effect Duration: 50, Last Available: "2014-12"
+Item	Smoldering Clover&trade; candle	Effect: "Good Things Are Coming, You Can Smell It", Effect Duration: 40, Last Available: "2021-08"
+Item	smudge stick	Effect: "Wreathed in Smoke", Effect Duration: 10, Last Available: "2014-12"
 Item	snake	Effect: "Sneaky Serpentine Subtlety", Effect Duration: 50, Wiki Name: "snake"
-Item	snow cleats	Effect: "Snow Shoes", Effect Duration: 30
+Item	snow cleats	Effect: "Snow Shoes", Effect Duration: 30, Last Available: "2014-01"
 Item	sodium pentasomething	Effect: "Truthful", Effect Duration: 20
-Item	sorority brain	Effect: "Let's Go Shopping!", Effect Duration: 20
-Item	sour powder	Effect: "Puckered Up", Effect Duration: 5
+Item	sorority brain	Effect: "Let's Go Shopping!", Effect Duration: 20, Last Available: "2011-10"
+Item	sour powder	Effect: "Puckered Up", Effect Duration: 5, Last Available: "2014-12"
 Item	Spant eggs	Effect: "Sugary World View", Effect Duration: 10
-Item	spare battery	Effect: "Tingly Tongue", Effect Duration: 20
+Item	spare battery	Effect: "Tingly Tongue", Effect Duration: 20, Last Available: "2022-05"
 Item	sparkler	Effect: "Sparkling Consciousness", Effect Duration: 50
 Item	Spechunky bar	Effect: "Chunky", Effect Duration: 10
 Item	SPF 451 lip balm	Effect: "Fireproof Lips", Effect Duration: 10
-Item	spidercow eye-cluster	Effect: "Spidercow Vision", Effect Duration: 10
+Item	spidercow eye-cluster	Effect: "Spidercow Vision", Effect Duration: 10, Last Available: "2016-02"
 Item	spirit gum	Effect: "Spirit Bubble", Effect Duration: 10
 Item	spooky eyeliner	Effect: "Gothy", Effect Duration: 10
 Item	spooky lipstick	Effect: "Gothy", Effect Duration: 10
 Item	spooky nuggets	Effect: "Spooky Weapon", Effect Duration: 5
 Item	spooky powder	Effect: "Spookypants", Effect Duration: 5
 # spooky sap: Weakens enemies a lot when used as a combat item
-Item	spooky sap	Effect: "Sugar Rush", Effect Duration: 5
+Item	spooky sap	Effect: "Sugar Rush", Effect Duration: 5, Last Available: "2009-10"
 Item	spooky sound effects record	Effect: "Permanent Halloween", Effect Duration: 10
-Item	spoonful of Linguine-Os	Effect: "Blessing of the Hot Linguine", Effect Duration: 10
-Item	Spring Break Beach &quot;swimsuit&quot;	Effect: "Painted-On Bikini", Effect Duration: 50
+Item	spoonful of Linguine-Os	Effect: "Blessing of the Hot Linguine", Effect Duration: 10, Last Available: "2013-11"
+Item	Spring Break Beach &quot;swimsuit&quot;	Effect: "Painted-On Bikini", Effect Duration: 50, Last Available: "2015-11"
 Item	Squat-Thrust Magazine	Effect: "Squatting and Thrusting", Effect Duration: 20
 Item	squeaky toy rose	Effect: "A Rose by Any Other Material", Effect Duration: 1
 Item	stained hard candy	Effect: "Stained", Effect Duration: 20
 Item	Steal This Candy	Effect: "A Revolution in Your Mouth", Effect Duration: 10
-Item	Stemonitis Staticus mushroom	Effect: "Stemonitis Storm", Effect Duration: 10
+Item	Stemonitis Staticus mushroom	Effect: "Stemonitis Storm", Effect Duration: 10, Last Available: "2014-05"
 Item	stench nuggets	Effect: "Stinky Weapon", Effect Duration: 5
 Item	stench powder	Effect: "Smelly Pants", Effect Duration: 5
 Item	Stephen's secret formula	Effect: "Spookyravin'", Effect Duration: 20
 Item	sterno-flavored Hob-O	Effect: "Fire Down Below", Effect Duration: 1
-Item	sticky lava globs	Effect: "Burning Hands", Effect Duration: 20
+Item	sticky lava globs	Effect: "Burning Hands", Effect Duration: 20, Last Available: "2015-08"
 Item	stone wool	Effect: "Stone-Faced", Effect Duration: 5
-Item	strawberry supersucker	Effect: "Strawberry Alarm", Effect Duration: 30
+Item	strawberry supersucker	Effect: "Strawberry Alarm", Effect Duration: 30, Last Available: "2011-11"
 Item	strawberry-flavored Hob-O	Effect: "Scariberi", Effect Duration: 1
 Item	STYX deodorant body spray	Effect: "Less Pervious", Effect Duration: 10
-Item	sugar banana	Effect: "Sweet and Yellow", Effect Duration: 10
-Item	sugar bunny	Effect: "Sweet Incentive", Effect Duration: 20
-Item	sugar cherry	Effect: "Sweet and Red", Effect Duration: 10
+Item	sugar banana	Effect: "Sweet and Yellow", Effect Duration: 10, Last Available: "2008-12"
+Item	sugar bunny	Effect: "Sweet Incentive", Effect Duration: 20, Last Available: "2014-05"
+Item	sugar cherry	Effect: "Sweet and Red", Effect Duration: 10, Last Available: "2008-12"
 Item	Sugar Cog	Effect: "Sugar Rush", Effect Duration: 5
-Item	sugar fairy	Effect: "Dance of the Sugar Fairy", Effect Duration: 20
-Item	sugar lime	Effect: "Sweet and Green", Effect Duration: 10
+Item	sugar fairy	Effect: "Dance of the Sugar Fairy", Effect Duration: 20, Last Available: "2014-05"
+Item	sugar lime	Effect: "Sweet and Green", Effect Duration: 10, Last Available: "2008-12"
 Item	sugar sphere	Effect: "Influence of Sphere", Effect Duration: 10
-Item	sugar-coated pine cone	Effect: "Sugar Rush", Effect Duration: 5
+Item	sugar-coated pine cone	Effect: "Sugar Rush", Effect Duration: 5, Last Available: "2020-09"
 Item	Super Weight-Gain 9000	Effect: "Superveiny 9000", Effect Duration: 10
 Item	super-spiky hair gel	Effect: "Spiky Hair", Effect Duration: 5
 Item	Superdrifter holo-record	Effect: "Superdrifting", Effect Duration: 10
 Item	superwater	Effect: "Ultrahydrated", Effect Duration: 50
 Item	Swabbie&trade; swab	Effect: "Well-Swabbed Ear", Effect Duration: 10
 Item	swamp lolly	Effect: "Sugar Rush", Effect Duration: 10
-Item	Sweet Sword	Effect: "Sugar Rush", Effect Duration: 10
-Item	sweet-corn-flavored Mr. Mediocrebar	Effect: "Kernel Panic!", Effect Duration: 30
+Item	Sweet Sword	Effect: "Sugar Rush", Effect Duration: 10, Last Available: "2011-10"
+Item	sweet-corn-flavored Mr. Mediocrebar	Effect: "Kernel Panic!", Effect Duration: 30, Last Available: "2012-12"
 Item	sweetened reindeer fat	Effect: "Sweetened and Fattened", Effect Duration: 20
 Item	Swizzler	Effect: "Sugar Rush", Effect Duration: 5
 Item	synthetic coffee	Effect: "Synthetic Buzz", Effect Duration: 10
-Item	Taco Dan's Taco Stand Chillacious Churro	Effect: "Churro Chiaroscuro", Effect Duration: 5
-Item	tainted icing	Effect: "Iced and Tainted", Effect Duration: 10
+Item	Taco Dan's Taco Stand Chillacious Churro	Effect: "Churro Chiaroscuro", Effect Duration: 5, Last Available: "2012-12"
+Item	tainted icing	Effect: "Iced and Tainted", Effect Duration: 10, Last Available: "2016-12"
 Item	tainted seal's blood	Effect: "Corruption of Wretched Wally", Effect Duration: 10
 Item	Take Eleven Bar	Effect: "Took Eleven", Effect Duration: 20
 # talisman of Horus: Attracts the attention of monsters
 Item	talisman of Horus	Effect: "Taunt of Horus", Effect Duration: 10
 Item	Tallowcreme Halloween Pumpkin	Effect: "Halloweeny", Effect Duration: 10
 Item	tamarind-flavored chewing gum	Effect: "Tamarind Torment", Effect Duration: 5
-Item	tangled mass of creepy pasta	Effect: "Blessing of the Creepy Pasta", Effect Duration: 10
+Item	tangled mass of creepy pasta	Effect: "Blessing of the Creepy Pasta", Effect Duration: 10, Last Available: "2013-11"
 Item	Tasty Fun Good rice candy	Effect: "Sugar Rush", Effect Duration: 5
 Item	teeny-tiny magic scroll	Effect: "Happy Trails", Effect Duration: 10
 Item	temporary teardrop tattoo	Effect: "Crocodile Tear", Effect Duration: 15
-Item	temporary X tattoos	Effect: "Straight-Edgy", Effect Duration: 100
+Item	temporary X tattoos	Effect: "Straight-Edgy", Effect Duration: 100, Last Available: "2017-10"
 Item	tempura air	Effect: "Pumped Stomach", Effect Duration: 20
 Item	terra panna cotta	Effect: "Panna Consideration", Effect Duration: 20
 Item	Texas tea	Effect: "Texas Elegance", Effect Duration: 10
-Item	That 70s Cologne	Effect: "Yeah, It's Just Gasoline", Effect Duration: 50
+Item	That 70s Cologne	Effect: "Yeah, It's Just Gasoline", Effect Duration: 50, Last Available: "2015-11"
 Item	that gum you like	Effect: "Sugar Rush", Effect Duration: 5
-Item	The Beast Within&trade; candle	Effect: "A Beastly Odor", Effect Duration: 40
-Item	the most dangerous bait	Effect: "Manbait", Effect Duration: 20
+Item	The Beast Within&trade; candle	Effect: "A Beastly Odor", Effect Duration: 40, Last Available: "2021-08"
+Item	the most dangerous bait	Effect: "Manbait", Effect Duration: 20, Last Available: "2014-10"
 Item	The Pigs holo-record	Effect: "Record Hunger", Effect Duration: 10
-Item	They liver	Effect: "You Liver", Effect Duration: 20
+Item	They liver	Effect: "You Liver", Effect Duration: 20, Last Available: "2014-09"
 Item	thin black candle	Effect: "Rainy Soul Miasma", Effect Duration: 10
 Item	Threatening Missive	Effect: "Annoyed by Threats", Effect Duration: 30
-Item	tightly-wound spine	Effect: "Tightly-Wound Spine", Effect Duration: 20
-Item	tin cup	Effect: "Tingling Feeling", Effect Duration: 20
-Item	tin magnolia	Effect: "Tin, Man", Effect Duration: 10
-Item	tin thermos of chai	Effect: "Chai Guru Deva Om", Effect Duration: 30
-Item	tiny bottle of absinthe	Effect: "Absinthe-Minded", Effect Duration: 10
+Item	tightly-wound spine	Effect: "Tightly-Wound Spine", Effect Duration: 20, Last Available: "2016-02"
+Item	tin cup	Effect: "Tingling Feeling", Effect Duration: 20, Last Available: "2013-09"
+Item	tin magnolia	Effect: "Tin, Man", Effect Duration: 10, Last Available: "2007-05"
+Item	tin thermos of chai	Effect: "Chai Guru Deva Om", Effect Duration: 30, Last Available: "2019-12"
+Item	tiny bottle of absinthe	Effect: "Absinthe-Minded", Effect Duration: 10, Last Available: "2007-06"
 Item	tiny dancer	Effect: "Held Closer", Effect Duration: 20
-Item	tiny handful of mixed nuts	Effect: "Mixed Nutrients", Effect Duration: 10
-Item	tobiko marble soda	Effect: "Pisces in the Skyces", Effect Duration: 15
+Item	tiny handful of mixed nuts	Effect: "Mixed Nutrients", Effect Duration: 10, Last Available: "2019-12"
+Item	tobiko marble soda	Effect: "Pisces in the Skyces", Effect Duration: 15, Last Available: "2011-03"
 Item	tomato juice of powerful power	Effect: "Tomato Power", Effect Duration: [R]
-Item	tonic o' Banderas	Effect: "Bandersnatched", Effect Duration: 20
-Item	too legit potion	Effect: "Hammertime", Effect Duration: 30
+Item	tonic o' Banderas	Effect: "Bandersnatched", Effect Duration: 20, Last Available: "2018-02"
+Item	too legit potion	Effect: "Hammertime", Effect Duration: 30, Last Available: "2011-09"
 Item	Trainbot circuitry	Effect: "Trainbot Circuitry", Effect Duration: 1
 Item	Trainbot linkages	Effect: "Trainbot Linkages", Effect Duration: 1
 Item	Trainbot optics	Effect: "Trainbot Optics", Effect Duration: 1
 Item	Trainbot plating	Effect: "Trainbot Plating", Effect Duration: 1
 Item	Trainbot servomotors	Effect: "Trainbot Servomotors", Effect Duration: 1
 Item	Trainbot tubing	Effect: "Trainbot Tubing", Effect Duration: 1
-Item	trampled ticket stub	Effect: "Feeling Sneaky", Effect Duration: 30
-Item	transporter transponder	Effect: "Transpondent", Effect Duration: 30
-Item	Tremella Tarantella mushroom	Effect: "Tremella Tremens", Effect Duration: 10
-Item	triggerfingerbone	Effect: "Itchy Trigger Finger", Effect Duration: 20
+Item	trampled ticket stub	Effect: "Feeling Sneaky", Effect Duration: 30, Last Available: "2022-06"
+Item	transporter transponder	Effect: "Transpondent", Effect Duration: 30, Last Available: "2011-06"
+Item	Tremella Tarantella mushroom	Effect: "Tremella Tremens", Effect Duration: 10, Last Available: "2014-05"
+Item	triggerfingerbone	Effect: "Itchy Trigger Finger", Effect Duration: 20, Last Available: "2016-02"
 Item	true grit	Effect: "Truly Gritty", Effect Duration: 10
 Item	tube of dread wax	Effect: "Crusty Head", Effect Duration: 10
 Item	turtle pheromones	Effect: "Eau de Tortue", Effect Duration: 30
-Item	turtle voicebox	Effect: "Song of the Southern Turtle", Effect Duration: 15
+Item	turtle voicebox	Effect: "Song of the Southern Turtle", Effect Duration: 15, Last Available: "2015-04"
 Item	twinkly nuggets	Effect: "Twinkly Weapon", Effect Duration: 5
 Item	twinkly powder	Effect: "Twinklebritches", Effect Duration: 5
-Item	ultra-soft ferns	Effect: "Ultra-Soft Steps", Effect Duration: 5
-Item	Ultrasoldier Serum	Effect: "Army of One", Effect Duration: 50
-Item	Uncle Greenspan's Bathroom Finance Guide	Effect: "Buy!  Sell!  Buy!  Sell!", Effect Duration: 100
-Item	unfinished pleasure	Effect: "Pleasant Forecast", Effect Duration: 20
-Item	universal antivenin	Lasts Until Rollover, Effect: "Fantastic Immunity", Effect Duration: 10
-Item	unstable DNA	Effect: "Yuletide Mutations", Effect Duration: 10
+Item	ultra-soft ferns	Effect: "Ultra-Soft Steps", Effect Duration: 5, Last Available: "2024-02"
+Item	Ultrasoldier Serum	Effect: "Army of One", Effect Duration: 50, Last Available: "2011-06"
+Item	Uncle Greenspan's Bathroom Finance Guide	Effect: "Buy!  Sell!  Buy!  Sell!", Effect Duration: 100, Last Available: "2011-11"
+Item	unfinished pleasure	Effect: "Pleasant Forecast", Effect Duration: 20, Last Available: "2019-12"
+Item	universal antivenin	Lasts Until Rollover, Effect: "Fantastic Immunity", Effect Duration: 10, Last Available: "2018-04"
+Item	unstable DNA	Effect: "Yuletide Mutations", Effect Duration: 10, Last Available: "2008-12"
 Item	unusual oil	Effect: "Unusual Perspective", Effect Duration: 20
-Item	upsy daisy	Effect: "Ass Over Teakettle", Effect Duration: 10
+Item	upsy daisy	Effect: "Ass Over Teakettle", Effect Duration: 10, Last Available: "2007-05"
 Item	Velougats&trade;	Effect: "Velougated", Effect Duration: 5
 Item	vial of baconstone juice	Effect: "Baconstoned", Effect Duration: 5
 Item	vial of blood simple syrup	Effect: "Blood-Gorged", Effect Duration: 20
@@ -11200,50 +11200,50 @@ Item	vial of squid ink	Effect: "Inky Camouflage", Effect Duration: 20
 Item	vial of The Glistening	Effect: "The Glistening", Effect Duration: 15
 Item	violent pastilles	Effect: "Everything Must Go!", Effect Duration: 10
 Item	virgin jello shot	Effect: "Sugar Rush", Effect Duration: 100
-Item	votive of confidence	Effect: "Confidence of the Votive", Effect Duration: 80
-Item	VYKEA woadpaint	Effect: "This Is Where You're a Viking", Effect Duration: 30
+Item	votive of confidence	Effect: "Confidence of the Votive", Effect Duration: 80, Last Available: "2021-08"
+Item	VYKEA woadpaint	Effect: "This Is Where You're a Viking", Effect Duration: 30, Last Available: "2015-11"
 Item	wad of cotton	Effect: "Cotton Mouthed", Effect Duration: 50
-Item	Wal-Mart &quot;diamond&quot; ring	Effect: "Coldfinger", Effect Duration: 50
-Item	warbear bearserker potion	Effect: "Bearserker Bearrage", Effect Duration: 20
-Item	warbear liquid lasers	Effect: "Eyes for Miles", Effect Duration: 20
-Item	warbear liquid overcoat	Effect: "Warbear on the Inside", Effect Duration: 20
-Item	warbear rejuvenation potion	Effect: "New and Improved", Effect Duration: 20
-Item	warbear robo-camouflage unit	Effect: "Robocamo", Effect Duration: 100
-Item	warbear superpotion	Effect: "Warbear Hunter", Effect Duration: 50
-Item	warbear wardance potion	Effect: "Dances with Warbears", Effect Duration: 20
+Item	Wal-Mart &quot;diamond&quot; ring	Effect: "Coldfinger", Effect Duration: 50, Last Available: "2015-11"
+Item	warbear bearserker potion	Effect: "Bearserker Bearrage", Effect Duration: 20, Last Available: "2013-12"
+Item	warbear liquid lasers	Effect: "Eyes for Miles", Effect Duration: 20, Last Available: "2013-12"
+Item	warbear liquid overcoat	Effect: "Warbear on the Inside", Effect Duration: 20, Last Available: "2013-12"
+Item	warbear rejuvenation potion	Effect: "New and Improved", Effect Duration: 20, Last Available: "2013-12"
+Item	warbear robo-camouflage unit	Effect: "Robocamo", Effect Duration: 100, Last Available: "2013-12"
+Item	warbear superpotion	Effect: "Warbear Hunter", Effect Duration: 50, Last Available: "2013-12"
+Item	warbear wardance potion	Effect: "Dances with Warbears", Effect Duration: 20, Last Available: "2013-12"
 Item	warm El Vibrato drone	Effect: "Well-preserved", Effect Duration: 10
-Item	wasabi marble soda	Effect: "Wasabi With You", Effect Duration: 15
+Item	wasabi marble soda	Effect: "Wasabi With You", Effect Duration: 15, Last Available: "2011-03"
 Item	Wax Flask	Effect: "Over the Ocean", Effect Duration: 1
 Item	weremoose spit	Effect: "Lycanthropy, Eh?", Effect Duration: 20
-Item	wet venom duct	Effect: "Duct Out of Water", Effect Duration: 10
-Item	whale cerebrospinal fluid	Effect: "Whalethoughts", Effect Duration: 50
+Item	wet venom duct	Effect: "Duct Out of Water", Effect Duration: 10, Last Available: "2010-09"
+Item	whale cerebrospinal fluid	Effect: "Whalethoughts", Effect Duration: 50, Last Available: "2023-12"
 Item	Whenchamacallit bar	Effect: "Spooky Blur", Effect Duration: 20
 Item	white blood cells	Effect: "White Blooded", Effect Duration: 50
-Item	white candy heart	Effect: "Heart of White", Effect Duration: 10
+Item	white candy heart	Effect: "Heart of White", Effect Duration: 10, Last Available: "2007-02"
 Item	Wickers bar	Effect: "Weally Satisfied", Effect Duration: 10
-Item	willyweed	Effect: "Wet Willied", Effect Duration: 30
+Item	willyweed	Effect: "Wet Willied", Effect Duration: 30, Last Available: "2011-05"
 Item	wind-up ensign	Effect: "Red-Shirted Escort", Effect Duration: 20
-Item	wind-up meatcar	Effect: "All Wound Up", Effect Duration: 100
+Item	wind-up meatcar	Effect: "All Wound Up", Effect Duration: 100, Last Available: "2011-11"
 Item	wind-up navigation droid	Effect: "Good Motivator", Effect Duration: 20
 Item	wind-up owl	Effect: "Well Owl Be!", Effect Duration: 20
 Item	wind-up vampire teeth	Effect: "Fangs and Pangs", Effect Duration: 20
 Item	wind-up Whatsian robot	Effect: "EVISCERATE!", Effect Duration: 20
 Item	Wint-O-Fresh mint	Effect: "Sugar Rush", Effect Duration: 3
 Item	wintergreen-flavored potato chips	Effect: "Wintergreen Warmongery", Effect Duration: 10
-Item	witch's brew	Effect: "Witch's Brood", Effect Duration: 50
+Item	witch's brew	Effect: "Witch's Brood", Effect Duration: 50, Last Available: "2014-12"
 Item	worst candy	Effect: "Predjudicetidigitation", Effect Duration: 10
-Item	wriggling worm	Effect: "Baited Hook", Effect Duration: 100
+Item	wriggling worm	Effect: "Baited Hook", Effect Duration: 100, Last Available: "2016-04"
 Item	writhing drippy candy bar	Effect: "Slithering Mounds", Effect Duration: 10
 Item	Wrotz	Effect: "Wrought Nerves", Effect Duration: 20
 Item	Ye Olde Bawdy Limerick	Effect: "From Nantucket", Effect Duration: 20
-Item	Yeg's Motel hand soap	Effect: "Sigils of Yeg", Effect Duration: 50
-Item	Yeg's Motel mouthwash	Effect: "Breath of Yeg", Effect Duration: 50
-Item	Yeg's Motel toothbrush	Effect: "Rictus of Yeg", Effect Duration: 50
-Item	yellow candy heart	Effect: "Heart of Yellow", Effect Duration: 10
-Item	yellow pixel potion	Effect: "WAKKA WAKKA WAKKA", Effect Duration: 20
-Item	yellow seashell	Effect: "Boisterous Oysterous", Effect Duration: 20
-Item	yellow snowcone	Effect: "Yellow Tongue", Effect Duration: 20
-Item	Yolo&trade; chocolates	Effect: "Yoloswagyoloswag", Effect Duration: 5
+Item	Yeg's Motel hand soap	Effect: "Sigils of Yeg", Effect Duration: 50, Last Available: "2020-09"
+Item	Yeg's Motel mouthwash	Effect: "Breath of Yeg", Effect Duration: 50, Last Available: "2020-09"
+Item	Yeg's Motel toothbrush	Effect: "Rictus of Yeg", Effect Duration: 50, Last Available: "2020-09"
+Item	yellow candy heart	Effect: "Heart of Yellow", Effect Duration: 10, Last Available: "2007-02"
+Item	yellow pixel potion	Effect: "WAKKA WAKKA WAKKA", Effect Duration: 20, Last Available: "2015-06"
+Item	yellow seashell	Effect: "Boisterous Oysterous", Effect Duration: 20, Last Available: "2019-07"
+Item	yellow snowcone	Effect: "Yellow Tongue", Effect Duration: 20, Last Available: "2006-04"
+Item	Yolo&trade; chocolates	Effect: "Yoloswagyoloswag", Effect Duration: 5, Last Available: "2020-09"
 Item	Yummy Tummy bean	Effect: "Sugar Rush", Effect Duration: 3
 
 # Avatar Potions section of modifiers.txt
@@ -11261,7 +11261,7 @@ Item	baggie of regular-sized tardigrades	Effect: "Waterborne", Effect Duration: 
 Item	baloney rotgut	Effect: "[1872]Hip to the Jive", Effect Duration: 100
 Item	Bangyomaman battle juice	Effect: "Pug Ugly", Effect Duration: 50
 Item	batarang	Effect: "Batwards Masking", Effect Duration: 50
-Item	bite-me-red lipstick	Effect: "Vampin'", Effect Duration: 30
+Item	bite-me-red lipstick	Effect: "Vampin'", Effect Duration: 30, Last Available: "2011-10"
 Item	black friar's tonsure	Effect: "Into the Friar", Effect Duration: 50
 Item	black magic powder	Effect: "Black Magic? Woah, Man!", Effect Duration: 50
 Item	blob of acid	Effect: "Lord of Acid", Effect Duration: 50
@@ -11321,7 +11321,7 @@ Item	funky eyepatch	Effect: "Godfather of Soul Patch", Effect Duration: 30
 Item	gamer slurry	Effect: "Guild by Association", Effect Duration: 50
 Item	garbage juice slurpee	Effect: "Slurpee-O'ed", Effect Duration: 30
 Item	Gearhead Goo	Effect: "Gearhead Gear", Effect Duration: 30
-Item	ghostly body paint	Effect: "Haunting Looks", Effect Duration: 30
+Item	ghostly body paint	Effect: "Haunting Looks", Effect Duration: 30, Last Available: "2011-10"
 Item	giant breath mint	Effect: "Three King-sized Sheets to the Wind", Effect Duration: 30
 Item	giant neckbeard	Effect: "Majestic Neckbeard", Effect Duration: 50
 Item	giant tube of black lipstick	Effect: "Visibly Goth", Effect Duration: 30
@@ -11367,7 +11367,7 @@ Item	Mansquito's blood	Effect: "Blood of the Jerk that Bit You", Effect Duration
 Item	mercenary headband	Effect: "Ramboner", Effect Duration: 30
 Item	Missing Eye Simulation Device	Effect: "Gnollivision", Effect Duration: 30
 Item	muscle oil	Effect: "Built Body", Effect Duration: 100
-Item	necrotizing body spray	Effect: "Dead Sexy", Effect Duration: 30
+Item	necrotizing body spray	Effect: "Dead Sexy", Effect Duration: 30, Last Available: "2011-10"
 Item	ninja eyeblack	Effect: "Waiting for Ninjas", Effect Duration: 50
 Item	ninja fear powder	Effect: "Ninja in Waiting", Effect Duration: 50
 Item	novelty fruit hat	Effect: "Skeleton in a Fruit Hat", Effect Duration: 30
@@ -11375,17 +11375,17 @@ Item	oil-filled donut	Effect: "To Protect and Servo", Effect Duration: 50
 Item	one glove	Effect: "Smoothly Criminal...ing", Effect Duration: 50
 Item	Osk'r Chow	Effect: "Walking Carpet", Effect Duration: 100
 Item	page of the Necrohobocon	Effect: "Ecce Wino", Effect Duration: 50
-Item	pebble of proud pyrite	Effect: "Pyrite Pride", Effect Duration: 20
+Item	pebble of proud pyrite	Effect: "Pyrite Pride", Effect Duration: 20, Last Available: "2023-02"
 Item	perpendicular guano	Effect: "Batted Around", Effect Duration: 30
 Item	pickpocket protector	Effect: "Ennerderated", Effect Duration: 50
 Item	piggy tattoo	Effect: "Pigulated", Effect Duration: 30
-Item	pile of gritty sand	Effect: "Gritty", Effect Duration: 20
+Item	pile of gritty sand	Effect: "Gritty", Effect Duration: 20, Last Available: "2023-02"
 Item	pirate cream pie	Effect: "Well Excuuuuse Me!", Effect Duration: 30
 Item	plague pie	Effect: "When the Plague Hits Your Eye", Effect Duration: 50
 Item	plastic Jefferson wings	Effect: "Jeffersonian", Effect Duration: 50
 Item	plunge-leg	Effect: "Pediplunger", Effect Duration: 30
 Item	porkpocket	Effect: "Porkpocketed", Effect Duration: 50
-Item	press-on ribs	Effect: "The Bone Us Round", Effect Duration: 30
+Item	press-on ribs	Effect: "The Bone Us Round", Effect Duration: 30, Last Available: "2011-10"
 Item	punk patch	Effect: "Patchy Punk", Effect Duration: 50
 Item	pygmy adder oil	Effect: "A Taste for Accounting", Effect Duration: 50
 Item	pygmy dart	Effect: "Short of Breath", Effect Duration: 30
@@ -11399,7 +11399,7 @@ Item	red-hot jawbreaker	Effect: "Burns Effect", Effect Duration: 50
 Item	Redeye&trade; Eyedrops	Effect: "Dazed, Confused", Effect Duration: 50
 Item	Rogue Windmill Rouge	Effect: "Mister Master", Effect Duration: 30
 Item	salt water taffy	Effect: "Bedraggled Dragoon", Effect Duration: 30
-Item	savings bond	Effect: "Earning Interest", Effect Duration: 30
+Item	savings bond	Effect: "Earning Interest", Effect Duration: 30, Last Available: "2022-06"
 Item	scrunchie tourniquet	Effect: "First, Like, Do No Harm?", Effect Duration: 50
 Item	Scuba Snack	Effect: "Jinkies!", Effect Duration: 100
 Item	secret mummy herbs and spices	Effect: "Like an Egyptian", Effect Duration: 30
@@ -11442,7 +11442,7 @@ Item	voodoo glowskull	Effect: "Shortie Shaman Shurprise", Effect Duration: 50
 Item	votive candle	Effect: "Clerical Aura", Effect Duration: 100
 Item	warehouse clerk's glasses	Effect: "Disguised as a Warehouse Clerk", Effect Duration: 30
 Item	warehouse walkie-talkie	Effect: "Wearing a Guard's Hat", Effect Duration: 30
-Item	whisker pencil	Effect: "Yiffable You", Effect Duration: 30
+Item	whisker pencil	Effect: "Yiffable You", Effect Duration: 30, Last Available: "2011-10"
 Item	White Chocolate Golem Seeds	Effect: "[1060]Chocolate Reign", Effect Duration: 30
 Item	wrestling mask	Effect: "Cavemanipulated", Effect Duration: 30
 Item	x-ray mirror	Effect: "The Visible Adventurer", Effect Duration: 30
@@ -11463,32 +11463,32 @@ Item	zombie hollandaise	Effect: "Chef Brains-are-dee", Effect Duration: 30
 # 33398 scroll: Mostly Just Confuses Enemies
 # 64067 scroll: Mostly Just Confuses Enemies
 # 64735 scroll: Mostly Just Confuses Enemies
-Item	A Beginner's Guide to Charming Snakes	Class: "Pastamancer", Skill: "Stringozzi Serpent"
-Item	A Beginner's Guide to Charming Snakes (used)	Class: "Pastamancer", Skill: "Stringozzi Serpent"
-Item	A Crimbo Carol, Ch. 1	Skill: "Holiday Weight Gain"
-Item	A Crimbo Carol, Ch. 1 (used)	Skill: "Holiday Weight Gain"
-Item	A Crimbo Carol, Ch. 2	Skill: "Jingle Bells"
-Item	A Crimbo Carol, Ch. 2 (used)	Skill: "Jingle Bells"
-Item	A Crimbo Carol, Ch. 3	Skill: "Candyblast"
-Item	A Crimbo Carol, Ch. 3 (used)	Skill: "Candyblast"
-Item	A Crimbo Carol, Ch. 4	Skill: "Surge of Icing"
-Item	A Crimbo Carol, Ch. 4 (used)	Skill: "Surge of Icing"
-Item	A Crimbo Carol, Ch. 5	Skill: "Stealth Mistletoe"
-Item	A Crimbo Carol, Ch. 5 (used)	Skill: "Stealth Mistletoe"
-Item	A Crimbo Carol, Ch. 6	Skill: "Cringle's Curative Carol"
-Item	A Crimbo Carol, Ch. 6 (used)	Skill: "Cringle's Curative Carol"
-Item	a cute angel	Free Pull
+Item	A Beginner's Guide to Charming Snakes	Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
+Item	A Beginner's Guide to Charming Snakes (used)	Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
+Item	A Crimbo Carol, Ch. 1	Skill: "Holiday Weight Gain", Last Available: "2009-12"
+Item	A Crimbo Carol, Ch. 1 (used)	Skill: "Holiday Weight Gain", Last Available: "2009-12"
+Item	A Crimbo Carol, Ch. 2	Skill: "Jingle Bells", Last Available: "2009-12"
+Item	A Crimbo Carol, Ch. 2 (used)	Skill: "Jingle Bells", Last Available: "2009-12"
+Item	A Crimbo Carol, Ch. 3	Skill: "Candyblast", Last Available: "2009-12"
+Item	A Crimbo Carol, Ch. 3 (used)	Skill: "Candyblast", Last Available: "2009-12"
+Item	A Crimbo Carol, Ch. 4	Skill: "Surge of Icing", Last Available: "2009-12"
+Item	A Crimbo Carol, Ch. 4 (used)	Skill: "Surge of Icing", Last Available: "2009-12"
+Item	A Crimbo Carol, Ch. 5	Skill: "Stealth Mistletoe", Last Available: "2009-12"
+Item	A Crimbo Carol, Ch. 5 (used)	Skill: "Stealth Mistletoe", Last Available: "2009-12"
+Item	A Crimbo Carol, Ch. 6	Skill: "Cringle's Curative Carol", Last Available: "2009-12"
+Item	A Crimbo Carol, Ch. 6 (used)	Skill: "Cringle's Curative Carol", Last Available: "2009-12"
+Item	a cute angel	Free Pull, Last Available: "2011-12"
 Item	A Guide to Burning Leaves	Free Pull, Leaves: +0.5
 Item	A Guide to Safari	Skill: "Experience Safari"
 # a ten-percent bonus: Gain 1,000 points in each stat
 # adder: Poisons your opponent
-Item	adventurer clone egg	Free Pull
+Item	adventurer clone egg	Free Pull, Last Available: "2013-06"
 Item	Aggressive Carrot	Free Pull
-Item	airplane charter: Conspiracy Island	Free Pull
-Item	airplane charter: Dinseylandfill	Free Pull
-Item	airplane charter: Spring Break Beach	Free Pull
-Item	airplane charter: That 70s Volcano	Free Pull
-Item	airplane charter: The Glaciest	Free Pull
+Item	airplane charter: Conspiracy Island	Free Pull, Last Available: "2014-10"
+Item	airplane charter: Dinseylandfill	Free Pull, Last Available: "2015-04"
+Item	airplane charter: Spring Break Beach	Free Pull, Last Available: "2014-05"
+Item	airplane charter: That 70s Volcano	Free Pull, Last Available: "2015-08"
+Item	airplane charter: The Glaciest	Free Pull, Last Available: "2015-11"
 # alien animal milk: Reduces your Fullness by 3
 # alien animal milk: (limit 1x / day)
 # alien gemstone: Worth 100 pages of Spacegate Research
@@ -11497,8 +11497,8 @@ Item	airplane charter: The Glaciest	Free Pull
 # alien plant pod: (limit 1x / day)
 # alien plant sample: Worth 3 pages of Spacegate Research
 # alien rock sample: Worth 3 pages of Spacegate Research
-Item	alien source code printout	Skill: "Alien Source Code"
-Item	alien source code printout (used)	Skill: "Alien Source Code"
+Item	alien source code printout	Skill: "Alien Source Code", Last Available: "2014-05"
+Item	alien source code printout (used)	Skill: "Alien Source Code", Last Available: "2014-05"
 # alien toenails: Worth 1 page of Spacegate Research
 # alien zoological sample: Worth 3 pages of Spacegate Research
 Item	all-purpose cleaner	Effect: "Soul-Crushing Headache", Effect Duration: 10
@@ -11509,7 +11509,7 @@ Item	all-year sucker	Effect: "Gonna Get You, Sucker", Effect Duration: 10
 # ancient Magi-Wipes: Restores 50-60 MP and HP and removes some negative effects
 # ancient poisoned dart: Poisons your opponent
 # ancient skull key: Presumably unlocks things in PirateRealm
-Item	ancient skull key	Lasts Until Rollover
+Item	ancient skull key	Lasts Until Rollover, Last Available: "2019-04"
 # ancient spice: Deals 30-40 Physical Damage
 # ancient spice: Weakens Enemies a Little Bit
 # anemone nematocyst: Stuns your opponent for a few rounds
@@ -11521,11 +11521,11 @@ Item	Antagonistic Snowman Kit	Skill: "Summon Carrot"
 # antique hand mirror: Be Careful!
 Item	antique hand mirror	Effect: "Bad Luck", Effect Duration: 7
 # antique tacklebox: (having more than one doesn't help)
-Item	antique tacklebox	Fishing Skill: +5
-Item	Apathargic Bandersnatch	Free Pull
+Item	antique tacklebox	Fishing Skill: +5, Last Available: "2016-04"
+Item	Apathargic Bandersnatch	Free Pull, Last Available: "2011-12"
 Item	Apriling band piccolo	Familiar Weight: +10, Lasts Until Rollover, Generic
-Item	arrest warrant	Lasts Until Rollover
-Item	arrowgram	Free Pull
+Item	arrest warrant	Lasts Until Rollover, Last Available: "2018-04"
+Item	arrowgram	Free Pull, Last Available: "2011-12"
 # artificial skylight: +3 Adventures Per Day
 # Artist's Butterknife of Regret: Deals 10-20 Physical Damage
 # Artist's Cookie Cutter of Loneliness: Deals 10-20 Physical Damage
@@ -11534,21 +11534,21 @@ Item	arrowgram	Free Pull
 # Artist's Whisk of Misery: Deals 10-20 Physical Damage
 # Asdon Martin keyfob
 Item	Asleep in the Cemetery	Skill: "Creepy Lullaby"
-Item	astral badger	Free Pull
-Item	Autobiography Of Dynamite Superman Jones (used)	Class: "Disco Bandit", Skill: "Kung Fu Hustler"
-Item	autumn dollar	Effect: "Bet Your Autumn Dollar", Effect Duration: 30
-Item	autumn leaf	Effect: "Crunching Leaves", Effect Duration: 20
-Item	autumn years wisdom	Effect: "Wisdom of the Autumn Years", Effect Duration: 30
-Item	avatar of the Unconscious Collective	Free Pull
+Item	astral badger	Free Pull, Last Available: "2006-06"
+Item	Autobiography Of Dynamite Superman Jones (used)	Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
+Item	autumn dollar	Effect: "Bet Your Autumn Dollar", Effect Duration: 30, Last Available: "2022-10"
+Item	autumn leaf	Effect: "Crunching Leaves", Effect Duration: 20, Last Available: "2022-10"
+Item	autumn years wisdom	Effect: "Wisdom of the Autumn Years", Effect Duration: 30, Last Available: "2022-10"
+Item	avatar of the Unconscious Collective	Free Pull, Last Available: "2013-12"
 # aviator goggles: Makes your mini kiwi lay mini kiwis more often
-Item	baby camelCalf	Free Pull
+Item	baby camelCalf	Free Pull, Last Available: "2020-07"
 Item	baby chest mimic	Free Pull
 Item	bad penguin egg	Free Pull
 # bag of airline peanuts: Deals 6-10 Physical Damage
 # bag of gross foreign snacks: Deals <font color=green>Stench Damage</font> every round to every monster you fight today in the zone where you used it
 Item	bag of Iunion stones	Free Pull
 # bag of park garbage: Maybe there's something valuable inside?
-Item	bagged Cargo Cultist Shorts	Free Pull
+Item	bagged Cargo Cultist Shorts	Free Pull, Last Available: "2020-09"
 # ball: Lets You Escape From Combat
 # ballpark hot daub: Deals 450-500 <font color=red>Hot Damage</font>, also briefly stuns enemies and weakens them a lot
 # banana peel: Comedy!
@@ -11557,27 +11557,27 @@ Item	bagged Cargo Cultist Shorts	Free Pull
 # bargain flash powder: Lets you escape from combat
 # baseball: Deals a 6-8 Physical Damage
 Item	Bash-&#332;s boxtop	Wiki Name: "Bash-Os boxtop"
-Item	basking robin	Free Pull
+Item	basking robin	Free Pull, Last Available: "2016-12"
 # Bastille Battalion cheese wheel: Lets you specify your favorite kind of cheese on your profile
 # Bastille Battalion control rig: Lets you control a mobile castle in Battle Royales for Cheese
-Item	Bastille Battalion control rig	Free Pull
-Item	Bastille Battalion control rig crate	Free Pull
+Item	Bastille Battalion control rig	Free Pull, Last Available: "2018-07"
+Item	Bastille Battalion control rig crate	Free Pull, Last Available: "2018-07"
 # Bat-Aid&trade; bandage: Quickly restores 20 Bat-Health
 # bat-bearing: Deals 15 damage and briefly stuns foes
 # bat-jute: Lets you tie up and interrogate a weakened foe
 # bat-o-mite: Defeats most foes in one shot
 # bat-oomerang: Deals 20 damage and disarms foes
 # Batfellow comic: Lets you have a fun adventure as a dark, brooding, bat-themed superhero.
-Item	Batfellow comic	Free Pull
+Item	Batfellow comic	Free Pull, Last Available: "2016-12"
 # Battlie Light Saver: Deals 30-50 Physical Damage and briefly stuns your foe
 # battoo kit: Unlocks a sweet Batfellow tattoo
-Item	Beach Comb Box	Free Pull
+Item	Beach Comb Box	Free Pull, Last Available: "2019-07"
 Item	beautiful rainbow	Skill: "Belch The Rainbow"
 # beehive: Full of bees!
 # beer bomb: Deals 55-75 Physical Damage
 # beer-scented teddy bear: Restores 15-20 MP
 Item	Benetton's Medley of Diversity	Skill: "Benetton's Medley of Diversity"
-Item	Better Shrooms and Gardens catalog	Free Pull
+Item	Better Shrooms and Gardens catalog	Free Pull, Last Available: "2020-03"
 Item	Biddy Cracker's Old-Fashioned Cookbook	Skill: "Eggsplosion"
 # big boom: Deals 80-120 Physical Damage
 # big glob of skin: Restores half of your missing Hit Points
@@ -11585,7 +11585,7 @@ Item	Biddy Cracker's Old-Fashioned Cookbook	Skill: "Eggsplosion"
 # Bird-a-Day calendar: Receive a blessing from a different bird each day
 Item	birthday candle	Effect: "Light!", Effect Duration: 3
 # bitchin' meatcar: <b>Allows Travel to Desert Beach</b>
-Item	Black and White Apron Enrollment Form	Free Pull
+Item	Black and White Apron Enrollment Form	Free Pull, Last Available: "2024-12"
 Item	Black Bart's Booty	Skill: "Pirate Bellow"
 # black BRICKO brick: Stuns your opponent for a few rounds
 # black BRICKO brick: (more effective against BRICKO monsters)
@@ -11610,8 +11610,8 @@ Item	blue potion	Effect: "Healthy Blue Glow", Effect Duration: 20
 # bobcat grenade: (super effective against beasts)
 # bodyguard badge: Gives your bodyguard the authority to always stop one assault
 # Bohemian rhapsody: Deals Physical Damage based on your Level
-Item	book of facts	Skill: "Just the Facts"
-Item	book of facts (dog-eared)	Skill: "Just the Facts"
+Item	book of facts	Skill: "Just the Facts", Last Available: "2023-09"
+Item	book of facts (dog-eared)	Skill: "Just the Facts", Last Available: "2023-09"
 # book of matches: Deals 40-60 <font color=red>Hot Damage</font>
 # Booke of Vampyric Knowledge: Grants one of several Vampyric skills
 # booze mailing list: Unlocks another row of houses for Crimbo activities
@@ -11627,7 +11627,7 @@ Item	bottle of Vangoghbitussin	Effect: "The 'Tussin", Effect Duration: 5
 Item	bottled green pixie	Free Pull
 # bottled swamp gas: Deals 15-20 <font color=green>Stench Damage</font>
 # bottled swamp gas: Weakens Enemies Very Slightly
-Item	bottled Vampire Vintner	Free Pull
+Item	bottled Vampire Vintner	Free Pull, Last Available: "2021-10"
 # boulder: Deals 20-30 Physical Damage
 # Bowl of Infinite Jelly: Improves the first thing you eat each day
 # bowl of potpourri: Gives some Moxie stats when you rest
@@ -11636,13 +11636,13 @@ Item	bottled Vampire Vintner	Free Pull
 # box of hammers: (way more effective against constructs)
 # box of old Crimbo decorations: Lets you give your Crimbo Shrub new decorations each day
 Item	box of sunshine	Free Pull
-Item	boxed Apriling band helmet	Free Pull
+Item	boxed Apriling band helmet	Free Pull, Last Available: "2024-04"
 Item	boxed august scepter	Free Pull
-Item	boxed autumn-aton	Free Pull
-Item	boxed bat wings	Free Pull
-Item	boxed Mayam Calendar	Free Pull
-Item	boxed Sept-Ember Censer	Free Pull
-Item	Boxing Day care package	Free Pull
+Item	boxed autumn-aton	Free Pull, Last Available: "2022-10"
+Item	boxed bat wings	Free Pull, Last Available: "2024-10"
+Item	boxed Mayam Calendar	Free Pull, Last Available: "2024-05"
+Item	boxed Sept-Ember Censer	Free Pull, Last Available: "2024-09"
+Item	Boxing Day care package	Free Pull, Last Available: "2018-12"
 # brain preservation fluid: Drink it for 5 Adventures!
 # brass abacus: Stuns your opponent for a few rounds
 Item	brass Dreadsylvanian flask	Effect: "Brass Loins", Effect Duration: 100
@@ -11663,18 +11663,18 @@ Item	BRICKO octopus	Wiki Name: "BRICKO octopus (item)"
 # bubblegum heart: Restores 80-100 Hit Points
 # buckyball: Lets you escape from combat
 # Build-a-City Gingerbread kit: Unlocks a Gingerbread City in the Big Mountains
-Item	Build-a-City Gingerbread kit	Free Pull
+Item	Build-a-City Gingerbread kit	Free Pull, Last Available: "2016-12"
 Item	Bulky Buddy Box	Wiki Name: "Bulky Buddy Box (hatchling)"
 # bundle of &quot;fragrant&quot; herbs: (up to 10 times per day)
 # bundle of &quot;fragrant&quot; herbs: (during the Crimbo 2015 event only)
 # bundle of &quot;fragrant&quot; herbs: Banish a monster for the rest of the day
 # burning newspaper: Deal a bunch of <font color=red>Hot Damage</font> and briefly stun your enemy
 # bus pass: Deals 45-50 Physical Damage
-Item	calm attention-deficit demon	Free Pull
+Item	calm attention-deficit demon	Free Pull, Last Available: "2006-10"
 # Camp Scout pup tent: Restores up to 1,000 HP
 # can of Ghuol-B-Gone&trade;: Repels Ghuols
 # can of sterno: Deals 15-20 <font color=red>Hot Damage</font> and 10-20 more each round for the rest of the fight
-Item	candy cornucopia	Free Pull
+Item	candy cornucopia	Free Pull, Last Available: "2011-12"
 # candy egg deviler: Convert any candy into a deviled candy egg (3x / day)
 # candy mailing list: Unlocks another row of houses for Crimbo activities
 # candycaine powder: Poisons your opponent
@@ -11682,32 +11682,32 @@ Item	candy cornucopia	Free Pull
 # carbonated soy milk: Restores 70-80 MP
 # carbonated water lily: Restores 60-70 MP
 # caret: Guarantees that your next regular attack will Critically Hit
-Item	Carol of the Bulls	Skill: "Carol of the Bulls"
-Item	Carol of the Bulls (used)	Skill: "Carol of the Bulls"
-Item	Carol of the Hells	Skill: "Carol of the Hells"
-Item	Carol of the Hells (used)	Skill: "Carol of the Hells"
-Item	Carol of the Thrills	Skill: "Carol of the Thrills"
-Item	Carol of the Thrills (used)	Skill: "Carol of the Thrills"
+Item	Carol of the Bulls	Skill: "Carol of the Bulls", Last Available: "2018-12"
+Item	Carol of the Bulls (used)	Skill: "Carol of the Bulls", Last Available: "2018-12"
+Item	Carol of the Hells	Skill: "Carol of the Hells", Last Available: "2018-12"
+Item	Carol of the Hells (used)	Skill: "Carol of the Hells", Last Available: "2018-12"
+Item	Carol of the Thrills	Skill: "Carol of the Thrills", Last Available: "2018-12"
+Item	Carol of the Thrills (used)	Skill: "Carol of the Thrills", Last Available: "2018-12"
 Item	carton of extra-sharp, rusty staples	Weapon Damage: +10, Spell Damage: +10
 # carton of rotten eggs: Deals 12-15 <font color=green>Stench Damage</font>
 # carton of rotten eggs: (can be used 8-10 times before the carton is empty)
 # cartoon heart: Restores 40-60 HP
 Item	cartoon heart	Effect: "Healthy Red Glow", Effect Duration: 10
 # cast: Restores 25-35 HP in combat, and 15-20 out of combat
-Item	Celsius 233	Skill: "Eternal Flame"
-Item	Celsius 233 (singed)	Skill: "Eternal Flame"
+Item	Celsius 233	Skill: "Eternal Flame", Last Available: "2017-06"
+Item	Celsius 233 (singed)	Skill: "Eternal Flame", Last Available: "2017-06"
 # chainsaw chain: Deals 60-80 Physical Damage and weakens enemies a lot
 # chaos butterfly: Is Unpredictable
 Item	Charter: Nellyville	Effect: "Hot in Herre", Effect Duration: 30
 # Chateau Mantegna room key: Permanently unlocks a new residence in the Big Mountains
-Item	Chateau Mantegna room key	Free Pull
+Item	Chateau Mantegna room key	Free Pull, Last Available: "2015-01"
 # cheer-o-gram: Send somebody a short but explosively cheerful message
 # Cherry Cloaca Cola: Restores 7-9 MP
-Item	Cheshire Bitten	Free Pull
+Item	Cheshire Bitten	Free Pull, Last Available: "2005-10"
 # chest of &quot;pirate gold&quot;: Contains 20 Pieces of 12 (so, 240 in total)
-Item	Cheswick Copperbottom's compass	Lasts Until Rollover
-Item	chewable paper	Free Pull
-Item	Chewsick Copperbottom's notes	Lasts Until Rollover
+Item	Cheswick Copperbottom's compass	Lasts Until Rollover, Last Available: "2018-04"
+Item	chewable paper	Free Pull, Last Available: "2014-08"
+Item	Chewsick Copperbottom's notes	Lasts Until Rollover, Last Available: "2018-04"
 # Chinese curse words: Stuns your opponent for a few rounds
 # chipotle wasabi cilantro aioli: Deals 30-40 Physical Damage and 8-10 Prismatic Damage
 # chlorine crystal: Deals 20-40 <font color=green>Stench Damage</font>
@@ -11720,17 +11720,17 @@ Item	Chorale of Companionship	Skill: "Chorale of Companionship"
 # cinnamon troll doll: Deals 3-5 <font color=red>Hot Damage</font>
 # cinnamon troll doll: (doesn't go away when used)
 # circle drum: Lets you form and/or join a drum circle!  Yay!
-Item	Clan Carnival Game	Free Pull
-Item	Clan Floundry	Free Pull
-Item	Clan hot dog stand	Free Pull
-Item	Clan looking glass	Free Pull
-Item	Clan pool table	Free Pull
-Item	Clan shower	Free Pull
-Item	Clan speakeasy	Free Pull
+Item	Clan Carnival Game	Free Pull, Last Available: "2018-02"
+Item	Clan Floundry	Free Pull, Last Available: "2016-04"
+Item	Clan hot dog stand	Free Pull, Last Available: "2013-07"
+Item	Clan looking glass	Free Pull, Last Available: "2010-03"
+Item	Clan pool table	Free Pull, Last Available: "2009-05"
+Item	Clan shower	Free Pull, Last Available: "2011-04"
+Item	Clan speakeasy	Free Pull, Last Available: "2014-07"
 Item	Clan VIP Lounge invitation	Free Pull
 # Clan VIP Lounge key: <b>Grants access to the Clan VIP Lounge</b>
 Item	Clan VIP Lounge key	Free Pull
-Item	class five ecto-larva	Free Pull
+Item	class five ecto-larva	Free Pull, Last Available: "2011-12"
 # classy monkey: Lets you escape from combat without spending an Adventure
 # clingfilm tangle: Stuns your opponent for a few rounds
 # Cloaca grenade: Deals 50-60 Physical Damage
@@ -11741,13 +11741,13 @@ Item	closed-circuit phone system	Free Pull
 # clutch of dodecapede eggs: Weakens enemies somewhat as it poisons them
 # coal snakeskin: Adds Spooky Damage to kicks with your cowboy boots
 # cocktail napkin: Deals 20-40 <font color=red>Hot Damage</font>
-Item	Cocktails of the Age of Sail	Skill: "Old-School Cocktailcrafting"
-Item	Cocktails of the Age of Sail (used)	Skill: "Old-School Cocktailcrafting"
+Item	Cocktails of the Age of Sail	Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
+Item	Cocktails of the Age of Sail (used)	Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 # cocoa of youth: Extend the duration of up to 10 of your effects by 5 Adventures
-Item	coffee sprite	Free Pull
+Item	coffee sprite	Free Pull, Last Available: "2005-10"
 # cold clusterbomb: Deals <font color=blue>Cold Damage</font> based on your highest stat
 # cold clusterbomb: (more effective against groups)
-Item	Cold Fang	Skill: "Frost Bite"
+Item	Cold Fang	Skill: "Frost Bite", Last Available: "2015-11"
 Item	cold sore	Cold Damage: +10, Cold Spell Damage: +10
 # Colon Annihilation Hot Sauce: Deals 6-8 <font color=red>Hot Damage</font> per round for the rest of the fight
 # comfy pillow: Restores 20-30 HP
@@ -11757,20 +11757,20 @@ Item	Comma Chameleon egg	Free Pull
 # complex alien zoological sample: Worth 10 pages of Spacegate Research
 # complimentary Dinsey refreshments: Ya eat 'em.  Well, tourists do.
 # Comprehensive Cartographic Compendium: Imparts deep cartographic knowledge
-Item	Comprehensive Cartographic Compendium	Free Pull
+Item	Comprehensive Cartographic Compendium	Free Pull, Last Available: "2020-10"
 # Comprehensive Cartographic Compendium (well-read): Imparts deep cartographic knowledge
 # confidence-building hug: Increases the damage of your bat-punches and bat-kicks
 # continental juice bar: Produces 3 random potions each day
-Item	control crystal	Free Pull
-Item	Convincing People You Can See The Future	Skill: "Inscrutable Gaze"
+Item	control crystal	Free Pull, Last Available: "2011-12"
+Item	Convincing People You Can See The Future	Skill: "Inscrutable Gaze", Last Available: "2018-02"
 # cool spore pod: Briefly enhances your Moxie
 # cop dollar
-Item	corked genie bottle	Free Pull
+Item	corked genie bottle	Free Pull, Last Available: "2017-09"
 # cosmic bowling ball: Throw it in various ways
 Item	cosmic bucket	Free Pull
 # cotton bandages: Restores 20-40 HP
 # cotton candy bale: Restores 41-82 HP and MP
-Item	cotton candy cocoon	Free Pull
+Item	cotton candy cocoon	Free Pull, Last Available: "2008-08"
 # cotton candy cone: Restores 26-52 HP and MP
 # cotton candy pillow: Restores 34-68 HP and MP
 # cotton candy pinch: Restores 7-15 HP and MP
@@ -11787,28 +11787,28 @@ Item	Covert Ops for Kids (used)	Skill: "Hide From Seekers"
 # crazy hobo notebook: Deals <font color=gray>Spooky Damage</font> every round to every monster you fight today in the zone where you used it
 Item	cream pie	Free Pull
 # creepy ginger ale: Restores 35-45 MP
-Item	CRIMBCO Employee Handbook (chapter 1)	Skill: "Fashionably Late"
-Item	CRIMBCO Employee Handbook (chapter 1) (used)	Skill: "Fashionably Late"
-Item	CRIMBCO Employee Handbook (chapter 2)	Skill: "Executive Narcolepsy"
-Item	CRIMBCO Employee Handbook (chapter 2) (used)	Skill: "Executive Narcolepsy"
-Item	CRIMBCO Employee Handbook (chapter 3)	Skill: "Lunch Break"
-Item	CRIMBCO Employee Handbook (chapter 3) (used)	Skill: "Lunch Break"
-Item	CRIMBCO Employee Handbook (chapter 4)	Skill: "Offensive Joke"
-Item	CRIMBCO Employee Handbook (chapter 4) (used)	Skill: "Offensive Joke"
-Item	CRIMBCO Employee Handbook (chapter 5)	Skill: "Managerial Manipulation"
-Item	CRIMBCO Employee Handbook (chapter 5) (used)	Skill: "Managerial Manipulation"
-Item	Crimbo Candy Cookbook	Skill: "Summon Crimbo Candy"
+Item	CRIMBCO Employee Handbook (chapter 1)	Skill: "Fashionably Late", Last Available: "2011-01"
+Item	CRIMBCO Employee Handbook (chapter 1) (used)	Skill: "Fashionably Late", Last Available: "2011-01"
+Item	CRIMBCO Employee Handbook (chapter 2)	Skill: "Executive Narcolepsy", Last Available: "2011-01"
+Item	CRIMBCO Employee Handbook (chapter 2) (used)	Skill: "Executive Narcolepsy", Last Available: "2011-01"
+Item	CRIMBCO Employee Handbook (chapter 3)	Skill: "Lunch Break", Last Available: "2011-01"
+Item	CRIMBCO Employee Handbook (chapter 3) (used)	Skill: "Lunch Break", Last Available: "2011-01"
+Item	CRIMBCO Employee Handbook (chapter 4)	Skill: "Offensive Joke", Last Available: "2011-01"
+Item	CRIMBCO Employee Handbook (chapter 4) (used)	Skill: "Offensive Joke", Last Available: "2011-01"
+Item	CRIMBCO Employee Handbook (chapter 5)	Skill: "Managerial Manipulation", Last Available: "2011-01"
+Item	CRIMBCO Employee Handbook (chapter 5) (used)	Skill: "Managerial Manipulation", Last Available: "2011-01"
+Item	Crimbo Candy Cookbook	Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 # Crimbo Credit: Use it to buy gifts in Crimbo Town!
-Item	crimbo elfling	Free Pull
+Item	crimbo elfling	Free Pull, Last Available: "2011-12"
 # Crimbo Factory surprise box: Full of Crimbo nostalgia!
-Item	Crimbo P. R. E. S. S. I. E.	Free Pull
-Item	Crimbo sapling	Free Pull
-Item	Crimbot ROM: Mathematical Precision	Skill: "Mathematical Precision"
-Item	Crimbot ROM: Mathematical Precision (dirty)	Skill: "Mathematical Precision"
-Item	Crimbot ROM: Rapid Prototyping	Skill: "Rapid Prototyping"
-Item	Crimbot ROM: Rapid Prototyping (dirty)	Skill: "Rapid Prototyping"
-Item	Crimbot ROM: Ruthless Efficiency	Skill: "Ruthless Efficiency"
-Item	Crimbot ROM: Ruthless Efficiency (dirty)	Skill: "Ruthless Efficiency"
+Item	Crimbo P. R. E. S. S. I. E.	Free Pull, Last Available: "2011-12"
+Item	Crimbo sapling	Free Pull, Last Available: "2014-12"
+Item	Crimbot ROM: Mathematical Precision	Skill: "Mathematical Precision", Last Available: "2014-12"
+Item	Crimbot ROM: Mathematical Precision (dirty)	Skill: "Mathematical Precision", Last Available: "2014-12"
+Item	Crimbot ROM: Rapid Prototyping	Skill: "Rapid Prototyping", Last Available: "2014-12"
+Item	Crimbot ROM: Rapid Prototyping (dirty)	Skill: "Rapid Prototyping", Last Available: "2014-12"
+Item	Crimbot ROM: Ruthless Efficiency	Skill: "Ruthless Efficiency", Last Available: "2014-12"
+Item	Crimbot ROM: Ruthless Efficiency (dirty)	Skill: "Ruthless Efficiency", Last Available: "2014-12"
 # Crimbuccaneer captain's purse: Contains a bunch of Pieces of 12
 # Crimbuccaneer invasion map: Globally increase MPC drops from Elf Guard enemies for an hour
 # Crimbuccaneer premium booty sack: Contains a random rare Crimbuccaneer item
@@ -11823,11 +11823,11 @@ Item	crumbling rat skull	Class: "Pastamancer"
 # cubic zirconia: Just sell it
 # cup of hickory chicory: Restores 30-50 MP
 # curious anemometer: Increases the sailing speed of your PirateRealm ship
-Item	curious anemometer	Lasts Until Rollover
+Item	curious anemometer	Lasts Until Rollover, Last Available: "2019-04"
 # cursed cannonball: Deals <font color=gray>Spooky Damage</font> based on your Muscle
 # cursed dirty joke scroll: Deals <font color=blueviolet>Sleaze Damage</font> and <font color=gray>Spooky Damage</font> based on your Moxie
 Item	cursed microwave	Free Pull
-Item	cursed monkey glove	Free Pull
+Item	cursed monkey glove	Free Pull, Last Available: "2023-04"
 Item	cursed pony keg	Free Pull
 # cursed voodoo skull: Deals <font color=red>Hot Damage</font> and <font color=gray>Spooky Damage</font> based on your Mysticality
 Item	custom avatar form	Free Pull
@@ -11842,14 +11842,14 @@ Item	d12	Effect: "Bastard!", Effect Duration: 10
 # d20	Effect: "Natural 1", Effect Duration: 1
 # d20	Effect: "Natural 20", Effect Duration: 1
 # daily dungeon malware: Hacks a Daily Dungeon Monster
-Item	dandy lion cub	Free Pull
+Item	dandy lion cub	Free Pull, Last Available: "2007-03"
 # dangerous chemicals: Take it to ChemiCorp's downtown office
 # dangerous jerkcicle: Deals 20-40 <font color=blue>Cold Damage</font>
-Item	Dark Jill-O-Lantern	Free Pull
-Item	Dark Jill-of-All-Trades	Free Pull
-Item	deactivated nanobots	Free Pull
+Item	Dark Jill-O-Lantern	Free Pull, Last Available: "2011-12"
+Item	Dark Jill-of-All-Trades	Free Pull, Last Available: "2023-10"
+Item	deactivated nanobots	Free Pull, Last Available: "2012-11"
 Item	deanimated reanimator's coffin	Free Pull
-Item	Dear Past Self Package	Free Pull
+Item	Dear Past Self Package	Free Pull, Last Available: "2016-09"
 # death blossom: Deals 20-25 Prismatic Damage
 # Deck of Every Card: Who knows what will happen when you draw from it!
 Item	decoded cult documents	Skill: "Bind Spaghetti Elemental"
@@ -11857,14 +11857,14 @@ Item	decorative fountain	Effect: "Sleepy", Effect Duration: 1
 Item	dedigitizer schematic: cybeer	Softcore Only
 Item	deed to Oliver's Place	Free Pull
 Item	defective Game Grid token	Effect: "Video... Games?", Effect Duration: 5
-Item	deflated inflatable dodecapede	Free Pull
+Item	deflated inflatable dodecapede	Free Pull, Last Available: "2011-12"
 # delicious shimmering moth: Restore 30-40 MP if you are a bird
 # deluxe mushroom: Heals 30 HP
 # deluxe Neverending Party favor: Contains extra-fabulous prizes!
 # depantsing bomb: Weakens enemies somewhat
 # Desert Bus pass: <b>Allows Travel to Desert Beach</b>
-Item	designer sweatpants (new old stock)	Free Pull
-Item	detective school application	Free Pull
+Item	designer sweatpants (new old stock)	Free Pull, Last Available: "2022-07"
+Item	detective school application	Free Pull, Last Available: "2016-07"
 # detective tattoo
 # diamondback skin: Adds +20 Monster Level to your cowboy boots
 # dictionary: Most Enemies Don't Care About It
@@ -11872,17 +11872,17 @@ Item	detective school application	Free Pull
 # dinged-up triangle: Summons a Hobo buddy
 # dingy dinghy: <b>Allows Travel to The Mysterious Island of Mystery</b>
 # dinosaur dart: Deal 500 damage to any non-Boss dinosaur
-Item	Dinsey Maintenance Manual	Skill: "Dinsey Operations Expert"
+Item	Dinsey Maintenance Manual	Skill: "Dinsey Operations Expert", Last Available: "2015-04"
 # Dinsey tattoo kit: Grants a cool Dinsey tattoo when used
 # dirty bottlecap: Absorb it for a useful skill!
 # dirty stinkbomb: Banishes a monster for a while
 # discarded button: Absorb it for a useful skill!
-Item	disconnected intergnat	Free Pull
-Item	Discontent&trade; Winter Garden Catalog	Free Pull
+Item	disconnected intergnat	Free Pull, Last Available: "2016-05"
+Item	Discontent&trade; Winter Garden Catalog	Free Pull, Last Available: "2014-01"
 # disease: Weakens enemies very slightly
 # disposable instant camera: Weakens enemies somewhat
 # disposable instant camera: (more effective against undead)
-Item	Distant Woods Getaway Brochure	Free Pull
+Item	Distant Woods Getaway Brochure	Free Pull, Last Available: "2019-08"
 # divine blowout: Deals Physical Damage based on your Moxie
 # divine blowout: Makes you cooler when you use it
 # divine can of silly string: Deals Physical Damage based on your Mysticality
@@ -11892,15 +11892,15 @@ Item	Distant Woods Getaway Brochure	Free Pull
 # divine cracker: (Maybe)
 # divine noisemaker: Deals Physical Damage based on your Muscle
 # divine noisemaker: Makes you stronger when you use it
-Item	DIY protonic accelerator kit	Free Pull
+Item	DIY protonic accelerator kit	Free Pull, Last Available: "2016-08"
 # DNA extraction syringe: Extracts DNA samples for analysis in your lab
 # DNA extraction syringe: (doesn't go away when used)
 Item	do-it-yourself laser eye surgery kit	Skill: "20/20 Vision"
-Item	Dolph Bossin's charity note	Free Pull
+Item	Dolph Bossin's charity note	Free Pull, Last Available: "2019-12"
 Item	doppelshifter egg	Free Pull
-Item	dragon aluminum ore	Lasts Until Rollover
+Item	dragon aluminum ore	Lasts Until Rollover, Last Available: "2018-04"
 # Dreadsylvanian seed pod: Fully restores your HP and removes negative status effects
-Item	dreaming Jung man	Free Pull
+Item	dreaming Jung man	Free Pull, Last Available: "2013-12"
 # drippy candy bar: It's too hard to chew
 # drone self-destruct chip: Deals 55-60 <font color=red>Hot Damage</font>
 # droopy doll eye: Deals 60-80 <font color=gray>Spooky Damage</font>
@@ -11924,38 +11924,38 @@ Item	El Vibrato punchcard (TARGET)	Wiki Name: "El Vibrato punchcard (142 holes)"
 Item	El Vibrato punchcard (WALL)	Wiki Name: "El Vibrato punchcard (176 holes)"
 # elbow soup: Add a pound and HP restore to your familiar
 Item	Eldritch Intellect: Journey into a Mind of Horror	Skill: "Eldritch Intellect"
-Item	eldritch tincture	Skill: "Evoke Eldritch Horror"
-Item	eldritch tincture (depleted)	Skill: "Evoke Eldritch Horror"
+Item	eldritch tincture	Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
+Item	eldritch tincture (depleted)	Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 # electric boning knife: Deals Physical Damage each round for the rest of the fight
 # electric muscle stimulator: Gives some Muscle stats when you rest
 Item	electronic Brain Trainer game	Skill: "Brain Games"
 # electronics kit: Shocks your opponent, weakening and briefly stunning them.<p>Also restores 30-40 MP.
 # eleven-foot pole: You know...  For traps.
-Item	Elf Guard Field Manual: Culinary Arts	Skill: "Elf Guard Cooking"
-Item	Elf Guard Field Manual: Culinary Arts (used)	Skill: "Elf Guard Cooking"
-Item	Elf Guard Field Manual: Extortion	Skill: "Elf Guard Extortion Techniques"
-Item	Elf Guard Field Manual: Extortion (used)	Skill: "Elf Guard Extortion Techniques"
-Item	Elf Guard Field Manual: Wilderness Sleeping	Skill: "Elf Guard Relaxation Techniques"
-Item	Elf Guard Field Manual: Wilderness Sleeping (used)	Skill: "Elf Guard Relaxation Techniques"
+Item	Elf Guard Field Manual: Culinary Arts	Skill: "Elf Guard Cooking", Last Available: "2023-12"
+Item	Elf Guard Field Manual: Culinary Arts (used)	Skill: "Elf Guard Cooking", Last Available: "2023-12"
+Item	Elf Guard Field Manual: Extortion	Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
+Item	Elf Guard Field Manual: Extortion (used)	Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
+Item	Elf Guard Field Manual: Wilderness Sleeping	Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
+Item	Elf Guard Field Manual: Wilderness Sleeping (used)	Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 # Elf Guard hangover cure: Reduces your Drunkenness by 5 (1 after Crimbo)
 # Elf Guard hangover cure: (limit 1x / day)
 # Elf Guard honor present: Contains a random rare Elf Guard item
 # Elf Guard payroll bag: Contains a bunch of Elf Guard MPCs
 # Elf Guard strategic map: Globally increase Piece of 12 drops from Crimbuccaneer enemies for an hour
 # Elf Guard tinsel grenade: Blow up a bunch of Crimbuccaneers
-Item	elf sleeper agent	Free Pull
-Item	Ellsbury's journal	Skill: "Unaccompanied Miner"
-Item	Ellsbury's journal (used)	Skill: "Unaccompanied Miner"
+Item	elf sleeper agent	Free Pull, Last Available: "2019-12"
+Item	Ellsbury's journal	Skill: "Unaccompanied Miner", Last Available: "2010-09"
+Item	Ellsbury's journal (used)	Skill: "Unaccompanied Miner", Last Available: "2010-09"
 Item	Elron's Explosive Etude	Skill: "Elron's Explosive Etude"
 # elven magi-pack: Restores 40-50 MP
 # elven medi-pack: Restores 80-100 HP
-Item	emo roe	Free Pull
-Item	emotion chip	Free Pull, Skill: "Emotionally Chipped"
+Item	emo roe	Free Pull, Last Available: "2005-04"
+Item	emotion chip	Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
 Item	Essence of Annoyance	Skill: "Summon Annoyance"
 Item	Essence of Bear	Skill: "Bear Essence"
 # eternal car battery: Restores 45-55 MP
 # eternal car battery: (doesn't go away when used)
-Item	experimental carbon fiber pasta additive	Class: "Pastamancer"
+Item	experimental carbon fiber pasta additive	Class: "Pastamancer", Last Available: "2013-11"
 # experimental gene therapy: Increases your maximum Bat-Health
 # exploding hacky-sack: Deals 75-100 Physical Damage
 # exploding kickball: Instantly ends a fight
@@ -11967,20 +11967,20 @@ Item	extra-strength red potion	Effect: "Healthy Red Glow", Effect Duration: 40
 # facehugging alien: Deals 100-300 Physical Damage after a few rounds have passed
 # facsimile dictionary: Most Enemies Don't Care About It
 # facsimile dictionary: (doesn't go away when used)
-Item	faerie dust	Lasts Until Rollover
-Item	fairy-worn boots	Free Pull
+Item	faerie dust	Lasts Until Rollover, Last Available: "2018-04"
+Item	fairy-worn boots	Free Pull, Last Available: "2011-08"
 # familiar-in-the-middle wrapper: CyberRealm: Your familiar will find an extra 1 at the end of combat
 Item	familiar-in-the-middle wrapper	Generic
 # fancy bath salts: Weakens enemies very slightly
 # fancy blue potion: Restores 90-110 MP
 Item	fancy blue potion	Effect: "Healthy Blue Glow", Effect Duration: 40
-Item	fancy calligraphy pen	Free Pull
+Item	fancy calligraphy pen	Free Pull, Last Available: "2015-01"
 # fancy dress ball: Lets You Escape From Combat
 # fancy oil painting: Useful for Bridge-Building
 # fancy stationery set: Produces 3 fancy calligraphy pens each day
 # FantasyRealm guest pass: Gives you access to FantasyRealm for the day
 # FantasyRealm membership packet: Permanently unlocks access to FantasyRealm
-Item	FantasyRealm membership packet	Free Pull
+Item	FantasyRealm membership packet	Free Pull, Last Available: "2018-04"
 # fascinating alien plant sample: Worth 20 pages of Spacegate Research
 # fascinating alien zoological sample: Worth 20 pages of Spacegate Research
 # fat bottom quark: Deals 25-40 <font color=green>Stench Damage</font>
@@ -11989,8 +11989,8 @@ Item	fat loot token	No Pull
 # ferret bait: Deals 45-60 Physical Damage
 # fetid feather: Deals 80-120 <font color=green>Stench Damage</font>
 Item	fettucini &eacute;pines Inconnu recipe	Recipe: "fettucini &eacute;pines Inconnu"
-Item	Field Guide to Skeletal Anatomy	Skill: "Natural Born Skeleton Killer"
-Item	Field Guide to Skeletal Anatomy (shredded)	Skill: "Natural Born Skeleton Killer"
+Item	Field Guide to Skeletal Anatomy	Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
+Item	Field Guide to Skeletal Anatomy (shredded)	Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 Item	figurine of a charred seal	Class: "Seal Clubber"
 Item	figurine of a cold seal	Class: "Seal Clubber"
 Item	figurine of a cute baby seal	Class: "Seal Clubber"
@@ -12009,7 +12009,7 @@ Item	figurine of an armored seal	Class: "Seal Clubber"
 # firebomb: Deals 40-50 <font color=red>Hot Damage</font>
 # fish-oil smoke bomb: Lets you escape from combat without spending an Adventure
 Item	fishy pipe	Effect: "Fishy", Effect Duration: 10
-Item	fist turkey outline	Free Pull
+Item	fist turkey outline	Free Pull, Last Available: "2014-11"
 # fistful of wood shavings: Stops Enemy From Attacking and Weakens it Very Slightly
 # fizzing spore pod: Deals 20-40 physical damage
 # flagellate flagon: Gain extra stats from your next drink
@@ -12017,19 +12017,19 @@ Item	fist turkey outline	Free Pull
 # flame orb: Burn up an enemy and none of its items
 # flaming feather: Deals 80-120 <font color=red>Hot Damage</font>
 # flaregun: Deals Various Kinds of Naval Damage
-Item	flask of holy water	Lasts Until Rollover
+Item	flask of holy water	Lasts Until Rollover, Last Available: "2018-04"
 # flirtatious feather: Deals 80-120 <font color=blueviolet>Sleaze Damage</font>
-Item	floaty stone sphere	Free Pull
+Item	floaty stone sphere	Free Pull, Last Available: "2009-09"
 # floorboard cruft: Deals 100-120 <font color=green>Stench Damage</font>
 # floorboard cruft: Weakens Enemies Somewhat
 Item	Fly-By-Knight Heraldry form	Free Pull
 # food mailing list: Unlocks another row of houses for Crimbo activities
 # forest tears: Restores 5-10 HP
 Item	foul cozy	Stench Damage: +10, Stench Spell Damage: +10
-Item	four-leaf potato sprout	Effect: "Luck of St. Patrick", Effect Duration: 30
+Item	four-leaf potato sprout	Effect: "Luck of St. Patrick", Effect Duration: 30, Last Available: "2024-12"
 Item	Fourth of May Cosplay Saber kit	Free Pull
-Item	fragment of Jarlsberg's soul	Free Pull
-Item	fresh can of paint	Free Pull
+Item	fragment of Jarlsberg's soul	Free Pull, Last Available: "2013-06"
+Item	fresh can of paint	Free Pull, Last Available: "2021-12"
 # frightful feather: Deals 80-120 <font color=gray>Spooky Damage</font>
 # frigid ninja stars: Deals 20-25 <font color=blue>Cold Damage</font>
 # frontwinder skin: Adds +50% Mysticality to your cowboy boots
@@ -12037,8 +12037,8 @@ Item	fresh can of paint	Free Pull
 # Frosty's iceball: (you can use it 2 times a day without melting it)
 # frozen feather: Deals 80-120 <font color=blue>Cold Damage</font>
 Item	fumble formula	Recipe: "concoction of clumsiness"
-Item	Fuzzby	Free Pull
-Item	GameInformPowerDailyPro subscription card	Free Pull
+Item	Fuzzby	Free Pull, Last Available: "2011-11"
+Item	GameInformPowerDailyPro subscription card	Free Pull, Last Available: "2013-02"
 # gas balloon: Stuns your opponent for a few rounds
 # Gathered Meat-Clip: Unclip some meat
 # gauze garter: Restores 80-120 HP
@@ -12046,7 +12046,7 @@ Item	GameInformPowerDailyPro subscription card	Free Pull
 # generic mana potion: Restores MP based on your level
 # generic restorative potion: Restores 4-5 HP and 2-3 MP
 # Ghost Dog Chow: Grants 20 Familiar XP
-Item	Ghost Pinching Quarterly	Skill: "Pinch Ghost"
+Item	Ghost Pinching Quarterly	Skill: "Pinch Ghost", Last Available: "2012-12"
 # ghost protocol: Makes you nearly impervious to damage for the duration of the fight
 # ghost trap: Traps ghosts
 # giant eraser: Lets you escape from combat without spending an Adventure
@@ -12059,7 +12059,7 @@ Item	Ghost Pinching Quarterly	Skill: "Pinch Ghost"
 # ginseng: Gives a Pokefamiliar Regeneration
 # glark cable: Instantly defeats most monsters on the Red Zeppelin
 # Glass Jack's spyglass: Reveals the distant secrets of PirateRealm
-Item	Glass Jack's spyglass	Lasts Until Rollover
+Item	Glass Jack's spyglass	Lasts Until Rollover, Last Available: "2019-04"
 Item	glass of warm water	Free Pull
 # Glenn's golden dice: Grants you some random beneficial effects
 # glitched malware: CyberRealm:  Banish a process for the rest of the day
@@ -12070,21 +12070,21 @@ Item	glass of warm water	Free Pull
 # glob of melted wax: Stuns enemies for a few rounds, dealing <font color=red>Hot Damage</font> all the while
 # glob of undifferentiated tissue: You have no idea what will happen!
 Item	glover liners	Pickpocket Chance: +10
-Item	glowing frisbee	Free Pull
+Item	glowing frisbee	Free Pull, Last Available: "2011-12"
 # glowing New Age crystal: Restores 500 MP
 # glowing New Age crystal: (and briefly stuns your opponent)
 # glowing spore pod: Briefly enhances your Mysticality
 # Glum berry: Removes negative effects and energizes you for a while
 # Gnomitronic Hyperspatial Demodulizer: Science!
 # gob of wet hair: Stops Enemy From Attacking and Weakens it Very Slightly
-Item	God Lobster Egg	Free Pull
+Item	God Lobster Egg	Free Pull, Last Available: "2018-05"
 # gold star: Restores 20-30 MP
 Item	gold star	Effect: "Healthy Blue Glow", Effect Duration: 10
-Item	golden gum	Free Pull
-Item	golden gun	Free Pull
+Item	golden gum	Free Pull, Last Available: "2017-06"
+Item	golden gun	Free Pull, Last Available: "2017-06"
 # Golden Kokomo Resort Chip: Shiny!
 # Golden Light: Vaporizes an enemy and causes all of its items to drop
-Item	golden monkey statuette	Free Pull
+Item	golden monkey statuette	Free Pull, Last Available: "2015-12"
 # golden plastic oyster egg: Lets you escape from combat without spending an Adventure
 # golden plastic oyster egg: (Maybe)
 # golden ring: Weakens enemies a lot
@@ -12096,7 +12096,7 @@ Item	googly chest eyes	Familiar Weight: +5
 # government booze shipment: Send 50 donated booze to another player (limit 1 per recipient per day)
 # government candy shipment: Send 50 donated candy to another player (limit 1 per recipient per day)
 # government food shipment: Send 50 donated food to another player (limit 1 per recipient per day)
-Item	Granny Tood's Thanksgarden Catalog	Free Pull
+Item	Granny Tood's Thanksgarden Catalog	Free Pull, Last Available: "2016-11"
 # grape troll doll: Deals 3-5 <font color=blueviolet>Sleaze Damage</font>
 # grape troll doll: (doesn't go away when used)
 # grass clippings: Weakens enemies very slightly
@@ -12110,17 +12110,17 @@ Item	Granny Tood's Thanksgarden Catalog	Free Pull
 # green BRICKO brick: (more effective against BRICKO monsters)
 # green face paint: Does not go away when used.
 # green face paint: Makes you green with holiday cheer!
-Item	green face paint	Free Pull
+Item	green face paint	Free Pull, Last Available: "2015-12"
 # green pill: It unlocks a tattoo.  That's what it does.
 # green pixel potion: Restores 40-60 HP and 30-40 MP
 # green smoke bomb: Lets you escape from combat without spending an Adventure
 # green smoke bomb: (Probably)
-Item	grey gosling	Free Pull
+Item	grey gosling	Free Pull, Last Available: "2022-03"
 Item	grim cellophane	Combat Rate: -5
 # grizzled bearskin Adds +50% Muscle to your cowboy boots
 # grody jug: Deals a Buttload of <font color=green>Stench Damage</font>
 # grogpagne: Restores 30-50 MP
-Item	grolblin rum	Lasts Until Rollover
+Item	grolblin rum	Lasts Until Rollover, Last Available: "2018-04"
 # grouchy restless spirit: Deals 40-45 <font color=gray>Spooky Damage</font>
 # groupie lipstick: Deals 150-250 <font color=blueviolet>Sleaze Damage</font>
 # groveling gravel: &quot;Defeat&quot; your opponent for meat and stats, but no items.
@@ -12133,7 +12133,7 @@ Item	Gygaxian Libram	Skill: "Summon Dice"
 # half-empty carton of milk: Deals 50-100 <font color=green>Stench Damage</font>
 # half-rotten brain: Disappoints Zombies
 # hand grenegg: Deals 6-8 <font color=green>Stench Damage</font> per round for the rest of the fight
-Item	hand turkey outline	Free Pull
+Item	hand turkey outline	Free Pull, Last Available: "2004-11"
 # handful of bees: Deals 80-100 Physical Damage per round for the rest of the fight
 # handful of napalm: Deals 100 <font color=red>Hot Damage</font> and sets your opponent on fire
 # handful of sand: Make stuff out of it!
@@ -12147,23 +12147,23 @@ Item	hand turkey outline	Free Pull
 Item	heart necklace	Free Pull
 # heart of dark chocolate: Restores 40-50 HP
 # heart of dark chocolate: (doesn't go away when used)
-Item	heart-shaped crate	Free Pull
+Item	heart-shaped crate	Free Pull, Last Available: "2017-02"
 Item	heat particle	Hot Damage: +10, Hot Spell Damage: +10
 # hedgeturtle: Causes Bleeding
 # hedgeturtle: Deals 30-60 Physical Damage
-Item	Hell and How I Bent It	Skill: "Bend Hell"
+Item	Hell and How I Bent It	Skill: "Bend Hell", Last Available: "2016-02"
 # hemp net: Deals 90-100 Physical Damage
 # hemp net: Weakens Enemies Somewhat
-Item	hero's skull	Lasts Until Rollover
-Item	hibernating Grimstone Golem	Free Pull
-Item	hibernating robot reindeer	Free Pull
+Item	hero's skull	Lasts Until Rollover, Last Available: "2018-04"
+Item	hibernating Grimstone Golem	Free Pull, Last Available: "2014-12"
+Item	hibernating robot reindeer	Free Pull, Last Available: "2010-12"
 # high-grade explosives: Can be used in the Bat-Cavern's Bat-Fab to make Bat-o-mite
 # high-grade metal: Can be used in the Bat-Cavern's Bat-Fab to make Bat-oomerangs
 # high-pressure seltzer bottle: Restores 150-200 MP
 # high-tensile-strength fibers: Can be used in the Bat-Cavern's Bat-Fab to make Bat-jute
-Item	History's Most Offensive Jokes, Vol. IX	Skill: "Unoffendable"
-Item	Hjodor's Guide to Arctic Dalmatians	Skill: "Frigidalmatian"
-Item	Hjodor's Guide to Arctic Dalmatians (used)	Skill: "Frigidalmatian"
+Item	History's Most Offensive Jokes, Vol. IX	Skill: "Unoffendable", Last Available: "2014-05"
+Item	Hjodor's Guide to Arctic Dalmatians	Skill: "Frigidalmatian", Last Available: "2012-07"
+Item	Hjodor's Guide to Arctic Dalmatians (used)	Skill: "Frigidalmatian", Last Available: "2012-07"
 # HOA citation pad: Weakens enemies a lot
 # HOA citation pad: (by 30% if they are dudes, hippies or orcs)
 # HOA citation pad: (doesn't go away when used)
@@ -12171,7 +12171,7 @@ Item	Hodgman's journal #1: The Lean Times	Skill: "Natural Born Scrabbler"
 Item	Hodgman's journal #2: Entrepreneurythmics	Skill: "Thrift and Grift"
 Item	Hodgman's journal #3: Pumping Tin	Skill: "Abs of Tin"
 Item	Hodgman's journal #4: View From The Big Top	Skill: "Marginally Insane"
-Item	Holiday Fun!	Free Pull
+Item	Holiday Fun!	Free Pull, Last Available: "2014-12"
 Item	Holiday Hal's Happy-Time Fun Book!	Skill: "Summon Holiday Fun!"
 Item	Holiday Multitasking	Skill: "Holiday Multitasking"
 Item	Holiday Multitasking (used)	Skill: "Holiday Multitasking"
@@ -12182,17 +12182,17 @@ Item	Holiday Multitasking (used)	Skill: "Holiday Multitasking"
 # holy bomb, batman: (way more effective against undead foes)
 # holy spring water: Restores 20-25 MP
 Item	holy spring water	Effect: "Spiritually Awake", Effect Duration: 10
-Item	homeless hobo spirit	Free Pull
+Item	homeless hobo spirit	Free Pull, Last Available: "2006-05"
 # honey-dipped locust: Restores 30-40 HP and MP
-Item	hopeful candle	Free Pull
+Item	hopeful candle	Free Pull, Last Available: "2017-01"
 # Horsery contract: Installs a Horsery in Seaside Town
 # Horsery contract: (and unlocks Horse Armor DLC for West of Loathing)
-Item	Horsery contract	Free Pull
+Item	Horsery contract	Free Pull, Last Available: "2018-08"
 # hot ashes: Deals <font color=red>Hot Damage</font> based on your highest stat
 # hot clusterbomb: Deals <font color=red>Hot Damage</font> based on your highest stat
 # hot clusterbomb: (more effective against groups)
 # hot spore pod: Briefly improves your <font color = red>Hot</font> spells
-Item	How To Get Bigger Without Really Trying	Skill: "Get Big"
+Item	How To Get Bigger Without Really Trying	Skill: "Get Big", Last Available: "2018-02"
 Item	How to Hold a Grudge	Skill: "Chip on your Shoulder"
 Item	How to Lose Friends and Attract Snakes	Skill: "Attract Snakes"
 Item	How to Lose Friends and Attract Snakes (used)	Skill: "Attract Snakes"
@@ -12202,31 +12202,31 @@ Item	Hoyle's Guide to Reindeer Games	Skill: "Reindeer Games"
 Item	Hoyle's Guide to Reindeer Games (used)	Skill: "Reindeer Games"
 Item	Huggler Radio	Free Pull
 # human musk: Banish an enemy for the rest of the day
-Item	hungover chauvinist pig	Free Pull
+Item	hungover chauvinist pig	Free Pull, Last Available: "2010-10"
 # ice hotel bell: Deals 250-300 Cold Damage
 # ice house: Banishes a monster more or less permanently
 # ice skate decoy: Put it down, and monsters will attack it instead of you
 # ice-cold Cloaca Zero: Deals 100-200 <font color=blue>Cold Damage</font> and restores up to 2,000 MP
 # illegal firecracker: Deals 15-20 Physical Damage and 15-20 <font color=red>Hot Damage</font>
-Item	Illustrated Mating Rituals of the Gallapagos	Skill: "Gallapagosian Mating Call"
+Item	Illustrated Mating Rituals of the Gallapagos	Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
 Item	imbued seal-blubber candle	Class: "Seal Clubber"
 # imitation crab meat: Deals 150-250 Physical Damage
 # imitation crab meat: (will backfire if used on land)
 # imp air: Deals 35-40 <font color=red>Hot Damage</font>
-Item	in-the-box spring shoes	Free Pull
+Item	in-the-box spring shoes	Free Pull, Last Available: "2024-02"
 # incriminating evidence: Take it downtown to Gotpork P. D.
-Item	infant sandworm	Free Pull
+Item	infant sandworm	Free Pull, Last Available: "2011-12"
 # infinite BACON machine: Generate 100 BACON per day
 # ingot turtle: Deals 90-110 <font color=red>Hot Damage</font> and changes your opponent's element to Hot
-Item	Inigo's Incantation of Inspiration	Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration"
-Item	Inigo's Incantation of Inspiration (crumpled)	Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration"
+Item	Inigo's Incantation of Inspiration	Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
+Item	Inigo's Incantation of Inspiration (crumpled)	Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 # ink bladder: Lets you escape from combat without spending an Adventure (underwater)
 # ink bladder: Weakens enemies significantly (on land)
 # inkwell: Weakens enemies a little bit
 # intact anemone spike: Deal 100 damage (Underwater only)
 # interesting clod of dirt: Absorb it for a useful skill!
 # internet point: Give yourself +1
-Item	Island Drinkin', a Tiki Mixology Odyssey	Skill: "Tiki Mixology"
+Item	Island Drinkin', a Tiki Mixology Odyssey	Skill: "Tiki Mixology", Last Available: "2019-04"
 Item	Jackass Plumber home game	Effect: "Gamer Rage", Effect Duration: 10
 # jagged scrap metal: Deals 20-30 Physical Damage and causes bleeding
 # jam band flyers: Advertise!
@@ -12235,7 +12235,7 @@ Item	Jamocha berry	Effect: "Berry Thorny", Effect Duration: 20
 # janitor sponge: Deals 20-30 <font color=green>Stench Damage</font> and briefly stuns your opponent
 # January's Garbage Tote: Allows you to rummage up Holiday Detritus
 # January's Garbage Tote (unopened): Allows you to rummage up Holiday Detritus
-Item	January's Garbage Tote (unopened)	Free Pull
+Item	January's Garbage Tote (unopened)	Free Pull, Last Available: "2018-01"
 # jar full of wind: Weakens enemies somewhat and briefly stuns them
 # jar of swamp gas: Deals 20-30 <font color=green>Stench Damage</font>
 # jar of swamp gas: Stuns enemies for a few rounds
@@ -12243,28 +12243,28 @@ Item	January's Garbage Tote (unopened)	Free Pull
 # Jick's autograph: Cool!
 # jigsaw blade: Deals 10-20 Physical Damage, causes a brief stun and less brief bleeding
 # jingling spore pod: Briefly improves your Ranged damage
-Item	jitterbug larva	Free Pull
+Item	jitterbug larva	Free Pull, Last Available: "2007-10"
 Item	jug of Sneaky Pete's Mojo	Free Pull
 # Junk-Bond: Weakens enemies somewhat and briefly stuns them
 # Keese berry: Improves your defenses and energizes you for a while
 Item	Keese berry	Effect: "Berry Defensive", Effect Duration: 20
-Item	kerosene-soaked skip	Free Pull
+Item	kerosene-soaked skip	Free Pull, Last Available: "2018-12"
 # kidnapped orphan: Take it downtown to Gotpork Orphanage
 # killing feather: Deals 100-120 Physical Damage
 # killing jar: Weakens enemies somewhat and briefly stuns them
 Item	Kissin' Cousins	Skill: "Awesome Balls of Fire"
 # kite: Weakens enemies somewhat and briefly stuns them
-Item	kitten burglar	Free Pull
+Item	kitten burglar	Free Pull, Last Available: "2018-07"
 # Knob Goblin firecracker: Deals 2-4 Physical Damage
 Item	Knob Goblin firecracker	Effect: "Missing Fingers", Effect Duration: 3
 # Knob Goblin seltzer: Restores 8-12 MP
 # Knob Goblin stink bomb: Weakens enemies slightly
 # Knob Goblin superseltzer: Restores 25-29 MP
 # Kokomo Resort Order Pad: Boring!
-Item	KoLHS Pep Squad Box	Free Pull
-Item	Kramco Industries packing carton	Free Pull
-Item	latte lovers club card	Free Pull
-Item	Lava Miner's Daughter	Skill: "Asbestos Heart"
+Item	KoLHS Pep Squad Box	Free Pull, Last Available: "2013-09"
+Item	Kramco Industries packing carton	Free Pull, Last Available: "2019-01"
+Item	latte lovers club card	Free Pull, Last Available: "2018-10"
+Item	Lava Miner's Daughter	Skill: "Asbestos Heart", Last Available: "2015-08"
 # lavender plastic oyster egg: Deals 40-50 Physical Damage
 # Law of Averages: Averages you out
 # Lazenby's Life Lesson: Increase your Social Capital in License to Adventure Runs
@@ -12272,15 +12272,15 @@ Item	Lazenby's Life Lesson	Free Pull
 # leftovers of indeterminate origin: Deals 8-10 <font color=green>Stench Damage</font>
 Item	Let Me Be!	Skill: "Raise Backup Dancer"
 # lewd playing card: Deals 100-150 Physical Damage and 100-150 <font color=blueviolet>Sleaze Damage</font>
-Item	LI-11 Motor Pool voucher	Free Pull
+Item	LI-11 Motor Pool voucher	Free Pull, Last Available: "2017-07"
 # li'l orphan tot: Does a multitude of things depending on outfit
-Item	li'l orphan tot	Free Pull
-Item	Libram of BRICKOs	Free Pull, Skill: "Summon BRICKOs"
-Item	Libram of Candy Heart Summoning	Free Pull, Skill: "Summon Candy Heart"
-Item	Libram of Divine Favors	Free Pull, Skill: "Summon Party Favor"
+Item	li'l orphan tot	Free Pull, Last Available: "2016-10"
+Item	Libram of BRICKOs	Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
+Item	Libram of Candy Heart Summoning	Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
+Item	Libram of Divine Favors	Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
 Item	Libram of Love Songs	Skill: "Summon Love Song"
-Item	Libram of Pulled Taffy	Free Pull, Skill: "Summon Taffy"
-Item	Libram of Resolutions	Free Pull, Skill: "Summon Resolutions"
+Item	Libram of Pulled Taffy	Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
+Item	Libram of Resolutions	Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
 # License To Kill: ???
 # Lil' Snowball Factory: Makes 3 perfect snowballs, every day!
 # linen bandages: Restores 10-20 HP
@@ -12292,33 +12292,33 @@ Item	Libram of Resolutions	Free Pull, Skill: "Summon Resolutions"
 # live nautical mine: Deals a bunch of Physical Damage
 # live nautical mine: Is unsafe on land
 Item	Living to Drink, Drinking to Live	Skill: "Drinking to Drink"
-Item	llama lama cria	Free Pull
+Item	llama lama cria	Free Pull, Last Available: "2008-06"
 # Loathing Legion jackhammer: Allows Meatsmithing without the Adventure cost (3 times a day)
-Item	Loathing Legion jackhammer	Softcore Only
+Item	Loathing Legion jackhammer	Softcore Only, Last Available: "2011-01"
 # locked mumming trunk: Dress your familiars up like weird old dramatic archetypes!
-Item	locked mumming trunk	Free Pull
-Item	lodestone	Effect: "Loded", Effect Duration: 5
+Item	locked mumming trunk	Free Pull, Last Available: "2017-12"
+Item	lodestone	Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 # logic grenade: Instantly kill a CyberRealm process
 # LOLmec statuette: Sells for 1 Million Meat
 # Louder Than Bomb: Banishes a monster for a while
-Item	Love Potions and the Wizards who Mix Them	Skill: "Love Mixology"
+Item	Love Potions and the Wizards who Mix Them	Skill: "Love Mixology", Last Available: "2018-02"
 # LT&T telegraph office deed: Opens a LT&T telegraph office in Seaside Town
-Item	LT&T telegraph office deed	Free Pull
+Item	LT&T telegraph office deed	Free Pull, Last Available: "2016-02"
 # lucky moai statuette: Contains three 11-leaf clovers
 # lump of frequently wriggling eldritch matter: Makes you feel Vaguely Uneasy
 # lump of not really wriggling eldritch matter: Makes you feel Vaguely Uneasy
-Item	Lump-Stacking for Beginners	Skill: "Stack Lumps"
-Item	luxury fly-tying workbench	Fishing Skill: +10
-Item	LyleCo Contractor's Manual	Skill: "Expert Corner-Cutter"
-Item	machine elf capsule	Free Pull
+Item	Lump-Stacking for Beginners	Skill: "Stack Lumps", Last Available: "2016-12"
+Item	luxury fly-tying workbench	Fishing Skill: +10, Last Available: "2016-04"
+Item	LyleCo Contractor's Manual	Skill: "Expert Corner-Cutter", Last Available: "2018-04"
+Item	machine elf capsule	Free Pull, Last Available: "2015-12"
 # mafia filofax: Organize some quiet moments in an area
 # magical mystery juice: Restores an amount of MP that increases as you level up
 # magnolia blossom: Restores 15-30 HP and MP
-Item	Manual of Lock Picking	Skill: "Lock Picking"
+Item	Manual of Lock Picking	Skill: "Lock Picking", Last Available: "2020-08"
 Item	Manual of Numberology	Skill: "Calculate the Universe"
 Item	Manual of Secret Door Detection	Skill: "Secret Door Awareness"
 Item	Manual of Transcendent Olfaction	Skill: "Transcendent Olfaction"
-Item	map to Dolph Bossin's hideout	Free Pull
+Item	map to Dolph Bossin's hideout	Free Pull, Last Available: "2019-12"
 Item	Map to Kokomo	Free Pull, Skill: "Summon Kokomo Resort Pass"
 # map to the Cursed Village: Gives permanent access to the Cursed Village in FantasyRealm
 # map to the Mystic Wood: Gives permanent access to the Forest in FantasyRealm
@@ -12331,12 +12331,12 @@ Item	March hat	Free Pull
 # Massive Manual of Marauder Mockery: Makes marauder mockery mossible
 # mauve plastic oyster egg: Deals 40-50 Physical Damage
 Item	Maxing, Relaxing	Skill: "Maximum Chill"
-Item	Mayam Calendar	Free Pull
+Item	Mayam Calendar	Free Pull, Last Available: "2024-05"
 # MayDay&trade; contract: Survival supplies will be delivered to you each day
-Item	MayDay&trade; contract	Free Pull
+Item	MayDay&trade; contract	Free Pull, Last Available: "2022-05"
 Item	MayDay&trade; supply package	Effect: "Ready to Survive", Effect Duration: 30
 # mayo lance: Unleash a torrent of inner mayonnaise.  The torrent will be yellow and ray-like.
-Item	mayo lance	Lasts Until Rollover
+Item	mayo lance	Lasts Until Rollover, Last Available: "2015-05"
 # Mayo Minder&trade;: Makes it so packets of prescription mayonnaise are automatically consumed as you eat
 # Mayodiol: One Fullness of the next thing you eat will be converted into Drunkenness
 # Mayoflex: The next thing you eat will grant an additional Adventure
@@ -12346,7 +12346,7 @@ Item	mayo lance	Lasts Until Rollover
 # Mayor Ghost's scissors: (doesn't go away when used)
 # Mayostat: Recover a portion of the next substantial thing you eat for later use
 # Mayozapine: Increases the stat gains from the next thing you eat
-Item	McHugeLarge deluxe ski set	Free Pull
+Item	McHugeLarge deluxe ski set	Free Pull, Last Available: "2025-01"
 Item	McPhee's Grimoire of Hilarious Object Summoning	Skill: "Summon Hilarious Objects"
 # meat vortex: Steals Some Meat From an Enemy
 # melty plastic grenade: Deals <font color=green>Stench Damage</font> based on your highest stat
@@ -12375,8 +12375,8 @@ Item	Mer-kin darkbook	Skill: "Deep Dark Visions"
 # Mer-kin sawdust: Weakens enemies a lot on land
 # Merc Core challenge coin: Grants a new tattoo when used
 # Merc Core deployment orders: Contains a one-day ticket to Conspiracy Island
-Item	Merc Core Field Manual: Intimidation Techniques	Skill: "Intimidating Mien"
-Item	Merc Core Field Manual: Sanity Maintenance	Skill: "Hypersane"
+Item	Merc Core Field Manual: Intimidation Techniques	Skill: "Intimidating Mien", Last Available: "2014-10"
+Item	Merc Core Field Manual: Sanity Maintenance	Skill: "Hypersane", Last Available: "2014-10"
 # metal meteoroid: Can be shaped into various pieces of equipment
 # metandienone: Increase a Pokefamiliar's power by 1
 # Meteorite-Ade: Gives 5 PvP fights
@@ -12387,8 +12387,8 @@ Item	Merc Core Field Manual: Sanity Maintenance	Skill: "Hypersane"
 # mime army challenge coin: Flip it.  I'm sure it's safe.
 # mime army shotglass: Your first 1-drunkenness booze item of the day doesn't count
 # mime eraser: Instantly destroy a mime in the Cheerless Spire
-Item	mini kiwi egg	Free Pull
-Item	mini kiwi invisible dirigible	Familiar Weight: -20, Generic
+Item	mini kiwi egg	Free Pull, Last Available: "2024-06"
+Item	mini kiwi invisible dirigible	Familiar Weight: -20, Last Available: "2024-06", Generic
 # miniature boiler: Deals 20-40 Physical Damage
 # miniature Embering Hulk: Fight an Embering Hulk
 # Miniborg beeper: Deals 20-25 Physical Damage and hurts you a little bit
@@ -12405,10 +12405,10 @@ Item	mini kiwi invisible dirigible	Familiar Weight: -20, Generic
 # Miniborg stomper: (doesn't go away when used)
 # Miniborg strangler: Weakens enemies slightly
 # Miniborg strangler: (doesn't go away when used)
-Item	miniscule temporal rip	Free Pull
-Item	mint condition Lil' Doctor&trade; bag	Free Pull
+Item	miniscule temporal rip	Free Pull, Last Available: "2005-11"
+Item	mint condition Lil' Doctor&trade; bag	Free Pull, Last Available: "2019-02"
 # mint condition magnifying glass: Helps you solve mysteries and is totally safe
-Item	mint-in-box Powerful Glove	Free Pull
+Item	mint-in-box Powerful Glove	Free Pull, Last Available: "2020-02"
 # Mmm-brr! brand mouthwash: Gain stats based on your cold protection
 # Mob Penguin cellular phone: Lets You Talk to Penguins
 # modern picture frame: Put abstractions in it to create abstract art!
@@ -12418,54 +12418,54 @@ Item	mint-in-box Powerful Glove	Free Pull
 # monomolecular yo-yo: Deals 35-45 Physical Damage
 # Monstar energy beverage: Restores 70-80 MP
 Item	Monster Manuel	Free Pull
-Item	Moping Artistic Goth Kid	Free Pull
+Item	Moping Artistic Goth Kid	Free Pull, Last Available: "2012-06"
 Item	mosquito speakers	Monster Level: +5
 # mossy stone sphere: Mysterious, Deprecated
 Item	mother's secret recipe	Recipe: "white chocolate chip brownies"
 # mountain lion skin: Adds +50% Moxie to your cowboy boots
 # Mountain Stream Code Black Alert: Restores 15-20 MP
 # Mountain Stream soda: Restores 30-40 MP
-Item	mummified entombed cookbookbat	Free Pull
+Item	mummified entombed cookbookbat	Free Pull, Last Available: "2022-11"
 # mumming trunk: Dress your familiars up like weird old dramatic archetypes!
 # murderbot live wire: Deals <font color=red>Hot Damage</font> every round to every monster you fight today in the zone where you used it
 # murderbot memory chip: Worth 15 pages of Spacegate Research
 # muscular soup: Add a pound and increase the combat damage of your familiar
 # mushroom: Heals 10 HP
-Item	My First Art of War	Skill: "Army of Toddlers"
+Item	My First Art of War	Skill: "Army of Toddlers", Last Available: "2018-12"
 # My First Paycheck envelope: Contains 50 Elf Guard MPCs
-Item	My Life of Crime, a Memoir	Skill: "Gingerbread Mob Hit"
-Item	My Own Pen Pal kit	Free Pull
+Item	My Life of Crime, a Memoir	Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
+Item	My Own Pen Pal kit	Free Pull, Last Available: "2011-12"
 # mylar scout drone: Weakens enemies somewhat
 # Mysterious Black Box: Can only be opened on February 29
 # Mysterious Blue Box: Can only be opened on February 29
-Item	mysterious chest	Free Pull
+Item	mysterious chest	Free Pull, Last Available: "2011-06"
 # Mysterious Green Box: Can only be opened on February 29
 # Mysterious Red Box: Can only be opened on February 29
 # Nadsat berry: Improves critical hit chance and energizes you for a while (also gives Berry Experiential)
 Item	Nadsat berry	Effect: "Berry Critical", Effect Duration: 20
 # Nardz energy beverage: Restores 50-70 MP
-Item	nasty haunch	Lasts Until Rollover
+Item	nasty haunch	Lasts Until Rollover, Last Available: "2018-04"
 # nasty-smelling moss: Restores 20-30 HP and briefly stuns opponents.
 # nasty-smelling moss: Doesn't go away when used.
 # nastygeist: Deals <font color=blueviolet>Sleaze Damage</font> each round for the rest of the fight
 # natural fennel soda: Restores 80-120 MP
 # naughty paper shuriken: Removes a monster's pants and stuns it for a few rounds
 # naughty paper shuriken: (if the monster is wearing pants)
-Item	nervous tick egg	Free Pull
-Item	Never Don't Stop Not Striving	Skill: "Always Never Not Guzzling"
+Item	nervous tick egg	Free Pull, Last Available: "2007-10"
+Item	Never Don't Stop Not Striving	Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 # Neverending Party favor: Contains fabulous prizes!
-Item	Neverending Party invitation envelope	Free Pull
+Item	Neverending Party invitation envelope	Free Pull, Last Available: "2018-09"
 # New Age healing crystal: Restores 500 HP
 # New Age healing crystal: (and briefly stuns your opponent)
 # New Age hurting crystal: Deals 500 Physical Damage and briefly stuns them
 # New Cloaca-Cola: Restores 140-160 MP
-Item	new-in-box toy Cupid bow	Free Pull
-Item	New-You Club Membership Form	Free Pull
+Item	new-in-box toy Cupid bow	Free Pull, Last Available: "2025-02"
+Item	New-You Club Membership Form	Free Pull, Last Available: "2017-05"
 # NG: Deals 40-70 Physical Damage
-Item	No Hats as Art	Skill: "Ceci N'Est Pas Un Chapeau"
-Item	Non-Euclidean Finance	Skill: "5-D Earning Potential"
+Item	No Hats as Art	Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
+Item	Non-Euclidean Finance	Skill: "5-D Earning Potential", Last Available: "2017-04"
 # notarized arrest warrant: Now it actually counts
-Item	notarized arrest warrant	Lasts Until Rollover
+Item	notarized arrest warrant	Lasts Until Rollover, Last Available: "2018-04"
 Item	note from Clancy	Skill: "Request Sandwich"
 # Notes from the Elfpocalypse, Chapter I: Restores 30-40 HP and MP
 # Notes from the Elfpocalypse, Chapter II: Restores 30-40 HP and MP
@@ -12473,7 +12473,7 @@ Item	note from Clancy	Skill: "Request Sandwich"
 # Notes from the Elfpocalypse, Chapter IV: Restores 30-40 HP and MP
 # Notes from the Elfpocalypse, Chapter V: Restores 30-40 HP and MP
 # Notes from the Elfpocalypse, Chapter VI: Restores 30-40 HP and MP
-Item	Now You're Cooking With Grease	Skill: "Grease Up"
+Item	Now You're Cooking With Grease	Skill: "Grease Up", Last Available: "2014-05"
 # noxious gas grenade: Deals 200-300 <font color=green>Stench Damage</font> and lingering Poison Damage
 # nuclear stockpile: Instantly destroy an enemy
 # nuclear stockpile: (up to 10 times per day)
@@ -12483,38 +12483,38 @@ Item	Now You're Cooking With Grease	Skill: "Grease Up"
 # off-white plastic oyster egg: Weakens enemies a little bit
 # oily boid: Weakens enemies a little bit as it briefly stuns them
 # old school beer pull tab: Causes a significant amount of bleeding
-Item	Olympic-sized Clan crate	Free Pull
+Item	Olympic-sized Clan crate	Free Pull, Last Available: "2012-05"
 # onion shurikens: Deals 10-15 <font color=blueviolet>Sleaze Damage</font>
 # opium grenade: Stuns your opponent for a few rounds
 # opium grenade: (extra effective against hippies)
 Item	Order of the Green Thumb Order Form	Free Pull
-Item	organ grinder	Free Pull
+Item	organ grinder	Free Pull, Last Available: "2011-12"
 # ornate picture frame: Weakens enemies somewhat and briefly stuns them
-Item	orphan baby yeti	Free Pull
+Item	orphan baby yeti	Free Pull, Last Available: "2011-12"
 # Oscus's neverending soda: Restores 200-300 MP
 # Oscus's neverending soda: (doesn't go away when used)
-Item	Our Daily Candles&trade; order form	Free Pull
-Item	OVERCLOCK(10) rom chip	Skill: "OVERCLOCK(10)"
+Item	Our Daily Candles&trade; order form	Free Pull, Last Available: "2021-08"
+Item	OVERCLOCK(10) rom chip	Skill: "OVERCLOCK(10)", Last Available: "2025-12"
 # overflowing gift basket: Produces a random food item (1x/day)
 # overloaded micro-reactor: Deals 300 Physical Damage
 # oversized snowflake: Stuns your opponent for a few rounds
 # ovoid leather thing: Deals 80-100 Physical Damage
 # pacification grenade: Weakens enemies somewhat
-Item	Pack of Every Card	Free Pull
-Item	packaged backup camera	Free Pull
-Item	packaged cold medicine cabinet	Free Pull
-Item	packaged Daylight Shavings Helmet	Free Pull
-Item	packaged Everfull Dart Holster	Free Pull
-Item	packaged familiar scrapbook	Free Pull
-Item	packaged industrial fire extinguisher	Free Pull
-Item	packaged June cleaver	Free Pull
-Item	packaged Jurassic Parka	Free Pull
-Item	packaged knock-off retro superhero cape	Free Pull
-Item	packaged miniature crystal ball	Free Pull
-Item	packaged model train set	Free Pull
-Item	packaged Pocket Professor	Free Pull
+Item	Pack of Every Card	Free Pull, Last Available: "2015-07"
+Item	packaged backup camera	Free Pull, Last Available: "2021-04"
+Item	packaged cold medicine cabinet	Free Pull, Last Available: "2021-12"
+Item	packaged Daylight Shavings Helmet	Free Pull, Last Available: "2021-11"
+Item	packaged Everfull Dart Holster	Free Pull, Last Available: "2024-03"
+Item	packaged familiar scrapbook	Free Pull, Last Available: "2021-06"
+Item	packaged industrial fire extinguisher	Free Pull, Last Available: "2021-09"
+Item	packaged June cleaver	Free Pull, Last Available: "2022-06"
+Item	packaged Jurassic Parka	Free Pull, Last Available: "2022-09"
+Item	packaged knock-off retro superhero cape	Free Pull, Last Available: "2020-11"
+Item	packaged miniature crystal ball	Free Pull, Last Available: "2021-01"
+Item	packaged model train set	Free Pull, Last Available: "2022-12"
+Item	packaged Pocket Professor	Free Pull, Last Available: "2019-09"
 Item	packaged Roman Candelabra	Free Pull
-Item	packaged SpinMaster&trade; lathe	Free Pull
+Item	packaged SpinMaster&trade; lathe	Free Pull, Last Available: "2020-08"
 # PADL Phone: Summons Frat Army Aid
 # paint bomb: Deals 5-10 Prismatic Damage
 # paint bomb: (keeps dealing damage every round)
@@ -12522,33 +12522,33 @@ Item	packaged SpinMaster&trade; lathe	Free Pull
 # paisley spore pod: Stuns your opponent for a couple of rounds.
 # palm-frond fan: Restores 35-45 HP and MP
 # palm-frond net: Weakens enemies somewhat
-Item	panicked kernel	Free Pull
-Item	pantogram	Free Pull
+Item	panicked kernel	Free Pull, Last Available: "2010-04"
+Item	pantogram	Free Pull, Last Available: "2017-11"
 # paperclip sproinger: Stuns your opponent for a couple of rounds and deals 10-15 Physical Damage
 Item	paranormal ricotta	Class: "Pastamancer"
 Item	parity bit	Familiar Weight: +5
-Item	Party Planning on a Budget	Skill: "Budget Conscious"
-Item	passed-out psychedelic bear	Free Pull
+Item	Party Planning on a Budget	Skill: "Budget Conscious", Last Available: "2018-09"
+Item	passed-out psychedelic bear	Free Pull, Last Available: "2009-10"
 # patchouli incense stick: Weakens enemies a little bit
 Item	patchouli incense stick	Effect: "Far Out", Effect: "Embarrassed", Effect Duration: 5
 # patchouli oil bomb: Deals 65-80 <font color=green>Stench Damage</font>
 # peace shooter: Makes an opponent peaceful for 3 rounds
-Item	peace turkey outline	Free Pull
-Item	Peek-a-Boo!	Skill: "Object Quasi-Permanence"
+Item	peace turkey outline	Free Pull, Last Available: "2024-11"
+Item	Peek-a-Boo!	Skill: "Object Quasi-Permanence", Last Available: "2017-04"
 # pencil kunai: Deals 20-30 Physical Damage
 # pencil stub: Does any number of crazy things
 # peppermint crook: Steals an item from your enemy
 # peppermint crook: (Maybe)
 # peppermint parasol: Lets you escape from combat without spending an Adventure
 # peppermint parasol: (Maybe)
-Item	perfectly ordinary frog	Free Pull
-Item	personal raindrop	Free Pull
-Item	personalized coffee mug	Free Pull
+Item	perfectly ordinary frog	Free Pull, Last Available: "2010-10"
+Item	personal raindrop	Free Pull, Last Available: "2005-04"
+Item	personalized coffee mug	Free Pull, Last Available: "2008-04"
 # personalized wassail stein: Produces a random booze item (1x/day)
 # petrified wood: Deals 50-60 Physical Damage and 50-60 <font color=gray>Spooky Damage</font>
 Item	phantom brace	Spooky Damage: +10, Spooky Spell Damage: +10
 # phonics down: Restores 46-50 HP and MP and also does other weird stuff
-Item	photo booth sized crate	Free Pull
+Item	photo booth sized crate	Free Pull, Last Available: "2024-10"
 # photoprotoneutron torpedo: Deals 30-40 Physical Damage
 # pink-belly slapper: Weakens enemies a little bit, brieftly stuns them, and restores 8-16 of your Hit Points
 # pint of sweat: Deals 25-30 <font color=green>Stench Damage</font> and 25-30 <font color=blueviolet>Sleaze Damage</font>
@@ -12558,7 +12558,7 @@ Item	photo booth sized crate	Free Pull
 # PirateRealm fun-a-log: Purchase gifts using PirateRealm FunPoints
 # PirateRealm guest pass: Gives you access to PirateRealm for the day
 # PirateRealm membership packet: Permanently unlocks access to PirateRealm
-Item	PirateRealm membership packet	Free Pull
+Item	PirateRealm membership packet	Free Pull, Last Available: "2019-04"
 # pixel coin: Sell it for 2,000 Meat
 # pixel cross: Deals 80-100 Physical Damage
 # pixel cross: (does it again the next round)
@@ -12577,7 +12577,7 @@ Item	plans for depleted Grimacite weightlifting belt	Recipe: "depleted Grimacite
 # plastic cup of flat beer: Deals 30-40 <font color=blueviolet>Sleaze Damage</font> and increases Item Drops by 15% if you win
 # plot hole: Deals 20-25 Physical Damage
 # plump juicy grub: Restores 90-100 HP
-Item	plump purple mushroom	Lasts Until Rollover
+Item	plump purple mushroom	Lasts Until Rollover, Last Available: "2018-04"
 # plus one: Give a pal +1
 # plus-sized phylactery: Contains the soul of a specific lihc
 Item	Pocket Guide to Mild Evil	Skill: "Perpetrate Mild Evil"
@@ -12595,15 +12595,15 @@ Item	Pocket Guide to Mild Evil (used)	Skill: "Perpetrate Mild Evil"
 # pog #09 (pirate): Does all sorts of crazy things
 # pog #10 (hobo): Does all sorts of crazy things
 # pog #11 (Naughty Sorceress): Does all sorts of crazy things
-Item	poisoned druidic s'more	Lasts Until Rollover
+Item	poisoned druidic s'more	Lasts Until Rollover, Last Available: "2018-04"
 # poisonsettia: Poisons an enemy for 25 and then doubles the amount of poison
-Item	Pok&eacute;fam Guide to Capturing All of Them	Free Pull
+Item	Pok&eacute;fam Guide to Capturing All of Them	Free Pull, Last Available: "2018-03"
 # poltergeist-in-the-jar-o: Deals 200-250 Physical Damage
 # pool of liquid metal: Does various things
 # pool torpedo: Deals 250-250 Physical Damage
 # pool torpedo: (underwater only)
 # pool torpedo: (has a chance to not go away when used)
-Item	Pop Art: a Guide	Skill: "Fifteen Minutes of Flame"
+Item	Pop Art: a Guide	Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
 # portable Mayo Clinic: Installs a mayonnaise-centered medical clinic in your workshed
 # portable photocopier: Makes a photocopy of an enemy
 # portable Spacegate: Provides one day's access to a random Spacegate planet
@@ -12616,15 +12616,15 @@ Item	Pop Art: a Guide	Skill: "Fifteen Minutes of Flame"
 # potted tea tree: 2) Get tea every day
 # powdered madness: Instantly dispatch a foe (limit 5/day)
 # powdered organs: Weakens enemies somewhat
-Item	power seed	Free Pull
-Item	praying Grim Brother	Free Pull
+Item	power seed	Free Pull, Last Available: "2021-03"
+Item	praying Grim Brother	Free Pull, Last Available: "2014-12"
 # precision snowball: Deal 100 Cold Damage to an enemy (or toss in your campground.)
 Item	Prelude of Precision	Skill: "Prelude of Precision"
 # print screen button: Copies a Monster
 # procrastination potion: Causes Enemy to Put Off Attacking You
 Item	profane eye patch	Sleaze Damage: +3
-Item	Professor of Spelunkology	Free Pull
-Item	Psycho From The Heat	Skill: "Pyromania"
+Item	Professor of Spelunkology	Free Pull, Last Available: "2015-12"
+Item	Psycho From The Heat	Skill: "Pyromania", Last Available: "2015-08"
 # psychokinetic energy blob: Restores 20-30 MP
 # puce plastic oyster egg: Deals 40-50 Physical Damage
 # pufferfish spine: Poisons your opponent, and using additional ones makes the poison way worse
@@ -12634,7 +12634,7 @@ Item	Psycho From The Heat	Skill: "Pyromania"
 # punching mirror: Punch it for 5 PvP fights per day
 Item	puppet strings	Free Pull
 # pygmy blowgun: Poisons enemies, dealing damage over multiple rounds
-Item	pygmy bugbear shaman	Free Pull
+Item	pygmy bugbear shaman	Free Pull, Last Available: "2011-12"
 # quantum nanopolymer spider web: Weakens enemies somewhat and briefly stuns them
 Item	quantum watch	Adventures: +2
 Item	quasi-ethereal macaroni fragments	Class: "Pastamancer"
@@ -12647,7 +12647,7 @@ Item	quasi-ethereal macaroni fragments	Class: "Pastamancer"
 # Rain-Doh orange agent: Deals Physical Damage for Meat
 # Rain-Doh orange agent: (doesn't go away when used)
 # rainbow bomb: Deals 20-30 Physical Damage and 20-30 Prismatic Damage
-Item	Rainbow's Gravity	Skill: "Rainbow Gravitation"
+Item	Rainbow's Gravity	Skill: "Rainbow Gravitation", Last Available: "2008-07"
 # rattler rattle: Weakens enemies by 25%
 # rattler rattle: (75% for beasts)
 # razor-sharp can lid: Deals 2-3 Physical Damage
@@ -12672,12 +12672,12 @@ Item	Recipe of Before Yore: ratatouille de Jarlsberg	Recipe: "ratatouille de Jar
 Item	Recipe of Before Yore: roasted vegetable focaccia	Recipe: "roasted vegetable focaccia"
 Item	Recipe of Before Yore: roasted vegetable of J.	Recipe: "roasted vegetable of Jarlsberg"
 Item	Recipe of Before Yore: St. Pete's sneaky smoothie	Recipe: "St. Pete's sneaky smoothie"
-Item	record of infuriating silence	Skill: "Silent Slam"
-Item	record of infuriating silence (used)	Skill: "Silent Slam"
-Item	record of menacing silence	Skill: "Silent Slice"
-Item	record of menacing silence (used)	Skill: "Silent Slice"
-Item	record of tranquil silence	Skill: "Silent Squirt"
-Item	record of tranquil silence (used)	Skill: "Silent Squirt"
+Item	record of infuriating silence	Skill: "Silent Slam", Last Available: "2012-10"
+Item	record of infuriating silence (used)	Skill: "Silent Slam", Last Available: "2012-10"
+Item	record of menacing silence	Skill: "Silent Slice", Last Available: "2012-10"
+Item	record of menacing silence (used)	Skill: "Silent Slice", Last Available: "2012-10"
+Item	record of tranquil silence	Skill: "Silent Squirt", Last Available: "2012-10"
+Item	record of tranquil silence (used)	Skill: "Silent Squirt", Last Available: "2012-10"
 # recovered elf magazine: Turn it in at the E. R. F. camp for 1 Crimbo Credit
 # recovered elf photo album: Turn it in at the E. R. F. camp for 4 Crimbo Credits
 # recovered elf pocketwatch: Turn it in at the E. R. F. camp for 3 Crimbo Credits
@@ -12691,31 +12691,31 @@ Item	red and green rain stick	Effect: "Peaceful, Easy Feeling", Effect Duration:
 # red coin: Try using 11 of them!
 # red face paint: Makes you red with holiday cheer!
 # red face paint: Does not go away when used.
-Item	red face paint	Free Pull
+Item	red face paint	Free Pull, Last Available: "2015-12"
 # red pixel potion: Heals 100-120 Hit Points
 # red plastic oyster egg: Restores 35-40 Hit Points
 # red potion: Restores 90-110 HP
 Item	red potion	Effect: "Healthy Red Glow", Effect Duration: 20
 # Red Roger's flag: Increases the likelihood of sea battles in PirateRealm
-Item	Red Roger's flag	Lasts Until Rollover
-Item	Red Roger's map	Lasts Until Rollover
-Item	red-spotted snapper roe	Free Pull
-Item	redwood rain stick	Effect: "You Have Ever Seen The Rain", Effect Duration: 20
+Item	Red Roger's flag	Lasts Until Rollover, Last Available: "2019-04"
+Item	Red Roger's map	Lasts Until Rollover, Last Available: "2019-04"
+Item	red-spotted snapper roe	Free Pull, Last Available: "2019-12"
+Item	redwood rain stick	Effect: "You Have Ever Seen The Rain", Effect Duration: 20, Last Available: "2020-08"
 # Regular Cloaca Cola: Restores 7-9 MP
-Item	rehearsing dramatic hedgehog	Free Pull
+Item	rehearsing dramatic hedgehog	Free Pull, Last Available: "2011-12"
 # replica bat-oomerang: Instantly kill a foe (up to 3x per day)
 # replica bat-oomerang: (does not go away when used)
 Item	replica emotion chip	Skill: "Replica Emotionally Chipped"
 Item	residual chitin paste	Skill: "Chitinous Soul"
-Item	Rethinking Candy	Skill: "Sweet Synthesis"
-Item	Retrospecs try-at-home kit	Free Pull
+Item	Rethinking Candy	Skill: "Sweet Synthesis", Last Available: "2016-12"
+Item	Retrospecs try-at-home kit	Free Pull, Last Available: "2020-01"
 # riboflavin: Increase a Pokefamiliar's maximum HP by 1
 Item	rift oculus	Combat Rate: +5
 Item	rigging knot	Familiar Weight: +5
 # Riker's Search History: Deals 900-1000 Sleaze Damage
 # robotronic egg: Crazy robotronic action!
 # rock band flyers: Advertise!
-Item	Rock Garden Guide	Free Pull
+Item	Rock Garden Guide	Free Pull, Last Available: "2023-01"
 # rocky raccoon: Deals 50-60 Physical Damage
 # rogue swarmer: Deals Physical Damage based on how many swarmers you have
 Item	roll of toilet paper	Free Pull
@@ -12726,9 +12726,9 @@ Item	ROM of Optimality	Skill: "Toggle Optimality"
 # rough stone sphere: Mysterious, Deprecated
 # round blue bomb: Deals 90-110 <font color=red>Hot Damage</font>
 # Rufus's shadow lodestone: Reveals hidden things in Shadow Rifts
-Item	rune-strewn spoon cocoon	Free Pull
+Item	rune-strewn spoon cocoon	Free Pull, Last Available: "2019-06"
 # rusty bonesaw: Saws bones
-Item	S.I.T. Course Voucher	Free Pull
+Item	S.I.T. Course Voucher	Free Pull, Last Available: "2023-02"
 # S.O.C.K.: Allows access to the Castle in the Clouds in the Sky
 # sacramental wine: Restores 80-100 MP
 Item	sacramental wine	Effect: "Spiritually Awash", Effect Duration: 10
@@ -12736,20 +12736,20 @@ Item	sacramental wine	Effect: "Spiritually Awash", Effect Duration: 10
 # sake bomb: Weakens Enemies a Little Bit
 # samurai turtle: Does various ninja things
 # sanctified cola: Restores 400-500 MP
-Item	sanctified cola	Lasts Until Rollover
-Item	sane hatrack	Free Pull
+Item	sanctified cola	Lasts Until Rollover, Last Available: "2018-04"
+Item	sane hatrack	Free Pull, Last Available: "2011-12"
 # sausage bomb: Deals 100-120 <font color=blueviolet>Sleaze Damage</font>
 # sausage bomb: Weakens Enemies Somewhat
 # sawblade fragment: Deals 100-150 Physical Damage and causes additional Bleeding over time
 # scented massage oil: Restores all HP
-Item	Schmalz's First Prize Beer	Free Pull
+Item	Schmalz's First Prize Beer	Free Pull, Last Available: "2011-12"
 # School of Hard Knocks Diploma: Brings up Enraging Memories
 Item	scintillating powder	Class: "Pastamancer"
-Item	Scratch 'n' Sniff Sticker Tome	Free Pull, Skill: "Summon Stickers"
-Item	Scratch-and-Sniff Guide to Dinseylandfill	Skill: "Olfactory Burnout"
+Item	Scratch 'n' Sniff Sticker Tome	Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+Item	Scratch-and-Sniff Guide to Dinseylandfill	Skill: "Olfactory Burnout", Last Available: "2015-04"
 # scroll of ancient forbidden unspeakable evil: Invokes Dangerous and Unpredictable Magic
 # scroll of drastic healing: Restores all HP
-Item	Scurvy and Sobriety Prevention	Skill: "Prevent Scurvy and Sobriety"
+Item	Scurvy and Sobriety Prevention	Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 # sea cowbell: Gives you a fever
 # sea lasso: Allows underwater rooting and tooting
 # seal tooth: Deals 1 Physical Damage
@@ -12782,20 +12782,20 @@ Item	shimmering tendrils	Class: "Pastamancer"
 Item	shingle	Effect: "Confused", Effect: "Amorous", Effect Duration: 10
 # short calculator: ???
 # short writ of habeas corpus: Lets you get away from pygmies without spending an Adventure
-Item	shortest-order cook	Free Pull
+Item	shortest-order cook	Free Pull, Last Available: "2021-05"
 Item	shot of Sneaky Pete's Mojo	Free Pull
-Item	shrine to the Barrel god	Free Pull
-Item	shrink-wrapped 2002 Mr. Store Catalog	Free Pull
-Item	shrink-wrapped Cincho de Mayo	Free Pull
+Item	shrine to the Barrel god	Free Pull, Last Available: "2015-09"
+Item	shrink-wrapped 2002 Mr. Store Catalog	Free Pull, Last Available: "2023-06"
+Item	shrink-wrapped Cincho de Mayo	Free Pull, Last Available: "2023-05"
 # shrinking powder: Reduce an enemy's size (Hit Points) by 35-50%
 # shuriken salad: Deals 25-35 Physical Damage, 25-35 <font color=blue>Cold Damage</font> and 25-35 <font color=green>Stench Damage</font>
-Item	siesta-ing Casagnova gnome	Free Pull
+Item	siesta-ing Casagnova gnome	Free Pull, Last Available: "2008-10"
 # silk bandages: Restores 40-80 HP
-Item	silk garter snake	Free Pull
-Item	Silly Little Love Song	Skill: "Paul's Passionate Pop Song"
+Item	silk garter snake	Free Pull, Last Available: "2011-12"
+Item	Silly Little Love Song	Skill: "Paul's Passionate Pop Song", Last Available: "2018-02"
 # silver cow skull: Sells for a pretty penny!
 Item	silver Dreadsylvanian flask	Effect: "Silver Age Secrets", Effect Duration: 100
-Item	sinistral homunculus	Free Pull
+Item	sinistral homunculus	Free Pull, Last Available: "2020-04"
 # Sitrep berry: Restores HP and energizes you for a while
 # skate skates: Deals 150-300 Physical Damage and briefly stuns your opponent
 # skeletal skiff: <b>Allows Travel to The Mysterious Island of Mystery</b>
@@ -12804,17 +12804,17 @@ Item	sinistral homunculus	Free Pull
 Item	slap and slap again recipe	Recipe: "slap and slap again"
 # sleaze clusterbomb: Deals <font color=blueviolet>Sleaze Damage</font> based on your highest stat
 # sleaze clusterbomb: (more effective against groups)
-Item	SLEEP(5) rom chip	Skill: "SLEEP(5)"
+Item	SLEEP(5) rom chip	Skill: "SLEEP(5)", Last Available: "2025-12"
 Item	sleeping patriotic eagle	Free Pull
-Item	sleeping piano cat	Free Pull
+Item	sleeping piano cat	Free Pull, Last Available: "2011-12"
 # slime stack: Deals 10-20% of a monster's current Hit Points in Physical Damage
 # slime stack: Weakens the monster by 10%
 Item	slime-soaked brain	Skill: "Slimy Synapses"
 Item	slime-soaked hypophysis	Skill: "Slimy Sinews"
 Item	slime-soaked sweat gland	Skill: "Slimy Shoulders"
-Item	Sloppy Seconds Diner Employee Handbook	Skill: "Sloppy Secrets"
+Item	Sloppy Seconds Diner Employee Handbook	Skill: "Sloppy Secrets", Last Available: "2014-05"
 # small golem: Deals Physical Damage each round for the rest of the fight
-Item	Small Medium	Free Pull
+Item	Small Medium	Free Pull, Last Available: "2012-03"
 # smoke grenade: Banishes a monster for a while
 # smoking grass: Deals 250-300 <font color=red>Hot Damage</font> and also, like, weakens enemies a bunch and briefly makes them forget what they were doing
 Item	smoking talon	Class: "Pastamancer"
@@ -12832,18 +12832,18 @@ Item	Snarf berry	Effect: "Berry Statistical", Effect Duration: 20
 # solid gold jewel: Can be sold for 100,000 Meat
 # sonar-in-a-biscuit: Freaks Bats Out
 # SongBoom&trade; BoomBox: Plays a Soundtrack for your Life<br />Lets you <i>Sing Along</i> during Fights
-Item	SongBoom&trade; BoomBox Box	Free Pull
+Item	SongBoom&trade; BoomBox Box	Free Pull, Last Available: "2018-06"
 Item	Sorcerers of the Shore Grimoire	Free Pull, Skill: "Summon Alice's Army Cards"
 # soup turtle: Deals 5-10 <font color=red>Hot Damage</font>
-Item	Source terminal	Free Pull
+Item	Source terminal	Free Pull, Last Available: "2016-06"
 Item	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	Skill: "Summon Tasteful Items"
 # space invader: Deals 300-400 Physical Damage
-Item	Space Pirate Astrogation Handbook	Skill: "Quantum Movement"
-Item	space planula	Free Pull
+Item	Space Pirate Astrogation Handbook	Skill: "Quantum Movement", Last Available: "2017-04"
+Item	space planula	Free Pull, Last Available: "2017-01"
 # Space Tours Tripple: Weakens enemies a little bit
 # Spacegate access badge: Unlocks billions of strange alien worlds
-Item	Spacegate access badge	Free Pull
-Item	Spacegate emergency disintegrator	Skill: "Disintegrate"
+Item	Spacegate access badge	Free Pull, Last Available: "2017-04"
+Item	Spacegate emergency disintegrator	Skill: "Disintegrate", Last Available: "2017-04"
 # spangly unitard: Deals 100-250 Physical Damage and weakens your opponent somewhat
 # spant egg casing: Worth 25 pages of Spacegate Research
 # sparking El Vibrato drone: Deals 250-300 Physical Damage
@@ -12855,14 +12855,14 @@ Item	Spacegate emergency disintegrator	Skill: "Disintegrate"
 # special clip: tracers: Deals <font color=red>Hot Damage</font> based on your Moxie
 # special clip: wailers: Deals <font color=gray>Spooky Damage</font> based on your Moxie
 # special edition Batfellow comic: Lets you have a fun adventure (once a week) as a dark, brooding, bat-themed superhero.
-Item	special edition Batfellow comic	Free Pull
+Item	special edition Batfellow comic	Free Pull, Last Available: "2016-12"
 # Special Seasoning: Kicks Food Up a Notch
 # spectral jelly: Makes you nearly impervious to damage for the duration of the fight
 # spectre scepter: Invoke the Ancient Gods!
 Item	Spellbook: Drescher's Annoying Noise	Skill: "Drescher's Annoying Noise"
 Item	Spellbook: Singer's Faithful Ocelot	Skill: "Singer's Faithful Ocelot"
 Item	Spellbook: Walberg's Dim Bulb	Skill: "Walberg's Dim Bulb"
-Item	Spelunker of Fortune	Skill: "Speluck"
+Item	Spelunker of Fortune	Skill: "Speluck", Last Available: "2015-12"
 Item	Spelunker of Fortune (used)	Skill: "Speluck"
 # spice melange: Makes you less full and more sober
 # spices: Deals 1 Physical Damage
@@ -12878,19 +12878,19 @@ Item	spirit beer	Effect: "Spiritually Aware", Effect Duration: 10
 # spooky music box mechanism: Deals 100-120 <font color=gray>Spooky Damage</font>
 # spooky music box mechanism: (unless you're in Spookyraven Manor, in which case it banishes a monster for a while)
 # Spooky Putty sheet: Makes a copy of a monster to fight later
-Item	spooky rattling cigar box	Free Pull
+Item	spooky rattling cigar box	Free Pull, Last Available: "2011-12"
 Item	spray paint	Effect: "Tagged", Effect Duration: 10
-Item	squamous polyp	Free Pull
+Item	squamous polyp	Free Pull, Last Available: "2011-12"
 Item	Stabonic scroll	Effect: "Bone Homie", Effect Duration: 20
 # star throwing star: Deals 50-75 Physical Damage
-Item	STATS+++ rom chip	Skill: "STATS+++"
+Item	STATS+++ rom chip	Skill: "STATS+++", Last Available: "2025-12"
 # steam-powered model rocketship: Allows access to the Hole in the Sky
 # stench clusterbomb: Deals <font color=green>Stench Damage</font> based on your highest stat
 # stench clusterbomb: (more effective against groups)
 # stick of dynamite: Deals 15-20 Physical Damage
 # stick-on-a-string: Either Slightly Damages or Slight Weakens Foes
 # sticky clay homunculus: Makes a copy of a monster to fight later
-Item	still grill	Free Pull
+Item	still grill	Free Pull, Last Available: "2014-06"
 Item	stomach churner	Sleaze Damage: +10, Sleaze Spell Damage: +10
 # stone frisbee: Deals 80-100 Physical Damage
 # strange goggles: ???
@@ -12898,7 +12898,7 @@ Item	stomach churner	Sleaze Damage: +10, Sleaze Spell Damage: +10
 # stuffed doppelshifter: Randomly Becomes a Different Combat Item When Used
 # stuffed gray blob: Randomly becomes a different combat item when used
 # stuffed yam stinkbomb: Banish a monster for 15 turns
-Item	stuffed-shirt scarecrow	Free Pull
+Item	stuffed-shirt scarecrow	Free Pull, Last Available: "2011-11"
 # sugar shard: Restores 10-20 HP and 5-10 MP
 Item	Summer Nights	Skill: "Grease Lightning"
 # super deluxe mushroom: Heals 100 HP
@@ -12907,25 +12907,25 @@ Item	Summer Nights	Skill: "Grease Lightning"
 # superamplified boom box: Briefly stuns your opponent
 # superduperheated metal: Vaporizes foes
 # surgical tape: Weakens enemies a little bit and restores 20-30 Hit Points
-Item	suspicious package	Free Pull
-Item	suspicious stocking	Free Pull
+Item	suspicious package	Free Pull, Last Available: "2017-06"
+Item	suspicious stocking	Free Pull, Last Available: "2009-12"
 Item	sweaty egg	HP Regen Min: 4, HP Regen Max: 8
-Item	sweet nutcracker	Free Pull
+Item	sweet nutcracker	Free Pull, Last Available: "2005-12"
 Item	sweet tooth	Wiki Name: "sweet tooth"
 # synaptic soup: Add a pound and MP restore to your familiar
 # T.U.R.D.S. Key: Lets you escape from combat without spending an Adventure
 # T.U.R.D.S. Key: (Maybe)
 # tabletop candy dispenser: Produces some random candy items (1x/day, costs 10 Meat)
-Item	tainted marshmallow	Lasts Until Rollover
+Item	tainted marshmallow	Lasts Until Rollover, Last Available: "2018-04"
 Item	Tales from the Fireside	Skill: "Conjure Relaxing Campfire"
-Item	Tales of a Kansas Toymaker	Skill: "Toynado"
-Item	Tales of a Kansas Toymaker (used)	Skill: "Toynado"
+Item	Tales of a Kansas Toymaker	Skill: "Toynado", Last Available: "2010-12"
+Item	Tales of a Kansas Toymaker (used)	Skill: "Toynado", Last Available: "2010-12"
 Item	Tales of Dread	Free Pull
 # Tales of Spelunking: Begins a Spelunking Adventure!
 # Tales of the West: Beanslinging: Teaches you Beanslinger skills
 # Tales of the West: Cow Punching: Teaches you Cow Puncher skills
 # Tales of the West: Snake Oiling: Teaches you Snake Oiler skills
-Item	Tales of Western Braggadoccio	Skill: "Bow-Legged Swagger"
+Item	Tales of Western Braggadoccio	Skill: "Bow-Legged Swagger", Last Available: "2016-02"
 # talisman of Renenutet: Massive boost to Item Drops from Monsters (for one fight)
 # talisman of Seshat: Grants one "skill point" to Ed the Undying
 Item	talisman of Seshat	Free Pull
@@ -12941,73 +12941,73 @@ Item	Tapioc berry	Effect: "Berry Elemental", Effect Duration: 20
 # tequila grenade: Deals 75-100 Physical Damage
 # terrible poem: Deals 5-6 Physical Damage
 # thanksgiving bomb: Deals 750-1000 Physical and Hot Damage
-Item	The Art of Slapfighting	Class: "Seal Clubber", Skill: "Iron Palm Technique"
-Item	The Art of Slapfighting (used)	Class: "Seal Clubber", Skill: "Iron Palm Technique"
-Item	The Autobiography Of Dynamite Superman Jones	Class: "Disco Bandit", Skill: "Kung Fu Hustler"
+Item	The Art of Slapfighting	Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
+Item	The Art of Slapfighting (used)	Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
+Item	The Autobiography Of Dynamite Superman Jones	Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 Item	The Ballad of Richie Thingfinder	Skill: "The Ballad of Richie Thingfinder"
 Item	The Big Book of Communism	Skill: "Communism!"
-Item	The Big Book of Communism (used)	Skill: "Communism!"
+Item	The Big Book of Communism (used)	Skill: "Communism!", Last Available: "2015-12"
 # The Big Book of Pirate Insults: Use it to insult Pirates
 # The Bomb: Deals 400-500 Physical Damage
-Item	The Chill of the Wild	Skill: "Beardfreeze"
-Item	The Confiscator's Grimoire	Free Pull, Skill: "Summon Confiscated Things"
-Item	the Crymbich Manuscript	Skill: "Ancient Crymbo Lore"
-Item	the Crymbich Manuscript (used)	Skill: "Ancient Crymbo Lore"
+Item	The Chill of the Wild	Skill: "Beardfreeze", Last Available: "2015-11"
+Item	The Confiscator's Grimoire	Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+Item	the Crymbich Manuscript	Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
+Item	the Crymbich Manuscript (used)	Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 # The Emperor's new cookie: So delicious!
-Item	The Encyclopedia of Fruit	Skill: "Fruit Recognition"
-Item	The Encyclopedia of Fruit (used)	Skill: "Fruit Recognition"
+Item	The Encyclopedia of Fruit	Skill: "Fruit Recognition", Last Available: "2023-12"
+Item	The Encyclopedia of Fruit (used)	Skill: "Fruit Recognition", Last Available: "2023-12"
 # The Fingernail of the Thing in the Basement: Jeremy Science will be interested in this
-Item	The Firegate Tapes	Skill: "Firegate"
-Item	The Fun-Guy Cold Weather Bartender's Guide	Skill: "Perfect Freeze"
-Item	The Gingerbread Vigilante's Handbook	Skill: "Licorice Rope"
-Item	The Groose in the Hoose	Free Pull
+Item	The Firegate Tapes	Skill: "Firegate", Last Available: "2015-08"
+Item	The Fun-Guy Cold Weather Bartender's Guide	Skill: "Perfect Freeze", Last Available: "2015-11"
+Item	The Gingerbread Vigilante's Handbook	Skill: "Licorice Rope", Last Available: "2016-12"
+Item	The Groose in the Hoose	Free Pull, Last Available: "2012-12"
 Item	The Imploded World	Skill: "Implode Universe"
-Item	The Journal of Mime Science Vol. 1	Skill: "Silent Hunter"
-Item	The Journal of Mime Science Vol. 1 (used)	Skill: "Silent Hunter"
-Item	The Journal of Mime Science Vol. 2	Skill: "Quiet Determination"
-Item	The Journal of Mime Science Vol. 2 (used)	Skill: "Quiet Determination"
-Item	The Journal of Mime Science Vol. 3	Skill: "Quiet Judgement"
-Item	The Journal of Mime Science Vol. 3 (used)	Skill: "Quiet Judgement"
-Item	The Journal of Mime Science Vol. 4	Skill: "Silent Treatment"
-Item	The Journal of Mime Science Vol. 4 (used)	Skill: "Silent Treatment"
-Item	The Journal of Mime Science Vol. 5	Skill: "Silent Knife"
-Item	The Journal of Mime Science Vol. 5 (used)	Skill: "Silent Knife"
-Item	The Journal of Mime Science Vol. 6	Skill: "Quiet Desperation"
-Item	The Journal of Mime Science Vol. 6 (used)	Skill: "Quiet Desperation"
-Item	The Joy of Wassailing	Skill: "Wassail"
-Item	The Joy of Wassailing (used)	Skill: "Wassail"
-Item	The Kloop in the Coop	Free Pull
+Item	The Journal of Mime Science Vol. 1	Skill: "Silent Hunter", Last Available: "2017-12"
+Item	The Journal of Mime Science Vol. 1 (used)	Skill: "Silent Hunter", Last Available: "2017-12"
+Item	The Journal of Mime Science Vol. 2	Skill: "Quiet Determination", Last Available: "2017-12"
+Item	The Journal of Mime Science Vol. 2 (used)	Skill: "Quiet Determination", Last Available: "2017-12"
+Item	The Journal of Mime Science Vol. 3	Skill: "Quiet Judgement", Last Available: "2017-12"
+Item	The Journal of Mime Science Vol. 3 (used)	Skill: "Quiet Judgement", Last Available: "2017-12"
+Item	The Journal of Mime Science Vol. 4	Skill: "Silent Treatment", Last Available: "2017-12"
+Item	The Journal of Mime Science Vol. 4 (used)	Skill: "Silent Treatment", Last Available: "2017-12"
+Item	The Journal of Mime Science Vol. 5	Skill: "Silent Knife", Last Available: "2017-12"
+Item	The Journal of Mime Science Vol. 5 (used)	Skill: "Silent Knife", Last Available: "2017-12"
+Item	The Journal of Mime Science Vol. 6	Skill: "Quiet Desperation", Last Available: "2017-12"
+Item	The Journal of Mime Science Vol. 6 (used)	Skill: "Quiet Desperation", Last Available: "2017-12"
+Item	The Joy of Wassailing	Skill: "Wassail", Last Available: "2010-12"
+Item	The Joy of Wassailing (used)	Skill: "Wassail", Last Available: "2010-12"
+Item	The Kloop in the Coop	Free Pull, Last Available: "2012-12"
 Item	The Legendary Beat	Effect: "Clyde's Blessing", Effect Duration: 20
 # The Lost Comb: Stuns your opponent for a few rounds
-Item	The Necbronomicon	Skill: "Summon &quot;Boner Battalion&quot;"
-Item	The Necbronomicon (used)	Skill: "Summon &quot;Boner Battalion&quot;"
-Item	The Night Before Crimbo, Ch. 1	Skill: "Long Winter's Nap"
-Item	The Night Before Crimbo, Ch. 1 (used)	Skill: "Long Winter's Nap"
-Item	The Night Before Crimbo, Ch. 2	Skill: "Bowl Full of Jelly"
-Item	The Night Before Crimbo, Ch. 2 (used)	Skill: "Bowl Full of Jelly"
-Item	The Night Before Crimbo, Ch. 3	Skill: "Ashes and Soot"
-Item	The Night Before Crimbo, Ch. 3 (used)	Skill: "Ashes and Soot"
-Item	The Night Before Crimbo, Ch. 4	Skill: "Eye and a Twist"
-Item	The Night Before Crimbo, Ch. 4 (used)	Skill: "Eye and a Twist"
-Item	The Night Before Crimbo, Ch. 5	Skill: "Dimples, How Merry!"
-Item	The Night Before Crimbo, Ch. 5 (used)	Skill: "Dimples, How Merry!"
-Item	The Night Before Crimbo, Ch. 6	Skill: "Chubby and Plump"
-Item	The Night Before Crimbo, Ch. 6 (used)	Skill: "Chubby and Plump"
-Item	The Nose Knows, A Guide to Smells	Skill: "Dead Nostrils"
-Item	The Nose Knows, A Guide to Smells (read)	Skill: "Dead Nostrils"
+Item	The Necbronomicon	Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
+Item	The Necbronomicon (used)	Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
+Item	The Night Before Crimbo, Ch. 1	Skill: "Long Winter's Nap", Last Available: "2020-12"
+Item	The Night Before Crimbo, Ch. 1 (used)	Skill: "Long Winter's Nap", Last Available: "2020-12"
+Item	The Night Before Crimbo, Ch. 2	Skill: "Bowl Full of Jelly", Last Available: "2020-12"
+Item	The Night Before Crimbo, Ch. 2 (used)	Skill: "Bowl Full of Jelly", Last Available: "2020-12"
+Item	The Night Before Crimbo, Ch. 3	Skill: "Ashes and Soot", Last Available: "2020-12"
+Item	The Night Before Crimbo, Ch. 3 (used)	Skill: "Ashes and Soot", Last Available: "2020-12"
+Item	The Night Before Crimbo, Ch. 4	Skill: "Eye and a Twist", Last Available: "2020-12"
+Item	The Night Before Crimbo, Ch. 4 (used)	Skill: "Eye and a Twist", Last Available: "2020-12"
+Item	The Night Before Crimbo, Ch. 5	Skill: "Dimples, How Merry!", Last Available: "2020-12"
+Item	The Night Before Crimbo, Ch. 5 (used)	Skill: "Dimples, How Merry!", Last Available: "2020-12"
+Item	The Night Before Crimbo, Ch. 6	Skill: "Chubby and Plump", Last Available: "2020-12"
+Item	The Night Before Crimbo, Ch. 6 (used)	Skill: "Chubby and Plump", Last Available: "2020-12"
+Item	The Nose Knows, A Guide to Smells	Skill: "Dead Nostrils", Last Available: "2021-08"
+Item	The Nose Knows, A Guide to Smells (read)	Skill: "Dead Nostrils", Last Available: "2021-08"
 # The Six-Pack of Pain: Deals Physical Damage based on your Muscle
 # The Six-Pack of Pain: Weakens Enemies a Whole Lot
-Item	The Smith's Tome	Free Pull, Skill: "Summon Smithsness"
-Item	The Snitch's Manifesto	Skill: "Tattle"
-Item	The Spirit of Giving	Skill: "The Spirit of Taking"
-Item	The Spirit of Giving (used)	Skill: "The Spirit of Taking"
+Item	The Smith's Tome	Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
+Item	The Snitch's Manifesto	Skill: "Tattle", Last Available: "2012-12"
+Item	The Spirit of Giving	Skill: "The Spirit of Taking", Last Available: "2019-12"
+Item	The Spirit of Giving (used)	Skill: "The Spirit of Taking", Last Available: "2019-12"
 Item	The Sword in the Steak	Wiki Name: "The Sword in the Steak (item)"
-Item	The Thorax's Codex of Tormenting Plants	Skill: "Torment Plant"
-Item	The Western Look	Skill: "Steely-Eyed Squint"
-Item	They'll Love You In Rhinestones	Skill: "Acquire Rhinestones"
+Item	The Thorax's Codex of Tormenting Plants	Skill: "Torment Plant", Last Available: "2012-12"
+Item	The Western Look	Skill: "Steely-Eyed Squint", Last Available: "2016-02"
+Item	They'll Love You In Rhinestones	Skill: "Acquire Rhinestones", Last Available: "2018-02"
 # thick walrus blubber: Weakens foes
 # thick walrus blubber: (much more effective in the Canadian Wildlife Preserve)
-Item	Thinknerd's Grimoire of Geeky Gifts	Free Pull, Skill: "Summon Geeky Gifts"
+Item	Thinknerd's Grimoire of Geeky Gifts	Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
 Item	throbbing rage gland	Skill: "Vent Rage Gland"
 # throwing candy: Deals 25-50 Physical Damage and weakens enemies somewhat
 # throwing fork: Deals 20-30 Physical Damage with each of its three tines
@@ -13015,10 +13015,10 @@ Item	throbbing rage gland	Skill: "Vent Rage Gland"
 # throwing spoon: Deals 50-60 Physical Damage and weakens enemies somewhat
 # tie-dye headband: Makes your peace turkey outline block delevel more often
 # time shuriken: (does not go away when used)
-Item	time sleigh	Free Pull
+Item	time sleigh	Free Pull, Last Available: "2006-12"
 # Time-Spinner: Allows you to travel through time
 # Time-Spinner: Weakens opponents in combat
-Item	time's arrow	Free Pull
+Item	time's arrow	Free Pull, Last Available: "2011-12"
 # tin lizzie: <b>Allows Travel to Desert Beach</b>
 # tin snips: Deals 8-10 Physical Damage and causes bleeding
 # tiny bomb: Deals moderate damage to enemies
@@ -13027,16 +13027,16 @@ Item	tiny ember	Cold Resistance: +1
 # tiny goth giant: Makes combat all Gothy
 # tiny goth giant: (doesn't go away when used)
 # tiny house: Restores 20-24 HP and MP and removes negative effects
-Item	To Build an Igloo	Skill: "Refusal to Freeze"
-Item	to-go brew	Lasts Until Rollover
+Item	To Build an Igloo	Skill: "Refusal to Freeze", Last Available: "2015-11"
+Item	to-go brew	Lasts Until Rollover, Last Available: "2018-04"
 # Tom's of the Spanish Main Toothpaste: Weakens enemies a little bit
 # tomayohawk-style reflex hammer: Stops enemy from attacking and deals <font color=blueviolet>Sleaze Damage</font> based on your blood-mayonnaise concentration.
-Item	tomayohawk-style reflex hammer	Lasts Until Rollover
+Item	tomayohawk-style reflex hammer	Lasts Until Rollover, Last Available: "2015-05"
 # tomb-opener: Opens a tomb, duh.
-Item	tomb-opener	Lasts Until Rollover
-Item	Tome of Clip Art	Free Pull, Skill: "Summon Clip Art"
-Item	Tome of Rad Libs	Free Pull, Skill: "Summon Rad Libs"
-Item	Tome of Snowcone Summoning	Free Pull, Skill: "Summon Snowcones"
+Item	tomb-opener	Lasts Until Rollover, Last Available: "2019-04"
+Item	Tome of Clip Art	Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
+Item	Tome of Rad Libs	Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
+Item	Tome of Snowcone Summoning	Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
 Item	Tome of Sugar Shummoning	Free Pull, Skill: "Summon Sugar Sheets"
 # tongue depressor: Briefly stuns a monster and reveals its vital statistics
 # tonic water: Restores 30-50 MP
@@ -13048,7 +13048,7 @@ Item	toothbrush	Effect: "Very Clean Teeth", Effect Duration: 10
 # toy Cupid bow: Occasionally snag a missed item drop
 # toy Cupid bow: Distract foes with a plunger to the face
 # toy Cupid bow: Lets your familiar fetch their own equipment after a while
-Item	toy Cupid bow	Experience (familiar): +2, Generic
+Item	toy Cupid bow	Experience (familiar): +2, Last Available: "2025-02", Generic
 # toy deathbot: Deals damage in exchange for some of your blood
 # toy mercenary: Charges Meat to Attack Foes
 # toy sixgun: Bang!
@@ -13056,14 +13056,14 @@ Item	toy Cupid bow	Experience (familiar): +2, Generic
 # toy soldier: (Not consumed when used)
 # train whistle: Blow it to weaken your foes
 # Trainbot autoassembly module: Gives you a piece of the Trainbot outfit
-Item	training scroll:  Shattering Punch	Skill: "Shattering Punch"
-Item	training scroll:  Shivering Monkey Technique	Skill: "Shivering Monkey Technique"
-Item	training scroll:  Snokebomb	Skill: "Snokebomb"
-Item	Trash, a Memoir	Skill: "Garbage Nova"
+Item	training scroll:  Shattering Punch	Skill: "Shattering Punch", Last Available: "2016-01"
+Item	training scroll:  Shivering Monkey Technique	Skill: "Shivering Monkey Technique", Last Available: "2016-01"
+Item	training scroll:  Snokebomb	Skill: "Snokebomb", Last Available: "2016-01"
+Item	Trash, a Memoir	Skill: "Garbage Nova", Last Available: "2015-04"
 Item	Travels with Jerry	Skill: "Mudbath"
 # tree-eating kite: Deals 20-25 Physical Damage
 # tropical orchid: Weakens enemies a little bit
-Item	Trout Fishing in Loathing	Skill: "Astute Angler"
+Item	Trout Fishing in Loathing	Skill: "Astute Angler", Last Available: "2016-04"
 # tryptophan dart: Knocks an enemy out.  You won't see them for the rest of the day.
 # tube of herbal ointment: Restores 14-16 HP
 # turtle-shaped rock: Deals 45-50 Physical Damage
@@ -13074,38 +13074,38 @@ Item	twitching trigger finger	Class: "Pastamancer"
 # Ultra Mega Sour Ball: Makes you less full and more sober
 # ultracalcium: Give a Pokefamiliar Thorns: 1
 # ultracoagulator: Restores all of your Bat-Health during a fight
-Item	Unagnimated Gnome	Free Pull
+Item	Unagnimated Gnome	Free Pull, Last Available: "2012-08"
 # unbearable light: Vaporizes an enemy and causes all of its items to drop
-Item	Uncle Romulus	Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin"
-Item	Uncle Romulus (used)	Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin"
-Item	undamaged Unbreakable Umbrella	Free Pull
+Item	Uncle Romulus	Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
+Item	Uncle Romulus (used)	Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
+Item	undamaged Unbreakable Umbrella	Free Pull, Last Available: "2022-04"
 # underwater slingshot: Deals 50-100 Physical Damage
 # underwater slingshot: (sometimes more)
 # underwater slingshot: (and only works underwater)
-Item	Underworld acorn	Free Pull
-Item	undrilled cosmic bowling ball	Free Pull
-Item	unearthed volcanic meteoroid	Skill: "Volcanometeor Showeruption"
-Item	unemployed hunchbacked minion	Free Pull
+Item	Underworld acorn	Free Pull, Last Available: "2009-10"
+Item	undrilled cosmic bowling ball	Free Pull, Last Available: "2022-01"
+Item	unearthed volcanic meteoroid	Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
+Item	unemployed hunchbacked minion	Free Pull, Last Available: "2008-10"
 Item	unevolved organism	Free Pull
 # unfinished ice sculpture: Makes a copy of a monster to fight later
-Item	uniclops egg	Free Pull
+Item	uniclops egg	Free Pull, Last Available: "2009-10"
 # universal biscuit: Gives your familiar 10 XP
 Item	Unmotivator: Crashed Meat Car	Free Pull
 Item	Unmotivator: Crashed Orca	Free Pull
 Item	Unmotivator: Success Warrior	Free Pull
 # unnatural gas: Weakens enemies a lot
-Item	unoccupied sheep suit	Free Pull
-Item	unopened Bird-a-Day calendar	Free Pull
-Item	unopened diabolic pizza cube box	Free Pull
-Item	Unopened Eight Days a Week Pill Keeper	Free Pull
-Item	unopened tiny stillsuit	Free Pull
-Item	unpowered Robortender	Free Pull
+Item	unoccupied sheep suit	Free Pull, Last Available: "2023-12"
+Item	unopened Bird-a-Day calendar	Free Pull, Last Available: "2020-01"
+Item	unopened diabolic pizza cube box	Free Pull, Last Available: "2019-11"
+Item	Unopened Eight Days a Week Pill Keeper	Free Pull, Last Available: "2019-10"
+Item	unopened tiny stillsuit	Free Pull, Last Available: "2022-08"
+Item	unpowered Robortender	Free Pull, Last Available: "2017-03"
 # unrefined Mountain Stream syrup: Restores 50-60 MP
 # unstable laser battery: Deals 200-250 <font color=red>Hot Damage</font>
 # unstable laser battery: Briefly stuns enemies
 Item	untorn tearaway pants package	Free Pull
 Item	unused walkie-talkie	Free Pull
-Item	unwound cymbal-playing monkey	Free Pull
+Item	unwound cymbal-playing monkey	Free Pull, Last Available: "2006-10"
 # unwrapped knock-off retro superhero cape
 Item	Valentine	Free Pull
 # valuable coin: Worth a lot!
@@ -13120,37 +13120,37 @@ Item	vampyric cloake pattern	Free Pull
 # viral video: Brainlock an enemy and causes all of its items to drop
 # void stone: I'm sure it's safe to just sell it
 # Volcoino: Spend it at the Towering Inferno Discotheque's Gift Shop
-Item	voter registration form	Free Pull
+Item	voter registration form	Free Pull, Last Available: "2018-11"
 Item	walkie-talkie	Free Pull
 # wand of pigification: Turns your foe into a pig
 # warbear auto-anvil: Allows Meatsmithing without using an Adventure
 # warbear auto-anvil: (5x / day)
 # warbear chemistry lab: Lets you occasionally cook extra Potions
-Item	warbear empathy chip	Skill: "Psychokinetic Hug"
-Item	warbear empathy chip (used)	Skill: "Psychokinetic Hug"
+Item	warbear empathy chip	Skill: "Psychokinetic Hug", Last Available: "2013-12"
+Item	warbear empathy chip (used)	Skill: "Psychokinetic Hug", Last Available: "2013-12"
 # warbear high-efficiency still: Sometimes recovers ingredients when you craft cocktails
 # warbear jackhammer drill press: Increases the effectiveness of Pulverize
 # warbear LP-ROM burner: Lets you make recordings of your Accordion Thief buffs
-Item	warbear metalworking primer	Skill: "Shrap"
-Item	warbear metalworking primer (used)	Skill: "Shrap"
-Item	warbear procedural hilarity drone	Free Pull
+Item	warbear metalworking primer	Skill: "Shrap", Last Available: "2013-12"
+Item	warbear metalworking primer (used)	Skill: "Shrap", Last Available: "2013-12"
+Item	warbear procedural hilarity drone	Free Pull, Last Available: "2013-12"
 Item	Wart Dinsey: An Afterlife	Skill: "Rotten Memories"
 # water pipe bomb: Deals 55-75 Physical Damage
 Item	water wings	Wiki Name: "water wings"
 # Way More Tears&trade; pepper spray: Deals 12-15 <font color=red>Hot Damage</font> and weakens enemies somewhat
 # Way More Tears&trade; pepper spray: (can be used 8-10 times before the can is empty)
 # Western Slang Vol. 1: Violence: Unlocks advanced Cow Puncher skills in the Avatar of West of Loathing Challenge Path
-Item	Western Slang Vol. 1: Violence	Free Pull
+Item	Western Slang Vol. 1: Violence	Free Pull, Last Available: "2016-02"
 # Western Slang Vol. 2: Cooking: Unlocks advanced Beanslinger skills in the Avatar of West of Loathing Challenge Path
-Item	Western Slang Vol. 2: Cooking	Free Pull
+Item	Western Slang Vol. 2: Cooking	Free Pull, Last Available: "2016-02"
 # Western Slang Vol. 3: Fraud: Unlocks advanced Snake Oiler skills in the Avatar of West of Loathing Challenge Path
-Item	Western Slang Vol. 3: Fraud	Free Pull
+Item	Western Slang Vol. 3: Fraud	Free Pull, Last Available: "2016-02"
 # whimpering willow bark: Restores up to 25% of your Maximum HP
 # white picket fence: Stops Enemy From Attacking and Restores 14-15 Hit Points
 Item	wine-soaked bone chips	Class: "Pastamancer"
 # Winifred's whistle: Banishes a monster for a while
-Item	Witchess Set	Free Pull
-Item	wizard action figure	Free Pull
+Item	Witchess Set	Free Pull, Last Available: "2016-03"
+Item	wizard action figure	Free Pull, Last Available: "2011-12"
 # Wolfman Nardz: Restores 200-300 MP
 # wood screw: Deals 20-30 Physical Damage and briefly stuns your opponent
 # world's most dangerous birdhouse: Instantly defeats most monsters
@@ -13161,27 +13161,27 @@ Item	wrapped candy cane sword cane	Free Pull
 # wussiness potion: Weakens enemies a little bit
 Item	wussiness potion	Effect: "Wussiness", Effect Duration: 3
 # X-32-F snowman crate: Installs a Combat Training Snowman in the Big Mountains
-Item	X-32-F snowman crate	Free Pull
-Item	xo-skeleton-in-a-box	Free Pull
+Item	X-32-F snowman crate	Free Pull, Last Available: "2016-01"
+Item	xo-skeleton-in-a-box	Free Pull, Last Available: "2017-10"
 # yam battery: Restore up to 1,000 MP
 # yam battery: Gain 3 Random Good Effects
 # Ye Olde Medieval Insult: Weakens enemies somewhat and briefly stuns them
 # Yeg's Motel disposable razor: Deals 50% of a monster's current Hit Points in Physical Damage
 # Yeg's Motel sewing kit: Restores all HP
 # yellow plastic oyster egg: Grants a Random Beneficial Effect
-Item	yellow puck	Free Pull
-Item	yellow puck with a bow on it	Free Pull
+Item	yellow puck	Free Pull, Last Available: "2015-06"
+Item	yellow puck with a bow on it	Free Pull, Last Available: "2015-06"
 # yellow submarine: Allows Travel to The Mysterious Island of Mystery
 # yellowcake bomb: Vaporizes an enemy and causes all of its items to drop
 # yo: Deals 15-20 Physical Damage
 # yo-yo: Deals 30-40 Physical Damage
 # your own black heart: Restores all HP and MP
-Item	yuletide troll chrysalis	Free Pull
+Item	yuletide troll chrysalis	Free Pull, Last Available: "2006-12"
 # Zombo's empty eye: Deals 150-200 <font color=gray>Spooky Damage</font>
 # Zombo's empty eye: Weakens Enemies a Lot
 # Zombo's empty eye: (doesn't go away when used)
-Item	Zu Mannk&auml;se Dienen	Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm"
-Item	Zu Mannk&auml;se Dienen (used)	Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm"
+Item	Zu Mannk&auml;se Dienen	Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
+Item	Zu Mannk&auml;se Dienen (used)	Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 
 # Florist section
 

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -105,7 +105,7 @@ Item	bat hat	Mysticality: +9, Item Drop: +5, Familiar Effect: "spooky atk, 1xVol
 Item	battered old top-hat	Maximum HP: +500, Muscle Percent: +5, Familiar Effect: "0.5xVolley, 0.75xFairy"
 Item	bauxite beret	Muscle: +11, Maximum HP: [23+floor(pref(daycareToddlers)^0.35)], Weapon Damage: [37+floor(pref(daycareToddlers)^0.35)], Last Available: "2018-12"
 Item	beer helmet	Maximum MP: +40, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-Item	beholed bedsheet	Familiar Effect: "8xVolley, 8xLep, cap 2"
+Item	beholed bedsheet	Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 # bellhop's hat: Helps you blend in at the Ice Hotel
 Item	bellhop's hat	Muscle: +10, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
 Item	big bad voodoo mask	Mysticality: +7, Spell Damage: +15, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
@@ -192,7 +192,7 @@ Item	draggin' ball hat	Moxie: +6, Muscle: -3, Familiar Effect: "atk, 1xVolley, c
 Item	dreadful fedora	Spooky Damage: +25, Spooky Spell Damage: +25, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
 Item	driftwood hat	Moxie: +5, Moxie Percent: +1, Damage Absorption: +1, Damage Reduction: 1, Ranged Damage: +1, Ranged Damage Percent: +1, Initiative: +1, Experience (Moxie): +2, Experience Percent (Moxie): +1, Lasts Until Rollover, Last Available: "2019-07"
 # drippy diadem: Significant protection from damage in The Drip
-Item	drippy diadem	Drippy Resistance: +15
+Item	drippy diadem	Last Available: "2020-08", Drippy Resistance: +15
 Item	duct tape fedora	Mysticality: +12, Maximum MP: +40, Familiar Effect: "1xBarrr, 1xLep, cap 48"
 # dwarvish war helmet: Heads Up!
 Item	dwarvish war helmet	Familiar Effect: "atk, 1xFairy, cap 41"
@@ -308,10 +308,10 @@ Item	ice crown	Maximum HP: +30, Maximum MP: +30, HP Regen Min: 10, HP Regen Max:
 Item	ice pick	Item Drop: +15, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 Item	indie comic hipster glasses	Muscle: +5, Mysticality: +5, Moxie: +5, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 # insane tophat: We're All Mad Here!
-Item	insane tophat	Familiar Effect: "1xVolley, 1xLep, cap 7"
+Item	insane tophat	Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
 Item	insulting hat	PvP Fights: +3, Familiar Effect: "cap 2"
 Item	intimidating coiffure	Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Familiar Effect: "hot afk, 1xPotato"
-Item	invisible bag	Familiar Effect: "8xVolley, 8xLep, cap 2"
+Item	invisible bag	Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 Item	irate sombrero	Weapon Damage: +3, Familiar Effect: "1xPotato, 3xLep, cap 11"
 Item	iron helmet	Cold Resistance: +2, MP Regen Min: 1, MP Regen Max: 2, Initiative: +10, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 # iron tricorn hat: Allows you to headbutt your foes
@@ -372,7 +372,7 @@ Item	Mer-kin headguard	PvP Fights: +2, Monster Level: +10, Weapon Damage Percent
 Item	Mer-kin scholar mask	Stench Resistance: +3, Item Drop: -25, Initiative: -50, Adventure Underwater, Familiar Effect: "cold atk"
 Item	Mer-kin sneakmask	Moxie Percent: +5, Initiative: +30, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
 Item	mesh cap	Muscle: +15, Moxie: -5, Familiar Effect: "atk, 1xVolley, cap 41"
-Item	metallic foil cat ears	Familiar Effect: "atk, cap 7", Alters Page Text
+Item	metallic foil cat ears	Last Available: "2007-02", Familiar Effect: "atk, cap 7", Alters Page Text
 Item	meteortarboard	MP Regen Min: 4, MP Regen Max: 8, Mysticality Percent: +15, Spell Critical Percent: +10, Last Available: "2017-08"
 Item	miming beret	Damage Reduction: 10, Stench Resistance: +3, Last Available: "2017-12"
 Item	miner's helmet	Item Drop: +5, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
@@ -385,7 +385,7 @@ Item	moss mitre	Mysticality: +10, Stench Resistance: +2, Last Available: "2024-1
 Item	Mu cap	Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4
 Item	muddy pirate hat	Item Drop: +5, Initiative: +20, Familiar Effect: "1xFairy, cap 31"
 Item	mullet wig	Sleaze Damage: +2, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
-Item	mummy costume	Familiar Effect: "1xVolley, 8xLep, cap 2"
+Item	mummy costume	Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 Item	mummy mask	Spooky Damage: +12, Familiar Effect: "1xBarrr, 1xFairy, cap 42"
 Item	murderbot mask	Muscle: +10, Maximum HP: +20, PvP Fights: +2, Avatar: "Murderbot", Last Available: "2017-04"
 Item	mushroom cap	Monster Level: +25, Adventures: +5, PvP Fights: +5, Last Available: "2020-03"
@@ -417,10 +417,10 @@ Item	paperclip turban	Muscle: +5, Mysticality: +5, Moxie: +5, Maximum HP: +5, Ma
 Item	papier-mitre	Familiar Weight: +5, PvP Fights: +2, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25", Alters Page Text
 # paraffin pith helmet: Lets you unleash a prismatic attack
 Item	paraffin pith helmet	Experience (Muscle): +2, Cold Damage: +10, Last Available: "2020-12"
-Item	parasitic headgnawer	Familiar Effect: "atk, cap 7", Thorns: 1
+Item	parasitic headgnawer	Last Available: "2008-12", Familiar Effect: "atk, cap 7", Thorns: 1
 # party hat: (On the Festival of Jarlsberg only)
 Item	party hat	MP Regen Min: [3*J], MP Regen Max: [5*J], Mysticality: +3, Familiar Effect: "4xLep, cap 7"
-Item	passable elf mask	Familiar Effect: "atk, cap 2"
+Item	passable elf mask	Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 Item	pentacorn hat	Familiar Effect: "atk, cap 10"
 Item	pentagram bandana	Mysticality: +15, Maximum MP: +15, Last Available: "2018-09"
 Item	petrified wood whoopie panama	Moxie Percent: +20, Critical Hit Percent: +10, Last Available: "2025-12", Thorns: 1
@@ -446,7 +446,7 @@ Item	primitive alien mask	Mysticality: +10, Maximum MP: +20, Adventures: +2, Las
 Item	prohie's hat	Booze Drop: +100
 Item	propeller beanie	Initiative: +10, Familiar Effect: "atk, cap 7"
 Item	psychic's circlet	Adventures: +3, MP Regen Min: 3, MP Regen Max: 6, Last Available: "2018-02"
-Item	pumpkinhead mask	Familiar Effect: "1xVolley, 8xLep, cap 2"
+Item	pumpkinhead mask	Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 Item	radiation-resistant helmet	Item Drop: -10, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
 Item	Radio Free Baseball Cap	Moxie: +20, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
 Item	raspberry beret	Hot Resistance: +2, Familiar Effect: "2xPotato, 2xLep, cap 12"
@@ -557,7 +557,7 @@ Item	warbear electro-spiked helm	WarBear Armor Penetration: +60, Muscle Percent:
 # warbear fancy fedora: +15% Item Drops from WarBears
 Item	warbear fancy fedora	Initiative: -25, Maximum HP: -50, Maximum MP: -50, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
 # warbear feathered fedora: +10% Item Drops from WarBears
-Item	warbear feathered fedora	Familiar Effect: "atk, 1xLep, cap 37"
+Item	warbear feathered fedora	Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
 # warbear foil hat: (additional +10 lbs. to Robotic Familiars)
 Item	warbear foil hat	Familiar Weight: [5+10*famattr(robot)], Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 Item	warbear heated ushanka	Supercold Resistance: +3, Weapon Damage Percent: -25, Spell Damage Percent: -50, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
@@ -572,9 +572,9 @@ Item	wax hat	Moxie: +7, Maximum HP: +10, Last Available: "2012-06", Familiar Eff
 Item	webbed comic mask	Muscle: +5, Mysticality: +5, Moxie: +5, Softcore Only, Familiar Effect: "1xVolley, 1xLep, cap 2"
 Item	whittled tiara	Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Experience: +3, Last Available: "2019-08"
 Item	willowy bonnet	Maximum MP: +40, Familiar Effect: "1xFairy, cap 18"
-Item	witch hat	Familiar Effect: "8xVolley, 8xLep, cap 2"
+Item	witch hat	Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 Item	wolf mask	Muscle: +4, Moxie: -5, Familiar Effect: "1xBarrr, HP regen, cap 37"
-Item	wolfman mask	Familiar Effect: "8xVolley, 8xLep, cap 2"
+Item	wolfman mask	Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
 Item	wolfskull mask	Monster Level: +15, Spooky Damage: +50, Familiar Effect: "spooky atk, 1xBarrr"
 Item	wooden salad bowl	Familiar Effect: "atk, cap 30"
 Item	wool hat	Damage Absorption: +20, Cold Resistance: +2, Familiar Effect: "1xLep, cap 43"
@@ -591,7 +591,7 @@ Item	Yeg's Motel shower cap	Spooky Resistance: +5, Moxie Percent: +66, Lasts Unt
 Item	yellow plastic hard hat	Familiar Effect: "atk, cap 22"
 Item	yellow traffic cone	Moxie: +3, Sleaze Resistance: +2, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 # Ze&trade; goggles: +25% Item Drops from Monsters (Underwater only)
-Item	Ze&trade; goggles	Item Drop: [25*env(underwater)], Familiar Effect: "Atk, cap 7"
+Item	Ze&trade; goggles	Last Available: "2012-05", Item Drop: [25*env(underwater)], Familiar Effect: "Atk, cap 7"
 Item	zombie mariachi hat	Moxie Percent: +50, Maximum HP: +150, Maximum MP: +150, Initiative: +40, Class: "Accordion Thief", Familiar Effect: "atk, 1xLep"
 Item	Zombo's skullcap	Muscle Percent: +20, Familiar Weight: +10, Class: "Turtle Tamer", Familiar Effect: "spooky atk"
 
@@ -932,7 +932,7 @@ Item	warbear battle greaves	WarBear Armor Penetration: +20, Weapon Damage Percen
 # warbear bearserker greaves: Troubling Vulnerability to All Elements (-5)
 Item	warbear bearserker greaves	WarBear Armor Penetration: +60, Muscle Percent: -25, Mysticality Percent: -25, Moxie Percent: -25, Last Available: "2013-12", Hot Resistance: -5, Cold Resistance: -5, Spooky Resistance: -5, Stench Resistance: -5, Sleaze Resistance: -5, Familiar Effect: "atk, 1xBarrr"
 # warbear ceremonial party pants: +10% Item Drops from WarBears
-Item	warbear ceremonial party pants	Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+Item	warbear ceremonial party pants	Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
 Item	warbear dress greaves	Muscle: +10, Food Drop: +25, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
 Item	warbear electric long johns	Supercold Resistance: +3, Weapon Damage Percent: -25, Spell Damage Percent: -50, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 Item	warbear fleece-lined long johns	Supercold Resistance: +2, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
@@ -1742,7 +1742,7 @@ Item	peace accordion	Stench Damage: [12*(1+skill(Accordion Appreciation))], Clas
 Item	Pener's drumstick	Hot Damage: +20, Initiative: +20, Critical Hit Percent: +5, Last Available: "2015-08"
 Item	penguin whip	Meat Drop: +3
 Item	pentatonic accordion	Cold Damage: [9*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 12
-Item	peppermint harpoon gun	Weapon Damage: [100*env(underwater)]
+Item	peppermint harpoon gun	Last Available: "2019-12", Weapon Damage: [100*env(underwater)]
 Item	peppermint spine	Mysticality: +10, Spell Critical Percent: +10, Last Available: "2019-12"
 Item	perforated battle paddle	Weapon Damage: +10
 Item	Periodical Paintbrush	Muscle Percent: [+5*G], Mysticality Percent: [+5*G], Moxie Percent: [+5*G], Softcore Only
@@ -1808,7 +1808,7 @@ Item	ratarang	Ranged Damage: +7, Moxie: +3
 Item	rattail whip	Moxie: +5, Monster Level: +5
 Item	rave whistle	Maximum HP: +10, Monster Level: +10, Raveosity: +1
 # Red Roger's red right hand: +50 Physical Damage (in PirateRealm only)
-Item	Red Roger's red right hand	Weapon Damage: [50*zone(PirateRealm)]
+Item	Red Roger's red right hand	Last Available: "2019-04", Weapon Damage: [50*zone(PirateRealm)]
 # Red Rover BB gun: You'll Put Your Eye Out!
 Item	Red Rover BB gun	Critical Hit Percent: +15, Last Available: "2009-12"
 Item	red-hot poker	Hot Damage: +15
@@ -1858,8 +1858,8 @@ Item	sawed-off blunderbuss	Pirate Warfare Effectiveness: +3, Muscle: +3, Mystica
 Item	scepter of the Skeleton Lord	Moxie Percent: +50, Adventures: +3, PvP Fights: +3, Single Equip, Last Available: "2018-04"
 # scorpion whip: 50% chance of poisoning opponent.
 Item	scorpion whip	Weapon Damage: +13
-Item	scratch 'n' sniff crossbow	none, Breakable
-Item	scratch 'n' sniff sword	none, Breakable
+Item	scratch 'n' sniff crossbow	Last Available: "2008-11", none, Breakable
+Item	scratch 'n' sniff sword	Last Available: "2008-11", none, Breakable
 Item	sea-worn candlestick	PvP Fights: +5, Meat Drop: +25, Sleaze Resistance: +3, Last Available: "2020-09"
 # seal-clubbing club
 Item	sealhide whip	Cold Damage: +25
@@ -2035,7 +2035,7 @@ Item	teflon spatula	Mysticality Percent: +10, Sleaze Resistance: +3, Spell Damag
 Item	terra cotta tongs	Experience (Mysticality): +3, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Last Available: "2020-12"
 # The Jokester's gun: Can be fired in a weird way once per day to instantly defeat an opponent
 Item	The Jokester's gun	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Initiative: +25, Pants Drop: +50, Last Available: "2016-12"
-Item	The Landscaper's leafblower	Monster Level: [pref(_leafblowerML)]
+Item	The Landscaper's leafblower	Last Available: "2010-04", Monster Level: [pref(_leafblowerML)]
 Item	The Necbromancer's Wizard Staff	Spell Damage Percent: +200, Sleaze Spell Damage: +30, MP Regen Min: 20, MP Regen Max: 30, Last Available: "2011-10"
 Item	The Nuge's favorite crossbow	Ranged Damage: +30, Initiative: +100, Adventures: +5
 # The Trickster's Trikitixa: Special Attack:  Extreme High Note
@@ -2130,7 +2130,7 @@ Item	wrench	Maximum MP: +50, Spell Damage Percent: +100, Lasts Until Rollover, L
 Item	wrought-iron whisk	Spooky Damage: +10, Monster Level: +10, Last Available: "2017-12"
 Item	wumpus-hair whip	Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2, Last Available: "2009-06"
 # X-37 gun: Shoots Elemental Blasts
-Item	X-37 gun	Breakable
+Item	X-37 gun	Last Available: "2009-06", Breakable
 Item	yak whip	Weakens Monster
 Item	yam cannon	Hot Damage: +50, Ranged Damage Percent: +25, Food Drop: +30, Lasts Until Rollover, Last Available: "2024-05"
 Item	yohohoyo	Critical Hit Percent: +5, Spooky Damage: +1, Stench Damage: +1, Hot Damage: +1, Cold Damage: +1, Sleaze Damage: +1
@@ -2280,7 +2280,7 @@ Item	cursed stats	Experience: +5, Muscle Limit: 69, Mysticality Limit: 69, Moxie
 Item	cyborg doll	Muscle: +3, Last Available: "2007-12"
 Item	Dallas Dynasty Falcon Crest shield	Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Damage Reduction: 15
 # deceased crimbo tree: Blocks damage while needles remain
-Item	deceased crimbo tree	Lasts Until Rollover, Breakable
+Item	deceased crimbo tree	Last Available: "2018-01", Lasts Until Rollover, Breakable
 Item	deck of lewd playing cards	Moxie Percent: +5, Sleaze Damage: +69, Sleaze Spell Damage: +69
 Item	deck of tropical cards	Experience: +1, Last Available: "2006-12", Stat Tuning: "Mysticality"
 # defective skull
@@ -2433,7 +2433,7 @@ Item	keg shield	Damage Absorption: +50, Mysticality: +5, Damage Reduction: 11
 Item	kickback cookbook	Spell Damage: +20
 Item	killer rag doll	Muscle: +3, Last Available: "2006-12"
 # KoL Con 13 snowglobe: Lets you recall precious memories at the end of every fight
-Item	KoL Con 13 snowglobe	Drops Items
+Item	KoL Con 13 snowglobe	Last Available: "2016-10", Drops Items
 Item	KoL Con IV Pole	Maximum HP: +4, Maximum MP: +4, Muscle: +4, Mysticality: +4, Moxie: +4, Hot Damage: +4, Last Available: "2007-09"
 Item	KoL Con Six Pack	Muscle: +5, Mysticality: +5, Moxie: +5, Booze Drop: +25
 Item	KoL Con X Treasure Map	Item Drop: +5, Meat Drop: +10
@@ -2515,7 +2515,7 @@ Item	moss megaphone	Muscle: +10, Cold Resistance: +2, Last Available: "2024-12"
 Item	moxie magnet	Moxie Controls MP
 Item	Mr. Balloon	Muscle: +3, Mysticality: +3, Moxie: +3
 # Mr. Haggis: Haggis!
-Item	Mr. Haggis	Damage Aura: 1
+Item	Mr. Haggis	Last Available: "2012-12", Damage Aura: 1
 Item	mushroom shield	Muscle: +40, Mysticality: -20, Moxie: -20, Combat Rate: +10, Damage Reduction: 6, Last Available: "2020-03"
 # Mylar balloon
 # naughty fortune teller: + Some Stats Per Fight
@@ -2613,7 +2613,7 @@ Item	recursed compass	Lasts Until Rollover, Last Available: "2019-04"
 Item	red book	Spell Damage: +20, HP Regen Min: 5, HP Regen Max: 10
 Item	red China marble	Hot Spell Damage: +40
 Item	red LavaCo Lamp&trade;	Adventures: +5, Rollover Effect: "Red Menace", Rollover Effect Duration: 50, Last Available: "2015-08"
-Item	Red Roger's red left hand	Item Drop: [100*zone(PirateRealm)]
+Item	Red Roger's red left hand	Last Available: "2019-04", Item Drop: [100*zone(PirateRealm)]
 Item	red wagon	Mysticality Percent: +15, Spell Damage Percent: +50, Maximum MP: +300
 Item	Red X Shield	Maximum HP: +20, Maximum MP: +20, Damage Reduction: 11
 Item	replica august scepter	Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50
@@ -2737,7 +2737,7 @@ Item	sturdy cane	PvP Fights: +4, Fumble: 2, Initiative: -25
 # sucker bucket: May Attract Walruses
 Item	sucker bucket	Candy Drop: +50, Last Available: "2011-11"
 # surprisingly capacious handbag: +50% Item Drops at the Neverending Party
-Item	surprisingly capacious handbag	Item Drop: [50*loc(The Neverending Party)]
+Item	surprisingly capacious handbag	Last Available: "2018-09", Item Drop: [50*loc(The Neverending Party)]
 Item	Sword of the Brouhaha Prince	Muscle Percent: +12, Last Available: "2011-10"
 # Taco Dan's Taco Stand Cocktail Sauce Bottle
 Item	tailbone shield	Stench Damage: +40, Damage Reduction: 16, Thorns: 1
@@ -3162,7 +3162,7 @@ Item	floaty rock necklace	Spell Critical Percent: +10, Single Equip
 # food drive button: Lets you collect food donations as you adventure
 Item	food drive button	Single Equip, Last Available: "2020-12"
 Item	Former Sheriff Dan's tin star	Muscle Percent: +25, Maximum HP: +50, HP Regen Min: 5, HP Regen Max: 10, Weapon Damage Percent: +25, Critical Hit Percent: +5, Last Available: "2016-02"
-Item	fossilized necklace	Muscle: [2*pref(fossilB)], Mysticality: [2*pref(fossilB)], Moxie: [2*pref(fossilB)], Spell Damage: [2*pref(fossilS)], Weapon Damage: [3*pref(fossilN)], Muscle Percent: [3*pref(fossilW)], Mysticality Percent: [3*pref(fossilW)], Moxie Percent: [3*pref(fossilW)], Hot Damage: [3*pref(fossilD)], Spooky Damage: [3*pref(fossilP)]
+Item	fossilized necklace	Last Available: "2010-09", Muscle: [2*pref(fossilB)], Mysticality: [2*pref(fossilB)], Moxie: [2*pref(fossilB)], Spell Damage: [2*pref(fossilS)], Weapon Damage: [3*pref(fossilN)], Muscle Percent: [3*pref(fossilW)], Mysticality Percent: [3*pref(fossilW)], Moxie Percent: [3*pref(fossilW)], Hot Damage: [3*pref(fossilD)], Spooky Damage: [3*pref(fossilP)]
 Item	frayed rope belt	Moxie Percent: +10, Single Equip
 # free boots: Give your opponents the old one-two (kick)
 Item	free boots	Sleaze Resistance: +3, HP Regen Min: 8, HP Regen Max: 12, MP Regen Min: 8, MP Regen Max: 12, Single Equip, Last Available: "2023-12"
@@ -3262,7 +3262,7 @@ Item	hamethyst necklace	Muscle: +4, Weapon Damage: +5, PvP Fights: +2, Single Eq
 Item	hamethyst ring	Muscle: +5, Maximum HP: +10, HP Regen Min: 2, HP Regen Max: 4, Single Equip
 Item	Hand in Glove	Muscle: +5, Smithsness: +5, Single Equip, Last Available: "2013-12", Monster Level: [K], Damage Aura: 1
 Item	hand-knitted Crimbo socks	Maximum HP: +10, HP Regen Min: 3, HP Regen Max: 5, Cold Resistance: +1
-Item	hand-knitted diving booties	Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)]
+Item	hand-knitted diving booties	Last Available: "2019-12", Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)]
 Item	hardened slime belt	Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, HP Regen Min: 10, HP Regen Max: 30, MP Regen Min: 10, MP Regen Max: 30, Mysticality Percent: +20, Single Equip
 Item	hare pin	Moxie Percent: +20, Initiative: +40, Single Equip, Last Available: "2014-12"
 # hazardous sauce dosimeter: Lets you gather more Soulsauce
@@ -3466,7 +3466,7 @@ Item	mysterious silver lapel pin	HP Regen Min: 5, HP Regen Max: 9, Meat Drop: +5
 Item	natty blue ascot	Meat Drop: +20
 Item	navel ring of navel gazing	Damage Reduction: [L], Mysticality Percent: +25, Spell Damage Percent: +100, Mana Cost: -1, Single Equip, Softcore Only, Last Available: "2007-09", Item Drop (sporadic): 4.25, Meat Drop (sporadic): 4.25, Experience: 0.6375, MP Regen Min: 2.125, MP Regen Max: 4.25
 Item	neck wreath	Spooky Resistance: [+5*event(December)], Stench Resistance: [+5*event(December)], Hot Resistance: [+5*event(December)], Cold Resistance: [+5*event(December)], Sleaze Resistance: [+5*event(December)], Single Equip, Last Available: "2020-12"
-Item	neverending wallet chain	Meat Drop: [30*loc(The Neverending Party)]
+Item	neverending wallet chain	Last Available: "2018-09", Meat Drop: [30*loc(The Neverending Party)]
 Item	Nickel Gamma of Frugality	Muscle: +9, Mysticality: +9, Moxie: +9, Item Drop: +7, Single Equip
 Item	nicksilver ring	Pickpocket Chance: +15, Item Drop: +15, Weapon Drop: +30, Single Equip, Last Available: "2016-02"
 Item	night-vision goggles	Moxie Percent: -10, Experience (Moxie): +1, Single Equip, Last Available: "2009-12"
@@ -3485,7 +3485,7 @@ Item	Official Council Aide Pin	Adventures: +4, PvP Fights: +2, Last Available: "
 Item	Ol' Scratch's manacles	Hot Spell Damage: +30, Moxie Percent: +15, Single Equip
 Item	old ball and chain	Initiative: -50, Cold Damage: +100, Single Equip
 # old school calculator watch: Math!
-Item	old school calculator watch	Sporadic Damage Aura: 0.25
+Item	old school calculator watch	Last Available: "2012-12", Sporadic Damage Aura: 0.25
 # old soft shoes: +30% Item Drops from Hobos
 Item	old soft shoes	Single Equip, Item Drop: [30*zone(Hobopolis)*(1-loc(Sewer Tunnels))]
 Item	orange glowstick	Maximum MP: +5, Moxie: -3, Last Available: "2006-10", Raveosity: +1
@@ -3816,10 +3816,10 @@ Item	string of blue beads	Mysticality: +1
 Item	string of green beads	Moxie: +1
 Item	string of moist beads	Pants Drop: +10, Last Available: "2014-05"
 Item	string of red beads	Muscle: +1
-Item	stuffed carpenter	Synergetic
+Item	stuffed carpenter	Last Available: "2010-03", Synergetic
 # stuffed mink
 Item	stuffed shoulder parrot	Maximum MP: +5
-Item	stuffed walrus	Synergetic
+Item	stuffed walrus	Last Available: "2010-03", Synergetic
 Item	super-strong air freshener	Stench Resistance: +2, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10
 # Superhero Reboots: Help You Run Faster
 Item	Superhero Reboots	Muscle: +5, Mysticality: +5, Moxie: +5, Initiative: +10
@@ -3941,7 +3941,7 @@ Item	tiny plastic briefcase bat	Monster Level: +1
 Item	tiny plastic bugaboo	Monster Level: +1, Last Available: "2012-12"
 Item	tiny plastic Bugbear Captain	Maximum HP: +20, Maximum MP: +20, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4, Single Equip, Last Available: "2012-12"
 Item	tiny plastic buzzerker	Monster Level: +1, Last Available: "2012-12"
-Item	tiny plastic caboose	Damage Reduction: 3
+Item	tiny plastic caboose	Last Available: "2022-12", Damage Reduction: 3
 Item	tiny plastic Caf&eacute; Elf	Hot Resistance: +1, Last Available: "2018-12"
 Item	tiny plastic Cafe	Food Drop: +3
 Item	tiny plastic Captain Kerkard	Monster Level: +1
@@ -4373,7 +4373,7 @@ Item	teddybear backpack	Meat Drop: +10, Raveosity: +1
 Item	terra cotta train	Mysticality Percent: +20, Item Drop: +10, Last Available: "2020-12"
 Item	thermal blanket	Cold Resistance: +2, Spooky Resistance: +1, Combat Rate: +5, Lasts Until Rollover, Last Available: "2022-05"
 Item	Time Bandit Time Towel	Muscle: +5, Mysticality: +5, Moxie: +5, Adventures: +1
-Item	Time Cape	Item Drop: [25*zone(Twitch)]
+Item	Time Cape	Last Available: "2014-11", Item Drop: [25*zone(Twitch)]
 # Time Cloak: Sometimes Find an Extra Chroner in the Time-Twitching Tower
 # toy jet pack: Jane!  Get Me Off This Crazy Thing!
 # Trainbot harness: Lets you rescue elves from passenger-occupied Crimbo train cars
@@ -4479,21 +4479,21 @@ Item	fuzzy polar bear ears	Familiar Weight: +5, Experience (Muscle): +3, Last Av
 Item	gazing shoes	Familiar Weight: +5, Last Available: "2011-12"
 # giant book of ancient carols: Causes the Ancient Yuletide Troll to drop carol pages more frequently
 Item	gill rings	Familiar Weight: +5
-Item	gnomish athlete's foot	Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
-Item	gnomish coal miner's lung	Equips On: "Reagnimated Gnome", Familiar Effect: "block"
-Item	gnomish housemaid's kgnee	Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
-Item	gnomish swimmer's ears	Underwater Familiar, Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)], Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
-Item	gnomish tennis elbow	Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+Item	gnomish athlete's foot	Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
+Item	gnomish coal miner's lung	Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+Item	gnomish housemaid's kgnee	Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+Item	gnomish swimmer's ears	Last Available: "2012-08", Underwater Familiar, Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)], Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+Item	gnomish tennis elbow	Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
 # God Lobster's Crown: Makes your God Lobster increase Item Drops
-Item	God Lobster's Crown	Fairy: 1, Equips On: "God Lobster", Familiar Effect: "fairy"
+Item	God Lobster's Crown	Last Available: "2018-05", Fairy: 1, Equips On: "God Lobster", Familiar Effect: "fairy"
 # God Lobster's Ring: Makes your God Lobster bestow stat gains based on an ancient mystic formula
-Item	God Lobster's Ring	Volleyball: -1, Sombrero: +1, Equips On: "God Lobster", Familiar Effect: "sombrero"
+Item	God Lobster's Ring	Last Available: "2018-05", Volleyball: -1, Sombrero: +1, Equips On: "God Lobster", Familiar Effect: "sombrero"
 # God Lobster's Robe: Makes your God Lobster prevent monster attacks
-Item	God Lobster's Robe	Equips On: "God Lobster", Familiar Effect: "block"
+Item	God Lobster's Robe	Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
 # God Lobster's Rod: Makes your God Lobster restore HP and MP after Combat
-Item	God Lobster's Rod	Equips On: "God Lobster", Familiar Effect: "whelp"
+Item	God Lobster's Rod	Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
 # God Lobster's Scepter: Makes your God Lobster slightly increase Item and Meat Drops
-Item	God Lobster's Scepter	Leprechaun: 0.5, Fairy: 0.5, Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+Item	God Lobster's Scepter	Last Available: "2018-05", Leprechaun: 0.5, Fairy: 0.5, Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
 Item	golden banana	Familiar Weight: +5
 Item	green pixie spog	Familiar Weight: +5, Last Available: "2007-06"
 Item	grey down vest	Experience (familiar): +2
@@ -4579,7 +4579,7 @@ Item	miniature pruning shears	Familiar Weight: +5
 Item	miniature tophat	Familiar Weight: +5
 # MiniMechaElf Laser Punch Missile Launcher: More likely to use more powerful attacks
 Item	miniscule beatbox	Familiar Weight: +5, Last Available: "2012-12"
-Item	mint-condition magic wand	Volleyball: 0.3334, Fairy: 0.3334
+Item	mint-condition magic wand	Last Available: "2011-12", Volleyball: 0.3334, Fairy: 0.3334
 Item	missing semicolon	Familiar Weight: +11
 # moonglasses: Makes Familiar Less Sensitive to Light
 Item	moveable feast	Familiar Weight: +5, Softcore Only, Last Available: "2009-11", Generic, Experience (familiar): +1, Sporadic Damage Aura: 0.35
@@ -4593,7 +4593,7 @@ Item	nosy nose ringy ring	Familiar Weight: +15
 Item	origami &quot;gentlemen's&quot; magazine	Softcore Only, Last Available: "2008-02", Generic
 Item	overclocked avian microprocessor	Familiar Weight: +5, Last Available: "2007-12"
 Item	overloaded Yule battery	Familiar Weight: +25, Last Available: "2022-12"
-Item	oversized fish scaler	Generic, Sporadic Damage Aura: 0.33
+Item	oversized fish scaler	Last Available: "2007-12", Generic, Sporadic Damage Aura: 0.33
 Item	oversized sparkler	Muscle Percent: +20, Mysticality Percent: +20, Moxie Percent: +20, Item Drop: +20, Lasts Until Rollover, Last Available: "2021-07"
 Item	palm-frond toupee	Familiar Weight: +5
 Item	Panda outfit	Familiar Weight: +5, Item Drop: +5, Generic
@@ -4708,7 +4708,7 @@ Item	tiny stillsuit	Familiar Weight: +5, Experience (familiar): +1, Familiar Dam
 Item	tiny Tina gun	Familiar Weight: +5
 # tiny top hat and cane: Lets your Li'l Xenomorph dance!
 # tiny top hat and cane: (adds item0 to familiar abilities)
-Item	tiny top hat and cane	Fairy: 1.0
+Item	tiny top hat and cane	Last Available: "2011-06", Fairy: 1.0
 # tiny yam cannon: Gives your familiar an extra attack.
 Item	tiny yam cannon	Initiative: +50, Lasts Until Rollover, Last Available: "2024-05", Generic
 Item	Toddler-sized Dragon Costume	Familiar Weight: +5, Item Drop: +5, Softcore Only, Generic
@@ -4725,7 +4725,7 @@ Item	vicious spiked collar	Familiar Damage: +20, Generic
 Item	wax lips	Experience: +3, Softcore Only, Last Available: "2005-07", Generic
 # weegee sqouija: Hobo's Booze Is More Effective
 # white arm towel: Your familiar will find extra food and booze on the Crimbo Train
-Item	white arm towel	Generic
+Item	white arm towel	Last Available: "2022-12", Generic
 Item	woimbook	Familiar Weight: +5
 Item	woolen cravat	Familiar Weight: +5, Last Available: "2007-03"
 Item	Xiblaxian holo-bowtie	Familiar Weight: +5, Last Available: "2014-09"
@@ -5323,47 +5323,47 @@ Item	scratch 'n' sniff wrestler sticker	Muscle Percent: +10, Mysticality Percent
 
 # Alice's Army section of modifiers.txt
 
-Item	Alice's Army Alchemist	Spell Damage: +15
-Item	Alice's Army Bowman	Ranged Damage: +10
-Item	Alice's Army Cleric	HP Regen Min: 10, HP Regen Max: 20
-Item	Alice's Army Coward	Initiative: +20
+Item	Alice's Army Alchemist	Last Available: "2011-03", Spell Damage: +15
+Item	Alice's Army Bowman	Last Available: "2011-03", Ranged Damage: +10
+Item	Alice's Army Cleric	Last Available: "2011-03", HP Regen Min: 10, HP Regen Max: 20
+Item	Alice's Army Coward	Last Available: "2011-03", Initiative: +20
 # Alice's Army Dervish	Weapon Damage +1-20
-Item	Alice's Army Guard	Damage Reduction: 3
-Item	Alice's Army Halberder	Weapon Damage: +5
-Item	Alice's Army Hammerman	Critical Hit Percent: +1
-Item	Alice's Army Horseman	Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5
-Item	Alice's Army Lanceman	PvP Fights: +2
+Item	Alice's Army Guard	Last Available: "2011-03", Damage Reduction: 3
+Item	Alice's Army Halberder	Last Available: "2011-03", Weapon Damage: +5
+Item	Alice's Army Hammerman	Last Available: "2011-03", Critical Hit Percent: +1
+Item	Alice's Army Horseman	Last Available: "2011-03", Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5
+Item	Alice's Army Lanceman	Last Available: "2011-03", PvP Fights: +2
 # Alice's Army Mad Bomber	Weapon Damage +1-15
-Item	Alice's Army Martyr	Damage Reduction: 5
-Item	Alice's Army Ninja	Monster Level: +5
-Item	Alice's Army Nurse	HP Regen Min: 5, HP Regen Max: 10
-Item	Alice's Army Page	Weapon Damage: +5
-Item	Alice's Army Shieldmaiden	Damage Reduction: 3
-Item	Alice's Army Sniper	Weapon Damage: +10
-Item	Alice's Army Spearsman	Weapon Damage: +5
-Item	Alice's Army Swordsman	Weapon Damage: +5
-Item	Alice's Army Wallman	Damage Reduction: 3
+Item	Alice's Army Martyr	Last Available: "2011-03", Damage Reduction: 5
+Item	Alice's Army Ninja	Last Available: "2011-03", Monster Level: +5
+Item	Alice's Army Nurse	Last Available: "2011-03", HP Regen Min: 5, HP Regen Max: 10
+Item	Alice's Army Page	Last Available: "2011-03", Weapon Damage: +5
+Item	Alice's Army Shieldmaiden	Last Available: "2011-03", Damage Reduction: 3
+Item	Alice's Army Sniper	Last Available: "2011-03", Weapon Damage: +10
+Item	Alice's Army Spearsman	Last Available: "2011-03", Weapon Damage: +5
+Item	Alice's Army Swordsman	Last Available: "2011-03", Weapon Damage: +5
+Item	Alice's Army Wallman	Last Available: "2011-03", Damage Reduction: 3
 
-Item	Alice's Army Foil Alchemist	Spell Damage: +45
-Item	Alice's Army Foil Bowman	Ranged Damage: +30
-Item	Alice's Army Foil Cleric	HP Regen Min: 30, HP Regen Max: 60
-Item	Alice's Army Foil Coward	Initiative: +60
+Item	Alice's Army Foil Alchemist	Last Available: "2011-03", Spell Damage: +45
+Item	Alice's Army Foil Bowman	Last Available: "2011-03", Ranged Damage: +30
+Item	Alice's Army Foil Cleric	Last Available: "2011-03", HP Regen Min: 30, HP Regen Max: 60
+Item	Alice's Army Foil Coward	Last Available: "2011-03", Initiative: +60
 # Alice's Army Foil Dervish	Weapon Damage +1-60
-Item	Alice's Army Foil Guard	Damage Reduction: 9
-Item	Alice's Army Foil Halberder	Weapon Damage: +15
-Item	Alice's Army Foil Hammerman	Critical Hit Percent: +3
-Item	Alice's Army Foil Horseman	Muscle Percent: +15, Mysticality Percent: +15, Moxie Percent: +15
-Item	Alice's Army Foil Lanceman	PvP Fights: +6
+Item	Alice's Army Foil Guard	Last Available: "2011-03", Damage Reduction: 9
+Item	Alice's Army Foil Halberder	Last Available: "2011-03", Weapon Damage: +15
+Item	Alice's Army Foil Hammerman	Last Available: "2011-03", Critical Hit Percent: +3
+Item	Alice's Army Foil Horseman	Last Available: "2011-03", Muscle Percent: +15, Mysticality Percent: +15, Moxie Percent: +15
+Item	Alice's Army Foil Lanceman	Last Available: "2011-03", PvP Fights: +6
 # Alice's Army Foil Mad Bomber	Weapon Damage +1-45
-Item	Alice's Army Foil Martyr	Damage Reduction: 15
-Item	Alice's Army Foil Ninja	Monster Level: +15
-Item	Alice's Army Foil Nurse	HP Regen Min: 15, HP Regen Max: 30
-Item	Alice's Army Foil Page	Weapon Damage: +15
-Item	Alice's Army Foil Shieldmaiden	Damage Reduction: 9
-Item	Alice's Army Foil Sniper	Weapon Damage: +30
-Item	Alice's Army Foil Spearsman	Weapon Damage: +15
-Item	Alice's Army Foil Swordsman	Weapon Damage: +15
-Item	Alice's Army Foil Wallman	Damage Reduction: 9
+Item	Alice's Army Foil Martyr	Last Available: "2011-03", Damage Reduction: 15
+Item	Alice's Army Foil Ninja	Last Available: "2011-03", Monster Level: +15
+Item	Alice's Army Foil Nurse	Last Available: "2011-03", HP Regen Min: 15, HP Regen Max: 30
+Item	Alice's Army Foil Page	Last Available: "2011-03", Weapon Damage: +15
+Item	Alice's Army Foil Shieldmaiden	Last Available: "2011-03", Damage Reduction: 9
+Item	Alice's Army Foil Sniper	Last Available: "2011-03", Weapon Damage: +30
+Item	Alice's Army Foil Spearsman	Last Available: "2011-03", Weapon Damage: +15
+Item	Alice's Army Foil Swordsman	Last Available: "2011-03", Weapon Damage: +15
+Item	Alice's Army Foil Wallman	Last Available: "2011-03", Damage Reduction: 9
 
 # Folder section of modifiers.txt
 
@@ -5371,26 +5371,26 @@ Item	Alice's Army Foil Wallman	Damage Reduction: 9
 Item	folder (blue)	Mysticality: +20, Last Available: "2013-08"
 Item	folder (catfish)	Familiar Weight (hidden): [15*env(underwater)]
 Item	folder (cyan)	Mysticality: +15, Moxie: +15, Last Available: "2013-08"
-Item	folder (D-Team)	Experience (Muscle): +1, Experience (Mysticality): +1, Experience (Moxie): +1
-Item	folder (dancing dolphins)	Item Drop: [50*env(underwater)]
+Item	folder (D-Team)	Last Available: "2013-08", Experience (Muscle): +1, Experience (Mysticality): +1, Experience (Moxie): +1
+Item	folder (dancing dolphins)	Last Available: "2013-08", Item Drop: [50*env(underwater)]
 Item	folder (Ex-Files)	Combat Rate: +5, Last Available: "2013-08"
 Item	folder (green)	Moxie: +20, Last Available: "2013-08"
 Item	folder (heavy metal)	Familiar Weight: +5, Last Available: "2013-08"
 Item	folder (holographic fractal)	Cold Resistance: +4, Hot Resistance: +4, Sleaze Resistance: +4, Spooky Resistance: +4, Stench Resistance: +4
 Item	folder (Jackass Plumber)	Monster Level: +25, Last Available: "2013-08"
 Item	folder (Knight Writer)	Initiative: +40, Last Available: "2013-08"
-Item	folder (KOLHS)	Item Drop: [50*zone(KOL High School)]
+Item	folder (KOLHS)	Last Available: "2013-08", Item Drop: [50*zone(KOL High School)]
 Item	folder (magenta)	Muscle: +15, Mysticality: +15, Last Available: "2013-08"
-Item	folder (owl)	Item Drop: [500*zone(Dreadsylvania)]
-Item	folder (rainbow unicorn)	Thorns: 5
+Item	folder (owl)	Last Available: "2013-08", Item Drop: [500*zone(Dreadsylvania)]
+Item	folder (rainbow unicorn)	Last Available: "2013-08", Thorns: 5
 Item	folder (red)	Muscle: +20, Last Available: "2013-08"
-Item	folder (Seawolf)	Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)]
+Item	folder (Seawolf)	Last Available: "2013-08", Initiative Penalty: [10*env(underwater)], Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [10*env(underwater)]
 Item	folder (skull and crossbones)	Combat Rate: -5, Last Available: "2013-08"
 Item	folder (smiley face)	Experience (Muscle): +2, Last Available: "2013-08"
 Item	folder (space skeleton)	Experience (Moxie): +2, Last Available: "2013-08"
 Item	folder (sports car)	Adventures: +5, Last Available: "2013-08"
 Item	folder (sportsballs)	PvP Fights: +5, Last Available: "2013-08"
-Item	folder (Stinky Trash Kid)	Damage Aura: 1
+Item	folder (Stinky Trash Kid)	Last Available: "2013-08", Damage Aura: 1
 Item	folder (tranquil landscape)	Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
 Item	folder (wizard)	Experience (Mysticality): +2, Last Available: "2013-08"
 Item	folder (Yedi)	Spell Damage Percent: +50, Last Available: "2013-08"
@@ -5399,18 +5399,18 @@ Item	folder (yellow)	Muscle: +15, Moxie: +15, Last Available: "2013-08"
 # Cowboy boot decorations section of modifiers.txt
 
 # coal snakeskin: Adds Spooky Damage to kicks with your cowboy boots
-Item	diamondback skin	Monster Level: +20
+Item	diamondback skin	Last Available: "2016-02", Monster Level: +20
 Item	frontwinder skin	Mysticality Percent: +50, Last Available: "2016-02"
 Item	grizzled bearskin	Muscle Percent: +50, Last Available: "2016-02"
 Item	mountain lion skin	Moxie Percent: +50, Last Available: "2016-02"
 # rotting cowskin: Adds Demonic Bovine Taint to your cowboy boots
 
-Item	nicksilver spurs	Item Drop: +20
+Item	nicksilver spurs	Last Available: "2016-02", Item Drop: +20
 Item	quicksilver spurs	Initiative: +30, Last Available: "2016-02"
 # sicksilver spurs: Adds Stench Damage to kicks with your cowboy boots
 # slicksilver spurs: Adds Sleaze Damage to kicks with your cowboy boots
 Item	thicksilver spurs	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2
-Item	ticksilver spurs	Adventures: +5
+Item	ticksilver spurs	Last Available: "2016-02", Adventures: +5
 # wicksilver spurs: Adds Hot Damage to kicks with your cowboy boots
 
 # Campground equipment section of modifiers.txt
@@ -5423,35 +5423,35 @@ Item	bed of coals	Hot Resistance: +2
 Item	big rock	Base Resting HP: +4, Base Resting MP: +5
 # black-and-blue light
 # blue plasma ball
-Item	BRICKO pyramid	Base Resting HP: +34, Base Resting MP: +35
+Item	BRICKO pyramid	Last Available: "2010-02", Base Resting HP: +34, Base Resting MP: +35
 # chef-in-the-box
 # clockwork bartender-in-the-box
 # clockwork chef-in-the-box
 Item	clockwork maid	Adventures: +8
-Item	comfy blanket	Base Resting HP: +50
+Item	comfy blanket	Last Available: "2005-10", Base Resting HP: +50
 Item	comfy coffin	Spooky Resistance: +2
 Item	cottage	Base Resting HP: +29, Base Resting MP: +30
-Item	Crimbo candle	Adventures: [3*event(December)]
+Item	Crimbo candle	Last Available: "2018-12", Adventures: [3*event(December)]
 Item	cuckoo clock	Adventures: +3
-Item	elevent	Base Resting HP: +49, Base Resting MP: +50
+Item	elevent	Last Available: "2014-03", Base Resting HP: +49, Base Resting MP: +50
 Item	Feng Shui for Big Dumb Idiots	Bonus Resting MP: +7
 Item	filth-encrusted futon	Stench Resistance: +2
 Item	forest canopy bed	Free Rests: +5
 Item	frigid air mattress	Cold Resistance: +2
 Item	Frobozz Real-Estate Company Instant House (TM)	Base Resting HP: +39, Base Resting MP: +40
 Item	gauze hammock	Bonus Resting HP: +60
-Item	gingerbread house	Base Resting HP: +69, Base Resting MP: +70
+Item	gingerbread house	Last Available: "2009-12", Base Resting HP: +69, Base Resting MP: +70
 Item	giant Faraday cage	Base Resting HP: +50, Base Resting MP: +50
-Item	giant pilgrim hat	Base Resting HP: +39, Base Resting MP: +40
-Item	house-sized mushroom	Base Resting HP: +69, Base Resting MP: +70
-Item	ginormous pumpkin	Base Resting HP: +49, Base Resting MP: +50
+Item	giant pilgrim hat	Last Available: "2016-11", Base Resting HP: +39, Base Resting MP: +40
+Item	house-sized mushroom	Last Available: "2020-03", Base Resting HP: +69, Base Resting MP: +70
+Item	ginormous pumpkin	Last Available: "2010-11", Base Resting HP: +49, Base Resting MP: +50
 # haunted doghouse: Houses your very own Hallowiener Dog!
 Item	haunted doghouse	Free Pull, Last Available: "2015-10"
 Item	hobo fortress blueprints	Base Resting HP: +84, Base Resting MP: +85
-Item	house of twigs and spit	Base Resting HP: +59, Base Resting MP: +60
-Item	Lazybones&trade; recliner	Spooky Resistance: +2
+Item	house of twigs and spit	Last Available: "2008-06", Base Resting HP: +59, Base Resting MP: +60
+Item	Lazybones&trade; recliner	Last Available: "2012-10", Spooky Resistance: +2
 # Loudmouth Larry Lamprey
-Item	Meat Butler	Adventures: +4
+Item	Meat Butler	Last Available: "2023-06", Adventures: +4
 # meat golem
 Item	Meat maid	Adventures: +4
 Item	Newbiesport&trade; tent	Base Resting HP: +9, Base Resting MP: +10
@@ -5460,19 +5460,19 @@ Item	saltwaterbed	Item Drop Penalty: [10*env(underwater)], Meat Drop Penalty: [1
 Item	sandcastle	Base Resting HP: +49, Base Resting MP: +50
 # sleeping stocking
 # snow fort 10 turns of Snow Fortified (+25% item drop, +50% meat drop, +50 max MP, +100 max HP)
-Item	snow fort	Base Resting HP: +65, Base Resting MP: +65
+Item	snow fort	Last Available: "2014-01", Base Resting HP: +65, Base Resting MP: +65
 # spirit bed 20 turns of Spirit Schooled (+20% max MP)
 # spooky scarecrow
 Item	stained mattress	Sleaze Resistance: +2
-Item	tin roof (rusted)	PvP Fights: +5
-Item	Xiblaxian residence-cube	Base Resting HP: +99, Base Resting MP: +100
+Item	tin roof (rusted)	Last Available: "2013-09", PvP Fights: +5
+Item	Xiblaxian residence-cube	Last Available: "2014-09", Base Resting HP: +99, Base Resting MP: +100
 
 # Chateau section of modifiers.txt
 
-Item	antler chandelier	PvP Fights: +3
-Item	artificial skylight	Adventures: +3
+Item	antler chandelier	Last Available: "2015-01", PvP Fights: +3
+Item	artificial skylight	Last Available: "2015-01", Adventures: +3
 # bowl of potpourri: Gives some Moxie stats when you rest
-Item	ceiling fan	Free Rests: 5
+Item	ceiling fan	Last Available: "2015-01", Free Rests: 5
 # continental juice bar: Produces 3 random potions each day
 # electric muscle stimulator: Gives some Muscle stats when you rest
 # fancy stationery set: Produces 3 fancy calligraphy pens each day
@@ -9391,7 +9391,7 @@ Item	candy rations	Effect: "Toured of Duty", Effect Duration: 20, Last Available
 Item	carrot cake	Effect: "Pla-see-bo", Effect Duration: 10, Last Available: "2013-01"
 Item	carrot cake precipice bar	Effect: "On the Precipice of Carrots", Effect Duration: 30, Last Available: "2022-05"
 Item	centipede eggs	Effect: "Somewhat Poisoned", Effect Duration: 10
-Item	chaos popcorn	Effect Duration: 5
+Item	chaos popcorn	Last Available: "2011-04", Effect Duration: 5
 Item	cheezburger	Effect: "Yes, Can Haz", Effect Duration: 50, Last Available: "2011-09"
 Item	chilly dog	Effect: "Chill Out, Dog", Effect Duration: 30
 Item	Choco-Mint patty	Effect: "Alpine Mintiness", Effect Duration: 25, Last Available: "2015-01"
@@ -9626,7 +9626,7 @@ Item	tempura cauliflower	Effect: "Low on the Hog", Effect Duration: 20
 Item	thanksgiving turkey	Effect: "Thanksgetting", Effect Duration: 20, Last Available: "2016-11"
 # The Plumber's mushroom stew: Reduces your Drunkenness by 1
 Item	They liver popsicle	Effect: "You Liver", Effect Duration: 100, Last Available: "2014-09"
-Item	thyme jelly donut	Effect Duration: 5
+Item	thyme jelly donut	Last Available: "2011-09", Effect Duration: 5
 Item	Tiger-lily's milk	Effect: "Grrrrrrreat!", Effect Duration: 5, Last Available: "2010-03"
 Item	tin of submardines	Effect: "Appeteyes", Effect Duration: 50, Last Available: "2015-11", Wiki Name: "tin of submardines"
 # toast with cold jelly: Freezes your liver
@@ -9851,7 +9851,7 @@ Item	hot mint schnocolate	Effect: "Alpine Mintiness", Effect Duration: 25, Last 
 Item	Hot Socks	Effect: "[1701]Hip to the Jive", Effect Duration: 50, Last Available: "2014-07"
 Item	hot wine	Effect: "In a Stealin' Mood", Effect Duration: 50, Last Available: "2023-12"
 Item	Hundred Headed IPA	Effect: "Hoppyness", Effect Duration: 20, Last Available: "2013-12"
-Item	ice porter	Wiki Name: "ice porter (drink)"
+Item	ice porter	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 Item	ice wine	Effect: "Brain Freeze", Effect Duration: 50, Last Available: "2015-11"
 Item	Irish Coffee, English Heart	Effect: "Smithsness Cheer", Effect Duration: 100, Last Available: "2013-12"
 Item	Irish eggnog	Effect: "Green-Blooded", Effect Duration: 20, Last Available: "2024-12"
@@ -9970,7 +9970,7 @@ Item	Suppurating Sinner	Effect: "Heart Aflame", Effect Duration: 10, Last Availa
 Item	Swedish coffee	Effect: "Swedish Courage", Effect Duration: 50, Last Available: "2023-12"
 Item	swirling mushroom wine	Effect: "Tremella Tremens", Effect Duration: 80, Last Available: "2014-05"
 Item	Taco Dan's Taco Stand Chimichangarita	Effect: "Margaritish", Effect Duration: 10, Last Available: "2012-12"
-Item	Temps Tempranillo	Effect Duration: 5
+Item	Temps Tempranillo	Last Available: "2011-09", Effect Duration: 5
 Item	The Cooler Out of Space	Effect: "You Can Taste the Darkness", Effect Duration: 30, Last Available: "2011-10"
 # The Mad Liquor: Reduces your Fullness by 1
 Item	Third Base	Effect: "Third Based", Effect Duration: 40, Last Available: "2018-02"
@@ -10011,7 +10011,7 @@ Item	abstraction: perception	Effect: "Perception", Effect Duration: 50, Last Ava
 Item	abstraction: purpose	Effect: "Purpose", Effect Duration: 50, Last Available: "2015-12"
 Item	abstraction: sensation	Effect: "Sensation", Effect Duration: 50, Last Available: "2015-12"
 Item	abstraction: thought	Effect: "Thought", Effect Duration: 50, Last Available: "2015-12"
-Item	alien animal goo	Effect: "Celestial Body", Effect Duration: 40
+Item	alien animal goo	Last Available: "2017-04", Effect: "Celestial Body", Effect Duration: 40
 Item	alien plant goo	Effect: "Celestial Mind", Effect Duration: 40, Last Available: "2017-04"
 Item	ancient medicinal herbs	Effect: "Ancient Fortitude", Effect Duration: 50, Last Available: "2016-01"
 # ancient pills: Restore 30-40 MP
@@ -10153,14 +10153,14 @@ Item	yellow striped oyster egg	Effect: "Egg-stra Arm", Effect Duration: 20
 
 # Sixguns section of modifiers.txt
 
-Item	baconstone-handled sixgun	Sixgun Damage: [35*(1+skill(Well-Oiled Guns))]
-Item	custom sixgun	Sixgun Damage: [35*(1+skill(Well-Oiled Guns))]
-Item	hamethyst-handled sixgun	Sixgun Damage: [35*(1+skill(Well-Oiled Guns))]
-Item	makeshift sixgun	Sixgun Damage: [25*(1+skill(Well-Oiled Guns))]
-Item	Pecos Dave's sixgun	Sixgun Damage: [50*(1+skill(Well-Oiled Guns))]
-Item	porquoise-handled sixgun	Sixgun Damage: [35*(1+skill(Well-Oiled Guns))]
-Item	reliable sixgun	Sixgun Damage: [20*(1+skill(Well-Oiled Guns))]
-Item	rinky-dink sixgun	Sixgun Damage: [15*(1+skill(Well-Oiled Guns))]
+Item	baconstone-handled sixgun	Last Available: "2016-02", Sixgun Damage: [35*(1+skill(Well-Oiled Guns))]
+Item	custom sixgun	Last Available: "2016-02", Sixgun Damage: [35*(1+skill(Well-Oiled Guns))]
+Item	hamethyst-handled sixgun	Last Available: "2016-02", Sixgun Damage: [35*(1+skill(Well-Oiled Guns))]
+Item	makeshift sixgun	Last Available: "2016-02", Sixgun Damage: [25*(1+skill(Well-Oiled Guns))]
+Item	Pecos Dave's sixgun	Last Available: "2016-02", Sixgun Damage: [50*(1+skill(Well-Oiled Guns))]
+Item	porquoise-handled sixgun	Last Available: "2016-02", Sixgun Damage: [35*(1+skill(Well-Oiled Guns))]
+Item	reliable sixgun	Last Available: "2016-02", Sixgun Damage: [20*(1+skill(Well-Oiled Guns))]
+Item	rinky-dink sixgun	Last Available: "2016-02", Sixgun Damage: [15*(1+skill(Well-Oiled Guns))]
 Item	toy sixgun	Sixgun Damage: [5*(1+skill(Well-Oiled Guns))]
 
 # Potions section of modifiers.txt
@@ -10247,7 +10247,7 @@ Item	bloodstain stick	Effect: "Bloodstain-Resistant", Effect Duration: 20
 Item	blooper ink	Effect: "Blooper Inked", Effect Duration: 10
 Item	blue grass	Effect: "The Grass...  Is Blue...", Effect Duration: 20
 Item	blue snowcone	Effect: "Blue Tongue", Effect Duration: 20, Last Available: "2006-01"
-Item	blue-frosted astral cupcake	Effect: "Cupcake of Choice", Effect Duration: 20
+Item	blue-frosted astral cupcake	Last Available: "2006-06", Effect: "Cupcake of Choice", Effect Duration: 20
 Item	boiling broth	Effect: "Boiling Determination", Effect Duration: 1, Last Available: "2018-07"
 Item	boiling hot cocoa	Effect: "Cocoa-Crispy", Effect Duration: 20, Last Available: "2020-12"
 Item	boiling seal blood	Effect: "Abyssal Blood", Effect Duration: 20
@@ -10532,9 +10532,9 @@ Item	Flan in the Moon	Effect: "Heal Thy Nanoself", Effect Duration: 50, Last Ava
 Item	flapper fly	Effect: "Flapper Dancin'", Effect Duration: 20, Last Available: "2023-02"
 Item	flask of baconstone juice	Effect: "Baconstoned", Effect Duration: 10
 Item	flask of hamethyst juice	Effect: "Ham-Fisted", Effect Duration: 10
-Item	flask of mining oil	Effect Duration: 10
+Item	flask of mining oil	Last Available: "2014-12", Effect Duration: 10
 Item	flask of porquoise juice	Effect: "Je Ne Sais Porquoise", Effect Duration: 10
-Item	flask of tainted mining oil	Effect Duration: 0
+Item	flask of tainted mining oil	Last Available: "2014-12", Effect Duration: 0
 Item	Flaskfull of Hollow	Effect: "Merry Smithsness", Effect Duration: 150, Last Available: "2013-12"
 Item	fleshy putty	Effect: "Puttied, Fleshly", Effect Duration: 30, Last Available: "2021-12"
 Item	floaty sand	Effect: "5 Pounds Lighter", Effect Duration: 10
@@ -10617,7 +10617,7 @@ Item	green candy heart	Effect: "Heart of Green", Effect Duration: 10, Last Avail
 Item	green rock candy	Effect: "Sprinkle Sense", Effect Duration: 10, Last Available: "2016-12"
 Item	green seashell	Effect: "On Smellier Tides", Effect Duration: 20, Last Available: "2019-07"
 Item	green snowcone	Effect: "Green Tongue", Effect Duration: 20, Last Available: "2006-01"
-Item	green-frosted astral cupcake	Effect: "The Cupcake of Wrath", Effect Duration: 20
+Item	green-frosted astral cupcake	Last Available: "2006-06", Effect: "The Cupcake of Wrath", Effect Duration: 20
 Item	gremlin juice	Effect: "Comic Violence", Effect Duration: 5
 Item	gremlin mutagen	Effect: "Mutated", Effect Duration: 1
 Item	grisly shell fragment	Effect: "Thick, Sick", Effect Duration: 1
@@ -10846,7 +10846,7 @@ Item	one pill	Effect Duration: 0
 Item	orange and black Crimboween candy	Effect: "Sugar Rush", Effect Duration: 5, Last Available: "2020-09"
 Item	orange candy heart	Effect: "Heart of Orange", Effect Duration: 10, Last Available: "2007-02"
 Item	orange snowcone	Effect: "Orange Tongue", Effect Duration: 20, Last Available: "2006-01"
-Item	orange-frosted astral cupcake	Effect: "Shiny Happy Cupcake", Effect Duration: 20
+Item	orange-frosted astral cupcake	Last Available: "2006-06", Effect: "Shiny Happy Cupcake", Effect Duration: 20
 Item	orcish hand lotion	Effect: "Hairy Palms", Effect Duration: 10
 Item	orcish nailing lube	Effect: "Well-Lubed", Effect Duration: 10
 Item	orcish rubber	Effect: "Using Protection", Effect Duration: 10
@@ -10896,7 +10896,7 @@ Item	pile of ashes	Effect: "Ashen", Effect Duration: 20
 Item	pill cup	Effect: "Pill Party!", Effect Duration: 30
 Item	pine tar	Effect: "Sticky Hands", Effect Duration: 30
 Item	pink candy heart	Effect: "Heart of Pink", Effect Duration: 10, Last Available: "2007-02"
-Item	pink-frosted astral cupcake	Effect: "Your Cupcake Senses Are Tingling", Effect Duration: 20
+Item	pink-frosted astral cupcake	Last Available: "2006-06", Effect: "Your Cupcake Senses Are Tingling", Effect Duration: 20
 Item	piranha pollen	Effect: "Piranha Power", Effect Duration: 20, Last Available: "2020-03"
 Item	pirate brochure	Effect: "Muscularrr", Effect Duration: 10
 Item	pirate pamphlet	Effect: "Charrrming", Effect Duration: 10
@@ -10978,7 +10978,7 @@ Item	pulled yellow taffy	Effect: "Sour Softshoe", Effect Duration: 10, Last Avai
 Item	pumpkin juice	Effect: "Juiced and Jacked", Effect Duration: 10, Last Available: "2010-11"
 Item	Punching Potion	Effect: "Feeling Punchy", Effect Duration: 10, Last Available: "2018-06"
 Item	purple snowcone	Effect: "Purple Tongue", Effect Duration: 20, Last Available: "2006-01"
-Item	purple-frosted astral cupcake	Effect: "Tiny Bubbles in the Cupcake", Effect Duration: 20
+Item	purple-frosted astral cupcake	Last Available: "2006-06", Effect: "Tiny Bubbles in the Cupcake", Effect Duration: 20
 Item	pygmy phone number	Effect: "Pygmy Drinking Buddy", Effect Duration: 15
 Item	pygmy pygment	Effect: "Woad Warrior", Effect Duration: 10
 Item	R&uuml;mpelstiltz	Effect: "Rumpel-pumped", Effect Duration: 5, Last Available: "2014-12"
@@ -11502,7 +11502,7 @@ Item	alien source code printout (used)	Skill: "Alien Source Code", Last Availabl
 # alien toenails: Worth 1 page of Spacegate Research
 # alien zoological sample: Worth 3 pages of Spacegate Research
 Item	all-purpose cleaner	Effect: "Soul-Crushing Headache", Effect Duration: 10
-Item	all-year sucker	Effect: "Gonna Get You, Sucker", Effect Duration: 10
+Item	all-year sucker	Last Available: "2011-11", Effect: "Gonna Get You, Sucker", Effect Duration: 10
 # alpine watercolor set: Make a painting of a monster to hang on your wall
 # anchor bomb: Banish a foe for 30 turns
 # ancient cure-all: Allows you to remove an Effect
@@ -11572,7 +11572,7 @@ Item	Batfellow comic	Free Pull, Last Available: "2016-12"
 # Battlie Light Saver: Deals 30-50 Physical Damage and briefly stuns your foe
 # battoo kit: Unlocks a sweet Batfellow tattoo
 Item	Beach Comb Box	Free Pull, Last Available: "2019-07"
-Item	beautiful rainbow	Skill: "Belch The Rainbow"
+Item	beautiful rainbow	Last Available: "2014-11", Skill: "Belch The Rainbow"
 # beehive: Full of bees!
 # beer bomb: Deals 55-75 Physical Damage
 # beer-scented teddy bear: Restores 15-20 MP
@@ -11602,7 +11602,7 @@ Item	Blizzards I Have Died In	Skill: "Snowclone"
 # blue pixel potion: Restores 50-80 MP
 # blue plastic oyster egg: Restores 35-40 MP
 # blue potion: Restores 20-30 MP
-Item	blue potion	Effect: "Healthy Blue Glow", Effect Duration: 20
+Item	blue potion	Last Available: "2013-02", Effect: "Healthy Blue Glow", Effect Duration: 20
 # blue raspberry troll doll: Deals 3-5 <font color=blue>Cold Damage</font>
 # blue raspberry troll doll: (doesn't go away when used)
 # blue shell: Deals up to 25 Physical Damage to whoever is in the lead
@@ -11650,7 +11650,7 @@ Item	brass Dreadsylvanian flask	Effect: "Brass Loins", Effect Duration: 100
 Item	brick	Free Pull
 # brick of sand: Deals 60-80 Physical Damage
 # brick of sand: Weakens Enemies a Lot
-Item	BRICKO octopus	Wiki Name: "BRICKO octopus (item)"
+Item	BRICKO octopus	Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
 # BRICKO reactor: Deals 200-1000 Physical Damage
 # BRICKO reactor: (more effective against BRICKO monsters)
 # broken BRICKO brick: Deals Physical Damage every round for the rest of the fight
@@ -11664,7 +11664,7 @@ Item	BRICKO octopus	Wiki Name: "BRICKO octopus (item)"
 # buckyball: Lets you escape from combat
 # Build-a-City Gingerbread kit: Unlocks a Gingerbread City in the Big Mountains
 Item	Build-a-City Gingerbread kit	Free Pull, Last Available: "2016-12"
-Item	Bulky Buddy Box	Wiki Name: "Bulky Buddy Box (hatchling)"
+Item	Bulky Buddy Box	Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
 # bundle of &quot;fragrant&quot; herbs: (up to 10 times per day)
 # bundle of &quot;fragrant&quot; herbs: (during the Crimbo 2015 event only)
 # bundle of &quot;fragrant&quot; herbs: Banish a monster for the rest of the day
@@ -11692,13 +11692,13 @@ Item	carton of extra-sharp, rusty staples	Weapon Damage: +10, Spell Damage: +10
 # carton of rotten eggs: Deals 12-15 <font color=green>Stench Damage</font>
 # carton of rotten eggs: (can be used 8-10 times before the carton is empty)
 # cartoon heart: Restores 40-60 HP
-Item	cartoon heart	Effect: "Healthy Red Glow", Effect Duration: 10
+Item	cartoon heart	Last Available: "2013-02", Effect: "Healthy Red Glow", Effect Duration: 10
 # cast: Restores 25-35 HP in combat, and 15-20 out of combat
 Item	Celsius 233	Skill: "Eternal Flame", Last Available: "2017-06"
 Item	Celsius 233 (singed)	Skill: "Eternal Flame", Last Available: "2017-06"
 # chainsaw chain: Deals 60-80 Physical Damage and weakens enemies a lot
 # chaos butterfly: Is Unpredictable
-Item	Charter: Nellyville	Effect: "Hot in Herre", Effect Duration: 30
+Item	Charter: Nellyville	Last Available: "2023-06", Effect: "Hot in Herre", Effect Duration: 30
 # Chateau Mantegna room key: Permanently unlocks a new residence in the Big Mountains
 Item	Chateau Mantegna room key	Free Pull, Last Available: "2015-01"
 # cheer-o-gram: Send somebody a short but explosively cheerful message
@@ -11778,8 +11778,8 @@ Item	cotton candy cocoon	Free Pull, Last Available: "2008-08"
 # cotton candy skoshe: Restores 15-30 HP and MP
 # cotton candy smidgen: Restores 11-23 HP and MP
 # counterfeit city
-Item	Covert Ops for Kids	Skill: "Hide From Seekers"
-Item	Covert Ops for Kids (used)	Skill: "Hide From Seekers"
+Item	Covert Ops for Kids	Last Available: "2024-12", Skill: "Hide From Seekers"
+Item	Covert Ops for Kids (used)	Last Available: "2024-12", Skill: "Hide From Seekers"
 # cracked stone sphere: Mysterious, Deprecated
 # crappy camera: Makes a copy of a monster to fight later
 # crappy camera: (when it works)
@@ -11836,7 +11836,7 @@ Item	custom avatar form	Free Pull
 # d8: Deals Prismatic Damage based on your Level
 # d10: Weakens enemies somewhat
 # d12: Deals a bunch of damage of a random element
-Item	d12	Effect: "Bastard!", Effect Duration: 10
+Item	d12	Last Available: "2011-09", Effect: "Bastard!", Effect Duration: 10
 # d20: Deals 1-20 <font color=red>Hot Damage</font> times your Level
 # d20	Effect: "20/20 Vision", Effect Duration: 20d20
 # d20	Effect: "Natural 1", Effect Duration: 1
@@ -11854,7 +11854,7 @@ Item	Dear Past Self Package	Free Pull, Last Available: "2016-09"
 # Deck of Every Card: Who knows what will happen when you draw from it!
 Item	decoded cult documents	Skill: "Bind Spaghetti Elemental"
 Item	decorative fountain	Effect: "Sleepy", Effect Duration: 1
-Item	dedigitizer schematic: cybeer	Softcore Only
+Item	dedigitizer schematic: cybeer	Last Available: "2025-12", Softcore Only
 Item	deed to Oliver's Place	Free Pull
 Item	defective Game Grid token	Effect: "Video... Games?", Effect Duration: 5
 Item	deflated inflatable dodecapede	Free Pull, Last Available: "2011-12"
@@ -11962,7 +11962,7 @@ Item	experimental carbon fiber pasta additive	Class: "Pastamancer", Last Availab
 Item	extra DNA	Experience (familiar): +1
 # extra ooze: Increases sleaze damage
 # extra-strength red potion: Restores 190-210 HP
-Item	extra-strength red potion	Effect: "Healthy Red Glow", Effect Duration: 40
+Item	extra-strength red potion	Last Available: "2013-02", Effect: "Healthy Red Glow", Effect Duration: 40
 # fabric softener: Weakens enemies a lot
 # facehugging alien: Deals 100-300 Physical Damage after a few rounds have passed
 # facsimile dictionary: Most Enemies Don't Care About It
@@ -11970,10 +11970,10 @@ Item	extra-strength red potion	Effect: "Healthy Red Glow", Effect Duration: 40
 Item	faerie dust	Lasts Until Rollover, Last Available: "2018-04"
 Item	fairy-worn boots	Free Pull, Last Available: "2011-08"
 # familiar-in-the-middle wrapper: CyberRealm: Your familiar will find an extra 1 at the end of combat
-Item	familiar-in-the-middle wrapper	Generic
+Item	familiar-in-the-middle wrapper	Last Available: "2025-12", Generic
 # fancy bath salts: Weakens enemies very slightly
 # fancy blue potion: Restores 90-110 MP
-Item	fancy blue potion	Effect: "Healthy Blue Glow", Effect Duration: 40
+Item	fancy blue potion	Last Available: "2013-02", Effect: "Healthy Blue Glow", Effect Duration: 40
 Item	fancy calligraphy pen	Free Pull, Last Available: "2015-01"
 # fancy dress ball: Lets You Escape From Combat
 # fancy oil painting: Useful for Bridge-Building
@@ -12079,7 +12079,7 @@ Item	glowing frisbee	Free Pull, Last Available: "2011-12"
 # gob of wet hair: Stops Enemy From Attacking and Weakens it Very Slightly
 Item	God Lobster Egg	Free Pull, Last Available: "2018-05"
 # gold star: Restores 20-30 MP
-Item	gold star	Effect: "Healthy Blue Glow", Effect Duration: 10
+Item	gold star	Last Available: "2013-02", Effect: "Healthy Blue Glow", Effect Duration: 10
 Item	golden gum	Free Pull, Last Available: "2017-06"
 Item	golden gun	Free Pull, Last Available: "2017-06"
 # Golden Kokomo Resort Chip: Shiny!
@@ -12127,7 +12127,7 @@ Item	grolblin rum	Lasts Until Rollover, Last Available: "2018-04"
 # Gummi-Memory: Your future Gelatinous Noob runs will start with 5 extra skills (up to 20)
 # gun parts: Maybe you can make a gun out of them?
 Item	Guzzlr application	Free Pull
-Item	Gygaxian Libram	Skill: "Summon Dice"
+Item	Gygaxian Libram	Last Available: "2011-09", Skill: "Summon Dice"
 # gyroscope: Briefly distracts enemies
 # half of a gold tooth: It's gross.  Just sell it.
 # half-empty carton of milk: Deals 50-100 <font color=green>Stench Damage</font>
@@ -12173,8 +12173,8 @@ Item	Hodgman's journal #3: Pumping Tin	Skill: "Abs of Tin"
 Item	Hodgman's journal #4: View From The Big Top	Skill: "Marginally Insane"
 Item	Holiday Fun!	Free Pull, Last Available: "2014-12"
 Item	Holiday Hal's Happy-Time Fun Book!	Skill: "Summon Holiday Fun!"
-Item	Holiday Multitasking	Skill: "Holiday Multitasking"
-Item	Holiday Multitasking (used)	Skill: "Holiday Multitasking"
+Item	Holiday Multitasking	Last Available: "2024-12", Skill: "Holiday Multitasking"
+Item	Holiday Multitasking (used)	Last Available: "2024-12", Skill: "Holiday Multitasking"
 # holo-bomber: Deals 5,000 Physical Damage
 # holo-platoon: Deals 5,000 Physical Damage
 # holo-tank: Deals 5,000 Physical Damage
@@ -12194,12 +12194,12 @@ Item	Horsery contract	Free Pull, Last Available: "2018-08"
 # hot spore pod: Briefly improves your <font color = red>Hot</font> spells
 Item	How To Get Bigger Without Really Trying	Skill: "Get Big", Last Available: "2018-02"
 Item	How to Hold a Grudge	Skill: "Chip on your Shoulder"
-Item	How to Lose Friends and Attract Snakes	Skill: "Attract Snakes"
-Item	How to Lose Friends and Attract Snakes (used)	Skill: "Attract Snakes"
+Item	How to Lose Friends and Attract Snakes	Last Available: "2024-12", Skill: "Attract Snakes"
+Item	How to Lose Friends and Attract Snakes (used)	Last Available: "2024-12", Skill: "Attract Snakes"
 # How to Play Othello: Teaches you how to play Othello better
 Item	How to Tolerate Jerks	Skill: "Thick-Skinned"
-Item	Hoyle's Guide to Reindeer Games	Skill: "Reindeer Games"
-Item	Hoyle's Guide to Reindeer Games (used)	Skill: "Reindeer Games"
+Item	Hoyle's Guide to Reindeer Games	Last Available: "2024-12", Skill: "Reindeer Games"
+Item	Hoyle's Guide to Reindeer Games (used)	Last Available: "2024-12", Skill: "Reindeer Games"
 Item	Huggler Radio	Free Pull
 # human musk: Banish an enemy for the rest of the day
 Item	hungover chauvinist pig	Free Pull, Last Available: "2010-10"
@@ -12227,11 +12227,11 @@ Item	Inigo's Incantation of Inspiration (crumpled)	Class: "Accordion Thief", Ski
 # interesting clod of dirt: Absorb it for a useful skill!
 # internet point: Give yourself +1
 Item	Island Drinkin', a Tiki Mixology Odyssey	Skill: "Tiki Mixology", Last Available: "2019-04"
-Item	Jackass Plumber home game	Effect: "Gamer Rage", Effect Duration: 10
+Item	Jackass Plumber home game	Last Available: "2011-11", Effect: "Gamer Rage", Effect Duration: 10
 # jagged scrap metal: Deals 20-30 Physical Damage and causes bleeding
 # jam band flyers: Advertise!
 # Jamocha berry: Grants passive physical damage and energizes you for a while
-Item	Jamocha berry	Effect: "Berry Thorny", Effect Duration: 20
+Item	Jamocha berry	Last Available: "2018-03", Effect: "Berry Thorny", Effect Duration: 20
 # janitor sponge: Deals 20-30 <font color=green>Stench Damage</font> and briefly stuns your opponent
 # January's Garbage Tote: Allows you to rummage up Holiday Detritus
 # January's Garbage Tote (unopened): Allows you to rummage up Holiday Detritus
@@ -12247,7 +12247,7 @@ Item	jitterbug larva	Free Pull, Last Available: "2007-10"
 Item	jug of Sneaky Pete's Mojo	Free Pull
 # Junk-Bond: Weakens enemies somewhat and briefly stuns them
 # Keese berry: Improves your defenses and energizes you for a while
-Item	Keese berry	Effect: "Berry Defensive", Effect Duration: 20
+Item	Keese berry	Last Available: "2018-03", Effect: "Berry Defensive", Effect Duration: 20
 Item	kerosene-soaked skip	Free Pull, Last Available: "2018-12"
 # kidnapped orphan: Take it downtown to Gotpork Orphanage
 # killing feather: Deals 100-120 Physical Damage
@@ -12278,7 +12278,7 @@ Item	li'l orphan tot	Free Pull, Last Available: "2016-10"
 Item	Libram of BRICKOs	Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 Item	Libram of Candy Heart Summoning	Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
 Item	Libram of Divine Favors	Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
-Item	Libram of Love Songs	Skill: "Summon Love Song"
+Item	Libram of Love Songs	Last Available: "2009-02", Skill: "Summon Love Song"
 Item	Libram of Pulled Taffy	Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
 Item	Libram of Resolutions	Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
 # License To Kill: ???
@@ -12291,7 +12291,7 @@ Item	Libram of Resolutions	Free Pull, Last Available: "2012-01", Skill: "Summon 
 # little red book: Weakens enemies by 5% and briefly stuns them.
 # live nautical mine: Deals a bunch of Physical Damage
 # live nautical mine: Is unsafe on land
-Item	Living to Drink, Drinking to Live	Skill: "Drinking to Drink"
+Item	Living to Drink, Drinking to Live	Last Available: "2018-09", Skill: "Drinking to Drink"
 Item	llama lama cria	Free Pull, Last Available: "2008-06"
 # Loathing Legion jackhammer: Allows Meatsmithing without the Adventure cost (3 times a day)
 Item	Loathing Legion jackhammer	Softcore Only, Last Available: "2011-01"
@@ -12316,7 +12316,7 @@ Item	machine elf capsule	Free Pull, Last Available: "2015-12"
 # magnolia blossom: Restores 15-30 HP and MP
 Item	Manual of Lock Picking	Skill: "Lock Picking", Last Available: "2020-08"
 Item	Manual of Numberology	Skill: "Calculate the Universe"
-Item	Manual of Secret Door Detection	Skill: "Secret Door Awareness"
+Item	Manual of Secret Door Detection	Last Available: "2023-06", Skill: "Secret Door Awareness"
 Item	Manual of Transcendent Olfaction	Skill: "Transcendent Olfaction"
 Item	map to Dolph Bossin's hideout	Free Pull, Last Available: "2019-12"
 Item	Map to Kokomo	Free Pull, Skill: "Summon Kokomo Resort Pass"
@@ -12334,7 +12334,7 @@ Item	Maxing, Relaxing	Skill: "Maximum Chill"
 Item	Mayam Calendar	Free Pull, Last Available: "2024-05"
 # MayDay&trade; contract: Survival supplies will be delivered to you each day
 Item	MayDay&trade; contract	Free Pull, Last Available: "2022-05"
-Item	MayDay&trade; supply package	Effect: "Ready to Survive", Effect Duration: 30
+Item	MayDay&trade; supply package	Last Available: "2022-05", Effect: "Ready to Survive", Effect Duration: 30
 # mayo lance: Unleash a torrent of inner mayonnaise.  The torrent will be yellow and ray-like.
 Item	mayo lance	Lasts Until Rollover, Last Available: "2015-05"
 # Mayo Minder&trade;: Makes it so packets of prescription mayonnaise are automatically consumed as you eat
@@ -12347,7 +12347,7 @@ Item	mayo lance	Lasts Until Rollover, Last Available: "2015-05"
 # Mayostat: Recover a portion of the next substantial thing you eat for later use
 # Mayozapine: Increases the stat gains from the next thing you eat
 Item	McHugeLarge deluxe ski set	Free Pull, Last Available: "2025-01"
-Item	McPhee's Grimoire of Hilarious Object Summoning	Skill: "Summon Hilarious Objects"
+Item	McPhee's Grimoire of Hilarious Object Summoning	Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 # meat vortex: Steals Some Meat From an Enemy
 # melty plastic grenade: Deals <font color=green>Stench Damage</font> based on your highest stat
 # melty plastic grenade: (and leaves the monster permanently stinky)
@@ -12442,7 +12442,7 @@ Item	mysterious chest	Free Pull, Last Available: "2011-06"
 # Mysterious Green Box: Can only be opened on February 29
 # Mysterious Red Box: Can only be opened on February 29
 # Nadsat berry: Improves critical hit chance and energizes you for a while (also gives Berry Experiential)
-Item	Nadsat berry	Effect: "Berry Critical", Effect Duration: 20
+Item	Nadsat berry	Last Available: "2018-03", Effect: "Berry Critical", Effect Duration: 20
 # Nardz energy beverage: Restores 50-70 MP
 Item	nasty haunch	Lasts Until Rollover, Last Available: "2018-04"
 # nasty-smelling moss: Restores 20-30 HP and briefly stuns opponents.
@@ -12580,8 +12580,8 @@ Item	plans for depleted Grimacite weightlifting belt	Recipe: "depleted Grimacite
 Item	plump purple mushroom	Lasts Until Rollover, Last Available: "2018-04"
 # plus one: Give a pal +1
 # plus-sized phylactery: Contains the soul of a specific lihc
-Item	Pocket Guide to Mild Evil	Skill: "Perpetrate Mild Evil"
-Item	Pocket Guide to Mild Evil (used)	Skill: "Perpetrate Mild Evil"
+Item	Pocket Guide to Mild Evil	Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+Item	Pocket Guide to Mild Evil (used)	Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
 # Pocket Meteor Guide: Teaches you everything about meteors
 # Pocket Meteor Guide (well-thumbed): Teaches you everything about meteors
 # pog #01 (spider): Does all sorts of crazy things
@@ -12657,21 +12657,21 @@ Item	Really Expensive Jewelry and You	Skill: "Really Expensive Jewelrycrafting"
 # really really sticky spider web: Weakens enemies a little bit
 # really sticky spider web: Weakens enemies slightly
 # really thick bandage: Restores 100-120 HP
-Item	Recipe of Before Yore: baked veggie ricotta	Recipe: "baked veggie ricotta casserole"
-Item	Recipe of Before Yore: Boris's beer	Recipe: "Boris's beer"
-Item	Recipe of Before Yore: Boris's bread	Recipe: "Boris's bread"
-Item	Recipe of Before Yore: Calzone of Legend	Recipe: "Calzone of Legend"
-Item	Recipe of Before Yore: Deep Dish of Legend	Recipe: "Deep Dish of Legend"
-Item	Recipe of Before Yore: honey bun of Boris	Recipe: "honey bun of Boris"
-Item	Recipe of Before Yore: Jarlsberg's vegetable soup	Recipe: "Jarlsberg's vegetable soup"
-Item	Recipe of Before Yore: Pete's rich ricotta	Recipe: "Pete's rich ricotta"
-Item	Recipe of Before Yore: Pete's wily whey bar	Recipe: "Pete's wiley whey bar"
-Item	Recipe of Before Yore: Pizza of Legend	Recipe: "Pizza of Legend"
-Item	Recipe of Before Yore: plain calzone	Recipe: "plain calzone"
-Item	Recipe of Before Yore: ratatouille de Jarlsberg	Recipe: "ratatouille de Jarlsberg"
-Item	Recipe of Before Yore: roasted vegetable focaccia	Recipe: "roasted vegetable focaccia"
-Item	Recipe of Before Yore: roasted vegetable of J.	Recipe: "roasted vegetable of Jarlsberg"
-Item	Recipe of Before Yore: St. Pete's sneaky smoothie	Recipe: "St. Pete's sneaky smoothie"
+Item	Recipe of Before Yore: baked veggie ricotta	Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
+Item	Recipe of Before Yore: Boris's beer	Last Available: "2022-11", Recipe: "Boris's beer"
+Item	Recipe of Before Yore: Boris's bread	Last Available: "2022-11", Recipe: "Boris's bread"
+Item	Recipe of Before Yore: Calzone of Legend	Last Available: "2022-11", Recipe: "Calzone of Legend"
+Item	Recipe of Before Yore: Deep Dish of Legend	Last Available: "2022-11", Recipe: "Deep Dish of Legend"
+Item	Recipe of Before Yore: honey bun of Boris	Last Available: "2022-11", Recipe: "honey bun of Boris"
+Item	Recipe of Before Yore: Jarlsberg's vegetable soup	Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+Item	Recipe of Before Yore: Pete's rich ricotta	Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+Item	Recipe of Before Yore: Pete's wily whey bar	Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+Item	Recipe of Before Yore: Pizza of Legend	Last Available: "2022-11", Recipe: "Pizza of Legend"
+Item	Recipe of Before Yore: plain calzone	Last Available: "2022-11", Recipe: "plain calzone"
+Item	Recipe of Before Yore: ratatouille de Jarlsberg	Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+Item	Recipe of Before Yore: roasted vegetable focaccia	Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+Item	Recipe of Before Yore: roasted vegetable of J.	Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+Item	Recipe of Before Yore: St. Pete's sneaky smoothie	Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
 Item	record of infuriating silence	Skill: "Silent Slam", Last Available: "2012-10"
 Item	record of infuriating silence (used)	Skill: "Silent Slam", Last Available: "2012-10"
 Item	record of menacing silence	Skill: "Silent Slice", Last Available: "2012-10"
@@ -12695,7 +12695,7 @@ Item	red face paint	Free Pull, Last Available: "2015-12"
 # red pixel potion: Heals 100-120 Hit Points
 # red plastic oyster egg: Restores 35-40 Hit Points
 # red potion: Restores 90-110 HP
-Item	red potion	Effect: "Healthy Red Glow", Effect Duration: 20
+Item	red potion	Last Available: "2013-02", Effect: "Healthy Red Glow", Effect Duration: 20
 # Red Roger's flag: Increases the likelihood of sea battles in PirateRealm
 Item	Red Roger's flag	Lasts Until Rollover, Last Available: "2019-04"
 Item	Red Roger's map	Lasts Until Rollover, Last Available: "2019-04"
@@ -12756,8 +12756,8 @@ Item	Scurvy and Sobriety Prevention	Skill: "Prevent Scurvy and Sobriety", Last A
 Item	seal tooth	Effect: "Bloody Hand", Effect Duration: 3
 Item	seal-blubber candle	Class: "Seal Clubber"
 # sealhide snare: Stuns your opponent for a few rounds
-Item	Secrets of the Master Egg Hunters	Skill: "Master Egg Hunter"
-Item	Secrets of the Master Egg Hunters (used)	Skill: "Master Egg Hunter"
+Item	Secrets of the Master Egg Hunters	Last Available: "2024-12", Skill: "Master Egg Hunter"
+Item	Secrets of the Master Egg Hunters (used)	Last Available: "2024-12", Skill: "Master Egg Hunter"
 # self-defense training: Increases your Bat-Armor
 Item	Sensual Massage for Creeps	Skill: "Inappropriate Backrub"
 # Sept-Ember Censer: Generate 7 embers each day to magically consume
@@ -12822,7 +12822,7 @@ Item	smoking talon	Class: "Pastamancer"
 # smooth stone sphere: Mysterious, Deprecated
 # snake oil: Increase the venom and medicine level of your briefcase full of snakes
 # Snarf berry: Increases your stats and energizes you for a while
-Item	Snarf berry	Effect: "Berry Statistical", Effect Duration: 20
+Item	Snarf berry	Last Available: "2018-03", Effect: "Berry Statistical", Effect Duration: 20
 # sneaky wrapping paper: Hide gifts for other players in various locations
 # snow boards: Useful for Bridge-Building
 # soda water: Restores 3-5 MP
@@ -12836,7 +12836,7 @@ Item	SongBoom&trade; BoomBox Box	Free Pull, Last Available: "2018-06"
 Item	Sorcerers of the Shore Grimoire	Free Pull, Skill: "Summon Alice's Army Cards"
 # soup turtle: Deals 5-10 <font color=red>Hot Damage</font>
 Item	Source terminal	Free Pull, Last Available: "2016-06"
-Item	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	Skill: "Summon Tasteful Items"
+Item	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	Last Available: "2008-04", Skill: "Summon Tasteful Items"
 # space invader: Deals 300-400 Physical Damage
 Item	Space Pirate Astrogation Handbook	Skill: "Quantum Movement", Last Available: "2017-04"
 Item	space planula	Free Pull, Last Available: "2017-01"
@@ -12867,7 +12867,7 @@ Item	Spelunker of Fortune (used)	Skill: "Speluck"
 # spice melange: Makes you less full and more sober
 # spices: Deals 1 Physical Damage
 # spider web: Weakens enemies very slightly
-Item	spinal-fluid-covered emotion chip	Skill: "Emotionally Chipped"
+Item	spinal-fluid-covered emotion chip	Last Available: "2021-02", Skill: "Emotionally Chipped"
 # spinning wheel: Turns air into Meat (once per day)
 # spirit beer: Restores 40-50 MP
 Item	spirit beer	Effect: "Spiritually Aware", Effect Duration: 10
@@ -12881,7 +12881,7 @@ Item	spirit beer	Effect: "Spiritually Aware", Effect Duration: 10
 Item	spooky rattling cigar box	Free Pull, Last Available: "2011-12"
 Item	spray paint	Effect: "Tagged", Effect Duration: 10
 Item	squamous polyp	Free Pull, Last Available: "2011-12"
-Item	Stabonic scroll	Effect: "Bone Homie", Effect Duration: 20
+Item	Stabonic scroll	Last Available: "2010-10", Effect: "Bone Homie", Effect Duration: 20
 # star throwing star: Deals 50-75 Physical Damage
 Item	STATS+++ rom chip	Skill: "STATS+++", Last Available: "2025-12"
 # steam-powered model rocketship: Allows access to the Hole in the Sky
@@ -12911,7 +12911,7 @@ Item	suspicious package	Free Pull, Last Available: "2017-06"
 Item	suspicious stocking	Free Pull, Last Available: "2009-12"
 Item	sweaty egg	HP Regen Min: 4, HP Regen Max: 8
 Item	sweet nutcracker	Free Pull, Last Available: "2005-12"
-Item	sweet tooth	Wiki Name: "sweet tooth"
+Item	sweet tooth	Last Available: "2014-05", Wiki Name: "sweet tooth"
 # synaptic soup: Add a pound and MP restore to your familiar
 # T.U.R.D.S. Key: Lets you escape from combat without spending an Adventure
 # T.U.R.D.S. Key: (Maybe)
@@ -12933,7 +12933,7 @@ Item	talisman of Seshat	Free Pull
 Item	talking spade	Free Pull
 # tangle of rat tails: Deals 50-70 <font color=blueviolet>Sleaze Damage</font> and 100-120 <font color=green>Stench Damage</font>
 # Tapioc berry: Grants elemental resistance and energizes you for a while
-Item	Tapioc berry	Effect: "Berry Elemental", Effect Duration: 20
+Item	Tapioc berry	Last Available: "2018-03", Effect: "Berry Elemental", Effect Duration: 20
 # tattered scrap of paper: Lets you escape from combat without spending an Adventure
 # tattered scrap of paper: (Maybe)
 # tattoo of two turkeys: Grants a tattoo when used
@@ -12945,7 +12945,7 @@ Item	The Art of Slapfighting	Class: "Seal Clubber", Skill: "Iron Palm Technique"
 Item	The Art of Slapfighting (used)	Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 Item	The Autobiography Of Dynamite Superman Jones	Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 Item	The Ballad of Richie Thingfinder	Skill: "The Ballad of Richie Thingfinder"
-Item	The Big Book of Communism	Skill: "Communism!"
+Item	The Big Book of Communism	Last Available: "2015-12", Skill: "Communism!"
 Item	The Big Book of Communism (used)	Skill: "Communism!", Last Available: "2015-12"
 # The Big Book of Pirate Insults: Use it to insult Pirates
 # The Bomb: Deals 400-500 Physical Damage
@@ -12977,7 +12977,7 @@ Item	The Journal of Mime Science Vol. 6 (used)	Skill: "Quiet Desperation", Last 
 Item	The Joy of Wassailing	Skill: "Wassail", Last Available: "2010-12"
 Item	The Joy of Wassailing (used)	Skill: "Wassail", Last Available: "2010-12"
 Item	The Kloop in the Coop	Free Pull, Last Available: "2012-12"
-Item	The Legendary Beat	Effect: "Clyde's Blessing", Effect Duration: 20
+Item	The Legendary Beat	Last Available: "2010-04", Effect: "Clyde's Blessing", Effect Duration: 20
 # The Lost Comb: Stuns your opponent for a few rounds
 Item	The Necbronomicon	Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 Item	The Necbronomicon (used)	Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
@@ -13001,7 +13001,7 @@ Item	The Smith's Tome	Free Pull, Last Available: "2013-12", Skill: "Summon Smith
 Item	The Snitch's Manifesto	Skill: "Tattle", Last Available: "2012-12"
 Item	The Spirit of Giving	Skill: "The Spirit of Taking", Last Available: "2019-12"
 Item	The Spirit of Giving (used)	Skill: "The Spirit of Taking", Last Available: "2019-12"
-Item	The Sword in the Steak	Wiki Name: "The Sword in the Steak (item)"
+Item	The Sword in the Steak	Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
 Item	The Thorax's Codex of Tormenting Plants	Skill: "Torment Plant", Last Available: "2012-12"
 Item	The Western Look	Skill: "Steely-Eyed Squint", Last Available: "2016-02"
 Item	They'll Love You In Rhinestones	Skill: "Acquire Rhinestones", Last Available: "2018-02"

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -77,7 +77,7 @@ public class Modifiers {
   private final BooleanModifierCollection booleans = new BooleanModifierCollection();
   private final BitmapModifierCollection bitmaps = new BitmapModifierCollection();
   private final StringModifierCollection strings = new StringModifierCollection();
-  private ArrayList<Indexed<DoubleModifier, ModifierExpression>> expressions = null;
+  private ArrayList<Indexed<Modifier, ModifierExpression>> expressions = null;
   // These are used for Steely-Eyed Squint and so on
   private final DoubleModifierCollection accumulators = new DoubleModifierCollection();
 
@@ -812,8 +812,12 @@ public class Modifiers {
   // TODO: what does this do? what is expressions? Something to do with the [X] strings?
   public boolean override(final Lookup lookup) {
     if (this.expressions != null) {
-      for (Indexed<DoubleModifier, ModifierExpression> entry : this.expressions) {
-        this.setDouble(entry.index, entry.value.eval());
+      for (Indexed<Modifier, ModifierExpression> entry : this.expressions) {
+        if (entry.index instanceof DoubleModifier m) {
+          this.setDouble(m, entry.value.eval());
+        } else if (entry.index instanceof BooleanModifier m) {
+          this.setBoolean(m, entry.value.eval() != 0.0);
+        }
       }
     }
 
@@ -834,14 +838,14 @@ public class Modifiers {
     availableSkillsChanged = true;
   }
 
-  public void addExpression(Indexed<DoubleModifier, ModifierExpression> entry) {
+  public void addExpression(Indexed<Modifier, ModifierExpression> entry) {
     int index = -1;
 
     if (this.expressions == null) {
       this.expressions = new ArrayList<>();
     } else {
       for (int i = 0; i < this.expressions.size(); i++) {
-        Indexed<DoubleModifier, ModifierExpression> e = this.expressions.get(i);
+        Indexed<Modifier, ModifierExpression> e = this.expressions.get(i);
         if (e != null && e.index == entry.index) {
           index = i;
           break;

--- a/src/net/sourceforge/kolmafia/modifiers/BooleanModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/BooleanModifier.java
@@ -1,5 +1,7 @@
 package net.sourceforge.kolmafia.modifiers;
 
+import static net.sourceforge.kolmafia.persistence.ModifierDatabase.BOOLEAN_EXPR;
+
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Map;
@@ -13,7 +15,7 @@ public enum BooleanModifier implements Modifier {
   SOFTCORE(
       "Softcore Only",
       Pattern.compile("This item cannot be equipped while in Hardcore"),
-      Pattern.compile("Softcore Only")),
+      Pattern.compile("Softcore Only" + BOOLEAN_EXPR)),
   SINGLE("Single Equip", Pattern.compile("Single Equip")),
   ALWAYS_FUMBLE("Always Fumble", Pattern.compile("Always Fumble")),
   NEVER_FUMBLE("Never Fumble", Pattern.compile("Never Fumble"), Pattern.compile("Never Fumble")),
@@ -21,7 +23,7 @@ public enum BooleanModifier implements Modifier {
       "Weakens Monster",
       Pattern.compile("Successful hit weakens opponent"),
       Pattern.compile("Weakens Monster")),
-  FREE_PULL("Free Pull", Pattern.compile("Free Pull")),
+  FREE_PULL("Free Pull", Pattern.compile("Free Pull" + BOOLEAN_EXPR)),
   VARIABLE("Variable", Pattern.compile("Variable")),
   NONSTACKABLE_WATCH("Nonstackable Watch", Pattern.compile("Nonstackable Watch")),
   COLD_IMMUNITY("Cold Immunity", Pattern.compile("Cold Immunity")),
@@ -81,6 +83,7 @@ public enum BooleanModifier implements Modifier {
       "Negative Status Resist",
       Pattern.compile("75% Chance of Preventing Negative Status Attacks"),
       Pattern.compile("Negative Status Resist"));
+
   private final String name;
   private final Pattern[] descPatterns;
   private final Pattern tagPattern;

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -194,6 +194,8 @@ public class DebugDatabase {
     }
   }
 
+  private static final ItemMap UNKNOWN_ITEM_MAP = new ItemMap("Everything Else", ConsumptionType.UNKNOWN);
+
   private static final ItemMap[] ITEM_MAPS = {
     new ItemMap("Food", ConsumptionType.EAT),
     new ItemMap("Booze", ConsumptionType.DRINK),
@@ -208,23 +210,11 @@ public class DebugDatabase {
     new ItemMap("Familiar Items", ConsumptionType.FAMILIAR_EQUIPMENT),
     new ItemMap("Potions", ConsumptionType.POTION),
     new ItemMap("Avatar Potions", ConsumptionType.AVATAR_POTION),
-    new ItemMap("Everything Else", ConsumptionType.UNKNOWN),
+    UNKNOWN_ITEM_MAP,
   };
 
   private static ItemMap findItemMap(final ConsumptionType type) {
-    ItemMap other = null;
-    for (int i = 0; i < DebugDatabase.ITEM_MAPS.length; ++i) {
-      ItemMap map = DebugDatabase.ITEM_MAPS[i];
-      ConsumptionType mapType = map.getType();
-      if (mapType == type) {
-        return map;
-      }
-      if (mapType == ConsumptionType.UNKNOWN) {
-        other = map;
-      }
-    }
-
-    return other;
+    return Arrays.stream(ITEM_MAPS).filter(m -> m.getType() == type).findFirst().orElse(UNKNOWN_ITEM_MAP);
   }
 
   public static void checkItems(final int itemId) {
@@ -235,10 +225,7 @@ public class DebugDatabase {
 
     PrintStream report = DebugDatabase.openReport(ITEM_DATA);
 
-    for (int i = 0; i < DebugDatabase.ITEM_MAPS.length; ++i) {
-      ItemMap map = DebugDatabase.ITEM_MAPS[i];
-      map.clear();
-    }
+    Arrays.stream(DebugDatabase.ITEM_MAPS).forEach(ItemMap::clear);
 
     // Check item names, desc ID, consumption type
 
@@ -412,7 +399,7 @@ public class DebugDatabase {
     }
 
     ItemMap map = DebugDatabase.findItemMap(type);
-    map.put(name, text);
+    map.put(name, rawText);
 
     String descId = ItemDatabase.getDescriptionId(id);
 

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -194,7 +194,8 @@ public class DebugDatabase {
     }
   }
 
-  private static final ItemMap UNKNOWN_ITEM_MAP = new ItemMap("Everything Else", ConsumptionType.UNKNOWN);
+  private static final ItemMap UNKNOWN_ITEM_MAP =
+      new ItemMap("Everything Else", ConsumptionType.UNKNOWN);
 
   private static final ItemMap[] ITEM_MAPS = {
     new ItemMap("Food", ConsumptionType.EAT),
@@ -214,7 +215,10 @@ public class DebugDatabase {
   };
 
   private static ItemMap findItemMap(final ConsumptionType type) {
-    return Arrays.stream(ITEM_MAPS).filter(m -> m.getType() == type).findFirst().orElse(UNKNOWN_ITEM_MAP);
+    return Arrays.stream(ITEM_MAPS)
+        .filter(m -> m.getType() == type)
+        .findFirst()
+        .orElse(UNKNOWN_ITEM_MAP);
   }
 
   public static void checkItems(final int itemId) {

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -1416,7 +1416,8 @@ public class ModifierDatabase {
 
   // region: verify modifiers.txt
 
-  public static final void checkModifiers() {
+  public static final ArrayList<String> checkModifiers() {
+    var issues = new ArrayList<String>();
     for (Entry<ModifierType, Map<IntOrString, String>> typeEntry :
         modifierStringsByName.entrySet()) {
       ModifierType type = typeEntry.getKey();
@@ -1425,7 +1426,9 @@ public class ModifierDatabase {
         String modifierString = entry.getValue();
 
         if (modifierString == null) {
-          RequestLogger.printLine("Key \"" + type + ":" + key + "\" has no modifiers");
+          var issue = "Key \"" + type + ":" + key + "\" has no modifiers";
+          RequestLogger.printLine(issue);
+          issues.add(issue);
           continue;
         }
 
@@ -1457,11 +1460,14 @@ public class ModifierDatabase {
           if (type == ModifierType.THRONE && mod.isEmpty()) {
             continue; // these may be empty during spading
           }
-          RequestLogger.printLine(
-              "Key \"" + type + ":" + key + "\" has unknown modifier: \"" + mod + "\"");
+          var issue = "Key \"" + type + ":" + key + "\" has unknown modifier: \"" + mod + "\"";
+          issues.add(issue);
+          RequestLogger.printLine(issue);
         }
       }
     }
+
+    return issues;
   }
 
   // region: initial load of modifiers.txt

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -78,6 +78,7 @@ public class ModifierDatabase {
   // constant fields
 
   public static final String EXPR = "(?:([-+]?[\\d.]+)|\\[([^]]+)\\])";
+  public static final String BOOLEAN_EXPR = "(?:: \\[([^]]+)])?";
 
   private static final Pattern FAMILIAR_EFFECT_PATTERN =
       Pattern.compile("Familiar Effect: \"(.*?)\"");
@@ -680,7 +681,12 @@ public class ModifierDatabase {
           continue;
         }
 
-        newMods.setBoolean(mod, true);
+        if (matcher.groupCount() == 0 || matcher.group(1) == null) {
+          newMods.setBoolean(mod, true);
+        } else {
+          newMods.addExpression(
+              new Indexed<>(mod, ModifierExpression.getInstance(matcher.group(1), lookup)));
+        }
         continue modLoop;
       }
 

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -823,7 +823,7 @@ public class ModifierDatabase {
   }
 
   private static final Pattern LAST_AVAILABLE_PATTERN =
-      Pattern.compile("<!-- Last Available Date: (\\d{4}-\\d{2}) -->");
+      Pattern.compile("<![-—]+ Last Available Date: (\\d{4}-\\d{2}) [-—]+>");
 
   public static String parseLastAvailable(final String text) {
     var matcher = LAST_AVAILABLE_PATTERN.matcher(text);

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -1448,6 +1448,9 @@ public class ModifierDatabase {
           if (type == ModifierType.FAM_EQ) {
             continue; // these may contain freeform text
           }
+          if (type == ModifierType.THRONE && mod.isEmpty()) {
+            continue; // these may be empty during spading
+          }
           RequestLogger.printLine(
               "Key \"" + type + ":" + key + "\" has unknown modifier: \"" + mod + "\"");
         }

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -1595,4 +1595,27 @@ public class ModifiersTest {
       KoLCharacter.removeFamiliar(familiar);
     }
   }
+
+  @Nested
+  class DoubleExpressions {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void helmOnlyFreePullInAxecore(final boolean axecore) {
+      var cleanups = axecore ? withPath(Path.AVATAR_OF_BORIS) : new Cleanups();
+      try (cleanups) {
+        Modifiers mods = ModifierDatabase.getModifiers(ModifierType.ITEM, ItemPool.BORIS_HELM);
+        assertThat(mods.getBoolean(BooleanModifier.FREE_PULL), is(axecore));
+      }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void helmOnlySoftcoreOnlyNotInAxecore(final boolean axecore) {
+      var cleanups = axecore ? withPath(Path.AVATAR_OF_BORIS) : new Cleanups();
+      try (cleanups) {
+        Modifiers mods = ModifierDatabase.getModifiers(ModifierType.ITEM, ItemPool.BORIS_HELM);
+        assertThat(mods.getBoolean(BooleanModifier.SOFTCORE), is(!axecore));
+      }
+    }
+  }
 }


### PR DESCRIPTION
EDIT: This now includes all items, and is somewhat rigorously tested.

I think the only thing left to go is skills.

While I was in here, the modifier tools kept annoying me about the avatar IotMs that are only free pullable / only usable in hardcore in their special paths. I decided to make boolean modifiers support evaluating conditions, which was surprisingly easy. I retroactively applied that to the Time-Twitching Toolbelt, with which we had struggled before.