### PR TITLE
When visit scg after cave, auto visit a second time

### DIFF
--- a/src/net/sourceforge/kolmafia/request/GuildRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GuildRequest.java
@@ -4,6 +4,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.RequestLogger;
+import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.moods.HPRestoreItemList;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
@@ -408,6 +409,15 @@ public class GuildRequest extends GenericRequest {
 
       if (QuestDatabase.isQuestStep(Quest.NEMESIS, "step16")) {
         QuestDatabase.setQuestProgress(Quest.NEMESIS, "step16.5");
+        // Get around KoL bug by automatically submitting another visit
+        GuildRequest scg =
+            new GuildRequest("scg") {
+              @Override
+              protected boolean shouldSuppressUpdate() {
+                return true;
+              }
+            };
+        RequestThread.postRequest(scg);
       } else if (QuestDatabase.isQuestStep(Quest.NEMESIS, "step16.5")) {
         QuestDatabase.setQuestProgress(Quest.NEMESIS, "step17");
       }

--- a/test/net/sourceforge/kolmafia/request/GuildRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/GuildRequestTest.java
@@ -242,7 +242,7 @@ public class GuildRequestTest {
     }
 
     @Test
-    public void talkToGuildOnceIsStep16A() {
+    public void talkToGuildAutoAdvancesToStep17() {
       var builder = new FakeHttpClientBuilder();
       var client = builder.client;
 
@@ -251,31 +251,6 @@ public class GuildRequestTest {
 
       try (cleanups) {
         client.addResponse(200, html("request/test_nemesis_caveboss_guild_1.html"));
-        client.addResponse(200, ""); // api.php
-
-        GenericRequest visit = new GenericRequest("guild.php?place=scg");
-        visit.run();
-
-        assertThat(Quest.NEMESIS, isStep("step16.5"));
-
-        var requests = client.getRequests();
-        assertThat(requests, hasSize(2));
-
-        assertPostRequest(requests.get(0), "/guild.php", "place=scg");
-        assertPostRequest(requests.get(1), "/api.php", "what=status&for=KoLmafia");
-      }
-    }
-
-    @Test
-    public void talkToGuildAgainIsStep17() {
-      var builder = new FakeHttpClientBuilder();
-      var client = builder.client;
-
-      var cleanups =
-          new Cleanups(
-              withHttpClientBuilder(builder), withQuestProgress(Quest.NEMESIS, "step16.5"));
-
-      try (cleanups) {
         client.addResponse(200, html("request/test_nemesis_caveboss_guild_2.html"));
         client.addResponse(200, ""); // api.php
 
@@ -285,10 +260,11 @@ public class GuildRequestTest {
         assertThat(Quest.NEMESIS, isStep("step17"));
 
         var requests = client.getRequests();
-        assertThat(requests, hasSize(2));
+        assertThat(requests, hasSize(3));
 
         assertPostRequest(requests.get(0), "/guild.php", "place=scg");
-        assertPostRequest(requests.get(1), "/api.php", "what=status&for=KoLmafia");
+        assertPostRequest(requests.get(1), "/guild.php", "place=scg");
+        assertPostRequest(requests.get(2), "/api.php", "what=status&for=KoLmafia");
       }
     }
   }


### PR DESCRIPTION
In the Nemesis Quest, when you defeat your Nemesis in the mountain cave (step 15 -> 16), you must check back in with the guild (step 16 -> 16.5) This should enable the assassins, but due to a KoL bug, you must visit again (step 16.5 -> 17).

When we detect that the first visit has happened (16 -> 16.5), automatically make another visit in the background (16.5 -> 17).

If you've learned to visit the guild a second time, that's superfluous, but not an issue; you'll still see the same thing you always have.