### PR TITLE
fix: names for base hippy camp, frat house, video game dungeons

### DIFF
--- a/src/data/adventures.txt
+++ b/src/data/adventures.txt
@@ -220,11 +220,11 @@ The 8-Bit Realm	adventure=566	DiffLevel: mid Env: indoor	Megalo-City
 
 # Mysterious Island areas
 
-Island	adventure=27	DiffLevel: mid Env: indoor Stat: 30	Frat House	outfit|+1 bottle of rhinoceros hormones|+5 figurine of a slippery seal
-Island	adventure=29	DiffLevel: mid Env: indoor Stat: 30	Frat House (Frat Disguise)
+Island	adventure=27	DiffLevel: mid Env: indoor Stat: 30	The Orcish Frat House	outfit|+1 bottle of rhinoceros hormones|+5 figurine of a slippery seal
+Island	adventure=29	DiffLevel: mid Env: indoor Stat: 30	The Orcish Frat House (In Disguise)
 
-Island	adventure=26	DiffLevel: mid Env: outdoor Stat: 30	Hippy Camp	outfit|1 windchimes, 1 decorative fountain, 1 Feng Shui for Big Dumb Idiots|+1 teeny-tiny magic scroll|+5 figurine of a stinking seal
-Island	adventure=65	DiffLevel: mid Env: outdoor Stat: 30	Hippy Camp (Hippy Disguise)
+Island	adventure=26	DiffLevel: mid Env: outdoor Stat: 30	The Hippy Camp	outfit|1 windchimes, 1 decorative fountain, 1 Feng Shui for Big Dumb Idiots|+1 teeny-tiny magic scroll|+5 figurine of a stinking seal
+Island	adventure=65	DiffLevel: mid Env: outdoor Stat: 30	The Hippy Camp (In Disguise)
 
 Island	adventure=149	DiffLevel: high Env: outdoor Stat: 100	The Hippy Camp (Bombed Back to the Stone Age)	+5 figurine of a stinking seal
 Island	adventure=150	DiffLevel: high Env: outdoor Stat: 100	The Orcish Frat House (Bombed Back to the Stone Age)	+5 figurine of a slippery seal
@@ -575,9 +575,9 @@ Neverending Party	adventure=528	DiffLevel: mid Env: indoor Stat: 0	The Neverendi
 
 Shape of Mole	adventure=177	DiffLevel: low Env: underground Stat: 0	Mt. Molehill
 
-Video Game Dungeon	adventure=319	DiffLevel: mid Env: indoor Stat: 0	Video Game Level 1
-Video Game Dungeon	adventure=320	DiffLevel: mid Env: indoor Stat: 0	Video Game Level 2
-Video Game Dungeon	adventure=321	DiffLevel: mid Env: indoor Stat: 0	Video Game Level 3
+Video Game Dungeon	adventure=319	DiffLevel: mid Env: indoor Stat: 0	[DungeonFAQ - Level 1]
+Video Game Dungeon	adventure=320	DiffLevel: mid Env: indoor Stat: 0	[DungeonFAQ - Level 2]
+Video Game Dungeon	adventure=321	DiffLevel: mid Env: indoor Stat: 0	[DungeonFAQ - Level 3]
 
 Rabbit Hole	adventure=225	DiffLevel: mid Env: outdoor Stat: 0	The Red Queen's Garden	+1 reflection of a map
 

--- a/src/data/combats.txt
+++ b/src/data/combats.txt
@@ -144,7 +144,6 @@ Fightin' Fire	100	brushfire
 Fight in the Dirt	100	ncle	rutabaga bug	mesquito	senate fly
 Fight in the Tall Grass	100	daddy shortlegs	birdybug	kilopede
 Fight in the Very Tall Grass	100	flagellating mantis	beetle	terrorantula
-Frat House	100	Orcish Frat Boy (Music Lover)	Orcish Frat Boy (Paddler)	Orcish Frat Boy (Pledge)
 Fudge Mountain	95	fudge monkey	fudge oyster	fudge weasel	fudge vulture	fudge poodle	The Fudge Wizard	The Abominable Fudgeman
 Galley	100	angry cavebugbear	trendy bugbear chef
 Gingerbread Civic Center	100	gingerbread pigeon	gingerbread rat	gingerbread convict	gingerbread mad dog	gingerbread lawyer	Judge Fudge: 0
@@ -168,7 +167,6 @@ Haert of the Cyrpt	100	Bonerdagon
 Hamburglaris Shield Generator	100	alien hamsterpus	mutated alielephant	mutated alielf
 Hell	100	devil	magma man	vampire
 Hero's Field	100	Keese	Octorok	Tektite	Zol
-Hippy Camp	100	crusty hippy	crusty hippy jewelry maker	crusty hippy Vegan chef	dirty hippy	dirty hippy jewelry maker	dirty hippy Vegan chef	filthy hippy	filthy hippy jewelry maker	filthy hippy Vegan chef
 Hobopolis Town Square	95	Normal hobo	Hodgman, The Hoboverlord: 0
 Hottest Adventurer Contest	100	Fire Fighter	Cereal Arsonist	Burnglar	The Lavalier: 0
 Infernal Rackets Backstage	70	inkubus	serialbus	suckubus
@@ -397,6 +395,7 @@ The Hidden Hospital	100	pygmy janitor	pygmy orderlies	pygmy witch surgeon	pygmy 
 The Hidden Office Building	100	pygmy janitor	pygmy witch lawyer	pygmy witch accountant	pygmy headhunter	ancient protector spirit (The Hidden Office Building): 0
 The Hidden Park	85	boaraffe	pygmy blowgunner	pygmy assault squad	pygmy witch lawyer	pygmy janitor
 The Hidden Temple	90	baa-relief sheep	clan of cave bars: 0	craven carven raven	stone temple pirate	Baa'baa'bu'ran: 0
+The Hippy Camp	100	crusty hippy	crusty hippy jewelry maker	crusty hippy Vegan chef	dirty hippy	dirty hippy jewelry maker	dirty hippy Vegan chef	filthy hippy	filthy hippy jewelry maker	filthy hippy Vegan chef
 The Hippy Camp (Bombed Back to the Stone Age)	100	caveman hippy	cavewomyn hippy	sabre-toothed ferret
 The Hole in the Sky	100	Astronomer: 2r25	One-Eyed Willie: 1o	Burrowing Bishop: 1o	Family Jewels: 1o	Hooded Warrior: 1o	Junk: 1o	Pork Sword: 1o	Skinflute: 1o	Trouser Snake: 1o	Twig and Berries: 1o	Axe Wound: 1e	Beaver: 1e	Box: 1e	Bush: 1e	Camel's Toe: 1e	Flange: 1e	Honey Pot: 1e	Little Man in the Canoe: 1e	Muff: 1e	The Snake With Like Ten Heads: 0
 The Home of The Future	100	robot maid	wardrobe robot	exercise robot
@@ -436,6 +435,7 @@ The Old Gotpork Library	100	mid-level mook	very [adjective] henchwoman	very [adj
 The Old Landfill	100	junksprite bender	junksprite melter	junksprite sharpener	Doctor Oh, the Junksprite Boss: 0	The ghost of Vanillica "Trashblossom" Gorton: 0
 The Old Man's Bathtime Adventures	100	fearsome giant squid	ferocious roc	giant man-eating shark	Bristled Man-O-War	The Cray-Kin	Deadly Hydra
 The Old Rubee Mine	100	mining grobold
+The Orcish Frat House	100	Orcish Frat Boy (Music Lover)	Orcish Frat Boy (Paddler)	Orcish Frat Boy (Pledge)
 The Orcish Frat House (Bombed Back to the Stone Age)	100	caveman frat boy	caveman frat pledge	caveman sorority girl
 The Outer Compound	100	guard turtle
 The Outskirts of Cobb's Knob	80	Knob Goblin Assistant Chef	sleeping Knob Goblin Guard	Sub-Assistant Knob Mad Scientist	Knob Goblin Barbecue Team
@@ -512,9 +512,6 @@ Unleash Your Inner Wolf	100	befouled straw house	brick (suggestive pause) house	
 Vanya's Castle	100	fleaman	ghost	medusa
 Vanya's Castle Foyer	100	fleaman	ghost	medusa
 Veterans Day Island	100	Brandonian loyalist	Section 11	spectre of war
-Video Game Level 1	-1	Video Game Minion (weak)
-Video Game Level 2	-1	Video Game Minion (moderate)	Video Game Miniboss: 0
-Video Game Level 3	-1	Video Game Minion (strong)	Video Game Miniboss: 0	Video Game Boss: 0
 VYKEA	-1	VYKEA viking (female)	VYKEA viking (male)
 WarBear Fortress (First Level)	100	Warbear Foot Soldier
 WarBear Fortress (Second Level)	100	Warbear Officer
@@ -535,6 +532,9 @@ Your Mushroom Garden	100	piranha plant
 Your Nipple Chakra	100	that time you screwed everything up like a complete idiot	what you totally should have said that one time	the realization that everyone you love will die someday
 Your Nose Chakra	100	the most embarrassing moment in your entire life	imagining how your life would be better if you'd made different decisions	that time you screwed everything up like a complete idiot
 Your Hat Chakra	100	what you totally should have said that one time	fear of an uncertain future	imagining how your life would be better if you'd made different decisions	Your Brain: 0
+[DungeonFAQ - Level 1]	-1	Video Game Minion (weak)
+[DungeonFAQ - Level 2]	-1	Video Game Minion (moderate)	Video Game Miniboss: 0
+[DungeonFAQ - Level 3]	-1	Video Game Minion (strong)	Video Game Miniboss: 0	Video Game Boss: 0
 
 # PirateRealm Island
 # First Island - 4 combats and a boss or reward
@@ -568,10 +568,8 @@ Wrong Side of the Tracks, 28 Days Later	100	scary pirate	Zombie eXtreme Snowboar
 # Areas with no combats
 
 Anemone Mine (Mining)	0
-Frat House (Frat Disguise)	0
 Friar Ceremony Location	0
 Goat Party	0
-Hippy Camp (Hippy Disguise)	0
 Itznotyerzitz Mine (in Disguise)	0
 Lemon Party	0
 The Mine Foremens' Office	0
@@ -588,6 +586,8 @@ Sailing the PirateRealm Seas	0
 St. Sneaky Pete's Day Stupor	-1
 The Arrrboretum	0
 The Crimbonium Mine	0
+The Orcish Frat House (In Disguise)	0
+The Hippy Camp (In Disguise)	0
 The Knob Shaft (Mining)	0
 The Limerick Dungeon	0
 The Poker Room	0

--- a/src/data/encounters.txt
+++ b/src/data/encounters.txt
@@ -31,7 +31,7 @@ The Marinara Trench	STOP	You've Hit Bottom
 The Dive Bar	STOP	Ode to the Sea
 The Dive Bar	STOP	Boxing the Juke
 # Adventures that start the Around the World Quest
-Frat House	STOP	I Just Wanna Fly
+The Orcish Frat House	STOP	I Just Wanna Fly
 The Orcish Frat House (Bombed Back to the Stone Age)	STOP	Me Just Want Fly
 # Giant's castle end
 The Castle in the Clouds in the Sky (Top Floor)	STOP	Keep On Turnin' the Wheel in the Sky
@@ -81,11 +81,7 @@ Cola Wars Battlefield (Cloaca Uniform)	LUCKY	Prior to Always
 Cola Wars Battlefield (Dyspepsi Uniform)	LUCKY	Prior to Always
 Elf Alley	LUCKY	What a Tosser
 Exposure Esplanade	LUCKY	Cold Comfort
-Frat House	LUCKY	Sand in the Vaseline
-Frat House (Frat Disguise)	LUCKY	Lambda Upsilon Chi Kappa
 Guano Junction	LUCKY	Le Chauve-Souris du Parfum
-Hippy Camp	LUCKY	The Latest Sorcerous Developments
-Hippy Camp (Hippy Disguise)	LUCKY	A Case of the Baskets
 Itznotyerzitz Mine	LUCKY	Either Ore
 Lair of the Ninja Snowmen	LUCKY	Not Quite as Cold as Ice
 Lemon Party	LUCKY	Lemon Party Slot
@@ -131,12 +127,16 @@ The Haunted Storage Room	LUCKY	full-length mirror
 The Heap	LUCKY	Juicy!
 The Hidden Park	LUCKY	Two Sizes Too Small
 The Hidden Temple	LUCKY	Baa'baa'bu'ran
+The Hippy Camp	LUCKY	The Latest Sorcerous Developments
+The Hippy Camp (In Disguise)	LUCKY	A Case of the Baskets
 The Icy Peak	LUCKY	Encino Penguin
 The Knob Shaft	LUCKY	Junction in the Trunction
 The Limerick Dungeon	LUCKY	The Bleary-Eyed Cyclops
 The Mer-Kin Outpost	LUCKY	A Drawer of Chests
 The Oasis	LUCKY	Some Things Never Change
 The Obligatory Pirate's Cove	LUCKY	Yo Ho Ho and a Bottle of Whatever This Is
+The Orcish Frat House	LUCKY	Sand in the Vaseline
+The Orcish Frat House (In Disguise)	LUCKY	Lambda Upsilon Chi Kappa
 The Outskirts of Cobb's Knob	LUCKY	Lunchboxing
 The Poker Room	LUCKY	A Motor in your Head
 The Primordial Soup	LUCKY	Beginner's Luck
@@ -229,8 +229,8 @@ The Degrassi Knoll Restroom	TURTLE	A Rolling Turtle Gathers No Moss
 The Degrassi Knoll Bakery	TURTLE	A Rolling Turtle Gathers No Moss
 The Degrassi Knoll Gym	TURTLE	A Rolling Turtle Gathers No Moss
 The Degrassi Knoll Garage	TURTLE	A Rolling Turtle Gathers No Moss
-Frat House	TURTLE	The Horror...
-Frat House (Frat Disguise)	TURTLE	The Horror...
+The Orcish Frat House	TURTLE	The Horror...
+The Orcish Frat House (In Disguise)	TURTLE	The Horror...
 The Haunted Boiler Room	TURTLE	Slow Road to Hell
 The Outskirts of Cobb's Knob	TURTLE	C'mere, Little Fella
 Oil Peak	TURTLE	The Real Victims
@@ -245,8 +245,8 @@ The Haunted Conservatory	TURTLE	Turtles of the Universe
 The Spooky Forest	TURTLE	O Turtle Were Art Thou
 The Outer Compound	TURTLE	Allow 6-8 Weeks For Delivery
 The Haunted Pantry	TURTLE	Kick the Can
-Hippy Camp	TURTLE	Turtles All The Way Around
-Hippy Camp (Hippy Disguise)	TURTLE	Turtles All The Way Around
+The Hippy Camp	TURTLE	Turtles All The Way Around
+The Hippy Camp (In Disguise)	TURTLE	Turtles All The Way Around
 The eXtreme Slope	TURTLE	More eXtreme Than Usual
 South of the Border	TURTLE	Jewel in the Rough
 Guano Junction	TURTLE	The worst kind of drowning

--- a/src/net/sourceforge/kolmafia/persistence/AdventureDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/AdventureDatabase.java
@@ -370,12 +370,19 @@ public class AdventureDatabase {
     }
 
     // Backwards compatibility for changed adventure names
-    addSynonym("Hippy Camp (Hippy Disguise)", "Hippy Camp in Disguise");
-    addSynonym("Frat House (Frat Disguise)", "Frat House in Disguise");
+    addSynonym("The Hippy Camp (In Disguise)", "Hippy Camp in Disguise");
+    addSynonym("The Orcish Frat House (In Disguise)", "Frat House in Disguise");
     addSynonym("The Junkyard", "Post-War Junkyard");
     addSynonym("The Cola Wars Battlefield", "Battlefield (No Uniform)");
     addSynonym("Cola Wars Battlefield (Cloaca Uniform)", "Battlefield (Cloaca Uniform)");
     addSynonym("Cola Wars Battlefield (Dyspepsi Uniform)", "Battlefield (Dyspepsi Uniform)");
+    addSynonym("The Hippy Camp", "Hippy Camp");
+    addSynonym("The Hippy Camp (In Disguise)", "Hippy Camp (Hippy Disguise)");
+    addSynonym("The Orcish Frat House", "Frat House");
+    addSynonym("The Orcish Frat House (In Disguise)", "Frat House (Frat Disguise)");
+    addSynonym("[DungeonFAQ - Level 1]", "Video Game Level 1");
+    addSynonym("[DungeonFAQ - Level 2]", "Video Game Level 2");
+    addSynonym("[DungeonFAQ - Level 3]", "Video Game Level 3");
   }
 
   // For looking up adventures by legacy name

--- a/src/net/sourceforge/kolmafia/request/PlaceRequest.java
+++ b/src/net/sourceforge/kolmafia/request/PlaceRequest.java
@@ -38,18 +38,14 @@ public class PlaceRequest extends GenericRequest {
               "The Hippy Camp",
               List.of(
                   AdventurePool.HIPPY_CAMP,
-                  AdventurePool.HIPPY_CAMP_DISGUISED,
                   AdventurePool.WARTIME_HIPPY_CAMP,
-                  AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED,
-                  AdventurePool.BOMBED_HIPPY_CAMP)),
+                  AdventurePool.WARTIME_HIPPY_CAMP_DISGUISED)),
           Map.entry(
-              "The Frat House",
+              "The Orcish Frat House",
               List.of(
                   AdventurePool.FRAT_HOUSE,
-                  AdventurePool.FRAT_HOUSE_DISGUISED,
                   AdventurePool.WARTIME_FRAT_HOUSE,
-                  AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED,
-                  AdventurePool.BOMBED_FRAT_HOUSE)));
+                  AdventurePool.WARTIME_FRAT_HOUSE_DISGUISED)));
 
   private static final Pattern firstSotVisit =
       Pattern.compile("something over in (.+?) and he'd like");
@@ -465,9 +461,11 @@ public class PlaceRequest extends GenericRequest {
    * @return - A KoLAdventure matching the unique and available location or null
    */
   protected static KoLAdventure getAdventurableLocation(String location) {
+    if (!nameAliases.containsKey(location)) {
+      return AdventureDatabase.getAdventureByName(location);
+    }
     KoLAdventure aMatch = null;
-    KoLAdventure candidate = AdventureDatabase.getAdventureByName(location);
-    if (candidate != null) return candidate;
+    KoLAdventure candidate;
     List<Integer> possible = nameAliases.getOrDefault(location, new ArrayList<>());
     int count = 0;
     for (Integer i : possible) {

--- a/src/net/sourceforge/kolmafia/session/BadMoonManager.java
+++ b/src/net/sourceforge/kolmafia/session/BadMoonManager.java
@@ -100,7 +100,7 @@ public abstract class BadMoonManager {
     // Effects that adjust one stat by +50% and another by -50%
     new Encounter(
         "It's All The Rage",
-        "Frat House",
+        "The Orcish Frat House",
         null,
         EffectPool.get(EffectPool.THE_RAGE, 10),
         "Muscle +50%, Mysticality -50%",
@@ -108,7 +108,7 @@ public abstract class BadMoonManager {
         "badMoonEncounter07"),
     new Encounter(
         "Double-Secret Initiation",
-        "Frat House (Frat Disguise)",
+        "The Orcish Frat House (In Disguise)",
         null,
         EffectPool.get(EffectPool.SHAMED_AND_MANIPULATED, 10),
         "Muscle +50%, Moxie -50%",
@@ -116,7 +116,7 @@ public abstract class BadMoonManager {
         "badMoonEncounter08"),
     new Encounter(
         "Better Dread Than Dead",
-        "Hippy Camp",
+        "The Hippy Camp",
         null,
         EffectPool.get(EffectPool.DREADLOCKED, 10),
         "Mysticality +50%, Moxie -50%",
@@ -124,7 +124,7 @@ public abstract class BadMoonManager {
         "badMoonEncounter09"),
     new Encounter(
         "Drumroll, Please",
-        "Hippy Camp (Hippy Disguise)",
+        "The Hippy Camp (In Disguise)",
         null,
         EffectPool.get(EffectPool.DRUMMED_OUT, 10),
         "Mysticality +50%, Muscle -50%",

--- a/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
@@ -657,7 +657,7 @@ public abstract class ChoiceAdventures {
     new ChoiceAdventure(
         72,
         "Island",
-        "Frat House",
+        "The Orcish Frat House",
         // Option...
         new ChoiceOption("around the world", "around the world"),
         new ChoiceOption("skip adventure", "Spanish fly"));
@@ -976,7 +976,7 @@ public abstract class ChoiceAdventures {
     new ChoiceAdventure(
         136,
         "Island",
-        "Hippy Camp",
+        "The Hippy Camp",
         // Option...
         new ChoiceOption("filthy corduroys", "filthy corduroys"),
         new ChoiceOption("filthy knitted dread sack", "filthy knitted dread sack"),
@@ -987,7 +987,7 @@ public abstract class ChoiceAdventures {
     new ChoiceAdventure(
         137,
         "Island",
-        "Hippy Camp",
+        "The Hippy Camp",
         // Option...
         new ChoiceOption("filthy knitted dread sack", "filthy knitted dread sack"),
         new ChoiceOption("filthy corduroys", "filthy corduroys"),
@@ -998,7 +998,7 @@ public abstract class ChoiceAdventures {
     new ChoiceAdventure(
         138,
         "Island",
-        "Frat House",
+        "The Orcish Frat House",
         // Option...
         new ChoiceOption("Orcish cargo shorts", "Orcish cargo shorts"),
         new ChoiceOption("Orcish baseball cap", "Orcish baseball cap"),

--- a/src/net/sourceforge/kolmafia/session/LeprecondoManager.java
+++ b/src/net/sourceforge/kolmafia/session/LeprecondoManager.java
@@ -109,7 +109,7 @@ public class LeprecondoManager {
                 Need.BOOZE,
                 "plays beer pong for a while, but stops drinking before he finishes the whole table's worth"),
             Map.entry(Need.EXERCISE, "plays beer pong until he gets tired")),
-        "Frat House"),
+        "The Orcish Frat House"),
     WEIGHT_BENCH(
         "padded weight bench",
         11,
@@ -177,7 +177,7 @@ public class LeprecondoManager {
                 Need.DUMB_ENTERTAINMENT,
                 "sits on his couch and watches some reruns of old reality shows"),
             Map.entry(Need.SLEEP, "falls asleep on his comfy couch")),
-        "Frat House"),
+        "The Orcish Frat House"),
     KEGERATOR(
         "kegerator",
         19,

--- a/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
+++ b/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
@@ -4594,9 +4594,9 @@ public class KoLAdventureValidationTest {
     // AdventurePool.BOMBED_HIPPY_CAMP
 
     private static final KoLAdventure HIPPY_CAMP =
-        AdventureDatabase.getAdventureByName("Hippy Camp");
+        AdventureDatabase.getAdventureByName("The Hippy Camp");
     private static final KoLAdventure HIPPY_CAMP_DISGUISED =
-        AdventureDatabase.getAdventureByName("Hippy Camp (Hippy Disguise)");
+        AdventureDatabase.getAdventureByName("The Hippy Camp (In Disguise)");
     private static final KoLAdventure WARTIME_HIPPY_CAMP =
         AdventureDatabase.getAdventureByName("Wartime Hippy Camp");
     private static final KoLAdventure WARTIME_HIPPY_CAMP_DISGUISED =
@@ -4976,9 +4976,9 @@ public class KoLAdventureValidationTest {
     // AdventurePool.BOMBED_FRAT_HOUSE
 
     private static final KoLAdventure FRAT_HOUSE =
-        AdventureDatabase.getAdventureByName("Frat House");
+        AdventureDatabase.getAdventureByName("The Orcish Frat House");
     private static final KoLAdventure FRAT_HOUSE_DISGUISED =
-        AdventureDatabase.getAdventureByName("Frat House (Frat Disguise)");
+        AdventureDatabase.getAdventureByName("The Orcish Frat House (In Disguise)");
     private static final KoLAdventure WARTIME_FRAT_HOUSE =
         AdventureDatabase.getAdventureByName("Wartime Frat House");
     private static final KoLAdventure WARTIME_FRAT_HOUSE_DISGUISED =

--- a/test/net/sourceforge/kolmafia/persistence/AdventureDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/AdventureDatabaseTest.java
@@ -71,8 +71,8 @@ public class AdventureDatabaseTest {
 
     @ParameterizedTest
     @CsvSource({
-      "Hippy Camp (Hippy Disguise), Hippy Camp in Disguise",
-      "Frat House (Frat Disguise), Frat House in Disguise",
+      "The Hippy Camp (In Disguise), Hippy Camp in Disguise",
+      "The Orcish Frat House (In Disguise), Frat House in Disguise",
       "The Junkyard, Post-War Junkyard",
     })
     public void getAdventureRecognizesLegacySynonyms(String name, String synonym) {

--- a/test/net/sourceforge/kolmafia/request/PlaceRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/PlaceRequestTest.java
@@ -143,7 +143,7 @@ class PlaceRequestTest {
   }
 
   @Nested
-  class speakeasymapping {
+  class SpeakeasyMapping {
     @Test
     public void itDoesNotMapWithMinimalCharacterDataHippy() {
       KoLAdventure retVal = PlaceRequest.getAdventurableLocation("The Hippy Camp");
@@ -152,7 +152,7 @@ class PlaceRequestTest {
 
     @Test
     public void itDoesNotMapWithMinimalCharacterDataFrat() {
-      KoLAdventure retVal = PlaceRequest.getAdventurableLocation("The Frat House");
+      KoLAdventure retVal = PlaceRequest.getAdventurableLocation("The Orcish Frat House");
       assertNull(retVal);
     }
 
@@ -169,7 +169,7 @@ class PlaceRequestTest {
     public void itShouldMatchBeforeWarFrat() {
       var cleanups = new Cleanups(withProperty("lastIslandUnlock", KoLCharacter.getAscensions()));
       try (cleanups) {
-        KoLAdventure retVal = PlaceRequest.getAdventurableLocation("The Frat House");
+        KoLAdventure retVal = PlaceRequest.getAdventurableLocation("The Orcish Frat House");
         assertEquals(AdventureDatabase.getAdventure(AdventurePool.FRAT_HOUSE), retVal);
       }
     }
@@ -195,34 +195,8 @@ class PlaceRequestTest {
               withProperty("sideDefeated", "hippies"),
               withQuestProgress(QuestDatabase.Quest.ISLAND_WAR, QuestDatabase.FINISHED));
       try (cleanups) {
-        KoLAdventure retVal = PlaceRequest.getAdventurableLocation("The Frat House");
+        KoLAdventure retVal = PlaceRequest.getAdventurableLocation("The Orcish Frat House");
         assertEquals(AdventureDatabase.getAdventure(AdventurePool.FRAT_HOUSE), retVal);
-      }
-    }
-
-    @Test
-    public void itShouldMatchAfterWarHippyLose() {
-      var cleanups =
-          new Cleanups(
-              withProperty("lastIslandUnlock", KoLCharacter.getAscensions()),
-              withProperty("sideDefeated", "hippies"),
-              withQuestProgress(QuestDatabase.Quest.ISLAND_WAR, QuestDatabase.FINISHED));
-      try (cleanups) {
-        KoLAdventure retVal = PlaceRequest.getAdventurableLocation("The Hippy Camp");
-        assertEquals(AdventureDatabase.getAdventure(AdventurePool.BOMBED_HIPPY_CAMP), retVal);
-      }
-    }
-
-    @Test
-    public void itShouldMatchAfterWarFratLose() {
-      var cleanups =
-          new Cleanups(
-              withProperty("lastIslandUnlock", KoLCharacter.getAscensions()),
-              withProperty("sideDefeated", "fratboys"),
-              withQuestProgress(QuestDatabase.Quest.ISLAND_WAR, QuestDatabase.FINISHED));
-      try (cleanups) {
-        KoLAdventure retVal = PlaceRequest.getAdventurableLocation("The Frat House");
-        assertEquals(AdventureDatabase.getAdventure(AdventurePool.BOMBED_FRAT_HOUSE), retVal);
       }
     }
   }


### PR DESCRIPTION
Knowing the base game names for locations is useful for the Cookbookbat quest and the Sot's quest.

The Wartime versions (disguised and undisguised) have the same name as the undisguised standard versions, which is unhelpful, so these are left as they are.