### PR TITLE
fix: reset after exiting limit modes

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -1260,6 +1260,7 @@ public abstract class KoLCharacter {
       EffectPool.get(EffectPool.OFFHAND_REMARKABLE);
 
   public static void setLimitMode(final LimitMode limitmode) {
+    boolean resetAfter = false;
     switch (limitmode) {
       case NONE -> {
         // Check for "pseudo" LimitModes - when certain effects are active,
@@ -1292,13 +1293,17 @@ public abstract class KoLCharacter {
         // If it does require making requests, can't do it in a fight or choice
         if (KoLCharacter.limitMode.requiresReset()
             && !GenericRequest.abortIfInFightOrChoice(true)) {
-          KoLmafia.resetAfterLimitmode();
+          resetAfter = true;
         }
       }
       case BATMAN -> BatManager.setCombatSkills();
     }
 
     KoLCharacter.limitMode = limitmode;
+
+    if (resetAfter) {
+      KoLmafia.resetAfterLimitmode();
+    }
   }
 
   public static void setLimitMode(final String name) {


### PR DESCRIPTION
See: https://kolmafia.us/threads/getting-stuck-in-spelunky-limit-mode.31712/

When exiting Spelunky (and possibly Batfellow) limit mode, the reset method is called prior to changing to the new limit mode (none). This continues to use the char pane for a status update, preventing the status API from being called, and interferes with refreshing inventory/skills/etc. that we didn't have while limited.