### PR TITLE
feat: make effect database more like monster / consumables database

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -1774,7 +1774,7 @@ public class DebugDatabase {
   private static void checkEffects(final PrintStream report) {
     Set<Integer> keys =
         EffectDatabase.allEffects().stream()
-            .filter(entry -> entry.getValue().descriptionId != null)
+            .filter(entry -> entry.getValue().getDescriptionId() != null)
             .map(Entry::getKey)
             .collect(Collectors.toSet());
 

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -1772,7 +1772,10 @@ public class DebugDatabase {
   }
 
   private static void checkEffects(final PrintStream report) {
-    Set<Integer> keys = EffectDatabase.descriptionIdKeySet();
+    Set<Integer> keys = EffectDatabase.allEffects().stream()
+      .filter(entry -> entry.getValue().descriptionId != null)
+      .map(Entry::getKey)
+      .collect(Collectors.toSet());
 
     for (Integer key : keys) {
       int id = key;

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -1772,10 +1772,11 @@ public class DebugDatabase {
   }
 
   private static void checkEffects(final PrintStream report) {
-    Set<Integer> keys = EffectDatabase.allEffects().stream()
-      .filter(entry -> entry.getValue().descriptionId != null)
-      .map(Entry::getKey)
-      .collect(Collectors.toSet());
+    Set<Integer> keys =
+        EffectDatabase.allEffects().stream()
+            .filter(entry -> entry.getValue().descriptionId != null)
+            .map(Entry::getKey)
+            .collect(Collectors.toSet());
 
     for (Integer key : keys) {
       int id = key;

--- a/src/net/sourceforge/kolmafia/persistence/EffectData.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectData.java
@@ -5,9 +5,8 @@ import java.util.List;
 
 public final class EffectData {
   public enum Quality {
-    UNKNOWN(""),
-    GOOD("good"),
     NEUTRAL("neutral"),
+    GOOD("good"),
     BAD("bad");
 
     private final String description;

--- a/src/net/sourceforge/kolmafia/persistence/EffectData.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectData.java
@@ -9,7 +9,7 @@ public final class EffectData {
   public String descriptionId;
   public int quality;
   public List<String> attributes;
-  public String defaultAction;
+  public String actions;
 
   public void setQuality(final String quality) {
     this.quality = parseQuality(quality);
@@ -48,8 +48,8 @@ public final class EffectData {
     String effectString =
       effectId + "\t" + name + "\t" + image + "\t" + descriptionId + "\t" + getQualityDescription() + "\t" + attrs;
 
-    if (defaultAction != null) {
-      effectString += "\t" + defaultAction;
+    if (actions != null) {
+      effectString += "\t" + actions;
     }
 
     return effectString;

--- a/src/net/sourceforge/kolmafia/persistence/EffectData.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectData.java
@@ -1,0 +1,11 @@
+package net.sourceforge.kolmafia.persistence;
+
+import java.util.List;
+
+public final class EffectData {
+  public String image;
+  public String descriptionId;
+  public int quality;
+  public List<String> attributes;
+  public String defaultAction;
+}

--- a/src/net/sourceforge/kolmafia/persistence/EffectData.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectData.java
@@ -46,7 +46,17 @@ public final class EffectData {
     String attrs = (attributes == null) ? "none" : String.join(",", attributes);
 
     String effectString =
-      effectId + "\t" + name + "\t" + image + "\t" + descriptionId + "\t" + getQualityDescription() + "\t" + attrs;
+        effectId
+            + "\t"
+            + name
+            + "\t"
+            + image
+            + "\t"
+            + descriptionId
+            + "\t"
+            + getQualityDescription()
+            + "\t"
+            + attrs;
 
     if (actions != null) {
       effectString += "\t" + actions;

--- a/src/net/sourceforge/kolmafia/persistence/EffectData.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectData.java
@@ -36,44 +36,61 @@ public final class EffectData {
   private List<String> attributes = new LinkedList<>();
   private String actions;
 
-  public int getEffectId() {
-    return this.effectId;
+  public EffectData() {}
+
+  public EffectData(
+      final int effectId,
+      final String name,
+      final String image,
+      final String descriptionId,
+      final String quality,
+      final List<String> attributes,
+      final String actions) {
+    this(
+        effectId,
+        name,
+        image,
+        descriptionId,
+        Quality.fromDescription(quality),
+        attributes,
+        actions);
   }
 
-  public void setEffectId(final int effectId) {
+  public EffectData(
+      final int effectId,
+      final String name,
+      final String image,
+      final String descriptionId,
+      final Quality quality,
+      final List<String> attributes,
+      final String actions) {
     this.effectId = effectId;
+    this.name = name;
+    this.image = image;
+    this.descriptionId = descriptionId;
+    this.quality = quality;
+    this.attributes = attributes;
+    this.actions = actions;
+  }
+
+  public int getEffectId() {
+    return this.effectId;
   }
 
   public String getName() {
     return this.name;
   }
 
-  public void setName(final String name) {
-    this.name = name;
-  }
-
   public String getImage() {
     return this.image;
-  }
-
-  public void setImage(final String image) {
-    this.image = image;
   }
 
   public String getDescriptionId() {
     return this.descriptionId;
   }
 
-  public void setDescriptionId(final String descriptionId) {
-    this.descriptionId = descriptionId;
-  }
-
   public Quality getQuality() {
     return this.quality;
-  }
-
-  public void setQuality(final Quality quality) {
-    this.quality = quality;
   }
 
   public List<String> getAttributes() {
@@ -90,10 +107,6 @@ public final class EffectData {
 
   public void setActions(final String actions) {
     this.actions = actions;
-  }
-
-  public void setQuality(final String quality) {
-    this.quality = Quality.fromDescription(quality);
   }
 
   public String getQualityDescription() {

--- a/src/net/sourceforge/kolmafia/persistence/EffectData.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectData.java
@@ -119,7 +119,7 @@ public final class EffectData {
     String image = this.image == null ? "" : this.image;
     String descriptionId = this.descriptionId == null ? "" : this.descriptionId;
 
-    String attrs = (attributes == null) ? "none" : String.join(",", attributes);
+    String attrs = (attributes == null || attributes.isEmpty()) ? "none" : String.join(",", attributes);
 
     String effectString =
         effectId

--- a/src/net/sourceforge/kolmafia/persistence/EffectData.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectData.java
@@ -3,11 +3,55 @@ package net.sourceforge.kolmafia.persistence;
 import java.util.List;
 
 public final class EffectData {
-  public int itemId;
+  public int effectId;
   public String name;
   public String image;
   public String descriptionId;
   public int quality;
   public List<String> attributes;
   public String defaultAction;
+
+  public void setQuality(final String quality) {
+    this.quality = parseQuality(quality);
+  }
+
+  private int parseQuality(final String quality) {
+    return switch (quality) {
+      case "good" -> EffectDatabase.GOOD;
+      case "bad" -> EffectDatabase.BAD;
+      default -> EffectDatabase.NEUTRAL;
+    };
+  }
+
+  public String getQualityDescription() {
+    return switch (quality) {
+      case EffectDatabase.GOOD -> "good";
+      case EffectDatabase.BAD -> "bad";
+      case EffectDatabase.NEUTRAL -> "neutral";
+      default -> "";
+    };
+  }
+
+  public String toString() {
+    // The effect file can have 3, 4, or 5 fields. "image" must be
+    // present, even if we don't have the actual file name.
+    if (image == null) {
+      image = "";
+    }
+
+    if (descriptionId == null) {
+      descriptionId = "";
+    }
+
+    String attrs = (attributes == null) ? "none" : String.join(",", attributes);
+
+    String effectString =
+      effectId + "\t" + name + "\t" + image + "\t" + descriptionId + "\t" + getQualityDescription() + "\t" + attrs;
+
+    if (defaultAction != null) {
+      effectString += "\t" + defaultAction;
+    }
+
+    return effectString;
+  }
 }

--- a/src/net/sourceforge/kolmafia/persistence/EffectData.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectData.java
@@ -119,7 +119,8 @@ public final class EffectData {
     String image = this.image == null ? "" : this.image;
     String descriptionId = this.descriptionId == null ? "" : this.descriptionId;
 
-    String attrs = (attributes == null || attributes.isEmpty()) ? "none" : String.join(",", attributes);
+    String attrs =
+        (attributes == null || attributes.isEmpty()) ? "none" : String.join(",", attributes);
 
     String effectString =
         effectId

--- a/src/net/sourceforge/kolmafia/persistence/EffectData.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectData.java
@@ -3,6 +3,8 @@ package net.sourceforge.kolmafia.persistence;
 import java.util.List;
 
 public final class EffectData {
+  public int itemId;
+  public String name;
   public String image;
   public String descriptionId;
   public int quality;

--- a/src/net/sourceforge/kolmafia/persistence/EffectData.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectData.java
@@ -47,13 +47,8 @@ public final class EffectData {
   public String toString() {
     // The effect file can have 3, 4, or 5 fields. "image" must be
     // present, even if we don't have the actual file name.
-    if (image == null) {
-      image = "";
-    }
-
-    if (descriptionId == null) {
-      descriptionId = "";
-    }
+    String image = this.image == null ? "" : this.image;
+    String descriptionId = this.descriptionId == null ? "" : this.descriptionId;
 
     String attrs = (attributes == null) ? "none" : String.join(",", attributes);
 

--- a/src/net/sourceforge/kolmafia/persistence/EffectData.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectData.java
@@ -28,13 +28,69 @@ public final class EffectData {
     }
   }
 
-  public int effectId;
-  public String name;
-  public String image;
-  public String descriptionId;
-  public Quality quality = Quality.NEUTRAL;
-  public List<String> attributes = new LinkedList<>();
-  public String actions;
+  private int effectId;
+  private String name;
+  private String image;
+  private String descriptionId;
+  private Quality quality = Quality.NEUTRAL;
+  private List<String> attributes = new LinkedList<>();
+  private String actions;
+
+  public int getEffectId() {
+    return this.effectId;
+  }
+
+  public void setEffectId(final int effectId) {
+    this.effectId = effectId;
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getImage() {
+    return this.image;
+  }
+
+  public void setImage(final String image) {
+    this.image = image;
+  }
+
+  public String getDescriptionId() {
+    return this.descriptionId;
+  }
+
+  public void setDescriptionId(final String descriptionId) {
+    this.descriptionId = descriptionId;
+  }
+
+  public Quality getQuality() {
+    return this.quality;
+  }
+
+  public void setQuality(final Quality quality) {
+    this.quality = quality;
+  }
+
+  public List<String> getAttributes() {
+    return this.attributes;
+  }
+
+  public void setAttributes(final List<String> attributes) {
+    this.attributes = attributes;
+  }
+
+  public String getActions() {
+    return this.actions;
+  }
+
+  public void setActions(final String actions) {
+    this.actions = actions;
+  }
 
   public void setQuality(final String quality) {
     this.quality = Quality.fromDescription(quality);

--- a/src/net/sourceforge/kolmafia/persistence/EffectData.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectData.java
@@ -1,35 +1,48 @@
 package net.sourceforge.kolmafia.persistence;
 
+import java.util.LinkedList;
 import java.util.List;
 
 public final class EffectData {
+  public enum Quality {
+    UNKNOWN(""),
+    GOOD("good"),
+    NEUTRAL("neutral"),
+    BAD("bad");
+
+    private final String description;
+
+    Quality(final String description) {
+      this.description = description;
+    }
+
+    public String description() {
+      return this.description;
+    }
+
+    public static Quality fromDescription(final String description) {
+      return switch (description) {
+        case "good" -> GOOD;
+        case "bad" -> BAD;
+        default -> NEUTRAL;
+      };
+    }
+  }
+
   public int effectId;
   public String name;
   public String image;
   public String descriptionId;
-  public int quality;
-  public List<String> attributes;
+  public Quality quality = Quality.NEUTRAL;
+  public List<String> attributes = new LinkedList<>();
   public String actions;
 
   public void setQuality(final String quality) {
-    this.quality = parseQuality(quality);
-  }
-
-  private int parseQuality(final String quality) {
-    return switch (quality) {
-      case "good" -> EffectDatabase.GOOD;
-      case "bad" -> EffectDatabase.BAD;
-      default -> EffectDatabase.NEUTRAL;
-    };
+    this.quality = Quality.fromDescription(quality);
   }
 
   public String getQualityDescription() {
-    return switch (quality) {
-      case EffectDatabase.GOOD -> "good";
-      case EffectDatabase.BAD -> "bad";
-      case EffectDatabase.NEUTRAL -> "neutral";
-      default -> "";
-    };
+    return this.quality.description();
   }
 
   public String toString() {

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -133,6 +133,8 @@ public class EffectDatabase {
     EffectDatabase.nameById.put(effectId, name);
     EffectDatabase.addIdToName(canonicalName, effectId);
     EffectData effectData = EffectDatabase.effectDataById.computeIfAbsent(effectId, id -> new EffectData());
+    effectData.itemId = effectId;
+    effectData.name = name;
     effectData.image = image;
     effectData.descriptionId = null;
     effectData.defaultAction = null;
@@ -531,6 +533,8 @@ public class EffectDatabase {
     EffectDatabase.nameById.put(id, name);
     EffectDatabase.addIdToName(canonicalName, id);
     EffectData effectData = EffectDatabase.effectDataById.computeIfAbsent(id, key -> new EffectData());
+    effectData.itemId = id;
+    effectData.name = name;
     effectData.image = image;
     effectData.descriptionId = descId;
     effectData.quality = EffectDatabase.NEUTRAL;

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -34,7 +34,6 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class EffectDatabase {
   private static String[] canonicalNames = new String[0];
-  private static final Map<Integer, String> nameById = new TreeMap<>();
   private static final Map<String, int[]> effectIdSetByName = new TreeMap<>();
   private static final Map<Integer, EffectData> effectDataById = new HashMap<>();
   private static final Map<String, Integer> effectIdByDescription = new HashMap<>();
@@ -113,7 +112,6 @@ public class EffectDatabase {
       final String attributes,
       final String defaultAction) {
     String canonicalName = StringUtilities.getCanonicalName(name);
-    EffectDatabase.nameById.put(effectId, name);
     EffectDatabase.addIdToName(canonicalName, effectId);
     EffectData effectData = EffectDatabase.effectDataById.computeIfAbsent(effectId, id -> new EffectData());
     effectData.effectId = effectId;
@@ -278,7 +276,11 @@ public class EffectDatabase {
    * @return The name of the corresponding effect
    */
   public static final String getEffectName(final int effectId) {
-    return effectId == -1 ? null : EffectDatabase.nameById.get(effectId);
+    if (effectId == -1) {
+      return null;
+    }
+    var effect = EffectDatabase.effectDataById.get(effectId);
+    return effect == null ? null : effect.name;
   }
 
   public static final String getEffectName(final String descriptionId) {
@@ -305,10 +307,6 @@ public class EffectDatabase {
   public static final String getDescriptionId(final int effectId) {
     EffectData effectData = EffectDatabase.effectDataById.get(effectId);
     return effectData == null ? null : effectData.descriptionId;
-  }
-
-  static final Set<Entry<Integer, EffectData>> allEffects() {
-    return EffectDatabase.effectDataById.entrySet();
   }
 
   /**
@@ -431,16 +429,16 @@ public class EffectDatabase {
    *
    * @return The set of status effects keyed by Id
    */
-  public static final Set<Entry<Integer, String>> entrySet() {
-    return EffectDatabase.nameById.entrySet();
+  public static final Set<Entry<Integer, EffectData>> allEffects() {
+    return EffectDatabase.effectDataById.entrySet();
   }
 
-  public static final Collection<String> values() {
-    return EffectDatabase.nameById.values();
+  public static final Collection<EffectData> values() {
+    return EffectDatabase.effectDataById.values();
   }
 
   public static final Set<Integer> keys() {
-    return EffectDatabase.nameById.keySet();
+    return EffectDatabase.effectDataById.keySet();
   }
 
   /**
@@ -461,7 +459,7 @@ public class EffectDatabase {
     if (effectId == -1) {
       return false;
     }
-    return EffectDatabase.nameById.get(effectId) != null;
+    return EffectDatabase.effectDataById.get(effectId) != null;
   }
 
   /**
@@ -512,7 +510,6 @@ public class EffectDatabase {
     String canonicalName = StringUtilities.getCanonicalName(name);
     Integer id = effectId;
 
-    EffectDatabase.nameById.put(id, name);
     EffectDatabase.addIdToName(canonicalName, id);
     EffectData effectData = EffectDatabase.effectDataById.computeIfAbsent(id, key -> new EffectData());
     effectData.effectId = id;
@@ -693,7 +690,8 @@ public class EffectDatabase {
       return "poisoned";
     }
     int effectId = POISON_ID[level];
-    return EffectDatabase.nameById.get(effectId);
+    var effect = EffectDatabase.effectDataById.get(effectId);
+    return effect == null ? null : effect.name;
   }
 
   public static void parseVampireVintnerWineEffect(final String edesc, final int effectId) {

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -109,27 +109,18 @@ public class EffectDatabase {
       final String defaultAction) {
     String canonicalName = StringUtilities.getCanonicalName(name);
     EffectDatabase.addIdToName(canonicalName, effectId);
-    EffectData effectData =
-        EffectDatabase.effectDataById.computeIfAbsent(effectId, id -> new EffectData());
-    effectData.setEffectId(effectId);
-    effectData.setName(name);
-    effectData.setImage(image);
-
+    String knownDescriptionId = null;
     if (descriptionId != null && !descriptionId.equals("")) {
-      effectData.setDescriptionId(descriptionId);
+      knownDescriptionId = descriptionId;
       EffectDatabase.effectIdByDescription.put(descriptionId, effectId);
     }
-
-    effectData.setQuality(quality);
 
     String[] list = StringUtilities.splitByComma(attributes);
     List<String> attrs = new LinkedList<>(Arrays.asList(list));
     attrs.remove("none");
-    effectData.setAttributes(attrs);
-
-    if (defaultAction != null) {
-      effectData.setActions(defaultAction);
-    }
+    EffectData effectData =
+        new EffectData(effectId, name, image, knownDescriptionId, quality, attrs, defaultAction);
+    EffectDatabase.effectDataById.put(effectId, effectData);
   }
 
   public static final EffectData getEffectData(final int effectId) {
@@ -497,15 +488,9 @@ public class EffectDatabase {
 
     EffectDatabase.addIdToName(canonicalName, id);
     EffectData effectData =
-        EffectDatabase.effectDataById.computeIfAbsent(id, key -> new EffectData());
-    effectData.setEffectId(id);
-    effectData.setName(name);
-    effectData.setImage(image);
-    effectData.setDescriptionId(descId);
+        new EffectData(id, name, image, descId, Quality.NEUTRAL, new LinkedList<>(), defaultAction);
+    EffectDatabase.effectDataById.put(id, effectData);
     EffectDatabase.effectIdByDescription.put(descId, id);
-    if (defaultAction != null) {
-      effectData.setActions(defaultAction);
-    }
 
     String printMe;
 

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -51,14 +51,6 @@ public class EffectDatabase {
 
   private EffectDatabase() {}
 
-  private static class EffectData {
-    private String image;
-    private String descriptionId;
-    private int quality;
-    private List<String> attributes;
-    private String defaultAction;
-  }
-
   public static void reset() {
     EffectDatabase.newEffects = false;
 
@@ -331,11 +323,8 @@ public class EffectDatabase {
     return effectData == null ? null : effectData.descriptionId;
   }
 
-  static final Set<Integer> descriptionIdKeySet() {
-    return EffectDatabase.effectDataById.entrySet().stream()
-        .filter(entry -> entry.getValue().descriptionId != null)
-        .map(Entry::getKey)
-        .collect(Collectors.toSet());
+  static final Set<Entry<Integer, EffectData>> allEffects() {
+    return EffectDatabase.effectDataById.entrySet();
   }
 
   /**

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -112,12 +112,12 @@ public class EffectDatabase {
     EffectDatabase.addIdToName(canonicalName, effectId);
     EffectData effectData =
         EffectDatabase.effectDataById.computeIfAbsent(effectId, id -> new EffectData());
-    effectData.effectId = effectId;
-    effectData.name = name;
-    effectData.image = image;
+    effectData.setEffectId(effectId);
+    effectData.setName(name);
+    effectData.setImage(image);
 
     if (descriptionId != null && !descriptionId.equals("")) {
-      effectData.descriptionId = descriptionId;
+      effectData.setDescriptionId(descriptionId);
       EffectDatabase.effectIdByDescription.put(descriptionId, effectId);
     }
 
@@ -126,10 +126,10 @@ public class EffectDatabase {
     String[] list = StringUtilities.splitByComma(attributes);
     List<String> attrs = new LinkedList<>(Arrays.asList(list));
     attrs.remove("none");
-    effectData.attributes = attrs;
+    effectData.setAttributes(attrs);
 
     if (defaultAction != null) {
-      effectData.actions = defaultAction;
+      effectData.setActions(defaultAction);
     }
   }
 
@@ -138,7 +138,7 @@ public class EffectDatabase {
       return Quality.NEUTRAL;
     }
     EffectData effectData = EffectDatabase.effectDataById.get(effectId);
-    return effectData == null ? Quality.NEUTRAL : effectData.quality;
+    return effectData == null ? Quality.NEUTRAL : effectData.getQuality();
   }
 
   public static final String getQualityDescription(final int effectId) {
@@ -148,7 +148,7 @@ public class EffectDatabase {
 
   public static final List<String> getEffectAttributes(final int effectId) {
     EffectData effectData = EffectDatabase.effectDataById.get(effectId);
-    return effectData == null ? null : effectData.attributes;
+    return effectData == null ? null : effectData.getAttributes();
   }
 
   public static final boolean hasAttribute(final String name, final String attribute) {
@@ -237,7 +237,7 @@ public class EffectDatabase {
 
   public static final String getActions(final Integer effectId) {
     EffectData effectData = EffectDatabase.effectDataById.get(effectId);
-    return effectData == null ? null : effectData.actions;
+    return effectData == null ? null : effectData.getActions();
   }
 
   public static final void setActions(final int effectId, final String actions) {
@@ -247,13 +247,13 @@ public class EffectDatabase {
   public static final void setActions(final Integer effectId, final String actions) {
     EffectData effectData =
         EffectDatabase.effectDataById.computeIfAbsent(effectId, id -> new EffectData());
-    effectData.actions = actions;
+    effectData.setActions(actions);
   }
 
   public static final Set<Entry<Integer, String>> actionEntrySet() {
     return EffectDatabase.effectDataById.entrySet().stream()
-        .filter(entry -> entry.getValue().actions != null)
-        .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().actions))
+        .filter(entry -> entry.getValue().getActions() != null)
+        .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().getActions()))
         .entrySet();
   }
 
@@ -279,7 +279,7 @@ public class EffectDatabase {
       return null;
     }
     var effect = EffectDatabase.effectDataById.get(effectId);
-    return effect == null ? null : effect.name;
+    return effect == null ? null : effect.getName();
   }
 
   public static final String getEffectName(final String descriptionId) {
@@ -305,7 +305,7 @@ public class EffectDatabase {
 
   public static final String getDescriptionId(final int effectId) {
     EffectData effectData = EffectDatabase.effectDataById.get(effectId);
-    return effectData == null ? null : effectData.descriptionId;
+    return effectData == null ? null : effectData.getDescriptionId();
   }
 
   /**
@@ -412,7 +412,7 @@ public class EffectDatabase {
    */
   public static final String getImageName(final int effectId) {
     EffectData effectData = effectId == -1 ? null : EffectDatabase.effectDataById.get(effectId);
-    String imageName = effectData == null ? null : effectData.image;
+    String imageName = effectData == null ? null : effectData.getImage();
     return imageName == null ? "" : imageName;
   }
 
@@ -512,13 +512,13 @@ public class EffectDatabase {
     EffectDatabase.addIdToName(canonicalName, id);
     EffectData effectData =
         EffectDatabase.effectDataById.computeIfAbsent(id, key -> new EffectData());
-    effectData.effectId = id;
-    effectData.name = name;
-    effectData.image = image;
-    effectData.descriptionId = descId;
+    effectData.setEffectId(id);
+    effectData.setName(name);
+    effectData.setImage(image);
+    effectData.setDescriptionId(descId);
     EffectDatabase.effectIdByDescription.put(descId, id);
     if (defaultAction != null) {
-      effectData.actions = defaultAction;
+      effectData.setActions(defaultAction);
     }
 
     String printMe;
@@ -687,7 +687,7 @@ public class EffectDatabase {
     }
     int effectId = POISON_ID[level];
     var effect = EffectDatabase.effectDataById.get(effectId);
-    return effect == null ? null : effect.name;
+    return effect == null ? null : effect.getName();
   }
 
   public static void parseVampireVintnerWineEffect(final String edesc, final int effectId) {

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -113,7 +113,8 @@ public class EffectDatabase {
       final String defaultAction) {
     String canonicalName = StringUtilities.getCanonicalName(name);
     EffectDatabase.addIdToName(canonicalName, effectId);
-    EffectData effectData = EffectDatabase.effectDataById.computeIfAbsent(effectId, id -> new EffectData());
+    EffectData effectData =
+        EffectDatabase.effectDataById.computeIfAbsent(effectId, id -> new EffectData());
     effectData.effectId = effectId;
     effectData.name = name;
     effectData.image = image;
@@ -247,7 +248,8 @@ public class EffectDatabase {
   }
 
   public static final void setActions(final Integer effectId, final String actions) {
-    EffectData effectData = EffectDatabase.effectDataById.computeIfAbsent(effectId, id -> new EffectData());
+    EffectData effectData =
+        EffectDatabase.effectDataById.computeIfAbsent(effectId, id -> new EffectData());
     effectData.actions = actions;
   }
 
@@ -511,7 +513,8 @@ public class EffectDatabase {
     Integer id = effectId;
 
     EffectDatabase.addIdToName(canonicalName, id);
-    EffectData effectData = EffectDatabase.effectDataById.computeIfAbsent(id, key -> new EffectData());
+    EffectData effectData =
+        EffectDatabase.effectDataById.computeIfAbsent(id, key -> new EffectData());
     effectData.effectId = id;
     effectData.name = name;
     effectData.image = image;
@@ -575,9 +578,7 @@ public class EffectDatabase {
     writer.close();
   }
 
-  private static void writeEffect(
-      final PrintStream writer,
-      final EffectData data) {
+  private static void writeEffect(final PrintStream writer, final EffectData data) {
     writer.println(data.toString());
   }
 

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -104,23 +104,6 @@ public class EffectDatabase {
     EffectDatabase.effectIdSetByName.put(canonicalName, newSet);
   }
 
-  private static int parseQuality(final String quality) {
-    return switch (quality) {
-      case "good" -> EffectDatabase.GOOD;
-      case "bad" -> EffectDatabase.BAD;
-      default -> EffectDatabase.NEUTRAL;
-    };
-  }
-
-  private static String describeQuality(final Integer quality) {
-    return switch (quality) {
-      case EffectDatabase.GOOD -> "good";
-      case EffectDatabase.BAD -> "bad";
-      case EffectDatabase.NEUTRAL -> "neutral";
-      default -> "";
-    };
-  }
-
   private static void addToDatabase(
       final Integer effectId,
       final String name,
@@ -133,18 +116,16 @@ public class EffectDatabase {
     EffectDatabase.nameById.put(effectId, name);
     EffectDatabase.addIdToName(canonicalName, effectId);
     EffectData effectData = EffectDatabase.effectDataById.computeIfAbsent(effectId, id -> new EffectData());
-    effectData.itemId = effectId;
+    effectData.effectId = effectId;
     effectData.name = name;
     effectData.image = image;
-    effectData.descriptionId = null;
-    effectData.defaultAction = null;
 
     if (descriptionId != null && !descriptionId.equals("")) {
       effectData.descriptionId = descriptionId;
       EffectDatabase.effectIdByDescription.put(descriptionId, effectId);
     }
 
-    effectData.quality = EffectDatabase.parseQuality(quality);
+    effectData.setQuality(quality);
 
     String[] list = StringUtilities.splitByComma(attributes);
     List<String> attrs = new LinkedList<>(Arrays.asList(list));
@@ -165,7 +146,8 @@ public class EffectDatabase {
   }
 
   public static final String getQualityDescription(final int effectId) {
-    return EffectDatabase.describeQuality(EffectDatabase.getQuality(effectId));
+    EffectData effectData = EffectDatabase.effectDataById.get(effectId);
+    return effectData == null ? "" : effectData.getQualityDescription();
   }
 
   public static final List<String> getEffectAttributes(final int effectId) {
@@ -533,12 +515,13 @@ public class EffectDatabase {
     EffectDatabase.nameById.put(id, name);
     EffectDatabase.addIdToName(canonicalName, id);
     EffectData effectData = EffectDatabase.effectDataById.computeIfAbsent(id, key -> new EffectData());
-    effectData.itemId = id;
+    effectData.effectId = id;
     effectData.name = name;
     effectData.image = image;
     effectData.descriptionId = descId;
-    effectData.quality = EffectDatabase.NEUTRAL;
     EffectDatabase.effectIdByDescription.put(descId, id);
+    effectData.quality = EffectDatabase.NEUTRAL;
+    effectData.attributes = new LinkedList<>();
     if (defaultAction != null) {
       effectData.defaultAction = defaultAction;
     }
@@ -549,15 +532,7 @@ public class EffectDatabase {
     RequestLogger.printLine(printMe);
     RequestLogger.updateSessionLog(printMe);
 
-    printMe =
-        EffectDatabase.effectString(
-            effectId,
-            name,
-            image,
-            descId,
-            EffectDatabase.describeQuality(EffectDatabase.NEUTRAL),
-            "none",
-            defaultAction);
+    printMe = effectData.toString();
     RequestLogger.printLine(printMe);
     RequestLogger.updateSessionLog(printMe);
 
@@ -581,7 +556,7 @@ public class EffectDatabase {
 
     int lastInteger = 1;
 
-    for (Entry<Integer, String> entry : EffectDatabase.nameById.entrySet()) {
+    for (Entry<Integer, EffectData> entry : EffectDatabase.allEffects()) {
       Integer nextInteger = entry.getKey();
       int effectId = nextInteger.intValue();
 
@@ -596,19 +571,8 @@ public class EffectDatabase {
 
       lastInteger = effectId + 1;
 
-      List<String> attributes = EffectDatabase.getEffectAttributes(nextInteger);
-
-      String name = entry.getValue();
-      EffectData effectData = EffectDatabase.effectDataById.get(nextInteger);
-      String image = effectData == null ? null : effectData.image;
-      String descId = effectData == null ? null : effectData.descriptionId;
-      String quality =
-          EffectDatabase.describeQuality(effectData == null ? EffectDatabase.NEUTRAL : effectData.quality);
-      String attributesString = (attributes == null) ? "none" : String.join(",", attributes);
-
-      String defaultAction = effectData == null ? null : effectData.defaultAction;
-      EffectDatabase.writeEffect(
-          writer, effectId, name, image, descId, quality, attributesString, defaultAction);
+      EffectData effectData = entry.getValue();
+      EffectDatabase.writeEffect(writer, effectData);
     }
 
     writer.close();
@@ -616,44 +580,8 @@ public class EffectDatabase {
 
   private static void writeEffect(
       final PrintStream writer,
-      final int effectId,
-      final String name,
-      final String image,
-      final String descId,
-      final String quality,
-      final String attributes,
-      final String defaultAction) {
-    writer.println(
-        EffectDatabase.effectString(
-            effectId, name, image, descId, quality, attributes, defaultAction));
-  }
-
-  private static String effectString(
-      final int effectId,
-      final String name,
-      String image,
-      String descId,
-      final String quality,
-      final String attributes,
-      final String defaultAction) {
-    // The effect file can have 3, 4, or 5 fields. "image" must be
-    // present, even if we don't have the actual file name.
-    if (image == null) {
-      image = "";
-    }
-
-    if (descId == null) {
-      descId = "";
-    }
-
-    String effectString =
-        effectId + "\t" + name + "\t" + image + "\t" + descId + "\t" + quality + "\t" + attributes;
-
-    if (defaultAction != null) {
-      effectString += "\t" + defaultAction;
-    }
-
-    return effectString;
+      final EffectData data) {
+    writer.println(data.toString());
   }
 
   /**

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -25,6 +25,7 @@ import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
+import net.sourceforge.kolmafia.persistence.EffectData.Quality;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.textui.command.UseItemCommand;
 import net.sourceforge.kolmafia.textui.command.UseSkillCommand;
@@ -132,12 +133,12 @@ public class EffectDatabase {
     }
   }
 
-  public static final EffectData.Quality getQuality(final int effectId) {
+  public static final Quality getQuality(final int effectId) {
     if (effectId == -1) {
-      return EffectData.Quality.UNKNOWN;
+      return Quality.NEUTRAL;
     }
     EffectData effectData = EffectDatabase.effectDataById.get(effectId);
-    return effectData == null ? EffectData.Quality.UNKNOWN : effectData.quality;
+    return effectData == null ? Quality.NEUTRAL : effectData.quality;
   }
 
   public static final String getQualityDescription(final int effectId) {

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -132,6 +132,10 @@ public class EffectDatabase {
     }
   }
 
+  public static final EffectData getEffectData(final int effectId) {
+    return EffectDatabase.effectDataById.get(effectId);
+  }
+
   public static final Quality getQuality(final int effectId) {
     if (effectId == -1) {
       return Quality.NEUTRAL;
@@ -237,16 +241,6 @@ public class EffectDatabase {
   public static final String getActions(final Integer effectId) {
     EffectData effectData = EffectDatabase.effectDataById.get(effectId);
     return effectData == null ? null : effectData.getActions();
-  }
-
-  public static final void setActions(final int effectId, final String actions) {
-    EffectDatabase.setActions((Integer) effectId, actions);
-  }
-
-  public static final void setActions(final Integer effectId, final String actions) {
-    EffectData effectData =
-        EffectDatabase.effectDataById.computeIfAbsent(effectId, id -> new EffectData());
-    effectData.setActions(actions);
   }
 
   public static final String getActionNote(final int effectId) {

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
@@ -248,13 +247,6 @@ public class EffectDatabase {
     EffectData effectData =
         EffectDatabase.effectDataById.computeIfAbsent(effectId, id -> new EffectData());
     effectData.setActions(actions);
-  }
-
-  public static final Set<Entry<Integer, String>> actionEntrySet() {
-    return EffectDatabase.effectDataById.entrySet().stream()
-        .filter(entry -> entry.getValue().getActions() != null)
-        .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().getActions()))
-        .entrySet();
   }
 
   public static final String getActionNote(final int effectId) {

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -40,10 +40,6 @@ public class EffectDatabase {
 
   public static boolean newEffects = false;
 
-  public static final int GOOD = 0;
-  public static final int NEUTRAL = 1;
-  public static final int BAD = 2;
-
   static {
     EffectDatabase.reset();
   }
@@ -136,12 +132,12 @@ public class EffectDatabase {
     }
   }
 
-  public static final int getQuality(final int effectId) {
+  public static final EffectData.Quality getQuality(final int effectId) {
     if (effectId == -1) {
-      return -1;
+      return EffectData.Quality.UNKNOWN;
     }
     EffectData effectData = EffectDatabase.effectDataById.get(effectId);
-    return effectData == null ? -1 : effectData.quality;
+    return effectData == null ? EffectData.Quality.UNKNOWN : effectData.quality;
   }
 
   public static final String getQualityDescription(final int effectId) {
@@ -520,8 +516,6 @@ public class EffectDatabase {
     effectData.image = image;
     effectData.descriptionId = descId;
     EffectDatabase.effectIdByDescription.put(descId, id);
-    effectData.quality = EffectDatabase.NEUTRAL;
-    effectData.attributes = new LinkedList<>();
     if (defaultAction != null) {
       effectData.actions = defaultAction;
     }

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -133,7 +133,7 @@ public class EffectDatabase {
     effectData.attributes = attrs;
 
     if (defaultAction != null) {
-      effectData.defaultAction = defaultAction;
+      effectData.actions = defaultAction;
     }
   }
 
@@ -241,7 +241,7 @@ public class EffectDatabase {
 
   public static final String getActions(final Integer effectId) {
     EffectData effectData = EffectDatabase.effectDataById.get(effectId);
-    return effectData == null ? null : effectData.defaultAction;
+    return effectData == null ? null : effectData.actions;
   }
 
   public static final void setActions(final int effectId, final String actions) {
@@ -250,13 +250,13 @@ public class EffectDatabase {
 
   public static final void setActions(final Integer effectId, final String actions) {
     EffectData effectData = EffectDatabase.effectDataById.computeIfAbsent(effectId, id -> new EffectData());
-    effectData.defaultAction = actions;
+    effectData.actions = actions;
   }
 
   public static final Set<Entry<Integer, String>> actionEntrySet() {
     return EffectDatabase.effectDataById.entrySet().stream()
-        .filter(entry -> entry.getValue().defaultAction != null)
-        .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().defaultAction))
+        .filter(entry -> entry.getValue().actions != null)
+        .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().actions))
         .entrySet();
   }
 
@@ -523,7 +523,7 @@ public class EffectDatabase {
     effectData.quality = EffectDatabase.NEUTRAL;
     effectData.attributes = new LinkedList<>();
     if (defaultAction != null) {
-      effectData.defaultAction = defaultAction;
+      effectData.actions = defaultAction;
     }
 
     String printMe;

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -487,8 +487,20 @@ public class EffectDatabase {
     Integer id = effectId;
 
     EffectDatabase.addIdToName(canonicalName, id);
+    // if defaultAction is null, we want to keep the existing action
+    var existing = EffectDatabase.getEffectData(id);
+    if (existing == null) {
+      existing = new EffectData();
+    }
     EffectData effectData =
-        new EffectData(id, name, image, descId, Quality.NEUTRAL, new LinkedList<>(), defaultAction);
+        new EffectData(
+            id,
+            name,
+            image,
+            descId,
+            Quality.NEUTRAL,
+            existing.getAttributes(),
+            defaultAction == null ? existing.getActions() : defaultAction);
     EffectDatabase.effectDataById.put(id, effectData);
     EffectDatabase.effectIdByDescription.put(descId, id);
 

--- a/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EffectDatabase.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
@@ -35,13 +36,8 @@ public class EffectDatabase {
   private static String[] canonicalNames = new String[0];
   private static final Map<Integer, String> nameById = new TreeMap<>();
   private static final Map<String, int[]> effectIdSetByName = new TreeMap<>();
-  public static final HashMap<Integer, String> defaultActions = new HashMap<>();
-
-  private static final Map<Integer, String> imageById = new HashMap<>();
-  private static final Map<Integer, String> descriptionById = new TreeMap<>();
+  private static final Map<Integer, EffectData> effectDataById = new HashMap<>();
   private static final Map<String, Integer> effectIdByDescription = new HashMap<>();
-  private static final Map<Integer, Integer> qualityById = new HashMap<>();
-  private static final Map<Integer, List<String>> attributesById = new HashMap<>();
 
   public static boolean newEffects = false;
 
@@ -54,6 +50,14 @@ public class EffectDatabase {
   }
 
   private EffectDatabase() {}
+
+  private static class EffectData {
+    private String image;
+    private String descriptionId;
+    private int quality;
+    private List<String> attributes;
+    private String defaultAction;
+  }
 
   public static void reset() {
     EffectDatabase.newEffects = false;
@@ -136,28 +140,34 @@ public class EffectDatabase {
     String canonicalName = StringUtilities.getCanonicalName(name);
     EffectDatabase.nameById.put(effectId, name);
     EffectDatabase.addIdToName(canonicalName, effectId);
-    EffectDatabase.imageById.put(effectId, image);
+    EffectData effectData = EffectDatabase.effectDataById.computeIfAbsent(effectId, id -> new EffectData());
+    effectData.image = image;
+    effectData.descriptionId = null;
+    effectData.defaultAction = null;
 
     if (descriptionId != null && !descriptionId.equals("")) {
-      EffectDatabase.descriptionById.put(effectId, descriptionId);
+      effectData.descriptionId = descriptionId;
       EffectDatabase.effectIdByDescription.put(descriptionId, effectId);
     }
 
-    EffectDatabase.qualityById.put(effectId, EffectDatabase.parseQuality(quality));
+    effectData.quality = EffectDatabase.parseQuality(quality);
 
     String[] list = StringUtilities.splitByComma(attributes);
     List<String> attrs = new LinkedList<>(Arrays.asList(list));
     attrs.remove("none");
-    EffectDatabase.attributesById.put(effectId, attrs);
+    effectData.attributes = attrs;
 
     if (defaultAction != null) {
-      EffectDatabase.defaultActions.put(effectId, defaultAction);
+      effectData.defaultAction = defaultAction;
     }
   }
 
   public static final int getQuality(final int effectId) {
-    Integer quality = (effectId == -1) ? -1 : EffectDatabase.qualityById.get(effectId);
-    return quality == null ? -1 : quality;
+    if (effectId == -1) {
+      return -1;
+    }
+    EffectData effectData = EffectDatabase.effectDataById.get(effectId);
+    return effectData == null ? -1 : effectData.quality;
   }
 
   public static final String getQualityDescription(final int effectId) {
@@ -165,7 +175,8 @@ public class EffectDatabase {
   }
 
   public static final List<String> getEffectAttributes(final int effectId) {
-    return EffectDatabase.attributesById.get(effectId);
+    EffectData effectData = EffectDatabase.effectDataById.get(effectId);
+    return effectData == null ? null : effectData.attributes;
   }
 
   public static final boolean hasAttribute(final String name, final String attribute) {
@@ -190,7 +201,7 @@ public class EffectDatabase {
     if (effectId == -1) {
       return null;
     }
-    String rv = StringUtilities.getDisplayName(EffectDatabase.defaultActions.get(effectId));
+    String rv = StringUtilities.getDisplayName(EffectDatabase.getActions(effectId));
     if (rv == null) {
       return null;
     }
@@ -223,7 +234,7 @@ public class EffectDatabase {
     if (effectId == -1) {
       return new ArrayList<>();
     }
-    String actions = StringUtilities.getDisplayName(EffectDatabase.defaultActions.get(effectId));
+    String actions = StringUtilities.getDisplayName(EffectDatabase.getActions(effectId));
     if (actions == null) {
       return new ArrayList<>();
     }
@@ -253,7 +264,8 @@ public class EffectDatabase {
   }
 
   public static final String getActions(final Integer effectId) {
-    return EffectDatabase.defaultActions.get(effectId);
+    EffectData effectData = EffectDatabase.effectDataById.get(effectId);
+    return effectData == null ? null : effectData.defaultAction;
   }
 
   public static final void setActions(final int effectId, final String actions) {
@@ -261,14 +273,22 @@ public class EffectDatabase {
   }
 
   public static final void setActions(final Integer effectId, final String actions) {
-    EffectDatabase.defaultActions.put(effectId, actions);
+    EffectData effectData = EffectDatabase.effectDataById.computeIfAbsent(effectId, id -> new EffectData());
+    effectData.defaultAction = actions;
+  }
+
+  public static final Set<Entry<Integer, String>> actionEntrySet() {
+    return EffectDatabase.effectDataById.entrySet().stream()
+        .filter(entry -> entry.getValue().defaultAction != null)
+        .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().defaultAction))
+        .entrySet();
   }
 
   public static final String getActionNote(final int effectId) {
     if (effectId == -1) {
       return null;
     }
-    String rv = StringUtilities.getDisplayName(EffectDatabase.defaultActions.get(effectId));
+    String rv = StringUtilities.getDisplayName(EffectDatabase.getActions(effectId));
     if (rv != null && rv.startsWith("#")) {
       return rv.substring(1).trim();
     }
@@ -307,11 +327,15 @@ public class EffectDatabase {
   }
 
   public static final String getDescriptionId(final int effectId) {
-    return EffectDatabase.descriptionById.get(effectId);
+    EffectData effectData = EffectDatabase.effectDataById.get(effectId);
+    return effectData == null ? null : effectData.descriptionId;
   }
 
   static final Set<Integer> descriptionIdKeySet() {
-    return EffectDatabase.descriptionById.keySet();
+    return EffectDatabase.effectDataById.entrySet().stream()
+        .filter(entry -> entry.getValue().descriptionId != null)
+        .map(Entry::getKey)
+        .collect(Collectors.toSet());
   }
 
   /**
@@ -417,7 +441,8 @@ public class EffectDatabase {
    * @return The name of the corresponding effect
    */
   public static final String getImageName(final int effectId) {
-    String imageName = effectId == -1 ? null : EffectDatabase.imageById.get(effectId);
+    EffectData effectData = effectId == -1 ? null : EffectDatabase.effectDataById.get(effectId);
+    String imageName = effectData == null ? null : effectData.image;
     return imageName == null ? "" : imageName;
   }
 
@@ -516,12 +541,13 @@ public class EffectDatabase {
 
     EffectDatabase.nameById.put(id, name);
     EffectDatabase.addIdToName(canonicalName, id);
-    EffectDatabase.imageById.put(id, image);
-    EffectDatabase.descriptionById.put(id, descId);
-    EffectDatabase.qualityById.put(id, EffectDatabase.NEUTRAL);
+    EffectData effectData = EffectDatabase.effectDataById.computeIfAbsent(id, key -> new EffectData());
+    effectData.image = image;
+    effectData.descriptionId = descId;
+    effectData.quality = EffectDatabase.NEUTRAL;
     EffectDatabase.effectIdByDescription.put(descId, id);
     if (defaultAction != null) {
-      EffectDatabase.defaultActions.put(id, defaultAction);
+      effectData.defaultAction = defaultAction;
     }
 
     String printMe;
@@ -580,12 +606,14 @@ public class EffectDatabase {
       List<String> attributes = EffectDatabase.getEffectAttributes(nextInteger);
 
       String name = entry.getValue();
-      String image = EffectDatabase.imageById.get(nextInteger);
-      String descId = EffectDatabase.descriptionById.get(nextInteger);
-      String quality = EffectDatabase.describeQuality(EffectDatabase.qualityById.get(nextInteger));
+      EffectData effectData = EffectDatabase.effectDataById.get(nextInteger);
+      String image = effectData == null ? null : effectData.image;
+      String descId = effectData == null ? null : effectData.descriptionId;
+      String quality =
+          EffectDatabase.describeQuality(effectData == null ? EffectDatabase.NEUTRAL : effectData.quality);
       String attributesString = (attributes == null) ? "none" : String.join(",", attributes);
 
-      String defaultAction = EffectDatabase.defaultActions.get(nextInteger);
+      String defaultAction = effectData == null ? null : effectData.defaultAction;
       EffectDatabase.writeEffect(
           writer, effectId, name, image, descId, quality, attributesString, defaultAction);
     }

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -1356,7 +1356,7 @@ public class ModifierDatabase {
     Set<String> effects = new TreeSet<>();
 
     for (Entry<Integer, EffectData> entry : EffectDatabase.allEffects()) {
-      String name = entry.getValue().name;
+      String name = entry.getValue().getName();
       // Skip effect which is also an item
       effects.add(name);
     }

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -1355,8 +1355,8 @@ public class ModifierDatabase {
     // Make a map of status effects
     Set<String> effects = new TreeSet<>();
 
-    for (Entry<Integer, String> entry : EffectDatabase.entrySet()) {
-      String name = entry.getValue();
+    for (Entry<Integer, EffectData> entry : EffectDatabase.allEffects()) {
+      String name = entry.getValue().name;
       // Skip effect which is also an item
       effects.add(name);
     }

--- a/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
@@ -535,8 +535,8 @@ public class TCRSDatabase {
   public static boolean applyModifiers() {
     // Remove food/booze/spleen/potion sources for effects
     StringBuilder buffer = new StringBuilder();
-    for (Integer id : EffectDatabase.keys()) {
-      String actions = EffectDatabase.getActions(id);
+    for (var effect : EffectDatabase.values()) {
+      String actions = effect.getActions();
       if (actions == null || actions.startsWith("#")) {
         continue;
       }
@@ -559,7 +559,7 @@ public class TCRSDatabase {
           }
           buffer.append(action);
         }
-        EffectDatabase.setActions(id, buffer.isEmpty() ? null : buffer.toString());
+        effect.setActions(buffer.isEmpty() ? null : buffer.toString());
       }
     }
 
@@ -669,6 +669,7 @@ public class TCRSDatabase {
     if (effectId == -1) {
       return;
     }
+    var effect = EffectDatabase.getEffectData(effectId);
     String verb =
         switch (usage) {
           case EAT -> "eat ";
@@ -676,7 +677,7 @@ public class TCRSDatabase {
           case SPLEEN -> "chew ";
           default -> "use ";
         };
-    String actions = EffectDatabase.getActions(effectId);
+    String actions = effect.getActions();
     boolean added = false;
     StringBuilder buffer = new StringBuilder();
     if (actions != null) {
@@ -716,7 +717,7 @@ public class TCRSDatabase {
       buffer.append("1 ");
       buffer.append(itemName);
     }
-    EffectDatabase.setActions(effectId, buffer.toString());
+    effect.setActions(buffer.toString());
   }
 
   private static void applyConsumableModifiers(

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -58,6 +58,7 @@ import net.sourceforge.kolmafia.persistence.AdventureSpentDatabase;
 import net.sourceforge.kolmafia.persistence.BountyDatabase;
 import net.sourceforge.kolmafia.persistence.ConsumablesDatabase;
 import net.sourceforge.kolmafia.persistence.DailyLimitDatabase.DailyLimitType;
+import net.sourceforge.kolmafia.persistence.EffectData;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
 import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
 import net.sourceforge.kolmafia.persistence.FactDatabase;
@@ -6867,12 +6868,12 @@ public class FightRequest extends GenericRequest {
 
         if (status.hookah) {
           String message = null;
-          int quality = EffectDatabase.getQuality(effectId);
+          var quality = EffectDatabase.getQuality(effectId);
 
           if (EffectDatabase.hasAttribute(effectId, "nohookah")) {
             message =
                 result.getName() + " is available from the hookah, but KoLmafia thought it was not";
-          } else if (quality != EffectDatabase.GOOD) {
+          } else if (quality != EffectData.Quality.GOOD) {
             message =
                 result.getName()
                     + " is good quality, but KoLmafia thought it was "

--- a/src/net/sourceforge/kolmafia/request/UneffectRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UneffectRequest.java
@@ -48,7 +48,7 @@ public class UneffectRequest extends GenericRequest {
   public static final Map<String, String> EFFECT_SKILL = new HashMap<>();
 
   static {
-    for (Entry<Integer, String> entry : EffectDatabase.defaultActions.entrySet()) {
+    for (Entry<Integer, String> entry : EffectDatabase.actionEntrySet()) {
       if (entry.getValue().startsWith("cast 1")) {
         String effectName = EffectDatabase.getEffectName(entry.getKey());
         String skillName = entry.getValue().substring(7);

--- a/src/net/sourceforge/kolmafia/request/UneffectRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UneffectRequest.java
@@ -21,6 +21,7 @@ import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
+import net.sourceforge.kolmafia.persistence.EffectData;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.SkillDatabase;
@@ -48,10 +49,12 @@ public class UneffectRequest extends GenericRequest {
   public static final Map<String, String> EFFECT_SKILL = new HashMap<>();
 
   static {
-    for (Entry<Integer, String> entry : EffectDatabase.actionEntrySet()) {
-      if (entry.getValue().startsWith("cast 1")) {
-        String effectName = EffectDatabase.getEffectName(entry.getKey());
-        String skillName = entry.getValue().substring(7);
+    for (Entry<Integer, EffectData> effect : EffectDatabase.allEffects()) {
+      var action = effect.getValue().getActions();
+      if (action == null) continue;
+      if (action.startsWith("cast 1")) {
+        String effectName = EffectDatabase.getEffectName(effect.getKey());
+        String skillName = action.substring(7);
         if (skillName.contains("|")) {
           skillName = skillName.substring(0, skillName.indexOf("|"));
         }

--- a/src/net/sourceforge/kolmafia/swingui/DatabaseFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/DatabaseFrame.java
@@ -8,6 +8,7 @@ import javax.swing.ListSelectionModel;
 import net.java.dev.spellcast.utilities.LockableListModel;
 import net.sourceforge.kolmafia.MonsterData;
 import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.persistence.EffectData;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
 import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
 import net.sourceforge.kolmafia.persistence.FamiliarDatabase;
@@ -23,8 +24,8 @@ import net.sourceforge.kolmafia.utilities.LowerCaseEntry;
 public class DatabaseFrame extends GenericFrame {
   public static final LockableListModel<LowerCaseEntry<Integer, String>> allItems =
       LowerCaseEntry.createListModel(ItemDatabase.entrySet());
-  public static final LockableListModel<LowerCaseEntry<Integer, String>> allEffects =
-      LowerCaseEntry.createListModel(EffectDatabase.entrySet());
+  public static final LockableListModel<LowerCaseEntry<Integer, EffectData>> allEffects =
+      LowerCaseEntry.createListModel(EffectDatabase.allEffects());
   public static final LockableListModel<LowerCaseEntry<Integer, String>> allSkills =
       LowerCaseEntry.createListModel(SkillDatabase.entrySet());
   public static final LockableListModel<LowerCaseEntry<Integer, String>> allFamiliars =
@@ -147,13 +148,13 @@ public class DatabaseFrame extends GenericFrame {
     }
   }
 
-  private static class ExamineEffectsPanel extends ItemLookupPanel<String> {
+  private static class ExamineEffectsPanel extends ItemLookupPanel<EffectData> {
     public ExamineEffectsPanel() {
       super(DatabaseFrame.allEffects, "effect", "whicheffect");
     }
 
     @Override
-    public String getId(final Entry<Integer, String> e) {
+    public String getId(final Entry<Integer, EffectData> e) {
       return EffectDatabase.getDescriptionId(e.getKey().intValue());
     }
   }

--- a/src/net/sourceforge/kolmafia/swingui/panel/MoodOptionsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/MoodOptionsPanel.java
@@ -148,10 +148,10 @@ public class MoodOptionsPanel extends JPanel {
 
       this.typeSelect = new TypeComboBox();
 
-      Object[] names = EffectDatabase.values().toArray();
+      var effects = EffectDatabase.values();
 
-      for (int i = 0; i < names.length; ++i) {
-        this.EFFECT_MODEL.add(names[i].toString());
+      for (var effect : effects) {
+        this.EFFECT_MODEL.add(effect.name);
       }
 
       this.EFFECT_MODEL.sort();

--- a/src/net/sourceforge/kolmafia/swingui/panel/MoodOptionsPanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/MoodOptionsPanel.java
@@ -151,7 +151,7 @@ public class MoodOptionsPanel extends JPanel {
       var effects = EffectDatabase.values();
 
       for (var effect : effects) {
-        this.EFFECT_MODEL.add(effect.name);
+        this.EFFECT_MODEL.add(effect.getName());
       }
 
       this.EFFECT_MODEL.sort();

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -106,6 +106,7 @@ import net.sourceforge.kolmafia.persistence.CandyDatabase;
 import net.sourceforge.kolmafia.persistence.CandyDatabase.Candy;
 import net.sourceforge.kolmafia.persistence.CoinmastersDatabase;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
+import net.sourceforge.kolmafia.persistence.EffectData;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
 import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
 import net.sourceforge.kolmafia.persistence.FactDatabase;
@@ -11419,7 +11420,7 @@ public abstract class RuntimeLibrary {
         new ArrayList<>(
             IntStream.range(1, 2991)
                 .filter(i -> EffectDatabase.getEffectName(i) != null)
-                .filter(i -> EffectDatabase.getQuality(i) == EffectDatabase.GOOD)
+                .filter(i -> EffectDatabase.getQuality(i) == EffectData.Quality.GOOD)
                 .filter(i -> !EffectDatabase.hasAttribute(i, "nohookah") || i == EffectPool.FISHY)
                 .filter(i -> !EffectDatabase.hasAttribute(i, "notcrs"))
                 .boxed()

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Type.java
@@ -392,7 +392,7 @@ public class Type extends Symbol {
       case CLASS -> this.addValues(list, AscensionClass.allClasses());
       case STAT -> this.addValues(list, DataTypes.STAT_ARRAY, 0, 3);
       case SKILL -> this.addValues(list, SkillDatabase.entrySet());
-      case EFFECT -> this.addValues(list, EffectDatabase.entrySet());
+      case EFFECT -> this.addValues(list, EffectDatabase.allEffects());
       case FAMILIAR -> this.addValues(list, FamiliarDatabase.entrySet());
       case SLOT -> this.addValues(list, SlotSet.NAMES);
       case MONSTER -> this.addValues(list, MonsterDatabase.valueSet());


### PR DESCRIPTION
Combine all the maps into a single map of EffectData, like MonsterData.

The only change I noticed is positive: if you run `test neweffect whatever` for an existing effect that has a default action, it'll keep the default action in the printout.

The internal quality of $effect[none] is now neutral instead of "-1", but that's not surfaced anywhere.

Ref #1235.