### PR TITLE
Eliminate race condition in JavascriptRuntime

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
@@ -59,7 +59,6 @@ public class JavascriptRuntime extends AbstractRuntime {
   private File scriptFile = null;
   private String scriptString = null;
 
-  private Scriptable currentTopScope = null;
   private Scriptable currentStdLib = null;
 
   public static void clearSessionStorage() {
@@ -209,11 +208,7 @@ public class JavascriptRuntime extends AbstractRuntime {
   public Value execute(
       final String functionName, final Object[] arguments, final boolean executeTopLevel) {
     if (!executeTopLevel) {
-      if (currentTopScope == null) {
-        throw new ScriptException(
-            "Cannot run with executeTopLevel = false without running once first.");
-      }
-      return executeRun(functionName, arguments, false);
+      throw new ScriptException("Cannot run with executeTopLevel = false");
     }
 
     // TODO: Support for requesting user arguments if missing.
@@ -227,7 +222,6 @@ public class JavascriptRuntime extends AbstractRuntime {
     // TODO: Use a shared parent scope and initialize this with that as a prototype.
     // But be careful. May mess up our EnumeratedWrapper registries.
     Scriptable scope = cx.initSafeStandardObjects();
-    currentTopScope = scope;
 
     try {
       // If executing from GCLI (and not file), add std lib to top scope.
@@ -236,11 +230,11 @@ public class JavascriptRuntime extends AbstractRuntime {
 
       setState(State.NORMAL);
       if (ScriptRuntime.hasTopCall(cx)) {
-        return executeRun(functionName, arguments, true);
+        return executeRun(functionName, arguments, scope, true);
       } else {
         return (Value)
             ScriptRuntime.doTopCall(
-                (cx1, scope1, thisObj, args) -> executeRun(functionName, arguments, true),
+                (cx1, scope1, thisObj, args) -> executeRun(functionName, arguments, scope, true),
                 cx,
                 scope,
                 null,
@@ -255,7 +249,6 @@ public class JavascriptRuntime extends AbstractRuntime {
       return null;
     } finally {
       EnumeratedWrapper.cleanup(scope);
-      currentTopScope = null;
       runningRuntimes.remove(this);
       Context.exit();
     }
@@ -366,9 +359,11 @@ public class JavascriptRuntime extends AbstractRuntime {
   }
 
   private Value executeRun(
-      final String functionName, final Object[] arguments, final boolean executeTopLevel) {
+      final String functionName,
+      final Object[] arguments,
+      Scriptable scope,
+      final boolean executeTopLevel) {
     Context cx = Context.getCurrentContext();
-    Scriptable scope = currentTopScope;
     Object[] argumentsNonNull = arguments != null ? arguments : new Object[] {};
     Object[] runArguments = wrapMonsterArguments(scope, argumentsNonNull);
 
@@ -394,8 +389,7 @@ public class JavascriptRuntime extends AbstractRuntime {
                     : ScriptableObject.getProperty(exports, functionName);
 
             if (mainFunction instanceof Function) {
-              return ((Function) mainFunction)
-                  .call(cx, scope, cx.newObject(currentTopScope), runArguments);
+              return ((Function) mainFunction).call(cx, scope, cx.newObject(scope), runArguments);
             }
           }
 


### PR DESCRIPTION
This aims to fix the issue described here: https://kolmafia.us/threads/npe-caused-by-js-script.29840/

### Cause

Analysis of the stack trace and the relevant portions of code revealed that the direct cause for the NPE was `JavascriptRuntime.currentTopScope` being `null` when passed into `Context.newObject()`. At first this seems impossible: the value is always already-non-null or set to a non-null value, used, and then later disposed. However, instances of `JavascriptRuntime` are not one-time use; they are cached in `KoLmafiaASH.INTERPRETERS`, presumably to avoid repeatedly reading-from-disk and parsing the same script files. This produces the opportunity for multiple invocations of `JavascriptRuntime.execute()` to run concurrently and for the value of the instance variable `currentTopScope` to get clobbered unexpectedly. 

This is most likely to happen when a script gets executed multiple times in quick succession but in parallel. The easiest case to envision was having a long-running script that would often take actions that would call the spading script, and while it was running, take an action in the relay browser that would also cause the spading script to get called (such as opening an item description). Using a debugger, I was able to force this condition to happen, and it produced exactly the sort of error indicated in the bug report.

### Fix Options

I explored several options for fixes:

1. Adding the `synchronized` keyword to `JavascriptRuntime.execute()`
   - This indeed does prevent the problem from occurring, but it also has the effect of locking out parts of mafia (e.g. some relay browser functions) while long-lived JS scripts are running, which is not desirable. I could not identify a way to pare down the `synchronized` section to a small enough portion of the function to avoid this side effect without rendering the fix ineffective.
2. Converting `currentTopScope` to a `ThreadLocal<Scriptable>`
   - This would prevent one script's invocation of `execute()` from affecting the value that is already in-use by a script running in another thread. It would technically also preclude a script from one thread being able to call `execute()` with `executeTopLevel=false` and using a `currentTopScope` set from another thread, but I can't imagine this ever being desirable. Moreover, analysis of the `execute()` call sites indicates that `JavascriptRuntime.execute()` isn't ever actually called with `executeTopLevel=false` (except for in two places which already do not work because `currentTopScope` would definitely not be set). I tested this solution briefly, and it seemed to work fine.
 3. Eliminate the instance variable
    - Since the value of `currentTopScope` is explicitly disposed after `execute()` runs, and the analysis of the `execute()` call sites indicates that the value isn't actually used later in the call tree, it should be safe to eliminate the instance variable altogether and use a local variable instead (and just prohibit attempts to call `execute()` with `executeTopLevel=false` altogether). This seemed like the cleanest fix and is the one presented in this PR.

### Testing

As with most issues involving concurrency, writing a unit test to verify a fix is more-or-less impossible. My hope is that the analysis above is convincing enough. Additionally, I've been using a JAR modified to use this fix for over a week, running various JS scripts, and have not encountered any issues. It would be good for @libraryaddict to make sure this doesn't break anything from #3546; I'm not really sure exactly what a good test case for that is.