### PR TITLE
feat: log pokefam fights better

### DIFF
--- a/src/net/sourceforge/kolmafia/RequestLogger.java
+++ b/src/net/sourceforge/kolmafia/RequestLogger.java
@@ -404,7 +404,9 @@ public class RequestLogger extends NullStream {
     // If we are in a fight, don't even look at things which are
     // not fight.php, since they will immediately redirect to
     // continue the fight.
-    if (FightRequest.currentRound != 0 && !urlString.startsWith("fight.php")) {
+    if (FightRequest.currentRound != 0
+        && !urlString.startsWith("fight.php")
+        && !urlString.startsWith("fambattle.php")) {
       return;
     }
 

--- a/src/net/sourceforge/kolmafia/request/AdventureRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AdventureRequest.java
@@ -758,7 +758,7 @@ public class AdventureRequest extends GenericRequest {
     Matcher m = MONSTERID_PATTERN.matcher(responseText);
 
     if (!m.find()) {
-      // It does not do this if and only if you are blind.
+      // It does not do this if and only if you are blind, or in pokefam
       if (responseText.contains("darkness.gif")) {
         // Adventuring in the Wumpus cave while temporarily blind is
         // foolish, but since we won't clear the cave after defeating
@@ -766,12 +766,14 @@ public class AdventureRequest extends GenericRequest {
         return WumpusManager.isWumpus() ? WUMPUS : THE_DARKNESS;
       }
 
-      // As of 16-June-2020, KoL will provide MONSTERID with
-      // every round of combat. If it fails to do so when you
-      // are not blind, That would be a bug. Log it and
-      // attempt to identify the monster by name.
+      if (!KoLCharacter.inPokefam()) {
+        // As of 16-June-2020, KoL will provide MONSTERID with
+        // every round of combat. If it fails to do so when you
+        // are not blind, That would be a bug. Log it and
+        // attempt to identify the monster by name.
 
-      StaticEntity.printDebugText("MONSTERID not found", responseText);
+        StaticEntity.printDebugText("MONSTERID not found", responseText);
+      }
 
       encounter = ConsequenceManager.disambiguateMonster(encounter, responseText);
       MonsterData monster = MonsterDatabase.findMonster(encounter);

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -5911,7 +5911,6 @@ public class FightRequest extends GenericRequest {
     // allow regular node processing to glean whatever it wants
     // from what remains.
 
-    boolean done = false;
     int pokindex = 0;
     // Each familiar is in a table
     for (var child : node.select("table")) {
@@ -6069,7 +6068,7 @@ public class FightRequest extends GenericRequest {
         }
         case 2 -> {
           // Familiar name
-          name = tdnode.wholeText();
+          name = tdnode.text();
         }
         case 3 -> {
           // Familiar power: one image (blacksword.gif) per
@@ -6099,10 +6098,17 @@ public class FightRequest extends GenericRequest {
     String race = "";
 
     Elements row2Tags = rows.get(1).children();
-    if (row2Tags.size() > 0) {
+    if (!row2Tags.isEmpty()) {
       String famtype = row2Tags.get(0).wholeText();
       level = StringUtilities.parseInt(famtype.substring(4, 5));
       race = famtype.substring(6);
+    }
+
+    if (!myFamiliar) {
+      // log the enemy team
+      var message = name + ", Lv. " + level + " " + race;
+      RequestLogger.printLine(message);
+      RequestLogger.updateSessionLog(message);
     }
 
     // If this is your familiar, it might have been boosted with a pokepill

--- a/test/net/sourceforge/kolmafia/request/FightRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FightRequestTest.java
@@ -3224,6 +3224,7 @@ public class FightRequestTest {
       try (cleanups) {
         parseCombatData("request/test_fight_pokefam_start.html", "fambattle.php");
         var text = RequestLoggerOutput.stopStream();
+        assertThat(text, containsString("Horlotte, Lv. 1 Trick-or-Treating Tot"));
         assertThat(
             text,
             containsString("Pokefam move2 'Hug' -> 'hug': Heal the frontmost ally by [power]."));


### PR DESCRIPTION
MONSTERID is not present, log the enemy team, log moves again.

Logging the enemy team gives more evidence towards determining tags for the April Fools familiars. For example, it looks like hippies have pokefams that are "vegetable" or "food" (or possibly "edible" because the crossover is huge) or their element, almost always "stench".