### PR TITLE
feat: add modifiers for replacing / additional buff effects

### DIFF
--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -357,4 +357,4 @@
 320	Defective Childrens' Stapler	kidstaplerbad.gif	block,combat0	childrens' stapler	carton of extra-sharp, rusty staples	0	0	0	0	object,bite,cute,reallyevil,hasstinger
 321	Glover	glover.gif	combat0,delevel1	plover's egg	glover liners	0	0	0	0	hashands,hasclaws,wearsclothes,isclothes,hasbeak
 322	Zapper Bug	zapperbug.gif	combat0,mp0	electric flyswatter	mosquito speakers	0	0	0	0	cantalk,fast,flies,robot,insect
-323	Wet Paper Tiger	wetpapertiger2.gif	none	wet paper tiger	wet paper eye	0	0	0	0	
+323	Wet Paper Tiger	wetpapertiger2.gif	combat0,delevel1	wet paper tiger	wet paper eye	0	0	0	0	

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -903,8 +903,7 @@ Item	ultra-high-tension exoskeleton	Avoid Attack: 2
 Item	Uncle Hobo's gift baggy pants	Moxie Percent: +20, Critical Hit Percent: +5, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 Item	union scalemail pants	Familiar Effect: "2xBarrr, cap 12"
 Item	Unkillable Skeleton's shinguards	Sleaze Damage: +50, Hot Resistance: +5, Stench Resistance: +1, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
-# velour vaqueros: Triples the effectiveness of the Dirge of Dreadfulness
-Item	velour vaqueros	Moxie: +10, Pants Drop: +30, Last Available: "2021-12"
+Item	velour vaqueros	Moxie: +10, Pants Drop: +30, Last Available: "2021-12", Replace Buff Skill: "Dirge of Dreadfulness", Replace Buff Effect: "Dirge of Dreadfulness (Remastered)"
 Item	Vicar's Tutu	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, PvP Fights: +3, Smithsness: +5, Last Available: "2013-12", Maximum HP: [2*K], Familiar Effect: "1.2xFairy, cap 25"
 Item	Volartta's bellbottoms	Moxie: +11, Ranged Damage: +11, Class: "Disco Bandit", Familiar Effect: "1xPotato, 1.5xFairy, cap 31"
 Item	Voluminous Radio Pants	HP Regen Min: 5, HP Regen Max: 10, Familiar Effect: "2xGhoul, cap 37"
@@ -2058,8 +2057,7 @@ Item	unsanitized scalpel	Sleaze Damage: +25
 Item	vampire duck-on-a-string	Weapon Damage: +5, Item Drop: +5, Last Available: "2006-12"
 Item	velcro broadsword	Muscle Percent: +5, MP Regen Min: 6, MP Regen Max: 12, Hat Drop: +20, Pants Drop: +20
 Item	velcro paddle ball	Moxie Percent: +5, MP Regen Min: 6, MP Regen Max: 12, Accessory Drop: +20
-# velour voulge: Triples the effect of Snarl of the Timberwolf
-Item	velour voulge	Experience (Muscle): +2, Weapon Drop: +30, Last Available: "2021-12"
+Item	velour voulge	Experience (Muscle): +2, Weapon Drop: +30, Last Available: "2021-12", Replace Buff Skill: "Snarl of the Timberwolf", Replace Buff Effect: "Snarl of Three Timberwolves"
 Item	vibrating cyborg knife	Weapon Damage: +20, Fumble: 3, Last Available: "2007-12"
 Item	villainous scythe	Weapon Damage Percent: +30, Critical Hit Percent: +20, Slime Hates It: +2
 Item	void shard	Muscle Percent: +13, Mysticality Percent: +13, Moxie Percent: +13, Item Drop: +13, Monster Level: +13, Spooky Damage: +13, Last Available: "2022-12"
@@ -2141,7 +2139,7 @@ Item	antique nutcracker drumstick	MP Regen Min: 4, MP Regen Max: 8, Mysticality 
 Item	antique shield	Initiative: -10, Damage Reduction: 11, Breakable
 Item	antique spyglass	Reduce Enemy Defense: 15, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10
 # April Shower Thoughts shield: Improves some of your class skills!
-Item	April Shower Thoughts shield	Muscle: +10, Mysticality: +10, Moxie: +10, Maximum HP: +25, Maximum MP: +25, Damage Reduction: 6, Last Available: "2025-04"
+Item	April Shower Thoughts shield	Muscle: +10, Mysticality: +10, Moxie: +10, Maximum HP: +25, Maximum MP: +25, Damage Reduction: 6, Last Available: "2025-04", Add Buff Skill: "Seal Clubbing Frenzy", Add Buff Effect: "Slippery as a Seal", Add Buff Skill: "Patience of the Tortoise", Add Buff Effect: "Strength of the Tortoise", Add Buff Skill: "Manicotti Meditation", Add Buff Effect: "Tubes of Universal Meat", Add Buff Skill: "Sauce Contemplation", Add Buff Effect: "Lubricating Sauce", Add Buff Skill: "Disco Aerobics", Add Buff Effect: "Disco over Matter", Add Buff Skill: "Moxie of the Mariachi", Add Buff Effect: "Mariachi Moisture", Replace Buff Skill: "Empathy of the Newt", Replace Buff Effect: "Thoughtful Empathy"
 Item	Apriling band staff	Mysticality: +10, Mysticality Percent: +10, Spell Damage: +20, Spooky Resistance: +2, Sleaze Resistance: +2, Spell Damage Percent: +10, Lasts Until Rollover
 Item	arm buzzer	Maximum MP: +25, Damage Reduction: 6
 # arrow'd heart balloon
@@ -4105,8 +4103,7 @@ Item	velcro boots	Mysticality Percent: +10, MP Regen Min: 12, MP Regen Max: 24, 
 Item	velour vambraces	Muscle: +10, Candy Drop: +30, Single Equip, Last Available: "2021-12"
 # velour veil: Triples the damage of Fearful Fettucini
 Item	velour veil	Experience (Mysticality): +2, Accessory Drop: +30, Single Equip, Last Available: "2021-12"
-# velour viscometer: Triples the effectiveness of Scarysauce
-Item	velour viscometer	Mysticality: +10, Food Drop: +30, Single Equip, Last Available: "2021-12"
+Item	velour viscometer	Mysticality: +10, Food Drop: +30, Single Equip, Last Available: "2021-12", Replace Buff Skill: "Scarysauce", Replace Buff Effect: "Scariersauce"
 Item	vial of hot blood	Hot Resistance: +4, Single Equip
 Item	vinyl boots	Moxie Percent: [15*X], HP Regen Min: 15, HP Regen Max: 30, Weapon Damage Percent: +10, Single Equip
 Item	Voluminous Radio Sneakers	Muscle: +10, Mysticality: +10, Moxie: +10, Single Equip
@@ -9704,7 +9701,7 @@ Item	primitive candy cane	Last Available: "2018-12"
 Item	protein paste	Effect: "Pasty", Effect Duration: 10, Last Available: "2009-06"
 Item	pumpkin pie	Last Available: "2010-11"
 Item	quantum taco	Last Available: "2010-10"
-Item	queen cookie	Effect: "Towering Strength", Last Available: "2010-03"
+Item	queen cookie	Effect: "Towering Strength", Effect Duration: 30, Effect: "Mitre Cut", Effect Duration: 30, Effect: "Knightlife", Effect Duration: 30, Effect: "The Royal We", Effect Duration: 30, Last Available: "2010-03"
 Item	rack of dinosaur ribs	Effect: "Meat the Flintstones", Effect Duration: 30
 Item	raisin	Last Available: "2010-04"
 Item	ratatouille de Jarlsberg	Effect: "parfum d'herbes", Effect Duration: 30, Last Available: "2022-11"
@@ -11119,7 +11116,7 @@ Item	hoarded candy wad	Effect: "Not Sharing", Effect Duration: 10, Last Availabl
 Item	holly-flavored Hob-O	Effect: "Holiday Bliss", Effect Duration: 1, Last Available: "2020-09"
 Item	honey stick	Effect: "Stuck That Way", Effect Duration: 10
 Item	honeypot	Effect: "Float Like a Butterfly, Smell Like a Bee", Effect Duration: 100
-Item	Hot 'n' Scarys	Effect: "Sugar Rush", Effect Duration: 3, Effect: "Hot Breath", Effect: "Spooky Breath"
+Item	Hot 'n' Scarys	Effect: "Sugar Rush", Effect Duration: 3, Effect: "Hot Breath", Effect Duration: 3, Effect: "Spooky Breath", Effect Duration: 3
 Item	hot button candy	Effect: "Hot Buttoned", Effect Duration: 10
 Item	hot coal	Effect: "Fire Inside", Effect Duration: 15
 Item	hot cocoa au beurre	Effect: "Cocoa-Buttery", Effect Duration: 20, Last Available: "2020-12"
@@ -14026,7 +14023,7 @@ Item	Party Tattoo&trade; gift certificate	Last Available: "2018-09"
 Item	passed-out psychedelic bear	Free Pull, Last Available: "2009-10"
 Item	Pastaco shell	Last Available: "2014-05"
 # patchouli incense stick: Weakens enemies a little bit
-Item	patchouli incense stick	Effect: "Far Out", Effect: "Embarrassed", Effect Duration: 5
+Item	patchouli incense stick	Effect: "Far Out", Effect Duration: 5, Effect: "Embarrassed", Effect Duration: 5
 # patchouli oil bomb: Deals 65-80 <font color=green>Stench Damage</font>
 # peace shooter: Makes an opponent peaceful for 3 rounds
 Item	peace shooter	Last Available: "2024-11"
@@ -14488,7 +14485,7 @@ Item	shaving cream	Effect: "Clean-Shaven", Effect Duration: 5
 Item	SHAWARMA Initiative Keycard	Last Available: "2014-10"
 Item	shimmering tendrils	Class: "Pastamancer"
 # shingle: Stops Enemy From Attacking and Weakens it Slightly
-Item	shingle	Effect: "Confused", Effect: "Amorous", Effect Duration: 10
+Item	shingle	Effect: "Confused", Effect Duration: 10, Effect: "Amorous", Effect Duration: 10
 # short calculator: ???
 # short writ of habeas corpus: Lets you get away from pygmies without spending an Adventure
 Item	shortest-order cook	Free Pull, Last Available: "2021-05"

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -1,4 +1,6 @@
 3
+# Note that order matters for modifiers. For items with multiple "Replace Buff Skill", 
+# the corresponding "Replace Buff Effect" are expected to be ordered the same way.
 # Numeric modifiers can now be expressions, enclosed in square brackets.
 # No spaces are allowed within the expression, except as part of a zone/location name.
 # + - * / ( ) have their usual mathematical meaning and precedence.

--- a/src/net/sourceforge/kolmafia/modifiers/MultiStringModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/MultiStringModifier.java
@@ -22,7 +22,11 @@ public enum MultiStringModifier implements Modifier {
   CONDITIONAL_SKILL_INVENTORY(
       "Conditional Skill (Inventory)",
       Pattern.compile("Conditional Skill \\(Inventory\\): \"(.*?)\"")),
-  LANTERN_ELEMENT("Lantern Element", Pattern.compile("Lantern Element: \"(.*?)\""));
+  LANTERN_ELEMENT("Lantern Element", Pattern.compile("Lantern Element: \"(.*?)\"")),
+  REPLACE_BUFF_SKILL("Replace Buff Skill", Pattern.compile("Replace Buff Skill: \"(.*?)\"")),
+  REPLACE_BUFF_EFFECT("Replace Buff Effect", Pattern.compile("Replace Buff Effect: \"(.*?)\"")),
+  ADD_BUFF_SKILL("Add Buff Skill", Pattern.compile("Add Buff Skill: \"(.*?)\"")),
+  ADD_BUFF_EFFECT("Add Buff Effect", Pattern.compile("Add Buff Effect: \"(.*?)\""));
   private final String name;
   private final Pattern[] descPatterns;
   private final Pattern tagPattern;

--- a/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
@@ -33,6 +33,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
+import net.sourceforge.kolmafia.modifiers.ModifierList;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.CafeDatabase;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
@@ -530,13 +531,17 @@ public class DataFileConsistencyTest {
             if (val != null && val.startsWith("\"") && val.endsWith("\""))
               val = val.substring(1, val.length() - 1);
             switch (mod.getName()) {
-              case "Effect", "Rollover Effect" -> {
+              case "Effect", "Rollover Effect", "Add Buff Effect", "Replace Buff Effect" -> {
                 var effect = EffectDatabase.getEffectId(val, true);
                 if (effect < 0) {
                   fail("unrecognised effect " + mod.getValue());
                 }
               }
-              case "Skill", "Conditional Skill (Equipped)", "Conditional Skill (Inventory)" -> {
+              case "Skill",
+                  "Conditional Skill (Equipped)",
+                  "Conditional Skill (Inventory)",
+                  "Add Buff Skill",
+                  "Replace Buff Skill" -> {
                 var skill = SkillDatabase.getSkillId(val, true);
                 if (skill < 0) {
                   fail("unrecognised skill " + mod.getValue());
@@ -544,6 +549,51 @@ public class DataFileConsistencyTest {
               }
             }
           }
+        }
+      } catch (IOException e) {
+        fail("Couldn't read from " + file);
+      }
+    }
+
+    private void assertModCountEqual(ModifierList list, String element, String mod1, String mod2) {
+      var first = list.stream().filter(x -> mod1.equals(x.getName())).toList();
+      var second = list.stream().filter(x -> mod2.equals(x.getName())).toList();
+      if (first.size() != second.size()) {
+        switch (element) {
+          case "chaos popcorn", "thyme jelly donut" -> {
+            // some items give a randomly chosen effect
+          }
+          case "Temps Tempranillo" -> {
+            // this extends a current effect and maybe should have a different modifier
+          }
+          case "1950 Vampire Vintner wine",
+              "flask of mining oil",
+              "flask of tainted mining oil",
+              "half-baked potion",
+              "mysterious chemical residue",
+              "one pill" -> {
+            // some items give a non-deterministic effect
+          }
+          default -> fail(
+              "Expected " + mod1 + " and " + mod2 + " to appear in pairs on " + element);
+        }
+      }
+    }
+
+    @Test
+    public void modifiersShouldAppearInPairs() {
+      String file = "modifiers.txt";
+      int version = 3;
+      String[] fields;
+      try (BufferedReader reader = FileUtilities.getVersionedReader(file, version)) {
+        while ((fields = FileUtilities.readData(reader)) != null) {
+          String element = fields[1];
+          String modifierString = fields[2];
+          var mods = ModifierDatabase.splitModifiers(modifierString);
+          assertModCountEqual(mods, element, "Add Buff Skill", "Add Buff Effect");
+          assertModCountEqual(mods, element, "Replace Buff Skill", "Replace Buff Effect");
+          assertModCountEqual(mods, element, "Effect", "Effect Duration");
+          assertModCountEqual(mods, element, "Rollover Effect", "Rollover Effect Duration");
         }
       } catch (IOException e) {
         fail("Couldn't read from " + file);


### PR DESCRIPTION
This is step 1 for a project to support items which change buff skills by adding / replacing the effect they give.

The desired use-case is to make Lubricating Sauce / Tubes of Universal Meat / Thoughtful Empathy show up in maximizer. My current plan is to make a new command `ecast <num> <skill> @ <effect>` that I can add as a souce for these new skills / the effects that get replaced.