### PR TITLE
fix: allow parsing multistring modifiers with split_string

### DIFF
--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -730,6 +730,8 @@ public class Modifiers {
         return this.setBitmap(b, Integer.parseInt(mod.getValue()));
       } else if (modifier instanceof BooleanModifier b) {
         return this.setBoolean(b, mod.getValue().equals("true"));
+      } else if (modifier instanceof MultiStringModifier s) {
+        return this.setString(s, mod.getValue());
       }
     }
     return false;

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -202,6 +202,10 @@ public class ModifierDatabase {
       modifierTypesByName.put(modifier.getName(), modifier);
       modifierTypesByName.put(modifier.getTag(), modifier);
     }
+    for (var modifier : MultiStringModifier.MULTISTRING_MODIFIERS) {
+      modifierTypesByName.put(modifier.getName(), modifier);
+      modifierTypesByName.put(modifier.getTag(), modifier);
+    }
     resetModifiers();
   }
 

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -1273,6 +1273,22 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
     }
 
     @Test
+    void parsesMultiStringModifiers() {
+      String input =
+          "split_modifiers(`Effect: \"Dances with Tweedles\", Effect Duration: 6, Class: \"Seal Clubber\"`)";
+      String output = execute(input);
+      assertThat(
+          output,
+          is(
+              """
+                 Returned: aggregate string [modifier]
+                 Class => &quot;Seal Clubber&quot;
+                 Effect => &quot;Dances with Tweedles&quot;
+                 Effect Duration => 6
+                 """));
+    }
+
+    @Test
     void stringReadsStringAndMultistringModifiers() {
       String input = "string_modifier($item[blackberry polite], \"Effect\")";
       String output = execute(input);


### PR DESCRIPTION
Not sure if we want the &quot;, but that is how ModifierValue works internally at the moment.