### PR TITLE
to_float needs to parse strings as doubles, not floats.

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -4481,7 +4481,7 @@ public abstract class RuntimeLibrary {
     if (value.getType().equals(TypeSpec.STRING)) {
       String string = value.toString();
       try {
-        return new Value(StringUtilities.parseFloat(string));
+        return new Value(StringUtilities.parseDouble(string));
       } catch (NumberFormatException e) {
         Exception ex =
             controller.runtimeException(


### PR DESCRIPTION
Hats off to HippoKing for discovering this.
Formerly:
```
> ash to_float("80900913.84488438")

Returned: 80900912.0
```
Now:
```
> ash to_float("80900913.84488438")

Returned: 80900913.84488438
```
