### PR TITLE
Fix: Preserve current equipment after limited Maximizer searches

### DIFF
--- a/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
+++ b/src/net/sourceforge/kolmafia/maximizer/Maximizer.java
@@ -183,6 +183,7 @@ public class Maximizer {
     Maximizer.boosts.clear();
     if (filter.contains(KoLConstants.filterType.EQUIP)) {
       Maximizer.best.getScore();
+      MaximizerSpeculation currentEquipment = Maximizer.best.clone();
       // In case the current outfit scores better than any tried combination,
       // due to some newly-added constraint (such as +melee):
       Maximizer.best.failed = true;
@@ -212,6 +213,9 @@ public class Maximizer {
                 Slot.NONE,
                 null,
                 0.0));
+      }
+      if (!currentEquipment.failed && Maximizer.best.getScore() < currentEquipment.getScore()) {
+        Maximizer.best = currentEquipment;
       }
       MaximizerSpeculation.showProgress();
 

--- a/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
+++ b/test/net/sourceforge/kolmafia/maximizer/MaximizerTest.java
@@ -36,6 +36,7 @@ import static internal.matchers.Maximizer.recommendsSlot;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasToString;
@@ -59,6 +60,7 @@ import net.sourceforge.kolmafia.RestrictedItemType;
 import net.sourceforge.kolmafia.StaticEntity;
 import net.sourceforge.kolmafia.ZodiacSign;
 import net.sourceforge.kolmafia.equipment.Slot;
+import net.sourceforge.kolmafia.equipment.SlotSet;
 import net.sourceforge.kolmafia.modifiers.BitmapModifier;
 import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
@@ -3612,6 +3614,27 @@ public class MaximizerTest {
         assertThat(getBoosts(), hasItem(recommends(ItemPool.FLAK_SHIELD)));
         assertThat(modFor(DoubleModifier.DAMAGE_REDUCTION), equalTo(9.0));
       }
+    }
+  }
+
+  @Test
+  void keepsCurrentEquipmentWhenCombinationLimitIsReached() {
+    var watch = ItemPool.get("grandfather watch");
+    try (var cleanups =
+        new Cleanups(
+            withItem("Boots of Twilight Whispers"),
+            withEquipped(Slot.ACCESSORY1, "Elf Guard insignia (general)"),
+            withEquipped(Slot.ACCESSORY2, watch),
+            withEquipped(Slot.ACCESSORY3, ItemPool.THE_ETERNITY_CODPIECE),
+            withEquipped(Slot.FAMILIAR, "solid shifting time weirdness"),
+            withProperty("maximizerCombinationLimit", 1))) {
+      double current = new Evaluator("adv").getScore(KoLCharacter.getCurrentModifiers());
+
+      assertThat(maximize("adv"), is(true));
+      assertThat(Maximizer.best.getScore(), greaterThanOrEqualTo(current));
+      assertThat(
+          SlotSet.ACCESSORY_SLOTS.stream().map(Maximizer.best.equipment::get).toList(),
+          hasItem(watch));
     }
   }
 }


### PR DESCRIPTION
## Summary

Preserve the character's valid current equipment as a fallback when a
combination-limited or interrupted Maximizer search only evaluates worse
loadouts.

## Problem

Before beginning equipment enumeration, the Maximizer marks its current
speculation as failed so that an equal-scoring candidate can replace it.
This also removes the current equipment as a usable incumbent.

If the search then reaches `maximizerCombinationLimit` before finding an
equally good candidate, the Maximizer can recommend a worse loadout than
the one already equipped.

The regression test reproduces this with an Adventures maximization:

- the current loadout includes a grandfather watch;
- an alternative accessory is available;
- `maximizerCombinationLimit` is 1;
- the limited search finds a 52-adventure loadout while the current
  equipment scores 55.

## Change

Clone the valid current speculation before marking the search incumbent
as failed. After enumeration finishes or is stopped, restore that
speculation if every evaluated candidate scored worse.

This preserves existing behavior when the search finds an equal or
better result. It only changes the fallback when an incomplete search
would otherwise recommend a downgrade.

## Scope

This is a general Maximizer correctness fix. It does not change candidate
enumeration, scoring, ordering, or the meaning of the combination limit.

## Testing

Added `keepsCurrentEquipmentWhenCombinationLimitIsReached`, which verifies
that a limited search:

- does not return a score below the current equipment;
- retains the grandfather watch instead of recommending the inferior
  accessory configuration.

The test fails against the parent behavior with:

- current score: 55
- selected score: 52