### PR TITLE
Ash functions for selecting a seeded random number from a range

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/Rng.java
+++ b/src/net/sourceforge/kolmafia/textui/Rng.java
@@ -20,7 +20,15 @@ public class Rng {
     return rand.nextInt();
   }
 
+  public int nextRandInt(int min, int max) {
+    return rand.nextInt(min, max);
+  }
+
   public int nextMtRandInt() {
     return mtRand.nextInt();
+  }
+
+  public int nextMtRandInt(int min, int max) {
+    return mtRand.nextInt(min, max);
   }
 }

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -2556,7 +2556,21 @@ public abstract class RuntimeLibrary {
     params = List.of(namedParam("rng", DataTypes.RNG_TYPE));
     functions.add(new LibraryFunction("php_rand", DataTypes.INT_TYPE, params));
 
+    params =
+        List.of(
+            namedParam("rng", DataTypes.RNG_TYPE),
+            namedParam("min", DataTypes.INT_TYPE),
+            namedParam("max", DataTypes.INT_TYPE));
+    functions.add(new LibraryFunction("php_rand", DataTypes.INT_TYPE, params));
+
     params = List.of(namedParam("rng", DataTypes.RNG_TYPE));
+    functions.add(new LibraryFunction("php_mt_rand", DataTypes.INT_TYPE, params));
+
+    params =
+        List.of(
+            namedParam("rng", DataTypes.RNG_TYPE),
+            namedParam("min", DataTypes.INT_TYPE),
+            namedParam("max", DataTypes.INT_TYPE));
     functions.add(new LibraryFunction("php_mt_rand", DataTypes.INT_TYPE, params));
 
     // Assorted functions
@@ -9064,9 +9078,25 @@ public abstract class RuntimeLibrary {
     return new Value(r.nextRandInt());
   }
 
+  public static Value php_rand(
+      ScriptRuntime controller, final Value rng, final Value minValue, final Value maxValue) {
+    Rng r = (Rng) rng.rawValue();
+    int min = (int) minValue.intValue();
+    int max = (int) maxValue.intValue();
+    return new Value(r.nextRandInt(min, max));
+  }
+
   public static Value php_mt_rand(ScriptRuntime controller, final Value rng) {
     Rng r = (Rng) rng.rawValue();
     return new Value(r.nextMtRandInt());
+  }
+
+  public static Value php_mt_rand(
+      ScriptRuntime controller, final Value rng, final Value minValue, final Value maxValue) {
+    Rng r = (Rng) rng.rawValue();
+    int min = (int) minValue.intValue();
+    int max = (int) maxValue.intValue();
+    return new Value(r.nextMtRandInt(min, max));
   }
 
   public static Value expression_eval(ScriptRuntime controller, final Value expr) {


### PR DESCRIPTION
ASH currently provides the ability to get the raw next int for a seeded RNG, but this is a pain to work with (since the user ends up having to normalize it themselves). I don't want to go too crazy exposing additional RNG functions, but these ones (which allow the user to specify the range to select from) seem likely to be much more useful in most cases.