### PR TITLE
feat: limit workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 concurrency:
   group: build-and-tag-release
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   check:
     runs-on: ${{ matrix.os }}
@@ -72,4 +76,3 @@ jobs:
           name: coverage-${{ matrix.os }}-java-${{ matrix.java }}
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{secrets.CODECOV_TOKEN}}
-

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,4 +1,3 @@
-
 name: Publish Typescript definitions to NPM
 on:
   push:


### PR DESCRIPTION
Build needs `contents: write` to create releases.

Check needs `checks: write` to publish the test reports.