### PR TITLE
Improve valhalla detection

### DIFF
--- a/src/net/sourceforge/kolmafia/request/AfterLifeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AfterLifeRequest.java
@@ -4,7 +4,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.AscensionPath;
 import net.sourceforge.kolmafia.AscensionPath.Path;
-import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.ZodiacSign;
@@ -37,11 +37,10 @@ public class AfterLifeRequest extends GenericRequest {
     }
 
     if (responseText.isBlank()) {
-      KoLmafia.updateDisplay(
-          KoLConstants.MafiaState.ERROR,
-          "Received an empty response from afterlife.php. You are probably not in Valhalla.");
-      RequestLogger.updateSessionLog(
-          "Received an empty response from afterlife.php. You are probably not in Valhalla.");
+      String errorMsg =
+          "Received an empty response from afterlife.php. You are probably not in Valhalla.";
+      KoLmafia.updateDisplay(MafiaState.ERROR, errorMsg);
+      RequestLogger.updateSessionLog(errorMsg);
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/AfterLifeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AfterLifeRequest.java
@@ -40,6 +40,8 @@ public class AfterLifeRequest extends GenericRequest {
       KoLmafia.updateDisplay(
           KoLConstants.MafiaState.ERROR,
           "Received an empty response from afterlife.php. You are probably not in Valhalla.");
+      RequestLogger.updateSessionLog(
+          "Received an empty response from afterlife.php. You are probably not in Valhalla.");
       return false;
     }
 

--- a/src/net/sourceforge/kolmafia/request/AfterLifeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/AfterLifeRequest.java
@@ -4,12 +4,14 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.sourceforge.kolmafia.AscensionPath;
 import net.sourceforge.kolmafia.AscensionPath.Path;
+import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.ZodiacSign;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.SkillDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.session.ValhallaManager;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public class AfterLifeRequest extends GenericRequest {
@@ -32,6 +34,19 @@ public class AfterLifeRequest extends GenericRequest {
   public static boolean parseResponse(final String urlString, final String responseText) {
     if (!urlString.startsWith("afterlife.php")) {
       return false;
+    }
+
+    if (responseText.isBlank()) {
+      KoLmafia.updateDisplay(
+          KoLConstants.MafiaState.ERROR,
+          "Received an empty response from afterlife.php. You are probably not in Valhalla.");
+      return false;
+    }
+
+    // If the response isn't empty, we're actually in Valhalla.
+    // If this is not set to -1 then we haven't yet processed the ascension.
+    if (Preferences.getInteger("lastBreakfast") != -1) {
+      ValhallaManager.onAscension();
     }
 
     // If this is our first visit to the afterlife - we are outside

--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -2437,10 +2437,10 @@ public class GenericRequest implements Runnable {
           Preferences.setInteger("_godLobsterFights", 3);
         }
         // Unlike most ascension failures, this one happens as a redirect to main.php?nope=asc
-        if (this.responseText.contains("You may not enter the Astral Gash again until tomorrow.")) {
-          KoLmafia.updateDisplay(
-              KoLConstants.MafiaState.ERROR,
-              "Failed to ascend: You may not enter the Astral Gash again until tomorrow.");
+        String gashMessage = "You may not enter the Astral Gash again until tomorrow.";
+        if (this.responseText.contains(gashMessage)) {
+          KoLmafia.updateDisplay(KoLConstants.MafiaState.ERROR, "Failed to ascend: " + gashMessage);
+          RequestLogger.updateSessionLog("Failed to ascend: " + gashMessage);
         }
         return;
       }
@@ -2467,6 +2467,7 @@ public class GenericRequest implements Runnable {
           if (m.find()) {
             KoLmafia.updateDisplay(
                 KoLConstants.MafiaState.ERROR, "Failed to ascend: " + m.group(1));
+            RequestLogger.updateSessionLog("Failed to ascend: " + m.group(1));
           }
         }
         // Fall-through and allow other processing regardless

--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -2439,8 +2439,9 @@ public class GenericRequest implements Runnable {
         // Unlike most ascension failures, this one happens as a redirect to main.php?nope=asc
         String gashMessage = "You may not enter the Astral Gash again until tomorrow.";
         if (this.responseText.contains(gashMessage)) {
-          KoLmafia.updateDisplay(KoLConstants.MafiaState.ERROR, "Failed to ascend: " + gashMessage);
-          RequestLogger.updateSessionLog("Failed to ascend: " + gashMessage);
+          String errorMsg = "Failed to ascend: " + gashMessage;
+          KoLmafia.updateDisplay(MafiaState.ERROR, errorMsg);
+          RequestLogger.updateSessionLog(errorMsg);
         }
         return;
       }
@@ -2465,9 +2466,9 @@ public class GenericRequest implements Runnable {
                   "<b style=\"color: white\">Results:</b></td></tr><tr><td style=\"padding: 5px; border: 1px solid blue;\"><center><table><tr><td>(.*?)</td>");
           Matcher m = FAILED_ASCENSION.matcher(responseText);
           if (m.find()) {
-            KoLmafia.updateDisplay(
-                KoLConstants.MafiaState.ERROR, "Failed to ascend: " + m.group(1));
-            RequestLogger.updateSessionLog("Failed to ascend: " + m.group(1));
+            String errorMsg = "Failed to ascend: " + m.group(1);
+            KoLmafia.updateDisplay(MafiaState.ERROR, errorMsg);
+            RequestLogger.updateSessionLog(errorMsg);
           }
         }
         // Fall-through and allow other processing regardless

--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -1400,10 +1400,6 @@ public class GenericRequest implements Runnable {
       Preferences.setInteger("lastBreakfast", 0);
     }
 
-    if (urlString.startsWith("afterlife.php") && Preferences.getInteger("lastBreakfast") != -1) {
-      ValhallaManager.onAscension();
-    }
-
     this.externalExecute();
 
     if (!LoginRequest.isInstanceRunning() && !this.isChatRequest) {
@@ -2440,6 +2436,12 @@ public class GenericRequest implements Runnable {
             && this.responseText.contains("can't challenge your God Lobster anymore")) {
           Preferences.setInteger("_godLobsterFights", 3);
         }
+        // Unlike most ascension failures, this one happens as a redirect to main.php?nope=asc
+        if (this.responseText.contains("You may not enter the Astral Gash again until tomorrow.")) {
+          KoLmafia.updateDisplay(
+              KoLConstants.MafiaState.ERROR,
+              "Failed to ascend: You may not enter the Astral Gash again until tomorrow.");
+        }
         return;
       }
       case "campground.php" -> {
@@ -2452,6 +2454,22 @@ public class GenericRequest implements Runnable {
       case "inv_use.php" -> {
         UseItemRequest.parseGiftPackage(responseText);
         // Fallthrough; ResultProcessor will log "You acquire <stuff>."
+      }
+      case "ascend.php" -> {
+        // If we try to ascend and actually get a response back rather than being redirected to
+        // afterlife.php, there was probably something that stopped the ascension from happening.
+        // Make an attempt at figuring out what it was.
+        if (urlString.contains("confirm=on") && urlString.contains("confirm2=on")) {
+          Pattern FAILED_ASCENSION =
+              Pattern.compile(
+                  "<b style=\"color: white\">Results:</b></td></tr><tr><td style=\"padding: 5px; border: 1px solid blue;\"><center><table><tr><td>(.*?)</td>");
+          Matcher m = FAILED_ASCENSION.matcher(responseText);
+          if (m.find()) {
+            KoLmafia.updateDisplay(
+                KoLConstants.MafiaState.ERROR, "Failed to ascend: " + m.group(1));
+          }
+        }
+        // Fall-through and allow other processing regardless
       }
     }
 


### PR DESCRIPTION
Improve detection for when we have made it to Valhalla and don't actually perform `onAscension()` until we actually make it there. This should fix #3409. 

Due to the weird mechanism mafia uses to detect the on-ascension redirect from ascend.php to afterlife.php, the `lastBreakfast` preference still ends up getting clobbered if one tries to ascend but fails, but this is probably not that big of a deal on its own.