### PR TITLE
fix: `_seadentWaveUsed` should be set on successful cast

### DIFF
--- a/src/data/equipment.txt
+++ b/src/data/equipment.txt
@@ -2546,7 +2546,7 @@ blackberry galoshes	180	Mox: 60
 blackberry moccasins	180	Mys: 75
 blackberry slippers	180	Mys: 75
 Bling of the New Wave	150	Mox: 45
-blood cubic zirconia	0	none
+blood cubic zirconia	100	none
 Blue Diamond of Honesty	200	Mys: 85
 blue glowstick	20	none
 blue plastic baby	20	none

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -11985,7 +11985,7 @@
 11957	the gun	720217934	happiness.gif	weapon	q	0
 11958	fancy old wine	590385263	wine.gif	drink	t,d	500	bottles of fancy old wine
 11959
-11960	really, really nice swimming trunks	689309757	nicetrunks.gif	pants	q	0
+11960	really, really nice swimming trunks	689309757	nicetrunks.gif	pants	q	0	pairs of really, really nice swimming trunks
 11961	sand penny	692682835	sandpenny.gif	none	q	0	sand pennies
 11962	undersea surveying goggles	351851283	surveygoggles.gif	hat	q	0	pairs of undersea surveying goggles
 11963	Ocean-Touched Rum	224796689	emberbottle.gif	drink	t	0	bottles of Ocean-Touched Rum

--- a/src/data/monsters.txt
+++ b/src/data/monsters.txt
@@ -175,7 +175,7 @@ dairy goat	83	biggoat.gif	Atk: 68 Def: 61 HP: 50 Init: 80 Meat: 50 P: beast EA: 
 dancing mushroom guy	1806	mush_dancing.gif	Atk: 20 Def: 35 HP: 20 Init: 100 P: plant Article: a	cool spore pod (0)	cool mushroom (0)
 Danglin' Chad	519	chad.gif	BOSS NOCOPY Atk: 210 Def: 189 HP: 320 Init: 80 Meat: 300 P: orc ED: sleaze EA: sleaze EA: none	Danglin' Chad's loincloth (100)	white class ring (30)	beer helmet (0)	bejeweled pledge pin (0)	distressed denim pants (0)	kick-ass kicks (0)
 decent lumberjack	233	lumberjack.gif	Atk: 35 Def: 31 HP: 35 Init: 60 Meat: 20 P: dude Article: a	poutine (30)	disbelief suspenders (10)	jack flapper (10)	manly bloomers (p15)
-decent white shark	735	whiteshark.gif	Atk: 425 Def: 337 HP: 600 Init: 150 Meat: 240 P: fish Article: a	dull fish scale (n15)	shark cartilage (c10)	shark jumper (c3)	shark tooth (n2)	shark tooth (n1)
+decent white shark	735	whiteshark.gif	Atk: 425 Def: 337 HP: 600 Init: 150 Meat: 240 P: fish Article: a	dull fish scale (n15)	shark tooth (n2)	shark jumper (c3)	shark cartilage (c10)	shark tooth (n2)
 demonic icebox	373	demfridge.gif	Atk: 21 Def: 19 HP: 21 Init: 50 Meat: 5 P: demon EA: cold EA: hot EA: stench EA: none Article: a	accidental cider (30)	ancient frozen dinner (30)	dire fudgesicle (30)	leftovers of indeterminate origin (40)	ancient meat (5)	hand grenegg (p20)
 Demoninja	126	demoninja.gif	Atk: 48 Def: 27 HP: 48 Init: 75 Meat: 50 P: demon E: hot Article: a	demon skin (15)	hot katana blade (30)	ninja hot pants (5)
 dense liana	1426	liana.gif	Atk: 144 Def: 140 HP: 150 Init: -10000 P: plant Article: a	exotic jungle fruit (50)

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -6789,6 +6789,7 @@ public abstract class ChoiceControl {
           Matcher waveMatcher = SUMMON_WAVE_PATTERN.matcher(text);
           if (waveMatcher.find()) {
             Preferences.setString("_seadentWaveZone", waveMatcher.group(1));
+            Preferences.setBoolean("_seadentWaveUsed", true);
           }
         }
       }

--- a/test/net/sourceforge/kolmafia/session/ChoiceControlTest.java
+++ b/test/net/sourceforge/kolmafia/session/ChoiceControlTest.java
@@ -1731,10 +1731,12 @@ class ChoiceControlTest {
     var cleanups =
         new Cleanups(
             withProperty("_seadentWaveZone"),
+            withProperty("_seadentWaveUsed"),
             withPostChoice2(1566, 1, html("request/test_choice_summon_waves.html")));
 
     try (cleanups) {
       assertThat("_seadentWaveZone", isSetTo("Barf Mountain"));
+      assertThat("_seadentWaveUsed", isSetTo(true));
     }
   }
 }


### PR DESCRIPTION
`_seadentWaveUsed` should be set on successful cast, after the choice adventure.