### PR TITLE
fix: log speakeasy drinks and hot dogs in the session log

### DIFF
--- a/src/net/sourceforge/kolmafia/request/ClanLoungeRequest.java
+++ b/src/net/sourceforge/kolmafia/request/ClanLoungeRequest.java
@@ -1999,7 +1999,12 @@ public class ClanLoungeRequest extends GenericRequest {
     String message = ClanLoungeRequest.equipmentVisit(urlString);
 
     if (message == null) {
+      // The speakeasy, hot dog stand, pool table, shower and swimming pool all
+      // submit their real actions as "preaction", which getAction() ignores.
       String action = GenericRequest.getAction(urlString);
+      if (action == null) {
+        action = GenericRequest.getPreaction(urlString);
+      }
       if (action == null) {
         return true;
       }
@@ -2111,11 +2116,11 @@ public class ClanLoungeRequest extends GenericRequest {
             if (!m.find()) {
               return false;
             }
-            SpeakeasyDrink drink = SpeakeasyDrink.findId(StringUtilities.parseInt(m.group(0)));
+            SpeakeasyDrink drink = SpeakeasyDrink.findId(StringUtilities.parseInt(m.group(1)));
             if (drink == null) {
               return false;
             }
-            message = "drink 1 " + drink.getName();
+            message = "drink 1 " + StringUtilities.getEntityDecode(drink.getName());
             break;
           }
         default:

--- a/test/net/sourceforge/kolmafia/request/ClanLoungeRequestTest.java
+++ b/test/net/sourceforge/kolmafia/request/ClanLoungeRequestTest.java
@@ -380,4 +380,53 @@ public class ClanLoungeRequestTest {
       }
     }
   }
+
+  @Nested
+  class RegisterRequest {
+    // The speakeasy and hot dog stand submit their real action as "preaction",
+    // which getAction() ignores; registerRequest must still name the consumed
+    // drink / dog in the session log.
+
+    @Test
+    void logsSpeakeasyDrinkBoughtFromPreaction() {
+      SessionLoggerOutput.startStream();
+      boolean handled =
+          ClanLoungeRequest.registerRequest(
+              "clan_viplounge.php?preaction=speakeasydrink&drink=5&whichfloor=2");
+      var text = SessionLoggerOutput.stopStream();
+
+      assertTrue(handled);
+      assertThat(text, containsString("drink 1 Bee's Knees"));
+    }
+
+    @Test
+    void logsQuotedSpeakeasyDrinkWithoutHtmlEntities() {
+      SessionLoggerOutput.startStream();
+      ClanLoungeRequest.registerRequest(
+          "clan_viplounge.php?preaction=speakeasydrink&drink=1&whichfloor=2");
+      var text = SessionLoggerOutput.stopStream();
+
+      assertThat(text, containsString("drink 1 glass of \"milk\""));
+    }
+
+    @Test
+    void logsBasicHotDogEatenFromPreaction() {
+      SessionLoggerOutput.startStream();
+      boolean handled =
+          ClanLoungeRequest.registerRequest("clan_viplounge.php?preaction=eathotdog&whichdog=-92");
+      var text = SessionLoggerOutput.stopStream();
+
+      assertTrue(handled);
+      assertThat(text, containsString("eat 1 basic hot dog"));
+    }
+
+    @Test
+    void logsFancyHotDogEatenFromPreaction() {
+      SessionLoggerOutput.startStream();
+      ClanLoungeRequest.registerRequest("clan_viplounge.php?preaction=eathotdog&whichdog=-93");
+      var text = SessionLoggerOutput.stopStream();
+
+      assertThat(text, containsString("eat 1 savage macho dog"));
+    }
+  }
 }


### PR DESCRIPTION
### What

`ClanLoungeRequest.registerRequest` has `case "speakeasydrink"` / `case "eathotdog"` branches that build `drink 1 <name>` / `eat 1 <name>` and write them to the session log — but they were unreachable. The switch dispatches on `GenericRequest.getAction()`, whose pattern is `(?<!pre|sub)action=…`, i.e. it deliberately ignores `preaction=`. The speakeasy, hot dog stand, pool table, shower and swimming pool all submit their real action as `preaction=…`, so `getAction()` returned `null`, `registerRequest` returned early, and nothing was logged.

Net effect: buying a speakeasy drink or eating a fancy hot dog left no trace in the session log beyond the adventures / effect / stats / meat it granted — you couldn't tell *which* drink or dog it was.

This falls back to `getPreaction()` when `getAction()` is `null`. It also:

- fixes the speakeasy case reading capture group `0` (`"drink=5"`) instead of group `1` (`"5"`) — it happened to work via digit-stripping in `parseInt`, but it was wrong;
- decodes HTML entities in the speakeasy drink name, so `glass of "milk"` / `cup of "tea"` / `thermos of "whiskey"` are logged with real quotes instead of `&quot;`.

Side effect: pool games, showers and swim workouts (also `preaction=`) now get their existing `pool …` / `shower …` / `swimming pool …` session-log lines too. Those switch cases were already written; they just couldn't run.

### Testing

New `ClanLoungeRequestTest.RegisterRequest` nested class asserts `drink 1 Bee's Knees`, `drink 1 glass of "milk"`, `eat 1 basic hot dog` and `eat 1 savage macho dog` reach the session log. Full test suite + `spotlessCheck` pass.

### Why

Log-analysis tooling (and anyone reading their own session log) currently has to guess the drink/dog from the effect gained or the stat split. This makes the log self-describing on the same code path that already logs the consumption's results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
