### PR TITLE
Update inflationary coinmaster prices on shop load

### DIFF
--- a/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
+++ b/src/net/sourceforge/kolmafia/objectpool/ItemPool.java
@@ -4101,18 +4101,22 @@ public class ItemPool {
   public static final int UNDERDRAFT_PROTECTION = 12293;
   public static final int SOLVENT = 12294;
   public static final int SOYBEAN_FUTURES = 12295;
+  public static final int HOUSING_BUBBLE = 12296;
   public static final int FINANCIAL_INSTRUMENT = 12298;
   public static final int HEDGE_FUND_CLIPPERS = 12299;
   public static final int SELLING_SHORTS = 12300;
   public static final int BEAR_TATTOO = 12301;
   public static final int GOLD_401K_RING = 12303;
+  public static final int BALANCE_SHEET = 12304;
   public static final int INVISIBLE_HAND = 12305;
   public static final int CIRCLE_OF_OVERDRAFT_PROTECTION_SCROLL = 12306;
   public static final int MINT = 12307;
   public static final int SAVINGS_BONDO = 12308;
+  public static final int HOMEOWNERS_LOAM = 12309;
   public static final int TOXIC_ASSET = 12310;
   public static final int INTANGIBLE_ASSET = 12311;
   public static final int LIQUID_ASSET = 12312;
+  public static final int GROSS_PROPHET_CHRYSALIS = 12313;
 
   private ItemPool() {}
 

--- a/src/net/sourceforge/kolmafia/request/coinmaster/shop/InterestingCoinRequest.java
+++ b/src/net/sourceforge/kolmafia/request/coinmaster/shop/InterestingCoinRequest.java
@@ -1,11 +1,13 @@
 package net.sourceforge.kolmafia.request.coinmaster.shop;
 
+import java.util.List;
 import java.util.Set;
 import net.sourceforge.kolmafia.AdventureResult;
 import net.sourceforge.kolmafia.CoinmasterData;
 import net.sourceforge.kolmafia.objectpool.ItemPool;
 import net.sourceforge.kolmafia.persistence.ItemDatabase;
 import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.shop.ShopRow;
 
 public abstract class InterestingCoinRequest extends CoinMasterShopRequest {
   public static final String master = "Spend your Interesting Coins";
@@ -14,6 +16,7 @@ public abstract class InterestingCoinRequest extends CoinMasterShopRequest {
   public static final CoinmasterData DATA =
       new CoinmasterData(master, SHOPID, InterestingCoinRequest.class)
           .withNewShopRowFields(master, SHOPID)
+          .withVisitShopRows(InterestingCoinRequest::visitShopRows)
           .withCanBuyItem(InterestingCoinRequest::canBuyItem)
           .withVisitShop(InterestingCoinRequest::visitShop)
           .withPurchasedItem(InterestingCoinRequest::purchasedItem)
@@ -40,6 +43,14 @@ public abstract class InterestingCoinRequest extends CoinMasterShopRequest {
           ItemPool.ROTH_IPA,
           ItemPool.SAVINGS_BONDO,
           ItemPool.SOYBEAN_FUTURES);
+
+  // Prices increase as items are purchased
+  private static final Set<Integer> INFLATION_ITEMS =
+      Set.of(
+          ItemPool.HOMEOWNERS_LOAM,
+          ItemPool.HOUSING_BUBBLE,
+          ItemPool.BALANCE_SHEET,
+          ItemPool.GROSS_PROPHET_CHRYSALIS);
 
   // Once in a Lifetime Deals (1 per ascension)
   private static final Set<Integer> ASCENSION_ITEMS =
@@ -80,6 +91,15 @@ public abstract class InterestingCoinRequest extends CoinMasterShopRequest {
       Preferences.increment(dailyProperty(itemId), 1, 3, false);
     } else if (ASCENSION_ITEMS.contains(itemId)) {
       Preferences.setBoolean(ascensionProperty(itemId), true);
+    }
+  }
+
+  public static void visitShopRows(final List<ShopRow> shopRows, Boolean force) {
+    for (ShopRow shopRow : shopRows) {
+      int itemId = shopRow.getItem().getItemId();
+      if (INFLATION_ITEMS.contains(itemId)) {
+        DATA.getShopRow(itemId).setCosts(shopRow.getCosts());
+      }
     }
   }
 }


### PR DESCRIPTION
When visiting the Interesting Coin shop, set the internal prices of the inflationary items to reflect the actual current costs. This enables things like `sell_price($coinmaster[Spend your Interesting Coins], $item[homeowner's loam])` to return correct values. Note that when mafia starts (and maybe on ascension?) the prices will be out-of-sync until the shop is visited in the relay browser or `visit($coinmaster[Spend your Interesting Coins])` is called.

Side note: I initially had a more complicated solution that had a pref for each inflationary item that tracked how many had been bought this ascension, but the logic for fixing the pref if it was found to be out-of-sync was a bit annoying, and I couldn't really think of a case where a caller would actually care about how many were purchased (rather than what the cost of the next one is). If anyone has strong feelings that that version would be better for some reason, I can drop it in.