### PR TITLE
feat: add a pref for leprecondo furniture found today

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -2296,6 +2296,7 @@ user	_leavesJumped	false
 user	_legendaryBeat	false
 user	_legionJackhammerCrafting	0
 user	_leprecondoRearrangements	0
+user	_leprecondoFurniture	0
 user	_licenseToChillUsed	false
 user	_llamaCharge	0
 user	_locketMonstersFought

--- a/src/net/sourceforge/kolmafia/session/LeprecondoManager.java
+++ b/src/net/sourceforge/kolmafia/session/LeprecondoManager.java
@@ -293,6 +293,7 @@ public class LeprecondoManager {
     // Check for new furniture discovery
     var discovered = Furniture.byDiscovery(text);
     if (discovered != null) {
+      Preferences.increment("_leprecondoFurniture");
       Preferences.setString(
           "leprecondoDiscovered",
           Stream.concat(

--- a/test/net/sourceforge/kolmafia/request/FightRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FightRequestTest.java
@@ -3929,6 +3929,7 @@ public class FightRequestTest {
               withProperty("leprecondoDiscovered", "1,21"),
               withProperty("leprecondoCurrentNeed"),
               withProperty("leprecondoNeedOrder"),
+              withProperty("_leprecondoFurniture", 1),
               withFight(0));
       try (cleanups) {
         SessionLoggerOutput.startStream();
@@ -3938,6 +3939,7 @@ public class FightRequestTest {
             "Round 2: Gog spots a sous vide laboratory inside the garbage disposal and runs out of his condo. He drags it back to the condo and stores it in the attic.";
         assertThat(text, containsString(expected));
         assertThat("leprecondoDiscovered", isSetTo("1,13,21"));
+        assertThat("_leprecondoFurniture", isSetTo(2));
       }
     }
 


### PR DESCRIPTION
It's useful to know how much furniture you found today because the first furniture is ~6 turns, then 36, and then you should try tomorrow.