### PR TITLE
Support for monster images with overlapping .png files

### DIFF
--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -2383,10 +2383,10 @@ proto-protozoa	2450	protozoa.gif	Scale: ? Cap: 1000 Floor: ? Init: -10000 P: sli
 yeast gang	2452	yeast.gif	Scale: ? Cap: 1000 Floor: ? Init: 100 P: plant Article: a	protogenetic chunklet (muscle) (c0)	fermenting powder (100)	fermenting powder (10)
 
 # Twitch 11 - Skeleton War (July 2025)
-Axis artillery skeleton	2494	noart.gif	NOCOPY Scale: 10 Cap: 10000 Floor: ? Init: 150 P: undead ElemHot: 50 ElemCold: 25 ElemStench: 90 ElemSpooky: 90 ElemSleaze: 50 Article: an	Axis suspenders (1)	Axis helmet (1)	Axis fatigues (5)	ordnance magnet (c0.03)
-Axis grenadier skeleton	2495	noart.gif	NOCOPY Scale: 5 Cap: 10000 Floor: ? Init: 100 P: undead Phys: 25 ElemHot: 90 ElemCold: 50 ElemStench: 90 ElemSpooky: 50 ElemSleaze: 50 Article: an	Axis fatigues (1)	Axis suspenders (1)	Axis helmet (5)	confetti grenade (c0.1)
-Axis infantry skeleton	2493	noart.gif	NOCOPY Scale: 15 Cap: 10000 Floor: ? Init: 200 P: undead Phys: 75 ElemHot: 50 ElemCold: 50 ElemStench: 90 ElemSpooky: 90 ElemSleaze: 25 Article: an	Axis helmet (1)	Axis fatigues (1)	Axis suspenders (5)	orphaned baby skeleton (f0.1)
-Axis officer skeleton	2496	noart.gif	NOCOPY Scale: 20 Cap: 10000 Floor: ? Init: 250 P: undead Phys: 50 ElemHot: 90 ElemCold: 90 ElemStench: 50 ElemSpooky: 90 ElemSleaze: 90 Article: an	Axis helmet (10)	Axis fatigues (10)	Axis suspenders (10)	stolen artifact (4)	really expensive stolen artifact (2)	priceless stolen artifact (1)	Chroner (100)
+Axis artillery skeleton	2494	otherimages/skeletonwar/spine+rib1+head3+arms1+legs2	NOCOPY Scale: 10 Cap: 10000 Floor: ? Init: 150 P: undead ElemHot: 50 ElemCold: 25 ElemStench: 90 ElemSpooky: 90 ElemSleaze: 50 Article: an	Axis suspenders (1)	Axis helmet (1)	Axis fatigues (5)	ordnance magnet (c0.03)
+Axis grenadier skeleton	2495	otherimages/skeletonwar/spine+rib1+head4+arms2+legs1	NOCOPY Scale: 5 Cap: 10000 Floor: ? Init: 100 P: undead Phys: 25 ElemHot: 90 ElemCold: 50 ElemStench: 90 ElemSpooky: 50 ElemSleaze: 50 Article: an	Axis fatigues (1)	Axis suspenders (1)	Axis helmet (5)	confetti grenade (c0.1)
+Axis infantry skeleton	2493	otherimages/skeletonwar/spine+rib1+rib2+rib4+head1+arms1+legs2	NOCOPY Scale: 15 Cap: 10000 Floor: ? Init: 200 P: undead Phys: 75 ElemHot: 50 ElemCold: 50 ElemStench: 90 ElemSpooky: 90 ElemSleaze: 25 Article: an	Axis helmet (1)	Axis fatigues (1)	Axis suspenders (5)	orphaned baby skeleton (f0.1)
+Axis officer skeleton	2496	otherimages/skeletonwar/spine+rib1+rib3+rib5+rib6+head2+arms1+legs1	NOCOPY Scale: 20 Cap: 10000 Floor: ? Init: 250 P: undead Phys: 50 ElemHot: 90 ElemCold: 90 ElemStench: 50 ElemSpooky: 90 ElemSleaze: 90 Article: an	Axis helmet (10)	Axis fatigues (10)	Axis suspenders (10)	stolen artifact (4)	really expensive stolen artifact (2)	priceless stolen artifact (1)	Chroner (100)
 
 # Crimbo 2023 (December 2023)
 Elf Guard conscript	2392	egconscript.gif	NOWISH Scale: ? Init: -10000 P: elf Article: an	1-2 Elf Guard MPC (m100)	Elf Guard patrol cap (c0)

--- a/src/net/sourceforge/kolmafia/MonsterData.java
+++ b/src/net/sourceforge/kolmafia/MonsterData.java
@@ -30,6 +30,7 @@ import net.sourceforge.kolmafia.session.EncounterManager.EncounterType;
 import net.sourceforge.kolmafia.session.EquipmentManager;
 import net.sourceforge.kolmafia.session.GoalManager;
 import net.sourceforge.kolmafia.session.MonsterManuelManager;
+import net.sourceforge.kolmafia.utilities.GraphicsUtilities;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 @SuppressWarnings("incomplete-switch")
@@ -2045,6 +2046,10 @@ public class MonsterData extends AdventureResult {
         image = image.substring(slash);
       }
 
+      /* RequestFrame supports HTML 3.2.
+         We need something more capable to display a "div" of the sort KoL generated.
+         Here's how we'd do that:
+
       if (image.contains("+")) {
         // multiple layers
         String[] layers = image.split("\\+");
@@ -2065,19 +2070,32 @@ public class MonsterData extends AdventureResult {
         // This is exactly the "div" that KoL generates for overlapping .png images
         // Unfortunately, HTML rendering in KoLmafia command frames does not handle it.
 
-        // buffer.append(div);
-        path = "adventureimages/";
-        image = "noart.gif";
+        buffer.append(div);
       }
-      // else
-      {
-        // A single image
-        buffer.append("<img src=");
-        buffer.append(imageServerPath);
-        buffer.append(path);
-        buffer.append(image);
-        buffer.append(" style=\"max-width:350;\">");
+      */
+
+      // Instead, let's concatenate the layers into a single.png file
+      if (image.contains("+")) {
+        // multiple layers
+        ArrayList<String> paths = new ArrayList<>();
+
+        String[] layers = image.split("\\+");
+        for (String layer : layers) {
+          paths.add(path + layer + ".png");
+        }
+
+        var images = GraphicsUtilities.readImages(paths);
+        var generated = GraphicsUtilities.mergeImages(images);
+        image = "generatedImage.png";
+        GraphicsUtilities.writeImage(generated, path + image);
       }
+
+      // A single image
+      buffer.append("<img src=");
+      buffer.append(imageServerPath);
+      buffer.append(path);
+      buffer.append(image);
+      buffer.append(" style=\"max-width:350;\">");
 
       buffer.append("</td>");
     }

--- a/src/net/sourceforge/kolmafia/MonsterData.java
+++ b/src/net/sourceforge/kolmafia/MonsterData.java
@@ -2030,19 +2030,55 @@ public class MonsterData extends AdventureResult {
     // The image is first, spanning 4 rows
     {
       buffer.append("<td rowspan=4 valign=top style=\"max-width:350;\">");
-      buffer.append("<img src=");
-      buffer.append(imageServerPath);
 
       // Allow variants of image
       int variants = stats.images.length;
       String image =
           variants < 2 ? stats.image : variant < variants ? stats.images[variant] : stats.image;
 
-      if (!image.contains("/")) {
-        buffer.append("adventureimages/");
+      String path;
+      int slash = image.lastIndexOf("/") + 1;
+      if (slash == 0) {
+        path = "adventureimages/";
+      } else {
+        path = image.substring(0, slash);
+        image = image.substring(slash);
       }
-      buffer.append(image);
-      buffer.append(" style=\"max-width:350;\">");
+
+      if (image.contains("+")) {
+        // multiple layers
+        String[] layers = image.split("\\+");
+        StringBuilder div = new StringBuilder();
+        {
+          div.append("<div style='width: 100px; height: 100px; position: relative;'>");
+          for (String layer : layers) {
+            div.append("<img src=");
+            div.append(imageServerPath);
+            div.append(path);
+            div.append(layer);
+            div.append(".png");
+            div.append(" style=\"position: absolute; left: 0px; right: 0px\">");
+          }
+          div.append("</div>");
+        }
+
+        // This is exactly the "div" that KoL generates for overlapping .png images
+        // Unfortunately, HTML rendering in KoLmafia command frames does not handle it.
+
+        // buffer.append(div);
+        path = "adventureimages/";
+        image = "noart.gif";
+      }
+      // else
+      {
+        // A single image
+        buffer.append("<img src=");
+        buffer.append(imageServerPath);
+        buffer.append(path);
+        buffer.append(image);
+        buffer.append(" style=\"max-width:350;\">");
+      }
+
       buffer.append("</td>");
     }
 

--- a/src/net/sourceforge/kolmafia/swingui/MonsterDescriptionFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/MonsterDescriptionFrame.java
@@ -31,6 +31,11 @@ public class MonsterDescriptionFrame extends DescriptionFrame {
     this.getFramePanel().add(southPanel, BorderLayout.SOUTH);
   }
 
+  @Override
+  protected String getDisplayHTML(final String responseText) {
+    return responseText;
+  }
+
   public JToolBar createMonsterToolbar() {
     JToolBar toolbarPanel = null;
 

--- a/src/net/sourceforge/kolmafia/utilities/GraphicsUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/GraphicsUtilities.java
@@ -20,10 +20,8 @@ public class GraphicsUtilities {
   }
 
   public static BufferedImage[] readImages(List<String> paths) {
-    System.out.println(paths);
     ArrayList<BufferedImage> images = new ArrayList<>();
     for (String path : paths) {
-      System.out.println(path);
       File f = FileUtilities.downloadImage(path);
       BufferedImage image = readImage(f);
       if (image == null) {
@@ -32,7 +30,6 @@ public class GraphicsUtilities {
       }
       images.add(image);
     }
-    System.out.println(images.size());
     return images.toArray(new BufferedImage[0]);
   }
 

--- a/src/net/sourceforge/kolmafia/utilities/GraphicsUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/GraphicsUtilities.java
@@ -1,0 +1,70 @@
+package net.sourceforge.kolmafia.utilities;
+
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.imageio.ImageIO;
+import net.sourceforge.kolmafia.RequestLogger;
+
+public class GraphicsUtilities {
+
+  public static BufferedImage readImage(File f) {
+    try {
+      return ImageIO.read(f);
+    } catch (IOException x) {
+      return null;
+    }
+  }
+
+  public static BufferedImage[] readImages(List<String> paths) {
+    System.out.println(paths);
+    ArrayList<BufferedImage> images = new ArrayList<>();
+    for (String path : paths) {
+      System.out.println(path);
+      File f = FileUtilities.downloadImage(path);
+      BufferedImage image = readImage(f);
+      if (image == null) {
+        RequestLogger.printLine("Unable to load image file " + path);
+        continue;
+      }
+      images.add(image);
+    }
+    System.out.println(images.size());
+    return images.toArray(new BufferedImage[0]);
+  }
+
+  public static BufferedImage mergeImages(BufferedImage[] images) {
+    if (images.length == 0) {
+      return null;
+    }
+
+    // Assume images all have the same size.
+    int width = images[0].getWidth();
+    int height = images[0].getHeight();
+    BufferedImage output = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+
+    // Draw each of the input images onto the output image.
+    Graphics g = output.getGraphics();
+    for (BufferedImage image : images) {
+      g.drawImage(image, 0, 0, null);
+    }
+
+    return output;
+  }
+
+  public static void writeImage(BufferedImage image, String path) {
+    if (image == null) {
+      return;
+    }
+
+    try {
+      File f = FileUtilities.imageFile(path);
+      f.createNewFile();
+      ImageIO.write(image, "PNG", f);
+    } catch (IOException x) {
+    }
+  }
+}


### PR DESCRIPTION
Looking at the HTML that KoL generates for an Axis skeleton, I saw this:
```
Axis infantry soldier

<td>
  <div id='monpic'>
    <div style='width: 100px; height: 100px; position: relative;'>
      <img src="/images/otherimages/skeletonwar/spine.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/rib1.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/rib2.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/rib4.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/head1.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/arms1.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/legs2.png" style="position: absolute; left: 0px; right: 0px" />
    </div>
  </div>
</td>

Axis grenadier skeleton

<td>
  <div id='monpic'>
    <div style='width: 100px; height: 100px; position: relative;'>
      <img src="/images/otherimages/skeletonwar/spine.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/rib1.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/head4.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/arms2.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/legs1.png" style="position: absolute; left: 0px; right: 0px" />
    </div>
  </div>
</td>

Axis artillery skeleton

<td>
  <div id='monpic'>
    <div style='width: 100px; height: 100px; position: relative;'>
      <img src="/images/otherimages/skeletonwar/spine.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/rib1.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/head3.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/arms1.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/legs2.png" style="position: absolute; left: 0px; right: 0px" />
    </div>
  </div>
</td>

Axis officer skeleton

<td>
  <div id='monpic'>
    <div style='width: 100px; height: 100px; position: relative;'>
      <img src="/images/otherimages/skeletonwar/spine.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/rib1.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/rib3.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/rib5.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/rib6.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/head2.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/arms1.png" style="position: absolute; left: 0px; right: 0px" />
      <img src="/images/otherimages/skeletonwar/legs1.png" style="position: absolute; left: 0px; right: 0px" />
    </div>
  </div>
</td>
```
they all have a spine
heads are unique.
arms are either a sword or a bomb
there are a couple of possible legs.
there are 6 images for ribs, and which are included varies per skeleton.

I encoded them in monsters.txt like this:

```
Axis artillery skeleton	2494	otherimages/skeletonwar/spine+rib1+head3+arms1+legs2
Axis grenadier skeleton	2495	otherimages/skeletonwar/spine+rib1+head4+arms2+legs1
Axis infantry skeleton	2493	otherimages/skeletonwar/spine+rib1+rib2+rib4+head1+arms1+legs2
Axis officer skeleton	2496	otherimages/skeletonwar/spine+rib1+rib3+rib5+rib6+head2+arms1+legs1
```

I also wrote code in MonsterData.craftDescription - which generates HTML for the monster "description" as shown in the Encyclopedia frame - to generate a "div" pull of "img"  elements for that kind of image.

Unfortunately, the MonsterDescriptionFrame -> DescriptionFrame -> RequestFrame does not display a div with overlapping .pngs correctly.

Hmm. Perhaps I can override the "getDisplayHTML" method of RequestFrame to not "fix" the HTML to accommodate all the idiosyncrasies of KoL generated HTML?

Results:

Nope. The HTML that is built into a JEditorPane is version 3.2. That does not include "style" attributes.

New approach:

1) monsters.txt specified "layered" .png files, as specified above.
2) MonsterData.craftDescription recognizes that, downloads each source image into local image cache, and merges the image into "generatedImage.png" in the local image directory where the source images were.
3) The Monster Description references that image.

I suppose I could have created merged images and put them into our local source image folder, but this seems more versatile, and seems plenty fast enough.