### PR TITLE
Add daily limits for Heavy Rains 1/day skills

### DIFF
--- a/src/data/dailylimits.txt
+++ b/src/data/dailylimits.txt
@@ -136,6 +136,7 @@ Cast	Jump Shark	_peteJumpedShark	3
 Cast	KGB tranquilizer dart	_kgbTranquilizerDartUses	3
 Cast	Lash of the Cobra	_edLashCount	30
 Cast	Launch spikolodon spikes	_spikolodonSpikeUses	5
+Cast	Lightning Rod	_lightningRodCast
 Cast	Lock Picking	lockPicked
 Cast	Long Con	_longConUsed	5
 Cast	Lunch Break	_lunchBreak
@@ -161,6 +162,7 @@ Cast	Portscan	_sourceTerminalPortscanUses	3
 Cast	Prelude of Precision	_precisionCasts	10
 Cast	Prevent Scurvy and Sobriety	_preventScurvy
 Cast	Psychokinetic Hug	_psychokineticHugUsed
+Cast	Rain Coat	_rainCoatCast
 Cast	Rainbow Gravitation	prismaticSummons	3
 Cast	Recall Facts: %phylum Circadian Rhythms	_circadianRhythmsRecalled
 Cast	Recall Facts: Monster Habitats	_monsterHabitatsRecalled	3
@@ -202,6 +204,7 @@ Cast	The Ballad of Richie Thingfinder	_thingfinderCasts	10
 Cast	The Smile of Mr. A.	_smilesOfMrA	[pref(goldenMrAccessories)*5]
 Cast	Throw Latte on Opponent	_latteBanishUsed
 Cast	Throw Party	_petePartyThrown
+Cast	Thunder Down Underwear	_thunderDownUnderwearCast
 Cast	Transcendent Olfaction	_olfactionsUsed	3
 Cast	Turtle Power	_turtlePowerCast
 Cast	Use the Force	_saberForceUses	5

--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -2474,6 +2474,7 @@ user	_legionJackhammerCrafting	0
 user	_leprecondoRearrangements	0
 user	_leprecondoFurniture	0
 user	_licenseToChillUsed	false
+user	_lightningRodCast	false
 user	_llamaCharge	0
 user	_locketMonstersFought
 user	_lodestoneUsed	false
@@ -2659,6 +2660,7 @@ user	_questPartyFairQuest
 user	_questPirateRealm	unstarted
 user	_radlibSummons	0
 user	_raindohCopiesMade	0
+user	_rainCoatCast	false
 user	_rainStickUsed	false
 user	_rapidPrototypingUsed	0
 user	_raveStealCount	0
@@ -2816,6 +2818,7 @@ user	_thesisDelivered	false
 user	_thingfinderCasts	0
 user	_thinknerdPackageDrops	0
 user	_thorsPliersCrafting	0
+user	_thunderDownUnderwearCast	false
 user	_tiedUpFlamingLeafletFought	false
 user	_tiedUpFlamingMonsteraFought	false
 user	_tiedUpLeaviathanFought	false


### PR DESCRIPTION
Adds daily limits for Lightning Rod, Rain Coat, and Thunder Down Underwear. I verified that these can actually only be cast once per day despite the skill description not explicitly saying so (rather than, say, being castable multiple times but only doing something the first time).

ref: https://kolmafia.us/threads/all-skills-with-daily-limits-should-appear-in-dailylimits-txt.32632/post-179914