### PR TITLE
Implement replaceable effect mutexes

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -9489,7 +9489,6 @@ MutexI	work boots/fancy boots	none
 MutexI	booze drive button/candy drive button/food drive button	none
 MutexI	baywatch/Counterclockwise Watch/Crimbolex watch/dead guy's memento/dead guy's watch/glow-in-the-dark wristwatch/grandfather watch/imitation nice watch/Sasq&trade; watch/wristwatch of the white knight	none
 
-
 # Mutually exclusive effects section of modifiers.txt
 # Same as above
 MutexE	Shrieking Weasel/Power, Man/Lucky Struck/Ministrations in the Dark/Superdrifting	none
@@ -9498,12 +9497,14 @@ MutexE	Purple Tongue/Green Tongue/Orange Tongue/Red Tongue/Blue Tongue/Black Ton
 MutexE	Broken Heart/Fiery Heart/Cold Hearted/Sweet Heart/Withered Heart/Lustful Heart	none
 
 # While the groups below are mutex, replacing one effect with another is easy enough that other effects should be suggested anyway
-# MutexE	Snarl of the Timberwolf/Scowl of the Auk/Stiff Upper Lip/Patient Smile/Arched Eyebrow of the Archmage/Wizard Squint/Icy Glare/Wry Smile/Disco Leer/Disco Smirk/Suspicious Gaze/Knowing Smile	none
-# MutexE	Cautious Prowl/Prideful Strut/Leisurely Amblin'	none
-# MutexE	Pompadour/Cowlick/Fauxhawk/[1553]Slicked-Back Do	none
-# MutexE	Coffeesphere/Oilsphere/Chocolatesphere/Gristlesphere	none
-# MutexE	Song of Accompaniment/Song of Cockiness/Song of Fortune	none
-# MutexE	Spirit of Bacon Grease/Spirit of Cayenne/Spirit of Garlic/Spirit of Peppermint/Spirit of Wormwood	none
+MutexER	Snarl of the Timberwolf/Scowl of the Auk/Stiff Upper Lip/Patient Smile/Quiet Determination/Arched Eyebrow of the Archmage/Wizard Squint/Quiet Judgement/Icy Glare/Wry Smile/Disco Leer/Disco Smirk/Suspicious Gaze/Knowing Smile/Quiet Desperation/Inscrutable Gaze	none
+MutexER	Cautious Prowl/Prideful Strut/Leisurely Amblin'	none
+MutexER	Pompadour/Cowlick/Fauxhawk/[1553]Slicked-Back Do	none
+MutexER	Coffeesphere/Oilsphere/Chocolatesphere/Gristlesphere	none
+MutexER	Song of Accompaniment/Song of Cockiness/Song of Fortune/Song of Solitude/Song of Battle	none
+MutexER	Spirit of Bacon Grease/Spirit of Cayenne/Spirit of Garlic/Spirit of Peppermint/Spirit of Wormwood	none
+MutexER	Song of the North/Song of Slowness/Song of Starch/Song of Sauce/Song of Bravado	none
+MutexER	Let's Beat Up This Drunken Sailor/I'm Smarter Than a Drunken Sailor/Look At That Drunken Sailor Dance/Who's Going to Pay This Drunken Sailor?/Only Dogs Love a Drunken Sailor	none
 
 # Maximization categories section of modifiers.txt
 # These pseudo-items list the indirect benefits of certain classes of

--- a/src/net/sourceforge/kolmafia/ModifierType.java
+++ b/src/net/sourceforge/kolmafia/ModifierType.java
@@ -66,6 +66,7 @@ public enum ModifierType {
   MUTEX_GENERIC,
   MUTEX_I,
   MUTEX_E,
+  MUTEX_ER,
   PASSIVES,
   GENERATED,
   TERRARIUM_FAMILIAR,

--- a/src/net/sourceforge/kolmafia/Speculation.java
+++ b/src/net/sourceforge/kolmafia/Speculation.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -132,6 +133,12 @@ public class Speculation {
 
   public void addEffect(AdventureResult effect) {
     if (!this.effects.contains(effect)) {
+      Collection<AdventureResult> replaceableMutex =
+          ModifierDatabase.getReplaceableMutexFor(effect);
+      if (!replaceableMutex.isEmpty()) {
+        this.effects.removeAll(replaceableMutex);
+      }
+
       this.effects.add(effect);
     }
   }

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -44,6 +44,7 @@ import net.sourceforge.kolmafia.modifiers.Modifier;
 import net.sourceforge.kolmafia.modifiers.ModifierList;
 import net.sourceforge.kolmafia.modifiers.ModifierList.ModifierValue;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
+import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase.Element;
@@ -71,6 +72,10 @@ public class ModifierDatabase {
 
   /** List of slash-separated members of a mutex */
   private static final List<String> mutexes = new ArrayList<>();
+
+  /** Cache for which effects are automatically replaced when gaining another effect. */
+  private static final Map<AdventureResult, Collection<AdventureResult>> replaceableMutexEffects =
+      new HashMap<>();
 
   private static final HashSet<String> numericModifiers = new HashSet<>();
 
@@ -287,6 +292,19 @@ public class ModifierDatabase {
   // Returned set yields bitmaps keyed by names
   public static Set<Entry<String, Integer>> getSynergies() {
     return Collections.unmodifiableSet(synergies.entrySet());
+  }
+
+  public static Collection<AdventureResult> getReplaceableMutexFor(AdventureResult effect) {
+    if (!effect.isStatusEffect()) {
+      return Collections.emptyList();
+    }
+
+    Collection<AdventureResult> rv = replaceableMutexEffects.get(effect);
+    if (rv == null) {
+      return Collections.emptyList();
+    } else {
+      return rv;
+    }
   }
 
   // region: utility functions
@@ -1735,6 +1753,31 @@ public class ModifierDatabase {
     }
   }
 
+  private static void computeReplaceableEffectMutex(String name) {
+    String[] pieces = name.split("/");
+    if (pieces.length < 2) {
+      KoLmafia.updateDisplay(name + " contain less than 2 elements.");
+      return;
+    }
+    Set<AdventureResult> effects =
+        Arrays.stream(pieces)
+            .map(EffectDatabase::getEffectId)
+            .map(EffectPool::get)
+            .collect(Collectors.toUnmodifiableSet());
+    for (AdventureResult effect : effects) {
+      replaceableMutexEffects.put(effect, effects);
+    }
+  }
+
+  private static void computeReplaceableEffectMutexes() {
+    replaceableMutexEffects.clear();
+    for (IntOrString key : modifierStringsByName.getAll(ModifierType.MUTEX_ER).keySet()) {
+      if (!key.isString()) continue;
+      String name = key.getStringValue();
+      computeReplaceableEffectMutex(name);
+    }
+  }
+
   public static void resetModifiers() {
     // Don't reset any variables that are set up by loadAllModifiers, as subsequent calls to
     // resetModifiers then won't set them back up due to the if() guarding loadAllModifiers.
@@ -1750,5 +1793,6 @@ public class ModifierDatabase {
 
     computeSynergies();
     computeMutexes();
+    computeReplaceableEffectMutexes();
   }
 }

--- a/test/internal/matchers/Maximizer.java
+++ b/test/internal/matchers/Maximizer.java
@@ -26,6 +26,21 @@ public class Maximizer {
     };
   }
 
+  public static Matcher<Boost> recommendsEffect(String effectName) {
+    return new TypeSafeMatcher<>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("effect " + effectName);
+      }
+
+      @Override
+      protected boolean matchesSafely(Boost boost) {
+        AdventureResult item = boost.getItem();
+        return item.isStatusEffect() && equalsItem(effectName, item);
+      }
+    };
+  }
+
   public static Matcher<Boost> recommends(int itemId) {
     return new TypeSafeMatcher<>() {
       @Override

--- a/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
@@ -501,7 +501,7 @@ public class DataFileConsistencyTest {
                 }
               }
             }
-            case "MutexE" -> {
+            case "MutexE", "MutexER" -> {
               assertThat(name, containsString("/"));
               for (var effect : name.split("/")) {
                 var id = EffectDatabase.getEffectId(effect, true);

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -20,6 +20,7 @@ import static internal.helpers.Player.withItemInStorage;
 import static internal.helpers.Player.withLocation;
 import static internal.helpers.Player.withMCD;
 import static internal.helpers.Player.withMeat;
+import static internal.helpers.Player.withMoxie;
 import static internal.helpers.Player.withMuscle;
 import static internal.helpers.Player.withNotAllowedInStandard;
 import static internal.helpers.Player.withOverrideModifiers;
@@ -30,6 +31,7 @@ import static internal.helpers.Player.withSign;
 import static internal.helpers.Player.withSkill;
 import static internal.helpers.Player.withStats;
 import static internal.matchers.Maximizer.recommends;
+import static internal.matchers.Maximizer.recommendsEffect;
 import static internal.matchers.Maximizer.recommendsSlot;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -1161,6 +1163,74 @@ public class MaximizerTest {
         assertThat(getBoosts(), hasItem(recommendsSlot(Slot.ACCESSORY1, "time halo")));
         assertThat(getBoosts(), not(hasItem(recommendsSlot(Slot.ACCESSORY2))));
         assertThat(getBoosts(), not(hasItem(recommendsSlot(Slot.ACCESSORY3))));
+      }
+    }
+  }
+
+  @Nested
+  class ReplaceableMutex {
+    @Test
+    public void suggestBetterFacialExpression() {
+      var cleanups =
+          new Cleanups(
+              withMoxie(100),
+              withEffect("Disco Smirk"),
+              withSkill("Disco Smirk"),
+              withSkill("Quiet Desperation"));
+
+      try (cleanups) {
+        assertTrue(maximize("moxie"));
+
+        assertThat(getBoosts(), hasItem(recommendsEffect("Quiet Desperation")));
+      }
+    }
+
+    @Test
+    public void doNotSuggestWorseFacialExpression() {
+      var cleanups =
+          new Cleanups(
+              withMoxie(100),
+              withEffect("Quiet Desperation"),
+              withSkill("Disco Smirk"),
+              withSkill("Quiet Desperation"));
+
+      try (cleanups) {
+        assertTrue(maximize("moxie"));
+
+        assertThat(getBoosts(), not(hasItem(recommendsEffect("Disco Smirk"))));
+      }
+    }
+
+    @Test
+    public void suggestBetterShanty() {
+      var cleanups =
+          new Cleanups(
+              withFamiliar(FamiliarPool.BABY_GRAVY_FAIRY, 400),
+              withEffect("Only Dogs Love a Drunken Sailor"),
+              withSkill("Only Dogs Love a Drunken Sailor"),
+              withSkill("Who's Going to Pay This Drunken Sailor?"));
+
+      try (cleanups) {
+        assertTrue(maximize("item"));
+
+        assertThat(
+            getBoosts(), hasItem(recommendsEffect("Who's Going to Pay This Drunken Sailor?")));
+      }
+    }
+
+    @Test
+    public void doNotSuggestWorseShanty() {
+      var cleanups =
+          new Cleanups(
+              withFamiliar(FamiliarPool.BABY_GRAVY_FAIRY, 400),
+              withEffect("Who's Going to Pay This Drunken Sailor?"),
+              withSkill("Only Dogs Love a Drunken Sailor"),
+              withSkill("Who's Going to Pay This Drunken Sailor?"));
+
+      try (cleanups) {
+        assertTrue(maximize("item"));
+
+        assertThat(getBoosts(), not(hasItem(recommendsEffect("Only Dogs Love a Drunken Sailor"))));
       }
     }
   }


### PR DESCRIPTION
I took a stab at implementing something for the request in: https://kolmafia.us/threads/request-support-for-mutually-exclusive-buffs-in-maximizer.32504/

When speculating about casting a skill, consider not only the added effect from the skill but also the loss of any existing replaceable mutually-exclusive effects.

Looking for some feedback on the following:

- Is the implementation within `ModifierDatabase` okay? I opted to directly cache the set of effects that are removed when casting a skill for quick lookup, but am open to feedback on whether there's any better mechanism for doing this directly in mafia already.
- The names `MutexER` and "replaceable effect mutex" are both sort of terrible.
- This change is technically not completely correct: there are a few replaceable effect mutex groups whose effects are *wishable* and wishing for one of the effect *doesn't* remove the other effects in its mutex group. (For example, you can get both Coffeesphere and Oilsphere by having one and wishing for the other.) 
  - This... probably won't come up much--neither the Dread songs nor the Crimbo shanties are wishable, and it seems a bit unlikely anyone would be interested in wishing in order to get multiple effects from the other groups. And it seems even less likely that both effects would actually be relevant to whatever maximizer string is being queried.