### PR TITLE
feat: automatically equip familiars for skills when necessary

### DIFF
--- a/src/data/modifiers.txt
+++ b/src/data/modifiers.txt
@@ -4932,6 +4932,7 @@ Familiar	Llama Lama	Last Available: "2008-06", Volleyball: 0.5
 Familiar	Machine Elf	Last Available: "2015-12"
 Familiar	Mad Hatrack	Last Available: "2008-03"
 Familiar	Magic Dragonfish	Spell Damage Percent: [min(2*W,100^env(underwater)*100)]
+Familiar	Meat Shield Maiden	Conditional Skill (Equipped): "%fn, sing a song of my prowess"
 Familiar	Mechamelion	Last Available: "2018-03"
 Familiar	Mechanical Songbird	Fairy Effectiveness: [1.0+0.5*zone(Dreadsylvania)]
 Familiar	Melodramedary	Last Available: "2020-07"

--- a/src/net/sourceforge/kolmafia/FamiliarData.java
+++ b/src/net/sourceforge/kolmafia/FamiliarData.java
@@ -33,6 +33,7 @@ import net.sourceforge.kolmafia.persistence.FamiliarDatabase;
 import net.sourceforge.kolmafia.persistence.FamiliarDatabase.FamiliarRaceData;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.persistence.ModifierDatabase;
+import net.sourceforge.kolmafia.persistence.SkillDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
 import net.sourceforge.kolmafia.request.EquipmentRequest;
 import net.sourceforge.kolmafia.request.GenericRequest;
@@ -643,6 +644,7 @@ public class FamiliarData implements Comparable<FamiliarData> {
     EquipmentManager.setEquipment(Slot.FAMILIAR, current.getItem());
     FamiliarData.checkLockedItem(responseText);
     FamiliarData.parseSoup(responseText);
+    FamiliarData.checkSkillGrantingFamiliars();
   }
 
   private static FamiliarData registerFamiliar(final Matcher matcher, boolean idFirst) {
@@ -760,6 +762,24 @@ public class FamiliarData implements Comparable<FamiliarData> {
     this.soupAttributes.addAll(attributes);
   }
 
+  public static void checkSkillGrantingFamiliars() {
+    ModifierDatabase.getInventorySkillProviders().stream()
+        .filter(l -> l.getType() == ModifierType.FAMILIAR)
+        .map(Lookup::getStringKey)
+        .filter(race -> KoLCharacter.usableFamiliar(race) != null)
+        .flatMap(
+            race -> {
+              var mods = ModifierDatabase.getModifiers(ModifierType.FAMILIAR, race);
+              if (mods == null) {
+                return Stream.empty();
+              }
+              return mods.getStrings(StringModifier.CONDITIONAL_SKILL_EQUIPPED).stream();
+            })
+        .map(SkillDatabase::getSkillId)
+        .filter(id -> SkillDatabase.getSkillTags(id).contains(SkillDatabase.SkillTag.NONCOMBAT))
+        .forEach(KoLCharacter::addAvailableSkill);
+  }
+
   public void deactivate() {
     // Do anything necessary when this familiar is banished to the Terrarium
     this.active = false;
@@ -771,6 +791,7 @@ public class FamiliarData implements Comparable<FamiliarData> {
   public void activate() {
     // Do anything necessary when this familiar is removed from the Terrarium
     this.active = true;
+    addConditionalSkills();
     switch (this.getEffectiveId()) {
       case FamiliarPool.GREY_GOOSE -> {
         if (this.weight >= 6) {
@@ -778,6 +799,16 @@ public class FamiliarData implements Comparable<FamiliarData> {
         }
       }
     }
+  }
+
+  private void addConditionalSkills() {
+    var mods = ModifierDatabase.getModifiers(ModifierType.FAMILIAR, this.getRace());
+    if (mods == null) {
+      return;
+    }
+    mods.getStrings(StringModifier.CONDITIONAL_SKILL_EQUIPPED).stream()
+        .map(SkillDatabase::getSkillId)
+        .forEach(KoLCharacter::addAvailableSkill);
   }
 
   public void setWeight(final int weight) {

--- a/src/net/sourceforge/kolmafia/KoLCharacter.java
+++ b/src/net/sourceforge/kolmafia/KoLCharacter.java
@@ -3009,6 +3009,7 @@ public abstract class KoLCharacter {
         || oldPath == Path.JOURNEYMAN) {
       RequestThread.postRequest(new CharSheetRequest());
       InventoryManager.checkSkillGrantingEquipment();
+      FamiliarData.checkSkillGrantingFamiliars();
     }
 
     if (restricted

--- a/src/net/sourceforge/kolmafia/KoLmafia.java
+++ b/src/net/sourceforge/kolmafia/KoLmafia.java
@@ -927,6 +927,9 @@ public abstract class KoLmafia {
     // Items that conditionally grant skills
     InventoryManager.checkSkillGrantingEquipment();
 
+    // Familiars that conditionally grant skills
+    FamiliarData.checkSkillGrantingFamiliars();
+
     // Check Horsery if we haven't today
     if (Preferences.getBoolean("horseryAvailable")
         && Preferences.getString("_horseryCrazyMox").length() == 0) {

--- a/src/net/sourceforge/kolmafia/objectpool/FamiliarPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/FamiliarPool.java
@@ -162,6 +162,7 @@ public class FamiliarPool {
   public static final int OBSERVER = 318;
   public static final int SKELETON_OF_CRIMBO_PAST = 326;
   public static final int SWORD_OF_SWORDS = 330;
+  public static final int MEAT_SHIELD_MAIDEN = 332;
 
   private FamiliarPool() {}
 }

--- a/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/SkillPool.java
@@ -697,6 +697,7 @@ public class SkillPool {
   public static final int KILL_A_LOT = 7593;
   public static final int STOP_KILLING = 7594;
   public static final int EXERCISE_LIQUIDITY = 7596;
+  public static final int SING_A_SONG_OF_MY_PROWESS = 7598;
 
   public static final int GOOD_SINGING_VOICE = 11016;
   public static final int BANISHING_SHOUT = 11020;

--- a/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseSkillRequest.java
@@ -4,6 +4,7 @@ import static net.sourceforge.kolmafia.utilities.Statics.DateTimeManager;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -28,6 +29,7 @@ import net.sourceforge.kolmafia.equipment.SlotSet;
 import net.sourceforge.kolmafia.modifiers.BooleanModifier;
 import net.sourceforge.kolmafia.modifiers.DerivedModifier;
 import net.sourceforge.kolmafia.modifiers.DoubleModifier;
+import net.sourceforge.kolmafia.modifiers.Lookup;
 import net.sourceforge.kolmafia.modifiers.StringModifier;
 import net.sourceforge.kolmafia.moods.HPRestoreItemList;
 import net.sourceforge.kolmafia.moods.MoodManager;
@@ -1034,6 +1036,26 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
                                 .collect(Collectors.joining(", "))
                             + "."));
       }
+
+      var possibleFamiliars =
+          ModifierDatabase.getNonCombatSkillProviders().stream()
+              .filter(l -> l.getType() == ModifierType.FAMILIAR)
+              .filter(
+                  l ->
+                      ModifierDatabase.getMultiStringModifier(
+                              l, StringModifier.CONDITIONAL_SKILL_EQUIPPED)
+                          .stream()
+                          .mapToInt(SkillDatabase::getSkillId)
+                          .anyMatch(i -> i == skillId))
+              .map(Lookup::getStringKey)
+              .map(KoLCharacter::usableFamiliar)
+              .filter(Objects::nonNull)
+              .collect(Collectors.toList());
+
+      if (!possibleFamiliars.isEmpty() && !possibleFamiliars.contains(KoLCharacter.getFamiliar())) {
+        var familiar = possibleFamiliars.get(0);
+        RequestThread.postRequest(new FamiliarRequest(familiar));
+      }
     }
 
     if (Preferences.getBoolean("switchEquipmentForBuffs")) {
@@ -1285,6 +1307,7 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
 
     // Optimizing equipment can involve changing equipment.
     // Save a checkpoint so we can restore previous equipment.
+    var oldFamiliar = KoLCharacter.getFamiliar();
     try (Checkpoint checkpoint = new Checkpoint()) {
       optimizeEquipment();
       if (KoLmafia.refusesContinue()) {
@@ -1294,6 +1317,12 @@ public class UseSkillRequest extends GenericRequest implements Comparable<UseSki
 
       this.isRunning = true;
       this.useSkillLoop();
+
+      // optimizeEquipment may have changed the active familiar so that we
+      // could cast this skill. Restore the previous familiar.
+      if (!KoLmafia.refusesContinue() && !oldFamiliar.equals(KoLCharacter.getFamiliar())) {
+        RequestThread.postRequest(new FamiliarRequest(oldFamiliar));
+      }
     } finally {
       this.isRunning = false;
     }

--- a/test/internal/helpers/Player.java
+++ b/test/internal/helpers/Player.java
@@ -2727,6 +2727,11 @@ public class Player {
     return new Cleanups(new OrderedRunnable(KoLCharacter::recalculateAdjustments, 10));
   }
 
+  public static Cleanups withSkillGrantingFamiliarsChecked() {
+    FamiliarData.checkSkillGrantingFamiliars();
+    return new Cleanups(new OrderedRunnable(FamiliarData::checkSkillGrantingFamiliars, 9));
+  }
+
   public static Cleanups withNPCStoreReset() {
     NPCStoreDatabase.reset();
 

--- a/test/net/sourceforge/kolmafia/FamiliarDataTest.java
+++ b/test/net/sourceforge/kolmafia/FamiliarDataTest.java
@@ -6,12 +6,16 @@ import static internal.helpers.Player.withClass;
 import static internal.helpers.Player.withEffect;
 import static internal.helpers.Player.withEquipped;
 import static internal.helpers.Player.withFamiliar;
+import static internal.helpers.Player.withFamiliarInTerrarium;
 import static internal.helpers.Player.withNotAllowedInStandard;
 import static internal.helpers.Player.withPath;
 import static internal.helpers.Player.withProperty;
 import static internal.helpers.Player.withRestricted;
 import static internal.helpers.Player.withSkill;
+import static internal.helpers.Player.withSkillGrantingFamiliarsChecked;
 import static internal.helpers.Player.withStats;
+import static internal.helpers.Player.withoutFamiliarInTerrarium;
+import static internal.helpers.Player.withoutSkill;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -647,5 +651,48 @@ public class FamiliarDataTest {
     var id = FamiliarDatabase.getFamiliarId(name);
     var fam = new FamiliarData(id);
     assertThat(fam.canCarry(), is(expected));
+  }
+
+  @Nested
+  class ConditionalSkills {
+    @Test
+    public void absentFamiliarsDoNotProvideSkills() {
+      var cleanups =
+          new Cleanups(
+              withoutSkill(SkillPool.SING_A_SONG_OF_MY_PROWESS),
+              withoutFamiliarInTerrarium(FamiliarPool.MEAT_SHIELD_MAIDEN),
+              withSkillGrantingFamiliarsChecked());
+      try (cleanups) {
+        var fam = KoLCharacter.usableFamiliar(FamiliarPool.MEAT_SHIELD_MAIDEN);
+        assertThat(fam, nullValue());
+        assertFalse(KoLCharacter.hasSkill(SkillPool.SING_A_SONG_OF_MY_PROWESS));
+      }
+    }
+
+    @Test
+    public void familiarsInTerrariumProvideSkills() {
+      var cleanups =
+          new Cleanups(
+              withoutSkill(SkillPool.SING_A_SONG_OF_MY_PROWESS),
+              withFamiliarInTerrarium(FamiliarPool.MEAT_SHIELD_MAIDEN),
+              withSkillGrantingFamiliarsChecked());
+      try (cleanups) {
+        var fam = KoLCharacter.usableFamiliar(FamiliarPool.MEAT_SHIELD_MAIDEN);
+        assertThat(fam, notNullValue());
+        assertTrue(KoLCharacter.hasSkill(SkillPool.SING_A_SONG_OF_MY_PROWESS));
+      }
+    }
+
+    @Test
+    public void cannotUseFamiliarConditionalSkillsInAvatarPaths() {
+      var cleanups =
+          new Cleanups(
+              withPath(Path.AVATAR_OF_BORIS),
+              withFamiliarInTerrarium(FamiliarPool.MEAT_SHIELD_MAIDEN),
+              withSkillGrantingFamiliarsChecked());
+      try (cleanups) {
+        assertFalse(KoLCharacter.hasSkill(SkillPool.SING_A_SONG_OF_MY_PROWESS));
+      }
+    }
   }
 }

--- a/test/net/sourceforge/kolmafia/request/UseSkillRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/UseSkillRequestTest.java
@@ -3,12 +3,16 @@ package net.sourceforge.kolmafia.request;
 import static internal.helpers.HttpClientWrapper.getRequests;
 import static internal.helpers.Networking.assertGetRequest;
 import static internal.helpers.Networking.assertPostRequest;
+import static internal.helpers.Networking.getPostRequestBody;
 import static internal.helpers.Networking.html;
 import static internal.helpers.Player.withAdventuresLeft;
 import static internal.helpers.Player.withClass;
 import static internal.helpers.Player.withDay;
 import static internal.helpers.Player.withEquippableItem;
 import static internal.helpers.Player.withEquipped;
+import static internal.helpers.Player.withFamiliar;
+import static internal.helpers.Player.withFamiliarInTerrarium;
+import static internal.helpers.Player.withHttpClientBuilder;
 import static internal.helpers.Player.withInteractivity;
 import static internal.helpers.Player.withItem;
 import static internal.helpers.Player.withLevel;
@@ -17,15 +21,23 @@ import static internal.helpers.Player.withNextResponse;
 import static internal.helpers.Player.withPath;
 import static internal.helpers.Player.withProperty;
 import static internal.helpers.Player.withSkill;
+import static internal.helpers.Player.withSkillGrantingFamiliarsChecked;
+import static internal.helpers.Player.withoutSkill;
 import static internal.matchers.Preference.isSetTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import internal.helpers.Cleanups;
 import internal.helpers.HttpClientWrapper;
+import internal.network.FakeHttpClientBuilder;
+import internal.network.FakeHttpResponse;
+import java.net.http.HttpRequest;
 import java.time.Month;
 import net.sourceforge.kolmafia.AscensionClass;
 import net.sourceforge.kolmafia.AscensionPath.Path;
@@ -33,6 +45,7 @@ import net.sourceforge.kolmafia.KoLCharacter;
 import net.sourceforge.kolmafia.KoLmafia;
 import net.sourceforge.kolmafia.equipment.Slot;
 import net.sourceforge.kolmafia.objectpool.EffectPool;
+import net.sourceforge.kolmafia.objectpool.FamiliarPool;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.persistence.SkillDatabase;
@@ -697,6 +710,104 @@ class UseSkillRequestTest {
         assertThat("heartstoneBuffUnlocked", isSetTo(true));
         assertThat("heartstoneLuckUnlocked", isSetTo(true));
         assertThat("heartstonePalsUnlocked", isSetTo(true));
+      }
+    }
+  }
+
+  @Nested
+  class FamiliarGrantedSkill {
+    @BeforeEach
+    public void initializeState() {
+      KoLCharacter.reset("FamiliarGrantedSkill");
+      Preferences.reset("FamiliarGrantedSkill");
+    }
+
+    private FakeHttpResponse<String> getHttpResponses(HttpRequest r) {
+      if (r.uri().getPath().equals("/familiar.php")) {
+        var body = getPostRequestBody(r);
+        if (body.contains("newfam=" + FamiliarPool.MEAT_SHIELD_MAIDEN)) {
+          return new FakeHttpResponse<>("You take your Meat Shield Maiden with you.");
+        }
+        if (body.contains("newfam=" + FamiliarPool.MOSQUITO)) {
+          return new FakeHttpResponse<>("You take your Mosquito with you.");
+        }
+      }
+      return new FakeHttpResponse<>("");
+    }
+
+    @Test
+    public void switchesFamiliarAndRestoresAfterCasting() {
+      var builder = new FakeHttpClientBuilder();
+      builder.client.setResponseFunc(this::getHttpResponses);
+
+      var cleanups =
+          new Cleanups(
+              withHttpClientBuilder(builder),
+              withoutSkill(SkillPool.SING_A_SONG_OF_MY_PROWESS),
+              withFamiliar(FamiliarPool.MOSQUITO),
+              withFamiliarInTerrarium(FamiliarPool.MEAT_SHIELD_MAIDEN),
+              withMP(100, 100, 100),
+              withSkillGrantingFamiliarsChecked());
+
+      try (cleanups) {
+        assertTrue(KoLCharacter.hasSkill(SkillPool.SING_A_SONG_OF_MY_PROWESS));
+        assertThat(KoLCharacter.getFamiliar().getId(), is(FamiliarPool.MOSQUITO));
+
+        var req = UseSkillRequest.getInstance(SkillPool.SING_A_SONG_OF_MY_PROWESS, 1);
+        req.run();
+
+        var requests = builder.client.getRequests();
+        assertThat(requests, hasSize(greaterThanOrEqualTo(3)));
+        assertPostRequest(
+            requests.get(0),
+            "/familiar.php",
+            "action=newfam&newfam=" + FamiliarPool.MEAT_SHIELD_MAIDEN + "&ajax=1");
+        assertGetRequest(
+            requests.get(1),
+            "/runskillz.php",
+            "action=Skillz&whichskill="
+                + SkillPool.SING_A_SONG_OF_MY_PROWESS
+                + "&ajax=1&quantity=1");
+        // 2 is an api.php request call
+        assertPostRequest(
+            requests.get(3),
+            "/familiar.php",
+            "action=newfam&newfam=" + FamiliarPool.MOSQUITO + "&ajax=1");
+
+        assertThat(KoLCharacter.getFamiliar().getId(), is(FamiliarPool.MOSQUITO));
+      }
+    }
+
+    @Test
+    public void doesNotChangeFamiliarWithCorrectFamiliar() {
+      var builder = new FakeHttpClientBuilder();
+      builder.client.setResponseFunc(this::getHttpResponses);
+
+      var cleanups =
+          new Cleanups(
+              withHttpClientBuilder(builder),
+              withoutSkill(SkillPool.SING_A_SONG_OF_MY_PROWESS),
+              withFamiliar(FamiliarPool.MEAT_SHIELD_MAIDEN),
+              withMP(100, 100, 100),
+              withSkillGrantingFamiliarsChecked());
+
+      try (cleanups) {
+        assertTrue(KoLCharacter.hasSkill(SkillPool.SING_A_SONG_OF_MY_PROWESS));
+        assertThat(KoLCharacter.getFamiliar().getId(), is(FamiliarPool.MEAT_SHIELD_MAIDEN));
+
+        var req = UseSkillRequest.getInstance(SkillPool.SING_A_SONG_OF_MY_PROWESS, 1);
+        req.run();
+
+        var requests = builder.client.getRequests();
+        assertThat(requests, hasSize(equalTo(2)));
+        assertGetRequest(
+            requests.get(0),
+            "/runskillz.php",
+            "action=Skillz&whichskill="
+                + SkillPool.SING_A_SONG_OF_MY_PROWESS
+                + "&ajax=1&quantity=1");
+
+        assertThat(KoLCharacter.getFamiliar().getId(), is(FamiliarPool.MEAT_SHIELD_MAIDEN));
       }
     }
   }


### PR DESCRIPTION
Still need to check whether you can cast with a Comma imitating a Meat Shield Maiden.

Combat skills (e.g. Grey Goose, Melodramedary, Patriotic Eagle) not integrated into the equipment-like paradigm.