### PR TITLE
refactor: merge parallel entities in EquipmentDatabase into single Map

### DIFF
--- a/src/data/equipment.txt
+++ b/src/data/equipment.txt
@@ -1697,7 +1697,7 @@ spork	30	Mys: 0	1-handed utensil
 squeaky staff	75	Mus: 22	2-handed staff
 Squeezebox of the Ages	90	Mox: 15	2-handed accordion
 Staff of Blood and Pudding	10	Mys: 15	1-handed chefstaff
-Staff of Ed	100	Mus: 0	1-handed staff
+[7961]Staff of Ed	100	Mus: 0	1-handed staff
 [2268]Staff of Fats	100	Mys: 35	2-handed staff
 [7964]Staff of Fats	100	Mys: 35	2-handed staff
 Staff of Frozen Lard	10	Mys: 200	1-handed chefstaff
@@ -2296,7 +2296,7 @@ replica Kramco Sausage-o-Matic&trade;	100	none
 replica Operation Patriot Shield	240	none	shield
 reusable shopping bag	10	none
 rice bowl	30	none
-rock	0	none
+[8042]rock	0	none
 Roman Candelabra	0	none
 Royal scepter	100	none
 rubber baby doll	100	none

--- a/src/data/equipment.txt
+++ b/src/data/equipment.txt
@@ -154,6 +154,7 @@ fishin' hat	10	none
 five-gallon hat	100	none
 flagstone fez	120	Mys: 40
 flaming leaf crown	150	none
+flatusaur gasmask	100	none
 floaty rock helmet	100	Mox: 35
 foam commodore's hat	200	Mox: 85
 foolscap fool's cap	40	Mox: 5
@@ -348,6 +349,7 @@ raspberry beret	50	Mox: 10
 ratty knitted cap	50	none
 rave visor	150	Mox: 60
 ravioli hat	10	none
+real cowboy hat	50	none
 red traffic cone	60	Mox: 15
 reinforced beaded headband	170	Mox: 70
 replica jewel-eyed wizard hat	10	none
@@ -361,6 +363,7 @@ sea cowboy hat	200	Mox: 85
 seal-skull helmet	10	none
 sealhide hood	160	Mox: 65
 Seasonal Beret	100	Mys: 35
+senate fly thorax	10	none
 sequined fez	80	Mox: 25
 seven-gallon hat	140	none
 shadow chef's hat	100	none
@@ -611,6 +614,7 @@ Greatest American Pants	100	none
 Greaves of the Murk Lord	120	none
 Grimacite gaiters	150	Mox: 40
 Grimacite greaves	125	Mox: 47
+grubby wool trousers	50	none
 Guzzlr pants	100	none
 gym shorts	100	Mox: 35
 hardened slime pants	200	Mox: 200
@@ -862,7 +866,6 @@ dinosaur bone corset	100	none
 Dragonscale breastplate	200	Mus: 40
 dreadful sweater	200	Mys: 200
 duct tape shirt	195	Mus: 82
-elf army poncho	10	none
 embers-only jacket	100	none
 extra-see-thru nightie	200	Mus: 200
 extra-thick Crimbo sweater	100	none
@@ -872,9 +875,7 @@ famous blue raincoat	100	none
 filthy hippy poncho	40	Mus: 5
 First Post shirt - Cir Senam	100	none
 fishbone corset	20	none
-flagstone fleece	120	Mox: 40
 flaming pink shirt	100	none
-flatusaur gasmask	100	none
 floral print shirt	100	Mus: 35
 flyest of shirts	80	Mus: 25
 fresh coat of paint	100	none
@@ -894,7 +895,6 @@ Grateful Undead T-shirt	70	Mus: 20
 Gregarious Gregorian Smock	100	none
 Grimacite gown	150	Mus: 40
 Grimacite guayabera	125	Mus: 47
-grubby wool trousers	50	none
 grungy flannel shirt	150	Mox: 60
 hairshirt	150	Mus: 40
 harem girl t-shirt	25	none
@@ -933,11 +933,11 @@ psycho sweater	100	Mus: 35
 punk rock jacket	145	Mus: 57
 Quartet of Flare Masters Jacket	50	Mox: 11
 Radio Free Jersey	0	none
-real cowboy hat	50	none
 red coat	160	Mus: 65
 red shirt	150	Mus: 60
 red-and-green sweater	50	Mox: 35
 reflective vest	50	none
+replica Jurassic Parka	100	none
 rhinestone cowboy shirt	100	Mus: 35
 safety vest	70	Mus: 20
 scorched skeleton shirt	150	Mys: 60
@@ -984,12 +984,12 @@ zero-trust tanktop	100	none
 # Weapons section of equipment.txt
 
 &quot;honey&quot; dipper	150	Mys: 60	1-handed utensil
+17-alarm Saucepan	90	Mys: 15	1-handed saucepan
+25-meat staff	70	Mus: 20	2-handed staff
 4-dimensional guitar	80	Mox: 25	2-handed guitar
 5-Alarm Saucepan	50	Mys: 10	1-handed saucepan
 7-Foot Dwarven mattock	80	Mus: 25	2-handed axe
 7-inch discus	200	Mox: 85	1-handed boomerang
-17-alarm Saucepan	90	Mys: 15	1-handed saucepan
-25-meat staff	70	Mus: 20	2-handed staff
 a butt tuba	145	Mox: 57	2-handed horn
 accord ion	70	Mox: 20	1-handed accordion
 accordion file	60	Mox: 15	2-handed accordion
@@ -1486,7 +1486,6 @@ Monodent of the Sea	200	Mus: 0	1-handed spear
 Moonthril Flamberge	100	Mus: 40	2-handed sword
 Moonthril Longbow	100	Mox: 40	2-handed bow
 moss mace	50	Mus: 0	1-handed club
-mother's necklace	100	none
 muculent machete	60	Mus: 15	1-handed sword
 murderbot plasma rifle	150	Mox: 30	2-handed rifle
 murderbot whip	10	Mus: 30	1-handed whip
@@ -1599,7 +1598,6 @@ replica bottle-rocket crossbow	100	Mox: 0	1-handed crossbow
 replica Fourth of May Cosplay Saber	100	Mus: 0	1-handed saber
 replica haiku katana	100	Mus: 0	1-handed sword
 replica industrial fire extinguisher	100	Mus: 0	1-handed extinguisher
-replica Jurassic Parka	100	none
 revolver	100	Mox: 0	1-handed pistol
 rib of the Bonerdagon	80	Mus: 25	2-handed staff
 ridiculously huge sword	140	Mus: 55	3-handed sword
@@ -1782,7 +1780,6 @@ swordzall	80	Mus: 25	1-handed sword
 tail o' nine cats	30	Mus: 0	1-handed whip
 Tales of the Word Realms	0	Mus: 0	2-handed book
 tambourine	50	Mox: 10	1-handed drum
-teacher's pen	100	none
 teflon spatula	200	Mys: 85	1-handed utensil
 terra cotta tongs	120	Mys: 40	1-handed utensil
 the gun	100	Mox: 0	1-handed pistol
@@ -1880,9 +1877,10 @@ Zombo's shoulder blade	200	Mus: 200	2-handed sword
 
 # Off-hand Items section of equipment.txt
 
-'WILL WORK FOR BOOZE' sign	150	Mus: 175
 &quot;reusable&quot; grocery bag	10	none
+'WILL WORK FOR BOOZE' sign	150	Mus: 175
 1-ball	60	Mys: 15
+17-ball	200	none
 2-ball	60	Mys: 15
 3-ball	60	Mys: 15
 4-ball	60	Mys: 15
@@ -1890,7 +1888,6 @@ Zombo's shoulder blade	200	Mus: 200	2-handed sword
 6-ball	60	Mys: 15
 7-ball	60	Mys: 15
 9-ball	60	Mys: 15
-17-ball	200	none
 A Light that Never Goes Out	100	none
 Abracandalabra	100	none
 Abuela Crimbo's special magnet	10	none
@@ -2171,7 +2168,6 @@ Loathing Legion tape measure	0	none
 loose purse strings	10	none
 LOV Elephant	100	Mus: 25	shield
 low-budget shield	60	none	shield
-lube-shoes	0	none
 lucky lighter	35	Mys: 2
 mad scientist's sock monkey	110	Mys: 40
 magic lamp	30	none
@@ -2296,6 +2292,7 @@ Red Roger's red left hand	120	none
 red wagon	200	Mys: 200
 Red X Shield	180	Mus: 70	shield
 replica august scepter	0	none
+replica Kramco Sausage-o-Matic&trade;	100	none
 replica Operation Patriot Shield	240	none	shield
 reusable shopping bag	10	none
 rice bowl	30	none
@@ -2482,9 +2479,9 @@ zoological sample kit	10	none
 
 # Accessories section of equipment.txt
 
-[spelunking test kit]	0	none
 &quot;I survived Y2K&quot; T-Shirt	100	none
 &quot;I Voted!&quot; sticker	10	none
+[spelunking test kit]	0	none
 acid-squirting flower	50	Mys: 10
 actual reality goggles	10	none
 actual skeleton key	10	none
@@ -2954,6 +2951,7 @@ Lord Spookyraven's ear trumpet	150	Mys: 20
 Lord Spookyraven's spectacles	10	none
 LOV Earrings	100	none
 low-pressure oxygen tank	0	none
+lube-shoes	0	none
 lucky bottlecap	200	Mys: 200
 lucky cat collar	60	Mys: 15
 lucky Crimbo tiki necklace	10	none
@@ -3020,6 +3018,7 @@ mood ring	10	none
 moon-amber necklace	250	Mys: 200
 moss marlinspike	50	none
 moss medal	50	none
+mother's necklace	100	none
 motion sensor	0	none
 moustache sock	100	Mus: 10
 Mr. Accessaturday	0	none
@@ -3193,7 +3192,6 @@ replica Elf Guard medal	50	none
 replica Elvish sunglasses	0	none
 replica hewn moon-rune spoon	200	none
 replica Juju Mojo Mask	100	none
-replica Kramco Sausage-o-Matic&trade;	100	none
 replica navel ring of navel gazing	0	none
 replica over-the-shoulder Folder Holder	100	none
 replica plastic vampire fangs	0	none
@@ -3251,7 +3249,6 @@ sealhide gloves	160	Mys: 65
 sealhide moccasins	160	Mys: 65
 second-hand knockoff engagement ring	0	none
 self-repairing earmuffs	50	none
-senate fly thorax	10	none
 Senior LAAAAME merit badge	20	none
 severed rocking horse head	50	Mys: 10
 shadow monocle	0	none
@@ -3356,6 +3353,7 @@ Talisman of Bakula	200	none
 tap shoes	70	Mys: 20
 tarnished tastevin	150	Mys: 40
 tarrrnished charrrm bracelet	150	Mys: 60
+teacher's pen	100	none
 teflon swim fins	200	Mus: 85
 terra cotta tie tack	120	Mox: 40
 terra cotta truss	120	Mus: 40
@@ -3405,8 +3403,8 @@ tiny die-cast Uncle Hobo	50	none
 tiny die-cast Unionize the Elves Sign	10	none
 tiny die-cast Zeppo the Reindeer	10	none
 tiny plastic &quot;Santa Claus&quot;	10	none
-tiny plastic 7-foot dwarf	10	none
 tiny plastic 11 Dealer	0	none
+tiny plastic 7-foot dwarf	10	none
 tiny plastic abominable fudgeman	0	none
 tiny plastic Abuela Crimbo	25	none
 tiny plastic Abuela's cottage	10	none
@@ -3780,9 +3778,11 @@ Drapes-You-Regally	300	Mox: 250
 Drip harness	0	Mus: 100
 Drunkula's cape	300	Mys: 250
 Duke Vampire's regal cloak	200	Mox: 40
+elf army poncho	10	none
 Elf Guard fuel tank	100	none
 Elf Guard SCUBA tank	100	none
 fiberglass frock	120	Mus: 40
+flagstone fleece	120	Mox: 40
 frozen turtle shell	100	Mus: 50
 gabardine gunnysack	50	none
 ghost shawl	250	Mys: 200

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -2969,6 +2969,7 @@ public class ItemPool {
   public static final int STRANGE_DISC_GREEN = 8926;
   public static final int STRANGE_DISC_BLUE = 8927;
   public static final int STRANGE_DISC_YELLOW = 8928;
+  public static final int CUSTOM_SIXGUN = 8933;
   public static final int MOUNTAIN_SKIN = 8937;
   public static final int GRIZZLED_SKIN = 8938;
   public static final int DIAMONDBACK_SKIN = 8939;

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -1816,10 +1816,6 @@ public class DebugDatabase {
     }
 
     String descriptionName = DebugDatabase.parseName(text);
-    // Kludge to adjust known defective effect descriptions
-    if (effectId == 1659) {
-      descriptionName = StringUtilities.globalStringReplace(descriptionName, "  ", " ");
-    }
     if (!name.equals(descriptionName) && !decodedNamesEqual(name, descriptionName)) {
       report.println(
           "# *** " + name + " (" + effectId + ") has description of " + descriptionName + ".");

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -244,23 +244,23 @@ public class DebugDatabase {
 
     PrintStream report = DebugDatabase.openReport(ITEM_DATA);
 
-    Arrays.stream(DebugDatabase.ITEM_MAPS).forEach(ItemMap::clear);
+    try (report) {
+      Arrays.stream(DebugDatabase.ITEM_MAPS).forEach(ItemMap::clear);
 
-    // Check item names, desc ID, consumption type
+      // Check item names, desc ID, consumption type
 
-    if (itemId == 0) {
-      DebugDatabase.checkItems(report);
-    } else {
-      DebugDatabase.checkItem(itemId, report);
+      if (itemId == 0) {
+        DebugDatabase.checkItems(report);
+      } else {
+        DebugDatabase.checkItem(itemId, report);
+      }
+
+      // Check level limits, equipment, modifiers
+
+      DebugDatabase.checkConsumableItems(report);
+      DebugDatabase.checkEquipment(report);
+      DebugDatabase.checkItemModifiers(report);
     }
-
-    // Check level limits, equipment, modifiers
-
-    DebugDatabase.checkConsumableItems(report);
-    DebugDatabase.checkEquipment(report);
-    DebugDatabase.checkItemModifiers(report);
-
-    report.close();
   }
 
   private static void checkItems(final PrintStream report) {
@@ -1582,11 +1582,11 @@ public class DebugDatabase {
 
     PrintStream report = DebugDatabase.openReport(OUTFIT_DATA);
 
-    DebugDatabase.outfits.clear();
-    DebugDatabase.checkOutfits(report);
-    DebugDatabase.checkOutfitModifierMap(report);
-
-    report.close();
+    try (report) {
+      DebugDatabase.outfits.clear();
+      DebugDatabase.checkOutfits(report);
+      DebugDatabase.checkOutfitModifierMap(report);
+    }
   }
 
   private static void checkOutfits(final PrintStream report) {
@@ -1758,17 +1758,17 @@ public class DebugDatabase {
 
     PrintStream report = DebugDatabase.openReport(EFFECT_DATA);
 
-    DebugDatabase.effects.clear();
+    try (report) {
+      DebugDatabase.effects.clear();
 
-    if (effectId == 0) {
-      DebugDatabase.checkEffects(report);
-    } else {
-      DebugDatabase.checkEffect(effectId, report);
+      if (effectId == 0) {
+        DebugDatabase.checkEffects(report);
+      } else {
+        DebugDatabase.checkEffect(effectId, report);
+      }
+
+      DebugDatabase.checkEffectModifiers(report);
     }
-
-    DebugDatabase.checkEffectModifiers(report);
-
-    report.close();
   }
 
   private static void checkEffects(final PrintStream report) {
@@ -1999,17 +1999,17 @@ public class DebugDatabase {
 
     PrintStream report = DebugDatabase.openReport(SKILL_DATA);
 
-    DebugDatabase.passiveSkills.clear();
+    try (report) {
+      DebugDatabase.passiveSkills.clear();
 
-    if (skillId == 0) {
-      DebugDatabase.checkSkills(report);
-    } else {
-      DebugDatabase.checkSkill(skillId, report);
+      if (skillId == 0) {
+        DebugDatabase.checkSkills(report);
+      } else {
+        DebugDatabase.checkSkill(skillId, report);
+      }
+
+      DebugDatabase.checkSkillModifiers(report);
     }
-
-    DebugDatabase.checkSkillModifiers(report);
-
-    report.close();
   }
 
   private static void checkSkills(final PrintStream report) {
@@ -2315,36 +2315,37 @@ public class DebugDatabase {
     RequestLogger.printLine("Checking plurals...");
     PrintStream report =
         LogStream.openStream(new File(KoLConstants.DATA_LOCATION, "plurals.txt"), true);
-    if (!parameters.contains("-")) {
-      int itemId = StringUtilities.parseInt(parameters);
-      if (itemId == 0) {
-        for (Integer id : ItemDatabase.descriptionIdKeySet()) {
-          if (!KoLmafia.permitsContinue()) {
-            break;
+    try (report) {
+      if (!parameters.contains("-")) {
+        int itemId = StringUtilities.parseInt(parameters);
+        if (itemId == 0) {
+          for (Integer id : ItemDatabase.descriptionIdKeySet()) {
+            if (!KoLmafia.permitsContinue()) {
+              break;
+            }
+            if (id < 0) {
+              continue;
+            }
+            while (++itemId < id) {
+              report.println(itemId);
+            }
+            DebugDatabase.checkPlural(id, client, report);
           }
-          if (id < 0) {
-            continue;
-          }
-          while (++itemId < id) {
-            report.println(itemId);
-          }
-          DebugDatabase.checkPlural(id, client, report);
+        } else {
+          DebugDatabase.checkPlural(itemId, client, report);
         }
       } else {
-        DebugDatabase.checkPlural(itemId, client, report);
-      }
-    } else {
-      String[] points = parameters.split("-");
-      // parseInt will return 0 for null input so bother to check split for validity
-      int start = StringUtilities.parseInt(points[0]);
-      int end = StringUtilities.parseInt(points[1]);
-      start = Math.max(0, start);
-      end = Math.min(end, ItemDatabase.maxItemId());
-      for (int i = start; i < end; i++) {
-        DebugDatabase.checkPlural(i, client, report);
+        String[] points = parameters.split("-");
+        // parseInt will return 0 for null input so bother to check split for validity
+        int start = StringUtilities.parseInt(points[0]);
+        int end = StringUtilities.parseInt(points[1]);
+        start = Math.max(0, start);
+        end = Math.min(end, ItemDatabase.maxItemId());
+        for (int i = start; i < end; i++) {
+          DebugDatabase.checkPlural(i, client, report);
+        }
       }
     }
-    report.close();
   }
 
   private static void checkPlural(
@@ -3057,8 +3058,9 @@ public class DebugDatabase {
     DebugDatabase.loadScrapeData(rawItems, ITEM_HTML);
     RequestLogger.printLine("Checking internal data...");
     PrintStream report = DebugDatabase.openReport(CONSUMABLE_DATA);
-    DebugDatabase.checkConsumables(report);
-    report.close();
+    try (report) {
+      DebugDatabase.checkConsumables(report);
+    }
   }
 
   private static void checkConsumables(final PrintStream report) {
@@ -3966,24 +3968,25 @@ public class DebugDatabase {
     PrintStream report =
         LogStream.openStream(new File(KoLConstants.DATA_LOCATION, "zapreport.txt"), true);
 
-    String[] groups =
-        DebugDatabase.ZAPGROUP_PATTERN.split(DebugDatabase.readWikiItemData("Zapping", client));
-    for (int i = 1; i < groups.length; ++i) {
-      String group = groups[i];
-      int pos = group.indexOf("</td>");
-      if (pos != -1) {
-        group = group.substring(0, pos);
-      }
-      Matcher m = DebugDatabase.ZAPITEM_PATTERN.matcher(group);
-      ArrayList<String> items = new ArrayList<>();
-      while (m.find()) {
-        items.add(m.group(1));
-      }
-      if (items.size() > 1) {
-        DebugDatabase.checkZapGroup(items, report);
+    try (report) {
+      String[] groups =
+          DebugDatabase.ZAPGROUP_PATTERN.split(DebugDatabase.readWikiItemData("Zapping", client));
+      for (int i = 1; i < groups.length; ++i) {
+        String group = groups[i];
+        int pos = group.indexOf("</td>");
+        if (pos != -1) {
+          group = group.substring(0, pos);
+        }
+        Matcher m = DebugDatabase.ZAPITEM_PATTERN.matcher(group);
+        ArrayList<String> items = new ArrayList<>();
+        while (m.find()) {
+          items.add(m.group(1));
+        }
+        if (items.size() > 1) {
+          DebugDatabase.checkZapGroup(items, report);
+        }
       }
     }
-    report.close();
   }
 
   private static void checkZapGroup(ArrayList<String> items, PrintStream report) {

--- a/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
@@ -35,10 +35,9 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 @SuppressWarnings("incomplete-switch")
 public class EquipmentDatabase {
-  private static final Map<Integer, Integer> power = new HashMap<>();
-  private static final Map<Integer, Integer> hands = new HashMap<>();
-  private static final Map<Integer, String> itemTypes = new HashMap<>();
-  private static final Map<Integer, String> statRequirements = new HashMap<>();
+  private record EquipmentData(int power, String statRequirement, int hands, String itemType) {}
+
+  private static final Map<Integer, EquipmentData> equipmentById = new HashMap<>();
 
   private static final Map<Integer, Integer> outfitPieces = new HashMap<>();
   public static final Map<Integer, SpecialOutfit> normalOutfits = new HashMap<>();
@@ -119,10 +118,8 @@ public class EquipmentDatabase {
           continue;
         }
 
-        EquipmentDatabase.power.put(itemId, StringUtilities.parseInt(data[1]));
-
-        String reqs = data[2];
-        EquipmentDatabase.statRequirements.put(itemId, reqs);
+        var power = StringUtilities.parseInt(data[1]);
+        var statRequirement = data[2];
 
         int hval = 0;
         String tval = null;
@@ -139,8 +136,8 @@ public class EquipmentDatabase {
           }
         }
 
-        EquipmentDatabase.hands.put(itemId, hval);
-        EquipmentDatabase.itemTypes.put(itemId, tval);
+        EquipmentDatabase.equipmentById.put(
+            itemId, new EquipmentData(power, statRequirement, hval, tval));
       }
     } catch (IOException e) {
       StaticEntity.printStackTrace(e);
@@ -317,7 +314,8 @@ public class EquipmentDatabase {
       String req = EquipmentDatabase.getEquipRequirement(itemId);
       ConsumptionType usage = ItemDatabase.getConsumptionType(itemId);
       boolean isWeapon = usage == ConsumptionType.WEAPON;
-      String type = EquipmentDatabase.itemTypes.get(itemId);
+      EquipmentData equipmentData = EquipmentDatabase.equipmentById.get(itemId);
+      String type = equipmentData == null ? null : equipmentData.itemType;
       boolean isShield = type != null && type.equals("shield");
       String weaponType = "";
       if (isWeapon) {
@@ -369,15 +367,13 @@ public class EquipmentDatabase {
     String type = DebugDatabase.parseType(text);
     String req = DebugDatabase.parseReq(text, type);
 
-    EquipmentDatabase.power.put(itemId, power);
-    EquipmentDatabase.statRequirements.put(itemId, req);
-
     boolean isWeapon = false, isShield = false;
+    int hval = 0;
+    String itemType = null;
     String weaponType = "";
 
     if (type.indexOf("weapon") != -1) {
       Matcher matcher = WEAPON_TYPE_PATTERN.matcher(type);
-      int hval;
       String tval;
       if (matcher.find()) {
         weaponType = matcher.group(1);
@@ -388,14 +384,16 @@ public class EquipmentDatabase {
         hval = 0;
         tval = type;
       }
-      EquipmentDatabase.hands.put(itemId, hval);
-      EquipmentDatabase.itemTypes.put(itemId, tval);
+      itemType = tval;
       isWeapon = true;
     } else if (type.contains("shield")) {
       isShield = true;
       weaponType = "shield";
-      EquipmentDatabase.itemTypes.put(itemId, weaponType);
+      itemType = weaponType;
     }
+
+    var data = new EquipmentData(power, req, hval, itemType);
+    EquipmentDatabase.equipmentById.put(itemId, data);
 
     String printMe =
         EquipmentDatabase.equipmentString(itemName, power, req, weaponType, isWeapon, isShield);
@@ -470,8 +468,8 @@ public class EquipmentDatabase {
   public static final int nextEquipmentItemId(int prevId) {
     int limit = ItemDatabase.maxItemId();
     while (++prevId <= limit) {
-      String req = EquipmentDatabase.statRequirements.get(prevId);
-      if ((req != null && req.length() > 0)
+      EquipmentData equipmentData = EquipmentDatabase.equipmentById.get(prevId);
+      if (equipmentData != null
           || ItemDatabase.getConsumptionType(prevId) == ConsumptionType.FAMILIAR_EQUIPMENT
           || ItemDatabase.getConsumptionType(prevId) == ConsumptionType.SIXGUN) {
         return prevId;
@@ -514,23 +512,22 @@ public class EquipmentDatabase {
   }
 
   public static final boolean contains(final int itemId) {
-    return itemId > 0 && EquipmentDatabase.statRequirements.get(itemId) != null;
+    return itemId > 0 && EquipmentDatabase.equipmentById.get(itemId) != null;
   }
 
   public static final int getPower(final int itemId) {
-    return EquipmentDatabase.power.getOrDefault(itemId, 0);
-  }
-
-  public static final void setPower(final int itemId, final int power) {
-    EquipmentDatabase.power.put(itemId, power);
+    EquipmentData equipmentData = EquipmentDatabase.equipmentById.get(itemId);
+    return equipmentData == null ? 0 : equipmentData.power;
   }
 
   public static final int getHands(final int itemId) {
-    return EquipmentDatabase.hands.getOrDefault(itemId, 0);
+    EquipmentData equipmentData = EquipmentDatabase.equipmentById.get(itemId);
+    return equipmentData == null ? 0 : equipmentData.hands;
   }
 
   public static final String getEquipRequirement(final int itemId) {
-    return EquipmentDatabase.statRequirements.getOrDefault(itemId, "none");
+    EquipmentData equipmentData = EquipmentDatabase.equipmentById.get(itemId);
+    return equipmentData == null ? "none" : equipmentData.statRequirement;
   }
 
   public static final String getItemType(final int itemId) {
@@ -577,12 +574,14 @@ public class EquipmentDatabase {
         return "shirt";
       case WEAPON:
         {
-          String type = EquipmentDatabase.itemTypes.get(itemId);
+          EquipmentData equipmentData = EquipmentDatabase.equipmentById.get(itemId);
+          String type = equipmentData == null ? null : equipmentData.itemType;
           return type != null ? type : "weapon";
         }
       case OFFHAND:
         {
-          String type = EquipmentDatabase.itemTypes.get(itemId);
+          EquipmentData equipmentData = EquipmentDatabase.equipmentById.get(itemId);
+          String type = equipmentData == null ? null : equipmentData.itemType;
           return type != null ? type : "offhand";
         }
       case CONTAINER:

--- a/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
@@ -35,7 +35,18 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 @SuppressWarnings("incomplete-switch")
 public class EquipmentDatabase {
-  private record EquipmentData(int power, String statRequirement, int hands, String itemType) {}
+  private record EquipmentData(int power, String statRequirement, int hands, String itemType) {
+    String toDataLine(final int itemId) {
+      var name = ItemPool.get(itemId).getDisambiguatedName();
+      String output = name + "\t" + power + "\t" + statRequirement;
+      if (hands != 0) {
+        output += "\t" + hands + "-handed " + itemType;
+      } else if (itemType != null) {
+        output += "\t" + itemType;
+      }
+      return output;
+    }
+  }
 
   private static final Map<Integer, EquipmentData> equipmentById = new HashMap<>();
 
@@ -305,25 +316,11 @@ public class EquipmentDatabase {
     writer.println("# " + tag + " section of equipment.txt");
     writer.println();
 
-    String[] keys = map.keySet().toArray(new String[0]);
-    for (int i = 0; i < keys.length; ++i) {
-      String name = keys[i];
-      Integer val = map.get(name);
-      int itemId = val.intValue();
-      int power = EquipmentDatabase.getPower(itemId);
-      String req = EquipmentDatabase.getEquipRequirement(itemId);
-      ConsumptionType usage = ItemDatabase.getConsumptionType(itemId);
-      boolean isWeapon = usage == ConsumptionType.WEAPON;
+    var entries = map.entrySet();
+    for (var entry : entries) {
+      int itemId = entry.getValue();
       EquipmentData equipmentData = EquipmentDatabase.equipmentById.get(itemId);
-      String type = equipmentData == null ? null : equipmentData.itemType;
-      boolean isShield = type != null && type.equals("shield");
-      String weaponType = "";
-      if (isWeapon) {
-        int hands = getHands(itemId);
-        weaponType = hands + "-handed " + type;
-      }
-      EquipmentDatabase.writeEquipmentItem(
-          writer, name, power, req, weaponType, isWeapon, isShield);
+      writer.println(equipmentData.toDataLine(itemId));
     }
   }
 
@@ -367,36 +364,25 @@ public class EquipmentDatabase {
     String type = DebugDatabase.parseType(text);
     String req = DebugDatabase.parseReq(text, type);
 
-    boolean isWeapon = false, isShield = false;
-    int hval = 0;
+    int hands = 0;
     String itemType = null;
-    String weaponType = "";
 
-    if (type.indexOf("weapon") != -1) {
+    if (type.contains("weapon")) {
       Matcher matcher = WEAPON_TYPE_PATTERN.matcher(type);
-      String tval;
       if (matcher.find()) {
-        weaponType = matcher.group(1);
-        hval = StringUtilities.parseInt(matcher.group(2));
-        tval = matcher.group(3);
+        hands = StringUtilities.parseInt(matcher.group(2));
+        itemType = matcher.group(3);
       } else {
-        weaponType = type;
-        hval = 0;
-        tval = type;
+        itemType = type;
       }
-      itemType = tval;
-      isWeapon = true;
     } else if (type.contains("shield")) {
-      isShield = true;
-      weaponType = "shield";
-      itemType = weaponType;
+      itemType = "shield";
     }
 
-    var data = new EquipmentData(power, req, hval, itemType);
+    var data = new EquipmentData(power, req, hands, itemType);
     EquipmentDatabase.equipmentById.put(itemId, data);
 
-    String printMe =
-        EquipmentDatabase.equipmentString(itemName, power, req, weaponType, isWeapon, isShield);
+    String printMe = data.toDataLine(itemId);
     RequestLogger.printLine(printMe);
     RequestLogger.updateSessionLog(printMe);
   }

--- a/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -268,28 +269,28 @@ public class EquipmentDatabase {
 
   static void writeEquipment(final PrintStream writer) {
     // One map per equipment category
-    Map<String, Integer> hats = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    Map<String, Integer> weapons = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    Map<String, Integer> offhands = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    Map<String, Integer> shirts = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    Map<String, Integer> pants = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    Map<String, Integer> accessories = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    Map<String, Integer> containers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    Map<String, List<Integer>> hats = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    Map<String, List<Integer>> weapons = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    Map<String, List<Integer>> offhands = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    Map<String, List<Integer>> shirts = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    Map<String, List<Integer>> pants = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    Map<String, List<Integer>> accessories = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    Map<String, List<Integer>> containers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     // Iterate over all items and assign item id to category
     for (Entry<Integer, String> entry : ItemDatabase.dataNameEntrySet()) {
       Integer key = entry.getKey();
       String name = entry.getValue();
-      ConsumptionType type = ItemDatabase.getConsumptionType(key.intValue());
+      ConsumptionType type = ItemDatabase.getConsumptionType(key);
 
       switch (type) {
-        case HAT -> hats.put(name, key);
-        case PANTS -> pants.put(name, key);
-        case SHIRT -> shirts.put(name, key);
-        case WEAPON -> weapons.put(name, key);
-        case OFFHAND -> offhands.put(name, key);
-        case ACCESSORY -> accessories.put(name, key);
-        case CONTAINER -> containers.put(name, key);
+        case HAT -> hats.computeIfAbsent(name, k -> new ArrayList<>()).add(key);
+        case PANTS -> pants.computeIfAbsent(name, k -> new ArrayList<>()).add(key);
+        case SHIRT -> shirts.computeIfAbsent(name, k -> new ArrayList<>()).add(key);
+        case WEAPON -> weapons.computeIfAbsent(name, k -> new ArrayList<>()).add(key);
+        case OFFHAND -> offhands.computeIfAbsent(name, k -> new ArrayList<>()).add(key);
+        case ACCESSORY -> accessories.computeIfAbsent(name, k -> new ArrayList<>()).add(key);
+        case CONTAINER -> containers.computeIfAbsent(name, k -> new ArrayList<>()).add(key);
       }
     }
 
@@ -312,15 +313,17 @@ public class EquipmentDatabase {
   }
 
   private static void writeEquipmentCategory(
-      final PrintStream writer, final Map<String, Integer> map, final String tag) {
+      final PrintStream writer, final Map<String, List<Integer>> map, final String tag) {
     writer.println("# " + tag + " section of equipment.txt");
     writer.println();
 
-    var entries = map.entrySet();
-    for (var entry : entries) {
-      int itemId = entry.getValue();
-      EquipmentData equipmentData = EquipmentDatabase.equipmentById.get(itemId);
-      writer.println(equipmentData.toDataLine(itemId));
+    for (var entry : map.entrySet()) {
+      var itemIds = entry.getValue();
+      itemIds.sort(Comparator.naturalOrder());
+      for (var itemId : itemIds) {
+        EquipmentData equipmentData = EquipmentDatabase.equipmentById.get(itemId);
+        writer.println(equipmentData.toDataLine(itemId));
+      }
     }
   }
 

--- a/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -252,6 +251,14 @@ public class EquipmentDatabase {
   public static void writeEquipment(final File output) {
     RequestLogger.printLine("Writing data override: " + output);
 
+    // Open the output file
+    PrintStream writer = LogStream.openStream(output, true);
+    try (writer) {
+      writeEquipment(writer);
+    }
+  }
+
+  static void writeEquipment(final PrintStream writer) {
     // One map per equipment category
     Map<String, Integer> hats = new TreeMap<>();
     Map<String, Integer> weapons = new TreeMap<>();
@@ -262,9 +269,7 @@ public class EquipmentDatabase {
     Map<String, Integer> containers = new TreeMap<>();
 
     // Iterate over all items and assign item id to category
-    Iterator<Entry<Integer, String>> it = ItemDatabase.dataNameEntrySet().iterator();
-    while (it.hasNext()) {
-      Entry<Integer, String> entry = it.next();
+    for (Entry<Integer, String> entry : ItemDatabase.dataNameEntrySet()) {
       Integer key = entry.getKey();
       String name = entry.getValue();
       ConsumptionType type = ItemDatabase.getConsumptionType(key.intValue());
@@ -280,8 +285,6 @@ public class EquipmentDatabase {
       }
     }
 
-    // Open the output file
-    PrintStream writer = LogStream.openStream(output, true);
     writer.println(KoLConstants.EQUIPMENT_VERSION);
 
     // For each equipment category, write the map entries
@@ -298,8 +301,6 @@ public class EquipmentDatabase {
     EquipmentDatabase.writeEquipmentCategory(writer, accessories, "Accessories");
     writer.println();
     EquipmentDatabase.writeEquipmentCategory(writer, containers, "Containers");
-
-    writer.close();
   }
 
   private static void writeEquipmentCategory(

--- a/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
@@ -257,13 +257,13 @@ public class EquipmentDatabase {
 
   static void writeEquipment(final PrintStream writer) {
     // One map per equipment category
-    Map<String, Integer> hats = new TreeMap<>();
-    Map<String, Integer> weapons = new TreeMap<>();
-    Map<String, Integer> offhands = new TreeMap<>();
-    Map<String, Integer> shirts = new TreeMap<>();
-    Map<String, Integer> pants = new TreeMap<>();
-    Map<String, Integer> accessories = new TreeMap<>();
-    Map<String, Integer> containers = new TreeMap<>();
+    Map<String, Integer> hats = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    Map<String, Integer> weapons = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    Map<String, Integer> offhands = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    Map<String, Integer> shirts = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    Map<String, Integer> pants = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    Map<String, Integer> accessories = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    Map<String, Integer> containers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     // Iterate over all items and assign item id to category
     for (Entry<Integer, String> entry : ItemDatabase.dataNameEntrySet()) {
@@ -293,7 +293,7 @@ public class EquipmentDatabase {
     writer.println();
     EquipmentDatabase.writeEquipmentCategory(writer, weapons, "Weapons");
     writer.println();
-    EquipmentDatabase.writeEquipmentCategory(writer, offhands, "Off-hand");
+    EquipmentDatabase.writeEquipmentCategory(writer, offhands, "Off-hand Items");
     writer.println();
     EquipmentDatabase.writeEquipmentCategory(writer, accessories, "Accessories");
     writer.println();

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -2696,4 +2696,16 @@ public class MaximizerTest {
       assertThat(getBoosts(), hasItem(recommends(ItemPool.SILENT_NIGHTLIGHT)));
     }
   }
+
+  @Test
+  void shouldSuggestHolsteringIfAvailable() {
+    var cleanups =
+        new Cleanups(
+            withClass(AscensionClass.COW_PUNCHER), withEquippableItem(ItemPool.CUSTOM_SIXGUN));
+
+    try (cleanups) {
+      maximize("muscle");
+      assertThat(getBoosts(), hasItem(recommends(ItemPool.CUSTOM_SIXGUN)));
+    }
+  }
 }

--- a/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
@@ -60,6 +60,13 @@ public class EquipmentDatabaseTest {
     assertThat(data, containsString("antique shield\t180\tMus: 60\tshield\n"));
     assertThat(data, containsString("[10462]fire flower\t0\tMus: 0\t1-handed flower\n"));
     assertThat(data, containsString("World's Blackest-Eyed Peas\t30\tnone\tcan of beans\n"));
+    assertThat(
+        data,
+        containsString(
+            """
+      [2268]Staff of Fats\t100\tMys: 35\t2-handed staff
+      [7964]Staff of Fats\t100\tMys: 35\t2-handed staff
+      """));
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
@@ -54,9 +54,9 @@ public class EquipmentDatabaseTest {
     EquipmentDatabase.writeEquipment(ps);
     String data = os.toString();
 
-    // the order isn't right, because equipment pieces are sorted case-sensitively
-    // but should be sorted case-insensitively
-    // despite that, the entries seem present. Assert a spread.
+    // Assert a spread
+    // currently, this lacks the [itemid] differentiators for items with identical names
+    // and the "can of beans" type for bean cans
     assertThat(data, containsString("4-dimensional fez\t50\tnone\n"));
     assertThat(data, containsString("antique candy bucket\t10\tnone\n"));
     assertThat(data, containsString("antique shield\t180\tMus: 60\tshield\n"));

--- a/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
@@ -56,8 +56,10 @@ public class EquipmentDatabaseTest {
 
     // the order isn't right, because equipment pieces are sorted case-sensitively
     // but should be sorted case-insensitively
-    // despite that, the entries seem present. Assert one is.
-    assertThat(data, containsString("4-dimensional fez\t50\tnone"));
+    // despite that, the entries seem present. Assert a spread.
+    assertThat(data, containsString("4-dimensional fez\t50\tnone\n"));
+    assertThat(data, containsString("antique candy bucket\t10\tnone\n"));
+    assertThat(data, containsString("antique shield\t180\tMus: 60\tshield\n"));
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
@@ -19,6 +19,19 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class EquipmentDatabaseTest {
 
   @Test
+  public void itShouldReturnExpectedFieldsForKnownEquipmentRow() {
+    int itemId = ItemPool.ASPARAGUS_KNIFE;
+
+    assertThat(EquipmentDatabase.contains(itemId), is(true));
+    assertThat(EquipmentDatabase.getPower(itemId), is(15));
+    assertThat(EquipmentDatabase.getEquipRequirement(itemId), is("Mus: 0"));
+    assertThat(EquipmentDatabase.getHands(itemId), is(1));
+    assertThat(EquipmentDatabase.getItemType(itemId), is("knife"));
+    assertThat(EquipmentDatabase.getWeaponStat(itemId), is(KoLConstants.Stat.MUSCLE));
+    assertThat(EquipmentDatabase.getWeaponType(itemId), is(KoLConstants.WeaponType.MELEE));
+  }
+
+  @Test
   public void itShouldWriteEquipment() {
     // This is an awkward test because it generates a lot of coverage but verifying that file is
     // correct

--- a/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
@@ -34,6 +34,19 @@ public class EquipmentDatabaseTest {
   }
 
   @Test
+  public void itShouldReturnExpectedFieldsForNonShieldOffhand() {
+    int itemId = ItemPool.SEVENTEEN_BALL;
+
+    assertThat(EquipmentDatabase.contains(itemId), is(true));
+    assertThat(EquipmentDatabase.getPower(itemId), is(200));
+    assertThat(EquipmentDatabase.getEquipRequirement(itemId), is("none"));
+    assertThat(EquipmentDatabase.getHands(itemId), is(0));
+    assertThat(EquipmentDatabase.getItemType(itemId), is("offhand"));
+    assertThat(EquipmentDatabase.getWeaponStat(itemId), is(KoLConstants.Stat.NONE));
+    assertThat(EquipmentDatabase.getWeaponType(itemId), is(KoLConstants.WeaponType.NONE));
+  }
+
+  @Test
   public void itShouldWriteEquipment() {
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     PrintStream ps = new PrintStream(os);

--- a/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
@@ -55,11 +55,11 @@ public class EquipmentDatabaseTest {
     String data = os.toString();
 
     // Assert a spread
-    // currently, this lacks the [itemid] differentiators for items with identical names
-    // and the "can of beans" type for bean cans
     assertThat(data, containsString("4-dimensional fez\t50\tnone\n"));
     assertThat(data, containsString("antique candy bucket\t10\tnone\n"));
     assertThat(data, containsString("antique shield\t180\tMus: 60\tshield\n"));
+    assertThat(data, containsString("[10462]fire flower\t0\tMus: 0\t1-handed flower\n"));
+    assertThat(data, containsString("World's Blackest-Eyed Peas\t30\tnone\tcan of beans\n"));
   }
 
   @Test

--- a/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
@@ -2,12 +2,14 @@ package net.sourceforge.kolmafia.persistence;
 
 import static internal.helpers.Player.withItem;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
 
 import internal.helpers.Cleanups;
-import java.io.File;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.ConsumptionType;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -33,17 +35,16 @@ public class EquipmentDatabaseTest {
 
   @Test
   public void itShouldWriteEquipment() {
-    // This is an awkward test because it generates a lot of coverage but verifying that file is
-    // correct
-    // depends upon the dynamic state of the equipment file.  The attempts to read the version in
-    // the source
-    // tree or jar have failed so far.  Revisit when the test environment is better understood?
-    File equip = new File("testeqf.txt");
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    PrintStream ps = new PrintStream(os);
     EquipmentDatabase.reset();
-    EquipmentDatabase.writeEquipment(equip);
-    assertTrue(true);
-    // delete which is probably not helpful if test fails but...
-    equip.delete();
+    EquipmentDatabase.writeEquipment(ps);
+    String data = os.toString();
+
+    // the order isn't right, because equipment pieces are sorted case-sensitively
+    // but should be sorted case-insensitively
+    // despite that, the entries seem present. Assert one is.
+    assertThat(data, containsString("4-dimensional fez\t50\tnone"));
   }
 
   @Test


### PR DESCRIPTION
Also update equipment.txt, and change the code to generate it as desired. This changes the ordering, e.g. 17-ball is now before 2-ball. I could fix this, but then there are other issues: putting `"resuseable" grocery bag` before `'WILL WORK FOR BOOZE' sign` implies we're decoding HTML entities, but then `M&ouml;bius ring` should be after `Mafia bow tie`, not before, so I'm not really sure what sorting we were using.

The code generating it is the version in EquipmentDatabase that writes using Mafia data, not the version in DebugDatabase that writes using KoL data.