### PR TITLE
Added defaults

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1143,6 +1143,7 @@ user	maximizerIncludeAll	false
 user	maximizerMaxPrice	0
 user	maximizerNoAdventures	false
 user	maximizerPriceLevel	0
+user	maximizerUseScope	false
 user	maxManaBurn	1000
 user	mayflyExperience	0	roa
 user	mayoInMouth		roa
@@ -1990,6 +1991,7 @@ user	_coldMedicineEquipmentTaken	0
 user	_coldOne	false
 user	_communismUsed	false
 user	_companionshipCasts	0
+user	_concoctionDatabaseRefreshes	0
 user	_confusingLEDClockUsed	false
 user	_controlPanelUsed	false
 user	_cookbookbatCrafting	0


### PR DESCRIPTION
I rediscovered a script that looked for user settings and identified those that did not have a KoL default.  I discovered two that were used by KoLmafia.

It looks to me that maximizerUseScope is actually obsolete because I cannot find a place where KoLmafia actually sets it to false.

_concoctionDatabaseRefreshes is never used, only incremented, but the increment implicitly assumes that the daily reset returns it to zero.  Adding a default makes the initialization to zero more obvious.

