### PR TITLE
feat: show wishable effects in maximizer, enhance filter

### DIFF
--- a/src/data/maximizer-help.html
+++ b/src/data/maximizer-help.html
@@ -64,6 +64,8 @@ If the Max Price field is zero or blank, the limit will be the smaller of your a
 Prices are based on the mall price database, so if the price has been looked up in the last 7 days that value is used, otherwise the current mall price is queried. If preference <b>maximizerCurrentMallPrices</b> is set to <b>true</b> the current mall price is always queried, this will be much slower and cause many more server hits.
 <p>
 You can select multiple boosts, and the title of the list will indicate the net effect of applying them all - note that this isn't always just the sum of their individual effects.
+<p>
+Filtering checks that all the space separated words are present in the text displayed. You can use flags for custom behaviour: <b>'</b> starting a word will use literal substrings instead of Mafia's fuzzy matching. <b>!</b> starting a word will check for the absence of that word. For example, you could search <i>!monkeypaw !genie !cargo</i> to exclude effects that require wishes.
 <h3>CLI Use</h3>
 The Modifier Maximizer can be invoked from the gCLI or a script via <b>maximize <i>expression</i></b>, and will behave as if you'd selected Equipment: on-hand only, Max Price: don't check, and turned off the Include option.  The best equipment will automatically be equipped (unless you invoked the command as <b>maximize? <i>expression</i></b>), but you'll still need to visit the GUI to apply effect boosts - there are too many factors in choosing between the available boosts for that to be safely automated.  An error will be generated if the equipment changes weren't sufficient to fulfill all <b>min</b> keywords in the expression.
 <h3>Limitations &amp; Bugs</h3>

--- a/src/data/statuseffects.txt
+++ b/src/data/statuseffects.txt
@@ -1457,8 +1457,8 @@
 1454	Antibiotic Saucesphere	antibiosphere.gif	82aeaeb6a9cdc1c891e17321b88b040c	good	none	cast 1 antibiotic saucesphere
 1455	Sauce Monocle	saucemonocle.gif	23241f2b2e7a5948bc38ee5b501f0fb1	good	none	cast 1 sauce monocle
 1456	Simmering	simmer.gif	dad03f361c134a577b1eb9d818711d8e	good	nohookah	cast 1 simmer
-1457	Blood Sugar Sauce Magic	saucedrops.gif	2283eb9a3ee756de0c56f379307527f6	neutral	none	cast 1 Blood Sugar Sauce Magic
-1458	Blood Sugar Sauce Magic	saucedrops.gif	482968ee1b70ea9ddaf3579d0ff3101c	neutral	none	cast 1 Blood Sugar Sauce Magic
+1457	Blood Sugar Sauce Magic	saucedrops.gif	2283eb9a3ee756de0c56f379307527f6	neutral	nohookah	cast 1 Blood Sugar Sauce Magic
+1458	Blood Sugar Sauce Magic	saucedrops.gif	482968ee1b70ea9ddaf3579d0ff3101c	neutral	nohookah	cast 1 Blood Sugar Sauce Magic
 1459	Blessing of the Hot Linguine	linguinispoon.gif	868e6edb45c276c30db7fee03713039c	good	none	use 1 spoonful of Linguine-Os
 1460	Blessing of the Frozen Tortellini	tortelinus.gif	c6ed6eb619950fd4e56242748857f05b	good	none	use 1 freezer-burned frost-bitten tortellini
 1461	Blessing of the Stinking Alphredo&trade;	alphredo.gif	9ec25859336babf49ea198cfd49026ec	good	none	use 1 blob of Alphredo&trade;

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -2,7 +2,6 @@ package net.sourceforge.kolmafia.maximizer;
 
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -444,7 +443,7 @@ public class Maximizer {
       AdventureResult effect = EffectPool.get(effectId);
       String name = effect.getName();
       boolean hasEffect = KoLConstants.activeEffects.contains(effect);
-      Iterator<String> sources;
+      List<String> sources;
 
       if (!hasEffect) {
         spec.addEffect(effect);
@@ -469,9 +468,9 @@ public class Maximizer {
           continue;
         }
         sources = EffectDatabase.getAllActions(effectId);
-        if (!sources.hasNext()) {
+        if (sources.isEmpty()) {
           if (includeAll) {
-            sources = Collections.singletonList("(no known source of " + name + ")").iterator();
+            sources = Collections.singletonList("(no known source of " + name + ")");
           } else continue;
         }
       } else {
@@ -492,12 +491,12 @@ public class Maximizer {
             cmd = "(find some way to remove " + name + ")";
           } else continue;
         }
-        sources = Collections.singletonList(cmd).iterator();
+        sources = Collections.singletonList(cmd);
       }
 
       boolean haveVipKey = InventoryManager.getCount(ItemPool.VIP_LOUNGE_KEY) > 0;
       boolean orFlag = false;
-      while (sources.hasNext()) {
+      for (var source : sources) {
         if (!KoLmafia.permitsContinue()) {
           return;
         }
@@ -521,7 +520,7 @@ public class Maximizer {
         int itemsRemaining = 0;
         int itemsCreatable = 0;
 
-        cmd = text = sources.next();
+        cmd = text = source;
         AdventureResult item = null;
 
         // Check filters

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -7,9 +7,7 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -221,13 +219,13 @@ public class EffectDatabase {
     return rv.split("\\|")[0];
   }
 
-  public static final Iterator<String> getAllActions(final int effectId) {
+  public static final ArrayList<String> getAllActions(final int effectId) {
     if (effectId == -1) {
-      return Collections.emptyIterator();
+      return new ArrayList<>();
     }
     String actions = StringUtilities.getDisplayName(EffectDatabase.defaultActions.get(effectId));
     if (actions == null) {
-      return Collections.emptyIterator();
+      return new ArrayList<>();
     }
     ArrayList<String> rv = new ArrayList<>();
     String[] pieces = actions.split("\\|");
@@ -247,7 +245,7 @@ public class EffectDatabase {
       }
     }
 
-    return rv.iterator();
+    return rv;
   }
 
   public static final String getActions(final int effectId) {

--- a/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
@@ -12,10 +12,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
+import javax.swing.JList;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
@@ -39,12 +42,14 @@ import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.swingui.panel.GenericPanel;
 import net.sourceforge.kolmafia.swingui.panel.ScrollableFilteredPanel;
+import net.sourceforge.kolmafia.swingui.widget.AutoFilterTextField;
 import net.sourceforge.kolmafia.swingui.widget.AutoHighlightTextField;
 import net.sourceforge.kolmafia.swingui.widget.GenericScrollPane;
 import net.sourceforge.kolmafia.swingui.widget.ShowDescriptionList;
 import net.sourceforge.kolmafia.swingui.widget.SmartButtonGroup;
 import net.sourceforge.kolmafia.utilities.ByteBufferUtilities;
 import net.sourceforge.kolmafia.utilities.InputFieldUtilities;
+import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class MaximizerFrame extends GenericFrame implements ListSelectionListener {
   public static final JComboBox<String> expressionSelect = new JComboBox<>();
@@ -368,11 +373,98 @@ public class MaximizerFrame extends GenericFrame implements ListSelectionListene
     }
   }
 
+  private static class FilterBoosts extends AutoFilterTextField<Boost> {
+    private List<Filter> parsedText;
+
+    public FilterBoosts(JList<Boost> list) {
+      super(list);
+    }
+
+    private record Filter(String txt, boolean strict, boolean not) {}
+
+    private LinkedList<Filter> parseFilter(String text) {
+      var lst = new LinkedList<Filter>();
+      var split = text.split("\\s+");
+
+      for (var spl : split) {
+        if (spl.length() > 2 && spl.startsWith("!'")) {
+          lst.add(new Filter(spl.substring(2), true, true));
+          // backwards compat: accept '-' for not
+        } else if (spl.length() > 1 && (spl.startsWith("!") || spl.startsWith("-"))) {
+          lst.add(new Filter(spl.substring(1), false, true));
+        } else if (spl.length() > 1 && spl.startsWith("'")) {
+          lst.add(new Filter(spl.substring(1), true, false));
+        } else {
+          lst.add(new Filter(spl, false, false));
+        }
+      }
+
+      return lst;
+    }
+
+    @Override
+    public void update() {
+      try {
+        var text = this.getText().toLowerCase();
+        this.text = text;
+        this.parsedText = parseFilter(text);
+
+        if (parsedText.size() == 1 && !parsedText.get(0).strict) {
+          // use the old strict / non-strict behaviour: strict first, else non-strict if no matches
+          var filter = parsedText.get(0);
+          parsedText = List.of(new Filter(filter.txt, true, filter.not));
+          this.model.updateFilter(false);
+          if (this.model.getSize() == 0) {
+            parsedText = List.of(filter);
+            this.model.updateFilter(false);
+          }
+        } else {
+          this.model.updateFilter(false);
+        }
+        updateList();
+      } finally {
+        fireContentsChanged();
+      }
+    }
+
+    @Override
+    public boolean isVisible(final Object element) {
+      if (this.text == null || this.text.isEmpty()) {
+        return true;
+      }
+
+      var cmd = element.toString().toLowerCase();
+
+      for (var elt : parsedText) {
+        var matches = matchedFilter(cmd, elt);
+        if (!matches) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    private boolean matchedFilter(String cmd, Filter filter) {
+      var matches =
+          filter.strict ? cmd.contains(filter.txt) : StringUtilities.fuzzyMatches(cmd, filter.txt);
+      if (filter.not) {
+        matches = !matches;
+      }
+      return matches;
+    }
+  }
+
   private class BoostsPanel extends ScrollableFilteredPanel<Boost> {
     private final ShowDescriptionList<Boost> elementList;
 
     public BoostsPanel(final ShowDescriptionList<Boost> list) {
-      super("Current score: --- \u25CA Predicted: ---", "equip all", "exec selected", list);
+      super(
+          "Current score: --- \u25CA Predicted: ---",
+          "equip all",
+          "exec selected",
+          list,
+          new FilterBoosts(list));
       this.elementList = this.scrollComponent;
       MaximizerFrame.this.listTitle = this.titleComponent;
     }

--- a/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
@@ -27,6 +27,7 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import net.java.dev.spellcast.utilities.DataUtilities;
 import net.java.dev.spellcast.utilities.JComponentUtilities;
+import net.java.dev.spellcast.utilities.LockableListModel;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.filterType;
@@ -373,11 +374,15 @@ public class MaximizerFrame extends GenericFrame implements ListSelectionListene
     }
   }
 
-  private static class FilterBoosts extends AutoFilterTextField<Boost> {
+  static class FilterBoosts extends AutoFilterTextField<Boost> {
     private List<Filter> parsedText;
 
     public FilterBoosts(JList<Boost> list) {
       super(list);
+    }
+
+    LockableListModel<Boost> getModel() {
+      return this.model;
     }
 
     private record Filter(String txt, boolean strict, boolean not) {}

--- a/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/MaximizerFrame.java
@@ -461,17 +461,14 @@ public class MaximizerFrame extends GenericFrame implements ListSelectionListene
   }
 
   private class BoostsPanel extends ScrollableFilteredPanel<Boost> {
-    private final ShowDescriptionList<Boost> elementList;
-
     public BoostsPanel(final ShowDescriptionList<Boost> list) {
-      super(
-          "Current score: --- \u25CA Predicted: ---",
-          "equip all",
-          "exec selected",
-          list,
-          new FilterBoosts(list));
-      this.elementList = this.scrollComponent;
+      super("Current score: --- \u25CA Predicted: ---", "equip all", "exec selected", list);
       MaximizerFrame.this.listTitle = this.titleComponent;
+    }
+
+    @Override
+    protected AutoFilterTextField<Boost> createFilterField() {
+      return new FilterBoosts(this.elementList);
     }
 
     @Override

--- a/src/net/sourceforge/kolmafia/swingui/panel/ScrollableFilteredPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/ScrollableFilteredPanel.java
@@ -17,23 +17,9 @@ public class ScrollableFilteredPanel<E> extends ScrollablePanel<ShowDescriptionL
       final String confirmedText,
       final String cancelledText,
       final ShowDescriptionList<E> scrollComponent) {
-    this(
-        title,
-        confirmedText,
-        cancelledText,
-        scrollComponent,
-        new AutoFilterTextField<>(scrollComponent));
-  }
-
-  public ScrollableFilteredPanel(
-      final String title,
-      final String confirmedText,
-      final String cancelledText,
-      final ShowDescriptionList<E> scrollComponent,
-      final AutoFilterTextField<E> filterField) {
     super(title, confirmedText, cancelledText, scrollComponent);
     this.elementList = this.scrollComponent;
-    this.filterField = filterField;
+    this.filterField = createFilterField();
     JPanel topPanel = new JPanel(new BorderLayout());
 
     if (!title.equals("")) {
@@ -44,6 +30,10 @@ public class ScrollableFilteredPanel<E> extends ScrollablePanel<ShowDescriptionL
     topPanel.add(this.filterField, BorderLayout.CENTER);
     this.centerPanel.add(topPanel, BorderLayout.NORTH);
     this.filterItems();
+  }
+
+  protected AutoFilterTextField<E> createFilterField() {
+    return new AutoFilterTextField<>(this.elementList);
   }
 
   public void filterItems() {

--- a/src/net/sourceforge/kolmafia/swingui/panel/ScrollableFilteredPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/ScrollableFilteredPanel.java
@@ -17,9 +17,23 @@ public class ScrollableFilteredPanel<E> extends ScrollablePanel<ShowDescriptionL
       final String confirmedText,
       final String cancelledText,
       final ShowDescriptionList<E> scrollComponent) {
+    this(
+        title,
+        confirmedText,
+        cancelledText,
+        scrollComponent,
+        new AutoFilterTextField<>(scrollComponent));
+  }
+
+  public ScrollableFilteredPanel(
+      final String title,
+      final String confirmedText,
+      final String cancelledText,
+      final ShowDescriptionList<E> scrollComponent,
+      final AutoFilterTextField<E> filterField) {
     super(title, confirmedText, cancelledText, scrollComponent);
     this.elementList = this.scrollComponent;
-    this.filterField = new AutoFilterTextField<>(this.elementList);
+    this.filterField = filterField;
     JPanel topPanel = new JPanel(new BorderLayout());
 
     if (!title.equals("")) {

--- a/src/net/sourceforge/kolmafia/swingui/widget/AutoFilterTextField.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/AutoFilterTextField.java
@@ -288,21 +288,29 @@ public class AutoFilterTextField<E> extends AutoHighlightTextField
         AutoFilterTextField.this.model.updateFilter(false);
       }
 
-      if (AutoFilterTextField.this.list != null) {
-        JList<E> list = AutoFilterTextField.this.list;
-        if (AutoFilterTextField.this.model.getSize() == 1) {
-          list.setSelectedIndex(0);
-        } else if (list.getSelectedIndices().length == 1) {
-          list.ensureIndexIsVisible(list.getSelectedIndex());
-        } else {
-          list.clearSelection();
-        }
-      }
+      updateList();
     } finally {
-      if (AutoFilterTextField.this.model.size() > 0) {
-        AutoFilterTextField.this.model.fireContentsChanged(
-            AutoFilterTextField.this.model, 0, AutoFilterTextField.this.model.size() - 1);
+      fireContentsChanged();
+    }
+  }
+
+  protected void updateList() {
+    if (AutoFilterTextField.this.list != null) {
+      JList<E> list = AutoFilterTextField.this.list;
+      if (AutoFilterTextField.this.model.getSize() == 1) {
+        list.setSelectedIndex(0);
+      } else if (list.getSelectedIndices().length == 1) {
+        list.ensureIndexIsVisible(list.getSelectedIndex());
+      } else {
+        list.clearSelection();
       }
+    }
+  }
+
+  protected void fireContentsChanged() {
+    if (AutoFilterTextField.this.model.size() > 0) {
+      AutoFilterTextField.this.model.fireContentsChanged(
+          AutoFilterTextField.this.model, 0, AutoFilterTextField.this.model.size() - 1);
     }
   }
 

--- a/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ProxyRecordValue.java
@@ -3,7 +3,6 @@ package net.sourceforge.kolmafia.textui.parsetree;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.AdventureResult;
@@ -1380,9 +1379,9 @@ public class ProxyRecordValue extends RecordValue {
 
     public Value get_all() {
       ArrayList<Value> rv = new ArrayList<>();
-      Iterator<String> i = EffectDatabase.getAllActions((int) this.contentLong);
-      while (i.hasNext()) {
-        rv.add(new Value(i.next()));
+      List<String> i = EffectDatabase.getAllActions((int) this.contentLong);
+      for (var v : i) {
+        rv.add(new Value(v));
       }
       return new PluralValue(DataTypes.STRING_TYPE, rv);
     }

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -1992,40 +1992,64 @@ public class MaximizerTest {
       }
     }
 
-    @Nested
-    class BirdOfTheDay {
-      @Test
-      public void suggestsBirdIfRelevant() {
-        var cleanups =
-            new Cleanups(
-                withProperty("_canSeekBirds", true),
-                withProperty("_birdOfTheDay", "Filthy Smiling Pine Parrot"),
-                withProperty(
-                    "_birdOfTheDayMods",
-                    "Mysticality Percent: +75, Stench Resistance: +2, Experience: +2, MP Regen Min: 10, MP Regen Max: 20"),
-                withProperty("yourFavoriteBird", "Southern Clandestine Fig Chachalaca"),
-                withProperty(
-                    "yourFavoriteBirdMods",
-                    "Stench Resistance: +2, Combat Rate: -9, MP Regen Min: 10, MP Regen Max: 20"),
-                withSkill(SkillPool.SEEK_OUT_A_BIRD),
-                withSkill(SkillPool.VISIT_YOUR_FAVORITE_BIRD),
-                withOverrideModifiers(
-                    ModifierType.EFFECT,
-                    2551,
-                    "Mysticality Percent: +75, Stench Resistance: +2, Experience: +2, MP Regen Min: 10, MP Regen Max: 20"),
-                withOverrideModifiers(
-                    ModifierType.EFFECT,
-                    2552,
-                    "Stench Resistance: +2, Combat Rate: -9, MP Regen Min: 10, MP Regen Max: 20"));
+    @Test
+    public void suggestsSpiceHazeForNonPastamancer() {
+      var cleanups =
+          new Cleanups(
+              withClass(AscensionClass.ACCORDION_THIEF), withSkill(SkillPool.BIND_SPICE_GHOST));
 
-        try (cleanups) {
-          assertTrue(maximize("mp regen"));
-          assertThat(
-              getBoosts(), hasItem(hasProperty("cmd", startsWith("cast 1 Seek out a Bird"))));
-          assertThat(
-              getBoosts(),
-              hasItem(hasProperty("cmd", startsWith("cast 1 Visit your Favorite Bird"))));
-        }
+      try (cleanups) {
+        maximize("item");
+        assertThat(getBoosts(), hasItem(hasProperty("cmd", startsWith("cast 1 Bind Spice Ghost"))));
+      }
+    }
+
+    @Test
+    public void doesNotSuggestSpiceHazeForPastamancer() {
+      var cleanups =
+          new Cleanups(
+              withClass(AscensionClass.PASTAMANCER), withSkill(SkillPool.BIND_SPICE_GHOST));
+
+      try (cleanups) {
+        maximize("item");
+        assertThat(
+            getBoosts(), not(hasItem(hasProperty("cmd", startsWith("cast 1 Bind Spice Ghost")))));
+      }
+    }
+  }
+
+  @Nested
+  class BirdOfTheDay {
+    @Test
+    public void suggestsBirdIfRelevant() {
+      var cleanups =
+          new Cleanups(
+              withProperty("_canSeekBirds", true),
+              withProperty("_birdOfTheDay", "Filthy Smiling Pine Parrot"),
+              withProperty(
+                  "_birdOfTheDayMods",
+                  "Mysticality Percent: +75, Stench Resistance: +2, Experience: +2, MP Regen Min: 10, MP Regen Max: 20"),
+              withProperty("yourFavoriteBird", "Southern Clandestine Fig Chachalaca"),
+              withProperty(
+                  "yourFavoriteBirdMods",
+                  "Stench Resistance: +2, Combat Rate: -9, MP Regen Min: 10, MP Regen Max: 20"),
+              withSkill(SkillPool.SEEK_OUT_A_BIRD),
+              withSkill(SkillPool.VISIT_YOUR_FAVORITE_BIRD),
+              withOverrideModifiers(
+                  ModifierType.EFFECT,
+                  2551,
+                  "Mysticality Percent: +75, Stench Resistance: +2, Experience: +2, MP Regen Min: 10, MP Regen Max: 20"),
+              withOverrideModifiers(
+                  ModifierType.EFFECT,
+                  2552,
+                  "Stench Resistance: +2, Combat Rate: -9, MP Regen Min: 10, MP Regen Max: 20"));
+
+      try (cleanups) {
+        assertTrue(maximize("mp regen"));
+        assertThat(getBoosts(), hasItem(hasProperty("cmd", startsWith("cast 1 Seek out a Bird"))));
+        assertThat(
+            getBoosts(),
+            hasItem(hasProperty("cmd", startsWith("cast 1 Visit your Favorite Bird"))));
       }
     }
   }

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -2426,4 +2426,47 @@ public class MaximizerTest {
       assertEquals(31, modFor(DoubleModifier.HATDROP), 0.01);
     }
   }
+
+  @Nested
+  class Wishable {
+    @Test
+    public void recommendsOnlyWishableEffects() {
+      var cleanups = new Cleanups(withItem(ItemPool.POCKET_WISH));
+
+      try (cleanups) {
+        maximize("-combat");
+        var boosts = getBoosts();
+        assertThat(boosts, hasItem(hasProperty("cmd", startsWith("genie effect Disquiet Riot"))));
+        assertThat(
+            boosts,
+            not(hasItem(hasProperty("cmd", startsWith("genie effect Mild-Mannered Professor")))));
+      }
+    }
+
+    @Test
+    public void recommendsPawableEffectsWithPaw() {
+      var cleanups =
+          new Cleanups(
+              withItem(ItemPool.CURSED_MONKEY_PAW),
+              withProperty("_monkeyPawWishesUsed", 3),
+              withProperty("verboseMaximizer", true));
+
+      try (cleanups) {
+        maximize("-combat");
+        var boosts = getBoosts();
+        assertThat(boosts, hasItem(hasProperty("cmd", equalTo("monkeypaw effect Disquiet Riot"))));
+        assertThat(
+            boosts,
+            hasItem(
+                hasToString(
+                    equalTo(
+                        "monkeypaw effect Disquiet Riot (+20) [30 advs duration, 2 uses remaining]"))));
+        assertThat(
+            boosts,
+            not(
+                hasItem(
+                    hasProperty("cmd", startsWith("monkeypaw effect Mild-Mannered Professor")))));
+      }
+    }
+  }
 }

--- a/test/net/sourceforge/kolmafia/swingui/MaximizerFrameTest.java
+++ b/test/net/sourceforge/kolmafia/swingui/MaximizerFrameTest.java
@@ -1,0 +1,188 @@
+package net.sourceforge.kolmafia.swingui;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.LinkedList;
+import java.util.List;
+import net.java.dev.spellcast.utilities.LockableListModel;
+import net.sourceforge.kolmafia.maximizer.Boost;
+import net.sourceforge.kolmafia.swingui.MaximizerFrame.FilterBoosts;
+import net.sourceforge.kolmafia.swingui.widget.ShowDescriptionList;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class MaximizerFrameTest {
+  @Nested
+  class FilterBoostsTest {
+    @Test
+    void singleWordFiltersStrictly() {
+      var filter = createFilterBoosts();
+
+      filter.setText("car");
+      var model = filter.getModel();
+      var visible = visibleItems(model);
+      assertThat(visible, hasSize(3));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("cargo effect Finding Stuff"))));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("cargo effect Super Vision"))));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("daycare mysticality"))));
+    }
+
+    @Test
+    void singleWordFiltersLoosely() {
+      var filter = createFilterBoosts();
+
+      filter.setText("kacc");
+      var model = filter.getModel();
+      var visible = visibleItems(model);
+      assertThat(visible, hasSize(2));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("keep acc1: lucky gold ring"))));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("keep acc2: thumb ring"))));
+    }
+
+    @Test
+    void singleNegativeWordFiltersStrictly() {
+      var filter = createFilterBoosts();
+
+      filter.setText("-keep");
+      var model = filter.getModel();
+      var visible = visibleItems(model);
+      // backwards compat
+      assertThat(visible, hasSize(4));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("ledcandle disco"))));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("cargo effect Finding Stuff"))));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("cargo effect Super Vision"))));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("daycare mysticality"))));
+    }
+
+    @Test
+    void singleNegativeWordFiltersLoosely() {
+      var filter = createFilterBoosts();
+
+      filter.setText("-kacc");
+      var model = filter.getModel();
+      var visible = visibleItems(model);
+      // everything, backwards compat
+      assertThat(visible, hasSize(8));
+    }
+
+    @Test
+    void multipleWordsFilter() {
+      var filter = createFilterBoosts();
+
+      filter.setText("keep ring");
+      var model = filter.getModel();
+      var visible = visibleItems(model);
+      assertThat(visible, hasSize(2));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("keep acc1: lucky gold ring"))));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("keep acc2: thumb ring"))));
+    }
+
+    @Test
+    void multipleWordsFilterLoosely() {
+      var filter = createFilterBoosts();
+
+      filter.setText("keep tr");
+      var model = filter.getModel();
+      var visible = visibleItems(model);
+      assertThat(visible, hasSize(1));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("keep acc2: thumb ring"))));
+    }
+
+    @Test
+    void multipleWordsCustomStrictFilter() {
+      var filter = createFilterBoosts();
+
+      filter.setText("keep 'tr");
+      var model = filter.getModel();
+      var visible = visibleItems(model);
+      assertThat(visible, hasSize(0));
+    }
+
+    @Test
+    void multipleWordsNegatives() {
+      var filter = createFilterBoosts();
+
+      filter.setText("!keep !cargo");
+      var model = filter.getModel();
+      var visible = visibleItems(model);
+      assertThat(visible, hasSize(2));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("ledcandle disco"))));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("daycare mysticality"))));
+    }
+
+    @Test
+    void multipleWordsStrictAndNonStrict() {
+      var filter = createFilterBoosts();
+
+      filter.setText("'keep cl");
+      var model = filter.getModel();
+      var visible = visibleItems(model);
+      assertThat(visible, hasSize(2));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("keep weapon: June cleaver"))));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("keep back: vampyric cloake"))));
+    }
+
+    @Test
+    void singleWordExplicitStrictNoMatches() {
+      var filter = createFilterBoosts();
+
+      filter.setText("'ce");
+      var model = filter.getModel();
+      var visible = visibleItems(model);
+      assertThat(visible, hasSize(0));
+    }
+
+    @Test
+    void multipleWordsStrictMiddle() {
+      var filter = createFilterBoosts();
+
+      filter.setText("'keep 'ea");
+      var model = filter.getModel();
+      var visible = visibleItems(model);
+      assertThat(visible, hasSize(1));
+      assertThat(visible, hasItem(hasProperty("cmd", equalTo("keep weapon: June cleaver"))));
+    }
+
+    @Test
+    void strictNot() {
+      var filter = createFilterBoosts();
+
+      filter.setText("!'yst 'i");
+      var model = filter.getModel();
+      var visible = visibleItems(model);
+      // everything except cleaver and daycare
+      assertThat(visible, hasSize(6));
+    }
+
+    private FilterBoosts createFilterBoosts() {
+      var check =
+          List.of(
+              "keep weapon: June cleaver",
+              "keep back: vampyric cloake",
+              "keep acc1: lucky gold ring",
+              "keep acc2: thumb ring",
+              "ledcandle disco",
+              "cargo effect Finding Stuff",
+              "cargo effect Super Vision",
+              "daycare mysticality");
+      var boosts = check.stream().map(x -> new Boost(x, x, x, 0.0)).toList();
+      var llm = new LockableListModel<>(boosts);
+      var jlist = new ShowDescriptionList<>(llm);
+      return new FilterBoosts(jlist);
+    }
+
+    private List<Boost> visibleItems(LockableListModel<Boost> boosts) {
+      var lst = new LinkedList<Boost>();
+
+      for (int i = 0; i < boosts.getSize(); i++) {
+        lst.add(boosts.getElementAt(i));
+      }
+
+      return lst;
+    }
+  }
+}


### PR DESCRIPTION
Show monkey paw and genie wishable effects in the maximizer. These are easy to forget about.

Change the filter to allow searching for multiple (or searching for the absence of multiple) strings. For a motivating example, allow `!monkeypaw !genie` to remove monkeypaw / genie effects from search. Document this.

Keep searching for a single word working mostly like it used to, including a starting `-` being used to omit results.