### PR TITLE
fix: call spading manager in fight round after parsing combat skills

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -1824,6 +1824,9 @@ public class FightRequest extends GenericRequest {
     FightRequest.parseCombatItems(responseText);
     FightRequest.parseAvailableCombatSkills(responseText);
 
+    // Report combat round to spading manager
+    SpadingManager.processCombatRound(MonsterStatusTracker.getLastMonsterName(), responseText);
+
     // Now that we have processed the page, generated the decorated HTML
     FightRequest.lastDecoratedResponseText =
         RequestEditorKit.getFeatureRichHTML("fight.php", responseText);
@@ -2565,9 +2568,6 @@ public class FightRequest extends GenericRequest {
 
     // Perform other processing for the final round
     FightRequest.updateRoundData(macroMatcher);
-
-    // Report combat round to spading manager
-    SpadingManager.processCombatRound(MonsterStatusTracker.getLastMonsterName(), responseText);
 
     if (responseText.contains("Macro Abort")
         || responseText.contains("Macro abort")


### PR DESCRIPTION
`updateCombatData` is only called in `processResults` (outside test classes), so this should be safe.

This allows spading scripts to check available combat skills correctly.