### PR TITLE
Feat: Handle Codpiece insertion legality in the equip command

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/command/EquipCommand.java
+++ b/src/net/sourceforge/kolmafia/textui/command/EquipCommand.java
@@ -7,6 +7,7 @@ import net.sourceforge.kolmafia.KoLConstants.MafiaState;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.RequestThread;
 import net.sourceforge.kolmafia.equipment.Slot;
+import net.sourceforge.kolmafia.equipment.SlotSet;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.ItemFinder;
 import net.sourceforge.kolmafia.persistence.ItemFinder.Match;
@@ -96,6 +97,11 @@ public class EquipCommand extends AbstractCommand {
       if (!familiar.canEquip(match)) {
         KoLmafia.updateDisplay(
             MafiaState.ERROR, "Your " + familiar.getRace() + " can't wear a " + match.getName());
+        return;
+      }
+    } else if (SlotSet.CODPIECE_SLOTS.contains(slot)) {
+      if (!EquipmentRequest.isCodpieceGem(itemId)) {
+        KoLmafia.updateDisplay(MafiaState.ERROR, "You can't insert a " + match.getName());
         return;
       }
     } else if (!EquipmentManager.canEquip(itemId)) {

--- a/test/net/sourceforge/kolmafia/textui/command/EquipCommandTest.java
+++ b/test/net/sourceforge/kolmafia/textui/command/EquipCommandTest.java
@@ -6,6 +6,7 @@ import static internal.helpers.Player.withEquippableItem;
 import static internal.helpers.Player.withEquipped;
 import static internal.helpers.Player.withHandlingChoice;
 import static internal.helpers.Player.withItem;
+import static internal.helpers.Player.withStats;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -62,6 +63,43 @@ public class EquipCommandTest extends AbstractCommandTestBase {
       assertThat(requests, hasSize(2));
       assertPostRequest(requests.get(0), "/inventory.php", "action=useholder");
       assertPostRequest(requests.get(1), "/choice.php", "whichchoice=774&option=1&folder=1");
+    }
+  }
+
+  @Test
+  public void insertsCodpieceGemWithoutMeetingItsEquipmentRequirement() {
+    HttpClientWrapper.setupFakeClient();
+    var cleanups =
+        new Cleanups(
+            withStats(1, 1, 1),
+            withItem(ItemPool.BLACK_CATSEYE_MARBLE),
+            withEquipped(Slot.ACCESSORY1, ItemPool.THE_ETERNITY_CODPIECE),
+            withHandlingChoice(false));
+
+    try (cleanups) {
+      execute("codpiece1 black catseye marble");
+      assertContinueState();
+
+      var requests = getRequests();
+      assertThat(requests, hasSize(2));
+      assertPostRequest(requests.get(0), "/inventory.php", "action=docodpiece");
+      assertPostRequest(
+          requests.get(1), "/choice.php", "whichchoice=1588&option=1&which=1&iid=4104");
+    }
+  }
+
+  @Test
+  public void rejectsNonGemInCodpieceSlot() {
+    HttpClientWrapper.setupFakeClient();
+    var cleanups =
+        new Cleanups(
+            withEquippableItem(ItemPool.HOT_PLATE),
+            withEquipped(Slot.ACCESSORY1, ItemPool.THE_ETERNITY_CODPIECE));
+
+    try (cleanups) {
+      execute("codpiece1 hot plate");
+      assertErrorState();
+      assertThat(getRequests(), hasSize(0));
     }
   }
 }


### PR DESCRIPTION
## Summary

Treat Eternity Codpiece slots as insertion slots when processing the
`equip` command.

- Allow registered Codpiece gems to be inserted even when the character
  does not meet the gem's ordinary wearable requirements.
- Reject non-gem equipment passed to `codpiece1` through
  `codpiece5`.

## Why

Codpiece gems are inserted into the Eternity Codpiece rather than worn
as ordinary equipment. Applying `EquipmentManager.canEquip` to them can
incorrectly reject a valid insertion because of the gem's normal
equipment requirements.

Conversely, specifying a Codpiece slot previously allowed ordinary
equipment to proceed to the Codpiece choice request. The command now
validates that the selected item is a registered Codpiece gem before
sending any requests.

This change is limited to legality handling in the `equip` command. It
does not change general equipment legality or Maximizer search behavior.

## Testing

- Added an end-to-end command test showing that a valid Codpiece gem can
  be inserted with stats too low to equip it normally.
- Added a regression showing that attempting to insert a hot plate is
  rejected without sending requests.