### PR TITLE
Prevent maximizer recommending restricted equipment even if creatable

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Evaluator.java
@@ -1334,6 +1334,10 @@ public class Evaluator {
         continue;
       }
 
+      if (!StandardRequest.isAllowed(RestrictedItemType.ITEMS, item.getName())) {
+        continue;
+      }
+
       Slot auxSlot = Slot.NONE;
       gotItem:
       {

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerCreatableTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerCreatableTest.java
@@ -39,6 +39,24 @@ public class MaximizerCreatableTest {
     }
   }
 
+  @Test
+  public void doesNotRecommendTinyBlackHoleInStandard() {
+    var cleanups =
+        new Cleanups(
+            withRestricted(true),
+            withItem("coconut shell", 1),
+            withItem("lime", 1),
+            withItem("meat paste", 1),
+            withProperty("unknownRecipe5069", false),
+            withNotAllowedInStandard(RestrictedItemType.ITEMS, "tiny black hole"),
+            withConcoctionRefresh());
+
+    try (cleanups) {
+      maximizeCreatable("item +offhand");
+      assertThat(getBoosts(), not(hasItem(recommendsSlot(Slot.OFFHAND, "tiny black hole"))));
+    }
+  }
+
   @Nested
   class BarrelShrine {
     @Test


### PR DESCRIPTION
Currently, the maximizer doesn't actually check whether equipment is available under your current restrictions before recommending it. In the vast majority of cases this doesn't matter--you normally can't get it in your inventory, can't pull it, or creating it requires a resource or access to a location that is restricted. However, in a few rare cases, it is possible to have all of the ingredients to craft a restricted item (for example, the tiny black hole learned via 2011's clan shower), and if you have the ingredients on-hand the maximizer will happily recommend creating and equipping it.

This PR adds a sanity check to skip over any equipment that is not allowed by your current restrictions.