### PR TITLE
Fix maximizer recommending mode swaps when no score is achievable

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -1774,10 +1774,13 @@ public class Evaluator {
                         return forcedModeables.get(modeable);
                       }
 
-                      MaximizerSpeculation best = null;
                       CheckedItem item =
                           new CheckedItem(modeable.getItemId(), equipScope, maxPrice, priceLevel);
                       var bestMode = modeable.getState();
+                      MaximizerSpeculation best = new MaximizerSpeculation();
+                      best.attachment = item;
+                      best.equipment.put(modeable.getSlot(), item);
+                      best.setModeable(modeable, bestMode);
 
                       // Check each mode in modeable to determine the best
                       for (String mode : modeable.getModes()) {

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -1875,6 +1875,20 @@ public class MaximizerTest {
     }
 
     @Test
+    public void dontSwitchModeForZeroScoreWithoutTiebreaker() {
+      final var cleanups =
+          new Cleanups(
+              withEquipped(Slot.SHIRT, ItemPool.JURASSIC_PARKA),
+              withSkill(SkillPool.TORSO),
+              withProperty("parkaMode", "kachungasaur"));
+
+      try (cleanups) {
+        assertTrue(maximize("+adv, -tie"));
+        assertThat(getBoosts(), not(hasItem(hasProperty("cmd", startsWith("parka")))));
+      }
+    }
+
+    @Test
     public void higherBonusModeWins() {
       final var cleanups =
           new Cleanups(withEquippableItem("backup camera"), withProperty("backupCameraMode", "ml"));


### PR DESCRIPTION
https://kolmafia.us/threads/enable-item-modes-on-modifier-maximizer.32672/post-179940

Currently, there's a narrow case where if a modeable is already equipped, and there is no equipment available to get the score of the corresponding slot above zero, the maximizer result will recommend swapping to a random mode (depending on which mode's score it happened to calculate first). Instead, it should prefer keeping the current mode.