### PR TITLE
fix: warbear foil hat uses a hardcoded list of robots

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -552,7 +552,7 @@ Item	warbear fancy fedora	Initiative: -25, Maximum HP: -50, Maximum MP: -50, Las
 # warbear feathered fedora: +10% Item Drops from WarBears
 Item	warbear feathered fedora	Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
 # warbear foil hat: (additional +10 lbs. to Robotic Familiars)
-Item	warbear foil hat	Familiar Weight: [5+10*famattr(robot)], Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
+Item	warbear foil hat	Familiar Weight: [5+10*warbearfoilhat], Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 Item	warbear heated ushanka	Supercold Resistance: +3, Weapon Damage Percent: -25, Spell Damage Percent: -50, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 Item	warbear lined ushanka	Supercold Resistance: +2, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
 # warbear plain fedora: +5% Item Drops from WarBears

--- a/src/net/sourceforge/kolmafia/Expression.java
+++ b/src/net/sourceforge/kolmafia/Expression.java
@@ -6,6 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
+import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
@@ -396,6 +397,34 @@ public class Expression {
           String arg = (String) this.literals.get((int) s[--sp]);
           v = StringUtilities.parseRomanNumerals(arg);
         }
+          // Valid with Modifier Expression:
+        case '\u008b' -> v =
+            switch (KoLCharacter.getFamiliar().getId()) {
+              case FamiliarPool.AUTONOMOUS_DISCO_BALL,
+                  FamiliarPool.CLOCKWORK_GRAPEFRUIT,
+                  FamiliarPool.PRESSIE,
+                  FamiliarPool.CYMBAL_PLAYING_MONKEY,
+                  FamiliarPool.DATASPIDER,
+                  FamiliarPool.MEGADRONE,
+                  FamiliarPool.HOMEMADE_ROBOT,
+                  FamiliarPool.MAGIMECHTECH_MICROMECHAMECH,
+                  FamiliarPool.MECHANICAL_SONGBIRD,
+                  FamiliarPool.MINI_CRIMBOT,
+                  FamiliarPool.NANORHINO,
+                  FamiliarPool.NINJA_PIRATE_ZOMBIE_ROBOT,
+                  FamiliarPool.OAF,
+                  FamiliarPool.POCKET_PROFESSOR,
+                  FamiliarPool.ROBOGOOSE,
+                  FamiliarPool.ROBORTENDER,
+                  FamiliarPool.ROBOT_REINDEER,
+                  FamiliarPool.ORB,
+                  FamiliarPool.STEAM_CHEERLEADER,
+                  FamiliarPool.SWEET_NUTCRACKER,
+                  FamiliarPool.TEDDY_BORG,
+                  FamiliarPool.WARBEAR_DRONE,
+                  FamiliarPool.WIND_UP_CHATTERING_TEETH -> 1;
+              default -> 0;
+            };
           // Valid with Modifier Expression:
         case '\u0097' -> v = KoLCharacter.getBaseMuscle();
 

--- a/src/net/sourceforge/kolmafia/Expression.java
+++ b/src/net/sourceforge/kolmafia/Expression.java
@@ -399,7 +399,7 @@ public class Expression {
         }
           // Valid with Modifier Expression:
         case '\u008b' -> v =
-            switch (KoLCharacter.getFamiliar().getId()) {
+            switch (FamiliarDatabase.getFamiliarId(Modifiers.currentFamiliar)) {
               case FamiliarPool.AUTONOMOUS_DISCO_BALL,
                   FamiliarPool.CLOCKWORK_GRAPEFRUIT,
                   FamiliarPool.PRESSIE,

--- a/src/net/sourceforge/kolmafia/Expression.java
+++ b/src/net/sourceforge/kolmafia/Expression.java
@@ -410,6 +410,7 @@ public class Expression {
                   FamiliarPool.MAGIMECHTECH_MICROMECHAMECH,
                   FamiliarPool.MECHANICAL_SONGBIRD,
                   FamiliarPool.MINI_CRIMBOT,
+                  FamiliarPool.MINIMECHAELF,
                   FamiliarPool.NANORHINO,
                   FamiliarPool.NINJA_PIRATE_ZOMBIE_ROBOT,
                   FamiliarPool.OAF,

--- a/src/net/sourceforge/kolmafia/ModifierExpression.java
+++ b/src/net/sourceforge/kolmafia/ModifierExpression.java
@@ -107,6 +107,9 @@ public class ModifierExpression extends Expression {
     if (this.optional("roman(")) {
       return this.literal(this.until(")"), '\u008a');
     }
+    if (this.optional("warbearfoilhat")) {
+      return "\u008b";
+    }
     if (this.optional("mus")) {
       return "\u0080";
     }

--- a/src/net/sourceforge/kolmafia/objectpool/FamiliarPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/FamiliarPool.java
@@ -20,12 +20,18 @@ public class FamiliarPool {
   public static final int HAND_TURKEY = 25;
   public static final int CRIMBO_ELF = 26;
   public static final int EMO_SQUID = 30;
+  public static final int CLOCKWORK_GRAPEFRUIT = 32;
+  public static final int MAGIMECHTECH_MICROMECHAMECH = 33;
   public static final int DODECAPEDE = 38;
   public static final int PYGMY_BUGBEAR_SHAMAN = 39;
   public static final int DOPPEL = 40;
+  public static final int CYMBAL_PLAYING_MONKEY = 42;
   public static final int RIFTLET = 43;
+  public static final int SWEET_NUTCRACKER = 44;
   public static final int PET_ROCK = 45;
+  public static final int NINJA_PIRATE_ZOMBIE_ROBOT = 48;
   public static final int HARE = 50;
+  public static final int WIND_UP_CHATTERING_TEETH = 51;
   public static final int HOBO = 52;
   public static final int BADGER = 53;
   public static final int CHAMELEON = 54;
@@ -41,9 +47,12 @@ public class FamiliarPool {
   public static final int GHOST = 74;
   public static final int PRESSIE = 77;
   public static final int BUDDY_BOX = 78;
+  public static final int TEDDY_BORG = 79;
+  public static final int ROBOGOOSE = 80;
   public static final int MEGADRONE = 81;
   public static final int HATRACK = 82;
   public static final int ADORABLE_SEAL_LARVA = 83;
+  public static final int AUTONOMOUS_DISCO_BALL = 87;
   public static final int LLAMA = 90;
   public static final int CARNIE = 91;
   public static final int HAND = 92;
@@ -69,6 +78,7 @@ public class FamiliarPool {
   public static final int TRON = 135;
   public static final int HIPSTER = 136;
   public static final int GRINDER = 139;
+  public static final int ROBOT_REINDEER = 143;
   public static final int OBTUSE_ANGEL = 146;
   public static final int CROW = 147;
   public static final int ALIEN = 148;
@@ -91,6 +101,7 @@ public class FamiliarPool {
   public static final int CUBELING = 171;
   public static final int MECHANICAL_SONGBIRD = 175;
   public static final int REANIMATOR = 176;
+  public static final int WARBEAR_DRONE = 177;
   public static final int GRIMSTONE_GOLEM = 178;
   public static final int GRIM_BROTHER = 179;
   public static final int SWORD_AND_MARTINI_GUY = 180;
@@ -98,6 +109,7 @@ public class FamiliarPool {
   public static final int GALLOPING_GRILL = 183;
   public static final int FIST_TURKEY = 188;
   public static final int CRIMBO_SHRUB = 189;
+  public static final int MINI_CRIMBOT = 190;
   public static final int GOLDEN_MONKEY = 192;
   public static final int ADVENTUROUS_SPELUNKER = 193;
   public static final int PUCK_MAN = 196;

--- a/src/net/sourceforge/kolmafia/objectpool/FamiliarPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/FamiliarPool.java
@@ -97,6 +97,7 @@ public class FamiliarPool {
   public static final int NANORHINO = 167;
   public static final int WOIM = 168;
   public static final int HOMEMADE_ROBOT = 169;
+  public static final int MINIMECHAELF = 170;
   public static final int NOSY_NOSE = 173;
   public static final int CUBELING = 171;
   public static final int MECHANICAL_SONGBIRD = 175;

--- a/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
+++ b/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
@@ -533,6 +533,15 @@ public class ModifierExpressionTest {
   }
 
   @Test
+  public void canDetectWarbearFoilHatRobots() {
+    var cleanups = new Cleanups(withFamiliar(FamiliarPool.DATASPIDER));
+    try (cleanups) {
+      var exp = new ModifierExpression("warbearfoilhat", "Warbear Foil Hat");
+      assertThat(exp.eval(), is(1.0));
+    }
+  }
+
+  @Test
   public void canDetectBaseMuscle() {
     var cleanups = new Cleanups(withMuscle(4, 60));
     try (cleanups) {


### PR DESCRIPTION
For example, Dataspider and Pocket Professor count for this but aren't robots in Zoot.