### PR TITLE
Limiting Wet Crap For Sale to characters in 11,037 Leagues Under the Sea

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/NPCStoreDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/NPCStoreDatabase.java
@@ -510,6 +510,7 @@ public class NPCStoreDatabase {
         return KoLCharacter.inBadMoon();
       }
       case "sandpenny" -> {
+        // Wet Crap For Sale
         return KoLCharacter.inSeaPath();
       }
       case "town_giftshop.php" -> {

--- a/src/net/sourceforge/kolmafia/persistence/NPCStoreDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/NPCStoreDatabase.java
@@ -509,6 +509,9 @@ public class NPCStoreDatabase {
         // Nervewrecker's Store
         return KoLCharacter.inBadMoon();
       }
+      case "sandpenny" -> {
+        return KoLCharacter.inSeaPath();
+      }
       case "town_giftshop.php" -> {
         // Gift Shop
         if (KoLCharacter.inBadMoon() || KoLCharacter.isKingdomOfExploathing()) {


### PR DESCRIPTION
Fixes an issue where the maximizer would recommend buying scrolls from the Wet Crap For Sale shop, even if the user is not in the appropriate path.