### PR TITLE
Prefer equipping codpiece to use conditional skills of socketed gems

### DIFF
--- a/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
@@ -1013,7 +1013,7 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
               .anyMatch(i -> i == skillId);
 
       if (codpiecePossible) {
-        possibleEquipment.add(ItemPool.get(ItemPool.THE_ETERNITY_CODPIECE));
+        possibleEquipment.addFirst(ItemPool.get(ItemPool.THE_ETERNITY_CODPIECE));
       }
 
       if (!possibleEquipment.isEmpty()) {


### PR DESCRIPTION
ref: https://kolmafia.us/threads/heartstone-issue.32806/

With the changes from #3661, the code for equipping an item is able to detect that we own a gem that grants a conditional skill, even if it's socketed into The Eternity Codpiece. When it goes to equip an item to grant the skill, it tries to acquire the actual item first which results in it being unequipped from the Codpiece. This PR changes this behavior to instead prefer equipping the Codpiece instead. (It should theoretically still fall back to unsocketing and equipping the gem if it can't equip the Codpiece for some reason, though I can't think of a reason why that'd be the case.)