### PR TITLE
feat: trader jar, unironic knife plural

### DIFF
--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -5929,7 +5929,7 @@
 5901	jar of psychoses (The Old Man)	643517922	analjar_full.gif	usable	t	0	jars of psychoses (The Old Man)
 5902	jar of psychoses (The Pretentious Artist)	782884590	analjar_full.gif	usable	t	0	jars of psychoses (The Pretentious Artist)
 5903	jar of psychoses (The Meatsmith)	942166242	analjar_full.gif	usable	t	0	jars of psychoses (The Meatsmith)
-5904
+5904	[Jar of psychoses (Trader)]	664426198	analjar_full.gif	usable	t	0
 5905	jar of psychoses (Jick)	457683470	analjar_full.gif	usable	t	0	jars of psychoses (Jick)
 5906	pixel pill	439085798	pixelpill.gif	usable	t	0
 5907	pixel energy tank	337369749	pixeltank.gif	usable, combat	t	0

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11894,7 +11894,7 @@
 11866	crafting plans	218471243	boatplan.gif	usable	t,d	100	sets of crafting plans
 11867	Book of Irony	671417795	book5.gif	usable		0	Books of Irony
 11868	spoon	262321030	spoooon.gif	usable, combat	t,d	11
-11869	unironic knife	770625328	knife.gif	weapon	t	0
+11869	unironic knife	770625328	knife.gif	weapon	t	0	unironic knives
 11870	bar dart	979911176	nicedart.gif	none, combat	t,d	20
 11871	leprechaun antidepressant pill	798135927	pill3.gif	spleen, usable	t,d	50
 11872	Heck ramen	412904552	bowl.gif	food	t,d	25	bowls of Heck ramen


### PR DESCRIPTION
Trader jar isn't public, but is in the same boat as "pimonkey item", it's in Holder's DC.