### PR TITLE
You can no longer make a directed attack for fame in HC or Ronin

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/command/PvpAttackCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/PvpAttackCommand.java
@@ -92,7 +92,7 @@ public class PvpAttackCommand extends AbstractCommand {
       targets[i].run();
     }
 
-    String mission = KoLCharacter.canInteract() ? "lootwhatever" : "fame";
+    String mission = KoLCharacter.canInteract() ? "lootwhatever" : "flowers";
     PeeVPeeRequest request = new PeeVPeeRequest("", 0, mission);
     PvpManager.executePvpRequest(targets, request, stance);
   }


### PR DESCRIPTION
eusst told me that when you make a directed PVP attack - against a specific target, not a random target - if you are in HC or Ronin, you can no longer attack for "fame". Just "flowers".

The "pvp" or "steal" commands take a mode and a stance and goes against a random target, so is unaffected.
The "attack" command takes a stance and list of direct targets and attacks for "loot" or "fame".

The latter no longer works. Change it to "flowers".