### PR TITLE
Add git url remapping

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -60,6 +60,7 @@ global	getBreakfast
 global	gitInstallDependencies	true
 global	gitShowCommitMessages	false
 global	gitUpdateOnLogin	false
+global	gitUrlRemaps
 global	greenScreenProtection	false
 global	guiUsesOneWindow	false
 global	headerStates	Usable|item name:0|autosell:1|quantity:2|mallprice:-1|power:-1|fill:-1|adv/fill:-1;Restores|item name:0|autosell:1|quantity:2|mallprice:-1|HP restore:-1|MP restore:-1;General|item name:0|autosell:1|quantity:2|mallprice:-1|power:-1|fill:-1|adv/fill:-1;Recent|item name:0|autosell:1|quantity:2|mallprice:-1|power:-1|fill:-1|adv/fill:-1;Closet|item name:0|autosell:1|quantity:2|mallprice:-1|power:-1|fill:-1|adv/fill:-1;Storage|item name:0|autosell:1|quantity:2|mallprice:-1|power:-1|fill:-1|adv/fill:-1;Free Pulls|item name:0|autosell:1|quantity:2|mallprice:-1|power:-1|fill:-1|adv/fill:-1;Creatable|item name:0|autosell:1|quantity:2|mallprice:-1|fill:-1|adv/fill:-1|level req:-1;Cookable|item name:0|autosell:1|quantity:2|mallprice:-1|fill:-1|adv/fill:-1|level req:-1;Mixable|item name:0|autosell:1|quantity:2|mallprice:-1|fill:-1|adv/fill:-1|level req:-1;Fine Tuning|not implemented:0;Equipment|item name:0|power:1|quantity:2|mallprice:-1|autosell:-1;Storage|item name:0|autosell:1|quantity:2|mallprice:-1|power:-1|fill:-1|adv/fill:-1;Create|item name:0|autosell:1|quantity:2|mallprice:-1|fill:-1|adv/fill:-1|level req:-1;

--- a/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
@@ -59,6 +59,8 @@ public class GitManager extends ScriptManager {
   }
 
   public static boolean clone(String repoUrl, String branch) {
+    String originalUrl = repoUrl;
+    repoUrl = GitUrlRemap.remapUrl(repoUrl);
     String id = getRepoId(repoUrl, branch);
     Path projectPath = KoLConstants.GIT_LOCATION.toPath().resolve(id);
     if (Files.exists(projectPath)) {
@@ -66,6 +68,9 @@ public class GitManager extends ScriptManager {
           MafiaState.ERROR,
           "Cannot clone project to " + id + ", folder already exists. Please delete to checkout.");
       return false;
+    }
+    if (!originalUrl.equals(repoUrl)) {
+      RequestLogger.printLine("Remapped " + originalUrl + " => " + repoUrl);
     }
     var git =
         Git.cloneRepository()
@@ -586,6 +591,7 @@ public class GitManager extends ScriptManager {
   }
 
   public static String getRepoId(String repoUrl, String branch) {
+    repoUrl = GitUrlRemap.remapUrl(repoUrl);
     String dashBranch = branch == null ? "" : "-" + branch;
     if (repoUrl.endsWith(".git")) {
       repoUrl = repoUrl.substring(0, repoUrl.length() - 4);

--- a/src/net/sourceforge/kolmafia/scripts/git/GitUrlRemap.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitUrlRemap.java
@@ -1,0 +1,58 @@
+package net.sourceforge.kolmafia.scripts.git;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import net.sourceforge.kolmafia.listener.Listener;
+import net.sourceforge.kolmafia.listener.PreferenceListenerRegistry;
+import net.sourceforge.kolmafia.preferences.Preferences;
+
+public class GitUrlRemap implements Listener {
+  static {
+    PreferenceListenerRegistry.registerPreferenceListener("gitUrlRemaps", new GitUrlRemap());
+  }
+
+  private static volatile Map<String, String> urlRemaps = Map.of();
+
+  private GitUrlRemap() {}
+
+  public static String remapUrl(String url) {
+    if (url == null || url.isBlank()) return url;
+    var lowerUrl = url.toLowerCase();
+    for (var entry : urlRemaps.entrySet()) {
+      var key = entry.getKey();
+      var lowerKey = key.toLowerCase();
+      if (lowerUrl.startsWith(lowerKey)
+          && (lowerUrl.length() == lowerKey.length()
+              || lowerUrl.charAt(lowerKey.length()) == '/')) {
+        return entry.getValue() + url.substring(key.length());
+      }
+    }
+    return url;
+  }
+
+  @Override
+  public void update() {
+    reload();
+  }
+
+  static void reload() {
+    var value = Preferences.getString("gitUrlRemaps");
+    if (value == null || value.isBlank()) {
+      urlRemaps = Map.of();
+      return;
+    }
+    var result = new LinkedHashMap<String, String>();
+    for (var pair : value.split(";")) {
+      var trimmed = pair.trim();
+      if (trimmed.isBlank() || !trimmed.contains("|")) continue;
+      var idx = trimmed.indexOf('|');
+      result.put(trimmed.substring(0, idx).trim(), trimmed.substring(idx + 1).trim());
+    }
+    urlRemaps = result;
+  }
+
+  static Listener createListener() {
+    reload();
+    return new GitUrlRemap();
+  }
+}

--- a/src/net/sourceforge/kolmafia/scripts/git/GitUrlRemap.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitUrlRemap.java
@@ -23,7 +23,8 @@ public class GitUrlRemap implements Listener {
       var lowerKey = key.toLowerCase();
       if (lowerUrl.startsWith(lowerKey)
           && (lowerUrl.length() == lowerKey.length()
-              || lowerUrl.charAt(lowerKey.length()) == '/')) {
+              || lowerUrl.charAt(lowerKey.length()) == '/'
+              || lowerUrl.charAt(lowerKey.length()) == '.')) {
         return entry.getValue() + url.substring(key.length());
       }
     }

--- a/test/net/sourceforge/kolmafia/scripts/git/GitUrlRemapTest.java
+++ b/test/net/sourceforge/kolmafia/scripts/git/GitUrlRemapTest.java
@@ -1,0 +1,180 @@
+package net.sourceforge.kolmafia.scripts.git;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import net.sourceforge.kolmafia.preferences.Preferences;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class GitUrlRemapTest {
+
+  private void withRemaps(String value, Runnable fn) {
+    Preferences.setString("gitUrlRemaps", value);
+    GitUrlRemap.reload();
+    try {
+      fn.run();
+    } finally {
+      Preferences.setString("gitUrlRemaps", "");
+      GitUrlRemap.reload();
+    }
+  }
+
+  @Nested
+  class BasicRemap {
+    @Test
+    void shouldReturnNullForNullInput() {
+      assertEquals(null, GitUrlRemap.remapUrl(null));
+    }
+
+    @Test
+    void shouldReturnBlankForBlankInput() {
+      assertEquals("", GitUrlRemap.remapUrl(""));
+    }
+
+    @Test
+    void shouldReturnUnchangedWhenNoRemaps() {
+      assertEquals(
+          "https://github.com/org/repo.git",
+          GitUrlRemap.remapUrl("https://github.com/org/repo.git"));
+    }
+
+    @Test
+    void shouldApplyExactPrefixMatch() {
+      withRemaps(
+          "https://github.com/org|https://github.com/fork",
+          () -> {
+            assertEquals(
+                "https://github.com/fork/repo.git",
+                GitUrlRemap.remapUrl("https://github.com/org/repo.git"));
+          });
+    }
+
+    @Test
+    void shouldApplyFullUrlReplacement() {
+      withRemaps(
+          "https://github.com/original/repo.git|https://github.com/fork/alt-repo.git",
+          () -> {
+            assertEquals(
+                "https://github.com/fork/alt-repo.git",
+                GitUrlRemap.remapUrl("https://github.com/original/repo.git"));
+          });
+    }
+
+    @Test
+    void shouldNotMatchPartialPrefix() {
+      withRemaps(
+          "https://github.com/org|https://github.com/fork",
+          () -> {
+            // Should NOT match because org is followed by '2', not '/'
+            assertEquals(
+                "https://github.com/org2/repo.git",
+                GitUrlRemap.remapUrl("https://github.com/org2/repo.git"));
+          });
+    }
+
+    @Test
+    void shouldMatchExactUrlWithNoSuffix() {
+      withRemaps(
+          "https://github.com/org|https://github.com/fork",
+          () -> {
+            // Should match when the URL is exactly the prefix (edge case)
+            assertEquals("https://github.com/fork", GitUrlRemap.remapUrl("https://github.com/org"));
+          });
+    }
+  }
+
+  @Nested
+  class MultipleRemaps {
+    @Test
+    void shouldApplyFirstMatchingRemap() {
+      withRemaps(
+          "https://github.com/org1|https://github.com/fork1;https://github.com/org2|https://github.com/fork2",
+          () -> {
+            assertEquals(
+                "https://github.com/fork1/repo.git",
+                GitUrlRemap.remapUrl("https://github.com/org1/repo.git"));
+            assertEquals(
+                "https://github.com/fork2/other.git",
+                GitUrlRemap.remapUrl("https://github.com/org2/other.git"));
+          });
+    }
+
+    @Test
+    void shouldUseInsertionOrder() {
+      withRemaps(
+          "https://github.com/org/repo.git|https://github.com/fork/alt.git;https://github.com/org|https://github.com/fork",
+          () -> {
+            // First-defined remap takes precedence
+            assertEquals(
+                "https://github.com/fork/alt.git",
+                GitUrlRemap.remapUrl("https://github.com/org/repo.git"));
+            // Generic remap still works for other repos
+            assertEquals(
+                "https://github.com/fork/other.git",
+                GitUrlRemap.remapUrl("https://github.com/org/other.git"));
+          });
+    }
+  }
+
+  @Nested
+  class EdgeCases {
+    @Test
+    void shouldIgnoreMalformedRemap() {
+      withRemaps(
+          "no-pipe-here;https://github.com/org|https://github.com/fork",
+          () -> {
+            // Only the valid remap should be applied
+            assertEquals(
+                "https://github.com/fork/repo.git",
+                GitUrlRemap.remapUrl("https://github.com/org/repo.git"));
+          });
+    }
+
+    @Test
+    void shouldIgnoreEmptyRemap() {
+      withRemaps(
+          ";;https://github.com/org|https://github.com/fork;;",
+          () -> {
+            assertEquals(
+                "https://github.com/fork/repo.git",
+                GitUrlRemap.remapUrl("https://github.com/org/repo.git"));
+          });
+    }
+
+    @Test
+    void shouldHandleSpaces() {
+      withRemaps(
+          "  https://github.com/org | https://github.com/fork  ",
+          () -> {
+            assertEquals(
+                "https://github.com/fork/repo.git",
+                GitUrlRemap.remapUrl("https://github.com/org/repo.git"));
+          });
+    }
+  }
+
+  @Nested
+  class CaseInsensitivity {
+    @Test
+    void shouldMatchCaseInsensitive() {
+      withRemaps(
+          "https://github.com/ORG|https://github.com/fork",
+          () -> {
+            assertEquals(
+                "https://github.com/fork/repo.git",
+                GitUrlRemap.remapUrl("https://github.com/org/repo.git"));
+          });
+    }
+
+    @Test
+    void shouldPreserveOriginalCase() {
+      withRemaps(
+          "https://github.com/org|https://github.com/fork",
+          () -> {
+            assertEquals(
+                "https://github.com/fork/Repo.git",
+                GitUrlRemap.remapUrl("https://github.com/org/Repo.git"));
+          });
+    }
+  }
+}


### PR DESCRIPTION
Intent is to be able to use a fork of a git script and have any urls in dependencies.txt be remapped automatically.

The issue I'm trying to solve is that multiple git repos will be cloned and there is no way to control which one is synced to the scripts directory.

Format of the `gitUrlRemaps` property is `a|b:c|d:...`, the first matched is used. I also print out that a url has been remapped before cloning.