### PR TITLE
Remove Curse of Vacation daily limit

### DIFF
--- a/src/data/dailylimits.txt
+++ b/src/data/dailylimits.txt
@@ -85,7 +85,6 @@ Cast	Conjure Meat Product	_jarlsMeatSummoned
 Cast	Conjure Potato	_jarlsPotatoSummoned
 Cast	Conjure Vegetables	_jarlsVeggiesSummoned
 Cast	Creepy Grin	_vmaskBanisherUsed	1
-Cast	Curse of Vacation	_curseOfVacationUsed	5
 Cast	Demand Sandwich	_demandSandwich	3
 Cast	Digitize	_sourceTerminalDigitizeUses	[1+pref(sourceTerminalChips,TRAM)+pref(sourceTerminalChips,TRIGRAM)]
 Cast	Do an epic McTwist!	_epicMcTwistUsed

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -2142,7 +2142,6 @@ user	_cupOf13sCharges	5
 user	_cupOf13sDrops	0
 user	_cupOf13sJewels	13
 user	_currentDartboard
-user	_curseOfVacationUsed	0
 user	_cursedKegUsed	false
 user	_cursedMicrowaveUsed	false
 user	_curveballMonster


### PR DESCRIPTION
It turns out the wiki lied and Curse of Vacation doesn't actually have a daily limit.