### PR TITLE
Fix javascript combat macros by wrapping MonsterData & fix javascript claiming to exit exceptionally

### DIFF
--- a/src/net/sourceforge/kolmafia/combat/Macrofier.java
+++ b/src/net/sourceforge/kolmafia/combat/Macrofier.java
@@ -133,13 +133,14 @@ public class Macrofier {
         var macroScope = macroOverrideRec.macroScope;
         var macroFunction = macroOverrideRec.macroFunction;
         var macroThisArg = macroOverrideRec.macroThisArg;
+        Object[] jsParameters = JavascriptRuntime.wrapMonsterArguments(macroScope, parameters);
         // Execute a function from the JavaScript runtime maintaining the scope, thisObj etc
         returnValue =
             interpreter.executeFunction(
                 macroScope,
                 () -> {
                   Context cx = Context.getCurrentContext();
-                  return macroFunction.call(cx, macroScope, macroThisArg, parameters);
+                  return macroFunction.call(cx, macroScope, macroThisArg, jsParameters);
                 });
       } else {
         // Execute a single function in the scope of the

--- a/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
@@ -310,7 +310,10 @@ public class JavascriptRuntime extends AbstractRuntime {
       String escapedMessage = escapeHtmlInMessage("Script exception: " + e.getMessage());
       KoLmafia.updateDisplay(KoLConstants.MafiaState.ERROR, escapedMessage);
     } finally {
-      setState(State.EXIT);
+      // Reentrant (Macrofier calls back in mid-script), so only exit if KoLmafia says to abort.
+      if (!KoLmafia.permitsContinue()) {
+        setState(State.EXIT);
+      }
     }
 
     cx.getUnhandledPromiseTracker()

--- a/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
@@ -351,20 +351,23 @@ public class JavascriptRuntime extends AbstractRuntime {
     throw new JavaScriptException("Promise did not resolve or reject", null, 0);
   }
 
+  public static Object[] wrapMonsterArguments(Scriptable scope, Object[] arguments) {
+    return Arrays.stream(arguments)
+        .map(
+            o ->
+                o instanceof MonsterData monster
+                    ? EnumeratedWrapper.wrap(
+                        scope, MonsterProxy.class, DataTypes.makeMonsterValue(monster))
+                    : o)
+        .toArray();
+  }
+
   private Value executeRun(
       final String functionName, final Object[] arguments, final boolean executeTopLevel) {
     Context cx = Context.getCurrentContext();
     Scriptable scope = currentTopScope;
     Object[] argumentsNonNull = arguments != null ? arguments : new Object[] {};
-    Object[] runArguments =
-        Arrays.stream(argumentsNonNull)
-            .map(
-                o ->
-                    o instanceof MonsterData
-                        ? EnumeratedWrapper.wrap(
-                            scope, MonsterProxy.class, DataTypes.makeMonsterValue((MonsterData) o))
-                        : o)
-            .toArray();
+    Object[] runArguments = wrapMonsterArguments(scope, argumentsNonNull);
 
     return executeFunction(
         scope,

--- a/test/net/sourceforge/kolmafia/combat/MacrofierJavascriptFilterTest.java
+++ b/test/net/sourceforge/kolmafia/combat/MacrofierJavascriptFilterTest.java
@@ -1,0 +1,77 @@
+package net.sourceforge.kolmafia.combat;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.request.FightRequest;
+import net.sourceforge.kolmafia.textui.ScriptRuntime;
+import net.sourceforge.kolmafia.textui.javascript.JavascriptRuntime;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.BaseFunction;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
+public class MacrofierJavascriptFilterTest {
+  private static Context cx;
+  private static Scriptable scope;
+
+  @BeforeAll
+  public static void beforeAll() {
+    cx = Context.enter();
+    cx.setLanguageVersion(Context.VERSION_ES6);
+    scope = cx.initSafeStandardObjects();
+  }
+
+  @AfterAll
+  public static void afterAll() {
+    Context.exit();
+  }
+
+  @AfterEach
+  public void cleanup() {
+    Macrofier.resetMacroOverride();
+    FightRequest.combatFilterThatDidNothing = null;
+    KoLmafia.forceContinue();
+  }
+
+  private JavascriptRuntime withFilter(String javascript) {
+    var controller = new JavascriptRuntime("");
+    var baseFunction = (BaseFunction) cx.evaluateString(scope, javascript, "test filter", 1, null);
+    Macrofier.setJavaScriptMacroOverride(baseFunction, scope, scope);
+    Macrofier.setMacroOverride("filterPlaceholder", controller);
+    controller.setState(ScriptRuntime.State.NORMAL);
+    return controller;
+  }
+
+  @Test
+  public void filterSuccessDuringAbortSetsStateExit() {
+    var controller = withFilter("(round, monster, page) => 'attack'");
+    KoLmafia.updateDisplay(KoLConstants.MafiaState.ABORT, "Aborted state");
+
+    assertThat(Macrofier.macrofy(), is("abort"));
+    assertThat(controller.getState(), is(ScriptRuntime.State.EXIT));
+  }
+
+  @Test
+  public void filterSuccessSetsStateNormal() {
+    var controller = withFilter("(round, monster, page) => 'attack'");
+
+    assertThat(Macrofier.macrofy(), is("attack"));
+    assertThat(controller.getState(), is(ScriptRuntime.State.NORMAL));
+  }
+
+  @Test
+  public void filterThrowSetsStateExit() {
+    var controller =
+        withFilter("(function(round, monster, page) { throw new Error('This is an error'); })");
+
+    Macrofier.macrofy();
+
+    assertThat(controller.getState(), is(ScriptRuntime.State.EXIT));
+  }
+}


### PR DESCRIPTION
MonsterData was not wrapped when it should be, meaning javascript combat macros, passed as a function, via parameter, were erroring out when trying to access the `Monster` that they were given. `JavaScript evaluator exception: Invalid JavaScript value of type net.sourceforge.kolmafia.MonsterData`

This change wraps the `MonsterData` in a javascript wrapper, and fixes the error. Allowing javascript functions to be passed safely as a parameter to `adv1(location, turns, func)` and for the functions to handle monsters where previously they would just error.

The code has overlap with another area, so I extracted it into its own method.

As for tests, there are none. I can't figure out how to do tests without making this a whole ordeal because none of the tests seem to be testable this way, and the closest I got was atrocious, especially for how simple this is.

Regardless, pretty easy to verify at a glance.

I would have preferred to reassign `parameters` in the Macrofier, but the parameters variable needs to be `final`, and reassignment kind of invalidates that... I could have mutated the array, but that would kind of defeat the point of the method existing. And its easier to overcover this than to do the bare minimum.

Regardless, tested this and it seems to be working great, haven't noticed any issues.

# Edit:

Spotted another issue, it seems like the javascript function always sets the EXIT state when it executes, which is wrong in this case. It seems like EXIT is meant to say that the script is aborting or exiting, which seem to be about the same thing for the EXIT?

I can't really find much to indicate "This indicates the script is closing gracefully", it seems more... exceptional.

I only found it an issue because adv1 was returning false on every single invocation.