### PR TITLE
feat: update flatlaf to 3.7.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,9 +80,9 @@ dependencies {
   }
   testImplementation("org.junit-pioneer:junit-pioneer:2.3.0")
 
-  implementation("com.formdev:flatlaf:1.6.5")
-  implementation("com.formdev:flatlaf-intellij-themes:1.6.5")
-  implementation("com.formdev:flatlaf-swingx:1.6.5")
+  implementation("com.formdev:flatlaf:3.7.1")
+  implementation("com.formdev:flatlaf-intellij-themes:3.7.1")
+  implementation("com.formdev:flatlaf-swingx:3.7.1")
   // Optional runtime deps for svnkit
   runtimeOnly("com.trilead:trilead-ssh2:1.0.0-build222")
   runtimeOnly("net.java.dev.jna:jna:5.18.1")

--- a/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
+++ b/src/net/sourceforge/kolmafia/swingui/widget/RequestPane.java
@@ -7,6 +7,7 @@ import java.io.StringWriter;
 import java.util.Enumeration;
 import javax.swing.JEditorPane;
 import javax.swing.ToolTipManager;
+import javax.swing.UIManager;
 import javax.swing.text.Element;
 import javax.swing.text.LabelView;
 import javax.swing.text.SimpleAttributeSet;
@@ -114,6 +115,9 @@ public class RequestPane extends JEditorPane {
     this.setEditorKit(new WrappedHtmlEditorKit());
     this.setContentType("text/html");
     this.setEditable(false);
+    // FlatLaf sets the background to disabled if the pane isn't editable. I think we prefer the
+    // standard background.
+    this.setBackground(UIManager.getColor("EditorPane.background"));
     this.addFocusListener(
         new FocusListener() {
           @Override


### PR DESCRIPTION
Some visible changes: current tab has a highlighted background, subtabs on the same page have a different underline depending on which area is selected, some more corners are rounded.

One change averted: non-editable panels received the inactive background. For our HTML panels, manually set the background to the active one, which I think we want.