### PR TITLE
candy cane sword adds option to choice 888

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/panel/ChoiceOptionsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/ChoiceOptionsPanel.java
@@ -958,7 +958,7 @@ public class ChoiceOptionsPanel extends JTabbedPane implements Listener {
 
     switch (this.riseSelect.getSelectedIndex()) {
       case 0 -> // Ignore this adventure
-      Preferences.setString("choiceAdventure888", "4");
+      Preferences.setString("choiceAdventure888", "5");
       case 1 -> { // Mysticality
         Preferences.setString("choiceAdventure888", "3");
         Preferences.setString("choiceAdventure88", "1");


### PR DESCRIPTION
Used to be:

Take a Look, it's in a Book! - whichchoice=888
option 1 = Read "The Rise of the House of Spookyraven"
option 2 = Read "The Better Haunted Homes and Conservatories Cookbook"
option 3 = Read "Ancient Forbidden Unspeakable Evil, a Love Story"
option 4 = Reading is for losers. I'm outta here.

If you select "ignore this adventure" in the drop down, we did this:

```      Preferences.setString("choiceAdventure888", "4");```

Which used to be fine, except the choice adventure now has:

option 4 = Read "Ten Times Sword Canes have Changed History"
option 5 = Reading is for losers. I'm outta here.

Option 4 only shows if you have a candy cane sword cane equipped, but the "skip adventure" is always option 5, now.