### PR TITLE
fix: track machine elf adventures while using comma

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -3559,7 +3559,7 @@ public class FightRequest extends GenericRequest {
       KoLCharacter.getFamiliar().addCombatExperience(responseText);
       EdServantData.currentServant().addCombatExperience(responseText);
 
-      switch (familiar.getId()) {
+      switch (familiar.getEffectiveId()) {
         case FamiliarPool.RIFTLET -> {
           if (responseText.contains("shimmers briefly, and you feel it getting earlier.")) {
             Preferences.increment("_riftletAdv", 1);


### PR DESCRIPTION
As requested in https://kolmafia.us/threads/comma-chameleon-acting-as-machine-elf-does-not-increment-_machinetunnelsadv.30440/.

Tracks all the other familiar preferences as well, when using comma. I assume they all work.