### PR TITLE
Give scariersauce the thorns modifier

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -7750,7 +7750,7 @@ Effect	Savage Beast Inside	Muscle: +20
 Effect	Scared Stiff	Sleaze Resistance: +2, Cold Vulnerability, Spooky Vulnerability
 Effect	Scaredy Dog	Spooky Damage: +30, Cold Resistance: +3, Sleaze Resistance: +3, Combat Rate: -5
 Effect	Scariberi	Spooky Damage: [min(100,T)]
-Effect	Scariersauce	Sleaze Resistance: +6, Cold Resistance: +6
+Effect	Scariersauce	Sleaze Resistance: +6, Cold Resistance: +6, Thorns: 1
 Effect	Scarysauce	Sleaze Resistance: +2, Cold Resistance: +2, Thorns: 1
 Effect	Scavengers Scavenging	Item Drop: +20
 Effect	Scent of a Kitchen Elf	Mysticality: +40, Familiar Weight Percent: -50


### PR DESCRIPTION
As per the wiki and my own experience wailing on the [zombie hoa](https://wiki.kingdomofloathing.com/Zombie_Homeowners'_Association_(Hard_Mode)), [Scariersauce](https://wiki.kingdomofloathing.com/Scariersauce) has thorns.