### PR TITLE
feat: allow raw combat rate to be used in the maximizer

### DIFF
--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -343,6 +343,9 @@ public class Modifiers {
     if (modifier == DoubleModifier.PRISMATIC_DAMAGE) {
       return this.derivePrismaticDamage();
     }
+    if (modifier == DoubleModifier.RAW_COMBAT_RATE) {
+      return this.doubles.get(DoubleModifier.COMBAT_RATE);
+    }
     if (modifier == DoubleModifier.COMBAT_RATE) {
       return this.cappedCombatRate();
     }
@@ -380,9 +383,6 @@ public class Modifiers {
   }
 
   public double getDerived(final DerivedModifier modifier) {
-    if (modifier == DerivedModifier.RAW_COMBAT_RATE) {
-      return this.doubles.get(DoubleModifier.COMBAT_RATE);
-    }
     return this.predict().get(modifier);
   }
 

--- a/src/net/sourceforge/kolmafia/modifiers/DerivedModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DerivedModifier.java
@@ -13,8 +13,7 @@ public enum DerivedModifier implements Modifier {
   BUFFED_MYS("Buffed Mysticality"),
   BUFFED_MOX("Buffed Moxie"),
   BUFFED_HP("Buffed HP Maximum"),
-  BUFFED_MP("Buffed MP Maximum"),
-  RAW_COMBAT_RATE("Raw Combat Rate");
+  BUFFED_MP("Buffed MP Maximum");
 
   private final String name;
 

--- a/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
@@ -586,7 +586,8 @@ public enum DoubleModifier implements Modifier {
       Pattern.compile("([+-]\\d+) Damage vs. Undead"),
       Pattern.compile("Damage vs. Undead: " + EXPR)),
   RAM("RAM", Pattern.compile("([+-]\\d+) RAM"), Pattern.compile("RAM: " + EXPR)),
-  LANTERN("Lantern", Pattern.compile("Lantern: " + EXPR));
+  LANTERN("Lantern", Pattern.compile("Lantern: " + EXPR)),
+  RAW_COMBAT_RATE("Raw Combat Rate", null);
 
   private final String name;
   private final Pattern[] descPatterns;

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -147,10 +147,10 @@ public class ModifiersTest {
   public void correctlyCalculatesCappedCombatRate() {
     Modifiers mod = new Modifiers();
     mod.addDouble(DoubleModifier.COMBAT_RATE, 25, ModifierType.NONE, "");
-    assertEquals(25, mod.getDerived(DerivedModifier.RAW_COMBAT_RATE));
+    assertEquals(25, mod.getDouble(DoubleModifier.RAW_COMBAT_RATE));
     mod.addDouble(DoubleModifier.COMBAT_RATE, 7, ModifierType.NONE, "");
     assertEquals(26, mod.getDouble(DoubleModifier.COMBAT_RATE));
-    assertEquals(32, mod.getDerived(DerivedModifier.RAW_COMBAT_RATE));
+    assertEquals(32, mod.getDouble(DoubleModifier.RAW_COMBAT_RATE));
     mod.addDouble(DoubleModifier.COMBAT_RATE, 9, ModifierType.NONE, "");
     assertEquals(28, mod.getDouble(DoubleModifier.COMBAT_RATE));
     mod.addDouble(DoubleModifier.COMBAT_RATE, 9, ModifierType.NONE, "");
@@ -159,14 +159,14 @@ public class ModifiersTest {
     assertEquals(35, mod.getDouble(DoubleModifier.COMBAT_RATE));
     mod.addDouble(DoubleModifier.COMBAT_RATE, 50, ModifierType.NONE, "");
     assertEquals(35, mod.getDouble(DoubleModifier.COMBAT_RATE));
-    assertEquals(150, mod.getDerived(DerivedModifier.RAW_COMBAT_RATE));
+    assertEquals(150, mod.getDouble(DoubleModifier.RAW_COMBAT_RATE));
 
     mod = new Modifiers();
     mod.addDouble(DoubleModifier.COMBAT_RATE, -25, ModifierType.NONE, "");
-    assertEquals(-25, mod.getDerived(DerivedModifier.RAW_COMBAT_RATE));
+    assertEquals(-25, mod.getDouble(DoubleModifier.RAW_COMBAT_RATE));
     mod.addDouble(DoubleModifier.COMBAT_RATE, -7, ModifierType.NONE, "");
     assertEquals(-26, mod.getDouble(DoubleModifier.COMBAT_RATE));
-    assertEquals(-32, mod.getDerived(DerivedModifier.RAW_COMBAT_RATE));
+    assertEquals(-32, mod.getDouble(DoubleModifier.RAW_COMBAT_RATE));
     mod.addDouble(DoubleModifier.COMBAT_RATE, -9, ModifierType.NONE, "");
     assertEquals(-28, mod.getDouble(DoubleModifier.COMBAT_RATE));
     mod.addDouble(DoubleModifier.COMBAT_RATE, -9, ModifierType.NONE, "");
@@ -175,7 +175,7 @@ public class ModifiersTest {
     assertEquals(-35, mod.getDouble(DoubleModifier.COMBAT_RATE));
     mod.addDouble(DoubleModifier.COMBAT_RATE, -50, ModifierType.NONE, "");
     assertEquals(-35, mod.getDouble(DoubleModifier.COMBAT_RATE));
-    assertEquals(-150, mod.getDerived(DerivedModifier.RAW_COMBAT_RATE));
+    assertEquals(-150, mod.getDouble(DoubleModifier.RAW_COMBAT_RATE));
   }
 
   @Test


### PR DESCRIPTION
Follow-on to #2885.

Maximizer only accepts double / boolean modifiers. Make raw combat rate a double modifier.