### PR TITLE
Support unironic knife modifiers

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -2068,7 +2068,7 @@ Item	uncursed machete	Meat Drop: +20
 Item	Underworld flail	Experience (Moxie): +10, Ranged Damage: +30, Moxie Percent: +10, Last Available: "2009-10"
 Item	Underworld truncheon	Experience (Muscle): +10, Weapon Damage Percent: +20, Muscle Percent: +10, Last Available: "2009-10"
 Item	Unionize The Elves sign	Weakens Monster, Last Available: "2005-12"
-Item	unironic knife	Weapon Drop: +75
+Item	unironic knife	Weapon Drop: +75, Item Drop: [100*lte(advsleft,0)], Adventures: [10*gte(advsleft,200)]
 Item	Unkillable Skeleton's restless leg	Weapon Damage: +40, MP Regen Min: 20, MP Regen Max: 30
 Item	Unkillable Skeleton's sawsword	Damage vs. Skeletons: +100, Damage vs. Zombies: +50, Damage vs. Vampires: +50, Damage vs. Werewolves: +50, Damage vs. Ghosts: +50, Damage vs. Bugbears: +50
 Item	unsanitized scalpel	Sleaze Damage: +25

--- a/src/net/sourceforge/kolmafia/Expression.java
+++ b/src/net/sourceforge/kolmafia/Expression.java
@@ -199,6 +199,8 @@ public class Expression {
         case '≤' -> v = s[--sp] >= s[--sp] ? 1 : 0;
         case '>' -> v = s[--sp] < s[--sp] ? 1 : 0;
         case '≥' -> v = s[--sp] <= s[--sp] ? 1 : 0;
+        case '=' -> v = s[--sp] == s[--sp] ? 1 : 0;
+        case '≠' -> v = s[--sp] != s[--sp] ? 1 : 0;
         case 'o' -> {
           var token = (String) this.literals.get((int) s[--sp]);
           var item =
@@ -635,6 +637,12 @@ public class Expression {
     if (this.optional("lte(")) {
       return binary('≤');
     }
+    if (this.optional("eq(")) {
+      return binary('=');
+    }
+    if (this.optional("neq(")) {
+      return binary('≠');
+    }
     if (this.optional("abs(")) {
       return unary('a');
     }
@@ -712,6 +720,8 @@ public class Expression {
       case '≤':
       case '>':
       case '≥':
+      case '=':
+      case '≠':
       case 'x':
       case 'm':
         break;

--- a/src/net/sourceforge/kolmafia/Expression.java
+++ b/src/net/sourceforge/kolmafia/Expression.java
@@ -89,7 +89,7 @@ public class Expression {
     //	compiled = compiled.replaceAll( ".", "?$0" );
     // }
     this.bytecode = compiled.toCharArray();
-    if (this.text.length() > 0) {
+    if (!this.text.isEmpty()) {
       StringBuilder buf = this.newError();
       buf.append("Expected end, found ");
       buf.append(this.text);
@@ -232,6 +232,7 @@ public class Expression {
             throw new ArithmeticException("Can't take square root of a negative value");
           }
         }
+        case 't' -> v = KoLCharacter.getAdventuresLeft();
         case 'x' -> v = Math.max(s[--sp], s[--sp]);
         case '#' -> v = (Double) this.literals.get((int) s[--sp]);
 
@@ -643,13 +644,16 @@ public class Expression {
     if (this.optional("haveitem(")) {
       return this.literal(this.until(")"), 'o');
     }
+    if (this.optional("advsleft")) {
+      return "t";
+    }
 
     rv = this.function();
     if (rv != null) {
       return rv;
     }
 
-    if (this.text.length() == 0) {
+    if (this.text.isEmpty()) {
       StringBuilder buf = this.newError();
       buf.append("Unexpected end of expr");
       return "\u8000";

--- a/test/net/sourceforge/kolmafia/ExpressionTest.java
+++ b/test/net/sourceforge/kolmafia/ExpressionTest.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia;
 
+import static internal.helpers.Player.withAdventuresLeft;
 import static internal.helpers.Player.withItem;
 import static internal.helpers.Player.withItemInCloset;
 import static internal.helpers.Player.withItemInStorage;
@@ -44,6 +45,15 @@ public class ExpressionTest {
   public void invalidExpressionReturnsZero() {
     var exp = new Expression("@", "Invalid bytecode");
     assertEquals(0.0, exp.eval());
+  }
+
+  @Test
+  public void canReadAdventuresLeftBytecode() {
+    var cleanups = withAdventuresLeft(69);
+    try (cleanups) {
+      var exp = new Expression("advsleft", "Adventures left");
+      assertThat(exp.eval(), is(69.0));
+    }
   }
 
   @ParameterizedTest

--- a/test/net/sourceforge/kolmafia/ExpressionTest.java
+++ b/test/net/sourceforge/kolmafia/ExpressionTest.java
@@ -76,10 +76,14 @@ public class ExpressionTest {
     "'lte(5,5)', 1",
     "'lte(5,4)', 0",
     "sqrt(25), 5",
+    "'eq(4,4)', 1",
+    "'eq(4,5)', 0",
+    "'neq(4,4)', 0",
+    "'neq(4,5)', 1",
   })
-  public void canDoSupportedMathFunctions(String input, String expected) {
+  public void canDoSupportedMathFunctions(String input, Double expected) {
     var exp = new Expression(input, input);
-    assertEquals(Double.parseDouble(expected), exp.eval());
+    assertEquals(expected, exp.eval());
   }
 
   @Nested

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -1,5 +1,6 @@
 package net.sourceforge.kolmafia;
 
+import static internal.helpers.Player.withAdventuresLeft;
 import static internal.helpers.Player.withClass;
 import static internal.helpers.Player.withDay;
 import static internal.helpers.Player.withEffect;
@@ -1687,5 +1688,18 @@ public class ModifiersTest {
     Modifiers mods = new Modifiers();
     mods.applyPrismaticBeretModifiers(1370);
     assertThat(mods.getDouble(DoubleModifier.DAMAGE_ABSORPTION), closeTo(237, 0.001));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 100, 200})
+  public void unironicKnife(final int advs) {
+    var cleanup = withAdventuresLeft(advs);
+
+    try (cleanup) {
+      var mods = ModifierDatabase.getModifiers(ModifierType.ITEM, "unironic knife");
+
+      assertThat(mods.getDouble(DoubleModifier.ITEMDROP), equalTo(advs > 0 ? 0.0 : 100.0));
+      assertThat(mods.getDouble(DoubleModifier.ADVENTURES), equalTo(advs < 200 ? 0.0 : 10.0));
+    }
   }
 }


### PR DESCRIPTION
- **Add support for advsleft modifier symbol and mods for the unironic knife**
- **Didn't end up using, but might as well keep these eq() and neq() binary fns I added to the modifier language**
