### PR TITLE
Parameterized test

### DIFF
--- a/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
@@ -10,6 +10,7 @@ import static internal.helpers.Player.withHttpClientBuilder;
 import static internal.helpers.Player.withItem;
 import static internal.helpers.Player.withPasswordHash;
 import static internal.helpers.Player.withProperty;
+import static internal.helpers.Player.withSavePreferencesToFile;
 import static internal.matchers.Preference.isSetTo;
 import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.RACING;
 import static net.sourceforge.kolmafia.request.DeckOfEveryCardRequest.buffToCard;
@@ -163,6 +164,7 @@ class DeckOfEveryCardRequestTest {
             withGender(KoLCharacter.Gender.FEMALE),
             withGuildStoreOpen(false),
             withPasswordHash("cafebabe"),
+            withSavePreferencesToFile(),
             withAdventuresLeft(100));
     try (cleanups) {
       new DeckOfEveryCardRequest(mickey).run();

--- a/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/DeckOfEveryCardRequestTest.java
@@ -37,6 +37,8 @@ import net.sourceforge.kolmafia.persistence.MonsterDatabase;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class DeckOfEveryCardRequestTest {
   private static final String USERNAME = "DeckOfEveryCardRequestTest";
@@ -142,8 +144,9 @@ class DeckOfEveryCardRequestTest {
     }
   }
 
-  @Test
-  public void itShouldRunAndUpdatePreferences() {
+  @ParameterizedTest
+  @CsvSource({"true, true", "true, false", "false, true", "false, false"})
+  public void itShouldRunAndUpdatePreferences(boolean useUpdate, boolean useWrite) {
     DeckOfEveryCardRequest.EveryCard mickey = getCardById(58);
     var builder = new FakeHttpClientBuilder();
     var client = builder.client;
@@ -164,8 +167,12 @@ class DeckOfEveryCardRequestTest {
             withGender(KoLCharacter.Gender.FEMALE),
             withGuildStoreOpen(false),
             withPasswordHash("cafebabe"),
-            withSavePreferencesToFile(),
+            withProperty("saveSettingsOnSet", useUpdate),
             withAdventuresLeft(100));
+    // Because this is a test the assumption is that saving preferences is disabled
+    if (useWrite) {
+      cleanups.add(withSavePreferencesToFile());
+    }
     try (cleanups) {
       new DeckOfEveryCardRequest(mickey).run();
       var requests = builder.client.getRequests();


### PR DESCRIPTION
This test was intended as a canary for preference file corruption.  This parameterizes it so that all the combinations of two related preferences are checked.  This may be a step towards tests with Swing unavailable in #1889 