### PR TITLE
no McHuge mods for Noobs

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -6007,6 +6007,9 @@ public abstract class KoLCharacter {
   }
 
   private static int getMcHugeLargeLevel(Modifiers mods) {
+    if (KoLCharacter.inNoobcore()) {
+      return 0;
+    }
     int totalItems = mods.getBitmap(BitmapModifier.MCHUGELARGE);
     var itemLevel =
         switch (totalItems) {

--- a/src/net/sourceforge/kolmafia/textui/command/AbsorbCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/AbsorbCommand.java
@@ -16,7 +16,7 @@ import net.sourceforge.kolmafia.session.InventoryManager;
 
 public class AbsorbCommand extends AbstractCommand {
   public AbsorbCommand() {
-    this.usage = "[X] <item> - absorb item(s).";
+    this.usage = " [X] <item> - absorb item(s) in Gelatinous Noob";
   }
 
   @Override


### PR DESCRIPTION
https://kolmafia.us/threads/gelatinous-noob-modifiers.30637/

Mafia adds McHugeLarge bonuses as 'Outfit' bonuses, but they are not actually outfits in KoL because those bonuses do not apply from that equipment in GN.  This removes McHugeLarge bonuses in GN.
Also, tweak description of the CLI 'absorb' command