### PR TITLE
fix: use standard for Bookshelf: Florist Friar instead of item

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FloristRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FloristRequest.java
@@ -191,7 +191,7 @@ public class FloristRequest extends GenericRequest {
     boolean floristAvailable =
         (FloristRequest.ownsFlorist()
                     && StandardRequest.isAllowed(
-                        RestrictedItemType.ITEMS, "Order of the Green Thumb Order Form")
+                        RestrictedItemType.BOOKSHELF_BOOKS, "Florist Friar")
                 || KoLCharacter.inLegacyOfLoathing()
                     && Preferences.getBoolean("ownsReplicaFloristFriar"))
             && KoLAdventure.woodsOpen()

--- a/test/net/sourceforge/kolmafia/request/FloristRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FloristRequestTest.java
@@ -61,7 +61,7 @@ public class FloristRequestTest {
             withPath(Path.STANDARD),
             withRestricted(true),
             withNotAllowedInStandard(
-                RestrictedItemType.ITEMS, "Order of the Green Thumb Order Form"))) {
+                RestrictedItemType.BOOKSHELF_BOOKS, "Florist Friar"))) {
       assertThat(FloristRequest.haveFlorist(), is(false));
     }
   }

--- a/test/net/sourceforge/kolmafia/request/FloristRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/FloristRequestTest.java
@@ -60,8 +60,7 @@ public class FloristRequestTest {
             withProperty("ownsFloristFriar", true),
             withPath(Path.STANDARD),
             withRestricted(true),
-            withNotAllowedInStandard(
-                RestrictedItemType.BOOKSHELF_BOOKS, "Florist Friar"))) {
+            withNotAllowedInStandard(RestrictedItemType.BOOKSHELF_BOOKS, "Florist Friar"))) {
       assertThat(FloristRequest.haveFlorist(), is(false));
     }
   }


### PR DESCRIPTION
Order form does not show as missing in standard as reported https://github.com/kolmafia/kolmafia/pull/3617#issuecomment-5307251606