### PR TITLE
Fix ascension history image parsing

### DIFF
--- a/src/net/sourceforge/kolmafia/request/AscensionHistoryRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AscensionHistoryRequest.java
@@ -581,7 +581,7 @@ public class AscensionHistoryRequest extends GenericRequest
 
         this.path =
             Arrays.stream(Path.values())
-                .filter(p -> columns[8].contains(p.getImage()))
+                .filter(p -> columns[8].contains(String.format("/%s", p.getImage())))
                 .findAny()
                 .orElse(Path.NONE);
       } catch (Exception e) {

--- a/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AscensionHistoryRequestTest.java
@@ -47,5 +47,7 @@ public class AscensionHistoryRequestTest {
     assertEquals(22, Preferences.getInteger("plumberPoints"), "Plumber ascensions mismatch");
     assertEquals(3, Preferences.getInteger("youRobotPoints"), "You, Robot ascensions mismatch");
     assertEquals(0, Preferences.getInteger("quantumPoints"), "Quantum ascensions mismatch");
+    assertEquals(
+        10, Preferences.getInteger("twoCRSPoints"), "Two Crazy Random Summer ascensions mismatch");
   }
 }


### PR DESCRIPTION
Parsing the ascension history was checking for the path image by "image.gif", this prefixes the image with a forward slash "/image.gif" to fix updating path points for Two Crazy Random Summer specifically because "twocrazydice.gif" was being matched by the Crazy Random Summer "dice.gif"