### PR TITLE
feat: stop bulk purchasing sgeeas and tiny houses

### DIFF
--- a/src/net/sourceforge/kolmafia/session/InventoryManager.java
+++ b/src/net/sourceforge/kolmafia/session/InventoryManager.java
@@ -1462,8 +1462,6 @@ public abstract class InventoryManager {
     // We always bulk purchase certain specific items.
 
     switch (itemId) {
-      case ItemPool.REMEDY: // soft green echo eyedrop antidote
-      case ItemPool.TINY_HOUSE:
       case ItemPool.DRASTIC_HEALING:
       case ItemPool.ANTIDOTE:
         return true;


### PR DESCRIPTION
For tiny houses, I don't see any reason to favour them over over healing items.

For sgeeas, the current mall situation is that they cost mall-min, then 3.5k for 10, then 4.5k, and I don't think it's justifiable to buy 30 every time you want to use 1.

For antidotes they're NPC-buyable, so that's fine.