### PR TITLE
Add 'get_no_pulls' to retrieve 'No pull' items from storage

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -399,6 +399,7 @@ public abstract class KoLCharacter {
     KoLConstants.storage.clear();
     KoLCharacter.storageMeat = 0;
     KoLConstants.freepulls.clear();
+    KoLConstants.nopulls.clear();
     KoLConstants.collection.clear();
     KoLConstants.pulverizeQueue.clear();
     KoLCharacter.sessionMeat = 0;

--- a/src/net/sourceforge/kolmafia/request/StorageRequest.java
+++ b/src/net/sourceforge/kolmafia/request/StorageRequest.java
@@ -619,6 +619,7 @@ public class StorageRequest extends TransferItemRequest {
   public static final void emptyStorage(final String urlString) {
     KoLConstants.storage.clear();
     KoLConstants.freepulls.clear();
+    KoLConstants.nopulls.clear();
     KoLCharacter.setAvailableMeat(KoLCharacter.getStorageMeat() + KoLCharacter.getAvailableMeat());
     KoLCharacter.setStorageMeat(0);
 

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -1393,6 +1393,9 @@ public abstract class RuntimeLibrary {
     functions.add(new LibraryFunction("get_free_pulls", DataTypes.ITEM_TO_INT_TYPE, params));
 
     params = List.of();
+    functions.add(new LibraryFunction("get_no_pulls", DataTypes.ITEM_TO_INT_TYPE, params));
+
+    params = List.of();
     functions.add(new LibraryFunction("get_shop", DataTypes.ITEM_TO_INT_TYPE, params));
 
     params = List.of();
@@ -6363,6 +6366,19 @@ public abstract class RuntimeLibrary {
 
     AdventureResult[] items = new AdventureResult[KoLConstants.freepulls.size()];
     KoLConstants.freepulls.toArray(items);
+
+    for (AdventureResult item : items) {
+      value.aset(DataTypes.makeItemValue(item.getItemId(), true), new Value(item.getCount()));
+    }
+
+    return value;
+  }
+
+  public static Value get_no_pulls(ScriptRuntime controller) {
+    MapValue value = new MapValue(DataTypes.ITEM_TO_INT_TYPE);
+
+    AdventureResult[] items = new AdventureResult[KoLConstants.nopulls.size()];
+    KoLConstants.nopulls.toArray(items);
 
     for (AdventureResult item : items) {
       value.aset(DataTypes.makeItemValue(item.getItemId(), true), new Value(item.getCount()));


### PR DESCRIPTION
Adds a way to get `No pull` items from storage, identical logic as `get_free_pulls`.

Also fixes a bug where `No pull` items was not cleared when storage is emptied.