### PR TITLE
Update loose purse strings Cup of 13s tier

### DIFF
--- a/src/data/cup_of_13s.txt
+++ b/src/data/cup_of_13s.txt
@@ -3496,7 +3496,7 @@
 7028	Frankly Mr. Shank	4
 7029	Shakespeare's Sister's Accordion	4
 7030	third-hand lantern	1
-7031	loose purse strings	5
+7031	loose purse strings	1
 7032	pickled egg	1
 7033	cup of lukewarm tea	1
 7045	antimatter wad	5


### PR DESCRIPTION
The Cup of 13s tier for loose purse strings was nerfed today. No other tier changes are known.