### PR TITLE
Fix javascript stacktraces inside promises being swallowed

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
@@ -316,9 +316,13 @@ public class JavascriptRuntime extends AbstractRuntime {
               "JavaScript error: " + e.getErrorMessage() + "\n" + e.getScriptStackTrace());
       KoLmafia.updateDisplay(KoLConstants.MafiaState.ERROR, escapedMessage);
     } catch (JavaScriptException e) {
+      String stack = errorStack(e.getValue());
       String escapedMessage =
           escapeHtmlInMessage(
-              "JavaScript exception: " + e.getMessage() + "\n" + e.getScriptStackTrace());
+              "JavaScript exception: "
+                  + e.getMessage()
+                  + "\n"
+                  + (stack != null ? stack : e.getScriptStackTrace()));
       KoLmafia.updateDisplay(KoLConstants.MafiaState.ERROR, escapedMessage);
     } catch (ScriptException e) {
       String escapedMessage = escapeHtmlInMessage("Script exception: " + e.getMessage());
@@ -333,9 +337,12 @@ public class JavascriptRuntime extends AbstractRuntime {
     cx.getUnhandledPromiseTracker()
         .process(
             o -> {
-              String escapedMessage =
-                  escapeHtmlInMessage("Unhandled rejected Promise: " + o.toString());
-              KoLmafia.updateDisplay(KoLConstants.MafiaState.ERROR, escapedMessage);
+              String stack = errorStack(o);
+              String message =
+                  "Unhandled rejected Promise: "
+                      + o.toString()
+                      + (stack == null ? "" : "\n" + stack);
+              KoLmafia.updateDisplay(KoLConstants.MafiaState.ERROR, escapeHtmlInMessage(message));
             });
 
     try {
@@ -343,6 +350,19 @@ public class JavascriptRuntime extends AbstractRuntime {
     } catch (ValueConverter.ValueConverterException e) {
       throw new EvaluatorException(e.getMessage());
     }
+  }
+
+  /**
+   * The stack an Error captured when it was constructed, or null if the thrown value is not an
+   * Error. Rejected promises are reported after their frames have unwound, so the reporting
+   * exception has no script stack of its own.
+   */
+  private static String errorStack(Object thrown) {
+    Object stack =
+        thrown instanceof Scriptable scriptable
+            ? ScriptableObject.getProperty(scriptable, "stack")
+            : null;
+    return stack instanceof String text && !text.isBlank() ? text : null;
   }
 
   private static Object resolvePromise(Context cx, NativePromise promise) {

--- a/test/net/sourceforge/kolmafia/CustomScriptTest.java
+++ b/test/net/sourceforge/kolmafia/CustomScriptTest.java
@@ -114,7 +114,8 @@ class CustomScriptTest {
               .toString()
               .trim()
               // try to avoid environment-specific paths in stacktraces
-              .replaceAll("\\bfile:.*?([^\\\\/\\s]+#\\d+)\\b", "file:%%STACKTRACE_LOCATION%%/$1");
+              .replaceAll(
+                  "\\bfile:.*?([^\\\\/\\s]+[#:]\\d+)\\b", "file:%%STACKTRACE_LOCATION%%/$1");
       if (!expectedOutput.equals(output)) {
         System.out.println("expected = '" + expectedOutput + "'");
         System.out.println("output = '" + output + "'");

--- a/test/root/expected/promise_rejected_error_main.js.out
+++ b/test/root/expected/promise_rejected_error_main.js.out
@@ -1,0 +1,5 @@
+JavaScript exception: Error: deep failure
+	at file:%%STACKTRACE_LOCATION%%/promise_rejected_error_main.js:2 (fail)
+	at file:%%STACKTRACE_LOCATION%%/promise_rejected_error_main.js:6 (wrapper)
+	at file:%%STACKTRACE_LOCATION%%/promise_rejected_error_main.js:13 (anonymous)
+	at file:%%STACKTRACE_LOCATION%%/promise_rejected_error_main.js:11 (main)

--- a/test/root/expected/promise_rejected_unhandled_error.js.out
+++ b/test/root/expected/promise_rejected_unhandled_error.js.out
@@ -1,0 +1,6 @@
+foo
+Unhandled rejected Promise: Error: deep failure
+	at file:%%STACKTRACE_LOCATION%%/promise_rejected_unhandled_error.js:4 (fail)
+	at file:%%STACKTRACE_LOCATION%%/promise_rejected_unhandled_error.js:8 (wrapper)
+	at file:%%STACKTRACE_LOCATION%%/promise_rejected_unhandled_error.js:13 (anonymous)
+	at file:%%STACKTRACE_LOCATION%%/promise_rejected_unhandled_error.js:11

--- a/test/root/expected/throw_string_error.js.out
+++ b/test/root/expected/throw_string_error.js.out
@@ -1,0 +1,4 @@
+JavaScript exception: my error (file:%%STACKTRACE_LOCATION%%/throw_string_error.js#2)
+	at file:%%STACKTRACE_LOCATION%%/throw_string_error.js:2 (fail)
+	at file:%%STACKTRACE_LOCATION%%/throw_string_error.js:6 (wrapper)
+	at file:%%STACKTRACE_LOCATION%%/throw_string_error.js:9

--- a/test/root/scripts/promise_rejected_error_main.js
+++ b/test/root/scripts/promise_rejected_error_main.js
@@ -1,0 +1,18 @@
+function fail() {
+  throw new Error("deep failure");
+}
+
+function wrapper() {
+  fail();
+}
+
+module.exports = {
+  main: () =>
+    new Promise((resolve, reject) => {
+      try {
+        resolve(wrapper());
+      } catch (e) {
+        reject(e);
+      }
+    }),
+};

--- a/test/root/scripts/promise_rejected_unhandled_error.js
+++ b/test/root/scripts/promise_rejected_unhandled_error.js
@@ -1,0 +1,18 @@
+const { print } = require("kolmafia");
+
+function fail() {
+  throw new Error("deep failure");
+}
+
+function wrapper() {
+  fail();
+}
+
+new Promise((resolve, reject) => {
+  try {
+    resolve(wrapper());
+  } catch (e) {
+    reject(e);
+  }
+});
+print("foo");

--- a/test/root/scripts/throw_string_error.js
+++ b/test/root/scripts/throw_string_error.js
@@ -1,0 +1,9 @@
+function fail() {
+  throw "my error";
+}
+
+function wrapper() {
+  fail();
+}
+
+wrapper();


### PR DESCRIPTION
### Description

JavaScript exceptions inside Promises are losing their stack traces.

Before:

```
[00:20:54] JavaScript exception: TypeError: Cannot find function find. (file:KolMafia/scripts/autoscend.js#31548)                                                                                                                             
[00:20:54]  at file:KolMafia/scripts/autoscend.js:31548 (main2)   
```

With the fix:

```
[00:23:00] JavaScript exception: TypeError: Cannot find function find. (file:KolMafia/scripts/autoscend.js#31548)
[00:23:00]  at file:KolMafia/scripts/autoscend.js:20084 (auto_pre_adventure)                                    
[00:23:00]  at file:KolMafia/scripts/autoscend.js:20516 (auto_runPreAdventure)                                  
[00:23:00]  at file:KolMafia/scripts/autoscend.js:20544 (auto_triggerPreAdventure)                              
[00:23:00]  at file:KolMafia/scripts/autoscend.js:20571 (autoAdv)                                                                                                                                                                             
[00:23:00]  at file:KolMafia/scripts/autoscend.js:49061 (L11_hiddenCityZonesDo)                                 
[00:23:00]  at file:KolMafia/scripts/autoscend.js:19664 (_do)                                                                                                                                                                                 
[00:23:00]  at file:KolMafia/scripts/autoscend.js:18054 (execute)                                               
[00:23:00]  at file:KolMafia/scripts/autoscend.js:19730 (runQuestTask)                                          
[00:23:00]  at file:KolMafia/scripts/autoscend.js:49207 (L11_hiddenCityZones)                                   
[00:23:00]  at file:KolMafia/scripts/autoscend.js:64147 (auto_earlyRoutingHandlingDo)                           
[00:23:00]  at file:KolMafia/scripts/autoscend.js:19664 (_do)                                                   
[00:23:00]  at file:KolMafia/scripts/autoscend.js:18054 (execute)                                                                                                                                                                             
[00:23:00]  at file:KolMafia/scripts/autoscend.js:27358 (runNextTask)                                           
[00:23:00]  at file:KolMafia/scripts/autoscend.js:30219 (doTasks)                                               
[00:23:00]  at file:KolMafia/scripts/autoscend.js:30350 (auto_begin)                                            
[00:23:00]  at file:KolMafia/scripts/autoscend.js:30380 (safe_preference_reset_wrapper)                         
[00:23:00]  at file:KolMafia/scripts/autoscend.js:30383 (safe_preference_reset_wrapper)                                                                                                                                                       
[00:23:00]  at file:KolMafia/scripts/autoscend.js:30383 (safe_preference_reset_wrapper)                                                                                                                                                       
[00:23:00]  at file:KolMafia/scripts/autoscend.js:30383 (safe_preference_reset_wrapper)                         
[00:23:00]  at file:KolMafia/scripts/autoscend.js:31545 (main2)
```

### Cause

Rhino stores the stack trace when an Error is created. Rejected Promises are handled later, after the original stack has been lost.

### Fix

Use the Error object's `.stack` value when reporting exceptions. Fall back to the old behaviour if no stack is available.

Errors thrown via `throw "some error"` will still continue to be impacted by this, the scripts must use `Error` for a proper stacktrace.