### PR TITLE
Fix append_buffer_to_file, buffer is not converted to string

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/javascript/ValueConverter.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/ValueConverter.java
@@ -27,7 +27,8 @@ public abstract class ValueConverter<ObjectType> {
   // These need special treatment. They accept a buffer as a first parameter, but we should cast
   // string to buffer in that position. These are the only functions that take a buffer as an
   // argument at the time of this comment.
-  private static final List<String> bufferFunctions = List.of("write_ccs", "buffer_to_file");
+  private static final List<String> bufferFunctions =
+      List.of("write_ccs", "buffer_to_file", "append_buffer_to_file");
 
   public static class ValueConverterException extends RuntimeException {
     public ValueConverterException(String message) {

--- a/test/net/sourceforge/kolmafia/textui/javascript/JSONValueConverterTest.java
+++ b/test/net/sourceforge/kolmafia/textui/javascript/JSONValueConverterTest.java
@@ -427,7 +427,13 @@ public class JSONValueConverterTest {
               "[\"abc\", \"ccs/x.ccs\"]",
               List.of(
                   new Value(DataTypes.BUFFER_TYPE, 0, null, new StringBuffer("abc")),
-                  DataTypes.makeStringValue("ccs/x.ccs"))));
+                  DataTypes.makeStringValue("ccs/x.ccs"))),
+          Arguments.of(
+              "append_buffer_to_file",
+              "[\"abc\", \"data/x.txt\"]",
+              List.of(
+                  new Value(DataTypes.BUFFER_TYPE, 0, null, new StringBuffer("abc")),
+                  DataTypes.makeStringValue("data/x.txt"))));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
So this issue was caused by https://github.com/kolmafia/kolmafia/pull/3570

The original PR had tested against `bufferToFile("buffer", "file", true)` - an extra parameter. That was confusing, and was silently dropped, but wasn't re-tested against the newer function name until a hour ago when converting my scripts over to use `appendFileToBuffer`.

It turns out there's a hardcoded list of function names that need their buffer parameter converted, and my previous integration accidentally fell into that hardcoded list. When not using an existing function name, there is no conversion.

The first test is a failing test.