### PR TITLE
Fix maximizer recommending campaway cloud if not owned or while under Standard restrictions.

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -49,6 +49,7 @@ import net.sourceforge.kolmafia.persistence.QuestDatabase.Quest;
 import net.sourceforge.kolmafia.persistence.SkillDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.ApiRequest;
+import net.sourceforge.kolmafia.request.CampAwayRequest;
 import net.sourceforge.kolmafia.request.CampgroundRequest;
 import net.sourceforge.kolmafia.request.ClanLoungeRequest;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
@@ -1370,6 +1371,9 @@ public class Maximizer {
           duration = 50;
           usesRemaining = 3 - Preferences.getInteger("_photoBoothEffects");
         } else if (cmd.equals("campaway cloud")) {
+          if (!CampAwayRequest.campAwayTentAvailable()) {
+            continue;
+          }
           var used = Preferences.getInteger("_campAwayCloudBuffs");
           if (used > 0) {
             cmd = "";

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -2413,6 +2413,49 @@ public class MaximizerTest {
         assertThat(getBoosts(), not(hasItem(hasProperty("cmd", is("campaway cloud")))));
       }
     }
+
+    @Test
+    public void doesNotRecommendCampAwayCloudIfNotOwned() {
+      var cleanups =
+          new Cleanups(
+              withProperty("getawayCampsiteUnlocked", false),
+              withProperty("_campAwayCloudBuffs", 0),
+              withProperty("_campAwaySmileBuffs", 0));
+      try (cleanups) {
+        maximize("Muscle Experience Percent");
+        assertThat(getBoosts(), not(hasItem(hasProperty("cmd", is("campaway cloud")))));
+      }
+    }
+
+    @Test
+    public void recommendsCampAwayCloudInOldPath() {
+      var cleanups =
+          new Cleanups(
+              withRestricted(false),
+              withNotAllowedInStandard(RestrictedItemType.ITEMS, "Distant Woods Getaway Brochure"),
+              withProperty("getawayCampsiteUnlocked", true),
+              withProperty("_campAwayCloudBuffs", 0),
+              withProperty("_campAwaySmileBuffs", 0));
+      try (cleanups) {
+        maximize("Muscle Experience Percent");
+        assertThat(getBoosts(), hasItem(hasProperty("cmd", is("campaway cloud"))));
+      }
+    }
+
+    @Test
+    public void doesNotRecommendCampAwayCloudIfUnderStandardRestriction() {
+      var cleanups =
+          new Cleanups(
+              withRestricted(true),
+              withNotAllowedInStandard(RestrictedItemType.ITEMS, "Distant Woods Getaway Brochure"),
+              withProperty("getawayCampsiteUnlocked", true),
+              withProperty("_campAwayCloudBuffs", 0),
+              withProperty("_campAwaySmileBuffs", 0));
+      try (cleanups) {
+        maximize("Muscle Experience Percent");
+        assertThat(getBoosts(), not(hasItem(hasProperty("cmd", is("campaway cloud")))));
+      }
+    }
   }
 
   @Nested


### PR DESCRIPTION
Fixes issue described at: https://kolmafia.us/threads/maximizer-suggests-using-campaway-cloud-when-under-standard-restrictions.32503/