### PR TITLE
Retain pull order in _roninStoragePulls

### DIFF
--- a/src/net/sourceforge/kolmafia/request/StorageRequest.java
+++ b/src/net/sourceforge/kolmafia/request/StorageRequest.java
@@ -2,13 +2,6 @@ package net.sourceforge.kolmafia.request;
 
 import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.JSONObject;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.AdventureResult.AdventureLongCountResult;
 import net.sourceforge.kolmafia.KoLCharacter;
@@ -30,12 +23,21 @@ import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.session.ResultProcessor;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 @SuppressWarnings("incomplete-switch")
 public class StorageRequest extends TransferItemRequest {
   private StorageRequestType moveType;
   private boolean bulkTransfer;
 
-  public static final Set<Integer> roninStoragePulls = new HashSet<>();
+  public static final Set<Integer> roninStoragePulls = new LinkedHashSet<>();
 
   // Public interface
   public static void resetRoninStoragePulls() {

--- a/src/net/sourceforge/kolmafia/request/StorageRequest.java
+++ b/src/net/sourceforge/kolmafia/request/StorageRequest.java
@@ -2,6 +2,14 @@ package net.sourceforge.kolmafia.request;
 
 import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.JSONObject;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.AdventureResult.AdventureLongCountResult;
 import net.sourceforge.kolmafia.KoLCharacter;
@@ -22,15 +30,6 @@ import net.sourceforge.kolmafia.session.EquipmentManager;
 import net.sourceforge.kolmafia.session.InventoryManager;
 import net.sourceforge.kolmafia.session.ResultProcessor;
 import net.sourceforge.kolmafia.utilities.StringUtilities;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 @SuppressWarnings("incomplete-switch")
 public class StorageRequest extends TransferItemRequest {

--- a/test/net/sourceforge/kolmafia/request/StorageRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/StorageRequestTest.java
@@ -1,5 +1,29 @@
 package net.sourceforge.kolmafia.request;
 
+import internal.helpers.Cleanups;
+import internal.network.FakeHttpClientBuilder;
+import net.sourceforge.kolmafia.AdventureResult;
+import net.sourceforge.kolmafia.AdventureResult.AdventureLongCountResult;
+import net.sourceforge.kolmafia.AscensionPath.Path;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.MafiaState;
+import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
+import net.sourceforge.kolmafia.session.InventoryManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import static internal.helpers.Networking.html;
 import static internal.helpers.Player.withContinuationState;
 import static internal.helpers.Player.withHardcore;
@@ -19,32 +43,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import internal.helpers.Cleanups;
-import internal.network.FakeHttpClientBuilder;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import net.sourceforge.kolmafia.AdventureResult;
-import net.sourceforge.kolmafia.AdventureResult.AdventureLongCountResult;
-import net.sourceforge.kolmafia.AscensionPath.Path;
-import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLConstants;
-import net.sourceforge.kolmafia.KoLConstants.MafiaState;
-import net.sourceforge.kolmafia.StaticEntity;
-import net.sourceforge.kolmafia.objectpool.ItemPool;
-import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
-import net.sourceforge.kolmafia.preferences.Preferences;
-import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
-import net.sourceforge.kolmafia.session.InventoryManager;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
 public class StorageRequestTest {
 
-  private final Set<Integer> pulledItemSet = new LinkedHashSet<>();
+  private final Set<Integer> pulledItemSet = new HashSet<>();
   private String pulledItemProperty = "";
 
   // *** Here are tests for the primitives that handle ronin item pulls.

--- a/test/net/sourceforge/kolmafia/request/StorageRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/StorageRequestTest.java
@@ -1,29 +1,5 @@
 package net.sourceforge.kolmafia.request;
 
-import internal.helpers.Cleanups;
-import internal.network.FakeHttpClientBuilder;
-import net.sourceforge.kolmafia.AdventureResult;
-import net.sourceforge.kolmafia.AdventureResult.AdventureLongCountResult;
-import net.sourceforge.kolmafia.AscensionPath.Path;
-import net.sourceforge.kolmafia.KoLCharacter;
-import net.sourceforge.kolmafia.KoLConstants;
-import net.sourceforge.kolmafia.KoLConstants.MafiaState;
-import net.sourceforge.kolmafia.StaticEntity;
-import net.sourceforge.kolmafia.objectpool.ItemPool;
-import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
-import net.sourceforge.kolmafia.preferences.Preferences;
-import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
-import net.sourceforge.kolmafia.session.InventoryManager;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import static internal.helpers.Networking.html;
 import static internal.helpers.Player.withContinuationState;
 import static internal.helpers.Player.withHardcore;
@@ -43,9 +19,32 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import internal.helpers.Cleanups;
+import internal.network.FakeHttpClientBuilder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import net.sourceforge.kolmafia.AdventureResult;
+import net.sourceforge.kolmafia.AdventureResult.AdventureLongCountResult;
+import net.sourceforge.kolmafia.AscensionPath.Path;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLConstants;
+import net.sourceforge.kolmafia.KoLConstants.MafiaState;
+import net.sourceforge.kolmafia.StaticEntity;
+import net.sourceforge.kolmafia.objectpool.ItemPool;
+import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.request.StorageRequest.StorageRequestType;
+import net.sourceforge.kolmafia.session.InventoryManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
 public class StorageRequestTest {
 
-  private final Set<Integer> pulledItemSet = new HashSet<>();
+  private final Set<Integer> pulledItemSet = new LinkedHashSet<>();
   private String pulledItemProperty = "";
 
   // *** Here are tests for the primitives that handle ronin item pulls.

--- a/test/net/sourceforge/kolmafia/request/StorageRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/StorageRequestTest.java
@@ -24,6 +24,7 @@ import internal.network.FakeHttpClientBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import net.sourceforge.kolmafia.AdventureResult;
@@ -44,7 +45,7 @@ import org.junit.jupiter.api.Test;
 
 public class StorageRequestTest {
 
-  private final Set<Integer> pulledItemSet = new HashSet<>();
+  private final Set<Integer> pulledItemSet = new LinkedHashSet<>();
   private String pulledItemProperty = "";
 
   // *** Here are tests for the primitives that handle ronin item pulls.
@@ -221,6 +222,21 @@ public class StorageRequestTest {
     assertTrue(property.contains(Integer.toString(ItemPool.FIVE_ALARM_SAUCEPAN)));
     assertTrue(property.contains(Integer.toString(ItemPool.MACE_OF_THE_TORTOISE)));
     Preferences.setString("_roninStoragePulls", "");
+  }
+
+  @Test
+  public void itShouldKeepPulledItemsInInsertionOrder() {
+    roninStoragePropertySetup();
+    try (var cleanup = withProperty("_roninStoragePulls")) {
+      StorageRequest.addPulledItem(ItemPool.MACE_OF_THE_TORTOISE);
+      StorageRequest.addPulledItem(ItemPool.FIVE_ALARM_SAUCEPAN);
+      assertEquals(
+          List.of(ItemPool.MACE_OF_THE_TORTOISE, ItemPool.FIVE_ALARM_SAUCEPAN),
+          List.copyOf(StorageRequest.roninStoragePulls));
+      assertEquals(
+          ItemPool.MACE_OF_THE_TORTOISE + "," + ItemPool.FIVE_ALARM_SAUCEPAN,
+          Preferences.getString("_roninStoragePulls"));
+    }
   }
 
   // *** Here are tests for how StorageRequest generates subminstances.

--- a/test/net/sourceforge/kolmafia/request/StorageRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/StorageRequestTest.java
@@ -23,7 +23,6 @@ import internal.helpers.Cleanups;
 import internal.network.FakeHttpClientBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;


### PR DESCRIPTION
Currently the pull order of the preference is unsorted, it's using a HashSet which does not promise any order that makes sense to a normal user.

This means when you pull an item, your storage preference of the pulls done so far may be out of order from what actually happened.

This PR switches it to a LinkedHashSet which keeps the order. Even if there was a performance hit, it's only 20 items.

First commit is failing.