### PR TITLE
fix: add pwd to backpack request, observe sniper support

### DIFF
--- a/src/net/sourceforge/kolmafia/request/AlliedRadioRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AlliedRadioRequest.java
@@ -34,7 +34,9 @@ public class AlliedRadioRequest extends GenericRequest {
     if (InventoryManager.equippedOrInInventory(ItemPool.ALLIED_RADIO_BACKPACK)
         && Preferences.getInteger("_alliedRadioDropsUsed") < 3) {
       handheld = false;
-      GenericRequest radioReq = new GenericRequest("inventory.php?action=requestdrop", false);
+      GenericRequest radioReq =
+          new GenericRequest(
+              "inventory.php?action=requestdrop&pwd=" + GenericRequest.passwordHash, false);
       radioReq.run();
     } else if (InventoryManager.getCount(ItemPool.HANDHELD_ALLIED_RADIO) > 0) {
       handheld = true;
@@ -77,10 +79,10 @@ public class AlliedRadioRequest extends GenericRequest {
   private static final Pattern GREY_TEXT_PATTERN =
       Pattern.compile("<i style='color: #999'>([^<]+)</i>");
 
-  public static void postChoice(final String responseText, final boolean handheld) {
-    if (!responseText.contains("You acquire")) {
-      // request failed somehow
-      return;
+  public static void postChoice(
+      final String responseText, final boolean handheld, final String req) {
+    if (req.equals("sniper support")) {
+      Preferences.setBoolean("noncombatForcerActive", true);
     }
 
     Matcher matcher = AlliedRadioRequest.NUMBER_LETTER_PATTERN.matcher(responseText);

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -7064,13 +7064,19 @@ public abstract class ChoiceControl {
 
       case 1561:
         // Request Supply Drop
-        AlliedRadioRequest.postChoice(text, false);
-        break;
+        {
+          String req = request.getFormField("request");
+          AlliedRadioRequest.postChoice(text, false, req);
+          break;
+        }
 
       case 1563:
         // Request Supply Drop
-        AlliedRadioRequest.postChoice(text, true);
-        break;
+        {
+          String req = request.getFormField("request");
+          AlliedRadioRequest.postChoice(text, true, req);
+          break;
+        }
     }
   }
 

--- a/test/net/sourceforge/kolmafia/request/AlliedRadioRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/AlliedRadioRequestTest.java
@@ -58,7 +58,7 @@ public class AlliedRadioRequestTest {
 
     try (cleanups) {
       var resp = html("request/test_allied_radio_success.html");
-      AlliedRadioRequest.postChoice(resp, false);
+      AlliedRadioRequest.postChoice(resp, false, "radio");
       var text = SessionLoggerOutput.stopStream();
       assertThat("_alliedRadioDropsUsed", isSetTo(1));
       assertThat(text, containsString("Radio number / letter pattern received: 202 - P"));
@@ -74,7 +74,7 @@ public class AlliedRadioRequestTest {
 
     try (cleanups) {
       var resp = html("request/test_allied_radio_last.html");
-      AlliedRadioRequest.postChoice(resp, true);
+      AlliedRadioRequest.postChoice(resp, true, "radio");
       var text = SessionLoggerOutput.stopStream();
       assertThat("_alliedRadioDropsUsed", isSetTo(0));
       assertThat(InventoryManager.getCount(ItemPool.HANDHELD_ALLIED_RADIO), is(0));
@@ -89,7 +89,7 @@ public class AlliedRadioRequestTest {
 
     try (cleanups) {
       var resp = html("request/test_allied_radio_grey_text.html");
-      AlliedRadioRequest.postChoice(resp, false);
+      AlliedRadioRequest.postChoice(resp, false, "anything");
       var text = SessionLoggerOutput.stopStream();
       assertThat(text, containsString("Radio grey text received: ulH"));
     }
@@ -134,7 +134,7 @@ public class AlliedRadioRequestTest {
 
       assertThat(StaticEntity.getContinuationState(), is(MafiaState.CONTINUE));
       var requests = client.getRequests();
-      assertGetRequest(requests.get(0), "/inventory.php", "action=requestdrop");
+      assertGetRequest(requests.get(0), "/inventory.php", "action=requestdrop&pwd=");
       assertGetRequest(requests.get(1), "/choice.php", "forceoption=0");
       assertPostRequest(requests.get(2), "/api.php", "what=status&for=KoLmafia");
       assertPostRequest(requests.get(3), "/choice.php", "option=1&request=radio&whichchoice=1561");


### PR DESCRIPTION
Ref #2987.

Backpack use command needs `pwd` or else it doesn't redirect.

Sniper support doesn't have "you acquire", and should set `noncombatForcerActive` to `true` without needing to parse the charpane again.

Advances #2988.