### PR TITLE
Add mini kiwi aioli to item panel

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
@@ -508,17 +508,17 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
   }
 
   private static class AioliListener extends ThreadedListener {
-      @Override
-      protected void execute() {
-        RequestThread.postRequest(
-            UseItemRequest.getInstance(ItemPool.get(ItemPool.MINI_KIWI_AIOLI, 1)));
-      }
-
-      @Override
-      public String toString() {
-        return "use aioli";
-      }
+    @Override
+    protected void execute() {
+      RequestThread.postRequest(
+          UseItemRequest.getInstance(ItemPool.get(ItemPool.MINI_KIWI_AIOLI, 1)));
     }
+
+    @Override
+    public String toString() {
+      return "use aioli";
+    }
+  }
 
   private static class MilkListener extends ThreadedListener {
     @Override


### PR DESCRIPTION
I often forget to use mini kiwi aioli, added a 'use aioli' button to item manager below 'use milk'. Tested it locally and it worked fine, the preference changed correctly.