### PR TITLE
Arena stats for Baby Skeleton

### DIFF
--- a/src/data/familiars.txt
+++ b/src/data/familiars.txt
@@ -359,4 +359,4 @@
 322	Zapper Bug	zapperbug.gif	combat0,mp0	electric flyswatter	mosquito speakers	0	0	0	0	cantalk,fast,flies,robot,insect
 323	Wet Paper Tiger	wetpapertiger2.gif	combat0,delevel1	wet paper tiger	wet paper eye	0	0	0	0	animal,mineral,sentient,haslegs,hasclaws
 324	Cooler Yeti	cooleryeti.gif	passive,delevel0,item0	yeti in a travel cooler	cold exchanger	3	1	1	2	sentient,organic,humanoid,person,animal,hasbones,haseyes,hasclaws,cold
-325	Baby Skeleton	babyskel.gif	combat0,block	orphaned baby skeleton	bone pacifier	0	0	0	0
+325	Baby Skeleton	babyskel.gif	combat0,block	orphaned baby skeleton	bone pacifier	1	2	1	3


### PR DESCRIPTION
```
Results for Baby Skeleton after 12 trials using 144 turns:

Contest         XP[1]   XP[2]   XP[3]  Original Rank Derived Rank
Cage Match      60      37      11           0            1
Scavenger Hunt  52      58      57           0            2
Obstacle Course 55      46       5           0            1
Hide and Seek   27      31      57           0            3
```