### PR TITLE
Fix up some consumables data

### DIFF
--- a/src/data/fullness.txt
+++ b/src/data/fullness.txt
@@ -24,7 +24,7 @@ alien meat	1	1	good	3	0	0	0	gain 5 turns of a random positive effect
 alien sandwich	2	4	awesome	10	5-10	5-10	5-10	gain 10 turns of a random positive effect
 amok pudding	2	4	decent	3-5	5-10	5-10	5-10	20 Puddingface (+20 Sleaze Damage)
 ancient frozen dinner	4	1	decent	4-8	0	8-10	0
-ancient serpent roll	3	1	sushi	9-14	0	8-16	20-30	45/55 Fishy
+ancient serpent roll	3	1	pseudoitem	9-14	0	8-16	20-30	45/55 Fishy
 ancient unspeakable fruitcake	3	1	decent	3-6	15-20	15-20	15-20
 angel-food cake	3	1	crappy	3	0	0	0
 angst burger	5	1	awesome	0	0	0	0	+10 PvP fights
@@ -66,13 +66,13 @@ bear claw	2	1	good	4-8	20-30	0	0	30 Bear Clawed (+100% weapon dmg)
 beautiful soup	2	5	good	4-8	34-49	0	0
 Beefy Crunch Pastaco	2	3	EPIC	11-12	60-100	0	0	40 Boletus Swoletus (+40 Mus)
 beefy fish meat	1	1	good	2-3	4-8	0	0	5/15 Fishy
-beefy maki	3	1	sushi	7-12	8-16	0	0	45/55 Fishy
-beefy nigiri	2	1	sushi	4-8	8-16	0	0	20/30 Fishy
+beefy maki	3	1	pseudoitem	7-12	8-16	0	0	45/55 Fishy
+beefy nigiri	2	1	pseudoitem	4-8	8-16	0	0	20/30 Fishy
 beer basted brat	3	11	awesome	13-16	31-40	31-40	31-40
 bell-shaped Crimbo cookie	2	7	awesome	6-12	0	0	0	10/20 Fury of the Bells (+10% mus)
 berries of suffering	2	2	good	5-6	11-18	0	0
 Better Than Cuddling Cake	3	1	decent	4	0	0	0
-big merv's protein shakes	5	1	EPIC	60-80	220-400	0	0
+big merv's protein shakes	5	1	pseudoitem	60-80	220-400	0	0
 birthday party jellybean cheesecake	3	1	crappy	3	20	20	20
 bishop cookie	1	13	EPIC	4-6	0	45-50	0	30 Mitre Cut (+100..200% mys)
 Black Angus blackburger	2	1	good	5-7	0	0	0	100 The Power of Negative Thinking
@@ -308,26 +308,26 @@ eggwater	1	1	crappy	1	0	0	0	BEVERAGE
 eldritch mushroom	1	1	crappy	3	11	11	11
 eldritch mushroom pizza	3	12	awesome	9-11	333	333	333	gain eldritch effluvium, 1 Eldritch Attunement, PIZZA
 Eldritch snap	1	12	super EPIC	7	11	11	11	3 Eldritch Attunement
-electric ancient serpent roll	3	1	sushi	12-17	0	8-16	20-30	45/55 Fishy
-electric beefy maki	3	1	sushi	10-15	8-16	0	0	45/55 Fishy
-electric eleven oceans roll	3	1	sushi	12-17	20-30	20-30	28-46	45/55 Fishy
-electric giant dragon roll	3	1	sushi	12-17	28-46	0	0	45/55 Fishy
-electric glistening maki	3	1	sushi	10-15	0	8-16	0	45/55 Fishy
-electric Jack LaLanne roll	3	1	sushi	12-17	28-46	20-30	20-30	45/55 Fishy
-electric jacked Santa roll	3	1	sushi	10-15	8-16	0	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+electric ancient serpent roll	3	1	pseudoitem	12-17	0	8-16	20-30	45/55 Fishy
+electric beefy maki	3	1	pseudoitem	10-15	8-16	0	0	45/55 Fishy
+electric eleven oceans roll	3	1	pseudoitem	12-17	20-30	20-30	28-46	45/55 Fishy
+electric giant dragon roll	3	1	pseudoitem	12-17	28-46	0	0	45/55 Fishy
+electric glistening maki	3	1	pseudoitem	10-15	0	8-16	0	45/55 Fishy
+electric Jack LaLanne roll	3	1	pseudoitem	12-17	28-46	20-30	20-30	45/55 Fishy
+electric jacked Santa roll	3	1	pseudoitem	10-15	8-16	0	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
 electric Kool-Aid	2	1	EPIC	12-13	30-50	30-50	30-50	BEVERAGE, 50 Electric, Kool
-electric musclebound rabbit roll	3	1	sushi	12-17	8-16	20-30	0	45/55 Fishy
-electric omniscient Santa roll	3	1	sushi	10-15	0	8-16	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-electric python roll	3	1	sushi	12-17	8-16	0	20-30	45/55 Fishy
-electric slick maki	3	1	sushi	10-15	0	0	8-16	45/55 Fishy
-electric slippery snake roll	3	1	sushi	12-17	0	0	28-46	45/55 Fishy
-electric sneaky rabbit roll	3	1	sushi	12-17	0	20-30	8-16	45/55 Fishy
-electric sneaky Santa roll	3	1	sushi	10-15	0	0	8-16	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-electric tricky dragon roll	3	1	sushi	12-17	20-30	0	8-16	45/55 Fishy
-electric white rabbit roll	3	1	sushi	12-17	0	28-46	0	45/55 Fishy
-electric wise dragon roll	3	1	sushi	12-17	20-30	8-16	0	45/55 Fishy
-electric wizened master roll	3	1	sushi	12-17	20-30	28-46	20-30	45/55 Fishy
-eleven oceans roll	3	1	sushi	9-14	20-30	20-30	28-46	45/55 Fishy
+electric musclebound rabbit roll	3	1	pseudoitem	12-17	8-16	20-30	0	45/55 Fishy
+electric omniscient Santa roll	3	1	pseudoitem	10-15	0	8-16	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+electric python roll	3	1	pseudoitem	12-17	8-16	0	20-30	45/55 Fishy
+electric slick maki	3	1	pseudoitem	10-15	0	0	8-16	45/55 Fishy
+electric slippery snake roll	3	1	pseudoitem	12-17	0	0	28-46	45/55 Fishy
+electric sneaky rabbit roll	3	1	pseudoitem	12-17	0	20-30	8-16	45/55 Fishy
+electric sneaky Santa roll	3	1	pseudoitem	10-15	0	0	8-16	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+electric tricky dragon roll	3	1	pseudoitem	12-17	20-30	0	8-16	45/55 Fishy
+electric white rabbit roll	3	1	pseudoitem	12-17	0	28-46	0	45/55 Fishy
+electric wise dragon roll	3	1	pseudoitem	12-17	20-30	8-16	0	45/55 Fishy
+electric wizened master roll	3	1	pseudoitem	12-17	20-30	28-46	20-30	45/55 Fishy
+eleven oceans roll	3	1	pseudoitem	9-14	20-30	20-30	28-46	45/55 Fishy
 elf army field rations	1	1	awesome	4-5	5-15	5-15	5-15
 Elfin shortbread	3	2	decent	3-9	4-6	4-6	4-6
 elven <i>limbos</i> gingerbread	3	5	good	5-8	22-40	22-40	22-40	20 Yuletide Industry (+50% all stats)
@@ -402,7 +402,7 @@ ghuol egg	1	1	crappy	1	-3	0	0
 ghuol egg quiche	3	2	decent	3-9	0	0	0
 ghuol guolash	5	1	good	16-19	0	20-30	0
 ghuol-ear kabob	2	1	decent	2-5	0	0	0
-giant dragon roll	3	1	sushi	9-14	28-46	0	0	45/55 Fishy
+giant dragon roll	3	1	pseudoitem	9-14	28-46	0	0	45/55 Fishy
 giant grain of protein powder	1	7	good	2-3	30-40	0	0
 giant green gummi bear	4	4	good	9-10	0	80-150	0	40 Gummibrain (+100 Myst)
 giant heirloom grape tomato	5	6	good	13-15	20-30	20-30	20-30
@@ -424,8 +424,8 @@ glass of baboon milk	1	2	decent	2	3-5	0	0	BEVERAGE
 glass of goat's milk	1	1	crappy	1	0	0	0	BEVERAGE
 glass of raw eggs	1	1	EPIC	6-7	1-25	1-25	1-25	50 Boxing Day Breakfast (+50% gear drop, +50% weapon damage, +50% spell damage)
 glistening fish meat	1	1	good	2-3	0	4-8	0	5/15 Fishy
-glistening maki	3	1	sushi	7-12	0	8-16	0	45/55 Fishy
-glistening nigiri	2	1	sushi	4-8	0	8-16	0	20/30 Fishy
+glistening maki	3	1	pseudoitem	7-12	0	8-16	0	45/55 Fishy
+glistening nigiri	2	1	pseudoitem	4-8	0	8-16	0	20/30 Fishy
 glob of cream cheese	1	1	decent	2	0	0	0
 gloomy black mushroom	0	1	crappy	0	0	0	0	Inedible
 glowing fungus	3	1	good	6-7	0	3-5	0	8-10 MP
@@ -516,8 +516,8 @@ insanely spicy enchanted bean burrito	3	5	awesome	8-15	0	28-32	0	Chronic Indiges
 insanely spicy jumping bean burrito	3	4	awesome	7-14	0	0	33
 irradiated candy cane	1	1	good	1-5	10-20	10-20	10-20	10 Festive Radiation (+5% all stats)
 It Came From Beyond Dessert	4	1	decent	6-12	7-8	7-8	7-8	10 Sugar Rush
-Jack LaLanne roll	3	1	sushi	9-14	28-46	20-30	20-30	45/55 Fishy
-jacked Santa roll	3	1	sushi	10-15	8-16	0	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Jack LaLanne roll	3	1	pseudoitem	9-14	28-46	20-30	20-30	45/55 Fishy
+jacked Santa roll	3	1	pseudoitem	10-15	8-16	0	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
 Jarlsberg's key lime pie	4	6	awesome	14-16	0	28-33	0	Jarlsberg's key
 Jarlsberg's vegetable soup	1	1	EPIC	5-7	0	20-40	0	30 Souped Up (+5 Mysticality, +50% Mysticality, +50 DA), SALAD
 java cookie	2	1	awesome	7-11	0	0	0	10 Updated (+20 all stats)
@@ -589,26 +589,26 @@ long pork lasagna	3	10	awesome	12-16	0	46-55	0	LASAGNA
 Lord of the Flies-sized fries	3	1	decent	4-6	0	15-20	-15-20
 Lucky Surprise Egg	1	1	crappy	1	0	0	0	series 1 tiny plastic
 Ludovico Pastaco	2	3	EPIC	12-14	0	0	20-40	40 Tremella Tremens (+40 Item Drop)
-magical ancient serpent roll	3	1	sushi	9-14	0	8-16	20-30	50/60 Fishy
+magical ancient serpent roll	3	1	pseudoitem	9-14	0	8-16	20-30	50/60 Fishy
 magical baguette	2	1	decent	3-4	0	4-5	0
-magical beefy maki	3	1	sushi	7-12	8-16	0	0	50/60 Fishy
-magical eleven oceans roll	3	1	sushi	9-14	20-30	20-30	28-46	50/60 Fishy
-magical giant dragon roll	3	1	sushi	9-14	28-46	0	0	50/60 Fishy
-magical glistening maki	3	1	sushi	7-12	0	8-16	0	50/60 Fishy
-magical Jack LaLanne roll	3	1	sushi	9-14	28-46	20-30	20-30	50/60 Fishy
-magical jacked Santa roll	3	1	sushi	10-15	8-16	0	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-magical musclebound rabbit roll	3	1	sushi	9-14	8-16	20-30	0	50/60 Fishy
-magical omniscient Santa roll	3	1	sushi	10-15	0	8-16	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-magical python roll	3	1	sushi	9-14	8-16	0	20-30	50/60 Fishy
+magical beefy maki	3	1	pseudoitem	7-12	8-16	0	0	50/60 Fishy
+magical eleven oceans roll	3	1	pseudoitem	9-14	20-30	20-30	28-46	50/60 Fishy
+magical giant dragon roll	3	1	pseudoitem	9-14	28-46	0	0	50/60 Fishy
+magical glistening maki	3	1	pseudoitem	7-12	0	8-16	0	50/60 Fishy
+magical Jack LaLanne roll	3	1	pseudoitem	9-14	28-46	20-30	20-30	50/60 Fishy
+magical jacked Santa roll	3	1	pseudoitem	10-15	8-16	0	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+magical musclebound rabbit roll	3	1	pseudoitem	9-14	8-16	20-30	0	50/60 Fishy
+magical omniscient Santa roll	3	1	pseudoitem	10-15	0	8-16	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+magical python roll	3	1	pseudoitem	9-14	8-16	0	20-30	50/60 Fishy
 magical sausage	0	1	EPIC	1	0	0	0	999 MP
-magical slick maki	3	1	sushi	7-12	0	0	8-16	50/60 Fishy
-magical slippery snake roll	3	1	sushi	9-14	0	0	28-46	50/60 Fishy
-magical sneaky rabbit roll	3	1	sushi	9-14	0	20-30	8-16	50/60 Fishy
-magical sneaky Santa roll	3	1	sushi	10-15	0	0	8-16	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-magical tricky dragon roll	3	1	sushi	9-14	20-30	0	8-16	50/60 Fishy
-magical white rabbit roll	3	1	sushi	9-14	0	28-46	0	50/60 Fishy
-magical wise dragon roll	3	1	sushi	9-14	20-30	8-16	0	50/60 Fishy
-magical wizened master roll	3	1	sushi	9-14	20-30	28-46	20-30	50/60 Fishy
+magical slick maki	3	1	pseudoitem	7-12	0	0	8-16	50/60 Fishy
+magical slippery snake roll	3	1	pseudoitem	9-14	0	0	28-46	50/60 Fishy
+magical sneaky rabbit roll	3	1	pseudoitem	9-14	0	20-30	8-16	50/60 Fishy
+magical sneaky Santa roll	3	1	pseudoitem	10-15	0	0	8-16	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+magical tricky dragon roll	3	1	pseudoitem	9-14	20-30	0	8-16	50/60 Fishy
+magical white rabbit roll	3	1	pseudoitem	9-14	0	28-46	0	50/60 Fishy
+magical wise dragon roll	3	1	pseudoitem	9-14	20-30	8-16	0	50/60 Fishy
+magical wizened master roll	3	1	pseudoitem	9-14	20-30	28-46	20-30	50/60 Fishy
 mana curds	4	4	good	9-11	0	90-120	0	4-6 MP
 mana-basted tofurkey leg	3	5	awesome	7-14	0	70-75	0	20 Mana-Blasted (+50% Max MP, +3-5 MP Regen)
 mana-coated yams	3	5	awesome	7-14	0	70-75	0	20 Mana-Blasted (+50% Max MP, +3-5 MP Regen)
@@ -642,7 +642,7 @@ Mt. McLargeHuge oyster	3	1	decent	5-7	15-20	0	0
 muffled muffuletta	2	1	awesome	8-10	20-30	20-30	20-30	100 Noise Cancelled (-300% init)
 mugcake	1	1	crappy	1	0	0	0
 mulberry	1	5	good	3	0	0	5-15
-musclebound rabbit roll	3	1	sushi	9-14	8-16	20-30	0	45/55 Fishy
+musclebound rabbit roll	3	1	pseudoitem	9-14	8-16	20-30	0	45/55 Fishy
 mushroom filet	1	1	good	2-3	20-40	20-40	20-40
 mushroom pizza	3	2	good	3-10	0	15-18	0	PIZZA
 nachos of the night	2	1	decent	2-4	0	0	0	20 Night of the Nachos (+50 Spooky Spell Damage, +100% Spell Damage)
@@ -665,7 +665,7 @@ olive	1	1	crappy	1	0	0	0
 olive lo mein	3	6	awesome	10-14	10-14	0	10-14
 olive stir-fry	1	3	good	1-5	3-5	0	2-4
 Omega Sundae	7	1	EPIC	32-38	20-30	50-60	20-30
-omniscient Santa roll	3	1	sushi	10-15	0	8-16	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+omniscient Santa roll	3	1	pseudoitem	10-15	0	8-16	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
 one with everything	2	1	awesome	6-8	0	10-15	0	50 Inner Dog (+50% Myst, +10% Spell Crit, +50 Damage vs Zombies/Ghosts)
 optimal dog	1	1	awesome	4-5	0	0	0	Grants Lucky! intrinsic
 orange	1	1	crappy	1	0	0	0
@@ -753,7 +753,7 @@ primitive candy cane	1	1	good	3-4	0	0	0
 protein paste	2	7	good	4-8	38-60	0	0	10 Pasty (+50% mus)
 pumpkin pie	3	2	EPIC	16-18	12-24	12-24	12-24
 purple pixel pie	3	1	decent	3-6	12-18	12-18	12-18
-python roll	3	1	sushi	9-14	8-16	0	20-30	45/55 Fishy
+python roll	3	1	pseudoitem	9-14	8-16	0	20-30	45/55 Fishy
 quantum taco	0	1	???	0	0	0	0	random food
 queen cookie	1	13	EPIC	4-6	20-40	20-40	20-40	30 Towering Strength, Mitre Cut, Knightlife, The Royal We
 questionable taco	3	1	decent	4-5	0	0	0	lovecat tail
@@ -801,24 +801,24 @@ salacious crumbs	3	1	decent	5-7	0	0	15-20
 salmagumdi	1	1	awesome	0	0	0	0	Unspaded
 salt plum	2	1	good	6	0	0	0
 salted mutton	1	1	good	3	0	0	8-10	pirate encryption key
-salty ancient serpent roll	3	1	sushi	9-14	0	8-16	20-30	45/55 Fishy, 10 Salty Dogs
-salty beefy maki	3	1	sushi	7-12	8-16	0	0	45/55 Fishy, 10 Salty Dogs
-salty eleven oceans roll	3	1	sushi	9-14	20-30	20-30	28-46	45/55 Fishy, 10 Salty Dogs
-salty giant dragon roll	3	1	sushi	9-14	28-46	0	0	45/55 Fishy, 10 Salty Dogs
-salty glistening maki	3	1	sushi	7-12	0	8-16	0	45/55 Fishy, 10 Salty Dogs
-salty Jack LaLanne roll	3	1	sushi	9-14	28-46	20-30	20-30	45/55 Fishy, 10 Salty Dogs
-salty jacked Santa roll	3	1	sushi	10-15	8-16	0	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-salty musclebound rabbit roll	3	1	sushi	9-14	8-16	20-30	0	45/55 Fishy, 10 Salty Dogs
-salty omniscient Santa roll	3	1	sushi	10-15	0	8-16	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-salty python roll	3	1	sushi	9-14	8-16	0	20-30	45/55 Fishy, 10 Salty Dogs
-salty slick maki	3	1	sushi	7-12	0	0	8-16	45/55 Fishy, 10 Salty Dogs
-salty slippery snake roll	3	1	sushi	9-14	0	0	28-46	45/55 Fishy, 10 Salty Dogs
-salty sneaky rabbit roll	3	1	sushi	9-14	0	20-30	8-16	45/55 Fishy, 10 Salty Dogs
-salty sneaky Santa roll	3	1	sushi	10-15	0	0	8-16	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-salty tricky dragon roll	3	1	sushi	9-14	20-30	0	8-16	45/55 Fishy, 10 Salty Dogs
-salty white rabbit roll	3	1	sushi	9-14	0	28-46	0	45/55 Fishy, 10 Salty Dogs
-salty wise dragon roll	3	1	sushi	9-14	20-30	8-16	0	45/55 Fishy, 10 Salty Dogs
-salty wizened master roll	3	1	sushi	9-14	20-30	28-46	20-30	45/55 Fishy, 10 Salty Dogs
+salty ancient serpent roll	3	1	pseudoitem	9-14	0	8-16	20-30	45/55 Fishy, 10 Salty Dogs
+salty beefy maki	3	1	pseudoitem	7-12	8-16	0	0	45/55 Fishy, 10 Salty Dogs
+salty eleven oceans roll	3	1	pseudoitem	9-14	20-30	20-30	28-46	45/55 Fishy, 10 Salty Dogs
+salty giant dragon roll	3	1	pseudoitem	9-14	28-46	0	0	45/55 Fishy, 10 Salty Dogs
+salty glistening maki	3	1	pseudoitem	7-12	0	8-16	0	45/55 Fishy, 10 Salty Dogs
+salty Jack LaLanne roll	3	1	pseudoitem	9-14	28-46	20-30	20-30	45/55 Fishy, 10 Salty Dogs
+salty jacked Santa roll	3	1	pseudoitem	10-15	8-16	0	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+salty musclebound rabbit roll	3	1	pseudoitem	9-14	8-16	20-30	0	45/55 Fishy, 10 Salty Dogs
+salty omniscient Santa roll	3	1	pseudoitem	10-15	0	8-16	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+salty python roll	3	1	pseudoitem	9-14	8-16	0	20-30	45/55 Fishy, 10 Salty Dogs
+salty slick maki	3	1	pseudoitem	7-12	0	0	8-16	45/55 Fishy, 10 Salty Dogs
+salty slippery snake roll	3	1	pseudoitem	9-14	0	0	28-46	45/55 Fishy, 10 Salty Dogs
+salty sneaky rabbit roll	3	1	pseudoitem	9-14	0	20-30	8-16	45/55 Fishy, 10 Salty Dogs
+salty sneaky Santa roll	3	1	pseudoitem	10-15	0	0	8-16	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+salty tricky dragon roll	3	1	pseudoitem	9-14	20-30	0	8-16	45/55 Fishy, 10 Salty Dogs
+salty white rabbit roll	3	1	pseudoitem	9-14	0	28-46	0	45/55 Fishy, 10 Salty Dogs
+salty wise dragon roll	3	1	pseudoitem	9-14	20-30	8-16	0	45/55 Fishy, 10 Salty Dogs
+salty wizened master roll	3	1	pseudoitem	9-14	20-30	28-46	20-30	45/55 Fishy, 10 Salty Dogs
 sandwich of the gods	5	13	super EPIC	32-38	50-100	50-100	50-100
 sausage pizza	3	2	good	3-10	15-18	0	0	PIZZA
 sausage without a cause	10	1	awesome	40	0	0	0	1 East of Eaten (+200% Weapon Damage, +4 Hot res)
@@ -850,7 +850,7 @@ shrapnel jelly donut	1	4	awesome	3-5	40-60	0	0	30 Filled With Magic (+100% spell
 shushed potatoes	2	1	awesome	8-10	20-30	20-30	20-30	100 Noise Cancelled (-300% init)
 single-serving herbal stuffing	4	1	awesome	12-16	0	0	32-35
 six tiny wedges of goat cheese	2	1	crappy	3	0	0	0
-sizzling weasel on a stick	5	1	EPIC	60-80	0	0	220-400
+sizzling weasel on a stick	5	1	pseudoitem	60-80	0	0	220-400
 skeleton quiche	2	3	EPIC	10-12	5-15	5-15	5-15
 skewered cat appendix	2	1	decent	2-5	7-17	0	0
 skull-shaped Crimboween cookie	2	7	awesome	6-12	0	0	0	10/20 Carol of the Bones (+10% mus)
@@ -859,17 +859,17 @@ sleazy hi mein	5	12	EPIC	24-27	25-30	25-30	70-75	5 Sleazy Breath (combat skill),
 sleeping dog	2	1	awesome	9-10	0	0	0	acquire Dog Tired skill
 slice of pizza	1	1	good	3	12-15	12-15	12-15	PIZZA
 slick fish meat	1	1	good	2-3	0	0	4-8	5/15 Fishy
-slick maki	3	1	sushi	7-12	0	0	8-16	45/55 Fishy
-slick nigiri	2	1	sushi	4-8	0	0	8-16	20/30 Fishy
+slick maki	3	1	pseudoitem	7-12	0	0	8-16	45/55 Fishy
+slick nigiri	2	1	pseudoitem	4-8	0	0	8-16	20/30 Fishy
 slimy sweetbreads	1	6	good	2-3	0	0	0	20 Grimace (+25 ML, slime res)
-slippery snake roll	3	1	sushi	9-14	0	0	28-46	45/55 Fishy
+slippery snake roll	3	1	pseudoitem	9-14	0	0	28-46	45/55 Fishy
 sly dog	2	1	awesome	6-8	0	0	10-15	50 Top Dog (+50% Mox, +10% Crit Chance, +50 Dam vs Skeletons/Vampires)
 smashed danish	1	4	awesome	3-5	45-75	0	0	30 Danish Cunning (+25% pickpocket)
 smelted roe	1	4	good	3	10-20	0	0	50 Sizzling with Fury (+25 Hot Damage, +60 Init)
 SMOOCH soda	1	1	good	3-3	0	0	0	BEVERAGE, Gain 20-35 MP and SMOOCH bottlecap
 Sneaky Pete's key lime pie	4	6	awesome	14-16	0	0	28-33	Sneaky Pete's key
-sneaky rabbit roll	3	1	sushi	9-14	0	20-30	8-16	45/55 Fishy
-sneaky Santa roll	3	1	sushi	10-15	0	0	8-16	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+sneaky rabbit roll	3	1	pseudoitem	9-14	0	20-30	8-16	45/55 Fishy
+sneaky Santa roll	3	1	pseudoitem	10-15	0	0	8-16	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
 snow berries	1	1	good	2-3	3-5	3-5	3-5	30 Berry Berry Cold (+10 Cold Damage, +20 Cold Spell Damage)
 snow crab	1	1	EPIC	5-7	10-20	10-20	10-20
 Sogg-Os	1	11	EPIC	5	1-100	1-100	1-100
@@ -926,7 +926,7 @@ sublime deluxe hot dog	6	1	awesome	22-26	10-20	40-50	10-20
 sublime nachos	6	1	awesome	22-26	10-20	40-50	10-20
 sublime stew	6	1	awesome	22-26	0	40-50	20-30
 succulent marrow	3	1	decent	5-7	25-30	0	0
-suddenly salad!	5	1	EPIC	60-80	0	220-400	0
+suddenly salad!	5	1	pseudoitem	60-80	0	220-400	0
 sugarplum ration	5	1	awesome	17	0	0	0	50 Sugarplum Visions (more pieces of 12 from Crimbuccaneers)
 suggestive strozzapreti	5	7	awesome	16-19	0	0	20-30
 sun-dried tofu	2	3	crappy	2-4	0	0	0	gain Deadened Palate or lose Oversaturated Palate
@@ -949,54 +949,54 @@ tea for one	1	5	good	2-3	0	10-20	0	BEVERAGE, One For Tea (+10-15 MP Regen)
 Tea, Earl Grey, Hot	1	1	EPIC	6-7	0	0	0	BEVERAGE, +1000 MP, +1000 HP
 temperance whiskey	3	1	good	8-10	20-30	20-30	20-30	BEVERAGE, 100 Old Time Hydration (+30 all stats)
 tempura avocado	1	5	EPIC	5-7	0	0	50
-tempura avocado bento box with anemone sauce	5	1	EPIC	24-32	75-95	5-15	45-65	80 Fishy
-tempura avocado bento box with eel sauce	5	1	EPIC	24-32	5-15	5-15	45-65	80 Fishy
-tempura avocado bento box with inky squid sauce	5	1	EPIC	24-32	5-15	75-95	45-65	80 Fishy
-tempura avocado bento box with mer-kin weaksauce	5	1	EPIC	24-32	5-15	5-15	115-145	80 Fishy
-tempura avocado bento box with peanut sauce	5	1	EPIC	24-32	5-15	5-15	45-65	80 Fishy
-tempura avocado bento box with peppermint eel sauce	5	1	EPIC	24-32	5-15	5-15	75-95	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
+tempura avocado bento box with anemone sauce	5	1	pseudoitem	24-32	75-95	5-15	45-65	80 Fishy
+tempura avocado bento box with eel sauce	5	1	pseudoitem	24-32	5-15	5-15	45-65	80 Fishy
+tempura avocado bento box with inky squid sauce	5	1	pseudoitem	24-32	5-15	75-95	45-65	80 Fishy
+tempura avocado bento box with mer-kin weaksauce	5	1	pseudoitem	24-32	5-15	5-15	115-145	80 Fishy
+tempura avocado bento box with peanut sauce	5	1	pseudoitem	24-32	5-15	5-15	45-65	80 Fishy
+tempura avocado bento box with peppermint eel sauce	5	1	pseudoitem	24-32	5-15	5-15	75-95	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
 tempura broccoli	1	6	awesome	3-6	5	5	5	20 Down with Chow (+10 lbs)
-tempura broccoli bento box with anemone sauce	5	1	EPIC	24-32	75-95	5-15	5-15	80 Fishy
-tempura broccoli bento box with eel sauce	5	1	EPIC	24-32	5-15	5-15	5-15	80 Fishy
-tempura broccoli bento box with inky squid sauce	5	1	EPIC	24-32	5-15	75-95	5-15	80 Fishy
-tempura broccoli bento box with mer-kin weaksauce	5	1	EPIC	24-32	5-15	5-15	75-95	80 Fishy
-tempura broccoli bento box with peanut sauce	5	1	EPIC	24-32	5-15	5-15	5-15	80 Fishy
-tempura broccoli bento box with peppermint eel sauce	5	1	EPIC	24-32	45-65	45-65	45-65	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
+tempura broccoli bento box with anemone sauce	5	1	pseudoitem	24-32	75-95	5-15	5-15	80 Fishy
+tempura broccoli bento box with eel sauce	5	1	pseudoitem	24-32	5-15	5-15	5-15	80 Fishy
+tempura broccoli bento box with inky squid sauce	5	1	pseudoitem	24-32	5-15	75-95	5-15	80 Fishy
+tempura broccoli bento box with mer-kin weaksauce	5	1	pseudoitem	24-32	5-15	5-15	75-95	80 Fishy
+tempura broccoli bento box with peanut sauce	5	1	pseudoitem	24-32	5-15	5-15	5-15	80 Fishy
+tempura broccoli bento box with peppermint eel sauce	5	1	pseudoitem	24-32	45-65	45-65	45-65	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
 tempura carrot	1	5	EPIC	5-7	0	50	0
-tempura carrot bento box with anemone sauce	5	1	EPIC	24-32	75-95	45-65	5-15	80 Fishy
-tempura carrot bento box with eel sauce	5	1	EPIC	24-32	5-15	45-65	5-15	80 Fishy
-tempura carrot bento box with inky squid sauce	5	1	EPIC	24-32	5-15	115-145	5-15	80 Fishy
-tempura carrot bento box with mer-kin weaksauce	5	1	EPIC	24-32	5-15	45-65	75-95	80 Fishy
-tempura carrot bento box with peanut sauce	5	1	EPIC	24-32	5-15	45-65	5-15	80 Fishy
-tempura carrot bento box with peppermint eel sauce	5	1	EPIC	24-32	5-15	45-65	5-15	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
+tempura carrot bento box with anemone sauce	5	1	pseudoitem	24-32	75-95	45-65	5-15	80 Fishy
+tempura carrot bento box with eel sauce	5	1	pseudoitem	24-32	5-15	45-65	5-15	80 Fishy
+tempura carrot bento box with inky squid sauce	5	1	pseudoitem	24-32	5-15	115-145	5-15	80 Fishy
+tempura carrot bento box with mer-kin weaksauce	5	1	pseudoitem	24-32	5-15	45-65	75-95	80 Fishy
+tempura carrot bento box with peanut sauce	5	1	pseudoitem	24-32	5-15	45-65	5-15	80 Fishy
+tempura carrot bento box with peppermint eel sauce	5	1	pseudoitem	24-32	5-15	45-65	5-15	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
 tempura cauliflower	1	6	awesome	2-5	5	5	5	20 Low on the Hog (+100% meat)
-tempura cauliflower bento box with anemone sauce	5	1	EPIC	24-32	75-95	5-15	5-15	80 Fishy
-tempura cauliflower bento box with eel sauce	5	1	EPIC	24-32	5-15	5-15	5-15	80 Fishy
-tempura cauliflower bento box with inky squid sauce	5	1	EPIC	24-32	5-15	75-95	5-15	80 Fishy
-tempura cauliflower bento box with mer-kin weaksauce	5	1	EPIC	24-32	5-15	5-15	75-95	80 Fishy
-tempura cauliflower bento box with peanut sauce	5	1	EPIC	24-32	5-15	5-15	5-15	80 Fishy
-tempura cauliflower bento box with peppermint eel sauce	5	1	EPIC	24-32	35-55	35-55	55-75	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
+tempura cauliflower bento box with anemone sauce	5	1	pseudoitem	24-32	75-95	5-15	5-15	80 Fishy
+tempura cauliflower bento box with eel sauce	5	1	pseudoitem	24-32	5-15	5-15	5-15	80 Fishy
+tempura cauliflower bento box with inky squid sauce	5	1	pseudoitem	24-32	5-15	75-95	5-15	80 Fishy
+tempura cauliflower bento box with mer-kin weaksauce	5	1	pseudoitem	24-32	5-15	5-15	75-95	80 Fishy
+tempura cauliflower bento box with peanut sauce	5	1	pseudoitem	24-32	5-15	5-15	5-15	80 Fishy
+tempura cauliflower bento box with peppermint eel sauce	5	1	pseudoitem	24-32	35-55	35-55	55-75	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
 tempura cucumber	1	5	EPIC	5-7	50	0	0
-tempura cucumber bento box with anemone sauce	5	1	EPIC	24-32	115-145	5-15	5-15	80 Fishy
-tempura cucumber bento box with eel sauce	5	1	EPIC	24-32	45-65	5-15	5-15	80 Fishy
-tempura cucumber bento box with inky squid sauce	5	1	EPIC	24-32	45-65	75-95	5-15	80 Fishy
-tempura cucumber bento box with mer-kin weaksauce	5	1	EPIC	24-32	45-65	5-15	75-95	80 Fishy
-tempura cucumber bento box with peanut sauce	5	1	EPIC	24-32	45-65	5-15	5-15	80 Fishy
-tempura cucumber bento box with peppermint eel sauce	5	1	EPIC	24-32	45-65	5-15	5-15	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
+tempura cucumber bento box with anemone sauce	5	1	pseudoitem	24-32	115-145	5-15	5-15	80 Fishy
+tempura cucumber bento box with eel sauce	5	1	pseudoitem	24-32	45-65	5-15	5-15	80 Fishy
+tempura cucumber bento box with inky squid sauce	5	1	pseudoitem	24-32	45-65	75-95	5-15	80 Fishy
+tempura cucumber bento box with mer-kin weaksauce	5	1	pseudoitem	24-32	45-65	5-15	75-95	80 Fishy
+tempura cucumber bento box with peanut sauce	5	1	pseudoitem	24-32	45-65	5-15	5-15	80 Fishy
+tempura cucumber bento box with peppermint eel sauce	5	1	pseudoitem	24-32	45-65	5-15	5-15	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
 tempura green and red bean	1	1	EPIC	5-7	58	97	64
-tempura green and red bean bento box with anemone sauce	5	1	EPIC	24-32	75-95	15-25	5-15	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
-tempura green and red bean bento box with eel sauce	5	1	EPIC	24-32	5-15	15-25	5-15	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
-tempura green and red bean bento box with inky squid sauce	5	1	EPIC	24-32	5-15	155-175	5-15	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
-tempura green and red bean bento box with mer-kin weaksauce	5	1	EPIC	24-32	5-15	15-35	65-85	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
-tempura green and red bean bento box with peanut sauce	5	1	EPIC	24-32	75-95	125-145	75-95	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
-tempura green and red bean bento box with peppermint eel sauce	5	1	EPIC	24-32	5-15	5-15	5-15	40 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
+tempura green and red bean bento box with anemone sauce	5	1	pseudoitem	24-32	75-95	15-25	5-15	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
+tempura green and red bean bento box with eel sauce	5	1	pseudoitem	24-32	5-15	15-25	5-15	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
+tempura green and red bean bento box with inky squid sauce	5	1	pseudoitem	24-32	5-15	155-175	5-15	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
+tempura green and red bean bento box with mer-kin weaksauce	5	1	pseudoitem	24-32	5-15	15-35	65-85	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
+tempura green and red bean bento box with peanut sauce	5	1	pseudoitem	24-32	75-95	125-145	75-95	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
+tempura green and red bean bento box with peppermint eel sauce	5	1	pseudoitem	24-32	5-15	5-15	5-15	40 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
 tempura radish	1	7	EPIC	5-7	63	66	63
-tempura radish bento box with anemone sauce	5	1	EPIC	24-32	75-95	5-15	5-15	80 Fishy
-tempura radish bento box with eel sauce	5	1	EPIC	24-32	5-15	5-15	5-15	80 Fishy
-tempura radish bento box with inky squid sauce	5	1	EPIC	24-32	5-15	75-95	5-15	80 Fishy
-tempura radish bento box with mer-kin weaksauce	5	1	EPIC	24-32	5-15	5-15	75-95	80 Fishy
-tempura radish bento box with peanut sauce	5	1	EPIC	24-32	5-15	5-15	5-15	80 Fishy
-tempura radish bento box with peppermint eel sauce	5	1	EPIC	24-32	55-75	55-75	65-85	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
+tempura radish bento box with anemone sauce	5	1	pseudoitem	24-32	75-95	5-15	5-15	80 Fishy
+tempura radish bento box with eel sauce	5	1	pseudoitem	24-32	5-15	5-15	5-15	80 Fishy
+tempura radish bento box with inky squid sauce	5	1	pseudoitem	24-32	5-15	75-95	5-15	80 Fishy
+tempura radish bento box with mer-kin weaksauce	5	1	pseudoitem	24-32	5-15	5-15	75-95	80 Fishy
+tempura radish bento box with peanut sauce	5	1	pseudoitem	24-32	5-15	5-15	5-15	80 Fishy
+tempura radish bento box with peppermint eel sauce	5	1	pseudoitem	24-32	55-75	55-75	65-85	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 80 Fishy
 Thanksgiving ration	3	5	super ultra EPIC	24-30	20-60	20-60	20-60
 thanksgiving turkey	2	1	awesome	8-10	10-20	0	0	leftovers, 20 Thanksgetting (Variable +meat, +item, +familiar weight, +all res)
 The Plumber's mushroom stew	3	6	super EPIC	21-24	15-30	15-30	15-30	-1 drunkenness
@@ -1035,7 +1035,7 @@ traffic jam toast	1	1	decent	1-3	50	0	0
 transparent nog	1	1	crappy	1	0	0	0	BEVERAGE, 10 Holiday Disappointment (+50% all stats)
 tree-shaped Crimbo cookie	2	7	awesome	6-12	0	0	0	10/20 Yuletide Sappiness (+10% mys)
 triangular CRIMBCOOKIE	2	1	awesome	8-10	0	0	0	10 Triangle, Man (+10% mus)
-tricky dragon roll	3	1	sushi	9-14	20-30	0	8-16	45/55 Fishy
+tricky dragon roll	3	1	pseudoitem	9-14	20-30	0	8-16	45/55 Fishy
 Trollhouse cookies	2	1	decent	2-3	4-6	0	0
 tube of cranberry Go-Goo	3	1	awesome	8-14	0	0	31-34
 turkish mostaccioli	5	10	awesome	19-22	35-40	0	0	SAUCY
@@ -1092,14 +1092,14 @@ white chocolate chip cookies	2	1	decent	2-5	0	11-13	0
 white chocolate chips	1	1	crappy	1	0	0	0
 White Citadel burger	2	1	crappy	2-8	0	0	0
 White Citadel fries	2	1	decent	2-5	0	0	0
-white rabbit roll	3	1	sushi	9-14	0	28-46	0	45/55 Fishy
+white rabbit roll	3	1	pseudoitem	9-14	0	28-46	0	45/55 Fishy
 white rice	1	1	crappy	1	1	1-2	1-2
 whole roasted chicken	3	9	awesome	15	18-22	18-22	18-22
 whole turkey leg	1	4	awesome	4-5	0	0	0
 wild honey pie	2	1	decent	4-6	5-7	5-7	5-7	10 Sugar Rush
-wise dragon roll	3	1	sushi	9-14	20-30	8-16	0	45/55 Fishy
+wise dragon roll	3	1	pseudoitem	9-14	20-30	8-16	0	45/55 Fishy
 witch's bread	3	6	awesome	12-15	0	30-45	0	20 Witch Breaded (+100% Mys, +200% Spell Damage, +20% Spell Critical)
-wizened master roll	3	1	sushi	9-14	20-30	28-46	20-30	45/55 Fishy
+wizened master roll	3	1	pseudoitem	9-14	20-30	28-46	20-30	45/55 Fishy
 wreath-shaped Crimbo cookie	2	7	awesome	6-12	0	0	0	10/20 Wreathed in Merriment (+10% mox)
 Xiblaxian ultraburrito	4	7	EPIC	19-22	50	50	50
 yam	1	1	awesome	3-5	1-10	1-10	1-10
@@ -1112,21 +1112,21 @@ Yeg's Motel pillow mint	1	1	good	3	80-100	80-100	80-100	10 Really Quite Poisoned
 yellow drunki-bear	4	6	EPIC	22-26	0	0	200-240	4 Fullness 80 Gummskin (+100 Mox)
 yellow matter custard	2	6	good	4-8	10-15	10-15	10-15
 yule gruel	3	1	good	9-10	0	0	0
-Yuletide ancient serpent roll	3	1	sushi	12-17	0	8-16	20-30	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide beefy maki	3	1	sushi	10-15	8-16	0	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide eleven oceans roll	3	1	sushi	12-17	20-30	20-30	28-46	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide giant dragon roll	3	1	sushi	12-17	28-46	0	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide glistening maki	3	1	sushi	10-15	0	8-16	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide Jack LaLanne roll	3	1	sushi	12-17	28-46	20-30	20-30	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide jacked Santa roll	3	1	sushi	10-15	5-15	0	0	40 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide musclebound rabbit roll	3	1	sushi	12-17	8-16	20-30	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide omniscient Santa roll	3	1	sushi	10-15	0	5-15	0	40 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide python roll	3	1	sushi	12-17	8-16	0	20-30	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide slick maki	3	1	sushi	10-15	0	0	8-16	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide slippery snake roll	3	1	sushi	12-17	0	0	28-46	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide sneaky rabbit roll	3	1	sushi	12-17	0	20-30	8-16	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide sneaky Santa roll	3	1	sushi	10-15	0	0	5-15	40 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide tricky dragon roll	3	1	sushi	12-17	20-30	0	8-16	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide white rabbit roll	3	1	sushi	12-17	0	28-46	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide wise dragon roll	3	1	sushi	12-17	20-30	8-16	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
-Yuletide wizened master roll	3	1	sushi	12-17	20-30	28-46	20-30	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide ancient serpent roll	3	1	pseudoitem	12-17	0	8-16	20-30	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide beefy maki	3	1	pseudoitem	10-15	8-16	0	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide eleven oceans roll	3	1	pseudoitem	12-17	20-30	20-30	28-46	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide giant dragon roll	3	1	pseudoitem	12-17	28-46	0	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide glistening maki	3	1	pseudoitem	10-15	0	8-16	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide Jack LaLanne roll	3	1	pseudoitem	12-17	28-46	20-30	20-30	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide jacked Santa roll	3	1	pseudoitem	10-15	5-15	0	0	40 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide musclebound rabbit roll	3	1	pseudoitem	12-17	8-16	20-30	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide omniscient Santa roll	3	1	pseudoitem	10-15	0	5-15	0	40 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide python roll	3	1	pseudoitem	12-17	8-16	0	20-30	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide slick maki	3	1	pseudoitem	10-15	0	0	8-16	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide slippery snake roll	3	1	pseudoitem	12-17	0	0	28-46	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide sneaky rabbit roll	3	1	pseudoitem	12-17	0	20-30	8-16	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide sneaky Santa roll	3	1	pseudoitem	10-15	0	0	5-15	40 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide tricky dragon roll	3	1	pseudoitem	12-17	20-30	0	8-16	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide white rabbit roll	3	1	pseudoitem	12-17	0	28-46	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide wise dragon roll	3	1	pseudoitem	12-17	20-30	8-16	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
+Yuletide wizened master roll	3	1	pseudoitem	12-17	20-30	28-46	20-30	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy

--- a/src/data/fullness.txt
+++ b/src/data/fullness.txt
@@ -515,7 +515,7 @@ insanely spicy bean burrito	3	4	awesome	7-14	27-32	0	0
 insanely spicy enchanted bean burrito	3	5	awesome	8-15	0	28-32	0	Chronic Indigestion skill
 insanely spicy jumping bean burrito	3	4	awesome	7-14	0	0	33
 irradiated candy cane	1	1	good	1-5	10-20	10-20	10-20	10 Festive Radiation (+5% all stats)
-it came from beyond dessert	4	1	decent	6-12	7-8	7-8	7-8	10 Sugar Rush
+It Came From Beyond Dessert	4	1	decent	6-12	7-8	7-8	7-8	10 Sugar Rush
 Jack LaLanne roll	3	1	sushi	9-14	28-46	20-30	20-30	45/55 Fishy
 jacked Santa roll	3	1	sushi	10-15	8-16	0	0	20 Dreaming of a Wet Crimbo (better diver, +50 (underwater) Item Drop) 45/55 Fishy
 Jarlsberg's key lime pie	4	6	awesome	14-16	0	28-33	0	Jarlsberg's key

--- a/src/data/inebriety.txt
+++ b/src/data/inebriety.txt
@@ -682,7 +682,7 @@ stealth bomber	3	6	awesome	9-12	10-20	0	10-20
 Steamboat	3	1	awesome	12	15-30	15-30	15-30	20 Steamed (+3 Hot Resist, +20 Hot Dam, +20 Item Drop)
 steel margarita	5	5	quest	0	0	0	0	Liver of Steel skill
 stepmom's booze	3	5	decent	4-6	0	5-10	5-10	KOLHS
-stillsuit distillate	1	1	???	0	0	0	0	Buzzed on Distillate
+stillsuit distillate	1	1	pseudoitem	0	0	0	0	Buzzed on Distillate
 stinkwater	3	24	super ultra EPIC	25-29	20-30	20-30	20-30
 stinky mushroom wine	3	6	awesome	10-14	0	0	12-15	WINE
 strawberry daiquiri	3	1	decent	5-6	0	0	8-10

--- a/src/net/sourceforge/kolmafia/persistence/ConsumablesDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConsumablesDatabase.java
@@ -71,7 +71,7 @@ public class ConsumablesDatabase {
     QUEST("quest"),
     CHANGING("???"),
     DRIPPY("drippy", "#964B00"),
-    SUSHI("sushi");
+    PSEUDO("pseudoitem");
 
     static final Map<String, ConsumableQuality> nameToQuality = new HashMap<>();
 

--- a/test/net/sourceforge/kolmafia/DataFileTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileTest.java
@@ -63,7 +63,7 @@ public class DataFileTest {
               "\\d+", // fullness
               "\\d+", // level
               // Missing quality is only for fake drink "ice stein"
-              "(crappy|decent|good|awesome|(super (ultra (mega (turbo )?)?)?)?EPIC|\\?\\?\\?|drippy|quest|)", // quality
+              "(crappy|decent|good|awesome|(super (ultra (mega (turbo )?)?)?)?EPIC|\\?\\?\\?|drippy|pseudoitem|quest|)", // quality
               "-?\\d+(-\\d+)?", // adv
               "-?\\d+(-\\d+)?", // mus
               "-?\\d+(-\\d+)?", // mys

--- a/test/net/sourceforge/kolmafia/DataFileTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileTest.java
@@ -49,7 +49,7 @@ public class DataFileTest {
               "\\d+", // fullness
               "\\d+", // level
               // Missing quality is only for fake food "[glitch season reward name]"
-              "(crappy|decent|good|awesome|(super (ultra (mega (turbo )?)?)?)?EPIC|\\?\\?\\?|drippy|sushi|quest|)", // quality
+              "(crappy|decent|good|awesome|(super (ultra (mega (turbo )?)?)?)?EPIC|\\?\\?\\?|drippy|pseudoitem|quest|)", // quality
               "-?\\d+(-\\d+)?", // adv
               "-?\\d+(-\\d+)?", // mus
               "-?\\d+(-\\d+)?", // mys


### PR DESCRIPTION
- **Fix capitalisation of one item**
- **Rename sushi pseudoquality to pseudoitem, include other pseudoitems**

Removing fake quality tags from items that don't actually exist, let alone have a quality. Instead we can use `pseudoitem` as a catch-all for this kind of support.
