### PR TITLE
Display Sword of S Words kills on char pane

### DIFF
--- a/src/net/sourceforge/kolmafia/webui/CharPaneDecorator.java
+++ b/src/net/sourceforge/kolmafia/webui/CharPaneDecorator.java
@@ -722,6 +722,11 @@ public class CharPaneDecorator {
 
         return buffer;
       }
+      case FamiliarPool.SWORD_OF_SWORDS -> {
+        buffer.append(Preferences.getInteger("_swordOfSWordsKills"));
+        buffer.append("/100 kills");
+        return buffer;
+      }
     }
 
     if (familiar.hasDrop()) {


### PR DESCRIPTION
Display progress of Sword of S Words kills on the char pane. I considered instead adding this as an entry in the list of familiar drops, but that felt like it would have been janky in a way that the existing "fake" drops (e.g. cookbookbat recipes) aren't.