### PR TITLE
Log message when beach comb a message in a bottle

### DIFF
--- a/src/net/sourceforge/kolmafia/request/BeachCombRequest.java
+++ b/src/net/sourceforge/kolmafia/request/BeachCombRequest.java
@@ -427,6 +427,24 @@ public class BeachCombRequest extends GenericRequest {
   @Override
   public void processResults() {}
 
+  public static void parseCombUsage(String text) {
+    // Called (indirectly) from postChoice1 after we combed a tile
+    // This is before results are processed and Meat or items are logged.
+    //
+    // <span class='guts'>You comb the area and under the sand you find a bottle. It looks like it
+    // contains some sort of message? You pop the bottle open and look at the piece of paper inside.
+    // It says:<br><br>LIFE ON A DESSERT ISLAND -- SHOULD BE HARD, BUT REALLY IT IS A PIECE OF
+    // CAKE<br><br>Is that some sort of joke?</span>
+    //
+    // If we find a message in a bottle, there are no items or Meat.
+    // Log something so that the user can see what happened.
+    if (text.contains("you find a bottle")) {
+      String message = "You found a message in a bottle!";
+      RequestLogger.printLine(message);
+      RequestLogger.updateSessionLog(message);
+    }
+  }
+
   @Override
   public int getAdventuresUsed() {
     return getAdventuresUsed(this.command);

--- a/src/net/sourceforge/kolmafia/session/BeachManager.java
+++ b/src/net/sourceforge/kolmafia/session/BeachManager.java
@@ -155,12 +155,15 @@ public class BeachManager {
     // <span class='guts'>You comb the area and find something kind of interesting, as well as some
     // sand, which is not particularly interesting unless you personally happen to be interested in
     // sand, in which case boy howdy are you in luck. That stuff is <i>everywhere.</i>...
+    //
     // <span class='guts'>You comb the area and under the sand you find a bottle. It looks like it
     // contains some sort of message? You pop the bottle open and look at the piece of paper inside.
     // It says:<br><br>LIFE ON A DESSERT ISLAND -- SHOULD BE HARD, BUT REALLY IT IS A PIECE OF
     // CAKE<br><br>Is that some sort of joke?</span>
+    //
     // <span class='guts'>You comb all of the meat off the whale carcass, just like barbers used to
     // do back when they were surgeons.
+    //
     // <span class='guts'>You comb the sand and hear a hollow <i>clonk</i> that can only mean one
     // thing: pirate treasure chest! Heck yeah baby!
 
@@ -190,6 +193,9 @@ public class BeachManager {
       // Replace the setting
       String value = BeachManager.layoutToString(layout);
       Preferences.setString("_beachLayout", value);
+
+      // Perhaps we need special logging
+      BeachCombRequest.parseCombUsage(text);
     }
     return BeachManager.parseCombUsage(text);
   }
@@ -200,11 +206,6 @@ public class BeachManager {
     if (!text.contains("to the start of the beach to find")) {
       return false;
     }
-
-    // <span class='guts'>You comb the area and under the sand you find a bottle. It looks like it
-    // contains some sort of message? You pop the bottle open and look at the piece of paper inside.
-    // It says:<br><br>LIFE ON A DESSERT ISLAND -- SHOULD BE HARD, BUT REALLY IT IS A PIECE OF
-    // CAKE<br><br>Is that some sort of joke?</span>
 
     Matcher matcher = BeachManager.FREE_WALK_PATTERN.matcher(text);
     int walksAvailable = matcher.find() ? StringUtilities.parseInt(matcher.group(1)) : 0;

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -9724,54 +9724,47 @@ public abstract class ChoiceControl {
         }
 
         case 1063 -> { // Adjust your 'Edpiece
-          {
-            var state = EdPieceCommand.getStateFromDecision(decision);
+          var state = EdPieceCommand.getStateFromDecision(decision);
 
-            if (state != null) {
-              RequestLogger.updateSessionLog();
-              RequestLogger.updateSessionLog("edpiece " + state);
-            }
-
-            return true;
+          if (state != null) {
+            RequestLogger.updateSessionLog();
+            RequestLogger.updateSessionLog("edpiece " + state);
           }
+
+          return true;
         }
 
         case 1101 -> { // It's a Barrel Smashing Party!
-          {
-            if (decision == 2) {
-              // We're smashing 100 barrels
-              // The results don't say which barrels are being smashed, but it seems to happen in
-              // item order
-              int count = 100;
-              int itemId = ItemPool.LITTLE_FIRKIN;
-              RequestLogger.updateSessionLog("smashing 100 barrels");
-              while (count > 0 && itemId <= ItemPool.BARNACLED_BARREL) {
-                int smashNumber = Math.min(count, InventoryManager.getCount(itemId));
-                String name = ItemDatabase.getItemName(itemId);
-                if (smashNumber > 0 && name != null) {
-                  RequestLogger.updateSessionLog("smash " + smashNumber + " " + name);
-                  count -= smashNumber;
-                }
-                itemId++;
+          if (decision == 2) {
+            // We're smashing 100 barrels
+            // The results don't say which barrels are being smashed, but it seems to happen in
+            // item order
+            int count = 100;
+            int itemId = ItemPool.LITTLE_FIRKIN;
+            RequestLogger.updateSessionLog("smashing 100 barrels");
+            while (count > 0 && itemId <= ItemPool.BARNACLED_BARREL) {
+              int smashNumber = Math.min(count, InventoryManager.getCount(itemId));
+              String name = ItemDatabase.getItemName(itemId);
+              if (smashNumber > 0 && name != null) {
+                RequestLogger.updateSessionLog("smash " + smashNumber + " " + name);
+                count -= smashNumber;
               }
-              return true;
+              itemId++;
             }
-            int itemId = extractIidFromURL(urlString);
-            String name = ItemDatabase.getItemName(itemId);
-            if (name != null) {
-              RequestLogger.updateSessionLog("smash " + name);
-              return true;
-            }
-            break;
+            return true;
+          }
+          int itemId = extractIidFromURL(urlString);
+          String name = ItemDatabase.getItemName(itemId);
+          if (name != null) {
+            RequestLogger.updateSessionLog("smash " + name);
+            return true;
           }
         }
 
         case 1181 -> { // Your Witchess Set
-          {
-            String desc = ChoiceManager.choiceDescription(choice, decision);
-            RequestLogger.updateSessionLog("Took choice " + choice + "/" + decision + ": " + desc);
-            return true;
-          }
+          String desc = ChoiceManager.choiceDescription(choice, decision);
+          RequestLogger.updateSessionLog("Took choice " + choice + "/" + decision + ": " + desc);
+          return true;
         }
 
         case 1182 -> { // Play against the Witchess Pieces
@@ -9816,22 +9809,18 @@ public abstract class ChoiceControl {
         case 1352, //  Island #1, Who Are You?
             1353, //  What's Behind Island #2?
             1354 -> { //  Third Island's the Charm
-          {
-            // Get the island name here so that we can set the location name accordingly.
-            // Other choicey things should happen in postChoiceX
-            String desc = ChoiceManager.choiceDescription(choice, decision);
-            RequestLogger.updateSessionLog("Took choice " + choice + "/" + decision + ": " + desc);
-            if (desc != null && !desc.equals("Decide Later")) {
-              Preferences.setString("_lastPirateRealmIsland", desc);
-            }
-            return true;
+          // Get the island name here so that we can set the location name accordingly.
+          // Other choicey things should happen in postChoiceX
+          String desc = ChoiceManager.choiceDescription(choice, decision);
+          RequestLogger.updateSessionLog("Took choice " + choice + "/" + decision + ": " + desc);
+          if (desc != null && !desc.equals("Decide Later")) {
+            Preferences.setString("_lastPirateRealmIsland", desc);
           }
+          return true;
         }
 
         case 1388 -> { // Comb the Beach
-          {
-            return BeachCombRequest.registerRequest(urlString);
-          }
+          return BeachCombRequest.registerRequest(urlString);
         }
 
         case 1445, // Reassembly Station

--- a/test/root/request/test_beach_comb_bottle.html
+++ b/test/root/request/test_beach_comb_bottle.html
@@ -1,0 +1,202 @@
+<html><head>
+<script language=Javascript>
+<!--
+if (parent.frames.length == 0) location.href="game.php";
+top.charpane.location.href="charpane.php";
+//-->
+</script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/jquery-1.5.1.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/keybinds.min.2.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/window.20111231.js"></script>
+<script language="javascript">function chatFocus(){if(top.chatpane.document.chatform.graf) top.chatpane.document.chatform.graf.focus();}
+if (typeof defaultBind != 'undefined') { defaultBind(47, 2, chatFocus); defaultBind(190, 2, chatFocus);defaultBind(191, 2, chatFocus); defaultBind(47, 8, chatFocus);defaultBind(190, 8, chatFocus); defaultBind(191, 8, chatFocus); }</script><script>
+function switchFocus()
+{
+	if (top.chatpane.document.chatform.graf.focus) 
+		top.chatpane.document.chatform.graf.focus(); 
+	return false;
+}
+function repeat()
+{
+	var linx = document.getElementsByTagName("A");
+	for (var i = 0; i < linx.length; i++)
+	{
+		if (typeof timersfunc != 'undefined') {
+			if (!timersfunc()) { 
+				return; 
+			}
+			timersfunc = null;
+		}
+		var link = linx[i];
+		if (link.innerHTML.match(/Adventure Again/) || link.innerHTML.match(/Do it again/))
+			location.href = link.href;
+	}
+}
+
+defaultBind(47, CTRL, switchFocus);
+defaultBind(191, CTRL, switchFocus);
+defaultBind(47, META, switchFocus);
+defaultBind(191, META, switchFocus);
+defaultBind(192, NONE, repeat);
+defaultBind(220, NONE, repeat);
+</script><script language="javascript">
+	function updateParseItem(iid, field, info) {
+		var tbl = $('#ic'+iid);
+		var data = parseItem(tbl);
+		if (!data) return;
+		data[field] = info;
+		var out = [];
+		for (i in data) {
+			if (!data.hasOwnProperty(i)) continue;
+			out.push(i+'='+data[i]);
+		}
+		tbl.attr('rel', out.join('&'));
+	}
+	function parseItem(tbl) {
+		tbl = $(tbl);
+		var rel = tbl.attr('rel');
+		var data = {};
+		if (!rel) return data;
+		var parts = rel.split('&');
+		for (i in parts) {
+			if (!parts.hasOwnProperty(i)) continue;
+			var kv = parts[i].split('=');
+			tbl.data(kv[0], kv[1]);
+			data[kv[0]] = kv[1];
+		}
+		return data;
+	}
+</script><script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/pop_query.20230713.js"></script>
+<script type="text/javascript" src="https://d2uyhvukfffg5a.cloudfront.net/scripts/ircm.20230626.js"></script>
+<script type="text/javascript">
+var tp = top;
+function pop_ircm_contents(i, some) {
+	var contents = '',
+		shown = 0,
+		da = '&nbsp;<a href="#" rel="?" class="small dojaxy">[some]</a>&nbsp;<a href="#" rel="',
+		db = '" class="small dojaxy">[all]</a>',
+		dc = '<div style="width:100%; padding-bottom: 3px;" rel="',
+		dd = '<a href="#" rel="1" class="small dojaxy">[';
+	one = 'one'; ss=some;
+if (i.d==1 && i.s>0) { shown++; 
+contents += dc + 'sellstuff.php?action=sell&ajax=1&type=quant&whichitem%5B%5D=IID&howmany=NUM&pwd=65c648bba625194076ade22e078d0973" id="pircm_'+i.id+'"><b>Auto-Sell ('+i.s+' meat):</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'inventory.php?action=closetpush&ajax=1&whichitem=IID&qty=NUM&pwd=65c648bba625194076ade22e078d0973" id="pircm_'+i.id+'"><b>Closet:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0 && i.g==0 && i.t==1) { shown++; 
+contents += dc + 'managestore.php?action=additem&qty1=NUM&item1=IID&price1=&limit1=&ajax=1&pwd=65c648bba625194076ade22e078d0973" id="pircm_'+i.id+'"><b>Stock in Mall:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0) { shown++; 
+contents += dc + 'managecollection.php?action=put&ajax=1&whichitem1=IID&howmany1=NUM&pwd=65c648bba625194076ade22e078d0973" id="pircm_'+i.id+'"><b>Add to Display Case:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.q==0 && i.t==1) { shown++; 
+contents += dc + 'clan_stash.php?action=addgoodies&ajax=1&item1=IID&qty1=NUM&pwd=65c648bba625194076ade22e078d0973" id="pircm_'+i.id+'"><b>Contribute to Clan:</b> '+dd+one+']</a>';
+if (ss) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && !i.ac) { shown++; 
+contents += dc + 'inv_'+(i.u=="a"?"redir":(lab=(i.u=="u"?"use":(i.u=="e"?"eat":(i.u=="b"?"booze":(i.u=="s"?"spleen":"equip"))))))+'.php?ajax=1&whichitem=IID&itemquantity=NUM&quantity=NUM'+(i.u=="q"?"&action=equip":"")+'&pwd=65c648bba625194076ade22e078d0973" id="pircm_'+i.id+'"><b>'+ucfirst(unescape(i.ou ? i.ou.replace(/\+/g," ") : (lab=="booze"?"drink":lab)))+':</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=1&ajax=1&whichitem=IID&action=equip&pwd=65c648bba625194076ade22e078d0973" id="pircm_'+i.id+'"><b>Equip (slot 1):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=2&ajax=1&whichitem=IID&action=equip&pwd=65c648bba625194076ade22e078d0973" id="pircm_'+i.id+'"><b>Equip (slot 2):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+one = 'one'; ss=some;
+if (i.u && i.u != "." && i.ac) { shown++; 
+contents += dc + 'inv_equip.php?slot=3&ajax=1&whichitem=IID&action=equip&pwd=65c648bba625194076ade22e078d0973" id="pircm_'+i.id+'"><b>Equip (slot 3):</b> '+dd+one+']</a>';
+if (ss && i.u != 'q' && !(i.u=='u' && i.m==0)) { contents += da + i.n + db;}
+contents += '</div>';
+}
+
+	return [contents, shown];
+}
+tp=top
+var todo = [];
+function nextAction() {
+	var next_todo = todo.shift();
+	if (next_todo) {
+		eval(next_todo);
+	}
+}
+function dojax(dourl, afterFunc, hoverCaller, failureFunc, method, params) {
+	$.ajax({
+		type: method || 'GET', url: dourl, cache: false,
+		data: params || null,
+		global: false,
+		success: function (out) {
+			nextAction();
+			if (out.match(/no\|/)) {
+				var parts = out.split(/\|/);
+				if (failureFunc) failureFunc(parts[1]);
+				else if (window.dojaxFailure) window.dojaxFailure(parts[1]);
+				else if (tp.chatpane.handleMessage) tp.chatpane.handleMessage({type: 'event', msg: 'Oops!  Sorry, Dave, you appear to be ' + parts[1]});
+				else  $('#ChatWindow').append('<font color="green">Oops!  Sorry, Dave, you appear to be ' + parts[1] + '.</font><br />' + "\n");
+				return;
+			}
+
+			if (hoverCaller)  {
+				float_results(hoverCaller, out);
+				if (afterFunc) { afterFunc(out); }
+				return;
+			}
+$(tp.mainpane.document).find("#effdiv").remove(); if(!window.dontscroll || (window.dontscroll && dontscroll==0)) { window.scroll(0,0);}
+			var $eff = $(tp.mainpane.document).find('#effdiv');
+			if ($eff.length == 0) {
+				var d = tp.mainpane.document.createElement('DIV');
+				d.id = 'effdiv';
+				var b = tp.mainpane.document.body;
+				if ($('#content_').length > 0) {
+					b = $('#content_ div:first')[0];
+				}
+				b.insertBefore(d, b.firstChild);
+				$eff = $(d);
+			}
+			$eff.find('a[name="effdivtop"]').remove().end()
+				.prepend('<a name="effdivtop"></a><center>' + out + '</center>').css('display','block');
+			if (!window.dontscroll || (window.dontscroll && dontscroll==0)) {
+				tp.mainpane.document.location = tp.mainpane.document.location + "#effdivtop";
+			}
+			if (afterFunc) { afterFunc(out); }
+		}
+	});
+}
+</script>	<link rel="stylesheet" type="text/css" href="https://d2uyhvukfffg5a.cloudfront.net/styles.20230117d.css">
+<style type='text/css'>
+.faded {
+	zoom: 1;
+	filter: alpha(opacity=35);
+	opacity: 0.35;
+	-khtml-opacity: 0.35; 
+    -moz-opacity: 0.35;
+}
+</style>
+
+</head>
+
+<body>
+<Center><div id="results"><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="color: white;" align=center bgcolor=blue><b>Results:</b></td></tr><tr><td style="padding: 5px; border: 1px solid blue;"><center><table><tr><td><span class='guts'>You comb the area and under the sand you find a bottle. It looks like it contains some sort of message? You pop the bottle open and look at the piece of paper inside. It says:<br><br>LIFE ON A DESSERT ISLAND -- SHOULD BE HARD, BUT REALLY IT IS A PIECE OF CAKE<br><br>Is that some sort of joke?</span></td></tr></table></center></td></tr><tr><td height=4></td></tr></table></div><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="color: white;" align=center bgcolor=blue><b>Comb the Beach</b></td></tr><tr><td style="padding: 5px; border: 1px solid blue;"><center><table><tr><td><center><p>You grab your comb and head back to the start of the beach to find another good spot.<form method="post" action="choice.php"><input name="whichchoice" value="1388" type="hidden" /><input name="pwd" value="65c648bba625194076ade22e078d0973"  type="hidden" /><input name="option" value="1"  type="hidden" />Wander along the beach for <input type="number" name="minutes" /> minutes. <input type="submit" value="Go (1)" class="button" /></form><p></p><form method="post" action="choice.php"><input name="whichchoice" value="1388" type="hidden" /><input name="pwd" value="65c648bba625194076ade22e078d0973"  type="hidden" /><input name="option" value="2"  type="hidden" /><input type="submit" value="Wander to a random spot (1)" class="button" /></form><table border=0><tr><td valign='top'><form method="post" action="choice.php" style="display: inline-block; margin-top: 5px";><input name="whichchoice" value="1388" type="hidden" /><input name="pwd" value="65c648bba625194076ade22e078d0973"  type="hidden" /><input name="option" value="3"  type="hidden" /><input name="buff" value="1"  type="hidden" /><input type="submit" value="Visit Beach Head #1 (1)" class="button" /></form></td><td valign='top'><table><tr><td><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/beachface1.gif class=hand onClick='eff("af5a99b27a8c15613c6bcc38df7ce1b7");' border=0></td><td><b>Hot-Headed</b></td></tr></table></td></tr><tr><td valign='top'><form method="post" action="choice.php" style="display: inline-block; margin-top: 5px";><input name="whichchoice" value="1388" type="hidden" /><input name="pwd" value="65c648bba625194076ade22e078d0973"  type="hidden" /><input name="option" value="3"  type="hidden" /><input name="buff" value="2"  type="hidden" /><input type="submit" value="Visit Beach Head #2 (1)" class="button" /></form></td><td valign='top'><table><tr><td><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/beachface2.gif class=hand onClick='eff("06ee15b12b004fba16323c3d311d8bc0");' border=0></td><td><b>Cold as Nice</b></td></tr></table></td></tr><tr><td valign='top'><form method="post" action="choice.php" style="display: inline-block; margin-top: 5px";><input name="whichchoice" value="1388" type="hidden" /><input name="pwd" value="65c648bba625194076ade22e078d0973"  type="hidden" /><input name="option" value="3"  type="hidden" /><input name="buff" value="3"  type="hidden" /><input type="submit" value="Visit Beach Head #3 (1)" class="button" /></form></td><td valign='top'><table><tr><td><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/beachface3.gif class=hand onClick='eff("f812d44c25edc9317d1486d0190c22c4");' border=0></td><td><b>A Brush with Grossness</b></td></tr></table></td></tr><tr><td valign='top'><form method="post" action="choice.php" style="display: inline-block; margin-top: 5px";><input name="whichchoice" value="1388" type="hidden" /><input name="pwd" value="65c648bba625194076ade22e078d0973"  type="hidden" /><input name="option" value="3"  type="hidden" /><input name="buff" value="4"  type="hidden" /><input type="submit" value="Visit Beach Head #4 (1)" class="button" /></form></td><td valign='top'><table><tr><td><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/beachface4.gif class=hand onClick='eff("8dcd56352c0a918f21e940a61f0f0c81");' border=0></td><td><b>Does It Have a Skull In There??</b></td></tr></table></td></tr><tr><td valign='top'><form method="post" action="choice.php" style="display: inline-block; margin-top: 5px";><input name="whichchoice" value="1388" type="hidden" /><input name="pwd" value="65c648bba625194076ade22e078d0973"  type="hidden" /><input name="option" value="3"  type="hidden" /><input name="buff" value="5"  type="hidden" /><input type="submit" value="Visit Beach Head #5 (1)" class="button" /></form></td><td valign='top'><table><tr><td><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/beachface5.gif class=hand onClick='eff("f4e6230536590003cd903396c3bcc868");' border=0></td><td><b>Oiled, Slick</b></td></tr></table></td></tr><tr><td valign='top'><form method="post" action="choice.php" style="display: inline-block; margin-top: 5px";><input name="whichchoice" value="1388" type="hidden" /><input name="pwd" value="65c648bba625194076ade22e078d0973"  type="hidden" /><input name="option" value="3"  type="hidden" /><input name="buff" value="6"  type="hidden" /><input type="submit" value="Visit Beach Head #6 (1)" class="button" /></form></td><td valign='top'><table><tr><td><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/beachface6.gif class=hand onClick='eff("949a72c535a6942b9622fef2c38b5226");' border=0></td><td><b>Lack of Body-Building</b></td></tr></table></td></tr><tr><td valign='top'><form method="post" action="choice.php" style="display: inline-block; margin-top: 5px";><input name="whichchoice" value="1388" type="hidden" /><input name="pwd" value="65c648bba625194076ade22e078d0973"  type="hidden" /><input name="option" value="3"  type="hidden" /><input name="buff" value="7"  type="hidden" /><input type="submit" value="Visit Beach Head #7 (1)" class="button" /></form></td><td valign='top'><table><tr><td><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/beachface7.gif class=hand onClick='eff("30ec335a592282b39919cd6c3c18d9fb");' border=0></td><td><b>We're All Made of Starfish</b></td></tr></table></td></tr><tr><td valign='top'><form method="post" action="choice.php" style="display: inline-block; margin-top: 5px";><input name="whichchoice" value="1388" type="hidden" /><input name="pwd" value="65c648bba625194076ade22e078d0973"  type="hidden" /><input name="option" value="3"  type="hidden" /><input name="buff" value="8"  type="hidden" /><input type="submit" value="Visit Beach Head #8 (1)" class="button" /></form></td><td valign='top'><table><tr><td><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/beachface8.gif class=hand onClick='eff("b9072cf420d05090ce274e93f6755fa2");' border=0></td><td><b>Pomp & Circumsands</b></td></tr></table></td></tr><tr><td valign='top'><form method="post" action="choice.php" style="display: inline-block; margin-top: 5px";><input name="whichchoice" value="1388" type="hidden" /><input name="pwd" value="65c648bba625194076ade22e078d0973"  type="hidden" /><input name="option" value="3"  type="hidden" /><input name="buff" value="9"  type="hidden" /><input type="submit" value="Visit Beach Head #9 (1)" class="button" /></form></td><td valign='top'><table><tr><td><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/beachface9.gif class=hand onClick='eff("d62cd7322be9e2ecb0c8888efcd36efb");' border=0></td><td><b>Resting Beach Face</b></td></tr></table></td></tr><tr><td valign='top'><form method="post" action="choice.php" style="display: inline-block; margin-top: 5px";><input name="whichchoice" value="1388" type="hidden" /><input name="pwd" value="65c648bba625194076ade22e078d0973"  type="hidden" /><input name="option" value="3"  type="hidden" /><input name="buff" value="10"  type="hidden" /><input type="submit" value="Visit Beach Head #10 (1)" class="button" /></form></td><td valign='top'><table><tr><td><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/beachface10.gif class=hand onClick='eff("e36e09682be5b280c810bf5a2dc53469");' border=0></td><td><b>Do I Know You From Somewhere?</b></td></tr></table></td></tr><tr><td valign='top'><form method="post" action="choice.php" style="display: inline-block; margin-top: 5px";><input name="whichchoice" value="1388" type="hidden" /><input name="pwd" value="65c648bba625194076ade22e078d0973"  type="hidden" /><input name="option" value="3"  type="hidden" /><input name="buff" value="11"  type="hidden" /><input type="submit" value="Visit Beach Head #11 (1)" class="button" /></form></td><td valign='top'><table><tr><td><img src=https://d2uyhvukfffg5a.cloudfront.net/itemimages/beachface11.gif class=hand onClick='eff("441324a54b655f39e6302afd9ab44cb6");' border=0></td><td><b>You Learned Something Maybe!</b></td></tr></table></td></tr></table><form method="post" action="choice.php"><input name="whichchoice" value="1388" type="hidden" /><input name="pwd" value="65c648bba625194076ade22e078d0973"  type="hidden" /><input name="option" value="5"  type="hidden" /><input type="submit" value="Stop Beachcombing" class="button" /></form></center></td></tr></table></center></td></tr><tr><td height=4></td></tr></table><script>top.charpane.location.href="charpane.php";</script>
+</body></html>


### PR DESCRIPTION
When you comb a beach square, we log something like:

```
Combing square 9,6 (6079 minutes down the beach)
You gain 10,491,186 Meat
```
(for a whale) or
```
Combing square 9,6 (6079 minutes down the beach)
You acquire an item: rainbow pearl
```
(for an item).

If you find a message in a bottle, there is no item or Meat, and we log nothing.

Fix so that we log this:
```
Combing square 4,6 (1521 minutes down the beach)
You found a message in a bottle!
```

ChoiceControl.postChoice1 calls BeachManager.parseCombUsage calls BeachCombRequest.parseCombUsage.
BeachManager had already parsed the URL and figured out the text was a responseText from combing - as opposed to any other Beach Comb command - so I put the logging in BeachCombRequest, which already did logging.

I also noticed that ChoiceControl.registerRequest had been converted from an old choice to a new choice, and several of the cases - including 1388 - had their existing block surrounded by a new block. I fixed all of those.

I considered changing ChoiceControl.postChoice1 into a new-style switch, but that can go into a refactoring PR, rather than this feature PR.