### PR TITLE
add [turn] to skeleton spade fights

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -348,6 +348,14 @@ public abstract class ChoiceControl {
           Preferences.setInteger("lastShadowForgeUnlockAdventure", KoLCharacter.getCurrentRun());
         }
       }
+
+      case 1596 -> { // Dig up a skeleton
+        if (ChoiceManager.lastDecision == 3) {
+          String message = "[" + KoLAdventure.getAdventureCount() + "] Dig up a skeleton";
+          RequestLogger.printLine(message);
+          RequestLogger.updateSessionLog(message);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This adds [turns] to sessions similar to other encounters and fights, useful for log parsing