### PR TITLE
Effects acquired from buff skills using a casting aid are not shruggable by default

### DIFF
--- a/src/net/sourceforge/kolmafia/request/UneffectRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UneffectRequest.java
@@ -177,8 +177,21 @@ public class UneffectRequest extends GenericRequest {
     if (name == null) {
       return false;
     }
-    int id = SkillDatabase.getSkillId(UneffectRequest.effectToSkill(name));
-    return id != -1 && SkillDatabase.isBuff(id);
+    int skillId = SkillDatabase.getSkillId(UneffectRequest.effectToSkill(name));
+
+    // If there was no skill associated with the effect (and was not caught above), not shruggable.
+    if (skillId == -1) return false;
+
+    // If it's not a buff it isn't shruggable.
+    if (!SkillDatabase.isBuff(skillId)) return false;
+
+    // If it is acquired through a buff-like skill but achieved with a casting aid
+    // indicated by a " ^ " (e.g. an April Shower Calendar) it isn't shruggable.
+    var action = EffectDatabase.getDefaultAction(effectId);
+    if (action != null && action.contains(" ^ ")) return false;
+
+    // Otherwise we have found a normal buff and it should indeed be shruggable.
+    return true;
   }
 
   public static final boolean isShruggable(final String effectName) {


### PR DESCRIPTION
Fixes #2974
