### PR TITLE
Log after-battle message for Sword of S Words

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -9011,6 +9011,7 @@ public class FightRequest extends GenericRequest {
     for (Pattern p : SWORD_OF_SWORDS_KILLS) {
       Matcher matcher = p.matcher(text);
       if (matcher.find()) {
+        logText(text, status);
         Preferences.increment("_swordOfSWordsKills", 1, 100);
         return true;
       }

--- a/test/net/sourceforge/kolmafia/request/FightRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FightRequestTest.java
@@ -4459,6 +4459,7 @@ public class FightRequestTest {
 
   @Test
   public void tracksSwordOfSwordsKills() {
+    RequestLoggerOutput.startStream();
     var cleanups =
         new Cleanups(
             withFight(),
@@ -4470,7 +4471,9 @@ public class FightRequestTest {
     try (cleanups) {
       parseCombatData(
           "request/test_fight_sword_drop_table.html", "fight.php?action=skill&whichskill=7593");
+      String text = RequestLoggerOutput.stopStream();
 
+      assertThat(text, containsString("comes back with a hiltful of blood-covered items"));
       assertThat("swordOfSWordsMonster", isSetTo(1163));
       assertThat("_swordOfSWordsMonsterChanged", isSetTo(1));
       assertThat("_swordOfSWordsKills", isSetTo(1));


### PR DESCRIPTION
Log the after-battle message when the Sword of S Words replaces the monster's drop table.