### PR TITLE
removed coinmasters can be accessible

### DIFF
--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -1469,15 +1469,14 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   }
 
   public String accessible() {
-    // Returns an error reason or null
-    if ("Removed".equals(this.getRootZone())) {
-      return "Zone is no longer accessible";
-    }
-
     return this.accessible.get();
   }
 
   public String accessibleInternal() {
+    // Returns an error reason or null
+    if ("Removed".equals(this.getRootZone())) {
+      return "Zone is no longer accessible";
+    }
     return null;
   }
 

--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -1469,14 +1469,14 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   }
 
   public String accessible() {
-    return this.accessible.get();
+    String reason = this.accessible.get();
+    if (reason == null && "Removed".equals(this.getRootZone())) {
+      reason = "Zone is no longer accessible";
+    }
+    return reason;
   }
 
   public String accessibleInternal() {
-    // Returns an error reason or null
-    if ("Removed".equals(this.getRootZone())) {
-      return "Zone is no longer accessible";
-    }
     return null;
   }
 

--- a/src/net/sourceforge/kolmafia/CoinmasterData.java
+++ b/src/net/sourceforge/kolmafia/CoinmasterData.java
@@ -1469,14 +1469,14 @@ public class CoinmasterData implements Comparable<CoinmasterData> {
   }
 
   public String accessible() {
-    String reason = this.accessible.get();
-    if (reason == null && "Removed".equals(this.getRootZone())) {
-      reason = "Zone is no longer accessible";
-    }
-    return reason;
+    return this.accessible.get();
   }
 
   public String accessibleInternal() {
+    // Returns an error reason or null
+    if ("Removed".equals(this.getRootZone())) {
+      return "Zone is no longer accessible";
+    }
     return null;
   }
 


### PR DESCRIPTION
In particular, the Cheer-o-Vend 3000, even though Crimbo17 is Removed.

The "Removed" check was intended to allow coinmasters in a zone to have accessible methods and not have to edit the method, if the zone itself is Removed, but, we can't quite do that. We CAN delete the custom method, usually.

```
> inv crystalline cheer

> ash is_accessible($coinmaster[Cheer-o-Vend 3000])

Returned: false

> ash inaccessible_reason($coinmaster[Cheer-o-Vend 3000])

Returned: You need some crystalline cheer.

> pull 1 crystalline cheer

Pulling items from storage...
Requests complete.

> ash is_accessible($coinmaster[Cheer-o-Vend 3000])

Returned: true
```