### PR TITLE
Add preference to enable/disable Ash notify directives

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1305,6 +1305,7 @@ user	pathedSummonsHardcore	true
 user	pathedSummonsSoftcore	false
 user	peaceTurkeyIndex	0	roa
 user	pendingMapReflections	0	roa
+user	permitScriptNotify	true
 user	peteMotorbikeTires
 user	peteMotorbikeGasTank
 user	peteMotorbikeHeadlight

--- a/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
+++ b/src/net/sourceforge/kolmafia/swingui/OptionsFrame.java
@@ -463,6 +463,7 @@ public class OptionsFrame extends GenericFrame {
         {},
         {"useZoneComboBox", "Use zone selection instead of adventure name filter"},
         {"cacheMallSearches", "Cache mall search terms in mall search interface"},
+        {"permitScriptNotify", "Allow scripts to send a one-time thank you message to the author"},
         {"saveSettingsOnSet", "Save options to disk whenever they change"},
         {},
         {"removeMalignantEffects", "Auto-remove malignant status effects"},

--- a/src/net/sourceforge/kolmafia/textui/AshRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/AshRuntime.java
@@ -169,15 +169,17 @@ public class AshRuntime extends AbstractRuntime {
 
   @Override
   public Value execute(final String functionName, final Object[] parameters) {
-    String currentScript = this.getFileName() == null ? "<>" : "<" + this.getFileName() + ">";
-    String notifyList = Preferences.getString("previousNotifyList");
-    String notifyRecipient = this.parser.getNotifyRecipient();
+    if (Preferences.getBoolean("permitScriptNotify")) {
+      String currentScript = this.getFileName() == null ? "<>" : "<" + this.getFileName() + ">";
+      String notifyList = Preferences.getString("previousNotifyList");
+      String notifyRecipient = this.parser.getNotifyRecipient();
 
-    if (notifyRecipient != null && !notifyList.contains(currentScript)) {
-      Preferences.setString("previousNotifyList", notifyList + currentScript);
+      if (notifyRecipient != null && !notifyList.contains(currentScript)) {
+        Preferences.setString("previousNotifyList", notifyList + currentScript);
 
-      SendMailRequest notifier = new SendMailRequest(notifyRecipient, this);
-      RequestThread.postRequest(notifier);
+        SendMailRequest notifier = new SendMailRequest(notifyRecipient, this);
+        RequestThread.postRequest(notifier);
+      }
     }
 
     return this.execute(functionName, parameters, true);


### PR DESCRIPTION
Adds a preference to disable processing of `notify` directives for users who do not wish to notify script authors, per discussion in #3533 