### PR TITLE
Express more base game state as modifiers

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -15791,7 +15791,6 @@ Path	Dark Gyffte	Maximum HP: [20+20*pref(darkGyfftePoints)]
 Path	License to Adventure	Weapon Damage Percent: [50*pref(bondWpn)], Initiative: [30*pref(bondInit)], Damage Reduction: [10*pref(bondDR)], Maximum HP Percent: [20*pref(bondHP)], Item Drop: [10*pref(bondItem1)+20*pref(bondItem2)+30*pref(bondItem3)], Experience: [2*pref(bondStat)+5*pref(bondStat2)], Booze Drop: [100*pref(bondBooze)], Meat Drop: [20*pref(bondMeat)], Experience (Muscle): [2*pref(bondMus2)+pref(bondMus1)], Experience (Mysticality): [2*pref(bondMys2)+pref(bondMys1)], Experience (Moxie): [2*pref(bondMox2)+pref(bondMox1)], MP Regen Min: [10*pref(bondMPregen)], MP Regen Max: [15*pref(bondMPregen)], Weapon Damage: [10*pref(bondWeapon2)], Adventures: [11*pref(bondAdv)], Liver Capacity: [min(11,L)+pref(bondDrunk1)+(2*pref(bondDrunk2))], Spleen Capacity: [2*pref(bondSpleen)]
 Path	One Crazy Random Summer	Random Monster Modifiers: +1
 Path	Quantum Terrarium	Familiar Weight: [min(2*L,20)]
-Path	Slow and Steady	Adventures: +100
 Path	You, Robot	Energy: +1
 Path	WereProfessor	Liver Capacity: [3*(pref(wereProfessorLiver))], Stomach Capacity: [3*(pref(wereProfessorStomach))]
 

--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -343,11 +343,10 @@ public class FamiliarData implements Comparable<FamiliarData> {
     }
 
     int exp =
-        (1
-            + (int) experienceModifier
+        (int) experienceModifier
             + (KoLCharacter.hasSkill(SkillPool.TESTUDINAL_TEACHINGS)
                 ? determineTestTeachExperience()
-                : 0));
+                : 0);
 
     setExperience(this.experience + exp);
   }

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -3493,8 +3493,8 @@ public abstract class KoLCharacter {
   }
 
   /**
-   * Whether rollover adventures can come from anywhere other than the grant itself. In Slow and
-   * Steady the grant is a flat 100 and nothing else contributes.
+   * Whether rollover adventures can come from anywhere other than the daily grant itself. In Slow
+   * and Steady the grant is a flat 100 and nothing else contributes.
    *
    * @return true unless in Slow and Steady
    */
@@ -3503,10 +3503,8 @@ public abstract class KoLCharacter {
   }
 
   /**
-   * The adventures granted at rollover, before anything else contributes. You, Robot grants none at
-   * all, since its adventures come from the Chronolith instead.
-   *
-   * @return the adventures rollover grants
+   * The adventures granted at rollover, before anything else contributes. You, Robot grants none,
+   * since its adventures come from the Chronolith instead.
    */
   public static final int rolloverAdventuresGranted() {
     if (inRobocore()) return 0;
@@ -5522,10 +5520,7 @@ public abstract class KoLCharacter {
     // add rollover PvP fights
     newModifiers.applyRolloverPvpFightModifiers();
 
-    // add the familiar experience every fight grants
     newModifiers.applyBaseFamiliarExperienceModifiers();
-
-    // add the base chance of a critical hit
     newModifiers.applyBaseCriticalModifiers();
 
     // Organ capacity

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -3493,13 +3493,25 @@ public abstract class KoLCharacter {
   }
 
   /**
-   * Whether rollover adventures can come from anywhere other than the daily grant itself. In Slow
-   * and Steady the grant is a flat 100 and nothing else contributes.
+   * Whether rollover adventures can come from anywhere other than the grant itself. In Slow and
+   * Steady the grant is a flat 100 and nothing else contributes.
    *
    * @return true unless in Slow and Steady
    */
   public static final boolean canGainRolloverAdventures() {
     return !inSlowcore();
+  }
+
+  /**
+   * The adventures granted at rollover, before anything else contributes. You, Robot grants none at
+   * all, since its adventures come from the Chronolith instead.
+   *
+   * @return the adventures rollover grants
+   */
+  public static final int rolloverAdventuresGranted() {
+    if (inRobocore()) return 0;
+    if (inSlowcore()) return 100;
+    return 40;
   }
 
   public static final boolean isUnarmed() {
@@ -5509,6 +5521,12 @@ public abstract class KoLCharacter {
 
     // add rollover PvP fights
     newModifiers.applyRolloverPvpFightModifiers();
+
+    // add the familiar experience every fight grants
+    newModifiers.applyBaseFamiliarExperienceModifiers();
+
+    // add the base chance of a critical hit
+    newModifiers.applyBaseCriticalModifiers();
 
     // Organ capacity
     newModifiers.applyAdditionalStomachCapacityModifiers();

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -87,6 +87,9 @@ public class Modifiers {
 
   private static final AdventureResult FIDOXENE = EffectPool.get(EffectPool.FIDOXENE);
 
+  // The key the adventures and PvP fights granted at rollover are attributed to
+  private static final String ROLLOVER = "Rollover";
+
   public Modifiers() {
     // Everything should be initialized above.
   }
@@ -650,8 +653,8 @@ public class Modifiers {
         }
         break;
       case ADVENTURES:
-        // Slow and Steady's own grant arrives as a Path modifier, so let that one through
-        if (KoLCharacter.canGainRolloverAdventures() || type == ModifierType.PATH) {
+        // In Slow and Steady the rollover grant is all you get, so let that one through
+        if (KoLCharacter.canGainRolloverAdventures() || isRolloverGrant(type, key)) {
           this.doubles.increment(mod, value);
         }
         break;
@@ -659,6 +662,18 @@ public class Modifiers {
         this.doubles.increment(mod, value);
         break;
     }
+  }
+
+  /**
+   * Whether a modifier is the grant of adventures or PvP fights that rollover itself provides,
+   * rather than a bonus on top of it.
+   *
+   * @param type Type of the modifier's source
+   * @param key Key of the modifier's source
+   * @return true if this is the rollover grant
+   */
+  private static boolean isRolloverGrant(final ModifierType type, final IntOrString key) {
+    return type == ModifierType.GENERATED && ROLLOVER.equals(key.getStringValue());
   }
 
   public void addBitmap(BitmapModifier modifier, int bit) {
@@ -1062,13 +1077,24 @@ public class Modifiers {
   }
 
   public final void applyRolloverPvpFightModifiers() {
-    this.addDouble(DoubleModifier.PVP_FIGHTS, 10, ModifierType.GENERATED, "Rollover");
+    this.addDouble(DoubleModifier.PVP_FIGHTS, 10, ModifierType.GENERATED, ROLLOVER);
+  }
+
+  public final void applyBaseFamiliarExperienceModifiers() {
+    this.addDouble(DoubleModifier.FAMILIAR_EXP, 1, ModifierType.GENERATED, "Base");
+  }
+
+  public final void applyBaseCriticalModifiers() {
+    this.addDouble(DoubleModifier.CRITICAL_PCT, 9, ModifierType.GENERATED, "Base");
+    this.addDouble(DoubleModifier.SPELL_CRITICAL_PCT, 9, ModifierType.GENERATED, "Base");
   }
 
   public final void applyAdditionalRolloverAdventureModifiers() {
-    if (KoLCharacter.canGainRolloverAdventures()) {
-      this.addDouble(DoubleModifier.ADVENTURES, 40, ModifierType.GENERATED, "Rollover");
-    }
+    this.addDouble(
+        DoubleModifier.ADVENTURES,
+        KoLCharacter.rolloverAdventuresGranted(),
+        ModifierType.GENERATED,
+        ROLLOVER);
 
     var resolutionAdv = Preferences.getInteger("_resolutionAdv");
     if (resolutionAdv > 0) {

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -87,7 +87,6 @@ public class Modifiers {
 
   private static final AdventureResult FIDOXENE = EffectPool.get(EffectPool.FIDOXENE);
 
-  // The key the adventures and PvP fights granted at rollover are attributed to
   private static final String ROLLOVER = "Rollover";
 
   public Modifiers() {
@@ -653,7 +652,6 @@ public class Modifiers {
         }
         break;
       case ADVENTURES:
-        // In Slow and Steady the rollover grant is all you get, so let that one through
         if (KoLCharacter.canGainRolloverAdventures() || isRolloverGrant(type, key)) {
           this.doubles.increment(mod, value);
         }
@@ -664,14 +662,7 @@ public class Modifiers {
     }
   }
 
-  /**
-   * Whether a modifier is the grant of adventures or PvP fights that rollover itself provides,
-   * rather than a bonus on top of it.
-   *
-   * @param type Type of the modifier's source
-   * @param key Key of the modifier's source
-   * @return true if this is the rollover grant
-   */
+  /** Whether this is the grant rollover itself provides, rather than a bonus on top of it. */
   private static boolean isRolloverGrant(final ModifierType type, final IntOrString key) {
     return type == ModifierType.GENERATED && ROLLOVER.equals(key.getStringValue());
   }

--- a/src/net/sourceforge/kolmafia/swingui/panel/CompactSidePane.java
+++ b/src/net/sourceforge/kolmafia/swingui/panel/CompactSidePane.java
@@ -990,8 +990,7 @@ public class CompactSidePane extends JPanel implements Runnable {
       if (familiars && count < this.BONUS_LABELS) {
         this.bonusLabel[count].setText("   Fam Exp: ");
         this.bonusValueLabel[count].setText(
-            KoLConstants.ROUNDED_MODIFIER_FORMAT.format(
-                KoLCharacter.getFamiliarExperienceAdjustment()));
+            String.valueOf(KoLCharacter.getFamiliarExperienceAdjustment()));
         count++;
       }
       int hobo = KoLCharacter.getHoboPower();
@@ -1406,9 +1405,7 @@ public class CompactSidePane extends JPanel implements Runnable {
         KoLConstants.MODIFIER_FORMAT.format(
             KoLCharacter.currentNumericModifier(DoubleModifier.RANGED_DAMAGE_PCT)));
     buf.append("%</td></tr><tr><td>Critical</td><td>");
-    buf.append(
-        KoLConstants.MODIFIER_FORMAT.format(
-            KoLCharacter.currentNumericModifier(DoubleModifier.CRITICAL_PCT)));
+    buf.append((int) KoLCharacter.currentNumericModifier(DoubleModifier.CRITICAL_PCT));
     buf.append("%</td><td rowspan=2>MP cost:<br>");
     buf.append(KoLConstants.MODIFIER_FORMAT.format(KoLCharacter.getManaCostAdjustment()));
     int hpmin = (int) KoLCharacter.currentNumericModifier(DoubleModifier.HP_REGEN_MIN);

--- a/test/net/sourceforge/kolmafia/FamiliarDataTest.java
+++ b/test/net/sourceforge/kolmafia/FamiliarDataTest.java
@@ -431,6 +431,35 @@ public class FamiliarDataTest {
   }
 
   @Nested
+  class CombatExperience {
+    @Test
+    public void winningAFightGrantsOneExperience() {
+      var cleanups = withFamiliar(FamiliarPool.MOSQUITO);
+
+      try (cleanups) {
+        KoLCharacter.recalculateAdjustments();
+        var familiar = KoLCharacter.getFamiliar();
+        familiar.addCombatExperience("");
+        assertThat(familiar.getTotalExperience(), is(1));
+      }
+    }
+
+    @Test
+    public void familiarExperienceModifiersStackWithTheBase() {
+      var cleanups =
+          new Cleanups(
+              withFamiliar(FamiliarPool.MOSQUITO), withEquipped(Slot.WEAPON, "yule hatchet"));
+
+      try (cleanups) {
+        KoLCharacter.recalculateAdjustments();
+        var familiar = KoLCharacter.getFamiliar();
+        familiar.addCombatExperience("");
+        assertThat(familiar.getTotalExperience(), is(3));
+      }
+    }
+  }
+
+  @Nested
   class Comma {
     @Test
     public void correctEffectiveIdWhenCommaImitating() {

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -1023,7 +1023,8 @@ public class ModifiersTest {
         KoLCharacter.recalculateAdjustments();
         Modifiers current = KoLCharacter.getCurrentModifiers();
         assertEquals(30, current.getDouble(DoubleModifier.MEATDROP));
-        assertEquals(2, current.getDouble(DoubleModifier.FAMILIAR_EXP));
+        // the base 1 familiar experience every fight grants, plus the vote's 2
+        assertEquals(3, current.getDouble(DoubleModifier.FAMILIAR_EXP));
         assertEquals(4, current.getDouble(DoubleModifier.MUS_EXPERIENCE));
       }
     }
@@ -1359,6 +1360,75 @@ public class ModifiersTest {
 
       try (cleanups) {
         assertThat(currentAdventures(), equalTo(100.0));
+      }
+    }
+
+    @Test
+    void youRobotGrantsNoAdventures() {
+      var cleanups = withPath(Path.YOU_ROBOT);
+
+      try (cleanups) {
+        assertThat(currentAdventures(), equalTo(0.0));
+      }
+    }
+
+    @Test
+    void youRobotStillGainsAdventuresFromOtherSources() {
+      var cleanups =
+          new Cleanups(withPath(Path.YOU_ROBOT), withEquipped(Slot.HAT, ItemPool.TIME_HELMET));
+
+      try (cleanups) {
+        assertThat(currentAdventures(), equalTo(3.0));
+      }
+    }
+
+    @Test
+    void youRobotStillGainsPvpFights() {
+      var cleanups = withPath(Path.YOU_ROBOT);
+
+      try (cleanups) {
+        assertThat(current(DoubleModifier.PVP_FIGHTS), equalTo(10.0));
+      }
+    }
+  }
+
+  @Nested
+  class BaseChances {
+    private double current(final DoubleModifier modifier) {
+      KoLCharacter.recalculateAdjustments(false);
+      return KoLCharacter.getCurrentModifiers().getDouble(modifier);
+    }
+
+    @Test
+    void everyFightGrantsOneFamiliarExperience() {
+      assertThat(current(DoubleModifier.FAMILIAR_EXP), equalTo(1.0));
+    }
+
+    @Test
+    void otherSourcesStackWithBaseFamiliarExperience() {
+      var cleanups = withEquipped(Slot.WEAPON, "yule hatchet");
+
+      try (cleanups) {
+        assertThat(current(DoubleModifier.FAMILIAR_EXP), equalTo(3.0));
+      }
+    }
+
+    @Test
+    void thereIsABaseChanceOfACriticalHit() {
+      assertThat(current(DoubleModifier.CRITICAL_PCT), equalTo(9.0));
+    }
+
+    @Test
+    void thereIsABaseChanceOfASpellCriticalHit() {
+      assertThat(current(DoubleModifier.SPELL_CRITICAL_PCT), equalTo(9.0));
+    }
+
+    @Test
+    void otherSourcesStackWithTheBaseCriticalChance() {
+      var cleanups = withEquipped(Slot.HAT, "moose antlers");
+
+      try (cleanups) {
+        assertThat(current(DoubleModifier.CRITICAL_PCT), equalTo(14.0));
       }
     }
   }

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -1023,7 +1023,7 @@ public class ModifiersTest {
         KoLCharacter.recalculateAdjustments();
         Modifiers current = KoLCharacter.getCurrentModifiers();
         assertEquals(30, current.getDouble(DoubleModifier.MEATDROP));
-        // the base 1 familiar experience every fight grants, plus the vote's 2
+        // 1 base, plus the vote's 2
         assertEquals(3, current.getDouble(DoubleModifier.FAMILIAR_EXP));
         assertEquals(4, current.getDouble(DoubleModifier.MUS_EXPERIENCE));
       }

--- a/test/net/sourceforge/kolmafia/swingui/panel/CompactSidePaneTest.java
+++ b/test/net/sourceforge/kolmafia/swingui/panel/CompactSidePaneTest.java
@@ -55,4 +55,15 @@ class CompactSidePaneTest {
       assertThat(text, containsString("Adv 40<br>PvP 10<br>"));
     }
   }
+
+  @Test
+  void criticalHitChanceIsNotShownAsABonus() {
+    var cleanups = new Cleanups(withClass(AscensionClass.SEAL_CLUBBER));
+
+    try (cleanups) {
+      KoLCharacter.recalculateAdjustments();
+      var text = CompactSidePane.modifierPopupText();
+      assertThat(text, containsString("<td>Critical</td><td>9%"));
+    }
+  }
 }


### PR DESCRIPTION
Follow-up to #3621: You, Robot grants no rollover adventures, and the base familiar experience and critical hit chance are modifiers now too.