### PR TITLE
Check concoction names match items.txt spelling

### DIFF
--- a/src/data/concoctions.txt
+++ b/src/data/concoctions.txt
@@ -3094,7 +3094,7 @@ Melonegroni	MIX	antique watermelon	bottle of gin
 Quiskey Sour	MIX	quince	bottle of whiskey
 Aesop Daiquiri	MIX	classic banana	bottle of vodka
 Melonade Spritz	SCOCK	antique watermelon	boxed champagne
-Quinceañera Cooler	SCOCK	quince	bottle of Jorge Sinsonte
+Quincea&ntilde;era Cooler	SCOCK	quince	bottle of Jorge Sinsonte
 Monkey Congress	SCOCK	classic banana	bottle of Lieutenant Freeman
 concentrated watermelon juice	SAUCE	antique watermelon	scrumptious reagent
 quince quaff	SAUCE	quince	scrumptious reagent

--- a/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
@@ -765,6 +765,16 @@ public class DataFileConsistencyTest {
             if (id == -1) {
               fail("unrecognised item " + item + ".");
             }
+            // A leading [id] pins the item explicitly; the rest of the string is only a
+            // label and need not match. Otherwise the name must match items.txt exactly
+            // (e.g. HTML entities like &ntilde;).
+            if (!item.startsWith("[")) {
+              var canonical = ItemDatabase.getItemDataName(id);
+              if (canonical != null && !item.equals(canonical)) {
+                fail(
+                    "item name \"" + item + "\" in concoctions.txt should be \"" + canonical + "\".");
+              }
+            }
           }
         }
       }
@@ -800,6 +810,22 @@ public class DataFileConsistencyTest {
               var id = ItemDatabase.getExactItemId(ingredient);
               if (id == -1) {
                 fail("unrecognised item " + ingredient + " for item " + item + ".");
+              }
+              // A leading [id] pins the item explicitly; the rest of the string is only a
+              // label and need not match. Otherwise the name must match items.txt exactly
+              // (e.g. HTML entities like &ntilde;).
+              if (!ingredient.startsWith("[")) {
+                var canonical = ItemDatabase.getItemDataName(id);
+                if (canonical != null && !ingredient.equals(canonical)) {
+                  fail(
+                      "ingredient \""
+                          + ingredient
+                          + "\" for item "
+                          + item
+                          + " in concoctions.txt should be \""
+                          + canonical
+                          + "\".");
+                }
               }
             }
           }

--- a/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
+++ b/test/net/sourceforge/kolmafia/DataFileConsistencyTest.java
@@ -772,7 +772,11 @@ public class DataFileConsistencyTest {
               var canonical = ItemDatabase.getItemDataName(id);
               if (canonical != null && !item.equals(canonical)) {
                 fail(
-                    "item name \"" + item + "\" in concoctions.txt should be \"" + canonical + "\".");
+                    "item name \""
+                        + item
+                        + "\" in concoctions.txt should be \""
+                        + canonical
+                        + "\".");
               }
             }
           }


### PR DESCRIPTION
`DataFileConsistencyTest` now fails when a concoction output or ingredient name doesn't match the item's spelling in items.txt (e.g. a literal `ñ` instead of `&ntilde;`). Also fixes the one existing drift, Quinceañera Cooler.