### PR TITLE
Integrate JLine into KolMafia as a GUI replacement

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,6 +110,7 @@ dependencies {
   implementation("com.jgoodies:jgoodies-binding:2.13.0")
   implementation("org.eclipse.jgit:org.eclipse.jgit:7.4.0.202509020913-r")
   implementation("org.eclipse.jgit:org.eclipse.jgit.ssh.apache:7.4.0.202509020913-r")
+  implementation("org.jline:jline:4.1.0")
 
   checkstyle("com.puppycrawl.tools:checkstyle:${checkstyle.toolVersion}")
 }

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -17,6 +17,7 @@ global	allowNonMoodBurning	true
 global	allowSummonBurning	true
 global	autoLogin
 global	autoHighlightOnFocus	true
+global	brightenDarkCLIColors	true
 global	broadcastEvents	true
 global	browserBookmarks
 global	cacheMallSearches	false
@@ -53,6 +54,7 @@ global	defaultDropdown2	1
 global	defaultDropdownSplit	0
 global	defaultLimit	5
 global	displayName
+global	enableJLine	true
 global	externalEditor
 global	fixedThreadPoolSize	0
 global	gapProtection	false

--- a/src/net/sourceforge/kolmafia/KoLMafiaJLine.java
+++ b/src/net/sourceforge/kolmafia/KoLMafiaJLine.java
@@ -1,0 +1,306 @@
+package net.sourceforge.kolmafia;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.History;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.Reference;
+import org.jline.reader.UserInterruptException;
+import org.jline.reader.impl.LineReaderImpl;
+import org.jline.reader.impl.history.DefaultHistory;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStyle;
+
+public class KoLMafiaJLine {
+  private static PrintStream originalOut;
+  private static PrintStream originalErr;
+
+  private static LineReader jlineReader;
+  private static Terminal jlineTerminal;
+  private static Instant lastNoUserHistory;
+
+  private static int interruptCount = 0;
+  private static long lastInterruptTime = 0L;
+  private static final long INTERRUPT_RESET_SECS = 5;
+  private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss");
+
+  private KoLMafiaJLine() {}
+
+  public static boolean isJLineEnabled() {
+    return jlineReader != null;
+  }
+
+  public static void initialize() {
+    originalOut = System.out;
+    originalErr = System.err;
+
+    if (Preferences.getBoolean("disableJLine")) {
+      return;
+    }
+
+    createJline();
+  }
+
+  private static void createJline() {
+    try {
+      jlineTerminal =
+          TerminalBuilder.builder()
+              .system(true)
+              .jansi(true)
+              .signalHandler(Terminal.SignalHandler.SIG_DFL)
+              .build();
+
+      updateAttachedAccount();
+
+      // Intercept System.out and System.err, allows the program to continue using
+      // System.out.println
+      System.setOut(new PrintStream(new LineInterceptorStream(originalOut, false), true));
+      System.setErr(new PrintStream(new LineInterceptorStream(originalErr, true), true));
+    } catch (Throwable throwable) {
+      StaticEntity.printStackTrace(throwable, "Error creating JLine");
+    }
+  }
+
+  public static String readLine(String prompt) {
+    return readLine(prompt, null);
+  }
+
+  public static String readLine(String prompt, Character mask) {
+    if (jlineReader == null) {
+      return null;
+    }
+
+    try {
+      return jlineReader.readLine(prompt, mask);
+    } catch (UserInterruptException e) {
+      return handleInterrupt();
+    } catch (EndOfFileException e) {
+      return null;
+    }
+  }
+
+  private static String handleInterrupt() {
+    long now = System.currentTimeMillis();
+
+    if (now - lastInterruptTime > INTERRUPT_RESET_SECS * 1000) {
+      interruptCount = 0;
+    }
+
+    lastInterruptTime = now;
+
+    switch (++interruptCount) {
+      case 1 -> {
+        System.err.println(
+            "Killing running scripts... Ctrl + C again in the next "
+                + INTERRUPT_RESET_SECS
+                + " seconds to request shutdown.");
+        return "abort";
+      }
+
+      case 2 -> {
+        System.err.println(
+            "Asking KoLMafia to shut down... Ctrl + C again to terminate the process.");
+        KoLmafia.quit();
+        return "abort";
+      }
+
+      default -> {
+        System.err.println("Terminating the process.");
+        System.exit(1);
+        return null;
+      }
+    }
+  }
+
+  public static void addCommandToHistory(String command) {
+    if (jlineReader == null || command == null || command.isBlank()) {
+      return;
+    }
+
+    synchronized (jlineTerminal) {
+      History history = jlineReader.getHistory();
+
+      if (history == null || (!history.isEmpty() && history.get(history.last()).equals(command))) {
+        return;
+      }
+
+      history.add(command);
+    }
+  }
+
+  private static void createReader(DefaultHistory history, Path historyFile) {
+    jlineReader =
+        LineReaderBuilder.builder()
+            .terminal(jlineTerminal)
+            .history(history)
+            .variable(LineReader.HISTORY_FILE, historyFile)
+            .variable(LineReader.HISTORY_SIZE, 1000)
+            .variable(LineReader.HISTORY_FILE_SIZE, 1000)
+            .option(LineReader.Option.AUTO_FRESH_LINE, true)
+            .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true)
+            .option(LineReader.Option.HISTORY_IGNORE_DUPS, true)
+            // Prevents jline from prefixing characters for mutliline commands (eg, via copy/paste)
+            .variable(LineReader.SECONDARY_PROMPT_PATTERN, "")
+            // If multi-line commands are undesirable, it needs to be handled.
+            .build();
+
+    var main = jlineReader.getKeyMaps().get(LineReader.MAIN);
+
+    // Allows using Ctrl + Up/Down to go up and down history.
+    // Useful for multi-line commands
+    main.bind(new Reference(LineReader.UP_HISTORY), "\u001b[1;5A");
+    main.bind(new Reference(LineReader.DOWN_HISTORY), "\u001b[1;5B");
+  }
+
+  public static void updateAttachedAccount() {
+    if (jlineTerminal == null) {
+      return;
+    }
+
+    synchronized (jlineTerminal) {
+      History oldHistory = null;
+      Instant copyHistoryFrom = lastNoUserHistory;
+
+      if (jlineReader != null) {
+        try {
+          jlineReader.getHistory().save();
+          oldHistory = jlineReader.getHistory();
+        } catch (IOException e) {
+          StaticEntity.printStackTrace(e, "Error saving jline history");
+        }
+      }
+
+      String name = KoLCharacter.getUserName().trim().toLowerCase(Locale.ENGLISH);
+
+      if (name.isEmpty()) {
+        name = "no-user";
+
+        if (lastNoUserHistory == null) {
+          lastNoUserHistory = Instant.now();
+        }
+      } else {
+        lastNoUserHistory = null;
+      }
+
+      DefaultHistory newHistory = new DefaultHistory();
+      Path historyFile = Paths.get("history/" + name + "-terminal.txt");
+
+      try {
+        if (historyFile.getParent() != null) {
+          historyFile.getParent().toFile().mkdirs();
+        }
+      } catch (Exception ignored) {
+      }
+
+      if (jlineReader == null) {
+        createReader(newHistory, historyFile);
+      } else {
+        jlineReader.variable(LineReader.HISTORY_FILE, historyFile);
+        ((LineReaderImpl) jlineReader).setHistory(newHistory);
+        newHistory.attach(jlineReader);
+      }
+
+      copyHistory(oldHistory, newHistory, copyHistoryFrom);
+    }
+  }
+
+  /**
+   * Used to attribute commands run before a user was established, to a user
+   *
+   * @param oldHistory
+   * @param newHistory
+   * @param from Establishes this time onwards, to be attributed to the user
+   */
+  private static void copyHistory(History oldHistory, DefaultHistory newHistory, Instant from) {
+    if (oldHistory == null || from == null) {
+      return;
+    }
+
+    boolean added = false;
+
+    for (History.Entry entry : oldHistory) {
+      if (entry.time().isBefore(from)) {
+        continue;
+      }
+
+      if (!newHistory.isEmpty() && newHistory.get(newHistory.last()).equals(entry.line())) {
+        continue;
+      }
+
+      newHistory.add(entry.time(), entry.line());
+      added = true;
+    }
+
+    if (added) {
+      try {
+        newHistory.save();
+      } catch (IOException e) {
+        StaticEntity.printStackTrace(e, "Error saving merged history");
+      }
+    }
+  }
+
+  /** Intercepts bytes and sends to JLine to be printed in a nicer manner */
+  private static class LineInterceptorStream extends OutputStream {
+    private final PrintStream original;
+    private final boolean errorStream;
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+    LineInterceptorStream(PrintStream original, boolean errorStream) {
+      this.original = original;
+      this.errorStream = errorStream;
+    }
+
+    @Override
+    public synchronized void write(int b) {
+      if (b == '\n') {
+        String line = buffer.toString(StandardCharsets.UTF_8);
+        buffer.reset();
+
+        line = line.replace("\r", "");
+
+        print(original, line, errorStream);
+      } else {
+        buffer.write(b);
+      }
+    }
+
+    @Override
+    public synchronized void flush() {
+      original.flush();
+    }
+
+    static synchronized void print(PrintStream stream, String line, boolean error) {
+      // Gives the timestamp a gray color, unless it's an error
+      AttributedString timestamp =
+          new AttributedString(
+              "[" + LocalTime.now().format(TIME_FORMAT) + "] ",
+              AttributedStyle.DEFAULT.foreground(
+                  error ? AttributedStyle.RED : AttributedStyle.BRIGHT));
+
+      AttributedString as;
+
+      if (error) {
+        as = new AttributedString(line, AttributedStyle.DEFAULT.foreground(AttributedStyle.RED));
+      } else {
+        as = new AttributedString(line);
+      }
+
+      jlineReader.printAbove(AttributedString.join(AttributedString.EMPTY, timestamp, as));
+    }
+  }
+}

--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -279,6 +279,11 @@ public abstract class KoLmafia {
       }
     }
 
+    // Request terminal to be taken over, now that the desired state is known
+    if (!StaticEntity.isGUIRequired()) {
+      KoLmafiaTUI.initialize();
+    }
+
     // Start background process to detect and report deadlocks.
     DeadlockDetector.registerDeadlockDetector();
 
@@ -329,8 +334,6 @@ public abstract class KoLmafia {
 
     if (StaticEntity.isGUIRequired()) {
       KoLmafiaGUI.initialize();
-    } else {
-      KoLmafiaTUI.initialize();
     }
 
     // Now, maybe the person wishes to run something
@@ -360,7 +363,17 @@ public abstract class KoLmafia {
         actualScript = actualScript.substring(7);
       }
 
-      KoLmafiaCLI.DEFAULT_SHELL.executeLine("call " + actualScript);
+      String commandToRun = "call " + actualScript;
+      // Saves in jline history if needed
+      KoLMafiaJLine.addCommandToHistory(commandToRun);
+
+      if (!StaticEntity.isGUIRequired()) {
+        // Queue the command to run
+        KoLmafiaCLI.DEFAULT_SHELL.addQueuedLine(commandToRun);
+      } else {
+        // With a GUI, commands must be run directly
+        KoLmafiaCLI.DEFAULT_SHELL.executeLine(commandToRun);
+      }
     } else if (!StaticEntity.isGUIRequired()) {
       KoLmafiaCLI.DEFAULT_SHELL.attemptLogin("");
     }

--- a/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
+++ b/src/net/sourceforge/kolmafia/KoLmafiaCLI.java
@@ -84,8 +84,12 @@ public class KoLmafiaCLI {
     try {
       if (username == null || username.length() == 0) {
         System.out.println();
-        System.out.print("username: ");
-        username = this.commandStream.readLine();
+        if (KoLMafiaJLine.isJLineEnabled() && this == DEFAULT_SHELL) {
+          username = KoLMafiaJLine.readLine("username: ");
+        } else {
+          System.out.print("username: ");
+          username = this.commandStream.readLine();
+        }
       }
 
       if (username == null || username.length() == 0) {
@@ -100,8 +104,13 @@ public class KoLmafiaCLI {
       String password = KoLmafia.getSaveState(username);
 
       if (password == null) {
-        System.out.print("password: ");
-        password = this.commandStream.readLine();
+        if (KoLMafiaJLine.isJLineEnabled() && this == DEFAULT_SHELL) {
+          // Masks password with asterisks
+          password = KoLMafiaJLine.readLine("password: ", '*');
+        } else {
+          System.out.print("password: ");
+          password = this.commandStream.readLine();
+        }
       }
 
       if (password == null || password.length() == 0) {
@@ -126,8 +135,18 @@ public class KoLmafiaCLI {
       String line;
 
       try {
-        while ((line = KoLmafiaCLI.this.commandStream.readLine()) != null) {
-          if (line.equals("--")) {
+        while (true) {
+          if (KoLMafiaJLine.isJLineEnabled() && KoLmafiaCLI.this == KoLmafiaCLI.DEFAULT_SHELL) {
+            line = KoLMafiaJLine.readLine(" > ");
+          } else {
+            line = KoLmafiaCLI.this.commandStream.readLine();
+          }
+
+          if (line == null) {
+            break;
+          }
+
+          if (line.equals("--") || line.trim().equalsIgnoreCase("abort")) {
             RequestThread.declareWorldPeace();
 
             synchronized (KoLmafiaCLI.this.queuedLines) {
@@ -137,13 +156,13 @@ public class KoLmafiaCLI {
               || line.startsWith("#")
               || line.startsWith("//")
               || line.startsWith("'")) {
-            synchronized (KoLmafiaCLI.this.queuedLines) {
-              KoLmafiaCLI.this.queuedLines.addLast(null);
-            }
+            addQueuedLine(null);
           } else {
-            synchronized (KoLmafiaCLI.this.queuedLines) {
-              KoLmafiaCLI.this.queuedLines.addLast(line);
+            if (KoLmafiaCLI.this == KoLmafiaCLI.DEFAULT_SHELL) {
+              KoLMafiaJLine.addCommandToHistory(line);
             }
+
+            addQueuedLine(line);
           }
         }
 
@@ -171,9 +190,18 @@ public class KoLmafiaCLI {
         }
 
         if (line != null) {
-          KoLmafiaCLI.this.isGUI = false;
-          KoLmafiaCLI.this.executeLine(line);
-          KoLmafiaCLI.this.isGUI = true;
+          try {
+            KoLmafiaCLI.this.isGUI = false;
+            KoLmafiaCLI.this.executeLine(line);
+            KoLmafiaCLI.this.isGUI = true;
+          } catch (Throwable t) {
+            // If an error is thrown then there's a major issue, clear pending commands
+            synchronized (KoLmafiaCLI.this.queuedLines) {
+              KoLmafiaCLI.this.queuedLines.clear();
+            }
+
+            StaticEntity.printStackTrace(t, "Error in command processor thread");
+          }
         }
 
         if (KoLmafiaCLI.DEFAULT_SHELL == KoLmafiaCLI.this) {
@@ -190,6 +218,7 @@ public class KoLmafiaCLI {
       if (message != null
           && KoLmafiaCLI.this.queuedLines.isEmpty()
           && KoLmafiaCLI.DEFAULT_SHELL == KoLmafiaCLI.this
+          && !KoLMafiaJLine.isJLineEnabled()
           && KoLmafiaCLI.this.retriever.isAlive()) {
         RequestLogger.printLine();
 
@@ -208,7 +237,7 @@ public class KoLmafiaCLI {
         return null;
       }
 
-      if (KoLmafiaCLI.DEFAULT_SHELL == KoLmafiaCLI.this) {
+      if (KoLmafiaCLI.DEFAULT_SHELL == KoLmafiaCLI.this && !KoLMafiaJLine.isJLineEnabled()) {
         RequestLogger.printLine();
       }
 
@@ -233,6 +262,12 @@ public class KoLmafiaCLI {
     } else {
       this.retriever.run();
       this.processor.run();
+    }
+  }
+
+  public void addQueuedLine(String line) {
+    synchronized (KoLmafiaCLI.this.queuedLines) {
+      this.queuedLines.addLast(line);
     }
   }
 

--- a/src/net/sourceforge/kolmafia/KoLmafiaTUI.java
+++ b/src/net/sourceforge/kolmafia/KoLmafiaTUI.java
@@ -13,12 +13,16 @@ public class KoLmafiaTUI {
   private KoLmafiaTUI() {}
 
   static void initialize() {
-    try {
-      AnsiConsole.systemInstall();
-    } catch (Exception e) {
-      // Failed to install jansi. Continue as before.
-    } catch (LinkageError e) {
-      // Linking failed, but we can continue anyways.
+    if (Preferences.getBoolean("enableJLine")) {
+      KoLMafiaJLine.initialize();
+    } else {
+      try {
+        AnsiConsole.systemInstall();
+      } catch (Exception e) {
+        // Failed to install jansi. Continue as before.
+      } catch (LinkageError e) {
+        // Linking failed, but we can continue anyways.
+      }
     }
     out.openStandard();
   }

--- a/src/net/sourceforge/kolmafia/utilities/ColorConverter.java
+++ b/src/net/sourceforge/kolmafia/utilities/ColorConverter.java
@@ -1,0 +1,99 @@
+package net.sourceforge.kolmafia.utilities;
+
+/** A utility class for converting colors between RGB and HSL color spaces. */
+public class ColorConverter {
+
+  /**
+   * Converts an RGB color value to HSL. Conversion formula adapted from
+   * http://en.wikipedia.org/wiki/HSL_color_space. Assumes r, g, and b are contained in the set [0,
+   * 255] and returns h, s, and l in the set [0, 1].
+   *
+   * @param r The red color component
+   * @param g The green color component
+   * @param b The blue color component
+   * @return An array of three floats representing the HSL values: {hue, saturation, lightness}.
+   */
+  public static float[] rgbToHsl(int r, int g, int b) {
+    float red = r / 255f;
+    float green = g / 255f;
+    float blue = b / 255f;
+
+    float max = Math.max(red, Math.max(green, blue));
+    float min = Math.min(red, Math.min(green, blue));
+
+    float h = 0, s = 0, l = (max + min) / 2;
+
+    if (max == min) {
+      // achromatic (grey)
+      h = s = 0;
+    } else {
+      float d = max - min;
+      s = l > 0.5f ? d / (2f - max - min) : d / (max + min);
+
+      if (max == red) {
+        h = (green - blue) / d + (green < blue ? 6f : 0);
+      } else if (max == green) {
+        h = (blue - red) / d + 2f;
+      } else if (max == blue) {
+        h = (red - green) / d + 4f;
+      }
+      h /= 6f;
+    }
+
+    return new float[] {h, s, l};
+  }
+
+  /**
+   * Converts an HSL color value to RGB. Conversion formula adapted from
+   * http://en.wikipedia.org/wiki/HSL_color_space. Assumes h, s, and l are contained in the set [0,
+   * 1] and returns r, g, and b in the set [0, 255].
+   *
+   * @param h The hue
+   * @param s The saturation
+   * @param l The lightness
+   * @return An array of three integers representing the RGB values: {red, green, blue}.
+   */
+  public static int[] hslToRgb(float h, float s, float l) {
+    float r, g, b;
+
+    if (s == 0) {
+      // achromatic (grey)
+      r = g = b = l;
+    } else {
+      float q = l < 0.5f ? l * (1 + s) : l + s - l * s;
+      float p = 2 * l - q;
+      r = hueToRgb(p, q, h + 1f / 3f);
+      g = hueToRgb(p, q, h);
+      b = hueToRgb(p, q, h - 1f / 3f);
+    }
+
+    return new int[] {Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)};
+  }
+
+  /**
+   * Helper method that converts hue to an RGB component.
+   *
+   * @param p
+   * @param q
+   * @param t
+   * @return RGB component value
+   */
+  private static float hueToRgb(float p, float q, float t) {
+    if (t < 0) {
+      t += 1;
+    }
+    if (t > 1) {
+      t -= 1;
+    }
+    if (t < 1f / 6f) {
+      return p + (q - p) * 6f * t;
+    }
+    if (t < 1f / 2f) {
+      return q;
+    }
+    if (t < 2f / 3f) {
+      return p + (q - p) * (2f / 3f - t) * 6f;
+    }
+    return p;
+  }
+}

--- a/src/net/sourceforge/kolmafia/utilities/ColorParser.java
+++ b/src/net/sourceforge/kolmafia/utilities/ColorParser.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import net.sourceforge.kolmafia.preferences.Preferences;
 
 public class ColorParser {
 
@@ -30,6 +31,21 @@ public class ColorParser {
   }
 
   public static int rgb(int r, int g, int b) {
+    // True colors can be quite dark!
+    if (Preferences.getBoolean("brightenDarkCLIColors")) {
+      float[] hsb = ColorConverter.rgbToHsl(r, g, b);
+
+      if (hsb[2] < .7f) {
+        hsb[2] = hsb[2] + .20f;
+
+        int[] rgb = ColorConverter.hslToRgb(hsb[0], hsb[1], hsb[2]);
+
+        r = rgb[0];
+        g = rgb[1];
+        b = rgb[2];
+      }
+    }
+
     return ((r & 255) << 16) + ((g & 255) << 8) + (b & 255);
   }
 


### PR DESCRIPTION
This integrates [https://jline.org/](https://jline.org/) into KoLMafia for use when the GUI is not enabled. It also adds timestamps when JLine is in use.

JLine allows for better CLI interaction, such as navigating the command buffer with the arrow keys or scrolling through history. It prints console output above the input, very useful while you are typing something.

<img width="523" height="200" alt="image" src="https://github.com/user-attachments/assets/681b288e-a010-4d7e-89fe-265bd6ee5c3e" />

JLine in this PR starts up relatively late during boot, allowing other text to be printed to console, which is the reason behind the first line of the image not having a timestamp. 

This PR accomplishes the following when JLine is used, which is only when the GUI is disabled.

* JLine support
* Timestamps in the CLI
* Brightens dark true colors, which are otherwise hard to read against a dark background
* Intercepts Ctrl+C to first abort scripts, then shut down KoLMafia cleanly, then kill the process.
* Intercepts all System.out and System.err usage to pipe into JLine, which avoids any large refactoring
* JLine history files, which is not shared with KoLMafia’s gCLI command buffer
* Exceptional commands no longer kills the command retriever thread
* Adds the startup command to JLine's command history

A few notes:

1. I am well aware that the history implementation in this PR may be seen as undesirable. I do not believe the preferences file is a suitable place to store commands, maintainers are welcome to make their changes.
2. True colors can be quite dark and unreadable, which is the reason behind the color mutation. CLI colors are mutated even if not using JLine, but can be disabled via preference.
3. The JLine implemented here does not turn every line into its own command, this was not by design, but I have found useful. This could probably be addressed by splitting the string being read, but this also suits my use case, since I can test multiline scripts by pasting them in from an editor. That said, it will break other things, such as aliases, which do not expect newlines and will never save properly. To restate, this allows multiple lines to be pasted in and executed as a single command, this does not override the behavior when pressing `Enter`.
4. Commands that rely on html formatting for rendering will continue to be broken, such as `prefref`. I don't have a solution for this.

I am not interested in personally working on this further. For my builds of KoLMafia, this already does what I want, and I am happy for someone else to take it over. I made this PR for that purpose, and do not expect it to be accepted in it's current state.