### PR TITLE
feat: add Hat / Pants modifier

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -2093,7 +2093,7 @@ Item	Unkillable Skeleton's restless leg	Weapon Damage: +40, MP Regen Min: 20, MP
 Item	Unkillable Skeleton's sawsword	Damage vs. Skeletons: +100, Damage vs. Zombies: +50, Damage vs. Vampires: +50, Damage vs. Werewolves: +50, Damage vs. Ghosts: +50, Damage vs. Bugbears: +50
 Item	unsanitized scalpel	Sleaze Damage: +25
 Item	vampire duck-on-a-string	Weapon Damage: +5, Item Drop: +5, Last Available: "2006-12"
-Item	velcro broadsword	Muscle Percent: +5, MP Regen Min: 6, MP Regen Max: 12, Hat Pants Drop: +20
+Item	velcro broadsword	Muscle Percent: +5, MP Regen Min: 6, MP Regen Max: 12, Hat / Pants Drop: +20
 Item	velcro paddle ball	Moxie Percent: +5, MP Regen Min: 6, MP Regen Max: 12, Accessory Drop: +20
 # velour voulge: Triples the effect of Snarl of the Timberwolf
 Item	velour voulge	Experience (Muscle): +2, Weapon Drop: +30, Last Available: "2021-12"
@@ -2904,7 +2904,7 @@ Item	bakelite brooch	Mana Cost (combat): -2, Mysticality Percent: +20, Spell Dam
 # bananarama bangle: (only in the Candy Diorama)
 Item	bananarama bangle	Damage Reduction: [30*zone(The Candy Diorama)], Single Equip, Last Available: "2011-11", Enchantment Count: 1
 Item	Bandolier of the Spaghetti Elemental	Mysticality: +11, MP Regen Min: 10, MP Regen Max: 12, Class: "Pastamancer", Single Equip
-Item	baneful bandolier	Ranged Damage: +30, Slime Hates It: +1, Hat Pants Drop: +30
+Item	baneful bandolier	Ranged Damage: +30, Slime Hates It: +1, Hat / Pants Drop: +30
 Item	banjo kazoo mount	Maximum Hooch: +2, Single Equip
 Item	bark bracelet	Damage Reduction: 2, Single Equip
 Item	Baron von Ratsworth's money clip	Meat Drop: +15, Single Equip

--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -2093,7 +2093,7 @@ Item	Unkillable Skeleton's restless leg	Weapon Damage: +40, MP Regen Min: 20, MP
 Item	Unkillable Skeleton's sawsword	Damage vs. Skeletons: +100, Damage vs. Zombies: +50, Damage vs. Vampires: +50, Damage vs. Werewolves: +50, Damage vs. Ghosts: +50, Damage vs. Bugbears: +50
 Item	unsanitized scalpel	Sleaze Damage: +25
 Item	vampire duck-on-a-string	Weapon Damage: +5, Item Drop: +5, Last Available: "2006-12"
-Item	velcro broadsword	Muscle Percent: +5, MP Regen Min: 6, MP Regen Max: 12, Hat Drop: +20, Pants Drop: +20, Enchantment Count: 3
+Item	velcro broadsword	Muscle Percent: +5, MP Regen Min: 6, MP Regen Max: 12, Hat Pants Drop: +20
 Item	velcro paddle ball	Moxie Percent: +5, MP Regen Min: 6, MP Regen Max: 12, Accessory Drop: +20
 # velour voulge: Triples the effect of Snarl of the Timberwolf
 Item	velour voulge	Experience (Muscle): +2, Weapon Drop: +30, Last Available: "2021-12"
@@ -2904,7 +2904,7 @@ Item	bakelite brooch	Mana Cost (combat): -2, Mysticality Percent: +20, Spell Dam
 # bananarama bangle: (only in the Candy Diorama)
 Item	bananarama bangle	Damage Reduction: [30*zone(The Candy Diorama)], Single Equip, Last Available: "2011-11", Enchantment Count: 1
 Item	Bandolier of the Spaghetti Elemental	Mysticality: +11, MP Regen Min: 10, MP Regen Max: 12, Class: "Pastamancer", Single Equip
-Item	baneful bandolier	Ranged Damage: +30, Hat Drop: +30, Slime Hates It: +1, Pants Drop: +30, Enchantment Count: 2
+Item	baneful bandolier	Ranged Damage: +30, Slime Hates It: +1, Hat Pants Drop: +30
 Item	banjo kazoo mount	Maximum Hooch: +2, Single Equip
 Item	bark bracelet	Damage Reduction: 2, Single Equip
 Item	Baron von Ratsworth's money clip	Meat Drop: +15, Single Equip

--- a/src/net/sourceforge/kolmafia/Modifiers.java
+++ b/src/net/sourceforge/kolmafia/Modifiers.java
@@ -353,7 +353,17 @@ public class Modifiers {
     }
 
     if (modifier instanceof DoubleModifier dm) {
-      return this.doubles.getDouble(dm);
+      var value = this.doubles.getDouble(dm);
+      // A combined modifier (like "Hat/Pants Drop") may be stored explicitly.
+      // If it isn't present, derive it from the modifiers it subsumes, taking the minimum.
+      if (dm.getSubsumed().length > 0 && value == 0.0) {
+        double derived = Double.MAX_VALUE;
+        for (var sub : dm.getSubsumed()) {
+          derived = Math.min(derived, this.getDouble(sub));
+        }
+        return derived;
+      }
+      return value;
     }
 
     return 0.0;

--- a/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
@@ -627,9 +627,9 @@ public enum DoubleModifier implements Modifier {
       Pattern.compile("Kill (\\d+)% More Skeletons"),
       Pattern.compile("Kill More Skeletons: " + EXPR)),
   HAT_PANTS_DROP(
-      "Hat Pants Drop",
+      "Hat / Pants Drop",
       Pattern.compile("([+-]\\d+)% Hat/Pants Drops? [Ff]rom Monsters$"),
-      Pattern.compile("Hat Pants Drop: " + EXPR),
+      Pattern.compile("Hat / Pants Drop: " + EXPR),
       new DoubleModifier[] {HATDROP, PANTSDROP});
 
   private final String name;

--- a/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
+++ b/src/net/sourceforge/kolmafia/modifiers/DoubleModifier.java
@@ -241,7 +241,7 @@ public enum DoubleModifier implements Modifier {
       Pattern.compile("Booze Drop: " + EXPR)),
   HATDROP(
       "Hat Drop",
-      Pattern.compile("([+-]\\d+)% Hat(?:/Pants)? Drops? [Ff]rom Monsters$"),
+      Pattern.compile("([+-]\\d+)% Hat Drops? [Ff]rom Monsters$"),
       Pattern.compile("Hat Drop: " + EXPR)),
   WEAPONDROP(
       "Weapon Drop",
@@ -257,7 +257,7 @@ public enum DoubleModifier implements Modifier {
       Pattern.compile("Shirt Drop: " + EXPR)),
   PANTSDROP(
       "Pants Drop",
-      Pattern.compile("([+-]\\d+)% (?:Hat/)?Pants Drops? [Ff]rom Monsters$"),
+      Pattern.compile("([+-]\\d+)% Pants Drops? [Ff]rom Monsters$"),
       Pattern.compile("Pants Drop: " + EXPR)),
   ACCESSORYDROP(
       "Accessory Drop",
@@ -625,13 +625,19 @@ public enum DoubleModifier implements Modifier {
   KILL_MORE_SKELETONS(
       "Kill More Skeletons",
       Pattern.compile("Kill (\\d+)% More Skeletons"),
-      Pattern.compile("Kill More Skeletons: " + EXPR));
+      Pattern.compile("Kill More Skeletons: " + EXPR)),
+  HAT_PANTS_DROP(
+      "Hat Pants Drop",
+      Pattern.compile("([+-]\\d+)% Hat/Pants Drops? [Ff]rom Monsters$"),
+      Pattern.compile("Hat Pants Drop: " + EXPR),
+      new DoubleModifier[] {HATDROP, PANTSDROP});
 
   private final String name;
   private final Pattern[] descPatterns;
   private final Pattern tagPattern;
   private final String tag;
   private final boolean multiple;
+  private final DoubleModifier[] subsumed;
 
   DoubleModifier(String name, Pattern tagPattern) {
     this(name, (Pattern[]) null, tagPattern, name);
@@ -646,15 +652,19 @@ public enum DoubleModifier implements Modifier {
   }
 
   DoubleModifier(String name, Pattern descPattern, Pattern tagPattern) {
-    this(name, new Pattern[] {descPattern}, tagPattern, name);
+    this(name, new Pattern[] {descPattern}, tagPattern, name, false, null);
   }
 
   DoubleModifier(String name, Pattern descPattern, Pattern tagPattern, boolean multiple) {
-    this(name, new Pattern[] {descPattern}, tagPattern, name, multiple);
+    this(name, new Pattern[] {descPattern}, tagPattern, name, multiple, null);
   }
 
   DoubleModifier(String name, Pattern descPattern, Pattern tagPattern, String tag) {
-    this(name, new Pattern[] {descPattern}, tagPattern, tag);
+    this(name, new Pattern[] {descPattern}, tagPattern, tag, false, null);
+  }
+
+  DoubleModifier(String name, Pattern descPattern, Pattern tagPattern, DoubleModifier[] subsumed) {
+    this(name, new Pattern[] {descPattern}, tagPattern, name, false, subsumed);
   }
 
   DoubleModifier(String name, Pattern[] descPatterns, Pattern tagPattern) {
@@ -667,11 +677,22 @@ public enum DoubleModifier implements Modifier {
 
   DoubleModifier(
       String name, Pattern[] descPatterns, Pattern tagPattern, String tag, boolean multiple) {
+    this(name, descPatterns, tagPattern, tag, multiple, null);
+  }
+
+  DoubleModifier(
+      String name,
+      Pattern[] descPatterns,
+      Pattern tagPattern,
+      String tag,
+      boolean multiple,
+      DoubleModifier[] subsumed) {
     this.name = name;
     this.descPatterns = descPatterns;
     this.tagPattern = tagPattern;
     this.tag = tag;
     this.multiple = multiple;
+    this.subsumed = subsumed == null ? new DoubleModifier[0] : subsumed;
   }
 
   @Override
@@ -696,6 +717,10 @@ public enum DoubleModifier implements Modifier {
 
   public boolean isMultiple() {
     return multiple;
+  }
+
+  public DoubleModifier[] getSubsumed() {
+    return subsumed;
   }
 
   private static final Set<DoubleModifier> ENCHANTMENTS =
@@ -728,6 +753,7 @@ public enum DoubleModifier implements Modifier {
           FUMBLE,
           GHOST_DAMAGE,
           HATDROP,
+          HAT_PANTS_DROP,
           HOBO_POWER,
           HOT_DAMAGE,
           HOT_RESISTANCE,

--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -1209,6 +1209,7 @@ public class ItemPool {
   public static final int VELCRO_ORE = 3698;
   public static final int TEFLON_ORE = 3699;
   public static final int VINYL_ORE = 3700;
+  public static final int VELCRO_BROADSWORD = 3705;
   public static final int ANEMONE_MINE_MAP = 3701;
   public static final int TEFLON_SWIM_FINS = 3712;
   public static final int VINYL_BOOTS = 3716;
@@ -1350,6 +1351,7 @@ public class ItemPool {
   public static final int ESSENCE_OF_CUTE = 4072;
   public static final int SUPREME_BEING_GLOSSARY = 4073;
   public static final int MULTI_PASS = 4074;
+  public static final int BANEFUL_BANDOLIER = 4076;
   public static final int GRISLY_SHIELD = 4080;
   public static final int CYBER_MATTOCK = 4086;
   public static final int GREEN_PEAWEE_MARBLE = 4095;

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -795,7 +795,12 @@ public class ModifierDatabase {
         }
 
         if (matcher.group(1) != null) {
-          newMods.setDouble(mod, Double.parseDouble(matcher.group(1)));
+          double value = Double.parseDouble(matcher.group(1));
+          newMods.setDouble(mod, value);
+
+          for (var subsumed : mod.getSubsumed()) {
+            newMods.setDouble(subsumed, value);
+          }
         } else {
           newMods.addExpression(mod, ModifierExpression.getInstance(matcher.group(2), lookup));
         }

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -2061,12 +2061,12 @@ public class ModifiersTest {
       assertThat(
           ModifierDatabase.getStringModifier(
               ModifierType.ITEM, BANEFUL_BANDOLIER, StringModifier.MODIFIERS),
-          equalTo("Ranged Damage: +30, Slime Hates It: +1, Hat Pants Drop: +30"));
+          equalTo("Ranged Damage: +30, Slime Hates It: +1, Hat / Pants Drop: +30"));
 
       assertThat(
           ModifierDatabase.getStringModifier(
               ModifierType.ITEM, VELCRO_BROADSWORD, StringModifier.MODIFIERS),
-          equalTo("Muscle Percent: +5, MP Regen Min: 6, MP Regen Max: 12, Hat Pants Drop: +20"));
+          equalTo("Muscle Percent: +5, MP Regen Min: 6, MP Regen Max: 12, Hat / Pants Drop: +20"));
     }
 
     @Test
@@ -2106,7 +2106,7 @@ public class ModifiersTest {
     public void parsesCombinedEnchantmentIntoSingleModifier() {
       assertThat(
           ModifierDatabase.parseModifier("+30% Hat/Pants Drops from Monsters"),
-          equalTo("Hat Pants Drop: +30"));
+          equalTo("Hat / Pants Drop: +30"));
       // Individual drop types still parse to their own modifier
       assertThat(
           ModifierDatabase.parseModifier("+30% Pants Drops from Monsters"),

--- a/test/net/sourceforge/kolmafia/ModifiersTest.java
+++ b/test/net/sourceforge/kolmafia/ModifiersTest.java
@@ -2046,4 +2046,84 @@ public class ModifiersTest {
       }
     }
   }
+
+  @Nested
+  class HatPantsDrop {
+    // baneful bandolier has the combined "+30% Hat/Pants Drops from Monsters" enchantment
+    private static final int BANEFUL_BANDOLIER = ItemPool.BANEFUL_BANDOLIER;
+    // velcro broadsword has the combined "+20% Hat/Pants Drops from Monsters" enchantment
+    private static final int VELCRO_BROADSWORD = ItemPool.VELCRO_BROADSWORD;
+    // velour vaqueros has only "+30% Pants Drops from Monsters"
+    private static final int VELOUR_VAQUEROS = ItemPool.VELOUR_VAQUEROS;
+
+    @Test
+    public void combinedEnchantmentStoredAsHatPantsDrop() {
+      assertThat(
+          ModifierDatabase.getStringModifier(
+              ModifierType.ITEM, BANEFUL_BANDOLIER, StringModifier.MODIFIERS),
+          equalTo("Ranged Damage: +30, Slime Hates It: +1, Hat Pants Drop: +30"));
+
+      assertThat(
+          ModifierDatabase.getStringModifier(
+              ModifierType.ITEM, VELCRO_BROADSWORD, StringModifier.MODIFIERS),
+          equalTo("Muscle Percent: +5, MP Regen Min: 6, MP Regen Max: 12, Hat Pants Drop: +20"));
+    }
+
+    @Test
+    public void combinedImpliesHatAndPantsDropIndividually() {
+      for (int itemId : new int[] {BANEFUL_BANDOLIER, VELCRO_BROADSWORD}) {
+        assertThat(
+            ModifierDatabase.getNumericModifier(ModifierType.ITEM, itemId, DoubleModifier.HATDROP),
+            equalTo(itemId == BANEFUL_BANDOLIER ? 30.0 : 20.0));
+        assertThat(
+            ModifierDatabase.getNumericModifier(
+                ModifierType.ITEM, itemId, DoubleModifier.PANTSDROP),
+            equalTo(itemId == BANEFUL_BANDOLIER ? 30.0 : 20.0));
+        assertThat(
+            ModifierDatabase.getNumericModifier(
+                ModifierType.ITEM, itemId, DoubleModifier.HAT_PANTS_DROP),
+            equalTo(itemId == BANEFUL_BANDOLIER ? 30.0 : 20.0));
+      }
+    }
+
+    @Test
+    public void separatePantsDropDoesNotCreateHatPantsDrop() {
+      assertThat(
+          ModifierDatabase.getNumericModifier(
+              ModifierType.ITEM, VELOUR_VAQUEROS, DoubleModifier.PANTSDROP),
+          equalTo(30.0));
+      assertThat(
+          ModifierDatabase.getNumericModifier(
+              ModifierType.ITEM, VELOUR_VAQUEROS, DoubleModifier.HATDROP),
+          equalTo(0.0));
+      assertThat(
+          ModifierDatabase.getNumericModifier(
+              ModifierType.ITEM, VELOUR_VAQUEROS, DoubleModifier.HAT_PANTS_DROP),
+          equalTo(0.0));
+    }
+
+    @Test
+    public void parsesCombinedEnchantmentIntoSingleModifier() {
+      assertThat(
+          ModifierDatabase.parseModifier("+30% Hat/Pants Drops from Monsters"),
+          equalTo("Hat Pants Drop: +30"));
+      // Individual drop types still parse to their own modifier
+      assertThat(
+          ModifierDatabase.parseModifier("+30% Pants Drops from Monsters"),
+          equalTo("Pants Drop: +30"));
+      assertThat(
+          ModifierDatabase.parseModifier("+30% Hat Drops from Monsters"), equalTo("Hat Drop: +30"));
+    }
+
+    @Test
+    public void derivesHatPantsDropFromSeparatePartsWhenNotStored() {
+      Modifiers mods =
+          ModifierDatabase.parseModifiers(
+              new Lookup(ModifierType.ITEM, "test"), "Hat Drop: +20, Pants Drop: +30");
+
+      assertThat(mods.getDouble(DoubleModifier.HATDROP), equalTo(20.0));
+      assertThat(mods.getDouble(DoubleModifier.PANTSDROP), equalTo(30.0));
+      assertThat(mods.getDouble(DoubleModifier.HAT_PANTS_DROP), equalTo(20.0));
+    }
+  }
 }


### PR DESCRIPTION
TCRS is concerned about modifiers as they appear in the base game (ref #1767).

Some modifiers are "combined": that is, they could be expanded to individual modifiers. In the past, this is what we did.

In this PR, construct an architecture that allows us to include the original modifiers and note those they subsume. For consistency with the pre-existing "prismatic damage" that this PR does not affect (and backwards compatibility), the behaviour is:
* item with hat / pants drop has "hat / pants drop", "hat drop" and "pants drop" all set to that value
* theoretical item with both hat and pants drop separately has "hat / pants drop" set to the minimum of the two

More will come if everything looks good here.