### PR TITLE
Armory & Leggery coinmaster deduces lines to add to standard reward data files

### DIFF
--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -27,6 +27,7 @@ import net.sourceforge.kolmafia.shop.ShopDatabase;
 import net.sourceforge.kolmafia.shop.ShopDatabase.SHOP;
 import net.sourceforge.kolmafia.shop.ShopRow;
 import net.sourceforge.kolmafia.shop.ShopRowDatabase;
+import net.sourceforge.kolmafia.utilities.LockableListFactory;
 
 public class CoinmasterData implements Comparable<CoinmasterData> {
 
@@ -110,6 +111,7 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   private Function<Integer, Boolean> availableSkill = this::availableSkillInternal;
   private BiConsumer<AdventureResult, Boolean> purchasedItem = this::purchasedItemInternal;
   private Consumer<String> visitShop = this::visitShopInternal;
+  private Consumer<List<ShopRow>> visitShopRows = this::visitShopRowsInternal;
   private Supplier<String> canBuy = this::canBuyInternal;
   private Supplier<String> canSell = this::canSellInternal;
   private Supplier<String> accessible = this::accessibleInternal;
@@ -269,6 +271,10 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
    */
   public CoinmasterData withShopRows(String master) {
     this.shopRows = CoinmastersDatabase.getShopRows(master);
+    if (this.shopRows == null) {
+      // None are configured in coinmasters.txt, yet.
+      this.shopRows = LockableListFactory.getInstance(ShopRow.class);
+    }
     return this;
   }
 
@@ -709,6 +715,20 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   }
 
   /**
+   * Specifies a static method that will be invoked by <code>void
+   * visitShopRows(List<ShopRows> shopRows)</code>
+   *
+   * <p>Use this if you want to, for example, check for unlocked items.
+   *
+   * @param consumer - a Consumer object to be called by visitShopRows
+   * @return this - Allows fluid chaining of fields
+   */
+  public CoinmasterData withVisitShopRows(Consumer<List<ShopRow>> consumer) {
+    this.visitShopRows = consumer;
+    return this;
+  }
+
+  /**
    * Specifies a static method that will be invoked by <code>Boolean
    * canBuy()</code>
    *
@@ -910,6 +930,19 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
       }
     }
     return null;
+  }
+
+  public void setShopRows(List<ShopRow> shopRows) {
+    if (this.shopRows != null) {
+      this.shopRows.clear();
+      this.shopRows.addAll(shopRows);
+    }
+  }
+
+  public final void addShopRow(ShopRow shopRow) {
+    if (this.shopRows != null) {
+      this.shopRows.add(shopRow);
+    }
   }
 
   public Map<Integer, Integer> getRows() {
@@ -1477,6 +1510,12 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   }
 
   private void visitShopInternal(String responseText) {}
+
+  public void visitShopRows(final List<ShopRow> shopRows) {
+    this.visitShopRows.accept(shopRows);
+  }
+
+  private void visitShopRowsInternal(List<ShopRow> shopRows) {}
 
   public Boolean equip() {
     return this.equip.get();

--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -111,7 +111,7 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   private Function<Integer, Boolean> availableSkill = this::availableSkillInternal;
   private BiConsumer<AdventureResult, Boolean> purchasedItem = this::purchasedItemInternal;
   private Consumer<String> visitShop = this::visitShopInternal;
-  private Consumer<List<ShopRow>> visitShopRows = this::visitShopRowsInternal;
+  private BiConsumer<List<ShopRow>, Boolean> visitShopRows = this::visitShopRowsInternal;
   private Supplier<String> canBuy = this::canBuyInternal;
   private Supplier<String> canSell = this::canSellInternal;
   private Supplier<String> accessible = this::accessibleInternal;
@@ -723,7 +723,7 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
    * @param consumer - a Consumer object to be called by visitShopRows
    * @return this - Allows fluid chaining of fields
    */
-  public CoinmasterData withVisitShopRows(Consumer<List<ShopRow>> consumer) {
+  public CoinmasterData withVisitShopRows(BiConsumer<List<ShopRow>, Boolean> consumer) {
     this.visitShopRows = consumer;
     return this;
   }
@@ -1511,11 +1511,11 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
 
   private void visitShopInternal(String responseText) {}
 
-  public void visitShopRows(final List<ShopRow> shopRows) {
-    this.visitShopRows.accept(shopRows);
+  public void visitShopRows(final List<ShopRow> shopRows, Boolean force) {
+    this.visitShopRows.accept(shopRows, force);
   }
 
-  private void visitShopRowsInternal(List<ShopRow> shopRows) {}
+  private void visitShopRowsInternal(List<ShopRow> shopRows, Boolean force) {}
 
   public Boolean equip() {
     return this.equip.get();

--- a/src/net/sourceforge/kolmafia/persistence/CoinmastersDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/CoinmastersDatabase.java
@@ -39,7 +39,7 @@ public class CoinmastersDatabase {
 
   // Map from Integer to ShopRow
 
-  // *** Since I believe ROW numbers are unique, it would be nice to also
+  // *** Since ROW numbers are unique, it would be nice to
   // *** also register items in NPCstores and Concoctions
   // *** Put this into ShopRow.java?
   public static final Map<Integer, ShopRow> rowData = new TreeMap<>();

--- a/src/net/sourceforge/kolmafia/persistence/StandardRewardDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/StandardRewardDatabase.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.RequestLogger;
@@ -17,7 +18,7 @@ public class StandardRewardDatabase {
   public static record StandardReward(
       int itemId, int year, boolean type, AscensionClass cl, String row, String itemName) {}
 
-  public static Map<Integer, StandardReward> rewardByItemid = new HashMap<>();
+  public static Map<Integer, StandardReward> rewardByItemid = new TreeMap<>();
 
   public static Map<Integer, StandardReward> allStandardRewards() {
     return rewardByItemid;

--- a/src/net/sourceforge/kolmafia/persistence/StandardRewardDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/StandardRewardDatabase.java
@@ -8,7 +8,6 @@ import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.StaticEntity;
-import net.sourceforge.kolmafia.request.coinmaster.shop.ArmoryAndLeggeryRequest.CoinmasterItem;
 import net.sourceforge.kolmafia.utilities.FileUtilities;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
@@ -18,28 +17,52 @@ public class StandardRewardDatabase {
   public static record StandardReward(
       int itemId, int year, boolean type, AscensionClass cl, String row, String itemName) {}
 
-  // id	year	type	name
-  public static record StandardPulverized(int itemId, int year, boolean type, String itemName) {}
-
   public static Map<Integer, StandardReward> rewardByItemid = new HashMap<>();
-  public static Map<Integer, StandardPulverized> pulverizedByItemid = new HashMap<>();
-
-  // Map from year -> map from type -> StandardPulverized
-  public static Map<Integer, Map<Boolean, StandardPulverized>> pulverizedByYearAndType =
-      new HashMap<>();
-
-  static {
-    StandardRewardDatabase.reset();
-  }
 
   public static Map<Integer, StandardReward> allStandardRewards() {
     return rewardByItemid;
   }
 
+  public static StandardReward findStandardReward(final int itemId) {
+    return rewardByItemid.get(itemId);
+  }
+
+  public static void registerStandardReward(int itemId, StandardReward standardReward) {
+    rewardByItemid.put(itemId, standardReward);
+  }
+
+  // id	year	type	name
+  public static record StandardPulverized(int itemId, int year, boolean type, String itemName) {}
+
+  public static Map<Integer, StandardPulverized> pulverizedByItemid = new HashMap<>();
+
+  public static StandardPulverized findStandardPulverized(int itemId) {
+    return pulverizedByItemid.get(itemId);
+  }
+
+  // Map from year -> map from type -> StandardPulverized
+  public static Map<Integer, Map<Boolean, StandardPulverized>> pulverizedByYearAndType =
+      new HashMap<>();
+
+  public static void registerStandardPulverized(int itemId, StandardPulverized pulverized) {
+    pulverizedByItemid.put(itemId, pulverized);
+    int year = pulverized.year;
+    boolean type = pulverized.type;
+    Map<Boolean, StandardPulverized> map = pulverizedByYearAndType.get(year);
+    if (map == null) {
+      map = new HashMap<>();
+      pulverizedByYearAndType.put(year, map);
+    }
+    map.put(type, pulverized);
+  }
+
+  static {
+    StandardRewardDatabase.reset();
+  }
+
   public static void reset() {
     StandardRewardDatabase.readEquipment();
     StandardRewardDatabase.readPulverized();
-    StandardRewardDatabase.createPulverizedMap();
   }
 
   private static void readEquipment() {
@@ -107,14 +130,45 @@ public class StandardRewardDatabase {
         // Defined by itemId, so, for human use only
         String name = data[5];
 
-        rewardByItemid.put(itemId, new StandardReward(itemId, year, type, cl, row, name));
+        StandardReward toRegister = new StandardReward(itemId, year, type, cl, row, name);
+        registerStandardReward(itemId, toRegister);
       }
     } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
+  }
 
-    // System.out.println("There are " + rewardByItemid.size() + " kinds of standard reward
-    // equipment");
+  public static String toData(StandardReward reward) {
+    int itemId = reward.itemId();
+    String itemName = reward.itemName();
+    int year = reward.year();
+    boolean type = reward.type();
+    AscensionClass cl = reward.cl();
+    String row = reward.row();
+
+    StringBuilder buf = new StringBuilder();
+    buf.append(itemId);
+    buf.append("\t");
+    buf.append(year);
+    buf.append("\t");
+    buf.append(type ? "hard" : "norm");
+    buf.append("\t");
+    buf.append(
+        switch (cl) {
+          case SEAL_CLUBBER -> "SC";
+          case TURTLE_TAMER -> "TT";
+          case PASTAMANCER -> "PA";
+          case SAUCEROR -> "SA";
+          case DISCO_BANDIT -> "DB";
+          case ACCORDION_THIEF -> "AT";
+          default -> "NONE";
+        });
+    buf.append("\t");
+    buf.append(row);
+    buf.append("\t");
+    buf.append(itemName);
+
+    return buf.toString();
   }
 
   private static void readPulverized() {
@@ -152,29 +206,29 @@ public class StandardRewardDatabase {
         // Defined by itemId, so, for human use only
         String name = data[3];
 
-        pulverizedByItemid.put(itemId, new StandardPulverized(itemId, year, type, name));
+        StandardPulverized toRegister = new StandardPulverized(itemId, year, type, name);
+        registerStandardPulverized(itemId, toRegister);
       }
     } catch (IOException e) {
       StaticEntity.printStackTrace(e);
     }
-
-    // System.out.println("There are " + pulverizedByItemid.size() + " kinds of pulverized standard
-    // reward equipment");
   }
 
-  private static void createPulverizedMap() {
-    for (var entry : pulverizedByItemid.entrySet()) {
-      int itemId = entry.getKey();
-      var pulverized = entry.getValue();
-      int year = pulverized.year;
-      boolean type = pulverized.type;
-      Map<Boolean, StandardPulverized> map = pulverizedByYearAndType.get(year);
-      if (map == null) {
-        map = new HashMap<>();
-        pulverizedByYearAndType.put(year, map);
-      }
-      map.put(type, pulverized);
-    }
+  public static String toData(StandardPulverized pulverized) {
+    int itemId = pulverized.itemId();
+    String itemName = pulverized.itemName();
+    int year = pulverized.year();
+    boolean type = pulverized.type();
+
+    StringBuilder buf = new StringBuilder();
+    buf.append(itemId);
+    buf.append("\t");
+    buf.append(year);
+    buf.append("\t");
+    buf.append(type ? "hard" : "norm");
+    buf.append("\t");
+    buf.append(itemName);
+    return buf.toString();
   }
 
   public static int findPulverization(StandardReward item) {
@@ -206,60 +260,5 @@ public class StandardRewardDatabase {
       int result = findPulverization(item);
       EquipmentDatabase.addPulverization(itemId, result);
     }
-  }
-
-  public static String coinmasterString(CoinmasterItem reward) {
-    if (reward == null) {
-      return null;
-    }
-
-    int currency = ItemDatabase.getItemId(reward.currency());
-    if (currency == -1) {
-      RequestLogger.printLine("currency '" + reward.currency() + "' is unknown.");
-      return null;
-    }
-
-    StandardPulverized pulverized = pulverizedByItemid.get(currency);
-    if (pulverized == null) {
-      RequestLogger.printLine(
-          "currency '" + reward.currency() + "' is not registered yet as a currency.");
-      return null;
-    }
-
-    int itemId = reward.itemId();
-    String itemName = reward.itemName();
-    int year = pulverized.year() - 1;
-    boolean type = pulverized.type();
-    StandardReward current = rewardByItemid.get(itemId);
-    AscensionClass cl = current == null ? null : current.cl();
-    String row = "ROW" + reward.row();
-
-    StringBuilder buf = new StringBuilder();
-    buf.append(itemId);
-    buf.append("\t");
-    buf.append(year);
-    buf.append("\t");
-    buf.append(type ? "hard" : "norm");
-    buf.append("\t");
-    if (cl == null) {
-      buf.append("NONE");
-    } else {
-      buf.append(
-          switch (cl) {
-            case SEAL_CLUBBER -> "SC";
-            case TURTLE_TAMER -> "TT";
-            case PASTAMANCER -> "PA";
-            case SAUCEROR -> "SA";
-            case DISCO_BANDIT -> "DB";
-            case ACCORDION_THIEF -> "AT";
-            default -> "";
-          });
-    }
-    buf.append("\t");
-    buf.append(row);
-    buf.append("\t");
-    buf.append(itemName);
-
-    return buf.toString();
   }
 }

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/ArmoryAndLeggeryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/ArmoryAndLeggeryRequest.java
@@ -4,14 +4,10 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.AdventureResult;
-import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.CoinmasterData;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
-import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.StandardRewardDatabase;
 import net.sourceforge.kolmafia.persistence.StandardRewardDatabase.StandardPulverized;
 import net.sourceforge.kolmafia.persistence.StandardRewardDatabase.StandardReward;
@@ -192,70 +188,5 @@ public abstract class ArmoryAndLeggeryRequest extends CoinMasterShopRequest {
 
     RequestLogger.printLine(divider);
     RequestLogger.updateSessionLog(divider);
-  }
-
-  // *** Obsolete: used in "test standard-rewards", which should be
-  // *** subsumed by our shop.php inventory parsing
-
-  public static record CoinmasterReward(
-      int itemId, String itemName, String currency, int price, int row) {}
-
-  // <tr rel="7985"><td valign=center></td><td><img
-  // src="https://s3.amazonaws.com/images.kingdomofloathing.com/itemimages/polyparachute.gif"
-  // class=hand onClick='javascript:descitem(973760204)'></td><td valign=center><a
-  // onClick='javascript:descitem(973760204)'><b>polyester
-  // parachute</b>&nbsp;&nbsp;&nbsp;&nbsp;</a></td><td><img
-  // src=https://s3.amazonaws.com/images.kingdomofloathing.com/itemimages/wickerbits.gif width=30
-  // height=30 onClick='javascript:descitem(134381888)' alt="wickerbits"
-  // title="wickerbits"></td><td><b>1</b>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td></td><td>&nbsp;&nbsp;</td><td valign=center><input class="button doit multibuy "  type=button rel='shop.php?whichshop=armory&action=buyitem&quantity=1&whichrow=804&pwd=' value='Buy'></td></tr>
-
-  public static final Pattern ITEM_PATTERN =
-      Pattern.compile(
-          "<tr rel=\"(\\d+)\">.*?onClick='javascript:descitem\\((\\d+)\\)'>.*?<b>(.*?)</b>.*?title=\"(.*?)\".*?<b>([\\d,]+)</b>.*?whichrow=(\\d+)",
-          Pattern.DOTALL);
-
-  public static CoinmasterReward parseCoinmasterReward(Matcher matcher) {
-    int itemId = StringUtilities.parseInt(matcher.group(1));
-    String itemName = matcher.group(3).trim();
-    String currency = matcher.group(4);
-    int price = StringUtilities.parseInt(matcher.group(5));
-    int row = StringUtilities.parseInt(matcher.group(6));
-
-    // The currency must be an item
-    if (currency.equals("Meat")) {
-      return null;
-    }
-
-    return new CoinmasterReward(itemId, itemName, currency, price, row);
-  }
-
-  public static String toData(CoinmasterReward creward) {
-    if (creward == null) {
-      return null;
-    }
-
-    int currency = ItemDatabase.getItemId(creward.currency());
-    if (currency == -1) {
-      RequestLogger.printLine("currency '" + creward.currency() + "' is unknown.");
-      return null;
-    }
-
-    StandardPulverized pulverized = StandardRewardDatabase.findStandardPulverized(currency);
-    if (pulverized == null) {
-      RequestLogger.printLine(
-          "currency '" + creward.currency() + "' is not registered yet as a currency.");
-      return null;
-    }
-
-    int itemId = creward.itemId();
-    String itemName = creward.itemName();
-    int year = pulverized.year() - 1;
-    boolean type = pulverized.type();
-    StandardReward current = StandardRewardDatabase.findStandardReward(itemId);
-    AscensionClass cl = current == null ? null : current.cl();
-    String row = "ROW" + creward.row();
-
-    StandardReward sreward = new StandardReward(itemId, year, type, cl, row, itemName);
-    return StandardRewardDatabase.toData(sreward);
   }
 }

--- a/src/net/sourceforge/kolmafia/shop/ShopRequest.java
+++ b/src/net/sourceforge/kolmafia/shop/ShopRequest.java
@@ -267,8 +267,8 @@ public class ShopRequest extends GenericRequest {
     // observations of the inventory
     CoinmasterData cd = ShopDatabase.getCoinmasterData(shopId);
     if (cd != null) {
+      cd.visitShopRows(shopRows, force);
       cd.visitShop(responseText);
-      cd.visitShopRows(shopRows);
     }
 
     // KoL can add new items to existing coinmasters, npc stores, or

--- a/src/net/sourceforge/kolmafia/shop/ShopRequest.java
+++ b/src/net/sourceforge/kolmafia/shop/ShopRequest.java
@@ -260,15 +260,16 @@ public class ShopRequest extends GenericRequest {
       shopName = ShopDatabase.getShopName(shopId);
     }
 
+    // Find all the ShopRow objects. Register any new items seen.
+    List<ShopRow> shopRows = ShopRow.parseShop(responseText, true);
+
     // If this is a coinmaster, give it a chance to make its own
     // observations of the inventory
     CoinmasterData cd = ShopDatabase.getCoinmasterData(shopId);
     if (cd != null) {
       cd.visitShop(responseText);
+      cd.visitShopRows(shopRows);
     }
-
-    // Find all the ShopRow objects. Register any new items seen.
-    List<ShopRow> shopRows = ShopRow.parseShop(responseText, true);
 
     // KoL can add new items to existing coinmasters, npc stores, or
     // concoctions. We will log such items in the appropriate format.

--- a/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
@@ -925,7 +925,7 @@ public class TestCommand extends AbstractCommand {
       CoinmasterRegistry.reset();
       NPCStoreDatabase.contains(0);
       // Ditto for the Armory & Leggery, which registers standard rewards.
-      ArmoryAndLeggeryRequest.initializeCoinMasterInventory();
+      ArmoryAndLeggeryRequest.reset();
 
       // Certain items include a "mode" in their string representation.
       // We don't want that.
@@ -944,7 +944,7 @@ public class TestCommand extends AbstractCommand {
       CoinmasterRegistry.reset();
       NPCStoreDatabase.contains(0);
       // Ditto for the Armory & Leggery, which registers standard rewards.
-      ArmoryAndLeggeryRequest.initializeCoinMasterInventory();
+      ArmoryAndLeggeryRequest.reset();
 
       // Write a new shop.txt file
       ShopDatabase.writeShopFile();

--- a/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
@@ -49,7 +49,6 @@ import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import net.sourceforge.kolmafia.persistence.NPCStoreDatabase;
 import net.sourceforge.kolmafia.persistence.SkillDatabase;
-import net.sourceforge.kolmafia.persistence.StandardRewardDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.AdventureRequest;
 import net.sourceforge.kolmafia.request.CampAwayRequest;
@@ -68,6 +67,7 @@ import net.sourceforge.kolmafia.request.PlaceRequest;
 import net.sourceforge.kolmafia.request.ScrapheapRequest;
 import net.sourceforge.kolmafia.request.SpaaaceRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.ArmoryAndLeggeryRequest;
+import net.sourceforge.kolmafia.request.coinmaster.shop.ArmoryAndLeggeryRequest.CoinmasterReward;
 import net.sourceforge.kolmafia.request.concoction.CreateItemRequest;
 import net.sourceforge.kolmafia.session.BastilleBattalionManager;
 import net.sourceforge.kolmafia.session.BeachManager;
@@ -1313,13 +1313,12 @@ public class TestCommand extends AbstractCommand {
       TestCommand.contents = null;
       int count = 0;
       while (matcher.find()) {
-        ArmoryAndLeggeryRequest.CoinmasterItem reward =
-            ArmoryAndLeggeryRequest.parseCoinmasterItem(matcher);
+        CoinmasterReward reward = ArmoryAndLeggeryRequest.parseCoinmasterReward(matcher);
         if (reward == null) {
           // Skip items purchased with Meat
           continue;
         }
-        String line = StandardRewardDatabase.coinmasterString(reward);
+        String line = ArmoryAndLeggeryRequest.toData(reward);
         RequestLogger.updateSessionLog(line);
         count++;
       }

--- a/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
@@ -10,7 +10,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import net.java.dev.spellcast.utilities.DataUtilities;
 import net.sourceforge.kolmafia.AdventureResult;
@@ -67,7 +66,6 @@ import net.sourceforge.kolmafia.request.PlaceRequest;
 import net.sourceforge.kolmafia.request.ScrapheapRequest;
 import net.sourceforge.kolmafia.request.SpaaaceRequest;
 import net.sourceforge.kolmafia.request.coinmaster.shop.ArmoryAndLeggeryRequest;
-import net.sourceforge.kolmafia.request.coinmaster.shop.ArmoryAndLeggeryRequest.CoinmasterReward;
 import net.sourceforge.kolmafia.request.concoction.CreateItemRequest;
 import net.sourceforge.kolmafia.session.BastilleBattalionManager;
 import net.sourceforge.kolmafia.session.BeachManager;
@@ -1305,24 +1303,6 @@ public class TestCommand extends AbstractCommand {
     if (command.equals("speakeasy")) {
       ClanLoungeRequest.parseSpeakeasy(TestCommand.contents, true);
       TestCommand.contents = null;
-      return;
-    }
-
-    if (command.equals("standard-rewards")) {
-      Matcher matcher = ArmoryAndLeggeryRequest.ITEM_PATTERN.matcher(TestCommand.contents);
-      TestCommand.contents = null;
-      int count = 0;
-      while (matcher.find()) {
-        CoinmasterReward reward = ArmoryAndLeggeryRequest.parseCoinmasterReward(matcher);
-        if (reward == null) {
-          // Skip items purchased with Meat
-          continue;
-        }
-        String line = ArmoryAndLeggeryRequest.toData(reward);
-        RequestLogger.updateSessionLog(line);
-        count++;
-      }
-      RequestLogger.printLine(String.valueOf(count) + " items printed to session log.");
       return;
     }
 

--- a/test/net/sourceforge/kolmafia/persistence/StandardRewardDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/StandardRewardDatabaseTest.java
@@ -1,0 +1,275 @@
+package net.sourceforge.kolmafia.persistence;
+
+import static internal.helpers.Networking.html;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import internal.helpers.SessionLoggerOutput;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.shop.ShopRequest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class StandardRewardDatabaseTest {
+  @BeforeAll
+  static void beforeAll() {
+    KoLCharacter.reset("StandardRewardDatabaseTest");
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    Preferences.reset("StandardRewardDatabaseTest");
+  }
+
+  @Nested
+  class ArmoryAndLeggery {
+    // The Armory & Leggery will trade a pulverized standard reward for
+    // a previous year's standard reward.
+    //
+    // Therefore, 12 new rows are added each new year:
+    //
+    //   6 for Normal standard rewards
+    //   6 for Hardcore standard rewards
+    //
+    // Our protocol when a new standard season starts:
+    //
+    // 1) Add the pulverized Normal and Hardcore rewards to standard-pulverized.txt
+    // 2) Add the 12 new rewards to standard-rewards.txt with ROW = UNKNOWN
+    // 3) Update the previous year's UNKNOWN rows with what Armory & Leggery says
+
+    @Test
+    void canLogStandardRequestRows() {
+      SessionLoggerOutput.startStream();
+      String responseText = html("request/test_armorer_2024.html");
+
+      // Parse a responseText from visiting the Armory & Leggery.
+      // This one has the 2023 and 2024 standard rewards available.
+      // For each year
+      //
+      //   2 pulverized currencies
+      //   6 Normal and 6 Hardcore rewards
+      //
+      // Our data files contain all of those.  Normally, we'd log only
+      // new rows, but we can "force" everything to be logged.
+
+      ShopRequest.parseShopInventory("armory", responseText, true);
+      var text = SessionLoggerOutput.stopStream();
+
+      // Lines that go into standard_pulverized.txt
+
+      var expectedPulverized =
+          """
+    --------------------
+    11034	2023	norm	chiffon carbage
+    11026	2023	hard	ceramic scree
+    11510	2024	norm	moss mulch
+    11518	2024	hard	adobe assortment
+    --------------------""";
+      assertThat(text, containsString(expectedPulverized));
+
+      // Lines that go into standard_rewards.txt
+
+      var expectedRewards =
+          """
+    --------------------
+    10130	2022	norm	SC	1446	loofah lumberjack's hat
+    10131	2022	norm	TT	1447	loofah lei
+    10132	2022	norm	PA	1297	loofah lederhosen
+    10133	2022	norm	SA	1298	loofah ladle
+    10134	2022	norm	DB	1299	loofah legwarmers
+    10135	2022	norm	AT	1300	loofah lavalier
+    10138	2022	hard	SC	1301	flagstone flag
+    10139	2022	hard	TT	1302	flagstone flail
+    10140	2022	hard	PA	1303	flagstone flip-flops
+    10141	2022	hard	SA	1304	flagstone fez
+    10142	2022	hard	DB	1305	flagstone fleece
+    10143	2022	hard	AT	1306	flagstone fringe
+    11028	2023	norm	SC	1296	chiffon chevrons
+    11029	2023	norm	TT	1295	chiffon chapeau
+    11030	2023	norm	PA	1442	chiffon chamberpot
+    11031	2023	norm	SA	1443	chiffon chemise
+    11032	2023	norm	DB	1444	chiffon chakram
+    11033	2023	norm	AT	1445	chiffon chaps
+    11020	2023	hard	SC	1448	ceramic cestus
+    11021	2023	hard	TT	1449	ceramic centurion shield
+    11022	2023	hard	PA	1450	ceramic celery grater
+    11023	2023	hard	SA	1451	ceramic celsiturometer
+    11024	2023	hard	DB	1452	ceramic cerecloth belt
+    11025	2023	hard	AT	1453	ceramic cenobite's robe
+    --------------------""";
+      assertThat(text, containsString(expectedRewards));
+
+      // Lines that go into shoprows.txt:
+
+      var expectedShopRows =
+          """
+    1295	armory	chiffon chapeau	moss mulch
+    1296	armory	chiffon chevrons	moss mulch
+    1297	armory	loofah lederhosen	chiffon carbage
+    1298	armory	loofah ladle	chiffon carbage
+    1299	armory	loofah legwarmers	chiffon carbage
+    1300	armory	loofah lavalier	chiffon carbage
+    1301	armory	flagstone flag	ceramic scree
+    1302	armory	flagstone flail	ceramic scree
+    1303	armory	flagstone flip-flops	ceramic scree
+    1304	armory	flagstone fez	ceramic scree
+    1305	armory	flagstone fleece	ceramic scree
+    1306	armory	flagstone fringe	ceramic scree
+    1442	armory	chiffon chamberpot	moss mulch
+    1443	armory	chiffon chemise	moss mulch
+    1444	armory	chiffon chakram	moss mulch
+    1445	armory	chiffon chaps	moss mulch
+    1446	armory	loofah lumberjack's hat	chiffon carbage
+    1447	armory	loofah lei	chiffon carbage
+    1448	armory	ceramic cestus	adobe assortment
+    1449	armory	ceramic centurion shield	adobe assortment
+    1450	armory	ceramic celery grater	adobe assortment
+    1451	armory	ceramic celsiturometer	adobe assortment
+    1452	armory	ceramic cerecloth belt	adobe assortment
+    1453	armory	ceramic cenobite's robe	adobe assortment""";
+      assertThat(text, containsString(expectedShopRows));
+
+      // Lines that would normally go into coinmasters.txt, since
+      // ShopRequest knows that ArmoryAndLeggeryRequest is a coinmaster
+      // that uses ShopRows.  It doesn't know that that coinmaster
+      // constructs those rows using StandardRewardDatabase's data files.
+
+      var expectedCoinmasterRows =
+          """
+    --------------------
+    Armory and Leggery	ROW1446	loofah lumberjack's hat	chiffon carbage
+    Armory and Leggery	ROW1447	loofah lei	chiffon carbage
+    Armory and Leggery	ROW1297	loofah lederhosen	chiffon carbage
+    Armory and Leggery	ROW1298	loofah ladle	chiffon carbage
+    Armory and Leggery	ROW1299	loofah legwarmers	chiffon carbage
+    Armory and Leggery	ROW1300	loofah lavalier	chiffon carbage
+    Armory and Leggery	ROW1301	flagstone flag	ceramic scree
+    Armory and Leggery	ROW1302	flagstone flail	ceramic scree
+    Armory and Leggery	ROW1303	flagstone flip-flops	ceramic scree
+    Armory and Leggery	ROW1304	flagstone fez	ceramic scree
+    Armory and Leggery	ROW1305	flagstone fleece	ceramic scree
+    Armory and Leggery	ROW1306	flagstone fringe	ceramic scree
+    Armory and Leggery	ROW1296	chiffon chevrons	moss mulch
+    Armory and Leggery	ROW1295	chiffon chapeau	moss mulch
+    Armory and Leggery	ROW1442	chiffon chamberpot	moss mulch
+    Armory and Leggery	ROW1443	chiffon chemise	moss mulch
+    Armory and Leggery	ROW1444	chiffon chakram	moss mulch
+    Armory and Leggery	ROW1445	chiffon chaps	moss mulch
+    Armory and Leggery	ROW1448	ceramic cestus	adobe assortment
+    Armory and Leggery	ROW1449	ceramic centurion shield	adobe assortment
+    Armory and Leggery	ROW1450	ceramic celery grater	adobe assortment
+    Armory and Leggery	ROW1451	ceramic celsiturometer	adobe assortment
+    Armory and Leggery	ROW1452	ceramic cerecloth belt	adobe assortment
+    Armory and Leggery	ROW1453	ceramic cenobite's robe	adobe assortment
+    --------------------""";
+      assertThat(text, containsString(expectedCoinmasterRows));
+
+      // The Armory & Leggery is also an NPC store and sells items for Meat.
+
+      // More lines that go into shoprows.txt:
+
+      var expectedMeatShopRows =
+          """
+    466	armory	suede shortsword	270 Meat
+    467	armory	bamboo bokuto	675 Meat
+    468	armory	25-meat staff	472 Meat
+    469	armory	two-handed depthsword	810 Meat
+    470	armory	bill bec-de-bardiche glaive-guisarme	1,012 Meat
+    471	armory	lead yo-yo	540 Meat
+    472	armory	slightly peevedbow	405 Meat
+    473	armory	sack of doorknobs	742 Meat
+    474	armory	lucky ball-and-chain	877 Meat
+    475	armory	automatic catapult	1,012 Meat
+    476	armory	pentacorn hat	270 Meat
+    477	armory	goofily-plumed helmet	472 Meat
+    478	armory	yellow plastic hard hat	607 Meat
+    479	armory	wooden salad bowl	810 Meat
+    480	armory	football helmet	1,012 Meat
+    481	armory	chain-mail monokini	202 Meat
+    482	armory	union scalemail pants	337 Meat
+    483	armory	paper-plate-mail pants	540 Meat
+    484	armory	troutpiece	742 Meat
+    485	armory	alpha-mail pants	945 Meat
+    486	armory	Kentucky-style derby	45 Meat
+    487	armory	cool whip	27 Meat
+    488	armory	snorkel	27 Meat
+    489	armory	studded leather boxer shorts	45 Meat
+    490	armory	sweet ninja sword	45 Meat
+    491	armory	toy accordion	135 Meat
+    684	armory	rubber spatula	135 Meat
+    685	armory	wooden spoon	270 Meat
+    686	armory	crystalline reamer	472 Meat
+    687	armory	macroplane grater	675 Meat
+    688	armory	bastard baster	810 Meat
+    689	armory	obsidian nutcracker	1,012 Meat
+    818	armory	fishin' hat	9,000 Meat""";
+      assertThat(text, containsString(expectedMeatShopRows));
+
+      // Lines that go into npcstores.txt:
+
+      var expectedNPCStoreRows =
+          """
+    --------------------
+    Armory and Leggery	armory	cool whip	27	ROW487
+    Armory and Leggery	armory	sweet ninja sword	45	ROW490
+    Armory and Leggery	armory	suede shortsword	270	ROW466
+    Armory and Leggery	armory	25-meat staff	472	ROW468
+    Armory and Leggery	armory	bamboo bokuto	675	ROW467
+    Armory and Leggery	armory	two-handed depthsword	810	ROW469
+    Armory and Leggery	armory	bill bec-de-bardiche glaive-guisarme	1012	ROW470
+    Armory and Leggery	armory	rubber spatula	135	ROW684
+    Armory and Leggery	armory	wooden spoon	270	ROW685
+    Armory and Leggery	armory	crystalline reamer	472	ROW686
+    Armory and Leggery	armory	macroplane grater	675	ROW687
+    Armory and Leggery	armory	bastard baster	810	ROW688
+    Armory and Leggery	armory	obsidian nutcracker	1012	ROW689
+    Armory and Leggery	armory	toy accordion	135	ROW491
+    Armory and Leggery	armory	slightly peevedbow	405	ROW472
+    Armory and Leggery	armory	lead yo-yo	540	ROW471
+    Armory and Leggery	armory	sack of doorknobs	742	ROW473
+    Armory and Leggery	armory	lucky ball-and-chain	877	ROW474
+    Armory and Leggery	armory	automatic catapult	1012	ROW475
+    Armory and Leggery	armory	snorkel	27	ROW488
+    Armory and Leggery	armory	Kentucky-style derby	45	ROW486
+    Armory and Leggery	armory	pentacorn hat	270	ROW476
+    Armory and Leggery	armory	goofily-plumed helmet	472	ROW477
+    Armory and Leggery	armory	yellow plastic hard hat	607	ROW478
+    Armory and Leggery	armory	wooden salad bowl	810	ROW479
+    Armory and Leggery	armory	football helmet	1012	ROW480
+    Armory and Leggery	armory	fishin' hat	9000	ROW818
+    Armory and Leggery	armory	studded leather boxer shorts	45	ROW489
+    Armory and Leggery	armory	chain-mail monokini	202	ROW481
+    Armory and Leggery	armory	union scalemail pants	337	ROW482
+    Armory and Leggery	armory	paper-plate-mail pants	540	ROW483
+    Armory and Leggery	armory	troutpiece	742	ROW484
+    Armory and Leggery	armory	alpha-mail pants	945	ROW485
+    --------------------""";
+      assertThat(text, containsString(expectedNPCStoreRows));
+    }
+
+    @Test
+    void willNotLogKnownRows() {
+      SessionLoggerOutput.startStream();
+      String responseText = html("request/test_armorer_2024.html");
+
+      // Parse a responseText from visiting the Armory & Leggery.
+      // This one has the 2023 and 2024 standard rewards available.
+      // For each year
+      //
+      //   2 pulverized currencies
+      //   6 Normal and 6 Hardcore rewards
+      //
+      // Our data files contain all of those.
+      // Unless we "force" parsing the inventory, none will be logged.
+
+      ShopRequest.parseShopInventory("armory", responseText, false);
+      var text = SessionLoggerOutput.stopStream();
+
+      assertThat(text, is(""));
+    }
+  }
+}


### PR DESCRIPTION
Currently, to update standard-rewards.txt, you have to do this:

1) Add pulverized items to standard-pulverized.txt
2) Visit the Armory & Leggery and get a log with those in inventory
3)  Do "test load FILE" and "test standard-rewards"
4) Copy resulting lines into standard-rewards.txt
5) Add 12 more lines for THIS year's rewards and put them into standard-rewards.txt with UNKNOWN rows.

What with ShopRequest parsing inventory, I want to build off that and let ArmoryAndLeggeryRequest generate the lines that go into standard-pulverized and standard-rewards. New protocol:

1) Visit Armory & Leggery with new pulverized items in inventory.
(You don't have to have both HC and SC pulverized in inventory. You can do this twice, once for HC and once for SC.)
2) Copy lines into standard_pulverized.txt and standard-rewards.txt and shoprows.txt
3) Add 12 more lines for THIS year's rewards and put them into standard-rewards.txt with UNKNOWN rows.

To do:

1) Figure out how to test this - DONE.
2) Make sure everything works as intended - DONE.
3) Remove "test standard-rewards" and the code to support it in ArmoryAndLeggeryRequest - DONE.

We're good to go!