### PR TITLE
Fix interact() modifier expression parsing

### DIFF
--- a/src/net/sourceforge/kolmafia/ModifierExpression.java
+++ b/src/net/sourceforge/kolmafia/ModifierExpression.java
@@ -101,9 +101,6 @@ public class ModifierExpression extends Expression {
     if (this.optional("mod(")) {
       return this.literal(this.until(")"), '\u0093');
     }
-    if (this.optional("interact(")) {
-      return this.literal(this.until(")"), '\u0094');
-    }
     if (this.optional("stripcommas(")) {
       return this.literal(this.until(")"), '\u0096');
     }
@@ -130,6 +127,9 @@ public class ModifierExpression extends Expression {
     }
     if (this.optional("mox")) {
       return "\u0082";
+    }
+    if (this.optional("interact()")) {
+      return "\u0094";
     }
     if (this.optional("basemus")) {
       return "\u0097";

--- a/test/net/sourceforge/kolmafia/ExpressionTest.java
+++ b/test/net/sourceforge/kolmafia/ExpressionTest.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia;
 
 import static internal.helpers.Player.withAdventuresLeft;
+import static internal.helpers.Player.withInteractivity;
 import static internal.helpers.Player.withItem;
 import static internal.helpers.Player.withItemInCloset;
 import static internal.helpers.Player.withItemInStorage;
@@ -159,6 +160,17 @@ public class ExpressionTest {
     try (cleanups) {
       var exp = new Expression("haveitem(2528)", "have filet of tangy gnat");
       assertThat(exp.eval(), is(2.0));
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({"true,7", "false,3"})
+  void interactExpressions(boolean canInteract, double expectedOutput) {
+    var cleanups = new Cleanups(withInteractivity(canInteract));
+
+    try (cleanups) {
+      var exp = new ModifierExpression("interact()*7+(1-interact())*3", "Test expression");
+      assertThat(exp.eval(), equalTo(expectedOutput));
     }
   }
 


### PR DESCRIPTION
Because the `interact()` modifier expression function is formatted like a function but does not take any parameters, it is not being correctly parsed by the expression engine and can corrupt the expression stack and produce incorrect results for complex expressions. This fix changes it to be parsed like non-parameter-taking expression "functions" like `paradoxicity` and `unarmed`. 

I opted to leave it expressed as `interact()` rather than `interact`, but if anyone feels strongly about it, we can change it to `interact` in the very few places it's used.