### PR TITLE
Update image server URL to use HTTPS

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -170,7 +170,7 @@ public abstract class KoLmafia {
       Set.of(
           PREFERRED_IMAGE_SERVER_PATH,
           "https://s3.amazonaws.com/images.kingdomofloathing.com/",
-          "http://images.kingdomofloathing.com/");
+          "https://images.kingdomofloathing.com/");
   // Displays a warning in several areas when the JVM is running an older version
   public static final int MINIMUM_JAVA_VERSION = 21;
 


### PR DESCRIPTION
Referencing this report of a fix to mafia's images and js files breaking here:

OK, I figured it out, they moved it from http://images/... to https://images/... KoLmafia is specificially searching for the http:// version.
KoLmafia.java line 173 needs to be changed to https, I assume someone else can push this through a lot faster than I can.

https://discord.com/channels/466605739838930955/581155825385472001/1544834598029234337