### PR TITLE
fix: Gem stones not being decremented when equipped in codpiece

### DIFF
--- a/src/net/sourceforge/kolmafia/request/EquipmentRequest.java
+++ b/src/net/sourceforge/kolmafia/request/EquipmentRequest.java
@@ -944,7 +944,6 @@ public class EquipmentRequest extends PasswordHashRequest {
     if (urlString.startsWith("choice.php") && urlString.contains("whichchoice=1588")) {
       // instead of parsing the page, get our updated gems from api.php
       parseCodpiece(responseText);
-      ApiRequest.updateStatus();
       return;
     }
 


### PR DESCRIPTION
Addressing: https://kolmafia.us/threads/gems-equipped-to-the-eternity-codpiece-are-not-deducted-from-inventory.32396/
Looks like we have something that catches the "You acquire ..." but misses the "You lose a ..."

I think the card sleeve approach works so copied that over.