### PR TITLE
Add Brandish Moss Medal daily limit tracking

### DIFF
--- a/src/data/dailylimits.txt
+++ b/src/data/dailylimits.txt
@@ -54,6 +54,7 @@ Cast	Beret Boast	_beretBoastUses	11
 Cast	Beret Busking	_beretBuskingUses	5
 Cast	Bow-Legged Swagger	_bowleggedSwaggerUsed
 Cast	Bowl Full of Jelly	_bowlFullOfJellyUsed
+Cast	Brandish Moss Medal	_brandishMossMedalCast
 Cast	CHEAT CODE: Invisible Avatar	_powerfulGloveBatteryPowerUsed	100
 Cast	CHEAT CODE: Replace Enemy	_powerfulGloveBatteryPowerUsed	100
 Cast	CHEAT CODE: Shrink Enemy	_powerfulGloveBatteryPowerUsed	100

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1986,6 +1986,7 @@ user	_bczSweatEquityCasts	0
 user	_bczBloodThinnerCasts	0
 user	_bczSpinalTapasCasts	0
 user	_bczPheromoneCocktailCasts	0
+user	_brandishMossMedalCast	false
 user	_beachCombing	false
 user	_beachHeadsUsed
 user	_beachLayout

--- a/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
@@ -619,6 +619,7 @@ public class SkillPool {
   public static final int SURPRISINGLY_SWEET_SLASH = 7488;
   public static final int SURPRISINGLY_SWEET_STAB = 7489;
   public static final int LAY_AN_EGG = 7494;
+  public static final int BRANDISH_MOSS_MEDAL = 7499;
   public static final int SPRING_KICK = 7501;
   public static final int HUNT = 7509;
   public static final int PUNT_WEREPROF = 7510;

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -2877,4 +2877,16 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
       }
     }
   }
+
+  @Test
+  void haveSkillReturnsTrueEvenWhenDailyLimitExhausted() {
+    var cleanups =
+        new Cleanups(withSkill(SkillPool.PASTAMASTERY), withProperty("noodleSummons", 1));
+    try (cleanups) {
+      String output = execute("have_skill($skill[Pastamastery])");
+
+      assertContinueState();
+      assertThat(output, containsString("Returned: true"));
+    }
+  }
 }


### PR DESCRIPTION
Add `_brandishMossMedalCast` to `dailylimits.txt` and default to false.

Also adds `BRANDISH_MOSS_MEDAL = 7499` to `SkillPool` and a test confirming `have_skill()` returns `true` even when a skill's daily cast limit is exhausted.

---
Assisted by Claude Code — reviewed by @eegeeZA; verified by the test suite.