### PR TITLE
Use journals for writing prefs to reduce IO and increase stability

### DIFF
--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -1,19 +1,11 @@
 package net.sourceforge.kolmafia.preferences;
 
-import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -24,10 +16,8 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.UnaryOperator;
-import net.java.dev.spellcast.utilities.DataUtilities;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
-import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestLogger;
 import net.sourceforge.kolmafia.combat.CombatActionManager;
 import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
@@ -44,8 +34,6 @@ public class Preferences {
 
   private static final Object lock = new Object(); // used to synch io
 
-  private static final String[] characterMap = new String[65536];
-
   private static final HashMap<String, String> globalNames = new HashMap<>();
   private static final Map<String, Object> globalValues = new ConcurrentHashMap<>();
   // user/globalEncodedValues cache the byte sequence corresponding to the on-disk representation
@@ -53,13 +41,13 @@ public class Preferences {
   // concatenating all the cached values.
   private static final SortedMap<String, byte[]> globalEncodedValues =
       Collections.synchronizedSortedMap(new TreeMap<>());
-  private static File globalPropertiesFile = null;
+  private static PreferencesFile globalFile;
 
   private static final HashMap<String, String> userNames = new HashMap<>();
   private static final Map<String, Object> userValues = new ConcurrentHashMap<>();
   private static final SortedMap<String, byte[]> userEncodedValues =
       Collections.synchronizedSortedMap(new TreeMap<>());
-  private static File userPropertiesFile = null;
+  static PreferencesFile userFile; // Exposed for tests
 
   private static final Set<String> defaultsSet = new HashSet<>();
   private static final Set<String> perUserGlobalSet = new HashSet<>();
@@ -163,16 +151,22 @@ public class Preferences {
 
   /** Resets all settings so that the given user is represented whenever settings are modified. */
   public static synchronized void reset(String username) {
+    boolean loggingOut = username == null || username.isEmpty();
     // We might not have been tracking encoded values here before this save. Fix that.
     Preferences.reinitializeEncodedValues();
-    Preferences.saveToFile(Preferences.globalPropertiesFile, Preferences.globalEncodedValues);
+    // Only tear down the shared global journal on a logout, not a character switch.
+    Preferences.saveToFile(Preferences.globalFile, loggingOut);
+    // Save the logged in user. reset() is itself synchronized and is the only place userFile is
+    // ever reassigned, so this doesn't need the userValues lock below, which only guards the maps.
+    if (Preferences.userFile != null) {
+      Preferences.saveToFile(Preferences.userFile, true);
+    }
     // Prevent anybody from manipulating the user map until we are
     // done bulk-loading it.
     synchronized (Preferences.userValues) {
-      if (username == null || username.isEmpty()) {
-        if (Preferences.userPropertiesFile != null) {
-          Preferences.saveToFile(Preferences.userPropertiesFile, Preferences.userEncodedValues);
-          Preferences.userPropertiesFile = null;
+      if (loggingOut) {
+        if (Preferences.userFile != null) {
+          Preferences.userFile = null;
           Preferences.userValues.clear();
           Preferences.userEncodedValues.clear();
         }
@@ -197,13 +191,12 @@ public class Preferences {
   }
 
   private static void loadGlobalPreferences() {
-    File file =
-        new File(KoLConstants.SETTINGS_LOCATION, Preferences.baseUserName("") + "_prefs.txt");
-    File backupFile =
-        new File(KoLConstants.SETTINGS_LOCATION, Preferences.baseUserName("") + "_prefs.bak");
-    Preferences.globalPropertiesFile = file;
+    // Unfortunately, global prefs remain an issue and will continue to overwrite each other for the
+    // forseeable future.
+    Preferences.globalFile = new PreferencesFile(Preferences.baseUserName(""), globalEncodedValues);
 
-    Properties p = Preferences.loadPreferencesWithBackup(file, backupFile);
+    Properties p = Preferences.globalFile.loadWithBackup();
+    boolean hadJournal = Preferences.globalFile.applyJournal(p);
     Preferences.globalValues.clear();
     Preferences.globalEncodedValues.clear();
 
@@ -231,18 +224,21 @@ public class Preferences {
         Preferences.putGlobal(key, value);
       }
     }
+
+    if (hadJournal || Preferences.globalFile.prefsDoesNotExist()) {
+      Preferences.saveToFile(Preferences.globalFile, false);
+    }
   }
 
   private static void loadUserPreferences(String username) {
-    File userPrefsFile =
-        new File(KoLConstants.SETTINGS_LOCATION, Preferences.baseUserName(username) + "_prefs.txt");
-    File backupFile =
-        new File(KoLConstants.SETTINGS_LOCATION, Preferences.baseUserName(username) + "_prefs.bak");
+    PreferencesFile newUserFile =
+        new PreferencesFile(Preferences.baseUserName(username), userEncodedValues);
 
     synchronized (lock) {
-      Properties p = Preferences.loadPreferencesWithBackup(userPrefsFile, backupFile);
+      Properties p = newUserFile.loadWithBackup();
+      boolean hadJournal = newUserFile.applyJournal(p);
 
-      Preferences.userPropertiesFile = null;
+      Preferences.userFile = null;
       Preferences.userValues.clear();
       Preferences.userEncodedValues.clear();
 
@@ -250,7 +246,7 @@ public class Preferences {
         String key = (String) currentEntry.getKey();
         String value = (String) currentEntry.getValue();
 
-        Preferences.putUser(key, value);
+        Preferences.putUser(key, value, true);
       }
 
       for (Entry<String, String> entry : Preferences.userNames.entrySet()) {
@@ -271,130 +267,15 @@ public class Preferences {
                 : entry.getValue();
 
         // System.out.println( "Adding new built-in user setting: " + key );
-        Preferences.putUser(key, value);
+        Preferences.putUser(key, value, true);
       }
 
-      Preferences.userPropertiesFile = userPrefsFile;
-    }
-  }
+      Preferences.userFile = newUserFile;
 
-  private static Properties loadPreferencesWithBackup(File prefsFile, File backupFile) {
-    if (!prefsFile.exists() && !backupFile.exists()) {
-      return new Properties();
-    }
-
-    Properties p = Preferences.loadPreferences(prefsFile);
-
-    if (!Preferences.isValidPreferencesFile(prefsFile, p)) {
-      // Something went wrong reading the preferences.
-      if (backupFile.exists()) {
-        KoLmafia.updateDisplay(
-            prefsFile
-                + " could not be read, loading backup. "
-                + "This will restore the last successfully opened preferences");
-        // also tell system out, in case things are really fubar
-        System.out.println("Prefs could not be read and backup exists, trying backup. ");
-
-        p = Preferences.loadPreferences(backupFile);
-
-        if (Preferences.isValidPreferencesFile(backupFile, p)) {
-          try {
-            Files.copy(
-                backupFile.toPath(), prefsFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-
-          } catch (IOException ex) {
-
-            KoLmafia.updateDisplay(
-                "Error when restoring preferences from backup,  see session log for details");
-            RequestLogger.updateSessionLog(
-                prefsFile
-                    + " could not be read and backup was used. KoLmafia was unable to copy your backup file to "
-                    + "your preferences file and received error message:"
-                    + ex.getMessage()
-                    + "\nIf this is unexpected, please manually review your preferences and backup and repair any problems."
-                    + " If you have a damaged preferences file, "
-                    + "please consider creating a bug report on the forum, noting any special circumstances around "
-                    + "the failure, and attaching the preferences.");
-          }
-        }
-      } else {
-        // No backup to fall back on, recover whatever complete lines were written before the
-        // corruption point instead of loading a malformed line.
-        try {
-          byte[] safeBytes =
-              FileUtilities.truncateToLastGoodLineBeforeNullByte(
-                  Files.readAllBytes(prefsFile.toPath()));
-          Properties recovered = new Properties();
-          try (InputStream istream = new ByteArrayInputStream(safeBytes)) {
-            recovered.load(istream);
-          }
-          p = recovered;
-          KoLmafia.updateDisplay(
-              "Preferences was partially recovered from corruption, no backup exists.");
-        } catch (IOException e) {
-          p = new Properties();
-          KoLmafia.updateDisplay("Preferences could not be read and no backup exists.");
-        }
-        RequestLogger.updateSessionLog(
-            prefsFile
-                + " could not be read and backup there is no backup file found. "
-                + "If this is unexpected, please manually inspect "
-                + "your preferences file and repair any problems.  If you have a damaged preferences file, "
-                + "please consider creating a bug report on the forum, noting any special circumstances around "
-                + "the failure, and attaching the preferences.");
-      }
-    } else {
-      try {
-        Files.copy(prefsFile.toPath(), backupFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-      } catch (IOException ex) {
-        System.out.println("I/O Error when creating backup preferences file: " + ex.getMessage());
-        RequestLogger.updateSessionLog(
-            prefsFile
-                + " backup creation failed. Please manually inspect "
-                + "your preferences and backup files and repair any problems.  If you have a damaged preferences file, "
-                + "please consider creating a bug report on the forum, noting any special circumstances around "
-                + "the failure, and attaching the preferences.");
+      if (hadJournal || Preferences.userFile.prefsDoesNotExist()) {
+        Preferences.saveToFile(Preferences.userFile, false);
       }
     }
-
-    return p;
-  }
-
-  private static Properties loadPreferences(File file) {
-    Properties p = new Properties();
-    try (InputStream istream = DataUtilities.getInputStream(file)) {
-      p.load(istream);
-    } catch (IOException e) {
-      System.out.println(e.getMessage() + " trying to load preferences from file.");
-    }
-
-    return p;
-  }
-
-  /** A file is currently considered as invalid if it contains null bytes, or is empty */
-  private static boolean isValidPreferencesFile(File file, Properties p) {
-    if (p.isEmpty()) {
-      return false;
-    }
-    try {
-      return !FileUtilities.containsNullBytes(file);
-    } catch (IOException e) {
-      return false;
-    }
-  }
-
-  private static String encodeProperty(String name, String value) {
-    StringBuffer buffer = new StringBuffer();
-
-    Preferences.encodeString(buffer, name);
-
-    if (value != null && !value.isEmpty()) {
-      buffer.append("=");
-      Preferences.encodeString(buffer, value);
-    }
-    buffer.append(KoLConstants.LINE_BREAK);
-
-    return buffer.toString();
   }
 
   private static boolean mustTrackEncodedValues() {
@@ -407,7 +288,7 @@ public class Preferences {
       for (Entry<String, Object> entry : valuesMap.entrySet()) {
         encodedMap.put(
             entry.getKey(),
-            encodeProperty(entry.getKey(), entry.getValue().toString())
+            PreferencesFile.encodeProperty(entry.getKey(), entry.getValue().toString())
                 .getBytes(StandardCharsets.UTF_8));
       }
     }
@@ -422,57 +303,10 @@ public class Preferences {
 
     Preferences.reinitializeEncodedValuesOn(
         Preferences.globalValues, Preferences.globalEncodedValues);
-    Preferences.reinitializeEncodedValuesOn(Preferences.userValues, Preferences.userEncodedValues);
-  }
-
-  private static void encodeString(StringBuffer buffer, String string) {
-    int length = string.length();
-
-    for (int i = 0; i < length; ++i) {
-      char ch = string.charAt(i);
-      encodeCharacter(ch);
-      buffer.append(characterMap[ch]);
+    if (Preferences.userFile != null) {
+      Preferences.reinitializeEncodedValuesOn(
+          Preferences.userValues, Preferences.userEncodedValues);
     }
-  }
-
-  private static void encodeCharacter(char ch) {
-    if (characterMap[ch] != null) {
-      return;
-    }
-
-    switch (ch) {
-      case '\t' -> {
-        characterMap[ch] = "\\t";
-        return;
-      }
-      case '\n' -> {
-        characterMap[ch] = "\\n";
-        return;
-      }
-      case '\f' -> {
-        characterMap[ch] = "\\f";
-        return;
-      }
-      case '\r' -> {
-        characterMap[ch] = "\\r";
-        return;
-      }
-      case '\\', '=', ':', '#', '!' -> {
-        characterMap[ch] = "\\" + ch;
-        return;
-      }
-    }
-
-    characterMap[ch] =
-        (ch > 0x0019 && ch < 0x007f)
-            ? String.valueOf(ch)
-            : (ch < 0x0010)
-                ? "\\u000" + Integer.toHexString(ch)
-                : (ch < 0x0100)
-                    ? "\\u00" + Integer.toHexString(ch)
-                    : (ch < 0x1000)
-                        ? "\\u0" + Integer.toHexString(ch)
-                        : "\\u" + Integer.toHexString(ch);
   }
 
   public static boolean propertyExists(final String name) {
@@ -533,7 +367,9 @@ public class Preferences {
         if (trackEncoded) Preferences.userEncodedValues.remove(name);
       }
     }
-    Preferences.maybeSaveToFileAfterUpdating(trackEncoded, name);
+    // A no-default property isn't in globalNames, so isGlobalProperty(name) can't classify it,
+    // only the `global` flag can.
+    Preferences.maybeSaveToFileAfterUpdating(trackEncoded, global, name);
     PreferenceListenerRegistry.firePreferenceChanged(name);
   }
 
@@ -812,7 +648,7 @@ public class Preferences {
   public static void setBoolean(final String user, final String name, final boolean value) {
     boolean old = Preferences.getBoolean(user, name);
     if (old != value) {
-      Preferences.setObject(user, name, value ? "true" : "false", value);
+      Preferences.setObject(user, name, String.valueOf(value), value);
     }
   }
 
@@ -866,10 +702,14 @@ public class Preferences {
     if (name.equals("saveSettingsOnSet") && (boolean) object) {
       Preferences.reinitializeEncodedValues();
       trackEncoded |= Preferences.saveSettingsToFile;
+      // The changes above bypassed the journal, so save to get all prefs onto disk.
+      Preferences.saveToFile(Preferences.globalFile, false);
+      if (Preferences.userFile != null) {
+        Preferences.saveToFile(Preferences.userFile, false);
+      }
     }
 
     Preferences.put(user, name, object, trackEncoded);
-    Preferences.maybeSaveToFileAfterUpdating(trackEncoded, name);
 
     PreferenceListenerRegistry.firePreferenceChanged(name);
 
@@ -886,19 +726,17 @@ public class Preferences {
     Preferences.globalValues.put(name, value);
     if (updateEncoded) {
       Preferences.globalEncodedValues.put(
-          name, encodeProperty(name, value.toString()).getBytes(StandardCharsets.UTF_8));
+          name,
+          PreferencesFile.encodeProperty(name, value.toString()).getBytes(StandardCharsets.UTF_8));
     }
-  }
-
-  private static void putUser(final String name, final Object value) {
-    Preferences.putUser(name, value, true);
   }
 
   private static void putUser(final String name, final Object value, boolean updateEncoded) {
     Preferences.userValues.put(name, value);
     if (updateEncoded) {
       Preferences.userEncodedValues.put(
-          name, encodeProperty(name, value.toString()).getBytes(StandardCharsets.UTF_8));
+          name,
+          PreferencesFile.encodeProperty(name, value.toString()).getBytes(StandardCharsets.UTF_8));
     }
   }
 
@@ -907,17 +745,24 @@ public class Preferences {
     if (Preferences.isGlobalProperty(name)) {
       String actualName = Preferences.propertyName(user, name);
       Preferences.putGlobal(actualName, value, updateEncoded);
-    } else if (Preferences.userPropertiesFile != null) {
+      Preferences.maybeSaveToFileAfterUpdating(updateEncoded, true, actualName);
+    } else if (Preferences.userFile != null) {
       putUser(name, value, updateEncoded);
+      Preferences.maybeSaveToFileAfterUpdating(updateEncoded, false, name);
     }
   }
 
-  private static void maybeSaveToFileAfterUpdating(boolean enable, String updatedProperty) {
-    if (enable) {
-      if (Preferences.isGlobalProperty(updatedProperty)) {
-        Preferences.saveToFile(Preferences.globalPropertiesFile, Preferences.globalEncodedValues);
-      } else if (Preferences.userPropertiesFile != null) {
-        Preferences.saveToFile(Preferences.userPropertiesFile, Preferences.userEncodedValues);
+  private static void maybeSaveToFileAfterUpdating(
+      boolean enable, boolean global, String updatedProperty) {
+    if (!enable) {
+      return;
+    }
+
+    synchronized (lock) {
+      if (global) {
+        Preferences.globalFile.appendChange(updatedProperty);
+      } else if (Preferences.userFile != null) {
+        Preferences.userFile.appendChange(updatedProperty);
       }
     }
   }
@@ -926,30 +771,13 @@ public class Preferences {
     return user == null ? name : name + "." + Preferences.baseUserName(user);
   }
 
-  private static void saveToFile(File file, Map<String, byte[]> encodedData) {
+  private static void saveToFile(PreferencesFile file, boolean loggingOut) {
     if (!Preferences.saveSettingsToFile) {
       return;
     }
 
-    // See Collections.synchronizedSortedMap
-    //
-    // We are essentially iterating over the map. Not exactly - we
-    // are iterating over the entrySet - but let's keep the map and
-    // the file in synch atomically
-
     synchronized (lock) {
-      // Determine the contents of the file by
-      // actually printing them.
-
-      try (OutputStream fstream = new BufferedOutputStream(DataUtilities.getOutputStream(file))) {
-        synchronized (encodedData) {
-          for (Entry<String, byte[]> current : encodedData.entrySet()) {
-            fstream.write(current.getValue());
-          }
-        }
-      } catch (IOException e) {
-        System.out.println(e.getMessage() + " trying to write preferences as byte array.");
-      }
+      file.savePrefsFile(loggingOut);
     }
   }
 
@@ -1015,27 +843,25 @@ public class Preferences {
   }
 
   public static void resetDailies() {
-    // See Collections.synchronizedSortedMap
-    //
-    // userValues is a synchronized map, but we are doing a mass
-    // change to it.
-
+    // Copy the keys out first; removeProperty/setString below can hit the journal, and that
+    // shouldn't happen while holding this lock.
+    List<String> names;
     synchronized (Preferences.userValues) {
-      Iterator<String> it = Preferences.userValues.keySet().iterator();
-      while (it.hasNext()) {
-        String name = it.next();
-        if (isDaily(name)) {
-          if (!Preferences.containsDefault(name)) {
-            // fully delete preferences that start with _ and aren't in defaults.txt
-            it.remove();
-            userEncodedValues.remove(name);
-            continue;
-          }
-          String val = Preferences.userNames.get(name);
-          if (val == null) val = "";
-          Preferences.setString(name, val);
-        }
+      names = new ArrayList<>(Preferences.userValues.keySet());
+    }
+
+    for (String name : names) {
+      if (!isDaily(name)) {
+        continue;
       }
+      if (!Preferences.containsDefault(name)) {
+        // fully delete preferences that start with _ and aren't in defaults.txt
+        Preferences.removeProperty(name, false);
+        continue;
+      }
+      String val = Preferences.userNames.get(name);
+      if (val == null) val = "";
+      Preferences.setString(name, val);
     }
   }
 
@@ -1043,10 +869,11 @@ public class Preferences {
     // See Collections.synchronizedSortedMap
     //
     // globalValues is a synchronized map, but we are doing a mass
-    // change to it.
+    // change to it. Copy the keys out first since setString below mutates the map we'd otherwise
+    // be iterating over.
 
     synchronized (Preferences.globalValues) {
-      for (String name : Preferences.globalValues.keySet()) {
+      for (String name : new ArrayList<>(Preferences.globalValues.keySet())) {
         if (isDaily(name)) {
           String val = Preferences.globalNames.get(name);
           if (val == null) val = "";

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -32,8 +32,6 @@ public class Preferences {
   // If false, blocks saving of all preferences. Do not modify outside of tests.
   public static boolean saveSettingsToFile = true;
 
-  private static final Object lock = new Object(); // used to synch io
-
   private static final HashMap<String, String> globalNames = new HashMap<>();
   private static final Map<String, Object> globalValues = new ConcurrentHashMap<>();
   // user/globalEncodedValues cache the byte sequence corresponding to the on-disk representation
@@ -150,31 +148,32 @@ public class Preferences {
   }
 
   /** Resets all settings so that the given user is represented whenever settings are modified. */
-  public static synchronized void reset(String username) {
+  public static void reset(String username) {
     boolean loggingOut = username == null || username.isEmpty();
-    // We might not have been tracking encoded values here before this save. Fix that.
-    Preferences.reinitializeEncodedValues();
-    // Only tear down the shared global journal on a logout, not a character switch.
-    Preferences.saveToFile(Preferences.globalFile, loggingOut);
-    // Save the logged in user. reset() is itself synchronized and is the only place userFile is
-    // ever reassigned, so this doesn't need the userValues lock below, which only guards the maps.
-    if (Preferences.userFile != null) {
-      Preferences.saveToFile(Preferences.userFile, true);
-    }
-    // Prevent anybody from manipulating the user map until we are
-    // done bulk-loading it.
-    synchronized (Preferences.userValues) {
-      if (loggingOut) {
+    // Global as outer lock, user as inner, everywhere both locks are needed.
+    synchronized (globalEncodedValues) {
+      synchronized (userEncodedValues) {
+        // We might not have been tracking encoded values here before this save. Fix that.
+        Preferences.reinitializeEncodedValues();
+        // Only tear down the shared global journal on a logout, not a character switch.
+        Preferences.saveToFile(Preferences.globalFile, loggingOut);
+        // Save the logged in user.
         if (Preferences.userFile != null) {
-          Preferences.userFile = null;
-          Preferences.userValues.clear();
-          Preferences.userEncodedValues.clear();
+          Preferences.saveToFile(Preferences.userFile, true);
         }
 
-        return;
-      }
+        if (loggingOut) {
+          if (Preferences.userFile != null) {
+            Preferences.userFile = null;
+            Preferences.userValues.clear();
+            Preferences.userEncodedValues.clear();
+          }
 
-      Preferences.loadUserPreferences(username);
+          return;
+        }
+
+        Preferences.loadUserPreferences(username);
+      }
     }
 
     AdventureFrame.updateFromPreferences();
@@ -234,47 +233,45 @@ public class Preferences {
     PreferencesFile newUserFile =
         new PreferencesFile(Preferences.baseUserName(username), userEncodedValues);
 
-    synchronized (lock) {
-      Properties p = newUserFile.loadWithBackup();
-      boolean hadJournal = newUserFile.applyJournal(p);
+    Properties p = newUserFile.loadWithBackup();
+    boolean hadJournal = newUserFile.applyJournal(p);
 
-      Preferences.userFile = null;
-      Preferences.userValues.clear();
-      Preferences.userEncodedValues.clear();
+    Preferences.userFile = null;
+    Preferences.userValues.clear();
+    Preferences.userEncodedValues.clear();
 
-      for (Entry<Object, Object> currentEntry : p.entrySet()) {
-        String key = (String) currentEntry.getKey();
-        String value = (String) currentEntry.getValue();
+    for (Entry<Object, Object> currentEntry : p.entrySet()) {
+      String key = (String) currentEntry.getKey();
+      String value = (String) currentEntry.getValue();
 
-        Preferences.putUser(key, value, true);
+      Preferences.putUser(key, value, true);
+    }
+
+    for (Entry<String, String> entry : Preferences.userNames.entrySet()) {
+      String key = entry.getKey();
+      if (Preferences.userValues.containsKey(key)) {
+        continue;
       }
 
-      for (Entry<String, String> entry : Preferences.userNames.entrySet()) {
-        String key = entry.getKey();
-        if (Preferences.userValues.containsKey(key)) {
-          continue;
-        }
+      // If a user property in defaults.txt was not in
+      // NAME_prefs.txt, add to user map with default value
+      // (this is how we add a new user property)
+      //
+      // If it had a value in the GLOBAL map, use that (this
+      // is how we migrate a preference from GLOBAL to user)
+      String value =
+          Preferences.globalValues.containsKey(key)
+              ? (String) Preferences.globalValues.get(key)
+              : entry.getValue();
 
-        // If a user property in defaults.txt was not in
-        // NAME_prefs.txt, add to user map with default value
-        // (this is how we add a new user property)
-        //
-        // If it had a value in the GLOBAL map, use that (this
-        // is how we migrate a preference from GLOBAL to user)
-        String value =
-            Preferences.globalValues.containsKey(key)
-                ? (String) Preferences.globalValues.get(key)
-                : entry.getValue();
+      // System.out.println( "Adding new built-in user setting: " + key );
+      Preferences.putUser(key, value, true);
+    }
 
-        // System.out.println( "Adding new built-in user setting: " + key );
-        Preferences.putUser(key, value, true);
-      }
+    Preferences.userFile = newUserFile;
 
-      Preferences.userFile = newUserFile;
-
-      if (hadJournal || Preferences.userFile.prefsDoesNotExist()) {
-        Preferences.saveToFile(Preferences.userFile, false);
-      }
+    if (hadJournal || Preferences.userFile.prefsDoesNotExist()) {
+      Preferences.saveToFile(Preferences.userFile, false);
     }
   }
 
@@ -284,13 +281,11 @@ public class Preferences {
 
   private static void reinitializeEncodedValuesOn(
       Map<String, Object> valuesMap, Map<String, byte[]> encodedMap) {
-    synchronized (valuesMap) {
-      for (Entry<String, Object> entry : valuesMap.entrySet()) {
-        encodedMap.put(
-            entry.getKey(),
-            PreferencesFile.encodeProperty(entry.getKey(), entry.getValue().toString())
-                .getBytes(StandardCharsets.UTF_8));
-      }
+    for (Entry<String, Object> entry : valuesMap.entrySet()) {
+      encodedMap.put(
+          entry.getKey(),
+          PreferencesFile.encodeProperty(entry.getKey(), entry.getValue().toString())
+              .getBytes(StandardCharsets.UTF_8));
     }
   }
 
@@ -348,28 +343,30 @@ public class Preferences {
   }
 
   public static void removeProperty(final String name, final boolean global) {
-    boolean trackEncoded = Preferences.mustTrackEncodedValues();
-    // Remove only properties which do not have defaults
-    if (global) {
-      if (!Preferences.globalNames.containsKey(name)) {
-        // We are changing the structure of the map.
-        // globalValues is a synchronized map.
+    synchronized (global ? globalEncodedValues : userEncodedValues) {
+      boolean trackEncoded = Preferences.mustTrackEncodedValues();
+      // Remove only properties which do not have defaults
+      if (global) {
+        if (!Preferences.globalNames.containsKey(name)) {
+          // We are changing the structure of the map.
+          // globalValues is a synchronized map.
 
-        Preferences.globalValues.remove(name);
-        if (trackEncoded) Preferences.globalEncodedValues.remove(name);
-      }
-    } else {
-      if (!Preferences.userNames.containsKey(name)) {
-        // We are changing the structure of the map.
-        // userValues is a synchronized map.
+          Preferences.globalValues.remove(name);
+          if (trackEncoded) Preferences.globalEncodedValues.remove(name);
+        }
+      } else {
+        if (!Preferences.userNames.containsKey(name)) {
+          // We are changing the structure of the map.
+          // userValues is a synchronized map.
 
-        Preferences.userValues.remove(name);
-        if (trackEncoded) Preferences.userEncodedValues.remove(name);
+          Preferences.userValues.remove(name);
+          if (trackEncoded) Preferences.userEncodedValues.remove(name);
+        }
       }
+      // A no-default property isn't in globalNames, so isGlobalProperty(name) can't classify it,
+      // only the `global` flag can.
+      Preferences.maybeSaveToFileAfterUpdating(trackEncoded, global, name);
     }
-    // A no-default property isn't in globalNames, so isGlobalProperty(name) can't classify it,
-    // only the `global` flag can.
-    Preferences.maybeSaveToFileAfterUpdating(trackEncoded, global, name);
     PreferenceListenerRegistry.firePreferenceChanged(name);
   }
 
@@ -700,16 +697,22 @@ public class Preferences {
     // many encoded values will be out of date, and we don't know which ones, so we have to
     // recompute all of them.
     if (name.equals("saveSettingsOnSet") && (boolean) object) {
-      Preferences.reinitializeEncodedValues();
-      trackEncoded |= Preferences.saveSettingsToFile;
-      // The changes above bypassed the journal, so save to get all prefs onto disk.
-      Preferences.saveToFile(Preferences.globalFile, false);
-      if (Preferences.userFile != null) {
-        Preferences.saveToFile(Preferences.userFile, false);
+      // Touches both scopes, same order as reset().
+      synchronized (globalEncodedValues) {
+        synchronized (userEncodedValues) {
+          Preferences.reinitializeEncodedValues();
+          trackEncoded |= Preferences.saveSettingsToFile;
+          // The changes above bypassed the journal, so save to get all prefs onto disk.
+          Preferences.saveToFile(Preferences.globalFile, false);
+          if (Preferences.userFile != null) {
+            Preferences.saveToFile(Preferences.userFile, false);
+          }
+          Preferences.put(user, name, object, trackEncoded);
+        }
       }
+    } else {
+      Preferences.put(user, name, object, trackEncoded);
     }
-
-    Preferences.put(user, name, object, trackEncoded);
 
     PreferenceListenerRegistry.firePreferenceChanged(name);
 
@@ -744,26 +747,31 @@ public class Preferences {
       final String user, final String name, final Object value, boolean updateEncoded) {
     if (Preferences.isGlobalProperty(name)) {
       String actualName = Preferences.propertyName(user, name);
-      Preferences.putGlobal(actualName, value, updateEncoded);
-      Preferences.maybeSaveToFileAfterUpdating(updateEncoded, true, actualName);
-    } else if (Preferences.userFile != null) {
-      putUser(name, value, updateEncoded);
-      Preferences.maybeSaveToFileAfterUpdating(updateEncoded, false, name);
+      synchronized (globalEncodedValues) {
+        Preferences.putGlobal(actualName, value, updateEncoded);
+        Preferences.maybeSaveToFileAfterUpdating(updateEncoded, true, actualName);
+      }
+    } else {
+      synchronized (userEncodedValues) {
+        if (Preferences.userFile != null) {
+          putUser(name, value, updateEncoded);
+          Preferences.maybeSaveToFileAfterUpdating(updateEncoded, false, name);
+        }
+      }
     }
   }
 
+  /** Callers must already hold the matching scope's lock */
   private static void maybeSaveToFileAfterUpdating(
       boolean enable, boolean global, String updatedProperty) {
     if (!enable) {
       return;
     }
 
-    synchronized (lock) {
-      if (global) {
-        Preferences.globalFile.appendChange(updatedProperty);
-      } else if (Preferences.userFile != null) {
-        Preferences.userFile.appendChange(updatedProperty);
-      }
+    if (global) {
+      Preferences.globalFile.appendChange(updatedProperty);
+    } else if (Preferences.userFile != null) {
+      Preferences.userFile.appendChange(updatedProperty);
     }
   }
 
@@ -776,9 +784,7 @@ public class Preferences {
       return;
     }
 
-    synchronized (lock) {
-      file.savePrefsFile(loggingOut);
-    }
+    file.savePrefsFile(loggingOut);
   }
 
   public static void resetToDefault(String... names) {
@@ -843,36 +849,32 @@ public class Preferences {
   }
 
   public static void resetDailies() {
-    // Copy the keys out first; removeProperty/setString below can hit the journal, and that
-    // shouldn't happen while holding this lock.
-    List<String> names;
-    synchronized (Preferences.userValues) {
-      names = new ArrayList<>(Preferences.userValues.keySet());
-    }
-
-    for (String name : names) {
-      if (!isDaily(name)) {
-        continue;
+    // Also takes globalEncodedValues to avoid misclassified globals
+    // Copy the keys out first since setString/removeProperty below mutate the map we'd
+    // otherwise be iterating over.
+    synchronized (globalEncodedValues) {
+      synchronized (userEncodedValues) {
+        for (String name : new ArrayList<>(Preferences.userValues.keySet())) {
+          if (!isDaily(name)) {
+            continue;
+          }
+          if (!Preferences.containsDefault(name)) {
+            // fully delete preferences that start with _ and aren't in defaults.txt
+            Preferences.removeProperty(name, false);
+            continue;
+          }
+          String val = Preferences.userNames.get(name);
+          if (val == null) val = "";
+          Preferences.setString(name, val);
+        }
       }
-      if (!Preferences.containsDefault(name)) {
-        // fully delete preferences that start with _ and aren't in defaults.txt
-        Preferences.removeProperty(name, false);
-        continue;
-      }
-      String val = Preferences.userNames.get(name);
-      if (val == null) val = "";
-      Preferences.setString(name, val);
     }
   }
 
   public static void resetGlobalDailies() {
-    // See Collections.synchronizedSortedMap
-    //
-    // globalValues is a synchronized map, but we are doing a mass
-    // change to it. Copy the keys out first since setString below mutates the map we'd otherwise
-    // be iterating over.
-
-    synchronized (Preferences.globalValues) {
+    // Copy the keys out first since setString/setLong below mutate the map we'd otherwise be
+    // iterating over.
+    synchronized (globalEncodedValues) {
       for (String name : new ArrayList<>(Preferences.globalValues.keySet())) {
         if (isDaily(name)) {
           String val = Preferences.globalNames.get(name);

--- a/src/net/sourceforge/kolmafia/preferences/Preferences.java
+++ b/src/net/sourceforge/kolmafia/preferences/Preferences.java
@@ -31,6 +31,8 @@ import net.sourceforge.kolmafia.webui.CharPaneDecorator;
 public class Preferences {
   // If false, blocks saving of all preferences. Do not modify outside of tests.
   public static boolean saveSettingsToFile = true;
+  // Cache of escaped-string representation per character.
+  private static final String[] characterMap = new String[65536];
 
   private static final HashMap<String, String> globalNames = new HashMap<>();
   private static final Map<String, Object> globalValues = new ConcurrentHashMap<>();
@@ -275,6 +277,20 @@ public class Preferences {
     }
   }
 
+  static String encodeProperty(String name, String value) {
+    StringBuffer buffer = new StringBuffer();
+
+    encodeString(buffer, name);
+
+    if (value != null && !value.isEmpty()) {
+      buffer.append("=");
+      encodeString(buffer, value);
+    }
+    buffer.append(KoLConstants.LINE_BREAK);
+
+    return buffer.toString();
+  }
+
   private static boolean mustTrackEncodedValues() {
     return Preferences.getBoolean("saveSettingsOnSet") && Preferences.saveSettingsToFile;
   }
@@ -284,7 +300,7 @@ public class Preferences {
     for (Entry<String, Object> entry : valuesMap.entrySet()) {
       encodedMap.put(
           entry.getKey(),
-          PreferencesFile.encodeProperty(entry.getKey(), entry.getValue().toString())
+          encodeProperty(entry.getKey(), entry.getValue().toString())
               .getBytes(StandardCharsets.UTF_8));
     }
   }
@@ -302,6 +318,56 @@ public class Preferences {
       Preferences.reinitializeEncodedValuesOn(
           Preferences.userValues, Preferences.userEncodedValues);
     }
+  }
+
+  private static void encodeString(StringBuffer buffer, String string) {
+    int length = string.length();
+
+    for (int i = 0; i < length; ++i) {
+      char ch = string.charAt(i);
+      encodeCharacter(ch);
+      buffer.append(characterMap[ch]);
+    }
+  }
+
+  private static void encodeCharacter(char ch) {
+    if (characterMap[ch] != null) {
+      return;
+    }
+
+    switch (ch) {
+      case '\t' -> {
+        characterMap[ch] = "\\t";
+        return;
+      }
+      case '\n' -> {
+        characterMap[ch] = "\\n";
+        return;
+      }
+      case '\f' -> {
+        characterMap[ch] = "\\f";
+        return;
+      }
+      case '\r' -> {
+        characterMap[ch] = "\\r";
+        return;
+      }
+      case '\\', '=', ':', '#', '!' -> {
+        characterMap[ch] = "\\" + ch;
+        return;
+      }
+    }
+
+    characterMap[ch] =
+        (ch > 0x0019 && ch < 0x007f)
+            ? String.valueOf(ch)
+            : (ch < 0x0010)
+                ? "\\u000" + Integer.toHexString(ch)
+                : (ch < 0x0100)
+                    ? "\\u00" + Integer.toHexString(ch)
+                    : (ch < 0x1000)
+                        ? "\\u0" + Integer.toHexString(ch)
+                        : "\\u" + Integer.toHexString(ch);
   }
 
   public static boolean propertyExists(final String name) {
@@ -729,8 +795,7 @@ public class Preferences {
     Preferences.globalValues.put(name, value);
     if (updateEncoded) {
       Preferences.globalEncodedValues.put(
-          name,
-          PreferencesFile.encodeProperty(name, value.toString()).getBytes(StandardCharsets.UTF_8));
+          name, encodeProperty(name, value.toString()).getBytes(StandardCharsets.UTF_8));
     }
   }
 
@@ -738,8 +803,7 @@ public class Preferences {
     Preferences.userValues.put(name, value);
     if (updateEncoded) {
       Preferences.userEncodedValues.put(
-          name,
-          PreferencesFile.encodeProperty(name, value.toString()).getBytes(StandardCharsets.UTF_8));
+          name, encodeProperty(name, value.toString()).getBytes(StandardCharsets.UTF_8));
     }
   }
 

--- a/src/net/sourceforge/kolmafia/preferences/PreferencesFile.java
+++ b/src/net/sourceforge/kolmafia/preferences/PreferencesFile.java
@@ -1,0 +1,383 @@
+package net.sourceforge.kolmafia.preferences;
+
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import net.java.dev.spellcast.utilities.DataUtilities;
+import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.RequestLogger;
+import net.sourceforge.kolmafia.utilities.FileUtilities;
+
+/**
+ * Controls a preference snapshot/backup/journal file ([user]_prefs.txt/.bak/.journal) and it's IO.
+ * Changes are appended to the journal instead of rewriting the whole snapshot, and the journal is
+ * trimmed when needed. It's removed when logging out.
+ */
+class PreferencesFile {
+  private static final long TRIM_JOURNAL_BYTE_THRESHOLD = 10_000_000; // 10MB
+  static final long JOURNAL_MAX_AGE = TimeUnit.DAYS.toMillis(1);
+  // Cache of escaped-string representation per character.
+  private static final String[] characterMap = new String[65536];
+
+  private final File propertiesFile;
+  private final File backupFile;
+  private final File journalFile;
+  private final Map<String, byte[]> encodedData;
+
+  // Exposed for tests
+  long prefsFileLastSave = System.currentTimeMillis();
+
+  private long journalBytes;
+
+  PreferencesFile(String baseName, Map<String, byte[]> encodedData) {
+    this.encodedData = encodedData;
+    this.propertiesFile = new File(KoLConstants.SETTINGS_LOCATION, baseName + "_prefs.txt");
+    this.backupFile = new File(KoLConstants.SETTINGS_LOCATION, baseName + "_prefs.bak");
+    this.journalFile = new File(KoLConstants.SETTINGS_LOCATION, baseName + "_prefs.journal");
+    this.journalBytes = journalFile.length();
+  }
+
+  boolean prefsDoesNotExist() {
+    return !propertiesFile.exists();
+  }
+
+  Properties loadWithBackup() {
+    if (!propertiesFile.exists() && !backupFile.exists()) {
+      return new Properties();
+    }
+
+    Properties p = PreferencesFile.loadProperties(propertiesFile);
+
+    if (!PreferencesFile.isValidPreferencesFile(propertiesFile, p)) {
+      // Something went wrong reading the preferences.
+      if (backupFile.exists()) {
+        KoLmafia.updateDisplay(
+            propertiesFile
+                + " could not be read, loading backup. "
+                + "This will restore the last successfully opened preferences");
+        // also tell system out, in case things are really fubar
+        System.out.println("Prefs could not be read and backup exists, trying backup. ");
+
+        p = PreferencesFile.loadProperties(backupFile);
+
+        if (PreferencesFile.isValidPreferencesFile(backupFile, p)) {
+          try {
+            Files.copy(
+                backupFile.toPath(), propertiesFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+          } catch (IOException ex) {
+
+            KoLmafia.updateDisplay(
+                "Error when restoring preferences from backup,  see session log for details");
+            RequestLogger.updateSessionLog(
+                propertiesFile
+                    + " could not be read and backup was used. KoLmafia was unable to copy your backup file to "
+                    + "your preferences file and received error message:"
+                    + ex.getMessage()
+                    + "\nIf this is unexpected, please manually review your preferences and backup and repair any problems."
+                    + " If you have a damaged preferences file, "
+                    + "please consider creating a bug report on the forum, noting any special circumstances around "
+                    + "the failure, and attaching the preferences.");
+          }
+        }
+      } else {
+        // No backup to fall back on, recover whatever complete lines were written before the
+        // corruption point instead of loading a malformed line.
+        try {
+          byte[] safeBytes =
+              FileUtilities.truncateToLastGoodLineBeforeNullByte(
+                  Files.readAllBytes(propertiesFile.toPath()));
+          Properties recovered = new Properties();
+          try (InputStream istream = new ByteArrayInputStream(safeBytes)) {
+            recovered.load(istream);
+          }
+          p = recovered;
+          KoLmafia.updateDisplay(
+              "Preferences was partially recovered from corruption, no backup exists.");
+        } catch (IOException e) {
+          p = new Properties();
+          KoLmafia.updateDisplay("Preferences could not be read and no backup exists.");
+        }
+        RequestLogger.updateSessionLog(
+            propertiesFile
+                + " could not be read and backup there is no backup file found. "
+                + "If this is unexpected, please manually inspect "
+                + "your preferences file and repair any problems.  If you have a damaged preferences file, "
+                + "please consider creating a bug report on the forum, noting any special circumstances around "
+                + "the failure, and attaching the preferences.");
+      }
+    } else {
+      try {
+        Files.copy(
+            propertiesFile.toPath(), backupFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      } catch (IOException ex) {
+        System.out.println("I/O Error when creating backup preferences file: " + ex.getMessage());
+        RequestLogger.updateSessionLog(
+            propertiesFile
+                + " backup creation failed. Please manually inspect "
+                + "your preferences and backup files and repair any problems.  If you have a damaged preferences file, "
+                + "please consider creating a bug report on the forum, noting any special circumstances around "
+                + "the failure, and attaching the preferences.");
+      }
+    }
+
+    return p;
+  }
+
+  private static Properties loadProperties(File file) {
+    Properties properties = new Properties();
+    try (InputStream istream = DataUtilities.getInputStream(file)) {
+      properties.load(istream);
+    } catch (IOException e) {
+      System.out.println(e.getMessage() + " trying to load preferences from file.");
+    }
+
+    return properties;
+  }
+
+  /** A file is currently considered as invalid if it contains null bytes, or is empty */
+  private static boolean isValidPreferencesFile(File file, Properties p) {
+    if (p.isEmpty()) {
+      return false;
+    }
+    try {
+      return !FileUtilities.containsNullBytes(file);
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Applies the journal's lines, in order, onto a freshly loaded prefs.
+   *
+   * <p>A normal line sets a key, a line starting with "#" removes one. {@link #encodeCharacter}
+   * always escapes a literal '#' as "\#", so a raw "#" is unambiguous as the removal marker.
+   *
+   * @return true if a journal file existed and was fully applied
+   */
+  boolean applyJournal(Properties properties) {
+    if (journalFile.length() == 0) {
+      return false;
+    }
+
+    try {
+      byte[] bytes = Files.readAllBytes(journalFile.toPath());
+      byte[] safeBytes =
+          FileUtilities.truncateTrailingPartialLine(
+              FileUtilities.truncateToLastGoodLineBeforeNullByte(bytes));
+      if (safeBytes.length != bytes.length) {
+        System.out.println(journalFile + " was truncated after a corrupt trailing entry.");
+      }
+      try (BufferedReader reader =
+          new BufferedReader(
+              new InputStreamReader(
+                  new ByteArrayInputStream(safeBytes), StandardCharsets.ISO_8859_1))) {
+        // We can't really define a line as "deleted", without it being possibly a real key
+        // So we load each line one by one
+        Properties scratch = new Properties();
+        String line;
+        while ((line = reader.readLine()) != null) {
+          PreferencesFile.applyJournalLine(properties, scratch, line);
+        }
+      }
+    } catch (IOException e) {
+      System.out.println(e.getMessage() + " trying to load preferences journal.");
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * A "#" prefixed line removes the key it encodes, otherwise the line is a normal key=value entry.
+   * Reuses Properties.load() to unescape the line rather than reimplementing the escaping rules.
+   */
+  private static void applyJournalLine(Properties properties, Properties scratch, String line)
+      throws IOException {
+    if (line.isEmpty()) {
+      return;
+    }
+
+    boolean removal = line.charAt(0) == '#';
+    String encoded = removal ? line.substring(1) : line;
+
+    scratch.clear();
+    scratch.load(new StringReader(encoded + "\n"));
+
+    for (String key : scratch.stringPropertyNames()) {
+      if (removal) {
+        properties.remove(key);
+      } else {
+        properties.setProperty(key, scratch.getProperty(key));
+      }
+    }
+  }
+
+  /**
+   * Appends a changed key's line to the journal instead of rewriting the whole prefs file, then
+   * trims if the journal crosses the size/age threshold.
+   */
+  void appendChange(String propertyName) {
+    byte[] lineBytes = encodedData.get(propertyName);
+
+    if (lineBytes == null) {
+      // Removed, prepend with # to indicate it's removed.
+      lineBytes = ("#" + encodeProperty(propertyName, null)).getBytes(StandardCharsets.UTF_8);
+    }
+
+    try (OutputStream fstream = DataUtilities.getOutputStream(journalFile, true)) {
+      fstream.write(lineBytes);
+      journalBytes += lineBytes.length;
+    } catch (IOException e) {
+      System.out.println(e.getMessage() + " trying to append to preferences journal.");
+    }
+
+    if (shouldTrimJournal()) {
+      savePrefsFile(false);
+    }
+  }
+
+  /** Trim once the journal has grown too large, or it's been too long since the last one. */
+  private boolean shouldTrimJournal() {
+    return journalBytes >= PreferencesFile.TRIM_JOURNAL_BYTE_THRESHOLD
+        || (System.currentTimeMillis() - prefsFileLastSave) >= PreferencesFile.JOURNAL_MAX_AGE;
+  }
+
+  /** Saves the current prefs to file; global callers should {@link #applyJournal} first. */
+  void savePrefsFile(boolean loggingOut) {
+    // See Collections.synchronizedSortedMap
+    //
+    // We are essentially iterating over the map. Not exactly - we
+    // are iterating over the entrySet - but let's keep the map and
+    // the file in synch atomically
+
+    try (OutputStream fstream =
+        new BufferedOutputStream(DataUtilities.getOutputStream(propertiesFile))) {
+      synchronized (encodedData) {
+        for (Entry<String, byte[]> current : encodedData.entrySet()) {
+          fstream.write(current.getValue());
+        }
+      }
+    } catch (IOException e) {
+      System.out.println(e.getMessage() + " trying to write preferences as byte array.");
+      // We early exit as saving filed
+      return;
+    }
+
+    if (!writeLooksValid(propertiesFile)) {
+      // Bad write - leave the journal alone, it's the only record of the unsaved changes.
+      System.out.println(propertiesFile + " failed validation after saving, backup left as-is.");
+      return;
+    }
+
+    try {
+      Files.copy(propertiesFile.toPath(), backupFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    } catch (IOException e) {
+      System.out.println(e.getMessage() + " trying to refresh preferences backup.");
+    }
+
+    try {
+      if (loggingOut) {
+        Files.deleteIfExists(journalFile.toPath());
+      } else if (journalFile.exists()) {
+        try (OutputStream fstream = DataUtilities.getOutputStream(journalFile)) {
+          // Truncate the file to zero length.
+          fstream.write(new byte[0]);
+        }
+      }
+      journalBytes = 0;
+    } catch (IOException e) {
+      System.out.println(e.getMessage() + " trying to clear preferences journal.");
+    }
+    // We still update this, because why fail rapidly?
+    prefsFileLastSave = System.currentTimeMillis();
+  }
+
+  /** Same corruption check as {@link #isValidPreferencesFile}, without reparsing what we wrote. */
+  private boolean writeLooksValid(File file) {
+    if (encodedData.isEmpty()) {
+      return false;
+    }
+    try {
+      return !FileUtilities.containsNullBytes(file);
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  static String encodeProperty(String name, String value) {
+    StringBuffer buffer = new StringBuffer();
+
+    encodeString(buffer, name);
+
+    if (value != null && !value.isEmpty()) {
+      buffer.append("=");
+      encodeString(buffer, value);
+    }
+    buffer.append(KoLConstants.LINE_BREAK);
+
+    return buffer.toString();
+  }
+
+  private static void encodeString(StringBuffer buffer, String string) {
+    int length = string.length();
+
+    for (int i = 0; i < length; ++i) {
+      char ch = string.charAt(i);
+      encodeCharacter(ch);
+      buffer.append(characterMap[ch]);
+    }
+  }
+
+  private static void encodeCharacter(char ch) {
+    if (characterMap[ch] != null) {
+      return;
+    }
+
+    switch (ch) {
+      case '\t' -> {
+        characterMap[ch] = "\\t";
+        return;
+      }
+      case '\n' -> {
+        characterMap[ch] = "\\n";
+        return;
+      }
+      case '\f' -> {
+        characterMap[ch] = "\\f";
+        return;
+      }
+      case '\r' -> {
+        characterMap[ch] = "\\r";
+        return;
+      }
+      case '\\', '=', ':', '#', '!' -> {
+        characterMap[ch] = "\\" + ch;
+        return;
+      }
+    }
+
+    characterMap[ch] =
+        (ch > 0x0019 && ch < 0x007f)
+            ? String.valueOf(ch)
+            : (ch < 0x0010)
+                ? "\\u000" + Integer.toHexString(ch)
+                : (ch < 0x0100)
+                    ? "\\u00" + Integer.toHexString(ch)
+                    : (ch < 0x1000)
+                        ? "\\u0" + Integer.toHexString(ch)
+                        : "\\u" + Integer.toHexString(ch);
+  }
+}

--- a/src/net/sourceforge/kolmafia/preferences/PreferencesFile.java
+++ b/src/net/sourceforge/kolmafia/preferences/PreferencesFile.java
@@ -255,7 +255,7 @@ class PreferencesFile {
         || (System.currentTimeMillis() - prefsFileLastSave) >= PreferencesFile.JOURNAL_MAX_AGE;
   }
 
-  /** Saves the current prefs to file; global callers should {@link #applyJournal} first. */
+  /** Saves the current prefs to file */
   void savePrefsFile(boolean loggingOut) {
     // See Collections.synchronizedSortedMap
     //

--- a/src/net/sourceforge/kolmafia/preferences/PreferencesFile.java
+++ b/src/net/sourceforge/kolmafia/preferences/PreferencesFile.java
@@ -36,6 +36,7 @@ class PreferencesFile {
   private final File propertiesFile;
   private final File backupFile;
   private final File journalFile;
+  // Also doubles as this instance's lock, per Collections.synchronizedSortedMap's contract.
   private final Map<String, byte[]> encodedData;
 
   // Exposed for tests
@@ -56,85 +57,89 @@ class PreferencesFile {
   }
 
   Properties loadWithBackup() {
-    if (!propertiesFile.exists() && !backupFile.exists()) {
-      return new Properties();
-    }
+    synchronized (encodedData) {
+      if (!propertiesFile.exists() && !backupFile.exists()) {
+        return new Properties();
+      }
 
-    Properties p = PreferencesFile.loadProperties(propertiesFile);
+      Properties p = PreferencesFile.loadProperties(propertiesFile);
 
-    if (!PreferencesFile.isValidPreferencesFile(propertiesFile, p)) {
-      // Something went wrong reading the preferences.
-      if (backupFile.exists()) {
-        KoLmafia.updateDisplay(
-            propertiesFile
-                + " could not be read, loading backup. "
-                + "This will restore the last successfully opened preferences");
-        // also tell system out, in case things are really fubar
-        System.out.println("Prefs could not be read and backup exists, trying backup. ");
+      if (!PreferencesFile.isValidPreferencesFile(propertiesFile, p)) {
+        // Something went wrong reading the preferences.
+        if (backupFile.exists()) {
+          KoLmafia.updateDisplay(
+              propertiesFile
+                  + " could not be read, loading backup. "
+                  + "This will restore the last successfully opened preferences");
+          // also tell system out, in case things are really fubar
+          System.out.println("Prefs could not be read and backup exists, trying backup. ");
 
-        p = PreferencesFile.loadProperties(backupFile);
+          p = PreferencesFile.loadProperties(backupFile);
 
-        if (PreferencesFile.isValidPreferencesFile(backupFile, p)) {
-          try {
-            Files.copy(
-                backupFile.toPath(), propertiesFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-          } catch (IOException ex) {
+          if (PreferencesFile.isValidPreferencesFile(backupFile, p)) {
+            try {
+              Files.copy(
+                  backupFile.toPath(),
+                  propertiesFile.toPath(),
+                  StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException ex) {
 
-            KoLmafia.updateDisplay(
-                "Error when restoring preferences from backup,  see session log for details");
-            RequestLogger.updateSessionLog(
-                propertiesFile
-                    + " could not be read and backup was used. KoLmafia was unable to copy your backup file to "
-                    + "your preferences file and received error message:"
-                    + ex.getMessage()
-                    + "\nIf this is unexpected, please manually review your preferences and backup and repair any problems."
-                    + " If you have a damaged preferences file, "
-                    + "please consider creating a bug report on the forum, noting any special circumstances around "
-                    + "the failure, and attaching the preferences.");
+              KoLmafia.updateDisplay(
+                  "Error when restoring preferences from backup,  see session log for details");
+              RequestLogger.updateSessionLog(
+                  propertiesFile
+                      + " could not be read and backup was used. KoLmafia was unable to copy your backup file to "
+                      + "your preferences file and received error message:"
+                      + ex.getMessage()
+                      + "\nIf this is unexpected, please manually review your preferences and backup and repair any problems."
+                      + " If you have a damaged preferences file, "
+                      + "please consider creating a bug report on the forum, noting any special circumstances around "
+                      + "the failure, and attaching the preferences.");
+            }
           }
+        } else {
+          // No backup to fall back on, recover whatever complete lines were written before the
+          // corruption point instead of loading a malformed line.
+          try {
+            byte[] safeBytes =
+                FileUtilities.truncateToLastGoodLineBeforeNullByte(
+                    Files.readAllBytes(propertiesFile.toPath()));
+            Properties recovered = new Properties();
+            try (InputStream istream = new ByteArrayInputStream(safeBytes)) {
+              recovered.load(istream);
+            }
+            p = recovered;
+            KoLmafia.updateDisplay(
+                "Preferences was partially recovered from corruption, no backup exists.");
+          } catch (IOException e) {
+            p = new Properties();
+            KoLmafia.updateDisplay("Preferences could not be read and no backup exists.");
+          }
+          RequestLogger.updateSessionLog(
+              propertiesFile
+                  + " could not be read and backup there is no backup file found. "
+                  + "If this is unexpected, please manually inspect "
+                  + "your preferences file and repair any problems.  If you have a damaged preferences file, "
+                  + "please consider creating a bug report on the forum, noting any special circumstances around "
+                  + "the failure, and attaching the preferences.");
         }
       } else {
-        // No backup to fall back on, recover whatever complete lines were written before the
-        // corruption point instead of loading a malformed line.
         try {
-          byte[] safeBytes =
-              FileUtilities.truncateToLastGoodLineBeforeNullByte(
-                  Files.readAllBytes(propertiesFile.toPath()));
-          Properties recovered = new Properties();
-          try (InputStream istream = new ByteArrayInputStream(safeBytes)) {
-            recovered.load(istream);
-          }
-          p = recovered;
-          KoLmafia.updateDisplay(
-              "Preferences was partially recovered from corruption, no backup exists.");
-        } catch (IOException e) {
-          p = new Properties();
-          KoLmafia.updateDisplay("Preferences could not be read and no backup exists.");
+          Files.copy(
+              propertiesFile.toPath(), backupFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException ex) {
+          System.out.println("I/O Error when creating backup preferences file: " + ex.getMessage());
+          RequestLogger.updateSessionLog(
+              propertiesFile
+                  + " backup creation failed. Please manually inspect "
+                  + "your preferences and backup files and repair any problems.  If you have a damaged preferences file, "
+                  + "please consider creating a bug report on the forum, noting any special circumstances around "
+                  + "the failure, and attaching the preferences.");
         }
-        RequestLogger.updateSessionLog(
-            propertiesFile
-                + " could not be read and backup there is no backup file found. "
-                + "If this is unexpected, please manually inspect "
-                + "your preferences file and repair any problems.  If you have a damaged preferences file, "
-                + "please consider creating a bug report on the forum, noting any special circumstances around "
-                + "the failure, and attaching the preferences.");
       }
-    } else {
-      try {
-        Files.copy(
-            propertiesFile.toPath(), backupFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-      } catch (IOException ex) {
-        System.out.println("I/O Error when creating backup preferences file: " + ex.getMessage());
-        RequestLogger.updateSessionLog(
-            propertiesFile
-                + " backup creation failed. Please manually inspect "
-                + "your preferences and backup files and repair any problems.  If you have a damaged preferences file, "
-                + "please consider creating a bug report on the forum, noting any special circumstances around "
-                + "the failure, and attaching the preferences.");
-      }
-    }
 
-    return p;
+      return p;
+    }
   }
 
   private static Properties loadProperties(File file) {
@@ -169,35 +174,37 @@ class PreferencesFile {
    * @return true if a journal file existed and was fully applied
    */
   boolean applyJournal(Properties properties) {
-    if (journalFile.length() == 0) {
-      return false;
-    }
+    synchronized (encodedData) {
+      if (journalFile.length() == 0) {
+        return false;
+      }
 
-    try {
-      byte[] bytes = Files.readAllBytes(journalFile.toPath());
-      byte[] safeBytes =
-          FileUtilities.truncateTrailingPartialLine(
-              FileUtilities.truncateToLastGoodLineBeforeNullByte(bytes));
-      if (safeBytes.length != bytes.length) {
-        System.out.println(journalFile + " was truncated after a corrupt trailing entry.");
-      }
-      try (BufferedReader reader =
-          new BufferedReader(
-              new InputStreamReader(
-                  new ByteArrayInputStream(safeBytes), StandardCharsets.ISO_8859_1))) {
-        // We can't really define a line as "deleted", without it being possibly a real key
-        // So we load each line one by one
-        Properties scratch = new Properties();
-        String line;
-        while ((line = reader.readLine()) != null) {
-          PreferencesFile.applyJournalLine(properties, scratch, line);
+      try {
+        byte[] bytes = Files.readAllBytes(journalFile.toPath());
+        byte[] safeBytes =
+            FileUtilities.truncateTrailingPartialLine(
+                FileUtilities.truncateToLastGoodLineBeforeNullByte(bytes));
+        if (safeBytes.length != bytes.length) {
+          System.out.println(journalFile + " was truncated after a corrupt trailing entry.");
         }
+        try (BufferedReader reader =
+            new BufferedReader(
+                new InputStreamReader(
+                    new ByteArrayInputStream(safeBytes), StandardCharsets.ISO_8859_1))) {
+          // We can't really define a line as "deleted", without it being possibly a real key
+          // So we load each line one by one
+          Properties scratch = new Properties();
+          String line;
+          while ((line = reader.readLine()) != null) {
+            PreferencesFile.applyJournalLine(properties, scratch, line);
+          }
+        }
+      } catch (IOException e) {
+        System.out.println(e.getMessage() + " trying to load preferences journal.");
+        return false;
       }
-    } catch (IOException e) {
-      System.out.println(e.getMessage() + " trying to load preferences journal.");
-      return false;
+      return true;
     }
-    return true;
   }
 
   /**
@@ -237,14 +244,18 @@ class PreferencesFile {
       lineBytes = ("#" + encodeProperty(propertyName, null)).getBytes(StandardCharsets.UTF_8);
     }
 
-    try (OutputStream fstream = DataUtilities.getOutputStream(journalFile, true)) {
-      fstream.write(lineBytes);
-      journalBytes += lineBytes.length;
-    } catch (IOException e) {
-      System.out.println(e.getMessage() + " trying to append to preferences journal.");
+    boolean shouldTrim;
+    synchronized (encodedData) {
+      try (OutputStream fstream = DataUtilities.getOutputStream(journalFile, true)) {
+        fstream.write(lineBytes);
+        journalBytes += lineBytes.length;
+      } catch (IOException e) {
+        System.out.println(e.getMessage() + " trying to append to preferences journal.");
+      }
+      shouldTrim = shouldTrimJournal();
     }
 
-    if (shouldTrimJournal()) {
+    if (shouldTrim) {
       savePrefsFile(false);
     }
   }
@@ -257,52 +268,47 @@ class PreferencesFile {
 
   /** Saves the current prefs to file */
   void savePrefsFile(boolean loggingOut) {
-    // See Collections.synchronizedSortedMap
-    //
-    // We are essentially iterating over the map. Not exactly - we
-    // are iterating over the entrySet - but let's keep the map and
-    // the file in synch atomically
-
-    try (OutputStream fstream =
-        new BufferedOutputStream(DataUtilities.getOutputStream(propertiesFile))) {
-      synchronized (encodedData) {
+    synchronized (encodedData) {
+      try (OutputStream fstream =
+          new BufferedOutputStream(DataUtilities.getOutputStream(propertiesFile))) {
         for (Entry<String, byte[]> current : encodedData.entrySet()) {
           fstream.write(current.getValue());
         }
+      } catch (IOException e) {
+        System.out.println(e.getMessage() + " trying to write preferences as byte array.");
+        // We early exit as saving filed
+        return;
       }
-    } catch (IOException e) {
-      System.out.println(e.getMessage() + " trying to write preferences as byte array.");
-      // We early exit as saving filed
-      return;
-    }
 
-    if (!writeLooksValid(propertiesFile)) {
-      // Bad write - leave the journal alone, it's the only record of the unsaved changes.
-      System.out.println(propertiesFile + " failed validation after saving, backup left as-is.");
-      return;
-    }
+      if (!writeLooksValid(propertiesFile)) {
+        // Bad write - leave the journal alone, it's the only record of the unsaved changes.
+        System.out.println(propertiesFile + " failed validation after saving, backup left as-is.");
+        return;
+      }
 
-    try {
-      Files.copy(propertiesFile.toPath(), backupFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-    } catch (IOException e) {
-      System.out.println(e.getMessage() + " trying to refresh preferences backup.");
-    }
+      try {
+        Files.copy(
+            propertiesFile.toPath(), backupFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      } catch (IOException e) {
+        System.out.println(e.getMessage() + " trying to refresh preferences backup.");
+      }
 
-    try {
-      if (loggingOut) {
-        Files.deleteIfExists(journalFile.toPath());
-      } else if (journalFile.exists()) {
-        try (OutputStream fstream = DataUtilities.getOutputStream(journalFile)) {
-          // Truncate the file to zero length.
-          fstream.write(new byte[0]);
+      try {
+        if (loggingOut) {
+          Files.deleteIfExists(journalFile.toPath());
+        } else if (journalFile.exists()) {
+          try (OutputStream fstream = DataUtilities.getOutputStream(journalFile)) {
+            // Truncate the file to zero length.
+            fstream.write(new byte[0]);
+          }
         }
+        journalBytes = 0;
+      } catch (IOException e) {
+        System.out.println(e.getMessage() + " trying to clear preferences journal.");
       }
-      journalBytes = 0;
-    } catch (IOException e) {
-      System.out.println(e.getMessage() + " trying to clear preferences journal.");
+      // We still update this, because why fail rapidly?
+      prefsFileLastSave = System.currentTimeMillis();
     }
-    // We still update this, because why fail rapidly?
-    prefsFileLastSave = System.currentTimeMillis();
   }
 
   /** Same corruption check as {@link #isValidPreferencesFile}, without reparsing what we wrote. */

--- a/src/net/sourceforge/kolmafia/preferences/PreferencesFile.java
+++ b/src/net/sourceforge/kolmafia/preferences/PreferencesFile.java
@@ -36,7 +36,6 @@ class PreferencesFile {
   private final File propertiesFile;
   private final File backupFile;
   private final File journalFile;
-  // Also doubles as this instance's lock, per Collections.synchronizedSortedMap's contract.
   private final Map<String, byte[]> encodedData;
 
   // Exposed for tests
@@ -57,89 +56,85 @@ class PreferencesFile {
   }
 
   Properties loadWithBackup() {
-    synchronized (encodedData) {
-      if (!propertiesFile.exists() && !backupFile.exists()) {
-        return new Properties();
-      }
+    if (!propertiesFile.exists() && !backupFile.exists()) {
+      return new Properties();
+    }
 
-      Properties p = PreferencesFile.loadProperties(propertiesFile);
+    Properties p = PreferencesFile.loadProperties(propertiesFile);
 
-      if (!PreferencesFile.isValidPreferencesFile(propertiesFile, p)) {
-        // Something went wrong reading the preferences.
-        if (backupFile.exists()) {
-          KoLmafia.updateDisplay(
-              propertiesFile
-                  + " could not be read, loading backup. "
-                  + "This will restore the last successfully opened preferences");
-          // also tell system out, in case things are really fubar
-          System.out.println("Prefs could not be read and backup exists, trying backup. ");
+    if (!PreferencesFile.isValidPreferencesFile(propertiesFile, p)) {
+      // Something went wrong reading the preferences.
+      if (backupFile.exists()) {
+        KoLmafia.updateDisplay(
+            propertiesFile
+                + " could not be read, loading backup. "
+                + "This will restore the last successfully opened preferences");
+        // also tell system out, in case things are really fubar
+        System.out.println("Prefs could not be read and backup exists, trying backup. ");
 
-          p = PreferencesFile.loadProperties(backupFile);
+        p = PreferencesFile.loadProperties(backupFile);
 
-          if (PreferencesFile.isValidPreferencesFile(backupFile, p)) {
-            try {
-              Files.copy(
-                  backupFile.toPath(),
-                  propertiesFile.toPath(),
-                  StandardCopyOption.REPLACE_EXISTING);
-            } catch (IOException ex) {
-
-              KoLmafia.updateDisplay(
-                  "Error when restoring preferences from backup,  see session log for details");
-              RequestLogger.updateSessionLog(
-                  propertiesFile
-                      + " could not be read and backup was used. KoLmafia was unable to copy your backup file to "
-                      + "your preferences file and received error message:"
-                      + ex.getMessage()
-                      + "\nIf this is unexpected, please manually review your preferences and backup and repair any problems."
-                      + " If you have a damaged preferences file, "
-                      + "please consider creating a bug report on the forum, noting any special circumstances around "
-                      + "the failure, and attaching the preferences.");
-            }
-          }
-        } else {
-          // No backup to fall back on, recover whatever complete lines were written before the
-          // corruption point instead of loading a malformed line.
+        if (PreferencesFile.isValidPreferencesFile(backupFile, p)) {
           try {
-            byte[] safeBytes =
-                FileUtilities.truncateToLastGoodLineBeforeNullByte(
-                    Files.readAllBytes(propertiesFile.toPath()));
-            Properties recovered = new Properties();
-            try (InputStream istream = new ByteArrayInputStream(safeBytes)) {
-              recovered.load(istream);
-            }
-            p = recovered;
+            Files.copy(
+                backupFile.toPath(), propertiesFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+          } catch (IOException ex) {
+
             KoLmafia.updateDisplay(
-                "Preferences was partially recovered from corruption, no backup exists.");
-          } catch (IOException e) {
-            p = new Properties();
-            KoLmafia.updateDisplay("Preferences could not be read and no backup exists.");
+                "Error when restoring preferences from backup,  see session log for details");
+            RequestLogger.updateSessionLog(
+                propertiesFile
+                    + " could not be read and backup was used. KoLmafia was unable to copy your backup file to "
+                    + "your preferences file and received error message:"
+                    + ex.getMessage()
+                    + "\nIf this is unexpected, please manually review your preferences and backup and repair any problems."
+                    + " If you have a damaged preferences file, "
+                    + "please consider creating a bug report on the forum, noting any special circumstances around "
+                    + "the failure, and attaching the preferences.");
           }
-          RequestLogger.updateSessionLog(
-              propertiesFile
-                  + " could not be read and backup there is no backup file found. "
-                  + "If this is unexpected, please manually inspect "
-                  + "your preferences file and repair any problems.  If you have a damaged preferences file, "
-                  + "please consider creating a bug report on the forum, noting any special circumstances around "
-                  + "the failure, and attaching the preferences.");
         }
       } else {
+        // No backup to fall back on, recover whatever complete lines were written before the
+        // corruption point instead of loading a malformed line.
         try {
-          Files.copy(
-              propertiesFile.toPath(), backupFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException ex) {
-          System.out.println("I/O Error when creating backup preferences file: " + ex.getMessage());
-          RequestLogger.updateSessionLog(
-              propertiesFile
-                  + " backup creation failed. Please manually inspect "
-                  + "your preferences and backup files and repair any problems.  If you have a damaged preferences file, "
-                  + "please consider creating a bug report on the forum, noting any special circumstances around "
-                  + "the failure, and attaching the preferences.");
+          byte[] safeBytes =
+              FileUtilities.truncateToLastGoodLineBeforeNullByte(
+                  Files.readAllBytes(propertiesFile.toPath()));
+          Properties recovered = new Properties();
+          try (InputStream istream = new ByteArrayInputStream(safeBytes)) {
+            recovered.load(istream);
+          }
+          p = recovered;
+          KoLmafia.updateDisplay(
+              "Preferences was partially recovered from corruption, no backup exists.");
+        } catch (IOException e) {
+          p = new Properties();
+          KoLmafia.updateDisplay("Preferences could not be read and no backup exists.");
         }
+        RequestLogger.updateSessionLog(
+            propertiesFile
+                + " could not be read and backup there is no backup file found. "
+                + "If this is unexpected, please manually inspect "
+                + "your preferences file and repair any problems.  If you have a damaged preferences file, "
+                + "please consider creating a bug report on the forum, noting any special circumstances around "
+                + "the failure, and attaching the preferences.");
       }
-
-      return p;
+    } else {
+      try {
+        Files.copy(
+            propertiesFile.toPath(), backupFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      } catch (IOException ex) {
+        System.out.println("I/O Error when creating backup preferences file: " + ex.getMessage());
+        RequestLogger.updateSessionLog(
+            propertiesFile
+                + " backup creation failed. Please manually inspect "
+                + "your preferences and backup files and repair any problems.  If you have a damaged preferences file, "
+                + "please consider creating a bug report on the forum, noting any special circumstances around "
+                + "the failure, and attaching the preferences.");
+      }
     }
+
+    return p;
   }
 
   private static Properties loadProperties(File file) {
@@ -174,37 +169,35 @@ class PreferencesFile {
    * @return true if a journal file existed and was fully applied
    */
   boolean applyJournal(Properties properties) {
-    synchronized (encodedData) {
-      if (journalFile.length() == 0) {
-        return false;
-      }
-
-      try {
-        byte[] bytes = Files.readAllBytes(journalFile.toPath());
-        byte[] safeBytes =
-            FileUtilities.truncateTrailingPartialLine(
-                FileUtilities.truncateToLastGoodLineBeforeNullByte(bytes));
-        if (safeBytes.length != bytes.length) {
-          System.out.println(journalFile + " was truncated after a corrupt trailing entry.");
-        }
-        try (BufferedReader reader =
-            new BufferedReader(
-                new InputStreamReader(
-                    new ByteArrayInputStream(safeBytes), StandardCharsets.ISO_8859_1))) {
-          // We can't really define a line as "deleted", without it being possibly a real key
-          // So we load each line one by one
-          Properties scratch = new Properties();
-          String line;
-          while ((line = reader.readLine()) != null) {
-            PreferencesFile.applyJournalLine(properties, scratch, line);
-          }
-        }
-      } catch (IOException e) {
-        System.out.println(e.getMessage() + " trying to load preferences journal.");
-        return false;
-      }
-      return true;
+    if (journalFile.length() == 0) {
+      return false;
     }
+
+    try {
+      byte[] bytes = Files.readAllBytes(journalFile.toPath());
+      byte[] safeBytes =
+          FileUtilities.truncateTrailingPartialLine(
+              FileUtilities.truncateToLastGoodLineBeforeNullByte(bytes));
+      if (safeBytes.length != bytes.length) {
+        System.out.println(journalFile + " was truncated after a corrupt trailing entry.");
+      }
+      try (BufferedReader reader =
+          new BufferedReader(
+              new InputStreamReader(
+                  new ByteArrayInputStream(safeBytes), StandardCharsets.ISO_8859_1))) {
+        // We can't really define a line as "deleted", without it being possibly a real key
+        // So we load each line one by one
+        Properties scratch = new Properties();
+        String line;
+        while ((line = reader.readLine()) != null) {
+          PreferencesFile.applyJournalLine(properties, scratch, line);
+        }
+      }
+    } catch (IOException e) {
+      System.out.println(e.getMessage() + " trying to load preferences journal.");
+      return false;
+    }
+    return true;
   }
 
   /**
@@ -244,18 +237,14 @@ class PreferencesFile {
       lineBytes = ("#" + encodeProperty(propertyName, null)).getBytes(StandardCharsets.UTF_8);
     }
 
-    boolean shouldTrim;
-    synchronized (encodedData) {
-      try (OutputStream fstream = DataUtilities.getOutputStream(journalFile, true)) {
-        fstream.write(lineBytes);
-        journalBytes += lineBytes.length;
-      } catch (IOException e) {
-        System.out.println(e.getMessage() + " trying to append to preferences journal.");
-      }
-      shouldTrim = shouldTrimJournal();
+    try (OutputStream fstream = DataUtilities.getOutputStream(journalFile, true)) {
+      fstream.write(lineBytes);
+      journalBytes += lineBytes.length;
+    } catch (IOException e) {
+      System.out.println(e.getMessage() + " trying to append to preferences journal.");
     }
 
-    if (shouldTrim) {
+    if (shouldTrimJournal()) {
       savePrefsFile(false);
     }
   }
@@ -268,47 +257,44 @@ class PreferencesFile {
 
   /** Saves the current prefs to file */
   void savePrefsFile(boolean loggingOut) {
-    synchronized (encodedData) {
-      try (OutputStream fstream =
-          new BufferedOutputStream(DataUtilities.getOutputStream(propertiesFile))) {
-        for (Entry<String, byte[]> current : encodedData.entrySet()) {
-          fstream.write(current.getValue());
-        }
-      } catch (IOException e) {
-        System.out.println(e.getMessage() + " trying to write preferences as byte array.");
-        // We early exit as saving filed
-        return;
+    try (OutputStream fstream =
+        new BufferedOutputStream(DataUtilities.getOutputStream(propertiesFile))) {
+      for (Entry<String, byte[]> current : encodedData.entrySet()) {
+        fstream.write(current.getValue());
       }
-
-      if (!writeLooksValid(propertiesFile)) {
-        // Bad write - leave the journal alone, it's the only record of the unsaved changes.
-        System.out.println(propertiesFile + " failed validation after saving, backup left as-is.");
-        return;
-      }
-
-      try {
-        Files.copy(
-            propertiesFile.toPath(), backupFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-      } catch (IOException e) {
-        System.out.println(e.getMessage() + " trying to refresh preferences backup.");
-      }
-
-      try {
-        if (loggingOut) {
-          Files.deleteIfExists(journalFile.toPath());
-        } else if (journalFile.exists()) {
-          try (OutputStream fstream = DataUtilities.getOutputStream(journalFile)) {
-            // Truncate the file to zero length.
-            fstream.write(new byte[0]);
-          }
-        }
-        journalBytes = 0;
-      } catch (IOException e) {
-        System.out.println(e.getMessage() + " trying to clear preferences journal.");
-      }
-      // We still update this, because why fail rapidly?
-      prefsFileLastSave = System.currentTimeMillis();
+    } catch (IOException e) {
+      System.out.println(e.getMessage() + " trying to write preferences as byte array.");
+      // We early exit as saving filed
+      return;
     }
+
+    if (!writeLooksValid(propertiesFile)) {
+      // Bad write - leave the journal alone, it's the only record of the unsaved changes.
+      System.out.println(propertiesFile + " failed validation after saving, backup left as-is.");
+      return;
+    }
+
+    try {
+      Files.copy(propertiesFile.toPath(), backupFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    } catch (IOException e) {
+      System.out.println(e.getMessage() + " trying to refresh preferences backup.");
+    }
+
+    try {
+      if (loggingOut) {
+        Files.deleteIfExists(journalFile.toPath());
+      } else if (journalFile.exists()) {
+        try (OutputStream fstream = DataUtilities.getOutputStream(journalFile)) {
+          // Truncate the file to zero length.
+          fstream.write(new byte[0]);
+        }
+      }
+      journalBytes = 0;
+    } catch (IOException e) {
+      System.out.println(e.getMessage() + " trying to clear preferences journal.");
+    }
+    // We still update this, because why fail rapidly?
+    prefsFileLastSave = System.currentTimeMillis();
   }
 
   /** Same corruption check as {@link #isValidPreferencesFile}, without reparsing what we wrote. */

--- a/src/net/sourceforge/kolmafia/preferences/PreferencesFile.java
+++ b/src/net/sourceforge/kolmafia/preferences/PreferencesFile.java
@@ -30,8 +30,6 @@ import net.sourceforge.kolmafia.utilities.FileUtilities;
 class PreferencesFile {
   private static final long TRIM_JOURNAL_BYTE_THRESHOLD = 10_000_000; // 10MB
   static final long JOURNAL_MAX_AGE = TimeUnit.DAYS.toMillis(1);
-  // Cache of escaped-string representation per character.
-  private static final String[] characterMap = new String[65536];
 
   private final File propertiesFile;
   private final File backupFile;
@@ -163,7 +161,7 @@ class PreferencesFile {
   /**
    * Applies the journal's lines, in order, onto a freshly loaded prefs.
    *
-   * <p>A normal line sets a key, a line starting with "#" removes one. {@link #encodeCharacter}
+   * <p>A normal line sets a key, a line starting with "#" removes one. Preferences#encodeCharacter
    * always escapes a literal '#' as "\#", so a raw "#" is unambiguous as the removal marker.
    *
    * @return true if a journal file existed and was fully applied
@@ -234,7 +232,8 @@ class PreferencesFile {
 
     if (lineBytes == null) {
       // Removed, prepend with # to indicate it's removed.
-      lineBytes = ("#" + encodeProperty(propertyName, null)).getBytes(StandardCharsets.UTF_8);
+      lineBytes =
+          ("#" + Preferences.encodeProperty(propertyName, null)).getBytes(StandardCharsets.UTF_8);
     }
 
     try (OutputStream fstream = DataUtilities.getOutputStream(journalFile, true)) {
@@ -307,69 +306,5 @@ class PreferencesFile {
     } catch (IOException e) {
       return false;
     }
-  }
-
-  static String encodeProperty(String name, String value) {
-    StringBuffer buffer = new StringBuffer();
-
-    encodeString(buffer, name);
-
-    if (value != null && !value.isEmpty()) {
-      buffer.append("=");
-      encodeString(buffer, value);
-    }
-    buffer.append(KoLConstants.LINE_BREAK);
-
-    return buffer.toString();
-  }
-
-  private static void encodeString(StringBuffer buffer, String string) {
-    int length = string.length();
-
-    for (int i = 0; i < length; ++i) {
-      char ch = string.charAt(i);
-      encodeCharacter(ch);
-      buffer.append(characterMap[ch]);
-    }
-  }
-
-  private static void encodeCharacter(char ch) {
-    if (characterMap[ch] != null) {
-      return;
-    }
-
-    switch (ch) {
-      case '\t' -> {
-        characterMap[ch] = "\\t";
-        return;
-      }
-      case '\n' -> {
-        characterMap[ch] = "\\n";
-        return;
-      }
-      case '\f' -> {
-        characterMap[ch] = "\\f";
-        return;
-      }
-      case '\r' -> {
-        characterMap[ch] = "\\r";
-        return;
-      }
-      case '\\', '=', ':', '#', '!' -> {
-        characterMap[ch] = "\\" + ch;
-        return;
-      }
-    }
-
-    characterMap[ch] =
-        (ch > 0x0019 && ch < 0x007f)
-            ? String.valueOf(ch)
-            : (ch < 0x0010)
-                ? "\\u000" + Integer.toHexString(ch)
-                : (ch < 0x0100)
-                    ? "\\u00" + Integer.toHexString(ch)
-                    : (ch < 0x1000)
-                        ? "\\u0" + Integer.toHexString(ch)
-                        : "\\u" + Integer.toHexString(ch);
   }
 }

--- a/src/net/sourceforge/kolmafia/utilities/FileUtilities.java
+++ b/src/net/sourceforge/kolmafia/utilities/FileUtilities.java
@@ -579,13 +579,25 @@ public class FileUtilities {
       }
 
       // We started at a null, we cannot trust that this line is complete
-      // We start scanning backwards for the first newline that indicates a complete line
-      while (--i >= 0 && bytes[i] != '\n') {}
-
-      return Arrays.copyOf(bytes, i + 1);
+      return truncateBackToLastNewline(bytes, i);
     }
 
     return bytes;
+  }
+
+  /** Drops a trailing line with no terminator, left behind by a write cut off mid-line. */
+  public static byte[] truncateTrailingPartialLine(byte[] bytes) {
+    if (bytes.length == 0 || bytes[bytes.length - 1] == '\n') {
+      return bytes;
+    }
+    return truncateBackToLastNewline(bytes, bytes.length);
+  }
+
+  /** Scans backwards from {@code from} (exclusive) for the last newline and truncates after it. */
+  private static byte[] truncateBackToLastNewline(byte[] bytes, int from) {
+    int i = from;
+    while (--i >= 0 && bytes[i] != '\n') {}
+    return Arrays.copyOf(bytes, i + 1);
   }
 
   public static boolean isEmptyDirectory(Path path) throws IOException {

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -711,17 +711,25 @@ class PreferencesTest {
   @Nested
   class SaveTogglePreferencesTest {
     private final String USER_NAME = "PreferencesTestAlsoFakeUser".toLowerCase();
+    private final File userFile = new File("settings/" + USER_NAME + "_prefs.txt");
+    private final File backupFile = new File("settings/" + USER_NAME + "_prefs.bak");
+    private final File journalFile = new File("settings/" + USER_NAME + "_prefs.journal");
 
-    private String streamReadHelper(File userFile) {
+    private String streamReadHelper(File file) {
       String contents = "";
       final InputStream inputStream;
-      inputStream = DataUtilities.getInputStream(userFile);
+      inputStream = DataUtilities.getInputStream(file);
       try (inputStream) {
         contents = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
       } catch (IOException e) {
-        fail("Stream read for " + userFile + " failed with exception " + e.getMessage());
+        fail("Stream read for " + file + " failed with exception " + e.getMessage());
       }
       return contents;
+    }
+
+    // A change may be in the prefs or the journal, combine both so tests pass
+    private String combinedContents() {
+      return "\n" + streamReadHelper(userFile) + streamReadHelper(journalFile);
     }
 
     @BeforeEach
@@ -731,33 +739,25 @@ class PreferencesTest {
 
     @AfterEach
     public void resetCharAndPreferences() {
-      File userFile = new File("settings/" + USER_NAME + "_prefs.txt");
       verboseDelete(userFile);
-      File backupFile = new File("settings/" + USER_NAME + "_prefs.bak");
       verboseDelete(backupFile);
+      verboseDelete(journalFile);
     }
 
     @Test
     public void savesSettingsIfOn() {
-      String contents;
       var cleanups =
           new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
       try (cleanups) {
-        File userFile = new File("settings/" + USER_NAME + "_prefs.txt");
-        contents = streamReadHelper(userFile);
-        assertThat(contents, not(containsString("\nxyz=abc\n")));
+        assertThat(combinedContents(), not(containsString("\nxyz=abc\n")));
         Preferences.setString("xyz", "abc");
-        contents = streamReadHelper(userFile);
-        assertThat(contents, containsString("\nxyz=abc\n"));
+        assertThat(combinedContents(), containsString("\nxyz=abc\n"));
       }
     }
 
     @Test
     public void canToggle() {
-      String contents;
-      File userFile = new File("settings/" + USER_NAME + "_prefs.txt");
-      contents = streamReadHelper(userFile);
-      assertThat(contents, not(containsString("\nxyz=abc\n")));
+      assertThat(combinedContents(), not(containsString("\nxyz=abc\n")));
 
       var cleanups =
           new Cleanups(
@@ -765,17 +765,27 @@ class PreferencesTest {
               withProperty("saveSettingsOnSet", false),
               withProperty("xyz", "abc"));
       try (cleanups) {
-        contents = streamReadHelper(userFile);
-        assertThat(contents, not(containsString("\nxyz=abc\n")));
+        assertThat(combinedContents(), not(containsString("\nxyz=abc\n")));
         var cleanups2 =
             new Cleanups(withProperty("saveSettingsOnSet", true), withProperty("wxy", "def"));
         try (cleanups2) {
-          contents = streamReadHelper(userFile);
-          assertThat(contents, containsString("\nxyz=abc\n"));
-          assertThat(contents, containsString("\nwxy=def\n"));
+          assertThat(combinedContents(), containsString("\nxyz=abc\n"));
+          assertThat(combinedContents(), containsString("\nwxy=def\n"));
         }
       }
     }
+  }
+
+  /** Writes out parsable text, then \nul or \0 bytes to mimic a corrupted file */
+  private void corrupt(File file, String parsablePrefix) throws IOException {
+    // Turns the text into bytes
+    byte[] prefix = parsablePrefix.getBytes(StandardCharsets.UTF_8);
+    // The remaining bytes are null bytes
+    byte[] bytes = new byte[prefix.length + 64];
+    // Writes prefix into the bytes array
+    System.arraycopy(prefix, 0, bytes, 0, prefix.length);
+    // Writes to disk
+    Files.write(file.toPath(), bytes);
   }
 
   @Nested
@@ -784,12 +794,14 @@ class PreferencesTest {
     private final String USER_NAME = "PreferencesTestBackupUser".toLowerCase();
     private final File userFile = new File("settings/" + USER_NAME + "_prefs.txt");
     private final File backupFile = new File("settings/" + USER_NAME + "_prefs.bak");
+    private final File journalFile = new File("settings/" + USER_NAME + "_prefs.journal");
     private final String PREF_NAME = "somePreference";
 
     @BeforeEach
     public void deleteUserPrefs() {
       verboseDelete(userFile);
       verboseDelete(backupFile);
+      verboseDelete(journalFile);
     }
 
     @AfterEach
@@ -804,18 +816,6 @@ class PreferencesTest {
 
     private void logout() {
       Preferences.reset("");
-    }
-
-    /** Writes out parsable text, then \nul or \0 bytes to mimic a corrupted file */
-    private void corrupt(File file, String parsablePrefix) throws IOException {
-      // Turns the text into bytes
-      byte[] prefix = parsablePrefix.getBytes(StandardCharsets.UTF_8);
-      // The remaining bytes are null bytes
-      byte[] bytes = new byte[prefix.length + 64];
-      // Writes prefix into the bytes array
-      System.arraycopy(prefix, 0, bytes, 0, prefix.length);
-      // Writes to disk
-      Files.write(file.toPath(), bytes);
     }
 
     private void savePreference() {
@@ -919,6 +919,290 @@ class PreferencesTest {
         assertEquals("someValue", Preferences.getString(PREF_NAME));
         // Confirm problematic lines were not included
         assertFalse(Preferences.propertyExists("skippedKey"));
+      }
+    }
+  }
+
+  @Nested
+  class JournaledPreferenceWrites {
+    // Lowercase because of filenames
+    private final String USER_NAME = "PreferencesTestJournalUser".toLowerCase();
+    private final File userFile = new File("settings/" + USER_NAME + "_prefs.txt");
+    private final File backupFile = new File("settings/" + USER_NAME + "_prefs.bak");
+    private final File journalFile = new File("settings/" + USER_NAME + "_prefs.journal");
+    private final String PREF_NAME = "JournalTestPref";
+
+    @BeforeEach
+    public void deleteUserPrefs() {
+      verboseDelete(userFile);
+      verboseDelete(backupFile);
+      verboseDelete(journalFile);
+    }
+
+    @AfterEach
+    public void resetCharAndPreferences() {
+      deleteSerFiles(USER_NAME);
+      KoLCharacter.reset("");
+    }
+
+    private void login() {
+      Preferences.reset(USER_NAME);
+    }
+
+    private void logout() {
+      Preferences.reset("");
+    }
+
+    private void writeJournal(String string) throws IOException {
+      Files.writeString(journalFile.toPath(), string, StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void appendsToJournalLeavingPrefsUntouched() throws IOException {
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        login();
+        Preferences.setString(PREF_NAME, "initial");
+        Preferences.userFile.savePrefsFile(false);
+        String prefsBefore = Files.readString(userFile.toPath(), StandardCharsets.UTF_8);
+
+        Preferences.setString(PREF_NAME, "value");
+
+        // The prefs should not have changed
+        assertEquals(prefsBefore, Files.readString(userFile.toPath(), StandardCharsets.UTF_8));
+        // The journal contains this line
+        assertThat(
+            Files.readString(journalFile.toPath(), StandardCharsets.UTF_8),
+            containsString(PREF_NAME + "=value\n"));
+      }
+    }
+
+    @Test
+    public void loginReplaysJournalOntoPrefsAndEmptiesIt() throws IOException {
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        login();
+        Preferences.setString(PREF_NAME, "oldValue");
+        logout();
+        writeJournal(PREF_NAME + "=newValue" + KoLConstants.LINE_BREAK);
+        login();
+
+        // Relogging without logging out will remove your journal file, but that's minor
+        assertTrue(journalFile.exists(), "Journal should still exist as we are logged in");
+        assertEquals(0, journalFile.length(), "Journal should be an empty file");
+        assertEquals("newValue", Preferences.getString(PREF_NAME));
+        assertThat(
+            Files.readString(userFile.toPath(), StandardCharsets.UTF_8),
+            containsString(PREF_NAME + "=newValue\n"));
+      }
+    }
+
+    @Test
+    public void logoutDeletesJournalAndHasEverything() throws IOException {
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        login();
+        Preferences.setString(PREF_NAME, "oldValue");
+        // Save
+        Preferences.userFile.savePrefsFile(false);
+        Preferences.setString(PREF_NAME, "newValue");
+        // The prefs file is currently set to oldValue
+        assertThat(
+            Files.readString(userFile.toPath(), StandardCharsets.UTF_8),
+            containsString(PREF_NAME + "=oldValue\n"));
+        assertThat(
+            Files.readString(userFile.toPath(), StandardCharsets.UTF_8),
+            not(containsString(PREF_NAME + "=newValue\n")));
+        logout();
+
+        assertFalse(journalFile.exists(), "Journal should not exist");
+        assertThat(
+            Files.readString(userFile.toPath(), StandardCharsets.UTF_8),
+            containsString(PREF_NAME + "=newValue\n"));
+      }
+    }
+
+    @Test
+    public void reachingMaxAgeTriggersCompactionAndClearsJournal() throws IOException {
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        login();
+        Preferences.setString(PREF_NAME, "oldValue");
+        Preferences.userFile.savePrefsFile(false);
+        Preferences.setString(PREF_NAME, "pending");
+        assertNotEquals(0, journalFile.length());
+
+        // Claim a day passed since the last compaction.
+        Preferences.userFile.prefsFileLastSave =
+            System.currentTimeMillis() - PreferencesFile.JOURNAL_MAX_AGE - 1;
+
+        Preferences.setString(PREF_NAME, "afterADay");
+
+        assertEquals(0, journalFile.length(), "max age should have triggered a compaction");
+        assertThat(
+            Files.readString(userFile.toPath(), StandardCharsets.UTF_8),
+            containsString(PREF_NAME + "=afterADay\n"));
+      }
+    }
+
+    @Test
+    public void corruptedJournalIsSalvagedUpToLastCompleteLine() throws IOException {
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        corrupt(journalFile, PREF_NAME + "=someValue\nskippedKey=skippedValue");
+
+        login();
+
+        assertEquals("someValue", Preferences.getString(PREF_NAME));
+        assertFalse(Preferences.propertyExists("skippedKey"));
+      }
+    }
+
+    @Test
+    public void removePropertyAppendsRemovalLineToJournal() throws IOException {
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        login();
+        Preferences.setString(PREF_NAME, "value");
+        assertTrue(journalFile.exists());
+
+        Preferences.removeProperty(PREF_NAME, false);
+
+        assertThat(
+            Files.readString(journalFile.toPath(), StandardCharsets.UTF_8),
+            containsString("#" + PREF_NAME + "\n"));
+        assertFalse(Preferences.propertyExists(PREF_NAME, false));
+      }
+    }
+
+    @Test
+    public void journalRemovalLineIsAppliedOnReplay() throws IOException {
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        login();
+        Preferences.setString(PREF_NAME, "value");
+        logout();
+        writeJournal("#" + PREF_NAME + KoLConstants.LINE_BREAK);
+
+        login();
+
+        assertFalse(Preferences.propertyExists(PREF_NAME, false));
+      }
+    }
+
+    @Test
+    public void journalCanSetAndRemoveAndSetProperly() throws IOException {
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        String line1 = PREF_NAME + "=first";
+        String line2 = "#" + PREF_NAME;
+        String line3 = PREF_NAME + "=second";
+        writeJournal(
+            line1
+                + KoLConstants.LINE_BREAK
+                + line2
+                + KoLConstants.LINE_BREAK
+                + line3
+                + KoLConstants.LINE_BREAK);
+
+        login();
+
+        assertEquals("second", Preferences.getString(PREF_NAME));
+      }
+    }
+
+    @Test
+    public void journalHandlesSpecialCharacters() throws IOException {
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        login();
+
+        // Covers the characters encodeCharacter treats differently
+        String trickyName = "Journal#Test!Pref=With:Special\\Chars";
+        String trickyValue =
+            "back\\slash=equals:colon#hash!bang\ttab\nnewline\rcr\fff" + "café中😀emoji";
+
+        Preferences.setString(trickyName, trickyValue);
+        Preferences.setString(PREF_NAME, "toBeRemoved");
+        Preferences.removeProperty(PREF_NAME, false);
+
+        assertThat(
+            Files.readString(journalFile.toPath(), StandardCharsets.UTF_8),
+            containsString(PreferencesFile.encodeProperty(trickyName, trickyValue)));
+
+        login();
+
+        assertEquals(trickyValue, Preferences.getString(trickyName));
+        assertFalse(Preferences.propertyExists(PREF_NAME, false));
+
+        Preferences.removeProperty(trickyName, false);
+        login();
+
+        assertFalse(Preferences.propertyExists(trickyName, false));
+      }
+    }
+
+    @Test
+    public void removingDefaultPreferenceIsJournaledProperly() throws IOException {
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        login();
+
+        // "addingScrolls" has a default, so removing it is a no-op journal append, not a
+        // compaction.
+        Preferences.removeProperty("addingScrolls", false);
+
+        assertTrue(Preferences.propertyExists("addingScrolls", false));
+        assertThat(
+            Files.readString(journalFile.toPath(), StandardCharsets.UTF_8),
+            containsString("addingScrolls=1\n"));
+      }
+    }
+
+    @Test
+    public void resetDailiesWorksWithJournal() throws IOException {
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        login();
+        Preferences.setString("_journalTestDaily", "value");
+        assertTrue(journalFile.exists());
+
+        Preferences.resetDailies();
+
+        assertThat(
+            Files.readString(journalFile.toPath(), StandardCharsets.UTF_8),
+            containsString("#_journalTestDaily\n"));
+        assertFalse(Preferences.propertyExists("_journalTestDaily"));
+      }
+    }
+
+    @Test
+    public void globalPreferencesAreJournaledTheSameWay() throws IOException {
+      String key = "lastUsername";
+      String originalValue = Preferences.getString(key, true);
+      File globalJournalFile = new File("settings/GLOBAL_prefs.journal");
+      var cleanups =
+          new Cleanups(withSavePreferencesToFile(), withProperty("saveSettingsOnSet", true));
+      try (cleanups) {
+        Preferences.setString(key, "journalTestValue");
+
+        assertThat(
+            Files.readString(globalJournalFile.toPath(), StandardCharsets.UTF_8),
+            containsString(key + "=journalTestValue\n"));
+
+        // Restore while saving is still enabled, so this is actually persisted.
+        Preferences.setString(key, originalValue);
       }
     }
   }

--- a/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
+++ b/test/net/sourceforge/kolmafia/preferences/PreferencesTest.java
@@ -1137,7 +1137,7 @@ class PreferencesTest {
 
         assertThat(
             Files.readString(journalFile.toPath(), StandardCharsets.UTF_8),
-            containsString(PreferencesFile.encodeProperty(trickyName, trickyValue)));
+            containsString(Preferences.encodeProperty(trickyName, trickyValue)));
 
         login();
 


### PR DESCRIPTION
Discussion found here; https://kolmafia.us/threads/reduce-the-amount-of-i-o-wear-and-tear-from-writing-preferences.32681/

This PR aims to add journaling to lower IO usage for prefs.
It has the remarkable downside of still no decent globals handling, but that's complicated.
It moves file handling into a seperate class.
A notable downside is the way it loads from Properties file.