### PR TITLE
Fix Daily Dungeon incorrectly tracking non-DD fights

### DIFF
--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -495,6 +495,7 @@ public class FightRequest extends GenericRequest {
     // Categories of monsters
     BEE("bee"),
     CYRPT("Cyrpt"),
+    DAILY_DUNGEON("Daily Dungeon"),
     DMT("Deep Machine Tunnels"),
     EVENT("event monster"),
     GINGERBREAD("Gingerbread City"),
@@ -611,6 +612,16 @@ public class FightRequest extends GenericRequest {
     FightRequest.specialMonsters.put("gargantulihc", SpecialMonster.CYRPT);
     FightRequest.specialMonsters.put("giant skeelton", SpecialMonster.CYRPT);
     FightRequest.specialMonsters.put("huge ghuol", SpecialMonster.CYRPT);
+
+    FightRequest.specialMonsters.put("apathetic lizardman", SpecialMonster.DAILY_DUNGEON);
+    FightRequest.specialMonsters.put("dairy ooze", SpecialMonster.DAILY_DUNGEON);
+    FightRequest.specialMonsters.put("dodecapede", SpecialMonster.DAILY_DUNGEON);
+    FightRequest.specialMonsters.put("giant giant moth", SpecialMonster.DAILY_DUNGEON);
+    FightRequest.specialMonsters.put("mayonnaise wasp", SpecialMonster.DAILY_DUNGEON);
+    FightRequest.specialMonsters.put("pencil golem", SpecialMonster.DAILY_DUNGEON);
+    FightRequest.specialMonsters.put("sabre-toothed lime", SpecialMonster.DAILY_DUNGEON);
+    FightRequest.specialMonsters.put("tonic water elemental", SpecialMonster.DAILY_DUNGEON);
+    FightRequest.specialMonsters.put("vampire clam", SpecialMonster.DAILY_DUNGEON);
 
     FightRequest.specialMonsters.put("Performer of Actions", SpecialMonster.DMT);
     FightRequest.specialMonsters.put("Thinker of Thoughts", SpecialMonster.DMT);

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -613,16 +613,6 @@ public class FightRequest extends GenericRequest {
     FightRequest.specialMonsters.put("giant skeelton", SpecialMonster.CYRPT);
     FightRequest.specialMonsters.put("huge ghuol", SpecialMonster.CYRPT);
 
-    FightRequest.specialMonsters.put("apathetic lizardman", SpecialMonster.DAILY_DUNGEON);
-    FightRequest.specialMonsters.put("dairy ooze", SpecialMonster.DAILY_DUNGEON);
-    FightRequest.specialMonsters.put("dodecapede", SpecialMonster.DAILY_DUNGEON);
-    FightRequest.specialMonsters.put("giant giant moth", SpecialMonster.DAILY_DUNGEON);
-    FightRequest.specialMonsters.put("mayonnaise wasp", SpecialMonster.DAILY_DUNGEON);
-    FightRequest.specialMonsters.put("pencil golem", SpecialMonster.DAILY_DUNGEON);
-    FightRequest.specialMonsters.put("sabre-toothed lime", SpecialMonster.DAILY_DUNGEON);
-    FightRequest.specialMonsters.put("tonic water elemental", SpecialMonster.DAILY_DUNGEON);
-    FightRequest.specialMonsters.put("vampire clam", SpecialMonster.DAILY_DUNGEON);
-
     FightRequest.specialMonsters.put("Performer of Actions", SpecialMonster.DMT);
     FightRequest.specialMonsters.put("Thinker of Thoughts", SpecialMonster.DMT);
     FightRequest.specialMonsters.put("Perceiver of Sensations", SpecialMonster.DMT);
@@ -721,6 +711,7 @@ public class FightRequest extends GenericRequest {
     FightRequest.specialMonsters.put("void slab", SpecialMonster.VOID);
     FightRequest.specialMonsters.put("void spider", SpecialMonster.VOID);
 
+    FightRequest.addAreaMonsters("The Daily Dungeon", SpecialMonster.DAILY_DUNGEON);
     FightRequest.addAreaMonsters("A Maze of Sewer Tunnels", SpecialMonster.SEWER);
     FightRequest.addAreaMonsters("The Battlefield (Frat Uniform)", SpecialMonster.WAR_HIPPY);
     FightRequest.addAreaMonsters("The Battlefield (Hippy Uniform)", SpecialMonster.WAR_FRATBOY);

--- a/src/net/sourceforge/kolmafia/session/QuestManager.java
+++ b/src/net/sourceforge/kolmafia/session/QuestManager.java
@@ -39,6 +39,7 @@ import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.AdventureRequest;
 import net.sourceforge.kolmafia.request.CampgroundRequest;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
+import net.sourceforge.kolmafia.request.FightRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
 import net.sourceforge.kolmafia.request.OrcChasmRequest;
 import net.sourceforge.kolmafia.request.QuestLogRequest;
@@ -2424,7 +2425,10 @@ public class QuestManager {
         break;
 
       case AdventurePool.THE_DAILY_DUNGEON:
-        DailyDungeonManager.handleCurrentRoomCompletion(DailyDungeonManager.RoomType.MONSTER);
+        if (FightRequest.specialMonsterCategory(monsterName)
+            == FightRequest.SpecialMonster.DAILY_DUNGEON) {
+          DailyDungeonManager.handleCurrentRoomCompletion(DailyDungeonManager.RoomType.MONSTER);
+        }
         break;
 
       case AdventurePool.ARID_DESERT:

--- a/test/net/sourceforge/kolmafia/session/DailyDungeonManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/DailyDungeonManagerTest.java
@@ -123,6 +123,20 @@ public class DailyDungeonManagerTest {
     }
 
     @Test
+    public void dailyDungeonWrongMonsterVictoryIgnored() {
+      var cleanups =
+          new Cleanups(
+              withFight(),
+              withNextMonster("Quantum Mechanic"),
+              withLastLocation("The Daily Dungeon"),
+              withProperty("_lastDailyDungeonRoom", 1));
+      try (cleanups) {
+        FightRequest.updateFinalRoundData("", true, false);
+        assertThat("_lastDailyDungeonRoom", isSetTo(1));
+      }
+    }
+
+    @Test
     public void dailyDungeonMonsterLoss() {
       var cleanups =
           new Cleanups(


### PR DESCRIPTION
It is possible under certain conditions for a non-DD fight to be encountered in a way that mafia tracks as being in the Daily Dungeon. One example is by using a pocket wish (see: https://kolmafia.us/threads/genie-monster-resets-location.31697/ ), but I think there are other cases as well.

While cases that result in this are probably bugs in and of themselves, this PR changes the DD tracking to defensively only increment if the monster fought is actually one of the Daily Dungeon monsters as well as being in the Daily Dungeon.