### PR TITLE
Update the number of recent options shown in the maximizer when maximizerMRUSize is updated

### DIFF
--- a/src/net/sourceforge/kolmafia/swingui/menu/PartialMRUList.java
+++ b/src/net/sourceforge/kolmafia/swingui/menu/PartialMRUList.java
@@ -41,8 +41,8 @@ public class PartialMRUList extends ScriptMRUList implements Listener {
           new ComboSeparatorsRenderer(new DefaultListCellRenderer()) {
             @Override
             protected boolean addSeparatorAfter(JList<?> list, Object value, int index) {
-              if (PartialMRUList.this.maxMRU < 0) return false;
-              return index == PartialMRUList.this.maxMRU - 1;
+              int mruEntries = Math.min(mruList.size(), PartialMRUList.this.maxMRU);
+              return index == mruEntries - 1;
             }
           };
     } else {
@@ -52,6 +52,9 @@ public class PartialMRUList extends ScriptMRUList implements Listener {
 
   @Override
   public void update() {
+    // Ensure we update the properties in ScriptMRUList
+    super.update();
+
     String[] newlist = Preferences.getString(this.pDefaultList).split(" \\| ");
     this.defaultList.clear();
     Collections.addAll(this.defaultList, newlist);
@@ -73,11 +76,12 @@ public class PartialMRUList extends ScriptMRUList implements Listener {
     }
     jcb.removeAllItems();
 
-    int count = mruList.size();
-    if (count >= 1) {
-      for (String ob : mruList) {
-        jcb.addItem(ob);
-      }
+    int mruEntries = Math.min(mruList.size(), PartialMRUList.this.maxMRU);
+    int entriesAdded = 0;
+    for (String ob : mruList) {
+      if(entriesAdded >= mruEntries) { break; }
+      jcb.addItem(ob);
+      entriesAdded++;
     }
 
     for (String str : defaultList) {

--- a/src/net/sourceforge/kolmafia/swingui/menu/PartialMRUList.java
+++ b/src/net/sourceforge/kolmafia/swingui/menu/PartialMRUList.java
@@ -79,7 +79,9 @@ public class PartialMRUList extends ScriptMRUList implements Listener {
     int mruEntries = Math.min(mruList.size(), PartialMRUList.this.maxMRU);
     int entriesAdded = 0;
     for (String ob : mruList) {
-      if(entriesAdded >= mruEntries) { break; }
+      if (entriesAdded >= mruEntries) {
+        break;
+      }
       jcb.addItem(ob);
       entriesAdded++;
     }


### PR DESCRIPTION
Addresses issue described at https://kolmafia.us/threads/maximizermlist-does-not-correctly-handle-changes-to-maximizermrusize.32511/

Cursory inspection indicates that the change fixes the issue for the most part. There is one remaining issue: if the maximizer frame is open when the preference is changed, the number of MRU entries populated doesn't update immediately but the location of the separator does. This visual blemish only remains until the next time the frame is opened or until the "update" button actually causes an update of the Swing elements. 

There is also a separate issue where the MRU list seems to get padded with duplicates if its size is increased, but that's a matter of the actual preference getting duplicates put into it, not a display issue.