### PR TITLE
Do not reset laughing stock charges on drop

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -7360,7 +7360,6 @@ public class FightRequest extends GenericRequest {
         || str.contains("Someone in the crowd hurls a piece of fruit at you")
         || str.contains("Someone lobs a piece of fruit at you from the crowd")) {
       FightRequest.logText("You were pelted with fruit.", status);
-      Preferences.setInteger("_laughingStockCharges", 0);
       Preferences.increment("_laughingStockFruitDropped", 1);
     }
 

--- a/test/net/sourceforge/kolmafia/request/FightRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FightRequestTest.java
@@ -4515,7 +4515,7 @@ public class FightRequestTest {
         String text = RequestLoggerOutput.stopStream();
 
         assertThat(text, containsString("pelted with fruit"));
-        assertThat("_laughingStockCharges", isSetTo(1));
+        assertThat("_laughingStockCharges", isSetTo(21));
         assertThat("_laughingStockFruitDropped", isSetTo(12));
       }
     }


### PR DESCRIPTION
It turns out that the seeded RNG for the Portable Laughing Stock depends on a daily counter that increments on successful fight but *does not* reset after a fruit drop. (This distinction doesn't matter in most cases, but does if you change paths mid-day, say, because you broke the prism.)