### PR TITLE
feat: also read paradoxicity from api.php

### DIFF
--- a/src/net/sourceforge/kolmafia/request/CharPaneRequest.java
+++ b/src/net/sourceforge/kolmafia/request/CharPaneRequest.java
@@ -1815,6 +1815,9 @@ public class CharPaneRequest extends GenericRequest {
         KoLCharacter.setRadSickness(0);
       }
     }
+
+    int paradoxicity = json.getIntValue("paradoxicity");
+    KoLCharacter.setParadoxicity(paradoxicity);
   }
 
   private static void parseFamiliarStatus(final JSONObject json) {


### PR DESCRIPTION
This fixes the mobius enchants being wrong if the ring hasn't been equipped this session.