### PR TITLE
update after casting skill incorrectly unselects skill

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/SkillBuffFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/SkillBuffFrame.java
@@ -221,8 +221,6 @@ public class SkillBuffFrame extends GenericFrame {
       if (targets.length == 0) {
         RequestThread.checkpointedPostRequest(
             UseSkillRequest.getInstance(buffName, KoLCharacter.getUserName(), buffCount));
-        // If we've cast the daily limit, the skill is now disabled
-        SkillBuffFrame.this.skillSelect.update();
         return;
       }
 


### PR DESCRIPTION
Previous PR correctly deselected skill which was disabled, but also deselected skill which was not disabled after a cast.
Turns out that is a side effect of updating skill list after casting - which was new in that PR - and is unnecessary.
Remove that and only skill which is out of casts gets deselected.