### PR TITLE
Add can_walk_from_choice() - Can the choice be walked away from

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -2044,6 +2044,9 @@ public abstract class RuntimeLibrary {
     functions.add(new LibraryFunction("handling_choice", DataTypes.BOOLEAN_TYPE, params));
 
     params = List.of();
+    functions.add(new LibraryFunction("can_walk_from_choice", DataTypes.BOOLEAN_TYPE, params));
+
+    params = List.of();
     functions.add(new LibraryFunction("run_combat", DataTypes.BUFFER_TYPE, params));
 
     params = List.of(namedParam("filterFunction", DataTypes.STRING_TYPE));
@@ -8000,6 +8003,10 @@ public abstract class RuntimeLibrary {
 
   public static Value handling_choice(ScriptRuntime controller) {
     return DataTypes.makeBooleanValue(ChoiceManager.handlingChoice);
+  }
+
+  public static Value can_walk_from_choice(ScriptRuntime controller) {
+    return DataTypes.makeBooleanValue(ChoiceManager.canWalkAway());
   }
 
   public static Value run_combat(ScriptRuntime controller) {

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -92,6 +92,7 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.ApiRequest;
 import net.sourceforge.kolmafia.request.CharSheetRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
+import net.sourceforge.kolmafia.session.ChoiceManager;
 import net.sourceforge.kolmafia.session.GreyYouManager;
 import net.sourceforge.kolmafia.textui.command.AbstractCommandTestBase;
 import net.sourceforge.kolmafia.utilities.NullStream;
@@ -2908,5 +2909,17 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
   @CsvSource({"moxie weed,1", "spooky scarecrow,4", "cottage,3"})
   public void cupOf13sTiers(String item, int tier) {
     assertThat(execute("cup_of_13s_tier($item[" + item + "])").trim(), is("Returned: " + tier));
+  }
+
+  @ParameterizedTest
+  // 570: GameInformPowerDailyPro Walkthru is walkawayable
+  @CsvSource({"570, true", "1, false"})
+  void canWalkFromChoice(int choice, boolean expected) {
+    var request = new GenericRequest("choice.php?whichchoice=" + choice);
+    request.responseText = "whichchoice=" + choice;
+    ChoiceManager.visitChoice(request);
+
+    String output = execute("can_walk_from_choice()");
+    assertThat(output, containsString("Returned: " + expected));
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -2912,8 +2912,10 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
   }
 
   @ParameterizedTest
-  // 570: GameInformPowerDailyPro Walkthru is walkawayable
-  @CsvSource({"570, true", "1, false"})
+  @CsvSource({
+    "570, true", // GameInformPowerDailyPro Walkthru - can walkaway
+    "1, false"
+  })
   void canWalkFromChoice(int choice, boolean expected) {
     var request = new GenericRequest("choice.php?whichchoice=" + choice);
     request.responseText = "whichchoice=" + choice;


### PR DESCRIPTION
Exposes `ChoiceManager.canWalkAway()` as `can_walk_from_choice()`.
https://github.com/kolmafia/kolmafia/blob/057f8a9fc80623723ec580bfe0321bf19091dc3d/src/net/sourceforge/kolmafia/session/ChoiceManager.java#L66

The name of the function itself, I'm not sure if it could be better. "walkawayable" is not a real word.

Did consider allowing callers to provide a choice id as a parameter, however I'm struggling to think of a situation where the caller would care about such a choice that's not the current choice.

So, this just tells the caller if the current choice can be walked from or not.

Useful for checking if we're stuck in a choice or not without actually trying to leave, paired with `handling_choice()`.

Possible improvement of also checking if we're handling a choice before returning true. But would pair with `last_choice()` not being reset when we finish a choice.