### PR TITLE
familiar stats for Cooler Yeti

### DIFF
--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -358,4 +358,4 @@
 321	Glover	glover.gif	combat0,delevel1	plover's egg	glover liners	0	0	0	0	hashands,hasclaws,wearsclothes,isclothes,hasbeak
 322	Zapper Bug	zapperbug.gif	combat0,mp0	electric flyswatter	mosquito speakers	0	0	0	0	cantalk,fast,flies,robot,insect
 323	Wet Paper Tiger	wetpapertiger2.gif	combat0,delevel1	wet paper tiger	wet paper eye	0	0	0	0	animal,mineral,sentient,haslegs,hasclaws
-324	Cooler Yeti	cooleryeti.gif	passive,delevel0,item0	yeti in a travel cooler	cold exchanger	0	0	0	0	sentient,organic,humanoid,person,animal,hasbones,haseyes,hasclaws,cold
+324	Cooler Yeti	cooleryeti.gif	passive,delevel0,item0	yeti in a travel cooler	cold exchanger	3	1	1	2	sentient,organic,humanoid,person,animal,hasbones,haseyes,hasclaws,cold


### PR DESCRIPTION
```
Results for Cooler Yeti after 12 trials using 144 turns:

Contest         XP[1]   XP[2]   XP[3]  Original Rank Derived Rank
Cage Match      28      41      57           0            3
Scavenger Hunt  57      45       5           0            1
Obstacle Course 60      56      15           0            1
Hide and Seek   40      55      46           0            2
```