### PR TITLE
feat: update to node 24 for publishing types

### DIFF
--- a/.github/npm/package.json
+++ b/.github/npm/package.json
@@ -4,7 +4,10 @@
   "description": "Typings for the KoLmafia JS standard library",
   "main": "index.js",
   "types": "index.d.ts",
-  "repository": "https://github.com/kolmafia/kolmafia",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kolmafia/kolmafia.git"
+  },
   "author": "KoLmafia Team",
   "license": "MIT",
   "private": false,

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm


### PR DESCRIPTION
Installing the latest version of NPM installs version 12 which requires node 22. Upgrade to latest LTS.