### PR TITLE
feat: shallowly clone installed git repositories

### DIFF
--- a/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
@@ -71,6 +71,7 @@ public class GitManager extends ScriptManager {
         Git.cloneRepository()
             .setURI(repoUrl)
             .setCloneAllBranches(false)
+            .setDepth(1)
             .setDirectory(projectPath.toFile())
             .setProgressMonitor(new MafiaProgressMonitor());
     if (branch != null) {


### PR DESCRIPTION
Progresses https://kolmafia.us/threads/something-to-automatically-prune-git-history.30897/#post-177670

That thread mentions shallowly fetching as well: I think that's the wrong move, because we *do* want to get all changes after the single commit we have.

This saves ~100MB for me locally.