### PR TITLE
Fix further issues supplying a "bandersnatch" value for the Peridot choice

### DIFF
--- a/src/net/sourceforge/kolmafia/request/ForeseeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ForeseeRequest.java
@@ -45,7 +45,7 @@ public class ForeseeRequest extends GenericRequest {
     // Ensure the Peridot is equipped or in inventory.
     if (InventoryManager.getCount(ItemPool.PERIDOT_OF_PERIL) == 0
         && !KoLCharacter.hasEquipped(ItemPool.PERIDOT_OF_PERIL)) {
-      if (!InventoryManager.retrieveItem(ItemPool.COMBAT_LOVERS_LOCKET, 1)) {
+      if (!InventoryManager.retrieveItem(ItemPool.PERIDOT_OF_PERIL, 1)) {
         KoLmafia.updateDisplay(
             KoLConstants.MafiaState.ERROR, "Internal error: failed to retrieve Peridot of Peril");
         return;

--- a/src/net/sourceforge/kolmafia/utilities/ChoiceUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/ChoiceUtilities.java
@@ -34,7 +34,7 @@ public class ChoiceUtilities {
   };
 
   private ChoiceUtilities() {}
-  
+
   private static boolean isNonChoiceForm(final String form) {
     // We are searching for a form that submits to choice.php. With the assumption that a choice.php
     // page has been supplied, it must either have a choice.php action or no action at all.

--- a/src/net/sourceforge/kolmafia/utilities/ChoiceUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/ChoiceUtilities.java
@@ -35,6 +35,12 @@ public class ChoiceUtilities {
 
   private ChoiceUtilities() {}
 
+  private static boolean isChoiceForm(final String form) {
+    // We are searching for a form that submits to choice.php. With the assumption that a choice.php page has been
+    // supplied, it must either have a choice.php action or no action at all.
+    return form.contains("choice.php") || form.contains("<form method=\"post\">");
+  }
+
   // Extract choice number from URL
 
   public static final Pattern URL_CHOICE_PATTERN = Pattern.compile("whichchoice=(\\d+)");
@@ -258,9 +264,7 @@ public class ChoiceUtilities {
     Matcher m = FORM_PATTERN.matcher(responseText);
     while (m.find()) {
       String form = m.group();
-      if (!form.contains("choice.php")) {
-        continue;
-      }
+      if (!isChoiceForm(form)) continue;
       Matcher optMatcher = OPTION_PATTERN1.matcher(form);
       if (!optMatcher.find()) {
         continue;
@@ -306,9 +310,7 @@ public class ChoiceUtilities {
     Matcher m = FORM_PATTERN.matcher(responseText);
     while (m.find()) {
       String form = m.group();
-      if (!form.contains("choice.php")) {
-        continue;
-      }
+      if (!isChoiceForm(form)) continue;
       Matcher optMatcher = OPTION_PATTERN1.matcher(form);
       if (!optMatcher.find()) {
         continue;
@@ -360,9 +362,7 @@ public class ChoiceUtilities {
     Matcher m = FORM_PATTERN.matcher(responseText);
     while (m.find()) {
       String form = m.group();
-      if (!form.contains("choice.php")) {
-        continue;
-      }
+      if (!isChoiceForm(form)) continue;
       Matcher optMatcher = OPTION_PATTERN1.matcher(form);
       if (!optMatcher.find()) {
         continue;

--- a/src/net/sourceforge/kolmafia/utilities/ChoiceUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/ChoiceUtilities.java
@@ -35,11 +35,10 @@ public class ChoiceUtilities {
 
   private ChoiceUtilities() {}
 
-  private static boolean isChoiceForm(final String form) {
+  private static boolean isNonChoiceForm(final String form) {
     // We are searching for a form that submits to choice.php. With the assumption that a choice.php
-    // page has been
-    // supplied, it must either have a choice.php action or no action at all.
-    return form.contains("choice.php") || form.contains("<form method=\"post\">");
+    // page has been supplied, it must either have a choice.php action or no action at all.
+    return !form.contains("choice.php") && !form.contains("<form method=\"post\">");
   }
 
   // Extract choice number from URL
@@ -141,7 +140,7 @@ public class ChoiceUtilities {
     Matcher m = FORM_PATTERN.matcher(responseText);
     while (m.find()) {
       String form = m.group();
-      if (!isChoiceForm(form)) continue;
+      if (isNonChoiceForm(form)) continue;
       Matcher optMatcher = OPTION_PATTERN1.matcher(form);
       if (!optMatcher.find()) {
         continue;
@@ -165,7 +164,7 @@ public class ChoiceUtilities {
     m = LINK_PATTERN.matcher(responseText);
     while (m.find()) {
       String form = m.group();
-      if (!isChoiceForm(form)) continue;
+      if (isNonChoiceForm(form)) continue;
       Matcher optMatcher = OPTION_PATTERN2.matcher(form);
       if (!optMatcher.find()) {
         continue;
@@ -259,7 +258,7 @@ public class ChoiceUtilities {
     Matcher m = FORM_PATTERN.matcher(responseText);
     while (m.find()) {
       String form = m.group();
-      if (!isChoiceForm(form)) continue;
+      if (isNonChoiceForm(form)) continue;
       Matcher optMatcher = OPTION_PATTERN1.matcher(form);
       if (!optMatcher.find()) {
         continue;
@@ -305,7 +304,7 @@ public class ChoiceUtilities {
     Matcher m = FORM_PATTERN.matcher(responseText);
     while (m.find()) {
       String form = m.group();
-      if (!isChoiceForm(form)) continue;
+      if (isNonChoiceForm(form)) continue;
       Matcher optMatcher = OPTION_PATTERN1.matcher(form);
       if (!optMatcher.find()) {
         continue;
@@ -362,7 +361,7 @@ public class ChoiceUtilities {
     Matcher m = FORM_PATTERN.matcher(responseText);
     while (m.find()) {
       String form = m.group();
-      if (!isChoiceForm(form)) continue;
+      if (isNonChoiceForm(form)) continue;
       Matcher optMatcher = OPTION_PATTERN1.matcher(form);
       if (!optMatcher.find()) {
         continue;
@@ -402,6 +401,71 @@ public class ChoiceUtilities {
         continue;
       }
       var name = n.group(1);
+      choice.add(name);
+    }
+
+    return choice;
+  }
+
+  public static Map<Integer, Set<String>> parseHiddenInputs(final String responseText) {
+    Map<Integer, Set<String>> hiddens = new TreeMap<>();
+
+    if (responseText == null) {
+      return hiddens;
+    }
+
+    // Find all choice forms
+    Matcher m = FORM_PATTERN.matcher(responseText);
+    while (m.find()) {
+      String form = m.group();
+      if (isNonChoiceForm(form)) continue;
+      Matcher optMatcher = OPTION_PATTERN1.matcher(form);
+      if (!optMatcher.find()) {
+        continue;
+      }
+
+      // Collect all the text inputs from this form
+      var extra = extractExtraHiddenFields(form);
+
+      if (!extra.isEmpty()) {
+        hiddens
+            .computeIfAbsent(Integer.parseInt(optMatcher.group(1)), (k) -> new TreeSet<>())
+            .addAll(extra);
+      }
+    }
+
+    return hiddens;
+  }
+
+  private static final Set<String> STANDARD_HIDDEN_INPUT_FIELDS =
+      Set.of("option", "pwd", "whichchoice");
+
+  private static Set<String> extractExtraHiddenFields(String form) {
+    Set<String> choice = new TreeSet<>();
+
+    // Find all hidden "input" tags that are non-standard within this form
+    var i = INPUT_PATTERN.matcher(form);
+    while (i.find()) {
+      var typeMatcher = TYPE_PATTERN.matcher(i.group(1));
+      if (!typeMatcher.find()) {
+        continue;
+      }
+
+      if (!typeMatcher.group(1).equals("hidden")) {
+        continue;
+      }
+
+      var input = i.group(1);
+      var n = NAME_PATTERN.matcher(input);
+      if (!n.find()) {
+        continue;
+      }
+      var name = n.group(1);
+
+      if (STANDARD_HIDDEN_INPUT_FIELDS.contains(name)) {
+        continue;
+      }
+
       choice.add(name);
     }
 
@@ -465,18 +529,21 @@ public class ChoiceUtilities {
     }
 
     // Selects: get a map from CHOICE => map from NAME => set of OPTIONS
-    Map<Integer, Map<String, Set<String>>> formSelects =
-        ChoiceUtilities.parseSelectInputs(responseText);
+    var formSelects = ChoiceUtilities.parseSelectInputs(responseText);
 
     // Texts: get a map from CHOICE => set of NAMES
-    Map<Integer, Set<String>> formTexts = ChoiceUtilities.parseTextInputs(responseText);
+    var formTexts = ChoiceUtilities.parseTextInputs(responseText);
+
+    // Hidden overloads: get a map from CHOICE => set of NAMES
+    var formHiddens = ChoiceUtilities.parseHiddenInputs(responseText);
 
     // Does the decision have extra select or text inputs?
-    Integer key = StringUtilities.parseInt(decision);
-    Map<String, Set<String>> selects = formSelects.get(key);
-    Set<String> texts = formTexts.get(key);
+    var key = StringUtilities.parseInt(decision);
+    var selects = formSelects.get(key);
+    var texts = formTexts.get(key);
+    var hiddens = formHiddens.get(key);
 
-    if (selects == null && texts == null) {
+    if (selects == null && texts == null && hiddens == null) {
       // No. If the user supplied no extra fields, all is well
       if (extras.isEmpty()) {
         return (!errors.isEmpty()) ? errors.toString() : null;
@@ -486,7 +553,7 @@ public class ChoiceUtilities {
         errors
             .append("Choice option ")
             .append(choiceOption)
-            .append("does not require '")
+            .append(" does not require '")
             .append(extra)
             .append("'.\n");
       }
@@ -552,13 +619,31 @@ public class ChoiceUtilities {
       }
     }
 
+    // All extra hidden inputs in the form must have a value supplied
+    if (hiddens != null) {
+      for (String name : hiddens) {
+        String supplied = suppliedFields.get(name);
+        if (supplied == null) {
+          // Did not supply a value for a field
+          errors
+              .append("Choice option ")
+              .append(choiceOption)
+              .append(" requires '")
+              .append(name)
+              .append("' but not supplied.\n");
+        } else {
+          suppliedFields.remove(name);
+        }
+      }
+    }
+
     // No unnecessary fields in the form can be supplied
     for (Map.Entry<String, String> supplied : suppliedFields.entrySet()) {
       String name = supplied.getKey();
       errors
           .append("Choice option ")
           .append(choiceOption)
-          .append("does not require '")
+          .append(" does not require '")
           .append(name)
           .append("'.\n");
     }

--- a/src/net/sourceforge/kolmafia/utilities/ChoiceUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/ChoiceUtilities.java
@@ -424,7 +424,7 @@ public class ChoiceUtilities {
         continue;
       }
 
-      // Collect all the text inputs from this form
+      // Collect all the hidden inputs from this form
       var extra = extractExtraHiddenFields(form);
 
       if (!extra.isEmpty()) {

--- a/src/net/sourceforge/kolmafia/utilities/ChoiceUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/ChoiceUtilities.java
@@ -36,7 +36,8 @@ public class ChoiceUtilities {
   private ChoiceUtilities() {}
 
   private static boolean isChoiceForm(final String form) {
-    // We are searching for a form that submits to choice.php. With the assumption that a choice.php page has been
+    // We are searching for a form that submits to choice.php. With the assumption that a choice.php
+    // page has been
     // supplied, it must either have a choice.php action or no action at all.
     return form.contains("choice.php") || form.contains("<form method=\"post\">");
   }

--- a/src/net/sourceforge/kolmafia/utilities/ChoiceUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/ChoiceUtilities.java
@@ -103,9 +103,9 @@ public class ChoiceUtilities {
 
   public static final Pattern DECISION_BUTTON_PATTERN =
       Pattern.compile(
-          "<input type=hidden name=option value=(\\d+)>(?:.*?)<input +class=button type=submit value=\"(.*?)\">");
+          "<input type=hidden name=option value=(\\d+)>.*?<input +class=button type=submit value=\"(.*?)\">");
 
-  public static final String findChoiceDecisionIndex(final String text, final String responseText) {
+  public static String findChoiceDecisionIndex(final String text, final String responseText) {
     Matcher matcher = DECISION_BUTTON_PATTERN.matcher(responseText);
     while (matcher.find()) {
       String decisionText = matcher.group(2);
@@ -118,7 +118,7 @@ public class ChoiceUtilities {
     return "0";
   }
 
-  public static final String findChoiceDecisionText(final int index, final String responseText) {
+  public static String findChoiceDecisionText(final int index, final String responseText) {
     Matcher matcher = DECISION_BUTTON_PATTERN.matcher(responseText);
     while (matcher.find()) {
       int decisionIndex = Integer.parseInt(matcher.group(1));
@@ -140,16 +140,13 @@ public class ChoiceUtilities {
     Matcher m = FORM_PATTERN.matcher(responseText);
     while (m.find()) {
       String form = m.group();
-      if (!form.contains("choice.php")) {
-        continue;
-      }
+      if (!isChoiceForm(form)) continue;
       Matcher optMatcher = OPTION_PATTERN1.matcher(form);
       if (!optMatcher.find()) {
         continue;
       }
-      int decision = Integer.parseInt(optMatcher.group(1));
-      Integer key = decision;
-      if (rv.get(key) != null) {
+      var decision = Integer.parseInt(optMatcher.group(1));
+      if (rv.get(decision) != null) {
         continue;
       }
       Matcher textMatcher = TEXT_PATTERN1.matcher(form);
@@ -161,22 +158,19 @@ public class ChoiceUtilities {
                   : textMatcher.group(2) != null
                       ? textMatcher.group(2)
                       : textMatcher.group(3) != null ? textMatcher.group(3) : "(secret choice)";
-      rv.put(key, text);
+      rv.put(decision, text);
     }
 
     m = LINK_PATTERN.matcher(responseText);
     while (m.find()) {
       String form = m.group();
-      if (!form.contains("choice.php")) {
-        continue;
-      }
+      if (!isChoiceForm(form)) continue;
       Matcher optMatcher = OPTION_PATTERN2.matcher(form);
       if (!optMatcher.find()) {
         continue;
       }
-      int decision = Integer.parseInt(optMatcher.group(1));
-      Integer key = decision;
-      if (rv.get(key) != null) {
+      var decision = Integer.parseInt(optMatcher.group(1));
+      if (rv.get(decision) != null) {
         continue;
       }
       Matcher textMatcher = TEXT_PATTERN2.matcher(form);
@@ -188,7 +182,7 @@ public class ChoiceUtilities {
                   : textMatcher.group(2) != null
                       ? textMatcher.group(2)
                       : textMatcher.group(3) != null ? textMatcher.group(3) : "(secret choice)";
-      rv.put(key, text);
+      rv.put(decision, text);
     }
 
     return rv;
@@ -218,7 +212,7 @@ public class ChoiceUtilities {
       Integer key = entry.getKey();
       ChoiceOption option = ChoiceAdventures.findOption(options, key);
       if (option != null) {
-        String text = entry.getValue() + " (" + option.toString() + ")";
+        String text = entry.getValue() + " (" + option + ")";
         rv.put(key, text);
       }
     }
@@ -289,7 +283,7 @@ public class ChoiceUtilities {
         choice.put(name, options);
       }
 
-      if (choice.size() > 0) {
+      if (!choice.isEmpty()) {
         rv.put(Integer.parseInt(optMatcher.group(1)), choice);
       }
     }
@@ -317,31 +311,36 @@ public class ChoiceUtilities {
       }
 
       // Collect all the selects from this form
-      Map<String, Map<String, String>> choice = new TreeMap<>();
+      var choice = extractSelectInputChoices(form);
 
-      // Find all "select" tags within this form
-      Matcher s = SELECT_PATTERN.matcher(form);
-      while (s.find()) {
-        String name = s.group(1);
-
-        // For each, extract all the options into a map
-        Map<String, String> options = new TreeMap<>();
-
-        Matcher o = SELECT_OPTION_PATTERN.matcher(s.group(2));
-        while (o.find()) {
-          String option = o.group(1);
-          String tag = o.group(2);
-          options.put(option, tag);
-        }
-        choice.put(name, options);
-      }
-
-      if (choice.size() > 0) {
+      if (!choice.isEmpty()) {
         rv.put(Integer.parseInt(optMatcher.group(1)), choice);
       }
     }
 
     return rv;
+  }
+
+  private static Map<String, Map<String, String>> extractSelectInputChoices(String form) {
+    Map<String, Map<String, String>> choice = new TreeMap<>();
+
+    // Find all "select" tags within this form
+    var s = SELECT_PATTERN.matcher(form);
+    while (s.find()) {
+      var name = s.group(1);
+
+      // For each, extract all the options into a map
+      Map<String, String> options = new TreeMap<>();
+
+      var o = SELECT_OPTION_PATTERN.matcher(s.group(2));
+      while (o.find()) {
+        var option = o.group(1);
+        var tag = o.group(2);
+        options.put(option, tag);
+      }
+      choice.put(name, options);
+    }
+    return choice;
   }
 
   // Coordinates: <input name=word type=text size=15 maxlength=7><br>(a valid set of coordinates is
@@ -369,37 +368,43 @@ public class ChoiceUtilities {
       }
 
       // Collect all the text inputs from this form
-      Set<String> choice = new TreeSet<>();
+      var choice = extractTextInputChoices(form);
 
-      // Find all "input" tags within this form
-      Matcher i = INPUT_PATTERN.matcher(form);
-      while (i.find()) {
-        String input = i.group(1);
-        Matcher t = TYPE_PATTERN.matcher(input);
-        if (!t.find()) {
-          continue;
-        }
-
-        String type = t.group(1);
-
-        if (!type.equals("text")) {
-          continue;
-        }
-
-        Matcher n = NAME_PATTERN.matcher(input);
-        if (!n.find()) {
-          continue;
-        }
-        String name = n.group(1);
-        choice.add(name);
-      }
-
-      if (choice.size() > 0) {
+      if (!choice.isEmpty()) {
         rv.put(Integer.parseInt(optMatcher.group(1)), choice);
       }
     }
 
     return rv;
+  }
+
+  private static Set<String> extractTextInputChoices(String form) {
+    Set<String> choice = new TreeSet<>();
+
+    // Find all "input" tags within this form
+    var i = INPUT_PATTERN.matcher(form);
+    while (i.find()) {
+      var input = i.group(1);
+      var t = TYPE_PATTERN.matcher(input);
+      if (!t.find()) {
+        continue;
+      }
+
+      var type = t.group(1);
+
+      if (!type.equals("text")) {
+        continue;
+      }
+
+      var n = NAME_PATTERN.matcher(input);
+      if (!n.find()) {
+        continue;
+      }
+      var name = n.group(1);
+      choice.add(name);
+    }
+
+    return choice;
   }
 
   public static String validateChoiceFields(
@@ -449,7 +454,8 @@ public class ChoiceUtilities {
     // Extract supplied extra fields
     Set<String> extras = new TreeSet<>();
     for (String field : extraFields.split("&")) {
-      if (field.equals("")) {
+      if (field.isEmpty()) {
+        // Ignore
       } else if (field.contains("=")) {
         extras.add(field);
       } else {
@@ -471,8 +477,8 @@ public class ChoiceUtilities {
 
     if (selects == null && texts == null) {
       // No. If the user supplied no extra fields, all is well
-      if (extras.size() == 0) {
-        return (errors.length() > 0) ? errors.toString() : null;
+      if (extras.isEmpty()) {
+        return (!errors.isEmpty()) ? errors.toString() : null;
       }
       // Otherwise, list all unexpected extra fields
       for (String extra : extras) {
@@ -556,7 +562,7 @@ public class ChoiceUtilities {
           .append("'.\n");
     }
 
-    return (errors.length() > 0) ? errors.toString() : null;
+    return (!errors.isEmpty()) ? errors.toString() : null;
   }
 
   public static void printChoices(final String responseText) {

--- a/test/net/sourceforge/kolmafia/utilities/ChoiceUtilitiesTest.java
+++ b/test/net/sourceforge/kolmafia/utilities/ChoiceUtilitiesTest.java
@@ -4,12 +4,42 @@ import static internal.helpers.Networking.html;
 import static internal.helpers.Player.withProperty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class ChoiceUtilitiesTest {
+  @Nested
+  class ValidateChoiceFields {
+    @Test
+    void cannotSupplyRandomExtraValues() {
+      var page = html("request/test_choice_peridot_zone.html");
+      var errors = ChoiceUtilities.validateChoiceFields("1", "author=gausie&bandersnatch=1", page);
+      assertThat(errors, equalTo("Choice option 1557/1 does not require 'author'.\n"));
+    }
+
+    @Test
+    void cannotMissRequiredExtraValues() {
+      var page = html("request/test_choice_peridot_zone.html");
+      var errors = ChoiceUtilities.validateChoiceFields("1", "", page);
+      assertThat(
+          errors, equalTo("Choice option 1557/1 requires 'bandersnatch' but not supplied.\n"));
+    }
+
+    @Test
+    void canMixMultipleErrorMessages() {
+      var page = html("request/test_choice_peridot_zone.html");
+      var errors = ChoiceUtilities.validateChoiceFields("1", "author=gausie", page);
+      assertThat(
+          errors,
+          equalTo(
+              "Choice option 1557/1 requires 'bandersnatch' but not supplied.\nChoice option 1557/1 does not require 'author'.\n"));
+    }
+  }
 
   @Test
   void extractChoiceFromLyleOnDevServer() {
@@ -22,13 +52,23 @@ class ChoiceUtilitiesTest {
     }
   }
 
-  @Test
-  void parseChoicesFromPeridot() {
-    var page = html("request/test_choice_peridot_zone.html");
-    var choices = ChoiceUtilities.parseChoices(page);
-    assertThat(choices, aMapWithSize(2));
-    // The first value for option 1
-    assertThat(choices, hasEntry(1, "a sleeping Knob Goblin Guard"));
-    assertThat(choices, hasEntry(2, "I choose peace"));
+  @Nested
+  class PeridotOfPeril {
+    @Test
+    void parseChoicesFromPeridot() {
+      var page = html("request/test_choice_peridot_zone.html");
+      var choices = ChoiceUtilities.parseChoices(page);
+      assertThat(choices, aMapWithSize(2));
+      // The first value for option 1
+      assertThat(choices, hasEntry(1, "a sleeping Knob Goblin Guard"));
+      assertThat(choices, hasEntry(2, "I choose peace"));
+    }
+
+    @Test
+    void canSupplyBandersnatchToPeridot() {
+      var page = html("request/test_choice_peridot_zone.html");
+      var errors = ChoiceUtilities.validateChoiceFields("1", "bandersnatch=555", page);
+      assertThat(errors, is(nullValue()));
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/utilities/ChoiceUtilitiesTest.java
+++ b/test/net/sourceforge/kolmafia/utilities/ChoiceUtilitiesTest.java
@@ -3,6 +3,9 @@ package net.sourceforge.kolmafia.utilities;
 import static internal.helpers.Networking.html;
 import static internal.helpers.Player.withProperty;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
@@ -18,5 +21,15 @@ class ChoiceUtilitiesTest {
       var choice = ChoiceUtilities.extractChoice(page);
       assertThat(choice, is(1309));
     }
+  }
+
+  @Test
+  void parseChoicesFromPeridot() {
+    var page = html("request/test_choice_peridot_zone.html");
+    var choices = ChoiceUtilities.parseChoices(page);
+    assertThat(choices, aMapWithSize(2));
+    // The first value for option 1
+    assertThat(choices, hasEntry(1, "a sleeping Knob Goblin Guard"));
+    assertThat(choices, hasEntry(2, "I choose peace"));
   }
 }

--- a/test/net/sourceforge/kolmafia/utilities/ChoiceUtilitiesTest.java
+++ b/test/net/sourceforge/kolmafia/utilities/ChoiceUtilitiesTest.java
@@ -5,7 +5,6 @@ import static internal.helpers.Player.withProperty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
- **Fix peridot parsing by widening choice parsing appropriately**
- **Linting for ChoiceUtilities class**
- **Formatting**
- **Quick fix of semi-unrelated issue**
- **Support filling extra hidden fields with the extra field in choiceAdventureXXX**

Re-fixes #2904

Whielw e were able to successfully parse the options for the choice in #2905, the choice adventure validation code was not ready to deal with multiple forms that submit the same option with a different value'd hidden input. This is essentially an alternative way of producing a single option with an extra select input. Seems reasonable to support generically so we do that.

There are some forms one could imagine in future (where mutliple overloads for a single decision form have differing sets of hidden input field), but we can deal with those if and when such a form is introduced.
