### PR TITLE
feat: separate shield DR from enchantment DR

### DIFF
--- a/src/data/equipment.txt
+++ b/src/data/equipment.txt
@@ -1910,38 +1910,38 @@ adhesive tape dolly	0	none
 adobe abacus	120	Mys: 40
 Adventurer bobblehead	100	none
 aerogel attache case	50	none
-ancient calendar	70	Mus: 20	shield
+ancient calendar	70	Mus: 20	shield: 4
 ancient hot dog wrapper	200	Mys: 85
-ancient stone head	85	Mus: 27	shield
+ancient stone head	85	Mus: 27	shield: 5
 anniversary balloon	10	none
 anniversary chutney sculpture	10	none
 antique Canadian lantern	150	Mys: 60
 antique candy bucket	10	none
 antique nutcracker drumstick	150	Mys: 30
-antique shield	180	Mus: 60	shield
+antique shield	180	Mus: 60	shield: 11
 antique spyglass	225	Mys: 200
-April Shower Thoughts shield	100	none	shield
+April Shower Thoughts shield	100	none	shield: 6
 Apriling band staff	100	none
-arm buzzer	100	Mus: 25	shield
+arm buzzer	100	Mus: 25	shield: 6
 arrow'd heart balloon	10	none
-astral shield	240	none	shield
+astral shield	240	none	shield: 15
 astral statuette	50	none
 august scepter	0	none
-autumn debris shield	150	none	shield
-autumnal aegis	150	Mus: 25	shield
+autumn debris shield	150	none	shield: 9
+autumnal aegis	150	Mus: 25	shield: 9
 Bag o' Tricks	0	none
 bag of Crotchety Pine saplings	10	none
 bag of Laughing Willow saplings	10	none
 bag of Saccharine Maple saplings	10	none
 bakelite bowl	120	Mus: 40
 ball-in-a-cup	20	none
-balloon shield	50	Mus: 10	shield
-barrel lid	150	none	shield
-barskin buckler	25	none	shield
-basaltamander buckler	240	Mus: 40	shield
+balloon shield	50	Mus: 10	shield: 3
+barrel lid	150	none	shield: 9
+barskin buckler	25	none	shield: 1
+basaltamander buckler	240	Mus: 40	shield: 15
 Baseball Diamond	100	none
 basic meat foon	50	Mys: 10
-battered hubcap	220	Mus: 65	shield
+battered hubcap	220	Mus: 65	shield: 14
 beach ball marble	209	Mys: 85
 beetle antenna	0	none
 beige clambroth marble	207	Mys: 85
@@ -1950,7 +1950,7 @@ big bumboozer marble	211	Mys: 85
 big hot pepper	50	none
 birdybug antenna	0	none
 black catseye marble	210	Mys: 85
-black shield	160	Mus: 65	shield
+black shield	160	Mus: 65	shield: 10
 blue LavaCo Lamp&trade;	100	Mys: 35
 bobble-hip hula elf doll	40	Mys: 5
 bone abacus	100	Mys: 5
@@ -1962,25 +1962,25 @@ bottle of Goldschn&ouml;ckered	75	Mox: 22
 bouquet of all-natural free-range flowers	10	none
 bowl of petunias	100	Mys: 44
 box	10	none
-box turtle	50	Mus: 10	shield
+box turtle	50	Mus: 10	shield: 3
 box-in-the-box	20	none
 box-in-the-box-in-the-box	30	none
 Brand of Violence	200	Mus: 125
-brass dorsal fin	200	Mus: 85	shield
+brass dorsal fin	200	Mus: 85	shield: 13
 bread basket	0	none
-BRICKO bulwark	60	none	shield
-Brimstone Bunker	240	Mus: 30	shield
+BRICKO bulwark	60	none	shield: 3
+Brimstone Bunker	240	Mus: 30	shield: 15
 brown crock marble	202	Mys: 85
 bumblebee marble	205	Mys: 85
 burning paper crane	100	none
 C.H.U.M. lantern	100	Mus: 150
 can of mixed everything	100	Mys: 30
 card sleeve	10	none
-cardboard box turtle	70	Mus: 20	shield
+cardboard box turtle	70	Mus: 20	shield: 4
 cardboard wine carrier	10	none
 carnivorous potted plant	150	none
-catskin buckler	180	Mus: 75	shield
-ceramic centurion shield	150	Mus: 40	shield
+catskin buckler	180	Mus: 75	shield: 11
+ceramic centurion shield	150	Mus: 40	shield: 9
 Chalice of the Malkovich Prince	0	none
 chalk chalice	50	none
 charged druidic orb	10	none
@@ -1988,12 +1988,12 @@ charged magnet	30	none
 chiffon chamberpot	50	none
 chipped coffee mug	50	none
 chocolate and nylons detector	10	Mys: 20
-Cloaca-Cola shield	70	none	shield
+Cloaca-Cola shield	70	none	shield: 4
 clockwork detective skull	80	Mox: 25
-clownskin buckler	60	Mus: 15	shield
+clownskin buckler	60	Mus: 15	shield: 3
 cobbled-together Meat detector	10	none
 Codex of Capsaicin Conjuration	30	none
-coffin lid	50	Mus: 10	shield
+coffin lid	50	Mus: 10	shield: 3
 Cold Stone of Hatred	200	Mus: 125
 collapsible baton	200	Mys: 85
 complicated device	200	Mys: 200
@@ -2023,18 +2023,18 @@ cursed magnifying glass	100	none
 cursed ship's lantern	120	Mys: 20
 cursed stats	0	none
 cyborg doll	110	Mys: 40
-Dallas Dynasty Falcon Crest shield	240	Mus: 85	shield
+Dallas Dynasty Falcon Crest shield	240	Mus: 85	shield: 15
 deceased crimbo tree	50	none
 deck of lewd playing cards	75	Mys: 22
 deck of tropical cards	20	none
 defective skull	60	none
 deft pirate hook	100	none
-demon buckler	80	Mus: 25	shield
+demon buckler	80	Mus: 25	shield: 5
 depleted Grimacite gravy boat	100	Mus: 35
 detective skull	60	none
-detour shield	100	Mus: 35	shield
+detour shield	100	Mus: 35	shield: 6
 Diamond HP-35 Calculator	0	none
-Dinsey's radar dish	240	Mus: 100	shield
+Dinsey's radar dish	240	Mus: 100	shield: 15
 dirty rigging rope	100	Mus: 30
 discarded finger painting	50	none
 disturbing fanfic	60	Mys: 15
@@ -2042,11 +2042,11 @@ double-ice box	70	Mys: 20
 drippy shield	0	none
 druidic orb	10	none
 Drunkula's wineglass	300	Mys: 100
-duct tape buckler	195	Mus: 82	shield
+duct tape buckler	195	Mus: 82	shield: 12
 Dungeon Fist gauntlet	100	Mus: 35
-Dyspepsi-Cola shield	70	none	shield
+Dyspepsi-Cola shield	70	none	shield: 4
 easter egg balloon	100	Mys: 35
-eelskin shield	200	Mus: 85	shield
+eelskin shield	200	Mus: 85	shield: 13
 Elf Guard clipboard	100	none
 Elf Guard safety bear	10	none
 Elf Guard war standard	50	none
@@ -2061,7 +2061,7 @@ eye of the Tiger-lily	70	Mys: 20
 faded green protest sign	10	none
 faded red protest sign	0	none
 fake hand	10	none
-fake washboard	200	Mus: 50	shield
+fake washboard	200	Mus: 50	shield: 13
 familiar scrapbook	100	none
 fancy marzipan briefcase	100	Mys: 10
 fancy opera glasses	50	Mys: 10
@@ -2069,13 +2069,13 @@ fiberglass fetish	120	Mus: 40
 fireproof megaphone	10	none
 fishbone catcher's mitt	20	none
 flagstone flag	120	Mus: 40
-flak shield	150	Mus: 30	shield
+flak shield	150	Mus: 30	shield: 9
 flaming fistbone	150	Mys: 60
 flaming talons	90	Mys: 30
-fleshy lump	50	none	shield
+fleshy lump	50	none	shield: 3
 flickering flashlight	50	none
-flimsy clipboard	50	Mus: 10	shield
-flimsy plastic shield	50	none	shield
+flimsy clipboard	50	Mus: 10	shield: 3
+flimsy plastic shield	50	none	shield: 3
 flimsy ski pole	50	none
 foon	30	none
 foon of fearfulness	50	Mys: 10
@@ -2086,36 +2086,36 @@ foon of fulmination	50	Mys: 10
 Franken Stein	0	none
 frankincenser	100	none
 Frigid Northern Beans	30	none	can of beans
-furry yam buckler	50	none	shield
+furry yam buckler	50	none	shield: 3
 Gazpacho's Glacial Grimoire	30	none
 geofencing shield	150	none
 geological sample kit	10	none
-ghast iron heater shield	180	Mus: 75	shield
+ghast iron heater shield	180	Mus: 75	shield: 11
 ghostly reins	50	none
-giant clay ashtray	60	none	shield
-giant penguin keychain	155	Mus: 62	shield
+giant clay ashtray	60	none	shield: 3
+giant penguin keychain	155	Mus: 62	shield: 10
 giant stuffed bugbear	10	none
 gingerbread moneybag	0	none
 Glass Balls of the Goblin King	70	Mys: 20
 glass gnoll eye	35	Mys: 2
-glass pie plate	120	none	shield
+glass pie plate	120	none	shield: 7
 glow-in-the-dark stuffed burrowgrub	0	none
 glowing esca	200	Mys: 85
 glowstick on a string	150	Mox: 60
 glued-together crystal ball	50	none
-gnauga hide buckler	90	Mus: 30	shield
+gnauga hide buckler	90	Mus: 30	shield: 5
 Golden HP-35 Calculator	0	none
 golden sausage	0	none
 goo magnet	10	none
 gore bucket	10	none
-gravyskin buckler	120	Mus: 30	shield
+gravyskin buckler	120	Mus: 30	shield: 7
 Great Wolf's left paw	300	Mus: 250
 green balloon	10	none
 green LavaCo Lamp&trade;	100	Mox: 35
 green peawee marble	201	Mys: 85
 Grey Guanon	60	Mys: 15
-grisly shield	200	Mus: 150	shield
-gunwale	150	none	shield
+grisly shield	200	Mus: 150	shield: 13
+gunwale	150	none	shield: 9
 Guzzlr souvenir stein	100	none
 Half a Purse	100	none
 hand of Mr. Cards	10	none
@@ -2123,11 +2123,11 @@ handmade hobby horse	20	none
 heart-shaped balloon	10	none
 heavy duty umbrella	10	none
 heavy pickaxe	0	none
-heavy-duty clipboard	125	Mus: 47	shield
+heavy-duty clipboard	125	Mus: 47	shield: 8
 Heimz Fortified Kidney Beans	40	Mys: 5	can of beans
 Hellfire Spicy Beans	30	none	can of beans
-hippo skin buckler	90	Mus: 30	shield
-HOA regulation book	350	Mus: 100	shield
+hippo skin buckler	90	Mus: 30	shield: 5
+HOA regulation book	350	Mus: 100	shield: 23
 hobo code binder	10	none
 Hodgman's almanac	200	Mys: 200
 Hodgman's cane	200	Mys: 200
@@ -2136,22 +2136,22 @@ Hodgman's harmonica	200	Mox: 200
 Hodgman's imaginary hamster	200	Mys: 200
 Hodgman's metal detector	200	Mus: 200
 Hodgman's varcolac paw	200	Mus: 200
-hors d'oeuvre tray	90	Mus: 25	shield
-hot plate	60	Mus: 15	shield
+hors d'oeuvre tray	90	Mus: 25	shield: 5
+hot plate	60	Mus: 15	shield: 3
 HP-35 Calculator	0	none
 hypnodisk	200	none
 ice baby	0	none
 ice bucket	100	none
 Idol of Ak'gyxoth	200	none
 incredibly creepy marionette	110	Mys: 40
-iShield	100	Mus: 35	shield
+iShield	100	Mus: 35	shield: 6
 ivory cue ball	30	none
 jar of frostigkraut	100	Mys: 35
 Jarlsberg's pan	0	none
 Jarlsberg's pan (Cosmic portal mode)	0	none
 jet bennie marble	206	Mys: 85
 joybuzzer	20	none
-keg shield	170	Mus: 70	shield
+keg shield	170	Mus: 70	shield: 11
 Kevlar balloon	10	none
 kickback cookbook	40	Mys: 5
 killer rag doll	110	Mys: 40
@@ -2179,11 +2179,11 @@ Loathing Legion electric knife	0	none
 Loathing Legion kitchen sink	0	none
 Loathing Legion many-purpose hook	0	none
 Loathing Legion moondial	0	none
-Loathing Legion pizza stone	100	none	shield
+Loathing Legion pizza stone	100	none	shield: 6
 Loathing Legion tape measure	0	none
 loose purse strings	10	none
-LOV Elephant	100	Mus: 25	shield
-low-budget shield	60	none	shield
+LOV Elephant	100	Mus: 25	shield: 6
+low-budget shield	60	none	shield: 3
 lucky lighter	35	Mys: 2
 mad scientist's sock monkey	110	Mys: 40
 magic lamp	30	none
@@ -2197,15 +2197,15 @@ marionette	110	Mys: 40
 marionette collective	110	Mys: 40
 martini dregs	50	none
 McHugeLarge left pole	100	none
-meat shield	60	Mus: 15	shield
+meat shield	60	Mus: 15	shield: 3
 Medallion of the Ventrilo Prince	0	none
 Mer-kin begsign	200	Mus: 85
-Mer-kin roundshield	215	Mus: 85	shield
+Mer-kin roundshield	215	Mus: 85	shield: 14
 Mer-kin stopwatch	200	Mys: 85
 Mer-kin takebag	200	Mys: 85
 mesquito proboscis	0	none
 meteorb	100	none
-meteorite guard	150	none	shield
+meteorite guard	150	none	shield: 9
 Microplushie: Bropane	5	none
 Microplushie: Dorkonide	5	none
 Microplushie: Ermahgerdic Acid	5	none
@@ -2233,7 +2233,7 @@ moss megaphone	50	none
 moxie magnet	30	none
 Mr. Balloon	20	none
 Mr. Haggis	10	none
-mushroom shield	100	none	shield
+mushroom shield	100	none	shield: 6
 Mylar balloon	10	none
 naughty fortune teller	0	none
 Necrotelicomnicon	30	none
@@ -2242,35 +2242,35 @@ nozzle of the Phoenix	200	Mys: 40
 off-hand balloon	20	none
 oil lamp	120	Mus: 45
 Ol' Scratch's ash can	200	Mys: 200
-Ol' Scratch's stove door	240	Mus: 200	shield
-old pizza box	100	none	shield
+Ol' Scratch's stove door	240	Mus: 200	shield: 15
+old pizza box	100	none	shield: 6
 old school flying disc	220	Mus: 200	shield: 14
 Operation Patriot Shield	240	none	shield
 optimal spreadsheet	10	none
 orcish stud-finder	85	Mys: 27
 ornate dowsing rod	10	none
-Oscus's garbage can lid	240	Mus: 200	shield
-Ouija Board, Ouija Board	120	none	shield
+Oscus's garbage can lid	240	Mus: 200	shield: 15
+Ouija Board, Ouija Board	120	none	shield: 7
 outmoded fidget toy	50	none
 oversized monocle on a stick	10	none
-ox-head shield	250	Mus: 10	shield
+ox-head shield	250	Mus: 10	shield: 16
 oyster basket	10	none
 oyster egg balloon	100	Mys: 35
-padded tortoise	100	Mus: 35	shield
+padded tortoise	100	Mus: 35	shield: 6
 paint palette	100	Mys: 20
-painted shield	120	Mus: 45	shield
+painted shield	120	Mus: 45	shield: 7
 Paradaisical Cheeseburger recipe	10	none
 parasitic strangleworm	30	none
-party crasher	150	Mus: 20	shield
-peanut brittle shield	50	Mus: 10	shield
-penguin skin buckler	90	Mus: 30	shield
+party crasher	150	Mus: 20	shield: 9
+peanut brittle shield	50	Mus: 10	shield: 3
+penguin skin buckler	90	Mus: 30	shield: 5
 penguin thesaurus	30	none
 petrified wood water purifier	120	Mys: 40
 photo booth supply list	10	none
 pilgrim shield	240	none	shield
 pirate hook	30	none
 pixel grappling hook	200	Mox: 200
-pixel shield	50	Mus: 10	shield
+pixel shield	50	Mus: 10	shield: 3
 Platinum HP-35 Calculator	0	none
 plush alielf	0	none
 plush alien hamsterpus	0	none
@@ -2280,20 +2280,20 @@ plush hamsterpus	0	none
 plush mutated alielephant	0	none
 plush mutated alielf	0	none
 pocketwatch on a chain	50	Mys: 10
-polyalloy shield	140	Mus: 55	shield
-polyester pad	50	none	shield
+polyalloy shield	140	Mus: 55	shield: 9
+polyester pad	50	none	shield: 3
 pool skimmer	10	none
 porcelain pepper mill	120	Mys: 40
 Pork 'n' Pork 'n' Pork 'n' Beans	30	none	can of beans
-portable dam	150	Mus: 60	shield
+portable dam	150	Mus: 60	shield: 9
 portable Othello set	75	Mys: 15
 pot	0	none
-pottery shield	50	none	shield
+pottery shield	50	none	shield: 3
 pretty bouquet	0	none
 primitive alien totem	50	Mus: 10
 psychic's crystal ball	100	Mys: 35
 pumpkin spice candle	100	Mus: 20
-radiator heater shield	100	Mus: 35	shield
+radiator heater shield	100	Mus: 35	shield: 6
 rag doll	110	Mys: 40
 Raggedy Hippy doll	10	none
 Rain-Doh green lantern	100	none
@@ -2306,7 +2306,7 @@ red China marble	203	Mys: 85
 red LavaCo Lamp&trade;	100	Mus: 35
 Red Roger's red left hand	120	none
 red wagon	200	Mys: 200
-Red X Shield	180	Mus: 70	shield
+Red X Shield	180	Mus: 70	shield: 11
 replica august scepter	0	none
 replica Kramco Sausage-o-Matic&trade;	100	none
 replica Operation Patriot Shield	240	none	shield
@@ -2316,30 +2316,30 @@ rice bowl	30	none
 Roman Candelabra	0	none
 Royal scepter	100	none
 rubber baby doll	100	none
-rubber ribcage	120	Mus: 45	shield
+rubber ribcage	120	Mus: 45	shield: 7
 rusty compass	60	Mys: 15
 rusty empty nacho cheese can	0	none
 rusty kettle bell	50	none
 rusty old lantern	200	Mys: 85
-rxr shield	100	Mus: 35	shield
+rxr shield	100	Mus: 35	shield: 6
 SalesCo sample kit	50	none
-sawblade shield	180	Mus: 75	shield
+sawblade shield	180	Mus: 75	shield: 11
 Scepter of Loathing	200	Mys: 150
 Sceptre of the Torremolinos Prince	0	none
 Science Notebook	0	Mys: 11
 scissor duck	0	none
 scorched skull trophy	200	Mus: 85
-sealhide buckler	160	Mus: 65	shield
+sealhide buckler	160	Mus: 65	shield: 10
 sealskin drum	160	Mus: 150
-sebaceous shield	35	Mus: 2	shield
+sebaceous shield	35	Mus: 2	shield: 2
 security flashlight	50	Mys: 10
 set of jacks	20	none
 Seven Loco	0	none
-sewer turtle	20	none	shield
+sewer turtle	20	none	shield: 1
 shadow candle	0	none
 shadowy seal eye	100	Mus: 35
-Shield of Icy Fate	120	none	shield
-shield of the Skeleton Lord	300	Mus: 50	shield
+Shield of Icy Fate	120	none	shield: 7
+shield of the Skeleton Lord	300	Mus: 50	shield: 19
 Shrub's Premium Baked Beans	50	none	can of beans
 shrunken head	0	none
 signal receiver	0	none
@@ -2347,44 +2347,44 @@ silver cow creamer	200	Mys: 85
 Silver HP-35 Calculator	0	none
 silver sausage	0	none
 Sinful Desires	30	none
-six-rainbow shield	190	Mus: 70	shield
+six-rainbow shield	190	Mus: 70	shield: 12
 skull gearshift knob	150	Mus: 60
 skull of the Bonerdagon	0	none
 slime-covered compass	200	Mys: 200
 slime-covered lantern	200	Mys: 200
-slippery when wet shield	100	Mus: 35	shield
+slippery when wet shield	100	Mus: 35	shield: 6
 smirking shrunken head	170	Mys: 70
-snake shield	115	Mus: 42	shield
+snake shield	115	Mus: 42	shield: 7
 snapdragon pistil	70	Mys: 20
-snarling wolf shield	115	Mus: 42	shield
+snarling wolf shield	115	Mus: 42	shield: 7
 snow mobile	100	none
 snowstick	225	Mys: 200
 sock monkey	110	Mys: 40
 Solstice Shield	0	none
 sommelier's towel	150	Mys: 60
 sonar fishfinder	10	none
-space shield	150	none	shield
+space shield	150	none	shield: 9
 Space Tourist palmdoctor	50	none
 spaghetti-box banjo	160	Mys: 150
 Spanish fly trap	10	none
-spant shield	100	Mus: 20	shield
-speed limit shield	100	Mus: 35	shield
-spiky turtle shield	130	Mus: 50	shield
-spongy shield	220	Mus: 95	shield
+spant shield	100	Mus: 20	shield: 6
+speed limit shield	100	Mus: 35	shield: 6
+spiky turtle shield	130	Mus: 50	shield: 8
+spongy shield	220	Mus: 95	shield: 14
 spooky little girl	0	none
 sprinkle shaker	10	none
 sprinkle-begging cup	100	Mys: 20
 stack of communist leaflets	10	none
-stained glass shield	120	Mus: 40	shield
+stained glass shield	120	Mus: 40	shield: 7
 standards and practices guide	100	Mys: 10
 stapler bear	0	none
-star buckler	165	Mus: 67	shield
+star buckler	165	Mus: 67	shield: 10
 steaming evil	180	Mys: 75
 steely marble	208	Mys: 85
-stinky cheese wheel	100	none	shield
-stop shield	100	Mus: 35	shield
+stinky cheese wheel	100	none	shield: 6
+stop shield	100	Mus: 35	shield: 6
 stress ball	100	Mys: 35
-studded sealhide shield	110	none	shield
+studded sealhide shield	110	none	shield: 7
 stuffed astral badger	10	none
 stuffed baby gravy fairy	10	none
 stuffed bandersnatch	10	none
@@ -2430,8 +2430,8 @@ sucker bucket	50	none
 surprisingly capacious handbag	50	none
 Sword of the Brouhaha Prince	0	none
 Taco Dan's Taco Stand Cocktail Sauce Bottle	10	none
-tailbone shield	250	Mus: 200	shield
-teflon shield	220	Mus: 85	shield
+tailbone shield	250	Mus: 200	shield: 16
+teflon shield	220	Mus: 85	shield: 14
 Temporal Tempera Tube	10	none
 terra cotta tambourine	120	Mox: 40
 Tesla's Electroplated Beans	40	Mys: 5	can of beans
@@ -2449,49 +2449,49 @@ tinsel orb	200	Mus: 75
 tiny black hole	10	none
 tip jar	135	Mys: 52
 torch	0	none
-tortoboggan shield	100	Mus: 35	shield
+tortoboggan shield	100	Mus: 35	shield: 6
 toy Crimbot super fist	50	none
 Trader Olaf's Exotic Stinkbeans	30	none	can of beans
 trench lighter	200	Mus: 200
 trojan horseshoe	50	none
 tropical paperweight	20	none
 Tuesday's ruby	120	Mys: 45
-turtle wax shield	40	Mus: 5	shield
+turtle wax shield	40	Mus: 5	shield: 2
 turtling rod	10	none
 unbreakable umbrella	100	none
 uncursed arcane orb	0	none
 uncursed stats	0	none
-Unkillable Skeleton's shield	350	Mus: 100	shield
+Unkillable Skeleton's shield	350	Mus: 100	shield: 23
 unstable fulminate	0	none
 UV-resistant compass	0	none
 Val-U Brand Every Bean Salad	60	Mys: 15
 vampire pellet	180	Mys: 35
-velcro shield	220	Mus: 85	shield
+velcro shield	220	Mus: 85	shield: 14
 velour valise	50	none
 vengeful spirit	225	Mys: 200
-vermiculite shield	150	Mus: 20	shield
+vermiculite shield	150	Mus: 20	shield: 9
 Victor, the Insult Comic Hellhound Puppet	10	none
-vinyl shield	220	Mus: 85	shield
+vinyl shield	220	Mus: 85	shield: 14
 visual packet sniffer	50	none
 voodoo doll	20	none
 wad of Crovacite	200	none
 Wal-Mart snowglobe	200	Mus: 50
 Walford's bucket	10	none
 Wand of Oscus	200	Mys: 200
-washboard shield	160	Mus: 150	shield
+washboard shield	160	Mus: 150	shield: 10
 water candle	0	none
 Whatsian Ionic Pliers	110	Mys: 40
 white balloon	10	none
-white satin shield	80	Mus: 25	shield
+white satin shield	80	Mus: 25	shield: 5
 whittled walking stick	200	Mus: 50
 wicker clicker	50	none
-wicker shield	170	Mus: 70	shield
-wonderwall shield	190	Mus: 70	shield
+wicker shield	170	Mus: 70	shield: 11
+wonderwall shield	190	Mus: 70	shield: 12
 World's Blackest-Eyed Peas	30	none	can of beans
-yakskin buckler	90	Mus: 30	shield
-yield shield	100	Mus: 35	shield
+yakskin buckler	90	Mus: 30	shield: 5
+yield shield	100	Mus: 35	shield: 6
 Yorick	150	Mys: 25
-Zombo's shield	240	Mus: 200	shield
+Zombo's shield	240	Mus: 200	shield: 15
 zoological sample kit	10	none
 
 # Accessories section of equipment.txt

--- a/src/data/equipment.txt
+++ b/src/data/equipment.txt
@@ -1,4 +1,4 @@
-2
+3
 # Hats section of equipment.txt
 
 4-dimensional fez	50	none
@@ -2244,7 +2244,7 @@ oil lamp	120	Mus: 45
 Ol' Scratch's ash can	200	Mys: 200
 Ol' Scratch's stove door	240	Mus: 200	shield
 old pizza box	100	none	shield
-old school flying disc	220	Mus: 200	shield
+old school flying disc	220	Mus: 200	shield: 14
 Operation Patriot Shield	240	none	shield
 optimal spreadsheet	10	none
 orcish stud-finder	85	Mys: 27

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -2573,7 +2573,7 @@ Item	oil lamp	Sleaze Damage: +5, Hot Damage: +5
 Item	Ol' Scratch's ash can	Spell Damage Percent: +100, Hot Spell Damage: +30, Class: "Sauceror"
 Item	Ol' Scratch's stove door	Hot Damage: +20, Damage Reduction: 15, Thorns: 1
 Item	old pizza box	Damage Absorption: +50, Damage Reduction: 6, Last Available: "2020-04"
-Item	old school flying disc	Muscle Percent: +15, Damage Reduction: 24, Familiar Weight: +5
+Item	old school flying disc	Muscle Percent: +15, Damage Reduction: 10, Familiar Weight: +5
 Item	Operation Patriot Shield	Experience: +3, Maximum HP: +20, Maximum MP: +20, Softcore Only, Last Available: "2011-07", Variable, Conditional Skill (Equipped): "Throw Shield"
 # * Seal Clubber:
 # * Operation Patriot Shield	HP Regen Min: 10, HP Regen Max: 12, Weapon Damage: +15, Damage Reduction: 1

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -1171,7 +1171,7 @@ Item	a butt tuba	Sleaze Damage: +15
 Item	accord ion	Hot Damage: [5*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 10
 Item	accordion file	MP Regen Min: [2*(1+skill(Accordion Appreciation))], MP Regen Max: [4*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 10
 Item	Accordion of Jordion	Item Drop: [5*(1+skill(Accordion Appreciation))], Meat Drop: [10*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 14
-Item	accordionoid rocca	Damage Reduction: [10*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 18
+Item	accordionoid rocca	First Hit Damage Reduction: [10*(1+skill(Accordion Appreciation))], Class: "Accordion Thief", Song Duration: 18
 Item	acoustic guitarrr	Meat Drop: +8
 Item	adobe adze	Experience (Muscle): [3+3*min(1,effect(Adobe Adze Subscription))], Familiar Weight: [5+5*min(1,effect(Adobe Adze Subscription))], Single Equip, Last Available: "2024-12"
 # aerogel accordion: Only takes up one hand!
@@ -2467,10 +2467,10 @@ Item	iShield	Hot Resistance: +3, Damage Reduction: 10, Moxie Percent: +15
 Item	ivory cue ball	Item Drop: +5
 Item	jar of frostigkraut	Cold Damage: +10, Damage Aura: 1
 # Jarlsberg's pan: +1 Food Conjuration for Jarlsberg
-Item	Jarlsberg's pan	Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 10, Food Drop: +50, Experience (Mysticality): +2, Damage Reduction: 30, Softcore Only: [1-path(Avatar of Jarlsberg)], Free Pull: [path(Avatar of Jarlsberg)], Last Available: "2013-03"
+Item	Jarlsberg's pan	Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 10, Food Drop: +50, Experience (Mysticality): +2, First Hit Damage Reduction: 30, Softcore Only: [1-path(Avatar of Jarlsberg)], Free Pull: [path(Avatar of Jarlsberg)], Last Available: "2013-03"
 # Jarlsberg's pan (Cosmic portal mode): +1 Food Conjuration for Jarlsberg
 # Jarlsberg's pan (Cosmic portal mode): Converts dropped food and booze into Cosmic Calories
-Item	Jarlsberg's pan (Cosmic portal mode)	Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 10, Food Drop: +50, Experience (Mysticality): +2, Damage Reduction: 30, Softcore Only: [1-path(Avatar of Jarlsberg)], Free Pull: [path(Avatar of Jarlsberg)], Last Available: "2013-03"
+Item	Jarlsberg's pan (Cosmic portal mode)	Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 10, Food Drop: +50, Experience (Mysticality): +2, First Hit Damage Reduction: 30, Softcore Only: [1-path(Avatar of Jarlsberg)], Free Pull: [path(Avatar of Jarlsberg)], Last Available: "2013-03"
 Item	jet bennie marble	Spooky Spell Damage: +55
 Item	joybuzzer	Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
 Item	keg shield	Damage Absorption: +50, Mysticality: +5
@@ -2627,12 +2627,12 @@ Item	plush mutated alielf	Muscle Percent: [G], Mysticality Percent: [G], Moxie P
 Item	pocketwatch on a chain	Monster Level: -10, Experience (Mysticality): +1, Last Available: "2009-12"
 Item	polyalloy shield	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Muscle: +10, Last Available: "2007-12"
 # polyester pad: Shieldbutting Always Causes Bad Guys to Stagger
-Item	polyester pad	Damage Reduction: 10, HP Regen Min: 4, HP Regen Max: 8, Last Available: "2015-12"
+Item	polyester pad	First Hit Damage Reduction: 10, HP Regen Min: 4, HP Regen Max: 8, Last Available: "2015-12"
 # pool skimmer: Catches other people's washed-away items
 # porcelain pepper mill: Adds Physical Damage to Saucestorm
 Item	porcelain pepper mill	Spell Critical Percent: +10, Weakens Monster, Last Available: "2015-12"
 Item	Pork 'n' Pork 'n' Pork 'n' Beans	Sleaze Spell Damage: [15*(1+skill(Beanweaver))], Last Available: "2016-02"
-Item	portable dam	Damage Reduction: 100, Last Available: "2018-12"
+Item	portable dam	First Hit Damage Reduction: 100, Last Available: "2018-12"
 Item	portable Othello set	Othello Skill: +10
 Item	pottery shield	Hot Damage: +5, Last Available: "2010-09"
 Item	pretty bouquet	Moxie: +3
@@ -2859,7 +2859,7 @@ Item	zoological sample kit	Lasts Until Rollover, Last Available: "2017-04"
 Item	[spelunking test kit]	Maximum HP: +100, Muscle: +100, Mysticality: +100, Moxie: +100
 Item	&quot;I survived Y2K&quot; T-Shirt	Maximum HP: +2, Maximum MP: +2, Adventures: +2, Experience (Muscle): +2, Experience (Mysticality): +2, Experience (Moxie): +2, Single Equip, Last Available: "2023-06"
 Item	&quot;I Voted!&quot; sticker	Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Lasts Until Rollover, Last Available: "2018-11"
-Item	401k gold ring	Damage Reduction: 401, HP Regen Min: 4, HP Regen Max: 11, MP Regen Min: 4, MP Regen Max: 11, Last Available: "2026-08"
+Item	401k gold ring	First Hit Damage Reduction: 401, HP Regen Min: 4, HP Regen Max: 11, MP Regen Min: 4, MP Regen Max: 11, Last Available: "2026-08"
 Item	acid-squirting flower	Single Equip, Thorns: 1
 # actual reality goggles: Reveals peoples' true nature
 Item	actual reality goggles	Single Equip, Free Pull, Last Available: "2012-12"
@@ -3894,7 +3894,7 @@ Item	The One Mood Ring	Muscle Percent: [5*G], Mysticality Percent: [5*G], Moxie 
 Item	The Ring	Muscle: +3, Mysticality: +3, Moxie: +3, Spooky Damage: +40, Single Equip
 # The Superconductor's CPU: (based on Crimbo 22 Elf Gratitude)
 Item	The Superconductor's CPU	Maximum HP: [floor(sqrt(pref(elfGratitude)))], Maximum MP: [floor(sqrt(pref(elfGratitude)))], Single Equip, Last Available: "2022-12"
-Item	thicksilver ring	Damage Absorption: +30, Damage Reduction: 60, Single Equip, Last Available: "2016-02"
+Item	thicksilver ring	First Hit Damage Reduction: 50, Damage Absorption: +30, Damage Reduction: 10, Single Equip, Last Available: "2016-02"
 Item	third ear	Initiative: +50, Single Equip, Last Available: "2021-12"
 Item	ticksilver ring	Adventures: +6, PvP Fights: +4, Single Equip, Last Available: "2016-02"
 Item	tie-dyed fannypack	Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2, Item Drop: +10, Single Equip, Last Available: "2016-08"

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -2188,25 +2188,25 @@ Item	adobe abacus	Mysticality Percent: [20+20*min(1,effect(Adobe Abacus Subscrip
 Item	Adventurer bobblehead	Muscle Percent: [pref(nuclearAutumnPoints)], Mysticality Percent: [pref(nuclearAutumnPoints)], Moxie Percent: [pref(nuclearAutumnPoints)], Last Available: "2016-11"
 # aerogel attache case: Produce random cocktailcrafting ingredients as you adventure
 Item	aerogel attache case	Pickpocket Chance: +10, Stench Damage: +10, Last Available: "2017-12", Drops Items
-Item	ancient calendar	Adventures: +3, Damage Reduction: 4
+Item	ancient calendar	Adventures: +3
 Item	ancient hot dog wrapper	HP Regen Min: 25, HP Regen Max: 30, MP Regen Min: 25, MP Regen Max: 30
-Item	ancient stone head	Negative Status Resist, Damage Reduction: 5, Last Available: "2009-06"
+Item	ancient stone head	Negative Status Resist, Last Available: "2009-06"
 # anniversary balloon
 Item	anniversary chutney sculpture	Muscle: +1, Mysticality: +1, Moxie: +1
 Item	antique candy bucket	Candy Drop: +50, Lasts Until Rollover, Last Available: "2020-12"
 Item	antique nutcracker drumstick	MP Regen Min: 4, MP Regen Max: 8, Mysticality Percent: +15, Last Available: "2019-12"
-Item	antique shield	Initiative: -10, Damage Reduction: 11, Breakable
+Item	antique shield	Initiative: -10, Breakable
 Item	antique spyglass	Reduce Enemy Defense: 15, Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10
 # April Shower Thoughts shield: Improves some of your class skills!
-Item	April Shower Thoughts shield	Muscle: +10, Mysticality: +10, Moxie: +10, Maximum HP: +25, Maximum MP: +25, Damage Reduction: 6, Last Available: "2025-04"
+Item	April Shower Thoughts shield	Muscle: +10, Mysticality: +10, Moxie: +10, Maximum HP: +25, Maximum MP: +25, Last Available: "2025-04"
 Item	Apriling band staff	Mysticality: +10, Mysticality Percent: +10, Spell Damage: +20, Spooky Resistance: +2, Sleaze Resistance: +2, Spell Damage Percent: +10, Lasts Until Rollover
-Item	arm buzzer	Maximum MP: +25, Damage Reduction: 6
+Item	arm buzzer	Maximum MP: +25
 # arrow'd heart balloon
-Item	astral shield	Muscle Percent: +25, HP Regen Min: 5, HP Regen Max: 10, Damage Reduction: 15
+Item	astral shield	Muscle Percent: +25, HP Regen Min: 5, HP Regen Max: 10
 Item	astral statuette	Mysticality Percent: +25, Spell Damage Percent: +50, Adventures: +4
 Item	august scepter	Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
-Item	autumn debris shield	Damage Reduction: 19, Initiative: +30, Hot Damage: +20, Hot Spell Damage: +20, Lasts Until Rollover, Last Available: "2022-10"
-Item	autumnal aegis	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Absorption: +250, Damage Reduction: 9
+Item	autumn debris shield	Damage Reduction: 10, Initiative: +30, Hot Damage: +20, Hot Spell Damage: +20, Lasts Until Rollover, Last Available: "2022-10"
+Item	autumnal aegis	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Absorption: +250
 # Bag o' Tricks: Summons Animals During Combat
 Item	Bag o' Tricks	Item Drop: +10, Meat Drop: +15, MP Regen Min: 10, MP Regen Max: 12, Spell Damage Percent: +50, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
 # bag of Crotchety Pine saplings
@@ -2215,15 +2215,15 @@ Item	Bag o' Tricks	Item Drop: +10, Meat Drop: +15, MP Regen Min: 10, MP Regen Ma
 # bakelite bowl: Increase the number of Ravioli Shurikens you can conjure
 Item	bakelite bowl	Maximum MP: +20, Spell Damage: +20, Last Available: "2016-12"
 Item	ball-in-a-cup	Experience (Mysticality): +2, Last Available: "2007-12"
-Item	balloon shield	Damage Reduction: 3, Thorns: 1
-Item	barrel lid	Muscle Percent: +25, Monster Level: +50, Maximum HP: +100, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
-Item	barskin buckler	Muscle: +2, Damage Reduction: 1
-Item	basaltamander buckler	Experience Percent (Mysticality): +25, Damage Absorption: +50, Hat Drop: +75, Damage Reduction: 15, Last Available: "2015-08"
+Item	balloon shield	Thorns: 1
+Item	barrel lid	Muscle Percent: +25, Monster Level: +50, Maximum HP: +100, Lasts Until Rollover, Last Available: "2015-09"
+Item	barskin buckler	Muscle: +2
+Item	basaltamander buckler	Experience Percent (Mysticality): +25, Damage Absorption: +50, Hat Drop: +75, Last Available: "2015-08"
 # Baseball Diamond: Collect Players for a Quick Inning
 # Baseball Diamond: Play baseball to improve your diamond for the day
 Item	Baseball Diamond	Weapon Damage: +20, Last Available: "2026-04"
 Item	basic meat foon	Mysticality: +3, Spell Damage: +3
-Item	battered hubcap	Muscle: +15, Maximum HP: +100, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 14
+Item	battered hubcap	Muscle: +15, Maximum HP: +100, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2
 Item	beach ball marble	Spell Damage: +35, Hot Spell Damage: +35, Cold Spell Damage: +35
 Item	beetle antenna	Maximum MP: +30, Mysticality: [5*L]
 Item	beige clambroth marble	Spell Damage: +30, Hot Spell Damage: +30
@@ -2233,7 +2233,7 @@ Item	big bumboozer marble	Spell Damage: +80
 Item	big hot pepper	Spell Damage: +10, Hot Damage: +10, Last Available: "2023-02", Lantern: 1, Lantern Element: "Hot"
 Item	birdybug antenna	Maximum MP: +20, Mysticality: [4*L]
 Item	black catseye marble	Spooky Spell Damage: +75
-Item	black shield	Muscle: +5, Maximum HP: +20, Damage Reduction: 10
+Item	black shield	Muscle: +5, Maximum HP: +20
 Item	blue LavaCo Lamp&trade;	Adventures: +5, Rollover Effect: "Blue Eyed Devil", Rollover Effect Duration: 50, Last Available: "2015-08"
 Item	bobble-hip hula elf doll	Muscle: +5, Mysticality: +5, Moxie: +5, Meat Drop: +15, Last Available: "2006-12"
 # bone abacus: Helps you track your progress
@@ -2247,14 +2247,14 @@ Item	bottle of Goldschn&ouml;ckered	Hot Damage: +5, Cold Resistance: +2, Last Av
 Item	bouquet of all-natural free-range flowers	Last Available: "2015-12"
 Item	bowl of petunias	Muscle: +4, Mysticality: +4, Moxie: +4, Experience: +4, PvP Fights: +4, HP Regen Min: 4, HP Regen Max: 8, MP Regen Min: 4, MP Regen Max: 8, Last Available: "2013-11"
 Item	box	Meat Drop: +1, Wiki Name: "box"
-Item	box turtle	Muscle: +1, Damage Reduction: 3
+Item	box turtle	Muscle: +1
 Item	box-in-the-box	Meat Drop: +2
 Item	box-in-the-box-in-the-box	Meat Drop: +3
 Item	Brand of Violence	Moxie Percent: +20, Critical Hit Percent: +5, Weapon Damage Percent: +30, Conditional Skill (Equipped): "Brand"
-Item	brass dorsal fin	Weapon Damage Percent: +20, Damage Reduction: 13
+Item	brass dorsal fin	Weapon Damage Percent: +20
 Item	bread basket	Food Drop: +20
-Item	BRICKO bulwark	Maximum HP: +6, Damage Reduction: 3, Last Available: "2010-02"
-Item	Brimstone Bunker	Muscle Percent: +50, Moxie Percent: -20, Damage Reduction: 25, Brimstone
+Item	BRICKO bulwark	Maximum HP: +6, Last Available: "2010-02"
+Item	Brimstone Bunker	Muscle Percent: +50, Moxie Percent: -20, Damage Reduction: 10, Brimstone
 Item	brown crock marble	Stench Spell Damage: +35
 Item	Brutal brogues	Muscle Percent: +50, Weapon Damage Percent: +50, Familiar Weight: +8, Experience (Muscle): +4, Lasts Until Rollover, Last Available: "2018-07"
 Item	bumblebee marble	Spell Damage: +50
@@ -2264,12 +2264,12 @@ Item	C.H.U.M. lantern	Stench Damage: +17, Item Drop: [30*loc(Sewer Tunnels)]
 Item	can of mixed everything	Muscle: +5, Mysticality: +5, Moxie: +5, Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Last Available: "2021-12"
 # card sleeve: If you like it, you should put a card in it!
 Item	card sleeve	Last Available: "2011-03"
-Item	cardboard box turtle	Muscle: +3, Damage Reduction: 4
+Item	cardboard box turtle	Muscle: +3
 Item	cardboard wine carrier	Booze Drop: +50, Lasts Until Rollover, Last Available: "2020-12"
 # carnivorous potted plant: Occasionally swallows your enemy whole
 Item	carnivorous potted plant	Monster Level: +25, Last Available: "2021-12"
-Item	catskin buckler	Muscle: +10, Damage Absorption: +50, Damage Reduction: 11
-Item	ceramic centurion shield	Experience (Muscle): +3, Maximum HP: +40, HP Regen Min: 8, HP Regen Max: 16, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
+Item	catskin buckler	Muscle: +10, Damage Absorption: +50
+Item	ceramic centurion shield	Experience (Muscle): +3, Maximum HP: +40, HP Regen Min: 8, HP Regen Max: 16, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
 Item	Chalice of the Malkovich Prince	Muscle Percent: +4, Mysticality Percent: +4, Moxie Percent: +4, Last Available: "2011-10"
 # chalk chalice: Weakens enemies who hit you
 Item	chalk chalice	Maximum MP: +15, Hot Spell Damage: +20, Last Available: "2019-12"
@@ -2279,13 +2279,13 @@ Item	charged magnet	Maximum MP: +5, MP Regen Min: 1, MP Regen Max: 2, Last Avail
 Item	chiffon chamberpot	Mysticality: +10, Sleaze Damage: +10, Sleaze Spell Damage: +10, Last Available: "2023-12", Damage Aura: 1
 Item	chipped coffee mug	Maximum HP: +30, Maximum MP: +15, Last Available: "2020-04"
 # chocolate and nylons detector: Helps you find chocolates and nylons
-Item	Cloaca-Cola shield	Mysticality: +1, Damage Reduction: 4
+Item	Cloaca-Cola shield	Mysticality: +1
 # clockwork detective skull
-Item	clownskin buckler	Spooky Damage: +3, Damage Reduction: 3, Clowniness: 50
+Item	clownskin buckler	Spooky Damage: +3, Clowniness: 50
 Item	cobbled-together Meat detector	Meat Drop: +15, Lasts Until Rollover, Last Available: "2019-12"
 # Codex of Capsaicin Conjuration: All Spells Cast Are Hot
 Item	Codex of Capsaicin Conjuration	Spell Damage: +10
-Item	coffin lid	Spooky Resistance: +1, Damage Reduction: 3
+Item	coffin lid	Spooky Resistance: +1
 Item	Cold Stone of Hatred	Mysticality Percent: +20, Reduce Enemy Defense: 10, Spell Damage Percent: +60, Conditional Skill (Equipped): "Chilling Grip"
 Item	collapsible baton	Mysticality Percent: +10, Spell Critical Percent: +5
 Item	complicated device	Experience: +1, Hot Damage: +1, Cold Damage: +1, Stench Damage: +1, Spooky Damage: +1, Sleaze Damage: +1, Hot Spell Damage: +11, Cold Spell Damage: +11, Stench Spell Damage: +11, Spooky Spell Damage: +11, Sleaze Spell Damage: +11, Monster Level: +11, Initiative: +11, Damage Reduction: 11, Damage Absorption: +11, Meat Drop: +11, Item Drop: +11, Muscle: +11, Mysticality: +11, Moxie: +11, Muscle Percent: +11, Mysticality Percent: +11, Moxie Percent: +11, Maximum HP: +111, Maximum MP: +111, Maximum HP Percent: +111, Maximum MP Percent: +111, Last Available: "2020-09"
@@ -2319,7 +2319,7 @@ Item	cursed magnifying glass	Item Drop: +13, Spooky Damage: +13, Initiative: +13
 Item	cursed ship's lantern	Mysticality Percent: +10, Last Available: "2025-12"
 Item	cursed stats	Experience: +5, Muscle Limit: 69, Mysticality Limit: 69, Moxie Limit: 69
 Item	cyborg doll	Muscle: +3, Last Available: "2007-12"
-Item	Dallas Dynasty Falcon Crest shield	Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Damage Reduction: 15
+Item	Dallas Dynasty Falcon Crest shield	Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5
 # deceased crimbo tree: Blocks damage while needles remain
 Item	deceased crimbo tree	Last Available: "2018-01", Lasts Until Rollover, Breakable
 Item	deck of lewd playing cards	Moxie Percent: +5, Sleaze Damage: +69, Sleaze Spell Damage: +69
@@ -2328,12 +2328,12 @@ Item	deck of tropical cards	Experience: +1, Last Available: "2006-12", Stat Tuni
 Item	defective skull	Last Available: "2011-12"
 # deft pirate hook: Occasionally snags on your opponent's stuff
 Item	deft pirate hook	Muscle: +20, Weapon Damage: +10, Lasts Until Rollover, Last Available: "2024-12"
-Item	demon buckler	Hot Damage: +3, Damage Reduction: 5
+Item	demon buckler	Hot Damage: +3
 Item	depleted Grimacite gravy boat	Mysticality Percent: [5*G], Adventures: [G], Last Available: "2011-12"
 # detective skull
-Item	detour shield	Damage Absorption: +10, Damage Reduction: 6, Last Available: "2010-03"
+Item	detour shield	Damage Absorption: +10, Last Available: "2010-03"
 # Diamond HP-35 Calculator: Makes you look the most altruisticest
-Item	Dinsey's radar dish	MP Regen Min: 8, MP Regen Max: 10, Damage Reduction: 15, Last Available: "2015-04", Damage Aura: 1
+Item	Dinsey's radar dish	MP Regen Min: 8, MP Regen Max: 10, Last Available: "2015-04", Damage Aura: 1
 Item	dirty rigging rope	Initiative: +30, Stench Damage: +15, Last Available: "2015-04"
 Item	discarded finger painting	Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Last Available: "2020-04"
 Item	disturbing fanfic	Sleaze Spell Damage: +30
@@ -2344,11 +2344,11 @@ Item	druidic orb	Lasts Until Rollover, Last Available: "2018-04"
 # Drunkula's wineglass: Allows adventuring while falling-down drunk
 # Drunkula's wineglass: Prevents you from using skills and spells and combat items
 Item	Drunkula's wineglass	Familiar Weight: -30
-Item	duct tape buckler	Maximum HP: +65, Maximum MP: +65, Damage Reduction: 12
+Item	duct tape buckler	Maximum HP: +65, Maximum MP: +65
 Item	Dungeon Fist gauntlet	Weapon Damage: +25, Combat Rate: +5, Food Drop: -100, Last Available: "2011-06"
-Item	Dyspepsi-Cola shield	Mysticality: +1, Damage Reduction: 4
+Item	Dyspepsi-Cola shield	Mysticality: +1
 Item	easter egg balloon	Muscle: +5, Mysticality: +5, Moxie: +5
-Item	eelskin shield	Maximum HP: +55, Maximum MP: +55, Damage Reduction: 13, Thorns: [env(underwater)]
+Item	eelskin shield	Maximum HP: +55, Maximum MP: +55, Thorns: [env(underwater)]
 # Elf Guard clipboard: Increases Item Drops on Crimbo Battlefields
 Item	Elf Guard clipboard	Food Drop: +25, Booze Drop: +25, Meat Drop: +25, Last Available: "2023-12"
 Item	Elf Guard safety bear	Last Available: "2023-12"
@@ -2368,7 +2368,7 @@ Item	faded green protest sign	Last Available: "2015-12"
 Item	faded red protest sign	Last Available: "2015-12"
 # fake hand: Gives Extra Offhand Equipment Slot
 Item	fake hand	Weapon Damage: -1, Last Available: "2006-04"
-Item	fake washboard	Experience Percent (Muscle): +25, Damage Absorption: +50, Accessory Drop: +75, Damage Reduction: 13, Last Available: "2015-04"
+Item	fake washboard	Experience Percent (Muscle): +25, Damage Absorption: +50, Accessory Drop: +75, Last Available: "2015-04"
 Item	familiar scrapbook	HP Regen Min: [4+min(30,pref(scrapbookCharges)/10)], HP Regen Max: [6+min(30,pref(scrapbookCharges)/10)], MP Regen Min: [2+min(30,pref(scrapbookCharges)/10)], MP Regen Max: [3+min(30,pref(scrapbookCharges)/10)], Experience Percent (Muscle): [5+min(10,pref(scrapbookCharges)/10)], Experience Percent (Mysticality): [5+min(10,pref(scrapbookCharges)/10)], Experience Percent (Moxie): [5+min(10,pref(scrapbookCharges)/10)], Familiar Weight: +5, Experience (familiar): +1, Moxie: [min(1,floor(pref(scrapbookCharges)/1111))], Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
 Item	fancy marzipan briefcase	MP Regen Min: 4, MP Regen Max: 8, Combat Rate: -10, Lasts Until Rollover, Last Available: "2016-12"
 Item	fancy opera glasses	Meat Drop: +5, Item Drop: +5
@@ -2378,13 +2378,12 @@ Item	fireproof megaphone	Monster Level: +10, Hot Resistance: +2, Last Available:
 # fishbone catcher's mitt: Prevents some items from washing away in the Heavy Rains
 Item	flagstone flag	Experience (Muscle): +3, Item Drop: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
 # flak shield: Protects you from Axis grenades
-Item	flak shield	Damage Reduction: 9
 Item	flaming fistbone	Hot Spell Damage: +75, MP Regen Min: 4, MP Regen Max: 8, Experience (Mysticality): +2, Last Available: "2025-12"
 Item	flaming talons	Weapon Damage: +5, Hot Damage: +5
-Item	fleshy lump	Maximum HP: +20, HP Regen Min: 2, HP Regen Max: 4, Damage Reduction: 3, Last Available: "2016-08"
+Item	fleshy lump	Maximum HP: +20, HP Regen Min: 2, HP Regen Max: 4, Last Available: "2016-08"
 Item	flickering flashlight	Item Drop: +15, Last Available: "2020-04"
-Item	flimsy clipboard	Meat Drop: +5, Damage Reduction: 3
-Item	flimsy plastic shield	Damage Reduction: 8
+Item	flimsy clipboard	Meat Drop: +5
+Item	flimsy plastic shield	Damage Reduction: 5
 Item	flimsy ski pole	Initiative: +30, Last Available: "2020-04"
 Item	foon	Mysticality: +2
 Item	foon of fearfulness	Mysticality: +3, Spooky Spell Damage: +8
@@ -2394,41 +2393,41 @@ Item	foon of frigidity	Mysticality: +3, Cold Spell Damage: +8
 Item	foon of fulmination	Mysticality: +3, Hot Spell Damage: +8
 Item	Franken Stein	Conditional Skill (Equipped): "Toast your enemy"
 Item	frankincenser	Maximum MP: +10, Experience (Mysticality): +3, Last Available: "2020-12"
-Item	furry yam buckler	Cold Resistance: +4, Damage Reduction: 14, Negative Status Resist, Lasts Until Rollover, Last Available: "2024-05"
+Item	furry yam buckler	Cold Resistance: +4, Damage Reduction: 11, Negative Status Resist, Lasts Until Rollover, Last Available: "2024-05"
 # Gazpacho's Glacial Grimoire: All Spells Cast Are Cold
 Item	Gazpacho's Glacial Grimoire	Spell Damage: +10
 # geofencing shield: CyberRealm: Prevent most damage from processes
 Item	geofencing shield	Last Available: "2025-12"
 # geological sample kit: Increases the yield of Spacegate geology operations
 Item	geological sample kit	Lasts Until Rollover, Last Available: "2017-04"
-Item	ghast iron heater shield	Spooky Damage: +10, Hot Damage: +10, Damage Reduction: 11
+Item	ghast iron heater shield	Spooky Damage: +10, Hot Damage: +10
 Item	ghostly reins	Familiar Weight: +10, Experience (familiar): +2, Lasts Until Rollover, Last Available: "2016-08"
-Item	giant clay ashtray	Muscle: +5, Damage Reduction: 3, Last Available: "2011-05"
-Item	giant penguin keychain	HP Regen Min: 12, HP Regen Max: 16, Moxie: -5, Damage Reduction: 10
+Item	giant clay ashtray	Muscle: +5, Last Available: "2011-05"
+Item	giant penguin keychain	HP Regen Min: 12, HP Regen Max: 16, Moxie: -5
 # giant stuffed bugbear
 Item	gingerbread moneybag	Sprinkle Drop: +25, Last Available: "2016-12"
 Item	Glass Balls of the Goblin King	Mysticality: +14
 Item	glass gnoll eye	Mysticality: +3
 # glass pie plate: Half Damage from Ghosts
-Item	glass pie plate	Hot Resistance: +3, Damage vs. Ghosts: +25, Damage Reduction: 7, Last Available: "2016-11"
+Item	glass pie plate	Hot Resistance: +3, Damage vs. Ghosts: +25, Last Available: "2016-11"
 Item	glow-in-the-dark stuffed burrowgrub	Muscle: [9-M], Weapon Damage: [9-M], Last Available: "2009-01"
 Item	glowing esca	Item Drop: [20*env(underwater)]
 Item	glowstick on a string	Weapon Damage: +10, Raveosity: +1
 Item	glued-together crystal ball	Mysticality Percent: +50, Last Available: "2020-04"
-Item	gnauga hide buckler	Muscle: +3, Mysticality: +3, Moxie: +3, Damage Reduction: 5
+Item	gnauga hide buckler	Muscle: +3, Mysticality: +3, Moxie: +3
 # Golden HP-35 Calculator: Makes you look super altruistic
 # golden sausage
 # goo magnet: Automatically collects residual grey goo at Site Alpha locations
 Item	goo magnet	Last Available: "2021-12"
 Item	gore bucket	Last Available: "2014-10"
-Item	gravyskin buckler	Sleaze Damage: +11, Sleaze Spell Damage: +11, Damage Reduction: 7, Last Available: "2024-12"
+Item	gravyskin buckler	Sleaze Damage: +11, Sleaze Spell Damage: +11, Last Available: "2024-12"
 Item	Great Wolf's left paw	Critical Hit Percent: +10, Spooky Damage: +10, Stench Damage: +10, Hot Damage: +10, Cold Damage: +10, Sleaze Damage: +10, Never Fumble, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 # green balloon
 Item	green LavaCo Lamp&trade;	Adventures: +5, Rollover Effect: "Green Peace", Rollover Effect Duration: 50, Last Available: "2015-08"
 Item	green peawee marble	Stench Spell Damage: +30
 Item	Grey Guanon	Stench Damage: +5, Damage Aura: 1
-Item	grisly shield	Weapon Damage: +50, PvP Fights: +5, Slime Hates It: +1, Damage Reduction: 13
-Item	gunwale	Muscle Percent: +25, Maximum HP: +50, Damage Absorption: +75, Damage Reduction: 9, Last Available: "2023-12"
+Item	grisly shield	Weapon Damage: +50, PvP Fights: +5, Slime Hates It: +1
+Item	gunwale	Muscle Percent: +25, Maximum HP: +50, Damage Absorption: +75, Last Available: "2023-12"
 Item	Guzzlr souvenir stein	Booze Drop: +50, Last Available: "2020-05"
 Item	Half a Purse	Experience: +1, Damage Reduction: 3, Smithsness: +5, Last Available: "2013-12", Meat Drop: [2*K]
 Item	hand of Mr. Cards	Muscle: +5, Mysticality: +5, Moxie: +5, Conditional Skill (Equipped): "Throw a Mr. Card"
@@ -2436,11 +2435,11 @@ Item	handmade hobby horse	Experience (Muscle): +2, Last Available: "2007-12"
 # heart-shaped balloon
 # heavy duty umbrella: Reduces the level of nearby water.  Somehow.
 Item	heavy duty umbrella	Water Level: -2
-Item	heavy-duty clipboard	Mysticality: +10, Spell Critical Percent: +10, Spooky Resistance: +5, Damage Reduction: 8, Last Available: "2014-10"
+Item	heavy-duty clipboard	Mysticality: +10, Spell Critical Percent: +10, Spooky Resistance: +5, Last Available: "2014-10"
 Item	Heimz Fortified Kidney Beans	Maximum HP: [15*(1+skill(Beanweaver))], Spell Damage: [10*(1+skill(Beanweaver))], HP Regen Min: [4*(1+skill(Beanweaver))], HP Regen Max: [5*(1+skill(Beanweaver))], Last Available: "2016-02"
 Item	Hellfire Spicy Beans	Hot Spell Damage: [15*(1+skill(Beanweaver))], Last Available: "2016-02"
-Item	hippo skin buckler	Muscle: +5, Damage Reduction: 5
-Item	HOA regulation book	Reduce Enemy Defense: 20, Monster Level: -100, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 23
+Item	hippo skin buckler	Muscle: +5
+Item	HOA regulation book	Reduce Enemy Defense: 20, Monster Level: -100, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2
 Item	hobo code binder	Free Pull
 # Hodgman's almanac: Converts Hobo Power to Spell Damage
 Item	Hodgman's almanac	Spell Damage: [1.2*H]
@@ -2456,15 +2455,15 @@ Item	Hodgman's imaginary hamster	Muscle Percent: +20, Mysticality Percent: +20, 
 Item	Hodgman's metal detector	Item Drop: [0.5*H]
 # Hodgman's varcolac paw: Converts Hobo Power to Weapon Damage
 Item	Hodgman's varcolac paw	Weapon Damage: [0.8*H]
-Item	hors d'oeuvre tray	Initiative: +15, Damage Reduction: 5
-Item	hot plate	Hot Damage: +3, Damage Reduction: 3, Thorns: 1
+Item	hors d'oeuvre tray	Initiative: +15
+Item	hot plate	Hot Damage: +3, Thorns: 1
 # HP-35 Calculator: Makes you look altruistic
 Item	hypnodisk	Item Drop: +30
 Item	ice baby	Experience: +3, Softcore Only, Last Available: "2006-02"
 Item	ice bucket	Item Drop: +20, Lasts Until Rollover, Last Available: "2014-01"
 Item	Idol of Ak'gyxoth	Moxie: +43, Mana Cost: -1
 Item	incredibly creepy marionette	Mysticality: +3, Last Available: "2006-12"
-Item	iShield	Hot Resistance: +3, Damage Reduction: 16, Moxie Percent: +15
+Item	iShield	Hot Resistance: +3, Damage Reduction: 10, Moxie Percent: +15
 Item	ivory cue ball	Item Drop: +5
 Item	jar of frostigkraut	Cold Damage: +10, Damage Aura: 1
 # Jarlsberg's pan: +1 Food Conjuration for Jarlsberg
@@ -2474,7 +2473,7 @@ Item	Jarlsberg's pan	Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 1
 Item	Jarlsberg's pan (Cosmic portal mode)	Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 10, Food Drop: +50, Experience (Mysticality): +2, Damage Reduction: 30, Softcore Only: [1-path(Avatar of Jarlsberg)], Free Pull: [path(Avatar of Jarlsberg)], Last Available: "2013-03"
 Item	jet bennie marble	Spooky Spell Damage: +55
 Item	joybuzzer	Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-Item	keg shield	Damage Absorption: +50, Mysticality: +5, Damage Reduction: 11
+Item	keg shield	Damage Absorption: +50, Mysticality: +5
 # Kevlar balloon
 Item	kickback cookbook	Spell Damage: +20
 Item	killer rag doll	Muscle: +3, Last Available: "2006-12"
@@ -2503,11 +2502,10 @@ Item	Loathing Legion electric knife	Meat Drop: +20, Softcore Only, Last Availabl
 Item	Loathing Legion kitchen sink	Spell Damage Percent: +25, Softcore Only, Last Available: "2011-01"
 Item	Loathing Legion many-purpose hook	Item Drop: +10, Softcore Only, Last Available: "2011-01"
 Item	Loathing Legion moondial	Adventures: +4, Softcore Only, Last Available: "2011-01"
-Item	Loathing Legion pizza stone	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Damage Reduction: 6, Softcore Only, Last Available: "2011-01"
+Item	Loathing Legion pizza stone	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Softcore Only, Last Available: "2011-01"
 Item	Loathing Legion tape measure	Critical Hit Percent: +10, Softcore Only, Last Available: "2011-01"
 # loose purse strings: Monsters Will Drop Additional Meat
-Item	LOV Elephant	Damage Reduction: 16, Last Available: "2017-02"
-Item	low-budget shield	Damage Reduction: 3
+Item	LOV Elephant	Damage Reduction: 10, Last Available: "2017-02"
 Item	lucky lighter	Hot Damage: +6, Critical Hit Percent: +5
 Item	mad scientist's sock monkey	Moxie: +3, Last Available: "2006-12"
 Item	magic lamp	Mysticality: +5
@@ -2521,16 +2519,16 @@ Item	marionette	Mysticality: +3, Last Available: "2005-12"
 Item	marionette collective	Mysticality: +3, Last Available: "2007-12"
 Item	martini dregs	Moxie Percent: +50, Last Available: "2020-04"
 Item	McHugeLarge left pole	Mysticality: +10, Spell Damage: +10, Spell Damage Percent: +25, Last Available: "2025-01", McHugeLarge, Conditional Skill (Equipped): "McHugeLarge Slash"
-Item	meat shield	Meat Drop: +3, Damage Reduction: 3
+Item	meat shield	Meat Drop: +3
 Item	Medallion of the Ventrilo Prince	Moxie Percent: +12, Last Available: "2011-10"
 Item	Mer-kin begsign	Weakens Monster, Meat Drop: [40*env(underwater)]
-Item	Mer-kin roundshield	Damage Reduction: 19, Damage Absorption: +40, HP Regen Min: 10, HP Regen Max: 20
+Item	Mer-kin roundshield	Damage Reduction: 5, Damage Absorption: +40, HP Regen Min: 10, HP Regen Max: 20
 Item	Mer-kin stopwatch	Adventures: +3, Initiative: [50*env(underwater)]
 # Mer-kin takebag: (+15% Underwater)
 Item	Mer-kin takebag	Item Drop: [5+10*env(underwater)]
 Item	mesquito proboscis	Maximum MP: +5, Mysticality: [3*L]
 Item	meteorb	Mysticality: +5, Maximum MP: +10, Last Available: "2017-08", Lantern: 1, Lantern Element: "Hot"
-Item	meteorite guard	Stench Resistance: +3, Hot Resistance: +3, Negative Status Resist, Damage Reduction: 9, Last Available: "2017-08"
+Item	meteorite guard	Stench Resistance: +3, Hot Resistance: +3, Negative Status Resist, Last Available: "2017-08"
 Item	Microplushie: Bropane	Weapon Damage: +3, Last Available: "2012-12"
 Item	Microplushie: Dorkonide	Muscle: +1, Mysticality: +1, Moxie: +1, Last Available: "2012-12"
 Item	Microplushie: Ermahgerdic Acid	Hot Damage: +2, Last Available: "2012-12"
@@ -2559,7 +2557,7 @@ Item	moxie magnet	Moxie Controls MP
 Item	Mr. Balloon	Muscle: +3, Mysticality: +3, Moxie: +3
 # Mr. Haggis: Haggis!
 Item	Mr. Haggis	Last Available: "2012-12", Damage Aura: 1
-Item	mushroom shield	Muscle: +40, Mysticality: -20, Moxie: -20, Combat Rate: +10, Damage Reduction: 6, Last Available: "2020-03"
+Item	mushroom shield	Muscle: +40, Mysticality: -20, Moxie: -20, Combat Rate: +10, Last Available: "2020-03"
 # Mylar balloon
 # naughty fortune teller: + Some Stats Per Fight
 Item	naughty fortune teller	Softcore Only, Last Available: "2008-02"
@@ -2571,8 +2569,8 @@ Item	off-hand balloon	Muscle: +1, Mysticality: +1, Moxie: +1
 Item	oil lamp	Sleaze Damage: +5, Hot Damage: +5
 # Ol' Scratch's ash can: All Spells Cast Are Hot
 Item	Ol' Scratch's ash can	Spell Damage Percent: +100, Hot Spell Damage: +30, Class: "Sauceror"
-Item	Ol' Scratch's stove door	Hot Damage: +20, Damage Reduction: 15, Thorns: 1
-Item	old pizza box	Damage Absorption: +50, Damage Reduction: 6, Last Available: "2020-04"
+Item	Ol' Scratch's stove door	Hot Damage: +20, Thorns: 1
+Item	old pizza box	Damage Absorption: +50, Last Available: "2020-04"
 Item	old school flying disc	Muscle Percent: +15, Damage Reduction: 10, Familiar Weight: +5
 Item	Operation Patriot Shield	Experience: +3, Maximum HP: +20, Maximum MP: +20, Softcore Only, Last Available: "2011-07", Variable, Conditional Skill (Equipped): "Throw Shield"
 # * Seal Clubber:
@@ -2593,31 +2591,31 @@ Item	optimal spreadsheet	Muscle: +10, Mysticality: +10, Moxie: +10, PvP Fights: 
 Item	orcish stud-finder	Weapon Damage: +5, Sleaze Damage: +5
 # ornate dowsing rod: Aids in desert exploration
 Item	ornate dowsing rod	Last Available: "2014-12"
-Item	Oscus's garbage can lid	Stench Damage: +20, Damage Reduction: 15, Thorns: 1
+Item	Oscus's garbage can lid	Stench Damage: +20, Thorns: 1
 # Ouija Board, Ouija Board: Gain the favor of the Turtle Spirits more quickly
-Item	Ouija Board, Ouija Board	Familiar Weight: +5, Smithsness: +5, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12", Muscle Percent: [2*K]
+Item	Ouija Board, Ouija Board	Familiar Weight: +5, Smithsness: +5, Class: "Turtle Tamer", Last Available: "2013-12", Muscle Percent: [2*K]
 Item	outmoded fidget toy	Experience: +2, Last Available: "2020-04"
 Item	oversized monocle on a stick	Mysticality Percent: +25, Item Drop: +25, Lasts Until Rollover, Last Available: "2024-10"
-Item	ox-head shield	Maximum HP: +100, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 26, PvP Fights: +8, Never Fumble, Lasts Until Rollover, Last Available: "2016-03"
+Item	ox-head shield	Maximum HP: +100, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 10, PvP Fights: +8, Never Fumble, Lasts Until Rollover, Last Available: "2016-03"
 # oyster basket
 Item	oyster egg balloon	Muscle: +5, Mysticality: +5, Moxie: +5
-Item	padded tortoise	Damage Absorption: +20, HP Regen Min: 4, HP Regen Max: 8, Damage Reduction: 6
+Item	padded tortoise	Damage Absorption: +20, HP Regen Min: 4, HP Regen Max: 8
 Item	paint palette	Spooky Damage: +8, Stench Damage: +8, Hot Damage: +8, Cold Damage: +8, Sleaze Damage: +8, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
-Item	painted shield	Muscle: +3, Mysticality: +3, Moxie: +3, Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2, Damage Reduction: 7
+Item	painted shield	Muscle: +3, Mysticality: +3, Moxie: +3, Spooky Damage: +2, Stench Damage: +2, Hot Damage: +2, Cold Damage: +2, Sleaze Damage: +2
 # Paradaisical Cheeseburger recipe
 Item	Paradaisical Cheeseburger recipe	Last Available: "2014-05"
 Item	parasitic strangleworm	Damage Reduction: [min(L,15)], Last Available: "2008-12"
 # party crasher: Lets you crash into your foes, stunning them
-Item	party crasher	Initiative: +25, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
-Item	peanut brittle shield	Candy Drop: +100, Damage Reduction: 3, Last Available: "2009-12"
-Item	penguin skin buckler	Moxie: +5, Damage Reduction: 5
+Item	party crasher	Initiative: +25, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
+Item	peanut brittle shield	Candy Drop: +100, Last Available: "2009-12"
+Item	penguin skin buckler	Moxie: +5
 Item	penguin thesaurus	Mysticality: +1, Maximum HP: +5, Maximum MP: +5, Last Available: "2008-12"
 Item	petrified wood water purifier	Experience (Mysticality): +3, Meat Drop: +20, Last Available: "2025-12", Lantern: 2, Lantern Element: "Cold", Lantern Element: "Sleaze"
 Item	photo booth supply list	Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Damage Reduction: 20, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
 Item	pilgrim shield	Maximum HP: +30, Weapon Damage: +15, Experience: +3, HP Regen Min: 10, HP Regen Max: 12, Weapon Drop: +50, Damage Reduction: [L], Softcore Only, Last Available: "2006-11"
 Item	pirate hook	Weapon Damage: +3
 Item	pixel grappling hook	Initiative: +40, Item Drop: +10
-Item	pixel shield	Muscle: +5, Damage Reduction: 3
+Item	pixel shield	Muscle: +5
 # Platinum HP-35 Calculator: Makes you look incredibly altruistic
 Item	plush alielf	Maximum HP: +30, Last Available: "2011-06"
 Item	plush alien hamsterpus	Muscle Percent: [2*G], Mysticality Percent: [2*G], Moxie Percent: [2*G], Last Available: "2011-06"
@@ -2627,21 +2625,21 @@ Item	plush hamsterpus	Maximum HP: +50, Maximum MP: +50, Last Available: "2011-06
 Item	plush mutated alielephant	Muscle Percent: [3*G], Mysticality Percent: [3*G], Moxie Percent: [3*G], Critical Hit Percent: +5, Last Available: "2011-06"
 Item	plush mutated alielf	Muscle Percent: [G], Mysticality Percent: [G], Moxie Percent: [G], Last Available: "2011-06"
 Item	pocketwatch on a chain	Monster Level: -10, Experience (Mysticality): +1, Last Available: "2009-12"
-Item	polyalloy shield	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Muscle: +10, Damage Reduction: 9, Last Available: "2007-12"
+Item	polyalloy shield	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Muscle: +10, Last Available: "2007-12"
 # polyester pad: Shieldbutting Always Causes Bad Guys to Stagger
-Item	polyester pad	Damage Reduction: 13, HP Regen Min: 4, HP Regen Max: 8, Last Available: "2015-12"
+Item	polyester pad	Damage Reduction: 10, HP Regen Min: 4, HP Regen Max: 8, Last Available: "2015-12"
 # pool skimmer: Catches other people's washed-away items
 # porcelain pepper mill: Adds Physical Damage to Saucestorm
 Item	porcelain pepper mill	Spell Critical Percent: +10, Weakens Monster, Last Available: "2015-12"
 Item	Pork 'n' Pork 'n' Pork 'n' Beans	Sleaze Spell Damage: [15*(1+skill(Beanweaver))], Last Available: "2016-02"
-Item	portable dam	Damage Reduction: 109, Last Available: "2018-12"
+Item	portable dam	Damage Reduction: 100, Last Available: "2018-12"
 Item	portable Othello set	Othello Skill: +10
-Item	pottery shield	Hot Damage: +5, Damage Reduction: 3, Last Available: "2010-09"
+Item	pottery shield	Hot Damage: +5, Last Available: "2010-09"
 Item	pretty bouquet	Moxie: +3
 Item	primitive alien totem	Damage Reduction: 25, Spooky Damage: +25, HP Regen Min: 2, HP Regen Max: 4, MP Regen Min: 2, MP Regen Max: 4, Last Available: "2017-04"
 Item	psychic's crystal ball	Muscle: +5, Mysticality: +5, Moxie: +5, Initiative: +20, Last Available: "2018-02"
 Item	pumpkin spice candle	Item Drop: +40, Lasts Until Rollover, Last Available: "2016-12"
-Item	radiator heater shield	Cold Resistance: +3, Damage Reduction: 6
+Item	radiator heater shield	Cold Resistance: +3
 Item	rag doll	Muscle: +3, Last Available: "2005-12"
 # Raggedy Hippy doll
 Item	Rain-Doh green lantern	Maximum MP: +20, Softcore Only, Last Available: "2012-02", Lantern: 1, Lantern Element: "Stench"
@@ -2655,7 +2653,7 @@ Item	red China marble	Hot Spell Damage: +40
 Item	red LavaCo Lamp&trade;	Adventures: +5, Rollover Effect: "Red Menace", Rollover Effect Duration: 50, Last Available: "2015-08"
 Item	Red Roger's red left hand	Last Available: "2019-04", Item Drop: [100*zone(PirateRealm)]
 Item	red wagon	Mysticality Percent: +15, Spell Damage Percent: +50, Maximum MP: +300
-Item	Red X Shield	Maximum HP: +20, Maximum MP: +20, Damage Reduction: 11
+Item	Red X Shield	Maximum HP: +20, Maximum MP: +20
 Item	replica august scepter	Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 Item	replica Operation Patriot Shield	Experience: +3, Maximum HP: +20, Maximum MP: +20, Variable, Conditional Skill (Equipped): "Throw Shield"
 Item	reusable shopping bag	Food Drop: +20, Booze Drop: +20, Candy Drop: +20, Last Available: "2015-12"
@@ -2663,31 +2661,31 @@ Item	rice bowl	Food Drop: +20
 Item	Roman Candelabra	Maximum HP: [10*(pref(romanCandelabraRedCasts)+2)], Maximum MP: [10*(pref(romanCandelabraYellowCasts)+2)], Muscle: [5*(pref(romanCandelabraBlueCasts)+2)], Mysticality: [5*(pref(romanCandelabraGreenCasts)+2)], Moxie: [5*(pref(romanCandelabraPurpleCasts)+2)], Spooky Damage: [10*(1-min(1,effect(Everything Looks Yellow)))], Cold Damage: [10*(1-min(1,effect(Everything Looks Blue)))], Hot Damage: [10*(1-min(1,effect(Everything Looks Red)))], Stench Damage: [10*(1-min(1,effect(Everything Looks Green)))], Sleaze Damage: [10*(1-min(1,effect(Everything Looks Purple)))], Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
 Item	Royal scepter	Adventures: +4, PvP Fights: +8, Rollover Effect: "It's Good To Be Royal!", Rollover Effect Duration: 5, Last Available: "2015-09"
 Item	rubber baby doll	Damage Aura: 1
-Item	rubber ribcage	Spooky Resistance: +3, Damage Reduction: 12
+Item	rubber ribcage	Spooky Resistance: +3, Damage Reduction: 5
 Item	rusty compass	Initiative: +30
 Item	rusty empty nacho cheese can	Water: +1
 Item	rusty kettle bell	Muscle Percent: +50, Last Available: "2020-04"
 # rusty old lantern
-Item	rxr shield	Damage Absorption: +10, Damage Reduction: 6, Last Available: "2010-06"
+Item	rxr shield	Damage Absorption: +10, Last Available: "2010-06"
 Item	SalesCo sample kit	Meat Drop: [30*event(December)], Last Available: "2020-12"
-Item	sawblade shield	Weapon Damage: +11, Damage Reduction: 11
+Item	sawblade shield	Weapon Damage: +11
 Item	Scepter of Loathing	Critical Hit Percent: +15, Spell Critical Percent: +15, Spooky Resistance: +5, Cloathing
 Item	Sceptre of the Torremolinos Prince	Mysticality Percent: +12, Last Available: "2011-10"
 # Science Notebook: Allows you to collect data about Tentacles
 Item	Science Notebook	Monster Level: +10
 Item	scissor duck	Mysticality: +5, Last Available: "2010-12"
 Item	scorched skull trophy	PvP Fights: +10, Last Available: "2025-12"
-Item	sealhide buckler	Damage Reduction: 17
+Item	sealhide buckler	Damage Reduction: 7
 Item	sealskin drum	Weapon Damage: +20, Class: "Seal Clubber"
-Item	sebaceous shield	Stench Damage: +1, Sleaze Damage: +1, Damage Reduction: 2
+Item	sebaceous shield	Stench Damage: +1, Sleaze Damage: +1
 Item	security flashlight	Monster Level: -10
 Item	set of jacks	Experience (Moxie): +2, Last Available: "2007-12"
 Item	Seven Loco	Booze Drop: +5, Candy Drop: +5, Last Available: "2010-09"
-Item	sewer turtle	Stench Damage: +1, Damage Reduction: 1
+Item	sewer turtle	Stench Damage: +1
 Item	shadow candle	Conditional Skill (Equipped): "Shadow Flame"
 Item	shadowy seal eye	Spooky Damage: +20, Monster Level: +15, Class: "Seal Clubber"
-Item	Shield of Icy Fate	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Weapon Damage Percent: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Damage Reduction: 7, Last Available: "2013-02"
-Item	shield of the Skeleton Lord	Muscle Percent: +50, Monster Level: +50, Familiar Weight: +5, Damage Reduction: 19, Last Available: "2018-04"
+Item	Shield of Icy Fate	Spooky Resistance: +1, Stench Resistance: +1, Hot Resistance: +1, Cold Resistance: +1, Sleaze Resistance: +1, Weapon Damage Percent: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Last Available: "2013-02"
+Item	shield of the Skeleton Lord	Muscle Percent: +50, Monster Level: +50, Familiar Weight: +5, Last Available: "2018-04"
 Item	Shrub's Premium Baked Beans	Maximum MP: [25*(1+skill(Beanweaver))], Spell Damage Percent: [25*(1+skill(Beanweaver))], Spell Critical Percent: [5*(1+skill(Beanweaver))], Last Available: "2016-02"
 Item	shrunken head	Damage Reduction: [5*L], Muscle: [3*L], Mysticality: [3*L], Moxie: [3*L], MP Regen Min: 13, MP Regen Max: 15, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
 # signal receiver: Receives signals, presumably
@@ -2695,17 +2693,17 @@ Item	silver cow creamer	Adventures: +3, PvP Fights: +3, Meat Drop: +30, Last Ava
 # silver sausage
 # Sinful Desires: All Spells Cast Are Sleazy
 Item	Sinful Desires	Spell Damage: +10
-Item	six-rainbow shield	Maximum HP: +50, Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Damage Reduction: 12, Last Available: "2008-07"
+Item	six-rainbow shield	Maximum HP: +50, Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Last Available: "2008-07"
 Item	skull gearshift knob	Spooky Damage: +20, Spooky Spell Damage: +25, Spell Damage Percent: +30, Last Available: "2014-12"
 Item	skull of the Bonerdagon	Spooky Damage: +5
 Item	slime-covered compass	Slime Resistance: +2, Initiative: +40
 Item	slime-covered lantern	Slime Resistance: +2, Maximum HP: +50, Maximum MP: +50, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 10, MP Regen Max: 15
-Item	slippery when wet shield	Damage Absorption: +10, Damage Reduction: 6, Last Available: "2010-04"
+Item	slippery when wet shield	Damage Absorption: +10, Last Available: "2010-04"
 Item	smirking shrunken head	Damage Aura: 1
-Item	snake shield	Muscle: +6, Damage Reduction: 7, Synergetic
+Item	snake shield	Muscle: +6, Synergetic
 # snapdragon pistil: All Spells Cast Are Hot
 Item	snapdragon pistil	Spell Critical Percent: +5, Last Available: "2010-03"
-Item	snarling wolf shield	Maximum HP: +40, Damage Reduction: 7, Synergetic
+Item	snarling wolf shield	Maximum HP: +40, Synergetic
 Item	snow mobile	Maximum MP: +20, Lasts Until Rollover, Last Available: "2014-01", Lantern: 1, Lantern Element: "Cold"
 Item	snowstick	Cold Spell Damage: +80
 Item	sock monkey	Moxie: +3, Last Available: "2005-12"
@@ -2713,29 +2711,28 @@ Item	Solstice Shield	Muscle Percent: [5*G], Mysticality Percent: [5*G], Moxie Pe
 Item	sommelier's towel	Booze Drop: +30
 Item	sonar fishfinder	Fishing Skill: +5, Last Available: "2016-04"
 # space shield: Deflects Invader Bullets
-Item	space shield	Damage Reduction: 9
 Item	Space Tourist palmdoctor	Maximum HP: +25, Maximum MP: +25, HP Regen Min: 4, HP Regen Max: 6, MP Regen Min: 4, MP Regen Max: 6, Lasts Until Rollover
 Item	spaghetti-box banjo	MP Regen Min: 5, MP Regen Max: 10, Class: "Pastamancer"
 # Spanish fly trap
-Item	spant shield	Muscle Percent: +15, Damage Absorption: +100, Damage Reduction: 6, Last Available: "2017-04"
-Item	speed limit shield	Damage Absorption: +10, Damage Reduction: 6, Last Available: "2009-12"
-Item	spiky turtle shield	Weapon Damage: +8, Item Drop: +10, Damage Reduction: 8
-Item	spongy shield	Muscle Percent: +10, HP Regen Min: 20, HP Regen Max: 50, Damage Absorption: +50, Damage Reduction: 14
+Item	spant shield	Muscle Percent: +15, Damage Absorption: +100, Last Available: "2017-04"
+Item	speed limit shield	Damage Absorption: +10, Last Available: "2009-12"
+Item	spiky turtle shield	Weapon Damage: +8, Item Drop: +10
+Item	spongy shield	Muscle Percent: +10, HP Regen Min: 20, HP Regen Max: 50, Damage Absorption: +50
 Item	spooky little girl	Item Drop: [G], Last Available: "2011-06"
 # sprinkle shaker
 Item	sprinkle shaker	Last Available: "2014-05"
 Item	sprinkle-begging cup	Sprinkle Drop: +50, Last Available: "2016-12"
 Item	stack of communist leaflets	Last Available: "2015-12"
-Item	stained glass shield	Experience (Muscle): +3, Cold Resistance: +3, Cold Damage: +5, Damage Reduction: 7, Last Available: "2021-12"
+Item	stained glass shield	Experience (Muscle): +3, Cold Resistance: +3, Cold Damage: +5, Last Available: "2021-12"
 Item	standards and practices guide	Sleaze Resistance: +2, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
 Item	stapler bear	Muscle: +5, Last Available: "2010-12", Damage Aura: 1
-Item	star buckler	Muscle: +2, Mysticality: +2, Moxie: +2, Damage Reduction: 10
+Item	star buckler	Muscle: +2, Mysticality: +2, Moxie: +2
 Item	steaming evil	Hot Damage: +6, Sleaze Damage: +6, Spooky Damage: +6
 Item	steely marble	Sleaze Spell Damage: +65
-Item	stinky cheese wheel	Damage Reduction: 6, Stinky Cheese, Softcore Only, Last Available: "2010-01", Damage Absorption: [max(1,min(50,floor(pref(_stinkyCheeseCount)/2)))]
-Item	stop shield	Damage Absorption: +10, Damage Reduction: 6, Last Available: "2009-12"
+Item	stinky cheese wheel	Stinky Cheese, Softcore Only, Last Available: "2010-01", Damage Absorption: [max(1,min(50,floor(pref(_stinkyCheeseCount)/2)))]
+Item	stop shield	Damage Absorption: +10, Last Available: "2009-12"
 Item	stress ball	Maximum HP: +100, Maximum MP: +100, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
-Item	studded sealhide shield	Muscle: +5, Maximum HP: +30, Damage Reduction: 7
+Item	studded sealhide shield	Muscle: +5, Maximum HP: +30
 # stuffed astral badger
 # stuffed baby gravy fairy
 Item	stuffed bandersnatch	Last Available: "2010-03"
@@ -2784,8 +2781,8 @@ Item	surprisingly capacious handbag	Last Available: "2018-09", Item Drop: [50*lo
 Item	Sword of the Brouhaha Prince	Muscle Percent: +12, Last Available: "2011-10"
 # Taco Dan's Taco Stand Cocktail Sauce Bottle
 Item	Taco Dan's Taco Stand Cocktail Sauce Bottle	Last Available: "2014-05"
-Item	tailbone shield	Stench Damage: +40, Damage Reduction: 16, Thorns: 1
-Item	teflon shield	Muscle Percent: +10, Damage Reduction: 24, Damage Absorption: +50
+Item	tailbone shield	Stench Damage: +40, Thorns: 1
+Item	teflon shield	Muscle Percent: +10, Damage Reduction: 10, Damage Absorption: +50
 Item	Temporal Tempera Tube	Muscle Percent: [5*G], Mysticality Percent: [5*G], Moxie Percent: [5*G]
 Item	terra cotta tambourine	Moxie Percent: +20, Monster Level: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
 Item	Tesla's Electroplated Beans	Maximum MP: [15*(1+skill(Beanweaver))], Spell Damage: [10*(1+skill(Beanweaver))], MP Regen Min: [4*(1+skill(Beanweaver))], MP Regen Max: [5*(1+skill(Beanweaver))], Last Available: "2016-02"
@@ -2804,7 +2801,7 @@ Item	tinsel orb	Accessory Drop: +100, Spooky Damage: +60, Class: "Turtle Tamer",
 # tiny black hole: Allows Pickpocketing
 Item	tiny black hole	Pickpocket Chance: +25, Initiative: -200, Last Available: "2011-04"
 Item	tip jar	Meat Drop: +5
-Item	tortoboggan shield	Initiative: +30, Cold Resistance: +2, Damage Reduction: 6
+Item	tortoboggan shield	Initiative: +30, Cold Resistance: +2
 Item	toy Crimbot super fist	Damage Reduction: 10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
 Item	Trader Olaf's Exotic Stinkbeans	Stench Spell Damage: [15*(1+skill(Beanweaver))], Last Available: "2016-02"
 Item	trench lighter	Experience Percent (Muscle): +10, Experience Percent (Mysticality): +10, Experience Percent (Moxie): +10, Last Available: "2014-10"
@@ -2813,24 +2810,24 @@ Item	trojan horseshoe	Last Available: "2025-12"
 Item	tropical paperweight	Experience: +1, Last Available: "2006-12", Stat Tuning: "Muscle"
 # Tuesday's ruby: Has day-dependent effects which are hard-coded
 Item	Tuesday's ruby	Variable
-Item	turtle wax shield	Maximum HP: +10, Damage Reduction: 2
+Item	turtle wax shield	Maximum HP: +10
 # turtling rod: Helps You Tame Turtles
 Item	turtling rod	Class: "Turtle Tamer"
 # unbreakable umbrella: Can alter final enchantment by reconfiguring umbrella
 Item	unbreakable umbrella	Maximum HP: +25, Maximum MP: +25, Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Initiative: +25, Meat Drop: +25
 Item	uncursed arcane orb	Spooky Damage: +1, Stench Damage: +1, Hot Damage: +1, Cold Damage: +1, Sleaze Damage: +1
 Item	uncursed stats	Experience: +1
-Item	Unkillable Skeleton's shield	Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Maximum MP: -300, Damage Reduction: 23, Thorns: 1
+Item	Unkillable Skeleton's shield	Spooky Resistance: +3, Stench Resistance: +3, Hot Resistance: +3, Cold Resistance: +3, Sleaze Resistance: +3, Maximum MP: -300, Thorns: 1
 # UV-resistant compass: Aids in desert exploration
 Item	Val-U Brand Every Bean Salad	Hot Spell Damage: +5, Cold Spell Damage: +5, Spooky Spell Damage: +5, Stench Spell Damage: +5, Sleaze Spell Damage: +5, Last Available: "2016-02"
 Item	vampire pellet	MP Regen Min: 4, MP Regen Max: 8, Spooky Damage: +10, Spooky Spell Damage: +20
-Item	velcro shield	Mysticality Percent: +10, Damage Reduction: 24, Weapon Drop: +25
+Item	velcro shield	Mysticality Percent: +10, Damage Reduction: 10, Weapon Drop: +25
 # velour valise: Triples the damage and deleveling of Tango of Terror
 Item	velour valise	Experience (Moxie): +2, Booze Drop: +30, Last Available: "2021-12"
 Item	vengeful spirit	Hot Spell Damage: +80
-Item	vermiculite shield	Damage Reduction: 19, Hot Resistance: +3, Last Available: "2025-12"
+Item	vermiculite shield	Damage Reduction: 10, Hot Resistance: +3, Last Available: "2025-12"
 Item	Victor, the Insult Comic Hellhound Puppet	Monster Level: +5
-Item	vinyl shield	Moxie Percent: +10, Damage Reduction: 24, Monster Level: +25
+Item	vinyl shield	Moxie Percent: +10, Damage Reduction: 10, Monster Level: +25
 # visual packet sniffer: CyberRealm:  Gives a chance for additional 1s to drop after combat
 Item	visual packet sniffer	Last Available: "2025-12"
 Item	voodoo doll	Mysticality: +1
@@ -2839,21 +2836,21 @@ Item	Wal-Mart snowglobe	Muscle Percent: +40, Experience (Muscle): +4, Familiar W
 Item	Walford's bucket	Last Available: "2015-11"
 # Wand of Oscus: All Spells Cast Are Stinky
 Item	Wand of Oscus	Spell Damage Percent: +100, Stench Spell Damage: +30, Class: "Pastamancer"
-Item	washboard shield	Damage Absorption: +50, Class: "Turtle Tamer", Damage Reduction: 10
+Item	washboard shield	Damage Absorption: +50, Class: "Turtle Tamer"
 Item	water candle	Hot Resistance: +3, Lasts Until Rollover, Water: +3
 Item	Whatsian Ionic Pliers	HP Regen Min: 3, HP Regen Max: 5, MP Regen Min: 3, MP Regen Max: 5
 # white balloon
-Item	white satin shield	Moxie: +2, Damage Reduction: 5
+Item	white satin shield	Moxie: +2
 Item	whittled walking stick	Adventures: +3, PvP Fights: +6, Combat Rate: +10, Item Drop: +20, Last Available: "2019-08"
 # wicker clicker: Cadenza will briefly stun opponents
 Item	wicker clicker	Experience (Moxie): +2, MP Regen Min: 2, MP Regen Max: 4, Last Available: "2016-12"
-Item	wicker shield	Moxie: +6, Damage Reduction: 11
-Item	wonderwall shield	Maximum HP: +50, Damage Reduction: 12
+Item	wicker shield	Moxie: +6
+Item	wonderwall shield	Maximum HP: +50
 Item	World's Blackest-Eyed Peas	Spooky Spell Damage: [15*(1+skill(Beanweaver))], Last Available: "2016-02"
-Item	yakskin buckler	Mysticality: +5, Damage Reduction: 5
-Item	yield shield	Damage Absorption: +10, Damage Reduction: 6, Last Available: "2009-09"
+Item	yakskin buckler	Mysticality: +5
+Item	yield shield	Damage Absorption: +10, Last Available: "2009-09"
 Item	Yorick	Experience: +2, HP Regen Min: 5, HP Regen Max: 10, MP Regen Min: 5, MP Regen Max: 10, Item Drop: +15
-Item	Zombo's shield	Damage Absorption: +50, Spooky Damage: +30, Muscle Percent: +20, Class: "Turtle Tamer", Damage Reduction: 15
+Item	Zombo's shield	Damage Absorption: +50, Spooky Damage: +30, Muscle Percent: +20, Class: "Turtle Tamer"
 # zoological sample kit: Increases the yield of Spacegate zoology operations
 Item	zoological sample kit	Lasts Until Rollover, Last Available: "2017-04"
 

--- a/src/net/sourceforge/kolmafia/KoLConstants.java
+++ b/src/net/sourceforge/kolmafia/KoLConstants.java
@@ -204,7 +204,7 @@ public interface KoLConstants extends UtilityConstants {
   int DAILYLIMITS_VERSION = 1;
   int DEFAULTS_VERSION = 2;
   int ENCOUNTERS_VERSION = 1;
-  int EQUIPMENT_VERSION = 2;
+  int EQUIPMENT_VERSION = 3;
   int FAMBATTLE_VERSION = 1;
   int FAMILIARS_VERSION = 4;
   int FAXBOTS_VERSION = 1;

--- a/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
@@ -47,6 +47,10 @@ public enum DoubleModifier implements Modifier {
       "Damage Absorption",
       Pattern.compile("Damage Absorption ([+-]\\d+)"),
       Pattern.compile("Damage Absorption: " + EXPR)),
+  FIRST_HIT_DAMAGE_REDUCTION(
+      "First Hit Damage Reduction",
+      Pattern.compile("Damage Reduction: ([+-]?\\d+) \\(First Hit Only\\)"),
+      Pattern.compile("First Hit Damage Reduction: " + EXPR)),
   DAMAGE_REDUCTION(
       "Damage Reduction",
       Pattern.compile("Damage Reduction: ([+-]?\\d+)"),

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -1685,6 +1685,7 @@ public class ItemPool {
   public static final int WASABI_POTION = 5019;
   public static final int TOBIKO_POTION = 5020;
   public static final int NATTO_POTION = 5021;
+  public static final int ASTRAL_SHIELD = 5029;
   public static final int PET_SWEATER = 5040;
   public static final int ASTRAL_SHIRT = 5041;
   public static final int ASTRAL_HOT_DOG = 5043;
@@ -3909,6 +3910,7 @@ public class ItemPool {
   public static final int MAYAM_CALENDAR = 11572;
   public static final int YAM_BATTERY = 11582;
   public static final int STUFFED_YAM_STINKBOMB = 11583;
+  public static final int FURRY_YAM_BUCKLER = 11584;
   public static final int YAMTILITY_BELT = 11586;
   public static final int MINI_KIWI = 11594;
   public static final int MINI_KIWI_AIOLI = 11598;
@@ -3999,6 +4001,7 @@ public class ItemPool {
   public static final int WET_BLANKET = 11891;
   public static final int PERIDOT_OF_PERIL = 11905;
   public static final int PRISMATIC_BERET = 11919;
+  public static final int FLAK_SHIELD = 11920;
   public static final int ALLIED_RADIO_BACKPACK = 11933;
   public static final int MOBIUS_RING = 11942;
   public static final int HANDHELD_ALLIED_RADIO = 11946;

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -1349,6 +1349,7 @@ public class ItemPool {
   public static final int BITTER_BOWTIE = 4112;
   public static final int BEWITCHING_BOOTS = 4113;
   public static final int SECRET_FROM_THE_FUTURE = 4114;
+  public static final int OLD_SCHOOL_FLYING_DISC = 4119;
   public static final int EMPTY_AGUA_DE_VIDA_BOTTLE = 4130;
   public static final int TEMPURA_AIR = 4133;
   public static final int PRESSURIZED_PNEUMATICITY = 4134;

--- a/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/DebugDatabase.java
@@ -944,7 +944,9 @@ public class DebugDatabase {
       }
     }
 
-    EquipmentDatabase.writeEquipmentItem(report, name, power, req, weaponType, isWeapon, isShield);
+    int shieldDamageReduction = isShield ? DebugDatabase.parseShieldDamageReduction(text) : 0;
+    EquipmentDatabase.writeEquipmentItem(
+        report, name, power, req, weaponType, isWeapon, isShield, shieldDamageReduction);
   }
 
   private static final Pattern POWER_PATTERN = Pattern.compile("Power: <b>(\\d+)</b>");
@@ -999,6 +1001,14 @@ public class DebugDatabase {
     }
 
     return "none";
+  }
+
+  private static final Pattern SHIELD_DR_PATTERN =
+      Pattern.compile("Damage Reduction: <b>([+-]?\\d+)</b>");
+
+  public static int parseShieldDamageReduction(final String text) {
+    Matcher matcher = DebugDatabase.SHIELD_DR_PATTERN.matcher(text);
+    return matcher.find() ? StringUtilities.parseInt(matcher.group(1)) : 0;
   }
 
   private static final Pattern FULLNESS_PATTERN = Pattern.compile("Size: <b>(\\d+)</b>");
@@ -1280,14 +1290,6 @@ public class DebugDatabase {
 
     // Several modifiers can appear outside the "Enchantments"
     // section of the item description.
-
-    // If we extracted Damage Reduction from the enchantments, we
-    // included shield DR as well, but for shields that have no
-    // enchantments, get DR here.
-    if (!known.containsModifier("Damage Reduction")) {
-      DebugDatabase.appendModifier(known, ModifierDatabase.parseDamageReduction(text));
-    }
-
     DebugDatabase.appendModifier(known, ModifierDatabase.parseSkill(text));
     DebugDatabase.appendModifier(known, ModifierDatabase.parseSingleEquip(text));
     DebugDatabase.appendModifier(known, ModifierDatabase.parseSoftcoreOnly(text));
@@ -1517,11 +1519,7 @@ public class DebugDatabase {
           }
         }
 
-        // Damage Reduction can appear in several
-        // places. Combine them all.
-        else if (mod.startsWith("Damage Reduction")) {
-          mod = ModifierDatabase.parseDamageReduction(text);
-        } else if (mod.equals("Class: \"December\"")) {
+        if (mod.equals("Class: \"December\"")) {
           decemberEvent = true;
           continue;
         }

--- a/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/EquipmentDatabase.java
@@ -39,7 +39,7 @@ import net.sourceforge.kolmafia.utilities.StringUtilities;
 @SuppressWarnings("incomplete-switch")
 public class EquipmentDatabase {
   private record EquipmentData(
-      String name, int power, String statRequirement, int hands, String itemType) {
+      String name, int power, String statRequirement, int hands, String itemType, int shieldDR) {
     String toDataLine(final int itemId) {
       var name = ItemPool.get(itemId).getDisambiguatedName();
       String output = name + "\t" + power + "\t" + statRequirement;
@@ -47,6 +47,9 @@ public class EquipmentDatabase {
         output += "\t" + hands + "-handed " + itemType;
       } else if (itemType != null) {
         output += "\t" + itemType;
+        if (itemType.equals("shield") && shieldDR > 0) {
+          output += ": " + shieldDR;
+        }
       }
       return output;
     }
@@ -143,6 +146,7 @@ public class EquipmentDatabase {
 
         int hval = 0;
         String tval = null;
+        int shieldDR = 0;
 
         if (data.length >= 4) {
           String str = data[3];
@@ -156,8 +160,17 @@ public class EquipmentDatabase {
           }
         }
 
+        // extract shield DR
+        if (tval != null && tval.startsWith("shield:")) {
+          String dr = tval.substring(7).trim();
+          if (StringUtilities.isNumeric(dr)) {
+            shieldDR = StringUtilities.parseInt(dr);
+            tval = "shield";
+          }
+        }
+
         EquipmentDatabase.equipmentById.put(
-            itemId, new EquipmentData(data[0], power, statRequirement, hval, tval));
+            itemId, new EquipmentData(data[0], power, statRequirement, hval, tval, shieldDR));
       }
     } catch (IOException e) {
       StaticEntity.printStackTrace(e);
@@ -342,12 +355,14 @@ public class EquipmentDatabase {
       final String req,
       final String weaponType,
       final boolean isWeapon,
-      final boolean isShield) {
+      final boolean isShield,
+      final int shieldDamageReduction) {
     if (isShield && power == 0) {
       writer.println("# *** " + name + " is a shield of unknown power.");
     }
     writer.println(
-        EquipmentDatabase.equipmentString(name, power, req, weaponType, isWeapon, isShield));
+        EquipmentDatabase.equipmentString(
+            name, power, req, weaponType, isWeapon, isShield, shieldDamageReduction));
   }
 
   public static String equipmentString(
@@ -356,11 +371,13 @@ public class EquipmentDatabase {
       final String req,
       final String weaponType,
       final boolean isWeapon,
-      final boolean isShield) {
+      final boolean isShield,
+      final int shieldDamageReduction) {
     if (isWeapon) {
       return name + "\t" + power + "\t" + req + "\t" + weaponType;
     } else if (isShield) {
-      return name + "\t" + power + "\t" + req + "\tshield";
+      String shield = shieldDamageReduction > 0 ? "shield: " + shieldDamageReduction : "shield";
+      return name + "\t" + power + "\t" + req + "\t" + shield;
     } else {
       return name + "\t" + power + "\t" + req;
     }
@@ -377,6 +394,7 @@ public class EquipmentDatabase {
 
     int hands = 0;
     String itemType = null;
+    int shieldDR = 0;
 
     if (type.contains("weapon")) {
       Matcher matcher = WEAPON_TYPE_PATTERN.matcher(type);
@@ -388,9 +406,10 @@ public class EquipmentDatabase {
       }
     } else if (type.contains("shield")) {
       itemType = "shield";
+      shieldDR = DebugDatabase.parseShieldDamageReduction(text);
     }
 
-    var data = new EquipmentData(itemName, power, req, hands, itemType);
+    var data = new EquipmentData(itemName, power, req, hands, itemType, shieldDR);
     EquipmentDatabase.equipmentById.put(itemId, data);
 
     String printMe = data.toDataLine(itemId);
@@ -520,6 +539,11 @@ public class EquipmentDatabase {
   public static final int getHands(final int itemId) {
     EquipmentData equipmentData = EquipmentDatabase.equipmentById.get(itemId);
     return equipmentData == null ? 0 : equipmentData.hands;
+  }
+
+  public static final int getShieldDamageReduction(final int itemId) {
+    EquipmentData equipmentData = EquipmentDatabase.equipmentById.get(itemId);
+    return equipmentData == null ? 0 : equipmentData.shieldDR;
   }
 
   public static final String getEquipRequirement(final int itemId) {

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -120,8 +120,6 @@ public class ModifierDatabase {
   private static final String MP_REGEN_MAX_TAG = DoubleModifier.MP_REGEN_MAX.getTag() + ": ";
 
   private static final Pattern SKILL_PATTERN = Pattern.compile("Grants Skill:.*?<b>(.*?)</b>");
-  private static final Pattern DR_PATTERN =
-      Pattern.compile("Damage Reduction: (<b>)?([+-]?\\d+)(</b>)?");
   private static final Pattern SINGLE_PATTERN =
       Pattern.compile("You may not equip more than one of these at a time");
   private static final Pattern SOFTCORE_PATTERN =
@@ -459,6 +457,19 @@ public class ModifierDatabase {
       modifiers.override(lookup);
       if (originalType != null) {
         modifiers.setLookup(new Lookup(originalType, key));
+      }
+    }
+
+    if (type == ModifierType.ITEM && key.isInt()) {
+      int shieldDR = EquipmentDatabase.getShieldDamageReduction(key.getIntValue());
+      if (shieldDR > 0) {
+        Modifiers copy = new Modifiers(modifiers);
+        copy.addDouble(
+            DoubleModifier.DAMAGE_REDUCTION,
+            shieldDR,
+            ModifierType.EQUIPMENT_POWER,
+            "shield damage reduction");
+        return copy;
       }
     }
 
@@ -828,21 +839,6 @@ public class ModifierDatabase {
     }
 
     return null;
-  }
-
-  public static final String parseDamageReduction(final String text) {
-    if (!text.contains("Damage Reduction:")) {
-      return null;
-    }
-
-    Matcher matcher = DR_PATTERN.matcher(text);
-    int dr = 0;
-
-    while (matcher.find()) {
-      dr += StringUtilities.parseInt(matcher.group(2));
-    }
-
-    return DoubleModifier.DAMAGE_REDUCTION.getTag() + ": " + dr;
   }
 
   public static final String parseSingleEquip(final String text) {

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -438,7 +438,9 @@ public class ModifierDatabase {
       String modifierString = getModifierString(new Lookup(type, key));
 
       if (modifierString == null) {
-        return null;
+        // Items with no modifiers.txt entry can still have innate shield
+        // Damage Reduction derived from their equipment power.
+        return shieldDamageReduction(type, key, null);
       }
 
       modifiers = parseModifiers(lookup, modifierString);
@@ -460,6 +462,12 @@ public class ModifierDatabase {
       }
     }
 
+    return shieldDamageReduction(type, key, modifiers);
+  }
+
+  /** Adds the innate shield Damage Reduction derived from equipment power, if any. */
+  private static Modifiers shieldDamageReduction(
+      final ModifierType type, final IntOrString key, final Modifiers modifiers) {
     if (type == ModifierType.ITEM && key.isInt()) {
       int shieldDR = EquipmentDatabase.getShieldDamageReduction(key.getIntValue());
       if (shieldDR > 0) {
@@ -472,7 +480,6 @@ public class ModifierDatabase {
         return copy;
       }
     }
-
     return modifiers;
   }
 
@@ -1798,5 +1805,18 @@ public class ModifierDatabase {
     computeSynergies();
     computeMutexes();
     computeReplaceableEffectMutexes();
+  }
+
+  /**
+   * Reset modifiers and re-read the base data from modifiers.txt.
+   *
+   * <p>TCRS files may contain lines for items that have no entry in modifiers.txt (such as shields
+   * whose damage reduction is derived from equipment power). Overriding those items adds their TCRS
+   * enchantments to modifierStringsByName, where they would otherwise persist for the rest of the
+   * session. This discards them so that only the enchantments in modifiers.txt remain.
+   */
+  public static void resetKnownModifiers() {
+    modifierStringsByName.clear();
+    resetModifiers();
   }
 }

--- a/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
@@ -772,7 +772,7 @@ public class TCRSDatabase {
 
     TCRSDatabase.reset();
 
-    ModifierDatabase.resetModifiers();
+    ModifierDatabase.resetKnownModifiers();
     EffectDatabase.reset();
     ConsumablesDatabase.reset();
 

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -2229,6 +2229,9 @@ public abstract class RuntimeLibrary {
     functions.add(new LibraryFunction("weapon_type", DataTypes.STAT_TYPE, params));
 
     params = List.of(namedParam("item", DataTypes.ITEM_TYPE));
+    functions.add(new LibraryFunction("shield_dr", DataTypes.INT_TYPE, params));
+
+    params = List.of(namedParam("item", DataTypes.ITEM_TYPE));
     functions.add(new LibraryFunction("get_power", DataTypes.INT_TYPE, params));
 
     params = List.of();
@@ -8364,6 +8367,10 @@ public abstract class RuntimeLibrary {
         : stat == Stat.MYSTICALITY
             ? DataTypes.MYSTICALITY_VALUE
             : stat == Stat.MOXIE ? DataTypes.MOXIE_VALUE : DataTypes.STAT_INIT;
+  }
+
+  public static Value shield_dr(ScriptRuntime controller, final Value item) {
+    return new Value(EquipmentDatabase.getShieldDamageReduction((int) item.intValue()));
   }
 
   public static Value get_power(ScriptRuntime controller, final Value item) {

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -806,4 +806,17 @@ public class KoLCharacterTest {
       }
     }
   }
+
+  @Nested
+  class DamageReduction {
+    @Test
+    void shieldInnateDamageReductionAddsToTotal() {
+      var cleanups = new Cleanups(withEquipped(Slot.OFFHAND, ItemPool.OLD_SCHOOL_FLYING_DISC));
+
+      try (cleanups) {
+        assertThat(
+            KoLCharacter.currentNumericModifier(DoubleModifier.DAMAGE_REDUCTION), equalTo(24.0));
+      }
+    }
+  }
 }

--- a/test/net/sourceforge/kolmafia/KoLCharacterTest.java
+++ b/test/net/sourceforge/kolmafia/KoLCharacterTest.java
@@ -818,5 +818,15 @@ public class KoLCharacterTest {
             KoLCharacter.currentNumericModifier(DoubleModifier.DAMAGE_REDUCTION), equalTo(24.0));
       }
     }
+
+    @Test
+    void shieldWithOnlyInnateDamageReductionIsTotal() {
+      var cleanups = new Cleanups(withEquipped(Slot.OFFHAND, ItemPool.ASTRAL_SHIELD));
+
+      try (cleanups) {
+        assertThat(
+            KoLCharacter.currentNumericModifier(DoubleModifier.DAMAGE_REDUCTION), equalTo(15.0));
+      }
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -3298,4 +3298,15 @@ public class MaximizerTest {
       assertThat(getBoosts(), hasItem(recommends(ItemPool.CUSTOM_SIXGUN)));
     }
   }
+
+  @Test
+  void maximizerCountsInnateShieldDamageReduction() {
+    var cleanups = new Cleanups(withEquippableItem(ItemPool.OLD_SCHOOL_FLYING_DISC));
+
+    try (cleanups) {
+      assertTrue(maximize("dr"));
+      assertThat(getBoosts(), hasItem(recommends(ItemPool.OLD_SCHOOL_FLYING_DISC)));
+      assertThat(modFor(DoubleModifier.DAMAGE_REDUCTION), equalTo(24.0));
+    }
+  }
 }

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -3300,8 +3300,13 @@ public class MaximizerTest {
   }
 
   @Test
-  void maximizerCountsInnateShieldDamageReduction() {
-    var cleanups = new Cleanups(withEquippableItem(ItemPool.OLD_SCHOOL_FLYING_DISC));
+  void maximizerCountsInnateShieldDamageReductionAndEnchant() {
+    var cleanups =
+        new Cleanups(
+            withEquippableItem(ItemPool.OLD_SCHOOL_FLYING_DISC), // base 14, 10 enchant
+            withEquippableItem(ItemPool.ASTRAL_SHIELD), // higher base: 15
+            withEquippableItem(ItemPool.FURRY_YAM_BUCKLER) // higher enchant: 11
+            );
 
     try (cleanups) {
       assertTrue(maximize("dr"));

--- a/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/EquipmentDatabaseTest.java
@@ -57,7 +57,7 @@ public class EquipmentDatabaseTest {
     // Assert a spread
     assertThat(data, containsString("4-dimensional fez\t50\tnone\n"));
     assertThat(data, containsString("antique candy bucket\t10\tnone\n"));
-    assertThat(data, containsString("antique shield\t180\tMus: 60\tshield\n"));
+    assertThat(data, containsString("antique shield\t180\tMus: 60\tshield: 11\n"));
     assertThat(data, containsString("[10462]fire flower\t0\tMus: 0\t1-handed flower\n"));
     assertThat(data, containsString("World's Blackest-Eyed Peas\t30\tnone\tcan of beans\n"));
     assertThat(

--- a/test/net/sourceforge/kolmafia/persistence/ModifierDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/ModifierDatabaseTest.java
@@ -17,6 +17,8 @@ import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
 import net.sourceforge.kolmafia.modifiers.Lookup;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -104,5 +106,33 @@ public class ModifierDatabaseTest {
     String enchantment = "Effect Duration: 5, Effect Duration: 10";
     var mods = ModifierDatabase.parseModifiers(new Lookup(ModifierType.ITEM, "1"), enchantment);
     assertThat(mods.getDoubles(DoubleModifier.EFFECT_DURATION), is(List.of(5.0, 10.0)));
+  }
+
+  @Nested
+  class DamageReduction {
+    @Test
+    void itemDamageReductionWithNoEnchantmentsIsInnateDamageReduction() {
+      assertThat(
+          ModifierDatabase.getNumericModifier(
+              ModifierType.ITEM, ItemPool.ASTRAL_SHIELD, DoubleModifier.DAMAGE_REDUCTION),
+          equalTo(15.0));
+    }
+
+    @Test
+    void itemWithEnchantmentHasSummedDamageReduction() {
+      // Brimstone Bunker: 15 innate + 10 enchantment
+      assertThat(
+          ModifierDatabase.getNumericModifier(
+              ModifierType.ITEM, ItemPool.BRIMSTONE_BUNKER, DoubleModifier.DAMAGE_REDUCTION),
+          equalTo(25.0));
+    }
+
+    @Test
+    void itemWithoutModifiersHasDamageReduction() {
+      assertThat(
+          ModifierDatabase.getNumericModifier(
+              ModifierType.ITEM, ItemPool.FLAK_SHIELD, DoubleModifier.DAMAGE_REDUCTION),
+          equalTo(9.0));
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/session/ChoiceControlTest.java
+++ b/test/net/sourceforge/kolmafia/session/ChoiceControlTest.java
@@ -676,7 +676,7 @@ class ChoiceControlTest {
         assertThat(
             "_savageBeastMods",
             isSetTo(
-                "Combat Rate: +25, Muscle Percent: 100, Maximum HP Percent: 100, Damage Reduction: 90, Mysticality Percent: 100, Hot Resistance: 6, Cold Resistance: 6, Stench Resistance: 6, Sleaze Resistance: 6, Spooky Resistance: 6, Item Drop: 75, Monster Level: 50, Moxie Percent: 100, Initiative: 200, Meat Drop: 150, Experience: +5, HP Regen Min: 9, HP Regen Max: 11"));
+                "Combat Rate: +25, Muscle Percent: 100, Maximum HP Percent: 100, Damage Reduction: 30, Mysticality Percent: 100, Hot Resistance: 6, Cold Resistance: 6, Stench Resistance: 6, Sleaze Resistance: 6, Spooky Resistance: 6, Item Drop: 75, Monster Level: 50, Moxie Percent: 100, Initiative: 200, Meat Drop: 150, Experience: +5, HP Regen Min: 9, HP Regen Max: 11"));
 
         var requests = client.getRequests();
 

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -2989,4 +2989,10 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
       Files.deleteIfExists(file.toPath());
     }
   }
+
+  @ParameterizedTest
+  @CsvSource({"flak shield,9", "sealhide buckler,10", "old school flying disc,14", "seal tooth,0"})
+  void shieldDrReturnsInnateDamageReduction(String item, int dr) {
+    assertThat(execute("shield_dr($item[" + item + "])").trim(), is("Returned: " + dr));
+  }
 }

--- a/test/net/sourceforge/kolmafia/textui/command/TestCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/TestCommandTest.java
@@ -115,8 +115,8 @@ public class TestCommandTest extends AbstractCommandTestBase {
               """
               --------------------
               4119\told school flying disc\t940588617\tpetfrisbee.gif\toffhand, combat\td\t800
-              old school flying disc\t0\tMus: 200\tshield
-              Item\told school flying disc\tMuscle Percent: +15, Damage Reduction: 24, Familiar Weight: +5
+              old school flying disc\t0\tMus: 200\tshield: 14
+              Item\told school flying disc\tMuscle Percent: +15, Damage Reduction: 10, Familiar Weight: +5
               --------------------
               """));
       assertThat(

--- a/test/net/sourceforge/kolmafia/textui/command/TestCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/TestCommandTest.java
@@ -1,10 +1,14 @@
 package net.sourceforge.kolmafia.textui.command;
 
+import static internal.helpers.Networking.html;
+import static internal.helpers.Player.withResponses;
 import static internal.helpers.Player.withStats;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 
+import internal.network.FakeHttpResponse;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -12,6 +16,10 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.ModifierType;
+import net.sourceforge.kolmafia.modifiers.DoubleModifier;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
@@ -83,6 +91,38 @@ public class TestCommandTest extends AbstractCommandTestBase {
             After Battle: You gain 19 Smarm
             """));
       }
+    }
+  }
+
+  @Test
+  public void oldSchoolFlyingDiscHasDamageReduction() {
+    var cleanups =
+        withResponses(
+            r -> {
+              var path = r.uri().getPath();
+              if (path.startsWith("/desc_item.php")) {
+                return new FakeHttpResponse<>(
+                    html("request/test_desc_item_old_school_flying_disc.html"));
+              }
+              return null;
+            });
+
+    try (cleanups) {
+      String output = execute("newitem 940588617");
+      assertThat(
+          output,
+          containsString(
+              """
+              --------------------
+              4119\told school flying disc\t940588617\tpetfrisbee.gif\toffhand, combat\td\t800
+              old school flying disc\t0\tMus: 200\tshield
+              Item\told school flying disc\tMuscle Percent: +15, Damage Reduction: 24, Familiar Weight: +5
+              --------------------
+              """));
+      assertThat(
+          ModifierDatabase.getNumericModifier(
+              ModifierType.ITEM, ItemPool.OLD_SCHOOL_FLYING_DISC, DoubleModifier.DAMAGE_REDUCTION),
+          equalTo(24.0));
     }
   }
 }

--- a/test/root/request/test_desc_item_old_school_flying_disc.html
+++ b/test/root/request/test_desc_item_old_school_flying_disc.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+	"http://www.w3.org/TR/html4/loose.dtd">
+<html><head>
+<title>Item Description</title>
+<link rel="stylesheet" type="text/css" href="https://d2uyhvukfffg5a.cloudfront.net/styles.20230117d.css">
+<style>
+a.hand {
+	cursor: pointer;
+}
+</style>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/keybinds.min.2.js"></script>
+<script language=Javascript src="https://d2uyhvukfffg5a.cloudfront.net/scripts/window.20111231.js"></script>
+</head>
+<body>
+
+<div id="description" class=small><center><img  src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/petfrisbee.gif" height=30 width=30 alt="petfrisbee"><br><b>old school flying disc</b></center><p><blockquote>Sadly, this little guy has seen his last trip through the seaside air -- being embedded in the Slime has completely petrified it.  Not in the "terrified" sense, but in the "turned to stone" one.  On the bright side, it's durable, it's not too heavy, and it's about the right size to use as a shield.<!-- itemid: 4119 --><br><br>Type: <b>off-hand item (shield)</b><br>Damage Reduction: <b>14</b><br>Muscle Required: <b>200</b><br>(can also be used in combat)<br>Selling Price: <b>800 Meat.</b><br>Cannot be traded<p><center><b><font color=blue>Muscle +15%<br>Damage Reduction: 10<br>+5 to Familiar Weight<br></font></b></center></blockquote><script type="text/javascript">
+<!--
+var resizetries = 0;
+var fsckinresize;
+setTimeout(fsckinresize = function ()  {
+	var desch = document.getElementById('description').offsetHeight;
+	if (desch < 100 && resizetries < 5) {
+		setTimeout(fsckinresize, 100);
+		resizetries++;
+	}
+	if (desch < 100) desch = 200; 
+	//alert('resizing on try #' + resizetries);
+	if (self.resizeTo && window.outerHeight) { 
+		self.resizeTo(400, desch + (window.outerHeight - window.innerHeight) + 50); 
+	}
+	else if (self.resizeTo ) { self.resizeTo(400, desch+130); }
+	else { window.innerHeight = newh; }
+}, 100);
+//-->
+</script>
+</div>
+</body>
+</html>


### PR DESCRIPTION
A change for #1767 and also to more precisely transcribe KoL data.

Extract normal DR for shields, store it in `equipment.txt`. For shields like pilgrim shield, operation patriot shield, and the replica version of that, DR scales with level so this works as before. I hope to implement this as a follow-up. 

Keep things working as before as far as interrogating shield DR modifiers go.

Additionally, fix the bug where we see DR that applies only to the first hit as DR.