### PR TITLE
Fix offhand remarkable left ski pole TCRS division by zero

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -5846,11 +5846,14 @@ public abstract class KoLCharacter {
 
     if (item.id == ItemPool.MCHUGELARGE_LEFT_POLE) {
       // we implement the bonus as though it were an outfit bonus, but it is properly on the item
-      int mcHugeLargeLevel = getMcHugeLargeLevel(newModifiers);
       int totalItems = newModifiers.getBitmap(BitmapModifier.MCHUGELARGE);
-      var mods = new Modifiers();
-      addMcHugeLargeModifiers(mods, mcHugeLargeLevel / totalItems);
-      addModifiersWithOffHandRemarkable(newModifiers, mods);
+
+      if (totalItems > 0) {
+        int mcHugeLargeLevel = getMcHugeLargeLevel(newModifiers);
+        var mods = new Modifiers();
+        addMcHugeLargeModifiers(mods, mcHugeLargeLevel / totalItems);
+        addModifiersWithOffHandRemarkable(newModifiers, mods);
+      }
     }
 
     // use sleeved card as source of modifiers if applicable


### PR DESCRIPTION
Fixes #2965

I'm really not sure about this, but I was able to see that at various points during the session initialization the totalItems bitmap modifier here is coming through as zero. I even got this crash when I opened the McHugeLarge duffel with Offhand Remarkable active (so with no MHL items equipped). This certainly fixes the problem, but I welcome any insight into why it's happening in the first place.
