### PR TITLE
chore: fix clean tasks after migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,35 +142,24 @@ spotless {
 }
 
 tasks.register<Delete>("cleanDist") {
+  val dist = file("dist")
   onlyIf {
-    file("dist").exists()
+    dist.exists()
   }
-  inputs.dir("dist")
-  outputs.upToDateWhen { true }
-  doLast {
-    file("dist").walkTopDown().forEach { file ->
-      if (file.isFile && file.name.startsWith("KoLmafia-") && file.name.endsWith(".jar")) {
-        delete(file)
-      }
-    }
-  }
+  delete(
+    dist.listFiles().filter { it.isFile && it.name.startsWith("KoLmafia-") && it.name.endsWith(".jar") }
+  )
 }
 
 tasks.register<Delete>("pruneDist") {
+  val dist = file("dist")
   onlyIf {
-    file("dist").exists()
+    dist.exists()
   }
-  inputs.dir("dist")
-  outputs.upToDateWhen { true }
-  doLast {
-    file("dist").walkTopDown().forEach { file ->
-      if (file.isFile && file.name.startsWith("KoLmafia-") && file.name.endsWith(".jar")) {
-        if (!file.name.contains(project.version.toString()) || (isDirty() != file.name.endsWith("-M.jar"))) {
-          delete(file)
-        }
-      }
-    }
-  }
+  delete(
+    dist.listFiles().filter { it.isFile && it.name.startsWith("KoLmafia-") && it.name.endsWith(".jar")
+     && (!it.name.contains(project.version.toString()) || (isDirty() != it.name.endsWith("-M.jar"))) }
+  )
 }
 
 tasks.test {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -147,7 +147,7 @@ tasks.register<Delete>("cleanDist") {
     dist.exists()
   }
   delete(
-    dist.listFiles().filter { it.isFile && it.name.startsWith("KoLmafia-") && it.name.endsWith(".jar") }
+    dist.listFiles().filter { it.isFile && it.name.startsWith("KoLmafia-") && it.name.endsWith(".jar") },
   )
 }
 
@@ -157,8 +157,10 @@ tasks.register<Delete>("pruneDist") {
     dist.exists()
   }
   delete(
-    dist.listFiles().filter { it.isFile && it.name.startsWith("KoLmafia-") && it.name.endsWith(".jar")
-     && (!it.name.contains(project.version.toString()) || (isDirty() != it.name.endsWith("-M.jar"))) }
+    dist.listFiles().filter {
+      it.isFile && it.name.startsWith("KoLmafia-") && it.name.endsWith(".jar") &&
+        (!it.name.contains(project.version.toString()) || (isDirty() != it.name.endsWith("-M.jar")))
+    },
   )
 }
 


### PR DESCRIPTION
Just rewrite them in Kotlin.

`outputs.upToDateWhen { true }` prevented them from running, but even after that was fixed they still didn't work. In lieu of finding out why I just changed them until they did.