### PR TITLE
feat: support skills that grant multiple effects

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/EffectPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/EffectPool.java
@@ -12,6 +12,12 @@ public class EffectPool {
   public static final int BLOODY_HAND = 15;
   public static final int LEASH_OF_LINGUINI = 16;
   public static final int GHOSTLY_SHELL = 18;
+  public static final int SEAL_CLUBBING_FRENZY = 21;
+  public static final int PATIENCE_OF_THE_TORTOISE = 22;
+  public static final int PASTA_ONENESS = 23;
+  public static final int SAUCEMASTERY = 24;
+  public static final int DISCO_STATE_OF_MIND = 25;
+  public static final int MARIACHI_MOOD = 26;
   public static final int EXPERT_OILINESS = 37;
   public static final int HERNIA = 39;
   public static final int SUNBURNED = 42;

--- a/src/net/sourceforge/kolmafia/request/UneffectRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UneffectRequest.java
@@ -333,6 +333,42 @@ public class UneffectRequest extends GenericRequest {
                 ? EffectPool.THOUGHTFUL_EMPATHY
                 : EffectPool.EMPATHY);
       }
+      case SkillPool.SEAL_CLUBBING_FRENZY -> {
+        return EffectDatabase.getEffectName(
+            KoLCharacter.hasEquipped(ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD)
+                ? EffectPool.SLIPPERY_AS_A_SEAL
+                : EffectPool.SEAL_CLUBBING_FRENZY);
+      }
+      case SkillPool.PATIENCE_OF_THE_TORTOISE -> {
+        return EffectDatabase.getEffectName(
+            KoLCharacter.hasEquipped(ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD)
+                ? EffectPool.STRENGTH_OF_THE_TORTOISE
+                : EffectPool.PATIENCE_OF_THE_TORTOISE);
+      }
+      case SkillPool.MANICOTTI_MEDITATION -> {
+        return EffectDatabase.getEffectName(
+            KoLCharacter.hasEquipped(ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD)
+                ? EffectPool.TUBES_OF_UNIVERSAL_MEAT
+                : EffectPool.PASTA_ONENESS);
+      }
+      case SkillPool.SAUCE_CONTEMPLATION -> {
+        return EffectDatabase.getEffectName(
+            KoLCharacter.hasEquipped(ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD)
+                ? EffectPool.LUBRICATING_SAUCE
+                : EffectPool.SAUCEMASTERY);
+      }
+      case SkillPool.DISCO_AEROBICS -> {
+        return EffectDatabase.getEffectName(
+            KoLCharacter.hasEquipped(ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD)
+                ? EffectPool.DISCO_OVER_MATTER
+                : EffectPool.DISCO_STATE_OF_MIND);
+      }
+      case SkillPool.MOXIE_OF_THE_MARIACHI -> {
+        return EffectDatabase.getEffectName(
+            KoLCharacter.hasEquipped(ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD)
+                ? EffectPool.MARIACHI_MOISTURE
+                : EffectPool.MARIACHI_MOOD);
+      }
     }
 
     // Handle remaining skills with a lookup
@@ -344,6 +380,18 @@ public class UneffectRequest extends GenericRequest {
     }
 
     return null;
+  }
+
+  public static final String[] skillToEffects(final String skillName) {
+    Set<String> effectSet = new HashSet<String>();
+
+    for (Entry<String, String> entry : UneffectRequest.EFFECT_SKILL.entrySet()) {
+      if (entry.getValue().equalsIgnoreCase(skillName)) {
+        effectSet.add(entry.getKey());
+      }
+    }
+
+    return effectSet.toArray(new String[0]);
   }
 
   private static Set<Entry<String, Set<Integer>>> REMOVABLE_BY_SKILL;

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -636,6 +636,10 @@ public abstract class RuntimeLibrary {
     params = List.of(namedParam("skill", DataTypes.SKILL_TYPE));
     functions.add(new LibraryFunction("to_effect", DataTypes.EFFECT_TYPE, params));
 
+    params = List.of(namedParam("skill", DataTypes.SKILL_TYPE));
+    functions.add(
+        new LibraryFunction("to_effects", new AggregateType(DataTypes.EFFECT_TYPE, 0), params));
+
     params = List.of(namedParam("name", DataTypes.STRICT_STRING_TYPE));
     functions.add(new LibraryFunction("to_familiar", DataTypes.FAMILIAR_TYPE, params));
     params = List.of(namedParam("id", DataTypes.INT_TYPE));
@@ -4635,6 +4639,19 @@ public abstract class RuntimeLibrary {
     DataTypes.EFFECT_TYPE.validateValue(controller, s1, effect);
 
     return effect;
+  }
+
+  public static ArrayValue to_effects(ScriptRuntime controller, final Value value) {
+    String[] effectNames = UneffectRequest.skillToEffects(value.toString());
+    ArrayValue effects =
+        new ArrayValue(new AggregateType(DataTypes.EFFECT_TYPE, effectNames.length));
+
+    int i = 0;
+    for (String effect : effectNames) {
+      effects.aset(DataTypes.makeIntValue(i++), DataTypes.parseEffectValue(effect, true));
+    }
+
+    return effects;
   }
 
   public static Value to_location(ScriptRuntime controller, final Value value) {

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -2319,4 +2319,69 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
               Mysticality => 50"""));
     }
   }
+
+  @Nested
+  class AprilShowerThoughtsShield {
+    final String skillEffects =
+        """
+        Seal Clubbing Frenzy,Seal Clubbing Frenzy,Slippery as a Seal
+        Patience of the Tortoise,Patience of the Tortoise,Strength of the Tortoise
+        Manicotti Meditation,Pasta Oneness,Tubes of Universal Meat
+        Sauce Contemplation,Saucemastery,Lubricating Sauce
+        Disco Aerobics,Disco State of Mind,Disco Over Matter
+        Moxie of the Mariachi,Mariachi Mood,Mariachi Moisture
+        """;
+
+    @ParameterizedTest
+    @CsvSource(skillEffects)
+    void onlyBasicEffectWithoutShieldEquipped(String skill, String basic, String bonus) {
+      String output = execute("$skill[" + skill + "].to_effect().name");
+      assertThat(output, both(containsString(basic)).and(not(containsString(bonus))));
+    }
+
+    @ParameterizedTest
+    @CsvSource(skillEffects)
+    void onlyBonusEffectWithShieldEquipped(String skill, String basic, String bonus) {
+      var cleanups = new Cleanups(withEquipped(ItemPool.APRIL_SHOWER_THOUGHTS_SHIELD));
+
+      try (cleanups) {
+        String output = execute("$skill[" + skill + "].to_effect().name");
+        assertThat(output, both(containsString(bonus)).and(not(containsString(basic))));
+      }
+    }
+
+    @ParameterizedTest
+    @CsvSource(skillEffects)
+    void toEffectsReturnsBothEffects(String skill, String basic, String bonus) {
+      String output = execute("$skill[" + skill + "].to_effects()");
+      assertThat(output, both(containsString(basic)).and(containsString(bonus)));
+    }
+  }
+
+  @Nested
+  class ToEffects {
+    @Test
+    void nullSkill() {
+      String output = execute("$skill[none].to_effects()");
+      assertThat(output, containsString("aggregate effect [0]"));
+    }
+
+    @Test
+    void skillWithNoEffects() {
+      String output = execute("$skill[Advanced Cocktailcrafting].to_effects()");
+      assertThat(output, containsString("aggregate effect [0]"));
+    }
+
+    @Test
+    void skillWithOneEffect() {
+      String output = execute("$skill[The Ode to Booze].to_effects()");
+      assertThat(output, containsString("aggregate effect [1]"));
+    }
+
+    @Test
+    void skillWithTwoEffects() {
+      String output = execute("$skill[Sauce Contemplation].to_effects()");
+      assertThat(output, containsString("aggregate effect [2]"));
+    }
+  }
 }


### PR DESCRIPTION
Implement a general `$skill.to_effects()` method, returning an aggregate of all relevant effects a given skill can/does grant.

Also default to the more relevant effect for April Shower-related skills, e.g. Sauce Contemplation currently returns only Lubricating Sauce, even if one doesn't own the April Shower Thoughts Shield at all, never mind having it equipped.

```
> ash $skill[Sauce Contemplation].to_effect()

Returned: Lubricating Sauce
...
```

```
> ash $skill[Sauce Contemplation].to_effect()

Returned: Saucemastery
...

> ash $skill[Sauce Contemplation].to_effects()

Returned: aggregate effect [2]
0 => Saucemastery
1 => Lubricating Sauce
```
