### PR TITLE
Named records for RuntimeLibrary types

### DIFF
--- a/src/net/sourceforge/kolmafia/KoLmafiaASH.java
+++ b/src/net/sourceforge/kolmafia/KoLmafiaASH.java
@@ -16,8 +16,10 @@ import net.sourceforge.kolmafia.textui.ScriptRuntime;
 import net.sourceforge.kolmafia.textui.javascript.JavascriptRuntime;
 import net.sourceforge.kolmafia.textui.parsetree.Function;
 import net.sourceforge.kolmafia.textui.parsetree.FunctionList;
+import net.sourceforge.kolmafia.textui.parsetree.Type;
 import net.sourceforge.kolmafia.textui.parsetree.VariableReference;
 import net.sourceforge.kolmafia.utilities.FileUtilities;
+import net.sourceforge.kolmafia.utilities.StringUtilities;
 
 public abstract class KoLmafiaASH {
   private static final HashMap<String, File> relayScriptMap = new HashMap<>();
@@ -249,6 +251,27 @@ public abstract class KoLmafiaASH {
     KoLmafiaASH.showFunctions(RuntimeLibrary.getFunctions(), filter.toLowerCase(), true);
   }
 
+  private static String getTypeString(Type type, boolean addLinks) {
+    String typeName = type.getName();
+
+    int idx = typeName.indexOf("=");
+    if (idx < 0) {
+      return typeName;
+    }
+
+    String displayName = typeName.substring(0, idx).trim();
+    String details = typeName.substring(idx + 1).trim();
+    if (addLinks) {
+      return "<font color='#008000' title='"
+          + StringUtilities.getEntityEncode(details)
+          + "'>"
+          + displayName
+          + "</font>";
+    } else {
+      return displayName;
+    }
+  }
+
   private static void showFunctions(
       final FunctionList functions, final String filter, boolean addLinks) {
     addLinks = addLinks && StaticEntity.isGUIRequired();
@@ -278,7 +301,7 @@ public abstract class KoLmafiaASH {
 
       StringBuilder description = new StringBuilder();
 
-      description.append(func.getType());
+      description.append(getTypeString(func.getType(), addLinks));
       description.append(" ");
       if (addLinks) {
         description.append("<a href='https://wiki.kolmafia.us/index.php?title=");
@@ -296,7 +319,7 @@ public abstract class KoLmafiaASH {
         description.append(sep);
         sep = ", ";
 
-        description.append(var.getRawType());
+        description.append(getTypeString(var.getRawType(), addLinks));
 
         if (var.getName() != null) {
           description.append(" ");

--- a/src/net/sourceforge/kolmafia/textui/Parser.java
+++ b/src/net/sourceforge/kolmafia/textui/Parser.java
@@ -261,7 +261,7 @@ public class Parser {
   }
 
   public static Scope getExistingFunctionScope() {
-    return new Scope(RuntimeLibrary.functions, null, DataTypes.simpleTypes);
+    return new Scope(RuntimeLibrary.functions, null, RuntimeLibrary.simpleTypesWithNamedRecords);
   }
 
   // **************** Parser *****************

--- a/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
+++ b/src/net/sourceforge/kolmafia/textui/RuntimeLibrary.java
@@ -243,6 +243,8 @@ import net.sourceforge.kolmafia.textui.parsetree.MapValue;
 import net.sourceforge.kolmafia.textui.parsetree.RecordType;
 import net.sourceforge.kolmafia.textui.parsetree.RecordValue;
 import net.sourceforge.kolmafia.textui.parsetree.Type;
+import net.sourceforge.kolmafia.textui.parsetree.TypeDef;
+import net.sourceforge.kolmafia.textui.parsetree.TypeList;
 import net.sourceforge.kolmafia.textui.parsetree.Value;
 import net.sourceforge.kolmafia.textui.parsetree.Variable;
 import net.sourceforge.kolmafia.textui.parsetree.VariableReference;
@@ -266,6 +268,24 @@ import org.tmatesoft.svn.core.wc.SVNWCUtil;
 
 @SuppressWarnings({"incomplete-switch", "unused"})
 public abstract class RuntimeLibrary {
+  public static final TypeList simpleTypesWithNamedRecords = new TypeList();
+
+  static {
+    simpleTypesWithNamedRecords.addAll(DataTypes.simpleTypes);
+  }
+
+  private static RecordType registerNamedRecord(RecordType type) {
+    String typeName = type.getName();
+    String name = type.getName();
+    int idx = name.indexOf("=");
+    if (idx > 0) {
+      name = name.substring(0, idx).trim();
+    }
+    Type typedef = new TypeDef(name, type, null);
+    simpleTypesWithNamedRecords.add(typedef);
+    return type;
+  }
+
   private static final RecordType itemDropRec =
       new RecordType(
           "{item drop; float rate; string type;}",
@@ -326,19 +346,20 @@ public abstract class RuntimeLibrary {
           });
 
   private static final RecordType pingTestRec =
-      new RecordType(
-          "{string page; int count; int low; int high; int total; int bytes; int average; int bps;}",
-          new String[] {"page", "count", "low", "high", "total", "bytes", "average", "bps"},
-          new Type[] {
-            DataTypes.STRING_TYPE,
-            DataTypes.INT_TYPE,
-            DataTypes.INT_TYPE,
-            DataTypes.INT_TYPE,
-            DataTypes.INT_TYPE,
-            DataTypes.INT_TYPE,
-            DataTypes.INT_TYPE,
-            DataTypes.INT_TYPE
-          });
+      registerNamedRecord(
+          new RecordType(
+              "km_ping_result={string page; int count; int low; int high; int total; int bytes; int average; int bps;}",
+              new String[] {"page", "count", "low", "high", "total", "bytes", "average", "bps"},
+              new Type[] {
+                DataTypes.STRING_TYPE,
+                DataTypes.INT_TYPE,
+                DataTypes.INT_TYPE,
+                DataTypes.INT_TYPE,
+                DataTypes.INT_TYPE,
+                DataTypes.INT_TYPE,
+                DataTypes.INT_TYPE,
+                DataTypes.INT_TYPE
+              }));
 
   private static final RecordType stackTraceRec =
       new RecordType(

--- a/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
+++ b/test/net/sourceforge/kolmafia/textui/RuntimeLibraryTest.java
@@ -1472,7 +1472,7 @@ public class RuntimeLibraryTest extends AbstractCommandTestBase {
             output,
             is(
                 """
-              Returned: record {string page; int count; int low; int high; int total; int bytes; int average; int bps;}
+              Returned: record km_ping_result={string page; int count; int low; int high; int total; int bytes; int average; int bps;}
               page => api
               count => 10
               low => 26


### PR DESCRIPTION
In #3715 there has been some discussion of the difficulties involved in using records as the return types of ASH methods in the runtime library. There are several issues:

1) Since the records do not have a name, callers need to define their variable to have the same type as the record signature, which can be cumbersome. For example, 
```
record {string page; int count; int low; int high; int total; int bytes; int average; int bps;} result=ping();
```
This is not only difficult to understand at a glance, but it also has the problem of drifting out of sync if the structure of the return type ever changes (e.g. by adding a field). Having a simple name to use to refer to the record type would both make it easier to comprehend and also prevent type drift between the runtime library and scripts.

2) Because assignment of records requires the source and destination to be structurally identical, any drift between types breaks backward-compatibility, even in cases where the only change is the addition of a field (which an oblivious caller could just ignore if not for the fact that the script now fails to validate). Ideally, it would be possible to assign a record onto a record variable who fields are a subset of the source record's fields.

This PR serves as a proof-of-concept for an idea I had to resolve the first issue and to reduce the number of cases where the second issue is a problem. It's not intended as a full solution in it's current state; instead the intent is to provide something to discuss without diving into too deep of an implementation first.

The main idea is to allow developers using record types as parameter/return values in the runtime library to assign a name to that record type. A `typedef` tying that name to the record type definition would then be included in the top-level scope of an ASH script. For the sake of example, I have given the record used in the `ping()` runtime library function the name `km_ping_result`. With these changes, the calling script can now work with the resulting record type using this name:
```
km_ping_result res=ping();
print(res.page +": "+res.average);
```

Since this isn't actually a new type definition but rather a typedef, the named version of the record and the unnamed version can be used interchangeably (which enables upgrading an existing library function to use a named record without breaking backward-compatibility). These are all valid operations:
```
km_ping_result res=ping();
record {string page; int count; int low; int high; int total; int bytes; int average; int bps;} res2=res;
print(res2.page +": "+res2.average);

record {string page; int count; int low; int high; int total; int bytes; int average; int bps;} res3=ping();
print(res3.page +": "+res3.average);

km_ping_result res4=res3;
print(res4.page +": "+res4.average);
```

I expect that this change would generally drive users to use the typedef'd representation of the record rather than the unnamed representation, which should (going forward) reduce the amount of problems like those from (2) above that will arise. Nonetheless, we'd likely want to implement a real fix for that issue before being too brazen about making changes to the record types. I haven't ruled out the possibility of including that in this PR; I just haven't had a chance to look at it yet.

Finally, as part of this POC I also made a modification to how these named records are represented by the `ashref` command. The function definition uses the named record, but displays the full structure on hover. (I'm open to ideas about how this could be better--this is just a proof-of-concept idea.)

<img width="487" height="129" alt="image" src="https://github.com/user-attachments/assets/63803f66-2d90-4220-b4b7-14c1c5968077" />

Finally, I suspect this could maybe have some impact on how the TS type stuff works, but I really don't know anything about that stuff. Maybe @gausie might have an opinion.

Thoughts? Is this a reasonable idea to pursue further, or are people satisfied with how the current system works?