### PR TITLE
fix: allow stealing monster's hearts

### DIFF
--- a/src/net/sourceforge/kolmafia/combat/CombatActionManager.java
+++ b/src/net/sourceforge/kolmafia/combat/CombatActionManager.java
@@ -306,7 +306,8 @@ public abstract class CombatActionManager {
         || (action.contains("steal")
             && !action.contains("stealth")
             && !action.contains("combo")
-            && !action.contains("accordion"))) {
+            && !action.contains("accordion")
+            && !action.contains("heart"))) {
       return "try to steal an item";
     }
 
@@ -491,7 +492,8 @@ public abstract class CombatActionManager {
         || (action.contains("steal")
             && !action.contains("stealth")
             && !action.contains("combo")
-            && !action.contains("accordion"))) {
+            && !action.contains("accordion")
+            && !action.contains("heart"))) {
       return "steal";
     }
 

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -1220,7 +1220,8 @@ public class FightRequest extends GenericRequest {
 
     if (FightRequest.nextAction.contains("steal")
         && !FightRequest.nextAction.contains("stealth")
-        && !FightRequest.nextAction.contains("accordion")) {
+        && !FightRequest.nextAction.contains("accordion")
+        && !FightRequest.nextAction.contains("heart")) {
       if (FightRequest.canStillSteal() && MonsterStatusTracker.shouldSteal()) {
         FightRequest.nextAction = "steal";
         this.addFormField("action", "steal");


### PR DESCRIPTION
Probably the place for it.

Not sure what "combo" is or why it's absent from one of the places (the other two are "Stealth Mistletoe" and "Steal Accordion").