### PR TITLE
Fix astral energy drink missing from the item manager's Spleen panel

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/Concoction.java
+++ b/src/net/sourceforge/kolmafia/objectpool/Concoction.java
@@ -197,20 +197,15 @@ public class Concoction implements Comparable<Concoction> {
 
   public ConcoctionType computeType() {
     int itemId = this.getItemId();
-    if (ConsumablesDatabase.getRawFullness(name) != null) {
+    if (forceFood.contains(itemId)) {
       return ConcoctionType.FOOD;
-    } else if (ConsumablesDatabase.getRawInebriety(name) != null) {
+    } else if (forceBooze.contains(itemId)) {
       return ConcoctionType.BOOZE;
-    } else if (ConsumablesDatabase.getRawSpleenHit(name) != null) {
-      return ConcoctionType.SPLEEN;
     } else
       return switch (ItemDatabase.getConsumptionType(itemId)) {
-        case FOOD_HELPER -> ConcoctionType.FOOD;
-        case DRINK_HELPER -> ConcoctionType.BOOZE;
-        case USE, USE_MULTIPLE ->
-            forceFood.contains(itemId)
-                ? ConcoctionType.FOOD
-                : forceBooze.contains(itemId) ? ConcoctionType.BOOZE : ConcoctionType.NONE;
+        case EAT, FOOD_HELPER -> ConcoctionType.FOOD;
+        case DRINK, DRINK_HELPER -> ConcoctionType.BOOZE;
+        case SPLEEN -> ConcoctionType.SPLEEN;
         case POTION, AVATAR_POTION -> ConcoctionType.POTION;
         default -> ConcoctionType.NONE;
       };

--- a/src/net/sourceforge/kolmafia/objectpool/Concoction.java
+++ b/src/net/sourceforge/kolmafia/objectpool/Concoction.java
@@ -93,10 +93,8 @@ public class Concoction implements Comparable<Concoction> {
       Set.of("steel margarita", "steel lasagna", "steel-scented air freshener");
   private static final Set<Integer> forceFood =
       Set.of(
-          ItemPool.QUANTUM_TACO,
           ItemPool.MUNCHIES_PILL,
           ItemPool.WHETSTONE,
-          ItemPool.MAGICAL_SAUSAGE,
           ItemPool.MAYONEX,
           ItemPool.MAYODIOL,
           ItemPool.MAYOSTAT,

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -1711,7 +1711,6 @@ public class ItemPool {
   public static final int EMU_ROCKET = 5136;
   public static final int EMU_HELMET = 5137;
   public static final int EMU_HARNESS = 5138;
-  public static final int ASTRAL_ENERGY_DRINK = 5140;
   public static final int EMU_UNIT = 5143;
   public static final int HONEYPOT = 5145;
   public static final int SPOOKY_LITTLE_GIRL = 5165;
@@ -3617,6 +3616,7 @@ public class ItemPool {
   public static final int MEATBALL_MACHINE = 10878;
   public static final int REFURBISHED_AIR_FRYER = 10879;
   public static final int ELEVEN_LEAF_CLOVER = 10881;
+  public static final int ASTRAL_ENERGY_DRINK = 10883;
   public static final int CURSED_MAGNIFYING_GLASS = 10885;
   public static final int COSMIC_BOWLING_BALL = 10891;
   public static final int COMBAT_LOVERS_LOCKET = 10893;

--- a/src/net/sourceforge/kolmafia/persistence/ConsumablesDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ConsumablesDatabase.java
@@ -598,9 +598,9 @@ public class ConsumablesDatabase {
     Consumable existing = ConsumablesDatabase.consumableByName.get(itemName);
     ConsumablesDatabase.setConsumptionData(
         itemName,
-        existing.getRawFullness() != null ? size : null,
-        existing.getRawInebriety() != null ? size : null,
-        existing.getRawSpleenHit() != null ? size : null,
+        (existing != null && existing.getRawFullness() != null) ? size : null,
+        (existing != null && existing.getRawInebriety() != null) ? size : null,
+        (existing != null && existing.getRawSpleenHit() != null) ? size : null,
         level,
         quality,
         advs,
@@ -1138,7 +1138,7 @@ public class ConsumablesDatabase {
     // (probably) capped at level 11 giving 29-35 adventures, and levels 1-3
     // are (probably) lumped together giving 13-19 adventures.
 
-    name = "astral energy drink";
+    name = "[5140]astral energy drink";
     size = ConsumablesDatabase.getSpleenHit(name);
     int a = 10 + level * 2;
     adventures = (a - 3) + "-" + (a + 3);

--- a/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/UseItemEnqueuePanel.java
@@ -709,6 +709,10 @@ public class UseItemEnqueuePanel extends ItemListManagePanel<Concoction> impleme
         }
       }
 
+      if (creation.getItemId() > 0) {
+        name = ItemPool.get(creation.getItemId()).getDisambiguatedName();
+      }
+
       if (ConsumablesDatabase.getRawFullness(name) == null
           && ConsumablesDatabase.getRawInebriety(name) == null
           && ConsumablesDatabase.getRawSpleenHit(name) == null) {

--- a/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/ListCellRendererFactory.java
@@ -406,6 +406,7 @@ public class ListCellRendererFactory {
         case ItemPool.MAYOSTAT -> stringForm.append("return some of next food");
         case ItemPool.MAYOZAPINE -> stringForm.append("x2 stat gain from next food");
         case ItemPool.MAYOFLEX -> stringForm.append("+1 adv from next food");
+        case ItemPool.ASTRAL_ENERGY_DRINK -> stringForm.append("Lucky!");
         default -> {
           Integer fullness = ConsumablesDatabase.getRawFullness(name);
           Integer inebriety = ConsumablesDatabase.getRawInebriety(name);

--- a/test/net/sourceforge/kolmafia/objectpool/ConcoctionTest.java
+++ b/test/net/sourceforge/kolmafia/objectpool/ConcoctionTest.java
@@ -375,4 +375,17 @@ public class ConcoctionTest {
       }
     }
   }
+
+  @ParameterizedTest
+  @ValueSource(
+      ints = {
+        ItemPool.QUANTUM_TACO,
+        ItemPool.MAGICAL_SAUSAGE,
+        ItemPool.GLITCH_ITEM,
+        ItemPool.RED_DRUNKI_BEAR
+      })
+  public void unusualConcoctionTypesComputedAsFood(int itemId) {
+    var con = ConcoctionPool.get(itemId);
+    assertThat(con.computeType(), is(ConcoctionType.FOOD));
+  }
 }

--- a/test/net/sourceforge/kolmafia/request/UseItemRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/UseItemRequestTest.java
@@ -317,7 +317,6 @@ class UseItemRequestTest {
       try (cleanups) {
         assertThat(ConsumablesDatabase.getRawSpleenHit("[5140]astral energy drink"), is(8));
         assertThat(ConsumablesDatabase.getRawSpleenHit("[10883]astral energy drink"), is(5));
-        assertThat(ConsumablesDatabase.getRawSpleenHit("astral energy drink"), is(0));
         assertThat(UseItemRequest.maximumUses("[5140]astral energy drink"), is(1));
         assertThat(UseItemRequest.maximumUses(5140), is(1));
         assertThat(UseItemRequest.maximumUses("[10883]astral energy drink"), is(3));


### PR DESCRIPTION
Fixes https://kolmafia.us/threads/astral-energy-drinks-dont-appear-in-item-manager.29865/

A few notes:
* This changes which consumable name is used by the `ConsumablesDatabase` code that automatically calculates the stats for the old astral energy drinks. I doubt this breaks anything; are these things even obtainable anymore?
* It changes the `UseItemEnqueuePanel` to use the disambiguated name of an item to calculate the characteristics of its consumable. This didn't appear to break anything or make anything display strangely, but I'm not 100% sure where exactly that name gets used.