### PR TITLE
Improve sell_cost(coinmaster, thing) for non-ShopRow coinmasters

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -6672,9 +6672,9 @@ public abstract class RuntimeLibrary {
     MapValue value = new MapValue(DataTypes.ITEM_TO_INT_TYPE);
 
     CoinmasterData data = (CoinmasterData) master.rawValue();
-    int id = (int) thing.intValue();
 
     if (data.getShopRows() != null) {
+      int id = (int) thing.intValue();
       var shopRow = data.getShopRow(id);
 
       if (shopRow == null) return value;
@@ -6686,24 +6686,28 @@ public abstract class RuntimeLibrary {
       return value;
     }
 
-    value.aset(DataTypes.makeItemValue(data.getItem()), sell_price(controller, master, thing));
+    AdventureResult cost = sell_price(data, thing);
+    if (cost == null) return value;
+    value.aset(DataTypes.makeItemValue(cost), DataTypes.makeIntValue(cost.getCount()));
 
     return value;
   }
 
   public static Value sell_price(ScriptRuntime controller, final Value master, final Value thing) {
     CoinmasterData data = (CoinmasterData) master.rawValue();
-    int id = (int) thing.intValue();
-    AdventureResult value =
-        (data == null)
-            ? null
-            : switch (thing.getType().getType()) {
-              case TypeSpec.ITEM -> data.itemBuyPrice(id);
-              case TypeSpec.SKILL -> data.skillBuyPrice(id);
-              default -> null;
-            };
-
+    AdventureResult value = sell_price(data, thing);
     return DataTypes.makeIntValue(value == null ? 0 : value.getCount());
+  }
+
+  private static AdventureResult sell_price(CoinmasterData data, Value thing) {
+    int id = (int) thing.intValue();
+    return (data == null)
+        ? null
+        : switch (thing.getType().getType()) {
+          case TypeSpec.ITEM -> data.itemBuyPrice(id);
+          case TypeSpec.SKILL -> data.skillBuyPrice(id);
+          default -> null;
+        };
   }
 
   public static Value historical_price(ScriptRuntime controller, final Value item) {


### PR DESCRIPTION
Do I need RuntimeLibrary tests?

```
> ash sell_cost($coinmaster[The Terrified Eagle Inn], $item[silver Dreadsylvanian flask])

Returned: aggregate int [item]
Freddy Kruegerand => 100

> ash sell_cost($coinmaster[Fancy Dan the Cocktail Man], $item[Marltini])

Returned: aggregate int [item]
drink chit => 1

> ash sell_cost($coinmaster[Fancy Dan the Cocktail Man], $item[Mysterious Stranger])
Returned: aggregate int [item]
milk cap => 1

> ash sell_cost($coinmaster[Cosmic Ray's Bazaar], $item[space shield])

Returned: aggregate int [item]
rare Meat isotope => 25

> ash sell_cost($coinmaster[Cosmic Ray's Bazaar], $item[digital key])

Returned: aggregate int [item]
white pixel => 30

> ash sell_cost($coinmaster[Cosmic Ray's Bazaar], $item[Boris's key])

Returned: aggregate int [item]
fat loot token => 1

> ash sell_cost($coinmaster[Your Spinmaster™ lathe], $item[birch battery])

Returned: aggregate int [item]
flimsy hardwood scraps => 1

> ash sell_cost($coinmaster[Your Spinmaster™ lathe], $item[wormwood wedding ring])

Returned: aggregate int [item]
wormwood stick => 1
bkolm