### PR TITLE
chore: update rhino library version in classpath from 1.7.15 to 1.8.1

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -22,7 +22,7 @@
 	<classpathentry kind="lib" path="src/jar/svnkit-cli-1.10.2.jar"/>
 	<classpathentry kind="lib" path="src/jar/svnkit-javahl16-1.10.2.jar"/>
 	<classpathentry kind="lib" path="src/jar/trilead-ssh2-1.0.0-build222.jar"/>
-	<classpathentry kind="lib" path="src/jar/rhino-1.7.15.jar"/>
+	<classpathentry kind="lib" path="src/jar/rhino-1.8.1.jar"/>
 	<classpathentry kind="lib" path="src/jar/svnkit-1.10.2.jar"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>


### PR DESCRIPTION
I was poking around looking for what version of rhino y'all were using and I saw the classpath wasn't updated in [3199](https://github.com/kolmafia/kolmafia/pull/3199)

I know it's teeny and inconsequential, but it's a start.