### PR TITLE
clear item monster when retrieve adventure.php

### DIFF
--- a/src/net/sourceforge/kolmafia/request/AdventureRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AdventureRequest.java
@@ -543,11 +543,11 @@ public class AdventureRequest extends GenericRequest {
 
     if (isFight) {
       type = "Combat";
-      encounter = AdventureRequest.parseCombatEncounter(responseText);
+      encounter = parseCombatEncounter(responseText);
     } else if (isChoice) {
       int choice = ChoiceUtilities.extractChoice(responseText);
       type = choiceType(choice);
-      encounter = AdventureRequest.parseChoiceEncounter(urlString, choice, responseText);
+      encounter = parseChoiceEncounter(urlString, choice, responseText);
       ChoiceManager.registerDeferredChoice(choice, encounter);
     } else {
       type = "Noncombat";

--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -2206,6 +2206,9 @@ public class GenericRequest implements Runnable {
     } else if (urlString.startsWith("api.php")) {
       ApiRequest.parseResponse(urlString, this.responseText);
       return;
+    } else if (urlString.startsWith("adventure.php")) {
+      // A non-combat
+      this.itemMonster = null;
     }
 
     EventManager.checkForNewEvents(this.responseText);


### PR DESCRIPTION
Before this, using a dolphin whistle, fighting the item monster, and then adventuring and getting a non-combat didn't log correctly.

Using an item to get a fight or choice logs the location and sets itemMonster.
Adventuring again and redirecting to a fight or choice clears itemMonster in checkItemRedirection or checkChoiceRedirection.
Getting an NC does not redirect and we didn't log the location, since itemMonster non-null indicated it was already logged.
Getting a response from adventure.php is an NC. Clear itemMonster in that case.