### PR TITLE
Suppress abort due to ascension error for 1-day CS

### DIFF
--- a/src/net/sourceforge/kolmafia/request/GenericRequest.java
+++ b/src/net/sourceforge/kolmafia/request/GenericRequest.java
@@ -2440,7 +2440,14 @@ public class GenericRequest implements Runnable {
         String gashMessage = "You may not enter the Astral Gash again until tomorrow.";
         if (this.responseText.contains(gashMessage)) {
           String errorMsg = "Failed to ascend: " + gashMessage;
-          KoLmafia.updateDisplay(MafiaState.ERROR, errorMsg);
+          if (KoLCharacter.isCommunityService() && !KoLCharacter.kingLiberated()) {
+            // If we're only reaching this point because we're donation-cancelling on the first day
+            // of a CS run, suppress the error.
+            errorMsg += " (expected)";
+            KoLmafia.updateDisplay(errorMsg);
+          } else {
+            KoLmafia.updateDisplay(MafiaState.ERROR, errorMsg);
+          }
           RequestLogger.updateSessionLog(errorMsg);
         }
         return;


### PR DESCRIPTION
Follow-up to #3518

Suppresses the error state normally generated when a redirect to `main.php?nope=asc` happens under the specific circumstance where we are body-donation-cancelling at the end of a 1-day Community Service run. The message still gets printed (with an indicator that we *expected* to arrive at this error message), but it should no longer cause scripts to abort in this case.