### PR TITLE
Count equipment container slots properly in codpiece and card sleeve

### DIFF
--- a/src/net/sourceforge/kolmafia/session/InventoryManager.java
+++ b/src/net/sourceforge/kolmafia/session/InventoryManager.java
@@ -260,6 +260,20 @@ public abstract class InventoryManager {
         ++count;
       }
     }
+    if (InventoryManager.equippedOrInInventory(ItemPool.THE_ETERNITY_CODPIECE)) {
+      for (var slot : SlotSet.CODPIECE_SLOTS) {
+        AdventureResult equipment = EquipmentManager.getEquipment(slot);
+        if (equipment != null && equipment.getItemId() == item.getItemId()) {
+          ++count;
+        }
+      }
+    }
+    if (InventoryManager.equippedOrInInventory(EquipmentManager.CARD_SLEEVE)) {
+      AdventureResult equipment = EquipmentManager.getEquipment(Slot.CARDSLEEVE);
+      if (equipment != null && equipment.getItemId() == item.getItemId()) {
+        ++count;
+      }
+    }
     if (KoLCharacter.inHatTrick()) {
       for (var hat : EquipmentManager.getHatTrickHats()) {
         if (hat == item.getItemId()) {
@@ -661,6 +675,33 @@ public abstract class InventoryManager {
           if (--missingCount <= 0) {
             return "";
           }
+        }
+      }
+      if (InventoryManager.equippedOrInInventory(ItemPool.THE_ETERNITY_CODPIECE)) {
+        for (var slot : SlotSet.CODPIECE_SLOTS) {
+          if (EquipmentManager.getEquipment(slot).equals(item)) {
+            if (sim) {
+              return "remove";
+            }
+
+            RequestThread.postRequest(new EquipmentRequest(EquipmentRequest.UNEQUIP, slot));
+
+            if (--missingCount <= 0) {
+              return "";
+            }
+          }
+        }
+      }
+      if (InventoryManager.equippedOrInInventory(EquipmentManager.CARD_SLEEVE)
+          && EquipmentManager.getEquipment(Slot.CARDSLEEVE).equals(item)) {
+        if (sim) {
+          return "remove";
+        }
+
+        RequestThread.postRequest(new EquipmentRequest(EquipmentRequest.UNEQUIP, Slot.CARDSLEEVE));
+
+        if (--missingCount <= 0) {
+          return "";
         }
       }
     }

--- a/test/net/sourceforge/kolmafia/session/InventoryManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/InventoryManagerTest.java
@@ -129,7 +129,8 @@ public class InventoryManagerTest {
 
     var cleanups =
         new Cleanups(
-            withItem(ItemPool.THE_ETERNITY_CODPIECE), withEquipped(Slot.CODPIECE1, PERIDOT_OF_PERIL));
+            withItem(ItemPool.THE_ETERNITY_CODPIECE),
+            withEquipped(Slot.CODPIECE1, PERIDOT_OF_PERIL));
 
     try (cleanups) {
       assertEquals(1, InventoryManager.getAccessibleCount(PERIDOT_OF_PERIL));

--- a/test/net/sourceforge/kolmafia/session/InventoryManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/InventoryManagerTest.java
@@ -108,6 +108,69 @@ public class InventoryManagerTest {
     }
   }
 
+  @Test
+  public void codpieceGemCountsAsAccessible() {
+    AdventureResult PERIDOT_OF_PERIL = ItemPool.get(ItemPool.PERIDOT_OF_PERIL);
+
+    var cleanups =
+        new Cleanups(
+            withEquipped(Slot.ACCESSORY1, ItemPool.THE_ETERNITY_CODPIECE),
+            withEquipped(Slot.CODPIECE1, PERIDOT_OF_PERIL));
+
+    try (cleanups) {
+      assertEquals(0, InventoryManager.getCount(PERIDOT_OF_PERIL));
+      assertEquals(1, InventoryManager.getAccessibleCount(PERIDOT_OF_PERIL));
+    }
+  }
+
+  @Test
+  public void codpieceGemCountsAsAccessibleWhenCodpieceIsUnwornButOwned() {
+    AdventureResult PERIDOT_OF_PERIL = ItemPool.get(ItemPool.PERIDOT_OF_PERIL);
+
+    var cleanups =
+        new Cleanups(
+            withItem(ItemPool.THE_ETERNITY_CODPIECE), withEquipped(Slot.CODPIECE1, PERIDOT_OF_PERIL));
+
+    try (cleanups) {
+      assertEquals(1, InventoryManager.getAccessibleCount(PERIDOT_OF_PERIL));
+    }
+  }
+
+  @Test
+  public void codpieceGemDoesNotCountAsAccessibleWithoutCodpiece() {
+    AdventureResult PERIDOT_OF_PERIL = ItemPool.get(ItemPool.PERIDOT_OF_PERIL);
+
+    var cleanups = withEquipped(Slot.CODPIECE1, PERIDOT_OF_PERIL);
+
+    try (cleanups) {
+      assertEquals(0, InventoryManager.getAccessibleCount(PERIDOT_OF_PERIL));
+    }
+  }
+
+  @Test
+  public void cardSleeveCardCountsAsAccessibleWhenSleeveIsUnwornButOwned() {
+    AdventureResult CARD = AdventureResult.tallyItem("Alice's Army Swordsman");
+
+    var cleanups =
+        new Cleanups(withItem(ItemPool.CARD_SLEEVE), withEquipped(Slot.CARDSLEEVE, CARD));
+
+    try (cleanups) {
+      assertEquals(0, InventoryManager.getCount(CARD));
+      assertEquals(1, InventoryManager.getAccessibleCount(CARD));
+    }
+  }
+
+  @Test
+  public void cardSleeveCardDoesNotCountAsAccessibleWithoutSleeve() {
+    AdventureResult CARD = AdventureResult.tallyItem("Alice's Army Swordsman");
+
+    var cleanups = withEquipped(Slot.CARDSLEEVE, CARD);
+
+    try (cleanups) {
+      assertEquals(0, InventoryManager.getAccessibleCount(CARD));
+    }
+  }
+
   @Nested
   class CrimboTrainingManual {
     @Test


### PR DESCRIPTION
Correctly kolmafia does not track the amount of slotted items properly.
Eg, codpiece will have mafia report that you don't own the slotted gem.
This also applies to card sleeve.

I probably misremember this somewhat. Regardless, it resulted in the case where kolmafia wasn't tracking slotted items properly, and wasn't handling them properly when acquiring items.

It broke #3655 by maximizer failing when it needed to unslot a gem that was going to be slotted elsewhere.