### PR TITLE
refactor: don't have loose 'avoid removal only' items

### DIFF
--- a/src/net/sourceforge/kolmafia/session/BuffBotManager.java
+++ b/src/net/sourceforge/kolmafia/session/BuffBotManager.java
@@ -237,7 +237,7 @@ public abstract class BuffBotManager {
     // Make sure that the buffbot is wearing the best
     // equipment they have available.
 
-    UseSkillRequest.optimizeEquipment(6003);
+    UseSkillRequest.getInstance(6003).optimizeEquipment();
 
     BuffBotHome.setBuffBotActive(true);
     BuffBotHome.timeStampedLogEntry(BuffBotHome.NOCOLOR, "Buffbot started.");


### PR DESCRIPTION
In the future, I hope to use "forcedItem" with the items mentioned in #2881.

This refactor can go in first. It is technically an improvement to only not remove the item required for the skill we're casting, but has no impact at the moment, as no back / pants have -MP and the powerful glove has +HP, so we never remove it anyway.