### PR TITLE
Update KOL image servers

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -170,7 +170,8 @@ public abstract class KoLmafia {
       Set.of(
           PREFERRED_IMAGE_SERVER_PATH,
           "https://s3.amazonaws.com/images.kingdomofloathing.com/",
-          "http://images.kingdomofloathing.com/");
+          "http://images.kingdomofloathing.com/",
+          "https://images.kingdomofloathing.com/");
   // Displays a warning in several areas when the JVM is running an older version
   public static final int MINIMUM_JAVA_VERSION = 21;
 

--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -164,14 +164,14 @@ public abstract class KoLmafia {
   private static File SESSION_FILE = null;
   private static boolean SESSION_ENDING = false;
   public static KoLAdventure currentAdventure;
-  private static final String PREFERRED_IMAGE_SERVER = "https://d2uyhvukfffg5a.cloudfront.net";
+  private static final String PREFERRED_IMAGE_SERVER = "https://images.kingdomofloathing.com";
   private static final String PREFERRED_IMAGE_SERVER_PATH = PREFERRED_IMAGE_SERVER + "/";
   public static final Set<String> IMAGE_SERVER_PATHS =
       Set.of(
           PREFERRED_IMAGE_SERVER_PATH,
           "https://s3.amazonaws.com/images.kingdomofloathing.com/",
           "http://images.kingdomofloathing.com/",
-          "https://images.kingdomofloathing.com/");
+          "https://d2uyhvukfffg5a.cloudfront.net/");
   // Displays a warning in several areas when the JVM is running an older version
   public static final int MINIMUM_JAVA_VERSION = 21;
 

--- a/test/net/sourceforge/kolmafia/swingui/CalendarFrameTest.java
+++ b/test/net/sourceforge/kolmafia/swingui/CalendarFrameTest.java
@@ -104,7 +104,7 @@ class CalendarFrameTest {
                            </tr>
                            <tr>
                              <td>
-                               <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/bikini/nov.gif">
+                               <img src="https://images.kingdomofloathing.com/otherimages/bikini/nov.gif">
                               \s
                              </td>
                            </tr>
@@ -136,8 +136,8 @@ class CalendarFrameTest {
                            </tr>
                            <tr>
                              <td colspan="2" align="center">
-                               <img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/smoon2.gif">
-                               <img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/smoon1a.gif">
+                               <img src="https://images.kingdomofloathing.com/itemimages/smoon2.gif">
+                               <img src="https://images.kingdomofloathing.com/itemimages/smoon1a.gif">
                               \s
                              </td>
                            </tr>


### PR DESCRIPTION
Adds a new image server that images and other files (e.g. CSS) just started getting served from, and sets the new server as the default. This was breaking the relay browser badly.

Simply adding the new server to the list of image servers fixed a lot of things, but the combat form was still broken for me. Setting it as the default server also fixed that issue.

I'm not sure that this is a total solution, but it seems to at least work for clicking around and doing stuff.