### PR TITLE
Allowing for arbitrarily renaming "/cli" chat command

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1434,6 +1434,7 @@ user	recentLocations	5
 user	recoveryScript
 user	redSnapperPhylum
 user	redSnapperProgress	0	roa
+user	relayChatCLITrigger	cli
 user	relayCounters
 user	relayPort	0
 user	relayShowSpoilers	false

--- a/src/net/sourceforge/kolmafia/chat/ChatSender.java
+++ b/src/net/sourceforge/kolmafia/chat/ChatSender.java
@@ -16,6 +16,8 @@ import net.sourceforge.kolmafia.session.ContactManager;
 import net.sourceforge.kolmafia.swingui.CommandDisplayFrame;
 import net.sourceforge.kolmafia.swingui.widget.ShowDescriptionList;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
+import net.sourceforge.kolmafia.preferences.Preferences;
+
 
 public class ChatSender {
   private static final Pattern PRIVATE_MESSAGE_PATTERN =
@@ -200,7 +202,7 @@ public class ChatSender {
   private static List<String> getGrafs(String contact, String message) {
     List<String> grafs = new LinkedList<>();
 
-    if (message.startsWith("/do ") || message.startsWith("/run ") || message.startsWith("/cli ")) {
+    if (message.startsWith("/do ") || message.startsWith("/run ") || message.startsWith("/" + Preferences.getString("relayChatCLITrigger") + " ")) {
       grafs.add(message);
 
       return grafs;
@@ -417,7 +419,7 @@ public class ChatSender {
       return false;
     }
 
-    if (!graf.startsWith("/do ") && !graf.startsWith("/run ") && !graf.startsWith("/cli ")) {
+    if (!graf.startsWith("/do ") && !graf.startsWith("/run ") && !graf.startsWith("/" + Preferences.getString("relayChatCLITrigger") + " ")) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/chat/ChatSender.java
+++ b/src/net/sourceforge/kolmafia/chat/ChatSender.java
@@ -11,13 +11,12 @@ import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.persistence.ItemFinder;
 import net.sourceforge.kolmafia.persistence.ItemFinder.Match;
+import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.ChatRequest;
 import net.sourceforge.kolmafia.session.ContactManager;
 import net.sourceforge.kolmafia.swingui.CommandDisplayFrame;
 import net.sourceforge.kolmafia.swingui.widget.ShowDescriptionList;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
-import net.sourceforge.kolmafia.preferences.Preferences;
-
 
 public class ChatSender {
   private static final Pattern PRIVATE_MESSAGE_PATTERN =
@@ -202,7 +201,10 @@ public class ChatSender {
   private static List<String> getGrafs(String contact, String message) {
     List<String> grafs = new LinkedList<>();
 
-    if (message.startsWith("/do ") || message.startsWith("/run ") || message.startsWith("/cli ") || message.startsWith("/" + Preferences.getString("relayChatCLITrigger") + " ")) {
+    if (message.startsWith("/do ")
+        || message.startsWith("/run ")
+        || message.startsWith("/cli ")
+        || message.startsWith("/" + Preferences.getString("relayChatCLITrigger") + " ")) {
       grafs.add(message);
 
       return grafs;
@@ -419,7 +421,10 @@ public class ChatSender {
       return false;
     }
 
-    if (!graf.startsWith("/do ") && !graf.startsWith("/run ") && !graf.startsWith("/cli ") && !graf.startsWith("/" + Preferences.getString("relayChatCLITrigger") + " ")) {
+    if (!graf.startsWith("/do ")
+        && !graf.startsWith("/run ")
+        && !graf.startsWith("/cli ")
+        && !graf.startsWith("/" + Preferences.getString("relayChatCLITrigger") + " ")) {
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/chat/ChatSender.java
+++ b/src/net/sourceforge/kolmafia/chat/ChatSender.java
@@ -202,7 +202,7 @@ public class ChatSender {
   private static List<String> getGrafs(String contact, String message) {
     List<String> grafs = new LinkedList<>();
 
-    if (message.startsWith("/do ") || message.startsWith("/run ") || message.startsWith("/" + Preferences.getString("relayChatCLITrigger") + " ")) {
+    if (message.startsWith("/do ") || message.startsWith("/run ") || message.startsWith("/cli ") || message.startsWith("/" + Preferences.getString("relayChatCLITrigger") + " ")) {
       grafs.add(message);
 
       return grafs;
@@ -419,7 +419,7 @@ public class ChatSender {
       return false;
     }
 
-    if (!graf.startsWith("/do ") && !graf.startsWith("/run ") && !graf.startsWith("/" + Preferences.getString("relayChatCLITrigger") + " ")) {
+    if (!graf.startsWith("/do ") && !graf.startsWith("/run ") && !graf.startsWith("/cli ") && !graf.startsWith("/" + Preferences.getString("relayChatCLITrigger") + " ")) {
       return false;
     }
 


### PR DESCRIPTION
Jimmyking asked earlier today if there was a way to shorten that command to something like "/l", but it seemed like there were only three hardcoded commands to use ("/do", "/run", and "/cli"), so I tried to make that possible for people to do without having to compile their own build.