### PR TITLE
feat: more legendary+bases, treasure chestnut

### DIFF
--- a/src/data/fullness.txt
+++ b/src/data/fullness.txt
@@ -143,7 +143,7 @@ campfire stew	1	1	awesome	4-5	0	15-30	0	60 Just Like Me, They Want to Be (+1 Res
 can of Adultwitch&trade;	2	4	decent	2-4	0	0	0	20 Greasy Visage (+50 Sleaze Spell Damage, +100% Spell Damage)
 can of franks 'n' beans	3	1	good	8-10	20-40	20-40	20-40	50 Crimbo Nostalgia (+5 exp)
 can of sardines	1	4	awesome	3-4	20-25	0	0
-can of tuna	1	1	good	0	0	0	0	Unspaded
+can of tuna	1	1	good	2-3	10-12	0	0
 can-shaped gelatinous cranberry sauce	3	6	awesome	9-17	0	0	71-74
 candied beef and cabbage	3	1	awesome	10-12	0	10-20	10-20	20 Green-Blooded (+25 MP, 5-15 MP regen)
 candied lime	4	1	good	16	0	0	0	50 Limed Up (+MPC drops)
@@ -591,7 +591,7 @@ lime	1	2	decent	2	0	0	0
 limp broccoli	2	5	good	4-6	10-20	10-20	10-20	100 Nutrient-Rich (+4 exp, +50% HP, +25% MP)
 linguini immondizia bianco	5	8	awesome	17-20	0	0	25-30	SAUCY
 linguini of the sea	5	10	awesome	19-22	0	0	35-40	SAUCY
-Linguini Ubriacapa	1	1	awesome	0	0	0	0	Unspaded
+Linguini Ubriacapa	1	1	awesome	4-5	0	0	20-40
 liquid bread	1	4	EPIC	5-6	5-10	5-10	5-10	BEVERAGE, 20 Comprehensively Nourished (+2 experience)
 liver and let pie	2	1	good	5-7	5-10	5-10	5-10
 liver popsicle	1	1	decent	2	0	0	0
@@ -686,7 +686,7 @@ one with everything	2	1	awesome	6-8	0	10-15	0	50 Inner Dog (+50% Myst, +10% Spel
 optimal dog	1	1	awesome	4-5	0	0	0	Grants Lucky! intrinsic
 orange	1	1	crappy	1	0	0	0
 orange popsicle	1	1	decent	2	0	0	0
-Orzo di Riso	1	1	awesome	0	0	0	0	Unspaded
+Orzo di Riso	1	1	awesome	4	20-40	0	0
 overcookie	1	3	decent	2	3-5	3-5	3-5
 P.B.L.T.	3	4	decent	6-8	18-25	0	0
 packet of beer nuts	1	2	crappy	1	0	0	0	1 Salty Mouth (+4-6 adv from Beers)
@@ -695,7 +695,7 @@ painful penne pasta	3	3	good	7-9	17-20	0	0	lose 20-23 HP
 papaya	1	1	crappy	1	0	0	0
 papaya taco	1	1	decent	2	8-12	0	8-12	TACO
 party platter for one	2	6	EPIC	12-14	20-40	20-40	20-40
-Pasta Grimavera	1	1	awesome	0	0	0	0	Unspaded
+Pasta Grimavera	1	1	awesome	4-5	0	20-40	0
 pat of butter	1	4	awesome	3-4	0	0	20-25
 pawn cookie	1	1	crappy	1-3	0	0	0	30 Pwnd (+1..10 all stats)
 PB&BP	3	1	decent	6-8	9-12	0	0
@@ -716,7 +716,7 @@ perfect breakfast	5	1	good	14-16	20-30	40-50	0
 perfect chef salad	5	1	good	14-16	10-20	40-50	10-20
 perfect sandwich	5	1	good	14-16	10-20	40-50	10-20
 personalized birthday cake	3	1	crappy	3	0	0	0
-Pesto alla Marziano	1	1	awesome	0	0	0	0	Unspaded
+Pesto alla Marziano	1	1	awesome	3-5	0	20-30	0
 pestopiary	2	1	good	5-7	0	15-20	0
 Pete's rich ricotta	1	1	super EPIC	6-8	0	0	40-80	30 Rippin' Riccotta (+200 Initiative, +10 Moxie, +100% Moxie)
 Pete's wiley whey bar	1	1	EPIC	5-7	0	0	20-40	30 Awfully Wily (+5 Moxie, +50% Moxie, +5 Sleaze Res)
@@ -1067,7 +1067,7 @@ traditional Crimbo cookie	2	1	awesome	7-11	0	0	0	75 Yeast-Hungry (+50% food drop
 traditional gingerloaf	4	1	awesome	17-19	0	0	0
 traffic jam toast	1	1	decent	1-3	50	0	0
 transparent nog	1	1	crappy	1	0	0	0	BEVERAGE, 10 Holiday Disappointment (+50% all stats)
-treasure chestnut	2	1	awesome	0	0	0	0	Unspaded
+treasure chestnut	2	1	awesome	8-12	4-6	4-6	4-6
 tree-shaped Crimbo cookie	2	7	awesome	6-12	0	0	0	10/20 Yuletide Sappiness (+10% mys)
 triangular CRIMBCOOKIE	2	1	awesome	8-10	0	0	0	10 Triangle, Man (+10% mus)
 tricky dragon roll	3	1	pseudoitem	9-14	20-30	0	8-16	45/55 Fishy

--- a/src/data/items.txt
+++ b/src/data/items.txt
@@ -12284,5 +12284,5 @@
 12255
 12256
 12257
-12258	shrink-wrapped Cup of 13s	832590849	13cup_box.gif	usable	t	0
-12259	Cup of 13s	840617830	13cup.gif	offhand		0
+12258	shrink-wrapped Cup of 13s	832590849	13cup_box.gif	usable	t	0	shrink-wrapped Cups of 13
+12259	Cup of 13s	840617830	13cup.gif	offhand		0	Cups of 13


### PR DESCRIPTION
Yes, Orzo di Riso has a max of 4, unlike the other two in its set.