### PR TITLE
feat: update `cast` for replacing / additional buff effects

### DIFF
--- a/src/data/statuseffects.txt
+++ b/src/data/statuseffects.txt
@@ -49,7 +49,7 @@
 47	Complete Delusion	wolfmask.gif	b00a05823151fd7e6c8fe7697c0420ca	good	nohookah	# wearing wolf mask
 48	The Smile of Mr. A.	gma.gif	59e9f58e87d531b3ef613515a3417210	good	none	use 1 box of sunshine
 49	Macho Profundo	strboost.gif	a02c6fb27a3f9f4bf2c48d59584adc56	good	none	use 1 mafia aria
-50	Empathy	empathy.gif	ac32e95f470a7e0999863fa0db58d808	good	none	cast 1 Empathy of the Newt
+50	Empathy	empathy.gif	ac32e95f470a7e0999863fa0db58d808	good	none	cast 1 Empathy of the Newt @ Empathy
 51	Tenacity of the Snapper	snapper.gif	c05dc4b01f6f2826be599f07620979f7	good	none	cast 1 Tenacity of the Snapper
 52	Astral Shell	blackshell.gif	4e66acac6b908fb6f70b49092dcff375	good	none	cast 1 Astral Shell
 53	Elemental Saucesphere	elesphere.gif	e3d1d1099648703e192a55a9aea17a1e	good	none	cast 1 Elemental Saucesphere
@@ -221,10 +221,10 @@
 219	Bubble, Bubble	sphere.gif	6ede1a75e47f82c98a429c9a50d067b4	neutral	none	use 1 alphabet gum
 220	Sticky Fingers	glove.gif	4becdf2ac82c2bf30dd433dd54465918	good	none	use 1 bag of Cheat-Os|cargo effect Sticky Fingers
 221	Chalky Hand	glove.gif	3e2eed0d70d0e023a11619655a3f48c0	good	none	use 1 handful of hand chalk
-222	Snarl of the Timberwolf	wolfmask.gif	2968e9397d3aa977b8cb3e9817ad8cdd	good	nohookah	cast 1 Snarl of the Timberwolf
+222	Snarl of the Timberwolf	wolfmask.gif	2968e9397d3aa977b8cb3e9817ad8cdd	good	nohookah	cast 1 Snarl of the Timberwolf @ Snarl of the Timberwolf
 223	Dreams and Lights	snowflakes.gif	360467118bd69ef869a1af2002117e63	good	none	# adv in Haunted Gallery
-224	Scarysauce	skullshld.gif	f7551a889b9c61510fc3f73f96ecc98e	good	none	cast 1 Scarysauce
-225	Dirge of Dreadfulness	dirge.gif	6121ba486d7ad86165d117ea62794d09	good	song	cast 1 Dirge of Dreadfulness
+224	Scarysauce	skullshld.gif	f7551a889b9c61510fc3f73f96ecc98e	good	none	cast 1 Scarysauce @ Scarysauce
+225	Dirge of Dreadfulness	dirge.gif	6121ba486d7ad86165d117ea62794d09	good	song	cast 1 Dirge of Dreadfulness @ Dirge of Dreadfulness
 226	Talking Like a Pirate	piratehead.gif	defbfe64c65b2d495dc0133506223c1f	neutral	none	use 1 can of Binarrrca
 227	The 'Tussin	bseye.gif	295f414c903d22c44ec2f92f789cad71	neutral	none	use 1 bottle of Vangoghbitussin
 228	Pie in the Face	pieface.gif	9c9794f2ff9a0fcb1090c281c2c442f1	neutral	none	# being hit with cream pie
@@ -2553,9 +2553,9 @@
 2550	Panna Consideration	tc_pannacotta.gif	22fef32a9bc3af04af21439f1c09e68b	good	nohookah	use 1 terra panna cotta
 2551	Blessing of the Bird	findbird.gif	8de6fb855433dc4b90fb4dbc2a5c919d	neutral	none	cast 1 Seek out a Bird
 2552	Blessing of your favorite Bird	favoritebird.gif	e9c3b4f9a7f9b24166b835481f15c875	neutral	none	cast 1 Visit your Favorite Bird
-2553	Scariersauce	scarysauce.gif	33e4e82db2376879224ab4d8d406325a	good	nohookah
-2554	Dirge of Dreadfulness (Remastered)	dirge.gif	ec4766a15304fe13ca2334dfb41fd494	good	song,nohookah
-2555	Snarl of Three Timberwolves	wolfmask.gif	193ef2bbdde7fe95e51e5a527ae4f42e	good	nohookah
+2553	Scariersauce	scarysauce.gif	33e4e82db2376879224ab4d8d406325a	good	nohookah	cast 1 Scarysauce @ Scariersauce
+2554	Dirge of Dreadfulness (Remastered)	dirge.gif	ec4766a15304fe13ca2334dfb41fd494	good	song,nohookah	cast 1 Dirge of Dreadfulness @ Dirge of Dreadfulness (Remastered)
+2555	Snarl of Three Timberwolves	wolfmask.gif	193ef2bbdde7fe95e51e5a527ae4f42e	good	nohookah	cast 1 Snarl of the Timberwolf @ Snarl of Three Timberwolves
 2556	Invisible Avatar	missingavatar.gif	da6f47ae655716b599e530128712c36c	neutral	none	cast 1 CHEAT CODE: Invisible Avatar
 2557	Triple-Sized	triplesize.gif	6be2d9af5964c3bc987c0696ea60eeeb	good	none	cast 1 CHEAT CODE: Triple Size
 2558	Warmed Up	mario_juggle.gif	9fea199e3a5fd92b82e46f9e0ecc203c	neutral	none
@@ -2983,13 +2983,13 @@
 2980	You Might Have Gotten Wet	watermelon.gif	1e66e3c47e8ed40930c6e846e32e2ef9	neutral	none
 2981	Sur La Table	portabletable.gif	1cf1e480f7ce07da51c613f6ad0d3a10	neutral	none
 2982	Ready for War	angry.gif	e62c60d23a0e76de9f6f09cd282ec8a3	neutral	none	chew 1 leprechaun antidepressant pill
-2983	Slippery as a Seal	wetpaper.gif	ae2845bf2dcdda691e98705c760f3765	neutral	none
-2984	Strength of the Tortoise	wetpaper.gif	3434e3b32cfaa9f7249d43e0ee1b42f4	neutral	none
-2985	Tubes of Universal Meat	wetpaper.gif	9b1a11e2ba8152c72d3bf6391371ac7f	neutral	none
-2986	Lubricating Sauce	wetpaper.gif	5aeff1779ef0ad97fbed13fd5bdb0968	neutral	none
-2987	Disco over Matter	wetpaper.gif	cc2d75a34ae14d132450bf8eee905a4f	neutral	none
-2988	Mariachi Moisture	wetpaper.gif	31192bed8fc75482f9f7c8486964d35f	neutral	none
-2989	Thoughtful Empathy	blackheart.gif	772532594322e2260a767bb71fe0d7fc	neutral	none
+2983	Slippery as a Seal	wetpaper.gif	ae2845bf2dcdda691e98705c760f3765	neutral	none	cast 1 Seal Clubbing Frenzy @ Slippery as a Seal
+2984	Strength of the Tortoise	wetpaper.gif	3434e3b32cfaa9f7249d43e0ee1b42f4	neutral	none	cast 1 Patience of the Tortoise @ Strength of the Tortoise
+2985	Tubes of Universal Meat	wetpaper.gif	9b1a11e2ba8152c72d3bf6391371ac7f	neutral	none	cast 1 Manicotti Meditation @ Tubes of Universal Meat
+2986	Lubricating Sauce	wetpaper.gif	5aeff1779ef0ad97fbed13fd5bdb0968	neutral	none	cast 1 Sauce Contemplation @ Lubricating Sauce
+2987	Disco over Matter	wetpaper.gif	cc2d75a34ae14d132450bf8eee905a4f	neutral	none	cast 1 Disco Aerobics @ Disco over Matter
+2988	Mariachi Moisture	wetpaper.gif	31192bed8fc75482f9f7c8486964d35f	neutral	none	cast 1 Moxie of the Mariachi @ Mariachi Moisture
+2989	Thoughtful Empathy	blackheart.gif	772532594322e2260a767bb71fe0d7fc	neutral	none	cast 1 Empathy of the Newt @ Thoughtful Empathy
 2990	Lifting Wets	wetpaperweight.gif	0d92d7086d0bd97090dc51d252f8b7b0	neutral	none	use 1 wet paper weights
 2991	Wetted Whistle	wetpaperdrink.gif	4c844da112766b6a6d262f86eb724701	neutral	none	drink 1 Three Sheets to the Wind
 2992	A Date With Tomorrow	wetpaperdates.gif	daed8a7f8faf412fd2b27b8cec36e7e3	neutral	none	eat 1 pile of wet dates

--- a/src/data/statuseffects.txt
+++ b/src/data/statuseffects.txt
@@ -49,7 +49,7 @@
 47	Complete Delusion	wolfmask.gif	b00a05823151fd7e6c8fe7697c0420ca	good	nohookah	# wearing wolf mask
 48	The Smile of Mr. A.	gma.gif	59e9f58e87d531b3ef613515a3417210	good	none	use 1 box of sunshine
 49	Macho Profundo	strboost.gif	a02c6fb27a3f9f4bf2c48d59584adc56	good	none	use 1 mafia aria
-50	Empathy	empathy.gif	ac32e95f470a7e0999863fa0db58d808	good	none	cast 1 Empathy of the Newt @ Empathy
+50	Empathy	empathy.gif	ac32e95f470a7e0999863fa0db58d808	good	none	cast 1 Empathy of the Newt ^ Empathy
 51	Tenacity of the Snapper	snapper.gif	c05dc4b01f6f2826be599f07620979f7	good	none	cast 1 Tenacity of the Snapper
 52	Astral Shell	blackshell.gif	4e66acac6b908fb6f70b49092dcff375	good	none	cast 1 Astral Shell
 53	Elemental Saucesphere	elesphere.gif	e3d1d1099648703e192a55a9aea17a1e	good	none	cast 1 Elemental Saucesphere
@@ -221,10 +221,10 @@
 219	Bubble, Bubble	sphere.gif	6ede1a75e47f82c98a429c9a50d067b4	neutral	none	use 1 alphabet gum
 220	Sticky Fingers	glove.gif	4becdf2ac82c2bf30dd433dd54465918	good	none	use 1 bag of Cheat-Os|cargo effect Sticky Fingers
 221	Chalky Hand	glove.gif	3e2eed0d70d0e023a11619655a3f48c0	good	none	use 1 handful of hand chalk
-222	Snarl of the Timberwolf	wolfmask.gif	2968e9397d3aa977b8cb3e9817ad8cdd	good	nohookah	cast 1 Snarl of the Timberwolf @ Snarl of the Timberwolf
+222	Snarl of the Timberwolf	wolfmask.gif	2968e9397d3aa977b8cb3e9817ad8cdd	good	nohookah	cast 1 Snarl of the Timberwolf ^ Snarl of the Timberwolf
 223	Dreams and Lights	snowflakes.gif	360467118bd69ef869a1af2002117e63	good	none	# adv in Haunted Gallery
-224	Scarysauce	skullshld.gif	f7551a889b9c61510fc3f73f96ecc98e	good	none	cast 1 Scarysauce @ Scarysauce
-225	Dirge of Dreadfulness	dirge.gif	6121ba486d7ad86165d117ea62794d09	good	song	cast 1 Dirge of Dreadfulness @ Dirge of Dreadfulness
+224	Scarysauce	skullshld.gif	f7551a889b9c61510fc3f73f96ecc98e	good	none	cast 1 Scarysauce ^ Scarysauce
+225	Dirge of Dreadfulness	dirge.gif	6121ba486d7ad86165d117ea62794d09	good	song	cast 1 Dirge of Dreadfulness ^ Dirge of Dreadfulness
 226	Talking Like a Pirate	piratehead.gif	defbfe64c65b2d495dc0133506223c1f	neutral	none	use 1 can of Binarrrca
 227	The 'Tussin	bseye.gif	295f414c903d22c44ec2f92f789cad71	neutral	none	use 1 bottle of Vangoghbitussin
 228	Pie in the Face	pieface.gif	9c9794f2ff9a0fcb1090c281c2c442f1	neutral	none	# being hit with cream pie
@@ -2553,9 +2553,9 @@
 2550	Panna Consideration	tc_pannacotta.gif	22fef32a9bc3af04af21439f1c09e68b	good	nohookah	use 1 terra panna cotta
 2551	Blessing of the Bird	findbird.gif	8de6fb855433dc4b90fb4dbc2a5c919d	neutral	none	cast 1 Seek out a Bird
 2552	Blessing of your favorite Bird	favoritebird.gif	e9c3b4f9a7f9b24166b835481f15c875	neutral	none	cast 1 Visit your Favorite Bird
-2553	Scariersauce	scarysauce.gif	33e4e82db2376879224ab4d8d406325a	good	nohookah	cast 1 Scarysauce @ Scariersauce
-2554	Dirge of Dreadfulness (Remastered)	dirge.gif	ec4766a15304fe13ca2334dfb41fd494	good	song,nohookah	cast 1 Dirge of Dreadfulness @ Dirge of Dreadfulness (Remastered)
-2555	Snarl of Three Timberwolves	wolfmask.gif	193ef2bbdde7fe95e51e5a527ae4f42e	good	nohookah	cast 1 Snarl of the Timberwolf @ Snarl of Three Timberwolves
+2553	Scariersauce	scarysauce.gif	33e4e82db2376879224ab4d8d406325a	good	nohookah	cast 1 Scarysauce ^ Scariersauce
+2554	Dirge of Dreadfulness (Remastered)	dirge.gif	ec4766a15304fe13ca2334dfb41fd494	good	song,nohookah	cast 1 Dirge of Dreadfulness ^ Dirge of Dreadfulness (Remastered)
+2555	Snarl of Three Timberwolves	wolfmask.gif	193ef2bbdde7fe95e51e5a527ae4f42e	good	nohookah	cast 1 Snarl of the Timberwolf ^ Snarl of Three Timberwolves
 2556	Invisible Avatar	missingavatar.gif	da6f47ae655716b599e530128712c36c	neutral	none	cast 1 CHEAT CODE: Invisible Avatar
 2557	Triple-Sized	triplesize.gif	6be2d9af5964c3bc987c0696ea60eeeb	good	none	cast 1 CHEAT CODE: Triple Size
 2558	Warmed Up	mario_juggle.gif	9fea199e3a5fd92b82e46f9e0ecc203c	neutral	none
@@ -2983,13 +2983,13 @@
 2980	You Might Have Gotten Wet	watermelon.gif	1e66e3c47e8ed40930c6e846e32e2ef9	neutral	none
 2981	Sur La Table	portabletable.gif	1cf1e480f7ce07da51c613f6ad0d3a10	neutral	none
 2982	Ready for War	angry.gif	e62c60d23a0e76de9f6f09cd282ec8a3	neutral	none	chew 1 leprechaun antidepressant pill
-2983	Slippery as a Seal	wetpaper.gif	ae2845bf2dcdda691e98705c760f3765	neutral	none	cast 1 Seal Clubbing Frenzy @ Slippery as a Seal
-2984	Strength of the Tortoise	wetpaper.gif	3434e3b32cfaa9f7249d43e0ee1b42f4	neutral	none	cast 1 Patience of the Tortoise @ Strength of the Tortoise
-2985	Tubes of Universal Meat	wetpaper.gif	9b1a11e2ba8152c72d3bf6391371ac7f	neutral	none	cast 1 Manicotti Meditation @ Tubes of Universal Meat
-2986	Lubricating Sauce	wetpaper.gif	5aeff1779ef0ad97fbed13fd5bdb0968	neutral	none	cast 1 Sauce Contemplation @ Lubricating Sauce
-2987	Disco over Matter	wetpaper.gif	cc2d75a34ae14d132450bf8eee905a4f	neutral	none	cast 1 Disco Aerobics @ Disco over Matter
-2988	Mariachi Moisture	wetpaper.gif	31192bed8fc75482f9f7c8486964d35f	neutral	none	cast 1 Moxie of the Mariachi @ Mariachi Moisture
-2989	Thoughtful Empathy	blackheart.gif	772532594322e2260a767bb71fe0d7fc	neutral	none	cast 1 Empathy of the Newt @ Thoughtful Empathy
+2983	Slippery as a Seal	wetpaper.gif	ae2845bf2dcdda691e98705c760f3765	neutral	none	cast 1 Seal Clubbing Frenzy ^ Slippery as a Seal
+2984	Strength of the Tortoise	wetpaper.gif	3434e3b32cfaa9f7249d43e0ee1b42f4	neutral	none	cast 1 Patience of the Tortoise ^ Strength of the Tortoise
+2985	Tubes of Universal Meat	wetpaper.gif	9b1a11e2ba8152c72d3bf6391371ac7f	neutral	none	cast 1 Manicotti Meditation ^ Tubes of Universal Meat
+2986	Lubricating Sauce	wetpaper.gif	5aeff1779ef0ad97fbed13fd5bdb0968	neutral	none	cast 1 Sauce Contemplation ^ Lubricating Sauce
+2987	Disco over Matter	wetpaper.gif	cc2d75a34ae14d132450bf8eee905a4f	neutral	none	cast 1 Disco Aerobics ^ Disco over Matter
+2988	Mariachi Moisture	wetpaper.gif	31192bed8fc75482f9f7c8486964d35f	neutral	none	cast 1 Moxie of the Mariachi ^ Mariachi Moisture
+2989	Thoughtful Empathy	blackheart.gif	772532594322e2260a767bb71fe0d7fc	neutral	none	cast 1 Empathy of the Newt ^ Thoughtful Empathy
 2990	Lifting Wets	wetpaperweight.gif	0d92d7086d0bd97090dc51d252f8b7b0	neutral	none	use 1 wet paper weights
 2991	Wetted Whistle	wetpaperdrink.gif	4c844da112766b6a6d262f86eb724701	neutral	none	drink 1 Three Sheets to the Wind
 2992	A Date With Tomorrow	wetpaperdates.gif	daed8a7f8faf412fd2b27b8cec36e7e3	neutral	none	eat 1 pile of wet dates

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -713,6 +713,13 @@ public class Maximizer {
             } else continue;
           }
 
+          if (cmd.contains(" @ ")) {
+            var req = UseSkillRequest.requiredItemForSkillEffect(skillId, effectId);
+            if (req != -1 && !InventoryManager.equippedOrInInventory(req)) {
+              continue;
+            }
+          }
+
           mpCost = SkillDatabase.getMPConsumptionById(skillId);
           advCost = SkillDatabase.getAdventureCost(skillId);
           soulsauceCost = SkillDatabase.getSoulsauceCost(skillId);

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -713,7 +713,7 @@ public class Maximizer {
             } else continue;
           }
 
-          if (cmd.contains(" @ ")) {
+          if (cmd.contains(" ^ ")) {
             var req = UseSkillRequest.requiredItemForSkillEffect(skillId, effectId);
             if (req != -1 && !InventoryManager.equippedOrInInventory(req)) {
               continue;

--- a/src/net/sourceforge/kolmafia/moods/MoodManager.java
+++ b/src/net/sourceforge/kolmafia/moods/MoodManager.java
@@ -555,8 +555,8 @@ public abstract class MoodManager {
         action = action.substring(spaceIndex + 1);
       }
 
-      if (action.contains(" @ ")) {
-        action = action.substring(0, action.indexOf(" @ "));
+      if (action.contains(" ^ ")) {
+        action = action.substring(0, action.indexOf(" ^ "));
       }
 
       String skillName = SkillDatabase.getSkillName(action);

--- a/src/net/sourceforge/kolmafia/moods/MoodManager.java
+++ b/src/net/sourceforge/kolmafia/moods/MoodManager.java
@@ -555,6 +555,10 @@ public abstract class MoodManager {
         action = action.substring(spaceIndex + 1);
       }
 
+      if (action.contains(" @ ")) {
+        action = action.substring(0, action.indexOf(" @ "));
+      }
+
       String skillName = SkillDatabase.getSkillName(action);
       if (skillName != null) {
         runningTally +=

--- a/src/net/sourceforge/kolmafia/moods/MoodTrigger.java
+++ b/src/net/sourceforge/kolmafia/moods/MoodTrigger.java
@@ -79,8 +79,8 @@ public class MoodTrigger implements Comparable<MoodTrigger> {
           parameters = parameters.substring(spaceIndex).trim();
         }
 
-        if (parameters.contains(" @ ")) {
-          parameters = parameters.substring(0, parameters.indexOf(" @ "));
+        if (parameters.contains(" ^ ")) {
+          parameters = parameters.substring(0, parameters.indexOf(" ^ "));
         }
 
         if (!SkillDatabase.contains(parameters)) {
@@ -95,7 +95,7 @@ public class MoodTrigger implements Comparable<MoodTrigger> {
                   + this.count
                   + " "
                   + this.skill.getSkillName()
-                  + (this.effect == null ? "" : " @ " + this.effect.getName());
+                  + (this.effect == null ? "" : " ^ " + this.effect.getName());
         }
       }
     }

--- a/src/net/sourceforge/kolmafia/moods/MoodTrigger.java
+++ b/src/net/sourceforge/kolmafia/moods/MoodTrigger.java
@@ -79,6 +79,10 @@ public class MoodTrigger implements Comparable<MoodTrigger> {
           parameters = parameters.substring(spaceIndex).trim();
         }
 
+        if (parameters.contains(" @ ")) {
+          parameters = parameters.substring(0, parameters.indexOf(" @ "));
+        }
+
         if (!SkillDatabase.contains(parameters)) {
           parameters = SkillDatabase.getUsableSkillName(parameters);
         }
@@ -86,7 +90,12 @@ public class MoodTrigger implements Comparable<MoodTrigger> {
         this.skill = UseSkillRequest.getInstance(parameters);
 
         if (this.skill != null) {
-          this.action = "cast " + this.count + " " + this.skill.getSkillName();
+          this.action =
+              "cast "
+                  + this.count
+                  + " "
+                  + this.skill.getSkillName()
+                  + (this.effect == null ? "" : " @ " + this.effect.getName());
         }
       }
     }

--- a/src/net/sourceforge/kolmafia/objectpool/EffectPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/EffectPool.java
@@ -54,7 +54,10 @@ public class EffectPool {
   public static final int SLEAZEFORM = 193;
   public static final int CURSED_BY_RNG = 217;
   public static final int CHALKY_HAND = 221;
+  public static final int SNARL_OF_THE_TIMBERWOLF = 222;
   public static final int DREAMS_AND_LIGHTS = 223;
+  public static final int SCARYSAUCE = 224;
+  public static final int DIRGE_OF_DREADFULNESS = 225;
   public static final int EAU_DE_TORTUE = 263;
   public static final int MAJORLY_POISONED = 264;
   public static final int TENUOUS_GRIP_ON_REALITY = 265;
@@ -346,6 +349,9 @@ public class EffectPool {
   public static final int FIDOXENE = 2520;
   public static final int BLESSING_OF_THE_BIRD = 2551;
   public static final int BLESSING_OF_YOUR_FAVORITE_BIRD = 2552;
+  public static final int SCARIERSAUCE = 2553;
+  public static final int DIRGE_OF_DREADFULNESS_REMASTERED = 2554;
+  public static final int SNARL_OF_THREE_TIMBERWOLVES = 2555;
   public static final int FIZZY_FIZZY = 2561;
   public static final int ENTAUNTAUNED = 2578;
   public static final int JOKE_MAD = 2582;
@@ -386,6 +392,13 @@ public class EffectPool {
   public static final int GRAFTED = 2964;
   public static final int MILK_OF_FAMILIAR_KINDNESS = 2965;
   public static final int MILK_OF_FAMILIAR_CRUELTY = 2966;
+  public static final int SLIPPERY_AS_A_SEAL = 2983;
+  public static final int STRENGTH_OF_THE_TORTOISE = 2984;
+  public static final int TUBES_OF_UNIVERSAL_MEAT = 2985;
+  public static final int LUBRICATING_SAUCE = 2986;
+  public static final int DISCO_OVER_MATTER = 2987;
+  public static final int MARIACHI_MOISTURE = 2988;
+  public static final int THOUGHTFUL_EMPATHY = 2989;
 
   public static final AdventureResult CURSE1_EFFECT = EffectPool.get(EffectPool.ONCE_CURSED);
   public static final AdventureResult CURSE2_EFFECT = EffectPool.get(EffectPool.TWICE_CURSED);

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -3311,6 +3311,9 @@ public class ItemPool {
   public static final int PARAFFIN_PSEUDOACCORDION = 10103;
   public static final int PARAFFIN_PIECES = 10104;
   public static final int TERRA_COTTA_TIDBITS = 10112;
+  public static final int VELOUR_VOULGE = 10114;
+  public static final int VELOUR_VISCOMETER = 10117;
+  public static final int VELOUR_VAQUEROS = 10119;
   public static final int TRYPTOPHAN_DART = 10159;
   public static final int DOCTOR_BAG = 10166;
   public static final int BLOOD_SNOWCONE = 10173;

--- a/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
@@ -134,6 +134,7 @@ public class SkillPool {
   public static final int OVERCLOCK10 = 243;
   public static final int GENERATE_IRONY = 245;
 
+  public static final int SEAL_CLUBBING_FRENZY = 1000;
   public static final int THRUST_SMACK = 1003;
   public static final int LUNGE_SMACK = 1004;
   public static final int LUNGING_THRUST_SMACK = 1005;
@@ -153,6 +154,7 @@ public class SkillPool {
   public static final int SILENT_HUNTER = 1041;
   public static final int GET_BIG = 1042;
   public static final int BLOOD_FRENZY = 1043;
+  public static final int PATIENCE_OF_THE_TORTOISE = 2000;
   public static final int ARMORCRAFTINESS = 2006;
   public static final int EMPATHY_OF_THE_NEWT = 2009;
   public static final int WISDOM_OF_THE_ELDER_TORTOISES = 2011;
@@ -172,6 +174,7 @@ public class SkillPool {
   public static final int TURTLE_POWER = 2041;
   public static final int MATING_CALL = 2043;
   public static final int BLOOD_BOND = 2044;
+  public static final int MANICOTTI_MEDITATION = 3000;
   public static final int RAVIOLI_SHURIKENS = 3003;
   public static final int ENTANGLING_NOODLES = 3004;
   public static final int CANNELLONI_CANNON = 3005;
@@ -203,6 +206,7 @@ public class SkillPool {
   public static final int BIND_SPAGHETTI_ELEMENTAL = 3041;
   public static final int INSCRUTABLE_GAZE = 3043;
   public static final int BLOOD_BUCATINI = 3044;
+  public static final int SAUCE_CONTEMPLATION = 4000;
   public static final int STREAM_OF_SAUCE = 4003;
   public static final int ADVANCED_SAUCECRAFTING = 4006;
   public static final int JALAPENO_SAUCESPHERE = 4008;
@@ -219,6 +223,7 @@ public class SkillPool {
   public static final int SAUCEMAVEN = 4039;
   public static final int LOVE_MIXOLOGY = 4041;
   public static final int BLOOD_BUBBLE = 4042;
+  public static final int DISCO_AEROBICS = 5000;
   public static final int DISCO_EYE_POKE = 5003;
   public static final int DISCO_DANCE_OF_DOOM = 5005;
   public static final int DISCO_NAP = 5007;
@@ -237,6 +242,7 @@ public class SkillPool {
   public static final int DISCO_DANCE_3 = 5036;
   public static final int ACQUIRE_RHINESTONES = 5041;
   public static final int BLOOD_BLADE = 5042;
+  public static final int MOXIE_OF_THE_MARIACHI = 6000;
   public static final int ANTIPHON = 6003;
   public static final int POLKA_OF_PLENTY = 6006;
   public static final int PHAT_LOOT = 6010;

--- a/src/net/sourceforge/kolmafia/request/UneffectRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UneffectRequest.java
@@ -55,8 +55,8 @@ public class UneffectRequest extends GenericRequest {
         if (skillName.contains("|")) {
           skillName = skillName.substring(0, skillName.indexOf("|"));
         }
-        if (skillName.contains(" @ ")) {
-          skillName = skillName.substring(0, skillName.indexOf(" @ "));
+        if (skillName.contains(" ^ ")) {
+          skillName = skillName.substring(0, skillName.indexOf(" ^ "));
         }
         UneffectRequest.EFFECT_SKILL.put(effectName, skillName);
       }

--- a/src/net/sourceforge/kolmafia/request/UneffectRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UneffectRequest.java
@@ -55,6 +55,9 @@ public class UneffectRequest extends GenericRequest {
         if (skillName.contains("|")) {
           skillName = skillName.substring(0, skillName.indexOf("|"));
         }
+        if (skillName.contains(" @ ")) {
+          skillName = skillName.substring(0, skillName.indexOf(" @ "));
+        }
         UneffectRequest.EFFECT_SKILL.put(effectName, skillName);
       }
     }
@@ -292,6 +295,30 @@ public class UneffectRequest extends GenericRequest {
             KoLCharacter.isSealClubber()
                 ? EffectPool.SILENT_HUNTING
                 : EffectPool.NEARLY_SILENT_HUNTING);
+      }
+      case SkillPool.SNARL_OF_THE_TIMBERWOLF -> {
+        return EffectDatabase.getEffectName(
+            KoLCharacter.hasEquipped(ItemPool.VELOUR_VOULGE)
+                ? EffectPool.SNARL_OF_THREE_TIMBERWOLVES
+                : EffectPool.SNARL_OF_THE_TIMBERWOLF);
+      }
+      case SkillPool.SCARYSAUCE -> {
+        return EffectDatabase.getEffectName(
+            KoLCharacter.hasEquipped(ItemPool.VELOUR_VISCOMETER)
+                ? EffectPool.SCARIERSAUCE
+                : EffectPool.SCARYSAUCE);
+      }
+      case SkillPool.DIRGE_OF_DREADFULNESS -> {
+        return EffectDatabase.getEffectName(
+            KoLCharacter.hasEquipped(ItemPool.VELOUR_VAQUEROS)
+                ? EffectPool.DIRGE_OF_DREADFULNESS_REMASTERED
+                : EffectPool.DIRGE_OF_DREADFULNESS);
+      }
+      case SkillPool.EMPATHY_OF_THE_NEWT -> {
+        return EffectDatabase.getEffectName(
+            KoLCharacter.hasEquipped(ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD)
+                ? EffectPool.THOUGHTFUL_EMPATHY
+                : EffectPool.EMPATHY);
       }
     }
 

--- a/src/net/sourceforge/kolmafia/request/UneffectRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UneffectRequest.java
@@ -137,31 +137,32 @@ public class UneffectRequest extends GenericRequest {
 
   public static final boolean isShruggable(final int effectId) {
     switch (effectId) {
-      case EffectPool.TIMER1:
-      case EffectPool.TIMER2:
-      case EffectPool.TIMER3:
-      case EffectPool.TIMER4:
-      case EffectPool.TIMER5:
-      case EffectPool.TIMER6:
-      case EffectPool.TIMER7:
-      case EffectPool.TIMER8:
-      case EffectPool.TIMER9:
-      case EffectPool.TIMER10:
-      case EffectPool.JUST_THE_BEST_ANAPESTS:
-      case EffectPool.REASSURED:
-      case EffectPool.HARE_BRAINED:
-      case EffectPool.RECORD_HUNGER:
-      case EffectPool.DRUNK_AVUNCULAR:
-      case EffectPool.SHRIEKING_WEASEL:
-      case EffectPool.POWER_MAN:
-      case EffectPool.LUCKY_STRUCK:
-      case EffectPool.MINISTRATIONS_IN_THE_DARK:
-      case EffectPool.SUPERDRIFTING:
-      case EffectPool.ELDRITCH_ATTUNEMENT:
-      case EffectPool.CARTOGRAPHICALLY_CHARGED:
-      case EffectPool.CARTOGRAPHICALLY_AWARE:
-      case EffectPool.CARTOGRAPHICALLY_ROOTED:
+      case EffectPool.TIMER1,
+          EffectPool.TIMER2,
+          EffectPool.TIMER3,
+          EffectPool.TIMER4,
+          EffectPool.TIMER5,
+          EffectPool.TIMER6,
+          EffectPool.TIMER7,
+          EffectPool.TIMER8,
+          EffectPool.TIMER9,
+          EffectPool.TIMER10,
+          EffectPool.JUST_THE_BEST_ANAPESTS,
+          EffectPool.REASSURED,
+          EffectPool.HARE_BRAINED,
+          EffectPool.RECORD_HUNGER,
+          EffectPool.DRUNK_AVUNCULAR,
+          EffectPool.SHRIEKING_WEASEL,
+          EffectPool.POWER_MAN,
+          EffectPool.LUCKY_STRUCK,
+          EffectPool.MINISTRATIONS_IN_THE_DARK,
+          EffectPool.SUPERDRIFTING,
+          EffectPool.ELDRITCH_ATTUNEMENT,
+          EffectPool.CARTOGRAPHICALLY_CHARGED,
+          EffectPool.CARTOGRAPHICALLY_AWARE,
+          EffectPool.CARTOGRAPHICALLY_ROOTED -> {
         return true;
+      }
     }
 
     // Some songs are not AT buffs but are still shruggable
@@ -238,56 +239,60 @@ public class UneffectRequest extends GenericRequest {
     int skillId = SkillDatabase.getSkillId(skillName);
 
     switch (skillId) {
-      case SkillPool.SPIRIT_BOON:
-        {
-          TurtleBlessing blessing = KoLCharacter.getBlessingType();
-          if (blessing == null) return "none";
-          return switch (blessing) {
-            case SHE_WHO_WAS -> EffectDatabase.getEffectName(EffectPool.BOON_OF_SHE_WHO_WAS);
-            case STORM -> EffectDatabase.getEffectName(EffectPool.BOON_OF_THE_STORM_TORTOISE);
-            case WAR -> EffectDatabase.getEffectName(EffectPool.BOON_OF_THE_WAR_SNAPPER);
-          };
-        }
-      case SkillPool.SHE_WHO_WAS_BLESSING:
+      case SkillPool.SPIRIT_BOON -> {
+        TurtleBlessing blessing = KoLCharacter.getBlessingType();
+        if (blessing == null) return "none";
+        return switch (blessing) {
+          case SHE_WHO_WAS -> EffectDatabase.getEffectName(EffectPool.BOON_OF_SHE_WHO_WAS);
+          case STORM -> EffectDatabase.getEffectName(EffectPool.BOON_OF_THE_STORM_TORTOISE);
+          case WAR -> EffectDatabase.getEffectName(EffectPool.BOON_OF_THE_WAR_SNAPPER);
+        };
+      }
+      case SkillPool.SHE_WHO_WAS_BLESSING -> {
         return EffectDatabase.getEffectName(
             KoLCharacter.isTurtleTamer()
                 ? EffectPool.BLESSING_OF_SHE_WHO_WAS
                 : EffectPool.DISDAIN_OF_SHE_WHO_WAS);
-      case SkillPool.STORM_BLESSING:
+      }
+      case SkillPool.STORM_BLESSING -> {
         return EffectDatabase.getEffectName(
             KoLCharacter.isTurtleTamer()
                 ? EffectPool.BLESSING_OF_THE_STORM_TORTOISE
                 : EffectPool.DISDAIN_OF_THE_STORM_TORTOISE);
-      case SkillPool.WAR_BLESSING:
+      }
+      case SkillPool.WAR_BLESSING -> {
         return EffectDatabase.getEffectName(
             KoLCharacter.isTurtleTamer()
                 ? EffectPool.BLESSING_OF_THE_WAR_SNAPPER
                 : EffectPool.DISDAIN_OF_THE_WAR_SNAPPER);
-      case SkillPool.TURTLE_POWER:
-        {
-          TurtleBlessing blessing = KoLCharacter.getBlessingType();
-          if (blessing == null) return "none";
-          return switch (blessing) {
-            case SHE_WHO_WAS -> EffectDatabase.getEffectName(EffectPool.AVATAR_OF_SHE_WHO_WAS);
-            case STORM -> EffectDatabase.getEffectName(EffectPool.AVATAR_OF_THE_STORM_TORTOISE);
-            case WAR -> EffectDatabase.getEffectName(EffectPool.AVATAR_OF_THE_WAR_SNAPPER);
-          };
-        }
-      case SkillPool.SHIELD_OF_THE_PASTALORD:
+      }
+      case SkillPool.TURTLE_POWER -> {
+        TurtleBlessing blessing = KoLCharacter.getBlessingType();
+        if (blessing == null) return "none";
+        return switch (blessing) {
+          case SHE_WHO_WAS -> EffectDatabase.getEffectName(EffectPool.AVATAR_OF_SHE_WHO_WAS);
+          case STORM -> EffectDatabase.getEffectName(EffectPool.AVATAR_OF_THE_STORM_TORTOISE);
+          case WAR -> EffectDatabase.getEffectName(EffectPool.AVATAR_OF_THE_WAR_SNAPPER);
+        };
+      }
+      case SkillPool.SHIELD_OF_THE_PASTALORD -> {
         return EffectDatabase.getEffectName(
             KoLCharacter.isPastamancer()
                 ? EffectPool.SHIELD_OF_THE_PASTALORD
                 : EffectPool.FLIMSY_SHIELD_OF_THE_PASTALORD);
-      case SkillPool.BLOOD_SUGAR_SAUCE_MAGIC:
+      }
+      case SkillPool.BLOOD_SUGAR_SAUCE_MAGIC -> {
         return EffectDatabase.getEffectName(
             KoLCharacter.isSauceror()
                 ? EffectPool.BLOOD_SUGAR_SAUCE_MAGIC
                 : EffectPool.BLOOD_SUGAR_SAUCE_MAGIC_LITE);
-      case SkillPool.SILENT_HUNTER:
+      }
+      case SkillPool.SILENT_HUNTER -> {
         return EffectDatabase.getEffectName(
             KoLCharacter.isSealClubber()
                 ? EffectPool.SILENT_HUNTING
                 : EffectPool.NEARLY_SILENT_HUNTING);
+      }
     }
 
     // Handle remaining skills with a lookup

--- a/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
@@ -378,23 +378,57 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
 
   private record ReplaceEffect(int skill, int item, int baseEffect, int newEffect) {}
 
-  private final static List<ReplaceEffect> replaceEffects = List.of(
-      new ReplaceEffect(SkillPool.SNARL_OF_THE_TIMBERWOLF, ItemPool.VELOUR_VOULGE, EffectPool.SNARL_OF_THE_TIMBERWOLF, EffectPool.SNARL_OF_THREE_TIMBERWOLVES),
-      new ReplaceEffect(SkillPool.SCARYSAUCE, ItemPool.VELOUR_VISCOMETER, EffectPool.SCARYSAUCE, EffectPool.SCARIERSAUCE),
-      new ReplaceEffect(SkillPool.DIRGE_OF_DREADFULNESS, ItemPool.VELOUR_VAQUEROS, EffectPool.DIRGE_OF_DREADFULNESS, EffectPool.DIRGE_OF_DREADFULNESS_REMASTERED),
-      new ReplaceEffect(SkillPool.EMPATHY_OF_THE_NEWT, ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD, EffectPool.EMPATHY, EffectPool.THOUGHTFUL_EMPATHY)
-  );
+  private static final List<ReplaceEffect> replaceEffects =
+      List.of(
+          new ReplaceEffect(
+              SkillPool.SNARL_OF_THE_TIMBERWOLF,
+              ItemPool.VELOUR_VOULGE,
+              EffectPool.SNARL_OF_THE_TIMBERWOLF,
+              EffectPool.SNARL_OF_THREE_TIMBERWOLVES),
+          new ReplaceEffect(
+              SkillPool.SCARYSAUCE,
+              ItemPool.VELOUR_VISCOMETER,
+              EffectPool.SCARYSAUCE,
+              EffectPool.SCARIERSAUCE),
+          new ReplaceEffect(
+              SkillPool.DIRGE_OF_DREADFULNESS,
+              ItemPool.VELOUR_VAQUEROS,
+              EffectPool.DIRGE_OF_DREADFULNESS,
+              EffectPool.DIRGE_OF_DREADFULNESS_REMASTERED),
+          new ReplaceEffect(
+              SkillPool.EMPATHY_OF_THE_NEWT,
+              ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD,
+              EffectPool.EMPATHY,
+              EffectPool.THOUGHTFUL_EMPATHY));
 
   private record AdditionalEffect(int skill, int item, int newEffect) {}
 
-  private final static List<AdditionalEffect> additionalEffects = List.of(
-      new AdditionalEffect(SkillPool.SEAL_CLUBBING_FRENZY, ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD, EffectPool.SLIPPERY_AS_A_SEAL),
-      new AdditionalEffect(SkillPool.PATIENCE_OF_THE_TORTOISE, ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD, EffectPool.STRENGTH_OF_THE_TORTOISE),
-      new AdditionalEffect(SkillPool.MANICOTTI_MEDITATION, ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD, EffectPool.TUBES_OF_UNIVERSAL_MEAT),
-      new AdditionalEffect(SkillPool.SAUCE_CONTEMPLATION, ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD, EffectPool.LUBRICATING_SAUCE),
-      new AdditionalEffect(SkillPool.DISCO_AEROBICS, ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD, EffectPool.DISCO_OVER_MATTER),
-      new AdditionalEffect(SkillPool.MOXIE_OF_THE_MARIACHI, ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD, EffectPool.MARIACHI_MOISTURE)
-  );
+  private static final List<AdditionalEffect> additionalEffects =
+      List.of(
+          new AdditionalEffect(
+              SkillPool.SEAL_CLUBBING_FRENZY,
+              ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD,
+              EffectPool.SLIPPERY_AS_A_SEAL),
+          new AdditionalEffect(
+              SkillPool.PATIENCE_OF_THE_TORTOISE,
+              ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD,
+              EffectPool.STRENGTH_OF_THE_TORTOISE),
+          new AdditionalEffect(
+              SkillPool.MANICOTTI_MEDITATION,
+              ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD,
+              EffectPool.TUBES_OF_UNIVERSAL_MEAT),
+          new AdditionalEffect(
+              SkillPool.SAUCE_CONTEMPLATION,
+              ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD,
+              EffectPool.LUBRICATING_SAUCE),
+          new AdditionalEffect(
+              SkillPool.DISCO_AEROBICS,
+              ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD,
+              EffectPool.DISCO_OVER_MATTER),
+          new AdditionalEffect(
+              SkillPool.MOXIE_OF_THE_MARIACHI,
+              ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD,
+              EffectPool.MARIACHI_MOISTURE));
 
   public static int requiredItemForSkillEffect(int skillId, int effId) {
     for (var replace : replaceEffects) {

--- a/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
@@ -287,31 +287,8 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
     this.addFormFields();
   }
 
-  private UseSkillRequest(final String skillName) {
-    super(UseSkillRequest.chooseURL(skillName));
-
-    this.skillId = SkillDatabase.getSkillId(skillName);
-    if (this.skillId == -1) {
-      RequestLogger.printLine("Unrecognized skill: " + skillName);
-      this.skillName = skillName;
-      this.isBuff = false;
-    } else {
-      this.skillName = SkillDatabase.getSkillName(this.skillId);
-      this.isBuff = SkillDatabase.isBuff(this.skillId);
-    }
-
-    this.canonical = StringUtilities.getCanonicalName(this.skillName);
-    this.target = null;
-    this.countFieldId = null;
-    this.addFormFields();
-  }
-
   private static String chooseURL(final int skillId) {
     return SkillDatabase.isBookshelfSkill(skillId) ? "campground.php" : "runskillz.php";
-  }
-
-  private static String chooseURL(final String skillName) {
-    return SkillDatabase.isBookshelfSkill(skillName) ? "campground.php" : "runskillz.php";
   }
 
   private void addFormFields() {
@@ -345,7 +322,7 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
   public void setTarget(final String target) {
     if (this.isBuff) {
       if (target == null
-          || target.trim().length() == 0
+          || target.trim().isEmpty()
           || target.equals(KoLCharacter.getPlayerId())
           || target.equals(KoLCharacter.getUserName())) {
         this.target = null;
@@ -1037,8 +1014,8 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
 
     AdventureResult[] effects = new AdventureResult[KoLConstants.activeEffects.size()];
     KoLConstants.activeEffects.toArray(effects);
-    for (int i = 0; i < effects.length; ++i) {
-      String skillName = UneffectRequest.effectToSkill(effects[i].getName());
+    for (AdventureResult effect : effects) {
+      String skillName = UneffectRequest.effectToSkill(effect.getName());
       if (SkillDatabase.contains(skillName)) {
         int skillId = SkillDatabase.getSkillId(skillName);
         if (SkillDatabase.isAccordionThiefSong(skillId)) {
@@ -1056,8 +1033,8 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
 
     AdventureResult[] effects = new AdventureResult[KoLConstants.activeEffects.size()];
     KoLConstants.activeEffects.toArray(effects);
-    for (int i = 0; i < effects.length; ++i) {
-      String skillName = UneffectRequest.effectToSkill(effects[i].getName());
+    for (AdventureResult effect : effects) {
+      String skillName = UneffectRequest.effectToSkill(effect.getName());
       if (SkillDatabase.contains(skillName)) {
         int effectSkillId = SkillDatabase.getSkillId(skillName);
         if (effectSkillId == skillId) {
@@ -1348,7 +1325,7 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
           this.addFormField(this.countFieldId, String.valueOf(currentCast), false);
         }
 
-        if (this.target == null || this.target.trim().length() == 0) {
+        if (this.target == null || this.target.trim().isEmpty()) {
           KoLmafia.updateDisplay("Casting " + this.skillName + " " + currentCast + " times...");
         } else {
           KoLmafia.updateDisplay(
@@ -1438,8 +1415,7 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
   }
 
   private static BuffTool findTool(BuffTool[] tools) {
-    for (int i = 0; i < tools.length; ++i) {
-      BuffTool tool = tools[i];
+    for (BuffTool tool : tools) {
       if (tool.hasItem(true)) {
         return tool;
       }
@@ -1555,7 +1531,7 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
 
     boolean shouldStop = UseSkillRequest.parseResponse(this.getURLString(), this.responseText);
 
-    if (!UseSkillRequest.lastUpdate.equals("")) {
+    if (!UseSkillRequest.lastUpdate.isEmpty()) {
       MafiaState state = shouldStop ? MafiaState.ERROR : MafiaState.CONTINUE;
       KoLmafia.updateDisplay(state, UseSkillRequest.lastUpdate);
 
@@ -1611,7 +1587,7 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
   public static final UseSkillRequest getInstance(
       final int skillId, final String target, final int buffCount) {
     UseSkillRequest request = new UseSkillRequest(skillId);
-    request.setTarget(target == null || target.equals("") ? KoLCharacter.getUserName() : target);
+    request.setTarget(target == null || target.isEmpty() ? KoLCharacter.getUserName() : target);
     request.setBuffCount(buffCount);
     return request;
   }
@@ -1669,7 +1645,7 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
   }
 
   private static SkillStatus responseStatus(final String responseText, int skillId, int count) {
-    if (responseText == null || responseText.trim().length() == 0) {
+    if (responseText == null || responseText.trim().isEmpty()) {
       long initialMP = KoLCharacter.getCurrentMP();
       ApiRequest.updateStatus();
 
@@ -2071,11 +2047,11 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
     } else if (SkillDatabase.isVampyreSkill(skillId)) {
       ResultProcessor.processResult(
           new AdventureLongCountResult(
-              AdventureResult.HP, 0 - SkillDatabase.getHPCost(skillId) * count));
+              AdventureResult.HP, (long) -SkillDatabase.getHPCost(skillId) * count));
     }
 
     if (mpCost > 0) {
-      ResultProcessor.processResult(new AdventureLongCountResult(AdventureResult.MP, 0 - mpCost));
+      ResultProcessor.processResult(new AdventureLongCountResult(AdventureResult.MP, -mpCost));
     }
 
     return SkillStatus.SUCCESS;

--- a/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
@@ -417,7 +417,7 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
         // Rainbow Gravitation can be cast 3 times per day.  Each
         // casting consumes five elemental wads and a twinkly wad
 
-      case SkillPool.RAINBOW_GRAVITATION:
+      case SkillPool.RAINBOW_GRAVITATION -> {
         var maximumCast = Math.max(3 - Preferences.getInteger("prismaticSummons"), 0);
         maximumCast = Math.min(InventoryManager.getAccessibleCount(ItemPool.COLD_WAD), maximumCast);
         maximumCast = Math.min(InventoryManager.getAccessibleCount(ItemPool.HOT_WAD), maximumCast);
@@ -428,66 +428,68 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
         maximumCast =
             Math.min(InventoryManager.getAccessibleCount(ItemPool.STENCH_WAD), maximumCast);
         return Math.min(InventoryManager.getAccessibleCount(ItemPool.TWINKLY_WAD), maximumCast);
+      }
 
         // Hobo skills
-      case SkillPool.THINGFINDER:
-      case SkillPool.BENETTONS:
-      case SkillPool.ELRONS:
-      case SkillPool.COMPANIONSHIP:
-      case SkillPool.PRECISION:
+      case SkillPool.THINGFINDER,
+          SkillPool.BENETTONS,
+          SkillPool.ELRONS,
+          SkillPool.COMPANIONSHIP,
+          SkillPool.PRECISION -> {
         // If you can't cast them, return zero
         if (!KoLCharacter.isAccordionThief() || KoLCharacter.getLevel() < 15) {
           return 0;
         }
         // Otherwise let daily limits database handle remaining casts
-        break;
+      }
 
         // Zombie Master skills
-      case SkillPool.SUMMON_MINION:
+      case SkillPool.SUMMON_MINION -> {
         return KoLCharacter.getAvailableMeat() / 100;
-
-      case SkillPool.SUMMON_HORDE:
+      }
+      case SkillPool.SUMMON_HORDE -> {
         return KoLCharacter.getAvailableMeat() / 1000;
+      }
 
         // Avatar of Jarlsberg skills
-      case SkillPool.EGGMAN:
+      case SkillPool.EGGMAN -> {
         boolean haveEgg = InventoryManager.getCount(ItemPool.COSMIC_EGG) > 0;
         boolean eggActive = KoLCharacter.getCompanion() == Companion.EGGMAN;
         return (haveEgg && !eggActive) ? 1 : 0;
-
-      case SkillPool.RADISH_HORSE:
+      }
+      case SkillPool.RADISH_HORSE -> {
         boolean haveVeggie = InventoryManager.getCount(ItemPool.COSMIC_VEGETABLE) > 0;
         boolean radishActive = KoLCharacter.getCompanion() == Companion.RADISH;
         return (haveVeggie && !radishActive) ? 1 : 0;
-
-      case SkillPool.HIPPOTATO:
+      }
+      case SkillPool.HIPPOTATO -> {
         boolean havePotato = InventoryManager.getCount(ItemPool.COSMIC_POTATO) > 0;
         boolean hippoActive = KoLCharacter.getCompanion() == Companion.HIPPO;
         return (havePotato && !hippoActive) ? 1 : 0;
-
-      case SkillPool.CREAMPUFF:
+      }
+      case SkillPool.CREAMPUFF -> {
         boolean haveCream = InventoryManager.getCount(ItemPool.COSMIC_CREAM) > 0;
         boolean creampuffActive = KoLCharacter.getCompanion() == Companion.CREAM;
         return (haveCream && !creampuffActive) ? 1 : 0;
-
-      case SkillPool.DEEP_VISIONS:
+      }
+      case SkillPool.DEEP_VISIONS -> {
         return KoLCharacter.getMaximumHP() >= 500 ? 1 : 0;
-
-      case SkillPool.WAR_BLESSING, SkillPool.SHE_WHO_WAS_BLESSING, SkillPool.STORM_BLESSING:
+      }
+      case SkillPool.WAR_BLESSING, SkillPool.SHE_WHO_WAS_BLESSING, SkillPool.STORM_BLESSING -> {
         return KoLConstants.activeEffects.contains(EffectPool.get(EffectPool.SPIRIT_PARIAH))
             ? 0
             : 1;
-
-      case SkillPool.SPIRIT_BOON:
+      }
+      case SkillPool.SPIRIT_BOON -> {
         return KoLCharacter.getBlessingLevel().isBlessing() ? Integer.MAX_VALUE : 0;
-
-      case SkillPool.TURTLE_POWER:
+      }
+      case SkillPool.TURTLE_POWER -> {
         return KoLCharacter.getBlessingLevel() == TurtleBlessingLevel.GLORIOUS_BLESSING
                 && !Preferences.getBoolean("_turtlePowerCast")
             ? 1
             : 0;
-
-      case SkillPool.SUMMON_ANNOYANCE:
+      }
+      case SkillPool.SUMMON_ANNOYANCE -> {
         if (Preferences.getInteger("summonAnnoyanceCost") == 11) {
           // If we made it this far, you should have the skill.
           // Update its cost.
@@ -503,96 +505,92 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
           return 0;
         }
         return 1;
-
-      case SkillPool.CALCULATE_THE_UNIVERSE:
-        {
-          if (KoLCharacter.getAdventuresLeft() == 0) {
-            return 0;
-          }
-          int skillLevel = Preferences.getInteger("skillLevel144");
-          if (!KoLCharacter.canInteract()) {
-            skillLevel = Math.min(skillLevel, 3);
-          }
-          int casts = Preferences.getInteger("_universeCalculated");
-          return Math.max(skillLevel - casts, 0);
+      }
+      case SkillPool.CALCULATE_THE_UNIVERSE -> {
+        if (KoLCharacter.getAdventuresLeft() == 0) {
+          return 0;
         }
-
-      case SkillPool.ANCESTRAL_RECALL:
+        int skillLevel = Preferences.getInteger("skillLevel144");
+        if (!KoLCharacter.canInteract()) {
+          skillLevel = Math.min(skillLevel, 3);
+        }
+        int casts = Preferences.getInteger("_universeCalculated");
+        return Math.max(skillLevel - casts, 0);
+      }
+      case SkillPool.ANCESTRAL_RECALL -> {
         return Math.min(
             10 - Preferences.getInteger("_ancestralRecallCasts"),
             InventoryManager.getAccessibleCount(ItemPool.BLUE_MANA));
-
-      case SkillPool.DARK_RITUAL:
+      }
+      case SkillPool.DARK_RITUAL -> {
         return InventoryManager.getAccessibleCount(ItemPool.BLACK_MANA);
-
-      case SkillPool.INTERNAL_SODA_MACHINE:
+      }
+      case SkillPool.INTERNAL_SODA_MACHINE -> {
         long meatLimit = KoLCharacter.getAvailableMeat() / 20;
         long mpLimit =
             (int) Math.ceil((KoLCharacter.getMaximumMP() - KoLCharacter.getCurrentMP()) / 10.0);
         return Math.min(meatLimit, mpLimit);
-
-      case SkillPool.STACK_LUMPS:
+      }
+      case SkillPool.STACK_LUMPS -> {
         return 1;
-
-      case SkillPool.LOVE_MIXOLOGY:
+      }
+      case SkillPool.LOVE_MIXOLOGY -> {
         return InventoryManager.getAccessibleCount(ItemPool.LOVE_POTION_XYZ) > 0
                 || KoLConstants.activeEffects.contains(UseSkillRequest.TAINTED_LOVE_POTION)
             ? 0
             : 1;
+      }
+      case SkillPool.SEEK_OUT_A_BIRD -> {
+        // On the seventh cast of the day, you are given the
+        // option to change your favorite bird.
+        //
+        // The choice adventure to select this is 1399.
+        // Option 1 changes the bird and the cast succeeds
+        // Option 2 does not change and the cast fails.
+        //
+        // Therefore:
+        //
+        // If you want option 1, casts are limited by MP
+        // If you want option 2, you get 6 casts per day
+        //
+        // If you have already summoned at least 7 birds today,
+        // you are past the choice and casts are unlimited
 
-      case SkillPool.SEEK_OUT_A_BIRD:
-        {
-          // On the seventh cast of the day, you are given the
-          // option to change your favorite bird.
-          //
-          // The choice adventure to select this is 1399.
-          // Option 1 changes the bird and the cast succeeds
-          // Option 2 does not change and the cast fails.
-          //
-          // Therefore:
-          //
-          // If you want option 1, casts are limited by MP
-          // If you want option 2, you get 6 casts per day
-          //
-          // If you have already summoned at least 7 birds today,
-          // you are past the choice and casts are unlimited
-
-          int option = Preferences.getInteger("choiceAdventure1399");
-          int birds = Preferences.getInteger("_birdsSoughtToday");
-          return (birds < 7 && option != 1) ? 6 - birds : Long.MAX_VALUE;
-        }
-
-      case SkillPool.AUG_1ST_MOUNTAIN_CLIMBING_DAY:
-      case SkillPool.AUG_2ND_FIND_AN_ELEVENLEAF_CLOVER_DAY:
-      case SkillPool.AUG_3RD_WATERMELON_DAY:
-      case SkillPool.AUG_4TH_WATER_BALLOON_DAY:
-      case SkillPool.AUG_5TH_OYSTER_DAY:
-      case SkillPool.AUG_6TH_FRESH_BREATH_DAY:
-      case SkillPool.AUG_7TH_LIGHTHOUSE_DAY:
-      case SkillPool.AUG_8TH_CAT_DAY:
-      case SkillPool.AUG_9TH_HAND_HOLDING_DAY:
-      case SkillPool.AUG_10TH_WORLD_LION_DAY:
-      case SkillPool.AUG_11TH_PRESIDENTIAL_JOKE_DAY:
-      case SkillPool.AUG_12TH_ELEPHANT_DAY:
-      case SkillPool.AUG_13TH_LEFTOFF_HANDERS_DAY:
-      case SkillPool.AUG_14TH_FINANCIAL_AWARENESS_DAY:
-      case SkillPool.AUG_15TH_RELAXATION_DAY:
-      case SkillPool.AUG_16TH_ROLLER_COASTER_DAY:
-      case SkillPool.AUG_17TH_THRIFTSHOP_DAY:
-      case SkillPool.AUG_18TH_SERENDIPITY_DAY:
-      case SkillPool.AUG_19TH_HONEY_BEE_AWARENESS_DAY:
-      case SkillPool.AUG_20TH_MOSQUITO_DAY:
-      case SkillPool.AUG_21ST_SPUMONI_DAY:
-      case SkillPool.AUG_22ND_TOOTH_FAIRY_DAY:
-      case SkillPool.AUG_23RD_RIDE_THE_WIND_DAY:
-      case SkillPool.AUG_24TH_WAFFLE_DAY:
-      case SkillPool.AUG_25TH_BANANA_SPLIT_DAY:
-      case SkillPool.AUG_26TH_TOILET_PAPER_DAY:
-      case SkillPool.AUG_27TH_JUST_BECAUSE_DAY:
-      case SkillPool.AUG_28TH_RACE_YOUR_MOUSE_DAY:
-      case SkillPool.AUG_29TH_MORE_HERBS_LESS_SALT_DAY:
-      case SkillPool.AUG_30TH_BEACH_DAY:
-      case SkillPool.AUG_31ST_CABERNET_SAUVIGNON_DAY:
+        int option = Preferences.getInteger("choiceAdventure1399");
+        int birds = Preferences.getInteger("_birdsSoughtToday");
+        return (birds < 7 && option != 1) ? 6 - birds : Long.MAX_VALUE;
+      }
+      case SkillPool.AUG_1ST_MOUNTAIN_CLIMBING_DAY,
+          SkillPool.AUG_2ND_FIND_AN_ELEVENLEAF_CLOVER_DAY,
+          SkillPool.AUG_3RD_WATERMELON_DAY,
+          SkillPool.AUG_4TH_WATER_BALLOON_DAY,
+          SkillPool.AUG_5TH_OYSTER_DAY,
+          SkillPool.AUG_6TH_FRESH_BREATH_DAY,
+          SkillPool.AUG_7TH_LIGHTHOUSE_DAY,
+          SkillPool.AUG_8TH_CAT_DAY,
+          SkillPool.AUG_9TH_HAND_HOLDING_DAY,
+          SkillPool.AUG_10TH_WORLD_LION_DAY,
+          SkillPool.AUG_11TH_PRESIDENTIAL_JOKE_DAY,
+          SkillPool.AUG_12TH_ELEPHANT_DAY,
+          SkillPool.AUG_13TH_LEFTOFF_HANDERS_DAY,
+          SkillPool.AUG_14TH_FINANCIAL_AWARENESS_DAY,
+          SkillPool.AUG_15TH_RELAXATION_DAY,
+          SkillPool.AUG_16TH_ROLLER_COASTER_DAY,
+          SkillPool.AUG_17TH_THRIFTSHOP_DAY,
+          SkillPool.AUG_18TH_SERENDIPITY_DAY,
+          SkillPool.AUG_19TH_HONEY_BEE_AWARENESS_DAY,
+          SkillPool.AUG_20TH_MOSQUITO_DAY,
+          SkillPool.AUG_21ST_SPUMONI_DAY,
+          SkillPool.AUG_22ND_TOOTH_FAIRY_DAY,
+          SkillPool.AUG_23RD_RIDE_THE_WIND_DAY,
+          SkillPool.AUG_24TH_WAFFLE_DAY,
+          SkillPool.AUG_25TH_BANANA_SPLIT_DAY,
+          SkillPool.AUG_26TH_TOILET_PAPER_DAY,
+          SkillPool.AUG_27TH_JUST_BECAUSE_DAY,
+          SkillPool.AUG_28TH_RACE_YOUR_MOUSE_DAY,
+          SkillPool.AUG_29TH_MORE_HERBS_LESS_SALT_DAY,
+          SkillPool.AUG_30TH_BEACH_DAY,
+          SkillPool.AUG_31ST_CABERNET_SAUVIGNON_DAY -> {
         // if we've already cast it, we can't cast it again
         if (!DailyLimitType.CAST.getDailyLimit(this.skillId).hasUsesRemaining()) {
           return 0;
@@ -610,6 +608,7 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
           }
         }
         return 0;
+      }
     }
 
     var dailyLimit = DailyLimitType.CAST.getDailyLimit(this.skillId);
@@ -1845,16 +1844,10 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
 
     // Deal with secondary effects from skill usage (not daily limitations)
     switch (skillId) {
-      case SkillPool.ODE_TO_BOOZE:
-        ConcoctionDatabase.getUsables().sort();
-        break;
-
-      case SkillPool.WALRUS_TONGUE:
-      case SkillPool.DISCO_NAP:
-        UneffectRequest.removeEffectsWithSkill(skillId);
-        break;
-
-      case SkillPool.RAINBOW_GRAVITATION:
+      case SkillPool.ODE_TO_BOOZE -> ConcoctionDatabase.getUsables().sort();
+      case SkillPool.WALRUS_TONGUE, SkillPool.DISCO_NAP -> UneffectRequest.removeEffectsWithSkill(
+          skillId);
+      case SkillPool.RAINBOW_GRAVITATION -> {
 
         // Each cast of Rainbow Gravitation consumes five
         // elemental wads and a twinkly wad
@@ -1865,154 +1858,100 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
         ResultProcessor.processResult(ItemPool.get(ItemPool.SPOOKY_WAD, -count));
         ResultProcessor.processResult(ItemPool.get(ItemPool.STENCH_WAD, -count));
         ResultProcessor.processResult(ItemPool.get(ItemPool.TWINKLY_WAD, -count));
-        break;
-
-      case SkillPool.TURTLE_POWER:
-      case SkillPool.WAR_BLESSING:
-      case SkillPool.SHE_WHO_WAS_BLESSING:
-      case SkillPool.STORM_BLESSING:
-        Preferences.setInteger("turtleBlessingTurns", 0);
-        break;
-
-      case SkillPool.CARBOLOADING:
-        Preferences.increment("carboLoading", 1);
-        break;
-
-      case SkillPool.SNOWCONE:
-      case SkillPool.STICKER:
-      case SkillPool.SUGAR:
-      case SkillPool.CLIP_ART:
-      case SkillPool.RAD_LIB:
-      case SkillPool.SMITHSNESS:
-        ConcoctionDatabase.setRefreshNeeded(false);
-        break;
-
-      case SkillPool.EGGMAN:
-        ResultProcessor.removeItem(ItemPool.COSMIC_EGG);
-        break;
-      case SkillPool.RADISH_HORSE:
-        ResultProcessor.removeItem(ItemPool.COSMIC_VEGETABLE);
-        break;
-      case SkillPool.HIPPOTATO:
-        ResultProcessor.removeItem(ItemPool.COSMIC_POTATO);
-        break;
-      case SkillPool.CREAMPUFF:
-        ResultProcessor.removeItem(ItemPool.COSMIC_CREAM);
-        break;
-
-      case SkillPool.DEEP_VISIONS:
-        DreadScrollManager.handleDeepDarkVisions(responseText);
-        break;
-
-      case SkillPool.BIND_VAMPIEROGHI:
-      case SkillPool.BIND_VERMINCELLI:
-      case SkillPool.BIND_ANGEL_HAIR_WISP:
-      case SkillPool.BIND_UNDEAD_ELBOW_MACARONI:
-      case SkillPool.BIND_PENNE_DREADFUL:
-      case SkillPool.BIND_LASAGMBIE:
-      case SkillPool.BIND_SPICE_GHOST:
-      case SkillPool.BIND_SPAGHETTI_ELEMENTAL:
-        PastaThrallData.handleBinding(skillId, responseText);
-        break;
-
-      case SkillPool.DISMISS_PASTA_THRALL:
-        PastaThrallData.handleDismissal(responseText);
-        break;
-
-      case SkillPool.SUMMON_ANNOYANCE:
-        Preferences.decrement("availableSwagger", Preferences.getInteger("summonAnnoyanceCost"));
-        break;
-
-      case SkillPool.ANCESTRAL_RECALL:
-        ResultProcessor.processResult(ItemPool.get(ItemPool.BLUE_MANA, -count));
-        break;
-
-      case SkillPool.DARK_RITUAL:
-        ResultProcessor.processResult(ItemPool.get(ItemPool.BLACK_MANA, -count));
-        break;
-
-      case SkillPool.STACK_LUMPS:
+      }
+      case SkillPool.TURTLE_POWER,
+          SkillPool.WAR_BLESSING,
+          SkillPool.SHE_WHO_WAS_BLESSING,
+          SkillPool.STORM_BLESSING -> Preferences.setInteger("turtleBlessingTurns", 0);
+      case SkillPool.CARBOLOADING -> Preferences.increment("carboLoading", 1);
+      case SkillPool.SNOWCONE,
+          SkillPool.STICKER,
+          SkillPool.SUGAR,
+          SkillPool.CLIP_ART,
+          SkillPool.RAD_LIB,
+          SkillPool.SMITHSNESS -> ConcoctionDatabase.setRefreshNeeded(false);
+      case SkillPool.EGGMAN -> ResultProcessor.removeItem(ItemPool.COSMIC_EGG);
+      case SkillPool.RADISH_HORSE -> ResultProcessor.removeItem(ItemPool.COSMIC_VEGETABLE);
+      case SkillPool.HIPPOTATO -> ResultProcessor.removeItem(ItemPool.COSMIC_POTATO);
+      case SkillPool.CREAMPUFF -> ResultProcessor.removeItem(ItemPool.COSMIC_CREAM);
+      case SkillPool.DEEP_VISIONS -> DreadScrollManager.handleDeepDarkVisions(responseText);
+      case SkillPool.BIND_VAMPIEROGHI,
+          SkillPool.BIND_VERMINCELLI,
+          SkillPool.BIND_ANGEL_HAIR_WISP,
+          SkillPool.BIND_UNDEAD_ELBOW_MACARONI,
+          SkillPool.BIND_PENNE_DREADFUL,
+          SkillPool.BIND_LASAGMBIE,
+          SkillPool.BIND_SPICE_GHOST,
+          SkillPool.BIND_SPAGHETTI_ELEMENTAL -> PastaThrallData.handleBinding(
+          skillId, responseText);
+      case SkillPool.DISMISS_PASTA_THRALL -> PastaThrallData.handleDismissal(responseText);
+      case SkillPool.SUMMON_ANNOYANCE -> Preferences.decrement(
+          "availableSwagger", Preferences.getInteger("summonAnnoyanceCost"));
+      case SkillPool.ANCESTRAL_RECALL -> ResultProcessor.processResult(
+          ItemPool.get(ItemPool.BLUE_MANA, -count));
+      case SkillPool.DARK_RITUAL -> ResultProcessor.processResult(
+          ItemPool.get(ItemPool.BLACK_MANA, -count));
+      case SkillPool.STACK_LUMPS -> {
         Preferences.increment("_stackLumpsUses");
         ResultProcessor.processResult(ItemPool.get(ItemPool.NEGATIVE_LUMP, -100));
-        break;
-
-      case SkillPool.LOVE_MIXOLOGY:
-        {
-          Matcher matcher = UseSkillRequest.LOVE_POTION_PATTERN.matcher(responseText);
-          if (matcher.find()) {
-            Preferences.setString("lovePotion", matcher.group(1).replaceAll(",", ""));
-          }
-          break;
+      }
+      case SkillPool.LOVE_MIXOLOGY -> {
+        Matcher matcher = UseSkillRequest.LOVE_POTION_PATTERN.matcher(responseText);
+        if (matcher.find()) {
+          Preferences.setString("lovePotion", matcher.group(1).replaceAll(",", ""));
         }
-
-      case SkillPool.CALCULATE_THE_UNIVERSE:
+      }
+      case SkillPool.CALCULATE_THE_UNIVERSE -> {
         if (Preferences.getInteger("skillLevel144") == 0) {
           // If the skill is being cast, then the limit must be at least 1
           Preferences.setInteger("skillLevel144", 1);
         }
-        break;
-
-      case SkillPool.SEEK_OUT_A_BIRD:
-        Preferences.increment("_birdsSoughtToday");
-        break;
-
-      case SkillPool.MAP_THE_MONSTERS:
-        Preferences.setBoolean("mappingMonsters", true);
-        break;
-
-      case SkillPool.MAKE_SWEATADE:
-      case SkillPool.DRENCH_YOURSELF_IN_SWEAT:
-      case SkillPool.SIP_SOME_SWEAT:
+      }
+      case SkillPool.SEEK_OUT_A_BIRD -> Preferences.increment("_birdsSoughtToday");
+      case SkillPool.MAP_THE_MONSTERS -> Preferences.setBoolean("mappingMonsters", true);
+      case SkillPool.MAKE_SWEATADE,
+          SkillPool.DRENCH_YOURSELF_IN_SWEAT,
+          SkillPool.SIP_SOME_SWEAT -> {
         Matcher sweatCheck = SWEAT_PATTERN.matcher(responseText);
         if (sweatCheck.find()) {
           int sweatCost = Integer.parseInt(sweatCheck.group(1));
           Preferences.decrement("sweat", sweatCost);
         }
-        break;
-
-      case SkillPool.SWEAT_OUT_BOOZE:
-        Preferences.decrement("sweat", count * 25);
-        break;
-
-      case SkillPool.CINCHO_DISPENSE_SALT_AND_LIME:
-        Preferences.increment("cinchoSaltAndLime");
-        break;
-
-      case SkillPool.CINCHO_FIESTA_EXIT:
-        Preferences.setBoolean("noncombatForcerActive", true);
-        break;
-
-      case SkillPool.AUG_1ST_MOUNTAIN_CLIMBING_DAY:
-      case SkillPool.AUG_2ND_FIND_AN_ELEVENLEAF_CLOVER_DAY:
-      case SkillPool.AUG_3RD_WATERMELON_DAY:
-      case SkillPool.AUG_4TH_WATER_BALLOON_DAY:
-      case SkillPool.AUG_5TH_OYSTER_DAY:
-      case SkillPool.AUG_6TH_FRESH_BREATH_DAY:
-      case SkillPool.AUG_7TH_LIGHTHOUSE_DAY:
-      case SkillPool.AUG_8TH_CAT_DAY:
-      case SkillPool.AUG_9TH_HAND_HOLDING_DAY:
-      case SkillPool.AUG_10TH_WORLD_LION_DAY:
-      case SkillPool.AUG_11TH_PRESIDENTIAL_JOKE_DAY:
-      case SkillPool.AUG_12TH_ELEPHANT_DAY:
-      case SkillPool.AUG_13TH_LEFTOFF_HANDERS_DAY:
-      case SkillPool.AUG_14TH_FINANCIAL_AWARENESS_DAY:
-      case SkillPool.AUG_15TH_RELAXATION_DAY:
-      case SkillPool.AUG_16TH_ROLLER_COASTER_DAY:
-      case SkillPool.AUG_17TH_THRIFTSHOP_DAY:
-      case SkillPool.AUG_18TH_SERENDIPITY_DAY:
-      case SkillPool.AUG_19TH_HONEY_BEE_AWARENESS_DAY:
-      case SkillPool.AUG_20TH_MOSQUITO_DAY:
-      case SkillPool.AUG_21ST_SPUMONI_DAY:
-      case SkillPool.AUG_22ND_TOOTH_FAIRY_DAY:
-      case SkillPool.AUG_23RD_RIDE_THE_WIND_DAY:
-      case SkillPool.AUG_24TH_WAFFLE_DAY:
-      case SkillPool.AUG_25TH_BANANA_SPLIT_DAY:
-      case SkillPool.AUG_26TH_TOILET_PAPER_DAY:
-      case SkillPool.AUG_27TH_JUST_BECAUSE_DAY:
-      case SkillPool.AUG_28TH_RACE_YOUR_MOUSE_DAY:
-      case SkillPool.AUG_29TH_MORE_HERBS_LESS_SALT_DAY:
-      case SkillPool.AUG_30TH_BEACH_DAY:
-      case SkillPool.AUG_31ST_CABERNET_SAUVIGNON_DAY:
+      }
+      case SkillPool.SWEAT_OUT_BOOZE -> Preferences.decrement("sweat", count * 25);
+      case SkillPool.CINCHO_DISPENSE_SALT_AND_LIME -> Preferences.increment("cinchoSaltAndLime");
+      case SkillPool.CINCHO_FIESTA_EXIT -> Preferences.setBoolean("noncombatForcerActive", true);
+      case SkillPool.AUG_1ST_MOUNTAIN_CLIMBING_DAY,
+          SkillPool.AUG_2ND_FIND_AN_ELEVENLEAF_CLOVER_DAY,
+          SkillPool.AUG_3RD_WATERMELON_DAY,
+          SkillPool.AUG_4TH_WATER_BALLOON_DAY,
+          SkillPool.AUG_5TH_OYSTER_DAY,
+          SkillPool.AUG_6TH_FRESH_BREATH_DAY,
+          SkillPool.AUG_7TH_LIGHTHOUSE_DAY,
+          SkillPool.AUG_8TH_CAT_DAY,
+          SkillPool.AUG_9TH_HAND_HOLDING_DAY,
+          SkillPool.AUG_10TH_WORLD_LION_DAY,
+          SkillPool.AUG_11TH_PRESIDENTIAL_JOKE_DAY,
+          SkillPool.AUG_12TH_ELEPHANT_DAY,
+          SkillPool.AUG_13TH_LEFTOFF_HANDERS_DAY,
+          SkillPool.AUG_14TH_FINANCIAL_AWARENESS_DAY,
+          SkillPool.AUG_15TH_RELAXATION_DAY,
+          SkillPool.AUG_16TH_ROLLER_COASTER_DAY,
+          SkillPool.AUG_17TH_THRIFTSHOP_DAY,
+          SkillPool.AUG_18TH_SERENDIPITY_DAY,
+          SkillPool.AUG_19TH_HONEY_BEE_AWARENESS_DAY,
+          SkillPool.AUG_20TH_MOSQUITO_DAY,
+          SkillPool.AUG_21ST_SPUMONI_DAY,
+          SkillPool.AUG_22ND_TOOTH_FAIRY_DAY,
+          SkillPool.AUG_23RD_RIDE_THE_WIND_DAY,
+          SkillPool.AUG_24TH_WAFFLE_DAY,
+          SkillPool.AUG_25TH_BANANA_SPLIT_DAY,
+          SkillPool.AUG_26TH_TOILET_PAPER_DAY,
+          SkillPool.AUG_27TH_JUST_BECAUSE_DAY,
+          SkillPool.AUG_28TH_RACE_YOUR_MOUSE_DAY,
+          SkillPool.AUG_29TH_MORE_HERBS_LESS_SALT_DAY,
+          SkillPool.AUG_30TH_BEACH_DAY,
+          SkillPool.AUG_31ST_CABERNET_SAUVIGNON_DAY -> {
         // is this our "today" skill?
         var date = DateTimeManager.getRolloverDateTime().getDayOfMonth();
         var isTodaySkill = skillId == date - 1 + SkillPool.AUG_1ST_MOUNTAIN_CLIMBING_DAY;
@@ -2022,7 +1961,7 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
         } else {
           Preferences.increment("_augSkillsCast", 1, 5, false);
         }
-        break;
+      }
     }
 
     // Now apply daily limits

--- a/src/net/sourceforge/kolmafia/textui/command/UseSkillCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/UseSkillCommand.java
@@ -56,7 +56,7 @@ public class UseSkillCommand extends AbstractCommand {
       if (splitParameters.length > 1) {
         player = splitParameters[1];
       }
-      var skillEffect = splitParameters[0].split(" ^ ");
+      var skillEffect = splitParameters[0].split(" \\^ ");
       if (skillEffect.length > 1) {
         effect = skillEffect[1];
       }

--- a/src/net/sourceforge/kolmafia/textui/command/UseSkillCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/UseSkillCommand.java
@@ -6,13 +6,14 @@ import net.sourceforge.kolmafia.KoLmafiaCLI;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.SpecialOutfit.Checkpoint;
+import net.sourceforge.kolmafia.persistence.EffectDatabase;
 import net.sourceforge.kolmafia.persistence.SkillDatabase;
 import net.sourceforge.kolmafia.request.UseSkillRequest;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class UseSkillCommand extends AbstractCommand {
   public UseSkillCommand() {
-    this.usage = "[?] [ [<count>] <skill> [on <player>] ] - list spells, or use one.";
+    this.usage = "[?] [ [<count>] <skill> [@ effect] [on <player>] ] - list spells, or use one.";
   }
 
   @Override
@@ -49,16 +50,19 @@ public class UseSkillCommand extends AbstractCommand {
   public static boolean cast(final String parameters, boolean sim) {
     String[] buffs = parameters.split("\\s*,\\s*");
 
-    for (int i = 0; i < buffs.length; ++i) {
-      String[] splitParameters = buffs[i].replaceFirst(" [oO][nN] ", " => ").split(" => ");
-
-      if (splitParameters.length == 1) {
-        splitParameters = new String[2];
-        splitParameters[0] = buffs[i];
-        splitParameters[1] = null;
+    for (String buff : buffs) {
+      String skill, effect = null, player = null;
+      String[] splitParameters = buff.replaceFirst(" [oO][nN] ", " => ").split(" => ");
+      if (splitParameters.length > 1) {
+        player = splitParameters[1];
       }
+      var skillEffect = splitParameters[0].split(" @ ");
+      if (skillEffect.length > 1) {
+        effect = skillEffect[1];
+      }
+      skill = skillEffect[0];
 
-      String[] buffParameters = AbstractCommand.splitCountAndName(splitParameters[0]);
+      String[] buffParameters = AbstractCommand.splitCountAndName(skill);
       String buffCountString = buffParameters[0];
       String skillNameString = buffParameters[1];
 
@@ -89,8 +93,14 @@ public class UseSkillCommand extends AbstractCommand {
         return true;
       }
 
+      var desiredEffect = -1;
+      if (effect != null) {
+        desiredEffect = EffectDatabase.getEffectId(effect);
+      }
+      var skillId = SkillDatabase.getSkillId(skillName);
+
       UseSkillRequest request =
-          UseSkillRequest.getInstance(skillName, splitParameters[1], buffCount);
+          UseSkillRequest.getInstance(skillId, player, buffCount, desiredEffect);
 
       if (sim) {
         return request.getMaximumCast() > 0;

--- a/src/net/sourceforge/kolmafia/textui/command/UseSkillCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/UseSkillCommand.java
@@ -13,7 +13,7 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class UseSkillCommand extends AbstractCommand {
   public UseSkillCommand() {
-    this.usage = "[?] [ [<count>] <skill> [@ effect] [on <player>] ] - list spells, or use one.";
+    this.usage = "[?] [ [<count>] <skill> [^ effect] [on <player>] ] - list spells, or use one.";
   }
 
   @Override
@@ -56,7 +56,7 @@ public class UseSkillCommand extends AbstractCommand {
       if (splitParameters.length > 1) {
         player = splitParameters[1];
       }
-      var skillEffect = splitParameters[0].split(" @ ");
+      var skillEffect = splitParameters[0].split(" ^ ");
       if (skillEffect.length > 1) {
         effect = skillEffect[1];
       }

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -1968,7 +1968,7 @@ public class MaximizerTest {
 
       try (cleanups) {
         assertTrue(maximize("cold res"));
-        assertThat(getBoosts(), hasItem(hasProperty("cmd", startsWith("cast 1 Scarysauce"))));
+        assertThat(getBoosts(), hasItem(hasProperty("cmd", startsWith("cast 1 Scarysauce @ Scarysauce"))));
       }
     }
 

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -1968,7 +1968,27 @@ public class MaximizerTest {
 
       try (cleanups) {
         assertTrue(maximize("cold res"));
-        assertThat(getBoosts(), hasItem(hasProperty("cmd", startsWith("cast 1 Scarysauce @ Scarysauce"))));
+        assertThat(
+            getBoosts(), hasItem(hasProperty("cmd", startsWith("cast 1 Scarysauce @ Scarysauce"))));
+        assertThat(
+            getBoosts(),
+            not(hasItem(hasProperty("cmd", startsWith("cast 1 Scarysauce @ Scariersauce")))));
+      }
+    }
+
+    @Test
+    public void suggestsSpecialEffectsFromSkillsIfHaveEquipment() {
+      var cleanups =
+          new Cleanups(
+              withSkill(SkillPool.SCARYSAUCE), withEquippableItem(ItemPool.VELOUR_VISCOMETER));
+
+      try (cleanups) {
+        assertTrue(maximize("cold res"));
+        assertThat(
+            getBoosts(), hasItem(hasProperty("cmd", startsWith("cast 1 Scarysauce @ Scarysauce"))));
+        assertThat(
+            getBoosts(),
+            hasItem(hasProperty("cmd", startsWith("cast 1 Scarysauce @ Scariersauce"))));
       }
     }
 

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -1969,10 +1969,10 @@ public class MaximizerTest {
       try (cleanups) {
         assertTrue(maximize("cold res"));
         assertThat(
-            getBoosts(), hasItem(hasProperty("cmd", startsWith("cast 1 Scarysauce @ Scarysauce"))));
+            getBoosts(), hasItem(hasProperty("cmd", startsWith("cast 1 Scarysauce ^ Scarysauce"))));
         assertThat(
             getBoosts(),
-            not(hasItem(hasProperty("cmd", startsWith("cast 1 Scarysauce @ Scariersauce")))));
+            not(hasItem(hasProperty("cmd", startsWith("cast 1 Scarysauce ^ Scariersauce")))));
       }
     }
 
@@ -1985,10 +1985,10 @@ public class MaximizerTest {
       try (cleanups) {
         assertTrue(maximize("cold res"));
         assertThat(
-            getBoosts(), hasItem(hasProperty("cmd", startsWith("cast 1 Scarysauce @ Scarysauce"))));
+            getBoosts(), hasItem(hasProperty("cmd", startsWith("cast 1 Scarysauce ^ Scarysauce"))));
         assertThat(
             getBoosts(),
-            hasItem(hasProperty("cmd", startsWith("cast 1 Scarysauce @ Scariersauce"))));
+            hasItem(hasProperty("cmd", startsWith("cast 1 Scarysauce ^ Scariersauce"))));
       }
     }
 

--- a/test/net/sourceforge/kolmafia/moods/MoodManagerTest.java
+++ b/test/net/sourceforge/kolmafia/moods/MoodManagerTest.java
@@ -319,8 +319,8 @@ class MoodManagerTest {
       var mood =
           """
           [ default ]
-          lose_effect empathy => cast 1 empathy of the newt @ empathy
-          lose_effect thoughtful empathy => cast 1 empathy of the newt @ thoughtful empathy
+          lose_effect empathy => cast 1 empathy of the newt ^ empathy
+          lose_effect thoughtful empathy => cast 1 empathy of the newt ^ thoughtful empathy
           lose_effect leash of linguini => cast 1 leash of linguini
           """;
       BufferedReader reader = new BufferedReader(new StringReader(mood));

--- a/test/net/sourceforge/kolmafia/moods/MoodManagerTest.java
+++ b/test/net/sourceforge/kolmafia/moods/MoodManagerTest.java
@@ -1,8 +1,12 @@
 package net.sourceforge.kolmafia.moods;
 
+import static internal.helpers.Player.withProperty;
+import static internal.helpers.Player.withSkill;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.*;
 
+import internal.helpers.Cleanups;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
@@ -301,5 +305,29 @@ class MoodManagerTest {
     assertEquals(3, triggerList.size(), "External list not as expected");
     // only one trigger in both lists
     assertEquals(3, MoodManager.getTriggers().size(), "Wrong number of triggers");
+  }
+
+  @Test
+  public void maintenanceCostForCustomEffectedSkills() throws IOException {
+    var cleanups =
+        new Cleanups(
+            withProperty("currentMood", "default"),
+            withSkill(SkillPool.EMPATHY_OF_THE_NEWT),
+            withSkill(SkillPool.LEASH_OF_LINGUINI));
+
+    try (cleanups) {
+      var mood =
+          """
+          [ default ]
+          lose_effect empathy => cast 1 empathy of the newt @ empathy
+          lose_effect thoughtful empathy => cast 1 empathy of the newt @ thoughtful empathy
+          lose_effect leash of linguini => cast 1 leash of linguini
+          """;
+      BufferedReader reader = new BufferedReader(new StringReader(mood));
+      try (reader) {
+        MoodManager.loadSettings(reader);
+      }
+      assertThat(MoodManager.getMaintenanceCost(), equalTo(42L));
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/command/MoodCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/MoodCommandTest.java
@@ -112,11 +112,11 @@ class MoodCommandTest extends AbstractCommandTestBase {
     String expected =
         "When I get Beaten Up, uneffect Beaten Up"
             + LS
-            + "When I run low on Empathy, cast 1 Empathy of the Newt"
+            + "When I run low on Empathy, cast 1 Empathy of the Newt ^ Empathy"
             + LS
-            + "When I run low on Leash of Linguini, cast 1 Leash of Linguini"
+            + "When I run low on Leash of Linguini, cast 1 Leash of Linguini ^ Leash of Linguini"
             + LS
-            + "When I run low on Singer's Faithful Ocelot, cast 1 Singer's Faithful Ocelot"
+            + "When I run low on Singer's Faithful Ocelot, cast 1 Singer's Faithful Ocelot ^ Singer's Faithful Ocelot"
             + LS;
     assertEquals(expected, output, "Unexpected output");
   }
@@ -144,13 +144,13 @@ class MoodCommandTest extends AbstractCommandTestBase {
     KoLCharacter.addAvailableSkill(SkillPool.POLKA_OF_PLENTY);
     String output = execute("autofill");
     String expected =
-        "When I run low on Empathy, cast 1 Empathy of the Newt"
+        "When I run low on Empathy, cast 1 Empathy of the Newt ^ Empathy"
             + LS
-            + "When I run low on Fat Leon's Phat Loot Lyric, cast 1 Fat Leon's Phat Loot Lyric"
+            + "When I run low on Fat Leon's Phat Loot Lyric, cast 1 Fat Leon's Phat Loot Lyric ^ Fat Leon's Phat Loot Lyric"
             + LS
-            + "When I run low on Leash of Linguini, cast 1 Leash of Linguini"
+            + "When I run low on Leash of Linguini, cast 1 Leash of Linguini ^ Leash of Linguini"
             + LS
-            + "When I run low on Polka of Plenty, cast 1 The Polka of Plenty"
+            + "When I run low on Polka of Plenty, cast 1 The Polka of Plenty ^ Polka of Plenty"
             + LS;
     assertEquals(expected, output, "Unexpected output");
   }

--- a/test/net/sourceforge/kolmafia/textui/command/UseSkillCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/UseSkillCommandTest.java
@@ -61,4 +61,16 @@ public class UseSkillCommandTest extends AbstractCommandTestBase {
       assertThat(output, containsString("Casting Disco Nap"));
     }
   }
+
+  @Test
+  void canCastSkillsForEffects() {
+    var cleanups = new Cleanups(withSkill(SkillPool.EMPATHY_OF_THE_NEWT), withMP(100, 100, 100));
+
+    try (cleanups) {
+      String output = execute("empathy ^ empathy");
+
+      assertContinueState();
+      assertThat(output, containsString("Casting Empathy of the Newt"));
+    }
+  }
 }


### PR DESCRIPTION
Replacement for #2881.

Update `cast` to allow `cast SKILL ^ EFFECT` so e.g. `cast Empathy ^ Empathy; cast Empathy ^ Thoughtful Empathy` will allow obtaining both empathy effects.