### PR TITLE
feat: allow assigning a record to a record with a subset of its values

### DIFF
--- a/src/net/sourceforge/kolmafia/textui/parsetree/ArrayValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/ArrayValue.java
@@ -61,6 +61,9 @@ public class ArrayValue extends AggregateValue {
 
     if (baseType.equals(valType)) {
       array[index] = val;
+    } else if (baseType instanceof RecordType recordType
+        && val instanceof RecordValue recordValue) {
+      array[index] = RecordValue.coerceTo(recordType, recordValue);
     } else if (baseType.equals(TypeSpec.STRING)) {
       array[index] = val.toStringValue();
     } else if (baseType.equals(TypeSpec.INT) && valType.equals(TypeSpec.FLOAT)) {

--- a/src/net/sourceforge/kolmafia/textui/parsetree/MapValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/MapValue.java
@@ -47,6 +47,9 @@ public class MapValue extends AggregateValue {
 
     if (baseType.equals(valType)) {
       map.put(key, val);
+    } else if (baseType instanceof RecordType recordType
+        && val instanceof RecordValue recordValue) {
+      map.put(key, RecordValue.coerceTo(recordType, recordValue));
     } else if (baseType.equals(TypeSpec.STRING)) {
       map.put(key, val.toStringValue());
     } else if (baseType.equals(TypeSpec.INT) && valType.equals(TypeSpec.FLOAT)) {

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Operator.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Operator.java
@@ -250,6 +250,14 @@ public class Operator extends Command {
       return true;
     }
 
+    // A record can be stored in a record whose fields are a subset of its own
+    // fields, matched by name; any extra source fields are ignored.
+    if (lhs instanceof RecordType lhr && rhs instanceof RecordType rhr) {
+      if (oper.equals("assign") || oper.equals("=")) {
+        return lhr.coercesFrom(rhr);
+      }
+    }
+
     if (lhs.equals(DataTypes.ANY_TYPE)) {
       return true;
     }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/RecordType.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/RecordType.java
@@ -89,13 +89,39 @@ public class RecordType extends CompositeType {
   }
 
   public Value getFieldIndex(final String field) {
+    int index = this.indexOf(field);
+    return index < 0 ? null : this.fieldIndices[index];
+  }
+
+  public int indexOf(final String field) {
     String val = field.toLowerCase();
     for (int index = 0; index < this.fieldNames.length; ++index) {
       if (val.equals(this.fieldNames[index])) {
-        return this.fieldIndices[index];
+        return index;
       }
     }
-    return null;
+    return -1;
+  }
+
+  /**
+   * Returns true if a value of the given record type can be stored in this record type.
+   *
+   * <p>Every field of this record must be present in {@code source} (matched by name, ignoring
+   * order) with a type that can be coerced to the field's type. Fields in {@code source} that do
+   * not appear in this record are ignored.
+   */
+  public boolean coercesFrom(final RecordType source) {
+    Type[] sourceTypes = source.getFieldTypes();
+    for (int i = 0; i < this.fieldNames.length; ++i) {
+      int sourceIndex = source.indexOf(this.fieldNames[i]);
+      if (sourceIndex < 0) {
+        return false;
+      }
+      if (!Operator.validCoercion(this.fieldTypes[i], sourceTypes[sourceIndex], "assign")) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override

--- a/src/net/sourceforge/kolmafia/textui/parsetree/RecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/RecordValue.java
@@ -29,6 +29,49 @@ public class RecordValue extends CompositeValue {
     return ((RecordType) this.type).getDataType(key);
   }
 
+  /**
+   * Returns a record value of the given type whose fields, matched by name, hold the (coerced)
+   * values of the corresponding fields of {@code source}. Fields present in {@code source} but
+   * absent from {@code type} are dropped.
+   */
+  public static RecordValue coerceTo(final RecordType type, final RecordValue source) {
+    if (type.equals(source.getRecordType())) {
+      return source;
+    }
+
+    RecordValue result = new RecordValue(type);
+    String[] names = type.getFieldNames();
+    Type[] dataTypes = type.getFieldTypes();
+    Value[] fields = result.getRecordFields();
+    RecordType sourceType = source.getRecordType();
+    for (int i = 0; i < names.length; ++i) {
+      int sourceIndex = sourceType.indexOf(names[i]);
+      if (sourceIndex >= 0) {
+        fields[i] = RecordValue.coerceValue(dataTypes[i], source.aref(sourceIndex, null));
+      }
+    }
+    return result;
+  }
+
+  private static Value coerceValue(final Type destination, final Value source) {
+    if (destination.equals(source.getType())) {
+      return source;
+    }
+    if (destination instanceof RecordType recordType && source instanceof RecordValue recordValue) {
+      return RecordValue.coerceTo(recordType, recordValue);
+    }
+    if (destination.equals(TypeSpec.STRING)) {
+      return source.toStringValue();
+    }
+    if (destination.equals(TypeSpec.INT) && source.getType().equals(TypeSpec.FLOAT)) {
+      return source.toIntValue();
+    }
+    if (destination.equals(TypeSpec.FLOAT) && source.getType().equals(TypeSpec.INT)) {
+      return source.toFloatValue();
+    }
+    return source;
+  }
+
   // The only comparison we implement is equality; we define no
   // "natural order" for a record value.
   //
@@ -139,6 +182,9 @@ public class RecordValue extends CompositeValue {
 
     if (array[index].getType().equals(val.getType())) {
       array[index] = val;
+    } else if (array[index].getType() instanceof RecordType recordType
+        && val instanceof RecordValue recordValue) {
+      array[index] = RecordValue.coerceTo(recordType, recordValue);
     } else if (array[index].getType().equals(TypeSpec.STRING)) {
       array[index] = val.toStringValue();
     } else if (array[index].getType().equals(TypeSpec.INT)

--- a/src/net/sourceforge/kolmafia/textui/parsetree/RecordValue.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/RecordValue.java
@@ -63,11 +63,14 @@ public class RecordValue extends CompositeValue {
     if (destination.equals(TypeSpec.STRING)) {
       return source.toStringValue();
     }
-    if (destination.equals(TypeSpec.INT) && source.getType().equals(TypeSpec.FLOAT)) {
+    if (destination.equals(TypeSpec.INT)) {
       return source.toIntValue();
     }
-    if (destination.equals(TypeSpec.FLOAT) && source.getType().equals(TypeSpec.INT)) {
+    if (destination.equals(TypeSpec.FLOAT)) {
       return source.toFloatValue();
+    }
+    if (destination.equals(TypeSpec.BOOLEAN)) {
+      return source.toBooleanValue();
     }
     return source;
   }

--- a/src/net/sourceforge/kolmafia/textui/parsetree/Variable.java
+++ b/src/net/sourceforge/kolmafia/textui/parsetree/Variable.java
@@ -80,6 +80,10 @@ public class Variable extends Symbol {
         || this.getBaseType().equals(targetValue.getType())) {
       this.content = targetValue;
       this.expression = null;
+    } else if (this.getBaseType() instanceof RecordType recordType
+        && targetValue instanceof RecordValue recordValue) {
+      this.content = RecordValue.coerceTo(recordType, recordValue);
+      this.expression = null;
     } else if (this.getBaseType().equals(TypeSpec.STRICT_STRING)
         || this.getBaseType().equals(TypeSpec.STRING)) {
       this.content = targetValue.toStringValue();

--- a/test/net/sourceforge/kolmafia/textui/parsetree/AssignmentTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/AssignmentTest.java
@@ -152,7 +152,25 @@ public class AssignmentTest {
             "Invalid assignment coercion - assignment",
             "boolean x; x += 'foo'",
             "Cannot store string in x of type boolean",
-            "char 12 to char 22"));
+            "char 12 to char 22"),
+        invalid(
+            "Cannot store record in record with extra fields",
+            "record f {string name;};\n"
+                + "record g {string name; int line;};\n"
+                + "f source = new f('a');\n"
+                + "g dest = source;\n"
+                + "print('FAIL');\n",
+            "Cannot store f in dest of type g",
+            "line 4, char 10 to char 16"),
+        invalid(
+            "Cannot store record in record with incompatible field type",
+            "record f {string name;};\n"
+                + "record g {int name;};\n"
+                + "f source = new f('a');\n"
+                + "g dest = source;\n"
+                + "print('FAIL');\n",
+            "Cannot store f in dest of type g",
+            "line 4, char 10 to char 16"));
   }
 
   @ParameterizedTest

--- a/test/net/sourceforge/kolmafia/textui/parsetree/RecordAssignmentTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/RecordAssignmentTest.java
@@ -247,6 +247,18 @@ public class RecordAssignmentTest {
     assertThat(output, containsString("3;done"));
   }
 
+  @Test
+  void storeRecordCoercePathToInt() {
+    String output =
+        runAsh(
+            """
+        record f {path pth;};
+        record {int pth;} dest = new f($path[Trendy]);
+        print(dest.pth + ';done');
+        """);
+    assertThat(output, containsString("7;done"));
+  }
+
   // Records containing records work if the contained record is a subset
 
   @Test

--- a/test/net/sourceforge/kolmafia/textui/parsetree/RecordAssignmentTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/RecordAssignmentTest.java
@@ -1,0 +1,207 @@
+package net.sourceforge.kolmafia.textui.parsetree;
+
+import static internal.helpers.RequestLoggerOutput.startStream;
+import static internal.helpers.RequestLoggerOutput.stopStream;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.KoLmafia;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.textui.AshRuntime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RecordAssignmentTest {
+  @BeforeEach
+  void reset() {
+    KoLCharacter.reset("RecordAssignmentTest");
+    Preferences.reset("RecordAssignmentTest");
+  }
+
+  @AfterEach
+  void afterEach() {
+    KoLmafia.forceContinue();
+  }
+
+  private static String runAsh(String source) {
+    startStream();
+    try {
+      var istream = new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8));
+      AshRuntime interpreter = new AshRuntime();
+      interpreter.validate(null, istream);
+      interpreter.execute("main", null);
+      return stopStream();
+    } catch (Throwable t) {
+      stopStream();
+      throw t;
+    }
+  }
+
+  // Same fields, matching name and order.
+
+  @Test
+  void storeRecordSameFieldsSameName() {
+    String output =
+        runAsh(
+            "record f {string file; string name; int line;};\n"
+                + "record {string file; string name; int line;} dest = new f('a','b',3);\n"
+                + "print(dest.name + dest.line + ';done');\n");
+    assertThat(output, containsString("b3;done"));
+  }
+
+  @Test
+  void storeRecordSameFieldsDifferentName() {
+    String output =
+        runAsh(
+            "record f {string file; string name; int line;};\n"
+                + "record g {string file; string name; int line;};\n"
+                + "f source = new f('a','b',3);\n"
+                + "g dest = source;\n"
+                + "print(dest.name + dest.line + ';done');\n");
+    assertThat(output, containsString("b3;done"));
+  }
+
+  @Test
+  void storeRecordSameFieldsFromFunction() {
+    String output =
+        runAsh(
+            "record {string file; string name; int line;} dest = get_stack_trace()[0];\n"
+                + "print('done');\n");
+    assertThat(output, containsString("done"));
+  }
+
+  // Fewer fields: the destination record keeps a subset of the source record's fields.
+
+  @Test
+  void storeRecordFewerFields() {
+    String output =
+        runAsh(
+            "record f {string file; string name; int line;};\n"
+                + "record g {string name; int line;};\n"
+                + "f source = new f('a','b',3);\n"
+                + "g dest = source;\n"
+                + "print(dest.name + dest.line + ';done');\n");
+    assertThat(output, containsString("b3;done"));
+  }
+
+  @Test
+  void storeRecordFewerFieldsRearranged() {
+    String output =
+        runAsh(
+            "record f {string file; string name; int line; boolean george;};\n"
+                + "record g {string name; boolean george; int line;};\n"
+                + "f source = new f('a','b',3,true);\n"
+                + "g dest = source;\n"
+                + "print(dest.name + dest.line + dest.george + ';done');\n");
+    assertThat(output, containsString("b3true;done"));
+  }
+
+  @Test
+  void storeRecordFewerFieldsFromFunction() {
+    String output =
+        runAsh(
+            "record {string name; int line;} dest = get_stack_trace()[0];\n" + "print('done');\n");
+    assertThat(output, containsString("done"));
+  }
+
+  @Test
+  void storeRecordSingleField() {
+    String output =
+        runAsh(
+            "record f {string file; string name; int line;};\n"
+                + "record g {int line;};\n"
+                + "f source = new f('a','b',77);\n"
+                + "g dest = source;\n"
+                + "print(dest.line + ';done');\n");
+    assertThat(output, containsString("77;done"));
+  }
+
+  @Test
+  void storeRecordFewerFieldsPlainAssignment() {
+    String output =
+        runAsh(
+            "record f {string file; string name; int line;};\n"
+                + "record g {string name; int line;};\n"
+                + "f source = new f('a','b',3);\n"
+                + "g dest;\n"
+                + "dest = source;\n"
+                + "print(dest.name + dest.line + ';done');\n");
+    assertThat(output, containsString("b3;done"));
+  }
+
+  // Fields are matched by name, ignoring their order in the record definitions.
+
+  @Test
+  void storeRecordSameFieldsDifferentOrder() {
+    String output =
+        runAsh(
+            "record f {string file; string name; int line;};\n"
+                + "record g {string name; int line; string file;};\n"
+                + "f source = new f('a','b',3);\n"
+                + "g dest = source;\n"
+                + "print(dest.name + dest.line + dest.file + ';done');\n");
+    assertThat(output, containsString("b3a;done"));
+  }
+
+  // Destination records that are not a subset of the source still fail to parse.
+
+  @Test
+  void storeRecordExtraFieldsDestinationFails() {
+    String output =
+        runAsh(
+            "record f {string name;};\n"
+                + "record g {string name; int line;};\n"
+                + "f source = new f('a');\n"
+                + "g dest = source;\n"
+                + "print('FAIL');\n");
+    assertThat(output, containsString("Cannot store"));
+  }
+
+  @Test
+  void storeRecordIncompatibleFieldTypeFails() {
+    String output =
+        runAsh(
+            "record f {string name;};\n"
+                + "record g {int name;};\n"
+                + "f source = new f('a');\n"
+                + "g dest = source;\n"
+                + "print('FAIL');\n");
+    assertThat(output, containsString("Cannot store"));
+  }
+
+  // Fields can be coerced using the same rules as straight assignment
+
+  @Test
+  void storeRecordCoerceFloatToInt() {
+    String output =
+        runAsh(
+            "record f {float item;};\n"
+                + "record {int item;} dest = new f(3.0);\n"
+                + "print(dest.item + ';done');\n");
+    assertThat(output, containsString("3;done"));
+  }
+
+  @Test
+  void storeRecordCoerceIntToFloat() {
+    String output =
+        runAsh(
+            "record f {int item;};\n"
+                + "record {float item;} dest = new f(3);\n"
+                + "print(dest.item + ';done');\n");
+    assertThat(output, containsString("3.0;done"));
+  }
+
+  @Test
+  void storeRecordCoerceIntToString() {
+    String output =
+        runAsh(
+            "record f {int item;};\n"
+                + "record {string item;} dest = new f(3);\n"
+                + "print(dest.item + ';done');\n");
+    assertThat(output, containsString("3;done"));
+  }
+}

--- a/test/net/sourceforge/kolmafia/textui/parsetree/RecordAssignmentTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/RecordAssignmentTest.java
@@ -47,9 +47,11 @@ public class RecordAssignmentTest {
   void storeRecordSameFieldsSameName() {
     String output =
         runAsh(
-            "record f {string file; string name; int line;};\n"
-                + "record {string file; string name; int line;} dest = new f('a','b',3);\n"
-                + "print(dest.name + dest.line + ';done');\n");
+            """
+            record f {string file; string name; int line;};
+            record {string file; string name; int line;} dest = new f('a','b',3);
+            print(dest.name + dest.line + ';done');
+            """);
     assertThat(output, containsString("b3;done"));
   }
 
@@ -57,11 +59,13 @@ public class RecordAssignmentTest {
   void storeRecordSameFieldsDifferentName() {
     String output =
         runAsh(
-            "record f {string file; string name; int line;};\n"
-                + "record g {string file; string name; int line;};\n"
-                + "f source = new f('a','b',3);\n"
-                + "g dest = source;\n"
-                + "print(dest.name + dest.line + ';done');\n");
+            """
+            record f {string file; string name; int line;};
+            record g {string file; string name; int line;};
+            f source = new f('a','b',3);
+            g dest = source;
+            print(dest.name + dest.line + ';done');
+            """);
     assertThat(output, containsString("b3;done"));
   }
 
@@ -69,8 +73,10 @@ public class RecordAssignmentTest {
   void storeRecordSameFieldsFromFunction() {
     String output =
         runAsh(
-            "record {string file; string name; int line;} dest = get_stack_trace()[0];\n"
-                + "print('done');\n");
+            """
+            record {string file; string name; int line;} dest = get_stack_trace()[0];
+            print('done');
+            """);
     assertThat(output, containsString("done"));
   }
 
@@ -80,11 +86,13 @@ public class RecordAssignmentTest {
   void storeRecordFewerFields() {
     String output =
         runAsh(
-            "record f {string file; string name; int line;};\n"
-                + "record g {string name; int line;};\n"
-                + "f source = new f('a','b',3);\n"
-                + "g dest = source;\n"
-                + "print(dest.name + dest.line + ';done');\n");
+            """
+            record f {string file; string name; int line;};
+            record g {string name; int line;};
+            f source = new f('a','b',3);
+            g dest = source;
+            print(dest.name + dest.line + ';done');
+            """);
     assertThat(output, containsString("b3;done"));
   }
 
@@ -92,11 +100,13 @@ public class RecordAssignmentTest {
   void storeRecordFewerFieldsRearranged() {
     String output =
         runAsh(
-            "record f {string file; string name; int line; boolean george;};\n"
-                + "record g {string name; boolean george; int line;};\n"
-                + "f source = new f('a','b',3,true);\n"
-                + "g dest = source;\n"
-                + "print(dest.name + dest.line + dest.george + ';done');\n");
+            """
+            record f {string file; string name; int line; boolean george;};
+            record g {string name; boolean george; int line;};
+            f source = new f('a','b',3,true);
+            g dest = source;
+            print(dest.name + dest.line + dest.george + ';done');
+            """);
     assertThat(output, containsString("b3true;done"));
   }
 
@@ -104,7 +114,10 @@ public class RecordAssignmentTest {
   void storeRecordFewerFieldsFromFunction() {
     String output =
         runAsh(
-            "record {string name; int line;} dest = get_stack_trace()[0];\n" + "print('done');\n");
+            """
+            record {string name; int line;} dest = get_stack_trace()[0];
+            print('done');
+            """);
     assertThat(output, containsString("done"));
   }
 
@@ -112,11 +125,13 @@ public class RecordAssignmentTest {
   void storeRecordSingleField() {
     String output =
         runAsh(
-            "record f {string file; string name; int line;};\n"
-                + "record g {int line;};\n"
-                + "f source = new f('a','b',77);\n"
-                + "g dest = source;\n"
-                + "print(dest.line + ';done');\n");
+            """
+            record f {string file; string name; int line;};
+            record g {int line;};
+            f source = new f('a','b',77);
+            g dest = source;
+            print(dest.line + ';done');
+            """);
     assertThat(output, containsString("77;done"));
   }
 
@@ -124,12 +139,14 @@ public class RecordAssignmentTest {
   void storeRecordFewerFieldsPlainAssignment() {
     String output =
         runAsh(
-            "record f {string file; string name; int line;};\n"
-                + "record g {string name; int line;};\n"
-                + "f source = new f('a','b',3);\n"
-                + "g dest;\n"
-                + "dest = source;\n"
-                + "print(dest.name + dest.line + ';done');\n");
+            """
+            record f {string file; string name; int line;};
+            record g {string name; int line;};
+            f source = new f('a','b',3);
+            g dest;
+            dest = source;
+            print(dest.name + dest.line + ';done');
+            """);
     assertThat(output, containsString("b3;done"));
   }
 
@@ -139,11 +156,13 @@ public class RecordAssignmentTest {
   void storeRecordSameFieldsDifferentOrder() {
     String output =
         runAsh(
-            "record f {string file; string name; int line;};\n"
-                + "record g {string name; int line; string file;};\n"
-                + "f source = new f('a','b',3);\n"
-                + "g dest = source;\n"
-                + "print(dest.name + dest.line + dest.file + ';done');\n");
+            """
+            record f {string file; string name; int line;};
+            record g {string name; int line; string file;};
+            f source = new f('a','b',3);
+            g dest = source;
+            print(dest.name + dest.line + dest.file + ';done');
+            """);
     assertThat(output, containsString("b3a;done"));
   }
 
@@ -153,11 +172,13 @@ public class RecordAssignmentTest {
   void storeRecordExtraFieldsDestinationFails() {
     String output =
         runAsh(
-            "record f {string name;};\n"
-                + "record g {string name; int line;};\n"
-                + "f source = new f('a');\n"
-                + "g dest = source;\n"
-                + "print('FAIL');\n");
+            """
+            record f {string name;};
+            record g {string name; int line;};
+            f source = new f('a');
+            g dest = source;
+            print('FAIL');
+            """);
     assertThat(output, containsString("Cannot store"));
   }
 
@@ -165,11 +186,13 @@ public class RecordAssignmentTest {
   void storeRecordIncompatibleFieldTypeFails() {
     String output =
         runAsh(
-            "record f {string name;};\n"
-                + "record g {int name;};\n"
-                + "f source = new f('a');\n"
-                + "g dest = source;\n"
-                + "print('FAIL');\n");
+            """
+            record f {string name;};
+            record g {int name;};
+            f source = new f('a');
+            g dest = source;
+            print('FAIL');
+            """);
     assertThat(output, containsString("Cannot store"));
   }
 
@@ -179,9 +202,11 @@ public class RecordAssignmentTest {
   void storeRecordCoerceFloatToInt() {
     String output =
         runAsh(
-            "record f {float item;};\n"
-                + "record {int item;} dest = new f(3.0);\n"
-                + "print(dest.item + ';done');\n");
+            """
+            record f {float item;};
+            record {int item;} dest = new f(3.0);
+            print(dest.item + ';done');
+            """);
     assertThat(output, containsString("3;done"));
   }
 
@@ -189,9 +214,11 @@ public class RecordAssignmentTest {
   void storeRecordCoerceIntToFloat() {
     String output =
         runAsh(
-            "record f {int item;};\n"
-                + "record {float item;} dest = new f(3);\n"
-                + "print(dest.item + ';done');\n");
+            """
+            record f {int item;};
+            record {float item;} dest = new f(3);
+            print(dest.item + ';done');
+            """);
     assertThat(output, containsString("3.0;done"));
   }
 
@@ -199,9 +226,11 @@ public class RecordAssignmentTest {
   void storeRecordCoerceIntToString() {
     String output =
         runAsh(
-            "record f {int item;};\n"
-                + "record {string item;} dest = new f(3);\n"
-                + "print(dest.item + ';done');\n");
+            """
+            record f {int item;};
+            record {string item;} dest = new f(3);
+            print(dest.item + ';done');
+            """);
     assertThat(output, containsString("3;done"));
   }
 }

--- a/test/net/sourceforge/kolmafia/textui/parsetree/RecordAssignmentTest.java
+++ b/test/net/sourceforge/kolmafia/textui/parsetree/RecordAssignmentTest.java
@@ -44,6 +44,19 @@ public class RecordAssignmentTest {
   // Same fields, matching name and order.
 
   @Test
+  void storeRecordSameType() {
+    String output =
+        runAsh(
+            """
+        record f {string file; string name; int line;};
+        f source = new f('a','b',3);
+        f dest = source;
+        print(dest.name + dest.line + ';done');
+        """);
+    assertThat(output, containsString("b3;done"));
+  }
+
+  @Test
   void storeRecordSameFieldsSameName() {
     String output =
         runAsh(
@@ -215,10 +228,10 @@ public class RecordAssignmentTest {
     String output =
         runAsh(
             """
-            record f {int item;};
-            record {float item;} dest = new f(3);
-            print(dest.item + ';done');
-            """);
+        record f {int item;};
+        record {float item;} dest = new f(3);
+        print(dest.item + ';done');
+        """);
     assertThat(output, containsString("3.0;done"));
   }
 
@@ -227,10 +240,64 @@ public class RecordAssignmentTest {
     String output =
         runAsh(
             """
-            record f {int item;};
-            record {string item;} dest = new f(3);
-            print(dest.item + ';done');
-            """);
+        record f {int item;};
+        record {string item;} dest = new f(3);
+        print(dest.item + ';done');
+        """);
     assertThat(output, containsString("3;done"));
+  }
+
+  // Records containing records work if the contained record is a subset
+
+  @Test
+  void storeRecordContainingRecord() {
+    String output =
+        runAsh(
+            """
+          record d {string name; string otherstuff;};
+          record e {string name;};
+          record f {d innerrec;};
+          record g {e innerrec;};
+          f source = new f(new d('a', 'b'));
+          g dest = source;
+          print(dest.innerrec.name + ';done');
+          """);
+    assertThat(output, containsString("a;done"));
+  }
+
+  // Arrays and maps can contain records as expected
+
+  @Test
+  void storeRecordInArray() {
+    String output =
+        runAsh(
+            """
+          record f {string name; string otherstuff;};
+          record g {string name;};
+          g[2] garray;
+          f source = new f('a', 'b');
+          g dest = new g('a');
+          garray[0] = source;
+          garray[1] = dest;
+          print(garray[0].name + ';done');
+          """);
+    assertThat(output, containsString("a;done"));
+  }
+
+  @Test
+  void storeRecordInMap() {
+    String output =
+        runAsh(
+            """
+          record f {string name; string otherstuff;};
+          record g {string name;};
+          g[int] gmap;
+          f source = new f('a', 'b');
+          g dest = new g('a');
+          gmap[0] = source;
+          gmap[1] = dest;
+          print(gmap[0].name + ';done');
+          """);
+    assertThat(output, containsString("a;done"));
   }
 }


### PR DESCRIPTION
In #3715, there was discussion that record types were somewhat tricky to use if we wanted to change the output of a function in the future.

Allow assigning a record to a type with a subset of its values, in any order. Also allow coercion on e.g. float -> int, which would have been useful when we changed the type of `item_drops_array` a while back ;)

The code was written by GLM and tidied up by me.

Might add some more tests if we're missing coverage.