### PR TITLE
Fix API status updates with Continuum Transfunctioner

### DIFF
--- a/src/net/sourceforge/kolmafia/request/ApiRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ApiRequest.java
@@ -81,15 +81,17 @@ public class ApiRequest extends GenericRequest {
       return ApiRequest.updateStatusFromCharpane();
     }
 
-    // Similarly, if you have the continuum transfunctioner equipped,
-    // the Character Pane shows you your (8-bit) Score
-    if (KoLCharacter.hasEquipped(TRANSFUNCTIONER)) {
-      return ApiRequest.updateStatusFromCharpane();
-    }
-
     ApiRequest.INSTANCE.silent = silent;
     ApiRequest.INSTANCE.run();
-    return ApiRequest.INSTANCE.redirectLocation;
+    String rv = ApiRequest.INSTANCE.redirectLocation;
+
+    // If you have the continuum transfunctioner equipped, the Character Pane shows you your (8-bit)
+    // Score, so request that as well.
+    if (KoLCharacter.hasEquipped(TRANSFUNCTIONER)) {
+      rv = ApiRequest.updateStatusFromCharpane();
+    }
+
+    return rv;
   }
 
   public static String updateStatusFromCharpane() {

--- a/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
+++ b/test/net/sourceforge/kolmafia/KoLAdventureValidationTest.java
@@ -2754,17 +2754,19 @@ public class KoLAdventureValidationTest {
               withEquippableItem(ItemPool.TRANSFUNCTIONER));
       try (cleanups) {
         client.addResponse(200, html("request/test_equip_transfunctioner.html"));
+        client.addResponse(200, ""); // api.php
         client.addResponse(200, ""); // charpane.php
         assertTrue(FUNGUS_PLAINS.canAdventure());
         assertTrue(FUNGUS_PLAINS.prepareForAdventure());
 
         var requests = client.getRequests();
-        assertThat(requests, hasSize(2));
+        assertThat(requests, hasSize(3));
         assertPostRequest(
             requests.get(0),
             "/inv_equip.php",
             "which=2&ajax=1&slot=1&action=equip&whichitem=" + ItemPool.TRANSFUNCTIONER);
-        assertGetRequest(requests.get(1), "/charpane.php", null);
+        assertPostRequest(requests.get(1), "/api.php", "what=status&for=KoLmafia");
+        assertGetRequest(requests.get(2), "/charpane.php", null);
       }
     }
 
@@ -2782,13 +2784,14 @@ public class KoLAdventureValidationTest {
       client.addResponse(200, ""); // api.php
       // inv_equip.php?which=2&ajax=1&slot=1&action=equip&whichitem=458
       client.addResponse(200, html("request/test_equip_transfunctioner.html"));
+      client.addResponse(200, ""); // api.php
       client.addResponse(200, ""); // charpane.php
 
       assertTrue(FUNGUS_PLAINS.canAdventure());
       assertTrue(FUNGUS_PLAINS.prepareForAdventure());
 
       var requests = client.getRequests();
-      assertThat(requests, hasSize(8));
+      assertThat(requests, hasSize(9));
       assertPostRequest(requests.get(0), "/place.php", "whichplace=forestvillage&action=fv_mystic");
       assertGetRequest(requests.get(1), "/choice.php", "forceoption=0");
       assertPostRequest(requests.get(2), "/choice.php", "whichchoice=664&option=1");
@@ -2799,7 +2802,8 @@ public class KoLAdventureValidationTest {
           requests.get(6),
           "/inv_equip.php",
           "which=2&ajax=1&slot=1&action=equip&whichitem=" + ItemPool.TRANSFUNCTIONER);
-      assertGetRequest(requests.get(7), "/charpane.php", null);
+      assertPostRequest(requests.get(7), "/api.php", "what=status&for=KoLmafia");
+      assertGetRequest(requests.get(8), "/charpane.php", null);
     }
 
     @Test


### PR DESCRIPTION
There's a number of places in mafia where `ApiRequest.updateStatus()` gets explicitly called to update information from api.php. However, if the user happens to have a Continuum Transfunctioner equipped at that time, the call gets dispatched as a char pane update instead. While this is useful if the intent is to update 8-Bit realm points, it would break updating other things. 

For example, if you happen to graft something in Z is for Zootomist while wearing the Continuum Transfunctioner, the call to `ApiRequest.updateStatus()` intended to cause your grafted familiar preferences (e.g. `zootGraftedButtCheekLeftFamiliar`) to get updated gets dispatched only to charpane.php and the desired update never happens.

This PR changes the behavior to always do the actual api.php call (unless we're in a limit mode), and *additionally* refreshes the charpane if the transfunctioner is equipped. I changed the control flow a little to ensure the return value is unchanged from the previous behavior (though I don't know that anything actually cares either way).