### PR TITLE
tests: avoid withMallPrice leaking prices

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/MallPriceDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/MallPriceDatabase.java
@@ -47,11 +47,16 @@ public class MallPriceDatabase {
   private static final int CONNECT_TIMEOUT = 15 * 1000;
 
   static {
-    updatePricesFromSource("mallprices.txt");
-    MallPriceDatabase.modCount = 0;
+    MallPriceDatabase.reset();
   }
 
   private MallPriceDatabase() {}
+
+  public static void reset() {
+    prices.clear();
+    updatePricesFromSource("mallprices.txt");
+    MallPriceDatabase.modCount = 0;
+  }
 
   private static int updatePricesFromSource(String filename) {
     int count = 0;

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -3045,6 +3045,7 @@ public class Player {
     return new Cleanups(
         () -> {
           MallPriceManager.reset();
+          MallPriceDatabase.reset();
           MallPriceDatabase.savePricesToFile = true;
         });
   }
@@ -3063,6 +3064,7 @@ public class Player {
     return new Cleanups(
         () -> {
           MallPriceManager.reset();
+          MallPriceDatabase.reset();
           MallPriceDatabase.savePricesToFile = true;
         });
   }

--- a/test/net/sourceforge/kolmafia/session/MallPriceManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/MallPriceManagerTest.java
@@ -161,6 +161,7 @@ public class MallPriceManagerTest {
   public static void beforeAll() {
     KoLCharacter.reset("MallPriceManager");
     MallPriceManager.reset();
+    MallPriceDatabase.reset();
     GenericRequest.sessionId = null;
     MallPriceDatabase.savePricesToFile = false;
   }
@@ -176,6 +177,7 @@ public class MallPriceManagerTest {
   @AfterEach
   public void AfterEach() {
     MallPriceManager.reset();
+    MallPriceDatabase.reset();
     MallPurchaseRequest.reset();
   }
 


### PR DESCRIPTION
As noted in https://github.com/kolmafia/kolmafia/pull/3655/changes/ff12faf08f0d43ddea285517976e470d67176603, `withMallPrice` leaks data into other tests.

Try to make it not do that. Tested on that branch, as an alternative to Mockito.