### PR TITLE
feat: add a connection timeout of non-infinity

### DIFF
--- a/src/net/sourceforge/kolmafia/utilities/HttpUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/HttpUtilities.java
@@ -2,6 +2,7 @@ package net.sourceforge.kolmafia.utilities;
 
 import java.net.http.HttpClient;
 import java.net.http.HttpClient.Redirect;
+import java.time.Duration;
 
 public class HttpUtilities {
   private HttpUtilities() {}
@@ -12,7 +13,10 @@ public class HttpUtilities {
   }
 
   private static ClientFactory clientFactory =
-      () -> HttpClient.newBuilder().followRedirects(Redirect.ALWAYS);
+      () ->
+          HttpClient.newBuilder()
+              .followRedirects(Redirect.ALWAYS)
+              .connectTimeout(Duration.ofSeconds(30L));
 
   // Injects custom URL handling logic, especially in tests.
   public static void setClientBuilder(ClientFactory function) {


### PR DESCRIPTION
This should prevent scripts (e.g. ChIT) hanging when zachbardon.com does not respond.

There is a potential issue with `pull all` not responding in time, but I think the connection itself completes within time -- just not the whole request. The timeout on the request itself is still infinity.