### PR TITLE
fix mall search for coinmaster items with capital letters

### DIFF
--- a/src/data/coinmasters.txt
+++ b/src/data/coinmasters.txt
@@ -878,6 +878,11 @@ Internet Meme Shop	buy	5000	infinite BACON machine	ROW828
 
 # Things you can buy with cop dollars
 
+# These are conditionally available (must have previous lesser badge) and require a ShopRow coinmaster
+# Precinct Materiel Division	ROW832	bronze detective badge	plastic detective badge	detective roscoe	cop dollar (50)
+# Precinct Materiel Division	ROW831	silver detective badge	bronze detective badge	detective roscoe	cop dollar (200)
+# Precinct Materiel Division	ROW833	gold detective badge	silver detective badge	detective roscoe	cop dollar (400)
+
 Precinct Materiel Division	buy	4	hardboiled egg	ROW839
 Precinct Materiel Division	buy	4	Falcon&trade; Maltese Liquor	ROW835
 Precinct Materiel Division	buy	10	shoe gum	ROW834

--- a/src/data/shoprows.txt
+++ b/src/data/shoprows.txt
@@ -829,9 +829,9 @@
 828	bacon	infinite BACON machine	BACON (5,000)
 829	bacon	First Post shirt package	BACON (150,000)
 830	detective	detective roscoe	cop dollar (50)
-831
-832
-833
+831	detective	silver detective badge	bronze detective badge	detective roscoe	cop dollar (200)
+832	detective	bronze detective badge	plastic detective badge	detective roscoe	cop dollar (50)
+833	detective	gold detective badge	silver detective badge	detective roscoe	cop dollar (400)
 834	detective	shoe gum	cop dollar (10)
 835	detective	Falcon&trade; Maltese Liquor	cop dollar (4)
 836	detective	noir fedora	cop dollar (200)

--- a/src/net/sourceforge/kolmafia/request/MallSearchRequest.java
+++ b/src/net/sourceforge/kolmafia/request/MallSearchRequest.java
@@ -453,7 +453,9 @@ public class MallSearchRequest extends GenericRequest {
           previousItemId = itemId;
           this.addNPCStoreItem(itemId);
           this.addCoinMasterItem(itemId);
-          itemNames.remove(itemName);
+          // itemName is a data name
+          // itemNames contains canonicalized names
+          itemNames.remove(StringUtilities.getCanonicalName(itemName));
         }
 
         // Only add mall store results if the NPC store option


### PR DESCRIPTION
1) I noticed that searching for "Easter eggnog" listed the (removed) coinmaster twice.
Ditto for Thanksgiving ration.
Needed to canonicalize  (lower case) the name when removing it from list of processed matches.
2) The "/buy" trick for discovering ROWs I cannot otherwise see worked for my character who has a detective school and already bought the gold detective badge.

```
<font color=green>Purchasing 1 bronze detective badge.<!--js(dojax('shop.php?pwd=2f28fe3e141806fcb5b6623f9dfe1060&buying=1&whichrow=832&quantity=1&whichshop=detective&ajax=1&action=buyitem');)--></font><br>
<font color=green>Purchasing 1 silver detective badge.<!--js(dojax('shop.php?pwd=2f28fe3e141806fcb5b6623f9dfe1060&buying=1&whichrow=831&quantity=1&whichshop=detective&ajax=1&action=buyitem');)--></font><br>
<font color=green>Purchasing 1 gold detective badge.<!--js(dojax('shop.php?pwd=2f28fe3e141806fcb5b6623f9dfe1060&buying=1&whichrow=833&quantity=1&whichshop=detective&ajax=1&action=buyitem');)--></font><br>
```

