### PR TITLE
Gate possession-granted noncombat equipped-conditional skills by their unlock state

### DIFF
--- a/src/net/sourceforge/kolmafia/session/EquipmentManager.java
+++ b/src/net/sourceforge/kolmafia/session/EquipmentManager.java
@@ -534,7 +534,7 @@ public class EquipmentManager {
     }
   }
 
-  private static boolean shouldApplySkill(Integer id) {
+  static boolean shouldApplySkill(Integer id) {
     return switch (id) {
       case SkillPool.BALL_BUST -> Preferences.getInteger("gladiatorBallMovesKnown") > 0;
       case SkillPool.BALL_SWEAT -> Preferences.getInteger("gladiatorBallMovesKnown") > 1;

--- a/src/net/sourceforge/kolmafia/session/InventoryManager.java
+++ b/src/net/sourceforge/kolmafia/session/InventoryManager.java
@@ -2014,8 +2014,9 @@ public abstract class InventoryManager {
         .filter(
             e ->
                 e.getKey()
-                    || SkillDatabase.getSkillTags(e.getValue())
-                        .contains(SkillDatabase.SkillTag.NONCOMBAT))
+                    || (SkillDatabase.getSkillTags(e.getValue())
+                            .contains(SkillDatabase.SkillTag.NONCOMBAT)
+                        && EquipmentManager.shouldApplySkill(e.getValue())))
         .map(Map.Entry::getValue)
         .forEach(KoLCharacter::addAvailableSkill);
   }

--- a/test/net/sourceforge/kolmafia/session/InventoryManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/InventoryManagerTest.java
@@ -30,6 +30,7 @@ import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.equipment.Slot;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.persistence.ConsumablesDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.ModifierDatabase;
@@ -425,6 +426,63 @@ public class InventoryManagerTest {
 
       assertThat(InventoryManager.getCount(ItemPool.WORTHLESS_TRINKET), is(25252));
       assertThat(InventoryManager.getCount(ItemPool.WORTHLESS_GEWGAW), is(10622));
+    }
+  }
+
+  @Nested
+  class NoncombatConditionalSkillGrant {
+    // Live repro: an item with a NONCOMBAT Conditional Skill (Equipped) whose own
+    // unlock gate is false, merely possessed (not equipped), must NOT grant the
+    // skill. Before the fix, checkSkillGrantingEquipment granted it on possession.
+    @Test
+    public void lockedHeartstoneSkillNotGrantedByPossession() {
+      KoLCharacter.resetSkills();
+      var cleanups =
+          new Cleanups(
+              withProperty("heartstonePalsUnlocked", false), withItem(ItemPool.HEARTSTONE));
+      try (cleanups) {
+        InventoryManager.checkSkillGrantingEquipment();
+        assertFalse(KoLCharacter.hasSkill(SkillPool.HEARTSTONE_PALS));
+      }
+    }
+
+    // Positive control: when the gate is unlocked, possession still grants
+    // (preserves the deliberate auto-equip-on-cast behaviour).
+    @Test
+    public void unlockedHeartstoneSkillGrantedByPossession() {
+      KoLCharacter.resetSkills();
+      var cleanups =
+          new Cleanups(withProperty("heartstonePalsUnlocked", true), withItem(ItemPool.HEARTSTONE));
+      try (cleanups) {
+        InventoryManager.checkSkillGrantingEquipment();
+        assertTrue(KoLCharacter.hasSkill(SkillPool.HEARTSTONE_PALS));
+      }
+    }
+
+    // Combat-tagged conditional skill is never granted by possession (NONCOMBAT
+    // branch short-circuits before shouldApplySkill) — unchanged by the fix.
+    @Test
+    public void combatHeartstoneSkillNotGrantedByPossession() {
+      KoLCharacter.resetSkills();
+      var cleanups =
+          new Cleanups(withProperty("heartstoneKillUnlocked", true), withItem(ItemPool.HEARTSTONE));
+      try (cleanups) {
+        InventoryManager.checkSkillGrantingEquipment();
+        assertFalse(KoLCharacter.hasSkill(SkillPool.HEARTSTONE_KILL));
+      }
+    }
+
+    // Covers the e.getKey()==true branch (CONDITIONAL_SKILL_INVENTORY): designer
+    // sweatpants grant "Sweat Out Some Booze" on mere possession, ungated.
+    @Test
+    public void inventoryConditionalSkillGrantedByPossession() {
+      KoLCharacter.resetSkills();
+      var cleanups = new Cleanups(withItem(ItemPool.DESIGNER_SWEATPANTS));
+      try (cleanups) {
+        assertFalse(KoLCharacter.hasSkill(SkillPool.SWEAT_OUT_BOOZE));
+        InventoryManager.checkSkillGrantingEquipment();
+        assertTrue(KoLCharacter.hasSkill(SkillPool.SWEAT_OUT_BOOZE));
+      }
     }
   }
 }

--- a/test/net/sourceforge/kolmafia/session/InventoryManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/InventoryManagerTest.java
@@ -36,6 +36,7 @@ import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -431,12 +432,16 @@ public class InventoryManagerTest {
 
   @Nested
   class NoncombatConditionalSkillGrant {
+    @AfterEach
+    void afterEach() {
+      KoLCharacter.resetSkills();
+    }
+
     // Live repro: an item with a NONCOMBAT Conditional Skill (Equipped) whose own
     // unlock gate is false, merely possessed (not equipped), must NOT grant the
     // skill. Before the fix, checkSkillGrantingEquipment granted it on possession.
     @Test
     public void lockedHeartstoneSkillNotGrantedByPossession() {
-      KoLCharacter.resetSkills();
       var cleanups =
           new Cleanups(
               withProperty("heartstonePalsUnlocked", false), withItem(ItemPool.HEARTSTONE));
@@ -450,7 +455,6 @@ public class InventoryManagerTest {
     // (preserves the deliberate auto-equip-on-cast behaviour).
     @Test
     public void unlockedHeartstoneSkillGrantedByPossession() {
-      KoLCharacter.resetSkills();
       var cleanups =
           new Cleanups(withProperty("heartstonePalsUnlocked", true), withItem(ItemPool.HEARTSTONE));
       try (cleanups) {
@@ -463,7 +467,6 @@ public class InventoryManagerTest {
     // branch short-circuits before shouldApplySkill) — unchanged by the fix.
     @Test
     public void combatHeartstoneSkillNotGrantedByPossession() {
-      KoLCharacter.resetSkills();
       var cleanups =
           new Cleanups(withProperty("heartstoneKillUnlocked", true), withItem(ItemPool.HEARTSTONE));
       try (cleanups) {
@@ -476,10 +479,8 @@ public class InventoryManagerTest {
     // sweatpants grant "Sweat Out Some Booze" on mere possession, ungated.
     @Test
     public void inventoryConditionalSkillGrantedByPossession() {
-      KoLCharacter.resetSkills();
       var cleanups = new Cleanups(withItem(ItemPool.DESIGNER_SWEATPANTS));
       try (cleanups) {
-        assertFalse(KoLCharacter.hasSkill(SkillPool.SWEAT_OUT_BOOZE));
         InventoryManager.checkSkillGrantingEquipment();
         assertTrue(KoLCharacter.hasSkill(SkillPool.SWEAT_OUT_BOOZE));
       }


### PR DESCRIPTION
## Problem

`InventoryManager.checkSkillGrantingEquipment()` grants an item's NONCOMBAT
`Conditional Skill (Equipped)` skills from mere inventory possession, with no
check of the per-skill unlock state. With `heartstone*Unlocked=false`, a
refresh flips `have($skill("Heartstone: %pals"))` (and `%luck`/`%buff`) to
true; garbo then casts and KoL rejects it as "That skill is unavailable."

## Root cause

The terminal filter in `checkSkillGrantingEquipment` keeps an
equipped-conditional skill whenever it is NONCOMBAT-tagged, never consulting
`EquipmentManager.shouldApplySkill()` — the function that encodes each skill's
real gate (its `heartstone*Unlocked` pref; default `true` otherwise).

Live repro: with `heartstoneKillUnlocked` / `heartstoneLuckUnlocked` /
`heartstonePalsUnlocked` / `heartstoneBuffUnlocked` all `false` and a Heartstone
only in inventory (not equipped), `refresh all` flips `haveSkill()` to `true`
for `Heartstone: %pals`, `%luck`, `%buff` (all NONCOMBAT) but **not** `%kill`
(combat) — the add/skip-by-tag split fingerprints the NONCOMBAT-only filter.

## Fix

Gate the NONCOMBAT branch by `shouldApplySkill`. Locked Heartstone skills are
no longer granted; default-true skills (Sip Some Sweat, Cincho Fiesta Exit,
Powerful Glove cheat codes, codpiece, etc.) still grant on possession, so the
deliberate auto-equip-on-cast behaviour is preserved.

## Why not the unequip path (supersedes the prior version of this PR)

The earlier version of this branch changed `applyNoncombatSkills` to drop
noncombat skills on unequip. That is the wrong layer: skills are granted by
possession and re-granted on every refresh, so unequip-removal neither
explains nor fixes the bug, and it would have broken the deliberate
auto-equip-on-cast design that @midgleyc and @jaadams5 noted. That change is
reverted here.

## Tests

`InventoryManagerTest.NoncombatConditionalSkillGrant`: locked skill not granted
on possession, unlocked skill still granted, combat skill never granted, and
an inventory-conditional (designer sweatpants) control.