### PR TITLE
tests: upgrade to junit 6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,13 +67,13 @@ repositories {
 
 dependencies {
   // Use JUnit Jupiter for running JUnit5 tests.
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.14.0")
-  testRuntimeOnly("org.junit.jupiter:junit-jupiter:5.14.0")
+  testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.1.3")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter:6.1.3")
 
   testImplementation("org.hamcrest:hamcrest:3.0")
   testImplementation("com.spotify:hamcrest-optional:1.3.2")
-  testImplementation("org.junit.jupiter:junit-jupiter-api:5.14.0")
-  testImplementation("org.junit.jupiter:junit-jupiter-params:5.14.0")
+  testImplementation("org.junit.jupiter:junit-jupiter-api:6.1.3")
+  testImplementation("org.junit.jupiter:junit-jupiter-params:6.1.3")
   testImplementation("org.mockito:mockito-core:5.20.0")
   testImplementation("org.eclipse.xtext:org.eclipse.xtext.xbase.lib:2.41.0.M1") {
     because("assertion errors including Location/Range/Position need it")

--- a/test/net/sourceforge/kolmafia/session/QuestManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/QuestManagerTest.java
@@ -17,6 +17,7 @@ import static internal.helpers.Player.withHardcore;
 import static internal.helpers.Player.withHttpClientBuilder;
 import static internal.helpers.Player.withItem;
 import static internal.helpers.Player.withLastLocation;
+import static internal.helpers.Player.withNextMonster;
 import static internal.helpers.Player.withNextResponse;
 import static internal.helpers.Player.withNoEffects;
 import static internal.helpers.Player.withNoItems;
@@ -24,6 +25,7 @@ import static internal.helpers.Player.withPasswordHash;
 import static internal.helpers.Player.withPath;
 import static internal.helpers.Player.withProperty;
 import static internal.helpers.Player.withQuestProgress;
+import static internal.helpers.Player.withoutCounters;
 import static internal.matchers.Item.isInInventory;
 import static internal.matchers.Preference.hasIntegerValue;
 import static internal.matchers.Preference.isSetTo;
@@ -3505,6 +3507,8 @@ public class QuestManagerTest {
           new Cleanups(
               withProperty("autoQuest", true),
               withLastLocation("Madness Bakery"),
+              withNextMonster("Heimandatz, Nacho Golem"),
+              withoutCounters(),
               withHttpClientBuilder(builder));
 
       try (cleanup) {

--- a/test/net/sourceforge/kolmafia/swingui/panel/MallSearchResultsPanelTest.java
+++ b/test/net/sourceforge/kolmafia/swingui/panel/MallSearchResultsPanelTest.java
@@ -33,10 +33,12 @@ public class MallSearchResultsPanelTest {
   @BeforeEach
   public void beforeEach() {
     Preferences.reset("mallSearchResultsPanel");
+    MallPurchaseRequest.disabledStores.clear();
+    MallPurchaseRequest.ignoringStores.clear();
   }
 
   @AfterEach
-  public void AfterEach() {
+  public void afterEach() {
     MallPurchaseRequest.reset();
   }
 

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -2635,7 +2635,7 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
         Patience of the Tortoise,Patience of the Tortoise,Strength of the Tortoise
         Manicotti Meditation,Pasta Oneness,Tubes of Universal Meat
         Sauce Contemplation,Saucemastery,Lubricating Sauce
-        Disco Aerobics,Disco State of Mind,Disco Over Matter
+        Disco Aerobics,Disco State of Mind,Disco over Matter
         Moxie of the Mariachi,Mariachi Mood,Mariachi Moisture
         """;
 


### PR DESCRIPTION
This changes the test order, so fix some leaks.

Also fix Disco over Matter having the wrong case. I don't know why this passed before, `containsString` does default to not ignoring case, and it passes with either case.