### PR TITLE
Start Nemesis Assassin counter at step 17 of quest

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -3987,7 +3987,6 @@ public abstract class KoLCharacter {
     KoLConstants.availableSkillsSet.remove(skillId);
     KoLConstants.usableSkills.remove(skill);
     KoLConstants.summoningSkills.remove(skill);
-    KoLConstants.usableSkills.remove(skill);
     KoLConstants.remedySkills.remove(skill);
     KoLConstants.selfOnlySkills.remove(skill);
     KoLConstants.buffSkills.remove(skill);

--- a/src/net/sourceforge/kolmafia/request/GuildRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GuildRequest.java
@@ -16,6 +16,7 @@ import net.sourceforge.kolmafia.request.concoction.ChefStaffRequest;
 import net.sourceforge.kolmafia.request.concoction.CreateItemRequest;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.session.ResultProcessor;
+import net.sourceforge.kolmafia.session.TurnCounter;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class GuildRequest extends GenericRequest {
@@ -420,6 +421,9 @@ public class GuildRequest extends GenericRequest {
         RequestThread.postRequest(scg);
       } else if (QuestDatabase.isQuestStep(Quest.NEMESIS, "step16.5")) {
         QuestDatabase.setQuestProgress(Quest.NEMESIS, "step17");
+        TurnCounter.startCounting(5, "Nemesis Assassin window begin loc=*", "lparen.gif");
+        TurnCounter.startCounting(
+            15, "Nemesis Assassin window end loc=* type=wander", "rparen.gif");
       }
 
       return true;

--- a/src/net/sourceforge/kolmafia/session/InventoryManager.java
+++ b/src/net/sourceforge/kolmafia/session/InventoryManager.java
@@ -86,6 +86,9 @@ public abstract class InventoryManager {
   public static void refresh() {
     // Retrieve the contents of inventory via api.php
     ApiRequest.updateInventory();
+    // Items in inventory can grant modifiers.
+    // For example, Cincho de Mayo gives 3 free rests.
+    KoLCharacter.recalculateAdjustments();
   }
 
   public static final void parseInventory(final JSONObject json) {

--- a/test/net/sourceforge/kolmafia/request/GuildRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/GuildRequestTest.java
@@ -7,7 +7,9 @@ import static internal.helpers.Player.withHttpClientBuilder;
 import static internal.helpers.Player.withItem;
 import static internal.helpers.Player.withProperty;
 import static internal.helpers.Player.withQuestProgress;
+import static internal.helpers.Player.withoutCounters;
 import static internal.helpers.Player.withoutItem;
+import static internal.matchers.Preference.isSetTo;
 import static internal.matchers.Quest.isStep;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -247,7 +249,11 @@ public class GuildRequestTest {
       var client = builder.client;
 
       var cleanups =
-          new Cleanups(withHttpClientBuilder(builder), withQuestProgress(Quest.NEMESIS, "step16"));
+          new Cleanups(
+              withHttpClientBuilder(builder),
+              withoutCounters(),
+              withProperty("relayCounters", ""),
+              withQuestProgress(Quest.NEMESIS, "step16"));
 
       try (cleanups) {
         client.addResponse(200, html("request/test_nemesis_caveboss_guild_1.html"));
@@ -258,6 +264,10 @@ public class GuildRequestTest {
         visit.run();
 
         assertThat(Quest.NEMESIS, isStep("step17"));
+        assertThat(
+            "relayCounters",
+            isSetTo(
+                "5:Nemesis Assassin window begin loc=*:lparen.gif:15:Nemesis Assassin window end loc=* type=wander:rparen.gif"));
 
         var requests = client.getRequests();
         assertThat(requests, hasSize(3));


### PR DESCRIPTION
1) Having examined over 200 session logs, in all but 7, the menacing thug appeared between 5 and 15 turns after talk a second time to the scg in the guild - accounting for adventuring when/where wanderers are not welcome. Therefore, when the quest moves to step 17, start the Nemesis Assassin counter.
2) remove a duplicated line in KoLCharacter.removeAvailableSkill
3) I noticed that upon login I was getting "KoL thinks you have free rests but KoLmafia doesn't think so.
I added a call to KoLCharacter.recalculateAdjustments when refreshing inventory.