### PR TITLE
Implement since/script/notify directives for JS scripts

### DIFF
--- a/src/net/sourceforge/kolmafia/request/SendMailRequest.java
+++ b/src/net/sourceforge/kolmafia/request/SendMailRequest.java
@@ -5,7 +5,6 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.session.ContactManager;
 import net.sourceforge.kolmafia.session.ResultProcessor;
-import net.sourceforge.kolmafia.textui.AshRuntime;
 import net.sourceforge.kolmafia.utilities.CharacterEntities;
 
 public class SendMailRequest extends TransferItemRequest {
@@ -17,22 +16,6 @@ public class SendMailRequest extends TransferItemRequest {
 
     this.recipient = recipient;
     this.message = message;
-
-    this.addFormField("action", "send");
-    this.addFormField("towho", ContactManager.getPlayerId(this.recipient));
-    this.addFormField("message", this.message);
-
-    this.isInternal = true;
-  }
-
-  public SendMailRequest(final String recipient, final AshRuntime script) {
-    super("sendmessage.php");
-
-    this.recipient = recipient;
-    this.message =
-        "I have opted to let you know that I have chosen to run <"
-            + script.getParser().getScriptName()
-            + ">.  Thanks for writing this script!";
 
     this.addFormField("action", "send");
     this.addFormField("towho", ContactManager.getPlayerId(this.recipient));

--- a/src/net/sourceforge/kolmafia/textui/AbstractRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/AbstractRuntime.java
@@ -165,7 +165,7 @@ public abstract class AbstractRuntime implements ScriptRuntime {
         // case you should be able to run anything.
         if (currentRevision != 0 && currentRevision < targetRevision) {
           String template =
-              "'%s' requires revision r%s of kolmafia or higher (current: r%s). Up-to-date builds can be found at https://github.com/kolmafia/kolmafia/releases/.";
+              "'%s' requires revision r%s of kolmafia or higher (current: r%s).  Up-to-date builds can be found at https://github.com/kolmafia/kolmafia/releases/.";
           return new SinceStatus(
               "SINCE", String.format(template, filename, targetRevision, currentRevision));
         }

--- a/src/net/sourceforge/kolmafia/textui/AbstractRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/AbstractRuntime.java
@@ -3,7 +3,11 @@ package net.sourceforge.kolmafia.textui;
 import java.io.PrintStream;
 import java.util.LinkedHashMap;
 import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.RequestThread;
+import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.RelayRequest;
+import net.sourceforge.kolmafia.request.SendMailRequest;
 import net.sourceforge.kolmafia.textui.parsetree.Value;
 import net.sourceforge.kolmafia.utilities.NullStream;
 
@@ -131,5 +135,58 @@ public abstract class AbstractRuntime implements ScriptRuntime {
       this.indentLine(this.traceIndentation);
       traceStream.println(string);
     }
+  }
+
+  public static void handleNotify(
+      String scriptFilename, String scriptName, String notifyRecipient) {
+    String notifyList = Preferences.getString("previousNotifyList");
+    String notifyKey = (scriptFilename == null) ? "<>" : "<" + scriptFilename + ">";
+    if (notifyRecipient != null && !notifyRecipient.isBlank() && !notifyList.contains(notifyKey)) {
+      Preferences.setString("previousNotifyList", notifyList + notifyKey);
+
+      String message =
+          "I have opted to let you know that I have chosen to run <"
+              + scriptName
+              + ">.  Thanks for writing this script!";
+      SendMailRequest notifier = new SendMailRequest(notifyRecipient, message);
+      RequestThread.postRequest(notifier);
+    }
+  }
+
+  public record SinceStatus(String status, String message) {}
+
+  public static SinceStatus handleSince(String revision, String filename) {
+    try {
+      if (revision.startsWith("r")) { // revision
+        revision = revision.substring(1);
+        int targetRevision = Integer.parseInt(revision);
+        int currentRevision = StaticEntity.getRevision();
+        // A revision of zero means you're probably running in a debugger, in which
+        // case you should be able to run anything.
+        if (currentRevision != 0 && currentRevision < targetRevision) {
+          String template =
+              "'%s' requires revision r%s of kolmafia or higher (current: r%s). Up-to-date builds can be found at https://github.com/kolmafia/kolmafia/releases/.";
+          return new SinceStatus(
+              "SINCE", String.format(template, filename, targetRevision, currentRevision));
+        }
+      } else { // version (or syntax error)
+        String[] target = revision.split("\\.");
+        if (target.length != 2) {
+          return new SinceStatus("SYNTAX", "invalid 'since' format");
+        }
+
+        int targetMajor = Integer.parseInt(target[0]);
+        int targetMinor = Integer.parseInt(target[1]);
+
+        if (targetMajor > 21 || targetMajor == 21 && targetMinor > 9) {
+          return new SinceStatus(
+              "SYNTAX", "invalid 'since' format (21.09 was the final point release)");
+        }
+      }
+    } catch (NumberFormatException e) {
+      return new SinceStatus("SYNTAX", "invalid 'since' format");
+    }
+
+    return new SinceStatus("OK", null);
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/AshRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/AshRuntime.java
@@ -13,10 +13,8 @@ import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestLogger;
-import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.preferences.Preferences;
-import net.sourceforge.kolmafia.request.SendMailRequest;
 import net.sourceforge.kolmafia.textui.parsetree.ArrayValue;
 import net.sourceforge.kolmafia.textui.parsetree.Evaluable;
 import net.sourceforge.kolmafia.textui.parsetree.Function;
@@ -169,16 +167,8 @@ public class AshRuntime extends AbstractRuntime {
 
   @Override
   public Value execute(final String functionName, final Object[] parameters) {
-    String currentScript = this.getFileName() == null ? "<>" : "<" + this.getFileName() + ">";
-    String notifyList = Preferences.getString("previousNotifyList");
-    String notifyRecipient = this.parser.getNotifyRecipient();
-
-    if (notifyRecipient != null && !notifyList.contains(currentScript)) {
-      Preferences.setString("previousNotifyList", notifyList + currentScript);
-
-      SendMailRequest notifier = new SendMailRequest(notifyRecipient, this);
-      RequestThread.postRequest(notifier);
-    }
+    AbstractRuntime.handleNotify(
+        this.getFileName(), this.parser.getScriptName(), this.parser.getNotifyRecipient());
 
     return this.execute(functionName, parameters, true);
   }

--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -5567,14 +5567,6 @@ public class Parser {
     return this.error(f.getLocation(), buffer);
   }
 
-  private AshDiagnostic sinceError(
-      final String current, final String target, final Range directiveRange) {
-    String template =
-        "'%s' requires revision r%s of kolmafia or higher (current: r%s).  Up-to-date builds can be found at https://github.com/kolmafia/kolmafia/releases/.";
-
-    return this.error(directiveRange, String.format(template, this.shortFileName, target, current));
-  }
-
   public static String undefinedFunctionMessage(
       final String name, final List<? extends TypedNode> params) {
     StringBuilder buffer = new StringBuilder();
@@ -5587,36 +5579,12 @@ public class Parser {
 
   private void enforceSince(String revision, final Range directiveRange) {
     final ErrorManager sinceErrors = new ErrorManager();
-
-    try {
-      if (revision.startsWith("r")) { // revision
-        revision = revision.substring(1);
-        int targetRevision = Integer.parseInt(revision);
-        int currentRevision = StaticEntity.getRevision();
-        // A revision of zero means you're probably running in a debugger, in which
-        // case you should be able to run anything.
-        if (currentRevision != 0 && currentRevision < targetRevision) {
-          sinceErrors.submitError(
-              this.sinceError(String.valueOf(currentRevision), revision, directiveRange));
-        }
-      } else { // version (or syntax error)
-        String[] target = revision.split("\\.");
-        if (target.length != 2) {
-          sinceErrors.submitSyntaxError(this.error(directiveRange, "invalid 'since' format"));
-          return;
-        }
-
-        int targetMajor = Integer.parseInt(target[0]);
-        int targetMinor = Integer.parseInt(target[1]);
-
-        if (targetMajor > 21 || targetMajor == 21 && targetMinor > 9) {
-          sinceErrors.submitError(
-              this.error(
-                  directiveRange, "invalid 'since' format (21.09 was the final point release)"));
-        }
-      }
-    } catch (NumberFormatException e) {
-      sinceErrors.submitSyntaxError(this.error(directiveRange, "invalid 'since' format"));
+    AbstractRuntime.SinceStatus response =
+        AbstractRuntime.handleSince(revision, this.getShortFileName());
+    if (response.status().equals("SINCE")) {
+      sinceErrors.submitError(this.error(directiveRange, response.message()));
+    } else if (response.status().equals("SYNTAX")) {
+      sinceErrors.submitSyntaxError(this.error(directiveRange, response.message()));
     }
   }
 

--- a/src/net/sourceforge/kolmafia/textui/javascript/JsPostLoadScript.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/JsPostLoadScript.java
@@ -3,6 +3,7 @@ package net.sourceforge.kolmafia.textui.javascript;
 import java.util.Map;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.textui.AbstractRuntime;
 import net.sourceforge.kolmafia.textui.ScriptException;
 import org.mozilla.javascript.Context;
@@ -65,7 +66,8 @@ public class JsPostLoadScript implements Script {
           AbstractRuntime.SinceStatus response =
               AbstractRuntime.handleSince(since, scriptShortFilename);
           if (!response.status().equals("OK")) {
-            throw new ScriptException(response.message());
+            throw new ScriptException(
+                String.format("In <%s>: %s", scriptShortFilename, response.message()));
           }
         }
 
@@ -78,7 +80,9 @@ public class JsPostLoadScript implements Script {
     } catch (Exception e) {
       // Apart from the ScriptException we intend to throw, never ever let this handling propagate
       // an unexpected exception.
-      KoLmafia.updateDisplay("Unexpected error while handling metadata: " + e.getMessage());
+      String errMsg = "Unexpected error while handling metadata: " + e.getMessage();
+      KoLmafia.updateDisplay(errMsg);
+      RequestLogger.updateSessionLog(errMsg);
     }
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/javascript/JsPostLoadScript.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/JsPostLoadScript.java
@@ -11,7 +11,7 @@ import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.commonjs.module.ModuleScope;
 
-public class MainWarningScript implements Script {
+public class JsPostLoadScript implements Script {
   // This is a slight hack to perform checks after loading a JS file. At this time, we warn folks
   // who have failed to export main() and check for script/notify/since directives.
   @Override

--- a/src/net/sourceforge/kolmafia/textui/javascript/MainWarningScript.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/MainWarningScript.java
@@ -1,14 +1,19 @@
 package net.sourceforge.kolmafia.textui.javascript;
 
+import java.util.Map;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.textui.AbstractRuntime;
+import net.sourceforge.kolmafia.textui.ScriptException;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.commonjs.module.ModuleScope;
 
 public class MainWarningScript implements Script {
-  // This is a slight hack to warn folks who have failed to export main().
+  // This is a slight hack to perform checks after loading a JS file. At this time, we warn folks
+  // who have failed to export main() and check for script/notify/since directives.
   @Override
   public Object exec(Context cx, Scriptable scope, Scriptable thisObj) {
     Object requireObject = ScriptableObject.getProperty(scope, "require");
@@ -23,6 +28,9 @@ public class MainWarningScript implements Script {
     if (!(moduleExports instanceof Scriptable)) {
       return null;
     }
+
+    // Handle any metadata that is present.
+    handleMetadata((Scriptable) moduleExports, scope);
 
     if (JavascriptRuntime.getValidDefaultExport(moduleExports) != Scriptable.NOT_FOUND) {
       return null;
@@ -39,5 +47,38 @@ public class MainWarningScript implements Script {
               + "You may want to set module.exports.main = main in order for it to run.");
     }
     return null;
+  }
+
+  private void handleMetadata(Scriptable exports, Scriptable scope) {
+    try {
+      Object metadataObj = exports.get("__metadata", exports);
+      if (metadataObj instanceof Map metadata && scope instanceof ModuleScope moduleScope) {
+        String scriptFilename = moduleScope.getUri().getPath().substring(1);
+        String scriptShortFilename = scriptFilename.substring(scriptFilename.lastIndexOf("/") + 1);
+        String scriptName = scriptShortFilename;
+
+        if (metadata.get("script") instanceof String _scriptName) {
+          scriptName = _scriptName;
+        }
+
+        if (metadata.get("since") instanceof String since) {
+          AbstractRuntime.SinceStatus response =
+              AbstractRuntime.handleSince(since, scriptShortFilename);
+          if (!response.status().equals("OK")) {
+            throw new ScriptException(response.message());
+          }
+        }
+
+        if (metadata.get("notify") instanceof String notify) {
+          AbstractRuntime.handleNotify(scriptFilename, scriptName, notify);
+        }
+      }
+    } catch (ScriptException e) {
+      throw e;
+    } catch (Exception e) {
+      // Apart from the ScriptException we intend to throw, never ever let this handling propagate
+      // an unexpected exception.
+      KoLmafia.updateDisplay("Unexpected error while handling metadata: " + e.getMessage());
+    }
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/javascript/SafeRequire.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/SafeRequire.java
@@ -34,7 +34,7 @@ public class SafeRequire extends Require {
         nativeScope,
         new SoftCachingModuleScriptProvider(new KoLmafiaUrlModuleSourceProvider()),
         null,
-        new MainWarningScript(),
+        new JsPostLoadScript(),
         true);
     this.stdLib = stdLib;
   }


### PR DESCRIPTION
Implements functionality similar to Ash's `since`, `script`, and `notify` directives for use in JS scripts. This is done by reading from an exported objected named `__metadata` which can contain the necessary values. For example:

```
module.exports.__metadata={script:"test script", notify:"VeeArr", since:"r29081"};
```

These should function more-or-less the same as the corresponding Ash directives. I'm not really familiar with all the ways typescript is used to produce JS scripts, but I tested with a small TS script based on [kol-ts-starter](https://github.com/docrostov/kol-ts-starter), and the following in `main.ts` had the desired effect:

```
export const __metadata={script:"test script", notify:"VeeArr", since:"r29081"};
```

Notes:

* `__metadata` was chosen as a name that was almost certainly not already being used by someone. If someone has a better idea for a name, I'm open to suggestions.
* One file was expanded and renamed (`MainWarningScript` => `JsPostLoadScript`). The rename is in its own commit, so the actual code changes to the file are more easily seen in commit 9be2b13.
* In most cases, the `since` directive will behave in a similar manner to Ash. However, if `require()` is used within a code block (rather than at the top-level scope), the imported file doesn't get processed (and thus any since directive doesn't get checked) until that portion of code executes.
* In my test cases, the directives get processed on a per-file basis. So if you have a bunch of TS that all gets compiled to a single JS script, only `__metadata` exported from the "top" file get read. Again, I'm not super familiar with the TS toolchain so this may be an artifact of how I tested it. Regardless, I don't imagine this being a problem in practice.
