### PR TITLE
Fix Encyclopedia wiki links

### DIFF
--- a/src/net/sourceforge/kolmafia/utilities/WikiUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/WikiUtilities.java
@@ -10,6 +10,7 @@ import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase.QueuedConcoction;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
+import net.sourceforge.kolmafia.persistence.FamiliarDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
@@ -49,7 +50,7 @@ public class WikiUtilities {
       Modifiers mods = ModifierDatabase.getModifiers(modType, name);
       if (mods != null) {
         String wikiname = mods.getString(StringModifier.WIKI_NAME);
-        if (wikiname != null && wikiname.length() > 0) {
+        if (wikiname != null && !wikiname.isEmpty()) {
           name = wikiname;
           checkOtherTables = false;
         }
@@ -186,6 +187,11 @@ public class WikiUtilities {
     } else if (item instanceof SoldItem si) {
       name = si.getItemName();
       type = WikiType.ITEM;
+    } else if (item instanceof ItemDatabase.ItemData id) {
+      name = id.name();
+      type = WikiType.ITEM;
+    } else if (item instanceof FamiliarDatabase fd) {
+      name = "xx";
     } else if (item instanceof String s) {
       name = s;
     }

--- a/src/net/sourceforge/kolmafia/utilities/WikiUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/WikiUtilities.java
@@ -9,6 +9,7 @@ import net.sourceforge.kolmafia.maximizer.Boost;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase.QueuedConcoction;
+import net.sourceforge.kolmafia.persistence.EffectData;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
 import net.sourceforge.kolmafia.persistence.FamiliarDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
@@ -190,8 +191,14 @@ public class WikiUtilities {
     } else if (item instanceof ItemDatabase.ItemData id) {
       name = id.name();
       type = WikiType.ITEM;
-    } else if (item instanceof FamiliarDatabase fd) {
-      name = "xx";
+    } else if (item instanceof FamiliarDatabase.FamiliarRaceData fr) {
+      name = fr.name();
+    } else if (item instanceof SkillDatabase.SkillData sk) {
+      name = sk.name();
+      type = WikiType.SKILL;
+    } else if (item instanceof EffectData ed) {
+      name = ed.getName();
+      type = WikiType.EFFECT;
     } else if (item instanceof String s) {
       name = s;
     }


### PR DESCRIPTION
The wiki links for items were not working although the in game links were.  I fixed that and the discovered familiars, skills and effects were also broken.  So I fixed them as well.

I am leaving this as draft for now for two reasons.  One, Vampire Bat as a familiar doesn't work as expected.  Either it is not being disambiguated or disambiguation needs to be tweaked.  Second I can't recall any recent changes in this area.  Breaking this may have been a side effect of some refactoring or structural things and if that is correct then my fix may be wrong.