### PR TITLE
Fix maximizer changing modes of items in ignored slots

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -2332,7 +2332,14 @@ public class Evaluator {
             backupSlots.add(Slot.FAMILIAR);
           }
 
-          if (backupSlots.stream().anyMatch(s -> spec.equipment.get(s) == null)) {
+          // Slots we're ignoring are not considered, they keep their modes
+          // A slot is considered ignored if not null
+          boolean itemInIgnoredSlot =
+              spec.equipment.values().stream()
+                  .anyMatch(i -> i != null && i.getItemId() == modeable.getItemId());
+
+          if (!itemInIgnoredSlot
+              && backupSlots.stream().anyMatch(s -> spec.equipment.get(s) == null)) {
             spec.setModeable(modeable, mode);
           }
         });

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -1553,6 +1553,33 @@ public class MaximizerTest {
         assertThat(getBoosts(), not(hasItem(hasProperty("cmd", startsWith("ledcandle disco")))));
       }
     }
+
+    @Test
+    public void doesNotChangeModeOfItemInExcludedSlot() {
+      final var cleanups =
+          new Cleanups(
+              withEquipped(Slot.ACCESSORY1, "backup camera"),
+              withProperty("backupCameraMode", "init"));
+
+      try (cleanups) {
+        assertTrue(maximize("meat, -acc1"));
+        assertThat(getBoosts(), not(hasItem(hasProperty("cmd", startsWith("backupcamera")))));
+      }
+    }
+
+    @Test
+    public void doesNotChangeModeOfUmbrellaInExcludedSlot() {
+      final var cleanups =
+          new Cleanups(
+              withEquipped(Slot.OFFHAND, "unbreakable umbrella"),
+              withFamiliarInTerrarium(FamiliarPool.LEFT_HAND),
+              withProperty("umbrellaState", "cocoon"));
+
+      try (cleanups) {
+        assertTrue(maximize("ml, -offhand, switch left-hand man"));
+        assertThat(getBoosts(), not(hasItem(hasProperty("cmd", startsWith("umbrella")))));
+      }
+    }
   }
 
   @Nested

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -1580,6 +1580,37 @@ public class MaximizerTest {
         assertThat(getBoosts(), not(hasItem(hasProperty("cmd", startsWith("umbrella")))));
       }
     }
+
+    @Test
+    public void doesChangeModeOfUmbrellaInNonExcludedSlot() {
+      final var cleanups =
+          new Cleanups(
+              withEquipped(Slot.OFFHAND, "unbreakable umbrella"),
+              withFamiliarInTerrarium(FamiliarPool.LEFT_HAND),
+              withProperty("umbrellaState", "cocoon"));
+
+      try (cleanups) {
+        assertTrue(maximize("ml"));
+        assertThat(getBoosts(), hasItem(hasProperty("cmd", startsWith("umbrella"))));
+      }
+    }
+
+    @Test
+    public void doesChangeModeOfUmbrellaInNonExcludedSlot2() {
+      final var cleanups =
+          new Cleanups(
+              withEquipped(Slot.OFFHAND, "unbreakable umbrella"),
+              withEquipped(Slot.ACCESSORY1, "backup camera"),
+              withFamiliarInTerrarium(FamiliarPool.LEFT_HAND),
+              withProperty("umbrellaState", "cocoon"),
+              withProperty("backupCameraMode", "meat"));
+
+      try (cleanups) {
+        assertTrue(maximize("ml, -offhand"));
+        assertThat(getBoosts(), not(hasItem(hasProperty("cmd", startsWith("umbrella")))));
+        assertThat(getBoosts(), hasItem(hasProperty("cmd", startsWith("backupcamera"))));
+      }
+    }
   }
 
   @Nested


### PR DESCRIPTION
Maximizer currently considers items in slots we ignore, to see if it can mess with their modes.

This generally isn't desirable or expected from a user perspective.

The user expects `maximize meat -acc1` not to mess with the backup camera in acc1. And yet...

This PR aims to fix that by skipping items already equipped, in a slot that we're ignoring.