### PR TITLE
remove floristFriarChecked

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -736,7 +736,6 @@ user	flickeringPixel6	false
 user	flickeringPixel7	false
 user	flickeringPixel8	false
 user	floristFriarAvailable	false	roa
-user	floristFriarChecked	false	roa
 user	flyeredML	0
 user	forbiddenStores
 user	fossilB	0

--- a/src/net/sourceforge/kolmafia/request/FloristRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FloristRequest.java
@@ -145,8 +145,10 @@ public class FloristRequest extends GenericRequest {
   }
 
   public static void reset() {
-    Preferences.setBoolean("floristFriarChecked", false);
     FloristRequest.floristPlants.clear();
+    if (Preferences.propertyExists("floristFriarChecked")) {
+      Preferences.removeProperty("floristFriarChecked", false);
+    }
   }
 
   // forestvillage.php?action=floristfriar
@@ -177,6 +179,14 @@ public class FloristRequest extends GenericRequest {
       return;
     }
 
+    if (FloristRequest.haveFlorist()) {
+      return;
+    }
+
+    if (!FloristRequest.ownsFlorist()) {
+      return;
+    }
+
     PlaceRequest forestVisit = new PlaceRequest("forestvillage", "fv_friar", true);
     RequestThread.postRequest(forestVisit);
     FloristRequest.setFloristFriarAvailable(
@@ -190,9 +200,7 @@ public class FloristRequest extends GenericRequest {
       return;
     }
 
-    if (!Preferences.getBoolean("floristFriarChecked")) {
-      checkFloristAvailable();
-    }
+    checkFloristAvailable();
 
     if (!FloristRequest.haveFlorist()) {
       return;
@@ -203,16 +211,15 @@ public class FloristRequest extends GenericRequest {
     super.run();
   }
 
-  public static boolean haveFlorist() {
-    if (!Preferences.getBoolean("floristFriarChecked")) {
-      return false;
-    }
+  private static boolean ownsFlorist() {
+    return Preferences.getBoolean("ownsFloristFriar");
+  }
 
-    return Preferences.getBoolean("floristFriarAvailable");
+  public static boolean haveFlorist() {
+    return FloristRequest.ownsFlorist() && Preferences.getBoolean("floristFriarAvailable");
   }
 
   public static void setFloristFriarAvailable(final boolean floristAvailable) {
-    Preferences.setBoolean("floristFriarChecked", true);
     Preferences.setBoolean("floristFriarAvailable", floristAvailable);
   }
 

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -11122,9 +11122,7 @@ public abstract class RuntimeLibrary {
   }
 
   public static Value florist_available(ScriptRuntime controller) {
-    if (!Preferences.getBoolean("floristFriarChecked")) {
-      FloristRequest.checkFloristAvailable();
-    }
+    FloristRequest.checkFloristAvailable();
     return DataTypes.makeBooleanValue(FloristRequest.haveFlorist());
   }
 

--- a/test/net/sourceforge/kolmafia/DebugModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/DebugModifiersTest.java
@@ -357,7 +357,9 @@ public class DebugModifiersTest {
   @Test
   void listsFlorist() {
     try (var cleanups =
-        withFlorist(AdventurePool.NOOB_CAVE, FloristRequest.Florist.HORN_OF_PLENTY)) {
+        new Cleanups(
+            withProperty("ownsFloristFriar", true),
+            withFlorist(AdventurePool.NOOB_CAVE, FloristRequest.Florist.HORN_OF_PLENTY))) {
       evaluateDebugModifiers(DoubleModifier.ITEMDROP);
       assertThat(output(), containsDebugRow("Florist", "Horn of Plenty", 25.0, 25.0));
     }

--- a/test/net/sourceforge/kolmafia/request/FloristRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FloristRequestTest.java
@@ -1,9 +1,12 @@
 package net.sourceforge.kolmafia.request;
 
 import static internal.helpers.Networking.html;
+import static internal.helpers.Player.withPath;
+import static internal.helpers.Player.withProperty;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import internal.helpers.Cleanups;
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.preferences.Preferences;
@@ -19,33 +22,39 @@ public class FloristRequestTest {
 
   @Test
   public void unowned() {
-    Preferences.setBoolean("ownsFloristFriar", false);
-    FloristRequest.setFloristFriarAvailable(true);
-    assertFalse(FloristRequest.haveFlorist());
+    try (var cleanups =
+        new Cleanups(
+            withProperty("ownsFloristFriar", false), withProperty("floristFriarAvailable", true))) {
+      FloristRequest.setFloristFriarAvailable(true);
+      assertFalse(FloristRequest.haveFlorist());
+    }
   }
 
   @Test
   public void unavailable() {
-    Preferences.setBoolean("ownsFloristFriar", true);
-    String responseText = html("request/test_cant_get_there.html");
-    FloristRequest.parseResponse("choice.php?whichchoice=720", responseText);
-    assertFalse(FloristRequest.haveFlorist());
+    try (var cleanups = new Cleanups(withProperty("ownsFloristFriar", true))) {
+      String responseText = html("request/test_cant_get_there.html");
+      FloristRequest.parseResponse("choice.php?whichchoice=720", responseText);
+      assertFalse(FloristRequest.haveFlorist());
+    }
   }
 
   @Test
   public void available() {
-    Preferences.setBoolean("ownsFloristFriar", true);
-    String responseText = html("request/test_florist_friar.html");
-    FloristRequest.parseResponse("choice.php?whichchoice=720", responseText);
-    assertTrue(FloristRequest.haveFlorist());
+    try (var cleanups = new Cleanups(withProperty("ownsFloristFriar", true))) {
+      String responseText = html("request/test_florist_friar.html");
+      FloristRequest.parseResponse("choice.php?whichchoice=720", responseText);
+      assertTrue(FloristRequest.haveFlorist());
+    }
   }
 
   @Test
   public void availableLegacy() {
-    Preferences.setBoolean("ownsFloristFriar", true);
-    KoLCharacter.setPath(Path.LEGACY_OF_LOATHING);
-    String responseText = html("request/test_florist_friar.html");
-    FloristRequest.parseResponse("choice.php?whichchoice=720", responseText);
-    assertTrue(FloristRequest.haveFlorist());
+    try (var cleanups =
+        new Cleanups(withPath(Path.LEGACY_OF_LOATHING), withProperty("ownsFloristFriar", true))) {
+      String responseText = html("request/test_florist_friar.html");
+      FloristRequest.parseResponse("choice.php?whichchoice=720", responseText);
+      assertTrue(FloristRequest.haveFlorist());
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/request/FloristRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FloristRequestTest.java
@@ -6,8 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import net.sourceforge.kolmafia.AscensionPath.Path;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.persistence.QuestDatabase;
-import net.sourceforge.kolmafia.persistence.QuestDatabase.Quest;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,40 +18,34 @@ public class FloristRequestTest {
   }
 
   @Test
-  public void checked() {
-    FloristRequest.checkFloristAvailable();
+  public void unowned() {
+    Preferences.setBoolean("ownsFloristFriar", false);
+    FloristRequest.setFloristFriarAvailable(true);
     assertFalse(FloristRequest.haveFlorist());
-    assertFalse(Preferences.getBoolean("floristFriarChecked"));
-
-    QuestDatabase.setQuest(Quest.LARVA, QuestDatabase.STARTED);
-    FloristRequest.checkFloristAvailable();
-    assertFalse(FloristRequest.haveFlorist());
-    assertTrue(Preferences.getBoolean("floristFriarChecked"));
   }
 
   @Test
   public void unavailable() {
+    Preferences.setBoolean("ownsFloristFriar", true);
     String responseText = html("request/test_cant_get_there.html");
     FloristRequest.parseResponse("choice.php?whichchoice=720", responseText);
     assertFalse(FloristRequest.haveFlorist());
-    assertFalse(Preferences.getBoolean("floristFriarChecked"));
   }
 
   @Test
   public void available() {
+    Preferences.setBoolean("ownsFloristFriar", true);
     String responseText = html("request/test_florist_friar.html");
     FloristRequest.parseResponse("choice.php?whichchoice=720", responseText);
     assertTrue(FloristRequest.haveFlorist());
-    assertTrue(Preferences.getBoolean("floristFriarChecked"));
   }
 
   @Test
   public void availableLegacy() {
+    Preferences.setBoolean("ownsFloristFriar", true);
     KoLCharacter.setPath(Path.LEGACY_OF_LOATHING);
     String responseText = html("request/test_florist_friar.html");
     FloristRequest.parseResponse("choice.php?whichchoice=720", responseText);
     assertTrue(FloristRequest.haveFlorist());
-    assertTrue(Preferences.getBoolean("floristFriarChecked"));
-    assertFalse(Preferences.getBoolean("ownsFloristFriar"));
   }
 }


### PR DESCRIPTION
Now that we can rely on ownsFloristFriar being set from api.php coolitems, remove floristFriarChecked and don't check if floristFriar is available unless it is owned. This should prevent cases where checked was set incorrectly and florist friar was seen as unavailable when it should have been.