### PR TITLE
Better preference backups + global prefs backups

### DIFF
--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -2,7 +2,9 @@ package net.sourceforge.kolmafia.preferences;
 
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -239,7 +241,7 @@ public class Preferences {
     synchronized (lock) {
       Properties p = Preferences.loadPreferences(userPrefsFile);
 
-      if (p.isEmpty()) {
+      if (!Preferences.isValidPreferencesFile(userPrefsFile, p)) {
         // Something went wrong reading the preferences.
         if (backupFile.exists()) {
           KoLmafia.updateDisplay(
@@ -251,7 +253,7 @@ public class Preferences {
 
           p = Preferences.loadPreferences(backupFile);
 
-          if (!p.isEmpty()) {
+          if (Preferences.isValidPreferencesFile(backupFile, p)) {
             try {
               Files.copy(
                   backupFile.toPath(), userPrefsFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
@@ -272,7 +274,23 @@ public class Preferences {
             }
           }
         } else {
-          KoLmafia.updateDisplay("Preferences could not be read and no backup exists.");
+          // No backup to fall back on, recover whatever complete lines were written before the
+          // corruption point instead of loading a malformed line.
+          try {
+            byte[] safeBytes =
+                FileUtilities.truncateToLastGoodLineBeforeNullByte(
+                    Files.readAllBytes(userPrefsFile.toPath()));
+            Properties recovered = new Properties();
+            try (InputStream istream = new ByteArrayInputStream(safeBytes)) {
+              recovered.load(istream);
+            }
+            p = recovered;
+            KoLmafia.updateDisplay(
+                "Preferences was partially recovered from corruption, no backup exists.");
+          } catch (IOException e) {
+            p = new Properties();
+            KoLmafia.updateDisplay("Preferences could not be read and no backup exists.");
+          }
           RequestLogger.updateSessionLog(
               userPrefsFile
                   + " could not be read and backup there is no backup file found. "
@@ -341,6 +359,18 @@ public class Preferences {
     }
 
     return p;
+  }
+
+  /** A file is currently considered as invalid if it contains null bytes, or is empty */
+  private static boolean isValidPreferencesFile(File file, Properties p) {
+    if (p.isEmpty()) {
+      return false;
+    }
+    try {
+      return !FileUtilities.containsNullBytes(file);
+    } catch (IOException e) {
+      return false;
+    }
   }
 
   private static String encodeProperty(String name, String value) {

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -4,7 +4,6 @@ import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -200,9 +199,11 @@ public class Preferences {
   private static void loadGlobalPreferences() {
     File file =
         new File(KoLConstants.SETTINGS_LOCATION, Preferences.baseUserName("") + "_prefs.txt");
+    File backupFile =
+        new File(KoLConstants.SETTINGS_LOCATION, Preferences.baseUserName("") + "_prefs.bak");
     Preferences.globalPropertiesFile = file;
 
-    Properties p = Preferences.loadPreferences(file);
+    Properties p = Preferences.loadPreferencesWithBackup(file, backupFile);
     Preferences.globalValues.clear();
     Preferences.globalEncodedValues.clear();
 
@@ -239,80 +240,7 @@ public class Preferences {
         new File(KoLConstants.SETTINGS_LOCATION, Preferences.baseUserName(username) + "_prefs.bak");
 
     synchronized (lock) {
-      Properties p = Preferences.loadPreferences(userPrefsFile);
-
-      if (!Preferences.isValidPreferencesFile(userPrefsFile, p)) {
-        // Something went wrong reading the preferences.
-        if (backupFile.exists()) {
-          KoLmafia.updateDisplay(
-              userPrefsFile
-                  + " could not be read, loading backup. "
-                  + "This will restore the last successfully opened preferences");
-          // also tell system out, in case things are really fubar
-          System.out.println("Prefs could not be read and backup exists, trying backup. ");
-
-          p = Preferences.loadPreferences(backupFile);
-
-          if (Preferences.isValidPreferencesFile(backupFile, p)) {
-            try {
-              Files.copy(
-                  backupFile.toPath(), userPrefsFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-
-            } catch (IOException ex) {
-
-              KoLmafia.updateDisplay(
-                  "Error when restoring preferences from backup,  see session log for details");
-              RequestLogger.updateSessionLog(
-                  userPrefsFile
-                      + " could not be read and backup was used. KoLmafia was unable to copy your backup file to "
-                      + "your preferences file and received error message:"
-                      + ex.getMessage()
-                      + "\nIf this is unexpected, please manually review your preferences and backup and repair any problems."
-                      + " If you have a damaged preferences file, "
-                      + "please consider creating a bug report on the forum, noting any special circumstances around "
-                      + "the failure, and attaching the preferences.");
-            }
-          }
-        } else {
-          // No backup to fall back on, recover whatever complete lines were written before the
-          // corruption point instead of loading a malformed line.
-          try {
-            byte[] safeBytes =
-                FileUtilities.truncateToLastGoodLineBeforeNullByte(
-                    Files.readAllBytes(userPrefsFile.toPath()));
-            Properties recovered = new Properties();
-            try (InputStream istream = new ByteArrayInputStream(safeBytes)) {
-              recovered.load(istream);
-            }
-            p = recovered;
-            KoLmafia.updateDisplay(
-                "Preferences was partially recovered from corruption, no backup exists.");
-          } catch (IOException e) {
-            p = new Properties();
-            KoLmafia.updateDisplay("Preferences could not be read and no backup exists.");
-          }
-          RequestLogger.updateSessionLog(
-              userPrefsFile
-                  + " could not be read and backup there is no backup file found. "
-                  + "If this is unexpected, please manually inspect "
-                  + "your preferences file and repair any problems.  If you have a damaged preferences file, "
-                  + "please consider creating a bug report on the forum, noting any special circumstances around "
-                  + "the failure, and attaching the preferences.");
-        }
-      } else {
-        try {
-          Files.copy(
-              userPrefsFile.toPath(), backupFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException ex) {
-          System.out.println("I/O Error when creating backup preferences file: " + ex.getMessage());
-          RequestLogger.updateSessionLog(
-              userPrefsFile
-                  + " backup creation failed. Please manually inspect "
-                  + "your preferences and backup files and repair any problems.  If you have a damaged preferences file, "
-                  + "please consider creating a bug report on the forum, noting any special circumstances around "
-                  + "the failure, and attaching the preferences.");
-        }
-      }
+      Properties p = Preferences.loadPreferencesWithBackup(userPrefsFile, backupFile);
 
       Preferences.userPropertiesFile = null;
       Preferences.userValues.clear();
@@ -348,6 +276,88 @@ public class Preferences {
 
       Preferences.userPropertiesFile = userPrefsFile;
     }
+  }
+
+  private static Properties loadPreferencesWithBackup(File prefsFile, File backupFile) {
+    if (!prefsFile.exists() && !backupFile.exists()) {
+      return new Properties();
+    }
+
+    Properties p = Preferences.loadPreferences(prefsFile);
+
+    if (!Preferences.isValidPreferencesFile(prefsFile, p)) {
+      // Something went wrong reading the preferences.
+      if (backupFile.exists()) {
+        KoLmafia.updateDisplay(
+            prefsFile
+                + " could not be read, loading backup. "
+                + "This will restore the last successfully opened preferences");
+        // also tell system out, in case things are really fubar
+        System.out.println("Prefs could not be read and backup exists, trying backup. ");
+
+        p = Preferences.loadPreferences(backupFile);
+
+        if (Preferences.isValidPreferencesFile(backupFile, p)) {
+          try {
+            Files.copy(
+                backupFile.toPath(), prefsFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+          } catch (IOException ex) {
+
+            KoLmafia.updateDisplay(
+                "Error when restoring preferences from backup,  see session log for details");
+            RequestLogger.updateSessionLog(
+                prefsFile
+                    + " could not be read and backup was used. KoLmafia was unable to copy your backup file to "
+                    + "your preferences file and received error message:"
+                    + ex.getMessage()
+                    + "\nIf this is unexpected, please manually review your preferences and backup and repair any problems."
+                    + " If you have a damaged preferences file, "
+                    + "please consider creating a bug report on the forum, noting any special circumstances around "
+                    + "the failure, and attaching the preferences.");
+          }
+        }
+      } else {
+        // No backup to fall back on, recover whatever complete lines were written before the
+        // corruption point instead of loading a malformed line.
+        try {
+          byte[] safeBytes =
+              FileUtilities.truncateToLastGoodLineBeforeNullByte(
+                  Files.readAllBytes(prefsFile.toPath()));
+          Properties recovered = new Properties();
+          try (InputStream istream = new ByteArrayInputStream(safeBytes)) {
+            recovered.load(istream);
+          }
+          p = recovered;
+          KoLmafia.updateDisplay(
+              "Preferences was partially recovered from corruption, no backup exists.");
+        } catch (IOException e) {
+          p = new Properties();
+          KoLmafia.updateDisplay("Preferences could not be read and no backup exists.");
+        }
+        RequestLogger.updateSessionLog(
+            prefsFile
+                + " could not be read and backup there is no backup file found. "
+                + "If this is unexpected, please manually inspect "
+                + "your preferences file and repair any problems.  If you have a damaged preferences file, "
+                + "please consider creating a bug report on the forum, noting any special circumstances around "
+                + "the failure, and attaching the preferences.");
+      }
+    } else {
+      try {
+        Files.copy(prefsFile.toPath(), backupFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      } catch (IOException ex) {
+        System.out.println("I/O Error when creating backup preferences file: " + ex.getMessage());
+        RequestLogger.updateSessionLog(
+            prefsFile
+                + " backup creation failed. Please manually inspect "
+                + "your preferences and backup files and repair any problems.  If you have a damaged preferences file, "
+                + "please consider creating a bug report on the forum, noting any special circumstances around "
+                + "the failure, and attaching the preferences.");
+      }
+    }
+
+    return p;
   }
 
   private static Properties loadPreferences(File file) {

--- a/src/net/sourceforge/kolmafia/utilities/FileUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/FileUtilities.java
@@ -582,7 +582,7 @@ public class FileUtilities {
       // We start scanning backwards for the first newline that indicates a complete line
       while (--i >= 0 && bytes[i] != '\n') {}
 
-      return Arrays.copyOf(bytes, i >= 0 ? i + 1 : 0);
+      return Arrays.copyOf(bytes, i + 1);
     }
 
     return bytes;

--- a/src/net/sourceforge/kolmafia/utilities/FileUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/FileUtilities.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 import javax.swing.ImageIcon;
@@ -558,6 +559,33 @@ public class FileUtilities {
     s = matchPathLists(homelist, filelist);
 
     return s;
+  }
+
+  public static boolean containsNullBytes(File file) throws IOException {
+    for (byte b : Files.readAllBytes(file.toPath())) {
+      if (b == 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Truncates {@code bytes} to the end of the last complete line before the first null byte. */
+  public static byte[] truncateToLastGoodLineBeforeNullByte(byte[] bytes) {
+    for (int i = 0; i < bytes.length; i++) {
+      // Skip non-null
+      if (bytes[i] != 0) {
+        continue;
+      }
+
+      // We started at a null, we cannot trust that this line is complete
+      // We start scanning backwards for the first newline that indicates a complete line
+      while (--i >= 0 && bytes[i] != '\n') {}
+
+      return Arrays.copyOf(bytes, i >= 0 ? i + 1 : 0);
+    }
+
+    return bytes;
   }
 
   public static boolean isEmptyDirectory(Path path) throws IOException {

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -773,6 +774,151 @@ class PreferencesTest {
           assertThat(contents, containsString("\nxyz=abc\n"));
           assertThat(contents, containsString("\nwxy=def\n"));
         }
+      }
+    }
+  }
+
+  @Nested
+  class AvoidsPartialSaveCorruption {
+    // Lowercase because of filenames
+    private final String USER_NAME = "PreferencesTestBackupUser".toLowerCase();
+    private final File userFile = new File("settings/" + USER_NAME + "_prefs.txt");
+    private final File backupFile = new File("settings/" + USER_NAME + "_prefs.bak");
+    private final String PREF_NAME = "somePreference";
+
+    @BeforeEach
+    public void deleteUserPrefs() {
+      verboseDelete(userFile);
+      verboseDelete(backupFile);
+    }
+
+    @AfterEach
+    public void resetCharAndPreferences() {
+      deleteSerFiles(USER_NAME);
+      KoLCharacter.reset("");
+    }
+
+    private void login() {
+      Preferences.reset(USER_NAME);
+    }
+
+    private void logout() {
+      Preferences.reset("");
+    }
+
+    /** Writes out parsable text, then \nul or \0 bytes to mimic a corrupted file */
+    private void corrupt(File file, String parsablePrefix) throws IOException {
+      // Turns the text into bytes
+      byte[] prefix = parsablePrefix.getBytes(StandardCharsets.UTF_8);
+      // The remaining bytes are null bytes
+      byte[] bytes = new byte[prefix.length + 64];
+      // Writes prefix into the bytes array
+      System.arraycopy(prefix, 0, bytes, 0, prefix.length);
+      // Writes to disk
+      Files.write(file.toPath(), bytes);
+    }
+
+    private void savePreference() {
+      Preferences.setString(PREF_NAME, "someValue");
+    }
+
+    /** Logs in, saves a preference, and logs back out, leaving a valid file & backup on disk. */
+    private void setupNonCorruptedState() {
+      login(); // Ensure we're logged in
+      savePreference();
+      login(); // reload the saved file, triggers backup creation
+      assertTrue(userFile.exists(), "Prefs was not written");
+      assertTrue(backupFile.exists(), "Backup was not written");
+      assertEquals("someValue", Preferences.getString(PREF_NAME));
+      logout(); // Proves we're not reading from the logged in user
+    }
+
+    @Test
+    public void normalSaveContainsNoNullBytes() throws IOException {
+      // This test proves that null bytes are not something that can be replicated by a user
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      // octal escape, unicode escape, char literal, char valueOf, char array
+      var stringWithNulChars =
+          "unicode é" + "\0" + "\u0000" + '\0' + (char) 0 + new String(new char[] {0}) + "string.";
+
+      try (cleanups) {
+        login();
+        Preferences.setString(PREF_NAME, stringWithNulChars);
+        logout();
+        // Prove it didn't persist
+        assertEquals("", Preferences.getString(PREF_NAME));
+        // Prove no nulls in the file
+        assertFalse(FileUtilities.containsNullBytes(userFile));
+        login();
+        // Prove string is identical
+        assertEquals(stringWithNulChars, Preferences.getString(PREF_NAME));
+      }
+    }
+
+    @Test
+    public void backupIsRestoredOnCorruption() throws IOException {
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        // Sets up the backup file
+        setupNonCorruptedState();
+        // Corrupt the user's file
+        corrupt(userFile, "");
+        // The file is corrupt
+        assertTrue(FileUtilities.containsNullBytes(userFile));
+        assertThat(
+            Files.readString(userFile.toPath(), StandardCharsets.UTF_8),
+            not(containsString(PREF_NAME + "=someValue")));
+        // It's not in memory
+        assertEquals("", Preferences.getString(PREF_NAME));
+        login();
+        // It was loaded from backup
+        assertEquals("someValue", Preferences.getString(PREF_NAME));
+        // Both files are valid
+        assertFalse(FileUtilities.containsNullBytes(userFile));
+        assertFalse(FileUtilities.containsNullBytes(backupFile));
+      }
+    }
+
+    @Test
+    public void backupIsPreferedOverPartial() throws IOException {
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        setupNonCorruptedState();
+        // Write the corrupt file, but partially parsable with a different value
+        corrupt(userFile, PREF_NAME + "=oldValue\n");
+        login();
+        // The partially parsable file was not loaded, we restored from backup
+        assertEquals("someValue", Preferences.getString(PREF_NAME));
+      }
+    }
+
+    @Test
+    public void emptyIsRestoredFromBackup() throws IOException {
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        setupNonCorruptedState();
+        Files.write(userFile.toPath(), new byte[0]);
+        login();
+        assertEquals("someValue", Preferences.getString(PREF_NAME));
+      }
+    }
+
+    @Test
+    public void partialRecoveryDoesntIncludeProblematicLines() throws IOException {
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        // Corrupt the file, along with a partially written value that didn't end with a newline
+        corrupt(userFile, PREF_NAME + "=someValue\nskippedKey=skippedValue");
+        login();
+        // Confirm partial recovery worked
+        assertEquals("someValue", Preferences.getString(PREF_NAME));
+        // Confirm problematic lines were not included
+        assertFalse(Preferences.propertyExists("skippedKey"));
       }
     }
   }


### PR DESCRIPTION
I'm not sure why global backups isn't a thing already, but that's included in this PR.

The first commit is a failing test.

The reason preference files get filled with nulls is because the filesystem metadata was written to disk and the power was cut before the file was written.

Eg; https://serverfault.com/questions/1067720/what-could-cause-files-to-end-up-zeroed-out

I think `fileStream.getFD().sync()` would fix a majority of that for users, by reducing the time at risk?, but I'm not willing to do that as it comes with the tradeoff of constant writes to disk, instead of hitting the cache. It'd also slow down operations.

This PR aims to

1. If a file contains nulls, we always try to restore from backup
2. If the backup is missing, we try to load from only the good lines, a line is not good if the line has null bytes in it
3. Add global prefs to the backups

As a side effect, it'll stop clobbering the backups when the first file attempted is not empty but contains nulls.