### PR TITLE
feat: if casting a non-restore, allow swapping in equipment

### DIFF
--- a/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
@@ -867,6 +867,8 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
       return;
     }
 
+    var isRestore = SkillDatabase.isRemedy(skillId);
+
     var slotType =
         EquipmentManager.consumeFilterToEquipmentType(
             ItemDatabase.getConsumptionType(item.getItemId()));
@@ -900,9 +902,14 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
     Slot slot =
         UseSkillRequest.attemptSwitch(skillId, item, slot1Allowed, slot2Allowed, slot3Allowed);
 
-    if (slot == Slot.NONE) {
-      KoLmafia.updateDisplay(
-          MafiaState.ERROR, "Cannot choose slot to equip " + item.getName() + ".");
+    if (isRestore) {
+      if (slot == Slot.NONE) {
+        KoLmafia.updateDisplay(
+            MafiaState.ERROR, "Cannot choose slot to equip " + item.getName() + ".");
+      }
+    } else {
+      // just use accessory 3
+      (new EquipmentRequest(item, Slot.ACCESSORY3)).run();
     }
   }
 

--- a/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
@@ -902,14 +902,14 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
     Slot slot =
         UseSkillRequest.attemptSwitch(skillId, item, slot1Allowed, slot2Allowed, slot3Allowed);
 
-    if (isRestore) {
-      if (slot == Slot.NONE) {
+    if (slot == Slot.NONE) {
+      if (isRestore) {
         KoLmafia.updateDisplay(
             MafiaState.ERROR, "Cannot choose slot to equip " + item.getName() + ".");
+      } else {
+        // just use accessory 3
+        (new EquipmentRequest(item, Slot.ACCESSORY3)).run();
       }
-    } else {
-      // just use accessory 3
-      (new EquipmentRequest(item, Slot.ACCESSORY3)).run();
     }
   }
 


### PR DESCRIPTION
This will drop HP / MP but means that "cast fiesta exit" will always work, which is more valuable.

For restores, keep them non casting.