### PR TITLE
Fix choice decoration for NC number 208

### DIFF
--- a/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceAdventures.java
@@ -1553,7 +1553,7 @@ public abstract class ChoiceAdventures {
         "Hobopolis",
         "The Ancient Hobo Burial Ground",
         // Option...
-        new ChoiceOption("increase spooky hobos & decrease stench"),
+        new ChoiceOption("increase spooky hobo ML & decrease stench"),
         SKIP_ADVENTURE);
 
     // Choice 209 is Timbarrrr!


### PR DESCRIPTION
Fixes issue from https://kolmafia.us/threads/ancient-hobo-burial-ground-nc-choice-208-description-is-wrong.32498/