### PR TITLE
fix: remove zone sea penalty, just have locations

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -9287,9 +9287,7 @@ Event	Feast of Boris	Stomach Capacity: [min(1,path(none)+path(Teetotaler))*(1-cl
 Event	April Fool's Day	Alters Page Text
 
 # Zone-specific section of modifiers.txt
-# -100% is the most common penalty in The Sea; use it as the default
 
-Zone	The Sea	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
 Zone	Shadow Rift	Item Drop: [-0.8*mod(Item Drop)]
 Zone	Suburbs	Alters Page Text
 
@@ -9297,17 +9295,26 @@ Zone	Suburbs	Alters Page Text
 
 Loc	The Haiku Dungeon	Alters Page Text
 
-Loc	The Briniest Deepests	Initiative Penalty: +25, Item Drop Penalty: +25, Meat Drop Penalty: +25
-Loc	The Brinier Deepers	Initiative Penalty: +50, Item Drop Penalty: +50, Meat Drop Penalty: +50
-Loc	The Briny Deeps	Initiative Penalty: +75, Item Drop Penalty: +75, Meat Drop Penalty: +75
-Loc	Mer-kin Elementary School	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
-Loc	Mer-kin Library	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
-Loc	Mer-kin Gymnasium	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
-Loc	Mer-kin Colosseum	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
-Loc	Anemone Mine	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
-Loc	The Caliginous Abyss	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
-Loc	The Dive Bar	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
-Loc	The Marinara Trench	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
+Loc	The Briny Deeps	Initiative Penalty: -25, Item Drop Penalty: -25, Meat Drop Penalty: -25
+Loc	The Brinier Deepers	Initiative Penalty: -50, Item Drop Penalty: -50, Meat Drop Penalty: -50
+Loc	The Briniest Deepests	Initiative Penalty: -75, Item Drop Penalty: -75, Meat Drop Penalty: -75
+
+Loc	An Octopus's Garden	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
+Loc	Madness Reef	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
+Loc	The Coral Corral	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
+Loc	The Mer-Kin Outpost	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
+Loc	The Skate Park	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
+Loc	The Wreck of the Edgar Fitzsimmons	Initiative Penalty: -100, Item Drop Penalty: -100, Meat Drop Penalty: -100
+
+Loc	Mer-kin Elementary School	Initiative Penalty: -150, Item Drop Penalty: -150, Meat Drop Penalty: -150
+Loc	Mer-kin Library	Initiative Penalty: -150, Item Drop Penalty: -150, Meat Drop Penalty: -150
+Loc	Mer-kin Gymnasium	Initiative Penalty: -150, Item Drop Penalty: -150, Meat Drop Penalty: -150
+Loc	Mer-kin Colosseum	Initiative Penalty: -150, Item Drop Penalty: -150, Meat Drop Penalty: -150
+
+Loc	Anemone Mine	Initiative Penalty: -200, Item Drop Penalty: -200, Meat Drop Penalty: -200
+Loc	The Caliginous Abyss	Initiative Penalty: -200, Item Drop Penalty: -200, Meat Drop Penalty: -200
+Loc	The Dive Bar	Initiative Penalty: -200, Item Drop Penalty: -200, Meat Drop Penalty: -200
+Loc	The Marinara Trench	Initiative Penalty: -200, Item Drop Penalty: -200, Meat Drop Penalty: -200
 
 Loc	Gingerbread Reef	Initiative Penalty: -50, Item Drop Penalty: -50, Meat Drop Penalty: -50
 Loc	The Wreck of the H. M. S. Kringle	Initiative Penalty: -75, Item Drop Penalty: -75, Meat Drop Penalty: -75

--- a/src/net/sourceforge/kolmafia/objectpool/EffectPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/EffectPool.java
@@ -348,6 +348,7 @@ public class EffectPool {
   public static final int MIST_FORM = 2450;
   public static final int BATS_FORM = 2451;
   public static final int FIDOXENE = 2520;
+  public static final int SPIRIT_OF_TAKING = 2541;
   public static final int BLESSING_OF_THE_BIRD = 2551;
   public static final int BLESSING_OF_YOUR_FAVORITE_BIRD = 2552;
   public static final int SCARIERSAUCE = 2553;

--- a/test/net/sourceforge/kolmafia/DebugModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/DebugModifiersTest.java
@@ -166,12 +166,21 @@ public class DebugModifiersTest {
   }
 
   @Test
-  void listsZoneLoc() {
+  void listsLoc() {
     try (var cleanups = withLocation("The Briniest Deepests")) {
       evaluateDebugModifiers(DoubleModifier.ITEMDROP);
     }
-    assertThat(output(), containsDebugRow("Loc", "The Briniest Deepests", 25.0, 25.0));
-    assertThat(output(), containsDebugRow("Zone", "The Sea", -100.0, -75.0));
+    assertThat(output(), containsDebugRow("Loc", "The Briniest Deepests", -75.0, -75.0));
+  }
+
+  @Test
+  void listsZone() {
+    try (var cleanups =
+        new Cleanups(
+            withLocation("Shadow Rift (Desert Beach)"), withEffect(EffectPool.SPIRIT_OF_TAKING))) {
+      evaluateDebugModifiers(DoubleModifier.ITEMDROP);
+    }
+    assertThat(output(), containsDebugRow("Zone", "Shadow Rift", -8.0, 2.0));
   }
 
   @Test


### PR DESCRIPTION
Also fix the Mer-kin zone penalties, they are -150% not -200% by the wiki.

Don't have a default penalty, this makes it harder to compare the penalties with the wiki.