### PR TITLE
Clear error state if falling back to replica deck.

### DIFF
--- a/src/net/sourceforge/kolmafia/request/DeckOfEveryCardRequest.java
+++ b/src/net/sourceforge/kolmafia/request/DeckOfEveryCardRequest.java
@@ -13,6 +13,7 @@ import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLConstants.Stat;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestLogger;
+import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.moods.RecoveryManager;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -265,6 +266,8 @@ public class DeckOfEveryCardRequest extends GenericRequest {
       deckUsed = ItemPool.DECK_OF_EVERY_CARD;
     } else if (KoLCharacter.inLegacyOfLoathing()
         && InventoryManager.retrieveItem(ItemPool.REPLICA_DECK_OF_EVERY_CARD, 1, true)) {
+      // retrieveItem failed for the regular Deck of Every Card.
+      StaticEntity.setContinuationState(MafiaState.CONTINUE);
       deckUsed = ItemPool.REPLICA_DECK_OF_EVERY_CARD;
     } else {
       // If you can't get a deck into inventory, punt


### PR DESCRIPTION
retrieveItem sets Mafia's state to ERROR when it fails. However, in this case, we expect the failure and wish to fall back to an alternative.

Context: https://kolmafia.us/threads/31406/