### PR TITLE
Perform fuzzy matching for hermit CLI command.

### DIFF
--- a/src/net/sourceforge/kolmafia/request/coinmaster/HermitRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/HermitRequest.java
@@ -108,8 +108,6 @@ public class HermitRequest extends CoinMasterRequest {
       registerHermitItem(ItemPool.ANCIENT_SEAL, PurchaseRequest.MAX_QUANTITY);
     }
 
-    registerHermitItem(ItemPool.ELEVEN_LEAF_CLOVER, -1);
-
     resetPurchaseRequests();
   }
 

--- a/src/net/sourceforge/kolmafia/textui/command/HermitCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/HermitCommand.java
@@ -6,6 +6,8 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.KoLmafiaCLI;
+import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
@@ -60,6 +62,10 @@ public class HermitCommand extends AbstractCommand {
 
       for (var item : KoLConstants.hermitItems) {
         if (names.contains(item.getName())) {
+          if (KoLmafiaCLI.isExecutingCheckOnlyCommand) {
+            RequestLogger.printLine(item.getName());
+            return;
+          }
           itemId = item.getItemId();
           break;
         }

--- a/src/net/sourceforge/kolmafia/textui/command/HermitCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/HermitCommand.java
@@ -59,13 +59,13 @@ public class HermitCommand extends AbstractCommand {
       }
     } else {
       Set<String> names = new HashSet(ItemDatabase.getMatchingNames(parameters));
-
       for (var item : KoLConstants.hermitItems) {
         if (names.contains(item.getName())) {
           if (KoLmafiaCLI.isExecutingCheckOnlyCommand) {
             RequestLogger.printLine(item.getName());
             return;
           }
+
           itemId = item.getItemId();
           break;
         }

--- a/src/net/sourceforge/kolmafia/textui/command/HermitCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/HermitCommand.java
@@ -1,14 +1,14 @@
 package net.sourceforge.kolmafia.textui.command;
 
-import net.sourceforge.kolmafia.AdventureResult;
+import java.util.HashSet;
+import java.util.Set;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
-import net.sourceforge.kolmafia.KoLmafiaCLI;
-import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.coinmaster.HermitRequest;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
@@ -56,14 +56,10 @@ public class HermitCommand extends AbstractCommand {
         itemId = ItemPool.ELEVEN_LEAF_CLOVER;
       }
     } else {
-      for (AdventureResult item : KoLConstants.hermitItems) {
-        String name = item.getName();
-        if (name.toLowerCase().contains(parameters)) {
-          if (KoLmafiaCLI.isExecutingCheckOnlyCommand) {
-            RequestLogger.printLine(name);
-            return;
-          }
+      Set<String> names = new HashSet(ItemDatabase.getMatchingNames(parameters));
 
+      for (var item : KoLConstants.hermitItems) {
+        if (names.contains(item.getName())) {
           itemId = item.getItemId();
           break;
         }

--- a/test/net/sourceforge/kolmafia/textui/command/HermitCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/HermitCommandTest.java
@@ -1,0 +1,38 @@
+package net.sourceforge.kolmafia.textui.command;
+
+import static internal.helpers.HttpClientWrapper.getLastRequest;
+import static internal.helpers.Networking.assertPostRequest;
+import static internal.helpers.Player.withItems;
+
+import internal.helpers.HttpClientWrapper;
+import net.sourceforge.kolmafia.KoLConstants.MafiaState;
+import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.request.coinmaster.HermitRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class HermitCommandTest extends AbstractCommandTestBase {
+
+  public HermitCommandTest() {
+    this.command = "hermit";
+  }
+
+  @BeforeEach
+  public void initializeState() {
+    HttpClientWrapper.setupFakeClient();
+    StaticEntity.setContinuationState(MafiaState.CONTINUE);
+    HermitRequest.initialize();
+  }
+
+  @Test
+  public void acquiresJabaneroPepper() {
+    var cleanups = withItems(ItemPool.WORTHLESS_TRINKET, ItemPool.HERMIT_PERMIT);
+
+    try (cleanups) {
+      execute("jabanero");
+    }
+
+    assertPostRequest(getLastRequest(), "/hermit.php", "action=trade&quantity=1&whichitem=55");
+  }
+}


### PR DESCRIPTION
I had tried using ItemFinder.getFirstMatchingItem(), but that apparently tries to find matching items, independent of the values in the provided source list.

Note that I removed 11-leaf clover from being added to hermitItems with a count of -1 -- nothing seems to rely on this existing. However, the presence of this entry was causing cloverCount() to return -1, which was less than the 0 clovers needed.