### PR TITLE
fix: spies can eat sausages

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -547,6 +547,8 @@ public abstract class KoLCharacter {
     if (!KoLCharacter.canEat()) return false;
     // Robots can eat size-0 magical sausages but have no fullness
     if (inRobocore()) return false;
+    // Spies can eat size-0 magical sausages but have no fullness
+    if (inBondcore()) return false;
     // Grey Goo can "eat" things but they don't go into a stomach.
     if (isGreyGoo()) return false;
 
@@ -3441,7 +3443,7 @@ public abstract class KoLCharacter {
       return false;
     }
 
-    if (KoLCharacter.inNoobcore() || KoLCharacter.inBondcore()) {
+    if (KoLCharacter.inNoobcore()) {
       return false;
     }
 


### PR DESCRIPTION
Magical sausages came long after spies, and spies can still eat them.