### PR TITLE
feat: add display name for legendaries and Crimbo '23 tiny plastics

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -1663,9 +1663,9 @@ Item	leechknife	Maximum HP: +10, Maximum MP: +5, HP Regen Min: 4, HP Regen Max: 
 # legendary pasta wand: Summon Legendary Noodles
 # legendary pasta wand: Cook up to 5 items per day without using an Adventure
 # legendary pasta wand: Pasta Thralls Go Up to 11 (Pastamancer Only)
-Item	legendary pasta wand	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Single Equip, Last Available: "2026-05", Pasta Thrall Experience: 1
+Item	legendary pasta wand	Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Single Equip, Last Available: "2026-05", Pasta Thrall Experience: 1, Display Name: "<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>"
 # legendary seal-clubbing club: Increase Fury Capacity and Generation (Seal Clubbers Only)
-Item	legendary seal-clubbing club	Muscle Percent: +50, Weapon Damage: [10*L], Initiative: +50, Attacks Can't Miss, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+Item	legendary seal-clubbing club	Muscle Percent: +50, Weapon Damage: [10*L], Initiative: +50, Attacks Can't Miss, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Display Name: "<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>"
 # licorice whip: Candiful Crits
 Item	licorice whip	Critical Hit Percent: +5, Last Available: "2014-12"
 Item	lightning rod	Spell Damage Percent: +200, Maximum MP: +50, MP Regen Min: 5, MP Regen Max: 10, Lasts Until Rollover
@@ -3945,7 +3945,7 @@ Item	tiny plastic 7-foot dwarf	Monster Level: +1
 Item	tiny plastic 11 Dealer	Meat Drop: +4, Last Available: "2009-12"
 Item	tiny plastic abominable fudgeman	Weapon Damage: +10, Last Available: "2011-12"
 Item	tiny plastic Abuela Crimbo	Spooky Resistance: +1, Last Available: "2018-12"
-Item	tiny plastic Abuela's cottage	Muscle: +3, Mysticality: +3, Moxie: +3
+Item	tiny plastic Abuela's cottage	Muscle: +3, Mysticality: +3, Moxie: +3, Display Name: "tiny plastic Abuela's Cottage (Pirate Control)"
 Item	tiny plastic accordion thief	Moxie: +2, Mysticality: +1
 Item	tiny plastic ambulatory robo-minecart	Moxie: +1, Last Available: "2014-12"
 Item	tiny plastic Ancient Unspeakable Bugbear	Monster Level: +1, Last Available: "2012-12"
@@ -3957,12 +3957,12 @@ Item	tiny plastic angry vikings	Weapon Damage: +10, Last Available: "2016-12"
 Item	tiny plastic anime smiley	Monster Level: +1
 Item	tiny plastic animelf	Initiative: +5, Last Available: "2012-12"
 Item	tiny plastic apathetic lizardman	Monster Level: +1
-Item	tiny plastic Armory	Weapon Damage: +3
+Item	tiny plastic Armory	Weapon Damage: +3, Display Name: "tiny plastic Elf Guard Armory"
 Item	tiny plastic astronomer	Monster Level: +1
 Item	tiny plastic Axe Wound	Monster Level: +1
 Item	tiny plastic baby gravy fairy	Familiar Weight: +1
 Item	tiny plastic bad vibe	Monster Level: +2, Last Available: "2016-12"
-Item	tiny plastic Bar	Booze Drop: +3
+Item	tiny plastic Bar	Booze Drop: +3, Display Name: "tiny plastic Crimbuccaneer Grog Hall"
 Item	tiny plastic Baron von Ratsworth	Meat Drop: +3
 Item	tiny plastic barrrnacle	Familiar Weight: +1
 Item	tiny plastic batbugbear	Monster Level: +1, Last Available: "2012-12"
@@ -3991,7 +3991,7 @@ Item	tiny plastic Bugbear Captain	Maximum HP: +20, Maximum MP: +20, HP Regen Min
 Item	tiny plastic buzzerker	Monster Level: +1, Last Available: "2012-12"
 Item	tiny plastic caboose	Last Available: "2022-12", Damage Reduction: 3
 Item	tiny plastic Caf&eacute; Elf	Hot Resistance: +1, Last Available: "2018-12"
-Item	tiny plastic Cafe	Food Drop: +3
+Item	tiny plastic Cafe	Food Drop: +3, Display Name: "tiny plastic Elf Guard Mess Hall"
 Item	tiny plastic Captain Kerkard	Monster Level: +1
 Item	tiny plastic cavebugbear	Monster Level: +1, Last Available: "2012-12"
 Item	tiny plastic Charity the Zombie Hunter	Monster Level: +1, Last Available: "2012-12"
@@ -4033,7 +4033,7 @@ Item	tiny plastic Duke Starkiller	Monster Level: +1
 Item	tiny plastic Easter Island Bunny	Damage Reduction: 3, Last Available: "2024-12"
 Item	tiny plastic Ed the Undying	Maximum HP: +30, Damage Absorption: +30
 Item	tiny plastic exo-suited miner	Muscle: +1, Last Available: "2014-12"
-Item	tiny plastic Factory	Initiative: +3
+Item	tiny plastic Factory	Initiative: +3, Display Name: "tiny Crimbuccaneer Foundry"
 Item	tiny plastic fat stack of cash	Meat Drop: +3, Last Available: "2008-12"
 Item	tiny plastic Father McGruber	Monster Level: +1, Last Available: "2012-12"
 Item	tiny plastic fax machine	Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2, Last Available: "2010-12"

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -2419,7 +2419,7 @@ public abstract class KoLCharacter {
     return name.contains("u") || name.contains("U");
   }
 
-  private static final Pattern S_WORD_PATTERN = Pattern.compile("(?<!\\S)[Ss]\\S*");
+  private static final Pattern S_WORD_PATTERN = Pattern.compile("(?<![^\\s<])[Ss]\\S*");
 
   public static final int getSwordOfSWordsosity() {
     return KoLCharacter.getSwordOfSWordsosity(EquipmentManager.currentEquipment());
@@ -2431,7 +2431,10 @@ public abstract class KoLCharacter {
     for (var slot : SlotSet.SLOTS) {
       var equip = equipment.get(slot);
       if (equip == null) continue;
-      String name = equip.getName();
+      String displayName =
+          ModifierDatabase.getStringModifier(
+              ModifierType.ITEM, equip.id, StringModifier.DISPLAY_NAME);
+      String name = displayName.isEmpty() ? equip.getName() : displayName;
       swords += KoLCharacter.getSwordOfSWordsosity(name);
     }
 

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -2419,7 +2419,7 @@ public abstract class KoLCharacter {
     return name.contains("u") || name.contains("U");
   }
 
-  private static final Pattern S_WORD_PATTERN = Pattern.compile("(?<![^\\s<])[Ss]\\S*");
+  private static final Pattern S_WORD_PATTERN = Pattern.compile("(?<!\\S)[Ss]\\S*");
 
   public static final int getSwordOfSWordsosity() {
     return KoLCharacter.getSwordOfSWordsosity(EquipmentManager.currentEquipment());
@@ -2442,6 +2442,7 @@ public abstract class KoLCharacter {
   }
 
   public static final int getSwordOfSWordsosity(String name) {
+    name = name.replaceAll("[^0-9A-Za-z ]", "");
     return (int) KoLCharacter.S_WORD_PATTERN.matcher(name).results().count();
   }
 

--- a/src/net/sourceforge/kolmafia/modifiers/StringModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/StringModifier.java
@@ -68,7 +68,8 @@ public enum StringModifier implements Modifier {
       "Conditional Skill (Inventory)",
       Pattern.compile("Conditional Skill \\(Inventory\\): \"(.*?)\""),
       true),
-  LANTERN_ELEMENT("Lantern Element", Pattern.compile("Lantern Element: \"(.*?)\""), true);
+  LANTERN_ELEMENT("Lantern Element", Pattern.compile("Lantern Element: \"(.*?)\""), true),
+  DISPLAY_NAME("Display Name", Pattern.compile("Display Name: \"(.*?)\""));
   private final String name;
   private final Pattern[] descPatterns;
   private final Pattern tagPattern;

--- a/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
+++ b/test/net/sourceforge/kolmafia/ModifierExpressionTest.java
@@ -627,6 +627,8 @@ public class ModifierExpressionTest {
       "Stick-Knife of Loathing, 1",
       "spooky staff, 2",
       "star sword, 2",
+      "legendary pasta wand, 2",
+      "legendary seal-clubbing club, 3",
     })
     public void canDetectSwordOfSwords(String item, String expected) {
       var cleanups = withEquipped(Slot.WEAPON, item);


### PR DESCRIPTION
Adjust the S Word detection to agree with observed behaviour for the legendary weapons.

Closes #3482.