### PR TITLE
Let JS scripts import the constants we export by default

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/JavascriptRuntime.java
@@ -418,8 +418,9 @@ public class JavascriptRuntime extends AbstractRuntime {
             if (scriptFile != null) {
               exports = require.requireMain(cx, scriptFile.toURI().toString());
             } else {
-              require.install(scope);
-              return cx.evaluateString(scope, scriptString, "command line", 1, null);
+              var commandScope = ScopeIsolationScript.newScriptScope(scope);
+              require.install(commandScope);
+              return cx.evaluateString(commandScope, scriptString, "command line", 1, null);
             }
           }
           if (functionName != null && exports != null) {

--- a/src/net/sourceforge/kolmafia/textui/javascript/SafeRequire.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/SafeRequire.java
@@ -33,7 +33,7 @@ public class SafeRequire extends Require {
         cx,
         nativeScope,
         new SoftCachingModuleScriptProvider(new KoLmafiaUrlModuleSourceProvider()),
-        null,
+        new ScopeIsolationScript(nativeScope),
         new MainWarningScript(),
         true);
     this.stdLib = stdLib;

--- a/src/net/sourceforge/kolmafia/textui/javascript/ScopeIsolationScript.java
+++ b/src/net/sourceforge/kolmafia/textui/javascript/ScopeIsolationScript.java
@@ -1,0 +1,69 @@
+package net.sourceforge.kolmafia.textui.javascript;
+
+import static org.mozilla.javascript.ScriptableObject.DONTENUM;
+import static org.mozilla.javascript.ScriptableObject.PERMANENT;
+import static org.mozilla.javascript.ScriptableObject.READONLY;
+
+import java.util.List;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Script;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
+
+/**
+ * Runs before a module body to move our default exports from the module's prototype chain into its
+ * parent scope chain.
+ *
+ * <p>Rhino rejects a top-level {@code const Item = ...} if {@code Item} is visible on the scope's
+ * prototype chain, where its module loader puts the global scope. Names reached through the parent
+ * scope chain resolve identically but are not redeclarations, so a script can use ours or declare
+ * its own.
+ */
+public class ScopeIsolationScript implements Script {
+  /** Globals that ES makes non-configurable, so a script may not declare over them. */
+  private static final List<String> RESTRICTED_GLOBALS = List.of("undefined", "NaN", "Infinity");
+
+  private final Scriptable globalScope;
+
+  public ScopeIsolationScript(Scriptable globalScope) {
+    this.globalScope = globalScope;
+  }
+
+  @Override
+  public Object exec(Context cx, Scriptable scope, Scriptable thisObj) {
+    isolate(scope, globalScope);
+    return null;
+  }
+
+  public static TopLevel newScriptScope(Scriptable globalScope) {
+    var scope = new TopLevel();
+    scope.setPrototype(globalScope);
+    scope.cacheBuiltins(globalScope, false);
+    isolate(scope, globalScope);
+    return scope;
+  }
+
+  /**
+   * Reparents a script scope so the global scope is a parent rather than a prototype. The scope
+   * must already have cached its builtins.
+   */
+  private static void isolate(Scriptable scriptScope, Scriptable globalScope) {
+    // Undeclared assignments land in the top scope, so give each script its own.
+    var parent = new TopLevel();
+    parent.setPrototype(globalScope);
+    parent.cacheBuiltins(globalScope, false);
+
+    scriptScope.setPrototype(null);
+    scriptScope.setParentScope(parent);
+
+    // Dropping the prototype lost Rhino's only reason to refuse these.
+    for (var name : RESTRICTED_GLOBALS) {
+      ScriptableObject.defineProperty(
+          scriptScope,
+          name,
+          ScriptableObject.getProperty(globalScope, name),
+          DONTENUM | READONLY | PERMANENT);
+    }
+  }
+}

--- a/test/root/expected/import_enumerated_types.cli.out
+++ b/test/root/expected/import_enumerated_types.cli.out
@@ -1,0 +1,2 @@
+seal tooth
+Returned: function

--- a/test/root/expected/import_enumerated_types.js.out
+++ b/test/root/expected/import_enumerated_types.js.out
@@ -1,0 +1,5 @@
+Confidence!
+seal tooth
+function
+helper
+main

--- a/test/root/expected/shadow_globals.js.out
+++ b/test/root/expected/shadow_globals.js.out
@@ -1,0 +1,4 @@
+shadowed
+not an effect
+2 Confidence!
+undefined false true

--- a/test/root/expected/shadow_restricted_globals.js.out
+++ b/test/root/expected/shadow_restricted_globals.js.out
@@ -1,0 +1,1 @@
+JavaScript error: redeclaration of const undefined.

--- a/test/root/scripts/Excluded/import_enumerated_types_helper.js
+++ b/test/root/scripts/Excluded/import_enumerated_types_helper.js
@@ -1,0 +1,3 @@
+var moduleLocal = "helper";
+
+module.exports.getModuleLocal = () => moduleLocal;

--- a/test/root/scripts/Excluded/shadow_globals_helper.js
+++ b/test/root/scripts/Excluded/shadow_globals_helper.js
@@ -1,0 +1,2 @@
+module.exports.describe = () =>
+  Math.max(1, 2) + " " + Effect.get("Confidence!").name;

--- a/test/root/scripts/import_enumerated_types.cli
+++ b/test/root/scripts/import_enumerated_types.cli
@@ -1,0 +1,1 @@
+js const { Item, print } = require("kolmafia"); print(Item.get("seal tooth").name); typeof Effect

--- a/test/root/scripts/import_enumerated_types.js
+++ b/test/root/scripts/import_enumerated_types.js
@@ -1,0 +1,13 @@
+const { Item, print } = require("kolmafia");
+const helper = require("./Excluded/import_enumerated_types_helper.js");
+
+// Available by default.
+print(Effect.get("Confidence!").name);
+
+print(Item.get("seal tooth").name);
+print(typeof Item);
+
+// Top level vars stay local to their script.
+var moduleLocal = "main";
+print(helper.getModuleLocal());
+print(moduleLocal);

--- a/test/root/scripts/shadow_globals.js
+++ b/test/root/scripts/shadow_globals.js
@@ -1,0 +1,15 @@
+const { print } = require("kolmafia");
+const helper = require("./Excluded/shadow_globals_helper.js");
+
+// A script may declare over anything in the global scope, ours or a builtin.
+const Math = { max: () => "shadowed" };
+const Effect = "not an effect";
+
+print(Math.max(1, 2));
+print(Effect);
+
+// Other scripts keep the real ones.
+print(helper.describe());
+
+// Globals it may not declare over stay readable.
+print([typeof undefined, NaN === NaN, Infinity > 0].join(" "));

--- a/test/root/scripts/shadow_restricted_globals.js
+++ b/test/root/scripts/shadow_restricted_globals.js
@@ -1,0 +1,6 @@
+const { print } = require("kolmafia");
+
+// Non-configurable, so this is an error.
+const undefined = 5;
+
+print("should not get here: " + undefined);


### PR DESCRIPTION
We currently don't allow a top level `const { Item } = require("kolmafia")`, because the original implementation of JS decided to make our constants globals by default so this is as a redeclaration. This was a bad idea, but is also annoying for trying to write JS with `// @ts-check`, so I decided to allow redeclaring them. In my implementation, nothing changes about what is exported by default, shadowing stays local to the script that does it, and `undefined`, `NaN` and `Infinity` are explicity off limits for shadowing.