### PR TITLE
Only list unrefined Mountain Stream syrup once as a MP restore item

### DIFF
--- a/src/net/sourceforge/kolmafia/moods/MPRestoreItemList.java
+++ b/src/net/sourceforge/kolmafia/moods/MPRestoreItemList.java
@@ -134,7 +134,6 @@ public abstract class MPRestoreItemList {
         new MPRestoreItemItem("Notes from the Elfpocalypse, Chapter V", 35, false),
         new MPRestoreItemItem("Notes from the Elfpocalypse, Chapter VI", 35, false),
         new MPRestoreItemItem("dueling turtle", 15, false),
-        new MPRestoreItemItem("unrefined Mountain Stream syrup", 55, true),
         new MPRestoreItemItem("grogpagne", 40, false)
       };
 


### PR DESCRIPTION
Eliminated a duplicate list entry and used canonical capitalization.

Cleaned up some static, final.

See https://kolmafia.us/threads/duplicate-option-for-unrefined-mountain-stream-syrup-on-hp-mp-usage-tab.30958/