### PR TITLE
Automatically trigger description reads for unusual events

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -1614,6 +1614,7 @@ public class ItemPool {
   public static final int FOSSILIZED_TORSO = 4693;
   public static final int FOSSILIZED_SPINE = 4694;
   public static final int GREAT_PANTS = 4696;
+  public static final int FOSSILIZED_NECKLACE = 4697;
   public static final int IMP_AIR = 4698;
   public static final int BUS_PASS = 4699;
   public static final int FOSSILIZED_SPIKE = 4700;

--- a/src/net/sourceforge/kolmafia/request/FightRequest.java
+++ b/src/net/sourceforge/kolmafia/request/FightRequest.java
@@ -57,6 +57,7 @@ import net.sourceforge.kolmafia.persistence.AdventureSpentDatabase;
 import net.sourceforge.kolmafia.persistence.BountyDatabase;
 import net.sourceforge.kolmafia.persistence.ConsumablesDatabase;
 import net.sourceforge.kolmafia.persistence.DailyLimitDatabase.DailyLimitType;
+import net.sourceforge.kolmafia.persistence.DebugDatabase;
 import net.sourceforge.kolmafia.persistence.EffectData;
 import net.sourceforge.kolmafia.persistence.EffectDatabase;
 import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
@@ -4306,6 +4307,16 @@ public class FightRequest extends GenericRequest {
 
       switch (monsterName) {
         case "black pudding" -> Preferences.increment("blackPuddingsDefeated", 1);
+        case "reanimated bat skeleton",
+            "reanimated serpent skeleton",
+            "reanimated baboon skeleton",
+            "reanimated wyrm skeleton",
+            "reanimated demon skeleton",
+            "reanimated giant spider skeleton" -> {
+          if (responseText.contains("you grab one of its teeth")) {
+            DebugDatabase.itemDescriptionText(ItemPool.FOSSILIZED_NECKLACE, true);
+          }
+        }
         case "general seal" -> ResultProcessor.removeItem(ItemPool.ABYSSAL_BATTLE_PLANS);
         case "Frank &quot;Skipper&quot; Dan, the Accordion Lord" ->
             ResultProcessor.removeItem(ItemPool.SUSPICIOUS_ADDRESS);

--- a/src/net/sourceforge/kolmafia/request/UseItemRequest.java
+++ b/src/net/sourceforge/kolmafia/request/UseItemRequest.java
@@ -2926,6 +2926,10 @@ public class UseItemRequest extends GenericRequest {
           String skill = UseItemRequest.itemToSkill(itemId);
           if (skill != null) {
             ResponseTextParser.learnSkill(skill);
+            if (itemId == ItemPool.RESIDUAL_CHITIN_PASTE) {
+              // Ensure we have the correct strength for Chitinous Soul
+              DebugDatabase.readSkillDescriptionText(SkillPool.CHITINOUS_SOUL);
+            }
           }
 
           break;

--- a/src/net/sourceforge/kolmafia/session/QuestManager.java
+++ b/src/net/sourceforge/kolmafia/session/QuestManager.java
@@ -30,6 +30,7 @@ import net.sourceforge.kolmafia.objectpool.SkillPool;
 import net.sourceforge.kolmafia.persistence.AdventureDatabase;
 import net.sourceforge.kolmafia.persistence.AdventureSpentDatabase;
 import net.sourceforge.kolmafia.persistence.ConcoctionDatabase;
+import net.sourceforge.kolmafia.persistence.DebugDatabase;
 import net.sourceforge.kolmafia.persistence.EquipmentDatabase;
 import net.sourceforge.kolmafia.persistence.ModifierDatabase;
 import net.sourceforge.kolmafia.persistence.MonsterDatabase;
@@ -101,10 +102,18 @@ public class QuestManager {
     String field = request.getFormField("snarfblat");
     int locationId = StringUtilities.isNumeric(field) ? StringUtilities.parseInt(field) : 0;
 
+    // In License to Adventure, update the strength of the Disavowed buff when going to a non-Lair
+    // adventure.php location, regardless of whether we're getting redirected to a fight or choice
+    // or not at all.
+    if (KoLCharacter.inBondcore() && locationId != 495 && location.startsWith("adventure.php")) {
+      if (Preferences.getInteger("_villainLairProgress") < 999) {
+        DebugDatabase.readEffectDescriptionText(EffectPool.DISAVOWED);
+      }
+    }
+
     // If we redirected to a choice or fight, there is no response
     // text here. Look for the above-mentioned quest changes which
     // don't depend on a responseText.
-
     String redirectLocation = request.redirectLocation;
     if (redirectLocation != null) {
       if (location.startsWith("adventure")) {


### PR DESCRIPTION
Add automatic triggering of description reads to keep mafia prefs (used to calculate certain modifiers) in sync with reality:

* `fossilB/D/N/P/S/W`: When completing combat against one of the creatures that adds a tooth to the necklace, if a tooth is stolen, parse the fossilized necklace's item description to ensure mafia has the prefs set correctly.
* `_disavowed`: In LTA, when adventuring somewhere other than the Villain's Lair before completing the Villain's Lair, parse the Disavowed effect description to get the current penalties.
* `skillLevel227`: When using residual chitin paste, automatically parse the Chitinous Soul skill description to ensure the strength of the bonus is up-to-date. (We already did something similar for the Slime Tube skills.)

Closes #3652 