### PR TITLE
Show "Steal Monster Heart:  -> A" instead of "Steal Monster Heart: GONE -> GONEA"

### DIFF
--- a/src/net/sourceforge/kolmafia/persistence/SkillDatabase.java
+++ b/src/net/sourceforge/kolmafia/persistence/SkillDatabase.java
@@ -381,11 +381,8 @@ public class SkillDatabase {
         if (newHeart == null) {
           return name;
         }
-        return "Steal Monster's Heart: "
-            + currentHearts
-            + " -> "
-            + currentHearts
-            + newHeart.letter();
+        var currentWord = currentHearts.length() > 3 ? "" : currentHearts;
+        return "Steal Monster's Heart: " + currentHearts + " -> " + currentWord + newHeart.letter();
       }
     }
     return name;

--- a/test/net/sourceforge/kolmafia/webui/StationaryButtonDecoratorTest.java
+++ b/test/net/sourceforge/kolmafia/webui/StationaryButtonDecoratorTest.java
@@ -134,6 +134,23 @@ class StationaryButtonDecoratorTest {
             "steal monster's heart: t -> ta", StationaryButtonDecorator.getActionName("7585"));
       }
     }
+
+    @Test
+    void stealHeartRestartsWordWhenFull() {
+      var cleanups =
+          new Cleanups(
+              withProperty("heartstoneLetters", "GONE"),
+              withFight(),
+              withNextMonster("oil cartel"));
+
+      try (cleanups) {
+        assertEquals(
+            "Steal Monster's Heart: GONE -> A",
+            SkillDatabase.getPrettySkillName(SkillPool.STEAL_HEART));
+        assertEquals(
+            "steal monster's heart: gone -> a", StationaryButtonDecorator.getActionName("7585"));
+      }
+    }
   }
 
   @Nested


### PR DESCRIPTION
So ideally we would have the word reset itself when it hits 4 letters, instead of on the next letter. But I can see the argument otherwise. Being "a script may want to know what the word was", and a script can find the operation of slicing it to 0 chars easier, than trying to recover the word.

So this PR is just to prevent mafia from announcing that the player is landing a 5 letter word when using the skill.

The double spaces is, I'm going to call it a feature.

```
Round 1: irrat casts STEAL MONSTER'S HEART: BOFF -> BOFFF!
```

As always, the first commit is a problem I created.