### PR TITLE
TCRS follow-ups: consumable notes, bitmap bit reuse

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -172,6 +172,7 @@ public class ItemPool {
   public static final int FERRIGNOS_ELIXIR_OF_POWER = 418;
   public static final int POTION_OF_POTENCY = 422;
   public static final int BEANBAG_CHAIR = 429;
+  public static final int CLOWN_SHOES = 431;
   public static final int LONG_SKINNY_BALLOON = 433;
   public static final int BALLOON_MONKEY = 436;
   public static final int CHEF = 438;
@@ -774,6 +775,7 @@ public class ItemPool {
   public static final int ODOR_EXTRACTOR = 2462;
   public static final int OLFACTION_BOOK = 2463;
   public static final int OREILLE_DIVISEE_BRANDY = 2465;
+  public static final int CLOWN_WIG = 2475;
   public static final int TUXEDO_SHIRT = 2489;
   public static final int SHIRT_KIT = 2491;
   public static final int TROPICAL_ORCHID = 2492;

--- a/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/ModifierDatabase.java
@@ -86,6 +86,10 @@ public class ModifierDatabase {
   private static final Map<BitmapModifier, Integer> bitmapMasks =
       new EnumMap<>(BitmapModifier.class);
 
+  // The bits each source has already been given, so reparsing reuses them.
+  private static final Map<BitmapModifier, Map<String, Integer>> bitmapMasksBySource =
+      new EnumMap<>(BitmapModifier.class);
+
   // constant fields
 
   public static final String EXPR = "(?:([-+]?[\\d.]+)|\\[([^]]+)\\])";
@@ -819,21 +823,8 @@ public class ModifierDatabase {
             bitcount = bitcount / 25;
           }
         }
-        // bitmapMasks stores the next mask we're going to use for modifier mod
-        int mask = bitmapMasks.get(mod);
-        bitmapMasks.put(mod, mask << bitcount);
-        for (int i = 0; i < bitcount - 1; i++) {
-          mask |= mask << 1;
-        }
-        if (bitmapMasks.get(mod) == 0) {
-          String message =
-              "ERROR: too many sources for bitmap modifier "
-                  + mod.getName()
-                  + ", consider using longs.";
-          KoLmafia.updateDisplay(message);
-        }
 
-        newMods.addBitmap(mod, mask);
+        newMods.addBitmap(mod, getBitmapMask(mod, lookup, bitcount));
         continue modLoop;
       }
 
@@ -1835,11 +1826,38 @@ public class ModifierDatabase {
     }
   }
 
+  /** Reparsing an item must reuse the same bits, of which there are only 32 to hand out. */
+  private static int getBitmapMask(
+      final BitmapModifier mod, final Lookup lookup, final int bitcount) {
+    var assigned = bitmapMasksBySource.computeIfAbsent(mod, k -> new HashMap<>());
+    Integer known = assigned.get(lookup.toString());
+    if (known != null) {
+      return known;
+    }
+
+    // bitmapMasks stores the next mask we're going to use for modifier mod
+    int mask = bitmapMasks.get(mod);
+    bitmapMasks.put(mod, mask << bitcount);
+    for (int i = 0; i < bitcount - 1; i++) {
+      mask |= mask << 1;
+    }
+    if (bitmapMasks.get(mod) == 0) {
+      KoLmafia.updateDisplay(
+          "ERROR: too many sources for bitmap modifier "
+              + mod.getName()
+              + ", consider using longs.");
+    }
+
+    assigned.put(lookup.toString(), mask);
+    return mask;
+  }
+
   public static void resetModifiers() {
     // Don't reset any variables that are set up by loadAllModifiers, as subsequent calls to
     // resetModifiers then won't set them back up due to the if() guarding loadAllModifiers.
     modifiersByName.clear();
     Modifiers.resetAvailablePassiveSkills();
+    bitmapMasksBySource.clear();
     for (var mod : BitmapModifier.BITMAP_MODIFIERS) {
       bitmapMasks.put(mod, 1);
     }

--- a/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/TCRSDatabase.java
@@ -1750,7 +1750,7 @@ public class TCRSDatabase {
     int mys = 0;
     int mox = 0;
 
-    var comment = new StringJoiner(", ").add("Unspaded");
+    var comment = new StringJoiner(", ");
 
     // Consumable attributes (like SAUCY, BEER, etc) are preserved
     ConsumablesDatabase.getAttributes(consumable).stream().map(Enum::name).forEach(comment::add);
@@ -1777,7 +1777,7 @@ public class TCRSDatabase {
         String.valueOf(mus),
         String.valueOf(mys),
         String.valueOf(mox),
-        comment.toString());
+        comment.length() == 0 ? null : comment.toString());
   }
 
   public static void resetModifiers() {

--- a/test/net/sourceforge/kolmafia/persistence/ConsumablesDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/ConsumablesDatabaseTest.java
@@ -18,15 +18,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import internal.helpers.Cleanups;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Month;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.AscensionPath;
 import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLConstants;
 import net.sourceforge.kolmafia.ZodiacSign;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
@@ -368,20 +363,13 @@ class ConsumablesDatabaseTest {
     }
 
     @AfterAll
-    static void afterAll() throws IOException {
+    static void afterAll() {
       CLEANUPS.close();
 
       DebugDatabase.cacheItemDescriptionText(
           ItemPool.RING, html("request/test_normal_desc_item_ring.html"));
       TCRSDatabase.resetModifiers();
       ConsumablesDatabase.clearAndRebuild();
-      try (var walker = Files.walk(KoLConstants.DATA_LOCATION.toPath())) {
-        walker
-            .map(Path::toFile)
-            .filter(f -> f.getName().startsWith("TCRS_"))
-            .filter(f -> f.getName().endsWith(".txt"))
-            .forEach(File::delete);
-      }
     }
 
     @Test

--- a/test/net/sourceforge/kolmafia/persistence/ModifierDatabaseTest.java
+++ b/test/net/sourceforge/kolmafia/persistence/ModifierDatabaseTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -26,6 +27,32 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 public class ModifierDatabaseTest {
+  @Test
+  public void reparsingAnItemReusesItsBitmapBits() {
+    var lookup = new Lookup(ModifierType.ITEM, ItemPool.CLOWN_WIG);
+
+    var first = ModifierDatabase.parseModifiers(lookup, "Clowniness: 50");
+    var second = ModifierDatabase.parseModifiers(lookup, "Clowniness: 50");
+
+    var mask = first.getRawBitmap(BitmapModifier.CLOWNINESS);
+    assertThat(mask, is(not(0)));
+    assertThat(second.getRawBitmap(BitmapModifier.CLOWNINESS), is(mask));
+  }
+
+  @Test
+  public void distinctItemsGetDistinctBitmapBits() {
+    var wig =
+        ModifierDatabase.parseModifiers(ModifierType.ITEM, ItemPool.CLOWN_WIG, "Clowniness: 50");
+    var shoes =
+        ModifierDatabase.parseModifiers(ModifierType.ITEM, ItemPool.CLOWN_SHOES, "Clowniness: 25");
+
+    var wigMask = wig.getRawBitmap(BitmapModifier.CLOWNINESS);
+    var shoesMask = shoes.getRawBitmap(BitmapModifier.CLOWNINESS);
+    assertThat(wigMask, is(not(0)));
+    assertThat(shoesMask, is(not(0)));
+    assertThat(wigMask & shoesMask, is(0));
+  }
+
   @Test
   public void testSynergies() {
     // The "synergy" bitmap modifier is assigned dynamically, based on appearance order in


### PR DESCRIPTION
Follow-ups to #1767, all found by running TCRS on a real account now that deriving happens at login.

Applying TCRS modifiers marked every consumable Unspaded, and reparsing every item's modifiers handed each one a second set of bitmap bits, exhausting the 32 an int holds for Clowniness and Raveosity.