### PR TITLE
feat: add types for zoot fams, split delevel before and during combat

### DIFF
--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -14,7 +14,8 @@
 # combat1 - Elemental Attack
 # drop - special drop
 # block - potato-like
-# delevel - barrrnacle-like
+# delevel0 - barrrnacle-like, delevels at start of combat
+# delevel1 - ghost pickle-like, delevels during combat
 # hp0 - restore hp during combat
 # mp0 - restore mp during combat
 # meat1 - drops meat during combat
@@ -35,9 +36,9 @@
 3	Levitating Potato	familiar3.gif	block	potato sprout	many-eyed glasses	0	1	2	3	organic,vegetable,haseyes,hovers,edible,food
 4	Angry Goat	familiar4.gif	combat0,combat1	goat	prosthetic forehead	3	0	2	1	sentient,organic,hasbones,haseyes,bite,haslegs,fast,stench,animal
 5	Sabre-Toothed Lime	familiar5.gif	combat0	sabre-toothed lime cub	tiny shaker of salt	3	0	2	1	sentient,organic,vegetable,bite,food,cute
-6	Fuzzy Dice	familiar6.gif	combat0,delevel,meat1,mp0,hp0	fuzzy dice	meatcar model	2	2	2	2	mineral,object,polygonal
-7	Spooky Pirate Skeleton	familiar7.gif	combat1,delevel	spooky pirate skeleton	blundarrrbus	2	3	1	0	sentient,organic,humanoid,undead,mineral,hasbones,haseyes,hashands,haslegs,hard,spooky,evil,cantalk
-8	Barrrnacle	familiar8.gif	delevel,underwater	barrrnacle	sucky decal	0	2	1	3	sentient,organic,swims,aquatic,hasshell,animal
+6	Fuzzy Dice	familiar6.gif	combat0,delevel1,meat1,mp0,hp0	fuzzy dice	meatcar model	2	2	2	2	mineral,object,polygonal
+7	Spooky Pirate Skeleton	familiar7.gif	combat1,delevel1	spooky pirate skeleton	blundarrrbus	2	3	1	0	sentient,organic,humanoid,undead,mineral,hasbones,haseyes,hashands,haslegs,hard,spooky,evil,cantalk
+8	Barrrnacle	familiar8.gif	delevel0,underwater	barrrnacle	sucky decal	0	2	1	3	sentient,organic,swims,aquatic,hasshell,animal
 9	Howling Balloon Monkey	familiar9.gif	combat0,mp0	balloon monkey	tiny balloon knife	1	3	2	0	sentient,humanoid,mineral,object,haslegs,hovers,animal
 10	Stab Bat	familiar10.gif	combat0	rewinged stab bat	shock collar	3	2	1	0	sentient,organic,hasbones,haseyes,haswings,flies,fast,phallic,spooky,evil,reallyevil,hasstinger,animal
 11	Grue	familiar11.gif	combat1	grue egg	moonglasses	2	0	1	3	sentient,organic,hasbones,haseyes,bite,flies,orb,spooky,evil,animal
@@ -45,10 +46,10 @@
 13
 14	Ghuol Whelp	familiar14.gif	hp1,mp1	fertilized ghuol egg	tiny knife and fork	1	2	0	3	sentient,organic,humanoid,person,undead,hasbones,haseyes,bite,hashands,hasclaws,haslegs,cute,spooky,evil
 15	Baby Gravy Fairy	familiar15.gif	item0	pregnant mushroom	eye-pod	0	3	1	2	sentient,vegetable,hasbones,haseyes,haswings,flies,cute,good
-16	Cocoabo	familiar16.gif	combat0,delevel,hp0,mp0,meat1	cocoa egg	chocolate spurs	2	3	0	1	sentient,hasbones,haseyes,hasclaws,haslegs,haswings,edible,food,cute,good,hasbeak,animal
+16	Cocoabo	familiar16.gif	combat0,delevel1,hp0,mp0,meat1	cocoa egg	chocolate spurs	2	3	0	1	sentient,hasbones,haseyes,hasclaws,haslegs,haswings,edible,food,cute,good,hasbeak,animal
 17	Star Starfish	familiar17.gif	combat0,mp0	star starfish	magnifying glass	2	1	3	0	sentient,flies,swims,aquatic,sleaze,animal
 18	Hovering Sombrero	hat2.gif	stat1	hovering sombrero	tiny maracas	0	3	2	1	undead,mineral,object,hovers,isclothes
-19	Ghost Pickle on a Stick	familiar19.gif	combat0,delevel	ghost pickle on a stick	skewer-mounted razor blade	3	1	0	2	undead,vegetable,object,hovers,phallic,edible,food,stench
+19	Ghost Pickle on a Stick	familiar19.gif	combat0,delevel1	ghost pickle on a stick	skewer-mounted razor blade	3	1	0	2	undead,vegetable,object,hovers,phallic,edible,food,stench
 20	Killer Bee	familiar20.gif	combat0,stat2	baby killer bee	brass stinger	3	1	2	0	sentient,organic,insect,haswings,flies,fast,evil,hasstinger,animal
 21	Whirling Maple Leaf	familiar21.gif	combat0,mp1	maple leaf	tiny Mountie hat	3	1	2	0	organic,vegetable,hovers,fast
 22	Coffee Pixie	familiar22.gif	item0,meat0	coffee sprite	miniature espresso maker	1	1	3	2	hashands,haseyes,haswings,fast,flies
@@ -59,8 +60,8 @@
 27	Hanukkimbo Dreidl	familiar27.gif	combat0,block,mp0,meat1	Hanukkimbo dreidl	menorette	2	1	3	1
 28	Baby Yeti	familiar28.gif	combat1,mp0	orphan baby yeti	penguin-smacking club	3	1	1	2	hashands,wearsclothes,animal,haseyes,bite
 29	Feather Boa Constrictor	familiar29.gif	combat1,block,meat1	silk garter snake	velvet choker	2	3	1	1	sentient,haseyes,phallic,isclothes,sleaze,animal
-30	Emo Squid	familiar30.gif	block,delevel,underwater	emo roe	gazing shoes	1	3	1	2	animal,haseyes
-31	Personal Raincloud	familiar31.gif	combat0,delevel,hp0,mp0,hp1,mp1,stat3	personal raindrop	rainbow tie	2	1	3	1	object,hovers
+30	Emo Squid	familiar30.gif	block,delevel0,underwater	emo roe	gazing shoes	1	3	1	2	animal,haseyes
+31	Personal Raincloud	familiar31.gif	combat0,delevel1,hp0,mp0,hp1,mp1,stat3	personal raindrop	rainbow tie	2	1	3	1	object,hovers
 32	Clockwork Grapefruit	familiar32.gif	combat0	unwound clockwork grapefruit	false eyelashes	3	2	0	1	organic,vegetable,object,robot,haslegs,edible,food,orb,evil,technological
 33	MagiMechTech MicroMechaMech	familiar33.gif	combat0,combat1	deactivated MicroMechaMech	targeting chip	3	0	1	2	mineral,robot,haslegs,hard,technological
 34	Flaming Gravy Fairy	familiar34.gif	combat1,item0	pregnant flaming mushroom	flaming glowsticks	2	3	1	2	sentient,vegetable,hasbones,haseyes,haswings,flies,cute,hot,good
@@ -72,19 +73,19 @@
 40	Doppelshifter	familiar40.gif	variable	doppelshifter egg	tiny makeup kit	3	3	3	3	sentient,haseyes
 41	Attention-Deficit Demon	familiar41.gif	item0,meat0	calm attention-deficit demon	attention spanner	1	1	3	2	hashands,haseyes,haswings,fast,evil,hot,flies
 42	Cymbal-Playing Monkey	familiar42.gif	stat0,meat0	unwound cymbal-playing monkey	funky brass fez	1	2	3	1	sentient,organic,humanoid,object,robot,hasbones,haseyes,hashands,haslegs,wearsclothes,spooky,evil,animatedart,technological,animal
-43	Temporal Riftlet	familiar43.gif	block,delevel,other1	miniscule temporal rip	1.21 jigawatts	1	3	1	2	object,hovers
+43	Temporal Riftlet	familiar43.gif	block,delevel0,other1	miniscule temporal rip	1.21 jigawatts	1	3	1	2	object,hovers
 44	Sweet Nutcracker	familiar44.gif	combat0,other0	sweet nutcracker	metal mandible	2	3	0	2	wearsclothes,haseyes,robot
 45	Pet Rock	familiar45.gif	none	pet rock	pet rock &quot;Snooty&quot; disguise	0	0	0	0	mineral,object,haseyes,polygonal
 46	Snowy Owl	familiar46.gif	combat0	sleeping snowy owl	Pretty Predator Clawicure Kit	3	3	3	3	sentient,organic,hasbones,haseyes,bite,hasclaws,haslegs,haswings,flies,cute,cold,hasbeak,animal
 47	Teddy Bear	familiar47.gif	other0	teddy bear	teddy bear sewing kit	3	2	0	1	humanoid,object,haseyes,bite,hasclaws,haslegs,cute,good,animal
-48	Ninja Pirate Zombie Robot	npzr.gif	combat0,block,delevel,hp0,mp0,meat1,other0	ninja pirate zombie robot	rhesus monkey	3	3	3	3	sentient,humanoid,person,undead,robot,hasbones,haseyes,hashands,hasclaws,haslegs,fast,hard,wearsclothes,spooky,evil,cantalk,technological
+48	Ninja Pirate Zombie Robot	npzr.gif	combat0,block,delevel1,hp0,mp0,meat1,other0	ninja pirate zombie robot	rhesus monkey	3	3	3	3	sentient,humanoid,person,undead,robot,hasbones,haseyes,hashands,hasclaws,haslegs,fast,hard,wearsclothes,spooky,evil,cantalk,technological
 49	Sleazy Gravy Fairy	slgfairy.gif	combat1,item0	pregnant oily golden mushroom	hot pink lipstick	3	3	2	1	sentient,person,vegetable,hasbones,haseyes,haswings,flies,cute,sleaze,good
 50	Wild Hare	hare.gif	item0,meat0,stat0,hp1,mp1,other1	March hat	miniature dormouse	1	3	2	0	animal,haseyes,fast
 51	Wind-up Chattering Teeth	chatteeth.gif	combat0	wind-up chattering teeth	diamond-studded fronts	3	0	2	1	mineral,object,robot,bite,hard,spooky
 52	Spirit Hobo	ghobo.gif	combat0,mp0,stat0	homeless hobo spirit	weegee sqouija	2	1	3	0	sentient,humanoid,person,undead,haseyes,hashands,haslegs,hovers,stench,cantalk
 53	Astral Badger	badger.gif	combat0,drop	astral badger	badger badge	3	0	2	3	animal,hashands,haseyes
 54	Comma Chameleon	commacha.gif	variable	Comma Chameleon egg		0	0	0	2	sentient,organic,hasbones,haseyes,hashands,haslegs,cute,animal
-55	Misshapen Animal Skeleton	animskel.gif	combat0,combat1,delevel	misshapen animal skeleton	bone collar	3	2	1	2	sentient,organic,undead,mineral,hasbones,haseyes,bite,hashands,hasclaws,haslegs,hard,orb,cute,spooky,evil
+55	Misshapen Animal Skeleton	animskel.gif	combat0,combat1,delevel1	misshapen animal skeleton	bone collar	3	2	1	2	sentient,organic,undead,mineral,hasbones,haseyes,bite,hashands,hasclaws,haslegs,hard,orb,cute,spooky,evil
 56	Scary Death Orb	orb.gif	combat1	scary death orb	tuning fork	3	2	1	0	mineral,object,hovers,fast,hard,spooky,evil,reallyevil,technological
 57	Jitterbug	jitterbug.gif	item0,meat0	jitterbug larva	bottle of perfume	1	3	2	2	animal,haseyes,fast
 58	Nervous Tick	tick.gif	stat0,meat0	nervous tick egg	spoon!	0	3	2	2	animal,haseyes,fast,bite
@@ -97,29 +98,29 @@
 65	Ancient Yuletide Troll	crimbotroll.gif	hp1,mp1,stat0,drop	yuletide troll chrysalis	giant book of ancient carols	2	3	1	0	sentient,humanoid,person,hasbones,haseyes,hashands,hasclaws,haslegs,phallic,cold,evil,cantalk
 66	Dandy Lion	dandylion.gif	hp1,mp1,item0	dandy lion cub	woolen cravat	0	3	2	1	sentient,organic,object,hasbones,haseyes,hasclaws,haslegs,sleaze,cantalk,animal
 67	O.A.F.	oaf.gif	none	Deactivated O. A. F.	hardware upgrade	0	0	0	0	humanoid,mineral,robot,haseyes,haslegs,hard,polygonal,cute,good,evil,cantalk,technological
-68	Penguin Goodfella	goodfella.gif	delevel,stat0,drop	bad penguin egg	tasteful black bow tie	3	2	1	0	sentient,organic,person,hasbones,haseyes,haslegs,haswings,swims,aquatic,sleaze,evil,hasbeak,cantalk,animal
+68	Penguin Goodfella	goodfella.gif	delevel0,stat0,drop	bad penguin egg	tasteful black bow tie	3	2	1	0	sentient,organic,person,hasbones,haseyes,haslegs,haswings,swims,aquatic,sleaze,evil,hasbeak,cantalk,animal
 69	Jumpsuited Hound Dog	hounddog.gif	item0	pompadour'd puppy	blue suede shoes	1	3	3	2	sentient,organic,humanoid,person,hasbones,haseyes,bite,hashands,hasclaws,haslegs,wearsclothes,animal
 70	Green Pixie	pictsie.gif	combat0,item0,drop	bottled green pixie	green pixie spog	3	2	0	2	sentient,humanoid,person,hasbones,haseyes,hashands,haslegs,haswings,flies,fast,wearsclothes,cute,good,cantalk
 71	Ragamuffin Imp	ragimp.gif	combat1	pile of smoking rags		3	3	3	3	sentient,organic,humanoid,person,hasbones,haseyes,hashands,hasclaws,haslegs,haswings,flies,wearsclothes,cute,hot,evil
 72	Exotic Parrot	parrot.gif	passive	exotic parrot egg	cracker	3	3	2	0	sentient,organic,hasbones,haseyes,bite,hasclaws,haslegs,haswings,flies,cute,hot,cold,spooky,stench,sleaze,hasbeak,cantalk,animal
-73	Wizard Action Figure	waf.gif	combat1,delevel,hp0,stat0,item0	wizard action figure	mint-condition magic wand	2	3	2	2	hashands,wearsclothes,haseyes
+73	Wizard Action Figure	waf.gif	combat1,delevel0,hp0,stat0,item0	wizard action figure	mint-condition magic wand	2	3	2	2	hashands,wearsclothes,haseyes
 74	Gluttonous Green Ghost	ggg.gif	combat0,mp0,stat0,other1	class five ecto-larva	plastic bib	2	3	3	1	hashands,haseyes,sleaze,undead,evil,bite
 75	Casagnova Gnome	cassagnome.gif	item0,meat0	siesta-ing Casagnova gnome	miniature castagnets	0	1	3	2	sentient,organic,humanoid,person,hasbones,haseyes,hashands,haslegs,wearsclothes,orb,cute,sleaze,animatedart
 76	Hunchbacked Minion	hunchback.gif	stat0,meat0	unemployed hunchbacked minion	miniature Jacob's ladder	1	3	0	2	hashands,wearsclothes,haseyes
-77	Crimbo P. R. E. S. S. I. E.	pressiebot.gif	combat0,stat0,block,delevel,mp0,other0	Crimbo P. R. E. S. S. I. E.	metallic foil bow	3	2	0	1	humanoid,mineral,object,robot,haseyes,hashands,haslegs,hard,technological
+77	Crimbo P. R. E. S. S. I. E.	pressiebot.gif	combat0,stat0,block,delevel1,mp0,other0	Crimbo P. R. E. S. S. I. E.	metallic foil bow	3	2	0	1	humanoid,mineral,object,robot,haseyes,hashands,haslegs,hard,technological
 78	Bulky Buddy Box	wcb.gif	none	Bulky Buddy Box		0	0	0	0	mineral,object,hard,polygonal,cute,technological
 79	Teddy Borg	teddyborg.gif	other0	teddy borg	teddy borg sewing kit	3	2	0	1	sentient,humanoid,mineral,object,robot,haseyes,bite,hasclaws,haslegs,cute,evil,technological
-80	RoboGoose	robogoose.gif	combat0,block,delevel,hp0,drop	deactivated RoboGoose	overclocked avian microprocessor	2	3	1	0	mineral,robot,haseyes,haslegs,haswings,flies,hard,hasbeak,technological,animal
+80	RoboGoose	robogoose.gif	combat0,block,delevel1,hp0,drop	deactivated RoboGoose	overclocked avian microprocessor	2	3	1	0	mineral,robot,haseyes,haslegs,haswings,flies,hard,hasbeak,technological,animal
 81	El Vibrato Megadrone	megadrone.gif	variable	El Vibrato Megadrone		3	3	3	3	mineral,robot,hovers,hard,polygonal,animatedart,technological
 82	Mad Hatrack	hatrack.gif	variable	sane hatrack		3	0	1	2	wearsclothes,haseyes
 83	Adorable Seal Larva	seallarva.gif	combat0,hp0,variable	adorable seal larva	pretty pink bow	3	2	1	2	sentient,organic,hasbones,haseyes,bite,haslegs,aquatic,cute,evil,reallyevil,animal
 84	Untamed Turtle	untamed.gif	block,variable	untamable turtle	smiley-face sticker	0	0	0	3	sentient,organic,hasbones,haseyes,bite,haslegs,aquatic,hasshell,animal
 85	Animated Macaroni Duck	macaroniduck.gif	combat0,mp0,variable	macaroni duck	farfalle bow tie	2	2	2	2	sentient,vegetable,object,hasbones,haseyes,haslegs,haswings,flies,hard,edible,food,hasbeak,animal
 86	Pet Cheezling	cheezblob.gif	hp1,mp1,variable	friendly cheez blob	jalape&ntilde;o slices	2	2	0	2	sentient,mineral,object,haseyes,edible,food,cute,hot,stench,sleaze
-87	Autonomous Disco Ball	discoball.gif	combat0,delevel,variable	unusual disco ball	stick-on mini solar panels	3	2	1	0	mineral,object,robot,hovers,hard,orb,technological
+87	Autonomous Disco Ball	discoball.gif	combat0,delevel1,variable	unusual disco ball	stick-on mini solar panels	3	2	1	0	mineral,object,robot,hovers,hard,orb,technological
 88	Mariachi Chihuahua	chihuahua.gif	combat0,variable	stray chihuahua	tiny sombrero	3	2	1	0	sentient,organic,hasbones,haseyes,hasclaws,haslegs,cute,evil,animal
 89	Hobo Monkey	hobomonkey.gif	meat0,meat1	hobo monkey	tiny bindle	0	3	3	3	sentient,organic,humanoid,hasbones,haseyes,hashands,haslegs,wearsclothes,cute,stench,animal
-90	Llama Lama	llama.gif	stat0,delevel,drop	llama lama cria	zen motorcycle	1	2	3	2	sentient,organic,hasbones,haseyes,haslegs,good,cantalk,animal
+90	Llama Lama	llama.gif	stat0,delevel1,drop	llama lama cria	zen motorcycle	1	2	3	2	sentient,organic,hasbones,haseyes,haslegs,good,cantalk,animal
 91	Cotton Candy Carnie	cccarnie.gif	block,hp1,mp1,drop	cotton candy cocoon	cotton candy cordial	0	2	2	3	sentient,person,vegetable,object,haseyes,haslegs,edible,food,cantalk
 92	Disembodied Hand	dishand.gif	combat0,variable	spooky rattling cigar box		3	2	0	2	organic,undead,hasbones,hashands,spooky
 93	Black Cat	blackcat.gif	none	black kitten		0	0	0	0	sentient,organic,hasbones,haseyes,bite,hasclaws,haslegs,spooky,evil,animal
@@ -132,7 +133,7 @@
 100	Cuddlefish	cuddlefish.gif	block,hp1,mp1,underwater	baby cuddlefish	six-armed sweater	0	1	3	3	sentient,organic,hasbones,haseyes,haslegs,swims,aquatic,cute,animal
 101	Sugar Fruit Fairy	sugarfairy.gif	stat0,item0,other1,drop	candy cornucopia	tiny ballet slippers	0	3	3	2	sentient,person,vegetable,hasbones,haseyes,haswings,flies,edible,food,wearsclothes,cute,good,cantalk
 102	Imitation Crab	crab.gif	combat0,underwater	imitation crab zoea	imitation whetstone	3	1	2	2	sentient,haseyes,hasclaws,haslegs,swims,aquatic,fast,food,animal
-103	Pair of Ragged Claws	raggedclaws.gif	combat0,combat1,delevel	pair of ragged claws	radioactive chew toy	1	1	1	1	object,undead,hashands,hasclaws,haslegs,fast,evil
+103	Pair of Ragged Claws	raggedclaws.gif	combat0,combat1,delevel0	pair of ragged claws	radioactive chew toy	1	1	1	1	object,undead,hashands,hasclaws,haslegs,fast,evil
 104	Magic Dragonfish	dragonfishfam.gif	passive,underwater	magic dragonfish fry	fin-bit wax	1	1	2	0	sentient,organic,hasbones,haseyes,swims,aquatic,animal
 105	Frumious Bandersnatch	bandersnatch.gif	other0,variable,stat0	Apathargic Bandersnatch	aquaviolet jub-jub bird	3	2	2	0	sentient,organic,hasbones,haseyes,haslegs,haswings,fast,animal
 106	Midget Clownfish	midgetclownfish.gif	combat1,mp0,underwater	midget clownfish	half-height unicycle	0	1	2	2	sentient,organic,hasbones,haseyes,swims,aquatic,animal
@@ -149,7 +150,7 @@
 117	Squamous Gibberer	gibberer.gif	block,hp1,mp1,other1,underwater	squamous polyp	unspeakable lozenges	1	2	2	3	sentient,organic,haslegs,hovers,aquatic,spooky,evil,reallyevil,cantalk
 118	Dancing Frog	dancfrog.gif	item0,meat0	perfectly ordinary frog	miniature tophat	1	2	2	3	sentient,organic,hasbones,haseyes,hashands,haslegs,aquatic,wearsclothes,cute,animatedart,cantalk,animal
 119	Chauvinist Pig	chauvpig.gif	stat0,meat0	hungover chauvinist pig	bottle of Cochon Noir	0	3	2	1	sentient,organic,humanoid,hasbones,haseyes,haslegs,sleaze,animatedart,cantalk,animal
-120	Stocking Mimic	smimic.gif	combat0,delevel,hp0,mp0,other0,meat1,drop	suspicious stocking	bag of many confections	0	0	0	0	object,haseyes,phallic,isclothes
+120	Stocking Mimic	smimic.gif	combat0,delevel1,hp0,mp0,other0,meat1,drop	suspicious stocking	bag of many confections	0	0	0	0	object,haseyes,phallic,isclothes
 121	Snow Angel	snowangel.gif	combat1,mp0	pile of loose snow	snow halo	2	1	3	2	sentient,humanoid,person,mineral,object,haswings,flies,cold,good
 122	Jack-in-the-Box	jackinthebox.gif	stat0,item0,other1	Jack-in-the-box	brass crank handle	0	0	0	0	mineral,object,haseyes,fast,hard,phallic,polygonal,technological
 123	BRICKO chick	brickochick.gif	combat0,drop	BRICKO egg	extra-heavy BRICKO brick	1	2	2	1	mineral,object,haseyes,haslegs,haswings,hard,polygonal,hasbeak,animal
@@ -165,9 +166,9 @@
 133	Plastic Grocery Bag	grocbag.gif	none			0	0	0	0
 134	Underworld Bonsai	uwbonsai.gif	combat1,mp0	Underworld sapling	miniature pruning shears	3	1	2	0	organic,vegetable,haseyes,phallic,evil
 135	Rogue Program	tronguy.gif	combat0,mp0,drop	glowing frisbee	portable motorcycle	3	2	2	0	humanoid,person,software,haseyes,hashands,haslegs,fast,wearsclothes,good,cantalk,technological
-136	Mini-Hipster	minihipster.gif	combat0,delevel,stat2,hp0,mp0,meat1,other1,variable	Schmalz's First Prize Beer	ironic moustache	0	3	2	1	sentient,humanoid,person,haseyes,hashands,haslegs,wearsclothes,cantalk
+136	Mini-Hipster	minihipster.gif	combat0,delevel1,stat2,hp0,mp0,meat1,other1,variable	Schmalz's First Prize Beer	ironic moustache	0	3	2	1	sentient,humanoid,person,haseyes,hashands,haslegs,wearsclothes,cantalk
 137	Pottery Barn Owl	sp_owl.gif	combat1,hp1,mp1,drop	pottery barn owl figurine	affordable teak perch	3	1	2	0	sentient,mineral,object,hasbones,haseyes,hasclaws,haslegs,haswings,flies,hard,hasbeak,animal
-138	Hippo Ballerina	hippo.gif	combat1,block,delevel,item0,meat0	hippo tutu	immense ballet shoes	3	2	3	0	wearsclothes,animal,haseyes
+138	Hippo Ballerina	hippo.gif	combat1,block,delevel1,item0,meat0	hippo tutu	immense ballet shoes	3	2	3	0	wearsclothes,animal,haseyes
 139	Knob Goblin Organ Grinder	organgoblin.gif	combat1,meat0,other1,drop	organ grinder	microwave stogie	0	3	2	1	hashands,haseyes,evil
 140	Piano Cat	pianocat.gif	item0,meat0	sleeping piano cat	kitty sheet music	2	3	2	0	hashands,animal,haseyes,bite
 141	Dramatic Hedgehog	dramahog.gif	stat0,meat0	rehearsing dramatic hedgehog	tiny prop sword	2	3	0	2	sentient,organic,hasbones,haseyes,hasclaws,haslegs,cute,animatedart,hasstinger,cantalk,animal
@@ -186,8 +187,8 @@
 154	Bloovian Groose	groose.gif	stat0,meat0,drop	The Groose in the Hoose	spruce juice	2	2	1	3	sleaze,animal,haseyes
 155	Blavious Kloop	kloop.gif	item0,meat0,drop	The Kloop in the Coop	miniscule beatbox	0	3	2	1	hashands,haseyes,evil
 156	Peppermint Rhino	pep_rhino.gif	item0,item3	peppermint rhino baby	licorice boa	1	3	1	0	sentient,hasbones,haseyes,haslegs,hard,edible,food,animal
-157	Tickle-Me Emilio	emiliofam.gif	combat0,combat1,delevel,hp0,mp0,meat1,stat0	Tickle-Me Emilio	tiny do-rag	3	1	1	0	haseyes,sleaze
-158	Steam-Powered Cheerleader	cheerleader.gif	delevel,item0	KoLHS Pep Squad Box	school spirit socket set	2	3	2	0	humanoid,person,mineral,robot,haseyes,hashands,haslegs,hard,wearsclothes,cute,cantalk,technological
+157	Tickle-Me Emilio	emiliofam.gif	combat0,combat1,delevel1,hp0,mp0,meat1,stat0	Tickle-Me Emilio	tiny do-rag	3	1	1	0	haseyes,sleaze
+158	Steam-Powered Cheerleader	cheerleader.gif	delevel0,item0	KoLHS Pep Squad Box	school spirit socket set	2	3	2	0	humanoid,person,mineral,robot,haseyes,hashands,haslegs,hard,wearsclothes,cute,cantalk,technological
 159	Happy Medium	medium_0.gif	other0,stat0,drop	Small Medium	crystal decanter	0	3	2	2	sentient,organic,humanoid,person,haseyes,hashands,haslegs,hovers,wearsclothes,spooky,cantalk
 160	Artistic Goth Kid	crayongoth.gif	other1,stat0	Moping Artistic Goth Kid	little wooden mannequin	0	2	2	3	sentient,organic,humanoid,person,hasbones,haseyes,hashands,haslegs,wearsclothes,spooky,cantalk
 161	Flaming Face	flameface.gif	combat1	hot egg	flaming nose	3	2	2	1	sentient,haseyes,bite,hovers,hot
@@ -196,13 +197,13 @@
 164	Mini-Skulldozer	minidozer.gif	combat1,block	skulldozer egg	ribcage rollcage	2	1	3	0	undead,mineral,object,hasbones,haseyes,hard,spooky,technological
 165	Angry Jung Man	jungman.gif	item0,meat0,drop	dreaming Jung man	Little Crimson Book	2	2	1	1	sentient,organic,humanoid,person,hasbones,haseyes,hashands,haslegs,wearsclothes,animatedart,cantalk
 166	Unconscious Collective	uc.gif	stat0,meat0,drop	avatar of the Unconscious Collective	blue canary nightlight	2	1	1	3	sentient,haseyes,hashands,haslegs,cute,animatedart,cantalk
-167	Nanorhino	nanorhino.gif	combat0,combat1,delevel,other0	deactivated nanobots	nanorhino credit card	3	1	1	3	sentient,hasbones,haseyes,haslegs,cute,technological,animal
+167	Nanorhino	nanorhino.gif	combat0,combat1,delevel0,other0	deactivated nanobots	nanorhino credit card	3	1	1	3	sentient,hasbones,haseyes,haslegs,cute,technological,animal
 168	Oily Woim	woim.gif	passive	woim	woimbook	2	1	3	1	sentient,organic,insect,phallic,sleaze,animal
 169	Homemade Robot	homemadebot.gif	none	homemade robot	homemade robot gear	0	0	0	0	mineral,robot,haseyes,hashands,fast,hard,cute,technological
 170	MiniMechaElf	mechaelf.gif	combat0	Deactivated MiniMechaElf	MiniMechaElf Laser Punch Missile Launcher	3	2	0	1	person,mineral,robot,haseyes,hashands,haslegs,hard,cute,good,technological
-171	Gelatinous Cubeling	gcube.gif	delevel,item0,drop	dried gelatinous cube	pile of dungeon junk	2	3	0	1	object,haseyes,polygonal
+171	Gelatinous Cubeling	gcube.gif	delevel0,item0,drop	dried gelatinous cube	pile of dungeon junk	2	3	0	1	object,haseyes,polygonal
 172	Adorable Space Buddy	starbuddy.gif	combat1,hp1,mp1,underwater	Star Spawn	cute bow from beyond the stars	1	2	3	3	sentient,mineral,flies,cute
-173	Nosy Nose	nosynose.gif	delevel,other0	wriggling severed nose	nosy nose ringy ring	1	3	1	2	organic,object,hasbones,stench
+173	Nosy Nose	nosynose.gif	delevel1,other0	wriggling severed nose	nosy nose ringy ring	1	3	1	2	organic,object,hasbones,stench
 174	Mini-Adventurer	miniadv0.gif	variable	adventurer clone egg	mini-Mr. Accessory	2	2	2	2	sentient,humanoid,person,hasbones,haseyes,hashands,haslegs,wearsclothes,cantalk
 175	Mechanical Songbird	mechbird.gif	item0	unwound mechanical songbird	shiny brass tailfeathers	1	2	2	0	mineral,robot,haseyes,hasclaws,haslegs,haswings,flies,fast,hard,hasbeak,technological,animal
 176	Reanimated Reanimator	reanimator.gif	stat0,other0,variable	deanimated reanimator's coffin	flask of embalming fluid	2	3	2	0	sentient,organic,humanoid,person,undead,hasbones,haseyes,hashands,haslegs,wearsclothes,spooky,cantalk
@@ -214,7 +215,7 @@
 182	Twitching Space Critter	spacebeastlet.gif	combat1,mp0	twitching space egg	ramekin of space nuts	3	1	1	1	sentient,organic,haseyes,fast,orb,cute,animatedart,animal
 183	Galloping Grill	galgrill.gif	combat1,mp0,stat1,drop	still grill	box of hickory chips	3	1	2	0	mineral,object,haseyes,haslegs,fast,hard,cute,hot,cantalk
 184
-185	Helix Fossil	foss_amm.gif	delevel,combat0,hp1,mp1	strange helix fossil	S.S. Ticket	0	0	0	3	mineral,object,hard,polygonal,good,hasshell
+185	Helix Fossil	foss_amm.gif	delevel0,combat0,hp1,mp1	strange helix fossil	S.S. Ticket	0	0	0	3	mineral,object,hard,polygonal,good,hasshell
 186	Xiblaxian Holo-Companion	holobuddy.gif	block,passive	Xiblaxian holo-buddy simcode	Xiblaxian holo-bowtie	1	2	1	2	haseyes,hovers,technological
 187	Baby Z-Rex	babyzrex.gif	combat1,stat0	zombie dinosaur egg	french-fry grabber	3	0	0	0	sentient,organic,undead,hasbones,haseyes,bite,hashands,hasclaws,haslegs,cute,animal
 188	Fist Turkey	fistturkey.gif	combat0,item0,meat1,stat2,drop	fist turkey outline	brass turkey knuckles	3	2	2	3	sentient,object,haseyes,haslegs,haswings,phallic,evil,hasbeak,animal
@@ -238,7 +239,7 @@
 206	Trick-or-Treating Tot	tottot.gif	hp1,mp1	li'l orphan tot	li'l knight costume	1	3	2	3	sentient,humanoid,person,haseyes,hashands,haslegs,wearsclothes,cute,good,cantalk
 207	Chocolate Lab	chocolab.gif	item0	chocolate puppy	chocolate leash	1	1	1	1	sentient,haseyes,bite,hasclaws,haslegs,edible,food,cute,animal
 208	Bad Vibe	lilbadvibe.gif	none	pet bad vibe	black gallstone	0	0	0	0	haseyes,haslegs,evil,reallyevil,cantalk
-209	Space Jellyfish	spacejelly.gif	underwater,delevel,drop	space planula	space jellybicycle	3	3	2	3	sentient,organic,flies,swims,aquatic,evil,hasstinger,animal
+209	Space Jellyfish	spacejelly.gif	underwater,delevel0,drop	space planula	space jellybicycle	3	3	2	3	sentient,organic,flies,swims,aquatic,evil,hasstinger,animal
 210	Optimistic Candle	opticandle.gif	stat0,item0,drop	hopeful candle	pewter candlestick	2	3	3	3	mineral,object,haseyes,phallic,polygonal,hot,good,animatedart,cantalk
 211	Robortender	robotender.gif	meat0,drop	unpowered Robortender	toggle switch (Bartend)	3	3	1	1	humanoid,person,mineral,robot,haseyes,hashands,haslegs,hard,cantalk,technological
 212	Cute Meteor	cutemeteor.gif	passive,combat1	cute meteoroid	meteor shower cap	1	1	1	1	mineral,object,haseyes,flies,fast,hard,orb,hot
@@ -301,7 +302,7 @@
 269	Yule Hound	yulehound.gif	hp1,mp1	yule pup	Crimbo dog sweater	2	3	1	1	sentient,organic,hasbones,haseyes,bite,hasclaws,haslegs,good,animal
 270	Sausage Golem	saugrindgolem.gif	combat1,mp0	sausage golem	jar of magical relish	3	1	1	1	sentient,organic,humanoid,hashands,haslegs,phallic,food,edible,sleaze
 271	Elf Operative	elfopelf.gif	stat0,item0,drop	elf sleeper agent	red-and-green microcamera	3	3	2	2	sentient,humanoid,person,hasbones,haseyes,hashands,haslegs,wearsclothes,good,cantalk
-272	Plastic Pirate Skull	pr_rogerskull.gif	delevel,hp1,mp1	Red Roger's skull	plastic pirate hat	0	0	0	0	sentient,mineral,object,haseyes,hard,orb,cute,spooky,cantalk
+272	Plastic Pirate Skull	pr_rogerskull.gif	delevel0,hp1,mp1	Red Roger's skull	plastic pirate hat	0	0	0	0	sentient,mineral,object,haseyes,hard,orb,cute,spooky,cantalk
 273	Pet Coral	petcoral.gif	none,underwater	piece of coral		0	0	0	0	mineral,object,haseyes,polygonal
 274	Pocket Professor	lilprofessoron.gif	item0,mp1	packaged Pocket Professor	Pocket Professor memory chip	0	2	2	3	software,object,hard,technological
 275	Red-Nosed Snapper	redsnapper.gif	item0,underwater	red-spotted snapper roe	tinsel fin	3	3	3	3	swims,aquatic,sentient,organic,haseyes,animal
@@ -312,9 +313,9 @@
 280	Ghost of Crimbo Carols	cghost_carols.gif	item0,other0	gregarious ghostling		0	0	0	0	sentient,person,undead,haseyes,hovers,spooky,cute,cantalk
 281	Ghost of Crimbo Cheer	cghost_cheer.gif	stat0,other1	grinning ghostling		0	0	0	0	sentient,person,undead,haseyes,hovers,spooky,cute,cantalk
 282	Ghost of Crimbo Commerce	cghost_commerce.gif	meat0,other0	greedy ghostling		0	0	0	0	sentient,person,undead,haseyes,hovers,spooky,cute,cantalk
-283	Shorter-Order Cook	shortchef.gif	combat0,combat1,delevel,drop	shortest-order cook	blue plate	3	3	1	1	sentient,organic,humanoid,person,hasbones,haseyes,hashands,haslegs,wearsclothes,hot,animal
+283	Shorter-Order Cook	shortchef.gif	combat0,combat1,delevel1,drop	shortest-order cook	blue plate	3	3	1	1	sentient,organic,humanoid,person,hasbones,haseyes,hashands,haslegs,wearsclothes,hot,animal
 284	Vampire Vintner	vampvint.gif	item2,combat0,hp0,drop	bottled Vampire Vintner	French-Transylvanian Dictionary	2	3	2	3	sentient,person,undead,spooky,cantalk,haseyes,bite
-285	Arachnelf	arachnelf.gif	delevel,combat1	festive egg sac	Site Alpha ID badge	3	1	3	1	sentient,organic,hasbones,haseyes,haslegs,fast,cold,spooky,evil,animal
+285	Arachnelf	arachnelf.gif	delevel0,combat1	festive egg sac	Site Alpha ID badge	3	1	3	1	sentient,organic,hasbones,haseyes,haslegs,fast,cold,spooky,evil,animal
 286	Synthetic Rock	synthrock.gif	none	synthetic rock		0	0	0	0	mineral,object,hard
 287	Grey Goose	greygoose.gif	item0	grey gosling	grey down vest	1	2	3	3	sentient,bite,haslegs,haswings,evil,hasbeak,organic,flies,animal
 288	Cookbookbat	bbat_fam.gif	item1,drop	mummified entombed cookbookbat	cookbookbat book	0	3	2	3	sentient,organic,robot,hasbones,haseyes,haswings,flies,wearsclothes,cantalk,undead,animal
@@ -323,9 +324,9 @@
 291	Pixel Rock	pixelrock.gif	none	pixel rock		0	0	0	0	mineral,haseyes,hard,cute
 292
 293	Patriotic Eagle	pateagle.gif	combat0,stat1,mp0	sleeping patriotic eagle	claw-held flag	3	3	1	2	hasclaws,hasbeak,flies,haswings,sentient,organic,haseyes,animal
-294	Jill-of-All-Trades	darkjill2f.gif	stat0,stat1,item0,meat0,combat0,drop,block,delevel,hp0,meat1,hp1,mp1,variable	Dark Jill-of-All-Trades	LED candle	1	2	3	3	organic,sentient,vegetable,object,haseyes,bite,edible,food,orb,hot,spooky,evil
+294	Jill-of-All-Trades	darkjill2f.gif	stat0,stat1,item0,meat0,combat0,drop,block,delevel0,hp0,meat1,hp1,mp1,variable	Dark Jill-of-All-Trades	LED candle	1	2	3	3	organic,sentient,vegetable,object,haseyes,bite,edible,food,orb,hot,spooky,evil
 295	Flaming Leafcutter Ant	al_ant.gif	hp1,mp1,combat1	smoldering leafcutter ant egg		2	3	3	1	sentient,organic,insect,haseyes,bite,haslegs,hot,animal
-296	Rigging Snake	rigsnake.gif	combat0,delevel	baby rigging snake	rigging knot	3	1	1	1	sentient,organic,haseyes,bite,phallic,cute,animal
+296	Rigging Snake	rigsnake.gif	combat0,delevel1	baby rigging snake	rigging knot	3	1	1	1	sentient,organic,haseyes,bite,phallic,cute,animal
 297	Pet Anchor	anchor.gif	none	pet anchor		0	0	0	0	mineral,object,hard
 298
 299	Chest Mimic	mimicchest.gif	item0,meat0	baby chest mimic	googly chest eyes	1	2	2	3	object,haseyes,hard,cute,polygonal,animal
@@ -335,20 +336,20 @@
 303	Burly Bodyguard	bodyguard.gif	combat0,block	baby bodyguard	bodyguard badge	3	3	3	3	sentient,organic,person,hasbones,haseyes,hashands,haslegs,wearsclothes,good,cantalk
 304	Doll Moll	molldoll.gif	combat0,meat	Doll Moll violin case	tiny Tina gun	3	3	2	2	sentient,organic,person,hasbones,haseyes,hashands,wearsclothes,cute,evil,cantalk
 305	Emberiza Aureola	emberbird.gif	combat1	ember egg	tiny ember	0	1	2	3	sentient,organic,haseyes,hasbones,hasclaws,haswings,flies,hot,hasbeak,animal
-306	Peace Turkey	pto_fam.gif	drop,delevel,block,passive,other1,hp1,mp1	peace turkey outline	tie-dye headband	0	3	1	3	sentient,object,animatedart,good,haseyes,hasbeak
+306	Peace Turkey	pto_fam.gif	drop,delevel0,block,passive,other1,hp1,mp1	peace turkey outline	tie-dye headband	0	3	1	3	sentient,object,animatedart,good,haseyes,hasbeak
 307	Quantum Entangler	qf.gif	block	quantized familiar	quantum watch	2	2	2	3	object
 308	Golden Pet Rock	ts_goldrock.gif	none	golden pet rock		0	0	0	0	mineral,object,haseyes,polygonal
 309
 310	Profane Parrot	ts_parrot2.gif	block,combat1	sleeping profane parrot	profane eye patch	2	3	2	2	sentient,organic,haseyes,hasclaws,haswings,flies,sleaze,hasbeak,animal
 311	Significant Bit	cr_sbit.gif	variable	insignificant bit	parity bit	1	1	1	3	software,hovers,polygonal,technological
-312	Heat Wave	heatwave.gif		heat arc	heat particle	0	0	0	0	hot
-313	Cold Cut	coldcut.gif		cold scrape	cold sore	0	0	0	0	cold
-314	Shame Spiral	shamespiral.gif		shame coil	stomach churner	0	0	0	0	sleaze
-315	Phantom Limb	phantomlimb.gif		phantom digit	phantom brace	0	0	0	0	spooky
-316	Foul Ball	foulball.gif		foul line	foul cozy	0	0	0	0	stench
-317	Dire Cassava	direcasanim.gif		dark manioc	grim cellophane	0	0	0	0	vegetable,hard,spooky,animatedart
-318	Observer	observer.gif		Observer source code	rift oculus	0	0	0	0	sentient,humanoid,software,haseyes,orb
-319	Cool Cucumber	coolcuke.gif		chill gherkin	sweaty egg	0	0	0	0	organic,phallic,edible,good,cold
-320	Defective Childrens' Stapler	kidstaplerbad.gif		childrens' stapler	carton of extra-sharp, rusty staples	0	0	0	0	object,bite,cute,reallyevil,hasstinger
-321	Glover	glover.gif		plover's egg	glover liners	0	0	0	0	hashands,hasclaws,wearsclothes,isclothes,hasbeak
-322	Zapper Bug	zapperbug.gif		electric flyswatter	mosquito speakers	0	0	0	0	cantalk,fast,flies,robot,insect
+312	Heat Wave	heatwave.gif	combat1,passive	heat arc	heat particle	0	0	0	0	hot
+313	Cold Cut	coldcut.gif	combat1,block	cold scrape	cold sore	0	0	0	0	cold
+314	Shame Spiral	shamespiral.gif	combat1,delevel1	shame coil	stomach churner	0	0	0	0	sleaze
+315	Phantom Limb	phantomlimb.gif	combat1,hp1	phantom digit	phantom brace	0	0	0	0	spooky
+316	Foul Ball	foulball.gif	combat1,passive	foul line	foul cozy	0	0	0	0	stench
+317	Dire Cassava	direcasanim.gif	passive	dark manioc	grim cellophane	0	0	0	0	vegetable,hard,spooky,animatedart
+318	Observer	observer.gif	item0,delevel0	Observer source code	rift oculus	0	0	0	0	sentient,humanoid,software,haseyes,orb
+319	Cool Cucumber	coolcuke.gif	hp1	chill gherkin	sweaty egg	0	0	0	0	organic,phallic,edible,good,cold
+320	Defective Childrens' Stapler	kidstaplerbad.gif	block,combat0	childrens' stapler	carton of extra-sharp, rusty staples	0	0	0	0	object,bite,cute,reallyevil,hasstinger
+321	Glover	glover.gif	combat0,delevel1	plover's egg	glover liners	0	0	0	0	hashands,hasclaws,wearsclothes,isclothes,hasbeak
+322	Zapper Bug	zapperbug.gif	combat0,mp0	electric flyswatter	mosquito speakers	0	0	0	0	cantalk,fast,flies,robot,insect

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -4837,6 +4837,7 @@ Familiar	Cymbal-Playing Monkey	Last Available: "2006-10"
 Familiar	Dancing Frog	Last Available: "2010-10"
 Familiar	Dandy Lion	Last Available: "2007-03"
 Familiar	Dataspider	Last Available: "2011-07"
+Familiar	Dire Cassava	Thorns: 1
 Familiar	Disembodied Hand	Last Available: "2008-10"
 Familiar	Disgeist	Combat Rate: [-min(10,floor(W/7.5))], Last Available: "2018-03"
 Familiar	Doppelshifter	Last Available: "2005-10"

--- a/src/net/sourceforge/kolmafia/persistence/FamiliarDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/FamiliarDatabase.java
@@ -57,7 +57,8 @@ public class FamiliarDatabase {
   private static final Set<Integer> combat0ById = new HashSet<>();
   private static final Set<Integer> combat1ById = new HashSet<>();
   private static final Set<Integer> blockById = new HashSet<>();
-  private static final Set<Integer> delevelById = new HashSet<>();
+  private static final Set<Integer> delevel0ById = new HashSet<>();
+  private static final Set<Integer> delevel1ById = new HashSet<>();
   private static final Set<Integer> meat1ById = new HashSet<>();
   private static final Set<Integer> stat2ById = new HashSet<>();
   private static final Set<Integer> hp0ById = new HashSet<>();
@@ -191,7 +192,7 @@ public class FamiliarDatabase {
     FamiliarDatabase.updateType(type, "combat0", id, combat0ById);
     FamiliarDatabase.updateType(type, "combat1", id, combat1ById);
     FamiliarDatabase.updateType(type, "block", id, blockById);
-    FamiliarDatabase.updateType(type, "delevel", id, delevelById);
+    FamiliarDatabase.updateType(type, "delevel0", id, delevel0ById);
     FamiliarDatabase.updateType(type, "hp0", id, hp0ById);
     FamiliarDatabase.updateType(type, "mp0", id, mp0ById);
     FamiliarDatabase.updateType(type, "meat1", id, meat1ById);
@@ -203,6 +204,7 @@ public class FamiliarDatabase {
     FamiliarDatabase.updateType(type, "mp1", id, mp1ById);
     FamiliarDatabase.updateType(type, "stat3", id, stat3ById);
     FamiliarDatabase.updateType(type, "other1", id, other1ById);
+    FamiliarDatabase.updateType(type, "delevel1", id, delevel1ById);
 
     // The following are other abilities that deserve their own category
     FamiliarDatabase.updateType(type, "passive", id, passiveById);
@@ -459,7 +461,8 @@ public class FamiliarDatabase {
     return FamiliarDatabase.combat0ById.contains(familiarId)
         || FamiliarDatabase.combat1ById.contains(familiarId)
         || FamiliarDatabase.blockById.contains(familiarId)
-        || FamiliarDatabase.delevelById.contains(familiarId)
+        || FamiliarDatabase.delevel0ById.contains(familiarId)
+        || FamiliarDatabase.delevel1ById.contains(familiarId)
         || FamiliarDatabase.hp0ById.contains(familiarId)
         || FamiliarDatabase.mp0ById.contains(familiarId)
         || FamiliarDatabase.other0ById.contains(familiarId);
@@ -482,7 +485,8 @@ public class FamiliarDatabase {
   }
 
   public static final boolean isDelevelType(final Integer familiarId) {
-    return FamiliarDatabase.delevelById.contains(familiarId);
+    return FamiliarDatabase.delevel0ById.contains(familiarId)
+        || FamiliarDatabase.delevel1ById.contains(familiarId);
   }
 
   public static final boolean isHp0Type(final Integer familiarId) {
@@ -603,10 +607,15 @@ public class FamiliarDatabase {
       sep = ",";
       buffer.append("block");
     }
-    if (FamiliarDatabase.delevelById.contains(familiarId)) {
+    if (FamiliarDatabase.delevel0ById.contains(familiarId)) {
       buffer.append(sep);
       sep = ",";
-      buffer.append("delevel");
+      buffer.append("delevel0");
+    }
+    if (FamiliarDatabase.delevel1ById.contains(familiarId)) {
+      buffer.append(sep);
+      sep = ",";
+      buffer.append("delevel1");
     }
     if (FamiliarDatabase.hp0ById.contains(familiarId)) {
       buffer.append(sep);


### PR DESCRIPTION
Heat Wave increases init, but apparently only in combat (doesn't show up on talking spade). I have bug reported and hopefully CDM will fix it to be like the Woim, which is more useful (e.g. for modern zmobies).

I have split "delevels before combat" from "delevels during combat". There should not be any user-visible changes from this yet.