### PR TITLE
Handle articles other than a or an in Cookbookbat fight text

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -8624,19 +8624,19 @@ public class FightRequest extends GenericRequest {
 
   private static final Pattern[] COOKBOOKBAT_QUEST = {
     Pattern.compile(
-        "\"As I recall, (?<ingredient>.*?) was common in (?<location>.*?), back in my day\\. +Perhaps if you kill (?:a|an|some|the)? (?<monster>.*?), you'll find one\\.\""),
+        "\"As I recall, (?<ingredient>.*?) was common in (?<location>.*?), back in my day\\. +Perhaps if you kill +(?:an?|the|some)? (?<monster>.*?), you'll find one\\.\""),
     Pattern.compile(
-        "\"If memory serves, (?<ingredient>.*?) was very popular in (?<location>.*?), during my time\\. +Perhaps if you find (?:a|an|some|the)? (?<monster>.*?), you'll collect one,\""),
+        "\"If memory serves, (?<ingredient>.*?) was very popular in (?<location>.*?), during my time\\. +Perhaps if you find +(?:an?|the|some)? (?<monster>.*?), you'll collect one,\""),
     Pattern.compile(
-        "\"My recollection is that (?<ingredient>.*?) was often collected from (?:a|an|some|the)? (?<monster>.*?)\\. +If I recall correctly, you can hunt them in (?<location>.*?)\\.\"")
+        "\"My recollection is that (?<ingredient>.*?) was often collected from +(?:an?|the|some)? (?<monster>.*?)\\. +If I recall correctly, you can hunt them in (?<location>.*?)\\.\"")
   };
 
   private static final Pattern[] COOKBOOKBAT_QUEST_REMINDER = {
     Pattern.compile(
-        "\"If I recall, I suggested that you look for (?:a|an|some|the)? (?<monster>.*?)\\.\""),
+        "\"If I recall, I suggested that you look for +(?:an?|the|some)? (?<monster>.*?)\\.\""),
     Pattern.compile("\"If my ancient memory serves, I suggested looking in (?<location>.*?)\\.\""),
     Pattern.compile(
-        "\"According to my memories, (?:a|an|some|the)? (?<monster>.*?) at (?<location>.*?) may have what you're looking for\\.\""),
+        "\"According to my memories, +(?:an?|the|some)? (?<monster>.*?) at (?<location>.*?) may have what you're looking for\\.\""),
   };
 
   private static final Pattern[] COOKBOOKBAT_QUEST_COMPLETE = {

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -8624,18 +8624,19 @@ public class FightRequest extends GenericRequest {
 
   private static final Pattern[] COOKBOOKBAT_QUEST = {
     Pattern.compile(
-        "\"As I recall, (?<ingredient>.*?) was common in (?<location>.*?), back in my day\\. +Perhaps if you kill an? (?<monster>.*?), you'll find one\\.\""),
+        "\"As I recall, (?<ingredient>.*?) was common in (?<location>.*?), back in my day\\. +Perhaps if you kill (?:a|an|some|the)? (?<monster>.*?), you'll find one\\.\""),
     Pattern.compile(
-        "\"If memory serves, (?<ingredient>.*?) was very popular in (?<location>.*?), during my time\\. +Perhaps if you find an? (?<monster>.*?), you'll collect one,\""),
+        "\"If memory serves, (?<ingredient>.*?) was very popular in (?<location>.*?), during my time\\. +Perhaps if you find (?:a|an|some|the)? (?<monster>.*?), you'll collect one,\""),
     Pattern.compile(
-        "\"My recollection is that (?<ingredient>.*?) was often collected from an? (?<monster>.*?)\\. +If I recall correctly, you can hunt them in (?<location>.*?)\\.\"")
+        "\"My recollection is that (?<ingredient>.*?) was often collected from (?:a|an|some|the)? (?<monster>.*?)\\. +If I recall correctly, you can hunt them in (?<location>.*?)\\.\"")
   };
 
   private static final Pattern[] COOKBOOKBAT_QUEST_REMINDER = {
-    Pattern.compile("\"If I recall, I suggested that you look for an? (?<monster>.*?)\\.\""),
+    Pattern.compile(
+        "\"If I recall, I suggested that you look for (?:a|an|some|the)? (?<monster>.*?)\\.\""),
     Pattern.compile("\"If my ancient memory serves, I suggested looking in (?<location>.*?)\\.\""),
     Pattern.compile(
-        "\"According to my memories, an? (?<monster>.*?) at (?<location>.*?) may have what you're looking for\\.\""),
+        "\"According to my memories, (?:a|an|some|the)? (?<monster>.*?) at (?<location>.*?) may have what you're looking for\\.\""),
   };
 
   private static final Pattern[] COOKBOOKBAT_QUEST_COMPLETE = {


### PR DESCRIPTION
I noticed some CBB quests weren't being parsed e.g. Iiti Kitty has no article in KoL & thus wasn't matching the regex. Pygmy orderlies article is `some`. Cabinet of Dr. Limpieza & Bubblemint Twins article is `the`
This appears to fix it.
I don't know if this is good regex for this or not because I can't stand regex.