### PR TITLE
Avoid conflicts for small-int optimization.

### DIFF
--- a/test/net/sourceforge/kolmafia/ExpressionTest.java
+++ b/test/net/sourceforge/kolmafia/ExpressionTest.java
@@ -34,6 +34,15 @@ public class ExpressionTest {
     assertEquals(Double.parseDouble(expected), exp.eval());
   }
 
+  @Test
+  public void canParseSmallNumericLiterals() {
+    for (int i = -32768; i < 32768; ++i) {
+      String s = String.valueOf(i);
+      var exp = new Expression(s, s);
+      assertEquals(i, exp.eval());
+    }
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"1/0", "-4^0.5", "999^999", "sqrt(-1)"})
   public void invalidArithmeticReturnsZero(String invalidExpr) {


### PR DESCRIPTION
Certain integers are mapped such that they result in a collision with non-ASCII comparison characters (>=, <=, !=).

Detect these cases and avoid using the compressed integer representation.

https://kolmafia.us/threads/modifier_eval-failing-with-some-negative-numbers.31408/