### PR TITLE
Fix maximiser ignoring equip keywords with -tie

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -980,6 +980,18 @@ public class Evaluator {
     return !this.noTiebreaker;
   }
 
+  boolean isWeaponTypeRequired() {
+    return this.requireClub
+        || this.requireUtensil
+        || this.requireSword
+        || this.requireKnife
+        || this.requireAccordion;
+  }
+
+  boolean isShieldRequired() {
+    return this.requireShield;
+  }
+
   enum Constraint {
     /** Item violates a constraint, don't use it */
     VIOLATES,

--- a/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
+++ b/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
@@ -99,6 +99,20 @@ public class MaximizerSpeculation extends Speculation
         this.simplicity += slot == Slot.WEAPON ? -1 : 1;
       }
     }
+    // When an equipment-type keyword (club, sword, shield, etc.) is active, prefer any
+    // qualifying item over leaving the slot empty: give it a nudge above UNEQUIP's +2.
+    if (Maximizer.eval.isWeaponTypeRequired()) {
+      AdventureResult weapon = this.equipment.get(Slot.WEAPON);
+      if (weapon != null && !weapon.equals(EquipmentRequest.UNEQUIP)) {
+        this.simplicity += 3;
+      }
+    }
+    if (Maximizer.eval.isShieldRequired()) {
+      AdventureResult offhand = this.equipment.get(Slot.OFFHAND);
+      if (offhand != null && !offhand.equals(EquipmentRequest.UNEQUIP)) {
+        this.simplicity += 3;
+      }
+    }
     return this.tiebreaker;
   }
 

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -804,6 +804,26 @@ public class MaximizerTest {
     }
 
     @Test
+    public void clubModifierWorksWithoutTieBreaker() {
+      final var cleanups = new Cleanups(withEquippableItem("lawn dart"));
+
+      try (cleanups) {
+        assertTrue(maximize("-tie, club"));
+        assertThat(getBoosts(), hasItem(recommendsSlot(Slot.WEAPON, "lawn dart")));
+      }
+    }
+
+    @Test
+    public void shieldModifierWorksWithoutTieBreaker() {
+      final var cleanups = new Cleanups(withEquippableItem("vinyl shield"));
+
+      try (cleanups) {
+        assertTrue(maximize("-tie, shield"));
+        assertThat(getBoosts(), hasItem(recommendsSlot(Slot.OFFHAND, "vinyl shield")));
+      }
+    }
+
+    @Test
     public void swordModifierFavorsSword() {
       final var cleanups =
           new Cleanups(withEquippableItem("sweet ninja sword"), withEquippableItem("spiked femur"));


### PR DESCRIPTION
## Problem

`maximize("-tie, club")` (and similarly for `sword`, `knife`, `utensil`, `accordion`, `shield`) does not recommend any qualifying item even when the character has one. Forum thread: https://kolmafia.us/threads/issues-with-maximiser-command.28691/

With no stat weights, every item scores 0.0. The simplicity comparison in `MaximizerSpeculation.compareTo` is not guarded by `isUsingTiebreaker()`, so it runs even with `-tie` active. The synthetic `(none)`/UNEQUIP item gets +2 simplicity (currently equipped) while a qualifying club scores 0, so UNEQUIP sorts first, its `Integer.MAX_VALUE` count fills the slot quota, and the club never enters `automaticEntry`.

The same mechanism breaks `shield` in the offhand slot: `maximize("-tie, shield")` with an equippable shield recommends nothing.

## Fix

**`MaximizerSpeculation.java`** -- in `getTiebreaker()`, add +3 simplicity for a non-UNEQUIP weapon when a weapon-type keyword is active, and for a non-UNEQUIP offhand when `shield` is required. The qualifying item then scores 3 vs UNEQUIP's 2 and enters the shortlist under the normal `total < useful` cutoff. No `automaticFlag` change is needed since qualifying items with `delta == 0` already reach the ranked list via the normal fall-through path.

**`Evaluator.java`** -- add `isWeaponTypeRequired()` and `isShieldRequired()` helpers used by `MaximizerSpeculation`.

## Tests

Added to `MaximizerTest.WeaponModifiers`:
- `clubModifierWorksWithoutTieBreaker`: `maximize("-tie, club")` recommends a lawn dart (a club) in the weapon slot.
- `shieldModifierWorksWithoutTieBreaker`: `maximize("-tie, shield")` recommends a vinyl shield in the offhand slot. This test fails without the fix.

This relates to PR #1576.