### PR TITLE
Daily limit for Calculate the Universe

### DIFF
--- a/src/data/dailylimits.txt
+++ b/src/data/dailylimits.txt
@@ -60,6 +60,7 @@ Cast	CHEAT CODE: Invisible Avatar	_powerfulGloveBatteryPowerUsed	100
 Cast	CHEAT CODE: Replace Enemy	_powerfulGloveBatteryPowerUsed	100
 Cast	CHEAT CODE: Shrink Enemy	_powerfulGloveBatteryPowerUsed	100
 Cast	CHEAT CODE: Triple Size	_powerfulGloveBatteryPowerUsed	100
+Cast	Calculate the Universe	_universeCalculated	[interact()*pref(skillLevel144)+(1-interact())*min(pref(skillLevel144),3)]
 Cast	Canticle of Carboloading	_carboLoaded
 Cast	Ceci N'Est Pas Un Chapeau	_ceciHatUsed
 Cast	Chest X-Ray	_chestXRayUsed	3

--- a/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
@@ -2132,6 +2132,10 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
           // If the skill is being cast, then the limit must be at least 1
           Preferences.setInteger("skillLevel144", 1);
         }
+
+        // Using the skill just sends us to the Doing the Maths choice adventure, and the skill is
+        // only actually used as a result of the choice, so skip handling it here.
+        return SkillStatus.WARNING;
       }
       case SkillPool.SEEK_OUT_A_BIRD -> Preferences.increment("_birdsSoughtToday");
       case SkillPool.MAP_THE_MONSTERS -> Preferences.setBoolean("mappingMonsters", true);

--- a/src/net/sourceforge/kolmafia/session/ChoiceControl.java
+++ b/src/net/sourceforge/kolmafia/session/ChoiceControl.java
@@ -44,6 +44,8 @@ import net.sourceforge.kolmafia.objectpool.OutfitPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
+import net.sourceforge.kolmafia.persistence.DailyLimitDatabase.DailyLimit;
+import net.sourceforge.kolmafia.persistence.DailyLimitDatabase.DailyLimitType;
 import net.sourceforge.kolmafia.persistence.DebugDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.ModifierDatabase;
@@ -5944,7 +5946,17 @@ public abstract class ChoiceControl {
       case 1103 -> {
         // Doing the Maths
         if (!text.contains("Try again")) {
-          Preferences.increment("_universeCalculated");
+          DailyLimit limit = DailyLimitType.CAST.getDailyLimit(SkillPool.CALCULATE_THE_UNIVERSE);
+          if (limit != null) {
+            limit.increment();
+            SkillDatabase.registerCasts(SkillPool.CALCULATE_THE_UNIVERSE, 1);
+            if (!KoLCharacter.canInteract() && limit.getUses() >= 3) {
+              // If the skill is used 3 times in-run, the skill can't be used more today even after
+              // breaking the prism.
+              Preferences.setInteger(
+                  "_universeCalculated", Preferences.getInteger("skillLevel144"));
+            }
+          }
         }
       }
 

--- a/test/net/sourceforge/kolmafia/request/NumberologyRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/NumberologyRequestTest.java
@@ -1,0 +1,59 @@
+package net.sourceforge.kolmafia.request;
+
+import static internal.helpers.Player.withInteractivity;
+import static internal.helpers.Player.withPostChoice2;
+import static internal.helpers.Player.withProperty;
+import static internal.matchers.Preference.isSetTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import internal.helpers.Cleanups;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.objectpool.SkillPool;
+import net.sourceforge.kolmafia.persistence.DailyLimitDatabase.DailyLimitType;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class NumberologyRequestTest {
+  @BeforeEach
+  public void beforeEach() {
+    KoLCharacter.reset("NumberologyRequestTest");
+    Preferences.reset("NumberologyRequestTest");
+  }
+
+  @ParameterizedTest
+  @CsvSource({"true,5", "false,2"})
+  void numberologyLimitedUnderRestrictions(boolean canInteract, int remainingUsesExpected) {
+    var cleanups =
+        new Cleanups(
+            withInteractivity(canInteract),
+            withProperty("_universeCalculated", 1),
+            withProperty("skillLevel144", 6));
+
+    try (cleanups) {
+      int remainingUses =
+          DailyLimitType.CAST.getDailyLimit(SkillPool.CALCULATE_THE_UNIVERSE).getUsesRemaining();
+      assertEquals(remainingUsesExpected, remainingUses);
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "false,6", // Third in-run use locks out skill for the rest of the day
+    "true,3" // Third use occurring out-of-run allows further uses
+  })
+  void numberologyQuirkHandled(boolean canInteract, int postCastUses) {
+    var cleanups =
+        new Cleanups(
+            withInteractivity(canInteract),
+            withProperty("_universeCalculated", 2),
+            withProperty("skillLevel144", 6),
+            withPostChoice2(1103, 0));
+
+    try (cleanups) {
+      assertThat("_universeCalculated", isSetTo(postCastUses));
+    }
+  }
+}


### PR DESCRIPTION
https://kolmafia.us/threads/all-skills-with-daily-limits-should-appear-in-dailylimits-txt.32632/
Another missing dailylimits.txt entry, this time for Calculate the Universe. This one is a bit weird due to all of the weird behavior of Calculate the Universe, which I *think* is now all properly tracked:

* Using the skill only sends you to the Doing the Maths choice, so avoid incrementing the counter when the skill is used and manually increment it if the choice results in something other than a Try Again.
* Some choices result in a combat. This seems to Just Work™️so I assume there's some redirect shenanigans going on, but I won't look a gift horse in the mouth.
* The daily limit depends on whether or not the user is in Ronin/HC, so we have to do weird gymnastics to set the daily limit.
  * Additionally there's a weird interaction where reaching the limit in Ronin/HC blocks further use of the skill for the rest of the day even if the prism is later broken.