### PR TITLE
do not auto-sell bar skin in choiceadv 504

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ChoiceManager.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceManager.java
@@ -1264,13 +1264,6 @@ public abstract class ChoiceManager {
         // Tree's Last Stand
       case 504:
 
-        // If we have Bar Skins, sell them all
-        if (InventoryManager.getCount(ItemPool.BAR_SKIN) > 1) {
-          return "2";
-        } else if (InventoryManager.getCount(ItemPool.BAR_SKIN) > 0) {
-          return "1";
-        }
-
         // If we don't have a Spooky Sapling, buy one
         // unless we've already unlocked the Hidden Temple
         //


### PR DESCRIPTION
https://kolmafia.us/threads/mafia-autosells-bar-skins.30629/

It seems that Mafia autosells bar skins via 'Tree's Last Stand' choice 504 in ChoiceManager.java
But bar skins are now more useful to have to create stuff like a barskin loincloth.
This change removes the auto-sell in choiceadv 504.  The user can still do this manually, by setting the choice, or with a choiceadv script.