### PR TITLE
Print when a git repo has file conflicts

### DIFF
--- a/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
+++ b/src/net/sourceforge/kolmafia/scripts/git/GitManager.java
@@ -16,8 +16,12 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
@@ -54,6 +58,13 @@ public class GitManager extends ScriptManager {
   protected static final String MANIFEST = "manifest.json";
   protected static final String MANIFEST_ROOTDIR = "root_directory";
 
+  // Cache of sync path -> projects, used to check for file conflicts
+  private static Map<Path, Set<String>> projectsSyncPaths = null;
+
+  private static void invalidateProjectsSyncPaths() {
+    projectsSyncPaths = null;
+  }
+
   public static void clone(String repoUrl) {
     clone(repoUrl, null);
   }
@@ -78,6 +89,7 @@ public class GitManager extends ScriptManager {
       git.setBranch(branch).setBranchesToClone(List.of("refs/heads/" + branch));
     }
     try (var ignored = git.call()) {
+      invalidateProjectsSyncPaths();
       sync(projectPath);
     } catch (InvalidRemoteException e) {
       KoLmafia.updateDisplay(MafiaState.ERROR, "Could not find project at " + repoUrl + ": " + e);
@@ -158,6 +170,7 @@ public class GitManager extends ScriptManager {
 
       if (!oldRoot.equals(newRoot)) {
         // the root directory has changed. Figuring out the diff is too hard, just sync
+        invalidateProjectsSyncPaths();
         return sync(projectPath);
       }
 
@@ -410,11 +423,11 @@ public class GitManager extends ScriptManager {
     }
     if (!errored) {
       KoLmafia.updateDisplay("Project " + folder + " removed.");
-      return true;
     } else {
       KoLmafia.updateDisplay(MafiaState.ERROR, "Failed to completely remove project " + folder);
-      return false;
     }
+    invalidateProjectsSyncPaths();
+    return !errored;
   }
 
   /** Copy files from all installed git projects to permissible folders. */
@@ -437,6 +450,27 @@ public class GitManager extends ScriptManager {
     sync(projectPath);
   }
 
+  private static Map<Path, Set<String>> getAllProjectsSyncPaths() {
+    if (projectsSyncPaths != null) {
+      return projectsSyncPaths;
+    }
+    projectsSyncPaths = new HashMap<>();
+    for (var folder : allFolders()) {
+      var projectPath = KoLConstants.GIT_LOCATION.toPath().resolve(folder);
+      try {
+        var root = getRoot(projectPath);
+        var files = getPermissibleFiles(root, false);
+        for (var f : files) {
+          var relPath = root.relativize(f);
+          projectsSyncPaths.computeIfAbsent(relPath, k -> new HashSet<>()).add(folder);
+        }
+      } catch (IOException e) {
+        continue;
+      }
+    }
+    return projectsSyncPaths;
+  }
+
   private static boolean sync(Path projectPath) {
     var folder = KoLConstants.GIT_LOCATION.toPath().relativize(projectPath);
     var root = getRoot(projectPath);
@@ -447,6 +481,28 @@ public class GitManager extends ScriptManager {
       KoLmafia.updateDisplay(MafiaState.ERROR, "Failed to sync project " + folder + ": " + e);
       return false;
     }
+    var projects = getAllProjectsSyncPaths();
+
+    // Detect all conflicts
+    var conflictingPaths = new ArrayList<Path>();
+    for (var absPath : toAdd) {
+      var toRel = root.relativize(absPath);
+      var conflictingProjects = projects.get(toRel);
+      // size > 1 as the entry would include the current project
+      if (conflictingProjects != null && conflictingProjects.size() > 1) {
+        conflictingPaths.add(toRel);
+      }
+    }
+
+    // Report conflicts
+    for (var toRel : conflictingPaths) {
+      var conflictingProjects = projects.get(toRel);
+      KoLmafia.updateDisplay(
+          MafiaState.CONTINUE,
+          "Conflict: " + toRel + " (" + String.join(", ", conflictingProjects) + ")");
+    }
+
+    // Copy all files
     IOException lastError = null;
     for (var absPath : toAdd) {
       try {


### PR DESCRIPTION
This adds a conflict print after cloning or syncing scripts, but otherwise does not affect what files are copied. My intention is to do a follow up PR which uses a property where you can set a preferred repo when a conflict is found which prevents the other conflicting repos from syncing

Example:
```
> git checkout Ezandora/gain

Starting
remote: Enumerating objects
remote: Counting objects
remote: Compressing objects
Receiving objects
Resolving deltas
Checking out files
Copying: scripts/gain.ash
Cloned project Ezandora-gain

> git checkout loathers/gain

Starting
remote: Enumerating objects
remote: Counting objects
remote: Compressing objects
Receiving objects
Resolving deltas
Checking out files
Conflict: scripts/gain.ash (Ezandora-gain, loathers-gain)
Copying: scripts/gain.ash
Cloned project loathers-gain

> git sync

Conflict: scripts/gain.ash (Ezandora-gain, loathers-gain)
Copying: scripts/gain.ash
Conflict: scripts/gain.ash (Ezandora-gain, loathers-gain)
Copying: scripts/gain.ash

> git delete Ezandora-gain

Removing project Ezandora-gain
scripts/gain.ash => DELETED
Project Ezandora-gain removed.

> git sync

Copying: scripts/gain.ash

> git checkout Ezandora/gain

Starting
remote: Enumerating objects
remote: Counting objects
remote: Compressing objects
Receiving objects
Resolving deltas
Checking out files
Conflict: scripts/gain.ash (Ezandora-gain, loathers-gain)
Copying: scripts/gain.ash
Cloned project Ezandora-gain
```

A few things of note:

https://github.com/kolmafia/kolmafia/blob/6d69f4283b69013f144f93c8a7e5c1b7e248f00e/src/net/sourceforge/kolmafia/scripts/git/GitManager.java#L159-L162
I believe there is a bug here where if the root changes, but also files have been moved/deleted when the repo's root changed it will leave stale files that were previously synced. I think this is when a root is defined in the manifest and that changes?

https://github.com/kolmafia/kolmafia/blob/6d69f4283b69013f144f93c8a7e5c1b7e248f00e/src/net/sourceforge/kolmafia/scripts/git/GitManager.java#L196-L208
I didn't add conflict checking here, maybe the both of these could be simplified by simply deleting all the files that were deleted or moved, then call sync() afterwards once?