### PR TITLE
Revert "no changing familiar nag in Zootomist"

### DIFF
--- a/src/net/sourceforge/kolmafia/request/RelayRequest.java
+++ b/src/net/sourceforge/kolmafia/request/RelayRequest.java
@@ -2510,8 +2510,7 @@ public class RelayRequest extends PasswordHashRequest {
 
     if (!KoLCharacter.getPath().canUseFamiliars()
         || KoLCharacter.inPokefam()
-        || KoLCharacter.inQuantum()
-        || KoLCharacter.inZootomist()) {
+        || KoLCharacter.inQuantum()) {
       return false;
     }
 


### PR DESCRIPTION
Reverts kolmafia/kolmafia#2840

As @Tokoeka [mentioned](https://github.com/kolmafia/kolmafia/pull/2840#issuecomment-2732037297), completing a 100% familiar run is possible in this path and the nag was useful in doing so.

As someone who doesn't do 100% familiar runs, the feature is not useful to me at all, so proposing a revert as a neutral observer :)