### PR TITLE
feat: Maximizer: consider Eternity Codpiece gem configurations

### DIFF
--- a/src/data/defaults.txt
+++ b/src/data/defaults.txt
@@ -1197,6 +1197,7 @@ user	maximizerMRUList	mainstat;mus;mys;mox;familiar weight;HP;MP;ML;DA;DR;+comba
 user	maximizerMRUSize	5
 user	maximizerAlwaysCurrent	false
 user	maximizerCombinationLimit	0
+user	maximizerConsiderCodpieceGems	true
 user	maximizerCreateOnHand	false
 user	maximizerCurrentMallPrices	false
 user	maximizerEquipmentLevel	1

--- a/src/net/sourceforge/kolmafia/maximizer/CheckedItem.java
+++ b/src/net/sourceforge/kolmafia/maximizer/CheckedItem.java
@@ -5,14 +5,18 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RestrictedItemType;
+import net.sourceforge.kolmafia.equipment.SlotSet;
+import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.objectpool.Concoction;
 import net.sourceforge.kolmafia.objectpool.ConcoctionPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.ItemDatabase.FoldGroup;
 import net.sourceforge.kolmafia.persistence.MallPriceDatabase;
+import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 import net.sourceforge.kolmafia.persistence.NPCStoreDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.ThriftyRequest;
 import net.sourceforge.kolmafia.request.coinmaster.MrStoreRequest;
 import net.sourceforge.kolmafia.session.InventoryManager;
@@ -20,11 +24,29 @@ import net.sourceforge.kolmafia.session.MallPriceManager;
 
 public class CheckedItem extends AdventureResult {
   public CheckedItem(int itemId, EquipScope equipScope, long maxPrice, PriceLevel priceLevel) {
+    this(itemId, equipScope, maxPrice, priceLevel, false);
+  }
+
+  /**
+   * @param ignoreStandardRestriction whether the item can be used even if Standard forbids it, as
+   *     an Eternity Codpiece gem can, since inserting a gem is not equipping it
+   */
+  CheckedItem(
+      int itemId,
+      EquipScope equipScope,
+      long maxPrice,
+      PriceLevel priceLevel,
+      boolean ignoreStandardRestriction) {
     super(itemId, 1, false);
 
     this.inventory = InventoryManager.getCount(itemId);
 
-    this.initial = InventoryManager.getAccessibleCount(itemId);
+    AdventureResult item = ItemPool.get(itemId, 1);
+    boolean restrictedGem = ignoreStandardRestriction && !ItemDatabase.isAllowed(item);
+    this.initial =
+        restrictedGem
+            ? this.inventory + InventoryManager.getEquippedCount(item)
+            : InventoryManager.getAccessibleCount(item);
 
     // special case used to get a CheckItem that .equals( EquipmentRequest.UNEQUIP ).
     if (itemId == -1) {
@@ -35,8 +57,18 @@ public class CheckedItem extends AdventureResult {
 
     String itemName = this.getName();
     this.foldable = 0;
+    boolean codpieceGem = EquipmentRequest.isCodpieceGem(itemId);
+    int maxUseful = 3;
+    if (codpieceGem) {
+      var modifiers = ModifierDatabase.getItemModifiers(itemId);
+      int equipmentLimit =
+          !ItemDatabase.isEquipment(itemId)
+              ? 0
+              : modifiers != null && modifiers.getBoolean(BooleanModifier.SINGLE) ? 1 : 3;
+      maxUseful = SlotSet.CODPIECE_SLOTS.size() + equipmentLimit;
+    }
 
-    if (itemId > 0 && Preferences.getBoolean("maximizerFoldables")) {
+    if (!restrictedGem && itemId > 0 && Preferences.getBoolean("maximizerFoldables")) {
       FoldGroup group = ItemDatabase.getFoldGroup(itemName);
       if (group != null) {
         for (int i = 0; i < group.names.size(); ++i) {
@@ -78,7 +110,7 @@ public class CheckedItem extends AdventureResult {
         Preferences.getBoolean("maximizerCreateOnHand")
             && equipScope == EquipScope.SPECULATE_INVENTORY
             && !ItemDatabase.isEquipment(itemId);
-    if (this.initial >= 3 || (equipScope.checkInventoryOnly() && !skillCreateCheck)) {
+    if (this.initial >= maxUseful || (equipScope.checkInventoryOnly() && !skillCreateCheck)) {
       return;
     }
 
@@ -89,7 +121,7 @@ public class CheckedItem extends AdventureResult {
 
     if (c.getAdventuresNeeded(1) > 0 && Preferences.getBoolean("maximizerNoAdventures")) {
       this.creatable = 0;
-    } else if (c.price > 0) {
+    } else if (!restrictedGem && c.price > 0) {
       long theoreticBuyable = maxPrice / c.price;
       int limit = CheckedItem.limitBuyable(itemId);
       if (limit < theoreticBuyable) {
@@ -100,11 +132,15 @@ public class CheckedItem extends AdventureResult {
       }
     }
 
-    if (this.getCount() >= 3 || equipScope != EquipScope.SPECULATE_ANY) {
+    if (this.getCount() >= maxUseful || equipScope != EquipScope.SPECULATE_ANY) {
       return;
     }
 
-    if (!ItemDatabase.isAllowed(this)) {
+    if (restrictedGem) {
+      return;
+    }
+
+    if (!ignoreStandardRestriction && !ItemDatabase.isAllowed(this)) {
       // Unallowed items can't be bought or pulled, though the original code
       // just reset everything to zero
 
@@ -112,13 +148,13 @@ public class CheckedItem extends AdventureResult {
       this.creatable = 0;
       this.npcBuyable = 0;
     } else if (InventoryManager.canUseMall(itemId)) {
-      // consider Mall buying, but only if none are otherwise available
-      if (this.getCount() == 0) {
+      int needed = codpieceGem ? maxUseful - this.getCount() : this.getCount() == 0 ? 1 : 0;
+      if (needed > 0) {
         // We include things with historical price up to twice as high as limit, as current price
         // may be lower
         long price = Math.min(maxPrice, KoLCharacter.getAvailableMeat());
         if (priceLevel == PriceLevel.DONT_CHECK || MallPriceDatabase.getPrice(itemId) < price * 2) {
-          this.mallBuyable = 1;
+          this.mallBuyable = needed;
           this.buyableFlag = true;
         }
       }
@@ -133,14 +169,14 @@ public class CheckedItem extends AdventureResult {
 
       this.pullBuyable = 0;
       if (InventoryManager.canUseMallToStorage(itemId)) {
-        // consider Mall buying, but only if none are otherwise available
-        if (this.getCount() == 0) {
+        int needed = codpieceGem ? maxUseful - this.getCount() : this.getCount() == 0 ? 1 : 0;
+        if (needed > 0) {
           // We include things with historical price up to twice as high as limit, as current price
           // may be lower
           long price = Math.min(maxPrice, KoLCharacter.getStorageMeat());
           if (priceLevel == PriceLevel.DONT_CHECK
               || MallPriceDatabase.getPrice(itemId) < price * 2) {
-            this.pullBuyable = 1;
+            this.pullBuyable = needed;
             this.buyableFlag = true;
           }
         }
@@ -188,18 +224,13 @@ public class CheckedItem extends AdventureResult {
       return Integer.MAX_VALUE;
     }
     if (this.singleFlag) {
-      return Math.min(
-          1,
-          this.initial
-              + this.creatable
-              + this.npcBuyable
-              + this.mallBuyable
-              + this.foldable
-              + this.pullable
-              + this.pullfoldable
-              + this.pullBuyable);
+      return Math.min(1, this.getCountIgnoringSingleEquip());
     }
 
+    return this.getCountIgnoringSingleEquip();
+  }
+
+  int getCountIgnoringSingleEquip() {
     return this.initial
         + this.creatable
         + this.npcBuyable
@@ -223,24 +254,21 @@ public class CheckedItem extends AdventureResult {
       return;
     }
 
-    // Check mall price
-    long price = MallPriceManager.getMallPrice(this.getItemId());
+    this.mallBuyable =
+        this.affordableMallQuantity(this.mallBuyable, KoLCharacter.getAvailableMeat(), maxPrice);
+    this.pullBuyable =
+        this.affordableMallQuantity(this.pullBuyable, KoLCharacter.getStorageMeat(), maxPrice);
+  }
 
-    // Check if too expensive for max price settings
-    if (price <= 0 || price > maxPrice) {
-      this.mallBuyable = 0;
-      this.pullBuyable = 0;
+  private int affordableMallQuantity(int quantity, long availableMeat, long maxPrice) {
+    while (quantity > 0) {
+      long price = MallPriceManager.getMallPrice(ItemPool.get(this.getItemId(), quantity));
+      if (price > 0 && price <= availableMeat && price <= maxPrice) {
+        break;
+      }
+      quantity--;
     }
-
-    // Check character has meat to buy with
-    if (price > KoLCharacter.getAvailableMeat()) {
-      this.mallBuyable = 0;
-    }
-
-    // Check character has storage meat to buy for pulling
-    if (price > KoLCharacter.getStorageMeat()) {
-      this.pullBuyable = 0;
-    }
+    return quantity;
   }
 
   private static int limitBuyable(final int itemId) {

--- a/src/net/sourceforge/kolmafia/maximizer/CodpieceMaximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/CodpieceMaximizer.java
@@ -1,0 +1,498 @@
+package net.sourceforge.kolmafia.maximizer;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.sourceforge.kolmafia.AdventureResult;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.ModifierType;
+import net.sourceforge.kolmafia.Modifiers;
+import net.sourceforge.kolmafia.equipment.Slot;
+import net.sourceforge.kolmafia.equipment.SlotSet;
+import net.sourceforge.kolmafia.modifiers.BitmapModifier;
+import net.sourceforge.kolmafia.modifiers.BooleanModifier;
+import net.sourceforge.kolmafia.modifiers.DoubleModifier;
+import net.sourceforge.kolmafia.modifiers.StringModifier;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.persistence.ItemDatabase;
+import net.sourceforge.kolmafia.persistence.ModifierDatabase;
+import net.sourceforge.kolmafia.request.EquipmentRequest;
+import net.sourceforge.kolmafia.session.EquipmentManager;
+import net.sourceforge.kolmafia.session.InventoryManager;
+
+/**
+ * Eternity Codpiece gem support for the Modifier Maximizer.
+ *
+ * <p>Gems are inserted into the codpiece rather than equipped, so they have no ordinary equipment
+ * slot and never reach the per-slot candidate loops in {@link Evaluator}. Candidates are discovered
+ * once per maximization; the combination itself is searched separately for every fully decided
+ * equipment branch, because a gem is only worth anything while the codpiece is worn and its value
+ * can depend on that branch's other equipment and familiar.
+ *
+ * <p>The search writes only to the speculation's own equipment map. It never changes
+ * EquipmentManager, and never posts a request.
+ */
+final class CodpieceMaximizer {
+  /**
+   * Modifiers whose score contribution is exactly the sum of each source's own raw value: {@link
+   * Evaluator#getScore} reads them directly rather than deriving them, and Modifiers.addDouble
+   * accumulates them without a cap, a floor, a conditional, or an "only the best applies" rule.
+   * Anything outside this set makes the suffix bound below unusable, and the search falls back to
+   * exact enumeration.
+   */
+  private static final EnumSet<DoubleModifier> SUMMABLE_MODIFIERS =
+      EnumSet.of(
+          DoubleModifier.ADVENTURES,
+          DoubleModifier.BOOZEDROP,
+          DoubleModifier.BUGBEAR_DAMAGE,
+          DoubleModifier.CANDYDROP,
+          DoubleModifier.DAMAGE_ABSORPTION,
+          DoubleModifier.DAMAGE_REDUCTION,
+          DoubleModifier.ENCHANTMENT_COUNT,
+          DoubleModifier.FAMILIAR_DAMAGE,
+          DoubleModifier.FAMILIAR_EXP,
+          DoubleModifier.FISHING_SKILL,
+          DoubleModifier.FOODDROP,
+          DoubleModifier.GHOST_DAMAGE,
+          DoubleModifier.HP_REGEN_MAX,
+          DoubleModifier.HP_REGEN_MIN,
+          DoubleModifier.MONSTER_LEVEL,
+          DoubleModifier.MOX_PCT,
+          DoubleModifier.MP_PCT,
+          DoubleModifier.MP_REGEN_MAX,
+          DoubleModifier.MP_REGEN_MIN,
+          DoubleModifier.MUS_PCT,
+          DoubleModifier.MYS_PCT,
+          DoubleModifier.PICKPOCKET_CHANCE,
+          DoubleModifier.POOL_SKILL,
+          DoubleModifier.PVP_FIGHTS,
+          DoubleModifier.SEAL_DAMAGE,
+          DoubleModifier.VAMPIRE_DAMAGE,
+          DoubleModifier.WEREWOLF_DAMAGE,
+          DoubleModifier.ZOMBIE_DAMAGE);
+
+  private record Gem(CheckedItem item, Modifiers mods, double delta, int count) {}
+
+  private final Evaluator evaluator;
+
+  private final List<Gem> catalogue = new ArrayList<>();
+
+  /** Available copies, including gems already installed in a retrievable codpiece. */
+  private final Map<Integer, Integer> countsByItemId = new HashMap<>();
+
+  private int combinationsEvaluated;
+
+  private List<Gem> candidates = List.of();
+  private int[] available = new int[0];
+  private List<Slot> freeSlots = List.of();
+  private ScoreBound bound;
+
+  CodpieceMaximizer(Evaluator evaluator) {
+    this.evaluator = evaluator;
+  }
+
+  int getCombinationsEvaluated() {
+    return this.combinationsEvaluated;
+  }
+
+  boolean hasCandidates() {
+    return !this.catalogue.isEmpty();
+  }
+
+  static int copiesInGemSlots(Map<Slot, AdventureResult> equipment, AdventureResult item) {
+    int count = 0;
+    for (Slot slot : SlotSet.CODPIECE_SLOTS) {
+      AdventureResult gem = equipment.get(slot);
+      if (gem != null && gem.getItemId() == item.getItemId()) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  static boolean hasEquippedGem(Map<Slot, AdventureResult> equipment, AdventureResult item) {
+    return isCodpieceWorn(equipment) && copiesInGemSlots(equipment, item) > 0;
+  }
+
+  /**
+   * Finds every gem the character could use. A gem is judged by the same isolated delta as any
+   * other candidate: one that cannot help the requested expression is dropped, one already in the
+   * codpiece is kept so it can be left alone, and one the user demanded is kept so the requirement
+   * can be met or reported as impossible.
+   */
+  void discoverGems(EquipScope equipScope, int maxPrice, PriceLevel priceLevel, double nullScore)
+      throws MaximizerInterruptedException {
+    for (var entry : ModifierDatabase.getAllModifiersOfType(ModifierType.ETERNITY_CODPIECE)) {
+      if (!entry.getKey().isInt()) continue;
+      int itemId = entry.getKey().getIntValue();
+      AdventureResult gem = ItemPool.get(itemId, 1);
+      if (this.evaluator.isForbidden(gem)) continue;
+      Modifiers mods = ModifierDatabase.getModifiers(ModifierType.ETERNITY_CODPIECE, itemId);
+      if (mods == null) continue;
+
+      int slotted = liveCopiesInGemSlots(gem);
+      boolean required = this.evaluator.isRequired(gem);
+      double delta = this.evaluator.getScore(mods, Map.of(Slot.NONE, gem), Map.of()) - nullScore;
+      Evaluator.Constraint constraint = this.evaluator.checkConstraints(mods);
+      boolean contributesToMinimum = this.evaluator.contributesToMinimum(mods);
+      boolean contributesToCappedScore = this.evaluator.contributesToCappedScore(mods);
+      if (constraint == Evaluator.Constraint.VIOLATES) continue;
+      if (delta < 0.0
+          && !required
+          && constraint == Evaluator.Constraint.IRRELEVANT
+          && !contributesToMinimum
+          && !contributesToCappedScore
+          && !this.contributesToInteractingScore(mods)) {
+        continue;
+      }
+      if (delta == 0.0
+          && slotted == 0
+          && !required
+          && constraint == Evaluator.Constraint.IRRELEVANT
+          && !contributesToMinimum
+          && !contributesToCappedScore
+          && !this.contributesToInteractingScore(mods)
+          && !hasNonNumericModifiers(mods)) {
+        continue;
+      }
+
+      CheckedItem item = new CheckedItem(itemId, equipScope, maxPrice, priceLevel, true);
+      item.validate(maxPrice, priceLevel);
+      int count = item.getCount();
+      if (!InventoryManager.equippedOrInInventory(ItemPool.THE_ETERNITY_CODPIECE)) {
+        count += slotted;
+      }
+      if (count == 0) continue;
+      this.countsByItemId.put(itemId, count);
+      this.catalogue.add(new Gem(item, mods, delta, count));
+    }
+    this.catalogue.sort(
+        Comparator.comparingDouble(Gem::delta)
+            .reversed()
+            .thenComparingInt(gem -> gem.item().getItemId()));
+  }
+
+  private boolean contributesToInteractingScore(Modifiers mods) {
+    if (this.evaluator.contributesToNonlinearScore(mods, SUMMABLE_MODIFIERS)) return true;
+    return this.evaluator.getActiveScoreModifiers().stream()
+        .anyMatch(
+            term ->
+                term.modifier() == DoubleModifier.PRISMATIC_DAMAGE
+                    && (mods.getDouble(DoubleModifier.HOT_DAMAGE) != 0.0
+                        || mods.getDouble(DoubleModifier.COLD_DAMAGE) != 0.0
+                        || mods.getDouble(DoubleModifier.SPOOKY_DAMAGE) != 0.0
+                        || mods.getDouble(DoubleModifier.STENCH_DAMAGE) != 0.0
+                        || mods.getDouble(DoubleModifier.SLEAZE_DAMAGE) != 0.0));
+  }
+
+  /**
+   * Chooses gems for one fully decided equipment branch and scores every combination it reaches.
+   * Exactly one {@link MaximizerSpeculation#checkBest} call happens for a branch with no gem
+   * decisions to make, so this replaces, rather than supplements, the leaf scoring it stands in
+   * for.
+   */
+  void search(MaximizerSpeculation spec) throws MaximizerInterruptedException {
+    this.freeSlots = new ArrayList<>();
+    for (Slot slot : SlotSet.CODPIECE_SLOTS) {
+      if (spec.equipment.get(slot) == null) {
+        this.freeSlots.add(slot);
+      }
+    }
+    if (this.freeSlots.isEmpty()) {
+      spec.checkBest();
+      return;
+    }
+
+    if (!isCodpieceWorn(spec.equipment)) {
+      // Gems only enchant while the codpiece is worn, and a codpiece that is not worn keeps
+      // whatever it already holds, unless the ordinary equipment search has committed that copy
+      // elsewhere.
+      for (Slot slot : this.freeSlots) {
+        AdventureResult gem = EquipmentManager.getEquipment(slot);
+        int available = this.availableCopies(gem);
+        spec.equipment.put(
+            slot,
+            gem != null
+                    && gem != EquipmentRequest.UNEQUIP
+                    && countInEquipment(spec.equipment, gem) < available
+                ? gem
+                : EquipmentRequest.UNEQUIP);
+      }
+      spec.checkBest();
+      return;
+    }
+
+    for (Slot slot : this.freeSlots) {
+      spec.equipment.put(slot, EquipmentRequest.UNEQUIP);
+    }
+    int filled = this.selectCandidates(spec);
+    this.bound = this.buildBound(spec, this.freeSlots.size() - filled);
+    this.searchGems(spec, filled, 0);
+  }
+
+  /**
+   * Works out which gems this branch can still use and how many copies of each, then places any
+   * required gem up front. Copies this branch has already committed elsewhere, including to an
+   * excluded gem slot, are subtracted, so one physical gem is never used twice.
+   *
+   * @return how many free gem slots were filled with required gems
+   */
+  private int selectCandidates(MaximizerSpeculation spec) {
+    this.candidates = new ArrayList<>();
+    List<Integer> counts = new ArrayList<>();
+    int filled = 0;
+    for (Gem gem : this.catalogue) {
+      AdventureResult item = gem.item();
+      int count = gem.count() - countInEquipment(spec.equipment, item);
+      if (count <= 0) continue;
+
+      // Placing a required gem first is only a shortcut. One that does not fit still fails the
+      // speculation, through Evaluator.checkEquipment, on every leaf this branch reaches.
+      if (filled < this.freeSlots.size()
+          && this.evaluator.isRequired(item)
+          && !KoLCharacter.hasEquipped(spec.equipment, item)
+          && copiesInGemSlots(spec.equipment, item) == 0) {
+        spec.equipment.put(this.claimSlot(item, filled++), item);
+        count--;
+      }
+      if (count <= 0) continue;
+
+      this.candidates.add(gem);
+      counts.add(Math.min(count, this.freeSlots.size()));
+    }
+    this.available = counts.stream().mapToInt(Integer::intValue).toArray();
+    return filled;
+  }
+
+  /**
+   * Enumerates gem multisets in canonical order: each candidate may fill progressively more of the
+   * remaining slots before the search moves on, so no combination is reached twice. Every node,
+   * including the one that adds no further gem, is scored by the same {@link
+   * MaximizerSpeculation#checkBest} the rest of the equipment search uses, so the answer is exact
+   * whether or not the bound is available.
+   */
+  private void searchGems(MaximizerSpeculation spec, int filled, int start)
+      throws MaximizerInterruptedException {
+    this.combinationsEvaluated++;
+    spec.checkBest();
+
+    int slotsLeft = this.freeSlots.size() - filled;
+    if (slotsLeft == 0) return;
+
+    var mark = spec.mark();
+    for (int pos = start; pos < this.candidates.size(); pos++) {
+      if (this.bound != null
+          && !Maximizer.best.failed
+          && this.bound.upperBound(pos, slotsLeft) < Maximizer.best.getScore()) {
+        // Nothing candidates[pos..] can add reaches the incumbent, and later candidates are worth
+        // no more than this one, so the rest of this node is dead.
+        break;
+      }
+      AdventureResult item = this.candidates.get(pos).item();
+      int copies = Math.min(this.available[pos], slotsLeft);
+      for (int used = 1; used <= copies; used++) {
+        spec.equipment.put(this.claimSlot(item, filled + used - 1), item);
+        if (this.bound != null) this.bound.select(pos, 1);
+        this.searchGems(spec, filled + used, pos + 1);
+      }
+      if (this.bound != null) this.bound.select(pos, -copies);
+      spec.restore(mark);
+    }
+  }
+
+  /**
+   * Picks which free gem slot the next copy goes in, preferring one that already holds that gem so
+   * that keeping a gem where it is reads as leaving equipment alone rather than as a removal plus
+   * an insertion. Only slots the search has not assigned yet are considered, and no score depends
+   * on which gem slot a gem occupies.
+   */
+  private Slot claimSlot(AdventureResult item, int index) {
+    for (int i = index; i < this.freeSlots.size(); i++) {
+      AdventureResult live = EquipmentManager.getEquipment(this.freeSlots.get(i));
+      if (live != null && live.getItemId() == item.getItemId()) {
+        Slot preferred = this.freeSlots.get(i);
+        this.freeSlots.set(i, this.freeSlots.get(index));
+        this.freeSlots.set(index, preferred);
+        break;
+      }
+    }
+    return this.freeSlots.get(index);
+  }
+
+  private ScoreBound buildBound(MaximizerSpeculation spec, int slotsLeft) {
+    if (slotsLeft == 0 || this.candidates.isEmpty()) return null;
+    if (!this.evaluator.scoreIsWeightedSumOfTerms()) return null;
+    List<Evaluator.ScoreModifier> terms = this.evaluator.getActiveScoreModifiers();
+    for (Evaluator.ScoreModifier term : terms) {
+      if (!SUMMABLE_MODIFIERS.contains(term.modifier())) return null;
+      if (term.modifier() == DoubleModifier.ADVENTURES
+          && !KoLCharacter.canGainRolloverAdventures()) {
+        return null;
+      }
+    }
+    for (Gem gem : this.candidates) {
+      if (!contributesLinearly(gem.mods())) return null;
+    }
+    spec.setUnscored();
+    return new ScoreBound(terms, spec.calculate(), this.candidates, this.available, slotsLeft);
+  }
+
+  /**
+   * Whether a gem's contribution to a summable modifier is exactly the raw value in its own
+   * enchantments. A rollover effect is scored directly by {@link Evaluator#getScore} rather than
+   * through a modifier, an intrinsic effect brings in modifiers that are not listed on the gem, and
+   * a bitmap such as Brimstone feeds a non-linear late calculation.
+   */
+  private static boolean contributesLinearly(Modifiers mods) {
+    return !hasNonNumericModifiers(mods);
+  }
+
+  private static boolean hasNonNumericModifiers(Modifiers mods) {
+    return EnumSet.allOf(BitmapModifier.class).stream()
+            .anyMatch(modifier -> mods.getRawBitmap(modifier) != 0)
+        || EnumSet.allOf(BooleanModifier.class).stream().anyMatch(mods::getBoolean)
+        || EnumSet.allOf(StringModifier.class).stream()
+            .filter(
+                modifier ->
+                    modifier != StringModifier.MODIFIERS
+                        && modifier != StringModifier.EVALUATED_MODIFIERS)
+            .anyMatch(
+                modifier ->
+                    modifier.isMultiple()
+                        ? !mods.getStrings(modifier).isEmpty()
+                        : !mods.getString(modifier).isEmpty());
+  }
+
+  private static boolean isCodpieceWorn(Map<Slot, AdventureResult> equipment) {
+    for (Slot slot : SlotSet.SLOTS) {
+      AdventureResult item = equipment.get(slot);
+      if (item != null && item.getItemId() == ItemPool.THE_ETERNITY_CODPIECE) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static int countInEquipment(Map<Slot, AdventureResult> equipment, AdventureResult item) {
+    int count = 0;
+    for (AdventureResult equipped : equipment.values()) {
+      if (equipped != null && equipped.getItemId() == item.getItemId()) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static int liveCopiesInGemSlots(AdventureResult item) {
+    int count = 0;
+    for (Slot slot : SlotSet.CODPIECE_SLOTS) {
+      AdventureResult gem = EquipmentManager.getEquipment(slot);
+      if (gem != null && gem.getItemId() == item.getItemId()) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private int availableCopies(AdventureResult item) {
+    if (item == null || item == EquipmentRequest.UNEQUIP) return 0;
+    Integer count = this.countsByItemId.get(item.getItemId());
+    if (count != null) return count;
+    count =
+        ItemDatabase.isAllowed(item)
+            ? InventoryManager.getAccessibleCount(item)
+            : InventoryManager.getCount(item) + InventoryManager.getEquippedCount(item);
+    if (!InventoryManager.equippedOrInInventory(ItemPool.THE_ETERNITY_CODPIECE)) {
+      count += liveCopiesInGemSlots(item);
+    }
+    return count;
+  }
+
+  /**
+   * An upper bound on the score of any combination still reachable from a search node, so that a
+   * node which cannot reach the incumbent need not be explored.
+   *
+   * <p>For each active term, {@code suffix[term][c][s]} is the most favourable raw value the gems
+   * from index {@code c} onwards can contribute using at most {@code s} slots -- the largest when
+   * the term's weight is positive, the smallest when it is negative, which is the direction that
+   * makes the term's weighted contribution largest. Adding that to the branch's own baseline and to
+   * what has already been selected therefore over-states every term, and hence the whole score.
+   * Math.nextUp and Math.nextDown keep that true through floating point rounding.
+   *
+   * <p>A term minimum, a total minimum, or a boolean requirement needs no allowance here: those
+   * only mark a combination as failed, and a failed combination already loses to the incumbent,
+   * which is only compared against while it has not itself failed.
+   */
+  private static final class ScoreBound {
+    private final List<Evaluator.ScoreModifier> terms;
+    private final double constant;
+    private final double[][] perCopy;
+    private final double[] baseline;
+    private final double[] selected;
+    private final double[][][] suffix;
+
+    ScoreBound(
+        List<Evaluator.ScoreModifier> terms,
+        Modifiers baseMods,
+        List<Gem> candidates,
+        int[] available,
+        int slotsLeft) {
+      this.terms = terms;
+      this.constant = baseMods.hasString(StringModifier.ROLLOVER_EFFECT) ? 0.01f : 0.0;
+      int size = terms.size();
+      this.baseline = new double[size];
+      this.selected = new double[size];
+      this.perCopy = new double[candidates.size()][size];
+      for (int t = 0; t < size; t++) {
+        DoubleModifier modifier = (DoubleModifier) terms.get(t).modifier();
+        this.baseline[t] = baseMods.getDouble(modifier);
+        for (int c = 0; c < candidates.size(); c++) {
+          this.perCopy[c][t] = candidates.get(c).mods().getDouble(modifier);
+        }
+      }
+      this.suffix = new double[size][][];
+      for (int t = 0; t < size; t++) {
+        this.suffix[t] = this.buildSuffix(t, available, slotsLeft);
+      }
+    }
+
+    private double[][] buildSuffix(int term, int[] available, int maxSlots) {
+      int size = this.perCopy.length;
+      boolean maximize = this.terms.get(term).weight() >= 0.0;
+      // suffix[size][*] stays zero: with no candidates left nothing more can be contributed.
+      double[][] suffix = new double[size + 1][maxSlots + 1];
+      for (int c = size - 1; c >= 0; c--) {
+        double value = this.perCopy[c][term];
+        for (int slots = 1; slots <= maxSlots; slots++) {
+          double best = suffix[c + 1][slots];
+          for (int used = 1; used <= Math.min(available[c], slots); used++) {
+            double total = used * value + suffix[c + 1][slots - used];
+            total = maximize ? Math.nextUp(total) : Math.nextDown(total);
+            best = maximize ? Math.max(best, total) : Math.min(best, total);
+          }
+          suffix[c][slots] = best;
+        }
+      }
+      return suffix;
+    }
+
+    void select(int candidate, int copies) {
+      for (int t = 0; t < this.terms.size(); t++) {
+        this.selected[t] += copies * this.perCopy[candidate][t];
+      }
+    }
+
+    double upperBound(int pos, int slotsLeft) {
+      double score = this.constant;
+      for (int t = 0; t < this.terms.size(); t++) {
+        Evaluator.ScoreModifier term = this.terms.get(t);
+        double value = this.baseline[t] + this.selected[t] + this.suffix[t][pos][slotsLeft];
+        score = Math.nextUp(score + Math.nextUp(term.weight() * Math.min(value, term.max())));
+      }
+      return score;
+    }
+  }
+}

--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -92,6 +92,8 @@ public class Evaluator {
   /** if slots[i] >= 0 then equipment of type i can be considered for maximization */
   private final EnumMap<Slot, Integer> slots = new EnumMap<>(Slot.class);
 
+  private final CodpieceMaximizer codpiece = new CodpieceMaximizer(this);
+
   private String weaponType = null;
   private int hands = 0;
   int melee = 0; // +/-2 or higher: require, +/-1: disallow other type
@@ -116,7 +118,76 @@ public class Evaluator {
 
   record ItemBonus(double base, Map<String, Double> modes) {}
 
-  private record ScoreModifier(Modifier modifier, double weight, double min, double max) {}
+  record ScoreModifier(Modifier modifier, double weight, double min, double max) {}
+
+  private static final EnumSet<Slot> SEARCHABLE_SLOTS = EnumSet.copyOf(SlotSet.SLOTS);
+
+  static {
+    SEARCHABLE_SLOTS.addAll(SlotSet.CODPIECE_SLOTS);
+  }
+
+  CodpieceMaximizer codpiece() {
+    return this.codpiece;
+  }
+
+  List<ScoreModifier> getActiveScoreModifiers() {
+    return this.activeScoreModifiers;
+  }
+
+  /**
+   * Whether {@link #getScore} is exactly the weighted, capped sum of its active modifier terms plus
+   * the constant rollover-effect fudge factor, with no per-item bonus or bitmap total mixed in.
+   */
+  boolean scoreIsWeightedSumOfTerms() {
+    return this.stinkycheese <= 0 && this.bonuses.isEmpty() && this.bonusFunc.isEmpty();
+  }
+
+  boolean isRequired(AdventureResult item) {
+    return this.posEquip.contains(item);
+  }
+
+  boolean isForbidden(AdventureResult item) {
+    return this.negEquip.contains(item);
+  }
+
+  boolean contributesToMinimum(Modifiers mods) {
+    var empty = new Modifiers();
+    var predicted = this.shouldPredictDerivedModifiers ? mods.predict() : null;
+    var emptyPredicted = this.shouldPredictDerivedModifiers ? empty.predict() : null;
+    return this.activeScoreModifiers.stream()
+        .filter(term -> term.min() != Double.NEGATIVE_INFINITY)
+        .anyMatch(
+            term ->
+                scoreValue(term.modifier(), mods, predicted)
+                    > scoreValue(term.modifier(), empty, emptyPredicted));
+  }
+
+  boolean contributesToCappedScore(Modifiers mods) {
+    var empty = new Modifiers();
+    var predicted = this.shouldPredictDerivedModifiers ? mods.predict() : null;
+    var emptyPredicted = this.shouldPredictDerivedModifiers ? empty.predict() : null;
+    return this.activeScoreModifiers.stream()
+        .filter(term -> term.max() != Double.POSITIVE_INFINITY)
+        .anyMatch(
+            term ->
+                scoreValue(term.modifier(), mods, predicted)
+                    != scoreValue(term.modifier(), empty, emptyPredicted));
+  }
+
+  boolean contributesToNonlinearScore(Modifiers mods, Set<DoubleModifier> summableModifiers) {
+    var empty = new Modifiers();
+    var predicted = this.shouldPredictDerivedModifiers ? mods.predict() : null;
+    var emptyPredicted = this.shouldPredictDerivedModifiers ? empty.predict() : null;
+    return this.activeScoreModifiers.stream()
+        .filter(
+            term ->
+                !(term.modifier() instanceof DoubleModifier modifier)
+                    || !summableModifiers.contains(modifier))
+        .anyMatch(
+            term ->
+                scoreValue(term.modifier(), mods, predicted)
+                    != scoreValue(term.modifier(), empty, emptyPredicted));
+  }
 
   private static final Pattern MUS_EXP_PERC_PATTERN =
       Pattern.compile("^mus(cle)? exp(erience)? perc(ent(age)?)?");
@@ -859,119 +930,8 @@ public class Evaluator {
       var mod = scoreModifier.modifier();
       double weight = scoreModifier.weight();
       double min = scoreModifier.min();
-      double val = 0.0;
+      double val = scoreValue(mod, mods, predicted);
       double max = scoreModifier.max();
-      if (mod instanceof BitmapModifier bitmapModifier) {
-        val = mods.getBitmap(bitmapModifier);
-      } else if (mod instanceof DoubleModifier) {
-        var doubleModifier = (DoubleModifier) mod;
-        val = mods.getDouble(doubleModifier);
-        switch (doubleModifier) {
-          case MUS:
-            val = predicted.get(DerivedModifier.BUFFED_MUS);
-            break;
-          case MYS:
-            val = predicted.get(DerivedModifier.BUFFED_MYS);
-            break;
-          case MOX:
-            val = predicted.get(DerivedModifier.BUFFED_MOX);
-            break;
-          case FAMILIAR_WEIGHT:
-            val += mods.getDouble(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT);
-            if (mods.getDouble(DoubleModifier.FAMILIAR_WEIGHT_PCT) < 0.0) {
-              val *= 0.5f;
-            }
-            break;
-          case MANA_COST:
-            val += mods.getDouble(DoubleModifier.STACKABLE_MANA_COST);
-            break;
-          case INITIATIVE:
-            val += Math.min(0.0, mods.getDouble(DoubleModifier.INITIATIVE_PENALTY));
-            break;
-          case MEATDROP:
-            val +=
-                100.0
-                    + Math.min(0.0, mods.getDouble(DoubleModifier.MEATDROP_PENALTY))
-                    + mods.getDouble(DoubleModifier.SPORADIC_MEATDROP)
-                    + mods.getDouble(DoubleModifier.MEAT_BONUS) / 10000.0;
-            break;
-          case ITEMDROP:
-            val +=
-                100.0
-                    + Math.min(0.0, mods.getDouble(DoubleModifier.ITEMDROP_PENALTY))
-                    + mods.getDouble(DoubleModifier.SPORADIC_ITEMDROP);
-            break;
-          case HP:
-            val = predicted.get(DerivedModifier.BUFFED_HP);
-            break;
-          case MP:
-            val = predicted.get(DerivedModifier.BUFFED_MP);
-            break;
-          case WEAPON_DAMAGE:
-            // Incorrect - needs to estimate base damage
-            val += mods.getDouble(DoubleModifier.WEAPON_DAMAGE_PCT);
-            break;
-          case RANGED_DAMAGE:
-            // Incorrect - needs to estimate base damage
-            val += mods.getDouble(DoubleModifier.RANGED_DAMAGE_PCT);
-            break;
-          case SPELL_DAMAGE:
-            // Incorrect - base damage depends on spell used
-            val += mods.getDouble(DoubleModifier.SPELL_DAMAGE_PCT);
-            break;
-          case COLD_RESISTANCE:
-            if (mods.getBoolean(BooleanModifier.COLD_IMMUNITY)) {
-              val = 100.0;
-            } else if (mods.getBoolean(BooleanModifier.COLD_VULNERABILITY)) {
-              val -= 100.0;
-            }
-            break;
-          case HOT_RESISTANCE:
-            if (mods.getBoolean(BooleanModifier.HOT_IMMUNITY)) {
-              val = 100.0;
-            } else if (mods.getBoolean(BooleanModifier.HOT_VULNERABILITY)) {
-              val -= 100.0;
-            }
-            break;
-          case SLEAZE_RESISTANCE:
-            if (mods.getBoolean(BooleanModifier.SLEAZE_IMMUNITY)) {
-              val = 100.0;
-            } else if (mods.getBoolean(BooleanModifier.SLEAZE_VULNERABILITY)) {
-              val -= 100.0;
-            }
-            break;
-          case SPOOKY_RESISTANCE:
-            if (mods.getBoolean(BooleanModifier.SPOOKY_IMMUNITY)) {
-              val = 100.0;
-            } else if (mods.getBoolean(BooleanModifier.SPOOKY_VULNERABILITY)) {
-              val -= 100.0;
-            }
-            break;
-          case STENCH_RESISTANCE:
-            if (mods.getBoolean(BooleanModifier.STENCH_IMMUNITY)) {
-              val = 100.0;
-            } else if (mods.getBoolean(BooleanModifier.STENCH_VULNERABILITY)) {
-              val -= 100.0;
-            }
-            break;
-          case EXPERIENCE:
-            double baseExp =
-                KoLCharacter.estimatedBaseExp(
-                    mods.getDouble(DoubleModifier.MONSTER_LEVEL)
-                        * (1 + mods.getDouble(DoubleModifier.MONSTER_LEVEL_PERCENT) / 100));
-            double expPct = mods.getDouble(DoubleModifier.primeStatExpPercent()) / 100.0f;
-            double exp = mods.getDouble(DoubleModifier.primeStatExp());
-
-            val = ((baseExp + exp) * (1 + expPct)) / 2.0f;
-            break;
-          case DAMAGE_AURA:
-            val += mods.getDouble(DoubleModifier.SPORADIC_DAMAGE_AURA);
-            break;
-          case THORNS:
-            val += mods.getDouble(DoubleModifier.SPORADIC_THORNS);
-            break;
-        }
-      }
       if (val < min) this.failed = true;
       score += weight * Math.min(val, max);
     }
@@ -1015,6 +975,123 @@ public class Evaluator {
     return score;
   }
 
+  private static double scoreValue(
+      Modifier scoreModifier, Modifiers mods, Map<DerivedModifier, Integer> predictedModifiers) {
+    if (scoreModifier instanceof BitmapModifier modifier) {
+      return mods.getBitmap(modifier);
+    }
+    if (!(scoreModifier instanceof DoubleModifier modifier)) {
+      return 0.0;
+    }
+    double val = mods.getDouble(modifier);
+    switch (modifier) {
+      case MUS:
+        val = predictedModifiers.get(DerivedModifier.BUFFED_MUS);
+        break;
+      case MYS:
+        val = predictedModifiers.get(DerivedModifier.BUFFED_MYS);
+        break;
+      case MOX:
+        val = predictedModifiers.get(DerivedModifier.BUFFED_MOX);
+        break;
+      case FAMILIAR_WEIGHT:
+        val += mods.getDouble(DoubleModifier.HIDDEN_FAMILIAR_WEIGHT);
+        if (mods.getDouble(DoubleModifier.FAMILIAR_WEIGHT_PCT) < 0.0) {
+          val *= 0.5f;
+        }
+        break;
+      case MANA_COST:
+        val += mods.getDouble(DoubleModifier.STACKABLE_MANA_COST);
+        break;
+      case INITIATIVE:
+        val += Math.min(0.0, mods.getDouble(DoubleModifier.INITIATIVE_PENALTY));
+        break;
+      case MEATDROP:
+        val +=
+            100.0
+                + Math.min(0.0, mods.getDouble(DoubleModifier.MEATDROP_PENALTY))
+                + mods.getDouble(DoubleModifier.SPORADIC_MEATDROP)
+                + mods.getDouble(DoubleModifier.MEAT_BONUS) / 10000.0;
+        break;
+      case ITEMDROP:
+        val +=
+            100.0
+                + Math.min(0.0, mods.getDouble(DoubleModifier.ITEMDROP_PENALTY))
+                + mods.getDouble(DoubleModifier.SPORADIC_ITEMDROP);
+        break;
+      case HP:
+        val = predictedModifiers.get(DerivedModifier.BUFFED_HP);
+        break;
+      case MP:
+        val = predictedModifiers.get(DerivedModifier.BUFFED_MP);
+        break;
+      case WEAPON_DAMAGE:
+        // Incorrect - needs to estimate base damage
+        val += mods.getDouble(DoubleModifier.WEAPON_DAMAGE_PCT);
+        break;
+      case RANGED_DAMAGE:
+        // Incorrect - needs to estimate base damage
+        val += mods.getDouble(DoubleModifier.RANGED_DAMAGE_PCT);
+        break;
+      case SPELL_DAMAGE:
+        // Incorrect - base damage depends on spell used
+        val += mods.getDouble(DoubleModifier.SPELL_DAMAGE_PCT);
+        break;
+      case COLD_RESISTANCE:
+        if (mods.getBoolean(BooleanModifier.COLD_IMMUNITY)) {
+          val = 100.0;
+        } else if (mods.getBoolean(BooleanModifier.COLD_VULNERABILITY)) {
+          val -= 100.0;
+        }
+        break;
+      case HOT_RESISTANCE:
+        if (mods.getBoolean(BooleanModifier.HOT_IMMUNITY)) {
+          val = 100.0;
+        } else if (mods.getBoolean(BooleanModifier.HOT_VULNERABILITY)) {
+          val -= 100.0;
+        }
+        break;
+      case SLEAZE_RESISTANCE:
+        if (mods.getBoolean(BooleanModifier.SLEAZE_IMMUNITY)) {
+          val = 100.0;
+        } else if (mods.getBoolean(BooleanModifier.SLEAZE_VULNERABILITY)) {
+          val -= 100.0;
+        }
+        break;
+      case SPOOKY_RESISTANCE:
+        if (mods.getBoolean(BooleanModifier.SPOOKY_IMMUNITY)) {
+          val = 100.0;
+        } else if (mods.getBoolean(BooleanModifier.SPOOKY_VULNERABILITY)) {
+          val -= 100.0;
+        }
+        break;
+      case STENCH_RESISTANCE:
+        if (mods.getBoolean(BooleanModifier.STENCH_IMMUNITY)) {
+          val = 100.0;
+        } else if (mods.getBoolean(BooleanModifier.STENCH_VULNERABILITY)) {
+          val -= 100.0;
+        }
+        break;
+      case EXPERIENCE:
+        double baseExp =
+            KoLCharacter.estimatedBaseExp(
+                mods.getDouble(DoubleModifier.MONSTER_LEVEL)
+                    * (1 + mods.getDouble(DoubleModifier.MONSTER_LEVEL_PERCENT) / 100));
+        double expPct = mods.getDouble(DoubleModifier.primeStatExpPercent()) / 100.0f;
+        double exp = mods.getDouble(DoubleModifier.primeStatExp());
+
+        val = ((baseExp + exp) * (1 + expPct)) / 2.0f;
+        break;
+      case DAMAGE_AURA:
+        val += mods.getDouble(DoubleModifier.SPORADIC_DAMAGE_AURA);
+        break;
+      case THORNS:
+        val += mods.getDouble(DoubleModifier.SPORADIC_THORNS);
+        break;
+    }
+    return val;
+  }
+
   public double getScore(Modifiers mods) {
     return this.getScore(mods, Map.of(), Map.of());
   }
@@ -1025,7 +1102,8 @@ public class Evaluator {
     if (!this.failed && !this.posEquip.isEmpty()) {
       equipSatisfied = true;
       for (AdventureResult item : this.posEquip) {
-        if (!KoLCharacter.hasEquipped(equipment, item)) {
+        if (!KoLCharacter.hasEquipped(equipment, item)
+            && !CodpieceMaximizer.hasEquippedGem(equipment, item)) {
           equipSatisfied = false;
           break;
         }
@@ -1172,6 +1250,16 @@ public class Evaluator {
     SlotList<CheckedItem> ranked = new SlotList<>(this.familiars.size());
 
     double nullScore = this.getScore(new Modifiers());
+    boolean considerCodpieceGems = Preferences.getBoolean("maximizerConsiderCodpieceGems");
+
+    // Codpiece gems are inserted into the codpiece rather than equipped, so they have no ordinary
+    // slot and never reach the per-slot candidate loop below. Discover them here instead,
+    // unless the codpiece itself is forbidden and no gem could ever be worn.
+    if (considerCodpieceGems
+        && (!this.negEquip.contains(EquipmentManager.ETERNITY_CODPIECE)
+            || KoLCharacter.hasEquipped(ItemPool.THE_ETERNITY_CODPIECE))) {
+      this.codpiece.discoverGems(equipScope, maxPrice, priceLevel, nullScore);
+    }
 
     Map<Integer, Boolean> usefulOutfits = new HashMap<>();
     Map<AdventureResult, AdventureResult> outfitPieces = new HashMap<>();
@@ -1647,6 +1735,14 @@ public class Evaluator {
         }
 
         if (id == ItemPool.CARD_SLEEVE) {
+          break gotItem;
+        }
+
+        // The codpiece is worth what its gems are worth, and those are chosen at the leaf of
+        // the search rather than here, so carry it through on its own rather than judging it
+        // by its bare enchantments.
+        if (id == ItemPool.THE_ETERNITY_CODPIECE && this.codpiece.hasCandidates()) {
+          item.automaticFlag = true;
           break gotItem;
         }
 
@@ -2390,7 +2486,10 @@ public class Evaluator {
     for (int thresh = 1; ; --thresh) {
       if (thresh < 0) return; // no slots enabled
       boolean anySlots = false;
-      for (var slot : SlotSet.SLOTS) {
+      // When Codpiece search is enabled, -codpiece2 excludes a gem slot exactly as -hat excludes
+      // the hat. Otherwise, leaving every gem slot seeded preserves the current configuration.
+      for (var slot : SEARCHABLE_SLOTS) {
+        if (!considerCodpieceGems && SlotSet.CODPIECE_SLOTS.contains(slot)) continue;
         if (this.slots.getOrDefault(slot, 0) >= thresh) {
           spec.equipment.put(slot, null);
           anySlots = true;

--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -1827,13 +1827,20 @@ public class Maximizer {
       }
       text = text + " (";
 
-      CheckedItem checkedItem = new CheckedItem(itemId, equipScope, maxPrice, priceLevel);
+      boolean codpieceSlot = SlotSet.CODPIECE_SLOTS.contains(slot);
+      CheckedItem checkedItem =
+          new CheckedItem(itemId, equipScope, maxPrice, priceLevel, codpieceSlot);
+      boolean preserveCodpieceGem =
+          EquipmentRequest.isCodpieceGem(itemId)
+              && CodpieceMaximizer.copiesInGemSlots(Maximizer.best.equipment, item) > 0;
 
       long price = 0L;
 
       // How many have been needed so far to make this maximization set?
       // We need 1 + that number to equip this item, not just 1
       int count = 0;
+      int consumed = 0;
+      int released = 0;
 
       // If we're running from command line then execute them straight away,
       // so we have to count how much we've used in 'earlier' items
@@ -1849,8 +1856,11 @@ public class Maximizer {
       } else {
         // Otherwise we iterate through the maximization set so far
         for (Boost boost : Maximizer.boosts) {
-          if (item.equals(boost.getItem())) {
+          if (codpieceSlot && Maximizer.releasesItem(boost, item)) {
+            released++;
+          } else if (item.equals(boost.getItem())) {
             count++;
+            if (!boost.getCmd().isEmpty()) consumed++;
           }
         }
       }
@@ -1880,22 +1890,42 @@ public class Maximizer {
       } else if (checkedItem.initial > count) {
         // This may look odd, but we need an item, not a checked item
         // The count of a checked item includes creatable, buyable, pullable etc.
+        boolean keepFamiliarCopy =
+            codpieceSlot && item.equals(Maximizer.best.equipment.get(Slot.FAMILIAR));
         String method =
-            InventoryManager.simRetrieveItem(
-                ItemPool.get(item.getItemId(), count + 1),
-                equipScope == EquipScope.EQUIP_NOW,
-                false);
+            codpieceSlot && checkedItem.inventory + released > consumed
+                ? "have"
+                : codpieceSlot && equipScope != EquipScope.EQUIP_NOW
+                    ? InventoryManager.simRetrieveItemFromAccessibleSources(
+                        ItemPool.get(item.getItemId(), consumed + 1 - released), !keepFamiliarCopy)
+                    : InventoryManager.simRetrieveItem(
+                        ItemPool.get(item.getItemId(), count + 1),
+                        equipScope == EquipScope.EQUIP_NOW,
+                        false);
         if (!method.equals("have")) {
           text = method + " & " + text;
         }
-        cmd =
-            switch (method) {
-              case "uncloset" -> "closet take 1 \u00B6" + item.getItemId() + ";" + cmd;
-              case "unstash" -> "stash take 1 \u00B6" + item.getItemId() + ";" + cmd;
-              // Should be only hitting this after Ronin I think
-              case "pull" -> "pull 1 \u00B6" + item.getItemId() + ";" + cmd;
-              default -> cmd;
-            };
+        Slot movableCodpieceSlot =
+            preserveCodpieceGem ? Maximizer.movableCodpieceSlot(item) : Slot.NONE;
+        if (movableCodpieceSlot != Slot.NONE) {
+          text = "unequip & " + text;
+          cmd = "unequip " + movableCodpieceSlot.name + ";" + cmd;
+        } else {
+          cmd =
+              switch (method) {
+                case "uncloset" -> "closet take 1 \u00B6" + item.getItemId() + ";" + cmd;
+                case "unstash" -> "stash take 1 \u00B6" + item.getItemId() + ";" + cmd;
+                // Should be only hitting this after Ronin I think
+                case "pull" -> "pull 1 \u00B6" + item.getItemId() + ";" + cmd;
+                case "free pull" ->
+                    preserveCodpieceGem ? "pull 1 \u00B6" + item.getItemId() + ";" + cmd : cmd;
+                case "create", "create or buy" ->
+                    preserveCodpieceGem ? "make \u00B6" + item.getItemId() + ";" + cmd : cmd;
+                case "buy" ->
+                    preserveCodpieceGem ? "buy 1 \u00B6" + item.getItemId() + ";" + cmd : cmd;
+                default -> cmd;
+              };
+        }
       } else if (checkedItem.creatable + checkedItem.initial > count) {
         text = "make & " + text;
         cmd = "make \u00B6" + item.getItemId() + ";" + cmd;
@@ -1944,6 +1974,9 @@ public class Maximizer {
         }
       } else { // Mall buyable
         text = "acquire & " + text;
+        if (preserveCodpieceGem) {
+          cmd = "buy 1 \u00B6" + itemId + ";" + cmd;
+        }
         if (priceLevel != PriceLevel.DONT_CHECK) {
           price = MallPriceManager.getMallPrice(itemId);
         }
@@ -1966,6 +1999,27 @@ public class Maximizer {
       Maximizer.boosts.add(boost);
     }
     return equipScope;
+  }
+
+  private static boolean releasesItem(Boost boost, AdventureResult item) {
+    Slot slot = boost.getSlot();
+    return slot != null
+        && slot != Slot.NONE
+        && EquipmentManager.getEquipment(slot).equals(item)
+        && !Objects.equals(Maximizer.best.equipment.get(slot), item);
+  }
+
+  private static Slot movableCodpieceSlot(AdventureResult item) {
+    for (Slot slot : SlotSet.CODPIECE_SLOTS) {
+      if (EquipmentManager.getEquipment(slot).equals(item)
+          && !Objects.equals(Maximizer.best.equipment.get(slot), item)
+          && Maximizer.boosts.stream()
+              .map(Boost::getCmd)
+              .noneMatch(command -> command.contains("unequip " + slot.name))) {
+        return slot;
+      }
+    }
+    return Slot.NONE;
   }
 
   private static boolean excludedTCRSItem(int itemId) {

--- a/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
+++ b/src/net/sourceforge/kolmafia/maximizer/MaximizerSpeculation.java
@@ -338,8 +338,8 @@ public class MaximizerSpeculation extends Speculation
     if (this.equipment.get(Slot.FAMILIAR) == null) {
       List<CheckedItem> possible = possibles.get(Slot.FAMILIAR);
       boolean any = false;
-      for (AdventureResult item : possible) {
-        int count = item.getCount();
+      for (CheckedItem item : possible) {
+        int count = countAfterCodpieceSlots(item);
         if (item.equals(this.equipment.get(Slot.OFFHAND))) {
           --count;
         }
@@ -454,8 +454,8 @@ public class MaximizerSpeculation extends Speculation
       List<CheckedItem> possible = possibles.get(Slot.ACCESSORY1);
       boolean any = false;
       for (; pos < possible.size(); ++pos) {
-        AdventureResult item = possible.get(pos);
-        int count = item.getCount();
+        CheckedItem item = possible.get(pos);
+        int count = countAfterCodpieceSlots(item);
         if (item.equals(this.equipment.get(Slot.ACCESSORY1))) {
           --count;
         }
@@ -465,6 +465,8 @@ public class MaximizerSpeculation extends Speculation
         if (item.equals(this.equipment.get(Slot.ACCESSORY3))) {
           --count;
         }
+        // A dual-role item locked into a codpiece gem slot is already committed; do not offer
+        // that same copy as an accessory too.
         FoldGroup group = ItemDatabase.getFoldGroup(item.getName());
         if (group != null && this.foldables) {
           String groupName = group.names.get(0);
@@ -743,6 +745,43 @@ public class MaximizerSpeculation extends Speculation
     this.restore(mark);
   }
 
+  /**
+   * Scores one fully decided equipment combination against the running best. Split out of the tail
+   * of {@link #tryOffhands} so that the codpiece gem search can score every combination it reaches
+   * with the same machinery the rest of the equipment search uses.
+   */
+  void checkBest() throws MaximizerInterruptedException {
+    this.calculated = false;
+    this.scored = false;
+    this.tiebreakered = false;
+    if (Maximizer.best == null) {
+      RequestLogger.updateSessionLog(
+          "Maximizer about to throw LimitExceeded because of null best.");
+      // this isn't really what is happening but trying to understand why this is happening, first.
+      throw new MaximizerLimitException();
+    }
+    if (this.compareTo(Maximizer.best) > 0) {
+      Maximizer.best = this.clone();
+    }
+    Maximizer.bestChecked++;
+    if ((Maximizer.bestChecked & 0x3FF) == 0) {
+      long t = System.currentTimeMillis();
+      if (t > Maximizer.bestUpdate) {
+        MaximizerSpeculation.showProgress();
+        Maximizer.bestUpdate = t + 5000;
+      }
+    }
+    if (!KoLmafia.permitsContinue()) {
+      throw new MaximizerInterruptedException();
+    }
+    if (this.exceeded) {
+      throw new MaximizerExceededException();
+    }
+    if (Maximizer.combinationLimit != 0 && Maximizer.bestChecked >= Maximizer.combinationLimit) {
+      throw new MaximizerLimitException();
+    }
+  }
+
   public void tryOffhands(SlotList<CheckedItem> possibles, AdventureResult bestCard)
       throws MaximizerInterruptedException {
     var mark = this.mark();
@@ -765,8 +804,8 @@ public class MaximizerSpeculation extends Speculation
           };
       boolean any = false;
 
-      for (AdventureResult item : possible) {
-        int count = item.getCount();
+      for (CheckedItem item : possible) {
+        int count = countAfterCodpieceSlots(item);
         if (item.equals(this.equipment.get(Slot.WEAPON))) {
           --count;
         }
@@ -800,37 +839,15 @@ public class MaximizerSpeculation extends Speculation
       this.equipment.put(Slot.OFFHAND, EquipmentRequest.UNEQUIP);
     }
 
-    // doit
-    this.calculated = false;
-    this.scored = false;
-    this.tiebreakered = false;
-    if (Maximizer.best == null) {
-      RequestLogger.updateSessionLog(
-          "Maximizer about to throw LimitExceeded because of null best.");
-      // this isn't really what is happening but trying to understand why this is happening, first.
-      throw new MaximizerLimitException();
-    }
-    if (this.compareTo(Maximizer.best) > 0) {
-      Maximizer.best = this.clone();
-    }
-    Maximizer.bestChecked++;
-    if ((Maximizer.bestChecked & 0x3FF) == 0) {
-      long t = System.currentTimeMillis();
-      if (t > Maximizer.bestUpdate) {
-        MaximizerSpeculation.showProgress();
-        Maximizer.bestUpdate = t + 5000;
-      }
-    }
+    Maximizer.eval.codpiece().search(this);
     this.restore(mark);
-    if (!KoLmafia.permitsContinue()) {
-      throw new MaximizerInterruptedException();
-    }
-    if (this.exceeded) {
-      throw new MaximizerExceededException();
-    }
-    if (Maximizer.combinationLimit != 0 && Maximizer.bestChecked >= Maximizer.combinationLimit) {
-      throw new MaximizerLimitException();
-    }
+  }
+
+  private int countAfterCodpieceSlots(CheckedItem item) {
+    int codpieceCopies = CodpieceMaximizer.copiesInGemSlots(this.equipment, item);
+    return item.singleFlag
+        ? Math.min(1, item.getCountIgnoringSingleEquip() - codpieceCopies)
+        : item.getCount() - codpieceCopies;
   }
 
   private static int getMutex(AdventureResult item) {

--- a/src/net/sourceforge/kolmafia/session/InventoryManager.java
+++ b/src/net/sourceforge/kolmafia/session/InventoryManager.java
@@ -491,6 +491,45 @@ public abstract class InventoryManager {
     return rv;
   }
 
+  public static String simRetrieveItemFromAccessibleSources(
+      final AdventureResult item, final boolean useFamiliar) {
+    int missingCount = item.getCount() - item.getCount(KoLConstants.inventory);
+    if (missingCount <= 0) return "have";
+
+    int itemId = item.getItemId();
+    boolean restricted = !ItemDatabase.isAllowed(item);
+    if (useFamiliar
+        && !restricted
+        && ItemDatabase.isEquipment(itemId)
+        && !KoLCharacter.inQuantum()) {
+      for (FamiliarData familiar : KoLCharacter.ownedFamiliars()) {
+        if (item.equals(familiar.getItem()) && --missingCount <= 0) return "steal";
+      }
+    }
+    if (!restricted && InventoryManager.canUseCloset()) {
+      missingCount -= item.getCount(KoLConstants.closet);
+      if (missingCount <= 0) return "uncloset";
+    }
+    if (!restricted
+        && (!KoLCharacter.inLegacyOfLoathing() || pullableInLoL(itemId))
+        && (!KoLCharacter.inSeaPath() || pullableInSeaPath(itemId))
+        && (!KoLCharacter.isThrifty()
+            || ThriftyRequest.isAllowed(
+                RestrictedItemType.ITEMS, ItemDatabase.getItemName(itemId)))) {
+      missingCount -= item.getCount(KoLConstants.freepulls);
+      if (missingCount <= 0) return "free pull";
+      if (InventoryManager.canUseStorage()) {
+        missingCount -= item.getCount(KoLConstants.storage);
+        if (missingCount <= 0) return "pull";
+      }
+    }
+    if (!restricted && InventoryManager.canUseClanStash()) {
+      missingCount -= item.getCount(ClanManager.getStash());
+      if (missingCount <= 0) return "unstash";
+    }
+    return "fail";
+  }
+
   private static String retrieveItem(
       final AdventureResult item,
       final boolean isAutomated,

--- a/test/net/sourceforge/kolmafia/maximizer/EternityCodpieceMaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/EternityCodpieceMaximizerTest.java
@@ -1,0 +1,449 @@
+package net.sourceforge.kolmafia.maximizer;
+
+import static internal.helpers.Maximizer.getBoosts;
+import static internal.helpers.Maximizer.maximize;
+import static internal.helpers.Maximizer.modFor;
+import static internal.helpers.Player.withClass;
+import static internal.helpers.Player.withEquippableItem;
+import static internal.helpers.Player.withEquipped;
+import static internal.helpers.Player.withFamiliar;
+import static internal.helpers.Player.withInteractivity;
+import static internal.helpers.Player.withItem;
+import static internal.helpers.Player.withItemInCloset;
+import static internal.helpers.Player.withItemInFreepulls;
+import static internal.helpers.Player.withMallPrice;
+import static internal.helpers.Player.withMeat;
+import static internal.helpers.Player.withNotAllowedInStandard;
+import static internal.helpers.Player.withOverrideModifiers;
+import static internal.helpers.Player.withPath;
+import static internal.helpers.Player.withProperty;
+import static internal.helpers.Player.withRestricted;
+import static internal.helpers.Player.withStats;
+import static internal.matchers.Maximizer.recommends;
+import static internal.matchers.Maximizer.recommendsSlot;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+
+import internal.helpers.Cleanups;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import net.sourceforge.kolmafia.AdventureResult;
+import net.sourceforge.kolmafia.AscensionClass;
+import net.sourceforge.kolmafia.AscensionPath.Path;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.ModifierType;
+import net.sourceforge.kolmafia.RestrictedItemType;
+import net.sourceforge.kolmafia.equipment.Slot;
+import net.sourceforge.kolmafia.equipment.SlotSet;
+import net.sourceforge.kolmafia.modifiers.DoubleModifier;
+import net.sourceforge.kolmafia.objectpool.FamiliarPool;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.persistence.ModifierDatabase;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.session.EquipmentManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+public class EternityCodpieceMaximizerTest {
+  private static final String CONTROL_CRYSTAL = "control crystal";
+  private static final String MASSIVE_GEMSTONE = "massive gemstone";
+  private static final String HEALING_CRYSTAL = "New Age healing crystal";
+  private static final String GLOWING_CRYSTAL = "glowing New Age crystal";
+  private static final String HEART_OF_THE_VOLCANO = "heart of the volcano";
+
+  @BeforeAll
+  static void beforeAll() {
+    KoLCharacter.reset("EternityCodpieceMaximizerTest");
+    Preferences.reset("EternityCodpieceMaximizerTest");
+  }
+
+  private static Cleanups withWornCodpiece(Cleanups... extras) {
+    var cleanups = new Cleanups(withEquipped(Slot.ACCESSORY1, ItemPool.THE_ETERNITY_CODPIECE));
+    for (var extra : extras) cleanups.add(extra);
+    return cleanups;
+  }
+
+  private static long selectedGems(String name) {
+    return SlotSet.CODPIECE_SLOTS.stream()
+        .map(Maximizer.best.equipment::get)
+        .filter(item -> item != null && name.equals(item.getName()))
+        .count();
+  }
+
+  private static int codpieceCombinations() {
+    return Maximizer.eval.codpiece().getCombinationsEvaluated();
+  }
+
+  @Test
+  void searchesOnlyAHypotheticalCodpiece() {
+    try (var cleanups =
+        withWornCodpiece(
+            withEquipped(Slot.CODPIECE2, ItemPool.get(MASSIVE_GEMSTONE)),
+            withItem(CONTROL_CRYSTAL))) {
+      var before = new EnumMap<Slot, AdventureResult>(Slot.class);
+      SlotSet.CODPIECE_SLOTS.forEach(slot -> before.put(slot, EquipmentManager.getEquipment(slot)));
+
+      assertThat(maximize("mys"), is(true));
+
+      assertThat(selectedGems(CONTROL_CRYSTAL), equalTo(1L));
+      assertThat(selectedGems(MASSIVE_GEMSTONE), equalTo(1L));
+      SlotSet.CODPIECE_SLOTS.forEach(
+          slot -> assertThat(EquipmentManager.getEquipment(slot), equalTo(before.get(slot))));
+    }
+  }
+
+  @Test
+  void canDisableCodpieceGemSearch() {
+    try (var cleanups =
+        new Cleanups(
+            withProperty("maximizerConsiderCodpieceGems", false),
+            withEquippableItem(ItemPool.THE_ETERNITY_CODPIECE),
+            withEquipped(Slot.CODPIECE1, ItemPool.get(MASSIVE_GEMSTONE)),
+            withItem(CONTROL_CRYSTAL),
+            withOverrideModifiers(
+                ModifierType.ETERNITY_CODPIECE, MASSIVE_GEMSTONE, "Mysticality: +25"),
+            withOverrideModifiers(
+                ModifierType.ETERNITY_CODPIECE, CONTROL_CRYSTAL, "Mysticality: +100"))) {
+      assertThat(maximize("mys, -tie"), is(true));
+      assertThat(getBoosts(), hasItem(recommends(ItemPool.THE_ETERNITY_CODPIECE)));
+      assertThat(selectedGems(MASSIVE_GEMSTONE), equalTo(1L));
+      assertThat(selectedGems(CONTROL_CRYSTAL), equalTo(0L));
+      assertThat(modFor(DoubleModifier.MYS), greaterThanOrEqualTo(25.0));
+    }
+  }
+
+  @Test
+  void equipsTheCodpieceBeforeInsertingItsGem() {
+    try (var cleanups =
+        new Cleanups(
+            withEquippableItem(ItemPool.THE_ETERNITY_CODPIECE), withItem(CONTROL_CRYSTAL))) {
+      assertThat(maximize("mys"), is(true));
+      var boosts = getBoosts();
+      int codpiece =
+          boosts.indexOf(
+              boosts.stream()
+                  .filter(recommends(ItemPool.THE_ETERNITY_CODPIECE)::matches)
+                  .findFirst()
+                  .orElseThrow());
+      int gem =
+          boosts.indexOf(
+              boosts.stream()
+                  .filter(recommends(CONTROL_CRYSTAL)::matches)
+                  .findFirst()
+                  .orElseThrow());
+      assertThat(gem, greaterThanOrEqualTo(codpiece + 1));
+    }
+  }
+
+  @Test
+  void honorsForbiddenAndExcludedCodpieceSlots() {
+    try (var cleanups =
+        new Cleanups(
+            withEquippableItem(ItemPool.THE_ETERNITY_CODPIECE), withItem(CONTROL_CRYSTAL))) {
+      assertThat(maximize("-equip eternity codpiece, mys"), is(true));
+      assertThat(getBoosts(), not(hasItem(recommends(CONTROL_CRYSTAL))));
+    }
+
+    try (var cleanups =
+        withWornCodpiece(withEquipped(Slot.CODPIECE3, ItemPool.get(MASSIVE_GEMSTONE)))) {
+      assertThat(maximize("-equip massive gemstone, -codpiece3, item drop"), is(true));
+      assertThat(Maximizer.best.equipment.get(Slot.CODPIECE3).getName(), equalTo(MASSIVE_GEMSTONE));
+    }
+  }
+
+  @Test
+  void failsWhenRequiredGemsAreUnavailableOrCannotFit() {
+    try (var cleanups = withWornCodpiece()) {
+      assertThat(maximize("+equip control crystal, meat drop"), is(false));
+    }
+
+    try (var cleanups =
+        withWornCodpiece(
+            withItem(CONTROL_CRYSTAL),
+            withItem(MASSIVE_GEMSTONE),
+            withItem(HEALING_CRYSTAL),
+            withItem(GLOWING_CRYSTAL),
+            withItem("baconstone"),
+            withItem("priceless diamond"))) {
+      assertThat(
+          maximize(
+              "+equip control crystal, +equip massive gemstone, +equip New Age healing crystal, "
+                  + "+equip glowing New Age crystal, +equip baconstone, +equip priceless diamond"),
+          is(false));
+    }
+  }
+
+  @Test
+  void accountsForDualRoleGemCopies() {
+    try (var cleanups =
+        withWornCodpiece(withStats(100, 100, 100), withItem(HEART_OF_THE_VOLCANO, 2))) {
+      assertThat(maximize("hp regen min 10 max, hot dmg"), is(true));
+      assertThat(getBoosts(), hasItem(recommendsSlot(Slot.ACCESSORY2, HEART_OF_THE_VOLCANO)));
+      assertThat(getBoosts(), hasItem(recommendsSlot(Slot.CODPIECE1, HEART_OF_THE_VOLCANO)));
+    }
+  }
+
+  @Test
+  void evaluatesFamiliarDependentGemsAtTheSearchLeaf() {
+    try (var cleanups =
+        withWornCodpiece(withFamiliar(FamiliarPool.MOSQUITO), withItem(ItemPool.HEARTSTONE))) {
+      assertThat(maximize("familiar weight"), is(true));
+      assertThat(selectedGems("Heartstone"), equalTo(1L));
+      assertThat(modFor(DoubleModifier.FAMILIAR_WEIGHT), greaterThanOrEqualTo(5.0));
+    }
+  }
+
+  @Test
+  void findsOptimalCappedAndInteractingGemCombinations() {
+    try (var cleanups =
+        withWornCodpiece(withItem(HEALING_CRYSTAL, 5), withItem(GLOWING_CRYSTAL, 5))) {
+      assertThat(maximize("10 hp regen min 25 max, 1 mp regen min"), is(true));
+      assertThat(selectedGems(HEALING_CRYSTAL), equalTo(3L));
+      assertThat(selectedGems(GLOWING_CRYSTAL), equalTo(2L));
+    }
+
+    try (var cleanups =
+        withWornCodpiece(
+            withItem(ItemPool.RUBEE),
+            withItem(ItemPool.SHARD_OF_DOUBLE_ICE),
+            withItem("Lapis Lazuli"),
+            withItem(ItemPool.SHADOW_GLASS),
+            withItem(ItemPool.AZURITE))) {
+      assertThat(maximize("10 prismatic damage, -1 hot damage, -tie"), is(true));
+      assertThat(
+          10 * modFor(DoubleModifier.PRISMATIC_DAMAGE) - modFor(DoubleModifier.HOT_DAMAGE),
+          equalTo(90.0));
+    }
+  }
+
+  @Test
+  void supportsBooleanAndBitmapGemRequirements() {
+    try (var cleanups =
+        withWornCodpiece(
+            withItem(ItemPool.ALIEN_GEMSTONE),
+            withOverrideModifiers(
+                ModifierType.ETERNITY_CODPIECE, ItemPool.ALIEN_GEMSTONE, "Adventure Underwater"))) {
+      assertThat(maximize("adventure underwater, -tie"), is(true));
+      assertThat(selectedGems("alien gemstone"), equalTo(1L));
+    }
+
+    try (var cleanups =
+        withWornCodpiece(
+            withItem(ItemPool.ALIEN_GEMSTONE),
+            withOverrideModifiers(
+                ModifierType.ETERNITY_CODPIECE, ItemPool.ALIEN_GEMSTONE, "Surgeonosity: +1"))) {
+      assertThat(maximize("1 surgeonosity, -tie"), is(true));
+      assertThat(selectedGems("alien gemstone"), equalTo(1L));
+    }
+  }
+
+  @Test
+  void permitsOwnedStandardRestrictedGemsButNotExternalCopies() {
+    var restriction =
+        new Cleanups(
+            withPath(Path.STANDARD),
+            withRestricted(true),
+            withNotAllowedInStandard(RestrictedItemType.ITEMS, CONTROL_CRYSTAL));
+    try (var cleanups = new Cleanups(restriction, withWornCodpiece(withItem(CONTROL_CRYSTAL)))) {
+      assertThat(maximize("mys"), is(true));
+      assertThat(selectedGems(CONTROL_CRYSTAL), equalTo(1L));
+    }
+
+    try (var cleanups =
+        new Cleanups(
+            withPath(Path.STANDARD),
+            withRestricted(true),
+            withNotAllowedInStandard(RestrictedItemType.ITEMS, CONTROL_CRYSTAL),
+            withProperty("autoSatisfyWithCloset", true),
+            withWornCodpiece(withItemInCloset(CONTROL_CRYSTAL)))) {
+      assertThat(maximize("mys"), is(true));
+      assertThat(selectedGems(CONTROL_CRYSTAL), equalTo(0L));
+    }
+  }
+
+  @Test
+  void usesInstalledGemsWhenRetrievingTheCodpiece() {
+    try (var cleanups =
+        new Cleanups(
+            withProperty("autoSatisfyWithCloset", true),
+            withItemInCloset(ItemPool.THE_ETERNITY_CODPIECE),
+            withEquipped(Slot.CODPIECE1, ItemPool.get(CONTROL_CRYSTAL)))) {
+      assertThat(maximize("mys"), is(true));
+      assertThat(getBoosts(), hasItem(recommends(ItemPool.THE_ETERNITY_CODPIECE)));
+      assertThat(getBoosts(), not(hasItem(recommendsSlot(Slot.CODPIECE1))));
+    }
+  }
+
+  @Test
+  void acquiresEveryAvailableCopyWithoutExceedingThePriceLimit()
+      throws MaximizerInterruptedException {
+    try (var cleanups =
+        withWornCodpiece(withInteractivity(false), withItemInFreepulls(CONTROL_CRYSTAL, 5))) {
+      assertThat(maximize("mys"), is(true));
+      assertThat(
+          getBoosts().stream().filter(recommends(CONTROL_CRYSTAL)::matches).count(), equalTo(5L));
+    }
+
+    var externalGem = ItemPool.get(ItemPool.BASEBALL_DIAMOND);
+    try (var cleanups =
+        withWornCodpiece(
+            withProperty("autoSatisfyWithCloset", true),
+            withFamiliar(FamiliarPool.LEFT_HAND),
+            withEquipped(Slot.FAMILIAR, externalGem),
+            withItemInCloset(externalGem.getItemId(), 1),
+            withItemInFreepulls(externalGem.getItemId(), 1))) {
+      assertThat(maximize("weapon damage, -offhand"), is(true));
+      var commands =
+          getBoosts().stream()
+              .filter(boost -> SlotSet.CODPIECE_SLOTS.contains(boost.getSlot()))
+              .map(Boost::getCmd)
+              .toList();
+      assertThat(commands, hasItem(startsWith("closet take 1 \u00B6" + externalGem.getItemId())));
+      assertThat(commands, hasItem(startsWith("pull 1 \u00B6" + externalGem.getItemId())));
+    }
+
+    var gem = ItemPool.get(MASSIVE_GEMSTONE);
+    try (var cleanups =
+        new Cleanups(
+            withProperty("autoSatisfyWithMall", true),
+            withInteractivity(true),
+            withMeat(1_000_000),
+            withMallPrice(gem.getItemId(), 100))) {
+      var checked =
+          new CheckedItem(
+              gem.getItemId(), EquipScope.SPECULATE_ANY, 350, PriceLevel.BUYABLE_ONLY, true);
+      checked.validate(350, PriceLevel.BUYABLE_ONLY);
+      assertThat(checked.mallBuyable, equalTo(3));
+    }
+  }
+
+  @Test
+  void retainsCandidatesNeededOnlyForMinimumsOrCappedInteractions() {
+    try (var cleanups = withWornCodpiece(withItem("priceless diamond"))) {
+      assertThat(maximize("0 da, 10 min, -tie"), is(true));
+      assertThat(getBoosts(), hasItem(recommends("priceless diamond")));
+    }
+
+    try (var cleanups =
+        withWornCodpiece(withItem("rainbow pearl"), withItem("18-picohertz resonator crystal"))) {
+      assertThat(
+          maximize("1 hot damage, 2 cold spell damage, -1.5 cold damage 5 max, -tie"), is(true));
+      assertThat(getBoosts(), hasItem(recommends("rainbow pearl")));
+      assertThat(getBoosts(), hasItem(recommends("18-picohertz resonator crystal")));
+    }
+  }
+
+  @Test
+  void usesExactFallbackAndSafePruning() {
+    try (var cleanups =
+        withWornCodpiece(
+            withStats(100, 100, 100),
+            withItem(CONTROL_CRYSTAL),
+            withItem("baconstone"),
+            withItem("stone of eXtreme power"))) {
+      assertThat(maximize("mys"), is(true));
+      assertThat(codpieceCombinations(), equalTo(8));
+    }
+
+    try (var cleanups =
+        withWornCodpiece(
+            withItem(HEALING_CRYSTAL), withItem(GLOWING_CRYSTAL), withItem(HEART_OF_THE_VOLCANO))) {
+      assertThat(maximize("hp regen min"), is(true));
+      assertThat(codpieceCombinations(), lessThan(8));
+    }
+  }
+
+  @Test
+  void countsGemSearchAgainstTheExistingCombinationLimit() {
+    try (var cleanups =
+        withWornCodpiece(
+            withProperty("maximizerCombinationLimit", 5),
+            withStats(100, 100, 100),
+            withItem(CONTROL_CRYSTAL),
+            withItem("baconstone"),
+            withItem("stone of eXtreme power"))) {
+      maximize("mys");
+      assertThat(Maximizer.bestChecked, equalTo(5));
+      assertThat(
+          getBoosts(),
+          hasItem(hasToString(containsString("hit combination limit, optimality not guaranteed"))));
+    }
+  }
+
+  @Test
+  void movesAnInstalledGemInsteadOfBuyingAnotherCopy() {
+    var gem = ItemPool.get("incredibly dense meat gem");
+    try (var cleanups =
+        withWornCodpiece(
+            withStats(100, 100, 100),
+            withEquipped(Slot.CODPIECE1, gem),
+            withEquipped(Slot.CODPIECE2, gem))) {
+      assertThat(maximize("meat drop, -codpiece1"), is(true));
+      var boost =
+          getBoosts().stream()
+              .filter(recommendsSlot(Slot.ACCESSORY2, gem.getName())::matches)
+              .findFirst()
+              .orElseThrow();
+      assertThat(boost.getCmd(), startsWith("unequip codpiece2;equip acc2 \u00B6"));
+    }
+  }
+
+  @Test
+  @EnabledIfEnvironmentVariable(named = "KOLMAFIA_CODPIECE_DEFAULTS_BENCHMARK", matches = "true")
+  void benchmarksEveryDefaultExpressionWithEveryCodpieceGem() {
+    var cleanups =
+        new Cleanups(
+            withClass(AscensionClass.SEAL_CLUBBER),
+            withStats(10_000, 10_000, 10_000),
+            withFamiliar(FamiliarPool.BABY_GRAVY_FAIRY, 20),
+            withEquipped(Slot.ACCESSORY1, ItemPool.THE_ETERNITY_CODPIECE),
+            withProperty("maximizerCombinationLimit", 0));
+    int gemCount = 0;
+    for (var entry : ModifierDatabase.getAllModifiersOfType(ModifierType.ETERNITY_CODPIECE)) {
+      if (entry.getKey().isInt()) {
+        cleanups.add(withItem(entry.getKey().getIntValue(), 5));
+        gemCount++;
+      }
+    }
+
+    try (cleanups) {
+      List<String> expressions = List.of(Preferences.getDefault("maximizerList").split(" \\| "));
+      var elapsed = new ArrayList<Double>();
+      long maxChecks = 0;
+      String exclusions =
+          ", -hat, -weapon, -offhand, -back, -shirt, -pants, -familiar, " + "-acc1, -acc2, -acc3";
+      for (String expression : expressions) {
+        long start = System.nanoTime();
+        maximize(expression + exclusions);
+        double millis = (System.nanoTime() - start) / 1_000_000.0;
+        elapsed.add(millis);
+        maxChecks = Math.max(maxChecks, codpieceCombinations());
+        System.out.printf(
+            "CODPIECE_DEFAULT_BENCHMARK expression=%s combinations=%d ms=%.3f%n",
+            expression, codpieceCombinations(), millis);
+      }
+      elapsed.sort(Double::compareTo);
+      double total = elapsed.stream().mapToDouble(Double::doubleValue).sum();
+      double median = elapsed.get(elapsed.size() / 2);
+      long exhaustiveCombinations = 1;
+      for (int slot = 1; slot <= SlotSet.CODPIECE_SLOTS.size(); slot++) {
+        exhaustiveCombinations = exhaustiveCombinations * (gemCount + slot) / slot;
+      }
+      System.out.printf(
+          "CODPIECE_DEFAULT_BENCHMARK_TOTAL expressions=%d gems=%d maxCombinations=%d "
+              + "medianMs=%.3f totalMs=%.3f%n",
+          expressions.size(), gemCount, maxChecks, median, total);
+      assertThat(maxChecks, lessThan(exhaustiveCombinations / 100));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Teach the Modifier Maximizer to consider obtainable Eternity Codpiece gem configurations instead of scoring only the gems that are currently installed.

The Codpiece search runs as part of the ordinary equipment search, so the Maximizer can choose whether a dual-use gem belongs in an equipment slot or in the Codpiece and can account for copies shared between those uses. It honors the active equipment scope, required and forbidden equipment, excluded slots, Standard restrictions, and the usual acquisition sources. The selected result includes the steps needed to acquire, move, insert, or remove gems; running the search itself does not change the installed configuration.

## Motivation

The Eternity Codpiece is effectively a configurable piece of equipment, but the Maximizer previously treated its installed gems as fixed. This meant that it could recommend an otherwise optimal outfit while overlooking a better configuration made from gems the player already had or could acquire. Users had to choose and move those gems manually, and the best Codpiece configuration could also depend on what occupied the ordinary equipment and familiar slots.

The goal of this change is to make Codpiece gems part of the same optimization problem as the rest of the outfit, so a maximize result represents the best complete configuration KoLmafia can reach under the user's constraints.

## Correctness and performance

Codpiece configurations are scored through the existing Maximizer evaluator rather than a separate approximation. The search avoids equivalent slot permutations and uses conservative bounds when the expression can be bounded safely. If an expression or modifier interaction is not supported by those bounds, it falls back to exact enumeration instead of ignoring that behavior.

This keeps ordinary searches practical while preserving the existing Maximizer semantics for caps, derived values, familiar interactions, bitmap modifiers, and other nonlinear cases.

## Compatibility

The new `maximizerConsiderCodpieceGems` preference defaults to `true`. Setting it to `false` restores the previous behavior: the Maximizer leaves the five installed gem slots unchanged and scores the Codpiece as it is currently configured.

## Testing

The end-to-end tests cover gem availability and acquisition, shared-copy accounting, required and forbidden gems, excluded slots, Standard restrictions, nonlinear modifier interactions, recommendation ordering, and the compatibility preference. They also retain regressions for the Maximizer behavior reported during review.

An opt-in benchmark exercises every default Maximizer expression against a deliberately large gem pool and verifies that bounded searches stay well below exhaustive enumeration.
