### PR TITLE
heartstone skills are not single cast

### DIFF
--- a/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
@@ -1527,9 +1527,7 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
           SkillPool.BCZ__SWEAT_EQUITY,
           SkillPool.BCZ__CREATE_BLOOD_THINNER,
           SkillPool.BCZ__PREPARE_SPINAL_TAPAS,
-          SkillPool.BCZ__CRAFT_A_PHEROMONE_COCKTAIL,
-          SkillPool.HEARTSTONE_BUFF,
-          SkillPool.HEARTSTONE_PALS ->
+          SkillPool.BCZ__CRAFT_A_PHEROMONE_COCKTAIL ->
           true;
       default -> false;
     };


### PR DESCRIPTION
I'm not sure why these were added as single cast skills, but I've had zero troubles using theses skills with the `quantity` parameter on `runskillz.php` having a value more than `1`. And mafia seems to recognize the result fine:

```
> ashq visit_url(`runskillz.php?pwd={my_hash()}&action=Skillz&whichskill={$skill[heartstone: %pals].id}&targetplayer={my_id()}&quantity=2`,false,true)

You acquire an effect: Best Pals (50)
Preference _heartstonePalsUsed changed from 1 to 3
```