### PR TITLE
Fix Javascript swallowing aborts

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/javascript/AbortException.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/AbortException.java
@@ -1,0 +1,55 @@
+package net.sourceforge.kolmafia.textui.javascript;
+
+import java.io.Serial;
+import net.sourceforge.kolmafia.KoLConstants.MafiaState;
+import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.textui.parsetree.Try;
+import org.mozilla.javascript.EvaluatorException;
+
+/**
+ * Thrown to stop the whole script when KoLmafia aborts. Rhino does not let JavaScript code catch a
+ * plain RuntimeException, but still runs its 'finally' clauses as the exception unwinds. ASH treats
+ * an abort the same way.
+ *
+ * <p>{@link #suspend} moves the abort out of the global continuation state and into this exception,
+ * so 'finally' blocks can still make library calls while the script unwinds. At the script
+ * boundary, {@link JavascriptRuntime#executeFunction} calls {@link #restore} to put the abort back
+ * for whoever ran the script.
+ *
+ * <p>ASH's {@link Try} does the same around a 'finally' clause; Saves the abort, forceContinue, run
+ * the clause, restore.
+ */
+public class AbortException extends RuntimeException {
+  @Serial private static final long serialVersionUID = 1L;
+
+  private final MafiaState continuationState;
+  private final boolean userAborted;
+  private final String scriptStackTrace;
+
+  private AbortException(final String message) {
+    super(message);
+    this.continuationState = StaticEntity.getContinuationState();
+    this.userAborted = StaticEntity.userAborted;
+    // Use Rhino's way to capture the current script stack.
+    // See NativeConsole.js_trace
+    this.scriptStackTrace = new EvaluatorException(message).getScriptStackTrace();
+  }
+
+  /** Moves the pending abort out of the global continuation state, into the returned exception. */
+  static AbortException suspend() {
+    AbortException abort = new AbortException(KoLmafia.getLastMessage());
+    KoLmafia.forceContinue();
+    return abort;
+  }
+
+  /** Puts the suspended abort back, as {@link #suspend} found it. */
+  public void restore() {
+    StaticEntity.setContinuationState(this.continuationState);
+    StaticEntity.userAborted = this.userAborted;
+  }
+
+  String getScriptStackTrace() {
+    return this.scriptStackTrace;
+  }
+}

--- a/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.MonsterData;
+import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.textui.AbstractRuntime;
@@ -274,6 +275,13 @@ public class JavascriptRuntime extends AbstractRuntime {
         returnValue = null;
         returnValue = resolvePromise(cx, promise);
       }
+    } catch (AbortException e) {
+      if (stackOnAbort) {
+        RequestLogger.printLine(
+            KoLConstants.MafiaState.ERROR, escapeHtmlInMessage(e.getScriptStackTrace()));
+      }
+      // The script has unwound; re-arm the abort for whatever ran this script.
+      e.restore();
     } catch (WrappedException e) {
       Throwable unwrapped = e.getWrappedException();
       if (unwrapped instanceof ScriptException) {
@@ -427,6 +435,10 @@ public class JavascriptRuntime extends AbstractRuntime {
       throw new JavaScriptException("Script interrupted.", null, 0);
     }
     if (!KoLmafia.permitsContinue()) {
+      if (KoLmafia.refusesContinue()) {
+        // An abort, it halts every script on the stack, and nothing may catch it.
+        throw AbortException.suspend();
+      }
       KoLmafia.forceContinue();
       throw new JavaScriptException("KoLmafia error: " + KoLmafia.getLastMessage(), null, 0);
     }

--- a/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
@@ -56,6 +56,10 @@ public class JavascriptRuntime extends AbstractRuntime {
 
   static final Set<JavascriptRuntime> runningRuntimes = ConcurrentHashMap.newKeySet();
   static final ContextFactory contextFactory = new ObservingContextFactory();
+
+  /** Set while an abort that's already printed, unwinds on this thread. */
+  private static final ThreadLocal<Boolean> abortUnwinding = ThreadLocal.withInitial(() -> false);
+
   static final Map<String, Storage> storedSessions = new HashMap<>();
   private File scriptFile = null;
   private String scriptString = null;
@@ -252,6 +256,10 @@ public class JavascriptRuntime extends AbstractRuntime {
       EnumeratedWrapper.cleanup(scope);
       runningRuntimes.remove(this);
       Context.exit();
+      if (Context.getCurrentContext() == null) {
+        // Outermost script on this thread has exited; any unwinding abort is over.
+        abortUnwinding.remove();
+      }
     }
   }
 
@@ -269,10 +277,15 @@ public class JavascriptRuntime extends AbstractRuntime {
         returnValue = resolvePromise(cx, promise);
       }
     } catch (AbortException e) {
-      if (stackOnAbort) {
+      if (stackOnAbort && !abortUnwinding.get()) {
         RequestLogger.printLine(
-            KoLConstants.MafiaState.ERROR, escapeHtmlInMessage(e.getScriptStackTrace()));
+            KoLConstants.MafiaState.ERROR,
+            escapeHtmlInMessage(
+                "Script aborted: " + e.getMessage() + "\n" + e.getScriptStackTrace()));
       }
+      // The stacktrace already contains the frames of the parent contexts (unless it's a large
+      // trace), we unwind them silently.
+      abortUnwinding.set(true);
       // The script has unwound; re-arm the abort for whatever ran this script.
       e.restore();
     } catch (WrappedException e) {

--- a/test/internal/matchers/StringMatcher.java
+++ b/test/internal/matchers/StringMatcher.java
@@ -1,0 +1,30 @@
+package internal.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+public class StringMatcher {
+  /** Matches when {@code substring} appears exactly {@code times} times in the string. */
+  public static Matcher<String> containsStringTimes(String substring, int times) {
+    return new TypeSafeMatcher<>() {
+      @Override
+      public void describeTo(Description description) {
+        description
+            .appendText("Expected a string containing " + times + " occurrences of: ")
+            .appendValue(substring);
+      }
+
+      @Override
+      public boolean matchesSafely(String string) {
+        int count = 0;
+        int index = string.indexOf(substring);
+        while (index != -1) {
+          count++;
+          index = string.indexOf(substring, index + substring.length());
+        }
+        return count == times;
+      }
+    };
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/AbortPropagationTest.java
+++ b/test/net/sourceforge/kolmafia/textui/AbortPropagationTest.java
@@ -438,15 +438,16 @@ public class AbortPropagationTest {
 
     /**
      * As in ASH, an abort prints its message once (from {@link RuntimeLibrary#abort(ScriptRuntime)}
-     * itself) and unwinds quietly. With 'printStackOnAbort', each script it unwinds also prints its
-     * stack trace, the Javascript version of {@link AshRuntime#setState(ScriptRuntime.State)}'s
-     * stack printing. Two scripts unwind here, the nested one and the caller, so two traces print,
-     * each a single "at command line" frame. Plus one for the test framework.
+     * itself) and unwinds quietly. With 'printStackOnAbort', the script the abort originated in
+     * also prints its stack trace, the Javascript version of {@link
+     * AshRuntime#setState(ScriptRuntime.State)}'s stack printing. Nested scripts share the context,
+     * so only the first trace gets printed, the remaining traces are suppressed for the current
+     * thread.
      *
      * <p>Note that the preference does not control if non-abort error stacks are printed.
      */
     @Test
-    void abortPrintsAStackTracePerUnwoundScriptWhenPreferenceSet() {
+    void abortPrintsOneStackTraceWhenPreferenceSet() {
       try (var cleanups = withProperty("printStackOnAbort", true)) {
         var run =
             runJs(
@@ -455,8 +456,27 @@ public class AbortPropagationTest {
                     print("After abort");
                     """);
 
-        assertThat(run.output().split("Nested abort", -1).length - 1, is(1));
-        assertThat(run.output().split("at command line", -1).length - 1, is(3));
+        // We expect only one "Script aborted: Nested abort\n<trace>"
+        assertThat(run.output().split("Script aborted", -1).length - 1, is(1));
+        assertThat(run.output().split("Nested abort", -1).length - 1, is(2));
+        assertThat(
+            run.output().split("Nested abort\nScript aborted: Nested abort\n", -1).length - 1,
+            is(1));
+        assertThat(run.output().split("at command line", -1).length - 1, is(2));
+      }
+    }
+
+    @Test
+    void abortTraceUnwindingCleanlyCloses() {
+      try (var cleanups = withProperty("printStackOnAbort", true)) {
+        var first = runJs("cliExecute(\"jsq abort('Nested abort')\");");
+        KoLmafia.forceContinue();
+        var second = runJs("cliExecute(\"jsq abort('Nested abort')\");");
+
+        assertThat(first.output().split("Script aborted: Nested abort", -1).length - 1, is(1));
+        assertThat(first.output().split("at command line", -1).length - 1, is(2));
+        assertThat(second.output().split("Script aborted: Nested abort", -1).length - 1, is(1));
+        assertThat(second.output().split("at command line", -1).length - 1, is(2));
       }
     }
 

--- a/test/net/sourceforge/kolmafia/textui/AbortPropagationTest.java
+++ b/test/net/sourceforge/kolmafia/textui/AbortPropagationTest.java
@@ -17,6 +17,7 @@ import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.textui.javascript.AbortException;
 import net.sourceforge.kolmafia.textui.javascript.AshStub;
 import net.sourceforge.kolmafia.textui.javascript.JavascriptRuntime;
 import net.sourceforge.kolmafia.textui.parsetree.Try;
@@ -519,15 +520,14 @@ public class AbortPropagationTest {
      */
     @Test
     void javascriptCheckpointSuspendsAnAbortIntoTheException() {
-      //      KoLmafia.updateDisplay(MafiaState.ABORT, "Hard abort, situation 3");
-      //
-      //      var exception = assertThrows(AbortException.class,
-      // JavascriptRuntime::checkInterrupted);
-      //      assertThat(exception.getMessage(), is("Hard abort, situation 3"));
-      //      assertThat(StaticEntity.getContinuationState(), is(MafiaState.CONTINUE));
-      //
-      //      exception.restore();
-      //      assertThat(StaticEntity.getContinuationState(), is(MafiaState.ABORT));
+      KoLmafia.updateDisplay(MafiaState.ABORT, "Hard abort, situation 3");
+
+      var exception = assertThrows(AbortException.class, JavascriptRuntime::checkInterrupted);
+      assertThat(exception.getMessage(), is("Hard abort, situation 3"));
+      assertThat(StaticEntity.getContinuationState(), is(MafiaState.CONTINUE));
+
+      exception.restore();
+      assertThat(StaticEntity.getContinuationState(), is(MafiaState.ABORT));
     }
 
     @Test

--- a/test/net/sourceforge/kolmafia/textui/AbortPropagationTest.java
+++ b/test/net/sourceforge/kolmafia/textui/AbortPropagationTest.java
@@ -1,0 +1,561 @@
+package net.sourceforge.kolmafia.textui;
+
+import static internal.helpers.Player.withProperty;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import internal.helpers.RequestLoggerOutput;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLConstants.MafiaState;
+import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.RequestThread;
+import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.textui.javascript.AshStub;
+import net.sourceforge.kolmafia.textui.javascript.JavascriptRuntime;
+import net.sourceforge.kolmafia.textui.parsetree.Try;
+import net.sourceforge.kolmafia.textui.parsetree.Value;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.JavaScriptException;
+
+/**
+ * When a script fails, KoLmafia has three situations and ASH and Javascript are meant to agree on
+ * all three.
+ *
+ * <ul>
+ *   <li>ASH is the reference behavior, the nested classes below test the situation in both
+ *       languages.
+ *   <li><b>Situation 1: Thrown exceptions</b>
+ *       <ul>
+ *         <li>A library function throws, bad script, thrown error. This is handled by the language,
+ *             unwinding the script's own stack, the state stays {@link MafiaState#CONTINUE}. Both
+ *             languages may catch these and carry on.
+ *       </ul>
+ *   <li><b>Situation 2: Soft stops</b>
+ *       <ul>
+ *         <li>Something failed and set {@link MafiaState#ERROR}, {@link KoLmafia#refusesContinue()}
+ *             is still false. Unlike situation '1' there is no exception to catch, only the state.
+ *             Exceptions can't cross a script boundary, so a nested script dying to one just leaves
+ *             the caller looking at ERROR.
+ *         <li>ASH halts unless the script handles the error, either by capturing the return value
+ *             or wrapping it in a catch.
+ *         <li>Both reset the state to CONTINUE.
+ *         <li>Javascript treats every ASH call as captured, so the call just returns false, the
+ *             state is reset, and the script decides what to do.
+ *       </ul>
+ *   <li><b>Situation 3: Aborts, or hard stops</b>
+ *       <ul>
+ *         <li>On {@link MafiaState#ABORT}, or the user hit stop {@link StaticEntity#userAborted},
+ *             so {@link KoLmafia#refusesContinue} is true. These halt every script on the stack, no
+ *             matter how deeply nested, eg 'betweenBattleScript' run from inside adv1(), and no
+ *             language may swallow them. The state stays ABORT until the outermost request sequence
+ *             closes.
+ *       </ul>
+ *   <li>For the tests we run them quietly, as otherwise it prints "Returned:" whose
+ *       updateDisplay(CONTINUE, ...) resets the state.
+ *   <li>Each run is wrapped in a RequestThread because hook scripts run inside an existing request
+ *       sequence.
+ *       <ul>
+ *         <li>Otherwise, {@link RequestThread#closeRequestSequence} would treat the nested call as
+ *             the outermost sequence and reset the state.
+ *         <li>See {@link Situation3Aborts#abortClearsWhenTheOutermostRequestSequenceCloses}.
+ *       </ul>
+ * </ul>
+ */
+public class AbortPropagationTest {
+  @BeforeEach
+  void beforeEach() {
+    KoLmafia.forceContinue();
+    KoLCharacter.reset("AbortPropagationTest");
+    Preferences.reset("AbortPropagationTest");
+  }
+
+  @AfterEach
+  void afterEach() {
+    KoLmafia.forceContinue();
+  }
+
+  /**
+   * @param output Output of the script
+   * @param stateDuringRun The state right after the script returned, while still inside the request
+   *     sequence, as a caller like {@link RuntimeLibrary#adv1} would observe
+   * @param stateAfterRun the state after the outer request sequence closed
+   */
+  private record ScriptRun(String output, MafiaState stateDuringRun, MafiaState stateAfterRun) {}
+
+  private static ScriptRun run(Runnable script) {
+    RequestLoggerOutput.startStream();
+    MafiaState stateDuringRun;
+    Integer seq = RequestThread.openRequestSequence();
+    try {
+      script.run();
+      stateDuringRun = StaticEntity.getContinuationState();
+    } finally {
+      RequestThread.closeRequestSequence(seq);
+    }
+    MafiaState stateAfterRun = StaticEntity.getContinuationState();
+    String output = RequestLoggerOutput.stopStream();
+    return new ScriptRun(output, stateDuringRun, stateAfterRun);
+  }
+
+  private static ScriptRun runAsh(String source) {
+    return run(
+        () -> {
+          var istream = new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8));
+          AshRuntime interpreter = new AshRuntime();
+          interpreter.validate(null, istream);
+          interpreter.execute("main", null);
+        });
+  }
+
+  private static ScriptRun runJs(String source) {
+    return run(() -> new JavascriptRuntime(source).execute(null, null, true));
+  }
+
+  @Nested
+  class Situation1ThrownExceptions {
+    @Test
+    void ashCatchCapturesAThrownException() {
+      var run =
+          runAsh(
+              """
+                string err = catch {
+                  session_logs(-1);
+                  print("Unseen");
+                };
+                print("Caught: " + (err != ""));
+                print("After exception");
+                """);
+
+      assertThat(run.output(), not(containsString("Unseen")));
+      assertThat(run.output(), containsString("Caught: true"));
+      assertThat(run.output(), containsString("After exception"));
+      assertThat(run.stateDuringRun(), is(MafiaState.CONTINUE));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+
+    @Test
+    void javascriptTryCatchCatchesAThrownException() {
+      var run =
+          runJs(
+              """
+                try {
+                  sessionLogs(-1);
+                  print("Unseen");
+                } catch (e) {
+                  print("Caught: " + (e !== ""));
+                }
+                print("After exception");
+                """);
+
+      assertThat(run.output(), not(containsString("Unseen")));
+      assertThat(run.output(), containsString("Caught: true"));
+      assertThat(run.output(), containsString("After exception"));
+      assertThat(run.stateDuringRun(), is(MafiaState.CONTINUE));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+  }
+
+  /**
+   * The nested script fails at runtime, its interpreter turns the thrown error into a soft stop
+   * {@link MafiaState#ERROR} which the calling script sees.
+   */
+  @Nested
+  class Situation2SoftFailures {
+    @Test
+    void ashHaltsWhenANestedScriptFails() {
+      var run =
+          runAsh(
+              """
+                cli_execute("ashq session_logs(-1)");
+                print("After error");
+                """);
+
+      assertThat(run.output(), not(containsString("After error")));
+      assertThat(run.stateDuringRun(), is(MafiaState.ERROR));
+      assertThat(run.stateAfterRun(), is(MafiaState.ERROR));
+    }
+
+    @Test
+    void ashContinuesWhenANestedScriptFailureIsCaptured() {
+      var run =
+          runAsh(
+              """
+                boolean success = cli_execute("ashq session_logs(-1)");
+                print("Captured: " + success);
+                print("After error");
+                """);
+
+      assertThat(run.output(), containsString("Captured: false"));
+      assertThat(run.output(), containsString("After error"));
+      assertThat(run.stateDuringRun(), is(MafiaState.CONTINUE));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+
+    @Test
+    void ashContinuesWhenANestedScriptFailureIsCaught() {
+      var run =
+          runAsh(
+              """
+                string err = catch cli_execute("ashq session_logs(-1)");
+                print("Caught: " + (err != ""));
+                print("After error");
+                """);
+
+      assertThat(run.output(), containsString("Caught: true"));
+      assertThat(run.output(), containsString("After error"));
+      assertThat(run.stateDuringRun(), is(MafiaState.CONTINUE));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+
+    /**
+     * Javascript's version has every call already behaves like a captured one {@link AshStub#call},
+     * the failure just comes back as false, the state is cleared, and the script carries on.
+     */
+    @Test
+    void javascriptContinuesWhenANestedScriptFails() {
+      var run =
+          runJs(
+              """
+                var success = cliExecute("jsq throw new Error('Nested error')");
+                print("Captured: " + success);
+                print("After error");
+                """);
+
+      assertThat(run.output(), containsString("Nested error"));
+      assertThat(run.output(), containsString("Captured: false"));
+      assertThat(run.output(), containsString("After error"));
+      assertThat(run.stateDuringRun(), is(MafiaState.CONTINUE));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+  }
+
+  @Nested
+  class Situation3Aborts {
+    @Test
+    void ashHaltsWhenANestedAshScriptAborts() {
+      var run =
+          runAsh(
+              """
+                cli_execute("ashq abort('Nested abort')");
+                print("After abort");
+                """);
+
+      assertThat(run.output(), containsString("Nested abort"));
+      assertThat(run.output(), not(containsString("After abort")));
+      assertThat(run.stateDuringRun(), is(MafiaState.ABORT));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+
+    @Test
+    void ashHaltsWhenANestedJavascriptScriptAborts() {
+      var run =
+          runAsh(
+              """
+                cli_execute("jsq abort('Nested abort')");
+                print("After abort");
+                """);
+
+      assertThat(run.output(), containsString("Nested abort"));
+      assertThat(run.output(), not(containsString("After abort")));
+      assertThat(run.stateDuringRun(), is(MafiaState.ABORT));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+
+    @Test
+    void javascriptHaltsWhenANestedAshScriptAborts() {
+      var run =
+          runJs(
+              """
+                cliExecute("ashq abort('Nested abort')");
+                print("After abort");
+                """);
+
+      assertThat(run.output(), containsString("Nested abort"));
+      assertThat(run.output(), not(containsString("After abort")));
+      assertThat(run.stateDuringRun(), is(MafiaState.ABORT));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+
+    @Test
+    void javascriptHaltsWhenANestedJavascriptScriptAborts() {
+      var run =
+          runJs(
+              """
+                cliExecute("jsq abort('Nested abort')");
+                print("After abort");
+                """);
+
+      assertThat(run.output(), containsString("Nested abort"));
+      assertThat(run.output(), not(containsString("After abort")));
+      assertThat(run.stateDuringRun(), is(MafiaState.ABORT));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+
+    /**
+     * Capturing the return value recovers from a soft failure; it shouldn't recover from an abort.
+     */
+    @Test
+    void ashCaptureCannotSwallowAnAbort() {
+      var run =
+          runAsh(
+              """
+                boolean success = cli_execute("ashq abort('Nested abort')");
+                print("After abort");
+                """);
+
+      assertThat(run.output(), containsString("Nested abort"));
+      assertThat(run.output(), not(containsString("After abort")));
+      assertThat(run.stateDuringRun(), is(MafiaState.ABORT));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+
+    /** ASH's catch recovers from a soft failure, same deal, it shouldn't recover from an abort. */
+    @Test
+    void ashCatchCannotSwallowAnAbort() {
+      var run =
+          runAsh(
+              """
+                string err = catch {
+                  cli_execute("ashq abort('Nested abort')");
+                };
+                print("After abort");
+                """);
+
+      assertThat(run.output(), containsString("Nested abort"));
+      assertThat(run.output(), not(containsString("After abort")));
+      assertThat(run.stateDuringRun(), is(MafiaState.ABORT));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+
+    /**
+     * A Javascript catch never sees the abort at all, Rhino only offers the exception to finally
+     * blocks. Same as ASH's catch refusing to swallow one {@link AshRuntime#captureValue}. The
+     * catch block here is skipped entirely and the script still halts.
+     */
+    @Test
+    void javascriptTryCatchCannotSwallowAnAbort() {
+      var run =
+          runJs(
+              """
+                try {
+                  cliExecute("jsq abort('Nested abort')");
+                } catch (e) {
+                  print("Caught: " + e);
+                }
+                print("After abort");
+                """);
+
+      assertThat(run.output(), containsString("Nested abort"));
+      assertThat(run.output(), not(containsString("Caught:")));
+      assertThat(run.output(), not(containsString("After abort")));
+      assertThat(run.stateDuringRun(), is(MafiaState.ABORT));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+
+    /** With both clauses present, catch is skipped, finally still runs, and the script halts. */
+    @Test
+    void javascriptTryCatchFinallySkipsCatchAndRunsFinallyOnAbort() {
+      var run =
+          runJs(
+              """
+                try {
+                  cliExecute("jsq abort('Nested abort')");
+                } catch (e) {
+                  print("Caught: " + e);
+                } finally {
+                  print("Finally ran");
+                }
+                print("After abort");
+                """);
+
+      assertThat(run.output(), containsString("Nested abort"));
+      assertThat(run.output(), not(containsString("Caught:")));
+      assertThat(run.output(), containsString("Finally ran"));
+      assertThat(run.output(), not(containsString("After abort")));
+      assertThat(run.stateDuringRun(), is(MafiaState.ABORT));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+
+    /**
+     * The reference behavior, from {@link Try}. A 'finally' clause always runs, the abort state is
+     * suspended while it does so its ash calls still work, then restored after so the script still
+     * halts.
+     */
+    @Test
+    void ashFinallyRunsCleanupAfterAnAbortAndStillHalts() {
+      var run =
+          runAsh(
+              """
+                try {
+                  cli_execute("ashq abort('Nested abort')");
+                } finally {
+                  print("Finally ran");
+                }
+                print("After abort");
+                """);
+
+      assertThat(run.output(), containsString("Nested abort"));
+      assertThat(run.output(), containsString("Finally ran"));
+      assertThat(run.output(), not(containsString("After abort")));
+      assertThat(run.stateDuringRun(), is(MafiaState.ABORT));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+
+    /**
+     * Javascript matching ASH, finally runs its cleanup (ash calls included), and the script still
+     * halts.
+     */
+    @Test
+    void javascriptFinallyRunsCleanupAfterAnAbortAndStillHalts() {
+      var run =
+          runJs(
+              """
+                try {
+                  cliExecute("jsq abort('Nested abort')");
+                } finally {
+                  print("Finally ran");
+                }
+                print("After abort");
+                """);
+
+      assertThat(run.output(), containsString("Nested abort"));
+      assertThat(run.output(), containsString("Finally ran"));
+      assertThat(run.output(), not(containsString("After abort")));
+      assertThat(run.stateDuringRun(), is(MafiaState.ABORT));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+
+    /**
+     * As in ASH, an abort prints its message once (from {@link RuntimeLibrary#abort(ScriptRuntime)}
+     * itself) and unwinds quietly. With 'printStackOnAbort', each script it unwinds also prints its
+     * stack trace, the Javascript version of {@link AshRuntime#setState(ScriptRuntime.State)}'s
+     * stack printing. Two scripts unwind here, the nested one and the caller, so two traces print,
+     * each a single "at command line" frame. Plus one for the test framework.
+     *
+     * <p>Note that the preference does not control if non-abort error stacks are printed.
+     */
+    @Test
+    void abortPrintsAStackTracePerUnwoundScriptWhenPreferenceSet() {
+      try (var cleanups = withProperty("printStackOnAbort", true)) {
+        var run =
+            runJs(
+                """
+                    cliExecute("jsq abort('Nested abort')");
+                    print("After abort");
+                    """);
+
+        assertThat(run.output().split("Nested abort", -1).length - 1, is(1));
+        assertThat(run.output().split("at command line", -1).length - 1, is(3));
+      }
+    }
+
+    /**
+     * Without 'printStackOnAbort' the unwind is silent past {@link
+     * RuntimeLibrary#abort(ScriptRuntime)}'s own message, same as ASH.
+     */
+    @Test
+    void abortUnwindsQuietlyByDefault() {
+      try (var cleanups = withProperty("printStackOnAbort", false)) {
+        var run =
+            runJs(
+                """
+                cliExecute("jsq abort('Nested abort')");
+                print("After abort");
+                """);
+
+        assertThat(run.output().split("Nested abort", -1).length - 1, is(1));
+        assertThat(run.output(), not(containsString("at command line")));
+      }
+    }
+
+    /**
+     * An abort outlives every script on the stack but not the command itself. Once the outer
+     * request sequence closes, the state resets so the next command starts clean, the same life an
+     * ASH abort has. We don't get stuck aborted.
+     */
+    @Test
+    void abortClearsWhenTheOutermostRequestSequenceCloses() {
+      var run =
+          runJs(
+              """
+                cliExecute("jsq abort('Nested abort')");
+                """);
+
+      assertThat(run.stateDuringRun(), is(MafiaState.ABORT));
+      assertThat(run.stateAfterRun(), is(MafiaState.CONTINUE));
+    }
+  }
+
+  /**
+   * Tests for the two methods everything above rests on. Each language has one place that decides
+   * whether a stopped state can be cleared so the script continues, {@link
+   * JavascriptRuntime#checkInterrupted} for Javascript and {@link AshRuntime#captureValue} for ASH.
+   * A {@link KoLmafia#refusesContinue} state is never cleared.
+   */
+  @Nested
+  class Checkpoints {
+    @Test
+    void javascriptCheckpointClearsASoftStopAndThrows() {
+      KoLmafia.updateDisplay(MafiaState.ERROR, "Soft failure, situation 2");
+
+      assertThrows(JavaScriptException.class, JavascriptRuntime::checkInterrupted);
+      assertThat(StaticEntity.getContinuationState(), is(MafiaState.CONTINUE));
+    }
+
+    /**
+     * A hard stop is held in the exception, so 'finally' can still make ash calls while the script
+     * unwinds, then restored at the script boundary {@link JavascriptRuntime#executeFunction}. The
+     * same save / forceContinue / restore that ASH's {@link Try} does on a 'finally' clause.
+     */
+    @Test
+    void javascriptCheckpointSuspendsAnAbortIntoTheException() {
+      //      KoLmafia.updateDisplay(MafiaState.ABORT, "Hard abort, situation 3");
+      //
+      //      var exception = assertThrows(AbortException.class,
+      // JavascriptRuntime::checkInterrupted);
+      //      assertThat(exception.getMessage(), is("Hard abort, situation 3"));
+      //      assertThat(StaticEntity.getContinuationState(), is(MafiaState.CONTINUE));
+      //
+      //      exception.restore();
+      //      assertThat(StaticEntity.getContinuationState(), is(MafiaState.ABORT));
+    }
+
+    @Test
+    void javascriptCheckpointIsQuietWhileContinuePermitted() {
+      assertDoesNotThrow(JavascriptRuntime::checkInterrupted);
+      assertThat(StaticEntity.getContinuationState(), is(MafiaState.CONTINUE));
+    }
+
+    @Test
+    void ashCaptureClearsASoftStop() {
+      var interpreter = new AshRuntime();
+      KoLmafia.updateDisplay(MafiaState.ERROR, "Soft failure, situation 2");
+
+      interpreter.captureValue(new Value(false));
+
+      assertThat(StaticEntity.getContinuationState(), is(MafiaState.CONTINUE));
+      assertThat(interpreter.getState(), is(ScriptRuntime.State.NORMAL));
+    }
+
+    @Test
+    void ashCaptureRefusesAnAbort() {
+      var interpreter = new AshRuntime();
+      KoLmafia.updateDisplay(MafiaState.ABORT, "Hard abort, situation 3");
+
+      interpreter.captureValue(new Value(false));
+
+      assertThat(StaticEntity.getContinuationState(), is(MafiaState.ABORT));
+      assertThat(interpreter.getState(), is(ScriptRuntime.State.EXIT));
+    }
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/AbortPropagationTest.java
+++ b/test/net/sourceforge/kolmafia/textui/AbortPropagationTest.java
@@ -1,6 +1,7 @@
 package net.sourceforge.kolmafia.textui;
 
 import static internal.helpers.Player.withProperty;
+import static internal.matchers.StringMatcher.containsStringTimes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -457,12 +458,11 @@ public class AbortPropagationTest {
                     """);
 
         // We expect only one "Script aborted: Nested abort\n<trace>"
-        assertThat(run.output().split("Script aborted", -1).length - 1, is(1));
-        assertThat(run.output().split("Nested abort", -1).length - 1, is(2));
+        assertThat(run.output(), containsStringTimes("Script aborted", 1));
+        assertThat(run.output(), containsStringTimes("Nested abort", 2));
         assertThat(
-            run.output().split("Nested abort\nScript aborted: Nested abort\n", -1).length - 1,
-            is(1));
-        assertThat(run.output().split("at command line", -1).length - 1, is(2));
+            run.output(), containsStringTimes("Nested abort\nScript aborted: Nested abort\n", 1));
+        assertThat(run.output(), containsStringTimes("at command line", 2));
       }
     }
 
@@ -473,10 +473,10 @@ public class AbortPropagationTest {
         KoLmafia.forceContinue();
         var second = runJs("cliExecute(\"jsq abort('Nested abort')\");");
 
-        assertThat(first.output().split("Script aborted: Nested abort", -1).length - 1, is(1));
-        assertThat(first.output().split("at command line", -1).length - 1, is(2));
-        assertThat(second.output().split("Script aborted: Nested abort", -1).length - 1, is(1));
-        assertThat(second.output().split("at command line", -1).length - 1, is(2));
+        assertThat(first.output(), containsStringTimes("Script aborted: Nested abort", 1));
+        assertThat(first.output(), containsStringTimes("at command line", 2));
+        assertThat(second.output(), containsStringTimes("Script aborted: Nested abort", 1));
+        assertThat(second.output(), containsStringTimes("at command line", 2));
       }
     }
 
@@ -494,7 +494,7 @@ public class AbortPropagationTest {
                 print("After abort");
                 """);
 
-        assertThat(run.output().split("Nested abort", -1).length - 1, is(1));
+        assertThat(run.output(), containsStringTimes("Nested abort", 1));
         assertThat(run.output(), not(containsString("at command line")));
       }
     }


### PR DESCRIPTION
# What's broken

Using `abort()` in a Javascript script does not actually abort. [`JavascriptRuntime.checkInterrupted()`](https://github.com/kolmafia/kolmafia/blob/2977765f95fd5001b5347b7b6649456c9dc65adc/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java#L419) treats every stopped state the same, with `!permitsContinue()` clearing the state and turning it into a `JavascriptException`.

1. The new exception is catchable, so scripts can swallow the abort and keep going. Even a user abort doesn't get through.
2. The state is cleared before the throw, so when a nested script aborts (e.g. `cliExecute("ashq abort('...')")` or a `betweenBattleScript` inside `adv1()`), the caller sees `CONTINUE` and carries on.

# How it should work

KoLmafia has three failure modes, I'm using ASH as defining the intended behavior.

1. *Thrown exceptions.* Library functions, bad scripts, or `throw`. These are language exceptions, the state remains `CONTINUE`, and scripts may catch them.
2. *Soft stops.* Something sets `ERROR`, but `refusesContinue()` is false. ASH halts unless the script handles the error. Javascript treats every ASH call as handled, so the call returns `false`, the state is reset, and the script decides what to do. This is unchanged.
3. *Aborts (hard stops).* These stop every script on the stack, regardless of nesting, and cannot be caught. The state remains `ABORT` until the stack finishes unwinding.

Javascript handled the first two, but treated `3. aborts` as soft stops.

# The fix

`checkInterrupted()` now checks `refusesContinue()` first and throws a new `AbortException` extending `RuntimeException`. Rhino does not let Javascript catch those, but still runs `finally` blocks while unwinding, matching ASH.

The exception temporarily suspends the global abort state so `finally` blocks can still make library calls. At the script boundary, `executeFunction()` restores the abort state for the caller. ASH's `Try` does the same: save the abort, `forceContinue()`, run `finally`, then restore.

With `printStackOnAbort` enabled, each unwound script also prints its stack trace, matching ASH. That preference applies to `ABORT`, not `ERROR`, so the failing test is correct.

* `catch`/`capture` cannot swallow an abort.
* `finally` still runs cleanup (including ASH calls).
* Stack traces only print when the preference is enabled.
* The abort clears once the outermost request sequence ends.

The tests should cover most cases, let me know if I missed something.

This will probably break a few scripts, but those were relying on buggy behavior by treating `abort()` like `throw`.

The main change people will see is that a single abort can now reliably stop Javascript scripts instead of requiring repeated aborts. Operations that hang (eg kolmafia code issues or networking) are a separate issue.

Relevant:

* https://kolmafia.us/threads/cant-stop-gash-jumping-in-preascensionscript-from-js-js-abort-and-ash-abort-behave-differently.29618/
* https://github.com/kolmafia/kolmafia/pull/3546#issuecomment-4887310854

# Closing thoughts

I note that when I abort() in my pre-adv script, it works as intended, but the stack trace is slightly confusing. The abort *message* only shows at the original abort, with the following stack traces only being a stack trace, no messages. This, might not be the best behavior.

But as a counterpoint, this is only visible when `printStackOnAbort` is set.

The other perspective is that the script should not be sending another stacktrace, I think it's already captured in the first stacktrace.

This didn't occur to me beforehand, so I'm not sure if it should change or if its best as it is now.

Eg
<img width="872" height="182" alt="image" src="https://github.com/user-attachments/assets/c13dfdb2-667f-4da9-8d09-23cbdb9b46c5" />
