### PR TITLE
Don't let ChoiceManager automate swimming pool

### DIFF
--- a/src/net/sourceforge/kolmafia/request/ClanLoungeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ClanLoungeRequest.java
@@ -737,6 +737,17 @@ public class ClanLoungeRequest extends GenericRequest {
     this.option = option;
   }
 
+  @Override
+  protected boolean shouldFollowRedirect() {
+    // We do not want ChoiceManager to automate redirection.
+    // I think that Cannonballing into the Swimming Pool is the
+    // only redirection to choice.php.
+    if (this.action == Action.SWIMMING_POOL && this.option == CANNONBALL) {
+      return true;
+    }
+    return false;
+  }
+
   public static final ClanLoungeRequest buyHotDogRequest(final String name) {
     int index = ClanLoungeRequest.hotdogNameToIndex(name);
     if (index < 0) {
@@ -1972,15 +1983,7 @@ public class ClanLoungeRequest extends GenericRequest {
     if (VISIT_REQUEST.responseText.contains("vippool.gif")
         && !Preferences.getBoolean("_olympicSwimmingPoolItemFound")) {
       try {
-        // We do not want ChoiceManager to automate the redirection
-        request =
-            new ClanLoungeRequest(Action.SWIMMING_POOL, CANNONBALL) {
-              @Override
-              protected boolean shouldFollowRedirect() {
-                return true;
-              }
-            };
-        RequestThread.postRequest(request);
+        RequestThread.postRequest(new ClanLoungeRequest(Action.SWIMMING_POOL, CANNONBALL));
         RequestThread.postRequest(
             new ClanLoungeSwimmingPoolRequest(ClanLoungeSwimmingPoolRequest.HANDSTAND));
         RequestThread.postRequest(

--- a/src/net/sourceforge/kolmafia/request/ClanLoungeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ClanLoungeRequest.java
@@ -1120,7 +1120,7 @@ public class ClanLoungeRequest extends GenericRequest {
         break;
 
       case SWIMMING_POOL:
-        if (this.redirectLocation != null && this.redirectLocation.startsWith("choice.php")) {
+        if (this.responseText.contains("Screwing Around!")) {
           RequestLogger.printLine("You start screwing around in the swimming pool.");
         } else if (responseText.contains("manage to swim")) {
           // the message is printed by parseResponse()
@@ -1972,7 +1972,15 @@ public class ClanLoungeRequest extends GenericRequest {
     if (VISIT_REQUEST.responseText.contains("vippool.gif")
         && !Preferences.getBoolean("_olympicSwimmingPoolItemFound")) {
       try {
-        RequestThread.postRequest(new ClanLoungeRequest(Action.SWIMMING_POOL, CANNONBALL));
+        // We do not want ChoiceManager to automate the redirection
+        request =
+            new ClanLoungeRequest(Action.SWIMMING_POOL, CANNONBALL) {
+              @Override
+              protected boolean shouldFollowRedirect() {
+                return true;
+              }
+            };
+        RequestThread.postRequest(request);
         RequestThread.postRequest(
             new ClanLoungeSwimmingPoolRequest(ClanLoungeSwimmingPoolRequest.HANDSTAND));
         RequestThread.postRequest(

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -7348,9 +7348,18 @@ public abstract class RuntimeLibrary {
     // Just in case someone assumed that use_skill would also work
     // in combat, go ahead and allow it here.
 
-    if (SkillDatabase.isCombat(skillId) && FightRequest.getCurrentRound() > 0) {
-      return RuntimeLibrary.visit_url(
-          controller, "fight.php?action=skill&whichskill=" + (int) skill.intValue());
+    if (SkillDatabase.isCombat(skillId)) {
+      // If we are in combat, go ahead and cast using fight.php
+
+      if (FightRequest.getCurrentRound() > 0) {
+        return RuntimeLibrary.visit_url(controller, "fight.php?action=skill&whichskill=" + skillId);
+      }
+
+      // If we are not in combat, bail if the skill can't be cast
+
+      if (!SkillDatabase.isNonCombat(skillId)) {
+        return DataTypes.STRING_INIT;
+      }
     }
 
     KoLmafiaCLI.DEFAULT_SHELL.executeCommand("cast", "1 " + SkillDatabase.getSkillName(skillId));

--- a/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/TestCommand.java
@@ -493,6 +493,17 @@ public class TestCommand extends AbstractCommand {
       return;
     }
 
+    if (command.equals("lounge")) {
+      boolean old = Preferences.getBoolean("_olympicSwimmingPoolItemFound");
+      try {
+        Preferences.setBoolean("_olympicSwimmingPoolItemFound", false);
+        ClanLoungeRequest.getBreakfast();
+      } finally {
+        Preferences.setBoolean("_olympicSwimmingPoolItemFound", old);
+      }
+      return;
+    }
+
     if (command.equals("neweffect")) {
       if (split.length < 2) {
         KoLmafia.updateDisplay(MafiaState.ERROR, "test neweffect descId");

--- a/test/root/request/test_clan_cannonball.html
+++ b/test/root/request/test_clan_cannonball.html
@@ -1,0 +1,349 @@
+<html><head>
+<script language=Javascript>
+<!--
+if (parent.frames.length == 0) location.href="game.php";
+//-->
+</script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/jquery-1.5.1.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/keybinds.min.2.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/window.20111231.js"></script>
+<script language="javascript">function chatFocus(){if(top.chatpane.document.chatform.graf) top.chatpane.document.chatform.graf.focus();}
+if (typeof defaultBind != 'undefined') { defaultBind(47, 2, chatFocus); defaultBind(190, 2, chatFocus);defaultBind(191, 2, chatFocus); defaultBind(47, 8, chatFocus);defaultBind(190, 8, chatFocus); defaultBind(191, 8, chatFocus); }</script><script>
+function switchFocus()
+{
+	if (top.chatpane.document.chatform.graf.focus) 
+		top.chatpane.document.chatform.graf.focus(); 
+	return false;
+}
+function repeat()
+{
+	var linx = document.getElementsByTagName("A");
+	for (var i = 0; i < linx.length; i++)
+	{
+		if (typeof timersfunc != 'undefined') {
+			if (!timersfunc()) { 
+				return; 
+			}
+			timersfunc = null;
+		}
+		var link = linx[i];
+		if (link.innerHTML.match(/Adventure Again/) || link.innerHTML.match(/Do it again/) || (link.getAttribute && link.getAttribute('id')=='againlink'))
+			location.href = link.href;
+	}
+}
+
+defaultBind(47, CTRL, switchFocus);
+defaultBind(191, CTRL, switchFocus);
+defaultBind(47, META, switchFocus);
+defaultBind(191, META, switchFocus);
+defaultBind(192, NONE, repeat);
+defaultBind(220, NONE, repeat);
+</script><script language="javascript">
+	function updateParseItem(iid, field, info) {
+		var tbl = $('#ic'+iid);
+		var data = parseItem(tbl);
+		if (!data) return;
+		data[field] = info;
+		var out = [];
+		for (i in data) {
+			if (!data.hasOwnProperty(i)) continue;
+			out.push(i+'='+data[i]);
+		}
+		tbl.attr('rel', out.join('&'));
+	}
+	function parseItem(tbl) {
+		tbl = $(tbl);
+		var rel = tbl.attr('rel');
+		var data = {};
+		if (!rel) return data;
+		var parts = rel.split('&');
+		for (i in parts) {
+			if (!parts.hasOwnProperty(i)) continue;
+			var kv = parts[i].split('=');
+			tbl.data(kv[0], kv[1]);
+			data[kv[0]] = kv[1];
+		}
+		return data;
+	}
+</script><script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/pop_query.20230713.js"></script>
+<script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/ircm.20230626.js"></script>
+<script type="text/javascript">
+var tp = top;
+function pop_ircm_contents(i, some) {
+	var contents = '',
+		shown = 0,
+		da = '&nbsp;<a href="#" rel="?" class="small dojaxy">[some]</a>&nbsp;<a href="#" rel="',
+		db = '" class="small dojaxy">[all]</a>',
+		dc = '<div style="width:100%; padding-bottom: 3px;" rel="',
+		dd = '<a href="#" rel="1" class="small dojaxy">[';
+	one = 'one'; ss=some;
+if (i.d==1 && i.s>0) { shown++; 
+contents += dc + 'sellstuff.php?action=sell&ajax=1&type=quant&whichitem%5B%5D=IID&howmany=NUM&pwd=bb735d51b6b12b6df11ceba2f49768cb" id="pircm_'+i.id+'"><b>Auto-Sell ('+i.s+' meat):</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'inventory.php?action=closetpush&ajax=1&whichitem=IID&qty=NUM&pwd=bb735d51b6b12b6df11ceba2f49768cb" id="pircm_'+i.id+'"><b>Closet:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0 && i.g==0 && i.t==1) { shown++; 
+contents += dc + 'managestore.php?action=additem&qty1=NUM&item1=IID&price1=&limit1=&ajax=1&pwd=bb735d51b6b12b6df11ceba2f49768cb" id="pircm_'+i.id+'"><b>Stock in Mall:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'managecollection.php?action=put&ajax=1&whichitem1=IID&howmany1=NUM&pwd=bb735d51b6b12b6df11ceba2f49768cb" id="pircm_'+i.id+'"><b>Add to Display Case:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0 && i.t==1) { shown++; 
+contents += dc + 'clan_stash.php?action=addgoodies&ajax=1&item1=IID&qty1=NUM&pwd=bb735d51b6b12b6df11ceba2f49768cb" id="pircm_'+i.id+'"><b>Contribute to Clan:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && !i.ac) { shown++; 
+contents += dc + 'inv_'+(i.u=="a"?"redir":(lab=(i.u=="u"?"use":(i.u=="e"?"eat":(i.u=="b"?"booze":(i.u=="s"?"spleen":"equip"))))))+'.php?ajax=1&whichitem=IID&itemquantity=NUM&quantity=NUM'+(i.u=="q"?"&action=equip":"")+'&pwd=bb735d51b6b12b6df11ceba2f49768cb" id="pircm_'+i.id+'"><b>'+ucfirst(unescape(i.ou ? i.ou.replace(/\+/g," ") : (lab=="booze"?"drink":lab)))+':</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=1&ajax=1&whichitem=IID&action=equip&pwd=bb735d51b6b12b6df11ceba2f49768cb" id="pircm_'+i.id+'"><b>Equip (slot 1):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=2&ajax=1&whichitem=IID&action=equip&pwd=bb735d51b6b12b6df11ceba2f49768cb" id="pircm_'+i.id+'"><b>Equip (slot 2):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=3&ajax=1&whichitem=IID&action=equip&pwd=bb735d51b6b12b6df11ceba2f49768cb" id="pircm_'+i.id+'"><b>Equip (slot 3):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+
+	return [contents, shown];
+}
+tp=top
+var todo = [];
+function nextAction() {
+	var next_todo = todo.shift();
+	if (next_todo) {
+		eval(next_todo);
+	}
+}
+function dojax(dourl, afterFunc, hoverCaller, failureFunc, method, params) {
+	$.ajax({
+		type: method || 'GET', url: dourl, cache: false,
+		data: params || null,
+		global: false,
+		success: function (out) {
+			nextAction();
+			if (out.match(/no\|/)) {
+				var parts = out.split(/\|/);
+				if (failureFunc) failureFunc(parts[1]);
+				else if (window.dojaxFailure) window.dojaxFailure(parts[1]);
+				else if (tp.chatpane.handleMessage) tp.chatpane.handleMessage({type: 'event', msg: 'Oops!  Sorry, Dave, you appear to be ' + parts[1]});
+				else  $('#ChatWindow').append('<font color="green">Oops!  Sorry, Dave, you appear to be ' + parts[1] + '.</font><br />' + "\n");
+				return;
+			}
+
+			if (hoverCaller)  {
+				float_results(hoverCaller, out);
+				if (afterFunc) { afterFunc(out); }
+				return;
+			}
+$(tp.mainpane.document).find("#effdiv").remove(); if(!window.dontscroll || (window.dontscroll && dontscroll==0)) { window.scroll(0,0);}
+			var $eff = $(tp.mainpane.document).find('#effdiv');
+			if ($eff.length == 0) {
+				var d = tp.mainpane.document.createElement('DIV');
+				d.id = 'effdiv';
+				var b = tp.mainpane.document.body;
+				if ($('#content_').length > 0) {
+					b = $('#content_ div:first')[0];
+				}
+				b.insertBefore(d, b.firstChild);
+				$eff = $(d);
+			}
+			$eff.find('a[name="effdivtop"]').remove().end()
+				.prepend('<a name="effdivtop"></a><center>' + out + '</center>').css('display','block');
+			if (!window.dontscroll || (window.dontscroll && dontscroll==0)) {
+				tp.mainpane.document.location = tp.mainpane.document.location + "#effdivtop";
+			}
+			if (afterFunc) { afterFunc(out); }
+		}
+	});
+}
+</script>	<link rel="stylesheet" type="text/css" href="https://d2uyhvukfffg5a.cloudfront.net/styles.20230117d.css">
+<style type='text/css'>
+.faded {
+	zoom: 1;
+	filter: alpha(opacity=35);
+	opacity: 0.35;
+	-khtml-opacity: 0.35; 
+    -moz-opacity: 0.35;
+}
+</style>
+
+</head>
+
+<body>
+<Center><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="background-color: blue" align=center ><b style="color: white">Screwing Around!</b></td></tr><tr><td style="padding: 5px; border: 1px solid blue;"><center><table><tr><td>     
+<div id="scroller" style="height: 800px">         
+<script type="text/javascript">               
+var me = 1764512;    
+var ht = 100;   
+var maxx = 10;
+var maxy = 5;                                   
+var state ={"121572":[0,2,0,"","classav6c_f","Veracity"],"1764512":[0,0,0,"","classav3c","Tebryn"]};//foo                                                    
+var build_pool = function (state) {                                                     
+    var pool = $('#pool');                                                                 
+    var map = {}; 
+    var blind = (state[me][2] & 2) > 0;                                                            
+    for (var i in  state) {                                                             
+        var p = state[i];
+        var duck = (p[2] & 4) > 0;                
+        if (!map[p[0]]) map[p[0]] = {};
+        map[p[0]][p[1]] = i;
+        if ($('#' + i).length) {
+           var newx = (p[0] * 60);
+           var newy = (p[1] * ht);
+           $('#'+i).animate({top: newy + 'px', left: newx+'px'},1000);
+           $('#s'+i).animate({top: (newy + (duck ? 45 : 60))+'px', left: newx},1000);
+           if ((p[2] & 1) > 0) $('#'+i).addClass('flip');
+           else $('#'+i).removeClass('flip');
+        }  else {                                            
+          var div = $('<div />').addClass('p').attr('id', i); 
+          if (i != me) div.addClass('notme');                                          
+          div.css({                                                                       
+              'background-image': 'url(https://d2uyhvukfffg5a.cloudfront.net/otherimages/' + p[4]+'.gif)',                                                                          
+              'top': (p[1] * ht) + 'px',                                                 
+              'left': (p[0] * 60) + 'px'                                                  
+          });                                                                              
+          if ((p[2] & 1) > 0) div.addClass('flip');                                            
+          pool.append(div);                                                               
+                                                                                        
+          var splash = $('<div />').addClass('splash').attr('id', 's'+i).text(p[5]);                                   
+          splash.css({                                                                    
+               'top': ((p[1] * ht) + (duck ? 45 : 60)) +'px',                                            
+              'left': (p[0] * 60) + 'px'                                                  
+           })              
+          if (duck) splash.css({'background-image': 'url(https://d2uyhvukfffg5a.cloudfront.net/otherimages/clanhall/swimmingpool/duck_overlay.png)', 'line-height':'53px', height:'60px'});
+          if (i != me) splash.addClass('notme');                                          
+                                                                
+           pool.append(splash);                                                            
+       }                                                                              
+       if (p[3] && p[3].length > 2 ) {
+              var emote = p[3] && p[3][1] && p[3][0] == 1;
+              if ($('#b'+i).length) {
+                var b =$('#b'+i);
+                b.animate({top: ((p[1] * ht)-30) + 'px', left:((p[0] * 60)-10) + 'px'}, 1000).find('span').html('&nbsp;&nbsp;'+p[3][1]+'&nbsp;&nbsp;');
+                if (emote) b.removeClass('bubble').addClass('sbubble');
+                else b.removeClass('sbubble').addClass('bubble');
+              } else {                                                      
+                var bub = $('<div><span></span><div class="bubblecap"></div></div>').addClass(emote ? 'sbubble' : 'bubble').attr('id', 'b'+i);                       
+                bub.find('span').html('&nbsp;&nbsp;'+p[3][1]+'&nbsp;&nbsp;');
+                bub.css({                                                                   
+                    'top': ((p[1] * ht) - 30) + 'px',                                             
+                    'left': ((p[0] * 60) - 10) + 'px'                                             
+                });
+                //bub.append('<div class="bubblecap"></div>');
+                pool.append(bub);                                                                        
+              }
+       } else { $('#b'+i).fadeOut(200, function () { $(this).remove(); }); }
+    }  
+    if (blind) $('.notme').hide();
+    else $('.notme').show(); 
+    $('.p').each(function () {
+      var i = $(this).attr('id');
+      if (!state[i]) {
+        $(this).remove();
+        $('#s'+i).remove();
+        $('#b'+i).remove();
+      }
+    });   
+
+    var x, y, who, wid;
+    for (x=0; x<maxx; x++) {
+      for (y =0; y<maxy; y++) {
+        who = map && map[x] && map[x][y];
+        var wid = '#w' + x + '_' + y;
+        if (!who || (blind && who != me)) {
+           var w = $(wid);
+           var img = 'https://d2uyhvukfffg5a.cloudfront.net/otherimages/clanhall/swimmingpool/wave'+Math.floor(1 + (Math.random() * 8))+'.gif'
+           if (w.length == 0) {
+             w = $('<img />').addClass('water').css({
+               top: (100 * y) + 'px',
+               left: (60* x) + 'px'
+             }).attr('src', img).attr('id', wid.replace('#',''));
+             pool.append(w);
+           } else w.attr('src', img);
+           w.css('display', Math.random() > .5 ? 'block' : 'none');
+        }  else {
+          $(wid).remove();
+        }
+      }
+    }                                                                              
+};                                                                                      
+jQuery(function ($) {                                                                   
+    build_pool(state);                                                                  
+    setInterval(function () {
+      $.get('/poolstate.php', build_pool, 'json');
+    }, 5000);    
+    $('form').live('submit',function (e) {
+      $('input').attr('disable', true).css('background-color', '#ccc');
+      if ($(this).find('input[name="action"]').val() == 'leave') return true;
+      e.preventDefault();
+      $.post('/choice.php', $(this).serialize(), function (res) { 
+         var s = res.replace(/[\s\S]*\nvar state =/, '').replace(/;\/\/foo[\s\S]*/, '');
+         state = $.parseJSON(s);
+         build_pool(state);
+         $('#controls').replaceWith($(res).find('#controls'));
+         $('input').attr('disable', true).css('background-color', '#ccc');
+         setTimeout(function () { $('input').attr('disable', false).css('background-color', ''); }, 1200);
+      }); //, 'json' );
+    });                                                                          
+});                                                                                     
+</script> 
+<style type="text/css">                                                                 
+#pool .p.flip {                                                                         
+  -moz-transform: rotate(180deg);                                                       
+    -webkit-transform: rotate(180deg);                                                  
+    -ms-transform: rotate(180deg);                                                      
+    -o-transform: rotate(180deg);                                                       
+    transform: rotate(180deg);                                                          
+    background-position: 0 -50px;                                                          
+}    
+.button:active { background-color: #ccc; }                                                                                   
+.bubble { 
+  position: absolute; z-index:3; padding-top: 10px; height:40px; background-image: url(https://d2uyhvukfffg5a.cloudfront.net/otherimages/bubble.png);
+  color: black; font-size: 14px; line-height: 14px; padding-left: 10px; white-space: nowrap;
+}  
+.sbubble { 
+  position: absolute; z-index:3; padding-top: 10px; height:40px; background-image: url(https://d2uyhvukfffg5a.cloudfront.net/otherimages/sbubble.png);
+  color: black; font-size: 14px; line-height: 14px; padding-left: 10px; white-space: nowrap;
+}  
+.bubblecap { height: 50px; width:10px; position:absolute; top:0px; right:-9px; background-image: url(https://d2uyhvukfffg5a.cloudfront.net/otherimages/cap.png); }                                        
+.splash { background-repeat: no-repeat; color: black; font-size: 10px; line-height: 12px; padding-top: 10px; text-align: center; position: absolute; z-index:2; height: 15px; width: 60px; background-image: url(https://d2uyhvukfffg5a.cloudfront.net/otherimages/clanhall/swimmingpool/water_overlay.png);}  
+.water { width:60px; height; 100px; position: absolute; z-index:0; }  
+.sbubble .bubblecap { background-image: url(https://d2uyhvukfffg5a.cloudfront.net/otherimages/scap.png); }                                        
+                                                                                  
+#pool { width: 600px; height: 500px; position: relative; color: blue;}                  
+#pool .p { overflow: hidden; height: 70px; width: 60px; background-position: 0 0; position: absolute; z-index: 1; background-repeat: no-repeat;}                                                               
+#controls { position: absolute; top: 650px; width: 100%; left: 0px; }
+#controls form { display: inline; text-align: center;}
+#poolc { width: 600px; height: 500px; padding: 50px 50px 25px 50px; background-image: url(https://d2uyhvukfffg5a.cloudfront.net/otherimages/clanhall/swimmingpool/pool_background.gif); }
+</style>                                                                                
+<div id="poolc"><div id="pool"></div>
+</div>  
+
+<div id="controls" style="text-align: left;"><table cellpadding=5 cellspacing=0 align=center><tr><td width=50></td><td width=50 align=center></td><td width=50></td><td rowspan=3 width=30></td><td width=150><form method='post' action='choice.php'><input type='hidden' value='585' name='whichchoice'/><input type='hidden' value='bb735d51b6b12b6df11ceba2f49768cb' name='pwd' /><input type='hidden' name='option' value='1'/><input type='hidden' name='action' value='flip'/><input type='submit' class='button' value='Handstand' /></form></td><td width=150><form method='post' action='choice.php'><input type='hidden' value='585' name='whichchoice'/><input type='hidden' value='bb735d51b6b12b6df11ceba2f49768cb' name='pwd' /><input type='hidden' name='option' value='1'/><input type='hidden' name='action' value='blink'/><input type='submit' class='button' value='Close Eyes' /></form></td></tr><tr><td align=center></td><td></td><td align=center><form method='post' action='choice.php'><input type='hidden' value='585' name='whichchoice'/><input type='hidden' value='bb735d51b6b12b6df11ceba2f49768cb' name='pwd' /><input type='hidden' name='option' value='1'/><input type='hidden' name='action' value='right'/><input type='submit' class='button' value='Right' /></form></td><td width=150><form method='post' action='choice.php'><input type='hidden' value='585' name='whichchoice'/><input type='hidden' value='bb735d51b6b12b6df11ceba2f49768cb' name='pwd' /><input type='hidden' name='option' value='1'/><input type='hidden' name='action' value='leave'/><input type='submit' class='button' value='Get Out' /></form></td><td width=150></td></tr><tr><td width=50></td><td width=50 align=center><form method='post' action='choice.php'><input type='hidden' value='585' name='whichchoice'/><input type='hidden' value='bb735d51b6b12b6df11ceba2f49768cb' name='pwd' /><input type='hidden' name='option' value='1'/><input type='hidden' name='action' value='down'/><input type='submit' class='button' value='Down' /></form></td><td width=50></td><td colspan=2><form method='post' action='choice.php'><input type='hidden' value='585' name='whichchoice'/><input type='hidden' value='bb735d51b6b12b6df11ceba2f49768cb' name='pwd' /><input type='hidden' name='option' value='1'/><input type='hidden' name='action' value='say'/><input type='submit' class='button' value='Say:' /><input type='text' name='say' maxlength='30' size='30' /></form></td></tr></table></div></div></td></tr></table></center></td></tr><tr><td height=4></td></tr></table></body></html>


### PR DESCRIPTION
1) Breakfast in a clan with a swimming pool started issuing an "Unexpected choice" error message.
Turns this is due to the recent change for detecting if we are still in a choice: cannonballing into the swimming pool redirects to a choice, but we didn't used to recognize we were in a choice. Now we do, and ChoiceManager wanted to automate it - and couldn't.

Subsequent requests were in ClanLoungeSwimmingPoolRequest, which already tells ChoiceManager to not automate.

I changed ClanLoungeRequest to automatically follow the redirect - like ClanLoungeSwimmingPoolRequest - for the "cannonball into the swimming pool" request.

I did not make every request of class do that, since there are a bunch of other redirections which we want to detect.
The difference is, I think, that those others do not go to choice.php.

2) I've been getting a lot of "Could not find a known, usable skill of yours uniquely matching "1 Saucegeyser".

Somehow, my ShadowRiftConsultScript was getting called after battles were complete - and not in the ShadowRift.
I have no idea how that could happen; my CCS had a Shadow Rift section which called it, but I SHOULD only be using that CCS when I am in my ShadowRift script. And it doesn't even need to be in the CCS; my script sets battleAction to use it, and restores it in try/finally.

I am going to try to figure out that mystery, but it revealed a bug in the ASH runtime:

use_skill($skill)
use_skill($skill, count)

both say
```
    // Just in case someone assumed that use_skill would also work
    // in combat, go ahead and allow it here.
```
The former would do that only if it is a combat skill FightRequest.currentRound was not 0 - i.e., we were in combat.
Otherwise, it would fall through to the "cast" CLI command.

The latter did the same for combat skills - but if you were NOT in combat, it would only "cast" if it was also a non-combat skill.

I fixed the one-arg form of the function to do the same.