### PR TITLE
fix: don't print '1 null' for weird special case

### DIFF
--- a/src/net/sourceforge/kolmafia/shop/ShopRow.java
+++ b/src/net/sourceforge/kolmafia/shop/ShopRow.java
@@ -99,6 +99,9 @@ public class ShopRow implements Comparable<ShopRow> {
     buf.append("(");
     for (AdventureResult cost : costs) {
       long price = cost.getCount() * count;
+      if (price == 0l) {
+        continue;
+      }
       if (cost.isMeat()) {
         price = NPCPurchaseRequest.currentDiscountedPrice(price);
       }
@@ -110,7 +113,11 @@ public class ShopRow implements Comparable<ShopRow> {
       buf.append(cost.getPluralName(price));
     }
     buf.append(")");
-    return buf.toString();
+    var str = buf.toString();
+    if (str.equals("()")) {
+      return "";
+    }
+    return str;
   }
 
   /* The Armory and Leggery: Meat


### PR DESCRIPTION
Follow-up to #3207.

Haven't actually been to Jarlsberg to check everything works, but this improves the frame display.

I decided to go for requesting 0 of an invalid item over not requesting any items because the assumption that `costs` always has at least one entry is spread throughout the codebase and I thought it would be a lot more work to untangle that.