### PR TITLE
feat: add preference to move window title above menu bar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# KoLmafia
+
+Java 21 desktop tool for [Kingdom of Loathing](https://kingdomofloathing.com).
+Main class: `net.sourceforge.kolmafia.KoLmafia`.
+
+## Build & test
+
+```sh
+./gradlew spotlessApply    # format (Google Java Style, enforced on PRs)
+./gradlew :test --tests "fully.qualified.TestName"   # single test
+./gradlew check            # format check + tests + checkstyle
+./gradlew shadowJar        # build fat jar in dist/
+./gradlew runShadow        # build and run
+```
+
+Tests run with `test/root` as working dir. JUnit 5 + Hamcrest.
+
+## Test patterns
+
+- Fixture HTML files in `test/root/request/` loaded via `Networking.html("request/test_foo.html")`
+- State setup via `Player.withXxx()` helpers — `withProperty`, `withChoice`, `withFight`, `withClass`, `withNextMonster`, `withItem`, etc.
+- Cleanup via try-with-resources on `Cleanups` (collects restore runnables, runs on close in order)
+- Test directory mirrors source: `test/net/sourceforge/kolmafia/…` matches `src/net/sourceforge/kolmafia/…`
+- Choice pages: use `Player.withChoice(choiceId, html)` to set `ChoiceManager.lastChoice`, `lastResponseText`, and `handlingChoice`
+- Assert with Hamcrest `assertThat` matchers, not JUnit `assertEquals`
+
+## Structure
+
+- `src/net/sourceforge/kolmafia/` — core, session, webui, utilities, request, textui
+- `src/data/` — bundled data files
+- `test/internal/helpers/` — test utilities (Networking, Player, Cleanups, etc.)
+- `test/root/request/` — HTML/JSON test fixtures (1537+ files)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,6 @@ Main class: `net.sourceforge.kolmafia.KoLmafia`.
 ```sh
 ./gradlew spotlessApply    # format (Google Java Style, enforced on PRs)
 ./gradlew :test --tests "fully.qualified.TestName"   # single test
-./gradlew check            # format check + tests + checkstyle
 ./gradlew shadowJar        # build fat jar in dist/
 ./gradlew runShadow        # build and run
 ```

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -163,6 +163,7 @@ global	saveState
 global	saveStateActive
 global	scriptButtonPosition	0
 global	scriptList	restore hp | restore mp
+global	separateTitleAndMenuBar	false
 global	sharePriceData	true
 global	showAllRequests	false
 global	showExceptionalRequests	false

--- a/src/net/sourceforge/kolmafia/CreateFrameRunnable.java
+++ b/src/net/sourceforge/kolmafia/CreateFrameRunnable.java
@@ -228,6 +228,7 @@ public class CreateFrameRunnable implements Runnable {
         // Set a menu bar for anything that doesn't
         // extend the KoLmafia frame classes.
 
+        KoLmafiaGUI.applyFlatLafMenuBarSettings(frame.getRootPane());
         frame.setJMenuBar(new GlobalMenuBar());
       }
 

--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -431,6 +431,7 @@ public abstract class KoLmafia {
 
     try {
       UIManager.setLookAndFeel(lookAndFeel);
+      KoLmafiaGUI.applyFlatLafMenuBarSettings();
       JFrame.setDefaultLookAndFeelDecorated(System.getProperty("os.name").startsWith("Mac"));
     } catch (Exception e) {
       // Should not happen, as we checked to see if

--- a/src/net/sourceforge/kolmafia/KoLmafiaGUI.java
+++ b/src/net/sourceforge/kolmafia/KoLmafiaGUI.java
@@ -3,6 +3,7 @@ package net.sourceforge.kolmafia;
 import java.awt.Color;
 import java.awt.Frame;
 import java.util.ArrayList;
+import javax.swing.JRootPane;
 import javax.swing.JTabbedPane;
 import javax.swing.UIManager;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
@@ -44,6 +45,9 @@ import net.sourceforge.kolmafia.webui.RelayServer;
 
 public class KoLmafiaGUI {
   private KoLmafiaGUI() {}
+
+  private static final String FLATLAF_TITLE_PANE_MENU_BAR_EMBEDDED = "TitlePane.menuBarEmbedded";
+  private static final String FLATLAF_ROOT_PANE_MENU_BAR_EMBEDDED = "JRootPane.menuBarEmbedded";
 
   /**
    * The main method. Currently, it instantiates a single instance of the <code>KoLmafia</code>after
@@ -268,6 +272,16 @@ public class KoLmafiaGUI {
     }
 
     (new CreateFrameRunnable(frameClass)).run();
+  }
+
+  public static void applyFlatLafMenuBarSettings() {
+    UIManager.put(
+        FLATLAF_TITLE_PANE_MENU_BAR_EMBEDDED, !Preferences.getBoolean("separateTitleAndMenuBar"));
+  }
+
+  public static void applyFlatLafMenuBarSettings(final JRootPane rootPane) {
+    rootPane.putClientProperty(
+        FLATLAF_ROOT_PANE_MENU_BAR_EMBEDDED, !Preferences.getBoolean("separateTitleAndMenuBar"));
   }
 
   public static JTabbedPane getTabbedPane() {

--- a/src/net/sourceforge/kolmafia/swingui/GenericFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/GenericFrame.java
@@ -105,6 +105,7 @@ public abstract class GenericFrame extends JFrame implements Runnable, FocusList
    */
   public GenericFrame(final String title) {
     this.setTitle(title);
+    KoLmafiaGUI.applyFlatLafMenuBarSettings(this.getRootPane());
     this.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 
     List<Image> images =

--- a/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
@@ -26,6 +26,7 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JDialog;
+import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JOptionPane;
@@ -1676,6 +1677,7 @@ public class OptionsFrame extends GenericFrame {
               {"addCreationQueue", "Add creation queueing interface to item manager"},
               {"addStatusBarToFrames", "Add a status line to independent windows"},
               {"autoHighlightOnFocus", "Highlight text fields when selected"},
+              {"separateTitleAndMenuBar", "Keep window title above menu bar in FlatLaf themes"},
               {},
               {"allowCloseableDesktopTabs", "Allow tabs on main window to be closed"},
             }
@@ -1690,6 +1692,7 @@ public class OptionsFrame extends GenericFrame {
                   {"addCreationQueue", "Add creation queueing interface to item manager"},
                   {"addStatusBarToFrames", "Add a status line to independent windows"},
                   {"autoHighlightOnFocus", "Highlight text fields when selected"},
+                  {"separateTitleAndMenuBar", "Keep window title above menu bar in FlatLaf themes"},
                   {},
                   {"allowCloseableDesktopTabs", "Allow tabs on main window to be closed"},
                   // { "darkThemeToolIconOverride", "Always use dark toolbar icons with dark Look
@@ -1704,6 +1707,7 @@ public class OptionsFrame extends GenericFrame {
                   {"addCreationQueue", "Add creation queueing interface to item manager"},
                   {"addStatusBarToFrames", "Add a status line to independent windows"},
                   {"autoHighlightOnFocus", "Highlight text fields when selected"},
+                  {"separateTitleAndMenuBar", "Keep window title above menu bar in FlatLaf themes"},
                   {},
                   {"allowCloseableDesktopTabs", "Allow tabs on main window to be closed"},
                 };
@@ -1713,6 +1717,7 @@ public class OptionsFrame extends GenericFrame {
     public UserInterfacePanel() {
       super(new Dimension(80, 22), new Dimension(280, 22));
       PreferenceListenerRegistry.registerPreferenceListener("swingLookAndFeel", this);
+      PreferenceListenerRegistry.registerPreferenceListener("separateTitleAndMenuBar", this);
 
       UIManager.LookAndFeelInfo[] installed = UIManager.getInstalledLookAndFeels();
       String[] installedLooks = new String[installed.length + 1];
@@ -1816,11 +1821,15 @@ public class OptionsFrame extends GenericFrame {
       }
       try {
         UIManager.setLookAndFeel(lookAndFeel);
+        KoLmafiaGUI.applyFlatLafMenuBarSettings();
         // This is where we invalidate the UI and re-draw it because we switched Lafs..."
         Frame[] frames = Frame.getFrames();
         for (Frame f : frames) {
           SwingUtilities.invokeLater(
               () -> {
+                if (f instanceof JFrame frame) {
+                  KoLmafiaGUI.applyFlatLafMenuBarSettings(frame.getRootPane());
+                }
                 SwingUtilities.updateComponentTreeUI(f); // update components
                 f.pack(); // adapt container size if required
               });


### PR DESCRIPTION
This is convenient for me when developing, to have the version number + character easily accessible on the login frame instead of way off to the right out of sight.

Also add an AGENTS.md, for LLMs. Doesn't seem to make much of a difference for the non-local ones, but stops Qwen from trying to respond in a non-code context at least.

This PR was written entirely by ChatGPT 5.5; I expect that to continue to be the case for the GUI code, as no active developers understand or have a desire to learn about it.

Tested manually: it works the way I want.