### PR TITLE
feat: add conditional noncombat skills

### DIFF
--- a/src/net/sourceforge/kolmafia/session/EquipmentManager.java
+++ b/src/net/sourceforge/kolmafia/session/EquipmentManager.java
@@ -11,7 +11,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.FamiliarData;
 import net.sourceforge.kolmafia.KoLAdventure;
@@ -464,9 +463,8 @@ public class EquipmentManager {
     }
     mods.getStrings(StringModifier.CONDITIONAL_SKILL_EQUIPPED).stream()
         .map(SkillDatabase::getSkillId)
-        .filter(Predicate.not(SkillDatabase::isNonCombat))
-        // always remove skills, or add skills available sometimes
-        .filter(x -> !add || EquipmentManager.shouldApplySkill(x))
+        // always remove non-noncombat skills, or add skills available sometimes
+        .filter(x -> add ? EquipmentManager.shouldApplySkill(x) : !SkillDatabase.isNonCombat(x))
         .forEach(cb);
   }
 


### PR DESCRIPTION
When equipping an item, add any noncombat skills it possesses.

I got into this state by removing a moss medal from my display case and then trying to cast its skill. I think if it had started out in my inventory, everything would have been fine, but that wasn't the case.